### PR TITLE
Polyhedron demo: changed() function enhancement

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -699,7 +699,7 @@ void MainWindow::reload_item() {
   new_item->setColor(item->color());
   new_item->setRenderingMode(item->renderingMode());
   new_item->setVisible(item->visible());
-  new_item->changed();
+  new_item->invalidate_buffers();
   scene->replaceItem(item_index, new_item, true);
   item->deleteLater();
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_corefinement_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_corefinement_plugin.cpp
@@ -168,7 +168,7 @@ void Polyhedron_demo_corefinement_plugin::corefinement()
     new_item->setColor(Qt::green);
     new_item->setRenderingMode(Wireframe);
     scene->addItem(new_item);  
-    new_item->changed();
+    new_item->invalidate_buffers();
     std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
       
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
@@ -473,6 +473,7 @@ void Polyhedron_demo_cut_plugin::cut() {
   }
 
   messages->information(QString("cut (%1 ms). %2 edges.").arg(time.elapsed()).arg(edges_item->edges.size()));
+  edges_item->invalidate_buffers();
   scene->itemChanged(edges_item);
   }
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
@@ -80,7 +80,7 @@ public:
   }
 
   // Wireframe OpenGL drawing in a display list
-  void changed()
+  void invalidate_buffers()
   {
       compute_elements();
       are_buffers_filled = false;
@@ -163,7 +163,7 @@ public:
                 bbox.ymax(),
                 bbox.zmax());
   }
-  void changed()
+  void invalidate_buffers()
   {
       compute_elements();
       are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_edit_polyhedron_plugin.cpp
@@ -156,6 +156,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_PrevCtrlVertPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->prev_ctrl_vertices_group();
+  edit_item->invalidate_buffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_NextCtrlVertPushButton_clicked()
@@ -174,6 +175,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_SelectAllVerticesPushButton_clic
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->set_all_vertices_as_roi();
+  edit_item->invalidate_buffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked()
@@ -183,6 +185,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->delete_ctrl_vertices_group();
+  edit_item->invalidate_buffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
@@ -192,6 +195,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->clear_roi();
+  edit_item->invalidate_buffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ApplyAndClosePushButton_clicked()
@@ -288,6 +292,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ReadROIPushButton_clicked()
   if(fileName.isNull()) { return; }
 
   edit_item->read_roi(fileName.toLocal8Bit().data());
+  edit_item->invalidate_buffers();
   scene->itemChanged(edit_item); 
 }
 void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool visible)

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_gocad_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_gocad_plugin.cpp
@@ -73,7 +73,7 @@ Polyhedron_demo_gocad_plugin::load(QFileInfo fileinfo) {
   if(qcolor.isValid()) 
   {  
     item->setColor(qcolor);
-    item->changed();
+    item->invalidate_buffers();
   }
   
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_hole_filling_plugin.cpp
@@ -338,6 +338,7 @@ protected:
 
   void change_poly_item_by_blocking(Scene_polyhedron_item* poly_item, Scene_hole_visualizer* collection) {
     if(collection) collection->block_poly_item_changed = true;
+    poly_item->invalidate_buffers();
     scene->itemChanged(poly_item);
     if(collection) collection->block_poly_item_changed = false;
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_inside_out_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_inside_out_plugin.cpp
@@ -55,9 +55,11 @@ void Polyhedron_demo_inside_out_plugin::on_actionInsideOut_triggered()
   
       // inside out
       CGAL::Polygon_mesh_processing::reverse_face_orientations(*pMesh);
+      poly_item->invalidate_buffers();
     }
     else {
       soup_item->inside_out();
+      soup_item->invalidate_buffers();
     }
 
     // update scene

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_intersection_plugin.cpp
@@ -210,7 +210,7 @@ void Polyhedron_demo_intersection_plugin::intersection()
   new_item->setColor(Qt::green);
   new_item->setRenderingMode(Wireframe);
   scene->addItem(new_item);
-  new_item->changed();
+  new_item->invalidate_buffers();
 
   QApplication::restoreOverrideCursor();
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_jet_fitting_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_jet_fitting_plugin.cpp
@@ -121,8 +121,8 @@ void Polyhedron_demo_jet_fitting_plugin::on_actionEstimateCurvature_triggered()
 
   scene->addItem(max_curv);
   scene->addItem(min_curv);
-  max_curv->changed();
-  min_curv->changed();
+  max_curv->invalidate_buffers();
+  min_curv->invalidate_buffers();
   
   // default cursor
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
@@ -82,6 +82,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionJoinPolyhedra_tri
     }
   }
 
+  mainSelectionItem->invalidate_buffers();
   scene->itemChanged(mainSelectionIndex);
 
   //remove the other items
@@ -162,6 +163,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionColorConnectedCom
         CGAL::internal::corefinement::Dummy_true(),
         marker
       );
+      item->invalidate_buffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
@@ -332,6 +332,7 @@ public:
   {
     CGAL::Polyhedron_copy_3<Mean_curvature_skeleton::Meso_skeleton, Polyhedron::HalfedgeDS> modifier(mcs->meso_skeleton());
     meso_skeleton->delegate(modifier);
+    scene->item(contractedItemIndex)->invalidate_buffers();
     scene->itemChanged(contractedItemIndex);
   }
 
@@ -661,6 +662,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   }
   // update scene
   update_meso_skeleton();
+  scene->item(fixedPointsItemIndex)->invalidate_buffers();
   scene->itemChanged(fixedPointsItemIndex);
   scene->setSelectedItem(index);
   QApplication::restoreOverrideCursor();
@@ -895,6 +897,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
     delete temp;
   }
 
+  scene->item(fixedPointsItemIndex)->invalidate_buffers();
   scene->itemChanged(fixedPointsItemIndex);
   update_meso_skeleton();
   scene->setSelectedItem(index);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
@@ -510,7 +510,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
 
     skeleton_item->setName(QString("Medial skeleton curve of %1").arg(item->name()));
     scene->addItem(skeleton_item);
-    skeleton_item->changed();
+    skeleton_item->invalidate_buffers();
 
     item->setPointsMode();
 
@@ -824,7 +824,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
 
   skeleton->setName(QString("skeleton curve of %1").arg(item->name()));
   scene->addItem(skeleton);
-  skeleton->changed();
+  skeleton->invalidate_buffers();
 
   // set the fixed points and contracted mesh as invisible
   if (fixedPointsItemIndex >= 0)

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
@@ -66,7 +66,7 @@ public:
         delete frame;
     }
 
-    void changed()
+    void invalidate_buffers()
     {
         compute_elements();
         are_buffers_filled = false;
@@ -75,7 +75,7 @@ public:
     void contextual_changed()
     {
         if(frame->isManipulated()||frame->isSpinning())
-            changed();
+            invalidate_buffers();
     }
     const C3t3& c3t3() const {
         return c3t3_;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
@@ -217,6 +217,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_SDF_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
+      item->invalidate_buffers();
       scene->itemChanged(index);
     }
 
@@ -288,6 +289,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_Partition_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
+      item->invalidate_buffers();
       scene->itemChanged(index);
     }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_simplification_plugin.cpp
