### PR TITLE
dD Triangulation: Make non-template methods inline

### DIFF
--- a/Triangulation/include/CGAL/Triangulation_full_cell.h
+++ b/Triangulation/include/CGAL/Triangulation_full_cell.h
@@ -121,12 +121,15 @@ protected:
 
 // FUNCTIONS THAT ARE NOT MEMBER FUNCTIONS:
 
+
+inline
 std::istream &
 operator>>(std::istream & is, No_full_cell_data &)
 {
     return is;
 }
 
+inline
 std::ostream &
 operator<<(std::ostream & os, const No_full_cell_data &)
 {

--- a/Triangulation/include/CGAL/Triangulation_vertex.h
+++ b/Triangulation/include/CGAL/Triangulation_vertex.h
@@ -93,12 +93,14 @@ public:
 
 // NON CLASS-MEMBER FUNCTIONS
 
+inline
 std::istream &
 operator>>(std::istream & is, No_vertex_data &)
 {
     return is;
 }
 
+inline
 std::ostream &
 operator<<(std::ostream & os, const No_vertex_data &)
 {


### PR DESCRIPTION
Avoid linking errors such as:

     In function 'CGAL::operator>>(std::istream&,
     CGAL::No_vertex_data&)':MeshSimplicial.cpp:(.text+0x490): multiple
     definition of 'CGAL::operator>>(std::istream&, CGAL::No_vertex_data&)'