### PR TITLE
Add void type in Cell_attribute and Cell_attribute_with_point when it is the case.

### DIFF
--- a/Combinatorial_map/include/CGAL/Cell_attribute.h
+++ b/Combinatorial_map/include/CGAL/Cell_attribute.h
@@ -314,6 +314,7 @@ namespace CGAL {
     typedef OnMerge                          On_merge;
     typedef OnSplit                          On_split;
     typedef void                             Info;
+    typedef void                             Point;
 
     //  protected:
     /// Default contructor.
@@ -348,6 +349,7 @@ namespace CGAL {
     typedef OnMerge                          On_merge;
     typedef OnSplit                          On_split;
     typedef Info_                            Info;
+    typedef void                             Point;
 
     bool operator==(const Self& other) const
     { return this->info()==other.info(); }

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
@@ -25,7 +25,6 @@
 #include <CGAL/Dimension.h>
 #include <CGAL/Kernel_traits.h>
 #include <vector>
-#include <boost/mpl/has_xxx.hpp>
 
 /* Definition of functors used internally to manage attributes (we need
  * functors as attributes are stored in tuple, thus all the access must be
@@ -638,8 +637,6 @@ struct Is_same_attribute_point_functor<Map1, Map2, T1, T2, false, false, i>
   { return true; }
 };
 // ****************************************************************************
-BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_point,Point,false)
-
 template<typename Attr, typename Info=typename Attr::Info>
 struct Is_nonvoid_attribute_has_non_void_info
 {
@@ -662,9 +659,20 @@ struct Is_attribute_has_non_void_info<CGAL::Void>
   static const bool value=false;
 };
 // ****************************************************************************
+template<typename Attr, typename Point=typename Attr::Point>
+struct Is_nonvoid_attribute_has_point
+{ static const bool value=true; };
+
+template<typename Attr>
+struct Is_nonvoid_attribute_has_point<Attr, void>
+{ static const bool value=false; };
+
 template<typename Attr>
 struct Is_attribute_has_point
-{ static const bool value=Has_point<Attr>::value; };
+{ static const bool value=Is_nonvoid_attribute_has_point<Attr>::value; };
+template<>
+struct Is_attribute_has_point<CGAL::Void>
+{ static const bool value=false; };
 // ****************************************************************************
 /// Test if the two darts are associated with the same attribute.
 template<typename Map1, typename Map2>

--- a/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
+++ b/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
@@ -129,6 +129,7 @@ namespace CGAL {
                            Functor_on_merge_, Functor_on_split_> Base1;
     typedef Point_for_cell<typename LCC::Point> Base2;
 
+    typedef void                            Info;
     typedef typename LCC::Point             Point;
     typedef typename LCC::Dart_handle       Dart_handle;
     typedef typename LCC::Dart_const_handle Dart_const_handle;


### PR DESCRIPTION
Use these type to test if an attribute has a point or not with template specialization.

Thanks to these types; we can always test `Point` and `Info` type for any attribute which simplify codes (we can replace the use of boost mpl by template specialization).