### PR TITLE
Add missing #include

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_insertions.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_insertions.h
@@ -20,6 +20,8 @@
 #ifndef CGAL_COMBINATORIAL_MAP_INSERTIONS_H
 #define CGAL_COMBINATORIAL_MAP_INSERTIONS_H
 
+#include <deque>
+
 namespace CGAL
 {
 /** @file Combinatorial_map_insertions.h


### PR DESCRIPTION
Add a missing #include in Combinatorial_map_insertions.h.

This is a trivial bugfix.
