### PR TITLE
Fix two issues with Surface_mesh and GCC4.4 + C++0x

### DIFF
--- a/BGL/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
@@ -26,11 +26,21 @@
 #include <boost/iterator/transform_iterator.hpp>
 
 #include <CGAL/boost/graph/properties_Surface_mesh.h>
-#include <CGAL/boost/graph/iterator.h>
+// ATTN: <CGAL/boost/graph/iterator.h> is included at the end of this
+// file, because we need to fix some calls in that file instead of
+// using ADL on broken compilers, hence those calls need to declared
+// before that.
 
 #include <CGAL/Surface_mesh.h>
 
+namespace CGAL {
 
+template<typename Graph>
+class In_edge_iterator;
+template<typename Graph>
+class Out_edge_iterator;
+
+}
 
 namespace boost {
 
@@ -532,8 +542,6 @@ bool is_valid(CGAL::Surface_mesh<P>& sm, bool verbose = false)
 
 } // namespace CGAL
 
-
-
-
+#include <CGAL/boost/graph/iterator.h>
 
 #endif // CGAL_BOOST_GRAPH_TRAITS_SURFACE_MESH_H

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -20,8 +20,6 @@
 #ifndef CGAL_BGL_ITERATORS_H
 #define CGAL_BGL_ITERATORS_H
 
-#include <stdexcept>
-
 #include <boost/graph/graph_traits.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
@@ -181,6 +179,28 @@ struct Opposite_face {
     return face(opposite(h,*g),*g);
   }
 };
+
+// With gcc 4.4 and std=c++0x do not use ADL to find next/prev.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=40497
+template<typename A, typename Mesh>
+A adl_next(A a, const Mesh& m) {
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __GNUC__ == 4 && __GNUC_MINOR__ == 4
+  return CGAL::next(a, m);
+#else
+  return next(a, m);
+#endif
+}
+
+template<typename A, typename Mesh>
+A adl_prev(A a, const Mesh& m) {
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __GNUC__ == 4 && __GNUC_MINOR__ == 4
+  return CGAL::prev(a, m);
+#else
+  return prev(a, m);
+#endif
+}
+
+
 } // namespace internal
 /// \endcond
 
