### PR TITLE
Fix linking issue caused by violation of the one definition rule.

### DIFF
--- a/Kinetic_data_structures/include/CGAL/Polynomial/CORE_Expr_root_stack.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/CORE_Expr_root_stack.h
@@ -260,7 +260,7 @@ protected:
   }
 };
 
-std::ostream &operator<<(std::ostream &out, const CORE_Expr_root_stack &o) {
+inline std::ostream &operator<<(std::ostream &out, const CORE_Expr_root_stack &o) {
   return o.write(out);
 }
 

--- a/Kinetic_data_structures/include/CGAL/Polynomial/internal/CORE_polynomial.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/internal/CORE_polynomial.h
@@ -268,7 +268,7 @@ inline std::istream &operator>>(std::basic_istream<C, Tr> &in,
   return in;
 }
 
-CORE_polynomial operator*(const CORE_polynomial::NT &a,
+inline CORE_polynomial operator*(const CORE_polynomial::NT &a,
 			  const CORE_polynomial &p){
   //CORE_polynomial::NT ac(a);
   return CORE_polynomial(CORE_polynomial::P(0, &a)*p.core_polynomial());


### PR DESCRIPTION
When including CGAL/Polynomial/CORE_Expr_root_stack.h in a header file
that in turn gets included in multiple .cpp files, code from
CORE_Expr_root_stack.h ends up in multiple object files and causes
linking problems:
  multiple definition of `CGAL::POLYNOMIAL::operator<<(std::ostream&, CGAL::POLYNOMIAL::CORE_Expr_root_stack const&)'
  multiple definition of `CGAL::POLYNOMIAL::internal::operator*(CORE::BigRat const&, CGAL::POLYNOMIAL::internal::CORE_polynomial const&)'

Work around this issue by declaring both operators inline.