@@ -76,6 +76,7 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
       << pMesh->size_of_halfedges() / 2 << " edges)" << std::endl;
 
     // update scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
     QApplication::restoreOverrideCursor();
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_normal_estimation_plugin.cpp
@@ -105,6 +105,7 @@ void Polyhedron_demo_normal_estimation_plugin::on_actionNormalInversion_triggere
     for(Point_set::iterator it = points->begin(); it != points->end(); ++it){
       it->normal() = -1 * it->normal();
     }
+    item->invalidate_buffers();
     scene->itemChanged(item);
   }
 }
@@ -206,6 +207,7 @@ void Polyhedron_demo_normal_estimation_plugin::on_actionNormalEstimation_trigger
     points->select(first_unoriented_point, points->end(), true);
 
     // Updates scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
@@ -106,7 +106,7 @@ void Polyhedron_demo_orient_soup_plugin::orient()
         poly_item->setColor(item->color());
         poly_item->setRenderingMode(item->renderingMode());
         poly_item->setVisible(item->visible());
-        poly_item->changed();
+        poly_item->invalidate_buffers();
         poly_item->setProperty("source filename", item->property("source filename"));
         scene->replaceItem(index, poly_item);
         delete item;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
@@ -111,6 +111,7 @@ void Polyhedron_demo_orient_soup_plugin::orient()
         scene->replaceItem(index, poly_item);
         delete item;
       } else {
+        item->invalidate_buffers();
         scene->itemChanged(item);
       }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_parameterization_plugin.cpp
@@ -130,6 +130,8 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
   new_item->setColor(Qt::white);
   new_item->setRenderingMode(poly_item->renderingMode());
 
+  poly_item->setVisible(false);
+  scene->itemChanged(index);
   scene->addItem(new_item);
 
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
@@ -169,6 +169,7 @@ public Q_SLOTS:
     Q_FOREACH(Scene_interface::Item_id id, scene->selectionIndices()) {
       Scene_points_with_normal_item* point_item = qobject_cast<Scene_points_with_normal_item*>(scene->item(id));
       if(point_item) { 
+        point_item->invalidate_buffers();
         scene->itemChanged(point_item);
       }
     }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_bilateral_smoothing_plugin.cpp
@@ -108,6 +108,7 @@ void Polyhedron_demo_point_set_bilateral_smoothing_plugin::on_actionBilateralSmo
 	      << std::endl;
 
     // Updates scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_outliers_removal_plugin.cpp
@@ -107,6 +107,7 @@ void Polyhedron_demo_point_set_outliers_removal_plugin::on_actionOutlierRemoval_
     points->select(first_point_to_remove, points->end(), true);
 
     // Updates scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_selection_plugin.cpp
@@ -147,7 +147,6 @@ public:
     if (update_polyline ())
       {
 	Q_EMIT itemChanged();
-	// polyline->changed();
       }
   }
 
@@ -358,7 +357,7 @@ protected:
 
       }
 
-    point_set_item->changed();
+    point_set_item->invalidate_buffers();
   }
 
   
@@ -442,7 +441,7 @@ public Q_SLOTS:
 	new_item->point_set()->push_back(*it);
     }
     new_item->resetSelection();
-    new_item->changed();
+    new_item->invalidate_buffers();
 
     scene->addItem(new_item);
  }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_simplification_plugin.cpp
@@ -125,6 +125,7 @@ void Polyhedron_demo_point_set_simplification_plugin::on_actionSimplify_triggere
     points->select(first_point_to_remove, points->end(), true);
 
     // Updates scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_smoothing_plugin.cpp
@@ -79,6 +79,7 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
     item->set_has_normals(false);
 
     // update scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_upsampling_plugin.cpp
@@ -128,6 +128,7 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
 		<< std::endl;
 
       // Updates scene
+      item->invalidate_buffers();
       scene->itemChanged(index);
 
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_slicer_plugin.cpp
@@ -306,7 +306,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
       new_polylines_item->setColor(Qt::green);
       new_polylines_item->setRenderingMode(Wireframe);
       scene->addItem(new_polylines_item);
-      new_polylines_item->changed();
+      new_polylines_item->invalidate_buffers();
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
@@ -156,6 +156,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionStitchBorders_trigger
     {
       Polyhedron* pMesh = item->polyhedron();
       CGAL::Polygon_mesh_processing::stitch_borders(*pMesh);
+      item->invalidate_buffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
@@ -139,7 +139,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionDetectBorders_trigger
         new_item->setName(tr("Boundary of %1").arg(item->name()));
         new_item->setColor(Qt::red);
         scene->addItem(new_item);
-        new_item->changed();
+        new_item->invalidate_buffers();
       }
     }
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polylines_io_plugin.cpp
@@ -76,7 +76,7 @@ Polyhedron_demo_polylines_io_plugin::load(QFileInfo fileinfo) {
   item->setColor(Qt::black);
   item->setProperty("polylines metadata", polylines_metadata);
   std::cerr << "Number of polylines in item: " << item->polylines.size() << std::endl;
-  item->changed();
+  item->invalidate_buffers();
   return item;
 }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_scale_space_reconstruction_plugin.cpp
@@ -142,8 +142,6 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
 				  map_i2i[(*it)[2]] );
         }
 
-        new_item->changed();
-
         new_item->setName(tr("%1-shell %2 (ss reconstruction)").arg(scene->item(index)->name()).arg(sh+1));
         new_item->setColor(Qt::magenta);
         new_item->setRenderingMode(FlatPlusEdges);
@@ -175,8 +173,6 @@ void Polyhedron_demo_scale_space_reconstruction_plugin::on_actionScaleSpaceRecon
 					     map_i2i_smoothed[(*it)[1]],
 					     map_i2i_smoothed[(*it)[2]] );
           }
-
-          new_item_smoothed->changed();
 
           new_item_smoothed->setName(tr("%1-shell %2 (ss smoothed reconstruction)").arg(scene->item(index)->name()).arg(sh+1));
           new_item_smoothed->setColor(Qt::magenta);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_selection_plugin.cpp
@@ -301,7 +301,7 @@ public Q_SLOTS:
     Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
     if(selection_item->export_selected_facets_as_polyhedron(poly_item->polyhedron())) {
       poly_item->setName(QString("%1-facets").arg(selection_item->name()));
-      poly_item->changed(); // for init()
+      poly_item->invalidate_buffers(); // for init()
       scene->setSelectedItem( scene->addItem(poly_item) );
       scene->itemChanged(poly_item);
     }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_self_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_self_intersection_plugin.cpp
@@ -72,6 +72,7 @@ void Polyhedron_demo_self_intersection_plugin::on_actionSelfIntersection_trigger
         selection_item->selected_facets.insert(fb->first);
         selection_item->selected_facets.insert(fb->second);
       }
+      selection_item->invalidate_buffers();
       selection_item->setName(tr("%1 (selection) (intersecting triangles)").arg(item->name()));
       scene->addItem(selection_item);
       item->setRenderingMode(Wireframe);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_subdivision_methods_plugin.cpp
@@ -48,6 +48,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionLoop_triggered()
   CGAL::Subdivision_method_3::Loop_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
+  item->invalidate_buffers();
   scene->itemChanged(item);
 }
 
@@ -68,6 +69,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionCatmullClark_triggered
   CGAL::Subdivision_method_3::CatmullClark_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
+  item->invalidate_buffers();
   scene->itemChanged(item);
 }
 
@@ -88,6 +90,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionSqrt3_triggered()
   CGAL::Subdivision_method_3::Sqrt3_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
