### PR TITLE
Default BBox returning changed for someitems

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
@@ -25,7 +25,7 @@ public:
     }
     bool isFinite() const { return true; }
     bool isEmpty() const { return true; }
-    Bbox bbox() const { return Bbox(); }
+    Bbox bbox() const { return scene->bbox(); }
 
     Scene_bbox_item* clone() const {
         return 0;

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -57,9 +57,10 @@ Scene::addItem(Scene_item* item)
             this, SLOT(itemChanged()));
     connect(item, SIGNAL(renderingModeChanged()),
             this, SLOT(callDraw()));
-    if(bbox_before + item->bbox() != bbox_before
-            && item->isFinite()
-            && !item->isEmpty())
+    if(item->isFinite()
+            && !item->isEmpty()
+            && bbox_before + item->bbox() != bbox_before
+            )
     {
         Q_EMIT updated_bbox();
     }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -58,12 +58,14 @@ Scene::addItem(Scene_item* item)
     connect(item, SIGNAL(renderingModeChanged()),
             this, SLOT(callDraw()));
     if(bbox_before + item->bbox() != bbox_before)
-{ Q_EMIT updated_bbox(); }
+    {
+        Q_EMIT updated_bbox();
+    }
     QAbstractListModel::beginResetModel();
     Q_EMIT updated();
     QAbstractListModel::endResetModel();
     Item_id id = m_entries.size() - 1;
-  Q_EMIT newItem(id);
+    Q_EMIT newItem(id);
     return id;
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -57,7 +57,9 @@ Scene::addItem(Scene_item* item)
             this, SLOT(itemChanged()));
     connect(item, SIGNAL(renderingModeChanged()),
             this, SLOT(callDraw()));
-    if(bbox_before + item->bbox() != bbox_before)
+    if(bbox_before + item->bbox() != bbox_before
+            && item->isFinite()
+            && !item->isEmpty())
     {
         Q_EMIT updated_bbox();
     }
@@ -836,7 +838,7 @@ Scene::Bbox Scene::bbox() const
     Bbox bbox;
     Q_FOREACH(Scene_item* item, m_entries)
     {
-        if(item->isFinite() && !item->isEmpty()) {
+        if(item->isFinite() && !item->isEmpty() && item->visible()) {
             if(bbox_initialized) {
                 bbox = bbox + item->bbox();
             }

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -42,7 +42,7 @@ public:
 
   bool isFinite() const { return false; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const { return scene->bbox(); }
+  Bbox bbox() const { return Bbox(); }
 
   bool manipulatable() const {
     return manipulable;

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -42,7 +42,7 @@ public:
 
   bool isFinite() const { return false; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const { return Bbox(); }
+  Bbox bbox() const { return scene->bbox(); }
 
   bool manipulatable() const {
     return manipulable;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -301,7 +301,7 @@ public:
         }
     }
 
-    if(!item_bbox) { return Bbox(); }
+    if(!item_bbox) { return this->poly_item->bbox(); }
     return Bbox(item_bbox->xmin(),item_bbox->ymin(),item_bbox->zmin(),
                 item_bbox->xmax(),item_bbox->ymax(),item_bbox->zmax());
   }


### PR DESCRIPTION
- Using tools like the selection tool creates items that make the scene
  re-center, and this can be annoying. To avoid that, I changed the default BBox
  of those items from BBox(), which is (0,0,0,1,1,1) to scene->bbox() for
  most of the cases. This way the scene bbox does not change and you don't
  lose your position when they are added.