### PR TITLE
Switch eigen_2 from std::sqrt to CGAL::sqrt

### DIFF
--- a/Principal_component_analysis/include/CGAL/eigen_2.h
+++ b/Principal_component_analysis/include/CGAL/eigen_2.h
@@ -86,8 +86,8 @@ namespace internal {
       }
       else // generic case
       {
-        FT l1 = (FT)(0.5 * ( -1*std::sqrt(p) + c + a));
-        FT l2 = (FT)(0.5 * (    std::sqrt(p) + c + a));
+        FT l1 = (FT)(0.5 * ( -1*CGAL::sqrt(p) + c + a));
+        FT l2 = (FT)(0.5 * (    CGAL::sqrt(p) + c + a));
 
         // all eigen values of a symmetric positive
         // definite matrix must be real and positive
@@ -101,15 +101,15 @@ namespace internal {
         {
           eigen_values.first  = l1;
           eigen_values.second = l2;
-          eigen_vectors.first  = Vector((FT)1.0, (FT)(-(std::sqrt(p)-c+a) / (2*b)));
-          eigen_vectors.second = Vector((FT)1.0, (FT)( (std::sqrt(p)+c-a) / (2*b)));
+          eigen_vectors.first  = Vector((FT)1.0, (FT)(-(CGAL::sqrt(p)-c+a) / (2*b)));
+          eigen_vectors.second = Vector((FT)1.0, (FT)( (CGAL::sqrt(p)+c-a) / (2*b)));
         }
         else
         {
           eigen_values.first  = l2;
           eigen_values.second = l1;
-          eigen_vectors.first  = Vector((FT)1.0, (FT)( (std::sqrt(p)+c-a) / (2*b)));
-          eigen_vectors.second = Vector((FT)1.0, (FT)(-(std::sqrt(p)-c+a) / (2*b)));
+          eigen_vectors.first  = Vector((FT)1.0, (FT)( (CGAL::sqrt(p)+c-a) / (2*b)));
+          eigen_vectors.second = Vector((FT)1.0, (FT)(-(CGAL::sqrt(p)-c+a) / (2*b)));
         }
       } // end generic case
     } // end non-degenerate case


### PR DESCRIPTION
Here's the stripped down test case to demonstrate the compilation error:
```c++
#include <iostream>
#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
#include <CGAL/Polygon_2.h>
#include <CGAL/linear_least_squares_fitting_2.h>

typedef CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt K;
typedef CGAL::Polygon_2<K> Polygon_2;

int main( int argc, const char* argv[] )
{
  K::Point_2 centroid = K::Point_2(0, 0);
  K::Line_2 line;
  CGAL::Dimension_tag<0> dt;
  Polygon_2 p;
  p.push_back(K::Point_2(0,1));
  p.push_back(K::Point_2(0,2));
  p.push_back(K::Point_2(2,2));

  CGAL::linear_least_squares_fitting_2( p.vertices_begin(), p.vertices_end(), line, centroid, dt);

  std::cout << centroid << std::endl;
}
```
Which gives:
```
In file included from cgal/sample/foo.cpp:4:
In file included from cgal/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_2.h:26:
In file included from cgal/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_points_2.h:25:
cgal/Principal_component_analysis/include/CGAL/eigen_2.h:89:33: error: no matching function for call to 'sqrt'
        FT l1 = (FT)(0.5 * ( -1*std::sqrt(p) + c + a));
[...]
/usr/include/math.h:447:15: note: candidate function not viable: no known conversion from 'FT' (aka 'CORE::Expr') to 'double' for 1st argument
extern double sqrt(double);
              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:1007:46: note: candidate function not
      viable: no known conversion from 'FT' (aka 'CORE::Expr') to 'float' for 1st argument
inline _LIBCPP_INLINE_VISIBILITY float       sqrt(float __x) _NOEXCEPT       {return sqrtf(__x);}
                                             ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:1008:46: note: candidate function not
      viable: no known conversion from 'FT' (aka 'CORE::Expr') to 'long double' for 1st argument
inline _LIBCPP_INLINE_VISIBILITY long double sqrt(long double __x) _NOEXCEPT {return sqrtl(__x);}
                                             ^
```
and then quite a few similar errors.

This is my first try at a PR for this project so please let me know what I need to do to help get this fixed.
