### PR TITLE
Spatial_searching : fix Fuzzy_sphere constructors

### DIFF
--- a/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
@@ -70,6 +70,8 @@ create_single_source_cgal_program( "searching_surface_mesh_vertices.cpp" )
 
 create_single_source_cgal_program( "searching_polyhedron_vertices.cpp" )
 
+create_single_source_cgal_program( "searching_polyhedron_vertices_with_fuzzy_sphere.cpp")
+
 create_single_source_cgal_program( "user_defined_point_and_distance.cpp" )
 
 create_single_source_cgal_program( "using_fair_splitting_rule.cpp" )

--- a/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
@@ -30,7 +30,6 @@ int main(int argc, char* argv[])
   Mesh mesh;
   std::ifstream in((argc>1)?argv[1]:"data/tripod.off");
   in  >> mesh;
-  const unsigned int K = 5;
 
   Vertex_point_pmap vppmap = get(CGAL::vertex_point,mesh);
 

--- a/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
@@ -1,0 +1,56 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
+
+#include <CGAL/Search_traits_3.h>
+#include <CGAL/Search_traits_adapter.h>
+#include <CGAL/Kd_tree.h>
+#include <CGAL/Fuzzy_sphere.h>
+
+#include <fstream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef Kernel::Point_3 Point_3;
+
+typedef CGAL::Polyhedron_3<Kernel> Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+
+typedef boost::property_map<Mesh,CGAL::vertex_point_t>::type Vertex_point_pmap;
+
+typedef CGAL::Search_traits_3<Kernel>                                    Traits_base;
+typedef CGAL::Search_traits_adapter<vertex_descriptor, Vertex_point_pmap, Traits_base> Traits;
+
+typedef CGAL::Kd_tree<Traits>                      Tree;
+typedef Tree::Splitter                             Splitter;
+
+int main(int argc, char* argv[])
+{
+  Mesh mesh;
+  std::ifstream in((argc>1)?argv[1]:"data/tripod.off");
+  in  >> mesh;
+  const unsigned int K = 5;
+
+  Vertex_point_pmap vppmap = get(CGAL::vertex_point,mesh);
+
+  // Insert number_of_data_points in the tree
+  Tree tree(vertices(mesh).begin(),
+            vertices(mesh).end(),
+            Splitter(),
+            Traits(vppmap)
+  );
+  Point_3 query(0.0, 0.0, 0.0);
+  double radius = 0.5;
+  double epsilon = 0.01;
+
+  // search vertices
+  CGAL::Fuzzy_sphere<Traits> fz(query, radius, epsilon);
+  
+  //collect vertices that are inside the sphere
+  std::list<vertex_descriptor> result;
+  tree.search(std::back_inserter(result), fz);
+  std::cout << "There are " << result.size() << " vertices inside the fuzzy sphere\n";
+
+  return 0;
+}

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -24,6 +24,9 @@
 #include <CGAL/Kd_tree_rectangle.h>
 #include <CGAL/Search_traits_adapter.h>
 
+#include <boost/type_traits.hpp>
+#include <boost/utility/enable_if.hpp>
+
 namespace CGAL {
 
   namespace internal{
@@ -150,8 +153,12 @@ namespace CGAL {
     Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){};
     Fuzzy_sphere(const typename Base_traits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) : 
       Base(center,radius,epsilon,traits_) {}
-    Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) : 
-      Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
+    Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
+                 const SearchTraits& traits_=SearchTraits(),
+                 typename boost::disable_if<
+                  boost::is_same<typename Base_traits::Point_d,
+                                 typename SearchTraits::Point_d> >::type* = 0)
+      : Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
   };
   
 } // namespace CGAL

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -25,7 +25,7 @@
 #include <CGAL/Search_traits_adapter.h>
 
 #include <boost/type_traits.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace CGAL {
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -25,7 +25,7 @@
 #include <CGAL/Search_traits_adapter.h>
 
 #include <boost/type_traits.hpp>
-#include <boost/core/enable_if.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace CGAL {
 


### PR DESCRIPTION
when both types `SearchTraits::Point_d` and `Base_traits::Point_d` are the same, both constructors are the same, leading to a compilation error

adding `boost::disable_if` solves this issue