### PR TITLE
Fix warning, after the replacement assert/CGAL_assertion

### DIFF
--- a/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v7.h
+++ b/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v7.h
@@ -38,6 +38,7 @@ typedef unsigned int uint;
 #include<CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/assertions.h>
+#include <CGAL/use.h>
 
 #include <boost/utility.hpp>
 
@@ -849,7 +850,7 @@ public:
         switch (ints.size()){
           case 1:
             ok=CGAL::assign(tmp_pt,ints[0]);
-            CGAL_assertion(ok);
+            CGAL_assertion(ok); CGAL_use(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[i]=index;
@@ -858,12 +859,12 @@ public:
           case 2:
             int right_ind=i<2?0:1;
             ok=CGAL::assign(tmp_pt,ints[right_ind]);
-            CGAL_assertion(ok);
+            CGAL_assertion(ok); CGAL_use(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[i]=index;
             ok=CGAL::assign(tmp_pt,ints[(right_ind+1)%2]);
-            CGAL_assertion(ok);
+            CGAL_assertion(ok); CGAL_use(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[(i+1)%4+4]=index;      

--- a/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v7.h
+++ b/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v7.h
@@ -850,7 +850,7 @@ public:
         switch (ints.size()){
           case 1:
             ok=CGAL::assign(tmp_pt,ints[0]);
-            CGAL_assertion(ok); CGAL_use(ok);
+            CGAL_assertion(ok); CGAL_USE(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[i]=index;
@@ -859,12 +859,12 @@ public:
           case 2:
             int right_ind=i<2?0:1;
             ok=CGAL::assign(tmp_pt,ints[right_ind]);
-            CGAL_assertion(ok); CGAL_use(ok);
+            CGAL_assertion(ok); CGAL_USE(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[i]=index;
             ok=CGAL::assign(tmp_pt,ints[(right_ind+1)%2]);
-            CGAL_assertion(ok); CGAL_use(ok);
+            CGAL_assertion(ok); CGAL_USE(ok);
             points.push_back(tmp_pt);
             index=points.size()-1;
             indices[(i+1)%4+4]=index;      


### PR DESCRIPTION
When CGAL_assertion is defined to the empty macro, then the variable
'ok' triggers a warning:
```
include/CGAL/CGAL_Ipelet_base_v7.h:848:14: warning: variable 'ok' set but not used [-Wunused-but-set-variable]
         bool ok=true;
              ^
```
See for example
https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.7-Ic-136/CGAL_ipelets_Demo/TestReport_lrineau_x86-64_Linux-Fedora19_g++-4.8_Release.gz

Related to the merge PR #297.