### PR TITLE
PMP : fix a bug in isotropic remeshing

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -1276,8 +1276,8 @@ namespace internal {
         mesh_,
         std::back_inserter(facets),
         PMP::parameters::vertex_point_map(vpmap_));
-      CGAL_assertion(facets.empty());
-      std::cout << "done." << std::endl;
+      //CGAL_assertion(facets.empty());
+      std::cout << "done ("<< facets.size() <<" facets)." << std::endl;
     }
 
     void debug_self_intersections(const vertex_descriptor& v) const
@@ -1289,8 +1289,8 @@ namespace internal {
         mesh_,
         std::back_inserter(facets),
         PMP::parameters::vertex_point_map(vpmap_));
-      CGAL_assertion(facets.empty());
-      std::cout << "done." << std::endl;
+      //CGAL_assertion(facets.empty());
+      std::cout << "done ("<< facets.size() <<" facets)." << std::endl;
     }
 #endif
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -901,6 +901,8 @@ namespace internal {
         return false;//too many cases to be handled
       else if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
         return false;//too many cases to be handled
+      if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
+        return false;//collapse would induce pinching the selection
       else
         return true;
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -834,7 +834,7 @@ namespace internal {
     void dump(const char* filename) const
     {
       std::ofstream out(filename);
-//      out << mesh_;
+      out << mesh_;
       out.close();
     }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -901,8 +901,6 @@ namespace internal {
         return false;//too many cases to be handled
       else if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
         return false;//too many cases to be handled
-      else if (is_on_patch_border(he) || is_on_patch_border(hopp))
-        return !protect_constraints_;//allowed only when no protection
       else
         return true;
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -1274,8 +1274,9 @@ namespace internal {
     {
       std::cout << "Test self intersections...";
       std::vector<std::pair<face_descriptor, face_descriptor> > facets;
-      PMP::does_self_intersect(
+      PMP::self_intersections(
         mesh_,
+        std::back_inserter(facets),
         PMP::parameters::vertex_point_map(vpmap_));
       CGAL_assertion(facets.empty());
       std::cout << "done." << std::endl;
@@ -1285,7 +1286,7 @@ namespace internal {
     {
       std::cout << "Test self intersections...";
       std::vector<std::pair<face_descriptor, face_descriptor> > facets;
-      PMP::does_self_intersect(
+      PMP::self_intersections(
         faces_around_target(halfedge(v, mesh_), mesh_),
         mesh_,
         std::back_inserter(facets),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -125,7 +125,7 @@ void isotropic_remeshing(PolygonMesh& pmesh
 
   typename internal::Incremental_remesher<PM, VPMap, GT>
     remesher(pmesh, vpmap, protect);
-  remesher.init_faces_remeshing(faces, ecmap);
+  remesher.init_remeshing(faces, ecmap);
 
   unsigned int nb_iterations = choose_param(get_param(np, number_of_iterations), 1);
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_type.h
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_type.h
@@ -9,6 +9,7 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_3.h>
 #include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
+#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Has_timestamp.h>
 #include <CGAL/tags.h>


### PR DESCRIPTION
This PR fixes a bug in isotropic_remeshing, that could happen for some parameters when the surface patch to be remeshed was "thinner" (in terms of width in number of edges) than the target edge length.