### PR TITLE
Add parameters to surface reconstruction plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -372,12 +372,14 @@ namespace SurfaceReconstruction
       }
   }
   
-  void advancing_front (const Point_set& points, Scene_polyhedron_item* new_item, double size)
+  void advancing_front (const Point_set& points, Scene_polyhedron_item* new_item, double size,
+                        double radius_ratio_bound = 5., double beta = 0.52)
   {
     Polyhedron& P = * const_cast<Polyhedron*>(new_item->polyhedron());
-    Radius filter(10 * size);
+    Radius filter (size);
 
-    CGAL::advancing_front_surface_reconstruction (points.begin (), points.end (), P, filter);
+    CGAL::advancing_front_surface_reconstruction (points.begin (), points.end (), P, filter,
+                                                  radius_ratio_bound, beta);
 						  
   }
 
@@ -422,6 +424,8 @@ public:
   bool boundaries () const { return m_boundaries->isChecked (); }
   bool interpolate () const { return m_interpolate->isChecked (); }
   double longest_edge () const { return m_longestEdge->value (); }
+  double radius_ratio_bound () const { return m_radiusRatioBound->value (); }
+  double beta_angle () const { return m_betaAngle->value (); }
   unsigned int neighbors () const { return m_neighbors->value (); }
   unsigned int samples () const { return m_samples->value (); }
   unsigned int iterations () const { return m_iterations->value (); }
@@ -621,7 +625,7 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	      time.restart();
 
 	      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-	      SurfaceReconstruction::advancing_front (*points, reco_item, (std::max)(noise_size, aniso_size));
+	      SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
 	      
 	      reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
 	      reco_item->setColor(Qt::magenta);
@@ -640,7 +644,7 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	      time.restart();
 
 	      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-	      SurfaceReconstruction::advancing_front (*points, reco_item, (std::max)(noise_size, aniso_size));
+	      SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
 	      
 	      reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
 	      reco_item->setColor(Qt::magenta);
@@ -718,7 +722,10 @@ void Polyhedron_demo_surface_reconstruction_plugin::advancing_front_reconstructi
       std::cerr << "Advancing front reconstruction... ";
 
       Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-      SurfaceReconstruction::advancing_front (*points, reco_item, dialog.longest_edge ());
+      SurfaceReconstruction::advancing_front (*points, reco_item,
+                                              dialog.longest_edge (),
+                                              dialog.radius_ratio_bound (),
+                                              CGAL_PI * dialog.beta_angle () / 180.);
 	      
       reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
       reco_item->setColor(Qt::magenta);

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.ui
@@ -40,6 +40,46 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Radius ratio bound</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Beta angle</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="m_radiusRatioBound">
+        <property name="minimum">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="m_betaAngle">
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="maximum">
+         <double>150.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>30.000000000000000</double>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
In the surface reconstruction plugin of the Polyhedron demo, only default parameters can be used for _advancing front_. This PR adds the two parameters (radius ratio bound and beta angle) to the dialog so that they can be user selected.