### PR TITLE
Polyhedron demo: quick moving display of point sets

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -246,7 +246,7 @@ MainWindow::MainWindow(QWidget* parent)
   connect(ui->actionDraw_two_sides, SIGNAL(toggled(bool)),
           viewer, SLOT(setTwoSides(bool)));
   connect(ui->actionQuick_camera_mode, SIGNAL(toggled(bool)),
-          viewer, SLOT(setQuickCameraMode(bool)));
+          viewer, SLOT(setFastDrawing(bool)));
 
   // add the "About CGAL..." and "About demo..." entries
   this->addAboutCGAL();

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -245,6 +245,8 @@ MainWindow::MainWindow(QWidget* parent)
 
   connect(ui->actionDraw_two_sides, SIGNAL(toggled(bool)),
           viewer, SLOT(setTwoSides(bool)));
+  connect(ui->actionQuick_camera_mode, SIGNAL(toggled(bool)),
+          viewer, SLOT(setQuickCameraMode(bool)));
 
   // add the "About CGAL..." and "About demo..." entries
   this->addAboutCGAL();

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -115,6 +115,7 @@
     <addaction name="action_Look_at"/>
     <addaction name="actionAntiAliasing"/>
     <addaction name="actionDraw_two_sides"/>
+    <addaction name="actionQuick_camera_mode"/>
     <addaction name="actionSetBackgroundColor"/>
     <addaction name="menuDockWindows"/>
     <addaction name="menuCamera"/>
@@ -640,6 +641,17 @@
   <action name="actionLoad_plugin">
    <property name="text">
     <string>Load plugin</string>
+   </property>
+  </action>
+  <action name="actionQuick_camera_mode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Quick camera mode</string>
    </property>
   </action>
  </widget>

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -169,7 +169,8 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
 
     //Shuffle container to allow quick display random points
     Point_set_3<Kernel> points = *m_points;
