### PR TITLE
Exact predicates exact constructions kernel with kth root hemmer

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel.h
@@ -17,6 +17,8 @@ constructions.
 \cgalModels `Kernel`
 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_root_of` 
 \sa `CGAL::Exact_predicates_inexact_constructions_kernel` 
 \sa `CGAL::Cartesian` 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
@@ -20,6 +20,8 @@ Note that it requires CORE or LEDA installed.
 \cgalModels `Kernel`
 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_root_of` 
 \sa `CGAL::Exact_predicates_inexact_constructions_kernel` 
 \sa `CGAL::Cartesian` 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
@@ -12,7 +12,7 @@ A typedef to a kernel which has the following properties:
 coordinates. 
 <LI>It provides both exact geometric predicates and exact geometric 
 constructions. 
-<LI>Its `FT` nested type is model of the 'FieldWithSqrt` concept. 
+<LI>Its `FT` nested type is model of the 'FieldWithKthRoot' concept. 
 </UL> 
 
 Note that it requires CORE or LEDA installed. 
@@ -25,10 +25,10 @@ Note that it requires CORE or LEDA installed.
 
 */
 
-class Exact_predicates_exact_constructions_kernel_with_sqrt {
+class Exact_predicates_exact_constructions_kernel_with_kth_root {
 public:
 
 /// @}
 
-}; /* end Exact_predicates_exact_constructions_kernel_with_sqrt */
+}; /* end Exact_predicates_exact_constructions_kernel_with_kth_root */
 } /* end namespace CGAL */

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
@@ -20,6 +20,8 @@ Note that it requires CORE or LEDA installed.
 \cgalModels `Kernel`
 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root` 
 \sa `CGAL::Exact_predicates_inexact_constructions_kernel` 
 \sa `CGAL::Cartesian` 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
@@ -12,7 +12,7 @@ A typedef to a kernel which has the following properties:
 coordinates. 
 <LI>It provides both exact geometric predicates and exact geometric 
 constructions. 
-<LI>Its `FT` nested type is model of the 'FieldWithSqrt` concept. 
+<LI>Its `FT` nested type is model of the 'FieldWithRootOf' concept. 
 </UL> 
 
 Note that it requires CORE or LEDA installed. 
@@ -25,10 +25,10 @@ Note that it requires CORE or LEDA installed.
 
 */
 
-class Exact_predicates_exact_constructions_kernel_with_sqrt {
+class Exact_predicates_exact_constructions_kernel_with_root_of {
 public:
 
 /// @}
 
-}; /* end Exact_predicates_exact_constructions_kernel_with_sqrt */
+}; /* end Exact_predicates_exact_constructions_kernel_with_root_of */
 } /* end namespace CGAL */

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h
@@ -20,6 +20,8 @@ Note that it requires CORE or LEDA installed.
 \cgalModels `Kernel`
 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_root_of` 
 \sa `CGAL::Exact_predicates_inexact_constructions_kernel` 
 \sa `CGAL::Cartesian` 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_inexact_constructions_kernel.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Exact_predicates_inexact_constructions_kernel.h
@@ -18,6 +18,8 @@ constructions.
 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel` 
 \sa `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root` 
+\sa `CGAL::Exact_predicates_exact_constructions_kernel_with_root_of` 
 \sa `CGAL::Cartesian` 
 
 */

--- a/Kernel_23/doc/Kernel_23/Kernel_23.txt
+++ b/Kernel_23/doc/Kernel_23/Kernel_23.txt
@@ -297,22 +297,27 @@ kernels.
 <LI>They are all %Cartesian kernels.
 <LI>They all support constructions of points from <TT>double</TT> %Cartesian
 coordinates.
-<LI>All these 3 kernels provide exact geometric predicates.
+<LI>All these 5 kernels provide exact geometric predicates.
 <LI>They handle geometric constructions differently:
 <UL>
+<LI>`Exact_predicates_inexact_constructions_kernel`: provides exact
+geometric predicates, but geometric constructions may be inexact due to
+round-off errors. It is however enough for many \cgal algorithms, and
+faster than the kernels with exact constructions below.
 <LI>`Exact_predicates_exact_constructions_kernel`: provides exact
 geometric constructions, in addition to exact geometric predicates.
 <LI>`Exact_predicates_exact_constructions_kernel_with_sqrt`:
 same as `Exact_predicates_exact_constructions_kernel`, but the
-number type it provides
-(`Exact_predicates_exact_constructions_kernel_with_sqrt::FT`)
-supports the square root operation exactly
+number type is a model of concept `FieldWithSqrt`. 
 \cgalFootnote{Currently it requires having either LEDA or CORE installed.}.
