### PR TITLE
Move functor that detect non void attributes and point in CGAL namespace.

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_functors.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_functors.h
@@ -24,6 +24,7 @@
 #include <CGAL/Combinatorial_map_basic_operations.h>
 #include <CGAL/internal/Combinatorial_map_internal_functors.h>
 #include <vector>
+#include <boost/mpl/has_xxx.hpp>
 
 /* Definition of functors used to manage attributes (we need functors as
  * attributes are stored in tuple, thus all the access must be done at
@@ -44,6 +45,13 @@
  *
  * Test_is_valid_attribute_functor<CMap> to test if an attribute is valid
  *    (used with Foreach_enabled_attributes)
+ *
+ * Is_attribute_has_non_void_info<Attr> to test if the attribute
+ *   Attr is non Void and has an non void Info as inner type
+ *
+ * Is_attribute_has_point<Attr> to test if the attribute
+ *   Attr is non Void and has a Point inner type
+ *
  */
 
 namespace CGAL
@@ -126,6 +134,34 @@ struct Set_i_attribute_functor<CMap,i,CGAL::Void>
                    typename CMap::template Attribute_handle<i>::type)
   {}
 };
+// ****************************************************************************
+BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_point,Point,false)
+
+template<typename Attr, typename Info=typename Attr::Info>
+struct Is_nonvoid_attribute_has_non_void_info
+{
+  static const bool value=true;
+};
+template<typename Attr>
+struct Is_nonvoid_attribute_has_non_void_info<Attr, void>
+{
+  static const bool value=false;
+};
+
+template<typename Attr>
+struct Is_attribute_has_non_void_info
+{
+  static const bool value=Is_nonvoid_attribute_has_non_void_info<Attr>::value;
+};
+template<>
+struct Is_attribute_has_non_void_info<CGAL::Void>
+{
+  static const bool value=false;
+};
+// ****************************************************************************
+template<typename Attr>
+struct Is_attribute_has_point
+{ static const bool value=Has_point<Attr>::value; };
 // ****************************************************************************
 } // namespace CGAL
 

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_copy_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_copy_functors.h
@@ -21,7 +21,7 @@
 #define CGAL_COMBINATORIAL_MAP_COPY_FUNCTORS_H
 
 #include <CGAL/internal/Combinatorial_map_utility.h>
-#include <CGAL/internal/Combinatorial_map_internal_functors.h>
+#include <CGAL/Combinatorial_map_functors.h>
 #include <CGAL/Dimension.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Cartesian_converter.h>
@@ -162,10 +162,10 @@ struct Get_convert_attribute_functor<Map1,Map2,i,Converters,false>
 // Call a given functor if both i-attribute have an non void info
 template< typename Map1, typename Map2, unsigned int i,
           typename Converters,
-          bool Withinfo1=CGAL::internal::template
+          bool Withinfo1=CGAL::template
           Is_attribute_has_non_void_info
           <typename Map1::template Attribute_type<i>::type>::value,
-          bool Withinfo2=CGAL::internal::template
+          bool Withinfo2=CGAL::template
           Is_attribute_has_non_void_info
           <typename Map2::template Attribute_type<i>::type>::value >
 struct Call_functor_if_both_attributes_have_info
@@ -199,9 +199,9 @@ struct Call_functor_if_both_attributes_have_info<Map1, Map2, i,
 // general case i!=0 or one attribute without point.
 template< typename Map1, typename Map2, unsigned int i,
           typename Pointconverter,
-          bool Withpoint1=CGAL::internal::template Is_attribute_has_point
+          bool Withpoint1=CGAL::template Is_attribute_has_point
           <typename Map1::template Attribute_type<i>::type>::value,
