### PR TITLE
Polyhedron demo: first check that the STL file is a polygon mesh before loading it

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -93,4 +93,5 @@ It can be made short to PM. And TriangleMesh (or TM) specifies when the paramete
 \todo document `BGL/include/CGAL/boost/graph/split_graph_into_polylines.h`
 \todo add in BGL `clear(pmesh)` and use it in `keep_largest_connected_components(pmesh, 0);`
 \todo document BGL/include/CGAL/boost/graph/Dual.h and remove the example from dont_submit
+\todo publish `is_polygon_soup_a_polygon_mesh` defined in `polygon_soup_to_polygon_mesh.h`
 */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -14,7 +14,7 @@
 //
 // $URL$
 // $Id$
-// 
+//
 //
 // Author(s)     : Laurent Rineau and Ilker O. Yaz
 
@@ -90,6 +90,42 @@ public:
   }
 };
 }//end namespace internal
+
+
+  /// \cond SKIP_IN_MANUAL
+  /**
+  * \ingroup PkgPolygonMeshProcessing
+  * returns `true` if the soup of polygons defines a valid polygon mesh
+  * that can be handled by `CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh()`.
+  *
+  * @tparam Polygon a `std::vector<std::size_t>` containing the indices
+  *         of the points of the polygon face
+  *
+  * @param polygons each element in the vector describes a polygon using the index of the vertices
+  *
+  */
+  template<class Polygon>
+  bool is_polygon_soup_a_polygon_mesh(const std::vector<Polygon>& polygons)
+  {
+    typedef typename std::iterator_traits<
+              typename Polygon::iterator >::value_type                   V_ID;
+
+    std::set< std::pair<V_ID, V_ID> > edge_set;
+    BOOST_FOREACH(const Polygon& polygon, polygons)
+    {
+      std::size_t nb_edges = polygon.size();
+      if (nb_edges<3) return false;
+      V_ID prev=polygon.back();
+      BOOST_FOREACH(V_ID id, polygon)
+        if (! edge_set.insert(std::pair<V_ID, V_ID>(prev,id)).second )
+          return false;
+        else
+          prev=id;
+    }
+
+    return true;
+  }
+  /// \endcond
 
   /**
   * \ingroup PkgPolygonMeshProcessing

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_stl_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_stl_plugin.cpp
@@ -59,7 +59,8 @@ Polyhedron_demo_stl_plugin::load(QFileInfo fileinfo) {
   try{
     // Try building a polyhedron
     Polyhedron P;
-    CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, triangles, P);
+    if (CGAL::Polygon_mesh_processing::is_polygon_soup_a_polygon_mesh(triangles))
+      CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, triangles, P);
     
     if(! P.is_valid() || P.empty()){
       std::cerr << "Error: Invalid polyhedron" << std::endl;


### PR DESCRIPTION
In the polyhedron demo, before loading a stl file as a polyhedron, check whether it fits in a polyhedron