### PR TITLE
Polyhedron demo: save memory by clearing the vectors after they are sent to OpenGL

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
@@ -11,7 +11,7 @@
 #include <QKeyEvent>
 #include <CGAL/corefinement_operations.h>
 
-Scene_combinatorial_map_item::Scene_combinatorial_map_item(Scene_interface* scene,void* address):last_known_scene(scene),volume_to_display(0),exportSelectedVolume(NULL),address_of_A(address){m_combinatorial_map=NULL; are_buffers_filled = false;;}
+Scene_combinatorial_map_item::Scene_combinatorial_map_item(Scene_interface* scene,void* address):last_known_scene(scene),volume_to_display(0),exportSelectedVolume(NULL),address_of_A(address){m_combinatorial_map=NULL; are_buffers_filled = false; nb_points = 0; nb_lines =0; nb_facets =0;}
 Scene_combinatorial_map_item::~Scene_combinatorial_map_item(){if (m_combinatorial_map!=NULL) delete m_combinatorial_map;}
 
 Scene_combinatorial_map_item* Scene_combinatorial_map_item::clone() const{return NULL;}
@@ -350,7 +350,9 @@ void Scene_combinatorial_map_item::initialize_buffers(Viewer_interface *viewer) 
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
         buffers[0].release();
-
+        nb_lines = positions_lines.size();
+        positions_lines.resize(0);
+        std::vector<double>(positions_lines).swap(positions_lines);
         vaos[0]->release();
         program->release();
     }
@@ -367,6 +369,9 @@ void Scene_combinatorial_map_item::initialize_buffers(Viewer_interface *viewer) 
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
         buffers[1].release();
         vaos[1]->release();
+        nb_points = positions_points.size();
+        positions_points.resize(0);
+        std::vector<double>(positions_points).swap(positions_points);
         program->release();
     }
     //vao for the facets
@@ -384,11 +389,15 @@ void Scene_combinatorial_map_item::initialize_buffers(Viewer_interface *viewer) 
 
         buffers[3].bind();
         buffers[3].allocate(normals.data(),
-                            static_cast<int>(positions_facets.size()*sizeof(double)));
+                            static_cast<int>(normals.size()*sizeof(double)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
         buffers[3].release();
-
+        nb_facets = positions_facets.size();
+        positions_facets.resize(0);
+        std::vector<double>(positions_facets).swap(positions_facets);
+        normals.resize(0);
+        std::vector<double>(normals).swap(normals);
         vaos[2]->release();
         program->release();
     }
@@ -469,7 +478,7 @@ void Scene_combinatorial_map_item::draw(Viewer_interface* viewer) const
     attrib_buffers(viewer,PROGRAM_WITH_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_facets.size()/3));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/3));
     vaos[2]->release();
     program->release();
 
@@ -486,7 +495,7 @@ void Scene_combinatorial_map_item::draw(Viewer_interface* viewer) const
      attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
      program->bind();
      program->setAttributeValue("colors", this->color());
-     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/3));
+     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
      vaos[0]->release();
      program->release();
 
@@ -503,7 +512,7 @@ void Scene_combinatorial_map_item::draw(Viewer_interface* viewer) const
      attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
      program->bind();
      program->setAttributeValue("colors", this->color());
-     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_points.size()/3));
+     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
      vaos[1]->release();
      program->release();
 

--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.h
@@ -77,6 +77,9 @@ private:
    mutable std::vector<double> positions_points;
    mutable std::vector<double> positions_facets;
    mutable std::vector<double> normals;
+   mutable int nb_lines;
+   mutable int nb_points;
+   mutable int nb_facets;
 
     mutable QOpenGLShaderProgram *program;
 

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
@@ -265,22 +265,29 @@ private:
   Ui::DeformMesh* ui_widget;
   Scene_polyhedron_item* poly_item;
   // For drawing
