### PR TITLE
Filter_predicate2.h has the wrong include guard

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
@@ -18,8 +18,8 @@
 //
 // Author(s)     : Sylvain Pion
 
-#ifndef CGAL_FILTERED_PREDICATE_H
-#define CGAL_FILTERED_PREDICATE_H
+#ifndef CGAL_FILTERED_PREDICATE2_H
+#define CGAL_FILTERED_PREDICATE2_H
 
 #include <string>
 #include <CGAL/config.h>
@@ -134,4 +134,4 @@ public:
 
 } //namespace CGAL
 
-#endif // CGAL_FILTERED_PREDICATE_H
+#endif // CGAL_FILTERED_PREDICATE2_H


### PR DESCRIPTION
The file was copied from Filtered_kernel and one class was renamed, but apparently the include guard was missed. This leads to missing types when code from Filtered_kernel is included first and vice versa.