### PR TITLE
Update the CGAL_ImageIO-VTK support to VTK 6.x

### DIFF
--- a/CGAL_ImageIO/demo/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/demo/CGALimageIO/CMakeLists.txt
@@ -1,66 +1,33 @@
 project(image_to_vtk_viewer)
 
-cmake_minimum_required(VERSION 2.6.2)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-  cmake_policy(VERSION 2.8.4)
-else()
-  cmake_policy(VERSION 2.6)
-endif()
-
-
-set(PACKAGE_ROOT ../..)
-
-# Add several CGAL packages to the include and link paths,
-# if they lie in ${PACKAGE_ROOT}/.
-foreach(INC_DIR ${PACKAGE_ROOT}/include 
-		${PACKAGE_ROOT}/../CGAL_ImageIO/include )
-  if(EXISTS ${INC_DIR})
-    include_directories (BEFORE ${INC_DIR})
-  endif()
-endforeach()
-foreach(LIB_DIR ${PACKAGE_ROOT}/../CGAL_ImageIO/src/CGAL_ImageIO)
-  if (EXISTS ${LIB_DIR})
-    link_directories (${LIB_DIR})
-  endif()
-endforeach()
-
+cmake_minimum_required(VERSION 2.8.11)
 
 find_package(CGAL REQUIRED ImageIO)
 include( ${CGAL_USE_FILE} )
-find_package(VTK QUIET)
-find_package(Qt4 QUIET)
+find_package(VTK QUIET NO_MODULE)
 
-if(QT_FOUND AND VTK_FOUND)
+if(VTK_FOUND)
   add_definitions(-DCGAL_USE_VTK)
-  include(${VTK_USE_FILE})
-  include(${QT_USE_FILE})
 
-  add_definitions(${QT_DEFINITIONS})
+  if(TARGET vtkRenderingQt AND TARGET vtkFiltersModeling)
+    find_package(VTK COMPONENTS vtkRenderingQt vtkFiltersModeling NO_MODULE)
+    include(${VTK_USE_FILE})
+    find_package(Qt${VTK_QT_VERSION} COMPONENTS QtGui)
+    if(NOT TARGET Qt${VTK_QT_VERSION}::QtGui)
+      message(STATUS "NOTICE: vtkRenderingQt needs Qt${VTK_QT_VERSION}, and will not be compiled.")
+      return()
+    endif()
 
-  if(VTK_USE_QVTK)
-    include_directories( ${VTK_QT_INCLUDE_DIR} )
-    include_directories( ${QT_INCLUDE_DIR} )
     add_executable( image_to_vtk_viewer image_to_vtk_viewer.cpp )
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS image_to_vtk_viewer )
 
     target_link_libraries( image_to_vtk_viewer
-      QVTK
-      vtkRendering
-      vtkGraphics
-      vtkIO
-      vtkCommon
       ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES}
-      ${VTK_QT_QT_LIBRARY}
-      ${QT_LIBRARIES}
+      ${VTK_LIBRARIES} Qt${VTK_QT_VERSION}::QtGui
       )
-  else(VTK_USE_QVTK)
-    message(STATUS "NOTICE: This demo needs QVTK, and will not be compiled.")
-  endif(VTK_USE_QVTK)
+  else()
+    message(STATUS "NOTICE: This demo needs vtkRenderingQt and vtkFiltersModeling, and will not be compiled.")
+  endif()
 else()
-  if(NOT VTK_FOUND)
-    message(STATUS "NOTICE: This demo needs VTK, and will not be compiled.")
-  endif()
-  if(NOT QT_FOUND)
-    message(STATUS "NOTICE: This demo needs Qt4, and will not be compiled.")
-  endif()
+  message(STATUS "NOTICE: This demo needs VTK, and will not be compiled.")
 endif()

--- a/CGAL_ImageIO/demo/CGALimageIO/image_to_vtk_viewer.cpp
+++ b/CGAL_ImageIO/demo/CGALimageIO/image_to_vtk_viewer.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
   widget.SetRenderWindow(renWin);
 
   vtkContourFilter *skinExtractor = vtkContourFilter::New();
-    skinExtractor->SetInput(vtk_image);
+    skinExtractor->SetInputData(vtk_image);
     skinExtractor->SetValue(0, isovalue);
 //     skinExtractor->SetComputeNormals(0);
   vtkPolyDataNormals *skinNormals = vtkPolyDataNormals::New();
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
   // An outline provides context around the data.
   //
   vtkOutlineFilter *outlineData = vtkOutlineFilter::New();
-    outlineData->SetInput(vtk_image);
+    outlineData->SetInputData(vtk_image);
   vtkPolyDataMapper *mapOutline = vtkPolyDataMapper::New();
     mapOutline->SetInputConnection(outlineData->GetOutputPort());
   vtkActor *outline = vtkActor::New();