-  std::vector<GLdouble> positions;
-  std::vector<unsigned int> tris;
-  std::vector<unsigned int> edges;
-  std::vector<GLdouble> color_lines;
-  std::vector<GLdouble> color_bbox;
-  std::vector<GLdouble> ROI_points;
-  std::vector<GLdouble> control_points;
-  std::vector<GLdouble> ROI_color;
-  std::vector<GLdouble> control_color;
-  std::vector<GLdouble> normals;
-  std::vector<GLdouble> pos_bbox;
-  std::vector<GLdouble> pos_axis;
-  std::vector<GLdouble> pos_sphere;
-  std::vector<GLdouble> normals_sphere;
+  mutable std::vector<GLdouble> positions;
+  mutable std::vector<unsigned int> tris;
+  mutable std::vector<unsigned int> edges;
+  mutable std::vector<GLdouble> color_lines;
+  mutable std::vector<GLdouble> color_bbox;
+  mutable std::vector<GLdouble> ROI_points;
+  mutable std::vector<GLdouble> control_points;
+  mutable std::vector<GLdouble> ROI_color;
+  mutable std::vector<GLdouble> control_color;
+  mutable std::vector<GLdouble> normals;
+  mutable std::vector<GLdouble> pos_bbox;
+  mutable std::vector<GLdouble> pos_axis;
+  mutable std::vector<GLdouble> pos_sphere;
+  mutable std::vector<GLdouble> normals_sphere;
   mutable QOpenGLShaderProgram *program;
   mutable QOpenGLShaderProgram bbox_program;
+  mutable int nb_ROI;
+  mutable int nb_sphere;
+  mutable int nb_control;
+  mutable int nb_axis;
+  mutable int nb_bbox;
+
+
 
   mutable QOpenGLBuffer *in_bu;
   using Scene_item::initialize_buffers;

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -52,6 +52,9 @@ Scene_nef_polyhedron_item::Scene_nef_polyhedron_item()
       nef_poly(new Nef_polyhedron)
 {
     is_selected = true;
+    nb_points = 0;
+    nb_lines = 0;
+    nb_facets = 0;
 }
 
 Scene_nef_polyhedron_item::Scene_nef_polyhedron_item(Nef_polyhedron* const p)
@@ -59,6 +62,9 @@ Scene_nef_polyhedron_item::Scene_nef_polyhedron_item(Nef_polyhedron* const p)
       nef_poly(p)
 {
     is_selected = true;
+    nb_points = 0;
+    nb_lines = 0;
+    nb_facets = 0;
 }
 
 Scene_nef_polyhedron_item::Scene_nef_polyhedron_item(const Nef_polyhedron& p)
@@ -66,6 +72,9 @@ Scene_nef_polyhedron_item::Scene_nef_polyhedron_item(const Nef_polyhedron& p)
       nef_poly(new Nef_polyhedron(p))
 {
      is_selected = true;
+     nb_points = 0;
+     nb_lines = 0;
+     nb_facets = 0;
 }
 
 Scene_nef_polyhedron_item::~Scene_nef_polyhedron_item()
@@ -104,6 +113,15 @@ void Scene_nef_polyhedron_item::initialize_buffers(Viewer_interface *viewer) con
         program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
         buffers[2].release();
         vaos[0]->release();
+        nb_facets = positions_facets.size();
+        positions_facets.resize(0);
+        std::vector<double>(positions_facets).swap(positions_facets);
+
+        normals.resize(0);
+        std::vector<double>(normals).swap(normals);
+
+        color_facets.resize(0);
+        std::vector<double>(color_facets).swap(color_facets);
         program->release();
 
     }
@@ -129,6 +147,12 @@ void Scene_nef_polyhedron_item::initialize_buffers(Viewer_interface *viewer) con
         program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
         buffers[4].release();
 
+        nb_lines = positions_lines.size();
+        positions_lines.resize(0);
+        std::vector<double>(positions_lines).swap(positions_lines);
+
+        color_lines.resize(0);
+        std::vector<double>(color_lines).swap(color_lines);
         vaos[1]->release();
         program->release();
     }
@@ -155,6 +179,13 @@ void Scene_nef_polyhedron_item::initialize_buffers(Viewer_interface *viewer) con
         buffers[6].release();
 
         vaos[2]->release();
