### PR TITLE
FindTBB : deal with msvc12 and msvc14

### DIFF
--- a/Installation/cmake/modules/FindTBB.cmake
+++ b/Installation/cmake/modules/FindTBB.cmake
@@ -102,6 +102,17 @@ if (WIN32)
     if(MSVC11)
         set(_TBB_COMPILER "vc11")
     endif(MSVC11)
+    if(MSVC12)
+	set(_TBB_COMPILER "vc12")
+    endif(MSVC12)
+    #note there was no MSVC13
+    if(MSVC14)
+	if(RUNNING_CGAL_AUTO_TEST)
+	    set (TBB_FOUND "NO")
+	    return()#binaries for TBB not publicly available when CGAL-4.7 is published
+	endif(RUNNING_CGAL_AUTO_TEST)
+	message(STATUS "[Warning] FindTBB.cmake: TBB 4.4 (latest available when CGAL-4.7 is published) does not provide support for MSVC 2015.")
+    endif(MSVC14)
     # Todo: add other Windows compilers such as ICL.
     set(_TBB_ARCHITECTURE ${TBB_ARCHITECTURE})
 endif (WIN32)


### PR DESCRIPTION
msvc12 (2013) now handled

until now, msvc14 (2015) is not supported by TBB (<= 4.4)
this commit prevents the testsuite from looking for it and then trying to use if it automatically finds some version of TBB on the computer