### PR TITLE
Mesh 3 : fix limit case in polylines protection

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1251,7 +1251,7 @@ change_ball_size(const Vertex_handle& v, const FT size, const bool special_ball)
   CGAL_assertion_code(Tr& tr = c3t3_.triangulation());
   CGAL_assertion_code(Cell_handle ch = tr.locate(p));
   CGAL_assertion_code(std::vector<Vertex_handle> hidden_vertices);
-  CGAL_assertion_code(if(tr.dimension() > 1)
+  CGAL_assertion_code(if(tr.dimension() > 2)
                       tr.vertices_inside_conflict_zone(Weighted_point(p, w),
                                                        ch,
                                                        std::back_inserter(hidden_vertices)));

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -166,7 +166,9 @@ public:
       // Increment iterators and update length
       ++previous;
       ++pit;
-      CGAL_assertion(pit != points_.end());
+
+      if (pit == points_.end())
+        return *previous;
 
       segment_length = this->distance(*previous,*pit);
     }


### PR DESCRIPTION
The Mesh_3 polylines protection algorithm incrementally inserts weighted points on input feature polylines. This PR deals with the limit case where protecting balls refinement attempts to insert a protecting ball very close (~10^-18) beyond the "endpoint/starting point" (arbitrarily chosen) of a cyclic polyline.

this PR fixes issue #416