+
+        nb_points = positions_points.size();
+        positions_points.resize(0);
+        std::vector<double>(positions_points).swap(positions_points);
+
+        color_points.resize(0);
+        std::vector<double>(color_points).swap(color_points);
         program->release();
     }
     are_buffers_filled = true;
@@ -462,7 +493,7 @@ void Scene_nef_polyhedron_item::draw(Viewer_interface* viewer) const
     program=getShaderProgram(PROGRAM_WITH_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITH_LIGHT);
     program->bind();
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_facets.size()/3));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/3));
     vaos[0]->release();
     program->release();
     GLfloat point_size;
@@ -482,7 +513,7 @@ void Scene_nef_polyhedron_item::draw_edges(Viewer_interface* viewer) const
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer ,PROGRAM_WITHOUT_LIGHT);
     program->bind();
-    viewer->glDrawArrays(GL_LINES,0,static_cast<GLsizei>(positions_lines.size()/3));
+    viewer->glDrawArrays(GL_LINES,0,static_cast<GLsizei>(nb_lines/3));
     vaos[1]->release();
     program->release();
     if(renderingMode() == PointsPlusNormals)
@@ -503,7 +534,7 @@ void Scene_nef_polyhedron_item::draw_points(Viewer_interface* viewer) const
     program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer ,PROGRAM_WITHOUT_LIGHT);
     program->bind();
-    viewer->glDrawArrays(GL_POINTS,0,static_cast<GLsizei>(positions_points.size()/3));
+    viewer->glDrawArrays(GL_POINTS,0,static_cast<GLsizei>(nb_points/3));
     vaos[2]->release();
     program->release();
 

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -73,13 +73,16 @@ private:
   Nef_polyhedron* nef_poly;
 
 
-  std::vector<double> positions_lines;
-  std::vector<double> positions_facets;
-  std::vector<double> positions_points;
-  std::vector<double> normals;
-  std::vector<double> color_lines;
-  std::vector<double> color_facets;
-  std::vector<double> color_points;
+  mutable std::vector<double> positions_lines;
+  mutable std::vector<double> positions_facets;
+  mutable std::vector<double> positions_points;
+  mutable std::vector<double> normals;
+  mutable std::vector<double> color_lines;
+  mutable std::vector<double> color_facets;
+  mutable std::vector<double> color_points;
+  mutable int nb_points;
+  mutable int nb_lines;
+  mutable int nb_facets;
 
   mutable QOpenGLShaderProgram *program;
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -29,6 +29,9 @@ Scene_points_with_normal_item::Scene_points_with_normal_item()
 {
   setRenderingMode(Points);
     is_selected = true;
+    nb_points = 0;
+    nb_selected_points = 0;
+    nb_lines = 0;
 }
 
 // Copy constructor
@@ -47,6 +50,9 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_
     setRenderingMode(Points);
         is_selected = true;
     }
+    nb_points = 0;
+    nb_selected_points = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -71,6 +77,9 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
 
   setRenderingMode(PointsPlusNormals);
     is_selected = true;
+    nb_points = 0;
+    nb_selected_points = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -98,6 +107,9 @@ void Scene_points_with_normal_item::initialize_buffers(Viewer_interface *viewer)
         buffers[0].release();
 
         vaos[0]->release();
+        nb_lines = positions_lines.size();
+        positions_lines.resize(0);
+        std::vector<double>(positions_lines).swap(positions_lines);
         program->release();
     }
     //vao for the points
@@ -113,6 +125,9 @@ void Scene_points_with_normal_item::initialize_buffers(Viewer_interface *viewer)
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
         buffers[1].release();
         vaos[1]->release();
+        nb_points = positions_points.size();
+        positions_points.resize(0);
+        std::vector<double>(positions_points).swap(positions_points);
         program->release();
     }
     //vao for the selected points
@@ -129,6 +144,9 @@ void Scene_points_with_normal_item::initialize_buffers(Viewer_interface *viewer)
         buffers[2].release();
 
         vaos[2]->release();
