### PR TITLE
acos makes that the green wedge in the user manual has an aperture of 0

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -746,7 +746,7 @@ namespace CGAL {
     void run(double radius_ratio_bound=5, double beta= 0.52)
     {
       K = radius_ratio_bound;
-      COS_BETA = acos(beta);
+      COS_BETA = cos(beta);
       if(T.dimension() < 3){
         return;
       }


### PR DESCRIPTION
Simon and I tested the reconstruction algorithm on several user data sets and only observed better results.  
The error makes that there is only an orange and red wedge, and that consequently only the criterium for faces in the orange wedge is applied.
