### PR TITLE
Polyhedron demo - Enhance selected points

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
@@ -651,9 +651,9 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   for (size_t i = 0; i < fixedPoints.size(); ++i)
   {
     UI_point_3<Kernel> point(fixedPoints[i].x(), fixedPoints[i].y(), fixedPoints[i].z());
-    ps->select(&point);
     ps->push_back(point);
   }
+  ps->select_all ();
 
   if (fixedPointsItemIndex == -1)
   {
@@ -714,10 +714,10 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
   for (size_t i = 0; i < fixedPoints.size(); ++i)
   {
     UI_point_3<Kernel> point(fixedPoints[i].x(), fixedPoints[i].y(), fixedPoints[i].z());
-    ps->select(&point);
     ps->push_back(point);
   }
-
+  ps->select_all();
+  
   if (fixedPointsItemIndex == -1)
   {
     fixedPointsItemIndex = scene->addItem(fixedPointsItem);
@@ -888,9 +888,10 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
   for (size_t i = 0; i < fixedPoints.size(); ++i)
   {
     UI_point_3<Kernel> point(fixedPoints[i].x(), fixedPoints[i].y(), fixedPoints[i].z());
-    ps->select(&point);
     ps->push_back(point);
   }
+  ps->select_all();
+  
   if (fixedPointsItemIndex == -1)
   {
     fixedPointsItemIndex = scene->addItem(fixedPointsItem);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_normal_estimation_plugin.cpp
@@ -210,8 +210,7 @@ void Polyhedron_demo_normal_estimation_plugin::on_actionNormalEstimation_trigger
                                     << std::endl;
 
     // Selects points with an unoriented normal
-    points->select(points->begin(), points->end(), false);
-    points->select(first_unoriented_point, points->end(), true);
+    points->set_first_selected (first_unoriented_point);
 
     // Updates scene
     item->invalidate_buffers();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
@@ -126,7 +126,7 @@ public Q_SLOTS:
     // deselect all points
     for(std::vector<Point_set*>::iterator point_set_it = point_sets.begin(); 
       point_set_it != point_sets.end(); ++point_set_it) {
-      (*point_set_it)->select((*point_set_it)->begin(), (*point_set_it)->end(), false);
+      (*point_set_it)->unselect_all();
     }
 
     CGAL::Timer timer; timer.start();
@@ -152,7 +152,7 @@ public Q_SLOTS:
             (on_boundary && res == CGAL::ON_BOUNDARY)     ||
             (outside     && res == CGAL::ON_UNBOUNDED_SIDE) )
         {
-          point_set->select(&*point_it); ++nb_selected;
+          point_set->select(point_it); ++nb_selected;
           break;//loop on i
         }
         }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_outliers_removal_plugin.cpp
@@ -103,8 +103,7 @@ void Polyhedron_demo_point_set_outliers_removal_plugin::on_actionOutlierRemoval_
                                     << std::endl;
 
     // Selects points to delete
-    points->select(points->begin(), first_point_to_remove, false);
-    points->select(first_point_to_remove, points->end(), true);
+    points->set_first_selected (first_point_to_remove);
 
     // Updates scene
     item->invalidate_buffers();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
@@ -163,7 +163,9 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
       Scene_points_with_normal_item *point_item = new Scene_points_with_normal_item;
       BOOST_FOREACH(std::size_t i, shape->indices_of_assigned_points())
         point_item->point_set()->push_back((*points)[i]);
-
+      
+      point_item->point_set()->unselect_all ();
+      
       unsigned char r, g, b;
       r = static_cast<unsigned char>(64 + rand.get_int(0, 192));
       g = static_cast<unsigned char>(64 + rand.get_int(0, 192));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_simplification_plugin.cpp
@@ -129,8 +129,7 @@ void Polyhedron_demo_point_set_simplification_plugin::on_actionSimplify_triggere
                                     << std::endl;
 
     // Selects points to delete
-    points->select(points->begin(), first_point_to_remove, false);
-    points->select(first_point_to_remove, points->end(), true);
+    points->set_first_selected(first_point_to_remove);
 
     // Updates scene
     item->invalidate_buffers();

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_upsampling_plugin.cpp
@@ -128,7 +128,8 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
       for (unsigned int i = 0; i < new_points.size (); ++ i)
 	points->push_back (Point_set::Point_with_normal (new_points[i].first,
 							 new_points[i].second));
-
+      points->unselect_all();
+      
       std::size_t memory = CGAL::Memory_sizer().virtual_size();
       std::cerr << task_timer.time() << " seconds, "
 		<< (memory>>20) << " Mb allocated)"

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -191,23 +191,7 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
         Kernel::Sphere_3 region_of_interest = m_points->region_of_interest();
         float normal_length = (float)std::sqrt(region_of_interest.squared_radius() / 1000.);
 
-        // Stock normals of *non-selected* points
-	for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); it++)
-	  {
-	    const UI_point& p = *it;
-	    const Point_set_3<Kernel>::Vector& n = p.normal();
-	    Point_set_3<Kernel>::Point q = p + normal_length * n;
-	    positions_lines.push_back(p.x());
-	    positions_lines.push_back(p.y());
-	    positions_lines.push_back(p.z());
-
-	    positions_lines.push_back(q.x());
-	    positions_lines.push_back(q.y());
-	    positions_lines.push_back(q.z());
-	  }
-
-        // Stock normals of *selected* points
-	for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); it++)
+	for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
 	  {
 	    const UI_point& p = *it;
 	    const Point_set_3<Kernel>::Vector& n = p.normal();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -166,37 +166,22 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
     //The points
     {
         // The *non-selected* points
-        if (m_points->nb_selected_points()< m_points->size())
-        {
-
-            for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
-            {
-                const UI_point& p = *it;
-                if ( ! p.is_selected() )
-                {
-                    positions_points.push_back(p.x());
-                    positions_points.push_back(p.y());
-                    positions_points.push_back(p.z());
-                }
-            }
-
-        }
+      for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); it++)
+	{
+	  const UI_point& p = *it;
+	  positions_points.push_back(p.x());
+	  positions_points.push_back(p.y());
+	  positions_points.push_back(p.z());
+	}
 
         // Draw *selected* points
