### PR TITLE
Set BOOST_PARAMETER_MAX_ARITY only in the packages concerned

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -88,17 +88,6 @@
 #  define BOOST_RANDOM_HPP
 #endif
 
-#ifdef BOOST_PARAMETER_MAX_ARITY
-#  if (BOOST_PARAMETER_MAX_ARITY < 12)
-#  error "BOOST_PARAMETER_MAX_ARITY must be at least 12 for some CGAL packages"
-#  endif
-#else
-// set it to 12 needed in
-// * <CGAL/lloyd_optimize_mesh_2.h>
-// * <CGAL/Mesh_3/global_parameters.h>
-#define  BOOST_PARAMETER_MAX_ARITY 12
-#endif
-
 // The following header file defines among other things  BOOST_PREVENT_MACRO_SUBSTITUTION 
 #include <boost/config.hpp>
 #include <boost/version.hpp>

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -29,6 +29,14 @@
 
 #include <fstream>
 
+#ifdef BOOST_PARAMETER_MAX_ARITY
+#  if (BOOST_PARAMETER_MAX_ARITY < 12)
+#    error "BOOST_PARAMETER_MAX_ARITY must be at least 8 for CGAL::lloyd_optimize_mesh_2()"
+#  endif
+#else
+#  define  BOOST_PARAMETER_MAX_ARITY 8
+#endif
+
 #include <boost/parameter.hpp>
 #include <boost/parameter/name.hpp>
 

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -30,7 +30,7 @@
 #include <fstream>
 
 #ifdef BOOST_PARAMETER_MAX_ARITY
-#  if (BOOST_PARAMETER_MAX_ARITY < 12)
+#  if (BOOST_PARAMETER_MAX_ARITY < 8)
 #    error "BOOST_PARAMETER_MAX_ARITY must be at least 8 for CGAL::lloyd_optimize_mesh_2()"
 #  endif
 #else

--- a/Mesh_3/demo/Mesh_3/C3t3_type.h
+++ b/Mesh_3/demo/Mesh_3/C3t3_type.h
@@ -1,6 +1,10 @@
 #ifndef CGAL_DEMO_MESH_3_C3T3_TYPE_H
 #define CGAL_DEMO_MESH_3_C3T3_TYPE_H
 
+// include this first to get #define BOOST_PARAMETER_MAX_ARITY 12
+// as otherwise it gets set via inclusion of Polyhedron_3.h
+#include <CGAL/Mesh_3/global_parameters.h>
+
 #include "Polyhedron_type.h"
 #include "Image_type.h"
 #include "implicit_functions/Implicit_function_interface.h"

--- a/Mesh_3/demo/Mesh_3/Mesh_3_plugin.cpp
+++ b/Mesh_3/demo/Mesh_3/Mesh_3_plugin.cpp
@@ -25,10 +25,11 @@
 
 #include "implicit_functions/Implicit_function_interface.h"
 #include "Image_type.h"
-#include "Polyhedron_type.h"
 
 #include "Scene_c3t3_item.h"
 #include "Meshing_thread.h"
+
+#include "Polyhedron_type.h"
 
 #include <iostream>
 #include <fstream>

--- a/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
+++ b/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
@@ -28,6 +28,14 @@
 #include <CGAL/config.h>
 #include <CGAL/Mesh_3/config.h>
 
+#ifdef BOOST_PARAMETER_MAX_ARITY
+#  if (BOOST_PARAMETER_MAX_ARITY < 12)
+#    error "BOOST_PARAMETER_MAX_ARITY must be at least 12 for CGAL::Mesh_3"
+#  endif
+#else
+#  define  BOOST_PARAMETER_MAX_ARITY 12
+#endif
+
 #include <boost/parameter.hpp>
 
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -29,6 +29,7 @@
 
 #include <CGAL/Polygon_mesh_processing/internal/Side_of_triangle_mesh/Point_inside_vertical_ray_cast.h>
 
+#include <CGAL/Mesh_3/global_parameters.h>
 #include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
 #include <CGAL/Mesh_3/Triangle_accessor_primitive.h>
 #include <CGAL/Triangle_accessor_3.h>

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -1,6 +1,10 @@
 #ifndef CGAL_DEMO_MESH_3_C3T3_TYPE_H
 #define CGAL_DEMO_MESH_3_C3T3_TYPE_H
 
+// include this to get #define BOOST_PARAMETER_MAX_ARITY 12
+// as otherwise it gets set via inclusion of Polyhedron_3.h
+#include <CGAL/Mesh_3/global_parameters.h>
+
 #include "Polyhedron_type.h"
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES
 #include "Image_type.h"


### PR DESCRIPTION
Instead of  setting it globally in include/CGAL/config.h   we set the value in the header files of Mesh_2 and Mesh_3.