### PR TITLE
Fix Scene_polyhedron_item::show_only_feature_edges

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -944,7 +944,8 @@ QMenu* Scene_polyhedron_item::contextMenu()
 void Scene_polyhedron_item::show_only_feature_edges(bool b)
 {
     show_only_feature_edges_m = b;
-  Q_EMIT itemChanged();
+    invalidate_buffers();
+    Q_EMIT itemChanged();
 }
 
 void Scene_polyhedron_item::enable_facets_picking(bool b)


### PR DESCRIPTION
The option "Show only feature edges" was no longer working. It seems that `invalidate_buffers()` must be called.
