### PR TITLE
Bugfix: always check if facet is sliver

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -1300,8 +1300,7 @@ namespace CGAL {
       int i1 = e.first.second, i2 = e.first.third;
       int i3 = 6 - e.second - i1 - i2;
 
-      Edge_incident_facet e_it = e, predone = previous(e);
-      Cell_handle c_predone = predone.first.first;
+      Edge_incident_facet e_it = e;
 
       coord_type min_valueP = NOT_VALID_CANDIDATE, min_valueA = HUGE_VAL;
       Facet min_facet, min_facetA;
@@ -1320,7 +1319,6 @@ namespace CGAL {
       coord_type norm12 = P2P1*P2P1;
 
       e_it = next(e_it);
-      bool succ_start(true);
 
       do
         {
@@ -1367,10 +1365,7 @@ namespace CGAL {
                   norm =  sqrt(norm1 * (v2*v2));
                   pscal = v1*v2;
                   // check if the triangle will produce a sliver on the surface
-                  bool sliver_facet = ((succ_start || (neigh == c_predone))&&
-                                       (pscal <= COS_ALPHA_SLIVER*norm));
-
-                  if (succ_start) succ_start = false;
+                  bool sliver_facet = (pscal <= COS_ALPHA_SLIVER*norm);
 
                   if (!sliver_facet)
                     {


### PR DESCRIPTION
When computing the priority of a facet in the _advancing front surface reconstruction_ algorithm, a test is performed to check if the facet forms a sliver with the surface (red wedge on [this figure](http://doc.cgal.org/4.7/Advancing_front_surface_reconstruction/index.html#title2)).

Currently, this test is only performed for the first and last facet visited around the current facet: although it is true that the chances of finding a sliver are higher when checking at the closest neighbors of the current facet, some other facets can form slivers too. Experimentally, this produced indeed slivers and badly shaped surfaces on some point sets (with double coverage in some parts).

It is unclear to me why this was done in the first place:
* Most probably for speed enhancement, but I can't imagine a situation where it would be noticeable
* It is not documented by a commentary
* It is not documented in the manual
* It is not documented in the original research article
* As far as I can see in the git history, it's been here since the beginning of the feature's existence in CGAL, so it is not documented by a commit either

This bugfix removes the tests that check if the facet is the first or the last, so that _all_ facets are checked to be slivers or not. Experimentally, this corrects the badly shaped surfaces that could appear before with no impact on the performances.