### PR TITLE
Contextual menu changed

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1023,12 +1023,9 @@ void MainWindow::showSceneContextMenu(int selectedItemIndex,
       menu->setProperty(prop_name, true);
     }
   }
-  QMenu *finalMenu = new QMenu();
-  finalMenu->addMenu(menu);
-  finalMenu->addMenu(ui->menuOperations);
-
+  menu->addMenu(ui->menuOperations);
   if(menu)
-    finalMenu->exec(global_pos);
+    menu->exec(global_pos);
 }
 
 void MainWindow::showSceneContextMenu(const QPoint& p) {


### PR DESCRIPTION
- Operations is now part of the item menu, so the first menu does not exists anymore.
  It is quicker to get to an action.