### PR TITLE
Renamed minkowski_sum_{full_convolution,reduced_convolution} => minko…

### DIFF
--- a/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/minkowski_sum_2.h
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/minkowski_sum_2.h
@@ -11,8 +11,8 @@ Computes the Minkowski sum \f$ P \oplus Q\f$ of two given polygons
 
 This method defaults to the reduced convolution method, see below.
 
-\sa `CGAL::minkowski_sum_reduced_convolution_2()`
-\sa `CGAL::minkowski_sum_full_convolution_2()`
+\sa `CGAL::minkowski_sum_by_reduced_convolution_2()`
+\sa `CGAL::minkowski_sum_by_full_convolution_2()`
  */
 template <typename Kernel, typename Container>
 Polygon_with_holes_2<Kernel, Container>
@@ -38,8 +38,8 @@ has many holes.
 
 template <typename Kernel, typename Container>
 Polygon_with_holes_2<Kernel, Container>
-minkowski_sum_reduced_convolution_2(const PolygonType1<Kernel, Container>& P,
-                                    const PolygonType2<Kernel, Container>& Q);
+minkowski_sum_by_reduced_convolution_2(const PolygonType1<Kernel, Container>& P,
+                                       const PolygonType2<Kernel, Container>& Q);
 
 /*!
 \ingroup PkgMinkowskiSum2
@@ -57,8 +57,8 @@ and `Q` are convex or non-convex.
 */
 template <typename Kernel, typename Container>
 Polygon_with_holes_2<Kernel, Container>
-minkowski_sum_full_convolution_2(const Polygon_2<Kernel, Container>& P,
-                                 const Polygon_2<Kernel, Container>& Q);
+minkowski_sum_by_full_convolution_2(const Polygon_2<Kernel, Container>& P,
+                                    const Polygon_2<Kernel, Container>& Q);
 
 /*!
 \ingroup PkgMinkowskiSum2

--- a/Minkowski_sum_2/doc/Minkowski_sum_2/Minkowski_sum_2.txt
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/Minkowski_sum_2.txt
@@ -155,10 +155,10 @@ The function template \link minkowski_sum_2() `minkowski_sum_2(P, Q)`\endlink
 accepts two simple polygons \f$ P\f$ and \f$ Q\f$ and computes their
 Minkowski sum \f$ S = P \oplus Q\f$ using the convolution method.
 \link minkowski_sum_2() `minkowski_sum_2(P, Q)`\endlink defaults to calling the
-function \link minkowski_sum_reduced_convolution_2() `minkowski_sum_reduced_convolution_2(P, Q)`\endlink,
+function \link minkowski_sum_by_reduced_convolution_2() `minkowski_sum_by_reduced_convolution_2(P, Q)`\endlink,
 which applies the reduced convolution aforementioned.
-Explicitly call the function \link minkowski_sum_full_convolution_2()
-`minkowski_sum_full_convolution_2(P, Q)`\endlink to apply
+Explicitly call the function \link minkowski_sum_by_full_convolution_2()
+`minkowski_sum_by_full_convolution_2(P, Q)`\endlink to apply
 the full convolution approach.
 The types of the operands are instances of the
 \link Polygon_2 `Polygon_2`\endlink class template. As the input polygons

--- a/Minkowski_sum_2/include/CGAL/minkowski_sum_2.h
+++ b/Minkowski_sum_2/include/CGAL/minkowski_sum_2.h
@@ -44,8 +44,10 @@ namespace CGAL {
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
-minkowski_sum_reduced_convolution_2(const Polygon_2<Kernel_, Container_>& pgn1,
-                                    const Polygon_2<Kernel_, Container_>& pgn2)
+minkowski_sum_by_reduced_convolution_2(const Polygon_2<Kernel_,
+                                       Container_>& pgn1,
+                                       const Polygon_2<Kernel_,
+                                       Container_>& pgn2)
 {
   typedef Kernel_                                    Kernel;
   typedef Container_                                 Container;
@@ -76,7 +78,7 @@ minkowski_sum_reduced_convolution_2(const Polygon_2<Kernel_, Container_>& pgn1,
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
-minkowski_sum_reduced_convolution_2
+minkowski_sum_by_reduced_convolution_2
 (const Polygon_with_holes_2<Kernel_, Container_>& pgn1,
  const Polygon_with_holes_2<Kernel_, Container_>& pgn2)
 {
@@ -116,7 +118,7 @@ minkowski_sum_reduced_convolution_2
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
-minkowski_sum_reduced_convolution_2
+minkowski_sum_by_reduced_convolution_2
 (const Polygon_2<Kernel_, Container_>& pgn1,
  const Polygon_with_holes_2<Kernel_, Container_>& pgn2)
 {
@@ -148,10 +150,10 @@ minkowski_sum_reduced_convolution_2
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
-minkowski_sum_reduced_convolution_2
+minkowski_sum_by_reduced_convolution_2
 (const Polygon_with_holes_2<Kernel_, Container_>& pgn1,
  const Polygon_2<Kernel_, Container_>& pgn2)
-{ return minkowski_sum_reduced_convolution_2(pgn2, pgn1); }
+{ return minkowski_sum_by_reduced_convolution_2(pgn2, pgn1); }
 
 /*!
  * Compute the Minkowski sum of two simple polygons using the (full)
@@ -165,8 +167,8 @@ minkowski_sum_reduced_convolution_2
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
-minkowski_sum_full_convolution_2(const Polygon_2<Kernel_, Container_>& pgn1,
-                                 const Polygon_2<Kernel_, Container_>& pgn2)
+minkowski_sum_by_full_convolution_2(const Polygon_2<Kernel_, Container_>& pgn1,
+                                    const Polygon_2<Kernel_, Container_>& pgn2)
 {
   typedef Kernel_                                    Kernel;
   typedef Container_                                 Container;
@@ -194,14 +196,14 @@ minkowski_sum_full_convolution_2(const Polygon_2<Kernel_, Container_>& pgn1,
  * \param[in] pgn2 The second polygon.
  * \return The resulting polygon with holes, representing the sum.
  *
- * \sa `CGAL::minkowski_sum_reduced_convolution_2()`
- * \sa `CGAL::minkowski_sum_full_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_reduced_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_full_convolution_2()`
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
 minkowski_sum_2(const Polygon_2<Kernel_, Container_>& pgn1,
                 const Polygon_2<Kernel_, Container_>& pgn2)
-{ return minkowski_sum_reduced_convolution_2(pgn1, pgn2); }
+{ return minkowski_sum_by_reduced_convolution_2(pgn1, pgn2); }
 
 /*!
  * Compute the Minkowski sum of two polygons with holes using the convolution
@@ -213,14 +215,14 @@ minkowski_sum_2(const Polygon_2<Kernel_, Container_>& pgn1,
  * \param[in] pgn2 The second polygon with holes.
  * \return The resulting polygon with holes, representing the sum.
  *
- * \sa `CGAL::minkowski_sum_reduced_convolution_2()`
- * \sa `CGAL::minkowski_sum_full_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_reduced_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_full_convolution_2()`
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
 minkowski_sum_2(const Polygon_with_holes_2<Kernel_, Container_>& pgn1,
                 const Polygon_with_holes_2<Kernel_, Container_>& pgn2)
-{ return minkowski_sum_reduced_convolution_2(pgn1, pgn2); }
+{ return minkowski_sum_by_reduced_convolution_2(pgn1, pgn2); }
 
 /*!
  * Compute the Minkowski sum of a simple polygon and a polygon with holes
@@ -232,14 +234,14 @@ minkowski_sum_2(const Polygon_with_holes_2<Kernel_, Container_>& pgn1,
  * \param[in] pgn2 The polygon with holes.
  * \return The resulting polygon with holes, representing the sum.
  *
- * \sa `CGAL::minkowski_sum_reduced_convolution_2()`
- * \sa `CGAL::minkowski_sum_full_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_reduced_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_full_convolution_2()`
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
 minkowski_sum_2(const Polygon_2<Kernel_, Container_>& pgn1,
                 const Polygon_with_holes_2<Kernel_, Container_>& pgn2)
-{ return minkowski_sum_reduced_convolution_2(pgn1, pgn2); }
+{ return minkowski_sum_by_reduced_convolution_2(pgn1, pgn2); }
 
   /*!
  * Compute the Minkowski sum of a simple polygon and a polygon with holes
@@ -251,14 +253,14 @@ minkowski_sum_2(const Polygon_2<Kernel_, Container_>& pgn1,
  * \param[in] pgn2 The simple polygon.
  * \return The resulting polygon with holes, representing the sum.
  *
- * \sa `CGAL::minkowski_sum_reduced_convolution_2()`
- * \sa `CGAL::minkowski_sum_full_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_reduced_convolution_2()`
+ * \sa `CGAL::minkowski_sum_by_full_convolution_2()`
  */
 template <typename Kernel_, typename Container_>
 Polygon_with_holes_2<Kernel_, Container_>
 minkowski_sum_2(const Polygon_with_holes_2<Kernel_, Container_>& pgn1,
                 const Polygon_2<Kernel_, Container_>& pgn2)
