### PR TITLE
make the call to readlink earlier to prevent usage of incorrect CGAL_DIR

### DIFF
--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -377,7 +377,7 @@ build_platforms_list()
 setup_dirs()
 {
   # dir for the actual release
-  CGAL_DIR=${CGAL_ROOT}/CGAL-I
+  CGAL_DIR=`readlink "${CGAL_ROOT}/CGAL-I"`
 
   CGAL_TEST_DIR=${CGAL_DIR}/test
 
@@ -391,7 +391,7 @@ setup_dirs()
     log "${ACTUAL_LOGFILE}" "Creating ${CGAL_DIR}/cmake/platforms"
   fi
 
-  CGAL_RELEASE_DIR=`readlink "${CGAL_DIR}"`
+  CGAL_RELEASE_DIR="${CGAL_DIR}"
 
   CGAL_RELEASE_ID=`basename "${CGAL_RELEASE_DIR}"`
 


### PR DESCRIPTION
Related to #87