### PR TITLE
make cgal_create_CMakeLists recognize all common C++ source file extensions

### DIFF
--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -35,6 +35,12 @@ make
 where the second line creates a `CMakeLists.txt` file (check
 its options in Section \ref seccreate_cgal_CMakeLists for various details).
 
+Note that, until CGAL 4.6, \ref seccreate_cgal_CMakeLists only recognized
+source files ending in `.cpp` or `.C`; if the above fails on the `cmake` command
+or produces an empty Makefile, check whether your source files go by such a name.
+Recent versions find all source files ending in
+`.cc`, `.cp`, `.cxx`, `.cpp`, `.CPP`, `.c++`, or `.C`.
+
 In a less ideal world, you probably have to install CMake, a makefile
 generator, and third party libraries. That is what this manual is about.
 
@@ -952,8 +958,9 @@ configuration.
 <DL>
 <DT><B>`-s source`</B><DD> If this parameter is given the script will
 create <B>a single executable</B> for 'source' linked with
-compilations of all other source files (`*.cpp`). This
-behaviour is usually needed for (graphical) demos. 
+compilations of all other source files
+(`*.cc`, `*.cp`, `*.cxx`, `*.cpp`, `*.CPP`, `*.c++`, or `*.C`).
+This behaviour is usually needed for (graphical) demos. 
 
 If the parameter is not given, the script creates <B>one executable for each given
 source file</B>.
@@ -983,7 +990,7 @@ contained in the `CGAL-\cgalReleaseNumber``/scripts` directory. It can be used
 to create `CMakeLists.txt` files for compiling \cgal
 applications. Executing `cgal_create_cmake_script` in an
 application directory creates a `CMakeLists.txt` containing
-rules for every `*.cpp` file there. The script is deprecated,
+rules for every C++ source file there. The script is deprecated,
 as it only works for applications with a single course file that only
 need libCGAL and libCGAL_Core.
 

--- a/Scripts/developer_scripts/create_cgal_test
+++ b/Scripts/developer_scripts/create_cgal_test
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #
 # =============================================================================
 # $URL: svn+ssh://fcacciola@scm.gforge.inria.fr/svn/cgal/trunk/Scripts/developer_scripts/create_cgal_test $
@@ -9,8 +9,8 @@
 # coordinator   : Utrecht University
 # =============================================================================
 #
-# This script creates a cgal_test_with_cmake script with entries for all .C and .cpp
-# files in the current test directory.
+# This script creates a cgal_test_with_cmake script with entries for files with a common
+# C++ file extension (as mentioned in the g++ man page) in the current test directory.
 
 VERSION=1.1
 
@@ -156,13 +156,18 @@ EOF
   # C:\Windows\system32 is used instead of /usr/bin/sort
   PATH=/usr/bin:$PATH
 
-  for file in `ls *.C *.cpp 2>/dev/null | sort` ; do
+  for file in `ls *.cc *.cp *.cxx *.cpp *.CPP *.c++ *.C 2> /dev/null | sort` ; do
     if [ -n "`grep '\<main\>' $file`" ] ; then
-      tmp=`basename $file .C`
-      tmp=`basename $tmp .cpp`
+      BASE=`basename $file .cc`
+      BASE=`basename $BASE .cp`
+      BASE=`basename $BASE .cxx`
+      BASE=`basename $BASE .cpp`
+      BASE=`basename $BASE .CPP`
+      BASE=`basename $BASE .c++`
+      BASE=`basename $BASE .C`
       cat <<EOF
-if grep -qE "^${tmp}:" Makefile; then
-  compile_and_run $tmp
+if grep -qE "^${BASE}:" Makefile; then
+  compile_and_run $BASE
   NEED_CLEAN=y
 fi
 EOF

--- a/Scripts/scripts/cgal_create_CMakeLists
+++ b/Scripts/scripts/cgal_create_CMakeLists
@@ -23,8 +23,9 @@
 #
 # Author(s)     : various
 