-<LI>`Exact_predicates_inexact_constructions_kernel`: provides exact
-geometric predicates, but geometric constructions may be inexact due to
-round-off errors. It is however enough for most \cgal algorithms, and
-faster than both `Exact_predicates_exact_constructions_kernel` and
-`Exact_predicates_exact_constructions_kernel_with_sqrt`.
+<LI>`Exact_predicates_exact_constructions_kernel_with_kth_root`
+same as `Exact_predicates_exact_constructions_kernel`, but the
+number type is a model of concept `FieldWithKthRoot`. 
+\cgalFootnote{Currently it requires having either LEDA or CORE installed.}.
+<LI>`Exact_predicates_exact_constructions_kernel_with_root_of`:
+same as `Exact_predicates_exact_constructions_kernel`, but the
+number type is a model of concept `FieldWithRootOf`. 
+\cgalFootnote{Currently it requires having either LEDA or CORE installed.}.
 </UL>
 </UL>
 

--- a/Kernel_23/include/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
+++ b/Kernel_23/include/CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2003  
+// Utrecht University (The Netherlands),
+// ETH Zurich (Switzerland),
+// INRIA Sophia-Antipolis (France),
+// Max-Planck-Institute Saarbruecken (Germany),
+// and Tel-Aviv University (Israel).  All rights reserved. 
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// 
+//
+// Author(s)     : Michael Hemmer
+
+#ifndef CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_KTH_ROOT_H
+#define CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_KTH_ROOT_H
+
+#include <CGAL/Simple_cartesian.h>
+
+#ifdef CGAL_USE_LEDA
+#  include <CGAL/leda_real.h>
+#elif defined CGAL_USE_CORE
+#  include <CGAL/CORE_Expr.h>
+#else
+#  error "You need LEDA or CORE installed."
+#endif
+
+namespace CGAL {
+
+#ifdef CGAL_USE_LEDA
+typedef Simple_cartesian< leda_real >
+        Exact_predicates_exact_constructions_kernel_with_kth_root;
+#elif defined CGAL_USE_CORE
+typedef Simple_cartesian< CORE::Expr >
+        Exact_predicates_exact_constructions_kernel_with_kth_root;
+#endif
+
+} //namespace CGAL
+
+#endif // CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_KTH_ROOT_H

--- a/Kernel_23/include/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
+++ b/Kernel_23/include/CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2003  
+// Utrecht University (The Netherlands),
+// ETH Zurich (Switzerland),
+// INRIA Sophia-Antipolis (France),
+// Max-Planck-Institute Saarbruecken (Germany),
+// and Tel-Aviv University (Israel).  All rights reserved. 
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// 
+//
+// Author(s)     : Michael Hemmer
+
+#ifndef CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_ROOT_OF_H
+#define CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_ROOT_OF_H
+
+#include <CGAL/Simple_cartesian.h>
+
+#ifdef CGAL_USE_LEDA
+#  include <CGAL/leda_real.h>
+#elif defined CGAL_USE_CORE
+#  include <CGAL/CORE_Expr.h>
+#else
+#  error "You need LEDA or CORE installed."
+#endif
+
+namespace CGAL {
+
+#ifdef CGAL_USE_LEDA
+typedef Simple_cartesian< leda_real >
+        Exact_predicates_exact_constructions_kernel_with_root_of;
+#elif defined CGAL_USE_CORE
+typedef Simple_cartesian< CORE::Expr >
+        Exact_predicates_exact_constructions_kernel_with_root_of;
+#endif
+
+} //namespace CGAL
+
+#endif // CGAL_EXACT_PREDICATES_EXACT_CONSTRUCTIONS_KERNEL_WITH_ROOT_OF_H

--- a/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
+++ b/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h>
+#include <CGAL/use.h> 
 
 int main(){
 
@@ -10,5 +11,10 @@ int main(){
   typedef CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root EPEKK;
   typedef CGAL::Exact_predicates_exact_constructions_kernel_with_root_of  EPEKR;
   
+  CGAL_USE_TYPE(EPEK); 
+  CGAL_USE_TYPE(EPEKS);
+  CGAL_USE_TYPE(EPEKK);
+  CGAL_USE_TYPE(EPEKR);
+
   return 0;
 }

--- a/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
+++ b/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
@@ -1,0 +1,14 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h>
+
+int main(){
+
+  typedef CGAL::Exact_predicates_exact_constructions_kernel               EPEK; 
+  typedef CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt     EPEKS;
+  typedef CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root EPEKK;
+  typedef CGAL::Exact_predicates_exact_constructions_kernel_with_root_of  EPEKR;
+  
+  return 0;
+}


### PR DESCRIPTION
Adding new typedefs and documentation for 
  - `CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root`
  - `CGAL::Exact_predicates_exact_constructions_kernel_with_root_of`

small feature:
https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/EPEC_with_kth_root

not approved yet 