### PR TITLE
Remove deprecated "register" keyword

### DIFF
--- a/CGAL_ImageIO/src/CGAL_ImageIO/convert_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/convert_impl.h
@@ -55,14 +55,14 @@ void ConvertBuffer( void *bufferIn,
 		    int bufferLength )
 {
   const char *proc = "ConvertBuffer";
-  register int i, min, max;
-  register u8 *u8buf;
-  register s8 *s8buf;
-  register u16 *u16buf;
-  register s16 *s16buf;
-  register s32 *s32buf;
-  register r32 *r32buf;
-  register r64 *r64buf;
+  int i, min, max;
+  u8 *u8buf;
+  s8 *s8buf;
+  u16 *u16buf;
+  s16 *s16buf;
+  s32 *s32buf;
+  r32 *r32buf;
+  r64 *r64buf;
 
   if ( (typeOut == typeIn) && (bufferOut == bufferIn) )
     return;
@@ -395,9 +395,9 @@ void Convert_r32_to_s8( r32 *theBuf,
 			s8 *resBuf,
 			int size )
 {
-  register int i;
-  register r32* tb = theBuf;
-  register s8* rb = resBuf;
+  int i;
+  r32* tb = theBuf;
+  s8* rb = resBuf;
   
   for ( i=0; i<size; i++, tb++, rb++ ) {
     if ( *tb < -128.0 ) {
@@ -421,9 +421,9 @@ void Convert_r32_to_u8( r32 *theBuf,
 			u8 *resBuf,
 			int size )
 {
-  register int i;
-  register r32* tb = theBuf;
-  register u8* rb = resBuf;
+  int i;
+  r32* tb = theBuf;
+  u8* rb = resBuf;
   
   for ( i=0; i<size; i++, tb++, rb++ ) {
     if ( *tb < 0.0 ) {
@@ -445,9 +445,9 @@ void Convert_r32_to_s16( r32 *theBuf,
 			 s16 *resBuf,
 			 int size )
 {
-  register int i;
-  register r32* tb = theBuf;
-  register s16* rb = resBuf;
+  int i;
+  r32* tb = theBuf;
+  s16* rb = resBuf;
   
   for ( i=0; i<size; i++, tb++, rb++ ) {
     if ( *tb < -32768.0 ) {
@@ -471,9 +471,9 @@ void Convert_r32_to_u16( r32 *theBuf,
 			 u16 *resBuf,
 			 int size )
 {
-  register int i;
-  register r32* tb = theBuf;
-  register u16* rb = resBuf;
+  int i;
+  r32* tb = theBuf;
+  u16* rb = resBuf;
   
   for ( i=0; i<size; i++, tb++, rb++ ) {
     if ( *tb < 0.0 ) {

--- a/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
@@ -131,9 +131,9 @@ int readGifImage(const char *name,_image *im) {
 FILE *fp;
 int   gif89 = 0;
 
-  register byte ch, ch1;
-  register byte *ptr, *ptr1;
-  register int i, block;
+  byte ch, ch1;
+  byte *ptr, *ptr1;
+  int i, block;
   int npixels, maxpixels, aspect, filesize;
   float normaspect;
   int OutCount = 0,		/* Decompressor output 'stack count' */

--- a/CGAL_ImageIO/src/CGAL_ImageIO/recbuffer_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/recbuffer_impl.h
@@ -1218,9 +1218,9 @@ int RecursiveFilterOnBuffer( void *bufferIn,
 			     recursiveFilterType filterType )
 {
   const char *proc = "RecursiveFilterOnBuffer";
-  register int dimx, dimxXdimy;
+  int dimx, dimxXdimy;
   int dimy, dimz;
-  register int x, y, z;
+  int x, y, z;
   /* 
    *obviously, we need to perform the computation 
    * with float or double values. For this reason,
@@ -1250,18 +1250,18 @@ int RecursiveFilterOnBuffer( void *bufferIn,
   /*
    * pointers for computations;
    */
-  register r32 *r32firstPoint = (r32*)NULL;
-  register r64 *r64firstPoint = (r64*)NULL;
-  register r32 *r32_pt = (r32*)NULL;
-  register r64 *r64_pt = (r64*)NULL;
-  register double *dbl_pt1 = (double*)NULL;
-  register double *dbl_pt2 = (double*)NULL;
-  register double dbl_first = 0.0;
-  register double dbl_last = 0.0;
+  r32 *r32firstPoint = (r32*)NULL;
+  r64 *r64firstPoint = (r64*)NULL;
+  r32 *r32_pt = (r32*)NULL;
+  r64 *r64_pt = (r64*)NULL;
+  double *dbl_pt1 = (double*)NULL;
+  double *dbl_pt2 = (double*)NULL;
+  double dbl_first = 0.0;
+  double dbl_last = 0.0;
   int offsetLastPoint = 0;
   int offsetNextFirstPoint = 0;
-  register r32 *r32firstPointResult = (r32*)NULL;
-  register r64 *r64firstPointResult = (r64*)NULL;
+  r32 *r32firstPointResult = (r32*)NULL;
+  r64 *r64firstPointResult = (r64*)NULL;
   double *theLinePlusBorder = (double*)NULL;
   double *resLinePlusBorder = (double*)NULL;
 

--- a/CGAL_ImageIO/src/CGAL_ImageIO/recline_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/recline_impl.h
@@ -507,12 +507,12 @@ int RecursiveFilter1D( RFcoefficientType *RFC,
 		       int dim )
 {
   const char *proc="RecursiveFilter1D";
-  register double rp0, rp1, rp2, rp3;
-  register double rd1, rd2, rd3, rd4;
-  register double rn0, rn1, rn2, rn3, rn4;
-  register int i;
-  register double *w0, *w1, *w2, *w3, *w4;
-  register double *d0, *d1, *d2, *d3, *d4;
+  double rp0, rp1, rp2, rp3;
+  double rd1, rd2, rd3, rd4;
+  double rn0, rn1, rn2, rn3, rn4;
+  int i;
+  double *w0, *w1, *w2, *w3, *w4;
+  double *d0, *d1, *d2, *d3, *d4;
 
   if ( RFC->type_filter == UNKNOWN_FILTER ) {
     if ( get_static_verbose_recline() != 0 )

--- a/CGAL_ImageIO/src/CGAL_ImageIO/reech4x4_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/reech4x4_impl.h
@@ -106,20 +106,20 @@ void Reech3DTriLin4x4_u8 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *tpt;
-  register u8 *rbuf = (u8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *tpt;
+  u8 *rbuf = (u8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -268,22 +268,22 @@ void Reech3DTriLin4x4gb_u8 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *tpt;
-  register u8 *rbuf = (u8*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *tpt;
+  u8 *rbuf = (u8*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -439,14 +439,14 @@ void Reech3DNearest4x4_u8 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z;
+  int i, j, k, ix, iy, iz;
+  double x, y, z;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *rbuf = (u8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *rbuf = (u8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -477,17 +477,17 @@ void Reech2DTriLin4x4_u8 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *tpt;
-  register u8 *rbuf = (u8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *tpt;
+  u8 *rbuf = (u8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -567,19 +567,19 @@ void Reech2DTriLin4x4gb_u8 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *tpt;
-  register u8 *rbuf = (u8*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *tpt;
+  u8 *rbuf = (u8*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -662,13 +662,13 @@ void Reech2DNearest4x4_u8 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy;
-  register double x, y;
+  int i, j, k, ix, iy;
+  double x, y;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register u8 *tbuf = (u8*)theBuf;
-  register u8 *rbuf = (u8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  u8 *tbuf = (u8*)theBuf;
+  u8 *rbuf = (u8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -722,20 +722,20 @@ void Reech3DTriLin4x4_s8 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *tpt;
-  register s8 *rbuf = (s8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *tpt;
+  s8 *rbuf = (s8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -884,22 +884,22 @@ void Reech3DTriLin4x4gb_s8 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *tpt;
-  register s8 *rbuf = (s8*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *tpt;
+  s8 *rbuf = (s8*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1055,14 +1055,14 @@ void Reech3DNearest4x4_s8 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z;
+  int i, j, k, ix, iy, iz;
+  double x, y, z;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *rbuf = (s8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *rbuf = (s8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1093,17 +1093,17 @@ void Reech2DTriLin4x4_s8 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *tpt;
-  register s8 *rbuf = (s8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *tpt;
+  s8 *rbuf = (s8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1183,19 +1183,19 @@ void Reech2DTriLin4x4gb_s8 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *tpt;
-  register s8 *rbuf = (s8*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *tpt;
+  s8 *rbuf = (s8*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1278,13 +1278,13 @@ void Reech2DNearest4x4_s8 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy;
-  register double x, y;
+  int i, j, k, ix, iy;
+  double x, y;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register s8 *tbuf = (s8*)theBuf;
-  register s8 *rbuf = (s8*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  s8 *tbuf = (s8*)theBuf;
+  s8 *rbuf = (s8*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1339,20 +1339,20 @@ void Reech3DTriLin4x4_u16 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *tpt;
-  register u16 *rbuf = (u16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *tpt;
+  u16 *rbuf = (u16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1501,22 +1501,22 @@ void Reech3DTriLin4x4gb_u16 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *tpt;
-  register u16 *rbuf = (u16*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *tpt;
+  u16 *rbuf = (u16*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1672,14 +1672,14 @@ void Reech3DNearest4x4_u16 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z;
+  int i, j, k, ix, iy, iz;
+  double x, y, z;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *rbuf = (u16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *rbuf = (u16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1710,17 +1710,17 @@ void Reech2DTriLin4x4_u16 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *tpt;
-  register u16 *rbuf = (u16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *tpt;
+  u16 *rbuf = (u16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1800,19 +1800,19 @@ void Reech2DTriLin4x4gb_u16 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *tpt;
-  register u16 *rbuf = (u16*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *tpt;
+  u16 *rbuf = (u16*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1895,13 +1895,13 @@ void Reech2DNearest4x4_u16 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy;
-  register double x, y;
+  int i, j, k, ix, iy;
+  double x, y;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register u16 *tbuf = (u16*)theBuf;
-  register u16 *rbuf = (u16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  u16 *tbuf = (u16*)theBuf;
+  u16 *rbuf = (u16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -1956,20 +1956,20 @@ void Reech3DTriLin4x4_s16 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *tpt;
-  register s16 *rbuf = (s16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *tpt;
+  s16 *rbuf = (s16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2118,22 +2118,22 @@ void Reech3DTriLin4x4gb_s16 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *tpt;
-  register s16 *rbuf = (s16*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *tpt;
+  s16 *rbuf = (s16*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2289,14 +2289,14 @@ void Reech3DNearest4x4_s16 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z;
+  int i, j, k, ix, iy, iz;
+  double x, y, z;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *rbuf = (s16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *rbuf = (s16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2327,17 +2327,17 @@ void Reech2DTriLin4x4_s16 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *tpt;
-  register s16 *rbuf = (s16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *tpt;
+  s16 *rbuf = (s16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2417,19 +2417,19 @@ void Reech2DTriLin4x4gb_s16 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *tpt;
-  register s16 *rbuf = (s16*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *tpt;
+  s16 *rbuf = (s16*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2512,13 +2512,13 @@ void Reech2DNearest4x4_s16 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy;
-  register double x, y;
+  int i, j, k, ix, iy;
+  double x, y;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register s16 *tbuf = (s16*)theBuf;
-  register s16 *rbuf = (s16*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  s16 *tbuf = (s16*)theBuf;
+  s16 *rbuf = (s16*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2573,20 +2573,20 @@ void Reech3DTriLin4x4_r32 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *tpt;
-  register r32 *rbuf = (r32*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *tpt;
+  r32 *rbuf = (r32*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2735,22 +2735,22 @@ void Reech3DTriLin4x4gb_r32 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
-  register double res;
+  int i, j, k, ix, iy, iz;
+  double x, y, z, dx, dy, dz, dxdy,dxdz,dydz,dxdydz;
+  double res;
   double v6, v5, v4;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
   int toffset1=tdimxy+tdimx+1, toffset2=tdimxy-tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register double ddimz = (double)tdimz-0.5;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *tpt;
-  register r32 *rbuf = (r32*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  double ddimz = (double)tdimz-0.5;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *tpt;
+  r32 *rbuf = (r32*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2906,14 +2906,14 @@ void Reech3DNearest4x4_r32 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy, iz;
-  register double x, y, z;
+  int i, j, k, ix, iy, iz;
+  double x, y, z;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1], tdimz=theDim[2];
   int tdimxy=tdimx*tdimy;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *rbuf = (r32*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1, t1dimz=tdimz-1;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *rbuf = (r32*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -2944,17 +2944,17 @@ void Reech2DTriLin4x4_r32 ( void* theBuf, /* buffer to be resampled */
 			     double* mat   /* transformation matrix */
 			     )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *tpt;
-  register r32 *rbuf = (r32*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *tpt;
+  r32 *rbuf = (r32*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -3034,19 +3034,19 @@ void Reech2DTriLin4x4gb_r32 ( void* theBuf, /* buffer to be resampled */
 			     float gain,
 			     float bias )
 {
-  register int i, j, k, ix, iy;
-  register double x, y, dx, dy, dxdy;
-  register double res, v;
+  int i, j, k, ix, iy;
+  double x, y, dx, dy, dxdy;
+  double res, v;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
   int toffset=tdimx-1;
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *tpt;
-  register r32 *rbuf = (r32*)resBuf;
-  register double b=bias;
-  register double g=gain;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  double ddimx = (double)tdimx-0.5, ddimy = (double)tdimy-0.5;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *tpt;
+  r32 *rbuf = (r32*)resBuf;
+  double b=bias;
+  double g=gain;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )
@@ -3129,13 +3129,13 @@ void Reech2DNearest4x4_r32 ( void* theBuf, /* buffer to be resampled */
 			      double* mat   /* transformation matrix */
 			      )
 {
-  register int i, j, k, ix, iy;
-  register double x, y;
+  int i, j, k, ix, iy;
+  double x, y;
   int rdimx=resDim[0], rdimy=resDim[1], rdimz=resDim[2];
   int tdimx=theDim[0], tdimy=theDim[1];
-  register int t1dimx=tdimx-1, t1dimy=tdimy-1;
-  register r32 *tbuf = (r32*)theBuf;
-  register r32 *rbuf = (r32*)resBuf;
+  int t1dimx=tdimx-1, t1dimy=tdimy-1;
+  r32 *tbuf = (r32*)theBuf;
+  r32 *rbuf = (r32*)resBuf;
 
   for ( k = 0; k < rdimz; k ++ ) {
     if ( get_static_verbose_reech4x4() != 0 )

--- a/Circular_kernel_2/benchmark/parser/benchmark_lexer.cpp
+++ b/Circular_kernel_2/benchmark/parser/benchmark_lexer.cpp
@@ -821,9 +821,9 @@ YY_MALLOC_DECL
 
 YY_DECL
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp = NULL, *yy_bp = NULL;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp = NULL, *yy_bp = NULL;
+	int yy_act;
 
 #line 148 "benchmark_lexer.l"
 
@@ -870,7 +870,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
 			if ( yy_accept[yy_current_state] )
 				{
 				yy_last_accepting_state = yy_current_state;
@@ -1362,9 +1362,9 @@ ECHO;
 
 static int yy_get_next_buffer()
 	{
-	register char *dest = yy_current_buffer->yy_ch_buf;
-	register char *source = yytext_ptr;
-	register int number_to_move, i;
+	char *dest = yy_current_buffer->yy_ch_buf;
+	char *source = yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
@@ -1494,14 +1494,14 @@ static int yy_get_next_buffer()
 
 static yy_state_type yy_get_previous_state()
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
 
 	yy_current_state = yy_start;
 
 	for ( yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			yy_last_accepting_state = yy_current_state;
@@ -1533,10 +1533,10 @@ static yy_state_type yy_try_NUL_trans( yy_current_state )
 yy_state_type yy_current_state;
 #endif
 	{
-	register int yy_is_jam;
-	register char *yy_cp = yy_c_buf_p;
+	int yy_is_jam;
+	char *yy_cp = yy_c_buf_p;
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		yy_last_accepting_state = yy_current_state;
@@ -1557,14 +1557,14 @@ yy_state_type yy_current_state;
 
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput( int c, register char *yy_bp )
+static void yyunput( int c, char *yy_bp )
 #else
 static void yyunput( c, yy_bp )
 int c;
-register char *yy_bp;
+char *yy_bp;
 #endif
 	{
-	register char *yy_cp = yy_c_buf_p;
+	char *yy_cp = yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
 	*yy_cp = yy_hold_char;
@@ -1572,10 +1572,10 @@ register char *yy_bp;
 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yy_n_chars + 2;
-		register char *dest = &yy_current_buffer->yy_ch_buf[
+		int number_to_move = yy_n_chars + 2;
+		char *dest = &yy_current_buffer->yy_ch_buf[
 					yy_current_buffer->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&yy_current_buffer->yy_ch_buf[number_to_move];
 
 		while ( source > yy_current_buffer->yy_ch_buf )
@@ -2032,7 +2032,7 @@ yyconst char *s2;
 int n;
 #endif
 	{
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 	}
@@ -2046,7 +2046,7 @@ static int yy_flex_strlen( s )
 yyconst char *s;
 #endif
 	{
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/Circular_kernel_2/benchmark/parser/benchmark_parser.cpp
+++ b/Circular_kernel_2/benchmark/parser/benchmark_parser.cpp
@@ -250,7 +250,7 @@ union yyalloc
 #   define YYCOPY(To, From, Count)		\
       do					\
 	{					\
-	  register YYSIZE_T yyi;		\
+	  YYSIZE_T yyi;		\
 	  for (yyi = 0; yyi < (Count); yyi++)	\
 	    (To)[yyi] = (From)[yyi];		\
 	}					\
@@ -896,7 +896,7 @@ yystrlen (yystr)
      const char *yystr;
 #   endif
 {
-  register const char *yys = yystr;
+  const char *yys = yystr;
 
   while (*yys++ != '\0')
     continue;
@@ -921,8 +921,8 @@ yystpcpy (yydest, yysrc)
      const char *yysrc;
 #   endif
 {
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
   while ((*yyd++ = *yys++) != '\0')
     continue;
@@ -1052,8 +1052,8 @@ yyparse ()
 #endif
 {
   
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   int yyresult;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
@@ -1071,12 +1071,12 @@ yyparse ()
   /* The state stack.  */
   short	yyssa[YYINITDEPTH];
   short *yyss = yyssa;
-  register short *yyssp;
+  short *yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE yyvsa[YYINITDEPTH];
   YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
+  YYSTYPE *yyvsp;
 
 
 

--- a/Convex_hull_d/include/CGAL/Delaunay_d.h
+++ b/Convex_hull_d/include/CGAL/Delaunay_d.h
@@ -758,7 +758,7 @@ incident_simplex_search(Vertex_handle v, Simplex_handle s) const
      the one opposite v */
 
   bool incident = false;
-  register int j;
+  int j;
   for (j = 0; j <= dcur; j++)
     if ( Base::vertex_of_simplex(s,j) == v ) incident = true;
   if ( !incident ) 
@@ -924,7 +924,7 @@ all_vertices_below(const Lifted_hyperplane_d& h,
 { 
   visited_mark(s) = true;
   bool some_vertex_on_or_below_h = false;
-  register int i;
+  int i;
   int low = (is_cocircular ? 0 : 1);
   for (i = low; i <= Base::current_dimension(); i++) {
     Vertex_handle v = Base::vertex_of_simplex(s,i);

--- a/Kinetic_data_structures/include/CGAL/Polynomial/internal/Turkowski_numeric_solvers_impl.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/internal/Turkowski_numeric_solvers_impl.h
@@ -142,7 +142,7 @@ FindPolynomialRoots(
 		    FLOAT           *u,                               /* Real component of each root */
 		    FLOAT           *v,                               /* Imaginary component of each root */
 		    FLOAT           *conv,                            /* Convergence constant associated with each root */
-		    register long   n,                                /* Degree of polynomial (order-1) */
+		    long            n,                                /* Degree of polynomial (order-1) */
 		    long            maxiter,                          /* Maximum number of iterations */
 		    long            fig                               /* The number of decimal figures to be computed */
 		    )
@@ -151,7 +151,7 @@ FindPolynomialRoots(
   int number_of_INIT=0;
   CGAL_precondition(static_cast<unsigned int>(fig) < MAXN);
   int i;
-  register int j;
+  int j;
   FLOAT h[MAXN + 3], b[MAXN + 3], c[MAXN + 3], d[MAXN + 3], e[MAXN + 3];
   /* [-2 : n] */
   FLOAT K, ps, qs, pt, qt, s, rev, r= std::numeric_limits<double>::infinity();

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_geometry_OGL.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_geometry_OGL.h
@@ -553,7 +553,7 @@ private:
 
 void construct_axes() const
 { int i;
-  register double f(1.02);
+  double f(1.02);
   glNewList(sphere_list_+3, GL_COMPILE);
   glLineWidth(2.0);
   // red x-axis and equator

--- a/Nef_S2/include/CGAL/Nef_S2/sphere_predicates.h
+++ b/Nef_S2/include/CGAL/Nef_S2/sphere_predicates.h
@@ -344,7 +344,7 @@ intersection(const CGAL::Sphere_circle<R>& c,
       s1 = *this; return 1;
     } 
     // now this is a halfcircle
-    register bool halfcircle_notin_hminus =
+    bool halfcircle_notin_hminus =
       (CGAL::orientation(source(),target(),
 			 CGAL::ORIGIN + c.orthogonal_vector(),
 			 CGAL::ORIGIN + sphere_circle().orthogonal_vector())

--- a/Surface_mesh_segmentation/include/CGAL/internal/auxiliary/graph.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/auxiliary/graph.h
@@ -796,7 +796,7 @@ inline void Graph::set_tweights(node_id i, captype cap_source, captype cap_sink)
 
 inline void Graph::add_tweights(node_id i, captype cap_source, captype cap_sink)
 {
-  register captype delta = ((node*)i) -> tr_cap;
+  captype delta = ((node*)i) -> tr_cap;
   if (delta > 0) cap_source += delta;
   else           cap_sink   -= delta;
   flow += (cap_source < cap_sink) ? cap_source : cap_sink;


### PR DESCRIPTION
The keyword _register_ is deprecated since c++11 (and anyway probably not really useful as recent compiler know better than the user how to use the registers...). There are some in CGAL, raising lots of warnings in the testsuite.

This PR removes all the occurrences of _register_ in CGAL.