+  item->invalidate_buffers();
   scene->itemChanged(item);
 }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_triangulate_facets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_triangulate_facets_plugin.cpp
@@ -96,6 +96,7 @@ public Q_SLOTS:
       }
       CGAL_assertion_code(pMesh->normalize_border());
       // CGAL_assertion(pMesh->is_valid(true, 3));
+      item->invalidate_buffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();
@@ -125,6 +126,7 @@ public Q_SLOTS:
       CGAL_assertion_code(pMesh->normalize_border());
       CGAL_assertion(pMesh->is_valid(false, 3));
 
+      item->invalidate_buffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
@@ -62,7 +62,7 @@ public:
 
     }
 
-    void changed()
+    void invalidate_buffers()
     {
         compute_elements();
         are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_vcm_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_vcm_normal_estimation_plugin.cpp
@@ -155,6 +155,7 @@ void Polyhedron_demo_vcm_normal_estimation_plugin::on_actionVCMNormalEstimation_
                                     << std::endl;
 
     // Updates scene
+    item->invalidate_buffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -56,6 +56,8 @@ Scene::addItem(Scene_item* item)
     m_entries.push_back(item);
     connect(item, SIGNAL(itemChanged()),
             this, SLOT(itemChanged()));
+    connect(item, SIGNAL(renderingModeChanged()),
+            this, SLOT(callDraw()));
     if(bbox_before + item->bbox() != bbox_before)
 { Q_EMIT updated_bbox(); }
     QAbstractListModel::beginResetModel();

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -657,9 +657,8 @@ void Scene::itemChanged(Item_id i)
                      this->createIndex(i, LastColumn));
 }
 
