### PR TITLE
Fix a warning in Arr_2 (version CGAL-4.6)

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
@@ -1593,7 +1593,7 @@ namespace CGAL {
               *oi++ = make_object(p);
               return oi;
             }
-            dir1 == SMALLER ? ++i1 : (i1 != 0) ? --i1 : INVALID_INDEX;
+            dir1 == SMALLER ? ++i1 : (i1 != 0) ? --i1 : std::size_t(INVALID_INDEX);
             left_res = EQUAL;
           }
         }
@@ -1615,7 +1615,7 @@ namespace CGAL {
               return oi;
             }
 
-            dir2 == SMALLER ? ++i2 : (i2 != 0) ? --i2 : INVALID_INDEX;
+            dir2 == SMALLER ? ++i2 : (i2 != 0) ? --i2 : std::size_t(INVALID_INDEX);
             left_res = EQUAL;
           }
         }
@@ -2772,7 +2772,7 @@ namespace CGAL {
         // segment that is closest to the point. Otherwise, the point is not
         // in the x-range of the polyline.
         return (is_vertical_2_object()(cv)) ?
-          ((res_to == SMALLER) ? from : to) : INVALID_INDEX;
+          ((res_to == SMALLER) ? from : to) : std::size_t(INVALID_INDEX);
 
       // Perform a binary search to locate the segment that contains q in its
       // range:


### PR DESCRIPTION
With gcc and -Wextra :

../CGAL/Arr_polyline_traits_2.h:2775: warning: enumeral and
non-enumeral type in conditional expression
../CGAL/Arr_polyline_traits_2.h:1596: warning: enumeral and
non-enumeral type in conditional expression
../CGAL/Arr_polyline_traits_2.h:1618: warning: enumeral and
non-enumeral type in conditional expression