### PR TITLE
Surface mesher - Improve support of vtk files as input

### DIFF
--- a/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
@@ -95,11 +95,22 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND CGAL_ImageIO_FOUND)
     qt5_use_modules(${prj} OpenGL Xml )
     
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS ${prj} )
+    
+    
+    find_package(VTK 6.0 COMPONENTS
+      vtkImagingCore
+      )
+    if(VTK_FOUND)
+        add_definitions(-DCGAL_USE_VTK)
+	set(VTK_LIBS vtkImagingCore)
+    else()
+        set(VTK_LIBS "")
+    endif()
 
     # Link the executable to CGAL and third-party libraries
-    target_link_libraries( ${prj} ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
+    target_link_libraries( ${prj} ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})    
     
-    target_link_libraries( ${prj} ${QT_LIBRARIES} ${QGLVIEWER_LIBRARIES} ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY} )
+    target_link_libraries( ${prj} ${QT_LIBRARIES} ${QGLVIEWER_LIBRARIES} ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY} ${VTK_LIBS})
     
   else( QGLVIEWER_FOUND AND Qt5_FOUND)
     message(STATUS "NOTICE: This demo needs libQGLViewer, and will not be compiled.")

--- a/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
@@ -27,9 +27,6 @@ find_package(VTK 6.0 COMPONENTS
   vtkGUISupportQt
   vtkIOImage
   vtkInteractionImage
-
-#  vtkCommon
-#  vtkGraphics
   )
 include(${VTK_USE_FILE})
 

--- a/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
@@ -19,67 +19,60 @@ foreach(LIB_DIR ${PACKAGE_ROOT}/../CGAL_ImageIO/src/CGAL_ImageIO)
   endif()
 endforeach()
 