+        nb_selected_points = positions_selected_points.size();
+        positions_selected_points.resize(0);
+        std::vector<double>(positions_selected_points).swap(positions_selected_points);
         program->release();
     }
     are_buffers_filled = true;
@@ -389,7 +407,7 @@ void Scene_points_with_normal_item::draw_edges(Viewer_interface* viewer) const
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/3));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     vaos[0]->release();
     program->release();
 }
@@ -403,7 +421,7 @@ void Scene_points_with_normal_item::draw_points(Viewer_interface* viewer) const
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_points.size()/3));
+    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
     vaos[1]->release();
     program->release();
     GLfloat point_size;
@@ -416,7 +434,7 @@ void Scene_points_with_normal_item::draw_points(Viewer_interface* viewer) const
     program->bind();
     program->setAttributeValue("colors", QColor(255,0,0));
     viewer->glDrawArrays(GL_POINTS, 0,
-                       static_cast<GLsizei>(positions_selected_points.size()/3));
+                       static_cast<GLsizei>(nb_selected_points/3));
     vaos[2]->release();
     program->release();
     viewer->glPointSize(point_size);

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -90,10 +90,13 @@ private:
   QAction* actionSelectDuplicatedPoints;
 
 
-  std::vector<double> positions_lines;
-  std::vector<double> positions_points;
-  std::vector<double> positions_selected_points;
-  std::vector<double> normals;
+  mutable std::vector<double> positions_lines;
+  mutable std::vector<double> positions_points;
+  mutable std::vector<double> positions_selected_points;
+  mutable std::vector<double> normals;
+  mutable int nb_points;
+  mutable int nb_selected_points;
+  mutable int nb_lines;
 
   mutable QOpenGLShaderProgram *program;
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -103,6 +103,12 @@ Scene_polygon_soup_item::initialize_buffers(Viewer_interface* viewer) const
 
         program->release();
         vaos[0]->release();
+        nb_polys = positions_poly.size();
+        positions_poly.resize(0);
+        std::vector<float>(positions_poly).swap(positions_poly);
+
+        normals.resize(0);
+        std::vector<float>(normals).swap(normals);
 
     }
     //vao containing the data for the edges
@@ -119,8 +125,11 @@ Scene_polygon_soup_item::initialize_buffers(Viewer_interface* viewer) const
         buffers[3].release();
 
         program->release();
-
         vaos[1]->release();
+
+        nb_lines = positions_lines.size();
+        positions_lines.resize(0);
+        std::vector<float>(positions_lines).swap(positions_lines);
 
     }
     are_buffers_filled = true;
@@ -329,6 +338,8 @@ Scene_polygon_soup_item::Scene_polygon_soup_item()
     soup(0),
     oriented(false)
 {
+    nb_polys = 0;
+    nb_lines = 0;
 }
 
 Scene_polygon_soup_item::~Scene_polygon_soup_item()
@@ -540,7 +551,7 @@ Scene_polygon_soup_item::draw(Viewer_interface* viewer) const {
     program->setAttributeValue("colors", v_colors);
     //draw the polygons
     // the third argument is the number of vec4 that will be entered
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_poly.size()/4));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_polys/4));
     // Clean-up
     program->release();
     vaos[0]->release();
