### PR TITLE
Do not check for the actual CMAKE_BUILD_TYPE

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -476,16 +476,20 @@ if ( CMAKE_COMPILER_IS_GNUCXX )
   
     if ( RUNNING_CGAL_AUTO_TEST )
       uniquely_add_flags( CGAL_CXX_FLAGS "-Wall" )
-      # Remove -g from the relevant CXX_FLAGS. This will also
+      # Remove -g from the relevant CMAKE_CXX_FLAGS. This will also
       # propagate to the rest of the tests, since we overwrite those
       # flags with the ones used to build CGAL.
       string(REGEX REPLACE "-g( |$)" ""
         CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS}")
-      string( TOUPPER "${CMAKE_BUILD_TYPE}" CGAL_BUILD_TYPE_UPPER )
-      string(REGEX REPLACE "-g( |$)" ""
-        CMAKE_CXX_FLAGS_${CGAL_BUILD_TYPE_UPPER}
-        "${CMAKE_CXX_FLAGS_${CGAL_BUILD_TYPE_UPPER}}")
+      # We only allow the release types DEBUG and RELEASE, but handle
+      # all possible values just to be sure.
+      foreach(release_type DEBUG RELEASE MINSIZEREL RELWITHDEBINFO)
+        string(REGEX REPLACE "-g( |$)" ""
+          CMAKE_CXX_FLAGS_${release_type}
+          "${CMAKE_CXX_FLAGS_${release_type}}")
+      endforeach()
+
     endif()
     
     if ( "${GCC_VERSION}" MATCHES "^[4-9]." )


### PR DESCRIPTION
If CMAKE_BUILD_TYPE is not set in the initial run, is only
defined *after* this code is run. Since the build type is cached this
seemed to work when a cmake cache was already present, but not without.