### PR TITLE
Fix a bug in Triangulation_2_projection_traits.h and its filtered version

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
@@ -45,7 +45,7 @@ public:
   typedef Triangulation_2_projection_traits_3<Approximate_kernel> Filtering_traits;
 
 public:
-  Triangulation_2_filtered_projection_traits_3(const typename K::Vector_3& n)
+  explicit Triangulation_2_filtered_projection_traits_3(const typename K::Vector_3& n)
     : Base(n)
   {
   }
@@ -67,22 +67,34 @@ public:
     return *this;
   }
 
-#define CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(P, Pf, obj)    \
+#define CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(P, Pf, ACCESSOR)    \
   typedef  Filtered_predicate< \
     typename Exact_traits::P, \
     typename Filtering_traits::P, \
     C2E, \
     C2F > P; \
   P Pf() const { \
-    return P(this->normal()); \
+    return P(this->ACCESSOR()); \
   }
   // std::cerr << #P << "_object()\n";
   CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Orientation_2,
                                                orientation_2_object,
-                                               orientation)
+                                               normal)
   CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Side_of_oriented_circle_2,
                                                side_of_oriented_circle_2_object,
-                                               side_of_oriented_circle)
+                                               normal)
+  CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Less_x_2,
+					       less_x_2_object,
+					       base1)
+  CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Less_y_2,
+					       less_y_2_object,
+					       base2)
+  CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Compare_x_2,
+					       compare_x_2_object,
+					       base1)
+  CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Compare_y_2,
+					       compare_y_2_object,
+					       base2)
 }; // end class Triangulation_2_projection_traits_3<Filtered_kernel>
 
 } // end namespace CGAL

--- a/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
@@ -50,23 +50,6 @@ public:
   {
   }
 
-  Triangulation_2_filtered_projection_traits_3(const Self& other)
-    : Base(other)
-  {
-    CGAL_PROFILER("Copy of the filtered traits")
-    CGAL_TIME_PROFILER("Copy of the filtered traits")
-//     std::cerr << "Copy of the filtered traits.\n";
-  }
-
-  Self& operator=(const Self& other)
-  {
-    std::cerr << "Assignement of the filtered traits.\n";
-    if(this != &other) {
-      Base::operator=(other);
-    }
-    return *this;
-  }
-
 #define CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(P, Pf, ACCESSOR)    \
   typedef  Filtered_predicate< \
     typename Exact_traits::P, \
@@ -76,7 +59,6 @@ public:
   P Pf() const { \
     return P(this->ACCESSOR()); \
   }
-  // std::cerr << #P << "_object()\n";
   CGAL_TRIANGULATION_2_PROJ_TRAITS_FILTER_PRED(Orientation_2,
                                                orientation_2_object,
                                                normal)

--- a/Triangulation_2/include/CGAL/Triangulation_2_projection_traits_3.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2_projection_traits_3.h
@@ -83,14 +83,6 @@ public:
   {
     CGAL_PROFILER("Construct Projected_side_of_oriented_circle_with_normal_3.")
     CGAL_TIME_PROFILER("Construct Projected_side_of_oriented_circle_with_normal_3.")
-//     std::cerr << "Projected_side_of_oriented_circle_with_normal_3(" << normal_ << ")\n";
-  }
-
-  Projected_side_of_oriented_circle_with_normal_3(const Self& other)
-    : normal(other.normal)
-  {
-    CGAL_PROFILER("Copy Projected_side_of_oriented_circle_with_normal_3::operator()")
-    CGAL_TIME_PROFILER("Copy Projected_side_of_oriented_circle_with_normal_3::operator()")
   }
 
   Oriented_side operator()(const Point& p,
@@ -101,7 +93,6 @@ public:
     CGAL_PROFILER("Projected_side_of_oriented_circle_with_normal_3::operator()")
     CGAL_TIME_PROFILER("Projected_side_of_oriented_circle_with_normal_3::operator()")
     const Vector_3& u = normal;
-//     std::cerr << "Projected_side_of_oriented_circle_with_normal_3::operator(). Normal=" << normal << ")\n";
 
     const Vector_3 tp = p - t;
     const Vector_3 tq = q - t;
@@ -326,30 +317,6 @@ public:
       b1 = Vector_3(ny, -nx, 0);
     }
     b2 = cross_product(n, b1);
-    // std::cerr << "\nTriangulation_2_projection_traits_3(" << b1 << "\n"
-    // 	      << "                                    " << b2 << "\n"
-    // 	      << "                                    " << n << "\n";
-  }
-
-  Triangulation_2_projection_traits_3(const Self& other)
-    : n(other.n), b1(other.b1), b2(other.b2)
-  {
-//     std::cerr << "Copy of a traits. Type="
-//               << typeid(*this).name() << std::endl
-//               << "normal=" << normal() << std::endl;
-  }
-
-  Self& operator=(const Self& other)
-  {
-    std::cerr << "Assign of a non-filtrered projected traits. Type="
-              << typeid(*this).name() << std::endl;
-    if(this != &other) {
-      n = other.n;
-      b1 = other.b1;
-      b2 = other.b2;
-    }
-    std::cerr << "Normal="<< this->normal() << std::endl;
-    return *this;
   }
 
   const Vector_3& normal() const

