### PR TITLE
Change the release month to April 2015

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -59,7 +59,7 @@
 <td width="28%">
 
 <table CELLSPACING=0>
-<tr><td><a href="#release4.6">4.6</a>&nbsp;<td> (March 2015)
+<tr><td><a href="#release4.6">4.6</a>&nbsp;<td> (April 2015)
 <tr><td><a href="#release4.5.2">4.5.2</a>&nbsp;<td> (February 2015)
 <tr><td><a href="#release4.5.1">4.5.1</a>&nbsp;<td> (December 2014)
 <tr><td><a href="#release4.5">4.5</a>&nbsp;<td> (October 2014)
@@ -114,7 +114,7 @@ and <code>src/</code> directories).
 
 <h2 id="release4.6">Release 4.6 </h2>
 <div>
-  <p>Release date: March 2015 </p>
+  <p>Release date: April 2015 </p>
 
 <!-- Installation (and general changes) -->
 <!-- New packages -->


### PR DESCRIPTION
We need to change the release month, because I will not managed to release 4.6 before 1st April.

I have modified `Installation/changes.html`, and forgot `Installation/CHANGES`.
