### PR TITLE
Typo in sse2.h

### DIFF
--- a/Number_types/include/CGAL/sse2.h
+++ b/Number_types/include/CGAL/sse2.h
@@ -29,7 +29,7 @@
 
 #if defined ( _WIN32 )
 #define CGAL_ALIGN_16  __declspec(align(16))
-#elif defined( __GNU__ ) || defined(__MINGW64__)
+#elif defined( __GNUC__ ) || defined(__MINGW64__)
 #define  CGAL_ALIGN_16 __attribute__((aligned(16))) 
 #endif
 


### PR DESCRIPTION
__GNUC__ is missing its 'C'. This probably makes the test for __MINGW64__ useless. (I am testing the github interface for minor edits)