### PR TITLE
Introduces a CGAL_destructor_assertion macro.

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -412,7 +412,7 @@ namespace CGAL {
     /// Destructor.
     ~CMap_non_basic_iterator()
     {
-      CGAL_assertion( this->mmark_number!=Map::INVALID_MARK );
+      CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved
           (this->mmark_number)==1)
         unmark_treated_darts();

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -410,7 +410,7 @@ namespace CGAL {
     {}
 
     /// Destructor.
-    ~CMap_non_basic_iterator()
+    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(false)
     {
       CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -410,7 +410,7 @@ namespace CGAL {
     {}
 
     /// Destructor.
-    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(false)
+    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
     {
       CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -410,7 +410,7 @@ namespace CGAL {
     {}
 
     /// Destructor.
-    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
+    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
     {
       CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
@@ -40,6 +40,11 @@ There are five types of checks.
 <LI><B>Static assertions</B>
       are compile-time assertions, used <I>e.g.</I> to verify the values of compile-time
       constants or compare types for (in)equality.
+<LI><B>Destructor assertions</B>
+      These are checks which can be made within normal clean up of an object.
+      A special macro `CGAL_destructor_assertion` is provided to ensure these
+      checks are not made when the object is being cleaned up during exception
+      handling.
 </UL>
 
 The according macro names all have the format `CGAL_<check_type>` where
@@ -50,6 +55,7 @@ The according macro names all have the format `CGAL_<check_type>` where
  <LI>`assertion`
  <LI>`warning`
  <LI>`static_assertion`
+ <LI>`destructor_assertion`
 </UL>
 
 Failures of the first three types are errors and lead to a halt of the
@@ -235,6 +241,10 @@ safety are: Appendix E of \cgalCite{cgal:s-cpl-97} (also available at
 <A HREF="http://www.research.att.com/~bs/3rd_safe0.html"><TT>http://www.research.att.com/~bs/3rd_safe0.html</TT></A>),
 and \cgalCite{cgal:a-esgc-98} (also available at
 <A HREF="http://www.boost.org/more/generic_exception_safety.html"><TT>http://www.boost.org/more/generic_exception_safety.html</TT></A>).
+Any destructor which might throw an exception, including a destructor which
+uses the `CGAL_destructor_assertion` macro, should be marked with the
+`CGAL_NOEXCEPT(false)` macro. This macro provides future compatibility with
+C++11 and above, which provides the `noexcept` keyword.
 
 \section secchecks_req_and_rec Requirements and recommendations 
 

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -464,7 +464,7 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 } //namespace CGAL
 
 //Support for c++11 noexcept
-#ifdef CGAL_CXX11
+#if BOOST_VERSION > 104600 && !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_NOEXCEPT)
 #define CGAL_NOEXCEPT(x) noexcept(x)
 #else
 #define CGAL_NOEXCEPT(x)

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -470,4 +470,10 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 #define CGAL_NOEXCEPT(x)
 #endif
 
+#ifndef CGAL_NO_ASSERTIONS
+#  define CGAL_NO_ASSERTIONS_BOOL false
+#else
+#  define CGAL_NO_ASSERTIONS_BOOL true
+#endif
+
 #endif // CGAL_CONFIG_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -463,4 +463,11 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 
 } //namespace CGAL
 
+//Support for c++11 noexcept
+#ifdef CGAL_CXX11
+#define CGAL_NOEXCEPT(x) noexcept(x)
+#else
+#define CGAL_NOEXCEPT(x)
+#endif
+
 #endif // CGAL_CONFIG_H

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
@@ -51,7 +51,7 @@ public:
     return reference_count_ != 0;
   }
 
-  virtual ~Ref_counted_base() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
+  virtual ~Ref_counted_base() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
   {
     CGAL_destructor_assertion(reference_count_==0);
   }

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
@@ -52,7 +52,7 @@ public:
   }
 
   virtual ~Ref_counted_base() {
-    CGAL_assertion(reference_count_==0);
+    CGAL_destructor_assertion(reference_count_==0);
   }
 
   friend void intrusive_ptr_release(const This *t);

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
@@ -51,7 +51,8 @@ public:
     return reference_count_ != 0;
   }
 
-  virtual ~Ref_counted_base() {
+  virtual ~Ref_counted_base() CGAL_NOEXCEPT(false)
+  {
     CGAL_destructor_assertion(reference_count_==0);
   }
 

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Ref_counted.h
@@ -51,7 +51,7 @@ public:
     return reference_count_ != 0;
   }
 
-  virtual ~Ref_counted_base() CGAL_NOEXCEPT(false)
+  virtual ~Ref_counted_base() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
   {
     CGAL_destructor_assertion(reference_count_==0);
   }

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -195,7 +195,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(false)
+    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -195,7 +195,8 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Polyhedron_incremental_builder_3() {
+    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(false)
+    {
         CGAL_destructor_assertion( check_protocoll == 0);
     }
 

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -195,7 +195,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
+    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -196,7 +196,7 @@ public:
     }
 
     ~Polyhedron_incremental_builder_3() {
-        CGAL_assertion( check_protocoll == 0);
+        CGAL_destructor_assertion( check_protocoll == 0);
     }
 
 // OPERATIONS

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -80,6 +80,7 @@ inline bool possibly(Uncertain<bool> c);
 
 #if defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_assertion(EX) (static_cast<void>(0))
+#  define CGAL_destructor_assertion(EX) (static_cast<void>(0))
 #  define CGAL_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_assertion_code(CODE)
 #  ifdef CGAL_ASSUME
@@ -92,6 +93,8 @@ inline bool possibly(Uncertain<bool> c);
 #else // no CGAL_NO_ASSERTIONS
 #  define CGAL_assertion(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
+#  define CGAL_destructor_assertion(EX) \
+   (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
 #  define CGAL_assertion_msg(EX,MSG) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__, MSG))
 #  define CGAL_assertion_code(CODE) CODE

--- a/Surface_mesher/include/CGAL/builder.h
+++ b/Surface_mesher/include/CGAL/builder.h
@@ -195,7 +195,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
+    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Surface_mesher/include/CGAL/builder.h
+++ b/Surface_mesher/include/CGAL/builder.h
@@ -195,7 +195,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(false)
+    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Surface_mesher/include/CGAL/builder.h
+++ b/Surface_mesher/include/CGAL/builder.h
@@ -195,7 +195,8 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Enriched_polyhedron_incremental_builder_3() {
+    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(false)
+    {
         CGAL_destructor_assertion( check_protocoll == 0);
     }
 

--- a/Surface_mesher/include/CGAL/builder.h
+++ b/Surface_mesher/include/CGAL/builder.h
@@ -196,7 +196,7 @@ public:
     }
 
     ~Enriched_polyhedron_incremental_builder_3() {
-        CGAL_assertion( check_protocoll == 0);
+        CGAL_destructor_assertion( check_protocoll == 0);
     }
 
 // OPERATIONS


### PR DESCRIPTION
**The problem:**  Throwing an exception from a destructor can cause problems since the callee is unable to catch an exception raised while the stack is unwinding. The result is the application will terminate with a hard crash.

**Consequence:** Since the exception is uncatchable, the program will terminate, but also the real exception is hidden by the the destructor exception.

**Solution:** Its desirable to not throw exceptions from the destructor if and only if an existing exception has not been caught, and the stack is unwinding. For this purpose I propose  a new macro that can safely be called from a destructor, even when the stack is currently unwinding. The macro makes use of `std::uncaught_exception()` and results in a nop when this is the case.

Additional discussions about this issue and what problems it can cause for client applications (rapcad and openscad) is detailed here: https://github.com/openscad/openscad/issues/410, there was also a discussion about the issue here: http://cgal-discuss.949826.n4.nabble.com/Uncatchable-exception-converting-from-Nef-polyhedron-to-Polyhedron-3-td4658603.html

Another instance of the same problem present in the openscad project: https://github.com/openscad/openscad/issues/1455