### PR TITLE
Polyhedron demo : sort operations by package

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_convex_hull_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_convex_hull_plugin.cpp
@@ -30,7 +30,8 @@ public:
         mw = mainWindow;
         scene = scene_interface;
         actions_map["actionConvexHull"] = getActionFromMainWindow(mw, "actionConvexHull");
-        actions_map["actionConvexHull"]->setProperty("subMenuName", "Object creation");
+        actions_map["actionConvexHull"]->setProperty("subMenuName",
+                                                     "3D Convex Hulls");
         autoConnectActions();
 
     }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_corefinement_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_corefinement_plugin.cpp
@@ -41,7 +41,7 @@ public:
     this->scene = scene_interface;
     this->mw = mainWindow;
     actionPolyhedronCorefinement_3 = new QAction("Polyhedra corefinement (A/B)", mw);
-    actionPolyhedronCorefinement_3->setProperty("subMenuName", "Operation on multiple polyhedra");
+    actionPolyhedronCorefinement_3->setProperty("subMenuName", "Operations on polyhedra");
     if(actionPolyhedronCorefinement_3) {
       connect(actionPolyhedronCorefinement_3, SIGNAL(triggered()),
               this, SLOT(corefinement()));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_cut_plugin.cpp
@@ -377,7 +377,7 @@ void Polyhedron_demo_cut_plugin::init(QMainWindow* mainWindow,
   scene = scene_interface;
   messages = m;
   actionCreateCutPlane = new QAction(tr("Create cutting plane"), mainWindow);
-  actionCreateCutPlane->setProperty("subMenuName","Operations with plane");
+  actionCreateCutPlane->setProperty("subMenuName","3D Fast Intersection and Distance Computation");
   connect(actionCreateCutPlane, SIGNAL(triggered()),
           this, SLOT(createCutPlane()));
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_edit_polyhedron_plugin.cpp
@@ -85,7 +85,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::init(QMainWindow* mainWindow, CGAL:
   mw = mainWindow;
   scene = scene_interface;
   actionDeformation = new QAction("Surface Mesh Deformation", mw);
-  actionDeformation->setProperty("subMenuName", "Action on mesh");
+  actionDeformation->setProperty("subMenuName", "Triangulated Surface Mesh Deformation");
 
   actionDeformation->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_E));
   connect(actionDeformation, SIGNAL(triggered()), this, SLOT(on_actionDeformation_triggered()));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_fairing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_fairing_plugin.cpp
@@ -47,7 +47,7 @@ public:
     scene = scene_interface;
     messages = m;
     actionFairing = new QAction(tr("Fairing"), mw);
-    actionFairing->setProperty("subMenuName", "Action on mesh");
+    actionFairing->setProperty("subMenuName", "Polygon Mesh Processing");
 
     connect(actionFairing, SIGNAL(triggered()), this, SLOT(fairing_action()));
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_hole_filling_plugin.cpp
@@ -396,7 +396,7 @@ void Polyhedron_demo_hole_filling_plugin::init(QMainWindow* mainWindow,
   messages = m;
 
   actionHoleFilling = new QAction(tr("Hole Filling"), mw);
-  actionHoleFilling->setProperty("subMenuName", "Action on mesh");
+  actionHoleFilling->setProperty("subMenuName", "Polygon Mesh Processing");
   connect(actionHoleFilling, SIGNAL(triggered()), this, SLOT(hole_filling_action()));
 
   dock_widget = new QDockWidget("Hole Filling", mw);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_inside_out_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_inside_out_plugin.cpp
@@ -30,7 +30,7 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionInsideOut"] = getActionFromMainWindow(mw, "actionInsideOut");
-      actions_map["actionInsideOut"]->setProperty("subMenuName", "Action on normals");
+      actions_map["actionInsideOut"]->setProperty("subMenuName", "Polygon Mesh Processing");
       autoConnectActions();
 
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_intersection_plugin.cpp
@@ -46,7 +46,7 @@ public:
     this->scene = scene_interface;
     this->mw = mainWindow;
     actionPolyhedronIntersection_3 = new QAction("Intersect polyhedra (A/B)", mw);
-    actionPolyhedronIntersection_3->setProperty("subMenuName", "Operation on multiple polyhedra");
+    actionPolyhedronIntersection_3->setProperty("subMenuName", "Operations on polyhedra");
     if(actionPolyhedronIntersection_3) {
       connect(actionPolyhedronIntersection_3, SIGNAL(triggered()),
               this, SLOT(intersection()));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_jet_fitting_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_jet_fitting_plugin.cpp
@@ -31,7 +31,8 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionEstimateCurvature"] = getActionFromMainWindow(mw, "actionEstimateCurvature");
-      actions_map["actionEstimateCurvature"]->setProperty("subMenuName", "Object creation");
+      actions_map["actionEstimateCurvature"]->setProperty("subMenuName",
+                                                          "Estimation of Local Differential Properties");
       autoConnectActions();
 
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_join_and_split_polyhedra_plugin.cpp
@@ -32,13 +32,15 @@ public:
   {
     msg_interface = m;
     actionJoinPolyhedra= new QAction(tr("Join selected polyhedra"), mainWindow);
-    actionJoinPolyhedra->setProperty("subMenuName", "Operation on multiple polyhedra");
+    actionJoinPolyhedra->setProperty("subMenuName", "Operations on polyhedra");
     actionJoinPolyhedra->setObjectName("actionJoinPolyhedra");
+
     actionSplitPolyhedra= new QAction(tr("Split selected polyhedra"), mainWindow);
-    actionSplitPolyhedra->setProperty("subMenuName", "Operation on multiple polyhedra");
+    actionSplitPolyhedra->setProperty("subMenuName", "Operations on polyhedra");
     actionSplitPolyhedra->setObjectName("actionSplitPolyhedra");
+
     actionColorConnectedComponents = new QAction(tr("Color each connected component of selected polyhedra"), mainWindow);
-    actionColorConnectedComponents ->setProperty("subMenuName", "Color alteration");
+    actionColorConnectedComponents ->setProperty("subMenuName", "Polygon Mesh Processing");
     actionColorConnectedComponents->setObjectName("actionColorConnectedComponents");
     Polyhedron_demo_plugin_helper::init(mainWindow, scene_interface);
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mean_curvature_flow_skeleton_plugin.cpp
@@ -119,12 +119,11 @@ public:
     ui = NULL;
 
     actionMCFSkeleton = new QAction(tr("Mean Curvature Skeleton (Advanced)"), mainWindow);
-    actionMCFSkeleton->setProperty("subMenuName", "Object creation");
+    actionMCFSkeleton->setProperty("subMenuName", "Triangulated Surface Mesh Skeletonization");
     actionMCFSkeleton->setObjectName("actionMCFSkeleton");
 
     actionConvert_to_medial_skeleton = new QAction(tr("Extract Medial Skeleton"), mainWindow);
-    actionConvert_to_medial_skeleton->setProperty("subMenuName", "Object creation");
-
+    actionConvert_to_medial_skeleton->setProperty("subMenuName", "Triangulated Surface Mesh Skeletonization");
     actionConvert_to_medial_skeleton->setObjectName("actionConvert_to_medial_skeleton");
 
     Polyhedron_demo_plugin_helper::init(mainWindow, scene_interface);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_3_plugin.cpp
@@ -39,7 +39,7 @@ public:
     this->mw = mainWindow;
     actionMesh_3 = new QAction("Create a tetrahedral mesh", mw);
     if(actionMesh_3) {
-      actionMesh_3->setProperty("subMenuName", "Operations with plane");
+      actionMesh_3->setProperty("subMenuName", "3D Mesh Generation");
       connect(actionMesh_3, SIGNAL(triggered()),
               this, SLOT(mesh_3()));
     }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_segmentation_plugin.cpp
@@ -68,7 +68,7 @@ public:
         this->scene = scene_interface;
         this->mw = mainWindow;
         actionSegmentation = new QAction("Mesh Segmentation", mw);
-        actionSegmentation->setProperty("subMenuName", "Color alteration");
+        actionSegmentation->setProperty("subMenuName", "Triangulated Surface Mesh Segmentation");
         connect(actionSegmentation, SIGNAL(triggered()),this, SLOT(on_actionSegmentation_triggered()));
 
         // adding slot for itemAboutToBeDestroyed signal, aim is removing item from item-functor map.

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_mesh_simplification_plugin.cpp
@@ -34,7 +34,8 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionSimplify"] = getActionFromMainWindow(mw, "actionSimplify");
-      actions_map["actionSimplify"]->setProperty("subMenuName", "Action on mesh");
+      actions_map["actionSimplify"]->setProperty("subMenuName",
+                                                 "Triangulated Surface Mesh Simplification");
       autoConnectActions();
 
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_nef_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_nef_plugin.cpp
@@ -37,7 +37,8 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionConvexDecomposition"] = getActionFromMainWindow(mw, "actionConvexDecomposition");
-      actions_map["actionConvexDecomposition"]->setProperty("subMenuName", "Object creation");
+      actions_map["actionConvexDecomposition"]->setProperty("subMenuName",
+                                                            "Convex Decomposition of Polyhedra");
 
       actions_map["actionToNef"] = getActionFromMainWindow(mw, "actionToNef");
       actions_map["actionToPoly"] = getActionFromMainWindow(mw, "actionToPoly");

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_orient_soup_plugin.cpp
@@ -62,18 +62,18 @@ void Polyhedron_demo_orient_soup_plugin::init(QMainWindow* mainWindow,
   messages = m;
   actionOrient = new QAction(tr("&Orient polygon soup"), mainWindow);
   actionOrient->setObjectName("actionOrient");
-  actionOrient->setProperty("subMenuName", "Action on normals");
+  actionOrient->setProperty("subMenuName", "Polygon Mesh Processing");
   connect(actionOrient, SIGNAL(triggered()),
           this, SLOT(orient()));
 
   actionShuffle = new QAction(tr("&Shuffle polygon soup"), mainWindow);
-  actionShuffle->setProperty("subMenuName", "Action on normals");
+  actionShuffle->setProperty("subMenuName", "Polygon Mesh Processing");
   connect(actionShuffle, SIGNAL(triggered()),
           this, SLOT(shuffle()));
 
   actionDisplayNonManifoldEdges = new QAction(tr("Display non manifold edges"),
                                               mainWindow);
-  actionDisplayNonManifoldEdges->setProperty("subMenuName", "Detection");
+  actionDisplayNonManifoldEdges->setProperty("subMenuName", "View");
   connect(actionDisplayNonManifoldEdges, SIGNAL(triggered()),
           this, SLOT(displayNonManifoldEdges()));
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_parameterization_plugin.cpp
@@ -47,16 +47,23 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionMVC"] = new QAction("MVC", mw);
-      actions_map["actionMVC"]->setProperty("subMenuName", "Color alteration/Parametrization");
+      actions_map["actionMVC"]->setProperty("subMenuName",
+        "Planar Parameterization of Triangulated Surface Meshes");
 
       actions_map["actionDCP"] = new QAction ("DCP", mw);
-      actions_map["actionDCP"]->setProperty("subMenuName", "Color alteration/Parametrization");
+      actions_map["actionDCP"]->setProperty("subMenuName",
+        "Planar Parameterization of Triangulated Surface Meshes");
+
+      actions_map["actionLSC"] = new QAction("LSC", mw);
+      actions_map["actionLSC"]->setProperty("subMenuName",
+        "Planar Parameterization of Triangulated Surface Meshes");
 
       connect(actions_map["actionMVC"], SIGNAL(triggered()),
               this, SLOT(on_actionMVC_triggered()));
       connect(actions_map["actionDCP"], SIGNAL(triggered()),
               this, SLOT(on_actionDCP_triggered()));
-
+      connect(actions_map["actionLSC"], SIGNAL(triggered()),
+              this, SLOT(on_actionLSC_triggered()));
   }
 
   bool applicable(QAction*) const { 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_pca_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_pca_plugin.cpp
@@ -47,10 +47,10 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionFitPlane"] = new QAction("Fit Plane", mw);
-      actions_map["actionFitPlane"]->setProperty("subMenuName", "Object creation/PCA");
+      actions_map["actionFitPlane"]->setProperty("subMenuName", "Principal Component Analysis");
 
       actions_map["actionFitLine"] = new QAction("Fit Line", mw);
-      actions_map["actionFitLine"]->setProperty("subMenuName", "Object creation/PCA");
+      actions_map["actionFitLine"]->setProperty("subMenuName", "Principal Component Analysis");
 
       connect(actions_map["actionFitPlane"], SIGNAL(triggered()),
               this, SLOT(on_actionFitPlane_triggered()));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_inside_polyhedron_plugin.cpp
@@ -63,7 +63,7 @@ public:
     messages = m;
 
     actionPointInsidePolyhedron = new QAction(tr("Point Inside Polyhedron"), mw);
-    actionPointInsidePolyhedron->setProperty("subMenuName", "Object creation");
+    actionPointInsidePolyhedron->setProperty("subMenuName", "Polygon Mesh Processing");
     connect(actionPointInsidePolyhedron, SIGNAL(triggered()), this, SLOT(point_inside_polyhedron_action()));
 
     dock_widget = new QDockWidget("Point Inside Polyhedron", mw);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_slicer_plugin.cpp
@@ -97,7 +97,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::init(QMainWindow* mainWindow,
   plane_item = NULL;
 
   actionSlicerWidget = new QAction(tr("Polyhedron Slicer"), mw);
-  actionSlicerWidget->setProperty("subMenuName", "Operations with plane");
+  actionSlicerWidget->setProperty("subMenuName", "Polygon Mesh Processing");
   connect(actionSlicerWidget, SIGNAL(triggered()), this, SLOT(slicer_widget_action()));
 
   dock_widget = new QDockWidget("Polyhedron Slicer", mw);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_polyhedron_stitching_plugin.cpp
@@ -54,7 +54,8 @@ public:
     actionStitchBorders= new QAction(tr("Stitch polyhedron duplicated boundaries"), mainWindow);
     actionDetectBorders->setObjectName("actionDetectBorders");
     actionStitchBorders->setObjectName("actionStitchBorders");
-    actionDetectBorders->setProperty("subMenuName", "Detection operations");
+    actionStitchBorders->setProperty("subMenuName", "Polygon Mesh Processing");
+    actionDetectBorders->setProperty("subMenuName", "Polygon Mesh Processing");
     Polyhedron_demo_plugin_helper::init(mainWindow, scene_interface);
   }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_remeshing_plugin.cpp
@@ -35,7 +35,7 @@ public:
     this->scene = scene_interface;
     this->mw = mainWindow;
     actionRemeshing = this->getActionFromMainWindow(mw, "actionRemeshing");
-    actionRemeshing->setProperty("subMenuName", "Action on mesh");
+    actionRemeshing->setProperty("subMenuName", "3D Surface Mesh Generation");
     if(actionRemeshing) {
       connect(actionRemeshing, SIGNAL(triggered()),
               this, SLOT(remesh()));

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_self_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_self_intersection_plugin.cpp
@@ -40,7 +40,7 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionSelfIntersection"] = getActionFromMainWindow(mw, "actionSelfIntersection");
-      actions_map["actionSelfIntersection"]->setProperty("subMenuName", "Detection operations");
+      actions_map["actionSelfIntersection"]->setProperty("subMenuName", "Polygon Mesh Processing");
       autoConnectActions();
 
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_shortest_path_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_shortest_path_plugin.cpp
@@ -89,7 +89,7 @@ public:
     connect(ui_widget.Primitives_type_combo_box, SIGNAL(currentIndexChanged(int)), this, SLOT(on_Primitives_type_combo_box_changed(int)));
 
     actionMakeShortestPaths = new QAction("Make Shortest Path", this->mw);
-    actionMakeShortestPaths->setProperty("subMenuName", "Object creation");
+    actionMakeShortestPaths->setProperty("subMenuName", "Triangulated Surface Mesh Shortest Paths");
 
     connect(actionMakeShortestPaths, SIGNAL(triggered()), this, SLOT(on_actionMakeShortestPaths_triggered()));
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_subdivision_methods_plugin.cpp
@@ -31,13 +31,13 @@ public:
       mw = mainWindow;
       scene = scene_interface;
       actions_map["actionLoop"] = new QAction("Loop", mw);
-      actions_map["actionLoop"]->setProperty("subMenuName", "Action on mesh/Subdivisions");
+      actions_map["actionLoop"]->setProperty("subMenuName", "3D Surface Subdivision Methods");
 
       actions_map["actionCatmullClark"] = new QAction("Catmull Clark", mw);
-      actions_map["actionCatmullClark"]->setProperty("subMenuName", "Action on mesh/Subdivisions");
+      actions_map["actionCatmullClark"]->setProperty("subMenuName", "3D Surface Subdivision Methods");
 
       actions_map["actionSqrt3"] = new QAction("Sqrt3", mw);
-      actions_map["actionSqrt3"]->setProperty("subMenuName", "Action on mesh/Subdivisions");
+      actions_map["actionSqrt3"]->setProperty("subMenuName", "3D Surface Subdivision Methods");
 
       //autoConnectActions();
       connect(actions_map["actionLoop"], SIGNAL(triggered()),

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_triangulate_facets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_triangulate_facets_plugin.cpp
@@ -28,13 +28,13 @@ public:
     this->mw = mainWindow;
     this->messages = m;
     actionTriangulateFacets = new QAction("Triangulate facets", mw);
-    actionTriangulateFacets->setProperty("subMenuName","Action on mesh");
+    actionTriangulateFacets->setProperty("subMenuName","Polygon Mesh Processing");
     if(actionTriangulateFacets) {
       connect(actionTriangulateFacets, SIGNAL(triggered()),
               this, SLOT(triangulate())); 
     }
     actionUnTriangulateFacets = new QAction("Untriangulate facets", mw);
-    actionUnTriangulateFacets->setProperty("subMenuName","Action on mesh");
+    actionUnTriangulateFacets->setProperty("subMenuName","Polygon Mesh Processing");
     if(actionUnTriangulateFacets) {
       connect(actionUnTriangulateFacets, SIGNAL(triggered()),
               this, SLOT(untriangulate())); 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_trivial_plugin.cpp
@@ -168,7 +168,7 @@ void Polyhedron_demo_trivial_plugin::init(QMainWindow* mainWindow, CGAL::Three::
 {
     scene = scene_interface;
     actionBbox = new QAction(tr("Create bbox"), mainWindow);
-    actionBbox->setProperty("subMenuName", "Object creation");
+    //actionBbox->setProperty("subMenuName", "Object creation");
     connect(actionBbox, SIGNAL(triggered()),
             this, SLOT(bbox()));
 }


### PR DESCRIPTION
Thanks to the new framework for sorting operations into subdirectories in the Polyhedron demo, we can produce a nicer layout of the list of available operations for each type of item.

After a local discussion at GF, I've decided to put every action in an "actions folder" that has the name of the corresponding CGAL package.

It is not absolutely perfect, because 
- some directories contain only one operation (which could easily be avoided by not creating this directory)
- some directories are big (nothing compared to how it was before)

but
- the "one operation directories" could/would easily be filled with operations available in the package
- it is easy for a developer to decide where to put his new operation : in the directory that has the same name as its corresponding package
- it is easy to decide whether to create a new subdirectory
- it is easy to find where the functionality you are looking for is in the demo, because it is documented in the CGAL documentation

Some actions still need to be sorted, but this PR is here to collect your feedback.

cc : @lrineau @sloriot @afabri.