### PR TITLE
Fix some Boost includes

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Xy_coordinate_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Xy_coordinate_2.h
@@ -25,7 +25,6 @@
 #define CGAL_ALGEBRAIC_CURVE_KERNEL_XY_COORDINATE_2_H
 
 #include <CGAL/basic.h>
-#include <boost/pool/pool_alloc.hpp>
 #include <boost/numeric/interval.hpp>
 
 #include <CGAL/Bbox_2.h>

--- a/Arrangement_on_surface_2/include/CGAL/Arr_rat_arc/Base_rational_arc_ds_1.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_rat_arc/Base_rational_arc_ds_1.h
@@ -31,8 +31,7 @@
 #include <CGAL/Arithmetic_kernel.h>
 #include <CGAL/Algebraic_kernel_d_1.h>
 
-#include <map>
-#include <boost/detail/algorithm.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 namespace CGAL {
 namespace Arr_rational_arc {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_rat_arc/Rational_arc_d_1.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_rat_arc/Rational_arc_d_1.h
@@ -39,7 +39,7 @@
 #include <CGAL/Arr_rat_arc/Rational_function.h>
 #include <CGAL/Arr_rat_arc/Rational_function_pair.h>
 
-#include <boost/detail/algorithm.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 namespace CGAL {
 namespace Arr_rational_arc {

--- a/Interval_support/include/CGAL/Bigfloat_interval_traits.h
+++ b/Interval_support/include/CGAL/Bigfloat_interval_traits.h
@@ -23,16 +23,9 @@
 #ifndef CGAL_BIGFLOAT_INTERVAL_TRAITS_H
 #define CGAL_BIGFLOAT_INTERVAL_TRAITS_H
 
-#include<CGAL/basic.h>
-
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 104000
-#  include <boost/serialization/static_warning.hpp>
-#else
-#  include <boost/static_warning.hpp>
-#endif
-
+#include <CGAL/basic.h>
 #include <CGAL/assertions.h>
+
 namespace CGAL {
 
 // TODO: rename this into MPFI_traits ? 

--- a/Kernel_d/include/CGAL/Filtered_kernel_d.h
+++ b/Kernel_d/include/CGAL/Filtered_kernel_d.h
@@ -24,8 +24,6 @@
 #include <CGAL/internal/Exact_type_selector.h>
 #include <CGAL/Kernel_d/Cartesian_converter_d.h>
 
-#include<boost/pool/pool_alloc.hpp>
-
 namespace CGAL {
 
 template<typename Kernel> // a dD kernel we want to filter

--- a/Mesh_3/applications/mesher_tester.h
+++ b/Mesh_3/applications/mesher_tester.h
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <algorithm>
-#include <boost/tr1/memory.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "thread_queue.h"
 
@@ -51,7 +51,7 @@ template <class C3T3, class Domain> struct Optimizer;
 template <class C3T3, class MeshCriteria, class Domain>
 struct Mesher
 {
-  Mesher(const std::tr1::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
+  Mesher(const boost::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
          const int mesh_nb,
          const std::string& filename,
          const std::string& output,
@@ -95,7 +95,7 @@ struct Mesher
     timer.start();
 
     // we keep c3t3 between lines
-    std::tr1::shared_ptr<C3T3> pc3t3_save (new C3T3());
+    boost::shared_ptr<C3T3> pc3t3_save (new C3T3());
 
     // Generate Mesh
     file_out << "Generate mesh...";
@@ -183,7 +183,7 @@ private:
   }
   
 private:
-  std::tr1::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
+  boost::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
   int mesh_nb_;
   std::string filename_;
   std::string output_prefix_;
@@ -196,8 +196,8 @@ private:
 template <class C3T3, class Domain>
 struct Optimizer
 {
-  Optimizer(const std::tr1::shared_ptr<C3T3>& pc3t3,
-            const std::tr1::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
+  Optimizer(const boost::shared_ptr<C3T3>& pc3t3,
+            const boost::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
             const int mesh_nb,
             const std::string& output,
             const std::string& command_line)
@@ -339,8 +339,8 @@ private:
 
   
 private:
-  std::tr1::shared_ptr<C3T3> pc3t3_;
-  std::tr1::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
+  boost::shared_ptr<C3T3> pc3t3_;
+  boost::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
   std::string mesh_nb_;
   std::string output_prefix_;
   std::string command_line_;
@@ -571,7 +571,7 @@ void mesh(const std::string& data, const std::string& output_dir, const int nb_t
     //Load the domain
     std::stringstream cout_loc;
     cout_loc << "+ [" << filename << "] Create domain...";
-    std::tr1::shared_ptr<Domain_builder<Domain> > pdomain_builder(new Domain_builder<Domain>(it->path().string()));
+    boost::shared_ptr<Domain_builder<Domain> > pdomain_builder(new Domain_builder<Domain>(it->path().string()));
     cout_loc << "done (" << timer.time() << "s)\n";
     std::cout << cout_loc.str();
     

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -44,8 +44,6 @@
 #include <boost/optional.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/function_output_iterator.hpp>
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/unordered_set.hpp>
@@ -939,9 +937,9 @@ public:
    */
   void reset_cache() const
   {
-    namespace bl = boost::lambda;
-    std::for_each(c3t3_.cells_in_complex_begin(),c3t3_.cells_in_complex_end(),
-                  bl::bind(&Cell::reset_cache_validity, bl::_1) );
+    for(typename C3T3::Cells_in_complex_iterator it = c3t3_.cells_in_complex_begin();
+        it != c3t3_.cells_in_complex_end(); ++it)
+      it->reset_cache_validity();
   }
 
 private:
@@ -2110,10 +2108,10 @@ private:
   void reset_sliver_cache(CellForwardIterator cells_begin,
                             CellForwardIterator cells_end) const
   {
-    // std::cerr << "reset_sliver_cache\n";
-    namespace bl = boost::lambda;
-    std::for_each(cells_begin, cells_end,
-                  bl::bind(&Cell::reset_cache_validity, *bl::_1) );
+    while(cells_begin != cells_end) {
+      (*cells_begin)->reset_cache_validity();
+      ++cells_begin;
+    }
   }
 
   template <typename CellRange>
@@ -2127,9 +2125,10 @@ private:
   void reset_circumcenter_cache(CellForwardIterator cells_begin,
                             CellForwardIterator cells_end) const
   {
-    namespace bl = boost::lambda;
-    std::for_each(cells_begin, cells_end,
-                  bl::bind(&Cell::invalidate_circumcenter, *bl::_1) );
+    while(cells_begin != cells_end) {
+      (*cells_begin)->invalidate_circumcenter();
+      ++cells_begin;
+    }
   }
 
 

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -40,7 +40,8 @@
 #endif
 
 #include <boost/foreach.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 #include <boost/optional.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/function_output_iterator.hpp>

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -46,8 +46,6 @@
 #include <list>
 #include <limits>
 
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/bind.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
 #ifdef CGAL_LINKED_WITH_TBB
@@ -1033,8 +1031,6 @@ bool
 Mesh_global_optimizer<C3T3,Md,Mf,V_>::
 check_convergence() const
 {
-  namespace bl = boost::lambda;
-
   FT sum(0);
   for( typename std::multiset<FT>::const_iterator
        it = big_moves_.begin(), end = big_moves_.end() ; it != end ; ++it )

--- a/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
@@ -66,8 +66,6 @@
 #else
 #include <CGAL/Modifiable_priority_queue.h>
 #endif //CGAL_MESH_3_USE_RELAXED_HEAP
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/bind.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
@@ -1551,11 +1549,11 @@ void
 Sliver_perturber<C3T3,Md,Sc,V_>::
 initialize_vertices_id() const
 {
-  namespace bl = boost::lambda;
   int cur_id = 0;
-
-  std::for_each(tr_.finite_vertices_begin(), tr_.finite_vertices_end(),
-                bl::bind(&Vertex::set_meshing_info, &bl::_1, bl::var(cur_id)++));
+  for(typename Tr::Finite_vertices_iterator it = tr_.finite_vertices_begin(); 
+      it != tr_.finite_vertices_end(); ++it) {
+    it->set_meshing_info(cur_id++);
+  }
 }
 
 

--- a/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
@@ -1,6 +1,4 @@
-#include <vector>
-
-#include <boost/assign.hpp>
+#include <iostream>
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>

--- a/Surface_mesher/include/CGAL/Surface_mesher/Polyhedral_oracle.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Polyhedral_oracle.h
@@ -21,9 +21,9 @@
 #ifndef CGAL_SURFACE_MESHER_POLYHEDRAL_ORACLE_H
 #define CGAL_SURFACE_MESHER_POLYHEDRAL_ORACLE_H
 
-#include <boost/static_warning.hpp>
 #include <utility>
 
+#include <CGAL/config.h> // CGAL_DEPRECATED
 #include <CGAL/iterator.h>
 #include <CGAL/Surface_mesher/Null_oracle_visitor.h>
 #include <CGAL/Surface_mesher/Has_edges.h>
@@ -392,14 +392,11 @@ private:
 template <class GT,
           class Visitor = Null_oracle_visitor
          >
-class Polyhedral : public Polyhedral_oracle<GT, Visitor>
+class CGAL_DEPRECATED Polyhedral : public Polyhedral_oracle<GT, Visitor>
 {
-  typedef int Deprecated__class__use__Polyhedral_oracle__instead;
-
   Polyhedral(Visitor visitor = Visitor())
     : Polyhedral_oracle<GT, Visitor>(visitor)
   {
-    BOOST_STATIC_WARNING(Deprecated__class__use__Polyhedral_oracle__instead() == 1);
   }
 };
 


### PR DESCRIPTION
While going through the list of [Boost libraries used](https://gist.github.com/bo0ts/dacb1a3100c49ea050d8) by CGAL I did a quick check of some suspicious includes and cleaned them up.

The most notable is the removal of Boost.Lambda code from Mesh_3.