-void Scene::itemChanged(Scene_item* item)
+void Scene::itemChanged(Scene_item* /* item */)
 {
-    item->invalidate_buffers();
   Q_EMIT dataChanged(this->createIndex(0, 0),
                      this->createIndex(m_entries.size() - 1, LastColumn));
 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -69,7 +69,7 @@ Scene::addItem(Scene_item* item)
 Scene_item*
 Scene::replaceItem(Scene::Item_id index, Scene_item* item, bool emit_item_about_to_be_destroyed)
 {
-    item->changed();
+    item->invalidate_buffers();
     if(index < 0 || index >= m_entries.size())
         return 0;
 
@@ -578,13 +578,13 @@ Scene::setData(const QModelIndex &index,
     {
     case NameColumn:
         item->setName(value.toString());
-        item->changed();
+        item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;
     case ColorColumn:
         item->setColor(value.value<QColor>());
-        item->changed();
+        item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;
@@ -599,7 +599,7 @@ Scene::setData(const QModelIndex &index,
             rendering_mode = static_cast<RenderingMode>( (rendering_mode+1) % NumberOfRenderingMode );
         }
         item->setRenderingMode(rendering_mode);
-        item->changed();
+        item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;
@@ -654,14 +654,14 @@ void Scene::itemChanged(Item_id i)
     if(i < 0 || i >= m_entries.size())
         return;
 
-    m_entries[i]->changed();
+    m_entries[i]->invalidate_buffers();
   Q_EMIT dataChanged(this->createIndex(i, 0),
                      this->createIndex(i, LastColumn));
 }
 
 void Scene::itemChanged(Scene_item* item)
 {
-    item->changed();
+    item->invalidate_buffers();
   Q_EMIT dataChanged(this->createIndex(0, 0),
                      this->createIndex(m_entries.size() - 1, LastColumn));
 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -652,7 +652,6 @@ void Scene::itemChanged(Item_id i)
     if(i < 0 || i >= m_entries.size())
         return;
 
-    m_entries[i]->invalidate_buffers();
   Q_EMIT dataChanged(this->createIndex(i, 0),
                      this->createIndex(i, LastColumn));
 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -599,7 +599,7 @@ Scene::setData(const QModelIndex &index,
             rendering_mode = static_cast<RenderingMode>( (rendering_mode+1) % NumberOfRenderingMode );
         }
         item->setRenderingMode(rendering_mode);
-        item->invalidate_buffers();
+        //item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -71,7 +71,6 @@ Scene::addItem(Scene_item* item)
 Scene_item*
 Scene::replaceItem(Scene::Item_id index, Scene_item* item, bool emit_item_about_to_be_destroyed)
 {
-    item->invalidate_buffers();
     if(index < 0 || index >= m_entries.size())
         return 0;
 
@@ -580,13 +579,11 @@ Scene::setData(const QModelIndex &index,
     {
     case NameColumn:
         item->setName(value.toString());
-        item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;
     case ColorColumn:
         item->setColor(value.value<QColor>());
-        item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;
@@ -601,7 +598,6 @@ Scene::setData(const QModelIndex &index,
             rendering_mode = static_cast<RenderingMode>( (rendering_mode+1) % NumberOfRenderingMode );
         }
         item->setRenderingMode(rendering_mode);
-        //item->invalidate_buffers();
     Q_EMIT dataChanged(index, index);
         return true;
         break;

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -14,6 +14,7 @@
 #include <QItemDelegate>
 #include <QPixmap>
 #include <QItemSelection>
+#include <QGLViewer/qglviewer.h>
 
 #include <iostream>
 #include <cmath>
@@ -161,6 +162,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void setSelectionRay(double, double, double, double, double, double);
+  void callDraw(){  QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin(); viewer->update();}
 
 private:
   void draw_aux(bool with_names, Viewer_interface*);

--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
@@ -52,6 +52,7 @@ void Scene_combinatorial_map_item::set_next_volume(){
     ++volume_to_display;
     volume_to_display=volume_to_display%(combinatorial_map().attributes<3>().size()+1);
   are_buffers_filled = false;
+  invalidate_buffers();
   Q_EMIT itemChanged();
 
     if (exportSelectedVolume!=NULL && ( volume_to_display==1 || volume_to_display==0 ) )

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
@@ -443,6 +443,7 @@ void Scene_edit_polyhedron_item::timerEvent(QTimerEvent* /*event*/)
 { // just handle deformation - paint like selection is handled in eventFilter()
   if(state.ctrl_pressing && (state.left_button_pressing || state.right_button_pressing)) {
     if(!ui_widget->ActivatePivotingCheckBox->isChecked()) {
+      invalidate_buffers();
       deform();
     }
     else {

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
@@ -27,7 +27,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
   connect(&k_ring_selector, SIGNAL(selected(const std::set<Polyhedron::Vertex_handle>&)), this,
           SLOT(selected(const std::set<Polyhedron::Vertex_handle>&)));
 
-  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in changed()
+  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in invalidate_buffers()
   poly_item->update_vertex_indices();
 
   length_of_axis = bbox().diagonal_length() / 15.0;
@@ -111,7 +111,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
 
     //the spheres :
     create_Sphere(length_of_axis/15.0);
-    changed();
+    invalidate_buffers();
 }
 
 Scene_edit_polyhedron_item::~Scene_edit_polyhedron_item()
@@ -682,7 +682,7 @@ void Scene_edit_polyhedron_item::compute_bbox(const Scene_interface::Bbox& bb){
     
 }
 
-void Scene_edit_polyhedron_item::changed()
+void Scene_edit_polyhedron_item::invalidate_buffers()
 {
     compute_normals_and_vertices();
     update_normals();

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
@@ -231,7 +231,7 @@ protected:
 
 
 public Q_SLOTS:
-  void changed();
+  void invalidate_buffers();
   void selected(const std::set<Polyhedron::Vertex_handle>& m)
   {
     bool any_changes = false;

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
@@ -249,7 +249,7 @@ public Q_SLOTS:
       }
       any_changes |= changed;
     }
-    if(any_changes) { Q_EMIT itemChanged(); }
+    if(any_changes) { invalidate_buffers(); Q_EMIT itemChanged(); }
   }
 
   void select(double orig_x,
@@ -396,6 +396,7 @@ public:
 
     active_group = --ctrl_vertex_frame_map.end();
 
+    invalidate_buffers();
     Q_EMIT itemChanged();
 
     print_message("A new empty group of control vertices is created.");
@@ -591,7 +592,7 @@ public:
       (vertices(*polyhedron()).first, vertices(*polyhedron()).second,
       polyhedron()->size_of_vertices(), Is_selected(deform_mesh), visitor);
 
-    if(visitor.any_inserted) { Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidate_buffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -367,7 +367,7 @@ Scene_implicit_function_item(Implicit_function_interface* f)
     frame_->setOrientation(1., 0, 0, 0);
     connect(frame_, SIGNAL(modified()), this, SLOT(plane_was_moved()));
 
-    changed();
+    invalidate_buffers();
 }
 
 
@@ -537,7 +537,7 @@ compute_function_grid() const
     }
 
     // Update
-    const_cast<Scene_implicit_function_item*>(this)->changed();
+    const_cast<Scene_implicit_function_item*>(this)->invalidate_buffers();
 
 }
 
@@ -575,9 +575,9 @@ compute_min_max()
 }
 
 void
-Scene_implicit_function_item::changed()
+Scene_implicit_function_item::invalidate_buffers()
 {
-    Scene_item::changed();
+    Scene_item::invalidate_buffers();
     compute_vertices_and_texmap();
     are_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -70,7 +70,7 @@ public:
 
   virtual QString toolTip() const;
   virtual void contextual_changed();
-  virtual void changed();
+  virtual void invalidate_buffers();
 public Q_SLOTS:
   void plane_was_moved() { need_update_ = true; }
   void compute_function_grid() const;

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -97,8 +97,6 @@ QMenu* Scene_item::contextMenu()
                                               .arg(mName),
                                               this,
                                               slotName(RenderingMode(mode)));
-        QObject::connect(action, SIGNAL(triggered()),
-                         this, SIGNAL(itemChanged()));
     }
     // defaultContextMenu->addAction(modeMenu->menuAction());
     return defaultContextMenu;

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -102,13 +102,9 @@ QMenu* Scene_item::contextMenu()
     return defaultContextMenu;
 }
 
-void Scene_item::invalidate_buffers() {
-  // Q_EMIT itemChanged();
-}
+void Scene_item::invalidate_buffers() {}
 
-void Scene_item::selection_changed(bool) {
-    // emit itemChanged();
-}
+void Scene_item::selection_changed(bool) {}
 
 
 void Scene_item::select(double /*orig_x*/,

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -104,7 +104,7 @@ QMenu* Scene_item::contextMenu()
     return defaultContextMenu;
 }
 
-void Scene_item::changed() {
+void Scene_item::invalidate_buffers() {
   // Q_EMIT itemChanged();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -92,11 +92,10 @@ QMenu* Scene_item::contextMenu()
     {
         if(!supportsRenderingMode(RenderingMode(mode))) continue;
         QString mName = modeName(RenderingMode(mode));
-        QAction* action =
-                defaultContextMenu->addAction(tr("Set %1 mode")
-                                              .arg(mName),
-                                              this,
-                                              slotName(RenderingMode(mode)));
+        defaultContextMenu->addAction(tr("Set %1 mode")
+                                      .arg(mName),
+                                      this,
+                                      slotName(RenderingMode(mode)));
     }
     // defaultContextMenu->addAction(modeMenu->menuAction());
     return defaultContextMenu;

--- a/Polyhedron/demo/Polyhedron/Scene_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_item.h
@@ -138,11 +138,11 @@ public:
 public Q_SLOTS:
   // Call that once you have finished changing something in the item
   // (either the properties or internal data)
-  virtual void changed();
+  virtual void invalidate_buffers();
   virtual void contextual_changed(){}
 
   // Setters for the four basic properties
-  virtual void setColor(QColor c) { color_ = c; changed(); }
+  virtual void setColor(QColor c) { color_ = c; invalidate_buffers(); }
   void setRbgColor(int r, int g, int b) { setColor(QColor(r, g, b)); }
   virtual void setName(QString n) { name_ = n; }
   virtual void setVisible(bool b) { visible_ = b; }

--- a/Polyhedron/demo/Polyhedron/Scene_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_item.h
@@ -149,6 +149,7 @@ public Q_SLOTS:
   virtual void setRenderingMode(RenderingMode m) { 
     if (supportsRenderingMode(m))
       rendering_mode = m; 
+    Q_EMIT renderingModeChanged();
   }
   void setPointsMode() {
     setRenderingMode(Points);
@@ -196,6 +197,7 @@ public Q_SLOTS:
 Q_SIGNALS:
   void itemChanged();
   void aboutToBeDestroyed();
+  void renderingModeChanged();
 
 protected:
   // The four basic properties

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -436,7 +436,7 @@ Scene_nef_polyhedron_item::load_from_off(std::istream& in)
     //   Polyhedron poly;
     //   in >> poly;
     //   *nef_poly = Nef_polyhedron(poly);
-    changed();
+    invalidate_buffers();
     return (bool) in;
 }
 
@@ -451,7 +451,7 @@ bool
 Scene_nef_polyhedron_item::load(std::istream& in)
 {
     in >> *nef_poly;
-    changed();
+    invalidate_buffers();
     return (bool) in;
 }
 
@@ -725,17 +725,17 @@ convex_decomposition(std::list< Scene_polyhedron_item*>& convex_parts)
             from_exact(P, *poly);
             Scene_polyhedron_item *spoly = new Scene_polyhedron_item(poly);
             convex_parts.push_back(spoly);
-            spoly->changed();
+            spoly->invalidate_buffers();
         }
     }
 }
 
 void
 Scene_nef_polyhedron_item::
-changed()
+invalidate_buffers()
 {
     //  init();
-    Base::changed();
+    Base::invalidate_buffers();
     compute_normals_and_vertices();
     are_buffers_filled = false;
 }
@@ -746,7 +746,7 @@ Scene_nef_polyhedron_item::selection_changed(bool p_is_selected)
     if(p_is_selected != is_selected)
     {
         is_selected = p_is_selected;
-        changed();
+        invalidate_buffers();
     }
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -26,7 +26,7 @@ public:
   QFont font() const;
   QString toolTip() const;
 
-  virtual void changed();
+  virtual void invalidate_buffers();
   virtual void selection_changed(bool);
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const { return m != Gouraud && m!=Splatting; } // CHECK THIS!

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -33,7 +33,7 @@ public:
   {
     setNormal(0., 0., 1.);
     //Generates an integer which will be used as ID for each buffer
-    changed();
+    invalidate_buffers();
   }
 
   ~Scene_plane_item() {
@@ -116,7 +116,7 @@ private:
   }
 
 public Q_SLOTS:
-  virtual void changed()
+  virtual void invalidate_buffers()
   {
       compute_normals_and_vertices();
       are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -93,6 +93,7 @@ Scene_points_with_normal_item::~Scene_points_with_normal_item()
 
 void Scene_points_with_normal_item::initialize_buffers(Viewer_interface *viewer) const
 {
+    compute_normals_and_vertices();
     //vao for the edges
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
@@ -150,10 +151,9 @@ void Scene_points_with_normal_item::initialize_buffers(Viewer_interface *viewer)
         program->release();
     }
     are_buffers_filled = true;
-
-
 }
-void Scene_points_with_normal_item::compute_normals_and_vertices(void)
+
+void Scene_points_with_normal_item::compute_normals_and_vertices() const
 {
     positions_points.resize(0);
     positions_lines.resize(0);
@@ -579,7 +579,6 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
 
 void Scene_points_with_normal_item::invalidate_buffers()
 {
-    compute_normals_and_vertices();
     are_buffers_filled = false;
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -279,6 +279,7 @@ void Scene_points_with_normal_item::deleteSelection()
   std::cerr << "done: " << task_timer.time() << " seconds, "
                         << (memory>>20) << " Mb allocated"
                         << std::endl;
+  invalidate_buffers();
   Q_EMIT itemChanged();
 }
 
@@ -286,6 +287,7 @@ void Scene_points_with_normal_item::deleteSelection()
 void Scene_points_with_normal_item::invertSelection()
 {
     m_points->invert_selection();
+  invalidate_buffers();
   Q_EMIT itemChanged();
 }
 
@@ -293,6 +295,7 @@ void Scene_points_with_normal_item::invertSelection()
 void Scene_points_with_normal_item::selectAll()
 {
     m_points->select(m_points->begin(), m_points->end(), true);
+  invalidate_buffers();
   Q_EMIT itemChanged();
 }
 // Reset selection mark
@@ -300,6 +303,7 @@ void Scene_points_with_normal_item::resetSelection()
 {
   // Un-select all points
   m_points->select(m_points->begin(), m_points->end(), false);
+  invalidate_buffers();
   Q_EMIT itemChanged();
 }
   //Select duplicated points
@@ -309,6 +313,7 @@ void Scene_points_with_normal_item::selectDuplicates()
   for (Point_set::Point_iterator ptit=m_points->begin(); ptit!=m_points->end();++ptit )
     if ( !unique_points.insert(*ptit).second )
       m_points->select(&(*ptit));
+  invalidate_buffers();
   Q_EMIT itemChanged();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -53,7 +53,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_
     nb_points = 0;
     nb_selected_points = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 // Converts polyhedron to point set
@@ -80,7 +80,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
     nb_points = 0;
     nb_selected_points = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 Scene_points_with_normal_item::~Scene_points_with_normal_item()
@@ -323,7 +323,7 @@ bool Scene_points_with_normal_item::read_off_point_set(std::istream& stream)
                                               std::back_inserter(*m_points),
                                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type())) &&
             !isEmpty();
-    changed();
+  invalidate_buffers();
   return ok;
 }
 
@@ -363,7 +363,7 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
       }
     }
   }
