### PR TITLE
Add Compact_container::is_used(Handle)

### DIFF
--- a/Combinatorial_map/doc/Combinatorial_map/Concepts/CombinatorialMap.h
+++ b/Combinatorial_map/doc/Combinatorial_map/Concepts/CombinatorialMap.h
@@ -323,6 +323,10 @@ Returns the number of <I>i</I>-attributes in the combinatorial map.
 template <unsigned int i>
 size_type number_of_attributes() const;
 
+/*! Returns true if dh points to a used dart (i.e. valid).
+ */
+bool is_dart_used(Dart_const_handle dh) const;
+
 /*!
 Returns \f$ \beta_j\f$(\f$ \beta_i\f$(`*dh`)).
 Overloads of this member function are defined that take from one to nine integer as arguments.
@@ -500,6 +504,12 @@ A shorcut for \link CombinatorialMap::dart_of_attribute(typename Attribute_const
 */
 template<unsigned int i>
 Dart_const_handle dart(Dart_const_handle adart) const;
+
+/*! Returns true if ah points to a used i-attribute (i.e. valid).
+\pre 0\f$ \leq\f$<I>i</I>\f$ \leq\f$\ref CombinatorialMap::dimension "dimension", and <I>i</I>-attributes are non `void`.
+ */
+template<unsigned int i>
+bool is_attribute_used(typename Attribute_const_handle<i>::type ah) const;
 
 /// @}
 

--- a/Combinatorial_map/doc/Combinatorial_map/Concepts/CombinatorialMap.h
+++ b/Combinatorial_map/doc/Combinatorial_map/Concepts/CombinatorialMap.h
@@ -323,7 +323,7 @@ Returns the number of <I>i</I>-attributes in the combinatorial map.
 template <unsigned int i>
 size_type number_of_attributes() const;
 
-/*! Returns true if dh points to a used dart (i.e. valid).
+/*! Returns true if dh points to a used dart (i.e.\ valid).
  */
 bool is_dart_used(Dart_const_handle dh) const;
 
@@ -505,7 +505,7 @@ A shorcut for \link CombinatorialMap::dart_of_attribute(typename Attribute_const
 template<unsigned int i>
 Dart_const_handle dart(Dart_const_handle adart) const;
 
-/*! Returns true if ah points to a used i-attribute (i.e. valid).
+/*! Returns true if ah points to a used i-attribute (i.e.\ valid).
 \pre 0\f$ \leq\f$<I>i</I>\f$ \leq\f$\ref CombinatorialMap::dimension "dimension", and <I>i</I>-attributes are non `void`.
  */
 template<unsigned int i>

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -468,6 +468,10 @@ namespace CGAL {
       mdarts.erase(adart);
     }
 
+    /// @return true if dh points to a used dart (i.e. valid).
+    bool is_dart_used(Dart_const_handle dh) const
+    { return mdarts.is_used(dh); }
+
     /// @return a Dart_range (range through all the darts of the map).
     Dart_range& darts()             { return mdarts;}
     Dart_const_range& darts() const { return mdarts; }
@@ -1441,6 +1445,16 @@ namespace CGAL {
                   "erase_attribute<i> but i-attributes are disabled");
       CGAL::cpp11::get<Helper::template Dimension_index<i>::value>
         (mattribute_containers).erase(h);
+    }
+
+    /// @return true if ah points to a used i-attribute (i.e. valid).
+    template<unsigned int i>
+    bool is_attribute_used(typename Attribute_const_handle< i >::type ah) const
+    {
+      CGAL_static_assertion_msg(Helper::template Dimension_index<i>::value>=0,
+                                "is_attribute_used<i> but i-attributes are disabled");
+      return CGAL::cpp11::get<Helper::template Dimension_index<i>::value>
+        (mattribute_containers).is_used(ah);
     }
 
     /// @return the number of attributes.

--- a/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_2_test.h
+++ b/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_2_test.h
@@ -55,9 +55,13 @@ bool test2D()
     dh = map.create_dart ();
     dh2 = map.create_dart();
 
+    if (!map.is_dart_used(dh) ) return false;
+
     if ( map.is_valid() ) cout << "Map valid." << endl;
     cout << "Nombre de brins : " << map.number_of_darts() << endl;
     map.clear();
+
+    if ( map.is_dart_used(dh) ) return false;
 
     cout << "***************************** TEST BASIC CREATION 2D DONE."
          << endl;

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
@@ -130,6 +130,9 @@ bool test_LCC_2()
   if ( !check_number_of_cells_2(lcc, 6, 3, 6, 3) )
     return false;
 
