### PR TITLE
<CGAL/Surface_mesh_deformation.h>: do not update coordinates of control vertices

### DIFF
--- a/Surface_modeling/include/CGAL/Surface_mesh_deformation.h
+++ b/Surface_modeling/include/CGAL/Surface_mesh_deformation.h
@@ -1303,7 +1303,8 @@ private:
     {
       std::size_t v_id = ros_id(ros[i]);
       Point p(X[v_id], Y[v_id], Z[v_id]);
-      solution[v_id] = p;
+      if (!is_ctrl_map[id(ros[i])])
+        solution[v_id] = p;
     }
   }
   /// calculate right-hand side of eq:lap_ber_rims in user manual and solve the system
@@ -1373,7 +1374,8 @@ private:
     {
       std::size_t v_id = ros_id(ros[i]);
       Point p(X[v_id], Y[v_id], Z[v_id]);
-      solution[v_id] = p;
+      if (!is_ctrl_map[id(ros[i])])
+        solution[v_id] = p;
     }
   }
 


### PR DESCRIPTION
this makes sure that the control vertices are at the expected position