### PR TITLE
Mesh 3 fix with time stamps gf

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1245,13 +1245,13 @@ namespace details {
   // Functor used by Protect_edges_sizing_field::check_and_repopulate_edges, below
   template <typename Set>
   class Erase_element_from_set {
-    Set& set;
+    Set* set_ptr;
   public:
-    Erase_element_from_set(Set& set) : set(set) {}
+    Erase_element_from_set(Set& set) : set_ptr(&set) {}
 
     void operator()(const typename Set::key_type& x)
     {
-      set.erase(x);
+      set_ptr->erase(x);
     }
   }; // end class Erase_element_from_set
 


### PR DESCRIPTION
This is an attemp of a pull request.
The branch as been merged in `releases/CGAL-4.5-branch` with the following message:

```
Fix a bug in Mesh_3, when timestamps are used to compare Vertex_handle
and Cell_handle. The bug was in the class
Protect_edges_sizing_field. Once a vertex is removed from a
triangulation, the timestamp of the Vertex can change. That means that
it invalidates any future use of the original Vertex_handle.

Bug-fix for CGAL-4.5, approved by the Release Manager.
```
