### PR TITLE
No need for a filtered predicate for Equal_3()(Vector_3, Vector_3)

### DIFF
--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Equal_3.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Equal_3.h
@@ -40,6 +40,7 @@ class Equal_3
   : public K_base::Equal_3
 {
   typedef typename K_base::Point_3   Point_3;
+  typedef typename K_base::Vector_3  Vector_3;
   typedef typename K_base::Equal_3   Base;
 
 public:
@@ -62,7 +63,7 @@ public:
   result_type operator()(const Point_3 &p, const Point_3& q) const
   {
     CGAL_BRANCH_PROFILER(std::string("semi-static attempts/calls to   : ") +
-                           std::string(CGAL_PRETTY_FUNCTION), tmp);
+                         std::string(CGAL_PRETTY_FUNCTION), tmp);
 
     Get_approx<Point_3> get_approx; // Identity functor for all points
                                     // but lazy points
@@ -71,7 +72,7 @@ public:
     if (fit_in_double(get_approx(p).x(), px) && fit_in_double(get_approx(p).y(), py) &&
         fit_in_double(get_approx(p).z(), pz) &&
         fit_in_double(get_approx(q).x(), qx) && fit_in_double(get_approx(q).y(), qy) &&
-        fit_in_double(get_approx(q).z(), qz) )      
+        fit_in_double(get_approx(q).z(), qz) )
     {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       return px == qx && py == qy && pz == qz;
@@ -79,6 +80,26 @@ public:
     return Base::operator()(p, q);
   }
 
+
+  result_type operator()(const Vector_3 &p, const Vector_3& q) const
+  {
+    CGAL_BRANCH_PROFILER(std::string("semi-static attempts/calls to   : ") +
+                         std::string(CGAL_PRETTY_FUNCTION), tmp);
+
+    Get_approx<Vector_3> get_approx; // Identity functor for all points
+                                     // but lazy points
+    double px, py, pz, qx, qy, qz;
+
+    if (fit_in_double(get_approx(p).x(), px) && fit_in_double(get_approx(p).y(), py) &&
+        fit_in_double(get_approx(p).z(), pz) &&
+        fit_in_double(get_approx(q).x(), qx) && fit_in_double(get_approx(q).y(), qy) &&
+        fit_in_double(get_approx(q).z(), qz) )
+    {
+      CGAL_BRANCH_PROFILER_BRANCH(tmp);
+      return px == qx && py == qy && pz == qz;
+    }
+    return Base::operator()(p, q);
+  }
 
 }; // end class Equal_3
 


### PR DESCRIPTION
Equal_3::operator()(Vector_3,Vector_3) will have a "static filter". That will remove the dynamic filtering using `Interval_nt`.
