### PR TITLE
Splat Fix for mesa

### DIFF
--- a/Polyhedron/demo/Polyhedron/GlSplat/Shader.cpp
+++ b/Polyhedron/demo/Polyhedron/GlSplat/Shader.cpp
@@ -34,7 +34,7 @@ bool Shader::loadSources(const char* vsrc, const char* fsrc)
     bool allIsOk = true;
     mProgramID = viewer->glCreateProgram();
 
-    std::string defineStr = "";
+    std::string defineStr = "#extension GL_ARB_texture_rectangle : enable\n";
     for(DefineMap::iterator it = mDefines.begin() ; it!=mDefines.end() ; ++it)
     {
       defineStr += "#define " + it->first + " " + it->second + "\n";

--- a/Polyhedron/demo/Polyhedron/GlSplat/shaders/Finalization.glsl
+++ b/Polyhedron/demo/Polyhedron/GlSplat/shaders/Finalization.glsl
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public
 // License along with GlSplat. If not, see <http://www.gnu.org/licenses/>.
 
-#extension GL_ARB_texture_rectangle : enable
+//#extension GL_ARB_texture_rectangle : enable
 
 #ifndef ES_DEPTH_INTERPOLATION
   #define ES_DEPTH_INTERPOLATION 0


### PR DESCRIPTION
- Moved an extension declaration at the beginning of the shader, before the
  #define are added. The problem is that it enables the extension for splatting
  shaders that don't require it, but I don't think it is really bad.