### PR TITLE
Cgal assert fix gf

### DIFF
--- a/CGAL_ImageIO/include/CGAL/Image_3_impl.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_impl.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <CGAL/gl.h>
+#include <CGAL/basic.h>
 
 namespace CGAL {
 
@@ -221,7 +222,7 @@ Image_3::read_vtk_image_data(vtkImageData* vtk_image)
   std::cerr << "GetNumberOfTuples()=" << vtk_image->GetPointData()->GetScalars()->GetNumberOfTuples()
             << "\nimage->size()=" << dims[0]*dims[1]*dims[2]
             << "\nwdim=" << image->wdim << '\n';
-  assert(vtk_image->GetPointData()->GetScalars()->GetNumberOfTuples() == dims[0]*dims[1]*dims[2]);
+  CGAL_assertion(vtk_image->GetPointData()->GetScalars()->GetNumberOfTuples() == dims[0]*dims[1]*dims[2]);
   vtk_image->GetPointData()->GetScalars()->ExportToVoidPointer(image->data);
 
   return this->private_read(image);

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_save_load.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_save_load.h
@@ -295,7 +295,7 @@ namespace CGAL {
   boost::property_tree::ptree cmap_save_darts
   (const CMap& amap, std::map<typename CMap::Dart_const_handle, typename CMap::size_type>& myDarts)
   {
-    assert( myDarts.empty() );
+    CGAL_assertion( myDarts.empty() );
     
     // First we numbered each dart by using the std::map.
     typename CMap::Dart_range::const_iterator it(amap.darts().begin());

--- a/Kinetic_data_structures/include/CGAL/Polynomial/internal/macros.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/internal/macros.h
@@ -57,11 +57,11 @@
 
 #include <cassert>
 
-#define CGAL_Polynomial_assertion(x) assert(x)
+#define CGAL_Polynomial_assertion(x) CGAL_assertion(x)
 // This does not work
 #define CGAL_Polynomial_assertion_code(x) x
-#define CGAL_Polynomial_precondition(x) assert(x)
-#define CGAL_Polynomial_postcondition(x) assert(x)
+#define CGAL_Polynomial_precondition(x) CGAL_assertion(x)
+#define CGAL_Polynomial_postcondition(x) CGAL_assertion(x)
 #define CGAL_Polynomial_expensive_precondition(x)
 #define CGAL_Polynomial_expensive_assertion(x)
 #define CGAL_Polynomial_expensive_postcondition(x)

--- a/Kinetic_data_structures/include/CGAL/Polynomial/internal/macros.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/internal/macros.h
@@ -57,11 +57,11 @@
 
 #include <cassert>
 
-#define CGAL_Polynomial_assertion(x) CGAL_assertion(x)
+#define CGAL_Polynomial_assertion(x) assert(x)
 // This does not work
 #define CGAL_Polynomial_assertion_code(x) x
-#define CGAL_Polynomial_precondition(x) CGAL_assertion(x)
-#define CGAL_Polynomial_postcondition(x) CGAL_assertion(x)
+#define CGAL_Polynomial_precondition(x) assert(x)
+#define CGAL_Polynomial_postcondition(x) assert(x)
 #define CGAL_Polynomial_expensive_precondition(x)
 #define CGAL_Polynomial_expensive_assertion(x)
 #define CGAL_Polynomial_expensive_postcondition(x)

--- a/Number_types/include/CGAL/Test/test_root_of_traits.h
+++ b/Number_types/include/CGAL/Test/test_root_of_traits.h
@@ -59,83 +59,83 @@ void test_root_of_traits(){
       Root_of_2 r  = ftd(make_root_of_2(T(0),T(-1),T(2))); //-sqrt(2)
       Root_of_2 rl = ftd(make_root_of_2(T(1),T(0),T(-2),true)); //-sqrt(2);
       Root_of_2 rr = ftd(make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      assert(r == rl);
-      assert(rl != rr);
+      CGAL_assertion(r == rl);
+      CGAL_assertion(rl != rr);
       
-      assert( ftd(r * Root_of_1(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
-      assert( ftd(r * T(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
+      CGAL_assertion( ftd(r * Root_of_1(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
+      CGAL_assertion( ftd(r * T(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
     }{
       Root_of_2 r  = ftd(CGAL::make_root_of_2(T(0),T(-1),T(2))); //-sqrt(2)
       Root_of_2 rl = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),true)); //-sqrt(2);
       Root_of_2 rr = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      assert(r == rl);
-      assert(rl != rr);
-      
-      assert( ftd(r * Root_of_1(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
-      assert( ftd(r * T(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
+      CGAL_assertion(r == rl);
+      CGAL_assertion(rl != rr);
+
+      CGAL_assertion( ftd(r * Root_of_1(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
+      CGAL_assertion( ftd(r * T(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
     }
 
    
     {
       Root_of_2 r  = ftd(make_sqrt(T(2))); //sqrt(2)
       Root_of_2 rr = ftd(make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      assert(r == rr);
+      CGAL_assertion(r == rr);
     }{
       Root_of_2 r  = ftd(CGAL::make_sqrt(T(2))); //sqrt(2)
       Root_of_2 rr = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      assert(r == rr);
+      CGAL_assertion(r == rr);
     }
 
     {
       Root_of_2 r  = ftd(inverse(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(1/ftd(CGAL::make_sqrt(T(2))));
-      assert(r == rr);
+      CGAL_assertion(r == rr);
     }{
         Root_of_2 r  = ftd(CGAL::inverse(ftd(CGAL::make_sqrt(T(2)))));
         Root_of_2 rr = ftd(1/ftd(CGAL::make_sqrt(T(2))));
-        assert(r == rr);
+        CGAL_assertion(r == rr);
     }
 
     {
       Root_of_2 r  = ftd(square(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(ftd(CGAL::make_sqrt(T(2)))*ftd(CGAL::make_sqrt(T(2))));
-      assert(r == rr);
+      CGAL_assertion(r == rr);
     }{
       Root_of_2 r  = ftd(CGAL::square(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(ftd(CGAL::make_sqrt(T(2)))*ftd(CGAL::make_sqrt(T(2))));
-      assert(r == rr);
+      CGAL_assertion(r == rr);
     }
 
     bool is_not_exact = !CGAL::Algebraic_structure_traits<T>::Is_exact::value; 
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(0),T(-2),std::back_inserter(roots));
-      assert(roots.size()==2);  
-      assert(roots[0]==-CGAL::make_sqrt(T(2)) || is_not_exact );
-      assert(roots[1]== CGAL::make_sqrt(T(2)) || is_not_exact );
+      CGAL_assertion(roots.size()==2);
+      CGAL_assertion(roots[0]==-CGAL::make_sqrt(T(2)) || is_not_exact );
+      CGAL_assertion(roots[1]== CGAL::make_sqrt(T(2)) || is_not_exact );
     }  
     {
       Root_of_2 roots[2]= {Root_of_2(1),Root_of_2(1)};
       CGAL::compute_roots_of_2(T(13),T(4),T(-23),roots); 
-      assert(roots[0]==CGAL::make_root_of_2(T(13),T(4),T(-23),true)  || is_not_exact );
-      assert(roots[1]==CGAL::make_root_of_2(T(13),T(4),T(-23),false) || is_not_exact );
+      CGAL_assertion(roots[0]==CGAL::make_root_of_2(T(13),T(4),T(-23),true)  || is_not_exact );
+      CGAL_assertion(roots[1]==CGAL::make_root_of_2(T(13),T(4),T(-23),false) || is_not_exact );
     }   
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(-6),T(9),std::back_inserter(roots));
-      assert(roots.size()==1);
-      assert(roots[0]==Root_of_2(3) || is_not_exact );
+      CGAL_assertion(roots.size()==1);
+      CGAL_assertion(roots[0]==Root_of_2(3) || is_not_exact );
     }  
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(0),T(2),std::back_inserter(roots));
-      assert(roots.size()==0);
+      CGAL_assertion(roots.size()==0);
     } 
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(0),T(2),T(3),std::back_inserter(roots));
-      assert(roots.size()==1);
-      assert(roots[0]==-Root_of_2(3)/Root_of_2(2) || is_not_exact );
+      CGAL_assertion(roots.size()==1);
+      CGAL_assertion(roots[0]==-Root_of_2(3)/Root_of_2(2) || is_not_exact );
     } 
     
 }

--- a/Number_types/include/CGAL/Test/test_root_of_traits.h
+++ b/Number_types/include/CGAL/Test/test_root_of_traits.h
@@ -59,83 +59,83 @@ void test_root_of_traits(){
       Root_of_2 r  = ftd(make_root_of_2(T(0),T(-1),T(2))); //-sqrt(2)
       Root_of_2 rl = ftd(make_root_of_2(T(1),T(0),T(-2),true)); //-sqrt(2);
       Root_of_2 rr = ftd(make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      CGAL_assertion(r == rl);
-      CGAL_assertion(rl != rr);
+      assert(r == rl);
+      assert(rl != rr);
       
-      CGAL_assertion( ftd(r * Root_of_1(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
-      CGAL_assertion( ftd(r * T(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
+      assert( ftd(r * Root_of_1(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
+      assert( ftd(r * T(2)) == ftd(make_root_of_2(T(0),T(-2),T(2))));
     }{
       Root_of_2 r  = ftd(CGAL::make_root_of_2(T(0),T(-1),T(2))); //-sqrt(2)
       Root_of_2 rl = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),true)); //-sqrt(2);
       Root_of_2 rr = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      CGAL_assertion(r == rl);
-      CGAL_assertion(rl != rr);
+      assert(r == rl);
+      assert(rl != rr);
 
-      CGAL_assertion( ftd(r * Root_of_1(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
-      CGAL_assertion( ftd(r * T(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
+      assert( ftd(r * Root_of_1(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
+      assert( ftd(r * T(2)) == ftd(CGAL::make_root_of_2(T(0),T(-2),T(2))));
     }
 
    
     {
       Root_of_2 r  = ftd(make_sqrt(T(2))); //sqrt(2)
       Root_of_2 rr = ftd(make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      CGAL_assertion(r == rr);
+      assert(r == rr);
     }{
       Root_of_2 r  = ftd(CGAL::make_sqrt(T(2))); //sqrt(2)
       Root_of_2 rr = ftd(CGAL::make_root_of_2(T(1),T(0),T(-2),false)); //+sqrt(2)
-      CGAL_assertion(r == rr);
+      assert(r == rr);
     }
 
     {
       Root_of_2 r  = ftd(inverse(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(1/ftd(CGAL::make_sqrt(T(2))));
-      CGAL_assertion(r == rr);
+      assert(r == rr);
     }{
         Root_of_2 r  = ftd(CGAL::inverse(ftd(CGAL::make_sqrt(T(2)))));
         Root_of_2 rr = ftd(1/ftd(CGAL::make_sqrt(T(2))));
-        CGAL_assertion(r == rr);
+        assert(r == rr);
     }
 
     {
       Root_of_2 r  = ftd(square(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(ftd(CGAL::make_sqrt(T(2)))*ftd(CGAL::make_sqrt(T(2))));
-      CGAL_assertion(r == rr);
+      assert(r == rr);
     }{
       Root_of_2 r  = ftd(CGAL::square(ftd(CGAL::make_sqrt(T(2)))));
       Root_of_2 rr = ftd(ftd(CGAL::make_sqrt(T(2)))*ftd(CGAL::make_sqrt(T(2))));
-      CGAL_assertion(r == rr);
+      assert(r == rr);
     }
 
     bool is_not_exact = !CGAL::Algebraic_structure_traits<T>::Is_exact::value; 
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(0),T(-2),std::back_inserter(roots));
-      CGAL_assertion(roots.size()==2);
-      CGAL_assertion(roots[0]==-CGAL::make_sqrt(T(2)) || is_not_exact );
-      CGAL_assertion(roots[1]== CGAL::make_sqrt(T(2)) || is_not_exact );
+      assert(roots.size()==2);
+      assert(roots[0]==-CGAL::make_sqrt(T(2)) || is_not_exact );
+      assert(roots[1]== CGAL::make_sqrt(T(2)) || is_not_exact );
     }  
     {
       Root_of_2 roots[2]= {Root_of_2(1),Root_of_2(1)};
       CGAL::compute_roots_of_2(T(13),T(4),T(-23),roots); 
-      CGAL_assertion(roots[0]==CGAL::make_root_of_2(T(13),T(4),T(-23),true)  || is_not_exact );
-      CGAL_assertion(roots[1]==CGAL::make_root_of_2(T(13),T(4),T(-23),false) || is_not_exact );
+      assert(roots[0]==CGAL::make_root_of_2(T(13),T(4),T(-23),true)  || is_not_exact );
+      assert(roots[1]==CGAL::make_root_of_2(T(13),T(4),T(-23),false) || is_not_exact );
     }   
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(-6),T(9),std::back_inserter(roots));
-      CGAL_assertion(roots.size()==1);
-      CGAL_assertion(roots[0]==Root_of_2(3) || is_not_exact );
+      assert(roots.size()==1);
+      assert(roots[0]==Root_of_2(3) || is_not_exact );
     }  
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(1),T(0),T(2),std::back_inserter(roots));
-      CGAL_assertion(roots.size()==0);
+      assert(roots.size()==0);
     } 
     {
       std::vector<Root_of_2> roots;
       CGAL::compute_roots_of_2(T(0),T(2),T(3),std::back_inserter(roots));
-      CGAL_assertion(roots.size()==1);
-      CGAL_assertion(roots[0]==-Root_of_2(3)/Root_of_2(2) || is_not_exact );
+      assert(roots.size()==1);
+      assert(roots[0]==-Root_of_2(3)/Root_of_2(2) || is_not_exact );
     } 
     
 }

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Scale_space_surface_reconstruction_3_impl.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Scale_space_surface_reconstruction_3_impl.h
@@ -712,7 +712,7 @@ detect_bubbles(FT border_angle) {
 		    {
 		      unsigned int i0 = (i + j + 1)%4;
 		      unsigned int i1 = (i + (j+1)%3 + 1)%4;
-		      assert (i0 != i && i1 != i);
+                      CGAL_assertion (i0 != i && i1 != i);
 		      Edge edge (c, i0, i1);
 
 		      if (_shape->classify (edge) != Shape::REGULAR)


### PR DESCRIPTION
This is a fix for #295 
Replaces assert() by CGAL_assertion() in the non-test header files, and CGAL_assertion() by assert in test header files.