### PR TITLE
Fix a compilation error with gcc44 -std=c++0x

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1207,7 +1207,8 @@ private:
       Intersection intersection = construct_intersection(dual);
       Surface_patch surface =
         (CGAL::cpp0x::get<2>(intersection) == 0) ? Surface_patch() :
-        domain_.surface_patch_index(CGAL::cpp0x::get<1>(intersection));
+        Surface_patch(
+          domain_.surface_patch_index(CGAL::cpp0x::get<1>(intersection)));
 
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
 

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1641,8 +1641,8 @@ compute_facet_properties(const Facet& facet,
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
       fp =  Facet_properties(CGAL::cpp11::make_tuple(*surface,
-                                               CGAL::cpp11::get<1>(intersect),
-                                               CGAL::cpp11::get<0>(intersect)));
+                                    CGAL::cpp11::get<1>(intersect),
+                                    Point(CGAL::cpp11::get<0>(intersect))));
       return;
     }
   }
@@ -1673,12 +1673,12 @@ compute_facet_properties(const Facet& facet,
           r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
-        {
-          fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
-                                              CGAL::cpp11::get<1>(intersect),
-                                              CGAL::cpp11::get<0>(intersect)));
-          return;
-        }
+       {
+         fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
+                                       CGAL::cpp11::get<1>(intersect),
+                                       Point(CGAL::cpp11::get<0>(intersect))));
+         return;
+       }
       
     }
   }
@@ -1716,8 +1716,8 @@ compute_facet_properties(const Facet& facet,
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
        {
 	      fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
-                                              CGAL::cpp11::get<1>(intersect),
-                                              CGAL::cpp11::get<0>(intersect)));
+                                       CGAL::cpp11::get<1>(intersect),
+                                       Point(CGAL::cpp11::get<0>(intersect))));
           return;
        }
     }

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1673,13 +1673,12 @@ compute_facet_properties(const Facet& facet,
           r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
-       {
-         fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
-                                       CGAL::cpp11::get<1>(intersect),
-                                       Point(CGAL::cpp11::get<0>(intersect))));
-         return;
-       }
-      
+      {
+        fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
+                                      CGAL::cpp11::get<1>(intersect),
+                                      Point(CGAL::cpp11::get<0>(intersect))));
+        return;
+      }
     }
   }
   // If the dual is a line
@@ -1714,12 +1713,12 @@ compute_facet_properties(const Facet& facet,
           r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
-       {
-	      fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
-                                       CGAL::cpp11::get<1>(intersect),
-                                       Point(CGAL::cpp11::get<0>(intersect))));
-          return;
-       }
+      {
+       fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
+                                     CGAL::cpp11::get<1>(intersect),
+                                     Point(CGAL::cpp11::get<0>(intersect))));
+       return;
+      }
     }
   }
   else

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1635,7 +1635,8 @@ compute_facet_properties(const Facet& facet,
       // the later does not work.
       Surface_patch surface =
         (CGAL::cpp11::get<2>(intersect) == 0) ? Surface_patch() :
-        r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect));
+        Surface_patch(
+          r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
       fp =  Facet_properties(CGAL::cpp11::make_tuple(*surface,
@@ -1667,7 +1668,8 @@ compute_facet_properties(const Facet& facet,
 #ifdef CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
       Surface_patch surface =
         (CGAL::cpp11::get<2>(intersect) == 0) ? Surface_patch() :
-        r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect));
+        Surface_patch(
+          r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
         {

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1595,9 +1595,10 @@ compute_facet_properties(const Facet& facet,
   // Functor
   typename Gt::Is_degenerate_3 is_degenerate = Gt().is_degenerate_3_object();
   typename Gt::Compare_xyz_3 compare_xyz = Gt().compare_xyz_3_object();
+#ifndef CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
   typename MD::Do_intersect_surface do_intersect_surface =
       r_oracle_.do_intersect_surface_object();
-
+#endif // not CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
 
   // Get dual of facet
   Object dual = (force_exact ? dual_exact(facet) : r_tr_.dual(facet));
@@ -1616,7 +1617,7 @@ compute_facet_properties(const Facet& facet,
       typename MD::Construct_intersection construct_intersection =
           r_oracle_.construct_intersection_object();
 
-      // Trick to have canonical vector : thus, we compute alwais the same
+      // Trick to have canonical vector : thus, we compute always the same
       // intersection
       Segment_3 segment = *p_segment;
       if ( compare_xyz(p_segment->source(),p_segment->target())
@@ -1684,13 +1685,15 @@ compute_facet_properties(const Facet& facet,
   // If the dual is a line
   else if ( const Line_3* p_line = object_cast<Line_3>(&dual) )
   {
+#ifndef CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
     Surface_patch surface = do_intersect_surface(*p_line);
     if ( surface )
+#endif // not CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
     {
       typename MD::Construct_intersection construct_intersection =
           r_oracle_.construct_intersection_object();
 
-      // Trick to have canonical vector : thus, we compute alwais the same
+      // Trick to have canonical vector : thus, we compute always the same
       // intersection
       Line_3 line = *p_line;
       typename Gt::Compare_xyz_3 compare_xyz = Gt().compare_xyz_3_object();
@@ -1704,10 +1707,19 @@ compute_facet_properties(const Facet& facet,
       }
 
       Intersection intersect = construct_intersection(line);
-      fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
+#ifdef CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
+      Surface_patch surface =
+        (CGAL::cpp11::get<2>(intersect) == 0) ? Surface_patch() :
+        Surface_patch(
+          r_oracle_.surface_patch_index(CGAL::cpp11::get<1>(intersect)));
+      if(surface)
+#endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
+       {
+	      fp = Facet_properties(CGAL::cpp11::make_tuple(*surface,
                                               CGAL::cpp11::get<1>(intersect),
                                               CGAL::cpp11::get<0>(intersect)));
-      return;
+          return;
+       }
     }
   }
   else


### PR DESCRIPTION
Should fix issue https://github.com/CGAL/cgal/issues/121

The error was that the "domain" class returns a `CGAL::Point_3<K>`, the
triangulation uses `CGAL::Weighted_point<CGAL::Point_3<K>, double>`, and
one piece of code from Mesh_3 in <CGAL/Mesh_3/Refine_facets_3.h> does an
implicit conversion from

    tuple<something_A, something_B, CGAL::Point_3<K> >
to

    tuple<something_A, something_B, CGAL::Weighted_point<P, double> >

and plug that into a `boost::optional`. For some reason, the g++-4.4
compiler does not like that, but recent g++ compilers do.

The fix is to explicit the conversion from `Point_3` to
`Weighted_point<Point_3, double>`.