### PR TITLE
Polyhedron demo scale space plugin speedup sgiraudot

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -230,6 +230,14 @@ and <code>src/</code> directories).
     </li>
   </ul>
 
+  
+  <h3>Polyhedron Demo (Scale Space Reconstruction Plugin)</h3>
+  <ul>
+    <li>Speed up construction of polygon soups by only inserting the
+      vertices that are actually used by each polygon soup.
+    </li>
+  </ul>
+
 
 <!-- end of the div for 4.7 -->
 </div>

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -230,14 +230,6 @@ and <code>src/</code> directories).
     </li>
   </ul>
 
-  
-  <h3>Polyhedron Demo (Scale Space Reconstruction Plugin)</h3>
-  <ul>
-    <li>Speed up construction of polygon soups by only inserting the
-      vertices that are actually used by each polygon soup.
-    </li>
-  </ul>
-
 
 <!-- end of the div for 4.7 -->
 </div>

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
@@ -84,14 +84,31 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
     time.start();
     std::cout << "Scale scape surface reconstruction...";
 
-    typedef CGAL::Scale_space_surface_reconstruction_3<Kernel> Recontructor;
-    Recontructor reconstruct( dialog.neighbors(), dialog.samples() );
+    typedef CGAL::Scale_space_surface_reconstruction_3<Kernel> Reconstructor;
+    Reconstructor reconstruct( dialog.neighbors(), dialog.samples() );
     reconstruct.reconstruct_surface(
       pts_item->point_set()->begin(),
       pts_item->point_set()->end(),
       dialog.iterations()
     );
     std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
