### PR TITLE
Selection tool : colors fix

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -117,7 +117,7 @@ public Q_SLOTS:
       int item_id = scene->addItem(new_item);
       QObject* scene_ptr = dynamic_cast<QObject*>(scene);
       if (scene_ptr)
-        connect(new_item,SIGNAL(simplicesSelected(Scene_item*)), scene_ptr, SLOT(setSelectedItem(Scene_item*)));
+        connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
       scene->setSelectedItem(item_id);
     }
   }
@@ -215,7 +215,6 @@ public Q_SLOTS:
        begin != selection_item->selected_vertices.end(); ++begin) {
        point_item->point_set()->push_back((*begin)->point());
     }
-    
     scene->setSelectedItem( scene->addItem(point_item) );
     scene->itemChanged(point_item);
   }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -32,5 +32,6 @@
         <file>resources/shader_with_textured_edges.v</file>
         <file>resources/shader_with_texture.v</file>
         <file>resources/shader_instanced.v</file>
+        <file>resources/shader_no_light_no_selection.f</file>
     </qresource>
 </RCC>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -32,7 +32,7 @@ void Scene_polyhedron_selection_item::initialize_buffers(CGAL::Three::Viewer_int
     }
     //vao containing the data for the unselected lines
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
         vaos[1]->bind();
 
@@ -50,7 +50,7 @@ void Scene_polyhedron_selection_item::initialize_buffers(CGAL::Three::Viewer_int
     }
     //vao containing the data for the points
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
         vaos[2]->bind();
 
@@ -201,9 +201,10 @@ void Scene_polyhedron_selection_item::draw_edges(CGAL::Three::Viewer_interface* 
 
     viewer->glLineWidth(3.f);
     vaos[1]->bind();
-    program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-    attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
+
     program->setAttributeValue("colors",edge_color);
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     program->release();
@@ -220,8 +221,8 @@ void Scene_polyhedron_selection_item::draw_points(CGAL::Three::Viewer_interface*
     }
     viewer->glPointSize(5.f);
     vaos[2]->bind();
-    program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-    attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors",vertex_color);
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -718,7 +718,7 @@ public:
   }
 
 Q_SIGNALS:
-  void simplicesSelected(Scene_item*);
+  void simplicesSelected(CGAL::Three::Scene_item*);
 
 public Q_SLOTS:
   void invalidate_buffers() {

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -37,7 +37,7 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
     QOpenGLShaderProgram *program;
    //vao for the lines
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
 
         vaos[Edges]->bind();
@@ -92,7 +92,7 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
         }
         else
         {
-            program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+            program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
             program->bind();
 
             vaos[Spheres]->bind();
@@ -441,8 +441,8 @@ Scene_polylines_item::draw(CGAL::Three::Viewer_interface* viewer) const {
         else
         {
             vaos[Spheres]->bind();
-            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-            attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
+            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_NO_SELECTION);
+            attrib_buffers(viewer, PROGRAM_NO_SELECTION);
             glPointSize(8.0f);
             glEnable(GL_POINT_SMOOTH);
             program->bind();
@@ -464,8 +464,8 @@ Scene_polylines_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
     }
 
     vaos[Edges]->bind();
-    attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
-    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
@@ -497,8 +497,8 @@ Scene_polylines_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
     }
 
     vaos[Edges]->bind();
-    attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
-    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_NO_SELECTION);
     program->bind();
     QColor temp = this->color();
     program->setAttributeValue("colors", temp);

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -3,7 +3,7 @@
 #include "Scene_polylines_item_config.h"
 #include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_item.h>
 
 #include <QString>
 #include <QMenu>

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -449,7 +449,11 @@ void Viewer::attrib_buffers(int program_name) const {
     program->bind();
     switch(program_name)
     {
-    /// @TODO: factorize that implementation!
+    case PROGRAM_NO_SELECTION:
+        program->setUniformValue("mvp_matrix", mvp_mat);
+
+        program->setUniformValue("f_matrix",f_mat);
+        break;
     case PROGRAM_WITH_LIGHT:
         program->setUniformValue("mvp_matrix", mvp_mat);
         program->setUniformValue("mv_matrix", mv_mat);
@@ -921,6 +925,27 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             }
             program->link();
             d->shader_programs[PROGRAM_WITHOUT_LIGHT] = program;
+            return program;
+        }
+        break;
+    case PROGRAM_NO_SELECTION:
+        if( d->shader_programs[PROGRAM_NO_SELECTION])
+        {
+            return d->shader_programs[PROGRAM_NO_SELECTION];
+        }
+        else
+        {
+            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_without_light.v"))
+            {
+                std::cerr<<"adding vertex shader FAILED"<<std::endl;
+            }
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_no_light_no_selection.f"))
+            {
+                std::cerr<<"adding fragment shader FAILED"<<std::endl;
+            }
+            program->link();
+            d->shader_programs[PROGRAM_NO_SELECTION] = program;
             return program;
         }
         break;

--- a/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
@@ -1,0 +1,6 @@
+#version 120
+varying highp vec4 color;
+void main(void) 
+{
+  gl_FragColor = color; 
+}  

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -55,6 +55,7 @@ class SCENE_ITEM_EXPORT Scene_item : public QObject {
 public:
   enum OpenGL_program_IDs { PROGRAM_WITH_LIGHT,
                             PROGRAM_WITHOUT_LIGHT,
+                            PROGRAM_NO_SELECTION,
                             PROGRAM_WITH_TEXTURE,
                             PROGRAM_WITH_TEXTURED_EDGES,
                             PROGRAM_INSTANCED,

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -45,6 +45,7 @@ class VIEWER_EXPORT Viewer_interface : public QGLViewer, public QOpenGLFunctions
 public:
   enum OpenGL_program_IDs { PROGRAM_WITH_LIGHT,
                             PROGRAM_WITHOUT_LIGHT,
+                            PROGRAM_NO_SELECTION,
                             PROGRAM_WITH_TEXTURE,
                             PROGRAM_WITH_TEXTURED_EDGES,
                             PROGRAM_INSTANCED,


### PR DESCRIPTION
- This PR fixes a color problem with the selection tool, and some warnings about Signals/Slots. There is currently a segfault remaining when trying to create a points set from a selection, but it should be solved by another PR(#498) from @sgiraudot 