-        if (m_points->nb_selected_points() > 0)
-        {
-            for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
-            {
-                const UI_point& p = *it;
-                if (p.is_selected())
-                {
-                    positions_selected_points.push_back(p.x());
-                    positions_selected_points.push_back(p.y());
-                    positions_selected_points.push_back(p.z());
-                }
-            }
-
-        }
+      for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); it++)
+	{
+	  const UI_point& p = *it;
+	  positions_selected_points.push_back(p.x());
+	  positions_selected_points.push_back(p.y());
+	  positions_selected_points.push_back(p.z());
+	}
     }
 
     //The lines
@@ -206,50 +191,34 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
         float normal_length = (float)std::sqrt(region_of_interest.squared_radius() / 1000.);
 
         // Stock normals of *non-selected* points
-        if (m_points->nb_selected_points() < m_points->size())
-        {
-            // Stock normals
-            for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
-            {
-                const UI_point& p = *it;
-                const Point_set_3<Kernel>::Vector& n = p.normal();
-                if (!p.is_selected())
-                {
-                    Point_set_3<Kernel>::Point q = p + normal_length * n;
-                    positions_lines.push_back(p.x());
-                    positions_lines.push_back(p.y());
-                    positions_lines.push_back(p.z());
+	for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); it++)
+	  {
+	    const UI_point& p = *it;
+	    const Point_set_3<Kernel>::Vector& n = p.normal();
+	    Point_set_3<Kernel>::Point q = p + normal_length * n;
+	    positions_lines.push_back(p.x());
+	    positions_lines.push_back(p.y());
+	    positions_lines.push_back(p.z());
 
-                    positions_lines.push_back(q.x());
-                    positions_lines.push_back(q.y());
-                    positions_lines.push_back(q.z());
-
-                }
-            }
-        }
+	    positions_lines.push_back(q.x());
+	    positions_lines.push_back(q.y());
+	    positions_lines.push_back(q.z());
+	  }
 
         // Stock normals of *selected* points
