### PR TITLE
fixes issue of infinite vertex in import_from_triangulation_3

### DIFF
--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -341,7 +341,7 @@ namespace CGAL {
           else if ( it->vertex(2) == atr.infinite_vertex() )
             dart = alcc.beta(res, 1, 1);
           else if ( it->vertex(3) == atr.infinite_vertex() )
-            dart = alcc.beta(res, 2, 1, 1);
+            dart = alcc.beta(res, 2, 0);
         }
         
         for (unsigned int i = 0; i < 4; ++i)

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -339,9 +339,9 @@ namespace CGAL {
           else if ( it->vertex(1) == atr.infinite_vertex() )
             dart = alcc.beta(res, 1);
           else if ( it->vertex(2) == atr.infinite_vertex() )
-            dart = alcc.beta(res, 2);
+            dart = alcc.beta(res, 1, 1);
           else if ( it->vertex(3) == atr.infinite_vertex() )
-            dart = alcc.beta(res, 2, 0);
+            dart = alcc.beta(res, 2, 1, 1);
         }
         
         for (unsigned int i = 0; i < 4; ++i)


### PR DESCRIPTION
I have tested this modification on a simple [code](https://gist.github.com/pranavkantgaur/9e928dc3fd5816cb891a#file-cubedtlccply-cpp), It:
* Preserves the coordinates of _finite vertices_ after import from Delaunay triangulation.
* (May not be important)Leaves coordinates of _infinite vertex_ in linear cell complex same as they were in corresponding Delaunay triangulation.

I have discussed this issue recently in CGAL [user forum](http://cgal-discuss.949826.n4.nabble.com/import-from-triangulation-3-Issue-in-number-of-vertices-stored-in-cell-complex-td4660599.html)