-# This script creates a CGAL cmake script with entries for .C and .cpp
-# files in the current directory - some options can be given or specified in a file
+# This script creates a CGAL cmake script with entries for files with a common
+# C++ file extension (as mentioned in the g++ man page) in the current directory.
+# Some options can be given or specified in a file.
 
 
 #LEDA
@@ -364,7 +365,7 @@ EOF
     cat << 'EOF'
 
 
-# Creating entries for all .cpp/.C files with "main" routine
+# Creating entries for all C++ files with "main" routine
 # ##########################################################
 
 EOF
@@ -392,10 +393,15 @@ if ( CGAL_Qt3_FOUND AND QT3_FOUND )
 EOF
       #-----------------------------------------------------------------------
 
-      for file in `ls *.C *.cpp 2> /dev/null | sort` ; do
+      for file in `ls *.cc *.cp *.cxx *.cpp *.CPP *.c++ *.C 2> /dev/null | sort` ; do
         # Create an executable for each cpp that  contains a function "main()"
-        BASE=`basename $file .C`
+        BASE=`basename $file .cc`
+        BASE=`basename $BASE .cp`
+        BASE=`basename $BASE .cxx`
         BASE=`basename $BASE .cpp`
+        BASE=`basename $BASE .CPP`
+        BASE=`basename $BASE .c++`
+        BASE=`basename $BASE .C`
         egrep '\bmain[ \t]*\(' $file >/dev/null 2>&1
         if [ $? -eq 0 ]; then
           echo "qt3_automoc( ${file} )"
@@ -435,10 +441,15 @@ EOF
       #-----------------------------------------------------------------------
     fi # qt4
 
-    for file in `ls *.C *.cpp 2> /dev/null | sort`; do
+    for file in `ls *.cc *.cp *.cxx *.cpp *.CPP *.c++ *.C 2> /dev/null | sort` ; do
       # Create an executable for each cpp that  contains a function "main()"
-      BASE=`basename $file .C`
+      BASE=`basename $file .cc`
+      BASE=`basename $BASE .cp`
+      BASE=`basename $BASE .cxx`
       BASE=`basename $BASE .cpp`
+      BASE=`basename $BASE .CPP`
+      BASE=`basename $BASE .c++`
+      BASE=`basename $BASE .C`
       egrep '\bmain[ \t]*\(' $file >/dev/null 2>&1
       if [ $? -eq 0 ]; then
         if [ "$qt4" = "y" ]; then
@@ -486,7 +497,7 @@ EOF
 EOF
     #-------------------------------------------------------------------------
 
-    for file in `ls *.C *.cpp 2> /dev/null | sort`; do
+    for file in `ls *.cc *.cp *.cxx *.cpp *.CPP *.c++ *.C 2> /dev/null | sort` ; do
       all="$all $file"
     done
 
@@ -556,8 +567,14 @@ EOF
           MOC_FILES="${BASE}.moc $MOC_FILES"
         fi
       done
-      for file in `ls *.cpp 2> /dev/null | sort`; do
-        BASE=`basename $file .cpp`
+      for file in `ls *.cc *.cp *.cxx *.cpp *.CPP *.c++ *.C 2> /dev/null | sort` ; do
+        BASE=`basename $file .cc`
+        BASE=`basename $BASE .cp`
+        BASE=`basename $BASE .cxx`
+        BASE=`basename $BASE .cpp`
+        BASE=`basename $BASE .CPP`
+        BASE=`basename $BASE .c++`
+        BASE=`basename $BASE .C`
         egrep 'Q_OBJECT' $file >/dev/null 2>&1
         if [ $? -eq 0 ]; then
           echo "  qt4_generate_moc( ${BASE}.cpp ${BASE}.moc )"
@@ -641,8 +658,38 @@ while getopts s:c:b:o:phvt OPT; do
   case "$OPT" in
     s)  SINGLE_SOURCE='y'
         SOURCE=$OPTARG
