### PR TITLE
Polyhedron demo: optimisation for VBOs/VBAs

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
@@ -344,17 +344,17 @@ void Scene_combinatorial_map_item::initialize_buffers(CGAL::Three::Viewer_interf
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_lines.data(),
+        vaos[Edges]->bind();
+        buffers[Edges_vertices].bind();
+        buffers[Edges_vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[0].release();
+        buffers[Edges_vertices].release();
         nb_lines = positions_lines.size();
         positions_lines.resize(0);
         std::vector<double>(positions_lines).swap(positions_lines);
-        vaos[0]->release();
+        vaos[Edges]->release();
         program->release();
     }
     //vao for the points
@@ -362,14 +362,14 @@ void Scene_combinatorial_map_item::initialize_buffers(CGAL::Three::Viewer_interf
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[1]->bind();
-        buffers[1].bind();
-        buffers[1].allocate(positions_points.data(),
+        vaos[Points]->bind();
+        buffers[Points_vertices].bind();
+        buffers[Points_vertices].allocate(positions_points.data(),
                             static_cast<int>(positions_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[1].release();
-        vaos[1]->release();
+        buffers[Points_vertices].release();
+        vaos[Points]->release();
         nb_points = positions_points.size();
         positions_points.resize(0);
         std::vector<double>(positions_points).swap(positions_points);
@@ -380,26 +380,26 @@ void Scene_combinatorial_map_item::initialize_buffers(CGAL::Three::Viewer_interf
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
 
-        vaos[2]->bind();
-        buffers[2].bind();
-        buffers[2].allocate(positions_facets.data(),
+        vaos[Facets]->bind();
+        buffers[Facets_vertices].bind();
+        buffers[Facets_vertices].allocate(positions_facets.data(),
                             static_cast<int>(positions_facets.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[2].release();
+        buffers[Facets_vertices].release();
 
-        buffers[3].bind();
-        buffers[3].allocate(normals.data(),
+        buffers[Facets_normals].bind();
+        buffers[Facets_normals].allocate(normals.data(),
                             static_cast<int>(normals.size()*sizeof(double)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
-        buffers[3].release();
+        buffers[Facets_normals].release();
         nb_facets = positions_facets.size();
         positions_facets.resize(0);
         std::vector<double>(positions_facets).swap(positions_facets);
         normals.resize(0);
         std::vector<double>(normals).swap(normals);
-        vaos[2]->release();
+        vaos[Facets]->release();
         program->release();
     }
     are_buffers_filled = true;
@@ -474,13 +474,13 @@ void Scene_combinatorial_map_item::draw(CGAL::Three::Viewer_interface* viewer) c
         compute_elements();
         initialize_buffers(viewer);
     }
-    vaos[2]->bind();
+    vaos[Facets]->bind();
     program=getShaderProgram(PROGRAM_WITH_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITH_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/3));
-    vaos[2]->release();
+    vaos[Facets]->release();
     program->release();
 
 }
@@ -491,13 +491,13 @@ void Scene_combinatorial_map_item::draw(CGAL::Three::Viewer_interface* viewer) c
          compute_elements();
          initialize_buffers(viewer);
      }
-     vaos[0]->bind();
+     vaos[Edges]->bind();
      program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
      attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
      program->bind();
      program->setAttributeValue("colors", this->color());
      viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
-     vaos[0]->release();
+     vaos[Edges]->release();
      program->release();
 
 }
@@ -508,13 +508,13 @@ void Scene_combinatorial_map_item::draw(CGAL::Three::Viewer_interface* viewer) c
          compute_elements();
          initialize_buffers(viewer);
      }
-     vaos[1]->bind();
+     vaos[Points]->bind();
      program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
      attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
      program->bind();
      program->setAttributeValue("colors", this->color());
      viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
-     vaos[1]->release();
+     vaos[Points]->release();
      program->release();
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.h
@@ -74,6 +74,19 @@ private:
     void* address_of_A;
     template <class Predicate> void export_as_polyhedron(Predicate,const QString&) const;
 
+   enum VAOs {
+       Edges = 0,
+       Points,
+       Facets,
+       NbOfVaos = Facets +1
+   };
+   enum VBOs {
+       Edges_vertices = 0,
+       Points_vertices,
+       Facets_vertices,
+       Facets_normals,
+       NbOfVbos = Facets_normals +1
+   };
 
    mutable std::vector<double> positions_lines;
    mutable std::vector<double> positions_points;

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.cpp
@@ -9,7 +9,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
 (Scene_polyhedron_item* poly_item,
  Ui::DeformMesh* ui_widget,
  QMainWindow* mw)
-  : Scene_item(19,8),
+  : Scene_item(NumberOfBuffers,8),
     ui_widget(ui_widget),
     poly_item(poly_item),
     deform_mesh(*(poly_item->polyhedron()), Deform_mesh::Vertex_index_map(), Deform_mesh::Hedge_index_map(), Array_based_vertex_point_map(&positions)),
@@ -133,19 +133,19 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program->bind();
 
         vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions.data(),
+        buffers[Facet_vertices].bind();
+        buffers[Facet_vertices].allocate(positions.data(),
                             static_cast<int>(positions.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[0].release();
+        buffers[Facet_vertices].release();
 
-        buffers[1].bind();
-        buffers[1].allocate(normals.data(),
+        buffers[Facet_normals].bind();
+        buffers[Facet_normals].allocate(normals.data(),
                             static_cast<int>(normals.size()*sizeof(double)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
-        buffers[1].release();
+        buffers[Facet_normals].release();
         vaos[0]->release();
         program->release();
     }
@@ -153,19 +153,12 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
     {   program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
         vaos[1]->bind();
-        buffers[2].bind();
-        buffers[2].allocate(ROI_points.data(),
+        buffers[Roi_points].bind();
+        buffers[Roi_points].allocate(ROI_points.data(),
                             static_cast<int>(ROI_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[2].release();
-
-        buffers[3].bind();
-        buffers[3].allocate(ROI_color.data(),
-                            static_cast<int>(ROI_color.size()*sizeof(double)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[3].release();
+        buffers[Roi_points].release();
         vaos[1]->release();
 
         program->release();
@@ -176,13 +169,10 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
         vaos[2]->bind();
-        buffers[4].bind();
-        buffers[4].allocate(positions.data(),
-                            static_cast<int>(positions.size()*sizeof(double)));
+        buffers[Facet_vertices].bind();
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[4].release();
-
+        buffers[Facet_vertices].release();
         vaos[2]->release();
         program->release();
     }
@@ -191,33 +181,24 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program = getShaderProgram(PROGRAM_INSTANCED, viewer);
         program->bind();
         vaos[3]->bind();
-        buffers[5].bind();
-        buffers[5].allocate(pos_sphere.data(),
+        buffers[Sphere_vertices].bind();
+        buffers[Sphere_vertices].allocate(pos_sphere.data(),
                             static_cast<int>(pos_sphere.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[5].release();
+        buffers[Sphere_vertices].release();
 
-        buffers[6].bind();
-        buffers[6].allocate(normals_sphere.data(),
+        buffers[Sphere_normals].bind();
+        buffers[Sphere_normals].allocate(normals_sphere.data(),
                             static_cast<int>(normals_sphere.size()*sizeof(double)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
-        buffers[6].release();
+        buffers[Sphere_normals].release();
 
-        buffers[7].bind();
-        buffers[7].allocate(ROI_color.data(),
-                            static_cast<int>(ROI_color.size()*sizeof(double)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[7].release();
-
-        buffers[8].bind();
-        buffers[8].allocate(ROI_points.data(),
-                            static_cast<int>(ROI_points.size()*sizeof(double)));
+        buffers[Roi_points].bind();
         program->enableAttributeArray("center");
         program->setAttributeBuffer("center",GL_DOUBLE,0,3);
-        buffers[8].release();
+        buffers[Roi_points].release();
 
         if(viewer->extension_is_found)
         {
@@ -235,19 +216,13 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
     {
         bbox_program.bind();
         vaos[4]->bind();
-        buffers[9].bind();
-        buffers[9].allocate(pos_bbox.data(),
+        buffers[Bbox_vertices].bind();
+        buffers[Bbox_vertices].allocate(pos_bbox.data(),
                              static_cast<int>(pos_bbox.size()*sizeof(double)));
         bbox_program.enableAttributeArray("vertex");
         bbox_program.setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[9].release();
+        buffers[Bbox_vertices].release();
 
-        buffers[10].bind();
-        buffers[10].allocate(color_bbox.data(),
-                             static_cast<int>(color_bbox.size()*sizeof(double)));
-        bbox_program.enableAttributeArray("colors");
-        bbox_program.setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[10].release();
         vaos[4]->release();
         nb_bbox = pos_bbox.size();
         pos_bbox.resize(0);
@@ -261,19 +236,13 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
         vaos[5]->bind();
-        buffers[11].bind();
-        buffers[11].allocate(control_points.data(),
+        buffers[Control_points].bind();
+        buffers[Control_points].allocate(control_points.data(),
                              static_cast<int>(control_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[11].release();
+        buffers[Control_points].release();
 
-        buffers[12].bind();
-        buffers[12].allocate(control_color.data(),
-                             static_cast<int>(control_color.size()*sizeof(double)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[12].release();
         vaos[5]->release();
         program->release();
     }
@@ -282,38 +251,23 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program = getShaderProgram(PROGRAM_INSTANCED, viewer);
         program->bind();
         vaos[6]->bind();
-        buffers[13].bind();
-        buffers[13].allocate(pos_sphere.data(),
-                             static_cast<int>(pos_sphere.size()*sizeof(double)));
+        buffers[Sphere_vertices].bind();
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[13].release();
 
-        buffers[14].bind();
-        buffers[14].allocate(normals_sphere.data(),
-                             static_cast<int>(normals_sphere.size()*sizeof(double)));
+        buffers[Sphere_normals].bind();
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
-        buffers[14].release();
+        buffers[Sphere_normals].release();
 
-        buffers[15].bind();
-        buffers[15].allocate(control_color.data(),
-                             static_cast<int>(control_color.size()*sizeof(double)));
-        program->enableAttributeArray("colors");
-        program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[15].release();
-
-        buffers[16].bind();
-        buffers[16].allocate(control_points.data(),
-                             static_cast<int>(control_points.size()*sizeof(double)));
+        buffers[Control_points].bind();
         program->enableAttributeArray("center");
         program->setAttributeBuffer("center",GL_DOUBLE,0,3);
-        buffers[16].release();
+        buffers[Control_points].release();
 
         if(viewer->extension_is_found)
         {
             viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
-            viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
         }
         vaos[6]->release();
         nb_sphere = pos_sphere.size();
@@ -332,19 +286,18 @@ void Scene_edit_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interfac
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
         vaos[7]->bind();
-        buffers[17].bind();
-        buffers[17].allocate(pos_axis.data(),
+        buffers[Axis_vertices].bind();
+        buffers[Axis_vertices].allocate(pos_axis.data(),
                              static_cast<int>(pos_axis.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[17].release();
-
-        buffers[18].bind();
-        buffers[18].allocate(color_lines.data(),
+        buffers[Axis_vertices].release();
+        buffers[Axis_colors].bind();
+        buffers[Axis_colors].allocate(color_lines.data(),
                              static_cast<int>(color_lines.size()*sizeof(double)));
         program->enableAttributeArray("colors");
         program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
-        buffers[18].release();
+        buffers[Axis_colors].release();
         vaos[7]->release();
         program->release();
         nb_axis = pos_axis.size();

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
@@ -291,8 +291,8 @@ private:
   {
       Facet_vertices =0,
       Facet_normals,
-      Roi_points,
-      Control_points,
+      Roi_vertices,
+      Control_vertices,
       Sphere_vertices,
       Sphere_normals,
       Bbox_vertices,
@@ -300,7 +300,18 @@ private:
       Axis_colors,
       NumberOfBuffers = Axis_colors+1
   };
-
+  enum Vao
+  {
+      Facets=0,
+      Roi_points,
+      Edges,
+      ROI_spheres,
+      BBox,
+      Control_points,
+      Control_spheres,
+      Axis,
+      NumberOfVaos= Axis+1
+  };
   mutable QOpenGLBuffer *in_bu;
   using Scene_item::initialize_buffers;
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer) const;

--- a/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_edit_polyhedron_item.h
@@ -287,7 +287,19 @@ private:
   mutable std::size_t nb_axis;
   mutable std::size_t nb_bbox;
 
-
+  enum Buffer
+  {
+      Facet_vertices =0,
+      Facet_normals,
+      Roi_points,
+      Control_points,
+      Sphere_vertices,
+      Sphere_normals,
+      Bbox_vertices,
+      Axis_vertices,
+      Axis_colors,
+      NumberOfBuffers = Axis_colors+1
+  };
 
   mutable QOpenGLBuffer *in_bu;
   using Scene_item::initialize_buffers;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -26,59 +26,59 @@ void Scene_implicit_function_item::initialize_buffers(CGAL::Three::Viewer_interf
     {
         program = getShaderProgram(PROGRAM_WITH_TEXTURE, viewer);
         program->bind();
-        vaos[0]->bind();
+        vaos[Plane]->bind();
 
 
-        buffers[0].bind();
-        buffers[0].allocate(positions_tex_quad.data(),
+        buffers[Quad_vertices].bind();
+        buffers[Quad_vertices].allocate(positions_tex_quad.data(),
                             static_cast<int>(positions_tex_quad.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        buffers[0].release();
+        buffers[Quad_vertices].release();
 
-        buffers[1].bind();
-        buffers[1].allocate(texture_map.data(),
+        buffers[TexMap].bind();
+        buffers[TexMap].allocate(texture_map.data(),
                             static_cast<int>(texture_map.size()*sizeof(float)));
         program->enableAttributeArray("v_texCoord");
         program->setAttributeBuffer("v_texCoord",GL_FLOAT,0,2);
-        buffers[1].release();
+        buffers[TexMap].release();
         program->setAttributeValue("normal", QVector3D(0,0,0));
 
         program->release();
-        vaos[0]->release();
+        vaos[Plane]->release();
     }
     //vao fot the bbox
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
-        vaos[1]->bind();
+        vaos[BBox]->bind();
 
 
-        buffers[2].bind();
-        buffers[2].allocate(positions_cube.data(),
+        buffers[Cube_vertices].bind();
+        buffers[Cube_vertices].allocate(positions_cube.data(),
                             static_cast<int>(positions_cube.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        buffers[2].release();
+        buffers[Cube_vertices].release();
 
         program->release();
-        vaos[1]->release();
+        vaos[BBox]->release();
     }
     //vao fot the grid
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
-        vaos[2]->bind();
+        vaos[Grid]->bind();
 
 
-        buffers[3].bind();
-        buffers[3].allocate(positions_grid.data(),
+        buffers[Grid_vertices].bind();
+        buffers[Grid_vertices].allocate(positions_grid.data(),
                             static_cast<int>(positions_grid.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        buffers[3].release();
+        buffers[Grid_vertices].release();
         program->release();
-        vaos[2]->release();
+        vaos[Grid]->release();
     }
 
 
@@ -395,7 +395,7 @@ Scene_implicit_function_item::draw(CGAL::Three::Viewer_interface* viewer) const
             need_update_ = false;
         }
     }
-    vaos[0]->bind();
+    vaos[Plane]->bind();
     viewer->glActiveTexture(GL_TEXTURE0);
     viewer->glBindTexture(GL_TEXTURE_2D, textureId);
     attrib_buffers(viewer, PROGRAM_WITH_TEXTURE);
@@ -413,7 +413,7 @@ Scene_implicit_function_item::draw(CGAL::Three::Viewer_interface* viewer) const
     program->setUniformValue("light_diff", QVector4D(0,0,0,1));
     program->setAttributeValue("color_facets", QVector3D(1.0,1.0,1.0));
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_tex_quad.size()/3));
-    vaos[0]->release();
+    vaos[Plane]->release();
     program->release();
 }
 
@@ -423,14 +423,14 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
     if(!are_buffers_filled)
         initialize_buffers(viewer);
     //  draw_aux(viewer, true);
-    vaos[1]->bind();
+    vaos[BBox]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", QVector3D(0,0,0));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_cube.size()/3));
-    vaos[1]->release();
-    vaos[2]->bind();
+    vaos[BBox]->release();
+    vaos[Grid]->bind();
     QMatrix4x4 f_mat;
     GLdouble d_mat[16];
     frame_->getMatrix(d_mat);
@@ -441,7 +441,7 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
     program->setUniformValue("f_matrix", f_mat);
     program->setAttributeValue("colors", QVector3D(0.6,0.6,0.6));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_grid.size()/3));
-    vaos[2]->release();
+    vaos[Grid]->release();
     program->release();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -61,7 +61,6 @@ void Scene_implicit_function_item::initialize_buffers(CGAL::Three::Viewer_interf
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
         buffers[2].release();
 
-        program->setAttributeValue("colors", QVector3D(0,0,0));
         program->release();
         vaos[1]->release();
     }
@@ -78,7 +77,6 @@ void Scene_implicit_function_item::initialize_buffers(CGAL::Three::Viewer_interf
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
         buffers[3].release();
-        program->setAttributeValue("colors", QVector3D(0.6f, 0.6f, 0.6f));
         program->release();
         vaos[2]->release();
     }
@@ -429,6 +427,7 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
+    program->setAttributeValue("colors", QVector3D(0,0,0));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_cube.size()/3));
     vaos[1]->release();
     vaos[2]->bind();
@@ -440,6 +439,7 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
         f_mat.data()[i] = GLfloat(d_mat[i]);
     }
     program->setUniformValue("f_matrix", f_mat);
+    program->setAttributeValue("colors", QVector3D(0.6,0.6,0.6));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_grid.size()/3));
     vaos[2]->release();
     program->release();

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -93,6 +93,20 @@ private:
   Color_ramp blue_color_ramp_;
   Color_ramp red_color_ramp_;
 
+  enum VAOs {
+      Plane = 0,
+      BBox,
+      Grid,
+      NbOfVaos = Grid +1
+  };
+  enum VBOs {
+      Quad_vertices = 0,
+      TexMap,
+      Cube_vertices,
+      Grid_vertices,
+      NbOfVbos = Grid_vertices +1
+  };
+
   std::vector<float> positions_cube;
   std::vector<float> positions_grid;
   std::vector<float> positions_tex_quad;

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -74,6 +74,19 @@ private:
 
   Nef_polyhedron* nef_poly;
 
+  enum VAOs {
+      Facets = 0,
+      Edges,
+      Points,
+      NbOfVaos = Points +1
+  };
+  enum VBOs {
+      Facets_vertices = 0,
+      Facets_normals,
+      Edges_vertices,
+      Points_vertices,
+      NbOfVbos = Points_vertices +1
+  };
 
   mutable std::vector<double> positions_lines;
   mutable std::vector<double> positions_facets;

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -6,25 +6,25 @@ void Scene_plane_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer)
 {
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
     program->bind();
-    vaos[0]->bind();
+    vaos[Facets]->bind();
 
-    buffers[0].bind();
-    buffers[0].allocate(positions_quad.data(),
+    buffers[Facets_vertices].bind();
+    buffers[Facets_vertices].allocate(positions_quad.data(),
                         static_cast<int>(positions_quad.size()*sizeof(float)));
     program->enableAttributeArray("vertex");
     program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-    buffers[0].release();
-    vaos[0]->release();
+    buffers[Facets_vertices].release();
+    vaos[Facets]->release();
 
 
-    vaos[1]->bind();
-    buffers[1].bind();
-    buffers[1].allocate(positions_lines.data(),
+    vaos[Edges]->bind();
+    buffers[Edges_vertices].bind();
+    buffers[Edges_vertices].allocate(positions_lines.data(),
                         static_cast<int>(positions_lines.size()*sizeof(float)));
     program->enableAttributeArray("vertex");
     program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-    buffers[1].release();
-    vaos[1]->release();
+    buffers[Edges_vertices].release();
+    vaos[Edges]->release();
 
     program->release();
     are_buffers_filled = true;
@@ -95,7 +95,7 @@ void Scene_plane_item::draw(CGAL::Three::Viewer_interface* viewer)const
 {
     if(!are_buffers_filled)
         initialize_buffers(viewer);
-    vaos[0]->bind();
+    vaos[Facets]->bind();
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     QMatrix4x4 f_matrix;
@@ -106,7 +106,7 @@ void Scene_plane_item::draw(CGAL::Three::Viewer_interface* viewer)const
     program->setAttributeValue("colors",this->color());
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_quad.size()/3));
     program->release();
-    vaos[0]->release();
+    vaos[Facets]->release();
 
 }
 
@@ -114,7 +114,7 @@ void Scene_plane_item::draw_edges(CGAL::Three::Viewer_interface* viewer)const
 {
     if(!are_buffers_filled)
         initialize_buffers(viewer);
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     QMatrix4x4 f_matrix;
@@ -125,5 +125,5 @@ void Scene_plane_item::draw_edges(CGAL::Three::Viewer_interface* viewer)const
     program->setAttributeValue("colors",QVector3D(0,0,0));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size()/3));
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -25,7 +25,7 @@ public:
   typedef qglviewer::ManipulatedFrame ManipulatedFrame;
 
   Scene_plane_item(const CGAL::Three::Scene_interface* scene_interface)
-      :Scene_item(2,2),
+      :Scene_item(NbOfVbos,NbOfVaos),
       scene(scene_interface),
       manipulable(false),
       can_clone(true),
@@ -150,6 +150,17 @@ private:
   bool manipulable;
   bool can_clone;
   qglviewer::ManipulatedFrame* frame;
+
+  enum VAOs {
+      Facets = 0,
+      Edges,
+      NbOfVaos = Edges +1
+  };
+  enum VBOs {
+      Facets_vertices = 0,
+      Edges_vertices,
+      NbOfVbos = Edges_vertices +1
+  };
 
   mutable std::vector<float> positions_lines;
   mutable std::vector<float> positions_quad;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -25,7 +25,7 @@
 
 
 Scene_points_with_normal_item::Scene_points_with_normal_item()
-    : Scene_item(3,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
     m_points(new Point_set),
     m_has_normals(false)
 {
@@ -38,7 +38,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item()
 
 // Copy constructor
 Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_with_normal_item& toCopy)
-    : Scene_item(3,3), // do not call superclass' copy constructor
+    :Scene_item(NbOfVbos,NbOfVaos), // do not call superclass' copy constructor
     m_points(new Point_set(*toCopy.m_points)),
     m_has_normals(toCopy.m_has_normals)
 {
@@ -60,7 +60,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_
 
 // Converts polyhedron to point set
 Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& input_mesh)
-    : Scene_item(6,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
     m_points(new Point_set),
     m_has_normals(true)
 {
@@ -102,15 +102,15 @@ void Scene_points_with_normal_item::initialize_buffers(CGAL::Three::Viewer_inter
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_lines.data(),
+        vaos[Edges]->bind();
+        buffers[Edges_vertices].bind();
+        buffers[Edges_vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[0].release();
+        buffers[Edges_vertices].release();
 
-        vaos[0]->release();
+        vaos[Edges]->release();
         nb_lines = positions_lines.size();
         positions_lines.resize(0);
         std::vector<double>(positions_lines).swap(positions_lines);
@@ -121,14 +121,14 @@ void Scene_points_with_normal_item::initialize_buffers(CGAL::Three::Viewer_inter
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[1]->bind();
-        buffers[1].bind();
-        buffers[1].allocate(positions_points.data(),
+        vaos[ThePoints]->bind();
+        buffers[Points_vertices].bind();
+        buffers[Points_vertices].allocate(positions_points.data(),
                             static_cast<int>(positions_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[1].release();
-        vaos[1]->release();
+        buffers[Points_vertices].release();
+        vaos[ThePoints]->release();
         nb_points = positions_points.size();
         positions_points.resize(0);
         std::vector<double>(positions_points).swap(positions_points);
@@ -139,15 +139,15 @@ void Scene_points_with_normal_item::initialize_buffers(CGAL::Three::Viewer_inter
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[2]->bind();
-        buffers[2].bind();
-        buffers[2].allocate(positions_selected_points.data(),
+        vaos[Selected_points]->bind();
+        buffers[Selected_points_vertices].bind();
+        buffers[Selected_points_vertices].allocate(positions_selected_points.data(),
                             static_cast<int>(positions_selected_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
-        buffers[2].release();
+        buffers[Selected_points_vertices].release();
 
-        vaos[2]->release();
+        vaos[Selected_points]->release();
         nb_selected_points = positions_selected_points.size();
         positions_selected_points.resize(0);
         std::vector<double>(positions_selected_points).swap(positions_selected_points);
@@ -423,13 +423,13 @@ void Scene_points_with_normal_item::draw_edges(CGAL::Three::Viewer_interface* vi
 {
     if(!are_buffers_filled)
         initialize_buffers(viewer);
-    vaos[0]->bind();
+    vaos[Edges]->bind();
     program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
-    vaos[0]->release();
+    vaos[Edges]->release();
     program->release();
 }
 void Scene_points_with_normal_item::draw_points(CGAL::Three::Viewer_interface* viewer) const
@@ -437,26 +437,26 @@ void Scene_points_with_normal_item::draw_points(CGAL::Three::Viewer_interface* v
     if(!are_buffers_filled)
         initialize_buffers(viewer);
 
-    vaos[1]->bind();
+    vaos[ThePoints]->bind();
     program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
-    vaos[1]->release();
+    vaos[ThePoints]->release();
     program->release();
     GLfloat point_size;
     viewer->glGetFloatv(GL_POINT_SIZE, &point_size);
     viewer->glPointSize(4.f);
 
-    vaos[2]->bind();
+    vaos[Selected_points]->bind();
     program=getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", QColor(255,0,0));
     viewer->glDrawArrays(GL_POINTS, 0,
                        static_cast<GLsizei>(nb_selected_points/3));
-    vaos[2]->release();
+    vaos[Selected_points]->release();
     program->release();
     viewer->glPointSize(point_size);
 }

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -93,6 +93,18 @@ private:
   QAction* actionResetSelection;
   QAction* actionSelectDuplicatedPoints;
 
+  enum VAOs {
+      Edges=0,
+      ThePoints,
+      Selected_points,
+      NbOfVaos = Selected_points+1
+  };
+  enum VBOs {
+      Edges_vertices = 0,
+      Points_vertices,
+      Selected_points_vertices,
+      NbOfVbos = Selected_points_vertices+1
+  };
 
   mutable std::vector<double> positions_lines;
   mutable std::vector<double> positions_points;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -84,25 +84,25 @@ Scene_polygon_soup_item::initialize_buffers(CGAL::Three::Viewer_interface* viewe
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
 
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_poly.data(),
+        vaos[Facets]->bind();
+        buffers[Facets_vertices].bind();
+        buffers[Facets_vertices].allocate(positions_poly.data(),
                             static_cast<int>(positions_poly.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[0].release();
+        buffers[Facets_vertices].release();
 
 
 
-        buffers[1].bind();
-        buffers[1].allocate(normals.data(),
+        buffers[Facets_normals].bind();
+        buffers[Facets_normals].allocate(normals.data(),
                             static_cast<int>(normals.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[1].release();
+        buffers[Facets_normals].release();
 
         program->release();
-        vaos[0]->release();
+        vaos[Facets]->release();
         nb_polys = positions_poly.size();
         positions_poly.resize(0);
         std::vector<float>(positions_poly).swap(positions_poly);
@@ -115,16 +115,16 @@ Scene_polygon_soup_item::initialize_buffers(CGAL::Three::Viewer_interface* viewe
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
-        vaos[1]->bind();
+        vaos[Edges]->bind();
 
-        buffers[3].bind();
-        buffers[3].allocate(positions_lines.data(),
+        buffers[Edges_vertices].bind();
+        buffers[Edges_vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[3].release();
+        buffers[Edges_vertices].release();
         program->release();
-        vaos[1]->release();
+        vaos[Edges]->release();
 
         nb_lines = positions_lines.size();
         positions_lines.resize(0);
@@ -135,14 +135,14 @@ Scene_polygon_soup_item::initialize_buffers(CGAL::Three::Viewer_interface* viewe
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
-        vaos[2]->bind();
-        buffers[4].bind();
-        buffers[4].allocate(positions_nm_lines.data(),
+        vaos[NM_Edges]->bind();
+        buffers[NM_Edges_vertices].bind();
+        buffers[NM_Edges_vertices].allocate(positions_nm_lines.data(),
                             static_cast<int>(positions_nm_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[4].release();
-        vaos[2]->release();
+        buffers[NM_Edges_vertices].release();
+        vaos[NM_Edges]->release();
         nb_nm_edges = positions_nm_lines.size();
         positions_nm_lines.resize(0);
         std::vector<float> (positions_nm_lines).swap(positions_nm_lines);
@@ -367,7 +367,7 @@ Scene_polygon_soup_item::compute_normals_and_vertices() const{
 
 
 Scene_polygon_soup_item::Scene_polygon_soup_item()
-    : Scene_item(5,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
     soup(0),
     oriented(false)
 {
@@ -574,7 +574,7 @@ Scene_polygon_soup_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(soup == 0) return;
     //Calls the buffer info again so that it's the right one used even if
     //there are several objects drawn
-    vaos[0]->bind();
+    vaos[Facets]->bind();
     attrib_buffers(viewer,PROGRAM_WITH_LIGHT);
     //fills the arraw of colors with the current color
 
@@ -588,7 +588,7 @@ Scene_polygon_soup_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_polys/4));
     // Clean-up
     program->release();
-    vaos[0]->release();
+    vaos[Facets]->release();
   }
 
 void
@@ -599,7 +599,7 @@ Scene_polygon_soup_item::draw_points(CGAL::Three::Viewer_interface* viewer) cons
       initialize_buffers(viewer);
     }
     if(soup == 0) return;
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -609,7 +609,7 @@ Scene_polygon_soup_item::draw_points(CGAL::Three::Viewer_interface* viewer) cons
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
 }
 
 void
@@ -620,7 +620,7 @@ Scene_polygon_soup_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
      initialize_buffers(viewer);
   }
     if(soup == 0) return;
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -631,10 +631,10 @@ Scene_polygon_soup_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
     viewer->glDrawArrays(GL_LINES, 0,static_cast<GLsizei>( nb_lines/4));
     // Clean-up
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
     if(displayNonManifoldEdges())
     {
-        vaos[2]->bind();
+        vaos[NM_Edges]->bind();
         attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
         program->bind();
@@ -645,7 +645,7 @@ Scene_polygon_soup_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
         viewer->glDrawArrays(GL_LINES, 0,static_cast<GLsizei>( nb_nm_edges/4));
         // Clean-up
         program->release();
-        vaos[2]->release();
+        vaos[NM_Edges]->release();
     }
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -169,6 +169,21 @@ private:
     typedef Polygon_soup::Polygons::const_iterator Polygons_iterator;
     Polygon_soup* soup;
     bool oriented;
+
+    enum VAOs {
+        Facets=0,
+        Edges,
+        NM_Edges,
+        NbOfVaos = NM_Edges+1
+    };
+    enum VBOs {
+        Facets_vertices = 0,
+        Facets_normals,
+        Edges_vertices,
+        NM_Edges_vertices,
+        NbOfVbos = NM_Edges_vertices+1
+    };
+
     mutable std::vector<float> positions_poly;
     mutable std::vector<float> positions_lines;
     mutable std::vector<float> normals;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -306,58 +306,58 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
         //flat
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_facets.data(),
+        vaos[Facets]->bind();
+        buffers[Facets_vertices].bind();
+        buffers[Facets_vertices].allocate(positions_facets.data(),
                             static_cast<int>(positions_facets.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[0].release();
+        buffers[Facets_vertices].release();
 
 
 
-        buffers[1].bind();
-        buffers[1].allocate(normals_flat.data(),
+        buffers[Facets_normals_flat].bind();
+        buffers[Facets_normals_flat].allocate(normals_flat.data(),
                             static_cast<int>(normals_flat.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[1].release();
+        buffers[Facets_normals_flat].release();
 
         if(!is_monochrome)
         {
-            buffers[2].bind();
-            buffers[2].allocate(color_facets.data(),
+            buffers[Facets_color].bind();
+            buffers[Facets_color].allocate(color_facets.data(),
                                 static_cast<int>(color_facets.size()*sizeof(float)));
             program->enableAttributeArray("colors");
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[2].release();
+            buffers[Facets_color].release();
         }
-        vaos[0]->release();
+        vaos[Facets]->release();
         //gouraud
-        vaos[2]->bind();
-        buffers[0].bind();
+        vaos[Gouraud_Facets]->bind();
+        buffers[Facets_vertices].bind();
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[0].release();
+        buffers[Facets_vertices].release();
 
-        buffers[5].bind();
-        buffers[5].allocate(normals_gouraud.data(),
+        buffers[Facets_normals_gouraud].bind();
+        buffers[Facets_normals_gouraud].allocate(normals_gouraud.data(),
                             static_cast<int>(normals_gouraud.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[5].release();
+        buffers[Facets_normals_gouraud].release();
         if(!is_monochrome)
         {
-            buffers[2].bind();
+            buffers[Facets_color].bind();
             program->enableAttributeArray("colors");
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[2].release();
+            buffers[Facets_color].release();
         }
         else
         {
             program->disableAttributeArray("colors");
         }
-        vaos[2]->release();
+        vaos[Gouraud_Facets]->release();
 
         program->release();
 
@@ -366,23 +366,23 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
-        vaos[1]->bind();
+        vaos[Edges]->bind();
 
-        buffers[3].bind();
-        buffers[3].allocate(positions_lines.data(),
+        buffers[Edges_vertices].bind();
+        buffers[Edges_vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[3].release();
+        buffers[Edges_vertices].release();
 
-        buffers[4].bind();
-        buffers[4].allocate(color_lines.data(),
+        buffers[Edges_color].bind();
+        buffers[Edges_color].allocate(color_lines.data(),
                             static_cast<int>(color_lines.size()*sizeof(float)));
        if(!is_monochrome)
        {
            program->enableAttributeArray("colors");
            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-           buffers[4].release();
+           buffers[Edges_color].release();
        }
        else
        {
@@ -390,7 +390,7 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
        }
         program->release();
 
-        vaos[1]->release();
+        vaos[Edges]->release();
 
     }
     nb_lines = positions_lines.size();
@@ -590,7 +590,7 @@ Scene_polyhedron_item::compute_colors() const
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item()
-    : Scene_item(6,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
       poly(new Polyhedron),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -607,7 +607,7 @@ Scene_polyhedron_item::Scene_polyhedron_item()
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
-    : Scene_item(6,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
       poly(p),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -624,7 +624,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
-    : Scene_item(6,3),
+    : Scene_item(NbOfVbos,NbOfVaos),
       poly(new Polyhedron(p)),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -832,10 +832,10 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
 
 
     if(renderingMode() == Flat || renderingMode() == FlatPlusEdges)
-        vaos[0]->bind();
+        vaos[Facets]->bind();
     else
     {
-        vaos[2]->bind();
+        vaos[Gouraud_Facets]->bind();
     }
     attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
     program = getShaderProgram(PROGRAM_WITH_LIGHT);
@@ -851,9 +851,9 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     program->release();
     if(renderingMode() == Flat || renderingMode() == FlatPlusEdges)
-        vaos[0]->release();
+        vaos[Facets]->release();
     else
-        vaos[2]->release();
+        vaos[Gouraud_Facets]->release();
 }
 
 // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
@@ -864,7 +864,7 @@ void Scene_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) co
         initialize_buffers(viewer);
     }
 
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -879,7 +879,7 @@ void Scene_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) co
     }
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
     }
 
 void
@@ -890,7 +890,7 @@ Scene_polyhedron_item::draw_points(CGAL::Three::Viewer_interface* viewer) const 
         initialize_buffers(viewer);
     }
 
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -898,7 +898,7 @@ Scene_polyhedron_item::draw_points(CGAL::Three::Viewer_interface* viewer) const 
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
 }
 
 Polyhedron*

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -97,40 +97,19 @@ Itag>             CDTbase;
 typedef CGAL::Constrained_triangulation_plus_2<CDTbase>              CDT;
 
 //Make sure all the facets are triangles
-void
-Scene_polyhedron_item::is_Triangulated() const
-{
-    typedef Polyhedron::Halfedge_around_facet_circulator HF_circulator;
-    Facet_iterator f = poly->facets_begin();
-    int nb_points_per_facet =0;
 
-    for(f = poly->facets_begin();
-        f != poly->facets_end();
-        f++)
-    {
-        HF_circulator he = f->facet_begin();
-        HF_circulator end = he;
-        CGAL_For_all(he,end)
-        {
-            nb_points_per_facet++;
-        }
-
-        if(nb_points_per_facet !=3)
-        {
-            is_Triangle = false;
-            break;
-        }
-
-        nb_points_per_facet = 0;
-    }
-}
 void
 Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
 {
     //Computes the normal of the facet
     Traits::Vector_3 normal =
             CGAL::Polygon_mesh_processing::compute_face_normal(fit,*poly);
-
+    //check if normal contains NaN values
+    if (normal.x() != normal.x() || normal.y() != normal.y() || normal.z() != normal.z())
+    {
+        qDebug()<<"Warning : normal is not valid. Facet not displayed";
+        return;
+    }
     P_traits cdt_traits(normal);
     CDT cdt(cdt_traits);
 
@@ -141,6 +120,7 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
     // Iterates on the vector of facet handles
     CDT::Vertex_handle previous, first;
     do {
+        std::cerr<<he_circ->vertex()->point()<<std::endl;
         CDT::Vertex_handle vh = cdt.insert(he_circ->vertex()->point());
         if(first == 0) {
             first = vh;
@@ -237,6 +217,12 @@ Scene_polyhedron_item::triangulate_facet_color(Facet_iterator fit) const
 {
     Traits::Vector_3 normal =
             CGAL::Polygon_mesh_processing::compute_face_normal(fit, *poly);
+    //check if normal contains NaN values
+    if (normal.x() != normal.x() || normal.y() != normal.y() || normal.z() != normal.z())
+    {
+        qDebug()<<"Warning : normal is not valid. Facet not displayed";
+        return;
+    }
 
     P_traits cdt_traits(normal);
     CDT cdt(cdt_traits);
@@ -296,24 +282,13 @@ Scene_polyhedron_item::triangulate_facet_color(Facet_iterator fit) const
         for(int i = 0; i<3; ++i)
         {
             const int this_patch_id = fit->patch_id();
+            color_facets.push_back(colors_[this_patch_id].redF());
+            color_facets.push_back(colors_[this_patch_id].greenF());
+            color_facets.push_back(colors_[this_patch_id].blueF());
 
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).redF());
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).greenF());
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).blueF());
-
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).redF());
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).greenF());
-                color_facets_selected.push_back(colors_[this_patch_id].lighter(120).blueF());
-
-                color_facets.push_back(colors_[this_patch_id].redF());
-                color_facets.push_back(colors_[this_patch_id].greenF());
-                color_facets.push_back(colors_[this_patch_id].blueF());
-
-                color_facets.push_back(colors_[this_patch_id].redF());
-                color_facets.push_back(colors_[this_patch_id].greenF());
-                color_facets.push_back(colors_[this_patch_id].blueF());
-
-
+            color_facets.push_back(colors_[this_patch_id].redF());
+            color_facets.push_back(colors_[this_patch_id].greenF());
+            color_facets.push_back(colors_[this_patch_id].blueF());
         }
     }
 }
@@ -326,7 +301,7 @@ Scene_polyhedron_item::triangulate_facet_color(Facet_iterator fit) const
 void
 Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer) const
 {
-    //vao containing the data for the unselected facets
+    //vao containing the data for the facets
     {
         program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
         program->bind();
@@ -359,18 +334,18 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
         }
         vaos[0]->release();
         //gouraud
-        vaos[4]->bind();
+        vaos[2]->bind();
         buffers[0].bind();
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
         buffers[0].release();
 
-        buffers[10].bind();
-        buffers[10].allocate(normals_gouraud.data(),
+        buffers[5].bind();
+        buffers[5].allocate(normals_gouraud.data(),
                             static_cast<int>(normals_gouraud.size()*sizeof(float)));
         program->enableAttributeArray("normals");
         program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[10].release();
+        buffers[5].release();
         if(!is_monochrome)
         {
             buffers[2].bind();
@@ -382,12 +357,12 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
         {
             program->disableAttributeArray("colors");
         }
-        vaos[4]->release();
+        vaos[2]->release();
 
         program->release();
 
     }
-    //vao containing the data for the unselected lines
+    //vao containing the data for the lines
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
@@ -418,95 +393,6 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
         vaos[1]->release();
 
     }
-    //vao containing the data for the selected facets
-    {
-
-        program = getShaderProgram(PROGRAM_WITH_LIGHT, viewer);
-        program->bind();
-
-        //flat
-        vaos[2]->bind();
-        buffers[5].bind();
-        buffers[5].allocate(positions_facets.data(),
-                            static_cast<int>(positions_facets.size()*sizeof(float)));
-        program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[5].release();
-
-        buffers[6].bind();
-        buffers[6].allocate(normals_flat.data(),
-                            static_cast<int>(normals_flat.size()*sizeof(float)));
-        program->enableAttributeArray("normals");
-        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[6].release();
-
-        if(!is_monochrome)
-        {
-            buffers[7].bind();
-            buffers[7].allocate(color_facets_selected.data(),
-                                static_cast<int>(color_facets_selected.size()*sizeof(float)));
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[7].release();
-        }
-        else
-        {
-            program->disableAttributeArray("colors");
-        }
-        vaos[2]->release();
-
-        //gouraud
-        vaos[5]->bind();
-        buffers[5].bind();
-        program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[5].release();
-
-        buffers[10].bind();
-        program->enableAttributeArray("normals");
-        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        buffers[10].release();
-
-        if(!is_monochrome)
-        {
-            buffers[7].bind();
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[7].release();
-        }
-        else
-        {
-            program->disableAttributeArray("colors");
-        }
-        vaos[5]->release();
-
-        program->release();
-    }
-    //vao containing the data for the selected lines
-    {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
-        vaos[3]->bind();
-        program->bind();
-        buffers[8].bind();
-        buffers[8].allocate(positions_lines.data(),
-                            static_cast<int>(positions_lines.size()*sizeof(float)));
-        program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[8].release();
-
-        buffers[9].bind();
-        buffers[9].allocate(color_lines_selected.data(),
-                            static_cast<int>(color_lines_selected.size()*sizeof(float)));
-        if(!is_monochrome)
-        {
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[9].release();
-        }
-        program->release();
-
-        vaos[3]->release();
-    }
     nb_lines = positions_lines.size();
     positions_lines.resize(0);
     std::vector<float>(positions_lines).swap(positions_lines);
@@ -515,10 +401,6 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
     std::vector<float>(positions_facets).swap(positions_facets);
 
 
-    color_lines_selected.resize(0);
-    std::vector<float>(color_lines_selected).swap(color_lines_selected);
-    color_facets_selected.resize(0);
-    std::vector<float>(color_facets_selected).swap(color_facets_selected);
     color_lines.resize(0);
     std::vector<float>(color_lines).swap(color_lines);
     color_facets.resize(0);
@@ -555,7 +437,7 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
         f++)
     {
 
-        if(!is_Triangle)
+        if(!is_triangle(f->halfedge(),*poly))
             triangulate_facet(f);
         else
         {
@@ -644,8 +526,6 @@ Scene_polyhedron_item::compute_colors() const
 {
     color_lines.resize(0);
     color_facets.resize(0);
-    color_lines_selected.resize(0);
-    color_facets_selected.resize(0);
     //Facets
     typedef Polyhedron::Facet_iterator Facet_iterator;
     typedef Polyhedron::Halfedge_around_facet_circulator HF_circulator;
@@ -659,7 +539,7 @@ Scene_polyhedron_item::compute_colors() const
         f != poly->facets_end();
         f++)
     {
-        if(!is_Triangle)
+        if(!is_triangle(f->halfedge(),*poly))
             triangulate_facet_color(f);
         else
         {
@@ -667,17 +547,10 @@ Scene_polyhedron_item::compute_colors() const
             HF_circulator end = he;
             CGAL_For_all(he,end)
             {
-
                 const int this_patch_id = f->patch_id();
-
-                    color_facets_selected.push_back(colors_[this_patch_id].lighter(120).redF());
-                    color_facets_selected.push_back(colors_[this_patch_id].lighter(120).greenF());
-                    color_facets_selected.push_back(colors_[this_patch_id].lighter(120).blueF());
-
-                    color_facets.push_back(colors_[this_patch_id].redF());
-                    color_facets.push_back(colors_[this_patch_id].greenF());
-                    color_facets.push_back(colors_[this_patch_id].blueF());
-
+                color_facets.push_back(colors_[this_patch_id].redF());
+                color_facets.push_back(colors_[this_patch_id].greenF());
+                color_facets.push_back(colors_[this_patch_id].blueF());
             }
 
         }
@@ -692,26 +565,13 @@ Scene_polyhedron_item::compute_colors() const
             he++)
         {
             if(he->is_feature_edge()) continue;
+            color_lines.push_back(this->color().lighter(50).redF());
+            color_lines.push_back(this->color().lighter(50).greenF());
+            color_lines.push_back(this->color().lighter(50).blueF());
 
-                color_lines_selected.push_back(0.0);
-                color_lines_selected.push_back(0.0);
-                color_lines_selected.push_back(0.0);
-
-                color_lines_selected.push_back(0.0);
-                color_lines_selected.push_back(0.0);
-                color_lines_selected.push_back(0.0);
-
-                color_lines.push_back(this->color().lighter(50).redF());
-                color_lines.push_back(this->color().lighter(50).greenF());
-                color_lines.push_back(this->color().lighter(50).blueF());
-
-                color_lines.push_back(this->color().lighter(50).redF());
-                color_lines.push_back(this->color().lighter(50).greenF());
-                color_lines.push_back(this->color().lighter(50).blueF());
-
-
-
-
+            color_lines.push_back(this->color().lighter(50).redF());
+            color_lines.push_back(this->color().lighter(50).greenF());
+            color_lines.push_back(this->color().lighter(50).blueF());
         }
     }
     for(he = poly->edges_begin();
@@ -726,20 +586,11 @@ Scene_polyhedron_item::compute_colors() const
         color_lines.push_back(1.0);
         color_lines.push_back(0.0);
         color_lines.push_back(0.0);
-
-        color_lines_selected.push_back(1.0);
-        color_lines_selected.push_back(0.0);
-        color_lines_selected.push_back(0.0);
-
-        color_lines_selected.push_back(1.0);
-        color_lines_selected.push_back(0.0);
-        color_lines_selected.push_back(0.0);
     }
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item()
-    : Scene_item(11,6),
-      is_Triangle(true),
+    : Scene_item(6,3),
       poly(new Polyhedron),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -756,8 +607,7 @@ Scene_polyhedron_item::Scene_polyhedron_item()
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
-    : Scene_item(11,6),
-      is_Triangle(true),
+    : Scene_item(6,3),
       poly(p),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -774,8 +624,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
-    : Scene_item(11,6),
-      is_Triangle(true),
+    : Scene_item(6,3),
       poly(new Polyhedron(p)),
       show_only_feature_edges_m(false),
       facet_picking_m(false),
@@ -977,22 +826,13 @@ void Scene_polyhedron_item::set_erase_next_picked_facet(bool b)
 void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        is_Triangulated();
         compute_normals_and_vertices();
         initialize_buffers(viewer);
     }
 
 
-    if(!is_selected && renderingMode() == Flat)
+    if(renderingMode() == Flat || renderingMode() == FlatPlusEdges)
         vaos[0]->bind();
-    else if(!is_selected && renderingMode() == Gouraud)
-    {
-        vaos[4]->bind();
-    }
-    else if (is_selected && renderingMode() == Gouraud)
-    {
-        vaos[5]->bind();
-    }
     else
     {
         vaos[2]->bind();
@@ -1002,19 +842,16 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     program->bind();
     if(is_monochrome)
     {
-        if(is_selected)
-            program->setAttributeValue("colors", this->color().lighter(120));
-        else
             program->setAttributeValue("colors", this->color());
     }
+    if(is_selected)
+            program->setUniformValue("is_selected", true);
+    else
+            program->setUniformValue("is_selected", false);
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     program->release();
-    if(!is_selected && renderingMode() == Flat)
+    if(renderingMode() == Flat || renderingMode() == FlatPlusEdges)
         vaos[0]->release();
-    else if(!is_selected && renderingMode() == Gouraud)
-        vaos[4]->release();
-    else if (is_selected && renderingMode() == Gouraud)
-        vaos[5]->release();
     else
         vaos[2]->release();
 }
@@ -1023,43 +860,32 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
 void Scene_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        is_Triangulated();
         compute_normals_and_vertices();
         initialize_buffers(viewer);
     }
 
-    if(!is_selected)
-    {
-        vaos[1]->bind();
-    }
-    else
-    {
-        vaos[3]->bind();
-    }
+    vaos[1]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     //draw the edges
     if(is_monochrome)
     {
+        program->setAttributeValue("colors", this->color().lighter(50));
         if(is_selected)
-            program->setAttributeValue("colors", QColor(0,0,0));
+            program->setUniformValue("is_selected", true);
         else
-            program->setAttributeValue("colors", this->color().lighter(50));
+            program->setUniformValue("is_selected", false);
     }
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
-    if(!is_selected)
-        vaos[1]->release();
-    else
-        vaos[3]->release();
-}
+    vaos[1]->release();
+    }
 
 void
 Scene_polyhedron_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        is_Triangulated();
         compute_normals_and_vertices();
         initialize_buffers(viewer);
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -35,7 +35,6 @@ public:
     // IO
     bool load(std::istream& in);
     bool save(std::ostream& out) const;
-    mutable bool is_Triangle;
 
     // Function for displaying meta-data of the item
     virtual QString toolTip() const;
@@ -118,8 +117,6 @@ private:
     mutable std::vector<float> normals_gouraud;
     mutable std::vector<float> color_lines;
     mutable std::vector<float> color_facets;
-    mutable std::vector<float> color_lines_selected;
-    mutable std::vector<float> color_facets_selected;
     mutable std::size_t nb_facets;
     mutable std::size_t nb_lines;
     mutable QOpenGLShaderProgram *program;
@@ -130,7 +127,6 @@ private:
     void compute_colors() const;
     void triangulate_facet(Facet_iterator ) const;
     void triangulate_facet_color(Facet_iterator ) const;
-    void is_Triangulated() const;
     double volume, area;
 
 }; // end class Scene_polyhedron_item

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -110,6 +110,21 @@ private:
     //the following variable is used to indicate if the color vector must not be automatically updated.
     bool plugin_has_set_color_vector_m;
 
+    enum VAOs {
+        Facets=0,
+        Edges,
+        Gouraud_Facets,
+        NbOfVaos = Gouraud_Facets+1
+    };
+    enum VBOs {
+        Facets_vertices = 0,
+        Facets_normals_flat,
+        Facets_color,
+        Edges_vertices,
+        Edges_color,
+        Facets_normals_gouraud,
+        NbOfVbos = Facets_normals_gouraud+1
+    };
 
     mutable std::vector<float> positions_lines;
     mutable std::vector<float> positions_facets;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.cpp
@@ -53,14 +53,14 @@ void Scene_polyhedron_shortest_path_item::initialize_buffers(CGAL::Three::Viewer
     //vao containing the data for the selected lines
     {
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
-        vaos[0]->bind();
+        vaos[Selected_Edges]->bind();
         program->bind();
-        buffers[0].bind();
-        buffers[0].allocate(vertices.data(), vertices.size()*sizeof(float));
+        buffers[Vertices].bind();
+        buffers[Vertices].allocate(vertices.data(), vertices.size()*sizeof(float));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        buffers[0].release();
-        vaos[0]->release();
+        buffers[Vertices].release();
+        vaos[Selected_Edges]->release();
     }
     are_buffers_filled = true;
 }
@@ -103,12 +103,12 @@ void Scene_polyhedron_shortest_path_item::draw_points(CGAL::Three::Viewer_interf
    glPointSize(4.0f);
    program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
    attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
-   vaos[0]->bind();
+   vaos[Selected_Edges]->bind();
    program->bind();
    program->setAttributeValue("colors", QColor(Qt::green));
    viewer->glDrawArrays(GL_POINTS, 0, vertices.size()/3);
    program->release();
-   vaos[0]->release();
+   vaos[Selected_Edges]->release();
    glPointSize(1.0f);
 }
   

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_shortest_path_item.h
@@ -72,6 +72,14 @@ public:
     FACE_MODE = 2
   };
   
+  enum VAOs {
+      Selected_Edges=0,
+      NbOfVaos = Selected_Edges+1
+  };
+  enum VBOs {
+      Vertices = 0,
+      NbOfVbos = Vertices+1
+  };
 private:
   Messages_interface* m_messages;
   QMainWindow* m_mainWindow;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.cpp
@@ -3,7 +3,7 @@
 #include "Polyhedron_type.h"
 
 Scene_polyhedron_transform_item::Scene_polyhedron_transform_item(const qglviewer::Vec& pos,const Scene_polyhedron_item* poly_item_,const CGAL::Three::Scene_interface*):
-    Scene_item(1,1),
+    Scene_item(NbOfVbos,NbOfVaos),
     poly_item(poly_item_),
     manipulable(false),
     frame(new ManipulatedFrame()),
@@ -22,17 +22,17 @@ void Scene_polyhedron_transform_item::initialize_buffers(CGAL::Three::Viewer_int
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_lines.data(),
+        vaos[Edges]->bind();
+        buffers[Vertices].bind();
+        buffers[Vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        buffers[0].release();
+        buffers[Vertices].release();
 
         QColor color = this->color();
         program->setAttributeValue("colors",color);
-        vaos[0]->release();
+        vaos[Edges]->release();
         program->release();
     }
     nb_lines = positions_lines.size();
@@ -71,7 +71,7 @@ void Scene_polyhedron_transform_item::draw_edges(CGAL::Three::Viewer_interface* 
 {
     if(!are_buffers_filled)
         initialize_buffers(viewer);
-    vaos[0]->bind();
+    vaos[Edges]->bind();
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -81,7 +81,7 @@ void Scene_polyhedron_transform_item::draw_edges(CGAL::Three::Viewer_interface* 
     }
     program->setUniformValue("f_matrix", f_matrix);
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
-    vaos[0]->release();
+    vaos[Edges]->release();
     program->release();
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_transform_item.h
@@ -36,6 +36,16 @@ private:
     qglviewer::ManipulatedFrame* frame;
     const Polyhedron* poly;
     qglviewer::Vec center_;
+
+    enum VAOs {
+        Edges=0,
+        NbOfVaos = Edges+1
+    };
+    enum VBOs {
+        Vertices = 0,
+        NbOfVbos = Vertices+1
+    };
+
     mutable QOpenGLShaderProgram *program;
     mutable std::vector<float> positions_lines;
     mutable std::size_t nb_lines;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -40,14 +40,14 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
         program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
         program->bind();
 
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_lines.data(),
+        vaos[Edges]->bind();
+        buffers[Edges_Vertices].bind();
+        buffers[Edges_Vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[0].release();
-        vaos[0]->release();
+        buffers[Edges_Vertices].release();
+        vaos[Edges]->release();
         program->release();
     }
    //vao for the spheres
@@ -57,34 +57,34 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
             program = getShaderProgram(PROGRAM_INSTANCED, viewer);
             program->bind();
 
-            vaos[1]->bind();
-            buffers[1].bind();
-            buffers[1].allocate(positions_spheres.data(),
+            vaos[Spheres]->bind();
+            buffers[Spheres_Vertices].bind();
+            buffers[Spheres_Vertices].allocate(positions_spheres.data(),
                                 static_cast<int>(positions_spheres.size()*sizeof(float)));
             program->enableAttributeArray("vertex");
             program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[1].release();
+            buffers[Spheres_Vertices].release();
 
-            buffers[2].bind();
-            buffers[2].allocate(normals_spheres.data(),
+            buffers[Spheres_Normals].bind();
+            buffers[Spheres_Normals].allocate(normals_spheres.data(),
                                 static_cast<int>(normals_spheres.size()*sizeof(float)));
             program->enableAttributeArray("normals");
             program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-            buffers[2].release();
+            buffers[Spheres_Normals].release();
 
-            buffers[3].bind();
-            buffers[3].allocate(color_spheres.data(),
+            buffers[Spheres_Colors].bind();
+            buffers[Spheres_Colors].allocate(color_spheres.data(),
                                 static_cast<int>(color_spheres.size()*sizeof(float)));
             program->enableAttributeArray("colors");
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[3].release();
+            buffers[Spheres_Colors].release();
 
-            buffers[4].bind();
-            buffers[4].allocate(positions_center.data(),
+            buffers[Spheres_Center].bind();
+            buffers[Spheres_Center].allocate(positions_center.data(),
                                 static_cast<int>(positions_center.size()*sizeof(float)));
             program->enableAttributeArray("center");
             program->setAttributeBuffer("center",GL_FLOAT,0,3);
-            buffers[4].release();
+            buffers[Spheres_Center].release();
 
             viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
             viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
@@ -95,22 +95,22 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
             program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
             program->bind();
 
-            vaos[1]->bind();
-            buffers[1].bind();
-            buffers[1].allocate(positions_center.data(),
+            vaos[Spheres]->bind();
+            buffers[Spheres_Vertices].bind();
+            buffers[Spheres_Vertices].allocate(positions_center.data(),
                                 static_cast<int>(positions_center.size()*sizeof(float)));
             program->enableAttributeArray("vertex");
             program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[1].release();
+            buffers[Spheres_Vertices].release();
 
-            buffers[2].bind();
-            buffers[2].allocate(color_spheres.data(),
+            buffers[Spheres_Normals].bind();
+            buffers[Spheres_Normals].allocate(color_spheres.data(),
                                 static_cast<int>(color_spheres.size()*sizeof(float)));
             program->enableAttributeArray("colors");
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[2].release();
+            buffers[Spheres_Normals].release();
         }
-        vaos[1]->release();
+        vaos[Spheres]->release();
 
         program->release();
     }
@@ -122,44 +122,35 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
             program = getShaderProgram(PROGRAM_INSTANCED_WIRE, viewer);
             program->bind();
 
-            vaos[2]->bind();
-            buffers[5].bind();
-            buffers[5].allocate(positions_wire_spheres.data(),
+            vaos[Wired_Spheres]->bind();
+            buffers[Wired_Spheres_Vertices].bind();
+            buffers[Wired_Spheres_Vertices].allocate(positions_wire_spheres.data(),
                                 static_cast<int>(positions_wire_spheres.size()*sizeof(float)));
             program->enableAttributeArray("vertex");
             program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[5].release();
+            buffers[Wired_Spheres_Vertices].release();
 
-
-            buffers[3].bind();
+            buffers[Spheres_Colors].bind();
             program->enableAttributeArray("colors");
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[3].release();
+            buffers[Spheres_Colors].release();
 
-            buffers[2].bind();
+            buffers[Spheres_Normals].bind();
             program->enableAttributeArray("normals");
             program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-            buffers[2].release();
+            buffers[Spheres_Normals].release();
 
-            buffers[6].bind();
-            buffers[6].allocate(color_spheres.data(),
-                                static_cast<int>(color_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[6].release();
 
-            buffers[7].bind();
-            buffers[7].allocate(positions_center.data(),
-                                static_cast<int>(positions_center.size()*sizeof(float)));
+            buffers[Spheres_Center].bind();
             program->enableAttributeArray("center");
             program->setAttributeBuffer("center",GL_FLOAT,0,3);
-            buffers[7].release();
+            buffers[Spheres_Center].release();
 
 
             viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
             viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
 
-            vaos[2]->release();
+            vaos[Wired_Spheres]->release();
             program->release();
 
             nb_lines = positions_lines.size();
@@ -331,7 +322,7 @@ Scene_polylines_item::compute_elements() const
 
 
 Scene_polylines_item::Scene_polylines_item() 
-    :Scene_item(8,3)
+    :Scene_item(NbOfVbos,NbOfVaos)
     ,d(new Scene_polylines_item_private())
     ,nbSpheres(0)
 {
@@ -438,18 +429,18 @@ Scene_polylines_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     {
         if(viewer->extension_is_found)
         {
-            vaos[1]->bind();
+            vaos[Spheres]->bind();
             QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_INSTANCED);
             attrib_buffers(viewer, PROGRAM_INSTANCED);
             program->bind();
             viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                           static_cast<GLsizei>(nb_spheres/3), nbSpheres);
             program->release();
-            vaos[1]->release();
+            vaos[Spheres]->release();
         }
         else
         {
-            vaos[1]->bind();
+            vaos[Spheres]->bind();
             QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
             attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
             glPointSize(8.0f);
@@ -458,7 +449,7 @@ Scene_polylines_item::draw(CGAL::Three::Viewer_interface* viewer) const {
             viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_centers/3));
             glDisable(GL_POINT_SMOOTH);
             program->release();
-            vaos[1]->release();
+            vaos[Spheres]->release();
         }
     }
 }
@@ -472,26 +463,26 @@ Scene_polylines_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
         initialize_buffers(viewer);
     }
 
-    vaos[0]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     program->release();
-    vaos[0]->release();
+    vaos[Edges]->release();
     if(d->draw_extremities)
     {
         if(viewer->extension_is_found)
         {
-            vaos[2]->bind();
+            vaos[Wired_Spheres]->bind();
             attrib_buffers(viewer, PROGRAM_INSTANCED_WIRE);
             program = getShaderProgram(PROGRAM_INSTANCED_WIRE);
             program->bind();
             viewer->glDrawArraysInstanced(GL_LINES, 0,
                                           static_cast<GLsizei>(nb_wire/3), nbSpheres);
             program->release();
-            vaos[2]->release();
+            vaos[Wired_Spheres]->release();
         }
     }
 
@@ -505,7 +496,7 @@ Scene_polylines_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
         initialize_buffers(viewer);
     }
 
-    vaos[0]->bind();
+    vaos[Edges]->bind();
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
@@ -513,7 +504,7 @@ Scene_polylines_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
     program->setAttributeValue("colors", temp);
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_lines/4));
     // Clean-up
-   vaos[0]->release();
+   vaos[Edges]->release();
    program->release();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -91,6 +91,23 @@ public:
     // http://en.wikipedia.org/wiki/D-pointer
     Scene_polylines_item_private* d;
 private:
+
+    enum VAOs {
+        Edges=0,
+        Spheres,
+        Wired_Spheres,
+        NbOfVaos = Wired_Spheres+1
+    };
+    enum VBOs {
+        Edges_Vertices = 0,
+        Spheres_Vertices,
+        Spheres_Normals,
+        Spheres_Colors,
+        Spheres_Center,
+        Wired_Spheres_Vertices,
+        NbOfVbos = Wired_Spheres_Vertices+1
+    };
+
     mutable std::vector<float> positions_lines;
     mutable std::vector<float> positions_spheres;
     mutable std::vector<float> positions_wire_spheres;

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -17,29 +17,29 @@ void Scene_textured_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_inte
     {
         program = getShaderProgram(PROGRAM_WITH_TEXTURE, viewer);
         program->bind();
-        vaos[0]->bind();
-        buffers[0].bind();
-        buffers[0].allocate(positions_facets.data(),
+        vaos[Facets]->bind();
+        buffers[Facets_Vertices].bind();
+        buffers[Facets_Vertices].allocate(positions_facets.data(),
                             static_cast<int>(positions_facets.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[0].release();
+        buffers[Facets_Vertices].release();
 
-        buffers[1].bind();
-        buffers[1].allocate(normals.data(),
+        buffers[Facets_Normals].bind();
+        buffers[Facets_Normals].allocate(normals.data(),
                             static_cast<int>(normals.size()*sizeof(float)));
         program->enableAttributeArray("normal");
         program->setAttributeBuffer("normal",GL_FLOAT,0,3);
-        buffers[1].release();
+        buffers[Facets_Normals].release();
 
 
-        buffers[2].bind();
-        buffers[2].allocate(textures_map_facets.data(),
+        buffers[Facets_Texmap].bind();
+        buffers[Facets_Texmap].allocate(textures_map_facets.data(),
                             static_cast<int>(textures_map_facets.size()*sizeof(float)));
         program->enableAttributeArray("v_texCoord");
         program->setAttributeBuffer("v_texCoord",GL_FLOAT,0,2);
-        buffers[2].release();
-        vaos[0]->release();
+        buffers[Facets_Texmap].release();
+        vaos[Facets]->release();
         program->release();
     }
 
@@ -47,22 +47,22 @@ void Scene_textured_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_inte
     {
         program = getShaderProgram(PROGRAM_WITH_TEXTURED_EDGES, viewer);
         program->bind();
-        vaos[1]->bind();
-        buffers[3].bind();
-        buffers[3].allocate(positions_lines.data(),
+        vaos[Edges]->bind();
+        buffers[Edges_Vertices].bind();
+        buffers[Edges_Vertices].allocate(positions_lines.data(),
                             static_cast<int>(positions_lines.size()*sizeof(float)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,4);
-        buffers[3].release();
+        buffers[Edges_Vertices].release();
 
 
-        buffers[4].bind();
-        buffers[4].allocate(textures_map_lines.data(), 
+        buffers[Edges_Texmap].bind();
+        buffers[Edges_Texmap].allocate(textures_map_lines.data(),
                             static_cast<int>(textures_map_lines.size()*sizeof(float)));
         program->enableAttributeArray("v_texCoord");
         program->setAttributeBuffer("v_texCoord",GL_FLOAT,0,2);
-        buffers[4].release();
-        vaos[1]->release();
+        buffers[Edges_Texmap].release();
+        vaos[Edges]->release();
         program->release();
     }
 
@@ -208,7 +208,7 @@ Scene_textured_polyhedron_item::compute_normals_and_vertices(void) const
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
-    : Scene_item(5,2),poly(new Textured_polyhedron), textureId(-1)
+    : Scene_item(NbOfVbos,NbOfVaos),poly(new Textured_polyhedron), textureId(-1)
 {
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     cur_shading=FlatPlusEdges;
@@ -219,7 +219,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedron* const p)
-    : Scene_item(5,2),poly(p),textureId(-1),smooth_shading(true)
+    : Scene_item(NbOfVbos,NbOfVaos),poly(p),textureId(-1),smooth_shading(true)
 {
     cur_shading=FlatPlusEdges;
     is_selected=false;
@@ -230,7 +230,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedr
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_polyhedron& p)
-    : Scene_item(5,2), poly(new Textured_polyhedron(p)),textureId(-1),smooth_shading(true)
+    : Scene_item(NbOfVbos,NbOfVaos), poly(new Textured_polyhedron(p)),textureId(-1),smooth_shading(true)
 {
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     cur_shading=FlatPlusEdges;
@@ -295,7 +295,7 @@ void Scene_textured_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer)
         initialize_buffers(viewer);
     }
 
-    vaos[0]->bind();
+    vaos[Facets]->bind();
     viewer->glActiveTexture(GL_TEXTURE0);
     viewer->glBindTexture(GL_TEXTURE_2D, textureId);
     attrib_buffers(viewer, PROGRAM_WITH_TEXTURE);
@@ -304,13 +304,13 @@ void Scene_textured_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer)
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(nb_facets/4));
     //Clean-up
     program->release();
-    vaos[0]->release();
+    vaos[Facets]->release();
 }
 void Scene_textured_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
         initialize_buffers(viewer);
 
-    vaos[1]->bind();
+    vaos[Edges]->bind();
     viewer->glActiveTexture(GL_TEXTURE0);
     viewer->glBindTexture(GL_TEXTURE_2D, textureId);
     attrib_buffers(viewer, PROGRAM_WITH_TEXTURED_EDGES);
@@ -320,7 +320,7 @@ void Scene_textured_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* v
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
     //Clean-up
     program->release();
-    vaos[1]->release();
+    vaos[Edges]->release();
 }
 
 Textured_polyhedron* 

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -51,6 +51,21 @@ public:
 private:
   Textured_polyhedron* poly;
   Texture texture;
+
+  enum VAOs {
+      Facets=0,
+      Edges,
+      NbOfVaos = Edges+1
+  };
+  enum VBOs {
+      Facets_Vertices,
+      Facets_Normals,
+      Facets_Texmap,
+      Edges_Vertices = 0,
+      Edges_Texmap= 0,
+      NbOfVbos = Edges_Texmap+1
+  };
+
   mutable std::vector<float> positions_lines;
   mutable std::vector<float> positions_facets;
   mutable std::vector<float> normals;

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.f
@@ -8,6 +8,7 @@ uniform highp vec4 light_spec;
 uniform highp vec4 light_amb;  
 uniform highp float spec_power ; 
 uniform int is_two_side; 
+uniform bool is_selected;
 void main(void) { 
    highp vec3 L = light_pos.xyz - fP.xyz; 
    highp vec3 V = -fP.xyz; 
@@ -25,5 +26,9 @@ void main(void) {
    else 
        diffuse = max(dot(N,L), 0.0) * light_diff * color; 
    highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; 
-gl_FragColor = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1); 
+   vec4 ret_color = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1); 
+   if(is_selected)
+       gl_FragColor = vec4(ret_color.r+70.0/255.0, ret_color.g+70.0/255.0, ret_color.b+70.0/255.0, 1.0);
+   else
+       gl_FragColor = ret_color;
 }  

--- a/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
@@ -1,6 +1,10 @@
 #version 120
 varying highp vec4 color;
+uniform bool is_selected;
 void main(void) 
 { 
+if(is_selected)
+  gl_FragColor = vec4(0,0,0,1.0); 
+else
   gl_FragColor = color; 
 }  


### PR DESCRIPTION
This is a fix for #449 
- Reduces the number of VBOs in the items
- Fixes a problem in the demo for the non triangulated items.