### PR TITLE
git based installation instructions use incorrect variable name

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
 cd /path/to/cgal.git
 mkdir -p build/debug
 cd build/debug
-cmake -DBUILD_TYPE=Debug ../..
+cmake -DCMAKE_BUILD_TYPE=Debug ../..
 make
 ```
 
@@ -31,7 +31,7 @@ Here is an example of how to build the library in Release:
   > cd /path/to/cgal.git
   > mkdir -p build/debug
   > cd build/debug
-  > cmake -DBUILD_TYPE=Release ../..
+  > cmake -DCMAKE_BUILD_TYPE=Release ../..
   > make
 ```
 Note that *no installation is required* to use that version of CGAL once it has been compiled.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,12 +27,12 @@ make
 
 Here is an example of how to build the library in Release:
 ``` {.bash}
-  > git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
-  > cd /path/to/cgal.git
-  > mkdir -p build/debug
-  > cd build/debug
-  > cmake -DCMAKE_BUILD_TYPE=Release ../..
-  > make
+git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
+cd /path/to/cgal.git
+mkdir -p build/release
+cd build/release
+cmake -DCMAKE_BUILD_TYPE=Release ../..
+make
 ```
 Note that *no installation is required* to use that version of CGAL once it has been compiled.
 


### PR DESCRIPTION
Following the old instructions I was getting this warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TYPE
```
Based on [this comment](https://github.com/CGAL/cgal/issues/39#issuecomment-90476304) I was able to determine the correct value.

Since we're giving directions for creating a release build it probably makes sense to put it in a directory named `release` rather than `debug`.