### PR TITLE
Polygon mesh processing - small fixes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -47,9 +47,9 @@ void sum_normals(const PM& pmesh,
   halfedge_descriptor end = he;
   do
   {
-    const Point& prv = vpmap[target(prev(he, pmesh), pmesh)];
-    const Point& curr = vpmap[target(he, pmesh)];
-    const Point& nxt = vpmap[target(next(he, pmesh), pmesh)];
+    const Point& prv = get(vpmap, target(prev(he, pmesh), pmesh));
+    const Point& curr = get(vpmap, target(he, pmesh));
+    const Point& nxt = get(vpmap, target(next(he, pmesh), pmesh));
     Vector n = CGAL::cross_product(nxt - curr, prv - curr);
     sum = sum + n;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -142,17 +142,17 @@ struct Intersect_facets
       // found shared vertex: 
       CGAL_assertion(target(h,m_tmesh) == target(v,m_tmesh));
       // geometric check if the opposite segments intersect the triangles
-      Triangle t1 = triangle_functor( m_vpmap[target(h,m_tmesh)],
-                                      m_vpmap[target(next(h,m_tmesh),m_tmesh)],
-                                      m_vpmap[target(next(next(h,m_tmesh),m_tmesh),m_tmesh)]);
-      Triangle t2 = triangle_functor( m_vpmap[target(v,m_tmesh)],
-                                      m_vpmap[target(next(v,m_tmesh),m_tmesh)],
-                                      m_vpmap[target(next(next(v,m_tmesh),m_tmesh),m_tmesh)]);
+      Triangle t1 = triangle_functor( get(m_vpmap,target(h,m_tmesh)),
+                                      get(m_vpmap, target(next(h,m_tmesh),m_tmesh)),
+                                      get(m_vpmap, target(next(next(h,m_tmesh),m_tmesh),m_tmesh)));
+      Triangle t2 = triangle_functor( get(m_vpmap, target(v,m_tmesh)),
+                                      get(m_vpmap, target(next(v,m_tmesh),m_tmesh)),
+                                      get(m_vpmap, target(next(next(v,m_tmesh),m_tmesh),m_tmesh)));
       
-      Segment s1 = segment_functor( m_vpmap[target(next(h,m_tmesh),m_tmesh)],
-                                    m_vpmap[target(next(next(h,m_tmesh),m_tmesh),m_tmesh)]);
-      Segment s2 = segment_functor( m_vpmap[target(next(v,m_tmesh),m_tmesh)],
-                                    m_vpmap[target(next(next(v,m_tmesh),m_tmesh),m_tmesh)]);
+      Segment s1 = segment_functor( get(m_vpmap, target(next(h,m_tmesh),m_tmesh)),
+                                    get(m_vpmap, target(next(next(h,m_tmesh),m_tmesh),m_tmesh)));
+      Segment s2 = segment_functor( get(m_vpmap, target(next(v,m_tmesh),m_tmesh)),
+                                    get(m_vpmap, target(next(next(v,m_tmesh),m_tmesh),m_tmesh)));
       
       if(do_intersect_3_functor(t1,s2)){
         *m_iterator_wrapper++ = std::make_pair(b->info(), c->info());
@@ -163,12 +163,12 @@ struct Intersect_facets
     }
     
     // check for geometric intersection
-    Triangle t1 = triangle_functor( m_vpmap[target(h,m_tmesh)],
-                                    m_vpmap[target(next(h,m_tmesh),m_tmesh)],
-                                    m_vpmap[target(next(next(h,m_tmesh),m_tmesh),m_tmesh)]);
-    Triangle t2 = triangle_functor( m_vpmap[target(g,m_tmesh)],
-                                    m_vpmap[target(next(g,m_tmesh),m_tmesh)],
-                                    m_vpmap[target(next(next(g,m_tmesh),m_tmesh),m_tmesh)]);
+    Triangle t1 = triangle_functor( get(m_vpmap, target(h,m_tmesh)),
+                                    get(m_vpmap, target(next(h,m_tmesh),m_tmesh)),
+                                    get(m_vpmap, target(next(next(h,m_tmesh),m_tmesh),m_tmesh)));
+    Triangle t2 = triangle_functor( get(m_vpmap, target(g,m_tmesh)),
+                                    get(m_vpmap, target(next(g,m_tmesh),m_tmesh)),
+                                    get(m_vpmap, target(next(next(g,m_tmesh),m_tmesh),m_tmesh)));
     if(do_intersect_3_functor(t1, t2)){
       *m_iterator_wrapper++ = std::make_pair(b->info(), c->info());
     }
@@ -312,9 +312,9 @@ self_intersections( const FaceRange& face_range,
 
   BOOST_FOREACH(face_descriptor f, face_range)
   {
-    boxes.push_back(Box( vpmap[target(halfedge(f,tmesh),tmesh)].bbox()
-      + vpmap[target(next(halfedge(f, tmesh), tmesh), tmesh)].bbox()
-      + vpmap[target(next(next(halfedge(f, tmesh), tmesh), tmesh), tmesh)].bbox(),
+    boxes.push_back(Box( get(vpmap, target(halfedge(f,tmesh),tmesh)).bbox()
+      + get(vpmap, target(next(halfedge(f, tmesh), tmesh), tmesh)).bbox()
+      + get(vpmap, target(next(next(halfedge(f, tmesh), tmesh), tmesh), tmesh)).bbox(),
     f));
   }
   // generate box pointers

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -357,8 +357,6 @@ OutputIterator self_intersections(const FaceRange& face_range,
  *
  * @tparam TriangleMesh a model of `FaceListGraph` that has an internal property map
  *         for `CGAL::vertex_point_t`
- * @tparam OutputIterator a model of `OutputIterator` holding objects of type
- *   `std::pair<boost::graph_traits<TriangleMesh>::%face_descriptor, boost::graph_traits<TriangleMesh>::%face_descriptor>`
  * @tparam NamedParameters a sequence of \ref namedparameters
  *
  * @param tmesh the triangulated surface mesh to be tested


### PR DESCRIPTION
Sometimes property maps don't have the operator[] available, so we need to use get() and put() everywhere.
This pull request fixes that in the Polygon_mesh_processing package.

This pull request also contains a documentation fix.