### PR TITLE
Apollonius graph 2: add warnings in examples

### DIFF
--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits.cpp
@@ -11,6 +11,13 @@
 
 typedef CGAL::MP_Float NT;
 
+// *** WARNING ***
+// The use of a kernel based on an exact number type is highly inefficient.
+// It is used in this example primarily for illustration purposes.
+// In an efficiency critical context, and/or for the purposes of
+// benchmarking the Apollonius_graph_filtered_traits_2<> class should
+// be used.
+
 // choose the kernel
 #include <CGAL/Simple_cartesian.h>
 

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
@@ -12,6 +12,12 @@
 #  include <CGAL/CORE_Expr.h>
 #endif
 
+// *** WARNING ***
+// The use of a kernel based on an exact number type is highly inefficient.
+// It is used in this example primarily for illustration purposes.
+// In an efficiency critical context, and/or for the purposes of
+// benchmarking the Apollonius_graph_filtered_traits_2<> class should
+// be used.
 
 #if defined CGAL_USE_LEDA
 // If LEDA is present use leda_real as the exact number type


### PR DESCRIPTION
Add warnings in two example files in the form of comments. The warnings indicate that the exact kernel used in the examples are for inllustration purposes only and should not be considered as an option when performing efficiency-critical computations and/or benchmarking.