### PR TITLE
Drop Boost.Fusion from Surface_mesh

### DIFF
--- a/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -22,7 +22,7 @@
 #define CGAL_PROPERTIES_SURFACE_MESH_H
 
 #include <CGAL/assertions.h>
-#include <CGAL/Surface_mesh/Surface_mesh.h>
+#include <CGAL/Surface_mesh.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/squared_distance_3.h>
 

--- a/BGL/test/BGL/test_Euler_operations.cpp
+++ b/BGL/test/BGL/test_Euler_operations.cpp
@@ -1,7 +1,7 @@
 
 #include "test_Prefix.h"
+#include <boost/range/distance.hpp>
 #include <CGAL/boost/graph/Euler_operations.h>
-
 
 template <typename T>
 void 

--- a/BGL/test/BGL/test_Prefix.h
+++ b/BGL/test/BGL/test_Prefix.h
@@ -7,8 +7,6 @@
 #include <fstream>
 
 #include <CGAL/boost/graph/properties.h>
-#include <boost/assign.hpp>
-#include <boost/mpl/list.hpp>
 
 #include <CGAL/Simple_cartesian.h>
 

--- a/Surface_mesh/include/CGAL/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh.h
@@ -19,8 +19,8 @@
 #ifndef CGAL_TOP_LEVEL_SURFACE_MESH_H
 #define CGAL_TOP_LEVEL_SURFACE_MESH_H
 
-#include "CGAL/Surface_mesh/Surface_mesh_fwd.h"
-#include "CGAL/Surface_mesh/Surface_mesh.h"
+#include <CGAL/Surface_mesh/Surface_mesh_fwd.h>
+#include <CGAL/Surface_mesh/Surface_mesh.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2249,34 +2249,34 @@ private: //--------------------------------------------------- property handling
   // dummy is necessary to make it a partial specialization (full
   // specializations are only allowed at namespace scope).
   template<typename, bool = true>
-  struct Property_selector;
+  struct Property_selector {};
 
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Vertex_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Vertex_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Vertex_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Vertex_index>&
     operator()() { return m_->vprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Halfedge_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Halfedge_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Halfedge_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Halfedge_index>&
     operator()() { return m_->hprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Edge_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Edge_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Edge_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Edge_index>&
     operator()() { return m_->eprops_; }
   };
   template<bool dummy>
-  struct Property_selector<typename Surface_mesh::Face_index, dummy> {
-    Surface_mesh* m_;
-    Property_selector(Surface_mesh* m) : m_(m) {}
-    Property_container<typename Surface_mesh::Face_index>&
+  struct Property_selector<typename CGAL::Surface_mesh<P>::Face_index, dummy> {
+    CGAL::Surface_mesh<P>* m_;
+    Property_selector(CGAL::Surface_mesh<P>* m) : m_(m) {}
+    Property_container<typename CGAL::Surface_mesh<P>::Face_index>&
     operator()() { return m_->fprops_; }
   };
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
@@ -18,8 +18,6 @@
 #ifndef CGAL_SURFACE_MESH_FWD_H
 #define CGAL_SURFACE_MESH_FWD_H
 
-#include <string>
-
 /// \file Surface_mesh_fwd.h
 /// Forward declarations of the Surface_mesh package.
 


### PR DESCRIPTION
Boost.Fusion only improves the code marginally and comes with a large number of includes. Remove it and clean up some other, unrelated includes.