-
-FIND_PACKAGE(CGAL REQUIRED ImageIO)
-IF(CGAL_FOUND)
-  include( ${CGAL_USE_FILE} )
-ENDIF(CGAL_FOUND)
-
-FIND_PACKAGE(VTK)
-ADD_DEFINITIONS(-DCGAL_USE_VTK)
-IF(NOT VTK_DIR)
-  MESSAGE(FATAL_ERROR "Please set VTK_DIR.")
-ENDIF(NOT VTK_DIR)
-INCLUDE(${VTK_USE_FILE})
-
-SET(QT_QMAKE_EXECUTABLE ${VTK_QT_QMAKE_EXECUTABLE} CACHE FILEPATH "")
-SET(QT_MOC_EXECUTABLE ${VTK_QT_MOC_EXECUTABLE} CACHE FILEPATH "")
-SET(QT_UIC_EXECUTABLE ${VTK_QT_UIC_EXECUTABLE} CACHE FILEPATH "")
-SET(DESIRED_QT_VERSION ${VTK_DESIRED_QT_VERSION} CACHE FILEPATH "")
-FIND_PACKAGE(Qt)
-IF(QT_USE_FILE)
-  INCLUDE(${QT_USE_FILE})
-ELSE(QT_USE_FILE)
-  SET(QT_LIBRARIES   ${QT_QT_LIBRARY})
-ENDIF(QT_USE_FILE)
-
-SET (SRCS
-  mesh_a_3D_image.cpp
-)
-
-SET (SRCS_VTK
-  mesh_a_VTK_3D_image.cpp
-)
-
-# Use the include path and library for Qt that is used by VTK.
-INCLUDE_DIRECTORIES( ${QT_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR}
-                     ${QT_QTCORE_INCLUDE_DIR})
-
-ADD_EXECUTABLE( mesh_a_3D_image MACOSX_BUNDLE ${SRCS})
-
-TARGET_LINK_LIBRARIES( mesh_a_3D_image
-  QVTK
-  ${QT_LIBRARIES}
-  vtkRendering
-  vtkGraphics
-  vtkIO
-  vtkCommon
-)
-
-SET (SRCS_VTK
-  mesh_a_VTK_3D_image.cpp
-)
-
-ADD_EXECUTABLE( mesh_a_VTK_3D_image MACOSX_BUNDLE ${SRCS_VTK})
-
-TARGET_LINK_LIBRARIES( mesh_a_VTK_3D_image
-  QVTK
-  ${QT_LIBRARIES}
-  vtkRendering
-  vtkGraphics
-  vtkIO
-  vtkCommon
-)
+set( QT_USE_QTOPENGL TRUE )
 
 
+find_package(VTK 6.0 COMPONENTS
+  vtkRenderingOpenGL
+  vtkGUISupportQt
+  vtkIOImage
+  vtkInteractionImage
+
+#  vtkCommon
+#  vtkGraphics
+  )
+include(${VTK_USE_FILE})
+
+if("${VTK_QT_VERSION}" STREQUAL "")
+  message(FATAL_ERROR "VTK was not built with Qt")
+endif()
+
+if(VTK_QT_VERSION VERSION_GREATER "4")
+  find_package(Qt5 COMPONENTS Core REQUIRED QUIET)
+
+  find_package(CGAL REQUIRED ImageIO Qt5)
+  IF(CGAL_FOUND AND CGAL_ImageIO_FOUND AND CGAL_Qt5_FOUND)
+
+    add_definitions(-DQT_NO_KEYWORDS)
+    include( ${CGAL_USE_FILE} )
+
+    find_package(Qt5 QUIET COMPONENTS OpenGL Xml )
+    find_package(OpenGL)
+
+    SET (SRCS  mesh_a_3D_image.cpp)
+    ADD_EXECUTABLE( mesh_a_3D_image MACOSX_BUNDLE ${SRCS})
+    qt5_use_modules(mesh_a_3D_image Core Gui Widgets)
+    TARGET_LINK_LIBRARIES( mesh_a_3D_image
+      ${VTK_LIBRARIES}
+      ${QT_LIBRARIES}
+      vtkRenderingOpenGL
+      vtkGUISupportQt
+      vtkInteractionImage
+      )
+
+    SET (SRCS_VTK  mesh_a_VTK_3D_image.cpp)
+    ADD_EXECUTABLE( mesh_a_VTK_3D_image MACOSX_BUNDLE ${SRCS_VTK})
+    qt5_use_modules(mesh_a_VTK_3D_image Core Gui Widgets)
+    TARGET_LINK_LIBRARIES( mesh_a_VTK_3D_image
+      ${VTK_LIBRARIES}
+      ${QT_LIBRARIES}
+      vtkRenderingOpenGL
+      vtkGUISupportQt
+      vtkIOImage
+      vtkInteractionImage
+      )
+
+  ENDIF(CGAL_FOUND AND CGAL_ImageIO_FOUND AND CGAL_Qt5_FOUND)
+
+endif() #VTK_QT_VERSION VERSION_GREATER
 

--- a/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
@@ -28,7 +28,10 @@ find_package(VTK 6.0 COMPONENTS
   vtkIOImage
   vtkInteractionImage
   )
-include(${VTK_USE_FILE})
+if(VTK_FOUND)
+  add_definitions(-DCGAL_USE_VTK)
+  include(${VTK_USE_FILE})
+endif(VTK_FOUND)
 
 if("${VTK_QT_VERSION}" STREQUAL "")
   message(FATAL_ERROR "VTK was not built with Qt")

--- a/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/VTK/CMakeLists.txt
@@ -1,3 +1,5 @@
+ cmake_minimum_required(VERSION 2.8.11)
+
 PROJECT( mesh_a_3D_image )
 
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)

--- a/Surface_mesher/demo/Surface_mesher/VTK/mesh_a_3D_image.cpp
+++ b/Surface_mesher/demo/Surface_mesher/VTK/mesh_a_3D_image.cpp
@@ -15,7 +15,7 @@
 
 #ifdef CGAL_USE_VTK
 