@@ -561,7 +572,7 @@ Scene_polygon_soup_item::draw_points(Viewer_interface* viewer) const {
     QColor color = this->color();
     program->setAttributeValue("colors", color);
     //draw the points
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
     program->release();
     vaos[1]->release();
@@ -583,7 +594,7 @@ Scene_polygon_soup_item::draw_edges(Viewer_interface* viewer) const {
 
     program->setAttributeValue("colors", color);
     //draw the edges
-    viewer->glDrawArrays(GL_LINES, 0,static_cast<GLsizei>( positions_lines.size()/4));
+    viewer->glDrawArrays(GL_LINES, 0,static_cast<GLsizei>( nb_lines/4));
     // Clean-up
     program->release();
     vaos[1]->release();

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -166,10 +166,11 @@ private:
     typedef Polygon_soup::Polygons::const_iterator Polygons_iterator;
     Polygon_soup* soup;
     bool oriented;
-    std::vector<float> positions_poly;
-    std::vector<float> positions_lines;
-    std::vector<float> normals;
-
+    mutable std::vector<float> positions_poly;
+    mutable std::vector<float> positions_lines;
+    mutable std::vector<float> normals;
+    mutable int nb_polys;
+    mutable int nb_lines;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
     void compute_normals_and_vertices(void);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -417,6 +417,24 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
 
         vaos[3]->release();
     }
+    nb_lines = positions_lines.size();
+    positions_lines.resize(0);
+    std::vector<float>(positions_lines).swap(positions_lines);
+    nb_facets = positions_facets.size();
+    positions_facets.resize(0);
+    std::vector<float>(positions_facets).swap(positions_facets);
+
+
+    color_lines_selected.resize(0);
+    std::vector<float>(color_lines_selected).swap(color_lines_selected);
+    color_facets_selected.resize(0);
+    std::vector<float>(color_facets_selected).swap(color_facets_selected);
+    color_lines.resize(0);
+    std::vector<float>(color_lines).swap(color_lines);
+    color_facets.resize(0);
+    std::vector<float>(color_facets).swap(color_facets);
+    normals.resize(0);
+    std::vector<float>(normals).swap(normals);
     are_buffers_filled = true;
 }
 
@@ -642,6 +660,8 @@ Scene_polyhedron_item::Scene_polyhedron_item()
 {
     cur_shading=FlatPlusEdges;
     is_selected = true;
+    nb_facets = 0;
+    nb_lines = 0;
     init();
 
 }
@@ -657,6 +677,8 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
 {
     cur_shading=FlatPlusEdges;
     is_selected = true;
+    nb_facets = 0;
+    nb_lines = 0;
     init();
     changed();
 }
@@ -673,6 +695,8 @@ Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
     cur_shading=FlatPlusEdges;
     is_selected=true;
     init();
+    nb_facets = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -865,7 +889,7 @@ void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
     attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
     program = getShaderProgram(PROGRAM_WITH_LIGHT);
     program->bind();
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_facets.size()/4));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     program->release();
     if(!is_selected)
         vaos[0]->release();
@@ -888,7 +912,7 @@ void Scene_polyhedron_item::draw_edges(Viewer_interface* viewer) const {
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     //draw the edges
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
     if(!is_selected)
         vaos[1]->release();
@@ -904,7 +928,7 @@ Scene_polyhedron_item::draw_points(Viewer_interface* viewer) const {
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     //draw the points
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
     program->release();
     vaos[1]->release();
@@ -967,7 +991,7 @@ Scene_polyhedron_item::selection_changed(bool p_is_selected)
     if(p_is_selected != is_selected)
     {
         is_selected = p_is_selected;
-         are_buffers_filled = false;
+         //are_buffers_filled = false;
     }
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -112,14 +112,15 @@ private:
     bool plugin_has_set_color_vector_m;
 
 
-    std::vector<float> positions_lines;
-    std::vector<float> positions_facets;
-    std::vector<float> normals;
-    std::vector<float> color_lines;
-    std::vector<float> color_facets;
-    std::vector<float> color_lines_selected;
-    std::vector<float> color_facets_selected;
-
+    mutable std::vector<float> positions_lines;
+    mutable std::vector<float> positions_facets;
+    mutable std::vector<float> normals;
+    mutable std::vector<float> color_lines;
+    mutable std::vector<float> color_facets;
+    mutable std::vector<float> color_lines_selected;
+    mutable std::vector<float> color_facets_selected;
+    mutable int nb_facets;
+    mutable int nb_lines;
     mutable QOpenGLShaderProgram *program;
 
     using Scene_item::initialize_buffers;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -65,6 +65,20 @@ void Scene_polyhedron_selection_item::initialize_buffers(Viewer_interface *viewe
 
         vaos[2]->release();
     }
+    nb_facets = positions_facets.size();
+    positions_facets.resize(0);
+    std::vector<float>(positions_facets).swap(positions_facets);
+
+    normals.resize(0);
+    std::vector<float>(normals).swap(normals);
+
+    nb_lines = positions_lines.size();
+    positions_lines.resize(0);
+    std::vector<float>(positions_lines).swap(positions_lines);
+
+    nb_points = positions_points.size();
+    positions_points.resize(0);
+    std::vector<float>(positions_points).swap(positions_points);
 
     are_buffers_filled = true;
 }
@@ -164,7 +178,7 @@ void Scene_polyhedron_selection_item::draw(Viewer_interface* viewer) const
     attrib_buffers(viewer,PROGRAM_WITH_LIGHT);
     program->bind();
     program->setAttributeValue("colors",facet_color);
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_facets.size()/3));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/3));
     program->release();
     vaos[0]->release();
     glPolygonOffset(offset_factor, offset_units);