+
+    std::vector<Point_set::Point> pts;
+    typedef Point_set::iterator Point_iterator;
+    for(Point_iterator it = pts_item->point_set()->begin(),
+                       end = pts_item->point_set()->end(); it!=end; ++it)
+    {
+      pts.push_back (*it);
+    }
+
+    std::vector<Reconstructor::Point> pts_smoothed;
+    typedef Reconstructor::Point_iterator SS_point_iterator;
+    
+    for(SS_point_iterator it = reconstruct.points_begin(),
+	  end = reconstruct.points_end(); it!=end; ++it)
+    {
+      pts_smoothed.push_back (*it);
+    }
 
     for( unsigned int sh = 0; sh < reconstruct.number_of_shells(); ++sh ) {
         // collect the number of triples.
@@ -103,18 +120,26 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
         new_item->init_polygon_soup(pts_item->point_set()->size(),
                                     num );
 
-        typedef Point_set::iterator Point_iterator;
+	std::map<unsigned int, unsigned int> map_i2i;
 
-        for(Point_iterator it = pts_item->point_set()->begin(),
-                           end = pts_item->point_set()->end(); it!=end; ++it)
-        {
-          new_item->new_vertex(it->x(), it->y(), it->z());
-        }
-
-        for (Recontructor::Triple_iterator it=reconstruct.shell_begin( sh ),
+	unsigned int current_index = 0;
+        for (Reconstructor::Triple_iterator it=reconstruct.shell_begin( sh ),
                                            end=reconstruct.shell_end( sh );it!=end;++it)
         {
-          new_item->new_triangle( (*it)[0], (*it)[1], (*it)[2] );
+	  for (unsigned int ind = 0; ind < 3; ++ ind)
+          {
+	    if (map_i2i.find ((*it)[ind]) == map_i2i.end ())
+            {
+	      map_i2i.insert (std::make_pair ((*it)[ind], current_index ++));
+	      new_item->new_vertex (pts[(*it)[ind]].x (),
+				    pts[(*it)[ind]].y (),
+				    pts[(*it)[ind]].z ());
+	    }
+
+	  }
+	  new_item->new_triangle( map_i2i[(*it)[0]],
+				  map_i2i[(*it)[1]],
+				  map_i2i[(*it)[2]] );
         }
 
         new_item->finalize_polygon_soup();
@@ -131,17 +156,27 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
           new_item_smoothed->init_polygon_soup(pts_item->point_set()->size(),
                                                num );
 
-          typedef Recontructor::Point_iterator SS_point_iterator;
-          for(SS_point_iterator it = reconstruct.points_begin(),
-                                end = reconstruct.points_end(); it!=end; ++it)
-          {
-            new_item_smoothed->new_vertex(it->x(), it->y(), it->z());
-          }
+	  std::map<unsigned int, unsigned int> map_i2i_smoothed;
 
-          for (Recontructor::Triple_iterator it=reconstruct.shell_begin( sh ),
+	  unsigned int current_index_smoothed = 0;
+          for (Reconstructor::Triple_iterator it=reconstruct.shell_begin( sh ),
                                              end=reconstruct.shell_end( sh );it!=end;++it)
           {
-            new_item_smoothed->new_triangle( (*it)[0], (*it)[1], (*it)[2] );
+	    for (unsigned int ind = 0; ind < 3; ++ ind)
+            {
+	      if (map_i2i_smoothed.find ((*it)[ind]) == map_i2i_smoothed.end ())
+	      {
+		map_i2i_smoothed.insert (std::make_pair ((*it)[ind], current_index_smoothed ++));
+		new_item_smoothed->new_vertex (pts_smoothed[(*it)[ind]].x (),
+					       pts_smoothed[(*it)[ind]].y (),
+					       pts_smoothed[(*it)[ind]].z ());
+	      }
+
+	    }
+
+	    new_item_smoothed->new_triangle( map_i2i_smoothed[(*it)[0]],
+					     map_i2i_smoothed[(*it)[1]],
+					     map_i2i_smoothed[(*it)[2]] );
           }
 
           new_item_smoothed->finalize_polygon_soup();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
@@ -127,16 +127,14 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
                                            end=reconstruct.shell_end( sh );it!=end;++it)
         {
 	  for (unsigned int ind = 0; ind < 3; ++ ind)
-          {
-	    if (map_i2i.find ((*it)[ind]) == map_i2i.end ())
-            {
-	      map_i2i.insert (std::make_pair ((*it)[ind], current_index ++));
-	      new_item->new_vertex (pts[(*it)[ind]].x (),
-				    pts[(*it)[ind]].y (),
-				    pts[(*it)[ind]].z ());
-	    }
+	    if (map_i2i.insert (std::make_pair ((*it)[ind], current_index)).second)
+	      {
+		new_item->new_vertex (pts[(*it)[ind]].x (),
+				      pts[(*it)[ind]].y (),
+				      pts[(*it)[ind]].z ());
+		++ current_index;
+	      }
 
-	  }
 	  new_item->new_triangle( map_i2i[(*it)[0]],
 				  map_i2i[(*it)[1]],
 				  map_i2i[(*it)[2]] );
@@ -163,16 +161,13 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
                                              end=reconstruct.shell_end( sh );it!=end;++it)
           {
 	    for (unsigned int ind = 0; ind < 3; ++ ind)
-            {
-	      if (map_i2i_smoothed.find ((*it)[ind]) == map_i2i_smoothed.end ())
-	      {
-		map_i2i_smoothed.insert (std::make_pair ((*it)[ind], current_index_smoothed ++));
-		new_item_smoothed->new_vertex (pts_smoothed[(*it)[ind]].x (),
-					       pts_smoothed[(*it)[ind]].y (),
-					       pts_smoothed[(*it)[ind]].z ());
-	      }
-
-	    }
+	      if (map_i2i_smoothed.insert (std::make_pair ((*it)[ind], current_index_smoothed)).second)
+		{
+		  new_item_smoothed->new_vertex (pts_smoothed[(*it)[ind]].x (),
+						 pts_smoothed[(*it)[ind]].y (),
+						 pts_smoothed[(*it)[ind]].z ());
+		  ++ current_index_smoothed;
+		}
 
 	    new_item_smoothed->new_triangle( map_i2i_smoothed[(*it)[0]],
 					     map_i2i_smoothed[(*it)[1]],

--- a/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
+++ b/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
@@ -111,7 +111,7 @@ else
       intersection_plugin \
       io_implicit_function_plugin \
       jet_fitting_plugin \
-      join_polyhedra_plugin \
+      join_and_split_polyhedra_plugin \
       kernel_plugin \
       mesh_3_plugin \
       mesh_segmentation_plugin \
@@ -137,6 +137,7 @@ else
       polylines_io_plugin \
       remeshing_plugin \
       scene_basic_objects \
+      scale_space_reconstruction_plugin \
       scene_c2t3_item \
       scene_combinatorial_map_item \
       scene_edit_polyhedron_item \
@@ -148,12 +149,14 @@ else
       scene_polyhedron_item_decorator \
       scene_polyhedron_item_k_ring_selection \
       scene_polyhedron_selection_item \
+      scene_polyhedron_shortest_path_item \
       scene_polyhedron_transform_item \
       scene_polylines_item \
       scene_textured_polyhedron_item \
       selection_io_plugin \
       selection_plugin \
       self_intersection_plugin \
+      shortest_path_plugin \
       stl_plugin \
       subdivision_methods_plugin \
       transform_polyhedron_plugin \


### PR DESCRIPTION
Only insert used points for polygon soups (speed-up and cleaner way of instanciating polygon soup).

Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.7-Ic-64.shtml