### PR TITLE
Fix polygon_soup and optimize loading time

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
@@ -131,7 +131,7 @@ void Polyhedron_demo_orient_soup_plugin::shuffle()
 
   if(item) {
     item->shuffle_orientations();
-    scene->itemChanged(item);
+    //scene->itemChanged(item);
   }
   else {
     Scene_polyhedron_item* poly_item = 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
@@ -161,7 +161,6 @@ void Polyhedron_demo_orient_soup_plugin::displayNonManifoldEdges()
   if(item)
   {
     item->setDisplayNonManifoldEdges(!item->displayNonManifoldEdges());
-    item->changed();
     scene->itemChanged(item);
   }
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
@@ -142,7 +142,7 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
 				  map_i2i[(*it)[2]] );
         }
 
-        new_item->finalize_polygon_soup();
+        new_item->changed();
 
         new_item->setName(tr("%1-shell %2 (ss reconstruction)").arg(scene->item(index)->name()).arg(sh+1));
         new_item->setColor(Qt::magenta);
@@ -176,7 +176,7 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
 					     map_i2i_smoothed[(*it)[2]] );
           }
 
-          new_item_smoothed->finalize_polygon_soup();
+          new_item_smoothed->changed();
 
           new_item_smoothed->setName(tr("%1-shell %2 (ss smoothed reconstruction)").arg(scene->item(index)->name()).arg(sh+1));
           new_item_smoothed->setColor(Qt::magenta);

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -343,24 +343,25 @@ Scene_polygon_soup_item::compute_normals_and_vertices() const{
             positions_lines.push_back(pb.z());
             positions_lines.push_back(1.0);
         }
-        //Non manifold edges
-        BOOST_FOREACH(const Polygon_soup::Edge& edge,
-                        soup->non_manifold_edges)
-          {
-
-            const Point_3& a = soup->points[edge[0]];
-            const Point_3& b = soup->points[edge[1]];
-            positions_nm_lines.push_back(a.x());
-            positions_nm_lines.push_back(a.y());
-            positions_nm_lines.push_back(a.z());
-            positions_nm_lines.push_back(1.0);
-
-            positions_nm_lines.push_back(b.x());
-            positions_nm_lines.push_back(b.y());
-            positions_nm_lines.push_back(b.z());
-            positions_nm_lines.push_back(1.0);
-          }
     }
+
+    //Non manifold edges
+    BOOST_FOREACH(const Polygon_soup::Edge& edge,
+                    soup->non_manifold_edges)
+      {
+
+        const Point_3& a = soup->points[edge[0]];
+        const Point_3& b = soup->points[edge[1]];
+        positions_nm_lines.push_back(a.x());
+        positions_nm_lines.push_back(a.y());
+        positions_nm_lines.push_back(a.z());
+        positions_nm_lines.push_back(1.0);
+
+        positions_nm_lines.push_back(b.x());
+        positions_nm_lines.push_back(b.y());
+        positions_nm_lines.push_back(b.z());
+        positions_nm_lines.push_back(1.0);
+      }
 
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -129,7 +129,7 @@ public:
             soup->polygons[i].assign(polygons[i].begin(), polygons[i].end());
 
         /// fill non-manifold edges container
-        soup->fill_edges();
+        //soup->fill_edges();
         oriented = false;
 
         Q_EMIT changed();
@@ -155,7 +155,6 @@ public:
     void new_triangle(const std::size_t, const std::size_t, const std::size_t);
 
     void init_polygon_soup(std::size_t nb_pts, std::size_t nb_polygons);
-    void finalize_polygon_soup();
 
 public Q_SLOTS:
     void shuffle_orientations();
@@ -179,8 +178,8 @@ private:
     mutable int nb_lines;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
-    void compute_normals_and_vertices(void);
-    void triangulate_polygon(Polygons_iterator );
+    void compute_normals_and_vertices(void) const;
+    void triangulate_polygon(Polygons_iterator ) const;
     mutable QOpenGLShaderProgram *program;
 
 }; // end class Scene_polygon_soup_item

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -88,7 +88,7 @@ typedef CGAL::Constrained_triangulation_plus_2<CDTbase>              CDT;
 
 //Make sure all the facets are triangles
 void
