### PR TITLE
Polyhedron demo manipulated frame fix gf

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -264,8 +264,8 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   FOREACH(SUB_DIR ${DEMO_PLUGINS})
       add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Plugins/${SUB_DIR}")
   ENDFOREACH()
-  add_executable(example_plugin IMPORTED)
-  set_property(TARGET example_plugin PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../../../Example_plugin/example_plugin.cmake")
+ # add_executable(example_plugin IMPORTED)
+ # set_property(TARGET example_plugin PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../../../Example_plugin/example_plugin.cmake")
 #
 # Exporting
 #

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -264,8 +264,6 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   FOREACH(SUB_DIR ${DEMO_PLUGINS})
       add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Plugins/${SUB_DIR}")
   ENDFOREACH()
- # add_executable(example_plugin IMPORTED)
- # set_property(TARGET example_plugin PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../../../Example_plugin/example_plugin.cmake")
 #
 # Exporting
 #

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -48,9 +48,9 @@ public:
 
   bool isFinite() const { return true; }
   bool isEmpty() const { return tree.empty(); }
-  Bbox bbox() const {
+  void compute_bbox() const {
     const CGAL::Bbox_3 bbox = tree.bbox();
-    return Bbox(bbox.xmin(),
+    _bbox = Bbox(bbox.xmin(),
                 bbox.ymin(),
                 bbox.zmin(),
                 bbox.xmax(),
@@ -84,6 +84,7 @@ public:
   {
       compute_elements();
       are_buffers_filled = false;
+      compute_bbox();
   }
 public:
   const AABB_tree& tree;
@@ -149,14 +150,15 @@ public:
   }
     bool isFinite() const { return true; }
   bool isEmpty() const { return edges.empty(); }
-  Bbox bbox() const {
+  void compute_bbox() const {
     if(isEmpty())
-      return Bbox();
+      _bbox = Bbox();
+    return;
     CGAL::Bbox_3 bbox = edges.begin()->bbox();
     for(size_t i = 1, end = edges.size(); i < end; ++i) {
       bbox = bbox + edges[i].bbox();
     }
-    return Bbox(bbox.xmin(),
+    _bbox = Bbox(bbox.xmin(),
                 bbox.ymin(),
                 bbox.zmin(),
                 bbox.xmax(),
@@ -167,6 +169,7 @@ public:
   {
       compute_elements();
       are_buffers_filled = false;
+      compute_bbox();
   }
 
   Scene_edges_item* clone() const {

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_polyhedron_shortest_path_item.cpp
@@ -184,6 +184,7 @@ void Scene_polyhedron_shortest_path_item::poly_item_changed()
 void Scene_polyhedron_shortest_path_item::invalidate_buffers()
 {
   compute_elements();
+  compute_bbox();
   are_buffers_filled = false;
 
 }
@@ -518,9 +519,9 @@ bool Scene_polyhedron_shortest_path_item::isEmpty() const
   return false;
 }
 
-Scene_polyhedron_shortest_path_item::Bbox Scene_polyhedron_shortest_path_item::bbox() const 
+void Scene_polyhedron_shortest_path_item::compute_bbox() const
 {
-  return polyhedron_item()->bbox();
+  _bbox = polyhedron_item()->bbox();
 }
 
 QString Scene_polyhedron_shortest_path_item::toolTip() const

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_polyhedron_shortest_path_item.h
@@ -145,7 +145,7 @@ protected:
   
   virtual bool isFinite() const;
   virtual bool isEmpty() const;
-  virtual Bbox bbox() const;
+  virtual void compute_bbox()const;
   virtual QString toolTip() const;
   
 protected:

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Scene_segmented_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Scene_segmented_image_item.cpp
@@ -645,11 +645,15 @@ void Scene_segmented_image_item::attrib_buffers(Viewer_interface* viewer) const
     rendering_program.release();
 }
 
-Scene_segmented_image_item::Bbox
-Scene_segmented_image_item::bbox() const
+void
+Scene_segmented_image_item::compute_bbox()const
 {
-  if(!m_image) return Bbox();
-  return Bbox(0, 0, 0,
+  if(!m_image)
+  {
+      _bbox = Bbox();
+      return;
+  }
+  _bbox = Bbox(0, 0, 0,
               m_image->xdim() * m_image->vx(),
               m_image->ydim() * m_image->vy(),
               m_image->zdim() * m_image->vz());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Scene_segmented_image_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Scene_segmented_image_item.h
@@ -26,7 +26,7 @@ public:
 
   bool isFinite() const { return true; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   Scene_segmented_image_item* clone() const { return NULL; }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -411,14 +411,14 @@ void Scene_combinatorial_map_item::initialize_buffers(CGAL::Three::Viewer_interf
 
 bool Scene_combinatorial_map_item::isEmpty() const {return combinatorial_map().number_of_darts()==0;}
 
-Scene_combinatorial_map_item::Bbox 
-Scene_combinatorial_map_item::bbox() const {
+void
+Scene_combinatorial_map_item::compute_bbox() const {
     typedef Combinatorial_map_3::Attribute_const_range<0>::type Point_range;
     const Point_range& points=combinatorial_map().attributes<0>();
     CGAL::Bbox_3 bbox=points.begin()->point().bbox();
     for(Point_range::const_iterator pit=boost::next(points.begin());pit!=points.end();++pit)
         bbox=bbox+pit->point().bbox();
-    return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+    _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.h
@@ -52,7 +52,7 @@ public:
     bool isFinite() const { return true; }
     bool is_from_corefinement() const {return address_of_A!=NULL;}
     bool isEmpty() const;
-    Bbox bbox() const;
+    void compute_bbox() const;
 
     const Combinatorial_map_3& combinatorial_map() const
     {

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -100,8 +100,8 @@ bool Scene_polyhedron_transform_item::keyPressEvent(QKeyEvent* e){
     return false;
 }
 
-Scene_polyhedron_transform_item::Bbox
-Scene_polyhedron_transform_item::bbox() const {
+void
+Scene_polyhedron_transform_item::compute_bbox() const {
     const Kernel::Point_3& p = *(poly->points_begin());
     CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
     for(Polyhedron::Point_const_iterator it = poly->points_begin();
@@ -109,7 +109,7 @@ Scene_polyhedron_transform_item::bbox() const {
         ++it) {
         bbox = bbox + it->bbox();
     }
-    return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+    _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 
@@ -118,5 +118,6 @@ void Scene_polyhedron_transform_item::invalidate_buffers()
 {
     compute_elements();
     are_buffers_filled = false;
+    compute_bbox();
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -29,9 +29,6 @@ void Scene_polyhedron_transform_item::initialize_buffers(CGAL::Three::Viewer_int
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
         buffers[Vertices].release();
-
-        QColor color = this->color();
-        program->setAttributeValue("colors",color);
         vaos[Edges]->release();
         program->release();
     }
@@ -80,6 +77,9 @@ void Scene_polyhedron_transform_item::draw_edges(CGAL::Three::Viewer_interface* 
         f_matrix.data()[i] = (float)frame->matrix()[i];
     }
     program->setUniformValue("f_matrix", f_matrix);
+    program->setUniformValue("is_selected", false);
+    QColor color = this->color();
+    program->setAttributeValue("colors",color);
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     vaos[Edges]->release();
     program->release();

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
@@ -19,7 +19,7 @@ public:
     Scene_item* clone() const{return NULL;}
     QString toolTip() const;
     void draw_edges(CGAL::Three::Viewer_interface*) const;
-    Bbox bbox() const;
+    void compute_bbox() const;
     ~Scene_polyhedron_transform_item() {delete frame; Q_EMIT killed();}
     bool manipulatable() const { return manipulable; }
     ManipulatedFrame* manipulatedFrame() { return frame; }

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
@@ -25,7 +25,7 @@ public:
     }
     bool isFinite() const { return true; }
     bool isEmpty() const { return true; }
-    Bbox bbox() const { return scene->bbox(); }
+    void compute_bbox() const { _bbox = scene->bbox(); }
 
     Scene_bbox_item* clone() const {
         return 0;
@@ -66,6 +66,7 @@ public:
     {
         compute_elements();
         are_buffers_filled = false;
+        compute_bbox();
     }
 
 private:

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -79,13 +79,13 @@ public:
   }
   bool isFinite() const { return true; }
   bool isEmpty() const { return polyline_data_list.empty(); }
-  Bbox bbox() const {
-    if(polyline_data_list.empty()) { return Bbox(); }
+  void compute_bbox() const {
+    if(polyline_data_list.empty()) { _bbox = Bbox(); return;}
     Bbox bbox = polyline_data_list.begin()->polyline->bbox();
     for(Polyline_data_list::const_iterator it = polyline_data_list.begin(); it != polyline_data_list.end(); ++it) {
       bbox = bbox + it->polyline->bbox();
     }
-    return bbox;
+    _bbox = bbox;
   }
   Scene_hole_visualizer* clone() const {
     return 0;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -117,7 +117,7 @@ public Q_SLOTS:
       int item_id = scene->addItem(new_item);
       QObject* scene_ptr = dynamic_cast<QObject*>(scene);
       if (scene_ptr)
-        connect(new_item,SIGNAL(simplicesSelected(Scene_item*)), scene_ptr, SLOT(setSelectedItem(Scene_item*)));
+        connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
       scene->setSelectedItem(item_id);
     }
   }
@@ -215,7 +215,6 @@ public Q_SLOTS:
        begin != selection_item->selected_vertices.end(); ++begin) {
        point_item->point_set()->push_back((*begin)->point());
     }
-    
     scene->setSelectedItem( scene->addItem(point_item) );
     scene->itemChanged(point_item);
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -59,8 +59,8 @@ public:
   }
   bool isFinite() const { return true; }
   bool isEmpty() const { return poly().empty(); }
-  Bbox bbox() const {
-    return point_set_bbox;
+  void compute_bbox() const {
+    _bbox = point_set_bbox;
   }
   Scene_point_set_selection_visualizer* clone() const {
     return 0;

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
@@ -823,6 +823,7 @@ void Scene_edit_polyhedron_item::invalidate_buffers()
 {
     compute_normals_and_vertices();
     update_normals();
+    compute_bbox();
     are_buffers_filled = false;
 }
 
@@ -857,8 +858,8 @@ QString Scene_edit_polyhedron_item::toolTip() const
 bool Scene_edit_polyhedron_item::isEmpty() const {
   return poly_item->isEmpty();
 }
-Scene_edit_polyhedron_item::Bbox Scene_edit_polyhedron_item::bbox() const {
-  return poly_item->bbox();
+void Scene_edit_polyhedron_item::compute_bbox() const {
+  _bbox = poly_item->bbox();
 }
 
 void Scene_edit_polyhedron_item::setVisible(bool b) {

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
@@ -234,7 +234,7 @@ public:
   // Get dimensions
   bool isFinite() const { return true; }
   bool isEmpty() const;
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   int get_k_ring()       { return k_ring_selector.k_ring; }
   void set_k_ring(int v) { k_ring_selector.k_ring = v; }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -32,5 +32,6 @@
         <file>resources/shader_with_textured_edges.v</file>
         <file>resources/shader_with_texture.v</file>
         <file>resources/shader_instanced.v</file>
+        <file>resources/shader_no_light_no_selection.f</file>
     </qresource>
 </RCC>

--- a/Polyhedron/demo/Polyhedron/Scene_c2t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c2t3_item.h
@@ -34,9 +34,9 @@ public:
     return c2t3().triangulation().number_of_vertices() == 0;
   }
 
-  Bbox bbox() const {
+  void compute_bbox() const {
     if(isEmpty())
-      return Bbox();
+      _bbox =  Bbox();
     else {
       bool first = true;
       CGAL::Bbox_3 result;
@@ -52,7 +52,7 @@ public:
           result = result + vit->point().bbox();
         }
       }
-      return Bbox(result.xmin(), result.ymin(), result.zmin(),
+      _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
                   result.xmax(), result.ymax(), result.zmax());
     }
   }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -415,9 +415,9 @@ Kernel::Plane_3 Scene_c3t3_item::plane() const {
   return Kernel::Plane_3(n[0], n[1], n[2], -n * pos);
 }
 
-Scene_item::Bbox Scene_c3t3_item::bbox() const {
+void Scene_c3t3_item::compute_bbox() const {
   if (isEmpty())
-    return Bbox();
+    _bbox = Bbox();
   else {
     CGAL::Bbox_3 result = c3t3().triangulation().finite_vertices_begin()->point().bbox();
     for (Tr::Finite_vertices_iterator
@@ -427,7 +427,7 @@ Scene_item::Bbox Scene_c3t3_item::bbox() const {
     {
       result = result + vit->point().bbox();
     }
-    return Bbox(result.xmin(), result.ymin(), result.zmin(),
+    _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
       result.xmax(), result.ymax(), result.zmax());
   }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -41,6 +41,7 @@ public:
   void invalidate_buffers()
   {
     are_buffers_filled = false;
+    compute_bbox();
   }
 
   void c3t3_changed();
@@ -75,7 +76,7 @@ public:
     return c3t3().triangulation().number_of_vertices() == 0;
   }
 
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   Scene_c3t3_item* clone() const {
     return 0;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -377,10 +377,10 @@ Scene_implicit_function_item::~Scene_implicit_function_item()
 }
 
 
-Scene_implicit_function_item::Bbox
-Scene_implicit_function_item::bbox() const
+void
+Scene_implicit_function_item::compute_bbox() const
 {
-    return function_->bbox();
+    _bbox = function_->bbox();
 }
 
 void
@@ -578,6 +578,7 @@ void
 Scene_implicit_function_item::invalidate_buffers()
 {
     Scene_item::invalidate_buffers();
+    compute_bbox();
     compute_vertices_and_texmap();
     are_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -52,7 +52,7 @@ public:
 
   bool isFinite() const { return true; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   Scene_implicit_function_item* clone() const { return NULL; }
 

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -478,17 +478,20 @@ Scene_nef_polyhedron_item::isEmpty() const {
     return (nef_poly == 0) || nef_poly->is_empty();
 }
 
-Scene_nef_polyhedron_item::Bbox
-Scene_nef_polyhedron_item::bbox() const {
+void
+Scene_nef_polyhedron_item::compute_bbox() const {
     if(isEmpty())
-        return Bbox();
+    {
+        _bbox = Bbox();
+        return;
+    }
     CGAL::Bbox_3 bbox(nef_poly->vertices_begin()->point().bbox());
     for(Nef_polyhedron::Vertex_const_iterator it = nef_poly->vertices_begin();
         it != nef_poly->vertices_end();
         ++it) {
         bbox = bbox + it->point().bbox();
     }
-    return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+    _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 
@@ -661,6 +664,7 @@ void
 Scene_nef_polyhedron_item::
 invalidate_buffers()
 {
+    compute_bbox();
     Base::invalidate_buffers();
     are_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -41,7 +41,7 @@ public:
 
   bool isFinite() const { return true; }
   bool isEmpty() const;
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   Nef_polyhedron* nef_polyhedron();
   const Nef_polyhedron* nef_polyhedron() const;

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -104,6 +104,7 @@ void Scene_plane_item::draw(CGAL::Three::Viewer_interface* viewer)const
     program->bind();
     program->setUniformValue("f_matrix", f_matrix);
     program->setAttributeValue("colors",this->color());
+    program->setUniformValue("is_selected", false);
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_quad.size()/3));
     program->release();
     vaos[Facets]->release();

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -43,7 +43,7 @@ public:
 
   bool isFinite() const { return false; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const { return Bbox(); }
+  void compute_bbox() const { _bbox = Bbox(); }
 
   bool manipulatable() const {
     return manipulable;
@@ -121,6 +121,7 @@ public Q_SLOTS:
   {
       compute_normals_and_vertices();
       are_buffers_filled = false;
+      compute_bbox();
   }
 
   void setPosition(float x, float y, float z) {

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -479,13 +479,13 @@ Scene_points_with_normal_item::isEmpty() const
   return m_points->empty();
 }
 
-Scene_points_with_normal_item::Bbox
-Scene_points_with_normal_item::bbox() const
+void
+Scene_points_with_normal_item::compute_bbox() const
 {
   Q_ASSERT(m_points != NULL);
 
   Kernel::Iso_cuboid_3 bbox = m_points->bounding_box();
-  return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+  _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
               bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 
@@ -578,5 +578,6 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
 void Scene_points_with_normal_item::invalidate_buffers()
 {
     are_buffers_filled = false;
+    compute_bbox();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -63,7 +63,7 @@ public:
   // Gets dimensions
   virtual bool isFinite() const { return true; }
   virtual bool isEmpty() const;
-  virtual Bbox bbox() const;
+  virtual void compute_bbox() const;
 
   virtual void setRenderingMode(RenderingMode m);
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -659,10 +659,10 @@ void
 Scene_polygon_soup_item::invalidate_buffers()
 {
     are_buffers_filled = false;
+    compute_bbox();
 }
 
-Scene_polygon_soup_item::Bbox
-Scene_polygon_soup_item::bbox() const {
+void Scene_polygon_soup_item::compute_bbox() const {
 
   const Point_3& p = *(soup->points.begin());
   CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
@@ -671,7 +671,7 @@ Scene_polygon_soup_item::bbox() const {
       ++it) {
     bbox = bbox + it->bbox();
   }
-  return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+  _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
               bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -149,7 +149,7 @@ public:
     void invalidate_buffers();
     bool isFinite() const { return true; }
     bool isEmpty() const;
-    Bbox bbox() const;
+    void compute_bbox() const;
 
     void new_vertex(const double&, const double&, const double&);
     void new_triangle(const std::size_t, const std::size_t, const std::size_t);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -843,6 +843,7 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     {
         compute_normals_and_vertices();
         initialize_buffers(viewer);
+        compute_bbox();
     }
 
 
@@ -878,6 +879,7 @@ void Scene_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) co
     {
         compute_normals_and_vertices();
         initialize_buffers(viewer);
+        compute_bbox();
     }
 
     vaos[Edges]->bind();
@@ -905,6 +907,7 @@ Scene_polyhedron_item::draw_points(CGAL::Three::Viewer_interface* viewer) const 
     {
         compute_normals_and_vertices();
         initialize_buffers(viewer);
+        compute_bbox();
     }
 
     vaos[Edges]->bind();
@@ -928,8 +931,7 @@ Scene_polyhedron_item::isEmpty() const {
     return (poly == 0) || poly->empty();
 }
 
-Scene_polyhedron_item::Bbox
-Scene_polyhedron_item::bbox() const {
+void Scene_polyhedron_item::compute_bbox() const {
     const Kernel::Point_3& p = *(poly->points_begin());
     CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
     for(Polyhedron::Point_iterator it = poly->points_begin();
@@ -937,7 +939,7 @@ Scene_polyhedron_item::bbox() const {
         ++it) {
         bbox = bbox + it->bbox();
     }
-    return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+    _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -58,7 +58,7 @@ public:
     // Get dimensions
     bool isFinite() const { return true; }
     bool isEmpty() const;
-    Bbox bbox() const;
+    void compute_bbox() const;
     std::vector<QColor>& color_vector() {return colors_;}
     void set_color_vector_read_only(bool on_off) {plugin_has_set_color_vector_m=on_off;}
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
@@ -55,9 +55,9 @@ Scene_polyhedron_item_decorator::isEmpty() const {
   return poly_item->isEmpty();
 }
 
-Scene_polyhedron_item_decorator::Bbox
-Scene_polyhedron_item_decorator::bbox() const {
-  return poly_item->bbox();
+void
+Scene_polyhedron_item_decorator::compute_bbox() const {
+  _bbox = poly_item->bbox();
 }
 
 
@@ -67,6 +67,7 @@ invalidate_buffers()
 {
   poly_item->invalidate_buffers();
   Scene_item::invalidate_buffers();
+  compute_bbox();
 }
 
 void 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
@@ -43,7 +43,7 @@ public:
   // Get dimensions
   bool isFinite() const { return true; }
   bool isEmpty() const;
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   bool delete_item() { return delete_poly_item; }
   void set_delete_item(bool delete_item) { delete_poly_item = delete_item; }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -32,7 +32,7 @@ void Scene_polyhedron_selection_item::initialize_buffers(CGAL::Three::Viewer_int
     }
     //vao containing the data for the unselected lines
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
         vaos[1]->bind();
 
@@ -50,7 +50,7 @@ void Scene_polyhedron_selection_item::initialize_buffers(CGAL::Three::Viewer_int
     }
     //vao containing the data for the points
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
         vaos[2]->bind();
 
@@ -201,9 +201,10 @@ void Scene_polyhedron_selection_item::draw_edges(CGAL::Three::Viewer_interface* 
 
     viewer->glLineWidth(3.f);
     vaos[1]->bind();
-    program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-    attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
+
     program->setAttributeValue("colors",edge_color);
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
     program->release();
@@ -220,8 +221,8 @@ void Scene_polyhedron_selection_item::draw_points(CGAL::Three::Viewer_interface*
     }
     viewer->glPointSize(5.f);
     vaos[2]->bind();
-    program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-    attrib_buffers(viewer,PROGRAM_WITHOUT_LIGHT);
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors",vertex_color);
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -281,7 +281,7 @@ public:
       else
         viewer->setNoBinding();
   }
-  Bbox bbox() const 
+  void compute_bbox() const
   {
     // Workaround a bug in g++-4.8.3:
     //   http://stackoverflow.com/a/21755207/1728537
@@ -316,8 +316,8 @@ public:
         }
     }
 
-    if(!item_bbox) { return this->poly_item->bbox(); }
-    return Bbox(item_bbox->xmin(),item_bbox->ymin(),item_bbox->zmin(),
+    if(!item_bbox) { _bbox = this->poly_item->bbox(); return;}
+    _bbox = Bbox(item_bbox->xmin(),item_bbox->ymin(),item_bbox->zmin(),
                 item_bbox->xmax(),item_bbox->ymax(),item_bbox->zmax());
   }
 
@@ -726,6 +726,7 @@ public Q_SLOTS:
     // do not use decorator function, which calls changed on poly_item which cause deletion of AABB
       //  poly_item->invalidate_buffers();
         are_buffers_filled = false;
+        compute_bbox();
   }
   // slots are called by signals of polyhedron_k_ring_selector
   void selected(const std::set<Polyhedron::Vertex_handle>& m)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -718,7 +718,7 @@ public:
   }
 
 Q_SIGNALS:
-  void simplicesSelected(Scene_item*);
+  void simplicesSelected(CGAL::Three::Scene_item*);
 
 public Q_SLOTS:
   void invalidate_buffers() {

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -37,7 +37,7 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
     QOpenGLShaderProgram *program;
    //vao for the lines
     {
-        program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+        program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
         program->bind();
 
         vaos[Edges]->bind();
@@ -92,7 +92,7 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
         }
         else
         {
-            program = getShaderProgram(PROGRAM_WITHOUT_LIGHT, viewer);
+            program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
             program->bind();
 
             vaos[Spheres]->bind();
@@ -444,8 +444,8 @@ Scene_polylines_item::draw(CGAL::Three::Viewer_interface* viewer) const {
         else
         {
             vaos[Spheres]->bind();
-            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-            attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
+            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_NO_SELECTION);
+            attrib_buffers(viewer, PROGRAM_NO_SELECTION);
             glPointSize(8.0f);
             glEnable(GL_POINT_SMOOTH);
             program->bind();
@@ -467,8 +467,8 @@ Scene_polylines_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
     }
 
     vaos[Edges]->bind();
-    attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
-    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/4));
@@ -500,8 +500,8 @@ Scene_polylines_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
     }
 
     vaos[Edges]->bind();
-    attrib_buffers(viewer, PROGRAM_WITHOUT_LIGHT);
-    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    QOpenGLShaderProgram *program = getShaderProgram(PROGRAM_NO_SELECTION);
     program->bind();
     QColor temp = this->color();
     program->setAttributeValue("colors", temp);

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -346,12 +346,15 @@ Scene_polylines_item::isEmpty() const {
     return polylines.empty();
 }
 
-CGAL::Three::Scene_interface::Bbox
-Scene_polylines_item::bbox() const {
+void
+Scene_polylines_item::compute_bbox() const {
     typedef K::Iso_cuboid_3 Iso_cuboid_3;
 
     if(isEmpty())
-        return Bbox();
+    {
+        _bbox =Bbox();
+        return;
+    }
     std::list<Point_3> boxes;
     for(std::list<std::vector<Point_3> >::const_iterator it = polylines.begin();
         it != polylines.end();
@@ -367,7 +370,7 @@ Scene_polylines_item::bbox() const {
                 CGAL::bounding_box(boxes.begin(), boxes.end()) :
                 Iso_cuboid_3();
 
-    return Bbox(bbox.xmin(),
+    _bbox = Bbox(bbox.xmin(),
                 bbox.ymin(),
                 bbox.zmin(),
                 bbox.xmax(),
@@ -537,6 +540,7 @@ QMenu* Scene_polylines_item::contextMenu()
 void Scene_polylines_item::invalidate_buffers()
 {
     are_buffers_filled = false;
+    compute_bbox();
 
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -3,7 +3,7 @@
 #include "Scene_polylines_item_config.h"
 #include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_item.h>
 
 #include <QString>
 #include <QMenu>

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -27,7 +27,7 @@ public:
 
     bool isFinite() const { return true; }
     bool isEmpty() const;
-    Bbox bbox() const;
+    void compute_bbox() const;
 
     Scene_polylines_item* clone() const;
 

--- a/Polyhedron/demo/Polyhedron/Scene_segmented_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_segmented_image_item.cpp
@@ -645,11 +645,13 @@ void Scene_segmented_image_item::attrib_buffers(Viewer_interface* viewer) const
     rendering_program.release();
 }
 
-Scene_segmented_image_item::Bbox
-Scene_segmented_image_item::bbox() const
+void
+Scene_segmented_image_item::compute_bbox() const
 {
-  if(!m_image) return Bbox();
-  return Bbox(0, 0, 0,
+  if(!m_image)
+    _bbox = Bbox();
+  else
+    _bbox = Bbox(0, 0, 0,
               m_image->xdim() * m_image->vx(),
               m_image->ydim() * m_image->vy(),
               m_image->zdim() * m_image->vz());

--- a/Polyhedron/demo/Polyhedron/Scene_segmented_image_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_segmented_image_item.h
@@ -26,7 +26,7 @@ public:
 
   bool isFinite() const { return true; }
   bool isEmpty() const { return false; }
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   Scene_segmented_image_item* clone() const { return NULL; }
 

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -333,8 +333,8 @@ Scene_textured_polyhedron_item::isEmpty() const {
     return (poly == 0) || poly->empty();
 }
 
-Scene_textured_polyhedron_item::Bbox
-Scene_textured_polyhedron_item::bbox() const {
+void
+Scene_textured_polyhedron_item::compute_bbox() const {
     const Point& p = *(poly->points_begin());
     CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
     for(Textured_polyhedron::Point_iterator it = poly->points_begin();
@@ -342,13 +342,14 @@ Scene_textured_polyhedron_item::bbox() const {
         ++it) {
         bbox = bbox + it->bbox();
     }
-    return Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
+    _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 void
 Scene_textured_polyhedron_item::invalidate_buffers()
 {
     are_buffers_filled = false;
+    compute_bbox();
 }
 void
 Scene_textured_polyhedron_item::

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -42,7 +42,7 @@ public:
   // Get dimensions
   bool isFinite() const { return true; }
   bool isEmpty() const;
-  Bbox bbox() const;
+  void compute_bbox() const;
 
   virtual void invalidate_buffers();
   virtual void contextual_changed();

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -449,7 +449,11 @@ void Viewer::attrib_buffers(int program_name) const {
     program->bind();
     switch(program_name)
     {
-    /// @TODO: factorize that implementation!
+    case PROGRAM_NO_SELECTION:
+        program->setUniformValue("mvp_matrix", mvp_mat);
+
+        program->setUniformValue("f_matrix",f_mat);
+        break;
     case PROGRAM_WITH_LIGHT:
         program->setUniformValue("mvp_matrix", mvp_mat);
         program->setUniformValue("mv_matrix", mv_mat);
@@ -921,6 +925,27 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             }
             program->link();
             d->shader_programs[PROGRAM_WITHOUT_LIGHT] = program;
+            return program;
+        }
+        break;
+    case PROGRAM_NO_SELECTION:
+        if( d->shader_programs[PROGRAM_NO_SELECTION])
+        {
+            return d->shader_programs[PROGRAM_NO_SELECTION];
+        }
+        else
+        {
+            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_without_light.v"))
+            {
+                std::cerr<<"adding vertex shader FAILED"<<std::endl;
+            }
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_no_light_no_selection.f"))
+            {
+                std::cerr<<"adding fragment shader FAILED"<<std::endl;
+            }
+            program->link();
+            d->shader_programs[PROGRAM_NO_SELECTION] = program;
             return program;
         }
         break;

--- a/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
@@ -1,0 +1,6 @@
+#version 120
+varying highp vec4 color;
+void main(void) 
+{
+  gl_FragColor = color; 
+}  

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -55,6 +55,7 @@ class SCENE_ITEM_EXPORT Scene_item : public QObject {
 public:
   enum OpenGL_program_IDs { PROGRAM_WITH_LIGHT,
                             PROGRAM_WITHOUT_LIGHT,
+                            PROGRAM_NO_SELECTION,
                             PROGRAM_WITH_TEXTURE,
                             PROGRAM_WITH_TEXTURED_EDGES,
                             PROGRAM_INSTANCED,

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -81,6 +81,7 @@ public:
       vaosSize(10),
       vaos(10)
   {
+      is_bbox_computed = false;
       is_monochrome = true;
       for(int i=0; i<vaosSize; i++)
       {
@@ -112,6 +113,7 @@ public:
       vaosSize(vaos_size),
       vaos(vaos_size)
   {
+      is_bbox_computed = false;
       is_monochrome = true;
       for(int i=0; i<vaosSize; i++)
       {
@@ -196,8 +198,12 @@ public:
   //! Specifies if the item is empty or null.
   virtual bool isEmpty() const { return true; }
   //!@returns the item's bounding box.
-  virtual Bbox bbox() const { return Bbox(); }
-
+  virtual Bbox bbox() const {
+      if(!is_bbox_computed)
+          compute_bbox();
+      is_bbox_computed = true;
+      return _bbox;
+  }
   // Function about manipulation
   //! Decides if the item can have a ManipulatedFrame.
   virtual bool manipulatable() const { return false; }
@@ -302,6 +308,10 @@ Q_SIGNALS:
   void redraw();
 
 protected:
+  //!Holds the BBox of the item
+  mutable Bbox _bbox;
+  mutable bool is_bbox_computed;
+  virtual void compute_bbox()const{}
   // The four basic properties
   //!The name of the item.
   QString name_;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -45,6 +45,7 @@ class VIEWER_EXPORT Viewer_interface : public QGLViewer, public QOpenGLFunctions
 public:
   enum OpenGL_program_IDs { PROGRAM_WITH_LIGHT,
                             PROGRAM_WITHOUT_LIGHT,
+                            PROGRAM_NO_SELECTION,
                             PROGRAM_WITH_TEXTURE,
                             PROGRAM_WITH_TEXTURED_EDGES,
                             PROGRAM_INSTANCED,


### PR DESCRIPTION
- Almost all the operations involving a manipulatedFrame were very slow on big items because of a massive call to bbox(), which computes the bbox everytime. This PR fixes the problem
- It also repairs the color of the cutting plane and the affine transformation
- There is also some clean-up in the CMakeLists, about two useless lines.