### PR TITLE
Support Qt-5.2

### DIFF
--- a/AABB_tree/demo/AABB_tree/AABB_demo.cpp
+++ b/AABB_tree/demo/AABB_tree/AABB_demo.cpp
@@ -36,7 +36,9 @@ int main(int argc, char **argv)
   app.setOrganizationName("INRIA");
   app.setApplicationName("AABB tree demo");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   app.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGALQt (Qt5).
   CGAL_QT_INIT_RESOURCES;

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
@@ -14,7 +14,9 @@ int main(int argc, char** argv)
   application.setOrganizationName("GeometryFactory");
   application.setApplicationName("Alpha Shape Reconstruction");
   //for Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   application.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGALQt (Qt5).
   // See http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
@@ -9,7 +9,9 @@ int main(int argc, char** argv)
   // Instantiate the viewer.
   Viewer viewer;
   //for Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   application.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
   viewer.setWindowTitle("Intersection points of randomly generated circles.");
 
   // Make the viewer window visible on screen.

--- a/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
@@ -37,7 +37,9 @@ int main(int argc, char** argv)
   application.setOrganizationName("CNRS and LIRIS' Establishments");
   application.setApplicationName("3D Linear Cell Complex");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   application.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGALQt5
   // See http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Mesh_3/demo/Mesh_3/Mesh_3.cpp
+++ b/Mesh_3/demo/Mesh_3/Mesh_3.cpp
@@ -11,7 +11,9 @@ int main(int argc, char **argv)
   app.setOrganizationName("GeometryFactory");
   app.setApplicationName("Mesh_3 demo");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   app.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGALQt ( Qt5).
   // See http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
@@ -10,7 +10,9 @@ int main(int argc, char** argv)
   application.setOrganizationName("INRIA");
   application.setApplicationName("3D Periodic Lloyd");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   application.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGAL (QT5).
   // See http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.cpp
@@ -39,7 +39,9 @@ int main(int argc, char **argv)
   app.setOrganizationName("GeometryFactory");
   app.setApplicationName("Polyhedron_3 demo");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   app.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   // Import resources from libCGAL (Qt5).
   CGAL_QT_INIT_RESOURCES;

--- a/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
+++ b/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
@@ -31,7 +31,9 @@ int main(int argc, char** argv)
   app.setOrganizationName("INRIA");
   app.setApplicationName("3D Triangulation Demo");
   //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   app.setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
 
   MainWindow mw;
   mw.show();


### PR DESCRIPTION
`Qt::AA_UseDesktopOpenGL` is usable from Qt-5.3 only. With that patch we should be able to support Qt-5.2 (default for current latest Ubuntu version).

See CGAL/cgal-testsuite-dockerfiles#23