### PR TITLE
suppress warning in boost as this has to be solved upstream

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
@@ -26,6 +26,9 @@
  * Definition of the specialized boost::graph_traits<Arrangement_2> class.
  */
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <CGAL/Arrangement_on_surface_2.h>

--- a/Arrangement_on_surface_2/include/CGAL/graph_traits_Dual_Arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/graph_traits_Dual_Arrangement_2.h
@@ -27,6 +27,9 @@
  * and the specialized boost::graph_traits<Dual<Arrangement_2> >class.
  */
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arrangement_2.h>
 

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_paths.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_paths.h
@@ -21,6 +21,9 @@
 #ifndef CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
 #define CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
 
+// This will push/pop a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/version.hpp>
 #include <climits>
 

--- a/BGL/include/CGAL/boost/graph/graph_traits_Arrangement_2.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Arrangement_2.h
@@ -22,6 +22,9 @@
 #ifndef CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H
 #define CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <CGAL/graph_traits_Arrangement_2.h>
 
 #endif //CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H

--- a/BGL/include/CGAL/boost/graph/graph_traits_Arrangement_2.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Arrangement_2.h
@@ -22,9 +22,6 @@
 #ifndef CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H
 #define CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H
 
-// include this to avoid a VC15 warning
-#include <CGAL/boost/graph/named_function_params.h>
-
 #include <CGAL/graph_traits_Arrangement_2.h>
 
 #endif //CGAL_BOOST_GRAPH_GRAPH_TRAITS_ARRANGEMENT_2_H

--- a/BGL/include/CGAL/boost/graph/graph_traits_CombinatorialMap.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_CombinatorialMap.h
@@ -22,6 +22,9 @@
 #include <utility>
 #include <iterator>
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/config.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>

--- a/BGL/include/CGAL/boost/graph/graph_traits_Delaunay_triangulation_2.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Delaunay_triangulation_2.h
@@ -20,6 +20,9 @@
 #ifndef CGAL_GRAPH_TRAITS_DELAUNAY_TRIANGULATION_2_H
 #define CGAL_GRAPH_TRAITS_DELAUNAY_TRIANGULATION_2_H
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/config.hpp>
 #include <boost/iterator_adaptors.hpp>
 #include <boost/graph/graph_traits.hpp>

--- a/BGL/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -22,6 +22,9 @@
 
 #include <functional>
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/config.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/transform_iterator.hpp>

--- a/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
@@ -20,6 +20,9 @@
 #ifndef CGAL_BOOST_GRAPH_GRAPH_TRAITS_POLYMESH_ARRAYKERNELT_H
 #define CGAL_BOOST_GRAPH_GRAPH_TRAITS_POLYMESH_ARRAYKERNELT_H
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 

--- a/BGL/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
@@ -20,6 +20,9 @@
 #ifndef CGAL_BOOST_GRAPH_TRAITS_SURFACE_MESH_H
 #define CGAL_BOOST_GRAPH_TRAITS_SURFACE_MESH_H
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 

--- a/BGL/include/CGAL/boost/graph/graph_traits_Triangulation_2.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_Triangulation_2.h
@@ -22,6 +22,9 @@
 
 #include <functional>
 
+// include this to avoid a VC15 warning
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/config.hpp>
 #include <boost/iterator_adaptors.hpp>
 #include <boost/graph/graph_traits.hpp>

--- a/BGL/include/CGAL/boost/graph/named_function_params.h
+++ b/BGL/include/CGAL/boost/graph/named_function_params.h
@@ -48,8 +48,20 @@
 #define CGAL_BOOST_GRAPH_NAMED_FUNCTION_PARAMS_H
 
 #include <CGAL/basic.h>
+
 #include <CGAL/boost/graph/properties.h>
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4172) // returning address of local variable or temporary
+#endif
+
 #include <boost/graph/named_function_params.hpp>
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
+
 #include <boost/type_traits/is_same.hpp>
 #include <boost/version.hpp>
 

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -81,6 +81,17 @@
 #  define BOOST_RANDOM_HPP
 #endif
 
+#ifdef BOOST_PARAMETER_MAX_ARITY
+#  if (BOOST_PARAMETER_MAX_ARITY < 12)
+#  error "BOOST_PARAMETER_MAX_ARITY must be at least 12 for some CGAL packages"
+#  endif
+#else
+// set it to 12 needed in
+// * <CGAL/lloyd_optimize_mesh_2.h>
+// * <CGAL/Mesh_3/global_parameters.h>
+#define  BOOST_PARAMETER_MAX_ARITY 12
+#endif
+
 // The following header file defines among other things  BOOST_PREVENT_MACRO_SUBSTITUTION 
 #include <boost/config.hpp>
 #include <boost/version.hpp>

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -29,7 +29,6 @@
 
 #include <fstream>
 
-#define BOOST_PARAMETER_MAX_ARITY 12
 #include <boost/parameter.hpp>
 #include <boost/parameter/name.hpp>
 

--- a/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
+++ b/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
@@ -28,7 +28,6 @@
 #include <CGAL/config.h>
 #include <CGAL/Mesh_3/config.h>
 
-#define BOOST_PARAMETER_MAX_ARITY 12
 #include <boost/parameter.hpp>
 
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -23,6 +23,8 @@
 
 #include<set>
 #include<vector>
+
+#include <CGAL/boost/graph/named_function_params.h>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/foreach.hpp>
 #include <boost/graph/filtered_graph.hpp>

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Alpha_expansion_graph_cut.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Alpha_expansion_graph_cut.h
@@ -39,6 +39,8 @@
 #endif
 #include <CGAL/trace.h>
 
+#include <CGAL/boost/graph/named_function_params.h>
+
 #include <boost/version.hpp>
 #ifdef CGAL_DO_NOT_USE_BOYKOV_KOLMOGOROV_MAXFLOW_SOFTWARE
 #include <boost/graph/adjacency_list.hpp>


### PR DESCRIPTION
It is a justified warning according to [connect.microsoft.com](https://connect.microsoft.com/VisualStudio/feedback/details/1425276/false-positive-error-c4172-returning-address-of-local-variable-or-temporary)

We push it away so that we only see CGAL related warnings in our testsuite.