### PR TITLE
Fix bug  in Halfedge_around_source_circulator

### DIFF
--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -524,7 +524,7 @@ public:
   {}
 
   Halfedge_around_source_circulator(halfedge_descriptor hd, const Graph& g)
-    : Halfedge_around_source_circulator::iterator_adaptor_(Halfedge_around_target_circulator<Graph>(hd,g)), opp(g)
+    : Halfedge_around_source_circulator::iterator_adaptor_(Halfedge_around_target_circulator<Graph>(opposite(hd,g),g)), opp(g)
   {}
 
   Halfedge_around_source_circulator(vertex_descriptor vd, const Graph& g)

--- a/BGL/test/BGL/test_circulator.cpp
+++ b/BGL/test/BGL/test_circulator.cpp
@@ -67,8 +67,10 @@ int main(int, char* argv[])
 
   {
     halfedge_around_target_circulator havc(hd,P), done(havc);
-    
+    vertex_descriptor vd = target(hd,P);
     do {
+      halfedge_descriptor hd2 = *havc;
+      assert(target(hd2,P) == vd);
       std::cout << get(CGAL::vertex_point, P, target(*havc,P)) << std::endl;
       ++havc;
     }while(havc != done);
@@ -91,8 +93,10 @@ int main(int, char* argv[])
   }
   {
     halfedge_around_source_circulator havc(hd,P), done(havc);
-    
+    vertex_descriptor vd = source(hd,P);
     do {
+      halfedge_descriptor hd2 = *havc;
+      assert(source(hd2,P) == vd);
       std::cout << get(CGAL::vertex_point, P, target(*havc,P)) << std::endl;
       ++havc;
     }while(havc != done);
@@ -100,10 +104,11 @@ int main(int, char* argv[])
 
   {
     halfedge_around_target_iterator vit, end;
+    vertex_descriptor vd = target(hd,P);
     boost::tie(vit,end) = halfedges_around_target(hd,P);
-    
     while(vit!= end) {
       halfedge_descriptor hd = *vit;
+      assert(target(hd,P) == vd);
       std::cout << get(CGAL::vertex_point, P, target(hd,P)) << std::endl;
       ++vit;
     }


### PR DESCRIPTION
As we want to circulate around the source, and as the implementation uses an around_target ciculator, we have to take the opposite input halfedge.

We fixed the bug and improved the testsuite.