### PR TITLE
Add Iso_cuboid_3 overload for CGAL::do_overlap().

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Iso_cuboid_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Iso_cuboid_3.h
@@ -225,4 +225,18 @@ Iso_cuboid_3<Kernel> transform(const Aff_transformation_3<Kernel> &t) const;
 /// @}
 
 }; /* end Iso_cuboid_3 */
+
+/// \ingroup do_overlap_grp
+/// @{
+
+/*!
+returns `true` iff `ic1` and `ic2` overlap, i.e., iff their
+intersection is non-empty.
+
+\relates Bbox_3
+*/
+do_overlap(const Iso_cuboid_3<Kernel>& ic1, const Iso_cuboid_3<Kernel>& ic2);
+
+/// @}
+
 } /* end namespace CGAL */

--- a/Kernel_23/doc/Kernel_23/CGAL/Iso_cuboid_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Iso_cuboid_3.h
@@ -235,6 +235,7 @@ intersection is non-empty.
 
 \relates Bbox_3
 */
+template< typename Kernel >
 do_overlap(const Iso_cuboid_3<Kernel>& ic1, const Iso_cuboid_3<Kernel>& ic2);
 
 /// @}

--- a/Kernel_23/doc/Kernel_23/CGAL/Iso_rectangle_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Iso_rectangle_2.h
@@ -203,4 +203,18 @@ Iso_rectangle_2<Kernel> transform(const Aff_transformation_2<Kernel> &t) const;
 /// @}
 
 }; /* end Iso_rectangle_2 */
+
+/// \ingroup do_overlap_grp
+/// @{
+
+/*!
+returns `true` iff `ir1` and `ir2` overlap, i.e., iff their
+intersection is non-empty.
+
+\relates Bbox_2
+*/
+do_overlap(const Iso_rectangle_2<Kernel> &ir1, const Iso_rectangle_2<Kernel> &ir2)
+
+/// @}
+
 } /* end namespace CGAL */

--- a/Kernel_23/doc/Kernel_23/CGAL/Iso_rectangle_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Iso_rectangle_2.h
@@ -213,7 +213,8 @@ intersection is non-empty.
 
 \relates Bbox_2
 */
-do_overlap(const Iso_rectangle_2<Kernel> &ir1, const Iso_rectangle_2<Kernel> &ir2)
+template< typename Kernel >
+do_overlap(const Iso_rectangle_2<Kernel> &ir1, const Iso_rectangle_2<Kernel> &ir2);
 
 /// @}
 

--- a/Kernel_23/include/CGAL/Iso_cuboid_3.h
+++ b/Kernel_23/include/CGAL/Iso_cuboid_3.h
@@ -234,6 +234,19 @@ public:
 
 };
 
+template < class R >
+inline
+bool
+do_overlap(const Iso_cuboid_3<R>& ic1, const Iso_cuboid_3<R>& ic2)
+{
+    if(ic1.xmax() < ic2.xmin() || ic2.xmax() < ic1.xmin())
+        return false;
+    if(ic1.ymax() < ic2.ymin() || ic2.ymax() < ic1.ymin())
+        return false;
+    if(ic1.zmax() < ic2.zmin() || ic2.zmax() < ic1.zmin())
+        return false;
+    return true;
+}
 
 template < class R >
 std::ostream &

--- a/Kernel_23/include/CGAL/Iso_rectangle_2.h
+++ b/Kernel_23/include/CGAL/Iso_rectangle_2.h
@@ -225,6 +225,18 @@ public:
   }
 };
 
+template < class R >
+inline
+bool
+do_overlap(const Iso_rectangle_2<R> &ir1, const Iso_rectangle_2<R> &ir2)
+{
+    // check for emptiness ??
+    if (ir1.xmax() < ir2.xmin() || ir2.xmax() < ir1.xmin())
+        return false;
+    if (ir1.ymax() < ir2.ymin() || ir2.ymax() < ir1.ymin())
+        return false;
+    return true;
+}
 
 template < class R >
 std::ostream &


### PR DESCRIPTION
The implementation is a copy of the existing function provided for
BBox_3, but allows the exact number type of the Kernel to be used
instead of rounding to doubles as is the case with BBox_3.

*NOTE:* I have further patches I would like to contribute to cgal and am just using this trivial patch as a test of the merge/pull request procedures.