### PR TITLE
External plugin loading fix

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1578,8 +1578,9 @@ void MainWindow::on_actionLoad_plugin_triggered()
     Q_FOREACH(QString fileName, paths)
     {
       if(fileName.contains("plugin") && QLibrary::isLibrary(fileName)) {
+          QFileInfo fileinfo(fileName);
         //set plugin name
-        QString name = fileName;
+        QString name = fileinfo.fileName();
         name.remove(QRegExp("^lib"));
         name.remove(QRegExp("\\..*"));
         QDebug qdebug = qDebug();


### PR DESCRIPTION
This PR fixes the error message when loading an external plugin.
- Use a QFileInfo to get only the plugin name without its path. 
