### PR TITLE
Polyedron_cut_plane_3 fix

### DIFF
--- a/HalfedgeDS/include/CGAL/halfedgeDS_cut_component.h
+++ b/HalfedgeDS/include/CGAL/halfedgeDS_cut_component.h
@@ -83,7 +83,11 @@ halfedgeDS_cut_component( HDS&                           hds,
             CGAL_assertion( g->next() != h && g->next()->opposite() != h);
             Halfedge_handle gnext = g->next()->opposite();
             D.remove_tip( g);
-            Vertex_handle v = D.vertices_push_back( Vertex());
+
+			/** Substituted Vertex_handle v = D.vertices_push_back( Vertex()) vertex creation by: */
+			Vertex_handle v = D.vertices_push_back(Vertex(pred.plane().projection(h->vertex()->point())));
+			/** Which is the vertex projection onto the cutting plane */
+
             D.close_tip( gnext, v);
             hnew = hds.edges_push_back( Halfedge(), Halfedge());
             hlast = hnew->opposite();
@@ -99,12 +103,12 @@ halfedgeDS_cut_component( HDS&                           hds,
                 // Create dummy edge and dummy vertex and attach it to g
                 g = hds.edges_push_back( Halfedge(), Halfedge());
                 D.insert_tip( g, gnext);
-                D.close_tip(g->opposite(), D.vertices_push_back(Vertex()));
+				D.close_tip(g->opposite(), D.vertices_push_back(Vertex(pred.plane().projection(h->vertex()->point()))));
                 D.set_vertex_halfedge( g);                
                 D.set_vertex_halfedge( g->opposite());                
             }
             D.remove_tip( g);
-            Vertex_handle v = D.vertices_push_back( Vertex());
+			Vertex_handle v = D.vertices_push_back(Vertex(pred.plane().projection(h->vertex()->point())));
             D.close_tip( hnew, v);
             D.insert_tip( gnext, hnew);
             hnew = hds.edges_push_back( Halfedge(), Halfedge());

--- a/Polyhedron/include/CGAL/polyhedron_cut_plane_3.h
+++ b/Polyhedron/include/CGAL/polyhedron_cut_plane_3.h
@@ -65,7 +65,7 @@ I_polyhedron_cut_component( Poly&                          poly,
     
 template < class Poly, class Plane, class Traits>
 class I_Polyhedron_cut_plane_predicate {
-    const Plane&  plane;
+    const Plane&  p;
     const Traits& traits;
 public:
     typedef typename Poly::Vertex_const_handle Vertex_const_handle;
@@ -74,6 +74,9 @@ public:
     bool operator()( Vertex_const_handle v) const {
         return traits.has_on_negative_side_3_object()( plane, v->point());
     }
+	const Plane & plane() const {
+		return p;
+	}
 };
 
 template <class Kernel>
@@ -121,8 +124,12 @@ polyhedron_cut_plane_3( Poly& poly,
     CGAL_precondition( pred( h->vertex()));
     CGAL_precondition( ! pred( h->opposite()->vertex()));
     h = I_polyhedron_cut_component( poly, h, pred);
+	/** We don't need this part of the code anymore, since the vertex 
+	/** calculation is going to be done inside I_polyhedron_cut_component 
+	/** method */
+
     // Assign geometry
-    h->facet()->plane() = plane;
+    /*h->facet()->plane() = plane;
     Halfedge_handle start = h;
     do {
         h->vertex()->point() = 
@@ -130,7 +137,8 @@ polyhedron_cut_plane_3( Poly& poly,
                              h->next()->opposite()->facet()->plane(),
                              h->opposite()->facet()->plane());
         h = h->next();
-    } while ( h != start);
+    } while ( h != start);*/
+
     CGAL_postcondition( poly.is_valid());
     return h;
 }


### PR DESCRIPTION
The standard polyhedron_cut_plane_3 function is not working. The problem is that I_Construct_point_3 function tries to calculate a new cut-point based on 3 undefined planes intersections. Therefore, the I_Construct_point_3 always returned the ORIGIN point. Even if you have planes that are well-defined, this algorithm will fail if you are trying to cut a polyhedral plane with a plane (two planes will be collinear in this case and the algorithm will fail).

I proposed a simple solution that worked partially: changed all Vertex() constructors from halfedgeDS_cut_component to Vertex(pred.getPlane().projection(h->vertex()->point())). Basically, this idea uses the projection of nearby mesh points into the plane to compute new vertices.

However, there's still one problem. The halfedgeDS_cut_component adds duplicated vertices to the cut edges, invalidating the polyhedron for futher operations as triangulate_polyhedron. 

I'm adding a snippet of the code to test the current polyhedron_cut_plane_3 function: http://pastebin.com/FkjSwfKY