-        if (m_points->nb_selected_points() > 0)
-        {
-            for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
-            {
-                const UI_point& p = *it;
-                const Point_set_3<Kernel>::Vector& n = p.normal();
-                if (p.is_selected())
-                {
-                    Point_set_3<Kernel>::Point q = p + normal_length * n;
-                    positions_lines.push_back(p.x());
-                    positions_lines.push_back(p.y());
-                    positions_lines.push_back(p.z());
+	for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); it++)
+	  {
+	    const UI_point& p = *it;
+	    const Point_set_3<Kernel>::Vector& n = p.normal();
+	    Point_set_3<Kernel>::Point q = p + normal_length * n;
+	    positions_lines.push_back(p.x());
+	    positions_lines.push_back(p.y());
+	    positions_lines.push_back(p.z());
 
-                    positions_lines.push_back(q.x());
-                    positions_lines.push_back(q.y());
-                    positions_lines.push_back(q.z());
-
-
-                }
-            }
-        }
+	    positions_lines.push_back(q.x());
+	    positions_lines.push_back(q.y());
+	    positions_lines.push_back(q.z());
+	  }
     }
 }
 
@@ -286,7 +255,7 @@ void Scene_points_with_normal_item::deleteSelection()
 // Invert selection
 void Scene_points_with_normal_item::invertSelection()
 {
-    m_points->invert_selection();
+  m_points->invert_selection();
   invalidate_buffers();
   Q_EMIT itemChanged();
 }
@@ -294,7 +263,7 @@ void Scene_points_with_normal_item::invertSelection()
 // Select everything
 void Scene_points_with_normal_item::selectAll()
 {
-    m_points->select(m_points->begin(), m_points->end(), true);
+  m_points->select_all();
   invalidate_buffers();
   Q_EMIT itemChanged();
 }
@@ -302,7 +271,7 @@ void Scene_points_with_normal_item::selectAll()
 void Scene_points_with_normal_item::resetSelection()
 {
   // Un-select all points
-  m_points->select(m_points->begin(), m_points->end(), false);
+  m_points->unselect_all();
   invalidate_buffers();
   Q_EMIT itemChanged();
 }
@@ -310,9 +279,9 @@ void Scene_points_with_normal_item::resetSelection()
 void Scene_points_with_normal_item::selectDuplicates()
 {
   std::set<Kernel::Point_3> unique_points;
-  for (Point_set::Point_iterator ptit=m_points->begin(); ptit!=m_points->end();++ptit )
+  for (Point_set::iterator ptit=m_points->begin(); ptit!=m_points->end();++ptit )
     if ( !unique_points.insert(*ptit).second )
-      m_points->select(&(*ptit));
+      m_points->select(ptit);
   invalidate_buffers();
   Q_EMIT itemChanged();
 }
@@ -328,6 +297,7 @@ bool Scene_points_with_normal_item::read_off_point_set(std::istream& stream)
                                               std::back_inserter(*m_points),
                                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type())) &&
             !isEmpty();
+  m_points->unselect_all();
   invalidate_buffers();
   return ok;
 }
@@ -368,6 +338,7 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
       }
     }
   }
+  m_points->unselect_all();
   invalidate_buffers();
   return ok;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -76,11 +76,12 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
   }
 
   setRenderingMode(PointsPlusNormals);
-    is_selected = true;
-    nb_points = 0;
-    nb_selected_points = 0;
-    nb_lines = 0;
-    invalidate_buffers();
+  is_selected = true;
+  nb_points = 0;
+  nb_selected_points = 0;
+  nb_lines = 0;
+  invalidate_buffers();
+  m_points->unselect_all();
 }
 
 Scene_points_with_normal_item::~Scene_points_with_normal_item()

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -139,19 +139,6 @@ public:
       }
   }
 
-  /// Mark a range of points as selected/not selected.
-  ///
-  /// @param first Iterator over first point to select/unselect.
-  /// @param beyond Past-the-end iterator.
-  void select(iterator first, iterator beyond,
-              bool selected = true)
-  {
-    for (iterator it = first; it != beyond; it++)
-      select (it, selected);
-
-    m_nb_selected_points = std::distance (m_first_selected, end());
-  }
-
   void select_all()
   {
     m_first_selected = begin();
@@ -167,10 +154,14 @@ public:
   // Invert selection
   void invert_selection()
   {
-    for (iterator it = begin(); it != end(); ++ it)
-      select (it, !(is_selected (it)));
+    iterator sel = end() - 1;
+    iterator unsel = begin();
 
-    m_nb_selected_points = size() - m_nb_selected_points;
+    while (sel != m_first_selected-1 && unsel != m_first_selected)
+      std::swap (*(sel --), *(unsel ++));
+    m_first_selected = begin() + m_nb_selected_points;
+
+    m_nb_selected_points = size() - m_nb_selected_points;	
   }
 
   /// Deletes selected points.

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -112,7 +112,7 @@ public:
 
     m_first_selected = end() - p.nb_selected_points();
     
-    m_radii_are_uptodate = m_radii_are_uptodate;
+    m_radii_are_uptodate = p.m_radii_are_uptodate;
   }
 
   // Repeat base class' public methods used below

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -67,10 +67,6 @@ public:
   // Its superclass:
   typedef typename UI_point::Point_with_normal Point_with_normal; ///< Position + normal
 