@@ -182,7 +196,7 @@ void Scene_polyhedron_selection_item::draw_edges(Viewer_interface* viewer) const
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors",edge_color);
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/3));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     program->release();
     vaos[1]->release();
     viewer->glLineWidth(1.f);
@@ -196,7 +210,7 @@ void Scene_polyhedron_selection_item::draw_points(Viewer_interface* viewer) cons
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors",vertex_color);
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_points.size()/3));
+    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
     program->release();
     vaos[2]->release();
     viewer->glPointSize(1.f);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -184,12 +184,18 @@ public:
         {
             buffers[i].create();
         }
+        nb_facets = 0;
+        nb_points = 0;
+        nb_lines = 0;
     }
 
   Scene_polyhedron_selection_item(Scene_polyhedron_item* poly_item, QMainWindow* mw) 
     : Scene_polyhedron_item_decorator(NULL, false)
     {
         nbVaos = 0;
+        nb_facets = 0;
+        nb_points = 0;
+        nb_lines = 0;
         for(int i=0; i<3; i++)
         {
             addVaos(i);
@@ -775,12 +781,14 @@ public:
 
 private:
 
-    std::vector<float> positions_facets;
-    std::vector<float> normals;
-    std::vector<float> positions_lines;
-    std::vector<float> positions_points;
-
-    mutable QOpenGLShaderProgram *program;
+    mutable std::vector<float> positions_facets;
+    mutable std::vector<float> normals;
+    mutable std::vector<float> positions_lines;
+    mutable std::vector<float> positions_points;
+  mutable int nb_facets;
+  mutable int nb_points;
+  mutable int nb_lines;
+  mutable QOpenGLShaderProgram *program;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
     void compute_elements();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -781,17 +781,17 @@ public:
 
 private:
 
-    mutable std::vector<float> positions_facets;
-    mutable std::vector<float> normals;
-    mutable std::vector<float> positions_lines;
-    mutable std::vector<float> positions_points;
+  mutable std::vector<float> positions_facets;
+  mutable std::vector<float> normals;
+  mutable std::vector<float> positions_lines;
+  mutable std::vector<float> positions_points;
   mutable int nb_facets;
   mutable int nb_points;
   mutable int nb_lines;
   mutable QOpenGLShaderProgram *program;
-    using Scene_item::initialize_buffers;
-    void initialize_buffers(Viewer_interface *viewer) const;
-    void compute_elements();
+  using Scene_item::initialize_buffers;
+  void initialize_buffers(Viewer_interface *viewer) const;
+  void compute_elements();
 
 };
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
@@ -12,6 +12,7 @@ Scene_polyhedron_transform_item::Scene_polyhedron_transform_item(const qglviewer
 
 {
     frame->setPosition(pos);
+    nb_lines = 0;
 }
 
 void Scene_polyhedron_transform_item::initialize_buffers(Viewer_interface *viewer =0) const
@@ -34,6 +35,10 @@ void Scene_polyhedron_transform_item::initialize_buffers(Viewer_interface *viewe
         vaos[0]->release();
         program->release();
     }
+    nb_lines = positions_lines.size();
+    positions_lines.resize(0);
+    std::vector<float>(positions_lines).swap(positions_lines);
+
     are_buffers_filled = true;
 }
 
@@ -75,7 +80,7 @@ void Scene_polyhedron_transform_item::draw_edges(Viewer_interface* viewer) const
         f_matrix.data()[i] = (float)frame->matrix()[i];
     }
     program->setUniformValue("f_matrix", f_matrix);
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/3));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     vaos[0]->release();
     program->release();
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
@@ -37,7 +37,8 @@ private:
     const Polyhedron* poly;
     qglviewer::Vec center_;
     mutable QOpenGLShaderProgram *program;
