### PR TITLE
Polyhedron demo, fix the use of texture2D in a shader

### DIFF
--- a/Polyhedron/demo/Polyhedron/resources/shader_with_texture.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_texture.f
@@ -5,5 +5,5 @@ uniform sampler2D s_texture;
  
 void main(void) 
 { 
-  gl_FragColor = vec4(vec3(texture(s_texture, f_texCoord))*fColors, 1.0);
+  gl_FragColor = vec4(vec3(texture2D(s_texture, f_texCoord))*fColors, 1.0);
 }  

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_textured_edges.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_textured_edges.f
@@ -5,5 +5,5 @@ uniform highp sampler2D s_texture;
  
 void main(void) 
 { 
-  gl_FragColor = vec4(vec3(texture(s_texture, f_texCoord))*fColors, 1.0); 
+  gl_FragColor = vec4(vec3(texture2D(s_texture, f_texCoord))*fColors, 1.0); 
 }


### PR DESCRIPTION
- Use texture2D instead of texture in the shaders to have it in glsl 1.2 and not 1.3. This should fix #308