### PR TITLE
Convert <code> sections into cgalExamples

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -746,7 +746,7 @@ namespace CGAL {
     void run(double radius_ratio_bound=5, double beta= 0.52)
     {
       K = radius_ratio_bound;
-      COS_BETA = acos(beta);
+      COS_BETA = cos(beta);
       if(T.dimension() < 3){
         return;
       }

--- a/Intersections_2/include/CGAL/Intersection_traits.h
+++ b/Intersections_2/include/CGAL/Intersection_traits.h
@@ -165,7 +165,7 @@ namespace internal {
   inline
   CGAL::Object intersection_return() { return CGAL::Object(); }
 #else
-  #if defined(CGAL_CFG_NO_CPP0X_RVALUE_REFERENCE)
+#if defined(CGAL_CFG_NO_CPP0X_RVALUE_REFERENCE)
     template<typename F, typename A, typename B, typename T>
     inline typename cpp11::result_of<F(A, B)>::type
     intersection_return(const T& t) { return typename cpp11::result_of<F(A, B)>::type(t); }

--- a/Intersections_3/include/CGAL/Intersections_3/intersection_3_1_impl.h
+++ b/Intersections_3/include/CGAL/Intersections_3/intersection_3_1_impl.h
@@ -1564,8 +1564,9 @@ intersection(const typename K::Segment_3 &seg,
     if (_max == _min) {
         return intersection_return<typename K::Intersect_3, typename K::Segment_3, typename K::Iso_cuboid_3>(Point_3(_ref_point + _dir * _min ));
     }
+   
     return intersection_return<typename K::Intersect_3, typename K::Segment_3, typename K::Iso_cuboid_3>(
-        Segment_3(_ref_point + _dir*_min, _ref_point + _dir*_max));
+            Segment_3(_ref_point + _dir*_min, _ref_point + _dir*_max));
 }
 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/intersections.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/intersections.h
@@ -334,7 +334,7 @@ As explained in the boost manual pages for <A HREF="http://www.boost.org/libs/va
 
 \cgalExample{Kernel_23/intersection_get.cpp}
 
-The second example uses`boost::apply_visitor`.
+The second example uses `boost::apply_visitor`.
 
 \cgalExample{Kernel_23/intersection_visitor.cpp}
 

--- a/Kernel_23/doc/Kernel_23/CGAL/intersections.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/intersections.h
@@ -127,9 +127,9 @@ depending on the arguments.
 
 The following tables give the possible values for `Type1` and `Type2`.
 
-\cgalHeading{2D intersections}
+\cgalHeading{2D Intersections}
 
-The return type can be obtained through `cpp11::result_of<Kernel::Intersect_2(A, B)>::%type`.
+The return type can be obtained through `CGAL::cpp11::result_of<Kernel::Intersect_2(A, B)>::%type`.
 It is equivalent to `boost::optional< boost::variant< T... > >`, the last column in the table providing the template parameter pack.
 
 <DIV ALIGN="CENTER">
@@ -217,9 +217,9 @@ It is equivalent to `boost::optional< boost::variant< T... > >`, the last column
 </TABLE>
 </DIV>
 
-\cgalHeading{3D intersections}
+\cgalHeading{3D Intersections}
 
-The return type can be obtained through `cpp11::result_of<Kernel::Intersect_3(A, B)>::%type`.
+The return type can be obtained through `CGAL::cpp11::result_of<Kernel::Intersect_3(A, B)>::%type`.
 It is equivalent to `boost::optional< boost::variant< T... > >`, the last column in the table providing the template parameter pack.
 
 <DIV ALIGN="CENTER">
@@ -316,57 +316,30 @@ p    <TD>Point_3, or Segment_3</TD>
 </TABLE>
 </DIV>
 
-\cgalHeading{Example}
+\cgalHeading{Examples}
 
-The following example demonstrates the most common use of
-`intersection` routines with the 2D and 3D Linear %Kernel.
+The following examples demonstrate the most common use of
+`intersection()` functions with the 2D and 3D Linear %Kernel.
 
-\code
-#include <CGAL/intersections.h>
+In the first two examples we intersect a segment and a line.
+The result type can be obtained with `CGAL::cpp11::result_of`. It looks simpler
+if you use a C++ compiler which supports `auto`,
+but you must anyways know that the result type is a `boost::optional<boost::variant<..> >`, in order to unpack the point or segment.
 
-template <typename R>
-struct Intersection_visitor {
-  typedef void result_type;
-  void operator()(const Point_2<R>& p) const
-  {
-    // handle point
-  }
-  void operator()(const Segment_2<R>& s) const
-  {
-    // handle segment
-  }
-};
+<A HREF="http://www.boost.org/libs/optional/">`boost::optional`</A> comes in
+as there might be no intersection. <A HREF="http://www.boost.org/libs/variant/">`boost::variant`</A> comes in
+as, if there is an intersection, it is either a point or a segment.
 
-template <typename R>
-void foo (const Segment_2<R>& seg, const Line_2<R>& lin)
-{
-  // with C++11 support
-  // auto result = intersection(seg, lin);
+As explained in the boost manual pages for <A HREF="http://www.boost.org/libs/variant/">`boost::variant`</A>, there are two ways to access the variants. The first examples uses `boost::get`.
 
-  // without C++11
-  cpp11::result_of<R::Intersect_2(Segment_2<R>, Line_2<R>)>::type
-    result = intersection(seg, lin);
+\cgalExample{Kernel_23/intersection_get.cpp}
 
-  if (result) { boost::apply_visitor(Intersection_visitor(), *result); }
-  else {
-    // no intersection
-  }
+The second example uses`boost::apply_visitor`.
 
-  // alternatively:
-  if (result) {
-    if (const Segment_2<R>* s = boost::get<Segment_2>(&*result)) {
-      // handle segment
-    } else {
-      const Point_2<R>* p = boost::get<Point_2<R> >(&*result);
-      // handle point
-    }
-  }
-}
-\endcode
+\cgalExample{Kernel_23/intersection_visitor.cpp}
 
-
-Another example showing the use of the intersection function as a
-plain function call and with `Dispatch_output_iterator` combined with
+A third example shows the use of the intersection function as a
+plain function call and with `Dispatch_output_iterator`, combined with
 a standard library algorithm.
 
 \cgalExample{Kernel_23/intersections.cpp}

--- a/Kernel_23/doc/Kernel_23/examples.txt
+++ b/Kernel_23/doc/Kernel_23/examples.txt
@@ -7,6 +7,8 @@
 \example Kernel_23/MyKernel.cpp
 \example Filtered_kernel/Filtered_predicate.cpp
 \example Kernel_23/cartesian_converter.cpp
+\example Kernel_23/intersection_get.cpp
+\example Kernel_23/intersection_visitor.cpp
 \example Kernel_23/intersections.cpp
 \example Kernel_23/points_and_segment.cpp
 \example Kernel_23/surprising.cpp

--- a/Kernel_23/examples/Kernel_23/intersection_get.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_get.cpp
@@ -15,10 +15,10 @@ int main()
     result = intersection(seg, lin);
   if (result) {
     if (const Segment_2* s = boost::get<Segment_2>(&*result)) {
-      // handle segment
+      std::cout << *s << std::endl;
     } else {
       const Point_2* p = boost::get<Point_2 >(&*result);
-      // handle point
+      std::cout << *s << std::endl;
     }
   }
   return 0;

--- a/Kernel_23/examples/Kernel_23/intersection_get.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_get.cpp
@@ -1,0 +1,24 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/intersections.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef K::Point_2 Point_2;
+typedef K::Segment_2 Segment_2;
+typedef K::Line_2 Line_2;
+typedef K::Intersect_2 Intersect_2;
+
+int main()
+{
+  Segment_2 seg(Point_2(0,0), Point_2(1,1));
+  Line_2 lin(1,0,0);
+
+  if (result) {
+    if (const Segment_2* s = boost::get<Segment_2>(&*result)) {
+      // handle segment
+    } else {
+      const Point_2* p = boost::get<Point_2 >(&*result);
+      // handle point
+    }
+  }
+  return 0;
+}

--- a/Kernel_23/examples/Kernel_23/intersection_get.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_get.cpp
@@ -9,8 +9,9 @@ typedef K::Intersect_2 Intersect_2;
 
 int main()
 {
-  Segment_2 seg(Point_2(0,0), Point_2(1,1));
-  Line_2 lin(1,0,0);
+  Segment_2 seg(Point_2(0,0), Point_2(2,2));
+  Line_2 lin(1,-1,0);
+
   CGAL::cpp11::result_of<Intersect_2(Segment_2, Line_2)>::type
     result = intersection(seg, lin);
   if (result) {
@@ -18,7 +19,7 @@ int main()
       std::cout << *s << std::endl;
     } else {
       const Point_2* p = boost::get<Point_2 >(&*result);
-      std::cout << *s << std::endl;
+      std::cout << *p << std::endl;
     }
   }
   return 0;

--- a/Kernel_23/examples/Kernel_23/intersection_get.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_get.cpp
@@ -11,7 +11,8 @@ int main()
 {
   Segment_2 seg(Point_2(0,0), Point_2(1,1));
   Line_2 lin(1,0,0);
-
+  CGAL::cpp11::result_of<Intersect_2(Segment_2, Line_2)>::type
+    result = intersection(seg, lin);
   if (result) {
     if (const Segment_2* s = boost::get<Segment_2>(&*result)) {
       // handle segment

--- a/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
@@ -9,13 +9,15 @@ typedef K::Intersect_2 Intersect_2;
 
 struct Intersection_visitor {
   typedef void result_type;
+
   void operator()(const Point_2& p) const
   {
-    // handle point
+    std::cout << p << std::endl;
   }
+
   void operator()(const Segment_2& s) const
   {
-    // handle segment
+    std::cout << s << std::endl;
   }
 };
 
@@ -29,10 +31,11 @@ int main()
   // without C++11
   CGAL::cpp11::result_of<Intersect_2(Segment_2, Line_2)>::type
     result = intersection(seg, lin);
-  if (result) { boost::apply_visitor(Intersection_visitor(), *result); }
-  else {
+  if (result) { 
+    boost::apply_visitor(Intersection_visitor(), *result); 
+  } else {
     // no intersection
   }
-
+  
   return 0;
 }

--- a/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
@@ -24,7 +24,7 @@ struct Intersection_visitor {
 int main()
 {
   Segment_2 seg(Point_2(0,0), Point_2(1,1));
-  Line_2 lin(1,0,0);
+  Line_2 lin(1,-1,0);
 
   // with C++11 support
   // auto result = intersection(seg, lin);

--- a/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
+++ b/Kernel_23/examples/Kernel_23/intersection_visitor.cpp
@@ -1,0 +1,38 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/intersections.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef K::Point_2 Point_2;
+typedef K::Segment_2 Segment_2;
+typedef K::Line_2 Line_2;
+typedef K::Intersect_2 Intersect_2;
+
+struct Intersection_visitor {
+  typedef void result_type;
+  void operator()(const Point_2& p) const
+  {
+    // handle point
+  }
+  void operator()(const Segment_2& s) const
+  {
+    // handle segment
+  }
+};
+
+int main()
+{
+  Segment_2 seg(Point_2(0,0), Point_2(1,1));
+  Line_2 lin(1,0,0);
+
+  // with C++11 support
+  // auto result = intersection(seg, lin);
+  // without C++11
+  CGAL::cpp11::result_of<Intersect_2(Segment_2, Line_2)>::type
+    result = intersection(seg, lin);
+  if (result) { boost::apply_visitor(Intersection_visitor(), *result); }
+  else {
+    // no intersection
+  }
+
+  return 0;
+}

--- a/Kernel_23/examples/Kernel_23/intersections.cpp
+++ b/Kernel_23/examples/Kernel_23/intersections.cpp
@@ -1,11 +1,10 @@
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/intersections.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/iterator.h>
 #include <CGAL/point_generators_2.h>
 
 #include <boost/bind.hpp>
 
-typedef CGAL::Simple_cartesian<double> K;
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
 typedef K::Point_2                     Point;
 typedef K::Segment_2                   Segment;
 
@@ -49,7 +48,7 @@ int main()
   std::vector<Segment> segments;
 
   typedef CGAL::Dispatch_output_iterator<
-    CGAL::cpp11::tuple<Point,Segment>, CGAL::cpp0x::tuple< std::back_insert_iterator<std::vector<Point> >,
+    CGAL::cpp11::tuple<Point,Segment>, CGAL::cpp11::tuple< std::back_insert_iterator<std::vector<Point> >,
                                                std::back_insert_iterator<std::vector<Segment> > > >
     Dispatcher;
 

--- a/STL_Extension/doc/STL_Extension/CGAL/iterator.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/iterator.h
@@ -109,7 +109,7 @@ The class `Dispatch_or_drop_output_iterator` defines an
 dispatches among those based on the type of the value type which is
 put in it. Besides defining assignment for all parameters of `V`
 and for a tuple of type `V`,  it is also defined for the types `boost::variant<T...>` and
-`boost::optional<boost::variant<T...>>`, where `T...`
+`boost::optional<boost::variant<T...> >`, where `T...`
 must be a subset of the parameters of `V`. Should the
 `boost::optional` be empty, it will be discarded.
 
@@ -195,12 +195,12 @@ The class `Dispatch_output_iterator` defines an
 dispatches among those based on the type of the value type which is
 put in it. Other types are also accepted, and the object is 
 discarded in this case. Besides defining assignment for all
-parameters of V and for a tuple of type `V`, it is also defined for the types
-`boost::variant<T...` and
-`boost::optional<boost::variant<T...>`, where `T...`
+parameters of `V` and for a tuple of type `V`, it is also defined for the types
+`boost::variant<T...>` and
+`boost::optional<boost::variant<T...> >`, where `T...`
 can be a list of arbitrary types.
 
-  It also inherits from `O, which makes it easy to treat like a
+  It also inherits from `O`, which makes it easy to treat like a
   tuple.
 
 \cgalHeading{Parameters}

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -1271,7 +1271,7 @@ struct Derivator<D, cpp11::tuple<V1, V...>, cpp11::tuple<O1, O...> >
 
 
 // OutputIterator which accepts several types in *o++= and dispatches,
-// wraps several other outputiterators, and dispatches accordingly.
+// wraps several other output iterators, and dispatches accordingly.
 template < typename V, typename O >
 class Dispatch_output_iterator;
 


### PR DESCRIPTION
This  at the same time fixes bugs as the examples where not 100 correct.

I have merged it into integration.