### PR TITLE
be more permissive for color reset

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -976,7 +976,7 @@ void
 Scene_polyhedron_item::setColor(QColor c)
 {
   // reset patch ids
-  if (plugin_has_set_color_vector_m)
+  if (colors_.size()>2 || plugin_has_set_color_vector_m)
   {
     BOOST_FOREACH(Polyhedron::Facet_handle fh, faces(*poly))
       fh->set_patch_id(1);


### PR DESCRIPTION
This enables the reset to work after a coloration per connected component