### PR TITLE
Bugfix: Only check orientation of polyhedron if it is closed

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -537,7 +537,8 @@ Scene_polygon_soup_item::exportAsPolyhedron(Polyhedron* out_polyhedron)
 
   if(out_polyhedron->size_of_vertices() > 0) {
     // Also check whether the consistent orientation is fine
-    if(!CGAL::Polygon_mesh_processing::is_outward_oriented(*out_polyhedron)) {
+    if(out_polyhedron->is_closed() &&
+       !CGAL::Polygon_mesh_processing::is_outward_oriented(*out_polyhedron)) {
       out_polyhedron->inside_out();
     }
     return true;


### PR DESCRIPTION
In Polyhedron demo, when orienting a polygon soup, an additional test is performed to check if the resulting polyhedron is outward oriented: this should not be done if the polyhedron is not closed as it violates the precondition (and can lead to crashes).