+  typename LCC::Vertex_attribute_handle vh=lcc.template attribute<0>(dh1);
+  if (!lcc.template is_attribute_used<0>(vh)) return false;
+
   trace_test_begin();
   lcc.template sew<0>(dh2,dh1);
   lcc.template sew<1>(dh2,dh3);
@@ -244,6 +247,8 @@ bool test_LCC_2()
   CGAL::remove_cell<LCC,1>(lcc, dh3);
   if ( !check_number_of_cells_2(lcc, 0, 0, 0, 0) )
     return false;
+
+  if (lcc.template is_attribute_used<0>(vh)) return false;
 
   {
     trace_test_begin();

--- a/STL_Extension/doc/STL_Extension/CGAL/Compact_container.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Compact_container.h
@@ -511,6 +511,12 @@ size_type capacity() const;
 
 /// \name Access Member Functions 
 /// @{ 
+
+/*!
+returns true if the element `pos` is used (i.e.\ valid).
+*/
+bool is_used(const_iterator pos) const;
+
 /*!
 returns true if the element at position `i` in the container is used
 (i.e.\ valid).

--- a/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
@@ -196,6 +196,11 @@ complexity. No exception is thrown.
 /// \name Access Member Functions 
 /// @{ 
 
+  /*!
+  returns true if the element `pos` is used (i.e.\ valid).
+  */
+  bool is_used(const_iterator pos) const;
+
   /// returns a mutable iterator referring to the first element in `ccc`.
   iterator begin();
   /// returns a constant iterator referring to the first element in `ccc`.

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -860,7 +860,10 @@ void Compact_container<T, Allocator, Increment_policy, TimeStamper>::clear()
     size_type s = it->second;
     for (pointer pp = p + 1; pp != p + s - 1; ++pp) {
       if (type(pp) == USED)
+      {
         alloc.destroy(pp);
+        set_type(pp, NULL, FREE);
+      }
     }
     alloc.deallocate(p, s);
   }

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -308,6 +308,11 @@ public:
     delete time_stamper;
   }
 
+  bool is_used(const_iterator ptr) const
+  {
+    return (type(&*ptr)==USED);
+  }
+
   bool is_used(size_type i) const
   {
     typename Self::size_type block_number, index_in_block;

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -1077,8 +1077,8 @@ namespace internal {
     {
       CGAL_assertion_msg(m_ptr.p != NULL,
          "Incrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(DSC::type(m_ptr.p) == DSC::USED,
-                         "Incrementing an invalid iterator.");
+      /* CGAL_assertion_msg(DSC::type(m_ptr.p) == DSC::USED,
+         "Incrementing an invalid iterator."); */
       increment();
       return *this;
     }
@@ -1087,9 +1087,9 @@ namespace internal {
     {
       CGAL_assertion_msg(m_ptr.p != NULL,
          "Decrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(DSC::type(m_ptr.p) == DSC::USED
+      /*CGAL_assertion_msg(DSC::type(m_ptr.p) == DSC::USED
                       || DSC::type(m_ptr.p) == DSC::START_END,
-                         "Decrementing an invalid iterator.");
+                      "Decrementing an invalid iterator.");*/
       decrement();
       return *this;
     }

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -233,6 +233,11 @@ public:
     clear();
   }
 
+  bool is_used(const_iterator ptr) const
+  {
+    return (type(&*ptr)==USED);
+  }
+
   void swap(Self &c)
   {
     std::swap(m_alloc, c.m_alloc);

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -937,8 +937,8 @@ namespace CCC_internal {
     {
       CGAL_assertion_msg(m_ptr.p != NULL,
    "Incrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED,
-                         "Incrementing an invalid iterator.");
+      /* CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED,
+         "Incrementing an invalid iterator."); */
       increment();
       return *this;
     }
@@ -947,9 +947,9 @@ namespace CCC_internal {
     {
       CGAL_assertion_msg(m_ptr.p != NULL,
    "Decrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED
+      /* CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED
           || CCC::type(m_ptr.p) == CCC::START_END,
-                         "Decrementing an invalid iterator.");
+          "Decrementing an invalid iterator."); */
       decrement();
       return *this;
     }


### PR DESCRIPTION
Add is_used(const_iterator pos) functions in compact container and in concurrent compact container.
Comment two assertions, allowing to increment/decrement iterators on removed elements.

Small feature https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_is_used_handle
Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.7-Ic-65.shtml