### PR TITLE
Polyhedron demo: Fix point selection behavior

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
@@ -177,8 +177,6 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
       BOOST_FOREACH(std::size_t i, shape->indices_of_assigned_points())
         point_item->point_set()->push_back((*points)[i]);
       
-      point_item->point_set()->unselect_all ();
-      
       unsigned char r, g, b;
       r = static_cast<unsigned char>(64 + rand.get_int(0, 192));
       g = static_cast<unsigned char>(64 + rand.get_int(0, 192));

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -128,7 +128,6 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
       for (unsigned int i = 0; i < new_points.size (); ++ i)
 	points->push_back (Point_set::Point_with_normal (new_points[i].first,
 							 new_points[i].second));
-      points->unselect_all();
       
       std::size_t memory = CGAL::Memory_sizer().virtual_size();
       std::cerr << task_timer.time() << " seconds, "

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -83,7 +83,6 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
   nb_selected_points = 0;
   nb_lines = 0;
   invalidate_buffers();
-  m_points->unselect_all();
 }
 
 Scene_points_with_normal_item::~Scene_points_with_normal_item()
@@ -297,7 +296,6 @@ bool Scene_points_with_normal_item::read_ply_point_set(std::istream& stream)
             }
         }
     }
-  m_points->unselect_all();
   invalidate_buffers();
   return ok;
 }
@@ -324,7 +322,6 @@ bool Scene_points_with_normal_item::read_off_point_set(std::istream& stream)
                                               std::back_inserter(*m_points),
                                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type())) &&
             !isEmpty();
-  m_points->unselect_all();
   invalidate_buffers();
   return ok;
 }
@@ -365,7 +362,6 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
       }
     }
   }
-  m_points->unselect_all();
   invalidate_buffers();
   return ok;
 }


### PR DESCRIPTION
The new selection behavior introduced by PR https://github.com/CGAL/cgal/pull/410 uses an iterator to the first selected point. This forces the user to call _unselect_all()_ after inserting points so that the iterator remains valid. I forgot to change this behavior in some plugins, which resulted for example in this bug: https://github.com/CGAL/cgal/pull/455

I found out there are other similar bugs remaining (WLOP plugin or Polyhedron selection when creating a point set from selected vertices).

This PR fixes all these bugs by introducing a slight change of behavior: the point set now stores the _number_ of selected points. The correct iterator is recomputed when needed (the container is a vector so this is straightforward). This behavior is more robust as the user does not need to call _unselect_all()_ after inserting points. I tested it on most of the plugins using selection and it works well.

Bugs may still arise if the user modifies the container (adding, removing points) when the selection is _not_ empty: I added a commentary on the header. But general behavior when creating a point set is much safer now (number of selected points is 0 so the iterator to the first selected is always _end()_) and no bug should remain in the current Polyhedron demo plugins.