-  // Iterator over Point_3 points
-  typedef typename std::deque<UI_point>::iterator        Point_iterator;
-  typedef typename std::deque<UI_point>::const_iterator  Point_const_iterator;
-
 // Data members
 private:
 
@@ -85,6 +81,8 @@ private:
 
   std::size_t m_nb_selected_points; // number of selected points
 
+  iterator m_first_selected; // handle selection
+
   bool m_radii_are_uptodate;
 
 // Public methods
@@ -94,6 +92,7 @@ public:
   Point_set_3()
   {
     m_nb_selected_points = 0;
+    m_first_selected = end();
     m_bounding_box_is_valid = false;
     m_radii_are_uptodate = false;
   }
@@ -107,17 +106,37 @@ public:
   using Base::size;
   /// @endcond
 
+  iterator first_selected() { return m_first_selected; }
+  const_iterator first_selected() const { return m_first_selected; }
+  void set_first_selected(iterator it)
+  {
+    m_first_selected = it;
+    m_nb_selected_points = std::distance (m_first_selected, end());
+  }
+
+  // Test if point is selected
+  bool is_selected(iterator it)
+  {
+    return std::distance (it, end()) <= std::distance (m_first_selected, end());
+  }
+
   /// Gets the number of selected points.
   std::size_t nb_selected_points() const { return m_nb_selected_points; }
 
   /// Mark a point as selected/not selected.
-  void select(UI_point* point, bool is_selected = true)
+  void select(iterator it, bool selected = true)
   {
-    if (point->is_selected() != is_selected)
-    {
-      point->select(is_selected);
-      m_nb_selected_points += (is_selected ? 1 : -1);
-    }
+    bool currently = is_selected (it);
+    if (currently && !selected)
+      {
+	std::swap (*it, *(m_first_selected ++));
+	m_nb_selected_points --;
+      }
+    else if (!currently && selected)
+      {
+	std::swap (*it, *(-- m_first_selected));
+	m_nb_selected_points ++;
+      }
   }
 
   /// Mark a range of points as selected/not selected.
@@ -125,20 +144,31 @@ public:
   /// @param first Iterator over first point to select/unselect.
   /// @param beyond Past-the-end iterator.
   void select(iterator first, iterator beyond,
-              bool is_selected = true)
+              bool selected = true)
   {
     for (iterator it = first; it != beyond; it++)
-      it->select(is_selected);
+      select (it, selected);
 
-    m_nb_selected_points = std::count_if(begin(), end(),
-                                         std::mem_fun_ref(&UI_point::is_selected));
+    m_nb_selected_points = std::distance (m_first_selected, end());
   }
+
+  void select_all()
+  {
+    m_first_selected = begin();
+    m_nb_selected_points = size();
+  }
+  void unselect_all()
+  {
+    m_first_selected = end();
+    m_nb_selected_points = 0;
+  }
+
 
   // Invert selection
   void invert_selection()
   {
     for (iterator it = begin(); it != end(); ++ it)
-      it->select(!(it->is_selected ()));
+      select (it, !(is_selected (it)));
 
     m_nb_selected_points = size() - m_nb_selected_points;
   }
@@ -147,12 +177,11 @@ public:
   void delete_selection()
   {
     // Deletes selected points using erase-remove idiom
-    erase(std::remove_if(begin(), end(), std::mem_fun_ref(&UI_point::is_selected)),
-          end());
+    erase (m_first_selected, end ());
 
     // after erase(), use Scott Meyer's "swap trick" to trim excess capacity
     Point_set_3(*this).swap(*this);
-
+    m_first_selected = end();
     m_nb_selected_points = 0;
     invalidate_bounds();
   }
