### PR TITLE
set_halfedge(..) was called twice

### DIFF
--- a/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
@@ -607,7 +607,7 @@ remove_face(typename boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >::f
   sm.request_face_status();
   sm.request_vertex_status();
   sm.request_halfedge_status();
-  set_halfedge(f, typename boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >::halfedge_descriptor(), sm);
+  
   set_halfedge(f, typename boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >::halfedge_descriptor(), sm);
   sm.status(f).set_deleted(true);
 }


### PR DESCRIPTION
I didn't merge it in integration.

I just realize that the branch name has nothing to do with Advancing Front Reconstruction
as it concerns the boost_graph_traits for OpenMesh.