+        if [ "${SOURCE:(-3)}" = ".cc" ]; then
+           echo "Error: Source must not end with '.cc'!" >&2
+           echo
+           usage
+           exit 2
+        fi
+        if [ "${SOURCE:(-3)}" = ".cp" ]; then
+           echo "Error: Source must not end with '.cp'!" >&2
+           echo
+           usage
+           exit 2
+        fi
+        if [ "${SOURCE:(-4)}" = ".cxx" ]; then
+           echo "Error: Source must not end with '.cxx'!" >&2
+           echo
+           usage
+           exit 2
+        fi
         if [ "${SOURCE:(-4)}" = ".cpp" ]; then
            echo "Error: Source must not end with '.cpp'!" >&2
+           echo
+           usage
+           exit 2
+        fi
+        if [ "${SOURCE:(-4)}" = ".CPP" ]; then
+           echo "Error: Source must not end with '.CPP'!" >&2
+           echo
+           usage
+           exit 2
+        fi
+        if [ "${SOURCE:(-4)}" = ".c++" ]; then
+           echo "Error: Source must not end with '.c++'!" >&2
            echo
            usage
            exit 2

--- a/Scripts/scripts/cgal_create_cmake_script
+++ b/Scripts/scripts/cgal_create_cmake_script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (c) 1999,2000,2002-2007
 # Utrecht University (The Netherlands),
@@ -23,8 +23,8 @@
 #
 # Author(s)     : various
 
-# This script creates a CGAL cmake script with entries for all .C and .cpp
-# files in the current directory.
+# This script creates a CGAL cmake script with entries for files with a common
+# C++ file extension (as mentioned in the g++ man page) in the current directory.
 #
 # Usage: cgal_create_cmake_script TYPE
 #
@@ -58,7 +58,7 @@ EOF
   if [ "${TYPE}" = "demo" ] ; then
     target_name="${PROJECT}_${TYPE}"
     
-    for file in `ls "$SOURCE_DIR"*.C "$SOURCE_DIR"*.cpp 2>/dev/null | sort` ; do
+    for file in `ls "$SOURCE_DIR"*.cc "$SOURCE_DIR"*.cp "$SOURCE_DIR"*.cxx "$SOURCE_DIR"*.cpp "$SOURCE_DIR"*.CPP "$SOURCE_DIR"*.c++ "$SOURCE_DIR"*.C 2>/dev/null | sort` ; do
       all="$all $file"
     done
     if [ -z "${all}" ]; then return; fi
@@ -147,10 +147,15 @@ EOF
       echo
     fi
     
-    for file in `ls "$SOURCE_DIR"*.C "$SOURCE_DIR"*.cpp 2>/dev/null | sort` ; do
+    for file in `ls "$SOURCE_DIR"*.cc "$SOURCE_DIR"*.cp "$SOURCE_DIR"*.cxx "$SOURCE_DIR"*.cpp "$SOURCE_DIR"*.CPP "$SOURCE_DIR"*.c++ "$SOURCE_DIR"*.C 2>/dev/null | sort` ; do
       # Create an executable for each cpp that  contains a function "main()"
-      BASE=`basename $file .C`
+      BASE=`basename $file .cc`
+      BASE=`basename $BASE .cp`
+      BASE=`basename $BASE .cxx`
       BASE=`basename $BASE .cpp`
+      BASE=`basename $BASE .CPP`
+      BASE=`basename $BASE .c++`
+      BASE=`basename $BASE .C`
       egrep '\bmain[ \t]*\(' $file >/dev/null 2>&1
       if [ $? -eq 0 ]; then
         echo "  create_single_source_cgal_program( \"$file\" )"


### PR DESCRIPTION
Rationale:
cgal_create_CMakeLists and related scripts used to not consider files ending on anything else than .cpp or .C as C++ sources. This patch allows for the list of extensions considered as C++ source files as stated in the g++ man page.