### PR TITLE
Bugfix: pair not compatible with Point_3 (clang)

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -45,7 +45,7 @@ class LineC3
   {
     Point_3 first;
     Vector_3 second;
-    Rep () : first(Point_3()), second(Vector_3()) { }
+    Rep () : first(), second() { }
     Rep (const Point_3& p, const Vector_3& v) : first(p), second(v) { }
     Rep (const Rep& r) : first(r.first), second(r.second) { }
   };

--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -45,6 +45,7 @@ class LineC3
   {
     Point_3 first;
     Vector_3 second;
+    Rep () : first(Point_3()), second(Vector_3()) { }
     Rep (const Point_3& p, const Vector_3& v) : first(p), second(v) { }
     Rep (const Rep& r) : first(r.first), second(r.second) { }
   };

--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -45,6 +45,8 @@ class LineC3
   {
     Point_3 first;
     Vector_3 second;
+    Rep (const Point_3& p, const Vector_3& v) : first(p), second(v) { }
+    Rep (const Rep& r) : first(r.first), second(r.second) { }
   };
 
   typedef typename R_::template Handle<Rep>::type  Base;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -25,7 +25,6 @@
 #ifndef CGAL_CARTESIAN_LINE_3_H
 #define CGAL_CARTESIAN_LINE_3_H
 
-#include <utility>
 #include <CGAL/Handle_for.h>
 
 namespace CGAL {
@@ -42,7 +41,12 @@ class LineC3
   typedef typename R_::Line_3               Line_3;
   typedef typename R_::Segment_3            Segment_3;
 
-  typedef std::pair<Point_3, Vector_3>             Rep;
+  struct Rep
+  {
+    Point_3 first;
+    Vector_3 second;
+  };
+
   typedef typename R_::template Handle<Rep>::type  Base;
 
   Base base;


### PR DESCRIPTION
Bugfix for the following issues: https://github.com/CGAL/cgal/issues/49 and https://github.com/CGAL/cgal/issues/343

It turns out that in recent versions of C++ (c++11 and c++14), a pair cannot be instantiated on incomplete types. Therefore, using a pair of _Point_3_ would not compile for the following reason:
* _Point_3_ is based on _Vector_3_
* _Vector_3_ has a constructor taking a _Line_3_ as an argument
* Because of the new behavior of pair, all methods of _Vector_3_ are checked, including this constructor
* _Line_3_ is using a _std::pair_ of _Point_3_ and _Vector_3_, resulting in a loop and a compilation error

This bug is fixed by replacing the pair inside _Line_3_ by an internal _struct_ reproducing the same behavior as _std::pair_. This has been tested in [4.8-Ic-75](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-75.shtml): the bug has disappeared from the clang columns with no visible regression on other platforms.