### PR TITLE
Use get_filename_component to manipulate paths

### DIFF
--- a/Installation/src/CMakeLists.txt
+++ b/Installation/src/CMakeLists.txt
@@ -117,8 +117,9 @@ set(CGAL_CONFIGURED_LIBRARIES "")
 foreach(package ${CGAL_CONFIGURED_PACKAGES}) 
   file(GLOB CONFIGURED_LIBS_IN_PACKAGE ${package}/src/CGAL_*/CMakeLists.txt)
   foreach (libconfigfile ${CONFIGURED_LIBS_IN_PACKAGE})
-    string(REPLACE "${package}/src/" "" libconfigfile ${libconfigfile})
-    string(REPLACE "//CMakeLists.txt" "" CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile})
+    get_filename_component(CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile} DIRECTORY)
+    get_filename_component(CGAL_CONFIGURED_LIBRARY_NAME ${CGAL_CONFIGURED_LIBRARY_NAME} NAME)
+
     if (NOT ${CGAL_CONFIGURED_LIBRARY_NAME} STREQUAL "CGAL")
 
      message(STATUS "Sources for CGAL component library '${CGAL_CONFIGURED_LIBRARY_NAME}' detected")

--- a/Installation/src/CMakeLists.txt
+++ b/Installation/src/CMakeLists.txt
@@ -117,7 +117,7 @@ set(CGAL_CONFIGURED_LIBRARIES "")
 foreach(package ${CGAL_CONFIGURED_PACKAGES}) 
   file(GLOB CONFIGURED_LIBS_IN_PACKAGE ${package}/src/CGAL_*/CMakeLists.txt)
   foreach (libconfigfile ${CONFIGURED_LIBS_IN_PACKAGE})
-    get_filename_component(CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile} DIRECTORY)
+    get_filename_component(CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile} PATH)
     get_filename_component(CGAL_CONFIGURED_LIBRARY_NAME ${CGAL_CONFIGURED_LIBRARY_NAME} NAME)
 
     if (NOT ${CGAL_CONFIGURED_LIBRARY_NAME} STREQUAL "CGAL")


### PR DESCRIPTION
Replaces #131 from Philipp:

> This caused a bug in CMake>=3.3.0 when file(GLOB) is not adding multiple
> slashes. The lack of trailing slashes is guaranteed and documented in
> `get_filename_component`.

> Verified against a build of Kitware/CMake@f4144af

The initial patch from #131 was not right, for CMake<=2.8.11. I have:
  - rebased the branch onto `releases/CGAL-4.6-branch`,
  - added a commit to use `PATH` instead of `DIRECTORY`.