--- a/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
@@ -113,13 +113,13 @@ struct VTK_type_generator<boost::uint32_t> {
   vtk_image->SetDimensions(image.xdim(),
                            image.ydim(),
                            image.zdim());
-  vtk_image->SetWholeExtent(0, image.xdim(),
-                            0, image.ydim(),
-                            0, image.zdim());
+  vtk_image->SetExtent(0, image.xdim()-1,
+                       0, image.ydim()-1,
+                       0, image.zdim()-1);
   vtk_image->SetSpacing(image.vx(),
                         image.vy(),
                         image.vz());
-  vtk_image->SetScalarType(type);
+  vtk_image->AllocateScalars(type, 1);
   vtk_image->GetPointData()->SetScalars(data_array);
   return vtk_image;
 } // end vtk_image_sharing_same_data_pointer

--- a/CGAL_ImageIO/src/CGAL_ImageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package( ZLIB )
 #option(WITH_VTK "Add VTK support to libCGAL_ImageIO." OFF)
 
 if(WITH_VTK)
-  find_package(VTK QUIET)
+  find_package(VTK COMPONENTS vtkImagingCore vtkIOImage vtkFiltersImaging NO_MODULE REQUIRED)
 endif(WITH_VTK)
 
 if(OPENGL_FOUND)
@@ -31,11 +31,10 @@ if(OPENGL_FOUND)
       
       message(STATUS "VTK-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION} found. Build VTK support in ${CGAL_ImageIO_BASENAME}.")
       include( ${VTK_USE_FILE} )
-      cache_set(CGAL_ImageIO_3RD_PARTY_DEFINITIONS  ${CGAL_ImageIO_3RD_PARTY_DEFINITIONS} -DCGAL_USE_VTK ${VTK_REQUIRED_CXX_FLAGS})
+      cache_set(CGAL_ImageIO_3RD_PARTY_DEFINITIONS  ${CGAL_ImageIO_3RD_PARTY_DEFINITIONS} -DCGAL_USE_VTK)
       cache_set(CGAL_ImageIO_3RD_PARTY_INCLUDE_DIRS ${CGAL_ImageIO_3RD_PARTY_INCLUDE_DIRS} ${VTK_INCLUDE_DIRS} )
-      cache_set(CGAL_ImageIO_3RD_PARTY_LIBRARIES_DIRS ${CGAL_ImageIO_3RD_PARTY_LIBRARIES_DIRS} ${VTK_LIBRARY_DIRS} )
+      cache_set(CGAL_ImageIO_3RD_PARTY_LIBRARIES_DIRS ${CGAL_ImageIO_3RD_PARTY_LIBRARIES_DIRS} ${vtkImagingCore_RUNTIME_LIBRARY_DIRS} ${vtkImagingCore_LIBRARY_DIRS} ${vtkIOImage_RUNTIME_LIBRARY_DIRS} ${vtkIOImage_LIBRARY_DIRS} ${vtkFiltersImaging_RUNTIME_LIBRARY_DIRS} ${vtkFiltersImaging_LIBRARY_DIRS})
       cache_set(CGAL_ImageIO_3RD_PARTY_LIBRARIES    ${CGAL_ImageIO_3RD_PARTY_LIBRARIES}   ${VTK_LIBRARIES}  )
-      
     else()
       message(STATUS "VTK not found.")
     endif()

--- a/CGAL_ImageIO/src/CGAL_ImageIO/Image_3.cpp
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/Image_3.cpp
@@ -197,7 +197,6 @@ Image_3::read_vtk_image_data(vtkImageData* vtk_image)
   image->vx = spacing[0];
   image->vy = spacing[1];
   image->vz = spacing[2];
-  vtk_image->Update();
   image->endianness = ::_getEndianness();
   int vtk_type = vtk_image->GetScalarType();
   if(vtk_type == VTK_SIGNED_CHAR) vtk_type = VTK_CHAR;

--- a/Surface_mesher/demo/Surface_mesher/volume.h
+++ b/Surface_mesher/demo/Surface_mesher/volume.h
@@ -21,6 +21,14 @@
 #include <QString>
 #include <QFileInfo>
 
+#ifdef CGAL_USE_VTK
+class vtkImageReader;
+class vtkImageData;
+class vtkDICOMImageReader;
+class vtkDemandDrivenPipeline;
+class vtkImageGaussianSmooth;
+#endif // CGAL_USE_VTK
+
 class QTreeWidgetItem;
 
 // kernel
@@ -83,7 +91,7 @@ class Volume : public Surface
   Q_OBJECT
 public:
   Volume(MainWindow* mw);
-  ~Volume() {}
+  ~Volume();
 
 private:
   Binary_image m_image;
@@ -142,6 +150,15 @@ private:
   bool m_view_mc; // that boolean is here even with if
 		  // CGAL_SURFACE_MESH_DEMO_USE_MARCHING_CUBE
                   // is not defined.
+
+#ifdef CGAL_USE_VTK
+  vtkImageReader* vtk_reader;
+  vtkImageData* vtk_image;
+  vtkDICOMImageReader* dicom_reader;
+  vtkDemandDrivenPipeline* executive;
+  vtkImageGaussianSmooth* smoother;
+#endif // CGAL_USE_VTK
+
 public Q_SLOTS:
 void display_marchin_cube();
 


### PR DESCRIPTION
The VTK support in CGAL_ImageIO is not documented, but some users/customers actually use it.

Since VTK 6, that support was broken. With this pull-request, the support of VTK<6.0 is dropped in favor of 6.0 and later.