@@ -258,7 +278,7 @@ public:
   }
 
   Self& operator++() {
-    pos = next(opposite(pos,*g),*g);
+    pos = internal::adl_next(opposite(pos,*g),*g);
     if ( pos == anchor)
       ++winding;
     return *this;
@@ -271,7 +291,7 @@ public:
   Self& operator--() {
     if ( pos == anchor)
       --winding;
-    pos = opposite(prev(pos,*g),*g);
+    pos = opposite(internal::adl_prev(pos,*g),*g);
     return *this;
   }
   Self  operator--(int) {
@@ -358,7 +378,7 @@ public:
   }
 
   Self& operator++() {
-    pos = opposite(next(pos,*g),*g);
+    pos = opposite(internal::adl_next(pos,*g),*g);
     if ( pos == anchor)
       ++winding;
     return *this;
@@ -371,7 +391,7 @@ public:
   Self& operator--() {
     if ( pos == anchor)
       --winding;
-    pos = prev(opposite(pos,*g),*g);
+    pos = internal::adl_prev(opposite(pos,*g),*g);
     return *this;
   }
   Self  operator--(int) {
@@ -464,7 +484,7 @@ public:
     if ( pos == anchor)
       --winding;
   
-    pos = prev(pos,*g);
+    pos = internal::adl_prev(pos,*g);
     return *this;
   }
 
@@ -684,7 +704,7 @@ public:
   Self& operator++() 
   {
     CGAL_assertion(g != NULL);
-    pos = opposite(next(pos,*g),*g);
+    pos = opposite(internal::adl_next(pos,*g),*g);
     return *this;
   }
 
@@ -699,7 +719,7 @@ public:
   Self& operator--() 
   {
     CGAL_assertion(g != NULL);
-    pos = prev(opposite(pos,*g),*g);
+    pos = internal::adl_prev(opposite(pos,*g),*g);
     return *this;
   }
 
@@ -779,7 +799,7 @@ public:
   Self& operator++() 
   {
     CGAL_assertion(g != NULL);
-    pos = next(pos,*g);
+    pos = internal::adl_next(pos,*g);
     return *this;
   }
 
@@ -794,7 +814,7 @@ public:
   Self& operator--() 
   {
     CGAL_assertion(g != NULL);
-    pos = prev(pos,*g);
+    pos = internal::adl_prev(pos,*g);
     return *this;
   }
 

--- a/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -22,7 +22,7 @@
 #define CGAL_PROPERTIES_SURFACE_MESH_H
 
 #include <CGAL/assertions.h>
-#include <CGAL/Surface_mesh/Surface_mesh.h>
+#include <CGAL/Surface_mesh.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/squared_distance_3.h>
 

--- a/Surface_mesh/include/CGAL/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh.h
@@ -19,8 +19,8 @@
 #ifndef CGAL_TOP_LEVEL_SURFACE_MESH_H
 #define CGAL_TOP_LEVEL_SURFACE_MESH_H
 
-#include "CGAL/Surface_mesh/Surface_mesh_fwd.h"
-#include "CGAL/Surface_mesh/Surface_mesh.h"
+#include <CGAL/Surface_mesh/Surface_mesh_fwd.h>
+#include <CGAL/Surface_mesh/Surface_mesh.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2089,34 +2089,34 @@ private: //--------------------------------------------------- property handling
   // dummy is necessary to make it a partial specialization (full
   // specializations are only allowed at namespace scope).
   template<typename, bool = true>
-  struct Property_selector;
+  struct Property_selector {};
 
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Vertex_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Vertex_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Vertex_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Vertex_index>&
     operator()() { return m_->vprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Halfedge_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Halfedge_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Halfedge_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Halfedge_index>&
     operator()() { return m_->hprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Edge_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Edge_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Edge_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Edge_index>&
     operator()() { return m_->eprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Face_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Face_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Face_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Face_index>&
     operator()() { return m_->fprops_; }
   };
 
@@ -2152,7 +2152,7 @@ private: //--------------------------------------------------- property handling
     template<class I, class T>
     std::pair<Property_map<I, T>, bool>
     add_property_map(const std::string& name, const T t=T()) {
-      return Property_selector<I>(this)().template add<T>(name, t);
+       return Property_selector<I>(this)().add<T>(name, t);
     }
 
  

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2152,7 +2152,7 @@ private: //--------------------------------------------------- property handling
     template<class I, class T>
     std::pair<Property_map<I, T>, bool>
     add_property_map(const std::string& name, const T t=T()) {
-       return Property_selector<I>(this)().add<T>(name, t);
+       return Property_selector<I>(this)().template add<T>(name, t);
     }
 
  

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -31,10 +31,6 @@
 #include <boost/cstdint.hpp>
 #include <boost/array.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/fusion/container/map.hpp>
-#include <boost/fusion/include/map.hpp>
-#include <boost/fusion/include/at_key.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/foreach.hpp>
 #include <boost/property_map/property_map.hpp>
 
@@ -2089,16 +2085,40 @@ public:
 
 private: //--------------------------------------------------- property handling
 
-    /// @cond BROKEN_DOC
-    typedef boost::fusion::map<
-      boost::fusion::pair< typename Surface_mesh::Vertex_index, Property_container<Vertex_index> (Surface_mesh::*)>,
-      boost::fusion::pair< typename Surface_mesh::Halfedge_index, Property_container<Halfedge_index> (Surface_mesh::*)>,
-      boost::fusion::pair< typename Surface_mesh::Edge_index, Property_container<Edge_index> (Surface_mesh::*)>,
-      boost::fusion::pair< typename Surface_mesh::Face_index, Property_container<Face_index> (Surface_mesh::*)> >
-        map_type;
+  // Property_selector maps an index type to a property_container, the
+  // dummy is necessary to make it a partial specialization (full
+  // specializations are only allowed at namespace scope).
+  template<typename, bool = true>
+  struct Property_selector;
 
-    map_type pmap_;
-    /// @endcond
+  template<bool dummy>
+  struct Property_selector<typename Surface_mesh::Vertex_index, dummy> {
+    Surface_mesh* m_;
+    Property_selector(Surface_mesh* m) : m_(m) {}
+    Property_container<typename Surface_mesh::Vertex_index>&
+    operator()() { return m_->vprops_; }
+  };
+  template<bool dummy>
+  struct Property_selector<typename Surface_mesh::Halfedge_index, dummy> {
+    Surface_mesh* m_;
+    Property_selector(Surface_mesh* m) : m_(m) {}
+    Property_container<typename Surface_mesh::Halfedge_index>&
+    operator()() { return m_->hprops_; }
+  };
+  template<bool dummy>
+  struct Property_selector<typename Surface_mesh::Edge_index, dummy> {
+    Surface_mesh* m_;
+    Property_selector(Surface_mesh* m) : m_(m) {}
+    Property_container<typename Surface_mesh::Edge_index>&
+    operator()() { return m_->eprops_; }
+  };
+  template<bool dummy>
+  struct Property_selector<typename Surface_mesh::Face_index, dummy> {
+    Surface_mesh* m_;
+    Property_selector(Surface_mesh* m) : m_(m) {}
+    Property_container<typename Surface_mesh::Face_index>&
+    operator()() { return m_->fprops_; }
+  };
 
     public:
  
@@ -2130,9 +2150,9 @@ private: //--------------------------------------------------- property handling
 
   
     template<class I, class T>
-      std::pair<Property_map<I, T>, bool>
+    std::pair<Property_map<I, T>, bool>
     add_property_map(const std::string& name, const T t=T()) {
-        return (this->*boost::fusion::at_key<I>(pmap_)).template add<T>(name, t);
+      return Property_selector<I>(this)().template add<T>(name, t);
     }
 
  
@@ -2143,7 +2163,7 @@ private: //--------------------------------------------------- property handling
     template <class I, class T>
     std::pair<Property_map<I, T>,bool> property_map(const std::string& name) const
     {
-      return (this->*boost::fusion::at_key<I>(pmap_)).template get<T>(name);
+      return Property_selector<I>(const_cast<Surface_mesh*>(this))().template get<T>(name);
     }
 
 
@@ -2152,7 +2172,7 @@ private: //--------------------------------------------------- property handling
     template<class I, class T>
     void remove_property_map(Property_map<I, T>& p)
     {
-        (this->*boost::fusion::at_key<I>(pmap_)).remove(p);
+      (Property_selector<I>(this)()).remove(p);
     }
 
     /// @cond CGAL_DOCUMENT_INTERNALS
@@ -2165,16 +2185,16 @@ private: //--------------------------------------------------- property handling
     template<class I>
     const std::type_info& property_type(const std::string& name)
     {
-        return (this->*boost::fusion::at_key<I>(pmap_)).get_type(name);
+      return Property_selector<I>(this)().get_type(name);
     }
-  /// @endcond
+    /// @endcond
 
     /// returns a vector with all strings that describe properties with the key type `I`.
     /// @tparam I The key type of the properties.
     template<class I>
     std::vector<std::string> properties() const
     {
-        return (this->*boost::fusion::at_key<I>(pmap_)).properties();
+      return Property_selector<I>(this)().properties();
     }
 
     /// returns the property for the string "v:point".
@@ -2365,10 +2385,6 @@ private: //------------------------------------------------------- private data
 template <typename P>
 Surface_mesh<P>::
 Surface_mesh()
-  : pmap_(boost::fusion::make_pair< typename Surface_mesh::Vertex_index >(&Surface_mesh::vprops_)
-          , boost::fusion::make_pair< typename Surface_mesh::Halfedge_index >(&Surface_mesh::hprops_)
-          , boost::fusion::make_pair< typename Surface_mesh::Edge_index >(&Surface_mesh::eprops_)
-          , boost::fusion::make_pair< typename Surface_mesh::Face_index >(&Surface_mesh::fprops_))
 {
     // allocate standard properties
     // same list is used in operator=() and assign()
@@ -2394,8 +2410,6 @@ operator=(const Surface_mesh<P>& rhs)
 {
     if (this != &rhs)
     {
-        pmap_ = rhs.pmap_;
-
         // deep copy of property containers
         vprops_ = rhs.vprops_;
         hprops_ = rhs.hprops_;

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
@@ -18,8 +18,6 @@
 #ifndef CGAL_SURFACE_MESH_FWD_H
 #define CGAL_SURFACE_MESH_FWD_H
 
-#include <string>
-
 /// \file Surface_mesh_fwd.h
 /// Forward declarations of the Surface_mesh package.
 


### PR DESCRIPTION
This PR removes Boost.Fusion as a dependency and removes the use of ADL in a special case to make Surface_mesh work with GCC4.4 and C++0x.