-    std::random_shuffle (points.begin(), points.end());
+    std::random_shuffle (points.begin(), points.end() - m_points->nb_selected_points());
+    std::random_shuffle (points.end() - m_points->nb_selected_points(), points.end());
     
     //The points
     {

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -425,10 +425,8 @@ void Scene_points_with_normal_item::draw_splats(CGAL::Three::Viewer_interface* v
 void Scene_points_with_normal_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
 {
     double ratio_displayed = 1.0;
-    if (viewer->quickCameraMode () &&
-        (nb_lines/6 > 300000) && // arbitrary large value
-        (viewer->camera()->frame()->isSpinning()
-         || viewer->camera()->frame()->isManipulated()))
+    if (viewer->inFastDrawing () &&
+        (nb_lines/6 > 300000)) // arbitrary large value
       ratio_displayed = 6 * 300000. / (double)(nb_lines);
 
     if(!are_buffers_filled)
@@ -449,10 +447,8 @@ void Scene_points_with_normal_item::draw_points(CGAL::Three::Viewer_interface* v
         initialize_buffers(viewer);
 
     double ratio_displayed = 1.0;
-    if (viewer->quickCameraMode () &&
-        ((nb_points + nb_selected_points)/3 > 300000) && // arbitrary large value
-        (viewer->camera()->frame()->isSpinning()
-         || viewer->camera()->frame()->isManipulated()))
+    if (viewer->inFastDrawing () &&
+        ((nb_points + nb_selected_points)/3 > 300000)) // arbitrary large value
       ratio_displayed = 3 * 300000. / (double)(nb_points + nb_selected_points);
 
     vaos[ThePoints]->bind();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -17,6 +17,7 @@
 
 #include <QObject>
 #include <QMenu>
+#include <QGLViewer/manipulatedCameraFrame.h>
 
 #include <set>
 #include <stack>
@@ -165,10 +166,15 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
     positions_points.reserve(m_points->size() * 3);
     positions_lines.reserve(m_points->size() * 3 * 2);
 
+
+    //Shuffle container to allow quick display random points
+    Point_set_3<Kernel> points = *m_points;
+    std::random_shuffle (points.begin(), points.end());
+    
     //The points
     {
         // The *non-selected* points
-      for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); it++)
+      for (Point_set_3<Kernel>::const_iterator it = points.begin(); it != points.first_selected(); it++)
 	{
 	  const UI_point& p = *it;
 	  positions_points.push_back(p.x());
@@ -177,7 +183,7 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
 	}
 
         // Draw *selected* points
-      for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); it++)
+      for (Point_set_3<Kernel>::const_iterator it = points.first_selected(); it != points.end(); it++)
 	{
 	  const UI_point& p = *it;
 	  positions_selected_points.push_back(p.x());
@@ -189,10 +195,10 @@ void Scene_points_with_normal_item::compute_normals_and_vertices() const
     //The lines
     {
         // Stock normals
-        Kernel::Sphere_3 region_of_interest = m_points->region_of_interest();
+        Kernel::Sphere_3 region_of_interest = points.region_of_interest();
         float normal_length = (float)std::sqrt(region_of_interest.squared_radius() / 1000.);
 
-	for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
+	for (Point_set_3<Kernel>::const_iterator it = points.begin(); it != points.end(); it++)
 	  {
 	    const UI_point& p = *it;
 	    const Point_set_3<Kernel>::Vector& n = p.normal();
@@ -417,6 +423,13 @@ void Scene_points_with_normal_item::draw_splats(CGAL::Three::Viewer_interface* v
 
 void Scene_points_with_normal_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
 {
+    double ratio_displayed = 1.0;
+    if (viewer->quickCameraMode () &&
+        (nb_lines/6 > 300000) && // arbitrary large value
+        (viewer->camera()->frame()->isSpinning()
+         || viewer->camera()->frame()->isManipulated()))
+      ratio_displayed = 6 * 300000. / (double)(nb_lines);
+
     if(!are_buffers_filled)
         initialize_buffers(viewer);
     vaos[Edges]->bind();
@@ -424,7 +437,8 @@ void Scene_points_with_normal_item::draw_edges(CGAL::Three::Viewer_interface* vi
     attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_lines/3));
+    viewer->glDrawArrays(GL_LINES, 0,
+                         static_cast<GLsizei>(((std::size_t)(ratio_displayed * nb_lines)/3)));
     vaos[Edges]->release();
     program->release();
 }
@@ -433,12 +447,20 @@ void Scene_points_with_normal_item::draw_points(CGAL::Three::Viewer_interface* v
     if(!are_buffers_filled)
         initialize_buffers(viewer);
 
+    double ratio_displayed = 1.0;
+    if (viewer->quickCameraMode () &&
+        ((nb_points + nb_selected_points)/3 > 300000) && // arbitrary large value
+        (viewer->camera()->frame()->isSpinning()
+         || viewer->camera()->frame()->isManipulated()))
+      ratio_displayed = 3 * 300000. / (double)(nb_points + nb_selected_points);
+
     vaos[ThePoints]->bind();
     program=getShaderProgram(PROGRAM_NO_SELECTION);
     attrib_buffers(viewer,PROGRAM_NO_SELECTION);
     program->bind();
     program->setAttributeValue("colors", this->color());
-    viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_points/3));
+    viewer->glDrawArrays(GL_POINTS, 0,
+                         static_cast<GLsizei>(((std::size_t)(ratio_displayed * nb_points)/3)));
     vaos[ThePoints]->release();
     program->release();
     GLfloat point_size;
@@ -451,7 +473,7 @@ void Scene_points_with_normal_item::draw_points(CGAL::Three::Viewer_interface* v
     program->bind();
     program->setAttributeValue("colors", QColor(255,0,0));
     viewer->glDrawArrays(GL_POINTS, 0,
-                       static_cast<GLsizei>(nb_selected_points/3));
+                         static_cast<GLsizei>(((std::size_t)(ratio_displayed * nb_selected_points)/3)));
     vaos[Selected_points]->release();
     program->release();
     viewer->glPointSize(point_size);

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -116,14 +116,12 @@ void Viewer::draw()
 {
   glEnable(GL_DEPTH_TEST);
   d->inFastDrawing = false;
-  QGLViewer::draw();
   d->draw_aux(false, this);
 }
 
 void Viewer::fastDraw()
 {
   d->inFastDrawing = true;
-  QGLViewer::fastDraw();
   d->draw_aux(false, this);
 }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -16,7 +16,6 @@ public:
   bool twosides;
   bool macro_mode;
   bool inFastDrawing;
-  bool quick_camera;
   
   void draw_aux(bool with_names, Viewer*);
 
@@ -30,8 +29,8 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->scene = 0;
   d->antialiasing = antialiasing;
   d->twosides = false;
-  d->quick_camera = true;
   d->macro_mode = false;
+  d->inFastDrawing = true;
   d->shader_programs.resize(NB_OF_PROGRAMS);
   setShortcut(EXIT_VIEWER, 0);
   setShortcut(DRAW_AXIS, 0);
@@ -97,31 +96,27 @@ void Viewer::setTwoSides(bool b)
 }
 
 
-bool Viewer::quickCameraMode() const
+void Viewer::setFastDrawing(bool b)
 {
-  return d->quick_camera;
-}
-
-void Viewer::setQuickCameraMode(bool b)
-{
-  d->quick_camera = b;
+  d->inFastDrawing = b;
   updateGL();
 }
 
-bool Viewer::inFastDrawing() const {
-  return d->inFastDrawing;
+bool Viewer::inFastDrawing() const
+{
+  return (d->inFastDrawing
+          && (camera()->frame()->isSpinning()
+              || camera()->frame()->isManipulated()));
 }
 
 void Viewer::draw()
 {
   glEnable(GL_DEPTH_TEST);
-  d->inFastDrawing = false;
   d->draw_aux(false, this);
 }
 
 void Viewer::fastDraw()
 {
-  d->inFastDrawing = true;
   d->draw_aux(false, this);
 }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -16,7 +16,8 @@ public:
   bool twosides;
   bool macro_mode;
   bool inFastDrawing;
-
+  bool quick_camera;
+  
   void draw_aux(bool with_names, Viewer*);
 
   //! Contains all the programs for the item rendering.
@@ -29,6 +30,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->scene = 0;
   d->antialiasing = antialiasing;
   d->twosides = false;
+  d->quick_camera = true;
   d->macro_mode = false;
   d->shader_programs.resize(NB_OF_PROGRAMS);
   setShortcut(EXIT_VIEWER, 0);
@@ -91,6 +93,18 @@ void Viewer::setAntiAliasing(bool b)
 void Viewer::setTwoSides(bool b)
 {
   d->twosides = b;
+  updateGL();
+}
+
+
+bool Viewer::quickCameraMode() const
+{
+  return d->quick_camera;
+}
+
+void Viewer::setQuickCameraMode(bool b)
+{
+  d->quick_camera = b;
   updateGL();
 }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -57,6 +57,8 @@ public:
   void setScene(CGAL::Three::Scene_draw_interface* scene);
   //! @returns the antialiasing state.
   bool antiAliasing() const;
+  //! @returns the quick camera state.
+  bool quickCameraMode() const;
   //! @returns the fastDrawing state.
   bool inFastDrawing() const;
   //! Implementation of `Viewer_interface::attrib_buffers()`
@@ -70,6 +72,9 @@ public Q_SLOTS:
   //! If b is true, facets will be ligted from both internal and external sides.
   //! If b is false, only the side that is exposed to the light source will be lighted.
   void setTwoSides(bool b);
+  //! If b is true, some items are displayed in a simplified version when moving the camera.
+  //! If b is false, items display is never altered, even when moving.
+  void setQuickCameraMode(bool b);
   //! Make the camera turn around.
   void turnCameraBy180Degres();
   //! @returns a QString containing the position and orientation of the camera.

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -57,8 +57,6 @@ public:
   void setScene(CGAL::Three::Scene_draw_interface* scene);
   //! @returns the antialiasing state.
   bool antiAliasing() const;
-  //! @returns the quick camera state.
-  bool quickCameraMode() const;
   //! @returns the fastDrawing state.
   bool inFastDrawing() const;
   //! Implementation of `Viewer_interface::attrib_buffers()`
@@ -74,7 +72,7 @@ public Q_SLOTS:
   void setTwoSides(bool b);
   //! If b is true, some items are displayed in a simplified version when moving the camera.
   //! If b is false, items display is never altered, even when moving.
-  void setQuickCameraMode(bool b);
+  void setFastDrawing(bool b);
   //! Make the camera turn around.
   void turnCameraBy180Degres();
   //! @returns a QString containing the position and orientation of the camera.

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -59,8 +59,6 @@ public:
   virtual void setScene(CGAL::Three::Scene_draw_interface* scene) = 0;
   //! @returns the antialiasing state.
   virtual bool antiAliasing() const = 0;
-  //! @returns the quick camera state.
-  virtual bool quickCameraMode() const = 0;
   
   // Those two functions are defined in Viewer.cpp
   //!Sets the position and orientation of a frame using a QString.
@@ -142,7 +140,7 @@ public Q_SLOTS:
   virtual void setTwoSides(bool b) = 0;
   //! If b is true, some items are displayed in a simplified version when moving the camera.
   //! If b is false, items display is never altered, even when moving.
-  virtual void setQuickCameraMode(bool b) = 0;
+  virtual void setFastDrawing(bool b) = 0;
   //! Make the camera turn around.
   virtual void turnCameraBy180Degres() = 0;
   //! @returns a QString containing the position and orientation of the camera.

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -59,7 +59,9 @@ public:
   virtual void setScene(CGAL::Three::Scene_draw_interface* scene) = 0;
   //! @returns the antialiasing state.
   virtual bool antiAliasing() const = 0;
-
+  //! @returns the quick camera state.
+  virtual bool quickCameraMode() const = 0;
+  
   // Those two functions are defined in Viewer.cpp
   //!Sets the position and orientation of a frame using a QString.
   //!@returns true if it worked.
@@ -138,6 +140,9 @@ public Q_SLOTS:
   //! If b is true, facets will be ligted from both internal and external sides.
   //! If b is false, only the side that is exposed to the light source will be lighted.
   virtual void setTwoSides(bool b) = 0;
+  //! If b is true, some items are displayed in a simplified version when moving the camera.
+  //! If b is false, items display is never altered, even when moving.
+  virtual void setQuickCameraMode(bool b) = 0;
   //! Make the camera turn around.
   virtual void turnCameraBy180Degres() = 0;
   //! @returns a QString containing the position and orientation of the camera.


### PR DESCRIPTION
When displaying a large point set, the number of FPS drops dramatically when moving the camera. This PR creates a "quick camera mode" that only displays a subset of points when moving if the number of points is higher than an arbitrary high value (hard coded). The full point set is only displayed when the camera stops.

This mode is on by default but can be disabled in the _View_ menu. So far it is only used for point sets, but it can be extended to other items provided a rational is found to simplify their display.