### PR TITLE
Polyhedron demo: Enhance RANSAC display

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -457,7 +457,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   
   qt5_wrap_ui(point_set_shape_detectionUI_FILES Polyhedron_demo_point_set_shape_detection_plugin.ui)
   polyhedron_demo_plugin(point_set_shape_detection_plugin Polyhedron_demo_point_set_shape_detection_plugin ${point_set_shape_detectionUI_FILES})
-  target_link_libraries(point_set_shape_detection_plugin scene_polyhedron_item scene_points_with_normal_item)
+  target_link_libraries(point_set_shape_detection_plugin scene_polygon_soup_item  scene_points_with_normal_item)
 
   qt5_wrap_ui(point_set_wlopFILES Polyhedron_demo_point_set_wlop_plugin.ui)
   polyhedron_demo_plugin(point_set_wlop_plugin Polyhedron_demo_point_set_wlop_plugin ${point_set_wlopFILES})

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -457,7 +457,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   
   qt5_wrap_ui(point_set_shape_detectionUI_FILES Polyhedron_demo_point_set_shape_detection_plugin.ui)
   polyhedron_demo_plugin(point_set_shape_detection_plugin Polyhedron_demo_point_set_shape_detection_plugin ${point_set_shape_detectionUI_FILES})
-  target_link_libraries(point_set_shape_detection_plugin scene_polygon_soup_item  scene_points_with_normal_item)
+  target_link_libraries(point_set_shape_detection_plugin scene_polygon_soup_item scene_polyhedron_item  scene_points_with_normal_item)
 
   qt5_wrap_ui(point_set_wlopFILES Polyhedron_demo_point_set_wlop_plugin.ui)
   polyhedron_demo_plugin(point_set_wlop_plugin Polyhedron_demo_point_set_wlop_plugin ${point_set_wlopFILES})

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
@@ -206,7 +206,8 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
                                  poly_item, dialog.cluster_epsilon());
           
               poly_item->setRbgColor(r-32, g-32, b-32);
-              poly_item->setName(QString("%1alpha_shape").arg(QString::fromStdString(ss.str())));
+              poly_item->setName(QString("%1%2_alpha_shape").arg(QString::fromStdString(ss.str()))
+                                 .arg (QString::number (shape->indices_of_assigned_points().size())));
               poly_item->setRenderingMode (Flat);
               scene->addItem(poly_item);
             }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
@@ -89,7 +89,9 @@ public:
   bool detect_sphere() const { return sphereCB->isChecked(); } 
   bool detect_cylinder() const { return cylinderCB->isChecked(); } 
   bool detect_torus() const { return torusCB->isChecked(); } 
-  bool detect_cone() const { return coneCB->isChecked(); } 
+  bool detect_cone() const { return coneCB->isChecked(); }
+  bool generate_alpha() const { return m_generate_alpha->isChecked(); }
+  bool generate_subset() const { return !(m_do_not_generate_subset->isChecked()); }
 };
 
 void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered() {
@@ -193,18 +195,20 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
         {
           ss << item->name().toStdString() << "_plane_";
 
-          // If plane, build alpha shape
-          Scene_polygon_soup_item* soup_item = new Scene_polygon_soup_item;
+          if (dialog.generate_alpha ())
+            {
+              // If plane, build alpha shape
+              Scene_polygon_soup_item* soup_item = new Scene_polygon_soup_item;
 
-          Plane_3 plane = (Plane_3)(*(dynamic_cast<CGAL::Shape_detection_3::Plane<Traits>*>(shape.get ())));
-          build_alpha_shape (*(point_item->point_set()), plane,
-                             soup_item, dialog.cluster_epsilon());
+              Plane_3 plane = (Plane_3)(*(dynamic_cast<CGAL::Shape_detection_3::Plane<Traits>*>(shape.get ())));
+              build_alpha_shape (*(point_item->point_set()), plane,
+                                 soup_item, dialog.cluster_epsilon());
           
-          soup_item->setRbgColor(r-32, g-32, b-32);
-          soup_item->setName(QString("%1alpha_shape").arg(QString::fromStdString(ss.str())));
-          soup_item->setRenderingMode (Flat);
-          scene->addItem(soup_item);
-
+              soup_item->setRbgColor(r-32, g-32, b-32);
+              soup_item->setName(QString("%1alpha_shape").arg(QString::fromStdString(ss.str())));
+              soup_item->setRenderingMode (Flat);
+              scene->addItem(soup_item);
+            }
         }
       else if (dynamic_cast<CGAL::Shape_detection_3::Cone<Traits> *>(shape.get()))
         ss << item->name().toStdString() << "_cone_";
@@ -220,7 +224,10 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
       point_item->setName(QString::fromStdString(ss.str()));
       point_item->set_has_normals(true);
       point_item->setRenderingMode(item->renderingMode());
-      scene->addItem(point_item);
+      if (dialog.generate_subset())
+        scene->addItem(point_item);
+      else
+        delete point_item;
 
       ++index;
     }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>444</width>
-    <height>205</height>
+    <height>269</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -196,6 +196,20 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="m_generate_alpha">
+     <property name="text">
+      <string>Generate alpha shapes for planes</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="m_do_not_generate_subset">
+     <property name="text">
+      <string>Do not generate point subsets</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
Additional option for the _point_set_shape_detection plugin_: for a plane, construct alpha shape of the points projected on the detected plane (stored in the form of a _Scene_polyhedron_item_). This is how RANSAC plane detection results are commonly displayed in literature.

This has not been tested yet (merged on _integration_ today).