-#include <qapplication.h>
+#include <QApplication>
 #include <iostream>
 #include <cstdlib>
 #include <sstream>
@@ -98,11 +98,11 @@ int main(int argc, char** argv) {
   vtkPolyDataNormals *skinNormals = vtkPolyDataNormals::New();
 //     skinNormals->SetInputConnection(skinExtractor->GetOutputPort());
   vtkPolyData* polydata = CGAL::output_c2t3_to_vtk_polydata(c2t3);
-  skinNormals->SetInput(polydata);
+  skinNormals->SetInputData(polydata);
     skinNormals->SetFeatureAngle(60.0);
   vtkPolyDataMapper *skinMapper = vtkPolyDataMapper::New();
 //     skinMapper->SetInputConnection(skinExtractor->GetOutputPort());
-  skinMapper->SetInput(polydata);
+  skinMapper->SetInputData(polydata);
     skinMapper->ScalarVisibilityOff();
   vtkActor *skin = vtkActor::New();
     skin->SetMapper(skinMapper);

--- a/Surface_mesher/demo/Surface_mesher/mainwindow.cpp
+++ b/Surface_mesher/demo/Surface_mesher/mainwindow.cpp
@@ -136,6 +136,29 @@ void MainWindow::on_action_Open_triggered()
   }
 }
 
