### PR TITLE
Polyhedron demo: Bugfix (missing UI include)

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_xyz_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_xyz_plugin.cpp
@@ -1,7 +1,4 @@
 #include "Scene_points_with_normal_item.h"
-#include "Scene_polyhedron_item.h"
-#include "Scene_polygon_soup_item.h"
-#include "Polyhedron_type.h"
 #include "Kernel_type.h"
 
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -7,8 +7,6 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
-
-
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <CGAL/Triangulation_face_base_with_info_2.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
@@ -30,6 +28,8 @@
 #include <QDialog>
 
 #include <boost/foreach.hpp>
+
+#include "ui_Polyhedron_demo_statistics_on_polyhedron_dialog.h"
 
 
 namespace PMP = CGAL::Polygon_mesh_processing;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -17,8 +17,6 @@
 
 #include <QColor>
 
-#include "ui_Polyhedron_demo_statistics_on_polyhedron_dialog.h"
-
 class QMenu;
 
 // This class represents a polyhedron in the OpenGL scene


### PR DESCRIPTION
Move the include of the UI file of statistics_on_polyhedron from _Scene_polyhedron_item.h_ to _Scene_polyhedron_item.cpp_ (this caused the bug https://github.com/CGAL/cgal/issues/438 when plugins were including the polyhedron item header).

Also remove some useless includes in _xyz_plugin_.