### PR TITLE
Fix for std::sqrt in Mesh_processing

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -100,7 +100,7 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
     , choose_param(get_param(np, vertex_point), get(CGAL::vertex_point, pmesh))
     , normal);
  
-  return normal / std::sqrt(normal * normal);
+  return normal / CGAL::sqrt(normal * normal);
 }
 
 /**
@@ -183,12 +183,12 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
     if (!is_border(he, pmesh))
     {
       Vector n = compute_face_normal(face(he, pmesh), pmesh, np);
-      normal = normal + (n / std::sqrt(n*n));
+      normal = normal + (n / CGAL::sqrt(n*n));
     }
     he = opposite(next(he, pmesh), pmesh);
   } while (he != end);
 
-  return normal / std::sqrt(normal * normal);
+  return normal / CGAL::sqrt(normal * normal);
 }
 
 /**

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -41,8 +41,8 @@ triangle_grid_sampling(const typename Kernel::Point_3& p0,
                 double distance,
                 OutputIterator out)
 {
-  const double d_p0p1 = std::sqrt( CGAL::squared_distance(p0, p1) );
-  const double d_p0p2 = std::sqrt( CGAL::squared_distance(p0, p2) );
+  const double d_p0p1 = CGAL::sqrt( CGAL::squared_distance(p0, p1) );
+  const double d_p0p2 = CGAL::sqrt( CGAL::squared_distance(p0, p2) );
 
   const double n = (std::max)(std::ceil( d_p0p1 / distance ),
                                    std::ceil( d_p0p2 / distance ));
@@ -88,7 +88,7 @@ sample_triangles(const TriangleRange& triangles, double distance, OutputIterator
       const Point_3& p1=t[(i+1)%3];
       if ( sampled_edges.insert(CGAL::make_sorted_pair(p0, p1)).second )
       {
-        const double d_p0p1 = std::sqrt( CGAL::squared_distance(p0, p1) );
+        const double d_p0p1 = CGAL::sqrt( CGAL::squared_distance(p0, p1) );
 
         const double nb_pts = std::ceil( d_p0p1 / distance );
         const Vector_3 step_vec = (p1 - p0) / nb_pts;
@@ -139,7 +139,7 @@ double approximated_Hausdorff_distance(
   double hdist = 0;
   BOOST_FOREACH(const typename Kernel::Point_3& pt, sample_points)
   {
-    double d = std::sqrt( tree.squared_distance(pt) );
+    double d = CGAL::sqrt( tree.squared_distance(pt) );
     // if ( d > 1e-1 ) std::cout << pt << "\n";
     if (d>hdist) hdist=d;
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -260,7 +260,7 @@ private:
       ang_max = (std::max)(ang_max, angle);
     }
    
-    w = std::make_pair(ang_max, std::sqrt(CGAL::squared_area(P[i],P[j],P[k])));
+    w = std::make_pair(ang_max, CGAL::sqrt(CGAL::squared_area(P[i],P[j],P[k])));
   }
 
 public:
@@ -330,7 +330,7 @@ private:
       // check whether the edge is border
       bool border = (v0 + 1 == v1) || (v0 == n-1 && v1 == 0);
       if(!border) {
-        total_length += std::sqrt(CGAL::squared_distance(P[v0],P[v1]));
+        total_length += CGAL::sqrt(CGAL::squared_distance(P[v0],P[v1]));
       }
     }
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Weights.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Weights.h
@@ -49,10 +49,10 @@ public:
     double e0_square = vec0.squared_length();
     double e1_square = vec1.squared_length();
     double e2_square = vec2.squared_length();
-    double e0 = std::sqrt(e0_square); 
-    double e2 = std::sqrt(e2_square);
+    double e0 = CGAL::sqrt(e0_square);
+    double e2 = CGAL::sqrt(e2_square);
     double cos_angle = ( e0_square + e2_square - e1_square ) / 2.0 / e0 / e2;
-    double sin_angle = std::sqrt(1-cos_angle*cos_angle);
+    double sin_angle = CGAL::sqrt(1-cos_angle*cos_angle);
 
     return (cos_angle/sin_angle);
   }
@@ -100,10 +100,10 @@ public:
     // rewritten for safer fp arithmetic
     //double dot_aa = a.squared_length();
     //double dot_bb = b.squared_length();
-    //double divider = std::sqrt( dot_aa * dot_bb - dot_ab * dot_ab );
+    //double divider = CGAL::sqrt( dot_aa * dot_bb - dot_ab * dot_ab );
 
     Vector cross_ab = CGAL::cross_product(a, b);
-    double divider = std::sqrt(cross_ab*cross_ab);
+    double divider = CGAL::sqrt(cross_ab*cross_ab);
 
     if(divider == 0 /*|| divider != divider*/) 
     {
@@ -273,7 +273,7 @@ public:
         voronoi_area += (1.0 / 8.0) * (term1 + term2);
       }
       else {
-        double area_t = std::sqrt(squared_area(v0_p, v1_p, v_op_p));
+        double area_t = CGAL::sqrt(squared_area(v0_p, v1_p, v_op_p));
         if(angle0 == CGAL::OBTUSE) {
           voronoi_area += area_t / 2.0;
         }
@@ -312,7 +312,7 @@ public:
   double operator()(vertex_descriptor v0, vertex_descriptor v1, vertex_descriptor v2)
   {
     return CotangentValue::operator()(v0, v1, v2)
-      / std::sqrt(squared_area(v0->point(), v1->point(), v2->point()));
+      / CGAL::sqrt(squared_area(v0->point(), v1->point(), v2->point()));
   }
 };
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -456,7 +456,7 @@ public:
     vertex_descriptor v0 = target(he, pmesh());
     vertex_descriptor v1 = source(he, pmesh());
     Vector vec = v0->point() - v1->point();
