### PR TITLE
Add pragmas in clang to disable -Wunused-local-typedef, locally

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -75,6 +75,30 @@
 #include <builtins.h>
 #endif
 
+#include <boost/static_assert.hpp>
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+#include <boost/version.hpp>
+
+// Standard way to deal with clang's __has_warning
+// http://clang.llvm.org/docs/LanguageExtensions.html#feature-checking-macros
+#ifndef __has_warning
+#  define __has_warning(x) 0
+#endif
+
+// If Clang has the warning -Wunused-local-typedef, then disable it temporarily.
+#if BOOST_WORKAROUND(BOOST_VERSION, BOOST_TESTED_AT(105800)) && BOOST_CLANG && __has_warning("-Wunused-local-typedef")
+#  define CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunused-local-typedef\"")
+#  define CGAL_CLANG_POP_DIAGNOSTIC _Pragma("clang diagnostic pop")
+#else
+#  define CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
+#  define CGAL_CLANG_POP_DIAGNOSTIC
+#endif
+
+CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
+
 #if defined(BOOST_MSVC)
 #  pragma warning(push)
 #  pragma warning(disable:4146 4244 4267 4800)
@@ -1126,6 +1150,11 @@ CGAL_DEFINE_COERCION_TRAITS_FROM_TO(mpz_class,Mpzf)
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)
 #endif
+
+CGAL_CLANG_POP_DIAGNOSTIC
+
+#undef CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
+#undef CGAL_CLANG_POP_DIAGNOSTIC
 
 #endif // GMP_NUMB_BITS == 64
 #endif // CGAL_MPZF_H


### PR DESCRIPTION
The subject said it all... Well, I will develop anyway.
The [testsuite of CGAL, with clang-3.6,][t] is full of that warning (in the two columns `ArchLinux-clang`):

[t]: https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.7-Ic-85.shtml
```
/mnt/testsuite/include/CGAL/Mpzf.h:421:5: warning: unused typedef 'boost_static_assert_typedef_421' [-Wunused-local-typedef]
    BOOST_STATIC_ASSERT(GMP_NUMB_BITS == 64);
    ^
/usr/include/boost/static_assert.hpp:170:16: note: expanded from macro 'BOOST_STATIC_ASSERT'
               BOOST_JOIN(boost_static_assert_typedef_, __LINE__) BOOST_STATIC_ASSERT_UNUSED_ATTRIBUTE
               ^
/usr/include/boost/config/suffix.hpp:544:28: note: expanded from macro 'BOOST_JOIN'
#define BOOST_JOIN( X, Y ) BOOST_DO_JOIN( X, Y )
                           ^
/usr/include/boost/config/suffix.hpp:545:31: note: expanded from macro 'BOOST_DO_JOIN'
#define BOOST_DO_JOIN( X, Y ) BOOST_DO_JOIN2(X,Y)
                              ^
/usr/include/boost/config/suffix.hpp:546:32: note: expanded from macro 'BOOST_DO_JOIN2'
#define BOOST_DO_JOIN2( X, Y ) X##Y
                               ^
<scratch space>:158:1: note: expanded from here
boost_static_assert_typedef_421
^
```

I have already reported the issue [in the trac of Boost][trac].

[trac]: https://svn.boost.org/trac/boost/ticket/7242#comment:7
We want to remove that warning because it can hide other warnings, more useful. Here I use a detection of clang (only recent ones, detected with `__has_warning("-Wunused-local-typedef")`), and in that case pragmas are used to disable `-Wunused-local-typedef` only locally.

