### PR TITLE
fix doc issues

### DIFF
--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -131,12 +131,14 @@ user might encounter.
 - `CGAL::is_bivalent_mesh()`
 - `CGAL::is_trivalent()`
 - `CGAL::is_trivalent_mesh()`
+- `CGAL::is_isolated_triangle()`
 - `CGAL::is_closed()`
 
 - `CGAL::is_triangle()`
 - `CGAL::is_triangle_mesh()`
 - `CGAL::is_quad()`
 - `CGAL::is_quad_mesh()`
+- `CGAL::is_isolated_quad()`
 
 - `CGAL::is_tetrahedron()`
 - `CGAL::is_hexahedron()`
@@ -150,10 +152,16 @@ user might encounter.
 - `CGAL::Halfedge_around_target_iterator`
 - `CGAL::Halfedge_around_face_iterator`
 - `CGAL::Vertex_around_target_iterator`
+- `CGAL::Vertex_around_face_iterator`
+- `CGAL::Face_around_face_iterator`
 - `CGAL::Face_around_target_iterator`
-- `CGAL::halfedges_around_source`
-- `CGAL::halfedges_around_target`
-- `CGAL::halfedges_around_face`
+- `CGAL::halfedges_around_source()`
+- `CGAL::halfedges_around_target()`
+- `CGAL::halfedges_around_face()`
+- `CGAL::faces_around_face()`
+- `CGAL::faces_around_target()`
+- `CGAL::vertices_around_face()`
+- `CGAL::vertices_around_target()`
 
 ## Circulators ##
 - `CGAL::Halfedge_around_source_circulator`
@@ -161,26 +169,29 @@ user might encounter.
 - `CGAL::Halfedge_around_face_circulator`
 - `CGAL::Vertex_around_target_circulator`
 - `CGAL::Face_around_target_circulator`
+- `CGAL::Face_around_face_circulator`
 
 ## Euler Operations ##
 
-- `CGAL::Euler::join_vertex()`
-- `CGAL::Euler::split_vertex()`
-- `CGAL::Euler::split_edge()`
-- `CGAL::Euler::join_face()`
-- `CGAL::Euler::split_face()`
-- `CGAL::Euler::join_loop()`
-- `CGAL::Euler::split_loop()`
-- `CGAL::Euler::remove_face()`
-- `CGAL::Euler::make_hole()`
-- `CGAL::Euler::fill_hole()`
 - `CGAL::Euler::add_center_vertex()`
+- `CGAL::Euler::add_edge()`
+- `CGAL::Euler::add_face()`
+- `CGAL::Euler::add_face_to_border()`
+- `CGAL::Euler::add_vertex_and_face_to_border()`
+- `CGAL::Euler::collapse_edge()`
+- `CGAL::Euler::does_satisfy_link_condition()`
+- `CGAL::Euler::fill_hole()`
+- `CGAL::Euler::flip_edge()`
+- `CGAL::Euler::join_face()`
+- `CGAL::Euler::join_loop()`
+- `CGAL::Euler::join_vertex()`
+- `CGAL::Euler::make_hole()`
 - `CGAL::Euler::remove_center_vertex()`
-- `CGAL::Euler::add_vertex_and_face_to_border()` 
-- `CGAL::Euler::add_face_to_border()` 
-- `CGAL::Euler::collapse_edge()` 
-- `CGAL::Euler::does_satisfy_link_condition()` 
-
+- `CGAL::Euler::remove_face()`
+- `CGAL::Euler::split_edge()`
+- `CGAL::Euler::split_face()`
+- `CGAL::Euler::split_loop()`
+- `CGAL::Euler::split_vertex()`
 
 */
 

--- a/BGL/include/CGAL/boost/graph/Euler_operations.h
+++ b/BGL/include/CGAL/boost/graph/Euler_operations.h
@@ -1455,6 +1455,7 @@ bool
 }
 
 #ifndef CGAL_NO_DEPRECATED_CODE
+/// \cond SKIP_IN_MANUAL
 template<typename Graph>
 bool
   satisfies_link_condition(typename boost::graph_traits<Graph>::edge_descriptor e,
@@ -1462,6 +1463,7 @@ bool
 {
   return does_satisfy_link_condition(e, g);
 }
+/// \endcond
 #endif
 /// @}
 

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -872,7 +872,16 @@ halfedges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h
   return make_range(I(h,g), I(h,g,1));
 }
 
-
+/**
+ * \ingroup PkgBGLIterators
+ * A bidirectional iterator with value type `boost::graph_traits<Graph>::%face_descriptor`.
+ * It iterates over the same halfedges as the `Halfedge_around_face_iterator`,
+ * and provides the face descriptor associated to the opposite halfedge.  The face descriptor
+ * may be the null face, and it may be several times the same face descriptor.
+ *
+ * \tparam Graph must be a model of the concept `HalfedgeGraph`
+ * \cgalModels `BidirectionalCirculator`
+ */
 template <typename Graph>
 class Face_around_face_iterator
 #ifndef DOXYGEN_RUNNING
@@ -1023,6 +1032,13 @@ private:
 #endif
 }; 
 
+/**
+ * \ingroup PkgBGLIterators
+ * A bidirectional iterator  with value type `boost::graph_traits<Graph>::%vertex_descriptor`
+ *  over all vertices incident to the same face or border.
+ * \tparam Graph must be a model of the concept `HalfedgeGraph`
+ * \cgalModels `BidirectionalIterator`
+ */
 template <typename Graph>
 class Vertex_around_face_iterator
 #ifndef DOXYGEN_RUNNING
@@ -1111,7 +1127,7 @@ opposite_edges_around_face(typename boost::graph_traits<Graph>::halfedge_descrip
 
 /**
  * \ingroup PkgBGLIterators
- * A bidirectional circulator  with value type `boost::graph_traits<Graph>::%vertex_descriptor` over all vertices adjacent to the same vertex.
+ * A bidirectional circulator with value type `boost::graph_traits<Graph>::%vertex_descriptor` over all vertices adjacent to the same vertex.
  * It circulates over the same halfedges as the `Halfedge_around_target_circulator`.
  *
  * \tparam Graph must be a model of the concept `HalfedgeGraph`


### PR DESCRIPTION
* add missing iterator doc (function documented but not the iterator type)
* add missing entries in the classified reference manual
* hide deprecated function from doxygen