### PR TITLE
Use CGAL_assertion_code() to avoid warnings

### DIFF
--- a/Convex_hull_d/include/CGAL/Delaunay_d.h
+++ b/Convex_hull_d/include/CGAL/Delaunay_d.h
@@ -993,8 +993,8 @@ std::list< typename Delaunay_d<R,Lifted_R>::Vertex_handle >
 Delaunay_d<R,Lifted_R>::
 range_search(const std::vector<Point_d>& A) const
 { 
-  typename R::Affinely_independent_d affinely_independent =
-    kernel().affinely_independent_d_object();
+  CGAL_assertion_code( typename R::Affinely_independent_d affinely_independent =
+                       kernel().affinely_independent_d_object());
   CGAL_assertion_msg( affinely_independent(A.begin(),A.end()),
     "Delaunay_d::range_search: simplex must be affinely independent.");
   typename R::Construct_sphere_d sphere_through =

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Regular_triangulation_3.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Regular_triangulation_3.h
@@ -886,7 +886,7 @@ protected:
 	CGAL_assertion(redundant_points_.find(pk) != redundant_points_.end());
 	Event_key k= redundant_points_.find(pk)->second;
 
-	Cell_handle ech= get_cell_handle(pk);
+	CGAL_assertion_code(Cell_handle ech= get_cell_handle(pk));
 	CGAL_assertion(ch== ech);
       }
     }


### PR DESCRIPTION
In KDS as well as Convex_hull_d I added   `CGAL_assertion_code( T v; )` so that we don't get a warning in a `CGAL_assertion(v ==.. )`

