### PR TITLE
Bugfix: OFF reader should accept comments and empty lines

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -95,6 +95,11 @@ read_off_points_and_normals(
   {
     iss.clear();
     iss.str(line);
+
+    // Ignore empty lines and comments
+    if (line.empty () || line[0] == '#')
+      continue;
+
     lineNumber++;
 
     // Reads file signature on first line


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/CGAL/cgal/issues/515

Tested on some OFF files with comments. OFF files without comments are not affected.