@@ -219,32 +248,24 @@ public:
   void gl_draw_vertices() const
   {
     // Draw *non-selected* points
-    if (m_nb_selected_points < size())
-    {
-      ::glBegin(GL_POINTS);
-      for (const_iterator it = begin(); it != end(); it++)
+    ::glBegin(GL_POINTS);
+    for (const_iterator it = begin(); it != m_first_selected; it++)
       {
         const UI_point& p = *it;
-        if ( ! p.is_selected() )
-          ::glVertex3dv(&p.x());
+	::glVertex3dv(&p.x());
       }
-      ::glEnd();
-    }
+    ::glEnd();
 
     // Draw *selected* points
-    if (m_nb_selected_points > 0)
-    {
-      ::glPointSize(4.f);    // selected => bigger
-      ::glColor3ub(255,0,0); // selected => red
-      ::glBegin(GL_POINTS);
-      for (const_iterator it = begin(); it != end(); it++)
+    ::glPointSize(4.f);    // selected => bigger
+    ::glColor3ub(255,0,0); // selected => red
+    ::glBegin(GL_POINTS);
+    for (const_iterator it = m_first_selected; it != end(); it++)
       {
         const UI_point& p = *it;
-        if (p.is_selected())
-          ::glVertex3dv(&p.x());
+	::glVertex3dv(&p.x());
       }
-      ::glEnd();
-    }
+    ::glEnd();
   }
 
   // Draw normals using OpenGL calls.
@@ -252,42 +273,30 @@ public:
   void gl_draw_normals(float scale = 1.0) const // scale applied to normal length
   {
     // Draw normals of *non-selected* points
-    if (m_nb_selected_points < size())
-    {
-      // Draw normals
-      ::glBegin(GL_LINES);
-      for (const_iterator it = begin(); it != end(); it++)
+    // Draw normals
+    ::glBegin(GL_LINES);
+    for (const_iterator it = begin(); it != m_first_selected; it++)
       {
         const UI_point& p = *it;
         const Vector& n = p.normal();
-        if (!p.is_selected())
-        {
-          Point q = p + scale * n;
-          ::glVertex3d(p.x(),p.y(),p.z());
-          ::glVertex3d(q.x(),q.y(),q.z());
-        }
+	Point q = p + scale * n;
+	::glVertex3d(p.x(),p.y(),p.z());
+	::glVertex3d(q.x(),q.y(),q.z());
       }
-      ::glEnd();
-    }
+    ::glEnd();
 
     // Draw normals of *selected* points
-    if (m_nb_selected_points > 0)
-    {
-      ::glColor3ub(255,0,0); // selected => red
-      ::glBegin(GL_LINES);
-      for (const_iterator it = begin(); it != end(); it++)
+    ::glColor3ub(255,0,0); // selected => red
+    ::glBegin(GL_LINES);
+    for (const_iterator it = m_first_selected; it != end(); it++)
       {
         const UI_point& p = *it;
         const Vector& n = p.normal();
-        if (p.is_selected())
-        {
-          Point q = p + scale * n;
-          ::glVertex3d(p.x(),p.y(),p.z());
-          ::glVertex3d(q.x(),q.y(),q.z());
-        }
+	Point q = p + scale * n;
+	::glVertex3d(p.x(),p.y(),p.z());
+	::glVertex3d(q.x(),q.y(),q.z());
       }
-      ::glEnd();
-    }
+    ::glEnd();
   }
 
   // Draw oriented points with radius using OpenGL calls.
@@ -327,7 +336,7 @@ private:
     xmax = ymax = zmax = -1e38;
     Vector v = CGAL::NULL_VECTOR;
     FT norm = 0;
-    for (Point_const_iterator it = begin(); it != end(); it++)
+    for (const_iterator it = begin(); it != end(); it++)
     {
       const Point& p = *it;
 
@@ -365,7 +374,7 @@ private:
     // Computes standard deviation of the distance to barycenter
     typename Geom_traits::Compute_squared_distance_3 sqd;
     FT sq_radius = 0;
-    for (Point_const_iterator it = begin(); it != end(); it++)
+    for (const_iterator it = begin(); it != end(); it++)
         sq_radius += sqd(*it, m_barycenter);
     sq_radius /= FT(size());
     m_diameter_standard_deviation = CGAL::sqrt(sq_radius);

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -83,6 +83,14 @@ private:
 
   bool m_radii_are_uptodate;
 
+  // Assignment operator not implemented and declared private to make
+  // sure nobody uses the default one without knowing it
+  Point_set_3& operator= (const Point_set_3& other)
+  {
+    return *this;
+  }
+
+  
 // Public methods
 public:
 
@@ -94,7 +102,18 @@ public:
     m_radii_are_uptodate = false;
   }
 
