### PR TITLE
Fix warnings: use CGAL_CORE_EXPORT instead of CGAL_EXPORT

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/CoreDefs.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreDefs.h
@@ -52,7 +52,7 @@
 #else // CGAL_HEADER_ONLY
 
   #define CGAL_GLOBAL_STATE_VAR(TYPE, NAME, VALUE)  \
-    CGAL_EXPORT extern TYPE NAME;                   \
+    CGAL_CORE_EXPORT extern TYPE NAME;                   \
     inline TYPE& get_static_##NAME()                \
     {                                               \
       return NAME;                                  \


### PR DESCRIPTION
This was a typo introduced by the header-only branch.