### PR TITLE
Mouse binding modification

### DIFF
--- a/Polyhedron/demo/Polyhedron/CGAL_demo/Viewer_interface.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_demo/Viewer_interface.h
@@ -38,6 +38,24 @@ public:
   PFNGLFRAMEBUFFERTEXTURE2DEXTPROC glFramebufferTexture2D;
   bool extension_is_found;
   GLfloat pickMatrix_[16];
+  //!Sets the binding for SHIFT+LEFT CLICK to SELECT (initially used in Scene_polyhedron_selection_item.h)
+  void setBindingSelect()
+  {
+#if QGLVIEWER_VERSION >= 0x020501
+    setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, SELECT);
+#else
+    setMouseBinding(Qt::SHIFT + Qt::LeftButton, SELECT);
+#endif
+  }
+  //!Sets the binding for SHIFT+LEFT CLICK to NO_CLICK_ACTION (initially used in Scene_polyhedron_selection_item.h)
+  void setNoBinding()
+  {
+#if QGLVIEWER_VERSION >= 0x020501
+    setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, NO_CLICK_ACTION);
+#else
+    ssetMouseBinding(Qt::SHIFT + Qt::LeftButton, NO_CLICK_ACTION);
+#endif
+  }
 
 Q_SIGNALS:
   void selected(int);

--- a/Polyhedron/demo/Polyhedron/CGAL_demo/Viewer_interface.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_demo/Viewer_interface.h
@@ -53,7 +53,7 @@ public:
 #if QGLVIEWER_VERSION >= 0x020501
     setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, NO_CLICK_ACTION);
 #else
-    ssetMouseBinding(Qt::SHIFT + Qt::LeftButton, NO_CLICK_ACTION);
+    setMouseBinding(Qt::SHIFT + Qt::LeftButton, NO_CLICK_ACTION);
 #endif
   }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -268,11 +268,14 @@ public:
   }
   void selection_changed(bool b)
   {
-      QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
-      if(b)
-          viewer->setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, Viewer::NO_CLICK_ACTION);
+      QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
+      Viewer_interface* viewer = dynamic_cast<Viewer_interface*>(v);
+      if(!viewer)
+          return;
+      if(!b)
+        viewer->setBindingSelect();
       else
-          viewer->setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, Viewer::SELECT);
+        viewer->setNoBinding();
   }
   Bbox bbox() const 
   {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -266,6 +266,14 @@ public:
   bool isEmpty() const {
     return selected_vertices.empty() && selected_edges.empty() && selected_facets.empty();
   }
+  void selection_changed(bool b)
+  {
+      QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+      if(b)
+          viewer->setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, Viewer::NO_CLICK_ACTION);
+      else
+          viewer->setMouseBinding(Qt::ShiftModifier, Qt::LeftButton, Viewer::SELECT);
+  }
   Bbox bbox() const 
   {
     // Workaround a bug in g++-4.8.3:

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -291,7 +291,6 @@ void Viewer_impl::draw_aux(bool with_names, Viewer* viewer)
 {
   if(scene == 0)
     return;
-
   viewer->glLineWidth(1.0f);
   viewer->glPointSize(2.f);
   viewer->glEnable(GL_POLYGON_OFFSET_FILL);


### PR DESCRIPTION
- When a selection item is selected, shift+left click does not call information requests
  for the selected point anymore. It makes the selection tool faster by far.