### PR TITLE
Add Iso_cuboid_3 to function documentation in CGAL::do_intersect()

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/intersections.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/intersections.h
@@ -68,6 +68,7 @@ In three-dimensional space, the types `Type1` and
 - `Ray_3<Kernel>`
 - `Segment_3<Kernel>`
 - `Triangle_3<Kernel>`.
+- `Iso_Cuboid_3<Kernel>`
 - `Bbox_3`.
 
 Also, `Type1` and `Type2` can be respectively of types

--- a/Kernel_23/doc/Kernel_23/CGAL/intersections.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/intersections.h
@@ -68,7 +68,7 @@ In three-dimensional space, the types `Type1` and
 - `Ray_3<Kernel>`
 - `Segment_3<Kernel>`
 - `Triangle_3<Kernel>`.
-- `Iso_Cuboid_3<Kernel>`
+- `Iso_cuboid_3<Kernel>`
 - `Bbox_3`.
 
 Also, `Type1` and `Type2` can be respectively of types


### PR DESCRIPTION
Iso_cuboid_3 is not mentioned in documentation as one of the acceptable types to the global function CGAL::do_intersect(). This patch simply adds this type to the documentation.