-    std::vector<float> positions_lines;
+    mutable std::vector<float> positions_lines;
+    mutable int nb_lines;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
     void compute_elements();

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -34,7 +34,7 @@ Scene_polylines_item::create_Sphere(double R)
 void
 Scene_polylines_item::initialize_buffers(Viewer_interface *viewer = 0) const
 {
-//vao for the lines
+   //vao for the lines
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
@@ -87,6 +87,20 @@ Scene_polylines_item::initialize_buffers(Viewer_interface *viewer = 0) const
 
             viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
             viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
+
+            nb_lines = positions_lines.size();
+            positions_lines.resize(0);
+            std::vector<float>(positions_lines).swap(positions_lines);
+            nb_spheres = positions_spheres.size();
+            positions_spheres.resize(0);
+            std::vector<float>(positions_spheres).swap(positions_spheres);
+            normals_spheres.resize(0);
+            std::vector<float>(normals_spheres).swap(normals_spheres);
+            color_spheres.resize(0);
+            std::vector<float>(color_spheres).swap(color_spheres);
+            nb_centers = positions_center.size();
+            positions_center.resize(0);
+            std::vector<float>(positions_center).swap(positions_center);
         }
         else
         {
@@ -319,6 +333,10 @@ Scene_polylines_item::Scene_polylines_item()
     ,nbSpheres(0)
 {
     setRenderingMode(Flat);
+    nb_spheres = 0;
+    nb_wire = 0;
+    nb_centers = 0;
+    nb_lines = 0;
     changed();
 
 }
@@ -417,7 +435,7 @@ Scene_polylines_item::draw(Viewer_interface* viewer) const {
             attrib_buffers(viewer, PROGRAM_INSTANCED);
             program->bind();
             viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
-                                          static_cast<GLsizei>(positions_spheres.size()/3), nbSpheres);
+                                          static_cast<GLsizei>(nb_spheres/3), nbSpheres);
             program->release();
             vaos[1]->release();
         }
@@ -429,7 +447,7 @@ Scene_polylines_item::draw(Viewer_interface* viewer) const {
             glPointSize(8.0f);
             glEnable(GL_POINT_SMOOTH);
             program->bind();
-            viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_center.size()/3));
+            viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_centers/3));
             glDisable(GL_POINT_SMOOTH);
             program->release();
             vaos[1]->release();
@@ -448,7 +466,7 @@ Scene_polylines_item::draw_edges(Viewer_interface* viewer) const {
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
     vaos[0]->release();
     if(d->draw_extremities)
@@ -460,7 +478,7 @@ Scene_polylines_item::draw_edges(Viewer_interface* viewer) const {
             program = getShaderProgram(PROGRAM_INSTANCED_WIRE);
             program->bind();
             viewer->glDrawArraysInstanced(GL_LINES, 0,
-                                          static_cast<GLsizei>(positions_wire_spheres.size()/3), nbSpheres);
+                                          static_cast<GLsizei>(nb_wire/3), nbSpheres);
             program->release();
             vaos[2]->release();
         }
