### PR TITLE
Remove the -g flag in testsuites

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -476,6 +476,16 @@ if ( CMAKE_COMPILER_IS_GNUCXX )
   
     if ( RUNNING_CGAL_AUTO_TEST )
       uniquely_add_flags( CGAL_CXX_FLAGS "-Wall" )
+      # Remove -g from the relevant CXX_FLAGS. This will also
+      # propagate to the rest of the tests, since we overwrite those
+      # flags with the ones used to build CGAL.
+      string(REGEX REPLACE "-g( |$)" ""
+        CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS}")
+      string( TOUPPER "${CMAKE_BUILD_TYPE}" CGAL_BUILD_TYPE_UPPER )
+      string(REGEX REPLACE "-g( |$)" ""
+        CMAKE_CXX_FLAGS_${CGAL_BUILD_TYPE_UPPER}
+        "${CMAKE_CXX_FLAGS_${CGAL_BUILD_TYPE_UPPER}}")
     endif()
     
     if ( "${GCC_VERSION}" MATCHES "^[4-9]." )


### PR DESCRIPTION
While it might seem cleaner to simply add the -g0 argument, removing -g
is safer: -g0 would need to be added after any possible -g flags. Since
CMake makes no guarantees how the COMPILE_OPTIONS of a target are
actually initialized and we cannot change them on an individual basis
this is not easy to achieve. Hence we strip the CXX_FLAGS of -g. This
also still allows specifying it manually through CGAL_CXX_FLAGS.