--- a/Triangulation_2/include/CGAL/Triangulation_2_projection_traits_3.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2_projection_traits_3.h
@@ -308,9 +308,7 @@ public:
     const FT& nx = n.x();
     const FT& ny = n.y();
     const FT& nz = n.z();
-    const FT anz = CGAL::abs(nz);
-    if(anz >= CGAL::abs(nx) &&
-       anz >= CGAL::abs(ny)) { // z is the max absolute coordinate of n
+    if(CGAL::abs(nz) >= CGAL::abs(ny)) {
       b1 = Vector_3(nz, 0, -nx);
     }
     else {

--- a/Triangulation_2/test/Triangulation_2/test_cdt_2_projection_traits_special_case.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_cdt_2_projection_traits_special_case.cpp
@@ -1,0 +1,79 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Triangulation_2_projection_traits_3.h>
+#include <CGAL/Triangulation_2_filtered_projection_traits_3.h>
+
+#include <string>
+#include <fstream>
+
+
+typedef const double vec[3];
+const vec input[10] =
+{ { -0.37503900000000001, 0.5, 0.47710999999999998                     },
+  { -0.37503900000000001, 0.5, 0.31415300000000002                     },
+  { -0.37503900000000001, 0.5, 0.151196                                },
+  { -0.37503900000000001, 0.10979194793565403, 0.151196                },
+  { -0.37503899999999996, -0.049577392484619259, 0.151196              },
+  { -0.37503900000000001, -0.18584700000000001, 0.151196               },
+  { -0.37503900000000001, -0.062128898913781927, 0.20998675245268067   },
+  { -0.37503900000000001, 0.11124288530418507, 0.29237289933619037     },
+  { -0.37503900000000001, 0.20409758712826165, 0.33649738670770629     },
+  { -0.37503900000000001, 0.29695228895233827, 0.38062187407922232     } };
+
+const vec input_normal = { 1., 0., 0. };
+
+template <typename Kernel, typename CDT_2_traits>
+bool test(std::string test_name)
+{
+  std::cerr << "Testing " << test_name << std::endl;
+  const unsigned nb_input_points = sizeof(input)/sizeof(vec);
+
+  typedef CGAL::Constrained_triangulation_face_base_2<CDT_2_traits>  CDT_2_fb;
+  typedef CGAL::Triangulation_vertex_base_2<CDT_2_traits>            CDT_2_vb;
+  typedef CGAL::Triangulation_data_structure_2<CDT_2_vb, CDT_2_fb>  CDT_2_tds;
+  typedef CGAL::No_intersection_tag                                CDT_2_itag;
+  typedef CGAL::Constrained_Delaunay_triangulation_2<CDT_2_traits,
+                                                     CDT_2_tds,
+                                                     CDT_2_itag>        CDT_2;
+
+  typename Kernel::Vector_3 normal(input_normal[0],
+                                   input_normal[1],
+                                   input_normal[2]);
+  CDT_2_traits traits(normal);
+  CDT_2 cdt(traits);
+  typedef typename CDT_2::Vertex_handle Vh;
+
+  Vh first, previous;
+  for(unsigned i = 0; i < nb_input_points; ++i)
+  {
+    typename Kernel::Point_3 p(input[i][0], input[i][1], input[i][2]);
+    Vh current = cdt.insert(p);
+    assert(current != previous);
+    if(previous != Vh()) cdt.insert_constraint(previous, current);
+    if(first == Vh()) first = current;
+    previous = current;
+  }
+  assert(first != Vh());
+  assert(previous != first);
+  cdt.insert_constraint(previous, first);
+  return cdt.is_valid();
+}
+
+int main()
+{
+  std::cerr.precision(17);
+  typedef CGAL::Exact_predicates_exact_constructions_kernel   Epeck;
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel Epick;
+
+  bool ok = true;
+  ok = ok &&
+      test<CGAL::Epick,
+           CGAL::Triangulation_2_filtered_projection_traits_3<Epick> >
+      ("CDT_2 in a 3D plane, with Epick");
+  ok = ok &&
+      test<CGAL::Epeck,
+           CGAL::Triangulation_2_projection_traits_3<Epeck> >
+      ("CDT_2 in a 3D plane, with Epeck");
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
There is a bug in the traits class for `Triangulation_2` that can use 3D points in an arbitrary plane (knowing the normal to the plane). The first commit  907201e shows a test case that fails. The second commit 5ea63b7 fixes the bug.

In CGAL, those traits classes are used only in the function that triangulates the faces of a non-triangle polyhedron.
