### PR TITLE
Adjusting zNear with wheel and shift

### DIFF
--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1041,3 +1041,19 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
         return 0;
     }
 }
+void Viewer::wheelEvent(QWheelEvent* e)
+{
+    if(e->modifiers().testFlag(Qt::ShiftModifier))
+    {
+        double delta = e->delta();
+        if(delta>0)
+        {
+            camera()->setZNearCoefficient(camera()->zNearCoefficient() * 1.01);
+        }
+        else
+            camera()->setZNearCoefficient(camera()->zNearCoefficient() / 1.01);
+        updateGL();
+    }
+    else
+        QGLViewer::wheelEvent(e);
+}

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -102,6 +102,7 @@ protected:
   bool axis_are_displayed;
   //!Defines the behaviour for the mouse press events
   void mousePressEvent(QMouseEvent*);
+  void wheelEvent(QWheelEvent *);
   //!Defines the behaviour for the key press events
   void keyPressEvent(QKeyEvent*);
   /*! \brief Encapsulates the pickMatrix.


### PR DESCRIPTION
Using Shift+wheel adjusts the zNear plane in the Frustum