-    changed();
+  invalidate_buffers();
   return ok;
 }
 
@@ -572,7 +572,7 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
   }
 }
 
-void Scene_points_with_normal_item::changed()
+void Scene_points_with_normal_item::invalidate_buffers()
 {
     compute_normals_and_vertices();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -44,7 +44,7 @@ public:
   // Function for displaying meta-data of the item
   virtual QString toolTip() const;
 
-  virtual void changed();
+  virtual void invalidate_buffers();
 
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -105,7 +105,7 @@ private:
   using Scene_item::initialize_buffers;
   void initialize_buffers(Viewer_interface *viewer) const;
 
-  void compute_normals_and_vertices(void);
+  void compute_normals_and_vertices() const;
 
 
 }; // end class Scene_points_with_normal_item

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -398,7 +398,7 @@ Scene_polygon_soup_item::load(std::istream& in)
   else soup->clear();
 
     bool result = CGAL::read_OFF(in, soup->points, soup->polygons);
-    Q_EMIT changed();
+    Q_EMIT invalidate_buffers();
     return result;
 }
 
@@ -427,7 +427,7 @@ void Scene_polygon_soup_item::load(Scene_polyhedron_item* poly_item) {
   CGAL::generic_print_polyhedron(std::cerr,
                                  *poly_item->polyhedron(),
                                  writer);
-  Q_EMIT changed();
+  Q_EMIT invalidate_buffers();
 }
 
 void
@@ -450,7 +450,7 @@ void Scene_polygon_soup_item::shuffle_orientations()
   {
     if(std::rand() % 2 == 0) soup->inverse_orientation(i);
   }
-
+  invalidate_buffers();
 }
 
 void Scene_polygon_soup_item::inside_out()
@@ -460,7 +460,7 @@ void Scene_polygon_soup_item::inside_out()
   {
     soup->inverse_orientation(i);
   }
-  changed();
+  invalidate_buffers();
 }
 
 bool 
@@ -654,7 +654,7 @@ Scene_polygon_soup_item::isEmpty() const {
   return (soup == 0 || soup->points.empty());
 }
 void
-Scene_polygon_soup_item::changed()
+Scene_polygon_soup_item::invalidate_buffers()
 {
     are_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -132,7 +132,7 @@ public:
         //soup->fill_edges();
         oriented = false;
 
-        Q_EMIT changed();
+        Q_EMIT invalidate_buffers();
     }
 
     bool save(std::ostream& out) const;
@@ -146,7 +146,7 @@ public:
     virtual void draw(Viewer_interface*) const;
     virtual void draw_points(Viewer_interface*) const;
     virtual void draw_edges(Viewer_interface* viewer) const;
-    void changed();
+    void invalidate_buffers();
     bool isFinite() const { return true; }
     bool isEmpty() const;
     Bbox bbox() const;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -192,35 +192,32 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
         positions_facets.push_back(ffit->vertex(2)->point().z());
         positions_facets.push_back(1.0);
 
-      //  if (cur_shading == Flat || cur_shading == FlatPlusEdges || cur_shading == Gouraud)
-      //  {
 
-            typedef Kernel::Vector_3	    Vector;
-            Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(fit, *poly);
-            normals_flat.push_back(n.x());
-            normals_flat.push_back(n.y());
-            normals_flat.push_back(n.z());
+        typedef Kernel::Vector_3	    Vector;
+        Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(fit, *poly);
+        normals_flat.push_back(n.x());
+        normals_flat.push_back(n.y());
+        normals_flat.push_back(n.z());
 
-            normals_flat.push_back(n.x());
-            normals_flat.push_back(n.y());
-            normals_flat.push_back(n.z());
+        normals_flat.push_back(n.x());
+        normals_flat.push_back(n.y());
+        normals_flat.push_back(n.z());
 
-            normals_flat.push_back(n.x());
-            normals_flat.push_back(n.y());
-            normals_flat.push_back(n.z());
+        normals_flat.push_back(n.x());
+        normals_flat.push_back(n.y());
+        normals_flat.push_back(n.z());
 
-            normals_gouraud.push_back(n.x());
-            normals_gouraud.push_back(n.y());
-            normals_gouraud.push_back(n.z());
+        normals_gouraud.push_back(n.x());
+        normals_gouraud.push_back(n.y());
+        normals_gouraud.push_back(n.z());
 