-    double norm = std::sqrt( vec.squared_length() );
+    double norm = CGAL::sqrt( vec.squared_length() );
 
     // Only one triangle for border edges
     if ( is_border_edge(he, pmesh()) )
@@ -492,8 +492,8 @@ private:
     double e0_square = vec0.squared_length();
     double e1_square = vec1.squared_length();
     double e2_square = vec2.squared_length();
-    double e0 = std::sqrt(e0_square); 
-    double e2 = std::sqrt(e2_square);
+    double e0 = CGAL::sqrt(e0_square);
+    double e2 = CGAL::sqrt(e2_square);
     double cos_angle = ( e0_square + e2_square - e1_square ) / 2.0 / e0 / e2;
     cos_angle = (std::max)(-1.0, (std::min)(1.0, cos_angle)); // clamp into [-1, 1]
     double angle = acos(cos_angle);
@@ -512,8 +512,8 @@ private:
     double dot_aa_bb = dot_aa * dot_bb;
 
     double cos_rep = dot_ab;
-    double sin_rep = std::sqrt(dot_aa_bb  - dot_ab * dot_ab);
-    double normalizer = std::sqrt(dot_aa_bb); // |a|*|b|
+    double sin_rep = CGAL::sqrt(dot_aa_bb  - dot_ab * dot_ab);
+    double normalizer = CGAL::sqrt(dot_aa_bb); // |a|*|b|
 
     return (normalizer - cos_rep) / sin_rep; // formula from [Floater04] page 4
                                              // tan(Q/2) = (1 - cos(Q)) / sin(Q)
@@ -590,7 +590,7 @@ public:
   double w_ij(halfedge_descriptor he)
   {
     Vector v = target(he, pmesh())->point() - source(he, pmesh())->point();
-    double divider = std::sqrt(v.squared_length());
+    double divider = CGAL::sqrt(v.squared_length());
     if(divider == 0.0) {
       CGAL_warning(!"Scale dependent weight - zero length edge.");
       return (std::numeric_limits<double>::max)();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
@@ -113,9 +113,9 @@ private:
       vertex_descriptor vk = target(prev(halfedge(fd,pmesh),pmesh),pmesh);
       Point_3 c = CGAL::centroid(vpmap[vi], vpmap[vj], vpmap[vk]);
       double sac  = (scale_attribute[vi] + scale_attribute[vj] + scale_attribute[vk])/3.0;
-      double dist_c_vi = std::sqrt(CGAL::squared_distance(c,vpmap[vi]));
-      double dist_c_vj = std::sqrt(CGAL::squared_distance(c,vpmap[vj]));
-      double dist_c_vk = std::sqrt(CGAL::squared_distance(c,vpmap[vk]));
+      double dist_c_vi = CGAL::sqrt(CGAL::squared_distance(c,vpmap[vi]));
+      double dist_c_vj = CGAL::sqrt(CGAL::squared_distance(c,vpmap[vj]));
+      double dist_c_vk = CGAL::sqrt(CGAL::squared_distance(c,vpmap[vk]));
       if((alpha * dist_c_vi > sac) &&
          (alpha * dist_c_vj > sac) &&
          (alpha * dist_c_vk > sac) &&
@@ -218,7 +218,7 @@ private:
       }
 
       const Point_3& vq = vpmap[target(opposite(*circ,pmesh),pmesh)];
-      sum += std::sqrt(CGAL::squared_distance(vp, vq));
+      sum += CGAL::sqrt(CGAL::squared_distance(vp, vq));
       ++deg;
     } while(++circ != done);
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
@@ -94,7 +94,7 @@ CGAL::internal::Weight_min_max_dihedral_and_area
       ang_max = (std::max)(angle, ang_max);
     }
 
-    double area = std::sqrt(CGAL::squared_area(ppmap[target(edge_it,poly)],
+    double area = CGAL::sqrt(CGAL::squared_area(ppmap[target(edge_it,poly)],
                                                ppmap[target(next(edge_it,poly),poly)],
                                                ppmap[target(prev(edge_it,poly),poly)]));
     res = res + Weight(ang_max,area);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_test.cpp
@@ -93,7 +93,7 @@ CGAL::internal::Weight_min_max_dihedral_and_area
       ang_max = (std::max)(angle, ang_max);
     }
 
-    double area = std::sqrt(CGAL::squared_area(ppmap[target(edge_it,poly)],
+    double area = CGAL::sqrt(CGAL::squared_area(ppmap[target(edge_it,poly)],
                                                ppmap[target(next(edge_it,poly),poly)],
                                                ppmap[target(prev(edge_it,poly),poly)]));
     res = res + Weight(ang_max,area);


### PR DESCRIPTION
This is a fix for #436 
- replaces all the std::sqrt by CGAL::sqrt

