### PR TITLE
Fix the output of a c3t3 to a polygon soup

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
@@ -288,6 +288,7 @@ public slots:
     if(!item->load(off_sstream))
     {
       delete item;
+      off_sstream.clear();
       off_sstream.str(backup);
 
       // Try to read .off in a polygon soup


### PR DESCRIPTION
The stream iostate must be cleared before it can be reused.
