### PR TITLE
OFF loading fix

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
@@ -88,7 +88,7 @@ public:
 public:
   const AABB_tree& tree;
 private:
-    std::vector<float> positions_lines;
+   mutable  std::vector<float> positions_lines;
 
     mutable QOpenGLShaderProgram *program;
 
@@ -111,7 +111,7 @@ private:
         are_buffers_filled = true;
     }
 
-    void compute_elements()
+    void compute_elements() const
     {
        positions_lines.clear();
 
@@ -207,7 +207,7 @@ public:
   bool top;
 
 private:
-    std::vector<float> positions_lines;
+    mutable std::vector<float> positions_lines;
     void timerEvent(QTimerEvent* /*event*/)
     {
        top = true;
@@ -233,7 +233,7 @@ private:
         vaos[0]->release();
         are_buffers_filled = true;
     }
-    void compute_elements()
+    void compute_elements() const
     {
        positions_lines.clear();
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin_cgal_code.cpp
@@ -217,7 +217,7 @@ public:
 private:
     void draw_triangle(const Kernel::Point_3& pa,
                        const Kernel::Point_3& pb,
-                       const Kernel::Point_3& pc, bool is_cut) {
+                       const Kernel::Point_3& pc, bool is_cut) const {
 
 #undef darker
         Kernel::Vector_3 n = cross_product(pb - pa, pc - pa);
@@ -264,7 +264,7 @@ else
 
     void draw_triangle_edges(const Kernel::Point_3& pa,
                        const Kernel::Point_3& pb,
-                       const Kernel::Point_3& pc) {
+                       const Kernel::Point_3& pc)const {
 
 #undef darker
         Kernel::Vector_3 n = cross_product(pb - pa, pc - pa);
@@ -375,13 +375,13 @@ private:
     Scene_interface* last_known_scene;
 
 
-    std::vector<float> positions_lines;
-    std::vector<float> positions_grid;
-    std::vector<float> positions_poly;
-    std::vector<float> normals;
-    std::vector<float> color_lines;
-    std::vector<float> color_poly;
-    std::vector<float> color_grid;
+    mutable std::vector<float> positions_lines;
+    mutable std::vector<float> positions_grid;
+    mutable std::vector<float> positions_poly;
+    mutable std::vector<float> normals;
+    mutable std::vector<float> color_lines;
+    mutable std::vector<float> color_poly;
+    mutable std::vector<float> color_grid;
 
     mutable QOpenGLShaderProgram *program;
 
@@ -467,7 +467,7 @@ private:
         }
         are_buffers_filled = true;
     }
-    void compute_elements()
+    void compute_elements() const
     {
         positions_lines.clear();
         positions_poly.clear();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
@@ -70,7 +70,7 @@ public:
 
 private:
 
-    std::vector<float> positions_lines;
+    mutable std::vector<float> positions_lines;
     mutable QOpenGLShaderProgram *program;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer)const
@@ -96,7 +96,7 @@ private:
         are_buffers_filled = true;
     }
 
-    void compute_elements()
+    void compute_elements() const
     {
         positions_lines.clear();
         const Bbox& bb = scene->bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_item.h
@@ -258,7 +258,7 @@ protected:
   int colorLoc;
 
   virtual void initialize_buffers(){}
-  virtual void compute_elements(){}
+  virtual void compute_elements() const{}
   virtual void attrib_buffers(Viewer_interface*, int program_name) const;
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1091,8 +1091,6 @@ invalidate_buffers()
     delete_aabb_tree(this);
     init();
     Base::invalidate_buffers();
-    is_Triangulated();
-    compute_normals_and_vertices();
     are_buffers_filled = false;
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -83,7 +83,7 @@ void Scene_polyhedron_selection_item::initialize_buffers(Viewer_interface *viewe
     are_buffers_filled = true;
 }
 
-void Scene_polyhedron_selection_item::compute_elements()
+void Scene_polyhedron_selection_item::compute_elements()const
 {
     positions_facets.clear();
     positions_lines.clear();
@@ -164,7 +164,10 @@ void Scene_polyhedron_selection_item::draw(Viewer_interface* viewer) const
 {
 
     if(!are_buffers_filled)
+    {
+        compute_elements();
         initialize_buffers(viewer);
+    }
 
     draw_points(viewer);
     GLfloat offset_factor;
@@ -189,6 +192,11 @@ void Scene_polyhedron_selection_item::draw(Viewer_interface* viewer) const
 
 void Scene_polyhedron_selection_item::draw_edges(Viewer_interface* viewer) const
 {
+    if(!are_buffers_filled)
+    {
+        compute_elements();
+        initialize_buffers(viewer);
+    }
 
     viewer->glLineWidth(3.f);
     vaos[1]->bind();
@@ -204,6 +212,11 @@ void Scene_polyhedron_selection_item::draw_edges(Viewer_interface* viewer) const
 
 void Scene_polyhedron_selection_item::draw_points(Viewer_interface* viewer) const
 {
+    if(!are_buffers_filled)
+    {
+        compute_elements();
+        initialize_buffers(viewer);
+    }
     viewer->glPointSize(5.f);
     vaos[2]->bind();
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -683,7 +683,6 @@ public Q_SLOTS:
 
     // do not use decorator function, which calls changed on poly_item which cause deletion of AABB
       //  poly_item->invalidate_buffers();
-        compute_elements();
         are_buffers_filled = false;
   }
   // slots are called by signals of polyhedron_k_ring_selector
@@ -796,7 +795,7 @@ private:
   mutable QOpenGLShaderProgram *program;
   using Scene_item::initialize_buffers;
   void initialize_buffers(Viewer_interface *viewer) const;
-  void compute_elements();
+  void compute_elements() const;
 
 };
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
@@ -31,7 +31,7 @@ Scene_polyhedron_shortest_path_item::~Scene_polyhedron_shortest_path_item()
   deinitialize();
 }
 
-void Scene_polyhedron_shortest_path_item::compute_elements()
+void Scene_polyhedron_shortest_path_item::compute_elements() const
 {
 
     vertices.resize(0);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
@@ -101,12 +101,12 @@ private:
   void get_as_edge_point(Face_location& inOutLocation);
   void get_as_vertex_point(Face_location& inOutLocation);
 
-  std::vector<float> vertices;
+  mutable std::vector<float> vertices;
   mutable QOpenGLShaderProgram *program;
 
   using Scene_polyhedron_item_decorator::initialize_buffers;
   void initialize_buffers(Viewer_interface *viewer = 0) const;
-  void compute_elements(void);
+  void compute_elements(void) const;
   
   
 public:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
@@ -42,7 +42,7 @@ void Scene_polyhedron_transform_item::initialize_buffers(Viewer_interface *viewe
     are_buffers_filled = true;
 }
 
-void Scene_polyhedron_transform_item::compute_elements()
+void Scene_polyhedron_transform_item::compute_elements() const
 {
      positions_lines.resize(0);
     typedef Kernel::Point_3		Point;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
@@ -41,7 +41,7 @@ private:
     mutable std::size_t nb_lines;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
-    void compute_elements();
+    void compute_elements() const;
 
 Q_SIGNALS:
     void stop();

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -26,7 +26,7 @@ public:
 };
 
 void
-Scene_polylines_item::create_Sphere(double R)
+Scene_polylines_item::create_Sphere(double R) const
 {
   create_flat_and_wire_sphere(R, positions_spheres, normals_spheres, positions_wire_spheres);
 }
@@ -180,7 +180,7 @@ Scene_polylines_item::initialize_buffers(Viewer_interface *viewer = 0) const
 
 }
 void
-Scene_polylines_item::compute_elements()
+Scene_polylines_item::compute_elements() const
 {
     positions_spheres.resize(0);
     positions_wire_spheres.resize(0);

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -108,10 +108,10 @@ private:
     mutable   GLuint nbSpheres;
     typedef std::map<Point_3, int> Point_to_int_map;
     typedef Point_to_int_map::iterator iterator;
-    void create_Sphere(double);
+    void create_Sphere(double) const;
     using Scene_item::initialize_buffers;
     void initialize_buffers(Viewer_interface *viewer) const;
-    void compute_elements();
+    void compute_elements() const;
 
 
 }; // end class Scene_polylines_item

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -102,7 +102,7 @@ void Scene_textured_polyhedron_item::initialize_buffers(Viewer_interface *viewer
 }
 
 void
-Scene_textured_polyhedron_item::compute_normals_and_vertices(void)
+Scene_textured_polyhedron_item::compute_normals_and_vertices(void) const
 {
     positions_facets.resize(0);
     positions_lines.resize(0);
@@ -290,7 +290,10 @@ Scene_textured_polyhedron_item::toolTip() const
 void Scene_textured_polyhedron_item::draw(Viewer_interface* viewer) const {
 
     if(!are_buffers_filled)
+    {
+        compute_normals_and_vertices();
         initialize_buffers(viewer);
+    }
 
     vaos[0]->bind();
     viewer->glActiveTexture(GL_TEXTURE0);
@@ -345,8 +348,8 @@ Scene_textured_polyhedron_item::bbox() const {
 void
 Scene_textured_polyhedron_item::invalidate_buffers()
 {
-    compute_normals_and_vertices();
-    are_buffers_filled = false;}
+    are_buffers_filled = false;
+}
 void
 Scene_textured_polyhedron_item::
 contextual_changed()

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -66,7 +66,7 @@ private:
 
   using Scene_item::initialize_buffers;
   void initialize_buffers(Viewer_interface *viewer) const;
-  void compute_normals_and_vertices(void);
+  void compute_normals_and_vertices(void) const;
 
 
 }; // end class Scene_textured_polyhedron_item


### PR DESCRIPTION
- Some items called `compute_normals_and_vertices` several times in a row. The fact that they don't anymore makes the loading of OFF files almost twice faster.