### PR TITLE
Mesh_3 - add a precondition to global optimizers

### DIFF
--- a/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
@@ -28,6 +28,7 @@
 #define CGAL_INTERNAL_MESH_3_CHECK_WEIGHTS_H
 
 #include <CGAL/tags.h>
+#include <CGAL/Mesh_3/Has_features.h>
 #include <boost/type_traits/is_same.hpp>
 
 namespace CGAL {
@@ -40,7 +41,7 @@ bool has_non_protecting_weights(const Triangulation& tr,
                                 const MeshDomain&)
 {
   bool with_features =
-    boost::is_same<typename MeshDomain::Has_features, CGAL::Tag_true>::value;
+    boost::is_same<Has_features<MeshDomain>, CGAL::Tag_true>::value;
 
   for (typename Triangulation::Finite_vertices_iterator
         vv = tr.finite_vertices_begin();

--- a/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 GeometryFactory (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL: https://scm.gforge.inria.fr/svn/cgal/branches/features/Mesh_3-experimental-GF/Mesh_3/include/CGAL/internal/Mesh_3/get_index.h $
+// $Id: get_index.h 67573 2012-02-02 14:54:51Z lrineau $
+//
+//
+// Author(s)     : Jane Tournois
+//
+//******************************************************************************
+// File Description :
+//
+//
+//******************************************************************************
+
+#ifndef CGAL_INTERNAL_MESH_3_CHECK_WEIGHTS_H
+#define CGAL_INTERNAL_MESH_3_CHECK_WEIGHTS_H
+
+#include <CGAL/tags.h>
+#include <boost/type_traits/is_same.hpp>
+
+namespace CGAL {
+namespace internal {
+namespace Mesh_3 {
+
+
+template<typename Triangulation, typename MeshDomain>
+bool has_non_protecting_weights(const Triangulation& tr,
+                                const MeshDomain&)
+{
+  bool with_features =
+    boost::is_same<typename MeshDomain::Has_features, CGAL::Tag_true>::value;
+
+  for (typename Triangulation::Finite_vertices_iterator
+        vv = tr.finite_vertices_begin();
+        vv != tr.finite_vertices_end();
+        ++vv)
+  {
+    if (vv->point().weight() != 0.)
+    {
+      if (with_features && vv->in_dimension() > 1)
+        return true;
+    }
+  }
+  return false;
+}
+
+
+}//end namespace Mesh_3
+}//end namespace internal
+}//end namespace CGAL
+
+#endif //CGAL_INTERNAL_MESH_3_CHECK_WEIGHTS_H
+

--- a/Mesh_3/include/CGAL/lloyd_optimize_mesh_3.h
+++ b/Mesh_3/include/CGAL/lloyd_optimize_mesh_3.h
@@ -31,6 +31,7 @@
 #include <CGAL/Mesh_3/Mesh_sizing_field.h>
 #include <CGAL/Mesh_optimization_return_code.h>
 #include <CGAL/Mesh_3/parameters_defaults.h>
+#include <CGAL/internal/Mesh_3/check_weights.h>
 
 namespace CGAL {
   
@@ -65,6 +66,9 @@ lloyd_optimize_mesh_3_impl(C3T3& c3t3,
                            const double freeze_bound
                            , const bool do_freeze)
 {
+  CGAL_precondition(
+    !internal::Mesh_3::has_non_protecting_weights(c3t3.triangulation(), domain));
+
   typedef typename C3T3::Triangulation  Tr;
   
   typedef Mesh_3::Mesh_sizing_field<Tr>               Sizing;

--- a/Mesh_3/include/CGAL/odt_optimize_mesh_3.h
+++ b/Mesh_3/include/CGAL/odt_optimize_mesh_3.h
@@ -32,6 +32,7 @@
 #include <CGAL/Mesh_3/Mesh_sizing_field.h>
 #include <CGAL/Mesh_optimization_return_code.h>
 #include <CGAL/Mesh_3/parameters_defaults.h>
+#include <CGAL/internal/Mesh_3/check_weights.h>
 
 namespace CGAL {
   
@@ -66,6 +67,9 @@ odt_optimize_mesh_3_impl(C3T3& c3t3,
                          const double freeze_ratio,
                          const bool do_freeze )
 {
+  CGAL_precondition(
+    !internal::Mesh_3::has_non_protecting_weights(c3t3.triangulation(), domain));
+
   typedef typename C3T3::Triangulation  Tr;
   
   typedef Mesh_3::Mesh_sizing_field<Tr>             Sizing;

--- a/Mesh_3/include/CGAL/perturb_mesh_3.h
+++ b/Mesh_3/include/CGAL/perturb_mesh_3.h
@@ -31,6 +31,7 @@
 #include <CGAL/Mesh_3/Sliver_perturber.h>
 #include <CGAL/Mesh_optimization_return_code.h>
 #include <CGAL/Mesh_3/parameters_defaults.h>
+#include <CGAL/internal/Mesh_3/check_weights.h>
 #include <vector>
 #include <CGAL/use.h>
 
@@ -96,6 +97,9 @@ perturb_mesh_3_impl(C3T3& c3t3,
                     const SliverCriterion& sliver_criterion,
                     const PPerturbationVector& perturbation_vector)
 {
+  CGAL_precondition(
+    !internal::Mesh_3::has_non_protecting_weights(c3t3.triangulation(), domain));
+
   typedef MeshDomain Md;
   typedef SliverCriterion Sc;
   


### PR DESCRIPTION
This precondition checks that global optimizers are not run on a triangulation with weights.

Running global optimizers on a triangulation with weights is not recomended. The behaviour is unknown and it usually leads to a crash.

Protecting balls are an exception and don't prevent global optimizers from running.

exude_mesh_3 is not concerned by this PR, since it's precisely its job to deal with weights.