-{ return minkowski_sum_reduced_convolution_2(pgn1, pgn2); }
+{ return minkowski_sum_by_reduced_convolution_2(pgn1, pgn2); }
 
 /*!
  * Compute the Minkowski sum of two simple polygons by decomposing each

--- a/Minkowski_sum_2/test/Minkowski_sum_2/test_minkowski_sum.cpp
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/test_minkowski_sum.cpp
@@ -52,10 +52,10 @@ Polygon_with_holes_2 compute_minkowski_sum_2(Polygon_2& p, Polygon_2& q,
 {
   switch (strategy) {
    case REDUCED_CONVOLUTION:
-    return minkowski_sum_reduced_convolution_2(p, q);
+    return minkowski_sum_by_reduced_convolution_2(p, q);
 
    case FULL_CONVOLUTION:
-    return minkowski_sum_full_convolution_2(p, q);
+    return minkowski_sum_by_full_convolution_2(p, q);
 
    case SSAB_DECOMP:
     {

--- a/Minkowski_sum_2/test/Minkowski_sum_2/test_minkowski_sum_with_holes.cpp
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/test_minkowski_sum_with_holes.cpp
@@ -42,7 +42,7 @@ Polygon_with_holes_2 compute_minkowski_sum_2(Polygon_with_holes_2& p,
   switch (strategy) {
    case REDUCED_CONVOLUTION:
     {
-     return minkowski_sum_reduced_convolution_2(p, q);
+     return minkowski_sum_by_reduced_convolution_2(p, q);
     }
    case VERTICAL_DECOMP:
     {


### PR DESCRIPTION
…wski_sum_by_{full_convolution,reduced_convolution}

This is a bug fix.
Running the test suite locally shows no errors.
Observe that the free functions being (slightly) renamed haven't been exposed yet via a public release.