-            normals_gouraud.push_back(n.x());
-            normals_gouraud.push_back(n.y());
-            normals_gouraud.push_back(n.z());
+        normals_gouraud.push_back(n.x());
+        normals_gouraud.push_back(n.y());
+        normals_gouraud.push_back(n.z());
 
-            normals_gouraud.push_back(n.x());
-            normals_gouraud.push_back(n.y());
-            normals_gouraud.push_back(n.z());
-      //  }
+        normals_gouraud.push_back(n.x());
+        normals_gouraud.push_back(n.y());
+        normals_gouraud.push_back(n.z());
 
     }
 }
@@ -528,25 +525,20 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
             CGAL_For_all(he,end)
             {
 
-               // // If Flat shading:1 normal per polygon added once per vertex
-               // if (cur_shading == FlatPlusEdges || cur_shading == Flat )
-               // {
+                // // If Flat shading:1 normal per polygon added once per vertex
 
-                    Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(f, *poly);
-                    normals_flat.push_back(n.x());
-                    normals_flat.push_back(n.y());
-                    normals_flat.push_back(n.z());
-                //}
+                Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(f, *poly);
+                normals_flat.push_back(n.x());
+                normals_flat.push_back(n.y());
+                normals_flat.push_back(n.z());
+
 
                 //// If Gouraud shading: 1 normal per vertex
-                //else if (cur_shading == Gouraud)
-                //{
 
-                    n = CGAL::Polygon_mesh_processing::compute_vertex_normal(he->vertex(), *poly);
-                    normals_gouraud.push_back(n.x());
-                    normals_gouraud.push_back(n.y());
-                    normals_gouraud.push_back(n.z());
-                //}
+                n = CGAL::Polygon_mesh_processing::compute_vertex_normal(he->vertex(), *poly);
+                normals_gouraud.push_back(n.x());
+                normals_gouraud.push_back(n.y());
+                normals_gouraud.push_back(n.z());
 
                 //position
                 const Point& p = he->vertex()->point();
@@ -1047,7 +1039,6 @@ void
 Scene_polyhedron_item::
 invalidate_buffers()
 {
-    qDebug()<<"inv buffers";
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -680,7 +680,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
     nb_facets = 0;
     nb_lines = 0;
     init();
-    changed();
+    invalidate_buffers();
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
@@ -697,7 +697,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
     init();
     nb_facets = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 Scene_polyhedron_item::~Scene_polyhedron_item()
@@ -775,7 +775,7 @@ Scene_polyhedron_item::load(std::istream& in)
 
     if ( in && !isEmpty() )
     {
-        changed();
+        invalidate_buffers();
         return true;
     }
     return false;
@@ -976,12 +976,15 @@ Scene_polyhedron_item::bbox() const {
 
 void
 Scene_polyhedron_item::
-changed()
+invalidate_buffers()
 {
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();
     Base::changed();
+    Base::invalidate_buffers();
+    is_Triangulated();
+    compute_normals_and_vertices();
     are_buffers_filled = false;
 
 }
@@ -995,7 +998,7 @@ contextual_changed()
         if(cur_shading == Flat || cur_shading == FlatPlusEdges ||cur_shading == Gouraud)
         {
             //Change the normals
-            changed();
+            invalidate_buffers();
         }
 
 }
@@ -1129,7 +1132,7 @@ Scene_polyhedron_item::select(double orig_x,
                         polyhedron()->erase_facet(selected_fh->halfedge());
                         polyhedron()->normalize_border();
                         //set_erase_next_picked_facet(false);
-                        changed();
+                        invalidate_buffers();
             Q_EMIT itemChanged();
                     }
                 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1042,7 +1042,6 @@ invalidate_buffers()
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();
-    Base::changed();
     Base::invalidate_buffers();
     is_Triangulated();
     compute_normals_and_vertices();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -192,23 +192,35 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
         positions_facets.push_back(ffit->vertex(2)->point().z());
         positions_facets.push_back(1.0);
 
-        if (cur_shading == Flat || cur_shading == FlatPlusEdges || cur_shading == Gouraud)
-        {
+      //  if (cur_shading == Flat || cur_shading == FlatPlusEdges || cur_shading == Gouraud)
+      //  {
 
             typedef Kernel::Vector_3	    Vector;
             Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(fit, *poly);
-            normals.push_back(n.x());
-            normals.push_back(n.y());
-            normals.push_back(n.z());
+            normals_flat.push_back(n.x());
+            normals_flat.push_back(n.y());
+            normals_flat.push_back(n.z());
 
-            normals.push_back(n.x());
-            normals.push_back(n.y());
-            normals.push_back(n.z());
+            normals_flat.push_back(n.x());
+            normals_flat.push_back(n.y());
+            normals_flat.push_back(n.z());
 
-            normals.push_back(n.x());
-            normals.push_back(n.y());
-            normals.push_back(n.z());
-        }
+            normals_flat.push_back(n.x());
+            normals_flat.push_back(n.y());
+            normals_flat.push_back(n.z());
+
+            normals_gouraud.push_back(n.x());
+            normals_gouraud.push_back(n.y());
+            normals_gouraud.push_back(n.z());
+
+            normals_gouraud.push_back(n.x());
+            normals_gouraud.push_back(n.y());
+            normals_gouraud.push_back(n.z());
+
+            normals_gouraud.push_back(n.x());
+            normals_gouraud.push_back(n.y());
+            normals_gouraud.push_back(n.z());
+      //  }
 
     }
 }
