### PR TITLE
handle when boundary of the selection is on the border

### DIFF
--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -145,12 +145,11 @@ erode_face_selection(
     {
       hd = opposite(hd, graph);
       face_descriptor fd=face( hd, graph );
-      while( get(is_selected,fd) )
+      while( face(hd, graph)!=GT::null_face() && get(is_selected,fd) )
       {
         elements_to_remove.insert(fd);
         hd=opposite( next(hd, graph), graph );
         fd=face(hd, graph);
-        if ( face(hd, graph)==GT::null_face() ) break;
       }
     }
 


### PR DESCRIPTION
Trivial bug fix in the polyhedron demo face selection erosion mechanism