### PR TITLE
small feature: prepare Segment Delaunay graph to support L_infinity metric

### DIFF
--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_2.h
@@ -7,11 +7,10 @@ namespace CGAL {
 The class `Segment_Delaunay_graph_2` represents the segment Delaunay graph (which is 
 the dual graph of the 2D segment Voronoi diagram). 
 Currently it supports only insertions of sites. 
-It is templated by two template arguments `Gt`, which 
-must be a model of `SegmentDelaunayGraphTraits_2` 
-and `DS`, 
-which must be a model of `SegmentDelaunayGraphDataStructure_2`. 
-The second template argument defaults to 
+
+\tparam Gt must be a model of `SegmentDelaunayGraphTraits_2` 
+\tparam DS must be a model of `SegmentDelaunayGraphDataStructure_2`. 
+`DS` defaults to 
 `CGAL::Triangulation_data_structure_2< CGAL::Segment_Delaunay_graph_vertex_base_2<Gt>, CGAL::Triangulation_face_base_2<Gt> >`. 
 
 \cgalHeading{Traversal of the Segment Delaunay Graph}

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
@@ -16,16 +16,19 @@ to those provided by the traits class
 `Segment_Delaunay_graph_traits_2<CK,CM>`, which means that 
 they may be inexact depending on the choice of the `CK` kernel. 
 
-This class has six template parameters. The first, third and fifth 
-template parameters must be a models of the `Kernel` concept. The 
-parameter `CK` is the construction kernel and it is the kernel 
-that will be used for constructions. The parameter `FK` is the 
-filtering kernel; this kernel will be used for performing the 
+This class has six template parameters. 
+\tparam CK is the construction kernel and it is the kernel 
+that will be used for constructions.
+\tparam CM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam FK is the  filtering kernel; this kernel will be used for performing the 
 arithmetic filtering for the predicates involved in the computation of 
-the segment Delaunay graph. Finally, the parameter `EK` is the 
-exact kernel; this kernel will be used for computing the predicates if 
+the segment Delaunay graph. 
+\tparam FM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
 the filtering kernel fails to produce an answer. 
+\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 
+The first, third and fifth template parameters must be models of the `Kernel` concept.
 The second, fourth and sixth template parameters correspond to how 
 predicates are evaluated. There are two predefined possible values for 
 these parameters, namely `Field_with_sqrt_tag` and 
@@ -35,23 +38,20 @@ expressions involving all four basic operations and square roots,
 whereas the second one requires that only field operations are 
 exact. Finally, in order to get exact constructions `CM` 
 must be set to `Field_with_sqrt_tag` and the number type in 
-`CK` must support operations involing divisions and square roots 
+`CK` must support operations involving divisions and square roots 
 (as well as the other three basic operations of course). 
 The way the predicates are evaluated is discussed in 
 \cgalCite{b-ecvdl-96} and \cgalCite{cgal:k-reisv-04} (the geometric filtering 
 part). 
 
-The default values for the template parameters are as follows: 
-`CM = Field_with_sqrt_tag` (it is assumed that 
-`Cartesian<double>` or `Simple_cartesian<double>` 
-will be the entry for the template parameter `CK`), 
-`EM = Field_tag`, 
-`FK = Simple_cartesian<Interval_nt<false> >`, 
-`FM = Field_with_sqrt_tag`. If the <span class="textsc">Gmp</span> package is 
-installed with \cgal, the template parameter `EK` has the default 
-value: `EK = Simple_cartesian<Gmpq>`, otherwise its 
-default value is 
-`EK = Simple_cartesian<Quotient<MP_Float> >`. 
+The default values for the template parameters are as follows:
+<ul>
+ <li> `CM = Field_with_sqrt_tag` (it is assumed that `Cartesian<double>` or `Simple_cartesian<double>`  will be the entry for the template parameter `CK`), 
+ <li> `EM = Field_tag`, 
+ <li> `FK = Simple_cartesian<Interval_nt<false> >`, 
+ <li> `FM = Field_with_sqrt_tag`. 
+ <li> If the \sc{Gmp} package is  installed with \cgal, the template parameter `EK` has the default   value: `EK = Simple_cartesian<Gmpq>`, otherwise its   default value is   `EK = Simple_cartesian<Quotient<MP_Float> >`. 
+</ul>
 
 \cgalModels `SegmentDelaunayGraphTraits_2`
 \cgalModels `DefaultConstructible`
@@ -166,16 +166,22 @@ to those provided by the traits class
 which means that they may be inexact, depending on the choice of the 
 `CK` kernel. 
 
-This class has six template parameters. The first, third and fifth 
-template parameters must be a models of the `Kernel` concept. The 
-parameter `CK` is the construction kernel and it is the kernel 
-that will be used for constructions. The parameter `FK` is the 
+This class has six template parameters. 
+
+\tparam CK is the construction kernel and it is the kernel 
+that will be used for constructions.
+\tparam CM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam FK is the 
 filtering kernel; this kernel will be used for performing the 
 arithmetic filtering for the predicates involved in the computation of 
-the segment Delaunay graph. Finally, the parameter `EK` is the 
-exact kernel; this kernel will be used for computing the predicates if 
+the segment Delaunay graph. 
+\tparam FM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
 the filtering kernel fails to produce an answer. 
+\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 
+The first, third and fifth 
+template parameters must be a models of the `Kernel` concept.
 The second, fourth and sixth template parameters 
 correspond to how predicates are evaluated. There are two predefined 
 possible values for these parameters, namely `Field_with_sqrt_tag` 
@@ -192,17 +198,20 @@ The way the predicates are evaluated is discussed in
 \cgalCite{b-ecvdl-96} and \cgalCite{cgal:k-reisv-04} (the geometric filtering 
 part). 
 
-The default values for the template parameters are as follows: 
-`CM = CGAL::Field_with_sqrt_tag` (it is assumed that 
+The default values for the template parameters are as follows:
+<ul>
+<li> `CM = CGAL::Field_with_sqrt_tag` (it is assumed that 
 `Cartesian<double>` or `Simple_cartesian<double>` 
 will be the entry for the template parameter `CK`), 
-`EM = CGAL::Euclidean_ring_tag`, 
-`FK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >`, 
-`FM = CGAL::Field_with_sqrt_tag`. If the <span class="textsc">Gmp</span> package is 
+<li> `EM = CGAL::Euclidean_ring_tag`, 
+<li> `FK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >`, 
+<li> `FM = CGAL::Field_with_sqrt_tag`. 
+<li> If the \sc{Gmp} package is 
 installed with \cgal, the template parameter `EK` has the default 
 value: `EK = CGAL::Simple_cartesian<CGAL::Gmpq>`, otherwise its 
 default value is 
 `EK = CGAL::Simple_cartesian<CGAL::MP_Float>`. 
+</ul>
 
 \cgalModels `SegmentDelaunayGraphTraits_2`
 \cgalModels `DefaultConstructible`

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_2.h
@@ -33,16 +33,12 @@ details are described in \cgalCite{cgal:k-reisv-04}.
 
 The class has three template parameters. The first and third 
 have essentially the same semantics as in the 
-`Segment_Delaunay_graph_2<Gt,DS>` class. The 
-first template parameter must be a model of the 
-`SegmentDelaunayGraphTraits_2` concept. The third template 
-parameter must be a model of the 
-`SegmentDelaunayGraphDataStructure_2` concept. However, the 
-vertex base class that is to be used in the segment Delaunay graph 
-data structure must be a model of the 
-`SegmentDelaunayGraphHierarchyVertexBase_2` 
-concept. The third template parameter defaults to 
-`Triangulation_data_structure_2< Segment_Delaunay_graph_hierarchy_vertex_base_2< Segment_Delaunay_graph_vertex_base_2<Gt> >, Triangulation_face_base_2<Gt> >`. The second template 
+`Segment_Delaunay_graph_2<Gt,DS>` class. 
+
+\tparam Gt must be a model of the 
+`SegmentDelaunayGraphTraits_2` concept. 
+
+\tparam STag The second template 
 parameter controls whether or not segments are added in the upper 
 levels of the hierarchy. It's possible values are `Tag_true` 
 and `Tag_false`. If it is set to `Tag_true`, 
@@ -50,6 +46,16 @@ segments are also inserted in the upper levels of the hierarchy. The
 value `Tag_false` indicates that only points are to be 
 inserted in the upper levels of the hierarchy. The default value for 
 the second template parameter is `Tag_false`. 
+
+\tparam DS must be a model of the 
+`SegmentDelaunayGraphDataStructure_2` concept. However, the 
+vertex base class that is to be used in the segment Delaunay graph 
+data structure must be a model of the 
+`SegmentDelaunayGraphHierarchyVertexBase_2` 
+concept. The third template parameter defaults to 
+`Triangulation_data_structure_2< Segment_Delaunay_graph_hierarchy_vertex_base_2< Segment_Delaunay_graph_vertex_base_2<Gt> >, Triangulation_face_base_2<Gt> >`. 
+
+
 
 The `Segment_Delaunay_graph_hierarchy_2` class derives publicly from the 
 `Segment_Delaunay_graph_2<Gt,DS>` class. The interface is 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_vertex_base_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_vertex_base_2.h
@@ -7,9 +7,9 @@ namespace CGAL {
 The class `Segment_Delaunay_graph_hierarchy_vertex_base_2` provides a model for the 
 `SegmentDelaunayGraphHierarchyVertexBase_2` concept, which is the 
 vertex base required by the 
-`Segment_Delaunay_graph_hierarchy_2<Gt,DS>` class. The class 
-`Segment_Delaunay_graph_hierarchy_vertex_base_2` is templated by a class `Vbb` which must be a model 
-of the `SegmentDelaunayGraphVertexBase_2` concept. 
+`Segment_Delaunay_graph_hierarchy_2<Gt,DS>` class. 
+
+\tparam Vbb must be a model of the `SegmentDelaunayGraphVertexBase_2` concept. 
 
 \cgalModels `SegmentDelaunayGraphHierarchyVertexBase_2`
 
@@ -22,7 +22,7 @@ of the `SegmentDelaunayGraphVertexBase_2` concept.
 
 */
 template< typename Vbb >
-class Segment_Delaunay_graph_hierarchy_vertex_base_2 : public Vcc {
+class Segment_Delaunay_graph_hierarchy_vertex_base_2 : public Vbb {
 public:
 
 /// @}

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_site_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_site_2.h
@@ -5,8 +5,8 @@ namespace CGAL {
 \ingroup PkgSegmentDelaunayGraph2
 
 The class `Segment_Delaunay_graph_site_2` is a model for the concept 
-`SegmentDelaunayGraphSite_2`. It is parametrized by a template 
-parameter `K` which must be a model of the `Kernel` concept. 
+`SegmentDelaunayGraphSite_2`. 
+\tparam K must be a model of the `Kernel` concept. 
 
 \cgalModels `SegmentDelaunayGraphSite_2`
 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_storage_site_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_storage_site_2.h
@@ -5,9 +5,9 @@ namespace CGAL {
 \ingroup PkgSegmentDelaunayGraph2
 
 The class `Segment_Delaunay_graph_storage_site_2` is a model for the concept 
-`SegmentDelaunayGraphStorageSite_2`. It is parametrized by a single 
-template parameter `Gt`, which must be a model of the 
-`SegmentDelaunayGraphTraits_2` concept. 
+`SegmentDelaunayGraphStorageSite_2`. 
+
+\tparam Gt must be a model of the `SegmentDelaunayGraphTraits_2` concept. 
 
 \cgalModels `SegmentDelaunayGraphStorageSite_2`
 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_traits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_traits_2.h
@@ -6,9 +6,10 @@ namespace CGAL {
 
 The class `Segment_Delaunay_graph_traits_2` provides a model for the 
 `SegmentDelaunayGraphTraits_2` concept. 
-This class has two template parameters. The first template parameter 
-must be a model of the `Kernel` concept. The second template 
-parameter corresponds to how predicates are evaluated. There are two 
+
+\tparam K  must be a model of the `Kernel` concept. 
+
+\tparam MTag corresponds to how predicates are evaluated. There are two 
 possible values for `MTag`, namely `Field_with_sqrt_tag` and 
 `Field_tag`. The first one must be used when the number type 
 used in the representation supports the exact evaluation of signs of 
@@ -78,9 +79,11 @@ namespace CGAL {
 
 The class `Segment_Delaunay_graph_traits_without_intersections_2` provides a model for the 
 `SegmentDelaunayGraphTraits_2` concept. 
-This class has two template parameters. 
-The first template parameter must be a model of the `Kernel` 
-concept. The second template parameter corresponds to how predicates 
+
+\tparam K  must be a model of the `Kernel` 
+concept. 
+
+\tparam MTag corresponds to how predicates 
 are evaluated. There are two possible values for `MTag`, namely 
 `Field_with_sqrt_tag` and `Euclidean_ring_tag`. The first one 
 must be used when the number type used in the representation supports 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_vertex_base_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_vertex_base_2.h
@@ -7,10 +7,10 @@ namespace CGAL {
 The class `Segment_Delaunay_graph_vertex_base_2` provides a model for the 
 `SegmentDelaunayGraphVertexBase_2` concept which is the vertex 
 base required by the `SegmentDelaunayGraphDataStructure_2` 
-concept. The class `Segment_Delaunay_graph_vertex_base_2` has two template arguments, the first 
-being the geometric traits of the segment Delaunay graph and should be a 
-model of the concept `SegmentDelaunayGraphTraits_2`. 
-The second template argument indicates whether 
+concept. 
+
+\tparam Gt must be a model of the concept `SegmentDelaunayGraphTraits_2`. 
+\tparam SSTag indicates whether 
 or not to use the simple storage site that does not support 
 intersecting segments, or the full storage site, that supports 
 intersecting segments. The possible values are `Tag_true` 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
@@ -7,12 +7,12 @@ The concept `SegmentDelaunayGraphDataStructure_2` refines the
 concept `ApolloniusGraphDataStructure_2`. In addition 
 it provides two methods for the merging of two vertices joined by an 
 edge of the data structure, and the splitting of a vertex into two. 
-The method that merges two vertices, called `join_vertices` 
+The method that merges two vertices, called `join_vertices()` 
 identifies the two vertices and deletes their common two faces. The 
-method that splits a vertex, called `split_vertex` introduces a 
+method that splits a vertex, called `split_vertex()` introduces a 
 new vertex that shares an edge and two faces with the old vertex (see 
-figure below). Notice that the `join_vertices` and 
-`split_vertex` operations are complementary, in the sense that one 
+figure below). Notice that the `join_vertices()` and 
+`split_vertex()` operations are complementary, in the sense that one 
 reverses the action of the other. 
 
 \anchor figsdgdssplitjoin 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
@@ -50,7 +50,7 @@ public:
 
 /*!
 Joins 
-the vertices that are endpoints of the edge `(f,i)`. It returns 
+the vertices that are endpoints of the edge `(f,i)` and returns 
 a vertex handle to common vertex. 
 */ 
 Vertex_handle join_vertices(Face_handle f, int i); 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphDataStructure_2.h
@@ -17,18 +17,16 @@ reverses the action of the other.
 
 \anchor figsdgdssplitjoin 
 
-\image html sdg-join_split.png
-\image latex sdg-join_split.png
-<center><b>
+\cgalFigureBegin{figsdgdssplitjoin,sdg-join_split.png}
 The join and split operations. Left to right: The vertex `v` is split
 into \f$ v_1\f$ and \f$ v_2\f$. The faces \f$ f\f$ and \f$ g\f$ are
 inserted after \f$ f_1\f$ and \f$ f_2\f$, respectively, in the
 counter-clockwise sense. The vertices \f$ v_1\f$, \f$ v_2\f$ and the
-faces \f$ f\f$ and \f$ g\f$ are returned as a `boost` `tuple` in that
+faces \f$ f\f$ and \f$ g\f$ are returned as a `boost::tuple` in that
 order. Right to left: The edge `(f,i)` is collapsed, and thus the
 vertices \f$ v_1\f$ and \f$ v_2\f$ are joined. The vertex `v` is
 returned.
-</b></center>
+\cgalFigureEnd
 
 We only describe the additional requirements with respect to the 
 `ApolloniusGraphDataStructure_2` concept. 
@@ -62,7 +60,7 @@ Splits the vertex `v` into two vertices `v1` and
 `v2`. The common faces `f` and `g` of `v1` and 
 `v2` are created after (in the counter-clockwise sense) the 
 faces `f1` and `f2`. The 4-tuple `(v1,v2,f,g)` is 
-returned (see Fig. \ref figsdgdssplitjoin). 
+returned (see \cgalFigureRef{figsdgdssplitjoin}). 
 */ 
 boost::tuples::tuple<Vertex_handle, Vertex_handle, Face_handle, 
 Face_handle> 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphSite_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphSite_2.h
@@ -75,7 +75,7 @@ static SegmentDelaunayGraphSite_2 construct_site_2(Point_2 p1, Point_2 p2,
                                                    Point_2 q1, Point_2 q2); 
 
 /*!
-Constructs a site from four points and a boolean: the 
+Constructs a site from four points and a Boolean: the 
 site represents a segment. If `b` is `true` the endpoints 
 are `p1` and \f$ p_\times\f$, otherwise \f$ p_\times\f$ and 
 `p2`. \f$ p_\times\f$ is the point of intersection of the segments 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphStorageSite_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphStorageSite_2.h
@@ -78,7 +78,7 @@ Point_handle hp2, Point_handle hq1, Point_handle hq2);
 
 /*!
 Constructs 
-a site from four point handles and a boolean. The storage site 
+a site from four point handles and a Boolean. The storage site 
 represents a segment. If `b` is `true`, the first endpoint 
 of the segment is the point associated with the handle `hp1` and 
 the second endpoint is the point of intersection of the segments the 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphTraits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphTraits_2.h
@@ -4,8 +4,8 @@
 \cgalConcept
 
 The concept `SegmentDelaunayGraphTraits_2` provides the traits 
-requirements for the `Segment_Delaunay_graph_2<Gt,DS>` and 
-`Segment_Delaunay_graph_hierarchy_2<Gt,STag,DS>` classes. In 
+requirements for the `CGAL::Segment_Delaunay_graph_2<Gt,DS>` and 
+`CGAL::Segment_Delaunay_graph_hierarchy_2<Gt,STag,DS>` classes. In 
 particular, it provides a type `Site_2`, which must be a model of 
 the concept `SegmentDelaunayGraphSite_2`. It also provides 
 constructions for sites and several function object 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
@@ -233,12 +233,12 @@ the subsegments
 subsegments \f$ p_2s_1\f$ and \f$ s_1q_2\f$. How do we represent the five new
 sites? \f$ s_1\f$ will be represented by its two defining segments \f$ t_1\f$
 and \f$ t_2\f$. The segment \f$ p_1s_1\f$ will be represented by two segments, a
-point, and a boolean. The first segment is \f$ t_1\f$, which is always the
+point, and a Boolean. The first segment is \f$ t_1\f$, which is always the
 segment with the same support as the newly created segment. The second
-segment is \f$ t_2\f$ and the point is \f$ p_1\f$. The boolean indicates whether
+segment is \f$ t_2\f$ and the point is \f$ p_1\f$. The Boolean indicates whether
 the first endpoint of \f$ p_1s_1\f$ is an input point; in this case the
-boolean is equal to `true`. The segment \f$ s_1q_1\f$ will also be
-represented by two segments, a point, and a boolean, namely, \f$ t_1\f$
+Boolean is equal to `true`. The segment \f$ s_1q_1\f$ will also be
+represented by two segments, a point, and a Boolean, namely, \f$ t_1\f$
 (the supporting segment of \f$ s_1q_1\f$), \f$ t_2\f$ and `false` (it is the
 second endpoint of \f$ s_1q_1\f$ that is an input point). Subsegments
 \f$ p_2s_1\f$ and \f$ s_1q_2\f$ are represented analogously.
@@ -246,7 +246,7 @@ Consider now what happens when we insert \f$ t_3\f$. The point
 \f$ s_2\f$ will again be represented by two segments, but not \f$ s_1q_1\f$ and
 \f$ t_3\f$. In fact, it will be represented by \f$ t_1\f$ (the supporting
 segment of \f$ s_1q_1\f$) and \f$ t_3\f$. \f$ s_2q_1\f$ will be represented
-by two segments, a point, and a boolean (\f$ t_1\f$, \f$ t_3\f$, \f$ q1\f$ and
+by two segments, a point, and a Boolean (\f$ t_1\f$, \f$ t_3\f$, \f$ q1\f$ and
 `false`), and similarly for \f$ p_3s_2\f$ and \f$ s_2q_3\f$. On the other
 hand, both endpoints of \f$ s_1s_2\f$ are non-input points. In such a
 case we represent the segment by three input segments.
@@ -258,7 +258,7 @@ supporting segment of \f$ s_1q_1\f$), \f$ t_2\f$ (it defines \f$ s_1\f$ along wi
 Site representation. The point \f$ s_1\f$ is represented by the four
 points \f$ p_1\f$, \f$ q_1\f$, \f$ p_2\f$ and \f$ q_2\f$. The segment
 \f$ p_1s_1\f$ is represented by the points \f$ p_1\f$, \f$ q_1\f$, \f$
-p_2\f$, \f$ q_2\f$ and a boolean which is set to <I>true</I> to
+p_2\f$, \f$ q_2\f$ and a Boolean which is set to `true` to
 indicate that the first endpoint in not a point of intersection. The
 segment \f$ s_1s_2\f$ is represented by the six points: \f$ p_1\f$,
 \f$ q_1\f$, \f$ p_2\f$, \f$ q_2\f$, \f$ p_3\f$ and \f$ q_3\f$. The
@@ -268,7 +268,7 @@ represented similarly.
 
 The five different presentations, two for points (coordinates; two
 input segments) and three for segments (two input points; two input
-segments, an input point and a boolean; three input segments),
+segments, an input point and a Boolean; three input segments),
 form a closed set of representations and thus represent
 any point of intersection or subsegment regardless of the number of
 input segments. Moreover, every point (input or intersection) has
@@ -280,7 +280,7 @@ our predicates will always be \f$ O(b)\f$, independently of the
 size of the input.
 The `SegmentDelaunayGraphSite_2` concept encapsulates the ideas
 presented above. A site is represented in this concept by up to four
-points and a boolean, or up to six points, depending on its type. The
+points and a Boolean, or up to six points, depending on its type. The
 class `Segment_Delaunay_graph_site_2<K>` implements this
 concept.
 

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-red-blue-info.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-red-blue-info.cpp
@@ -73,15 +73,13 @@ struct Red_blue_merge_info
 // choose the kernel
 #include <CGAL/Simple_cartesian.h>
 
-struct Rep : public CGAL::Simple_cartesian<double> {};
-
 // typedefs for the geometric traits, storage traits and the algorithm
 #include <CGAL/Segment_Delaunay_graph_2.h>
 #include <CGAL/Segment_Delaunay_graph_filtered_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h>
 
-
-typedef CGAL::Segment_Delaunay_graph_filtered_traits_2<Rep> Gt;
+typedef CGAL::Simple_cartesian<double> K;
+typedef CGAL::Segment_Delaunay_graph_filtered_traits_2<K> Gt;
 
 // define the storage traits with info
 typedef

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -1657,12 +1657,14 @@ protected:
   }
 
   inline Oriented_side
-  oriented_side(const Storage_site_2& q, const Storage_site_2& supp,
+  oriented_side(const Storage_site_2& s1, const Storage_site_2& s2,
+                const Storage_site_2& supp,
 		const Storage_site_2& p) const
   {
-    CGAL_precondition( q.is_point() && supp.is_segment() && p.is_point() );
+    CGAL_precondition( supp.is_segment() && p.is_point() );
     return
-      geom_traits().oriented_side_2_object()(q.site(), supp.site(), p.site());
+      geom_traits().oriented_side_2_object()(
+          s1.site(), s2.site(), supp.site(), p.site());
   }
 
   inline Oriented_side
@@ -1869,10 +1871,11 @@ protected:
   }
 
   inline Oriented_side
-  oriented_side(const Site_2& q, const Site_2& supp, const Site_2& p) const
+  oriented_side(const Site_2& s1, const Site_2&s2,
+                const Site_2& supp, const Site_2& p) const
   {
-    CGAL_precondition( q.is_point() && supp.is_segment() && p.is_point() );
-    return geom_traits().oriented_side_2_object()(q, supp, p);
+    CGAL_precondition( supp.is_segment() && p.is_point() );
+    return geom_traits().oriented_side_2_object()(s1, s2, supp, p);
   }
 
   inline Oriented_side

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -309,12 +309,35 @@ protected:
   CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::Internal::Which_list<Edge,List_tag>::List 
   List;
 
+
+protected:
+  // types for insert on segment functions
+  typedef Vertex_triple (Self::*Insert_on_Type)(
+      const Storage_site_2& ss, const Site_2& t,
+      Vertex_handle v, const Tag_true&);
+  Insert_on_Type insert_point_on_segment_ptr;
+
+  typedef Vertex_triple (Self::*Insert_Exact_on_Type)(
+      const Storage_site_2& ss, const Site_2& t,
+      Vertex_handle v);
+  Insert_Exact_on_Type insert_exact_point_on_segment_ptr;
+
+private:
+  // CREATION helper
+  void setup_insert_on_pointers_l2(void) {
+    insert_point_on_segment_ptr = &Self::insert_point_on_segment;
+    insert_exact_point_on_segment_ptr = &Self::insert_exact_point_on_segment;
+  }
+
 public:
   // CREATION
   //---------
   Segment_Delaunay_graph_2(const Geom_traits& gt = Geom_traits(),
 			   const Storage_traits& st = Storage_traits())
-    : DG(gt), st_(st) {}
+    : DG(gt), st_(st)
+  {
+    setup_insert_on_pointers_l2();
+  }
 
   template< class Input_iterator >
   Segment_Delaunay_graph_2(Input_iterator first, Input_iterator beyond,
@@ -322,6 +345,7 @@ public:
 			   const Storage_traits& st = Storage_traits())
     : DG(gt), st_(st)
   {
+    setup_insert_on_pointers_l2();
     insert(first, beyond);
   }
 
@@ -1061,11 +1085,11 @@ protected:
   Vertex_handle insert_point2(const Storage_site_2& ss,
 			      const Site_2& t, Vertex_handle vnear);
 
-  Triple<Vertex_handle,Vertex_handle,Vertex_handle>
+  Vertex_triple
   insert_point_on_segment(const Storage_site_2& ss, const Site_2& t,
 			  Vertex_handle v, const Tag_true&);
 
-  Triple<Vertex_handle,Vertex_handle,Vertex_handle>
+  Vertex_triple
   insert_exact_point_on_segment(const Storage_site_2& ss, const Site_2& t,
 				Vertex_handle v);
 

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -322,10 +322,33 @@ protected:
       Vertex_handle v);
   Insert_Exact_on_Type insert_exact_point_on_segment_ptr;
 
+  Vertex_triple
+  insert_point_on_segment(const Storage_site_2& ss, const Site_2& t,
+			  Vertex_handle v, const Tag_true&);
+
+  Vertex_triple
+  insert_exact_point_on_segment(const Storage_site_2& ss, const Site_2& t,
+				Vertex_handle v);
+
 private:
   // CREATION helper
-  void setup_insert_on_pointers_l2(void) {
+  template<class ITag>
+  inline
+  void setup_if_intersecting_pointer(ITag tag) {
+    setup_if_intersecting_pointer_with_tag(tag);
+  }
+
+  void setup_if_intersecting_pointer_with_tag(Tag_false) {
+    insert_point_on_segment_ptr = nullptr;
+  }
+
+  void setup_if_intersecting_pointer_with_tag(Tag_true) {
     insert_point_on_segment_ptr = &Self::insert_point_on_segment;
+  }
+
+  void setup_insert_on_pointers_l2(void) {
+    Intersections_tag itag;
+    setup_if_intersecting_pointer(itag);
     insert_exact_point_on_segment_ptr = &Self::insert_exact_point_on_segment;
   }
 
@@ -1084,14 +1107,6 @@ protected:
 			     const Site_2& t, Vertex_handle vnear);
   Vertex_handle insert_point2(const Storage_site_2& ss,
 			      const Site_2& t, Vertex_handle vnear);
-
-  Vertex_triple
-  insert_point_on_segment(const Storage_site_2& ss, const Site_2& t,
-			  Vertex_handle v, const Tag_true&);
-
-  Vertex_triple
-  insert_exact_point_on_segment(const Storage_site_2& ss, const Site_2& t,
-				Vertex_handle v);
 
   Vertex_handle insert_segment(const Storage_site_2& ss, const Site_2& t,
 			       Vertex_handle vnear);

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -339,7 +339,7 @@ private:
   }
 
   void setup_if_intersecting_pointer_with_tag(Tag_false) {
-    insert_point_on_segment_ptr = nullptr;
+    insert_point_on_segment_ptr = NULL;
   }
 
   void setup_if_intersecting_pointer_with_tag(Tag_true) {

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -1485,23 +1485,12 @@ protected:
 
 // choosing the correct bisector constructors
 private:
-  template<typename T>
-  struct CheckForTypeBis
-  {
-  private:
-    typedef char                      yes;
-    typedef struct { char array[2]; } no;
+  template <typename T, typename Tag_has_bisector_constructions>
+  struct ConstructionHelper {};
 
-    template<typename C> static yes test(
-                 typename C::Has_bisector_constructions_type*);
-    template<typename C> static no  test(...);
-  public:
-    static const bool value = sizeof(test<T>(0)) == sizeof(yes);
-  };
-
-  // default L2 constructors
-  template <typename T, bool>
-  struct ConstructionHelper
+  // take constructors from L2
+  template <typename T>
+  struct ConstructionHelper<T, Tag_false>
   {
     typedef CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::
               Construct_sdg_bisector_2<Gt,
@@ -1519,7 +1508,7 @@ private:
 
   // constructors from traits
   template <typename T>
-  struct ConstructionHelper<T, true>
+  struct ConstructionHelper<T, Tag_true>
   {
     typedef
             typename T:: template Construct_sdg_bisector_2
@@ -1538,9 +1527,9 @@ private:
   template <typename T>
   struct ConstructionChooser
   {
-    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbis tagbis;
-    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbisray tagbisray;
-    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbisseg tagbisseg;
+    typedef typename ConstructionHelper<T, typename T::Tag_has_bisector_constructions>::tagbis tagbis;
+    typedef typename ConstructionHelper<T, typename T::Tag_has_bisector_constructions>::tagbisray tagbisray;
+    typedef typename ConstructionHelper<T, typename T::Tag_has_bisector_constructions>::tagbisseg tagbisseg;
   };
 
 

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -146,9 +146,11 @@ namespace Internal {
 } //namespace SegmentDelaunayGraph_2
 
 
-template<class Gt, class ST, class STag, class D_S, class LTag >
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx >
 class Segment_Delaunay_graph_hierarchy_2;
 
+template<class Gt, class ST, class D_S, class LTag >
+class Segment_Delaunay_graph_Linf_2;
 
 
 template<class Gt,
@@ -161,8 +163,15 @@ class Segment_Delaunay_graph_2
   : private Triangulation_2<
           Segment_Delaunay_graph_traits_wrapper_2<Gt>, D_S >
 {
-  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_true,D_S,LTag>;
-  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_false,D_S,LTag>;
+  friend class Segment_Delaunay_graph_Linf_2<Gt,ST,D_S,LTag>;
+  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_true,D_S,LTag,
+   Segment_Delaunay_graph_2<Gt,ST,D_S,LTag> >;
+  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_false,D_S,LTag,
+   Segment_Delaunay_graph_2<Gt,ST,D_S,LTag> >;
+  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_true,D_S,LTag,
+   Segment_Delaunay_graph_Linf_2<Gt,ST,D_S,LTag> >;
+  friend class Segment_Delaunay_graph_hierarchy_2<Gt,ST,Tag_false,D_S,LTag,
+   Segment_Delaunay_graph_Linf_2<Gt,ST,D_S,LTag> >;
 protected:
   // LOCAL TYPES
   //------------

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -1435,6 +1435,67 @@ protected:
 #endif
 
 
+// choosing the correct bisector constructors
+private:
+  template<typename T>
+  struct CheckForTypeBis
+  {
+  private:
+    typedef char                      yes;
+    typedef struct { char array[2]; } no;
+
+    template<typename C> static yes test(
+                 typename C::Has_bisector_constructions_type*);
+    template<typename C> static no  test(...);
+  public:
+    static const bool value = sizeof(test<T>(0)) == sizeof(yes);
+  };
+
+  // default L2 constructors
+  template <typename T, bool>
+  struct ConstructionHelper
+  {
+    typedef CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::
+              Construct_sdg_bisector_2<Gt,
+                Integral_domain_without_division_tag>
+            tagbis;
+    typedef CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::
+              Construct_sdg_bisector_ray_2<Gt,
+                Integral_domain_without_division_tag>
+            tagbisray;
+    typedef CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::
+              Construct_sdg_bisector_segment_2<Gt,
+                Integral_domain_without_division_tag>
+            tagbisseg;
+  };
+
+  // constructors from traits
+  template <typename T>
+  struct ConstructionHelper<T, true>
+  {
+    typedef
+            typename T:: template Construct_sdg_bisector_2
+              <Gt, Integral_domain_without_division_tag>
+            tagbis;
+    typedef
+            typename T:: template Construct_sdg_bisector_ray_2
+              <Gt, Integral_domain_without_division_tag>
+            tagbisray;
+    typedef
+            typename T:: template Construct_sdg_bisector_segment_2
+              <Gt, Integral_domain_without_division_tag>
+            tagbisseg;
+  };
+
+  template <typename T>
+  struct ConstructionChooser
+  {
+    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbis tagbis;
+    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbisray tagbisray;
+    typedef typename ConstructionHelper<T, CheckForTypeBis<T>::value>::tagbisseg tagbisseg;
+  };
+
+
 protected:
   // TYPES AND ACCESS METHODS FOR VISUALIZATION
   //-------------------------------------------
@@ -1444,18 +1505,15 @@ protected:
   CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::Construct_sdg_circle_2<Gt,Integral_domain_without_division_tag>
   Construct_sdg_circle_2;
 
-  typedef
-  CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::Construct_sdg_bisector_2<Gt,Integral_domain_without_division_tag>
-  Construct_sdg_bisector_2;
-
-  typedef
-  CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::Construct_sdg_bisector_ray_2<Gt,Integral_domain_without_division_tag>
-  Construct_sdg_bisector_ray_2;
-
-  typedef
-  CGAL_SEGMENT_DELAUNAY_GRAPH_2_NS::
-  Construct_sdg_bisector_segment_2<Gt,Integral_domain_without_division_tag>
-  Construct_sdg_bisector_segment_2;
+  typedef typename
+          ConstructionChooser<Geom_traits>::tagbis
+          Construct_sdg_bisector_2;
+  typedef typename
+          ConstructionChooser<Geom_traits>::tagbisray
+          Construct_sdg_bisector_ray_2;
+  typedef typename
+          ConstructionChooser<Geom_traits>::tagbisseg
+          Construct_sdg_bisector_segment_2;
 
   // access
   inline Construct_sdg_circle_2

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Filtered_traits_base_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Filtered_traits_base_2.h
@@ -184,6 +184,9 @@ public:
 			C2E, C2F, E2C, F2C>
   Construct_svd_vertex_2;
 
+  // L2 traits do not contain bisector constructions
+  typedef Tag_false Tag_has_bisector_constructions;
+
   //  typedef typename CK::Construct_site_2   Construct_site_2;
 
   //  typedef typename CK_traits::Construct_sdg_circle_2

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Oriented_side_C2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Oriented_side_C2.h
@@ -60,6 +60,19 @@ public:
   typedef Oriented_side                       result_type;
   typedef Site_2                              argument_type;
 
+  // computes the oriented side of the Voronoi vertex of s1, s2, inf
+  // wrt the line that passes through the point p and its direction
+  // is the direction of the supporting line of s, rotated by 90
+  // degrees counterclockwise.
+  Oriented_side operator()(const Site_2& s1, const Site_2& s2,
+			   const Site_2& s, const Site_2& p) const
+  {
+    CGAL_precondition(s1.is_point() or s2.is_point());
+    CGAL_precondition(s1.is_segment() or s2.is_segment());
+
+    return this->operator()((s1.is_point()? s1: s2), s, p);
+  }
+
   // computes the oriented side of the point q
   // wrt the line that is passes through the point p and its direction
   // is the direction of the supporting line of s, rotated by 90

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Oriented_side_C2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Oriented_side_C2.h
@@ -67,8 +67,8 @@ public:
   Oriented_side operator()(const Site_2& s1, const Site_2& s2,
 			   const Site_2& s, const Site_2& p) const
   {
-    CGAL_precondition(s1.is_point() or s2.is_point());
-    CGAL_precondition(s1.is_segment() or s2.is_segment());
+    CGAL_precondition(s1.is_point() || s2.is_point());
+    CGAL_precondition(s1.is_segment() || s2.is_segment());
 
     return this->operator()((s1.is_point()? s1: s2), s, p);
   }

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -2567,17 +2567,13 @@ Object
 Segment_Delaunay_graph_2<Gt,ST,D_S,LTag>::
 primal(const Edge e) const
 {
-  typedef typename Gt::Line_2   Line_2;
-  typedef typename Gt::Ray_2    Ray_2;
-
   CGAL_precondition( !is_infinite(e) );
 
   if ( this->dimension() == 1 ) {
     Site_2 p = (e.first)->vertex(cw(e.second))->site();
     Site_2 q = (e.first)->vertex(ccw(e.second))->site();
 
-    Line_2 l = construct_sdg_bisector_2_object()(p,q);
-    return make_object(l);
+    return make_object(construct_sdg_bisector_2_object()(p,q));
   }
 
   // dimension == 2
@@ -2596,8 +2592,7 @@ primal(const Edge e) const
        is_infinite(e.first->neighbor(e.second)) )  {
     Site_2 p = (e.first)->vertex(cw(e.second))->site();
     Site_2 q = (e.first)->vertex(ccw(e.second))->site();
-    Line_2 l = construct_sdg_bisector_2_object()(p,q);
-    return make_object(l);
+    return make_object(construct_sdg_bisector_2_object()(p,q));
   }
 
   // only one of the adjacent faces is infinite
@@ -2621,8 +2616,7 @@ primal(const Edge e) const
   Site_2 q = ee.first->vertex(  cw(ee.second) )->site();
   Site_2 r = ee.first->vertex(     ee.second  )->site();
 
-  Ray_2 ray = construct_sdg_bisector_ray_2_object()(p,q,r);
-  return make_object(ray);
+  return make_object(construct_sdg_bisector_ray_2_object()(p,q,r));
 }
 
 //--------------------------------------------------------------------

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -572,7 +572,7 @@ find_faces_to_split(const Vertex_handle& v, const Site_2& t) const
     }
 
     if ( !found_f2 &&
-	 os1 == ON_POSITIVE_SIDE && os2 != ON_POSITIVE_SIDE ) {
+         os1 != ON_NEGATIVE_SIDE && os2 == ON_NEGATIVE_SIDE ) {
       f2 = ff2;
       found_f2 = true;
     }

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -338,7 +338,8 @@ insert_point(const Storage_site_2& ss, const Site_2& t,
     if ( at_res == AT2::INTERIOR ) {
       CGAL_assertion( t.is_input() );
 
-      Vertex_triple vt = insert_exact_point_on_segment(ss, t, vnearest);
+      Vertex_triple vt = (this->*insert_exact_point_on_segment_ptr)(
+          ss, t, vnearest);
       return vt.first;
     } else {
       // the point to be inserted does not belong to the interior of a
@@ -931,7 +932,7 @@ insert_intersecting_segment_with_tag(const Storage_site_2& ss,
     return v;
   }
 
-  Vertex_triple vt = insert_point_on_segment(ss, t, v, tag);
+  Vertex_triple vt = (this->*insert_point_on_segment_ptr)(ss, t, v, tag);
 
   Vertex_handle vsx = vt.first;
   
@@ -2778,6 +2779,11 @@ void
 Segment_Delaunay_graph_2<Gt,ST,D_S,LTag>::
 copy(Segment_Delaunay_graph_2& other)
 {
+  // copy the insert_on method pointers
+  insert_point_on_segment_ptr = other.insert_point_on_segment_ptr;
+  insert_exact_point_on_segment_ptr =
+    other.insert_exact_point_on_segment_ptr;
+
   // first copy the point container
   pc_ = other.pc_;
 

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -527,13 +527,13 @@ find_faces_to_split(const Vertex_handle& v, const Site_2& t) const
 	CGAL_assertion(  !is_infinite( ff1->vertex(ccw_v) )  );
 	CGAL_assertion( ff1->vertex(ccw_v)->site().is_point() );
 	sv_ep = ff1->vertex(ccw_v)->site();
+        os1 = oriented_side(v->site(), sv_ep, sitev_supp, t);
       } else {
 	CGAL_assertion(  !is_infinite( ff1->vertex( cw_v) )  );
 	CGAL_assertion( ff1->vertex( cw_v)->site().is_point() );
 	sv_ep = ff1->vertex( cw_v)->site();
+        os1 = oriented_side(sv_ep, v->site(), sitev_supp, t);
       }
-
-      os1 = oriented_side(sv_ep, sitev_supp, t);
     } else {
       os1 = oriented_side(fc1->vertex(0)->site(),
 			  fc1->vertex(1)->site(),
@@ -551,13 +551,13 @@ find_faces_to_split(const Vertex_handle& v, const Site_2& t) const
 	CGAL_assertion(  !is_infinite( ff2->vertex(ccw_v) )  );
 	CGAL_assertion( ff2->vertex(ccw_v)->site().is_point() );
 	sv_ep = ff2->vertex(ccw_v)->site();
+        os2 = oriented_side(v->site(), sv_ep, sitev_supp, t);
       } else {
 	CGAL_assertion(  !is_infinite( ff2->vertex( cw_v) )  );
 	CGAL_assertion( ff2->vertex( cw_v)->site().is_point() );
 	sv_ep = ff2->vertex( cw_v)->site();
+        os2 = oriented_side(sv_ep, v->site(), sitev_supp, t);
       }
-
-      os2 = oriented_side(sv_ep, sitev_supp, t);
     } else {
       os2 = oriented_side(fc2->vertex(0)->site(),
 			  fc2->vertex(1)->site(),

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -502,7 +502,7 @@ find_faces_to_split(const Vertex_handle& v, const Site_2& t) const
       if ( is_infinite(fc) ) { n_inf++; }
       fc++;
     } while ( fc != fc_start );
-    CGAL_assertion( n_inf == 0 || n_inf == 2 || n_inf == 4 );
+    CGAL_assertion( n_inf % 2 == 0 );
   }
 #endif
 

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2_impl.h
@@ -139,11 +139,14 @@ insert_third(const Site_2& t, const Storage_site_2& ss)
   Site_2 s2 = f->vertex(1)->site();
   Site_2 s3 = f->vertex(2)->site();
 
-  Orientation o =
-    geom_traits().orientation_2_object()(s1, s2, s3);
+  Sign s12i3 = geom_traits().vertex_conflict_2_object()(s1, s2, s3);
+  Sign s21i3 = geom_traits().vertex_conflict_2_object()(s2, s1, s3);
 
-  if ( o != COLLINEAR ) {
-    if ( o == RIGHT_TURN ) {
+  CGAL_assertion(s12i3 != ZERO);
+  CGAL_assertion(s21i3 != ZERO);
+
+  if ( s12i3 != s21i3 ) {
+    if ( s21i3 == NEGATIVE ) {
       f->reorient();
       for (int i = 0; i < 3; i++) {
 	f->neighbor(i)->reorient();

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_hierarchy_2_impl.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Segment_Delaunay_graph_hierarchy_2_impl.h
@@ -35,9 +35,9 @@ namespace CGAL {
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 init_hierarchy(const Geom_traits& gt)
 {
   hierarchy[0] = this; 
@@ -46,8 +46,8 @@ init_hierarchy(const Geom_traits& gt)
   }
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 Segment_Delaunay_graph_hierarchy_2(const Gt& gt)
   : Base(gt)
 { 
@@ -56,10 +56,10 @@ Segment_Delaunay_graph_hierarchy_2(const Gt& gt)
 
 
 // copy constructor duplicates vertices and faces
-template<class Gt, class ST, class STag, class D_S, class LTag>
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 Segment_Delaunay_graph_hierarchy_2
-(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &sdg)
+(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx> &sdg)
     : Base(sdg.geom_traits())
 { 
   // create an empty triangulation to be able to delete it !
@@ -72,8 +72,8 @@ Segment_Delaunay_graph_hierarchy_2
 //  destructor
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>:: 
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 ~Segment_Delaunay_graph_hierarchy_2()
 {
   clear();
@@ -87,10 +87,10 @@ Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
 // assignment operator
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
-operator=(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &sdg)
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx> &
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
+operator=(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx> &sdg)
 {
   if ( this != &sdg ) {
     copy(sdg);
@@ -108,9 +108,9 @@ operator=(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &sdg)
 // insertion of a point
 //--------------------------------------------------------------------
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 std::pair<bool,int>
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_point(const Point_2& p, const Storage_site_2& ss, int level,
 	     Vertex_handle* vertices)
 {
@@ -247,9 +247,9 @@ insert_point(const Point_2& p, const Storage_site_2& ss, int level,
 }
 
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_point(const Site_2& t, const Storage_site_2& ss,
 	     int low, int high, Vertex_handle vbelow,
 	     Vertex_handle* vertices)
@@ -310,10 +310,10 @@ insert_point(const Site_2& t, const Storage_site_2& ss,
 //--------------------------------------------------------------------
 // insertion of a segment
 //--------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_segment(const Point_2& p0, const Point_2& p1,
 	       const Storage_site_2& ss, int level)
 {
@@ -364,10 +364,10 @@ insert_segment(const Point_2& p0, const Point_2& p1,
   return vertex;
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_segment_interior(const Site_2& t, const Storage_site_2& ss,
 			const Vertex_handle* vertices, int level)
 {
@@ -514,9 +514,9 @@ insert_segment_interior(const Site_2& t, const Storage_site_2& ss,
 }
 
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_segment_in_upper_levels(const Site_2& t, const Storage_site_2& ss,
 			       Vertex_handle vbelow,
 			       const Vertex_handle* vertices,
@@ -554,10 +554,10 @@ insert_segment_in_upper_levels(const Site_2& t, const Storage_site_2& ss,
 // insertion of a segment that goes through a point
 //--------------------------------------------------------------------
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_segment_on_point(const Storage_site_2& ss,
 			const Vertex_handle& v,
 			int level, int which)
@@ -601,10 +601,10 @@ insert_segment_on_point(const Storage_site_2& ss,
 //--------------------------------------------------------------------
 // insertion of an intersecting segment
 //--------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_intersecting_segment_with_tag(const Storage_site_2& ss,
 				     const Site_2& t, Vertex_handle v,
 				     int level,
@@ -648,10 +648,10 @@ insert_intersecting_segment_with_tag(const Storage_site_2& ss,
   return vsx;
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 insert_intersecting_segment_with_tag(const Storage_site_2& ss,
 				     const Site_2& t, Vertex_handle v,
 				     int level,
@@ -751,9 +751,9 @@ insert_intersecting_segment_with_tag(const Storage_site_2& ss,
 //====================================================================
 //====================================================================
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 bool
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 remove(const Vertex_handle& v)
 {
   CGAL_precondition( !is_infinite(v) );
@@ -805,10 +805,10 @@ remove(const Vertex_handle& v)
 //  nearest neighbor location
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 typename
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::Vertex_handle 
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::Vertex_handle
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 nearest_neighbor(const Point_2& p, bool force_point) const
 {
   Vertex_handle vnear[sdg_hierarchy_2__maxlevel];
@@ -820,9 +820,9 @@ nearest_neighbor(const Point_2& p, bool force_point) const
   return vnear[0];
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 nearest_neighbor(const Site_2& t,
 		 Vertex_handle vnear[sdg_hierarchy_2__maxlevel],
 		 bool /* force_point */) const
@@ -862,10 +862,10 @@ nearest_neighbor(const Site_2& t,
 //  miscellaneous methods
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::   
-copy(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &sdg)
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
+copy(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx> &sdg)
 {
 #ifndef CGAL_NO_ASSERTIONS
   for (unsigned int i = 1; i < sdg_hierarchy_2__maxlevel; ++i) {
@@ -928,9 +928,9 @@ copy(const Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag> &sdg)
   //  hierarchy[0]->isc_ = sdg.hierarchy[0]->isc_;
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>:: 
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 clear()
 {
   for(unsigned int i = 0; i < sdg_hierarchy_2__maxlevel; ++i) {
@@ -938,10 +938,10 @@ clear()
   }
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>:: 
-swap(Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>& other)
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
+swap(Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>& other)
 {
   Base* temp;
   Base::swap(other);
@@ -957,9 +957,9 @@ swap(Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>& other)
 //  validity check
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 bool
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>:: 
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 is_valid(bool verbose, int level) const
 {
   bool result(true);
@@ -998,9 +998,9 @@ is_valid(bool verbose, int level) const
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 print_error_message() const
 {
   std::cerr << std::endl;
@@ -1020,9 +1020,9 @@ print_error_message() const
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 file_output(std::ostream& os) const
 {
   typedef std::map<Vertex_handle,int>        Vertex_map;
@@ -1099,9 +1099,9 @@ file_output(std::ostream& os) const
   delete[] V_down;
 }
 
-template<class Gt, class ST, class STag, class D_S, class LTag>
+template<class Gt, class ST, class STag, class D_S, class LTag, class SDGLx>
 void
-Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>::
+Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>::
 file_input(std::istream& is)
 {
   typedef std::vector<Vertex_handle>  Vertex_vector;

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Traits_base_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Traits_base_2.h
@@ -198,6 +198,9 @@ public:
     return Construct_svd_vertex_2();
   }
 
+  // L2 traits do not contain bisector constructions
+  typedef Tag_false Tag_has_bisector_constructions;
+
   /*
   Construct_svd_circle_2
   construct_svd_circle_2_object() const {

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_hierarchy_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_hierarchy_2.h
@@ -65,17 +65,18 @@ template < class Gt,
               Segment_Delaunay_graph_hierarchy_vertex_base_2<
 		Segment_Delaunay_graph_vertex_base_2<ST> >,
               Segment_Delaunay_graph_face_base_2<Gt> >,
-	   class LTag = Tag_false>
+	   class LTag = Tag_false,
+           class SDGLx = Segment_Delaunay_graph_2<Gt,ST,D_S,LTag> >
 class Segment_Delaunay_graph_hierarchy_2
-  : public Segment_Delaunay_graph_2<Gt,ST,D_S,LTag>
+  : public SDGLx
 {
 protected:
-  typedef Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag>  Self;
+  typedef Segment_Delaunay_graph_hierarchy_2<Gt,ST,STag,D_S,LTag,SDGLx>  Self;
 
 public:
   // PUBLIC TYPES
   //-------------
-  typedef Segment_Delaunay_graph_2<Gt,ST,D_S,LTag>  Base;
+  typedef SDGLx    Base;
 
   typedef typename Base::Geom_traits        Geom_traits;
   typedef typename Base::Storage_traits     Storage_traits;

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_2_et.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_2_et.cpp
@@ -49,8 +49,8 @@ typedef exact_field_t  field_number_t;
 #include <CGAL/Segment_Delaunay_graph_2.h>
 #include <CGAL/Segment_Delaunay_graph_traits_2.h>
 
-struct K_ring  : public CGAL::Simple_cartesian<ring_number_t> {};
-struct K_field : public CGAL::Simple_cartesian<field_number_t> {};
+typedef CGAL::Simple_cartesian<ring_number_t> K_ring;
+typedef CGAL::Simple_cartesian<field_number_t> K_field;
 
 typedef CGAL::Field_tag  MTag;
 typedef CGAL::Integral_domain_without_division_tag   MTag_wi;

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_2_et.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_2_et.cpp
@@ -47,8 +47,8 @@ typedef exact_field_t  field_number_t;
 #include <CGAL/Segment_Delaunay_graph_hierarchy_2.h>
 #include <CGAL/Segment_Delaunay_graph_traits_2.h>
 
-struct K_ring  : public CGAL::Simple_cartesian<ring_number_t> {};
-struct K_field : public CGAL::Simple_cartesian<field_number_t> {};
+typedef CGAL::Simple_cartesian<ring_number_t> K_ring;
+typedef CGAL::Simple_cartesian<field_number_t> K_field;
 
 typedef CGAL::Field_tag  MTag;
 typedef CGAL::Integral_domain_without_division_tag   MTag_wi;

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_info_2_no_up.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_info_2_no_up.cpp
@@ -1,6 +1,3 @@
-// file: multi_info.cpp
-#include <CGAL/basic.h>
-
 // standard includes
 #include <iostream>
 #include <fstream>
@@ -9,18 +6,15 @@
 // choose the kernel
 #include <CGAL/Simple_cartesian.h>
 
-struct Rep : public CGAL::Simple_cartesian<double> {};
+typedef CGAL::Simple_cartesian<double> K;
 
 // typedefs for the traits and the algorithm
 #include <CGAL/Segment_Delaunay_graph_hierarchy_2.h>
 #include <CGAL/Segment_Delaunay_graph_filtered_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h>
 
-typedef
-CGAL::Segment_Delaunay_graph_filtered_traits_2<Rep>
-Traits_x;
+typedef CGAL::Segment_Delaunay_graph_filtered_traits_2<K> Gt;
 
-struct Gt : public Traits_x {};
 
 #include "Multi_info.h"
 

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_info_2_up.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_hierarchy_info_2_up.cpp
@@ -1,6 +1,3 @@
-// file: multi_info.cpp
-#include <CGAL/basic.h>
-
 // standard includes
 #include <iostream>
 #include <fstream>
@@ -9,18 +6,15 @@
 // choose the kernel
 #include <CGAL/Simple_cartesian.h>
 
-struct Rep : public CGAL::Simple_cartesian<double> {};
+typedef CGAL::Simple_cartesian<double> K;
 
 // typedefs for the traits and the algorithm
 #include <CGAL/Segment_Delaunay_graph_hierarchy_2.h>
 #include <CGAL/Segment_Delaunay_graph_filtered_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h>
 
-typedef
-CGAL::Segment_Delaunay_graph_filtered_traits_2<Rep>
-Traits_x;
+typedef CGAL::Segment_Delaunay_graph_filtered_traits_2<K> Gt;
 
-struct Gt : public Traits_x {};
 
 #include "Multi_info.h"
 

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_info_2.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_info_2.cpp
@@ -1,5 +1,4 @@
 // file: test_sdg_info_2.cpp
-#include <CGAL/basic.h>
 
 // standard includes
 #include <iostream>
@@ -8,18 +7,14 @@
 // choose the kernel
 #include <CGAL/Simple_cartesian.h>
 
-struct Rep : public CGAL::Simple_cartesian<double> {};
+typedef CGAL::Simple_cartesian<double> K;
 
 // typedefs for the traits and the algorithm
 #include <CGAL/Segment_Delaunay_graph_2.h>
 #include <CGAL/Segment_Delaunay_graph_filtered_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h>
 
-typedef
-CGAL::Segment_Delaunay_graph_filtered_traits_2<Rep>
-Traits_x;
-
-struct Gt : public Traits_x {};
+typedef CGAL::Segment_Delaunay_graph_filtered_traits_2<K> Gt;
 
 #include "Multi_info.h"
 


### PR DESCRIPTION
The changes are in the sdg-generalize-philaris branch that can be merged to master.

Small feature page in the wiki:
https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/SDG_support_for_Linf_metric

Already merged in integration and tested in testsuite-Wednesday, CGAL-4.7-Ic-19:
https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.7-Ic-19.shtml

In the above testsuite, I checked the rows for: Segment_Delaunay_graph_2, Segment_Delaunay_graph_2_Demo, Segment_Delaunay_graph_2_Examples.
There is a warning in Segment_Delaunay_graph_2_Examples, which was also been there in previous testsuites and it seems to me to be from an over-fastidious compiler:

https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.7-Ic-19/Segment_Delaunay_graph_2_Examples/TestReport_lrineau_x86-64_Linux-Fedora19_g++-4.8_Release.gz