@@ -312,6 +324,7 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
     {
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
+        //flat
         vaos[0]->bind();
         buffers[0].bind();
         buffers[0].allocate(positions_facets.data(),
@@ -323,8 +336,8 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
 
 
         buffers[1].bind();
-        buffers[1].allocate(normals.data(),
-                            static_cast<int>(normals.size()*sizeof(float)));
+        buffers[1].allocate(normals_flat.data(),
+                            static_cast<int>(normals_flat.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[1].release();
@@ -336,6 +349,27 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->setAttributeBuffer("colors",GL_FLOAT,0,3);
         buffers[2].release();
         vaos[0]->release();
+
+        //gouraud
+        vaos[4]->bind();
+        buffers[0].bind();
+        program->enableAttributeArray("vertex");
+        program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
+        buffers[0].release();
+
+        buffers[10].bind();
+        buffers[10].allocate(normals_gouraud.data(),
+                            static_cast<int>(normals_gouraud.size()*sizeof(float)));
+        program->enableAttributeArray("normals");
+        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+        buffers[10].release();
+
+        buffers[2].bind();
+        program->enableAttributeArray("colors");
+        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+        buffers[2].release();
+        vaos[4]->release();
+
         program->release();
 
     }
@@ -365,11 +399,12 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
     }
     //vao containing the data for the selected facets
     {
+
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
+
+        //flat
         vaos[2]->bind();
-
-
         buffers[5].bind();
         buffers[5].allocate(positions_facets.data(),
                             static_cast<int>(positions_facets.size()*sizeof(float)));
@@ -378,8 +413,8 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         buffers[5].release();
 
         buffers[6].bind();
-        buffers[6].allocate(normals.data(),
-                            static_cast<int>(normals.size()*sizeof(float)));
+        buffers[6].allocate(normals_flat.data(),
+                            static_cast<int>(normals_flat.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[6].release();
@@ -391,9 +426,28 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->enableAttributeArray("colors");
         program->setAttributeBuffer("colors",GL_FLOAT,0,3);
         buffers[7].release();
-        program->release();
-
         vaos[2]->release();
+
+        //gouraud
+        vaos[5]->bind();
+        buffers[5].bind();
+        program->enableAttributeArray("vertex");
+        program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
+        buffers[5].release();
+
+        buffers[10].bind();
+        program->enableAttributeArray("normals");
+        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+        buffers[10].release();
+
+
+        buffers[7].bind();
+        program->enableAttributeArray("colors");
+        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+        buffers[7].release();
+        vaos[5]->release();
+
+        program->release();
     }
     //vao containing the data for the selected lines
     {
@@ -433,8 +487,10 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
     std::vector<float>(color_lines).swap(color_lines);
     color_facets.resize(0);
     std::vector<float>(color_facets).swap(color_facets);
-    normals.resize(0);
-    std::vector<float>(normals).swap(normals);
+    normals_flat.resize(0);
+    std::vector<float>(normals_flat).swap(normals_flat);
+    normals_gouraud.resize(0);
+    std::vector<float>(normals_gouraud).swap(normals_gouraud);
     are_buffers_filled = true;
 }
 
@@ -443,7 +499,8 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
 {
     positions_facets.resize(0);
     positions_lines.resize(0);
-    normals.resize(0);
+    normals_flat.resize(0);
+    normals_gouraud.resize(0);
 
 
     //Facets
@@ -471,25 +528,25 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
             CGAL_For_all(he,end)
             {
 
-                // If Flat shading:1 normal per polygon added once per vertex
-                if (cur_shading == FlatPlusEdges || cur_shading == Flat )
-                {
+               // // If Flat shading:1 normal per polygon added once per vertex
+               // if (cur_shading == FlatPlusEdges || cur_shading == Flat )
+               // {
 
                     Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(f, *poly);
-                    normals.push_back(n.x());
-                    normals.push_back(n.y());
-                    normals.push_back(n.z());
-                }
+                    normals_flat.push_back(n.x());
+                    normals_flat.push_back(n.y());
+                    normals_flat.push_back(n.z());
+                //}
 
-                // If Gouraud shading: 1 normal per vertex
-                else if (cur_shading == Gouraud)
-                {
+                //// If Gouraud shading: 1 normal per vertex
+                //else if (cur_shading == Gouraud)
+                //{
 
-                    Vector n = CGAL::Polygon_mesh_processing::compute_vertex_normal(he->vertex(), *poly);
-                    normals.push_back(n.x());
-                    normals.push_back(n.y());
-                    normals.push_back(n.z());
-                }
+                    n = CGAL::Polygon_mesh_processing::compute_vertex_normal(he->vertex(), *poly);
+                    normals_gouraud.push_back(n.x());
+                    normals_gouraud.push_back(n.y());
+                    normals_gouraud.push_back(n.z());
+                //}
 
                 //position
                 const Point& p = he->vertex()->point();
@@ -650,7 +707,7 @@ Scene_polyhedron_item::compute_colors() const
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item()
-    : Scene_item(10,4),
+    : Scene_item(11,6),
       is_Triangle(true),
       poly(new Polyhedron),
       show_only_feature_edges_m(false),
@@ -667,7 +724,7 @@ Scene_polyhedron_item::Scene_polyhedron_item()
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
-    : Scene_item(10,4),
+    : Scene_item(11,6),
       is_Triangle(true),
       poly(p),
       show_only_feature_edges_m(false),
@@ -684,7 +741,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
-    : Scene_item(10,4),
+    : Scene_item(11,6),
       is_Triangle(true),
       poly(new Polyhedron(p)),
       show_only_feature_edges_m(false),
@@ -884,8 +941,16 @@ void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
     }
 
 
-    if(!is_selected)
+    if(!is_selected && renderingMode() == Flat)
         vaos[0]->bind();
+    else if(!is_selected && renderingMode() == Gouraud)
+    {
+        vaos[4]->bind();
+    }
+    else if (is_selected && renderingMode() == Gouraud)
+    {
+        vaos[5]->bind();
+    }
     else
     {
         vaos[2]->bind();
@@ -895,8 +960,12 @@ void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
     program->bind();
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     program->release();
-    if(!is_selected)
+    if(!is_selected && renderingMode() == Flat)
         vaos[0]->release();
+    else if(!is_selected && renderingMode() == Gouraud)
+        vaos[4]->release();
+    else if (is_selected && renderingMode() == Gouraud)
+        vaos[5]->release();
     else
         vaos[2]->release();
 }
@@ -978,6 +1047,7 @@ void
 Scene_polyhedron_item::
 invalidate_buffers()
 {
+    qDebug()<<"inv buffers";
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();
@@ -998,7 +1068,7 @@ contextual_changed()
         if(cur_shading == Flat || cur_shading == FlatPlusEdges ||cur_shading == Gouraud)
         {
             //Change the normals
-            invalidate_buffers();
+           // invalidate_buffers();
         }
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -114,7 +114,8 @@ private:
 
     mutable std::vector<float> positions_lines;
     mutable std::vector<float> positions_facets;
-    mutable std::vector<float> normals;
+    mutable std::vector<float> normals_flat;
+    mutable std::vector<float> normals_gouraud;
     mutable std::vector<float> color_lines;
     mutable std::vector<float> color_facets;
     mutable std::vector<float> color_lines_selected;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -64,7 +64,7 @@ public:
     void set_color_vector_read_only(bool on_off) {plugin_has_set_color_vector_m=on_off;}
 
 public Q_SLOTS:
-    virtual void changed();
+    virtual void invalidate_buffers();
     virtual void contextual_changed();
     virtual void selection_changed(bool);
     virtual void setColor(QColor c);
@@ -89,7 +89,7 @@ Q_SIGNALS:
     void selected_facet(void*);
     void selected_edge(void*);
     void selected_halfedge(void*);
-    void item_is_about_to_be_changed(); // emitted in changed()
+    void item_is_about_to_be_changed(); // emitted in invalidate_buffers()
 
 private:
     // Initialization

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
@@ -63,10 +63,10 @@ Scene_polyhedron_item_decorator::bbox() const {
 
 void
 Scene_polyhedron_item_decorator::
-changed()
+invalidate_buffers()
 {
-  poly_item->changed();
-  Scene_item::changed();
+  poly_item->invalidate_buffers();
+  Scene_item::invalidate_buffers();
 }
 
 void 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
@@ -49,7 +49,7 @@ public:
   void set_delete_item(bool delete_item) { delete_poly_item = delete_item; }
 
 public Q_SLOTS:
-  void changed();
+  void invalidate_buffers();
   void select(double orig_x,
               double orig_y,
               double orig_z,

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -398,6 +398,7 @@ public:
     for(typename Tr::Iterator it = tr.iterator_begin() ; it != tr.iterator_end(); ++it) {
       tr.container().insert(*it);
     }
+    invalidate_buffers();
     Q_EMIT itemChanged();
   }
 
@@ -418,6 +419,7 @@ public:
 
     Selection_traits<HandleType, Scene_polyhedron_selection_item> tr(this);
     tr.container().clear();
+    invalidate_buffers();
     Q_EMIT itemChanged();
   }
 
@@ -463,7 +465,7 @@ public:
     Travel_isolated_components().travel<HandleType>
       (tr.iterator_begin(), tr.iterator_end(), tr.size(), tr.container(), visitor);
 
-    if(visitor.any_inserted) { Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidate_buffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 
@@ -561,7 +563,7 @@ public:
         any_change |= tr.container().insert(*it).second;
       }
     }
-    if(any_change) { Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
   }
 
   template <class Handle>
@@ -590,7 +592,7 @@ public:
         any_change |= (tr.container().erase(*it)!=0);
       }
     }
-    if(any_change) { Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
   }
 
   void erase_selected_facets() {
@@ -745,7 +747,7 @@ protected:
       BOOST_FOREACH(HandleType h, selection)
         any_change |= (tr.container().erase(h)!=0);
     }
-    if(any_change) { Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
   }
 
 public:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -207,7 +207,7 @@ public:
             buffers[i].create();
         }
         init(poly_item, mw);
-        changed();
+        invalidate_buffers();
     }
 
    ~Scene_polyhedron_selection_item()
@@ -667,7 +667,7 @@ public:
 
   void changed_with_poly_item() {
     // no need to update indices
-    poly_item->changed();
+    poly_item->invalidate_buffers();
     Q_EMIT itemChanged();
   }
 
@@ -675,9 +675,10 @@ Q_SIGNALS:
   void simplicesSelected(Scene_item*);
 
 public Q_SLOTS:
-  void changed() {
+  void invalidate_buffers() {
+
     // do not use decorator function, which calls changed on poly_item which cause deletion of AABB
-      //  poly_item->changed();
+      //  poly_item->invalidate_buffers();
         compute_elements();
         are_buffers_filled = false;
   }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -604,6 +604,7 @@ public:
       polyhedron()->erase_facet((*fb)->halfedge());
     }
     selected_facets.clear();
+    invalidate_buffers();
     changed_with_poly_item();
   }
 
