### PR TITLE
Fix warning `int `-> `size_t`

### DIFF
--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -340,7 +340,7 @@ public:
       }
 #endif // CGAL_CONCURRENT_TRIANGULATION_3_ADD_TEMPORARY_POINTS_ON_FAR_SPHERE
       
-      int i = 0;
+      size_t i = 0;
       // Insert "num_points_seq" points sequentially
       // (or more if dim < 3 after that)
       size_t num_points_seq = (std::min)(num_points, (size_t)100);

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -274,7 +274,7 @@ namespace CGAL {
         }
 #endif // CGAL_CONCURRENT_TRIANGULATION_3_ADD_TEMPORARY_POINTS_ON_FAR_SPHERE
       
-        int i = 0;
+        size_t i = 0;
         // Insert "num_points_seq" points sequentially
         // (or more if dim < 3 after that)
         size_t num_points_seq = (std::min)(num_points, (size_t)500);


### PR DESCRIPTION
Branch from Andreas Fabri.

Seems to be a bug-fix.

The branch is still under testing.
