### PR TITLE
Polyhedron demo mesh 3 plugin fix and enhancement

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin.cpp
@@ -296,7 +296,6 @@ void Polyhedron_demo_mesh_3_plugin::mesh_3()
                            .arg(facet_sizing)
                            .arg(tet_sizing)
                            .arg(approx));
-      //result_item->setColor(Qt::magenta);
       result_item->setItemIsMulticolor(true);
       result_item->setRenderingMode(FlatPlusEdges);
       item->setVisible(false);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin.cpp
@@ -296,7 +296,8 @@ void Polyhedron_demo_mesh_3_plugin::mesh_3()
                            .arg(facet_sizing)
                            .arg(tet_sizing)
                            .arg(approx));
-      result_item->setColor(Qt::magenta);
+      //result_item->setColor(Qt::magenta);
+      result_item->setItemIsMulticolor(true);
       result_item->setRenderingMode(FlatPlusEdges);
       item->setVisible(false);
       result_item->set_data_item(item);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -101,12 +101,15 @@ Scene_c3t3_item::Scene_c3t3_item()
   s_vertex.resize(0);
   s_normals.resize(0);
   ws_vertex.resize(0);
+  need_changed = false;
+  startTimer(0);
   connect(frame, SIGNAL(modified()), this, SLOT(changed()));
   c3t3_changed();
   setRenderingMode(FlatPlusEdges);
   compile_shaders();
   spheres_are_shown = false;
   create_flat_and_wire_sphere(1.0f,s_vertex,s_normals, ws_vertex);
+
 }
 
 Scene_c3t3_item::Scene_c3t3_item(const C3t3& c3t3)
@@ -124,6 +127,8 @@ Scene_c3t3_item::Scene_c3t3_item(const C3t3& c3t3)
   s_vertex.resize(0);
   s_normals.resize(0);
   ws_vertex.resize(0);
+  need_changed = false;
+  startTimer(0);
   connect(frame, SIGNAL(modified()), this, SLOT(changed()));
   c3t3_changed();
   setRenderingMode(FlatPlusEdges);
@@ -177,9 +182,16 @@ Scene_c3t3_item::c3t3()
 void
 Scene_c3t3_item::changed()
 {
-  this->c3t3_changed();
+
+  need_changed = true;
 }
 
+void Scene_c3t3_item::timerEvent(QTimerEvent* /*event*/)
+{ // just handle deformation - paint like selection is handled in eventFilter()
+  if(need_changed) {
+      c3t3_changed();
+  }
+}
 void
 Scene_c3t3_item::c3t3_changed()
 {
@@ -202,6 +214,7 @@ Scene_c3t3_item::c3t3_changed()
   build_histogram();
   //compute_elements();
   this->invalidate_buffers();
+  need_changed = false;
 }
 
 QPixmap

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -460,7 +460,7 @@ void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {
   program = getShaderProgram(PROGRAM_WITH_LIGHT);
   attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
   program->bind();
-  program->setAttributeValue("colors", this->color());
+  //program->setAttributeValue("colors", this->color());
   viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_poly.size() / 3));
   program->release();
   vaos[Facets]->release();
@@ -638,6 +638,8 @@ void Scene_c3t3_item::draw_triangle(const Kernel::Point_3& pa,
   positions_poly.push_back(pc.y());
   positions_poly.push_back(pc.z());
 
+
+
 }
 
 void Scene_c3t3_item::draw_triangle_edges(const Kernel::Point_3& pa,
@@ -763,6 +765,13 @@ void Scene_c3t3_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer)c
     program->enableAttributeArray("normals");
     program->setAttributeBuffer("normals", GL_FLOAT, 0, 3);
     buffers[Facet_normals].release();
+
+    buffers[Facet_colors].bind();
+    buffers[Facet_colors].allocate(f_colors.data(),
+      static_cast<int>(f_colors.size()*sizeof(float)));
+    program->enableAttributeArray("colors");
+    program->setAttributeBuffer("colors", GL_FLOAT, 0, 3);
+    buffers[Facet_colors].release();
 
     vaos[Facets]->release();
     program->release();
@@ -899,6 +908,7 @@ void Scene_c3t3_item::compute_elements() const
   positions_lines.clear();
   positions_poly.clear();
   normals.clear();
+  f_colors.resize(0);
   s_colors.resize(0);
   s_center.resize(0);
   s_radius.resize(0);
@@ -972,6 +982,19 @@ void Scene_c3t3_item::compute_elements() const
         sc != ON_ORIENTED_BOUNDARY &&
         sb == sa && sc == sa)
       {
+          if(cell->subdomain_index() == 0) {
+
+              QColor color = d->colors[cell->neighbor(index)->subdomain_index()];
+              f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+              f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+              f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+          }
+          else {
+            QColor color = d->colors[cell->subdomain_index()];
+            f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+            f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+            f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blue());
+          }
         if ((index % 2 == 1) == c3t3().is_in_complex(cell)) draw_triangle(pb, pa, pc, false);
         else draw_triangle(pa, pb, pc, false);
         draw_triangle_edges(pa, pb, pc);
@@ -1005,6 +1028,24 @@ void Scene_c3t3_item::compute_elements() const
         sd == ON_ORIENTED_BOUNDARY ||
         sb != sa || sc != sa || sd != sa)
       {
+        QColor color = d->colors[cit->subdomain_index()].darker(150);
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+        f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
+
+
         draw_triangle(pb, pa, pc, true);
         draw_triangle(pa, pb, pd, true);
         draw_triangle(pa, pd, pc, true);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -111,6 +111,7 @@ public:
   void draw_edges(CGAL::Three::Viewer_interface* viewer) const;
   void draw_points(CGAL::Three::Viewer_interface * viewer) const;
 private:
+  bool need_changed;
   void reset_cut_plane();
   void draw_triangle(const Kernel::Point_3& pa,
     const Kernel::Point_3& pb,
@@ -140,6 +141,8 @@ private:
   void update_histogram();
 
   void changed();
+
+  void timerEvent(QTimerEvent*);
 
 private:
   void build_histogram();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -159,6 +159,7 @@ private:
   {
       Facet_vertices =0,
       Facet_normals,
+      Facet_colors,
       Edges_vertices,
       Grid_vertices,
       Sphere_vertices,
@@ -201,6 +202,7 @@ private:
   mutable std::vector<float> positions_grid;
   mutable std::vector<float> positions_poly;
   mutable std::vector<float> normals;
+  mutable std::vector<float> f_colors;
   mutable std::vector<float> s_normals;
   mutable std::vector<float> s_colors;
   mutable std::vector<float> s_vertex;


### PR DESCRIPTION
This PR restores the multicolor aspect of the c3t3 items and smoothes the plane movements by using a timerEvent to avoid flooding events.