### PR TITLE
Call openmesh.garbage_collection() before writing after triangulate_holes()

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
@@ -13,6 +13,7 @@ typedef CGAL::Surface_mesh<Point>          Surface_mesh;
 int main(int argc, char* argv[])
 {
   const char* filename = (argc > 1) ? argv[1] : "data/P.off";
+  const char* outfilename = (argc > 2) ? argv[2] : "P_tri.off";
   std::ifstream input(filename);
 
   Surface_mesh mesh;
@@ -24,7 +25,7 @@ int main(int argc, char* argv[])
 
   CGAL::Polygon_mesh_processing::triangulate_faces(mesh);
 
-  std::ofstream cube_off("P_tri.off");
+  std::ofstream cube_off(outfilename);
   cube_off << mesh;
   cube_off.close();
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example_OM.cpp
@@ -16,6 +16,7 @@ typedef OpenMesh::PolyMesh_ArrayKernelT< > Mesh;
 int main(int argc, char* argv[])
 {
   const char* filename = (argc > 1) ? argv[1] : "data/cube_quad.off";
+  const char* outfilename = (argc > 2) ? argv[2] : "cube_tri.off";
   std::ifstream input(filename);
 
   Mesh mesh;
@@ -25,7 +26,8 @@ int main(int argc, char* argv[])
      CGAL::Polygon_mesh_processing::parameters::vertex_point_map(get(CGAL::vertex_point, mesh)).
                                                    geom_traits(Kernel()));
 
-  OpenMesh::IO::write_mesh(mesh,"cube_tri.off");
+  mesh.garbage_collection();
+  OpenMesh::IO::write_mesh(mesh,outfilename);
 
   return 0;
 }


### PR DESCRIPTION
This is necessary, as faces are deleted and new faces created,
and as in OpenMesh deleted faces are not reused.

I at the same time, un-hardwired the output filename