@@ -670,6 +671,7 @@ public:
   void changed_with_poly_item() {
     // no need to update indices
     poly_item->invalidate_buffers();
+    Q_EMIT poly_item->itemChanged();
     Q_EMIT itemChanged();
   }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
@@ -179,7 +179,7 @@ void Scene_polyhedron_shortest_path_item::poly_item_changed()
   recreate_shortest_path_object();
 }
   
-void Scene_polyhedron_shortest_path_item::changed()
+void Scene_polyhedron_shortest_path_item::invalidate_buffers()
 {
   compute_elements();
   are_buffers_filled = false;
@@ -380,7 +380,7 @@ bool Scene_polyhedron_shortest_path_item::run_point_select(const Ray_3& ray)
       }
       break;
     }
-    changed();
+    invalidate_buffers();
     return true;
   }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
@@ -177,6 +177,8 @@ void Scene_polyhedron_shortest_path_item::ensure_shortest_paths_tree()
 void Scene_polyhedron_shortest_path_item::poly_item_changed()
 {
   recreate_shortest_path_object();
+  invalidate_buffers();
+  Q_EMIT itemChanged();
 }
   
 void Scene_polyhedron_shortest_path_item::invalidate_buffers()

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
@@ -146,7 +146,7 @@ protected:
   
 public Q_SLOTS:
   virtual void poly_item_changed();
-  virtual void changed();
+  virtual void invalidate_buffers();
 };
 
 #endif // SCENE_POLYHEDRON_SHORTEST_PATH_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
@@ -114,7 +114,7 @@ Scene_polyhedron_transform_item::bbox() const {
 }
 
 
-void Scene_polyhedron_transform_item::changed()
+void Scene_polyhedron_transform_item::invalidate_buffers()
 {
     compute_elements();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
@@ -27,7 +27,7 @@ public:
     const Scene_polyhedron_item* getBase() const{ return poly_item;  };
     const qglviewer::Vec& center() const { return center_; }
     virtual bool supportsRenderingMode(RenderingMode m) const { return m==Wireframe ; }
-    virtual void changed();
+    virtual void invalidate_buffers();
     virtual bool keyPressEvent(QKeyEvent*);
 
 private:

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -337,7 +337,7 @@ Scene_polylines_item::Scene_polylines_item()
     nb_wire = 0;
     nb_centers = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 
 }
 
@@ -529,7 +529,7 @@ QMenu* Scene_polylines_item::contextMenu()
     return menu;
 }
 
-void Scene_polylines_item::changed()
+void Scene_polylines_item::invalidate_buffers()
 {
     compute_elements();
     are_buffers_filled = false;
@@ -567,7 +567,7 @@ void Scene_polylines_item::change_corner_radii(double r) {
     if(r >= 0) {
         d->spheres_drawn_radius = r;
         d->draw_extremities = (r > 0);
-        this->changed();
+        this->invalidate_buffers();
     Q_EMIT itemChanged();
     }
 }
@@ -669,6 +669,6 @@ Scene_polylines_item::merge(Scene_polylines_item* other_item) {
         metadata.append(other_metadata_variant.toStringList());
         setProperty("polylines metadata", metadata);
     }
-    changed();
+    invalidate_buffers();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -84,7 +84,8 @@ public Q_SLOTS:
     void smooth(){
         for (Polylines_container::iterator pit=polylines.begin(),pit_end=polylines.end();pit!=pit_end;++pit)
             smooth(*pit);
-    Q_EMIT itemChanged();
+      invalidate_buffers();
+      Q_EMIT itemChanged();
     }
 public:
     Polylines_container polylines;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -74,7 +74,7 @@ public:
     }
 
 public Q_SLOTS:
-    virtual void changed();
+    virtual void invalidate_buffers();
     void change_corner_radii(double);
     void change_corner_radii();
     void split_at_sharp_angles();

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -215,7 +215,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedron* const p)
@@ -226,7 +226,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedr
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     nb_facets = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_polyhedron& p)
@@ -237,7 +237,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_po
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    changed();
+    invalidate_buffers();
 }
 
 Scene_textured_polyhedron_item::~Scene_textured_polyhedron_item()
@@ -256,7 +256,7 @@ Scene_textured_polyhedron_item::load(std::istream& in)
 {
     std::cout<<"LOAD"<<std::endl;
     in >> *poly;
-    changed();
+    invalidate_buffers();
     return in && !isEmpty();
 }
 
@@ -343,7 +343,7 @@ Scene_textured_polyhedron_item::bbox() const {
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 void
-Scene_textured_polyhedron_item::changed()
+Scene_textured_polyhedron_item::invalidate_buffers()
 {
     compute_normals_and_vertices();
     are_buffers_filled = false;}
@@ -355,7 +355,7 @@ contextual_changed()
     cur_shading = renderingMode();
     if(prev_shading != cur_shading)
     {
-        changed();
+        invalidate_buffers();
     }
 }
 void

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -44,7 +44,7 @@ public:
   bool isEmpty() const;
   Bbox bbox() const;
 
-  virtual void changed();
+  virtual void invalidate_buffers();
   virtual void contextual_changed();
   virtual void selection_changed(bool);
 


### PR DESCRIPTION
- The function `changed()` in the Polyhedron demo has been renamed in invalidate_buffers() to avoid confusion with `itemChanged()`. 
- `invalidate_buffers()` is not called when changing the rendering mode anymore. It makes this change instant.