### PR TITLE
Triangulation_2: speed up fill_hole_delaunay()

### DIFF
--- a/Triangulation_2/benchmark/Triangulation_2/Delaunay_remove.cpp
+++ b/Triangulation_2/benchmark/Triangulation_2/Delaunay_remove.cpp
@@ -3,9 +3,6 @@
 #include <CGAL/Timer.h>
 #include <CGAL/point_generators_2.h>
 
-#include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <CGAL/Search_traits_2.h>
-
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/Triangulation_2/benchmark/Triangulation_2/Delaunay_remove.cpp
+++ b/Triangulation_2/benchmark/Triangulation_2/Delaunay_remove.cpp
@@ -3,6 +3,8 @@
 #include <CGAL/Timer.h>
 #include <CGAL/point_generators_2.h>
 
+#include <CGAL/Orthogonal_k_neighbor_search.h>
+#include <CGAL/Search_traits_2.h>
 
 #include <iostream>
 #include <fstream>
@@ -11,9 +13,10 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
 typedef CGAL::Delaunay_triangulation_2<K> Delaunay;
+typedef Delaunay::Finite_vertices_iterator FVI;
+typedef Delaunay::Vertex_handle Vertex_handle;
 typedef K::Point_2                                     Point;
 typedef CGAL::Creator_uniform_2<double,Point>  Creator;
-
 
 
 int main(int argc, char **argv)
@@ -34,10 +37,14 @@ int main(int argc, char **argv)
   double res=0;
   for (int r=0;r<rep;++r){
     Delaunay delaunay=original;
+    std::vector<Vertex_handle> vertices;
+    for(FVI fvi = delaunay.finite_vertices_begin(); fvi != delaunay.finite_vertices_end();++fvi){
+      vertices.push_back(fvi);
+    }
     CGAL::Timer t;
     t.start();
-    for (int k=0;k<n;++k)
-      delaunay.remove(delaunay.finite_vertices_begin());
+    for (int k=0; k<vertices.size(); ++k)
+      delaunay.remove(vertices[k]);
     t.stop();
     res+=t.time();
     if (delaunay.number_of_vertices()!=0){

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -1784,14 +1784,13 @@ fill_hole_delaunay(std::list<Edge> & first_hole)
   Face_handle  f, ff, fn;
   int i, ii, in;
   Hole_list hole_list;
-  Hole hole;
         
   hole_list.push_front(first_hole);
   
   while( ! hole_list.empty())
     {
-      hole = hole_list.front();
-      hole_list.pop_front();
+      Hole& hole = hole_list.front();
+     
       typename Hole::iterator hit = hole.begin();
   
       // if the hole has only three edges, create the triangle
@@ -1801,6 +1800,7 @@ fill_hole_delaunay(std::list<Edge> & first_hole)
 	ff = (* ++hit).first;    ii = (*hit).second;
 	fn = (* ++hit).first;    in = (*hit).second;
 	create_face(f,i,ff,ii,fn,in);
+        hole_list.pop_front();
 	continue;
       }
   
@@ -1879,7 +1879,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole)
 	newf = create_face(ff,ii,fn,in);
 	hole.pop_front();
 	hole.push_front(Edge( newf,1));
-	hole_list.push_front(hole);
       }
       else{
 	fn = (hole.back()).first;
@@ -1888,7 +1887,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole)
 	  newf = create_face(fn,in,ff,ii);
 	  hole.pop_back();
 	  hole.push_back(Edge(newf,1));
-	  hole_list.push_front(hole);
 	}
 	else{
 	  // split the hole in two holes
@@ -1903,7 +1901,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole)
   
 	  hole.push_front(Edge( newf,1));
 	  new_hole.push_front(Edge( newf,0));
-	  hole_list.push_front(hole);
 	  hole_list.push_front(new_hole);
 	}
       }
@@ -1933,8 +1930,7 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
   hole_list.push_front(first_hole);
 
   while(!hole_list.empty()) {
-    hole = hole_list.front();
-    hole_list.pop_front();
+    Hole hole = hole_list.front();
     typename Hole::iterator hit = hole.begin();
 
     if (hole.size() == 3) {
@@ -1944,6 +1940,7 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
       fn = (* ++hit).first;    in = (*hit).second;
       Face_handle newf = create_face(f,i,ff,ii,fn,in);
       *fit++ = newf;
+      hole_list.pop_front();
       continue;
     }
 
@@ -2001,7 +1998,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
       newf = create_face(ff,ii,fn,in);
       hole.pop_front();
       hole.push_front(Edge( newf,1));
-      hole_list.push_front(hole);
     } else {
       fn = (hole.back()).first;
       in = (hole.back()).second;
@@ -2009,7 +2005,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
         newf = create_face(fn,in,ff,ii);
         hole.pop_back();
         hole.push_back(Edge(newf,1));
-        hole_list.push_front(hole);
       } else {
   newf = create_face(ff,ii,v2);
   Hole new_hole;
@@ -2020,7 +2015,6 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
         }
         hole.push_front(Edge(newf, 1));
         new_hole.push_front(Edge(newf, 0));
-        hole_list.push_front(hole);
         hole_list.push_front(new_hole);
       }
     }

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -1925,12 +1925,10 @@ fill_hole_delaunay(std::list<Edge> & first_hole, OutputItFaces fit)
   Face_handle  f, ff, fn;
   int i, ii, in;
   Hole_list hole_list;
-  Hole hole;
-      
   hole_list.push_front(first_hole);
 
   while(!hole_list.empty()) {
-    Hole hole = hole_list.front();
+    Hole& hole = hole_list.front();
     typename Hole::iterator hit = hole.begin();
 
     if (hole.size() == 3) {


### PR DESCRIPTION
Avoiding copies of lists makes `Delaunay_2::remove(Vertex_handle)`  considerably faster.
@janetournois   Can you please double check that my changes are correct (testsuite passes locally)