### PR TITLE
Update Kernel--Side_of_oriented_sphere_d.h

### DIFF
--- a/Kernel_d/doc/Kernel_d/Concepts/Kernel--Side_of_oriented_sphere_d.h
+++ b/Kernel_d/doc/Kernel_d/Concepts/Kernel--Side_of_oriented_sphere_d.h
@@ -22,7 +22,7 @@ side is the bounded interior of the sphere.
 \pre `A` contains \f$ d+1\f$ points in \f$ d\f$-space.
 \cgalRequires The value type of `ForwardIterator` is `Kernel_d::Point_d`. 
 */ 
-template <class ForwardIterator> Bounded_side 
+template <class ForwardIterator> Oriented_side 
 operator()( ForwardIterator first, ForwardIterator last, const 
 Kernel_d::Point_d& p); 
 


### PR DESCRIPTION
Fix the return value of the functor. 

Every model available returns Oriented_side, which is the only option
because the functor does not know the orientation of the 
sphere and we don't want to compute it (to do that, one should
use Side_of_bounded_sphere_d).