### PR TITLE
Make the bibliography more uniform

### DIFF
--- a/Documentation/biblio/cgal_manual.bib
+++ b/Documentation/biblio/cgal_manual.bib
@@ -270,7 +270,8 @@ Boissonnat}
   ,author       = {Gavin Bell and Anthony Parisi and Mark Pesce}
   ,title        = {VRML The Virtual Reality Modeling Language:
                      Version 1.0 Specification}
-  ,howpublished = {\path|http://www.web3d.org/x3d/specifications/vrml/VRML1.0/index.html|}
+  ,howpublished = {\url{http://www.web3d.org/x3d/specifications/vrml/VRML1.0/index.html}}
+  ,url          = "http://www.web3d.org/x3d/specifications/vrml/VRML1.0/index.html"
   ,month        = {May 26}
   ,year         = 1995
   ,update       = "13.04 lrineau"
@@ -405,7 +406,7 @@ note="Conference version: Symp. on Geometry Processing 2003"
 , year        = 2009
 , volume      = 5757
 , pages       = "37--48"
-, note         = "Full version available as INRIA Research Report 6823 \path|http://hal.inria.fr/inria-00356871|"
+, note         = "Full version available as INRIA Research Report 6823 \url{http://hal.inria.fr/inria-00356871}"
 }
 
 @inproceedings{ cgal:cvmtwabw-se-96
@@ -418,7 +419,7 @@ note="Conference version: Symp. on Geometry Processing 2003"
   ,year         = 1996
   ,pages        = {119--128}
   ,note         = {Examples and code in
-                   \path|http://www.cs.unc.edu/~geom/envelope.html|}
+                   \url{http://www.cs.unc.edu/~geom/envelope.html}}
   ,update       = "97.08 kettner"
 }
 
@@ -576,7 +577,7 @@ year        =  {2006},
 institution = {INRIA},
 number      = {5968},
 type        = {Research Report},
-note         = {\path|http://hal.inria.fr/inria-00090522|}
+note         = {\url{ttp://hal.inria.fr/inria-00090522}}
 }
 
 @article{cgal:dw-tmgob-02,
@@ -605,7 +606,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,year         = 1995
   ,pages        = {173--182}
   ,note         = {Examples in
-                   \path|ftp://ftp.cs.washington.edu/pub/graphics|}
+                   \url{tp://ftp.cs.washington.edu/pub/graphics}}
   ,update       = "97.08 kettner"
 }
 
@@ -769,7 +770,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,number       = {B 98-05}
   ,year         = 1998
   ,month        = apr
-  ,note         = {URL \path|http://www.inf.fu-berlin.de/inst/pubs/tr-b-98-05.abstract.html|}
+  ,url          = {http://www.inf.fu-berlin.de/inst/pubs/tr-b-98-05.abstract.html}
   ,update       = "98.06 schoenherr"
 }
 
@@ -782,7 +783,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,number       = {B 98-04}
   ,year         = 1998
   ,month        = apr
-  ,note         = {URL \path|http://www.inf.fu-berlin.de/inst/pubs/tr-b-98-04.abstract.html|}
+  ,url          = {http://www.inf.fu-berlin.de/inst/pubs/tr-b-98-04.abstract.html}
   ,update       = "98.06 schoenherr"
 }
 
@@ -794,7 +795,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,number       = {B 97-03}
   ,year         = 1997
   ,month        = jun
-  ,note         = {URL \path|http://www.inf.fu-berlin.de/inst/pubs/tr-b-97-03.abstract.html|}
+  ,url          = {http://www.inf.fu-berlin.de/inst/pubs/tr-b-97-03.abstract.html}
   ,update       = "97.06 schoenherr, 98.02 schoenherr, 98.06 schoenherr"
 }
 
@@ -813,7 +814,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
                    Wieger Wesselink}
   ,title        = {Getting Started with {CGAL}}
   ,year         = 1998
-  ,note         = {{CGAL} {R}1.0. \path|http://www.cs.ruu.nl/CGAL|.}
+  ,note         = {{CGAL} {R}1.0. \url{http://www.cs.ruu.nl/CGAL}.}
   ,update       = "98.01 schoenherr"
 }
 
@@ -835,7 +836,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,edition      = {1.0.1}
   ,month        = {June}
   ,year         = {1999}
-  ,note         = {\path|http://clisp.cons.org/~haible/packages-cln.html|}
+  ,url          = {http://clisp.cons.org/~haible/packages-cln.html}
   ,update       = "99.06 pion"
 }
 
@@ -905,7 +906,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,year         = 1994
   ,pages        = {295--302}
   ,note         = {Examples and code in
-                   \path|ftp://ftp.cs.washington.edu/pub/graphics|}
+                   \url{ftp://ftp.cs.washington.edu/pub/graphics}}
   ,update       = "97.08 kettner"
 }
 
@@ -918,7 +919,7 @@ note         = {\path|http://hal.inria.fr/inria-00090522|}
   ,year         = 1993
   ,pages        = {19--26}
   ,note         = {Examples and code in
-                   \path|ftp://ftp.cs.washington.edu/pub/graphics|}
+                   \url{ftp://ftp.cs.washington.edu/pub/graphics}}
   ,update       = "97.08 kettner"
 }
 
@@ -1158,7 +1159,7 @@ weighted {V}oronoi diagram"
   ,type         = {Konstanzer Schriften in Mathematik und Informatik}
   ,number       = {Nr. 9}
   ,month        = may
-  ,note         = {\path|http://www.informatik.uni-konstanz.de/Schriften|}
+  ,url          = {http://www.informatik.uni-konstanz.de/Schriften}
   ,annote       = {recommended C++ reading.}
   ,update       = "97.04 kettner"
 }
@@ -1373,7 +1374,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   ,title        = {The {LEDA} {U}ser {M}anual}
   ,organization = {Max-Planck-Insitut f\"ur Informatik}
   ,address      = {66123 Saarbr\"ucken, Germany}
-  ,note         = {\path|http://www.mpi-sb.mpg.de/LEDA/leda.html|}
+  ,url         =  {http://www.mpi-sb.mpg.de/LEDA/leda.html}
   ,update       = "99.05 schirra, 00.09 hert"
 }
 
@@ -1421,7 +1422,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   title         = {{MPFR} - The Multiple Precision Floating-Point Reliable
                    Library},
   howpublished  = {The {MPFR} Team},
-  note          = {\path|http://mpfr.org|},
+  url           = {http://mpfr.org},
   update        = "09.11 penarand"
 }
 
@@ -1469,7 +1470,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   ,organization = {The Geometry Center}
   ,address      = {University of Minnesota}
   ,year         = 1996
-  ,note         = {\path|http://www.geom.umn.edu/software/download/geomview.html|}
+  ,url         =  {http://www.geom.umn.edu/software/download/geomview.html}
   ,annote       = {Reference for object file format (OFF).}
   ,update       = "03.04 kettner"
 }
@@ -1565,7 +1566,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   title         = {{MPFI} - The Multiple Precision Floating-Point Interval
                    Library},
   howpublished  = {{R}evol, {N}athalie and {R}ouillier, {F}abrice},
-  note          = {\path|http://perso.ens-lyon.fr/nathalie.revol/software.html|},
+  url           = {http://perso.ens-lyon.fr/nathalie.revol/software.html},
   update        = "09.11 penarand"
 }
 
@@ -1586,7 +1587,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   key           = {RS},
   title         = {{RS - A} Software for real solving of algebraic systems},
   howpublished  = {{R}ouillier, {F}abrice},
-  note          = {\path|http://www.loria.fr/equipes/vegas/rs/|},
+  url           = {http://www.loria.fr/equipes/vegas/rs/},
   update        = "09.11 penarand"
 }
 
@@ -1677,7 +1678,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   ,publisher    = "Springer-Verlag"
   ,year         = 1991
   ,pages        = "187--202"
-  ,note         = {\path|http://wwwjn.inf.ethz.ch/geobench/XYZGeoBench.html|}
+  ,url          = {http://wwwjn.inf.ethz.ch/geobench/XYZGeoBench.html}
   ,update       = "94.01 rote, 98.01 kettner"
 }
 
@@ -1720,7 +1721,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
 @misc{ cgal:sgcsi-stlpg-97
   ,author       = {{Silicon Graphics Computer Systems{,} Inc.}}
   ,title        = {Standard Template Library Programmer's Guide}
-  ,howpublished = {\path|http://www.sgi.com/Technology/STL/|}
+  ,url          = {http://www.sgi.com/Technology/STL/}
   ,year         = 1997
   ,annote       = {Web reference to the STL from SGI.
                    recommended C++ and STL reference material.}
@@ -1753,7 +1754,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   ,month        = dec
   ,year         = {2000}
   ,issn         = {0946-011X}
-  ,note         = {\path|http://www.mpi-sb.mpg.de/~mehlhorn/ftp/InfiFrames.ps|}
+  ,url          = {http://www.mpi-sb.mpg.de/~mehlhorn/ftp/InfiFrames.ps}
 }
 
 @InProceedings{cgal:sp-mrbee-05
@@ -1922,7 +1923,7 @@ location    = {Salt Lake City, Utah, USA}
   ,key          = {VRML2}
   ,title        = {The Virtual Reality Modeling Language Specification:
                   Version 2.0, {ISO}/{IEC} {CD} 14772}
-  ,howpublished = {\path|http://www.web3d.org/x3d/specifications/vrml/ISO-IEC-14772-VRML97/|}
+  ,url          = {http://www.web3d.org/x3d/specifications/vrml/ISO-IEC-14772-VRML97/}
   ,month        = {December}
   ,year         = 1997
   ,update       = "13.04 lrineau"


### PR DESCRIPTION
If a note is simply a URL turn it into a url. Also turn all occurrences
of \path|http://www.cgal.org| into \url{http://www.cgal.org}.