### PR TITLE
Polyhedron demo : fix conversion warnings

### DIFF
--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
@@ -1855,8 +1855,9 @@ public:
     
     internal_IOP::Non_intersection_halfedge<Polyhedron> criterium(border_halfedges);
 
-    int mark_index=final_map().get_new_mark(); //mark used to tag dart that are on an intersection
-    
+    int mark_index = static_cast<int>(final_map().get_new_mark());
+                     //mark used to tag dart that are on an intersection
+
     //define a map that will contain the correspondance between selected halfedges of the boundary and
     //their corresponding Dart_handle in the cmap.
     typedef std::map<Halfedge_const_handle,typename Combinatorial_map_3::Dart_handle,internal_IOP::Compare_address<Polyhedron> > Halfedge_to_dart_map;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_point_set_shape_detection_plugin.cpp
@@ -283,7 +283,7 @@ void Polyhedron_demo_point_set_shape_detection_plugin::build_alpha_shape
       if (ashape.classify (it) != Alpha_shape_2::INTERIOR)
         continue;
 
-      for (std::size_t i = 0; i < 3; ++ i)
+      for (int i = 0; i < 3; ++ i)
         {
           if (map_v2i.find (it->vertex (i)) == map_v2i.end ())
             {

--- a/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_combinatorial_map_item.cpp
@@ -236,8 +236,10 @@ void Scene_combinatorial_map_item::compute_elements(void) const{
     //Facets
     {
     std::size_t index = 0;
-    int voltreated = combinatorial_map().get_new_mark();
-    int facetreated = combinatorial_map().get_new_mark();
+    Combinatorial_map_3::size_type voltreated
+      = combinatorial_map().get_new_mark();
+    Combinatorial_map_3::size_type facetreated
+      = combinatorial_map().get_new_mark();
     Combinatorial_map_3::Dart_const_range::const_iterator
             darts_it=combinatorial_map().darts().begin(), darts_end=combinatorial_map().darts().end();
     for( ; darts_it!=darts_end; ++darts_it)

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -42,7 +42,7 @@ void Scene_implicit_function_item::initialize_buffers(CGAL::Three::Viewer_interf
         program->enableAttributeArray("v_texCoord");
         program->setAttributeBuffer("v_texCoord",GL_FLOAT,0,2);
         buffers[TexMap].release();
-        program->setAttributeValue("normal", QVector3D(0,0,0));
+        program->setAttributeValue("normal", QVector3D(0.f,0.f,0.f));
 
         program->release();
         vaos[Plane]->release();
@@ -409,9 +409,9 @@ Scene_implicit_function_item::draw(CGAL::Three::Viewer_interface* viewer) const
     program = getShaderProgram(PROGRAM_WITH_TEXTURE);
     program->bind();
     program->setUniformValue("f_matrix", f_mat);
-    program->setUniformValue("light_amb", QVector4D(1.0,1.0,1.0,1.0));
-    program->setUniformValue("light_diff", QVector4D(0,0,0,1));
-    program->setAttributeValue("color_facets", QVector3D(1.0,1.0,1.0));
+    program->setUniformValue("light_amb", QVector4D(1.f,1.f,1.f,1.f));
+    program->setUniformValue("light_diff", QVector4D(0.f,0.f,0.f,1.f));
+    program->setAttributeValue("color_facets", QVector3D(1.f,1.f,1.f));
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_tex_quad.size()/3));
     vaos[Plane]->release();
     program->release();
@@ -427,7 +427,7 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
     attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
     program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     program->bind();
-    program->setAttributeValue("colors", QVector3D(0,0,0));
+    program->setAttributeValue("colors", QVector3D(0.f,0.f,0.f));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_cube.size()/3));
     vaos[BBox]->release();
     vaos[Grid]->bind();
@@ -439,7 +439,7 @@ Scene_implicit_function_item::draw_edges(CGAL::Three::Viewer_interface* viewer) 
         f_mat.data()[i] = double(d_mat[i]);
     }
     program->setUniformValue("f_matrix", f_mat);
-    program->setAttributeValue("colors", QVector3D(0.6,0.6,0.6));
+    program->setAttributeValue("colors", QVector3D(0.6f, 0.6f, 0.6f));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_grid.size()/3));
     vaos[Grid]->release();
     program->release();

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -78,7 +78,7 @@ private:
 
   // Assignment operator not implemented and declared private to make
   // sure nobody uses the default one without knowing it
-  Point_set_3& operator= (const Point_set_3& other)
+  Point_set_3& operator= (const Point_set_3&)
   {
     return *this;
   }


### PR DESCRIPTION
This PR intends to fix warnings spotted by MSVC2013 about implicit conversions between float and double, and between int and std::size_t (possible loss of data)