-          bool Withpoint2=CGAL::internal::template Is_attribute_has_point
+          bool Withpoint2=CGAL::template Is_attribute_has_point
           <typename Map2::template Attribute_type<i>::type>::value >
 struct Call_functor_if_both_attributes_have_point
 {
@@ -288,7 +288,7 @@ struct Copy_attribute_functor_if_nonvoid<Map1, Map2, Converters,
     if ( cmap2->template attribute<0>(dh2)!=Map2::null_handle ) return;
 
     // Create the point if 0-attributes has Point.
-    if ( CGAL::internal::template Is_attribute_has_point
+    if ( CGAL::template Is_attribute_has_point
          <typename Map2::template Attribute_type<0>::type>::value )
       cmap2->template
           set_attribute<0>(dh2, cmap2->template create_attribute<0>());

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_group_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_group_functors.h
@@ -21,7 +21,6 @@
 #define CGAL_COMBINATORIAL_MAP_GROUP_FUNCTORS_H
 
 #include <CGAL/Unique_hash_map.h>
-#include <CGAL/internal/Combinatorial_map_internal_functors.h>
 #include <CGAL/Combinatorial_map_functors.h>
 
 /* Definition of functors used to group/ungroup attributes (we need functors

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
@@ -25,7 +25,6 @@
 #include <CGAL/Dimension.h>
 #include <CGAL/Kernel_traits.h>
 #include <vector>
-#include <boost/mpl/has_xxx.hpp>
 
 /* Definition of functors used internally to manage attributes (we need
  * functors as attributes are stored in tuple, thus all the access must be
@@ -65,12 +64,6 @@
  * internal::Test_is_same_attribute_functor<Map1, Map2> to test if two
  *   i-attributes of two darts are isomorphic.
  *
- * internal::Is_attribute_has_non_void_info<Attr> to test if the attribute
- *   Attr is non Void and has an non void Info as inner type
- *
- * internal::Is_attribute_has_point<Attr> to test if the attribute
- *   Attr is non Void and has a Point inner type
- *
  * internal::Reverse_orientation_of_map_functor<CMap> to reverse the
  *   orientation of a whole combinatorial map
  *
@@ -83,6 +76,11 @@
 
 namespace CGAL
 {
+//-----------------------------------------------------------------------------
+template<typename Attr>
+struct Is_attribute_has_non_void_info;
+template<typename Attr>
+struct Is_attribute_has_point;
 // ****************************************************************************
 namespace internal
 {
@@ -637,34 +635,6 @@ struct Is_same_attribute_point_functor<Map1, Map2, T1, T2, false, false, i>
                   typename Map2::Dart_const_handle)
   { return true; }
 };
-// ****************************************************************************
-BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_point,Point,false)
-
-template<typename Attr, typename Info=typename Attr::Info>
-struct Is_nonvoid_attribute_has_non_void_info
-{
-  static const bool value=true;
-};
-template<typename Attr>
-struct Is_nonvoid_attribute_has_non_void_info<Attr, void>
-{
-  static const bool value=false;
-};
-
-template<typename Attr>
-struct Is_attribute_has_non_void_info
-{
-  static const bool value=Is_nonvoid_attribute_has_non_void_info<Attr>::value;
-};
-template<>
-struct Is_attribute_has_non_void_info<CGAL::Void>
-{
-  static const bool value=false;
-};
-// ****************************************************************************
-template<typename Attr>
-struct Is_attribute_has_point
-{ static const bool value=Has_point<Attr>::value; };
 // ****************************************************************************
 /// Test if the two darts are associated with the same attribute.
 template<typename Map1, typename Map2>

--- a/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
+++ b/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
@@ -129,6 +129,7 @@ namespace CGAL {
                            Functor_on_merge_, Functor_on_split_> Base1;
     typedef Point_for_cell<typename LCC::Point> Base2;
 
+    typedef void                            Info;
     typedef typename LCC::Point             Point;
     typedef typename LCC::Dart_handle       Dart_handle;
     typedef typename LCC::Dart_const_handle Dart_const_handle;


### PR DESCRIPTION
(before they were in internal); add a missing void typedef.

For now, let the functor undocumented.

Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.7-Ic-33.shtml.