@@ -479,7 +497,7 @@ Scene_polylines_item::draw_points(Viewer_interface* viewer) const {
     program->bind();
     QColor temp = this->color();
     program->setAttributeValue("colors", temp);
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
    vaos[0]->release();
    program->release();

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -92,15 +92,17 @@ public:
     // http://en.wikipedia.org/wiki/D-pointer
     Scene_polylines_item_private* d;
 private:
-    std::vector<float> positions_lines;
-    std::vector<float> positions_spheres;
-    std::vector<float> positions_wire_spheres;
-    std::vector<float> positions_center;
-    std::vector<float> normals_spheres;
-    std::vector<float> color_spheres;
-    std::vector<float> color_wire_spheres;
-
-
+    mutable std::vector<float> positions_lines;
+    mutable std::vector<float> positions_spheres;
+    mutable std::vector<float> positions_wire_spheres;
+    mutable std::vector<float> positions_center;
+    mutable std::vector<float> normals_spheres;
+    mutable std::vector<float> color_spheres;
+    mutable std::vector<float> color_wire_spheres;
+    mutable int nb_spheres;
+    mutable int nb_wire;
+    mutable int nb_centers;
+    mutable int nb_lines;
   mutable QOpenGLShaderProgram *program;
   mutable   GLuint nbSpheres;
     typedef std::map<Point_3, int> Point_to_int_map;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -103,8 +103,8 @@ private:
     mutable int nb_wire;
     mutable int nb_centers;
     mutable int nb_lines;
-  mutable QOpenGLShaderProgram *program;
-  mutable   GLuint nbSpheres;
+    mutable QOpenGLShaderProgram *program;
+    mutable   GLuint nbSpheres;
     typedef std::map<Point_3, int> Point_to_int_map;
     typedef Point_to_int_map::iterator iterator;
     void create_Sphere(double);

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -85,6 +85,19 @@ void Scene_textured_polyhedron_item::initialize_buffers(Viewer_interface *viewer
     viewer->glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
+    nb_facets = positions_facets.size();
+    positions_facets.resize(0);
+    std::vector<float>(positions_facets).swap(positions_facets);
+    normals.resize(0);
+    std::vector<float>(normals).swap(normals);
+    textures_map_facets.resize(0);
+    std::vector<float>(textures_map_facets).swap(textures_map_facets);
+    nb_lines = positions_lines.size();
+    positions_lines.resize(0);
+    std::vector<float>(positions_lines).swap(positions_lines);
+    textures_map_lines.resize(0);
+    std::vector<float>(textures_map_lines).swap(textures_map_lines);
+
     are_buffers_filled = true;
 }
 
@@ -200,6 +213,8 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     cur_shading=FlatPlusEdges;
     is_selected=false;
+    nb_facets = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -209,6 +224,8 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedr
     cur_shading=FlatPlusEdges;
     is_selected=false;
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
+    nb_facets = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -218,6 +235,8 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_po
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     cur_shading=FlatPlusEdges;
     is_selected=false;
+    nb_facets = 0;
+    nb_lines = 0;
     changed();
 }
 
@@ -279,7 +298,7 @@ void Scene_textured_polyhedron_item::draw(Viewer_interface* viewer) const {
     attrib_buffers(viewer, PROGRAM_WITH_TEXTURE);
     program=getShaderProgram(PROGRAM_WITH_TEXTURE);
     program->bind();
-    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_facets.size()/4));
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     //Clean-up
     program->release();
     vaos[0]->release();
@@ -295,7 +314,7 @@ void Scene_textured_polyhedron_item::draw_edges(Viewer_interface* viewer) const 
 
     program=getShaderProgram(PROGRAM_WITH_TEXTURED_EDGES);
     program->bind();
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/4));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     //Clean-up
     program->release();
     vaos[1]->release();

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -51,12 +51,13 @@ public:
 private:
   Textured_polyhedron* poly;
   Texture texture;
-  std::vector<float> positions_lines;
-  std::vector<float> positions_facets;
-  std::vector<float> normals;
-  std::vector<float> textures_map_facets;
-  std::vector<float> textures_map_lines;
-
+  mutable std::vector<float> positions_lines;
+  mutable std::vector<float> positions_facets;
+  mutable std::vector<float> normals;
+  mutable std::vector<float> textures_map_facets;
+  mutable std::vector<float> textures_map_lines;
+  mutable int nb_facets;
+  mutable int nb_lines;
 
   mutable GLuint textureId;
   mutable QOpenGLShaderProgram* program;


### PR DESCRIPTION
This should lower the RAM consumption for big items.