### PR TITLE
fix a leak in the trapezoidal decomposition that occurs when a curve is removed

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
@@ -221,6 +221,8 @@ void Trapezoidal_decomposition_2<Td_traits>
 {
   CGAL_precondition(traits->is_active(trpz_node.get_data()));
   CGAL_precondition(traits->is_td_trapezoid(trpz_node.get_data()));
+  if ( Td_active_trapezoid* trap = boost::get<Td_active_trapezoid>(&trpz_node.get_data()) )
+    trap->clear_neighbors();
   trpz_node.set_data(Td_inactive_trapezoid());
   if (active_node)
     trpz_node.set_left_child(*active_node);


### PR DESCRIPTION
A dag node contains a variant that amongst other can point onto a
Tr_active_trapezoid. This class inherits from Handle in order to
reference count the data (of type Tr_active_trapezoid::Data) that
contains 4 neightbors, each being of type Tr_active_trapezoid.
The problem is that if a dag node is no longer used and if it
holds a instance of a Tr_active_trapezoid which neighbors trapezoid
are not cleared, we might have objects of type Tr_active_trapezoid
pointing onto each others preventing them from being deleted.