-Scene_polyhedron_item::is_Triangulated()
+Scene_polyhedron_item::is_Triangulated() const
 {
     typedef Polyhedron::Halfedge_around_facet_circulator HF_circulator;
     Facet_iterator f = poly->facets_begin();
@@ -115,7 +115,7 @@ Scene_polyhedron_item::is_Triangulated()
     }
 }
 void
-Scene_polyhedron_item::triangulate_facet(Facet_iterator fit)
+Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
 {
     //Computes the normal of the facet
     Traits::Vector_3 normal =
@@ -214,7 +214,7 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit)
 }
 
 void
-Scene_polyhedron_item::triangulate_facet_color(Facet_iterator fit)
+Scene_polyhedron_item::triangulate_facet_color(Facet_iterator fit) const
 {
     Traits::Vector_3 normal =
             CGAL::Polygon_mesh_processing::compute_face_normal(fit, *poly);
@@ -439,7 +439,7 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
 }
 
 void
-Scene_polyhedron_item::compute_normals_and_vertices(void)
+Scene_polyhedron_item::compute_normals_and_vertices(void) const
 {
     positions_facets.resize(0);
     positions_lines.resize(0);
@@ -552,7 +552,7 @@ Scene_polyhedron_item::compute_normals_and_vertices(void)
 }
 
 void
-Scene_polyhedron_item::compute_colors()
+Scene_polyhedron_item::compute_colors() const
 {
     color_lines.resize(0);
     color_facets.resize(0);
@@ -877,7 +877,11 @@ void Scene_polyhedron_item::set_erase_next_picked_facet(bool b)
 
 void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
     if(!are_buffers_filled)
+    {
+        is_Triangulated();
+        compute_normals_and_vertices();
         initialize_buffers(viewer);
+    }
 
 
     if(!is_selected)
@@ -899,6 +903,12 @@ void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
 
 // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
 void Scene_polyhedron_item::draw_edges(Viewer_interface* viewer) const {
+    if(!are_buffers_filled)
+    {
+        is_Triangulated();
+        compute_normals_and_vertices();
+        initialize_buffers(viewer);
+    }
 
     if(!is_selected)
     {
@@ -922,6 +932,12 @@ void Scene_polyhedron_item::draw_edges(Viewer_interface* viewer) const {
 
 void
 Scene_polyhedron_item::draw_points(Viewer_interface* viewer) const {
+    if(!are_buffers_filled)
+    {
+        is_Triangulated();
+        compute_normals_and_vertices();
+        initialize_buffers(viewer);
+    }
 
     vaos[1]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
@@ -966,8 +982,6 @@ changed()
     delete_aabb_tree(this);
     init();
     Base::changed();
-    is_Triangulated();
-    compute_normals_and_vertices();
     are_buffers_filled = false;
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -35,7 +35,7 @@ public:
     // IO
     bool load(std::istream& in);
     bool save(std::ostream& out) const;
-    bool is_Triangle;
+    mutable bool is_Triangle;
 
     // Function for displaying meta-data of the item
     virtual QString toolTip() const;
@@ -125,11 +125,11 @@ private:
 
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer = 0) const;
-    void compute_normals_and_vertices(void);
-    void compute_colors();
-    void triangulate_facet(Facet_iterator );
-    void triangulate_facet_color(Facet_iterator );
-    void is_Triangulated();
+    void compute_normals_and_vertices(void) const;
+    void compute_colors() const;
+    void triangulate_facet(Facet_iterator ) const;
+    void triangulate_facet_color(Facet_iterator ) const;
+    void is_Triangulated() const;
     double volume, area;
 
 }; // end class Scene_polyhedron_item


### PR DESCRIPTION
This pull request is a fix for a bug in the Polyhedron demo introduced with the fix for display manifold edges.

- fill_edges was called in a loop on the edges, which made the loading of big items extremely slow.
- fill_edges is now only called in compute_normals, when it was called several times when creating or converting a polygon_soup
- compute_normals_and_vertices is now const and called with initialized_buffers in the draw functions, which allows to reduce
  the number of times it is called, in Scene_polygon_soup_item and in Scene_polyhedron_item.