### PR TITLE
C map lcc add type in attribs gdamiand

### DIFF
--- a/Combinatorial_map/include/CGAL/Cell_attribute.h
+++ b/Combinatorial_map/include/CGAL/Cell_attribute.h
@@ -314,6 +314,7 @@ namespace CGAL {
     typedef OnMerge                          On_merge;
     typedef OnSplit                          On_split;
     typedef void                             Info;
+    typedef void                             Point;
 
     //  protected:
     /// Default contructor.
@@ -348,7 +349,8 @@ namespace CGAL {
     typedef OnMerge                          On_merge;
     typedef OnSplit                          On_split;
     typedef Info_                            Info;
-
+    typedef void                             Point;
+    
     bool operator==(const Self& other) const
     { return this->info()==other.info(); }
 

--- a/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
+++ b/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
@@ -129,6 +129,7 @@ namespace CGAL {
                            Functor_on_merge_, Functor_on_split_> Base1;
     typedef Point_for_cell<typename LCC::Point> Base2;
 
+    typedef void                            Info;
     typedef typename LCC::Point             Point;
     typedef typename LCC::Dart_handle       Dart_handle;
     typedef typename LCC::Dart_const_handle Dart_const_handle;


### PR DESCRIPTION
Add missing types in Cell_attribute and Cell_attribute_with_point in order to allow template specialization on these types.

Trivial modification.