### PR TITLE
Optimazing color handling

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
@@ -156,6 +156,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionColorConnectedCom
       qobject_cast<Scene_polyhedron_item*>(scene->item(index));
     if(item)
     {
+        item->setItemIsMulticolor(true);
       std::list<Polyhedron*> new_polyhedra;
       Polyhedron_cc_marker marker;
       CGAL::internal::corefinement::mark_connected_components(

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
@@ -472,6 +472,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
 
   scene->item(InputMeshItemIndex)->setVisible(false);
   Scene_polyhedron_item* item_segmentation = new Scene_polyhedron_item(segmented_polyhedron);
+  item_segmentation->setItemIsMulticolor(true);
   scene->addItem(item_segmentation);
   item_segmentation->setName(QString("segmentation"));
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
@@ -315,6 +315,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::colorize_sdf(
      SDFPropertyMap sdf_values,  
      std::vector<QColor>& color_vector)
 {
+    item->setItemIsMulticolor(true);
     Polyhedron* polyhedron = item->polyhedron();
     color_vector.clear();
     std::size_t patch_id = 0;
@@ -339,6 +340,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::colorize_segmentation(
      SegmentPropertyMap segment_ids,
      std::vector<QColor>& color_vector)
 {
+    item->setItemIsMulticolor(true);
     Polyhedron* polyhedron = item->polyhedron();
     color_vector.clear();
     std::size_t max_segment = 0;

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
@@ -318,10 +318,10 @@ void Scene_edit_polyhedron_item::initialize_buffers(Viewer_interface *viewer =0)
         }
         vaos[6]->release();
         nb_sphere = pos_sphere.size();
-        pos_sphere.resize(0);
-        std::vector<double>(pos_sphere).swap(pos_sphere);
-        normals_sphere.resize(0);
-        std::vector<double>(normals_sphere).swap(normals_sphere);
+        //pos_sphere.resize(0);
+        //std::vector<double>(pos_sphere).swap(pos_sphere);
+       // normals_sphere.resize(0);
+       // std::vector<double>(normals_sphere).swap(normals_sphere);
         control_color.resize(0);
         std::vector<double>(control_color).swap(control_color);
         nb_control = control_points.size();
@@ -545,6 +545,7 @@ void Scene_edit_polyhedron_item::draw_ROI_and_control_vertices(Viewer_interface*
             program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
             attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
             program->bind();
+            program->setAttributeValue("colors", QColor(0,255,0));
             viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_ROI/3));
             program->release();
             vaos[1]->release();
@@ -554,6 +555,8 @@ void Scene_edit_polyhedron_item::draw_ROI_and_control_vertices(Viewer_interface*
             program = getShaderProgram(PROGRAM_INSTANCED);
             attrib_buffers(viewer,PROGRAM_INSTANCED);
             program->bind();
+
+            program->setAttributeValue("colors", QColor(0,255,0));
             viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                         static_cast<GLsizei>(nb_sphere/3),
                                         static_cast<GLsizei>(nb_ROI/3));
@@ -567,6 +570,7 @@ void Scene_edit_polyhedron_item::draw_ROI_and_control_vertices(Viewer_interface*
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
         attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
         program->bind();
+        program->setAttributeValue("colors", QColor(255,0,0));
         viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_control/3));
         program->release();
         vaos[5]->release();
@@ -576,6 +580,7 @@ void Scene_edit_polyhedron_item::draw_ROI_and_control_vertices(Viewer_interface*
         program = getShaderProgram(PROGRAM_INSTANCED);
         attrib_buffers(viewer,PROGRAM_INSTANCED);
         program->bind();
+        program->setAttributeValue("colors", QColor(255,0,0));
         viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                     static_cast<GLsizei>(nb_sphere/3),
                                     static_cast<GLsizei>(nb_control/3));
@@ -638,6 +643,7 @@ void Scene_edit_polyhedron_item::draw_ROI_and_control_vertices(Viewer_interface*
                 bbox_program.setUniformValue("translation", vec);
                 bbox_program.setUniformValue("translation_2", vec2);
                 bbox_program.setUniformValue("mvp_matrix", mvp_mat);
+                program->setAttributeValue("colors", QColor(255,0,0));
                 viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_bbox/3));
                 bbox_program.release();
                 vaos[4]->release();

