### PR TITLE
Bugfix: unselect all points when reading PLY files

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -297,6 +297,7 @@ bool Scene_points_with_normal_item::read_ply_point_set(std::istream& stream)
             }
         }
     }
+  m_points->unselect_all();  
   invalidate_buffers();
   return ok;
 }


### PR DESCRIPTION
New selection behavior in Polyhedron demo and PLY reader were developed in parallel branches and new selection behavior was not taken into account when merging PLY reader.

When reading a point set, _m_points->unselect_all()_ must be called (otherwise the selection iterator is undefined, causing a segfault). This was done for _off_ and _xyz_, this branch adds it to the _ply_ reader.