### PR TITLE
Escape the word Index with '%'

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -45,7 +45,7 @@ public:
 /// @{
 
 /*!
-Index type. 
+%Index type. 
 */ 
 typedef Tr::Vertex::Index Index; 
 
@@ -60,12 +60,12 @@ Subdomain index type.
 typedef Tr::Cell::Subdomain_index Subdomain_index; 
 
 /*!
-`Corner_index` type. 
+ Corner index type. 
 */ 
 typedef CornerIndex Corner_index; 
 
 /*!
-`Curve_segment_index` type. 
+Curve segment index type. 
 */ 
 typedef CurveSegmentIndex Curve_segment_index; 
 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_constant_domain_field_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_constant_domain_field_3.h
@@ -15,7 +15,7 @@ where `Triangulation` is the nested type of the model of `MeshComplex_3InTriangu
 in the meshing process. 
 
 \tparam Index is the type of index of the vertices of the triangulation. 
-It must match the type `Index` of the model of `MeshDomain_3` used in the meshing process. 
+It must match the type `%Index` of the model of `MeshDomain_3` used in the meshing process. 
 
 \cgalModels `MeshDomainField_3` 
 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshCellBase_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshCellBase_3.h
@@ -78,7 +78,7 @@ typedef unspecified_type Surface_patch_index;;
  of the input complex on which a possible future Steiner vertex lies.
  Must match the type `MeshDomain_3::Index`.
 */
-typedef unspecified_type Index;;
+typedef unspecified_type Index;
 
 /// @} 
 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainField_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainField_3.h
@@ -5,7 +5,7 @@
 The concept `MeshDomainField_3` describes a scalar field which could be queried 
 at any point of the space. 
 
-\cgalHasModel `CGAL::Mesh_constant_domain_field_3<Gt,Index>` 
+\cgalHasModel `CGAL::Mesh_constant_domain_field_3<Gt,%Index>` 
 
 \sa `MeshDomain_3` 
 \sa `MeshDomainWithFeatures_3` 
@@ -32,7 +32,7 @@ Point type.
 typedef unspecified_type Point_3; 
 
 /*!
-Index type for points. Must match the type `MeshDomain_3::Index`. 
+%Index type for points. Must match the type `MeshDomain_3::Index`. 
 */ 
 typedef unspecified_type Index; 
 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -132,14 +132,14 @@ get_corners(OutputIterator corners) const;
 Fills `curves` with the curve segments
 of the input domain.
 `curves` value type must be
-`CGAL::cpp11::tuple<Curve_segment_index,std::pair<Point_3,Index>,std::pair<Point_3,Index> >`.
+`CGAL::cpp11::tuple<Curve_segment_index,std::pair<Point_3,%Index>,std::pair<Point_3,%Index> >`.
 If the curve segment corresponding to an entry
 in curves is not a cycle, the pair of associated points should
 belong to
 two corners incident on the curve segment.
 If it is a cycle, then the same `Point_3` should be given twice and must be any
 point on the cycle.
-The `Index` values associated to the points are their indices w.r.t.\ their dimension.
+The `%Index` values associated to the points are their indices w.r.t.\ their dimension.
 */
 template <typename OutputIterator>
 OutputIterator

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomain_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomain_3.h
@@ -111,7 +111,7 @@ typedef unspecified_type Index;
 Return type of `Construct_intersection` queries.
 `int` represents the
 dimension of the lower dimensional face of the input complex on which the intersection
-point lies and `Index` is the index of this face.
+point lies and `%Index` is the index of this face.
 */
 typedef CGAL::cpp11::tuple<Point_3, Index, int> Intersection;
 
@@ -130,7 +130,7 @@ following operators:
 
 Those two operators output a set of (`n`) surface points to the
 output iterator `pts`, as objects of type `std::pair<Point_3,
-Index>`. If `n` is not given, the functor must provide enough
+%Index>`. If `n` is not given, the functor must provide enough
 points to initialize the mesh generation process.
 */
 typedef unspecified_type Construct_initial_points;

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -88,7 +88,7 @@ related to the template parameters of some models of the main concepts:
 - `CGAL::Mesh_cell_criteria_3<Tr>`
 - `CGAL::Mesh_facet_criteria_3<Tr>`
 - `CGAL::Mesh_edge_criteria_3<Tr>`
-- `CGAL::Mesh_constant_domain_field_3<Gt,Index>`
+- `CGAL::Mesh_constant_domain_field_3<Gt,%Index>`
 
 The following classes are models of domain concepts
 and their associated classes:

--- a/Point_set_processing_3/doc/Property_map/Property_map.txt
+++ b/Point_set_processing_3/doc/Property_map/Property_map.txt
@@ -52,7 +52,7 @@ The following example reads a point set from an input file and writes it to a fi
 
 \subsection Property_mapExamplewithTuples Example with Tuples
 
-The following example reads a point set in the `xyz` format and computes the average spacing. Index, position and color are stored in a tuple and accessed through property maps.
+The following example reads a point set in the `xyz` format and computes the average spacing. %Index, position and color are stored in a tuple and accessed through property maps.
 \cgalExample{Point_set_processing_3/average_spacing_example.cpp}
 
 */ 

--- a/Point_set_processing_3/include/CGAL/property_map.h
+++ b/Point_set_processing_3/include/CGAL/property_map.h
@@ -285,7 +285,7 @@ Second_of_pair_property_map<Pair>
 /// 
 /// Property map that accesses the Nth item of a `boost::tuple`. 
 /// 
-/// \tparam N Index of the item to access.
+/// \tparam N %Index of the item to access.
 /// \tparam Tuple Instance of `boost::tuple`.
 /// 
 /// \cgalModels `LvaluePropertyMap`
@@ -321,7 +321,7 @@ Nth_of_tuple_property_map<N, typename CGAL::value_type_traits<Iter>::type>
 /// 
 /// Property map that accesses the Nth item of a `boost::tuple`. 
 /// 
-/// \tparam N Index of the item to access.
+/// \tparam N %Index of the item to access.
 /// \tparam Tuple Instance of `boost::tuple`.
 /// 
 /// \cgalModels `LvaluePropertyMap`


### PR DESCRIPTION
After having introduced the concept <code>Index</code> we have to take care of wrong links. 