-  // Default copy constructor and operator =() are fine.
+  // copy constructor 
+  Point_set_3 (const Point_set_3& p) : Base (p)
+  {
+    m_bounding_box_is_valid = p.m_bounding_box_is_valid;
+    m_bounding_box = p.m_bounding_box;
+    m_barycenter = p.m_barycenter;
+    m_diameter_standard_deviation = p.m_diameter_standard_deviation;
+
+    m_first_selected = end() - p.nb_selected_points();
+    
+    m_radii_are_uptodate = m_radii_are_uptodate;
+  }
 
   // Repeat base class' public methods used below
   /// @cond SKIP_IN_MANUAL

--- a/Polyhedron/demo/Polyhedron/include/UI_point_3.h
+++ b/Polyhedron/demo/Polyhedron/include/UI_point_3.h
@@ -15,7 +15,6 @@
 /// - a position,
 /// - a normal,
 /// - a radius,
-/// - a selection flag.
 ///
 /// @heading Parameters:
 /// @param Gt   Geometric traits class.
@@ -52,35 +51,30 @@ public:
     UI_point_3(const CGAL::Origin& o = CGAL::ORIGIN)
     : Base(o)
     {
-      m_is_selected = false;
       m_radius = FT(0);
     }
     UI_point_3(FT x, FT y, FT z,
                const Vector_3& normal = CGAL::NULL_VECTOR)
     : Base(x,y,z,normal)
     {
-      m_is_selected = false;
       m_radius = FT(0);
     }
     UI_point_3(RT hx, RT hy, RT hz, RT hw,
                const Vector_3& normal = CGAL::NULL_VECTOR)
     : Base(hx,hy,hz,hw,normal)
     {
-      m_is_selected = false;
       m_radius = FT(0);
     }
     UI_point_3(const Point_3& point,
                const Vector_3& normal = CGAL::NULL_VECTOR)
     : Base(point, normal)
     {
-      m_is_selected = false;
       m_radius = FT(0);
     }
     template <class K>
     UI_point_3(const CGAL::Point_with_normal_3<K>& pwn)
     : Base(pwn)
     {
-      m_is_selected = false;
       m_radius = FT(0);
     }
 
@@ -88,30 +82,23 @@ public:
     UI_point_3(const UI_point_3& upt)
     : Base(upt)
     {
-      m_is_selected = upt.m_is_selected;
       m_radius = upt.m_radius;
     }
     template<class K>
     UI_point_3(const UI_point_3<K>& upt)
     : Base(upt)
     {
-      m_is_selected = upt.is_selected();
       m_radius = upt.radius();
     }
     /// Operator =()
     UI_point_3& operator=(const UI_point_3& upt)
     {
       Base::operator=(upt);
-      m_is_selected = upt.m_is_selected;
       m_radius = upt.m_radius;
       return *this;
     }
 
     // Inherited operators ==() and !=() are fine.
-
-    /// Selection flag.
-    bool is_selected() const { return m_is_selected; }
-    void select(bool is_selected=true) { m_is_selected = is_selected; }
 
     /// Gets/sets radius.
     FT radius() const { return m_radius; }
@@ -119,9 +106,6 @@ public:
 
 // Data
 private:
-
-    // Selection flag.
-    bool m_is_selected;
 
     /// radius.
     FT m_radius;


### PR DESCRIPTION
Change how selection is handled in Polyhedron point sets:
* _Current behavior_: each point object embeds a boolean __m_is_selected__
* _Proposed behavior_: a single iterator __m_first_selected__ for the point set object (=end() if nothing is selected) with reordering for selection

This is much more efficient in terms of storage and also of time for some common operations (__select_all__, __unselect_all__, __remove_selection__, etc. are done in constant time instead of linear time). In addition, the selection is mostly used by __Point_set_processing_3__ algorithms which change the order of the point set and return an iterator to the first point to remove (for example), so this is more consistent and more direct to use.

All related functions (in display, items and plugins) have been updated and everything works fine (tested on my computer but not on __integration__ yet).