### PR TITLE
Lcc writeoff for 3 d gdamiand

### DIFF
--- a/Combinatorial_map/include/CGAL/Cell_const_iterators.h
+++ b/Combinatorial_map/include/CGAL/Cell_const_iterators.h
@@ -91,12 +91,13 @@ namespace CGAL {
     /// Constructor with a dart in parameter (for end iterator).
     CMap_one_dart_per_cell_const_iterator(const Map_& amap, 
                                           Dart_const_handle adart): 
-      Base(amap)
-    { this->set_current_dart(adart); }
+      Base(amap, adart)
+    {}
     /// Constructor from non const version.
     CMap_one_dart_per_cell_const_iterator
     (const CMap_one_dart_per_cell_iterator<Map_,i,dim,false>& it):
-      Base(*const_cast<const Map_*>(it.get_combinatorial_map()))
+      Base(*const_cast<const Map_*>(it.get_combinatorial_map()),
+           it.get_first_dart())
     {}
   };
   //****************************************************************************

--- a/Combinatorial_map/include/CGAL/Cell_iterators.h
+++ b/Combinatorial_map/include/CGAL/Cell_iterators.h
@@ -48,7 +48,7 @@ namespace CGAL {
   /* Class CMap_cell_iterator<Map,Ite,i,dim,Tag_true>: to iterate onto the
    * cells incident to the given iterator which uses mark.
    */
-  template <typename Map_,typename Ite,unsigned int i, 
+  template <typename Map_,typename Ite,unsigned int i,
             unsigned int dim,bool Const>
   class CMap_cell_iterator<Map_,Ite,i,dim,Const,Tag_true>: public Ite
   {
@@ -64,12 +64,12 @@ namespace CGAL {
     void unmark_treated_darts()
     {
       if (this->mmap->is_whole_map_unmarked(mcell_mark_number)) return;
-            
+
       this->mmap->negate_mark(this->mmark_number);
       this->mmap->negate_mark(mcell_mark_number);
 
       Ite::rewind();
-      mark_cell<Map,i,dim>(*this->mmap, (*this), 
+      mark_cell<Map,i,dim>(*this->mmap, (*this),
                            mcell_mark_number);
 
       while (this->mmap->number_of_unmarked_darts(mcell_mark_number) > 0 ||
@@ -77,14 +77,14 @@ namespace CGAL {
       {
         this->operator++();
       }
-      
+
       this->mmap->negate_mark(mcell_mark_number);
       this->mmap->negate_mark(this->mmark_number);
 
       CGAL_assertion(this->mmap->is_whole_map_unmarked(this->mmark_number));
       CGAL_assertion(this->mmap->is_whole_map_unmarked(mcell_mark_number));
     }
-      
+
   public:
     /// Main constructor.
     CMap_cell_iterator(Map& amap, Dart_handle adart):
@@ -94,10 +94,10 @@ namespace CGAL {
       CGAL_static_assertion( (boost::is_same<typename Ite::Basic_iterator,
                               Tag_true>::value) );
       CGAL_assertion(amap.is_whole_map_unmarked(mcell_mark_number));
-      
+
       mark_cell<Map,i,dim>(amap, adart, mcell_mark_number);
     }
-  
+
     /// Destructor.
     ~CMap_cell_iterator()
     {
@@ -105,6 +105,7 @@ namespace CGAL {
         unmark_treated_darts();
       this->mmap->free_mark(mcell_mark_number);
       this->mmap->free_mark(this->mmark_number);
+      this->mcell_mark_number = -1; // To avoid basic class to try to unmark darts.
       this->mmark_number = -1; // To avoid basic class to try to unmark darts.
     }
 
@@ -147,10 +148,10 @@ namespace CGAL {
       }
       while (this->cont() &&
              this->mmap->is_marked((*this), mcell_mark_number));
-      
+
       if (this->cont())
       {
-        mark_cell<Map,i,dim>(*this->mmap, (*this), 
+        mark_cell<Map,i,dim>(*this->mmap, (*this),
                              mcell_mark_number);
       }
       return *this;
@@ -168,7 +169,7 @@ namespace CGAL {
   /* Class CMap_cell_iterator<Map,Ite,i,dim,Tag_false>: to iterate onto the
    * cells incident to the given iterator which does not use mark.
    */
-  template <typename Map_,typename Ite, unsigned int i, 
+  template <typename Map_,typename Ite, unsigned int i,
             unsigned int dim,bool Const>
   class CMap_cell_iterator<Map_,Ite,i,dim,Const,Tag_false>: public Ite
   {
@@ -190,7 +191,7 @@ namespace CGAL {
       if (this->mmap->is_whole_map_unmarked(mmark_number)) return;
 
       Ite::rewind();
-      mark_cell<Map,i,dim>(*this->mmap, (*this), 
+      mark_cell<Map,i,dim>(*this->mmap, (*this),
                            mmark_number);
       while (this->mmap->number_of_unmarked_darts(mmark_number) > 0)
         this->operator++();
@@ -205,7 +206,7 @@ namespace CGAL {
       mmark_number(amap.get_new_mark())
     {
       CGAL_static_assertion( (boost::is_same<typename Ite::Basic_iterator,
-                              Tag_true>::value) );      
+                              Tag_true>::value) );
       CGAL_assertion(amap.is_whole_map_unmarked(mmark_number));
       mark_cell<Map,i,dim>(amap, adart, mmark_number);
     }
@@ -216,6 +217,7 @@ namespace CGAL {
       if (this->mmap->get_number_of_times_mark_reserved(mmark_number)==1)
         unmark_treated_darts();
       this->mmap->free_mark(mmark_number);
+      this->mmark_number = -1; // To avoid basic class to try to unmark darts.
     }
 
     /// Copy constructor.
@@ -270,12 +272,12 @@ namespace CGAL {
   };
   //****************************************************************************
   /* Class CMap_cell_iterator<Map,CMap_dart_iterator_basic_of_all<Map>,
-     i,dim,Tag_false>: specialization to iterate onto 
+     i,dim,Tag_false>: specialization to iterate onto
      * all the cells of the map.
      */
   template <typename Map_,unsigned int i,unsigned int dim,bool Const>
   class CMap_cell_iterator<Map_,CMap_dart_iterator_basic_of_all<Map_,Const>,
-                           i,dim,Const,Tag_false>: 
+                           i,dim,Const,Tag_false>:
     public CMap_dart_iterator_basic_of_all<Map_,Const>
   {
   public:
@@ -284,7 +286,7 @@ namespace CGAL {
 
     typedef typename Base::Dart_handle Dart_handle;
     typedef typename Base::Map Map;
-  
+
   protected:
     /// Unmark all the marked darts during the iterator.
     void unmark_treated_darts()
@@ -296,7 +298,7 @@ namespace CGAL {
       if (this->mmap->is_whole_map_unmarked(mmark_number)) return;
 
       Base::rewind();
-      mark_cell<Map,i,dim>(*this->mmap, (*this), 
+      mark_cell<Map,i,dim>(*this->mmap, (*this),
                            mmark_number);
       while (this->mmap->number_of_unmarked_darts(mmark_number) > 0)
         this->operator++();
@@ -316,12 +318,22 @@ namespace CGAL {
       mark_cell<Map,i,dim>(amap, (*this), mmark_number);
     }
 
+   /// Constructor with a dart in parameter (for end iterator).
+    CMap_cell_iterator(Map& amap, Dart_handle adart):
+      Base(amap, adart),
+      mmark_number(amap.get_new_mark())
+    {
+      if (adart!=this->mmap->null_handle)
+        mark_cell<Map,i,dim>(amap, (*this), mmark_number);
+    }
+
     /// Destructor.
     ~CMap_cell_iterator()
     {
       if (this->mmap->get_number_of_times_mark_reserved(mmark_number)==1)
         unmark_treated_darts();
       this->mmap->free_mark(mmark_number);
+      this->mmark_number = -1; // To avoid basic class to try to unmark darts.
     }
 
     /// Copy constructor.
@@ -378,10 +390,10 @@ namespace CGAL {
   /* Class CMap_one_dart_per_incident_cell_iterator<Map,i,j,dim>: to iterate
    * onto one dart per i-cell incident to the given j-cell.
    */
-  template <typename Map_,unsigned int i,unsigned int j, 
+  template <typename Map_,unsigned int i,unsigned int j,
             unsigned int dim=Map_::dimension,bool Const=false>
   class CMap_one_dart_per_incident_cell_iterator:
-    public CMap_cell_iterator<Map_, 
+    public CMap_cell_iterator<Map_,
                               CMap_dart_iterator_basic_of_cell
                               <Map_,j,dim,Const>, i,dim,Const>
   {
@@ -394,12 +406,12 @@ namespace CGAL {
 
     typedef typename Base::Dart_handle Dart_handle;
     typedef typename Base::Map Map;
-    
+
     typedef Tag_false Use_mark;
     typedef Tag_false Basic_iterator;
-    
+
     /// Main constructor.
-    CMap_one_dart_per_incident_cell_iterator(Map& amap, Dart_handle adart): 
+    CMap_one_dart_per_incident_cell_iterator(Map& amap, Dart_handle adart):
       Base(amap, adart)
     {}
   };
@@ -416,21 +428,22 @@ namespace CGAL {
   public:
     typedef CMap_one_dart_per_cell_iterator<Map_,i,dim,Const> Self;
     typedef CMap_cell_iterator<Map_,
-                               CMap_dart_iterator_basic_of_all<Map_,Const>, 
+                               CMap_dart_iterator_basic_of_all<Map_,Const>,
                                i,dim,Const> Base;
 
     typedef typename Base::Dart_handle Dart_handle;
     typedef typename Base::Map Map;
-    
+
     typedef Tag_false Use_mark;
     typedef Tag_false Basic_iterator;
-    
+
     /// Main constructor.
     CMap_one_dart_per_cell_iterator(Map& amap): Base(amap)
     {}
     /// Constructor with a dart in parameter (for end iterator).
-    CMap_one_dart_per_cell_iterator(Map& amap, Dart_handle adart): Base(amap)
-    { this->set_current_dart(adart); }
+    CMap_one_dart_per_cell_iterator(Map& amap, Dart_handle adart):
+	     Base(amap, adart)
+    {}
   };
 //****************************************************************************
 //****************************************************************************

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -3265,7 +3265,7 @@ namespace CGAL {
       iterator end()   { return iterator(mmap,mmap.null_handle); }
       const_iterator begin() const { return const_iterator(mmap); }
       const_iterator end() const   { return const_iterator(mmap,mmap.null_handle); }
-      size_type size()
+      size_type size() const
       { return mmap.number_of_darts(); }
       bool empty() const
       { return mmap.is_empty(); }
@@ -3337,10 +3337,10 @@ namespace CGAL {
       iterator end()   { return iterator(mmap,mmap.null_handle); }
       const_iterator begin() const { return const_iterator(mmap); }
       const_iterator end() const   { return const_iterator(mmap,mmap.null_handle); }
-      size_type size()
+      size_type size() const
       {
         if (msize==0)
-          for ( const_iterator it=begin(); it!=end(); ++it)
+          for ( const_iterator it=begin(), itend=end(); it!=end(); ++it)
             ++msize;
         return msize;
       }
@@ -3348,7 +3348,7 @@ namespace CGAL {
       { return mmap.is_empty(); }
     private:
       Self & mmap;
-      size_type msize;
+      mutable size_type msize;
     };
     //**************************************************************************
     // One_dart_per_cell_const_range
@@ -3360,10 +3360,10 @@ namespace CGAL {
       {}
       const_iterator begin() const { return const_iterator(mmap); }
       const_iterator end() const   { return const_iterator(mmap,mmap.null_handle); }
-      size_type size()
+      size_type size() const
       {
         if (msize==0)
-          for ( const_iterator it=begin(); it!=end(); ++it)
+          for ( const_iterator it=begin(), itend=end(); it!=end(); ++it)
             ++msize;
         return msize;
       }
@@ -3371,7 +3371,7 @@ namespace CGAL {
       { return mmap.is_empty(); }
     private:
       const Self & mmap;
-      size_type msize;
+      mutable size_type msize;
     };
     //**************************************************************************
     /// @return a range on the i-cells incindent to the given j-cell.

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -36,6 +36,10 @@ namespace CGAL {
    *    the involution Bi.
    *  - CMap_non_basic_iterator<Map_,Ite> to transform the basic iterator Ite
    *    into the corresponding non basic iterator.
+   *  - CMap_range<Map,It,ConstIt,BasicIt> generic definition of a range
+   *    given an iterator and its const version
+   *  - CMap_const_range<Map,It,ConstIt,BasicIt> generic definition of a const
+   *    range given an iterator and its const version
    */
   //****************************************************************************
   /// OperationState: type to keep the last operation used by the previous ++.
@@ -56,7 +60,7 @@ namespace CGAL {
     OP_BETA21,     ///< Previous op was beta21.
     OP_JUMP,      ///< Previous op was a jump .
     OP_POP,       ///< Previous op pop a dart from a stack or a queue.
-    OP_END        ///< Previous op go out of the iterator.    
+    OP_END        ///< Previous op go out of the iterator.
   };
   //****************************************************************************
   /** Generic class of iterator onto darts.
@@ -87,14 +91,14 @@ namespace CGAL {
     typedef typename Base::value_type value_type;
     typedef typename Base::difference_type difference_type;
     typedef typename Base::pointer pointer;
-    typedef typename Base::reference reference;    
+    typedef typename Base::reference reference;
 
     /// true iff this iterator is basic
     typedef Tag_true Basic_iterator;
 
   public:
     /// Main constructor.
-    CMap_dart_iterator(Map& amap, Dart_handle adart): 
+    CMap_dart_iterator(Map& amap, Dart_handle adart):
       Base(adart),
       mmap(&amap),
       mfirst_dart(adart),
@@ -105,7 +109,7 @@ namespace CGAL {
     bool operator==(const Self& aiterator) const
     {
       return ( ((*this==mmap->null_handle) && (aiterator==mmap->null_handle)) ||
-               (mfirst_dart == aiterator.mfirst_dart && 
+               (mfirst_dart == aiterator.mfirst_dart &&
                static_cast<const Base&>(*this)==
                 static_cast<const Base&>(aiterator)) );
     }
@@ -119,7 +123,7 @@ namespace CGAL {
 
     /// Accessor to the combinatorial map.
     Map* get_combinatorial_map() const { return mmap; }
-    
+
     /// Rewind of the iterator to its beginning.
     void rewind()
     { set_current_dart(mfirst_dart); mprev_op = OP_NONE; }
@@ -179,7 +183,7 @@ namespace CGAL {
     OperationState mprev_op;
   };
   //****************************************************************************
-  /* Class CMap_extend_iterator<Map,Ite,Bi> which extend a given iterator by 
+  /* Class CMap_extend_iterator<Map,Ite,Bi> which extend a given iterator by
    * adding Bi and by using a stack and a mark.
    * General case when Ite does not have already a stack.
    */
@@ -198,7 +202,7 @@ namespace CGAL {
 
     CGAL_static_assertion( (Bi<=Map::dimension &&
                             boost::is_same<Ite_has_stack,Tag_false>::value) );
-    
+
   public:
     /// Main constructor.
     CMap_extend_iterator(Map& amap, Dart_handle adart, int amark):
@@ -247,7 +251,7 @@ namespace CGAL {
       }
       while ( this->cont() &&
               this->mmap->is_marked(*this, mmark_number) );
-      
+
       if ( !this->cont() )
       {
         if ( !mto_treat.empty() )
@@ -300,7 +304,7 @@ namespace CGAL {
     Dart_handle minitial_dart;
   };
   //****************************************************************************
-  /* Class CMap_extend_iterator<Map,Ite,Bi> which extend a given iterator by 
+  /* Class CMap_extend_iterator<Map,Ite,Bi> which extend a given iterator by
    * adding Bi and by using a stack and a mark.
    * Specialization when Ite has already a stack.
    */
@@ -371,18 +375,18 @@ namespace CGAL {
   //****************************************************************************
   //* Class CMap_non_basic_iterator allows to transform a basic_iterator onto
   //* a non basic one, depending if the basic iterator uses mark or not.
-  template <typename Map_,typename Basic_iterator, 
+  template <typename Map_,typename Basic_iterator,
             typename Use_mark=typename Basic_iterator::Use_mark>
   class CMap_non_basic_iterator;
   //****************************************************************************
   template <typename Map_,typename Base_>
-  class CMap_non_basic_iterator<Map_,Base_,Tag_true>: 
+  class CMap_non_basic_iterator<Map_,Base_,Tag_true>:
     public Base_
   {
   public:
     typedef CMap_non_basic_iterator<Map_,Base_,Tag_true> Self;
     typedef Base_ Base;
-    
+
     typedef typename Base::Map Map;
     typedef typename Base::Dart_handle Dart_handle;
 
@@ -391,7 +395,7 @@ namespace CGAL {
 
     CGAL_static_assertion( (boost::is_same<typename Base::Basic_iterator,
                             Tag_true>::value) );
-    
+
     /// Main constructor.
     CMap_non_basic_iterator(Map& amap, Dart_handle adart1):
       Base(amap, adart1, amap.get_new_mark())
@@ -405,11 +409,12 @@ namespace CGAL {
           (this->mmark_number)==1)
         unmark_treated_darts();
       this->mmap->free_mark(this->mmark_number);
+      this->mmark_number = -1; // To avoid basic class to try to unmark darts.
     }
 
     /// Copy constructor.
     CMap_non_basic_iterator(const Self& aiterator):
-      Base(aiterator)      
+      Base(aiterator)
     { this->mmap->share_a_mark(this->mmark_number); }
 
     /// Assignment operator.
@@ -421,6 +426,7 @@ namespace CGAL {
             (this->mmark_number)==1)
           unmark_treated_darts();
         this->mmap->free_mark(this->mmark_number);
+        this->mmark_number = -1;
 
         Base::operator=(aiterator);
         this->mmap->share_a_mark(this->mmark_number);
@@ -460,13 +466,13 @@ namespace CGAL {
   };
   //****************************************************************************
   template <typename Map_,typename Base_>
-  class CMap_non_basic_iterator<Map_,Base_,Tag_false>: 
+  class CMap_non_basic_iterator<Map_,Base_,Tag_false>:
     public Base_
   {
   public:
     typedef CMap_non_basic_iterator<Map_,Base_,Tag_false> Self;
     typedef Base_ Base;
-    
+
     typedef typename Base::Map Map;
     typedef typename Base::Dart_handle Dart_handle;
 
@@ -475,7 +481,7 @@ namespace CGAL {
 
     CGAL_static_assertion( (boost::is_same<typename Base::Basic_iterator,
                             Tag_true>::value) );
-    
+
     /// Main constructor.
     CMap_non_basic_iterator(Map& amap, Dart_handle adart):
       Base(amap, adart)
@@ -495,10 +501,10 @@ namespace CGAL {
     iterator end()               { return iterator(mmap,mmap.null_handle); }
     const_iterator begin() const { return const_iterator(mmap,mdart); }
     const_iterator end() const   { return const_iterator(mmap,mmap.null_handle); }
-    typename Map_::size_type size()
+    typename Map_::size_type size() const
     {
       if (msize==0)
-        for (const_iterator it=begin(); it!=end(); ++it)
+        for ( const_iterator it=begin(), itend=end(); it!=end(); ++it)
           ++msize;
       return msize;
     }
@@ -507,7 +513,7 @@ namespace CGAL {
   private:
     Map_ & mmap;
     typename Map_::Dart_handle mdart;
-    typename Map_::size_type msize;
+    mutable typename Map_::size_type msize;
   };
   //****************************************************************************
   template <typename Map_, typename It, typename Const_it>
@@ -523,7 +529,7 @@ namespace CGAL {
     iterator end()               { return iterator(mmap,mmap.null_handle,mmark); }
     const_iterator begin() const { return const_iterator(mmap,mdart,mmark); }
     const_iterator end() const   { return const_iterator(mmap,mmap.null_handle,mmark); }
-    typename Map_::size_type size()
+    typename Map_::size_type size() const
     {
       if (msize==0)
         for ( CMap_non_basic_iterator<Map_,const_iterator> it(mmap,mdart);
@@ -536,7 +542,7 @@ namespace CGAL {
   private:
     Map_ & mmap;
     typename Map_::Dart_handle mdart;
-    typename Map_::size_type msize;
+    mutable typename Map_::size_type msize;
     int mmark;
   };
   //****************************************************************************
@@ -550,10 +556,10 @@ namespace CGAL {
     {}
     const_iterator begin() const { return const_iterator(mmap,mdart); }
     const_iterator end() const   { return const_iterator(mmap,mmap.null_handle); }
-    typename Map_::size_type size()
+    typename Map_::size_type size() const
     {
       if (msize==0)
-        for (const_iterator it=begin(); it!=end(); ++it)
+        for ( const_iterator it=begin(), itend=end(); it!=end(); ++it)
           ++msize;
       return msize;
     }
@@ -562,7 +568,7 @@ namespace CGAL {
   private:
     const Map_ & mmap;
     typename Map_::Dart_const_handle mdart;
-    typename Map_::size_type msize;
+    mutable typename Map_::size_type msize;
   };
   //****************************************************************************
   template <typename Map_, typename Const_it>
@@ -575,7 +581,7 @@ namespace CGAL {
     {}
     const_iterator begin() const { return const_iterator(mmap,mdart,mmark); }
     const_iterator end() const   { return const_iterator(mmap,mmap.null_handle,mmark); }
-    typename Map_::size_type size()
+    typename Map_::size_type size() const
     {
       if (msize==0)
         for ( CMap_non_basic_iterator<Map_,const_iterator> it(mmap,mdart);
@@ -588,7 +594,7 @@ namespace CGAL {
   private:
     const Map_ & mmap;
     typename Map_::Dart_const_handle mdart;
-    typename Map_::size_type msize;
+    mutable typename Map_::size_type msize;
     int mmark;
   };
   //****************************************************************************

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 # Option allowing to profile each operation of the demo (cout times on stdout).
 add_definitions(-DCGAL_PROFILE_LCC_DEMO)
+add_definitions("-Wall")
 
 ##################
 find_package(CGAL COMPONENTS Qt4)

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -25,7 +25,6 @@ endif()
 
 # Option allowing to profile each operation of the demo (cout times on stdout).
 add_definitions(-DCGAL_PROFILE_LCC_DEMO)
-add_definitions("-Wall")
 
 ##################
 find_package(CGAL COMPONENTS Qt4)

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -555,14 +555,11 @@ namespace CGAL {
     writer.header().set_polyhedral_surface(true);
     writer.header().set_halfedges( alcc.number_of_darts());
 
-    std::vector<unsigned int> cells; cells.push_back(2);
-    std::vector<unsigned int> res = alcc.count_cells(cells);
-
     // Print header.
     writer.write_header( out,
                          alcc.number_of_vertex_attributes(),
                          alcc.number_of_darts(),
-                         res[2]);
+                         alcc.template one_dart_per_cell<2,2>().size() );
 
     typedef typename LCC::Vertex_attribute_range::iterator VCI;
     VCI vit, vend = alcc.vertex_attributes().end();
@@ -587,18 +584,18 @@ namespace CGAL {
       {
         std::size_t n = 0;
         // First we count the number of vertices of the face.
-        for ( typename LCC::template Dart_of_cell_range<2>::iterator
-                itf=alcc.template darts_of_cell<2>(itall).begin(),
-                itfend=alcc.template darts_of_cell<2>(itall).end();
+        for ( typename LCC::template Dart_of_cell_range<2,2>::iterator
+                itf=alcc.template darts_of_cell<2,2>(itall).begin(),
+                itfend=alcc.template darts_of_cell<2,2>(itall).end();
               itf!=itfend; ++itf, ++n );
 
         CGAL_assertion( n>=3 );
         writer.write_facet_begin(n);
 
         // Second we write the indices of vertices.
-        for ( typename LCC::template Dart_of_cell_range<2>::iterator
-                itf=alcc.template darts_of_cell<2>(itall).begin(),
-                itfend=alcc.template darts_of_cell<2>(itall).end();
+        for ( typename LCC::template Dart_of_cell_range<2,2>::iterator
+                itf=alcc.template darts_of_cell<2,2>(itall).begin(),
+                itfend=alcc.template darts_of_cell<2,2>(itall).end();
               itf!=itfend; ++itf )
         {
           // TODO case with index

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -545,6 +545,8 @@ namespace CGAL {
                                     <typename LCC::Traits> > (alcc, P);
   }
 
+  /** Export the alcc in off file format. If dimension>2, export all faces but only once.
+   */
   template < class LCC >
   void write_off(LCC& alcc, std::ostream& out)
   {
@@ -559,7 +561,7 @@ namespace CGAL {
     writer.write_header( out,
                          alcc.number_of_vertex_attributes(),
                          alcc.number_of_darts(),
-                         alcc.template one_dart_per_cell<2,2>().size() );
+                         alcc.template one_dart_per_cell<2>().size() );
 
     typedef typename LCC::Vertex_attribute_range::iterator VCI;
     VCI vit, vend = alcc.vertex_attributes().end();
@@ -584,23 +586,28 @@ namespace CGAL {
       {
         std::size_t n = 0;
         // First we count the number of vertices of the face.
-        for ( typename LCC::template Dart_of_cell_range<2,2>::iterator
-                itf=alcc.template darts_of_cell<2,2>(itall).begin(),
-                itfend=alcc.template darts_of_cell<2,2>(itall).end();
+        for ( typename LCC::template Dart_of_orbit_range<1>::iterator
+                itf=alcc.template darts_of_orbit<1>(itall).begin(),
+                itfend=alcc.template darts_of_orbit<1>(itall).end();
               itf!=itfend; ++itf, ++n );
 
         CGAL_assertion( n>=3 );
         writer.write_facet_begin(n);
 
         // Second we write the indices of vertices.
-        for ( typename LCC::template Dart_of_cell_range<2,2>::iterator
-                itf=alcc.template darts_of_cell<2,2>(itall).begin(),
-                itfend=alcc.template darts_of_cell<2,2>(itall).end();
+        for ( typename LCC::template Dart_of_orbit_range<1>::iterator
+                itf=alcc.template darts_of_orbit<1>(itall).begin(),
+                itfend=alcc.template darts_of_orbit<1>(itall).end();
               itf!=itfend; ++itf )
         {
           // TODO case with index
           writer.write_facet_vertex_index(index[VCI(alcc.vertex_attribute(itf))]);
-          alcc.mark(itf, m);
+
+          for ( typename LCC::template Dart_of_involution_basic_range<1>::iterator
+                  itinv=alcc.template darts_of_involution_basic<1>(itf, m).begin(),
+                  itinvend=alcc.template darts_of_involution_basic<1>(itf, m).end();
+                itinv!=itinvend; ++itinv )
+            alcc.mark(itinv, m);
         }
         writer.write_facet_end();
       }

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
@@ -90,6 +90,15 @@ namespace CGAL {
         public Helper::template Attribute_const_range<i>
     {};
 
+    typedef typename Attribute_type<0>::type Vertex_attribute;
+    typedef typename Attribute_handle<0>::type Vertex_attribute_handle;
+    typedef typename Attribute_const_handle<0>::type
+    Vertex_attribute_const_handle;
+
+    typedef typename Attribute_range<0>::type Vertex_attribute_range;
+    typedef typename Attribute_const_range<0>::type
+    Vertex_attribute_const_range;
+
     /// Number of marks
     static const size_type NB_MARKS = 32;
 


### PR DESCRIPTION
Bug fix in size methods of range in Combinatorial map.

In the previous version, const iterator are constructed at each loop using the non const version. This is ok but leads to useless additional time.

This is corrected in this patch by modifying the loop used in size methods; and by modifying CMap_cell_iterator iterator in order to add the missing constructor using a dart in parameter.

Update also the undocumented function write_off to use the size function.

Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.6-Ic-144.shtml 