+void MainWindow::on_action_OpenDirectory_triggered()
+{
+  QSettings settings;
+  QString start_dir = settings.value("Open directory",
+                                     QDir::current().dirName()).toString();
+  QString dir =
+    QFileDialog::getExistingDirectory(this,
+                                      tr("Open directory"),
+                                      start_dir,
+                                      QFileDialog::ShowDirsOnly
+                                      | QFileDialog::DontResolveSymlinks);
+
+  if (!dir.isEmpty()) {
+    QFileInfo fileinfo(dir);
+    if (fileinfo.isDir() && fileinfo.isReadable())
+    {
+      settings.setValue("Open directory",
+        fileinfo.absoluteDir().absolutePath());
+      surface_open(dir);
+    }
+  }
+}
+
 void MainWindow::on_action_Quit_triggered()
 {
   this->writeState();

--- a/Surface_mesher/demo/Surface_mesher/mainwindow.h
+++ b/Surface_mesher/demo/Surface_mesher/mainwindow.h
@@ -26,6 +26,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
   void on_action_Open_triggered();
+  void on_action_OpenDirectory_triggered();
   void on_action_Quit_triggered();
   void on_action_Clone_triggered();
   

--- a/Surface_mesher/demo/Surface_mesher/ui/mainwindow.ui
+++ b/Surface_mesher/demo/Surface_mesher/ui/mainwindow.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="utf-8"?>
+<ui version="4.0">
  <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow" >
-  <property name="geometry" >
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,22 +10,22 @@
     <height>648</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>CGAL Surface mesh generator</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="../surface_mesher.qrc" >
+  <property name="windowIcon">
+   <iconset resource="../surface_mesher.qrc">
     <normaloff>:/icons/cgal_logo.xpm</normaloff>:/icons/cgal_logo.xpm</iconset>
   </property>
-  <property name="dockNestingEnabled" >
+  <property name="dockNestingEnabled">
    <bool>true</bool>
   </property>
-  <widget class="QWidget" name="centralwidget" >
-   <layout class="QGridLayout" name="gridLayout_4" >
-    <item row="0" column="0" >
-     <widget class="Viewer" name="viewer" >
-      <property name="sizePolicy" >
-       <sizepolicy vsizetype="Preferred" hsizetype="Preferred" >
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout_4">
+    <item row="0" column="0">
+     <widget class="Viewer" name="viewer" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>1</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
@@ -33,172 +34,173 @@
     </item>
    </layout>
   </widget>
-  <widget class="QMenuBar" name="menubar" >
-   <property name="geometry" >
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
      <width>1147</width>
-     <height>29</height>
+     <height>21</height>
     </rect>
    </property>
-   <widget class="QMenu" name="menu_File" >
-    <property name="title" >
+   <widget class="QMenu" name="menu_File">
+    <property name="title">
      <string>&amp;File</string>
     </property>
-    <addaction name="action_Open" />
-    <addaction name="actionSave" />
-    <addaction name="actionExport_surface_mesh_to_OFF" />
-    <addaction name="separator" />
-    <addaction name="action_Quit" />
+    <addaction name="action_Open"/>
+    <addaction name="action_OpenDirectory"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionExport_surface_mesh_to_OFF"/>
+    <addaction name="separator"/>
+    <addaction name="action_Quit"/>
    </widget>
-   <widget class="QMenu" name="menuOptions" >
-    <property name="title" >
+   <widget class="QMenu" name="menuOptions">
+    <property name="title">
      <string>&amp;Options</string>
     </property>
-    <property name="show_only_in" stdset="0" >
+    <property name="show_only_in" stdset="0">
      <stringlist>
       <string>volume</string>
       <string>polyhedral</string>
      </stringlist>
     </property>
-    <addaction name="actionInverse_normals" />
-    <addaction name="actionDisplay_octree" />
-    <addaction name="actionDisplay_surface" />
-    <addaction name="actionDisplay_control_edges" />
-    <addaction name="actionDisplay_all_edges" />
-    <addaction name="action_Options" />
-    <addaction name="actionAuto_resize" />
-    <addaction name="actionDisplay_front_and_back" />
-    <addaction name="actionDraw_triangles_edges" />
-    <addaction name="actionUse_Gouraud_shading" />
-    <addaction name="actionShow_triangulation" />
-    <addaction name="actionTriangulation_edges_color" />
-    <addaction name="actionShow_the_image_bounding_box" />
+    <addaction name="actionInverse_normals"/>
+    <addaction name="actionDisplay_octree"/>
+    <addaction name="actionDisplay_surface"/>
+    <addaction name="actionDisplay_control_edges"/>
+    <addaction name="actionDisplay_all_edges"/>
+    <addaction name="action_Options"/>
+    <addaction name="actionAuto_resize"/>
+    <addaction name="actionDisplay_front_and_back"/>
+    <addaction name="actionDraw_triangles_edges"/>
+    <addaction name="actionUse_Gouraud_shading"/>
+    <addaction name="actionShow_triangulation"/>
+    <addaction name="actionTriangulation_edges_color"/>
+    <addaction name="actionShow_the_image_bounding_box"/>
    </widget>
-   <widget class="QMenu" name="menuEdit" >
-    <property name="title" >
+   <widget class="QMenu" name="menuEdit">
+    <property name="title">
      <string>&amp;Edit</string>
     </property>
-    <property name="show_only_in" stdset="0" >
+    <property name="show_only_in" stdset="0">
      <stringlist>
       <string>polyhedral</string>
      </stringlist>
     </property>
-    <addaction name="actionSubdivision" />
+    <addaction name="actionSubdivision"/>
    </widget>
-   <addaction name="menu_File" />
-   <addaction name="menuEdit" />
-   <addaction name="menuOptions" />
+   <addaction name="menu_File"/>
+   <addaction name="menuEdit"/>
+   <addaction name="menuOptions"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar" />
-  <widget class="QToolBar" name="toolBar" >
-   <property name="windowTitle" >
+  <widget class="QStatusBar" name="statusbar"/>
+  <widget class="QToolBar" name="toolBar">
+   <property name="windowTitle">
     <string>Actions toolbar</string>
    </property>
-   <property name="allowedAreas" >
+   <property name="allowedAreas">
     <set>Qt::AllToolBarAreas</set>
    </property>
-   <attribute name="toolBarArea" >
+   <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
    </attribute>
-   <attribute name="toolBarBreak" >
+   <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="action_Open" />
-   <addaction name="actionExport_surface_mesh_to_OFF" />
-   <addaction name="separator" />
-   <addaction name="actionAuto_resize" />
-   <addaction name="actionDisplay_front_and_back" />
-   <addaction name="actionInverse_normals" />
-   <addaction name="actionShow_the_image_bounding_box" />
-   <addaction name="separator" />
-   <addaction name="actionDisplay_surface" />
-   <addaction name="actionDisplay_octree" />
-   <addaction name="actionDisplay_edges_octree" />
+   <addaction name="action_Open"/>
+   <addaction name="actionExport_surface_mesh_to_OFF"/>
+   <addaction name="separator"/>
+   <addaction name="actionAuto_resize"/>
+   <addaction name="actionDisplay_front_and_back"/>
+   <addaction name="actionInverse_normals"/>
+   <addaction name="actionShow_the_image_bounding_box"/>
+   <addaction name="separator"/>
+   <addaction name="actionDisplay_surface"/>
+   <addaction name="actionDisplay_octree"/>
+   <addaction name="actionDisplay_edges_octree"/>
   </widget>
-  <widget class="QToolBar" name="toolBar_meshing" >
-   <property name="enabled" >
+  <widget class="QToolBar" name="toolBar_meshing">
+   <property name="enabled">
     <bool>true</bool>
    </property>
-   <property name="windowTitle" >
+   <property name="windowTitle">
     <string>Meshing toolbar</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
-   <attribute name="toolBarArea" >
+   <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
    </attribute>
-   <attribute name="toolBarBreak" >
+   <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionMarching_cubes" />
-   <addaction name="actionSurface_mesher" />
+   <addaction name="actionMarching_cubes"/>
+   <addaction name="actionSurface_mesher"/>
   </widget>
-  <widget class="QDockWidget" name="ImageOptions" >
-   <property name="allowedAreas" >
+  <widget class="QDockWidget" name="ImageOptions">
+   <property name="allowedAreas">
     <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
    </property>
-   <property name="windowTitle" >
+   <property name="windowTitle">
     <string>Images options</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
-   <attribute name="dockWidgetArea" >
+   <attribute name="dockWidgetArea">
     <number>1</number>
    </attribute>
-   <widget class="QWidget" name="ImageOptionsContents" >
-    <layout class="QGridLayout" name="gridLayout_2" >
-     <item row="0" column="0" >
-      <layout class="QVBoxLayout" name="verticalLayout_3" >
+   <widget class="QWidget" name="ImageOptionsContents">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QGroupBox" name="groupBoxImageType" >
-         <property name="sizePolicy" >
-          <sizepolicy vsizetype="Fixed" hsizetype="Preferred" >
+        <widget class="QGroupBox" name="groupBoxImageType">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title" >
+         <property name="title">
           <string>&amp;Image type</string>
          </property>
-         <property name="show_only_in" stdset="0" >
+         <property name="show_only_in" stdset="0">
           <stringlist>
            <string>volume</string>
           </stringlist>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout" >
+         <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QRadioButton" name="grayLevelRadioButton" >
-            <property name="sizePolicy" >
-             <sizepolicy vsizetype="Fixed" hsizetype="Minimum" >
+           <widget class="QRadioButton" name="grayLevelRadioButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>Grayscale image</string>
             </property>
-            <property name="checked" >
+            <property name="checked">
              <bool>true</bool>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QRadioButton" name="labellizedRadioButton" >
-            <property name="sizePolicy" >
-             <sizepolicy vsizetype="Fixed" hsizetype="Minimum" >
+           <widget class="QRadioButton" name="labellizedRadioButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>Segmented image</string>
             </property>
            </widget>
@@ -207,27 +209,27 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox" >
-         <property name="title" >
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
           <string>&amp;Operations</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4" >
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QCheckBox" name="interpolationCheckBox" >
-            <property name="text" >
+           <widget class="QCheckBox" name="interpolationCheckBox">
+            <property name="text">
              <string>Trilinear interpolation</string>
             </property>
-            <property name="checked" >
+            <property name="checked">
              <bool>true</bool>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="searchSeedsCheckBox" >
-            <property name="text" >
+           <widget class="QCheckBox" name="searchSeedsCheckBox">
+            <property name="text">
              <string>Search for seeds</string>
             </property>
-            <property name="checked" >
+            <property name="checked">
              <bool>true</bool>
             </property>
            </widget>
@@ -236,74 +238,74 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBoxCriteria" >
-         <property name="sizePolicy" >
-          <sizepolicy vsizetype="Minimum" hsizetype="Preferred" >
+        <widget class="QGroupBox" name="groupBoxCriteria">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title" >
+         <property name="title">
           <string>C&amp;riteria</string>
          </property>
-         <property name="show_only_in" stdset="0" >
+         <property name="show_only_in" stdset="0">
           <stringlist>
            <string>volume</string>
           </stringlist>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2" >
+         <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QCheckBox" name="manifoldCheckBox" >
-            <property name="text" >
+           <widget class="QCheckBox" name="manifoldCheckBox">
+            <property name="text">
              <string>Manifold</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="sameIndexCheckBox" >
-            <property name="text" >
+           <widget class="QCheckBox" name="sameIndexCheckBox">
+            <property name="text">
              <string>Facets vertices have same index</string>
             </property>
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="gridLayout" >
-            <item row="0" column="0" >
-             <widget class="QLabel" name="label" >
-              <property name="text" >
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
                <string>&amp;Sizing bound:</string>
               </property>
-              <property name="buddy" >
+              <property name="buddy">
                <cstring>spinBox_radius_bound</cstring>
               </property>
              </widget>
             </item>
-            <item row="0" column="1" >
-             <widget class="QDoubleSpinBox" name="spinBox_radius_bound" >
-              <property name="decimals" >
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="spinBox_radius_bound">
+              <property name="decimals">
                <number>5</number>
               </property>
-              <property name="maximum" >
+              <property name="maximum">
                <double>9999.989999999999782</double>
               </property>
              </widget>
             </item>
-            <item row="1" column="0" >
-             <widget class="QLabel" name="label_2" >
-              <property name="text" >
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
                <string>&amp;Distance bound:</string>
               </property>
-              <property name="buddy" >
+              <property name="buddy">
                <cstring>spinBox_distance_bound</cstring>
               </property>
              </widget>
             </item>
-            <item row="1" column="1" >
-             <widget class="QDoubleSpinBox" name="spinBox_distance_bound" >
-              <property name="decimals" >
+            <item row="1" column="1">
+             <widget class="QDoubleSpinBox" name="spinBox_distance_bound">
+              <property name="decimals">
                <number>5</number>
               </property>
-              <property name="maximum" >
+              <property name="maximum">
                <double>9999.989999999999782</double>
               </property>
              </widget>
@@ -315,15 +317,15 @@
        </item>
       </layout>
      </item>
-     <item row="1" column="0" >
-      <spacer name="verticalSpacer" >
-       <property name="orientation" >
+     <item row="1" column="0">
+      <spacer name="verticalSpacer">
+       <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
-       <property name="sizeType" >
+       <property name="sizeType">
         <enum>QSizePolicy::Expanding</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>20</width>
          <height>0</height>
@@ -334,41 +336,41 @@
     </layout>
    </widget>
   </widget>
-  <widget class="QDockWidget" name="ImageLabels" >
-   <property name="sizePolicy" >
-    <sizepolicy vsizetype="Expanding" hsizetype="Expanding" >
+  <widget class="QDockWidget" name="ImageLabels">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
      <horstretch>0</horstretch>
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <property name="windowTitle" >
+   <property name="windowTitle">
     <string>Image sub-domaines</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
-   <attribute name="dockWidgetArea" >
+   <attribute name="dockWidgetArea">
     <number>1</number>
    </attribute>
-   <widget class="QWidget" name="ImageLabelsContents" >
-    <property name="sizePolicy" >
-     <sizepolicy vsizetype="Expanding" hsizetype="Expanding" >
+   <widget class="QWidget" name="ImageLabelsContents">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
       <horstretch>10</horstretch>
       <verstretch>10</verstretch>
      </sizepolicy>
     </property>
-    <layout class="QGridLayout" name="gridLayout_3" >
-     <item row="0" column="0" >
-      <widget class="Values_list" native="1" name="values" >
-       <property name="sizePolicy" >
-        <sizepolicy vsizetype="Expanding" hsizetype="Expanding" >
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="0">
+      <widget class="Values_list" name="values" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>5</verstretch>
         </sizepolicy>
        </property>
-       <property name="show_only_in" stdset="0" >
+       <property name="show_only_in" stdset="0">
         <stringlist>
          <string>volume</string>
         </stringlist>
@@ -378,390 +380,399 @@
     </layout>
    </widget>
   </widget>
-  <action name="action_Open" >
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+  <action name="action_Open">
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/fileopen.png</normaloff>:/icons/fileopen.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>&amp;Open...</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+O</string>
    </property>
   </action>
-  <action name="action_Quit" >
-   <property name="text" >
+  <action name="action_Quit">
+   <property name="text">
     <string>&amp;Quit</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+Q</string>
    </property>
-   <property name="menuRole" >
+   <property name="menuRole">
     <enum>QAction::QuitRole</enum>
    </property>
   </action>
-  <action name="actionInverse_normals" >
-   <property name="checkable" >
+  <action name="actionInverse_normals">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/flip.png</normaloff>:/icons/flip.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>&amp;Inverse normals</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Flip</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+I</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_octree" >
-   <property name="checkable" >
+  <action name="actionDisplay_octree">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/bbox.png</normaloff>:/icons/bbox.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display oc&amp;tree</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+T</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_surface" >
-   <property name="checkable" >
+  <action name="actionDisplay_surface">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/surface.png</normaloff>:/icons/surface.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display &amp;surface</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="action_Options" >
-   <property name="text" >
+  <action name="action_Options">
+   <property name="text">
     <string>&amp;Options...</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionSubdivision" >
-   <property name="text" >
+  <action name="actionSubdivision">
+   <property name="text">
     <string>Piecewise-smooth &amp;subdivision</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_all_edges" >
-   <property name="checkable" >
+  <action name="actionDisplay_all_edges">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>true</bool>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display &amp;all edges</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+A</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_control_edges" >
-   <property name="checkable" >
+  <action name="actionDisplay_control_edges">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>false</bool>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display &amp;control edges</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+C</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_edges_octree" >
-   <property name="checkable" >
+  <action name="actionDisplay_edges_octree">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/bbox-red.png</normaloff>:/icons/bbox-red.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display edges octree</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionMarching_cubes" >
-   <property name="text" >
+  <action name="actionMarching_cubes">
+   <property name="text">
     <string>Marching &amp;cubes</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Marching &amp;cubes</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionSurface_mesher" >
-   <property name="text" >
+  <action name="actionSurface_mesher">
+   <property name="text">
     <string>Surface &amp;mesher</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Surface &amp;mesher</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDisplay_front_and_back" >
-   <property name="checkable" >
+  <action name="actionDisplay_front_and_back">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/twosides.png</normaloff>:/icons/twosides.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Display facets with &amp;front and back</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Two-sides</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+F</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="action_Clone" >
-   <property name="text" >
+  <action name="action_Clone">
+   <property name="text">
     <string>Clone</string>
    </property>
   </action>
-  <action name="actionAuto_resize" >
-   <property name="checkable" >
+  <action name="actionAuto_resize">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>false</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/resize.png</normaloff>:/icons/resize.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Auto-&amp;resize</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Auto-&amp;resize</string>
    </property>
-   <property name="toolTip" >
+   <property name="toolTip">
     <string>Automaticaly zoom in or out when the object change.</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
      <string>polyhedral</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionDraw_triangles_edges" >
-   <property name="checkable" >
+  <action name="actionDraw_triangles_edges">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>true</bool>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Draw triangles &amp;edges</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Draw triangles &amp;edges</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+E</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionUse_Gouraud_shading" >
-   <property name="checkable" >
+  <action name="actionUse_Gouraud_shading">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>false</bool>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Use &amp;Gouraud shading (marching cube only)</string>
    </property>
-   <property name="iconText" >
+   <property name="iconText">
     <string>Use &amp;Gouraud shading</string>
    </property>
-   <property name="statusTip" >
+   <property name="statusTip">
     <string>Use Gouraud shading to display the marching cubes.</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+G</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionShow_triangulation" >
-   <property name="checkable" >
+  <action name="actionShow_triangulation">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Show the whole &amp;triangulation (surface mesher only)</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+T</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionTriangulation_edges_color" >
-   <property name="text" >
+  <action name="actionTriangulation_edges_color">
+   <property name="text">
     <string>Choose the triangulation edges &amp;color...</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionExport_surface_mesh_to_OFF" >
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+  <action name="actionExport_surface_mesh_to_OFF">
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/filesave.png</normaloff>:/icons/filesave.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Export surface mesh to OFF...</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionShow_the_image_bounding_box" >
-   <property name="checkable" >
+  <action name="actionShow_the_image_bounding_box">
+   <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked" >
+   <property name="checked">
     <bool>true</bool>
    </property>
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/bbox.png</normaloff>:/icons/bbox.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Show the image &amp;bounding box</string>
    </property>
-   <property name="shortcut" >
+   <property name="shortcut">
     <string>Ctrl+B</string>
    </property>
-   <property name="show_only_in" stdset="0" >
+   <property name="show_only_in" stdset="0">
     <stringlist>
      <string>volume</string>
     </stringlist>
    </property>
   </action>
-  <action name="actionSave" >
-   <property name="icon" >
-    <iconset resource="../surface_mesher.qrc" >
+  <action name="actionSave">
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
      <normaloff>:/icons/filesave.png</normaloff>:/icons/filesave.png</iconset>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Save the image as Inrimage...</string>
+   </property>
+  </action>
+  <action name="action_OpenDirectory">
+   <property name="icon">
+    <iconset resource="../surface_mesher.qrc">
+     <normaloff>:/icons/fileopen.png</normaloff>:/icons/fileopen.png</iconset>
+   </property>
+   <property name="text">
+    <string>Open directory...</string>
    </property>
   </action>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Viewer</class>
-   <extends>QGLViewer</extends>
-   <header>viewer.h</header>
-  </customwidget>
-  <customwidget>
    <class>Values_list</class>
    <extends>QWidget</extends>
    <header>values_list.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Viewer</class>
+   <extends>QWidget</extends>
+   <header>viewer.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -774,7 +785,7 @@
   <tabstop>spinBox_distance_bound</tabstop>
  </tabstops>
  <resources>
-  <include location="../surface_mesher.qrc" />
+  <include location="../surface_mesher.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -783,11 +794,11 @@
    <receiver>sameIndexCheckBox</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>130</x>
      <y>172</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>139</x>
      <y>414</y>
     </hint>

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
@@ -56,7 +56,6 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
   {
     typedef typename Triangulation::Point Point;
     const Point& p = vit->point();
-    double pts[3];
     vtk_points->InsertNextPoint(CGAL::to_double(p.x()),
                                 CGAL::to_double(p.y()),
                                 CGAL::to_double(p.z()));


### PR DESCRIPTION
This PR updates the CMakeLists to handle recent (>= 6.0) versions of vtk, and update Surface_mesher/demo/Surface_mesher/VTK examples to Qt5 and VTK6.

Also add a menu to the Surface_mesher demo to open a directory (previously one could only open a directory with drag-and-drop)