--- a/Polyhedron/demo/Polyhedron/Scene_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_item.h
@@ -50,7 +50,7 @@ public:
       buffersSize(20),
       vaosSize(10)
   {
-
+      is_monochrome = true;
       nbVaos = 0;
       for(int i=0; i<vaosSize; i++)
       {
@@ -75,6 +75,7 @@ public:
       buffersSize(buffers_size),
       vaosSize(vaos_size)
   {
+      is_monochrome = true;
       nbVaos = 0;
       for(int i=0; i<vaosSize; i++)
       {
@@ -142,7 +143,14 @@ public Q_SLOTS:
   virtual void contextual_changed(){}
 
   // Setters for the four basic properties
-  virtual void setColor(QColor c) { color_ = c; invalidate_buffers(); }
+  virtual void setColor(QColor c) {
+    color_ = c;
+    if(!is_monochrome)
+    {
+        setItemIsMulticolor(false);
+        invalidate_buffers();
+    }
+  }
   void setRbgColor(int r, int g, int b) { setColor(QColor(r, g, b)); }
   virtual void setName(QString n) { name_ = n; }
   virtual void setVisible(bool b) { visible_ = b; }
@@ -184,6 +192,13 @@ public Q_SLOTS:
   void setSplattingMode(){
     setRenderingMode(Splatting);
   }
+
+  //! If b is true, the item will use buffers to render the color.
+  //! If b is false, it will use a uniform value. For example, when
+  //! using the mesh segmentation plugin, the item must be multicolor.
+  void setItemIsMulticolor(bool b){
+    is_monochrome = !b;
+  }
   
   virtual void itemAboutToBeDestroyed(Scene_item*);
 
@@ -205,6 +220,9 @@ protected:
   QColor color_;
   bool visible_;
   bool is_selected;
+  //! Specifies if the item is monochrome and uses uniform attribute for its color
+  //! or is multicolor and uses buffers.
+  bool is_monochrome;
   mutable bool are_buffers_filled;
   RenderingMode rendering_mode;
   QMenu* defaultContextMenu;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -339,14 +339,16 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[1].release();
 
-        buffers[2].bind();
-        buffers[2].allocate(color_facets.data(),
-                            static_cast<int>(color_facets.size()*sizeof(float)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[2].release();
+        if(!is_monochrome)
+        {
+            buffers[2].bind();
+            buffers[2].allocate(color_facets.data(),
+                                static_cast<int>(color_facets.size()*sizeof(float)));
+            program->enableAttributeArray("colors");
+            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+            buffers[2].release();
+        }
         vaos[0]->release();
-
         //gouraud
         vaos[4]->bind();
         buffers[0].bind();
@@ -360,11 +362,17 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[10].release();
-
-        buffers[2].bind();
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[2].release();
+        if(!is_monochrome)
+        {
+            buffers[2].bind();
+            program->enableAttributeArray("colors");
+            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+            buffers[2].release();
+        }
+        else
+        {
+            program->disableAttributeArray("colors");
+        }
         vaos[4]->release();
 
         program->release();
@@ -386,9 +394,16 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         buffers[4].bind();
         buffers[4].allocate(color_lines.data(),
                             static_cast<int>(color_lines.size()*sizeof(float)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[4].release();
+       if(!is_monochrome)
+       {
+           program->enableAttributeArray("colors");
+           program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+           buffers[4].release();
+       }
+       else
+       {
+           program->disableAttributeArray("colors");
+       }
         program->release();
 
         vaos[1]->release();
@@ -416,13 +431,19 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[6].release();
 
-
-        buffers[7].bind();
-        buffers[7].allocate(color_facets_selected.data(),
-                            static_cast<int>(color_facets_selected.size()*sizeof(float)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[7].release();
+        if(!is_monochrome)
+        {
+            buffers[7].bind();
+            buffers[7].allocate(color_facets_selected.data(),
+                                static_cast<int>(color_facets_selected.size()*sizeof(float)));
+            program->enableAttributeArray("colors");
+            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+            buffers[7].release();
+        }
+        else
+        {
+            program->disableAttributeArray("colors");
+        }
         vaos[2]->release();
 
         //gouraud
@@ -437,11 +458,17 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
         buffers[10].release();
 
-
-        buffers[7].bind();
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[7].release();
+        if(!is_monochrome)
+        {
+            buffers[7].bind();
+            program->enableAttributeArray("colors");
+            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+            buffers[7].release();
+        }
+        else
+        {
+            program->disableAttributeArray("colors");
+        }
         vaos[5]->release();
 
         program->release();
@@ -461,9 +488,12 @@ Scene_polyhedron_item::initialize_buffers(Viewer_interface* viewer) const
         buffers[9].bind();
         buffers[9].allocate(color_lines_selected.data(),
                             static_cast<int>(color_lines_selected.size()*sizeof(float)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-        buffers[9].release();
+        if(!is_monochrome)
+        {
+            program->enableAttributeArray("colors");
+            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+            buffers[9].release();
+        }
         program->release();
 
         vaos[3]->release();
@@ -707,6 +737,7 @@ Scene_polyhedron_item::Scene_polyhedron_item()
       erase_next_picked_facet_m(false),
       plugin_has_set_color_vector_m(false)
 {
+   // setItemIsMulticolor(true);
     cur_shading=FlatPlusEdges;
     is_selected = true;
     nb_facets = 0;
@@ -724,6 +755,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
       erase_next_picked_facet_m(false),
       plugin_has_set_color_vector_m(false)
 {
+   // setItemIsMulticolor(true);
     cur_shading=FlatPlusEdges;
     is_selected = true;
     nb_facets = 0;
@@ -741,6 +773,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
       erase_next_picked_facet_m(false),
       plugin_has_set_color_vector_m(false)
 {
+    //setItemIsMulticolor(true);
     cur_shading=FlatPlusEdges;
     is_selected=true;
     init();
@@ -950,6 +983,13 @@ void Scene_polyhedron_item::draw(Viewer_interface* viewer) const {
     attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
     program = getShaderProgram(PROGRAM_WITH_LIGHT);
     program->bind();
+    if(is_monochrome)
+    {
+        if(is_selected)
+            program->setAttributeValue("colors", this->color().lighter(120));
+        else
+            program->setAttributeValue("colors", this->color());
+    }
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     program->release();
     if(!is_selected && renderingMode() == Flat)
@@ -983,6 +1023,13 @@ void Scene_polyhedron_item::draw_edges(Viewer_interface* viewer) const {
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     //draw the edges
+    if(is_monochrome)
+    {
+        if(is_selected)
+            program->setAttributeValue("colors", QColor(0,0,0));
+        else
+            program->setAttributeValue("colors", this->color().lighter(50));
+    }
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
     if(!is_selected)


### PR DESCRIPTION
- Corrected a bug in edit polyhedron with the Spheres that were not displayed.
- Added a boolean member to scene_item determining if the color should be handled by
  a single value, which avoids having to re-compute the color of each vertex when
  the color is changed through the UI, or by the buffers (only for certain plugins).