### PR TITLE
Remove Mesh_3 warnings in Boost.Parameters

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/config.h
+++ b/Mesh_3/include/CGAL/Mesh_3/config.h
@@ -65,7 +65,8 @@
 
 #if defined(__clang__) || (BOOST_GCC >= 40600)
 #  define CGAL_MESH_3_IGNORE_UNUSED_VARIABLES \
-    _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
+    _Pragma("GCC diagnostic ignored \"-Wunused-variable\"") \
+    _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
 #else
 #  define CGAL_MESH_3_IGNORE_UNUSED_VARIABLES
 #endif

--- a/Mesh_3/include/CGAL/exude_mesh_3.h
+++ b/Mesh_3/include/CGAL/exude_mesh_3.h
@@ -34,6 +34,11 @@
 
 namespace CGAL {
 
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
 BOOST_PARAMETER_FUNCTION(
   (Mesh_optimization_return_code),
   exude_mesh_3,
@@ -47,6 +52,7 @@ BOOST_PARAMETER_FUNCTION(
 {
   return exude_mesh_3_impl(c3t3, time_limit_, sliver_bound_);
 }
+CGAL_PRAGMA_DIAG_POP
 
 
 

--- a/Mesh_3/include/CGAL/lloyd_optimize_mesh_3.h
+++ b/Mesh_3/include/CGAL/lloyd_optimize_mesh_3.h
@@ -35,6 +35,11 @@
 
 namespace CGAL {
   
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
 BOOST_PARAMETER_FUNCTION(
   (Mesh_optimization_return_code),
   lloyd_optimize_mesh_3,
@@ -53,6 +58,7 @@ BOOST_PARAMETER_FUNCTION(
                                     convergence_, freeze_bound_
                                     , do_freeze_);
 } 
+CGAL_PRAGMA_DIAG_POP
 
   
   

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -354,6 +354,10 @@ C3T3 make_mesh_3(const MD& md, const MC& mc, const Arg1& a1, const Arg2& a2,
 
 #endif  
   
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
 
 BOOST_PARAMETER_FUNCTION(
   (void),
@@ -377,7 +381,7 @@ BOOST_PARAMETER_FUNCTION(
                    exude_param, perturb_param, odt_param, lloyd_param,
                    features_param.features(), mesh_options_param);
 }
-  
+CGAL_PRAGMA_DIAG_POP
 
 /**
  * @brief This function meshes the domain defined by mesh_traits

--- a/Mesh_3/include/CGAL/odt_optimize_mesh_3.h
+++ b/Mesh_3/include/CGAL/odt_optimize_mesh_3.h
@@ -36,6 +36,11 @@
 
 namespace CGAL {
   
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
 BOOST_PARAMETER_FUNCTION(
   (Mesh_optimization_return_code),
   odt_optimize_mesh_3,
@@ -54,7 +59,7 @@ BOOST_PARAMETER_FUNCTION(
                                   convergence_, freeze_bound_
                                   , do_freeze_ );
 } 
-
+CGAL_PRAGMA_DIAG_POP
 
 
 template <typename C3T3, typename MeshDomain> 

--- a/Mesh_3/include/CGAL/perturb_mesh_3.h
+++ b/Mesh_3/include/CGAL/perturb_mesh_3.h
@@ -37,6 +37,11 @@
 
 namespace CGAL {
 
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
 BOOST_PARAMETER_FUNCTION(
   (Mesh_optimization_return_code),
   perturb_mesh_3,
@@ -56,6 +61,7 @@ BOOST_PARAMETER_FUNCTION(
   return perturb_mesh_3_impl(c3t3, domain, time_limit_, sliver_criterion_,
                              perturbation_vector_);
 }
+CGAL_PRAGMA_DIAG_POP
 
 
 template <typename C3T3, 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -189,12 +189,13 @@ namespace parameters {
     }; // end struct Mesh_3_options
 
   } // end namespace internal
-#if defined(__clang__) || defined(__GNUC__) && CGAL_GCC_VERSION >= 40600
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-// remove a warning about an unused parameter "args" in the definition of
-// BOOST_PARAMETER_FUNCTION
-#endif
+
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
+
   // -----------------------------------
   // Perturb
   // -----------------------------------
@@ -320,11 +321,8 @@ namespace parameters {
     return options;
   }
 
-#if defined(__clang__) || defined(__GNUC__) && CGAL_GCC_VERSION >= 40600
-//#if defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ > 5
-#pragma GCC diagnostic pop
-#endif
-  
+CGAL_PRAGMA_DIAG_POP
+
   // -----------------------------------
   // Reset_c3t3 (undocumented)
   // -----------------------------------
@@ -349,7 +347,11 @@ CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
 CGAL_PRAGMA_DIAG_POP
 } // end namespace parameters
   
-  
+// see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/Mesh_3/config.h>
+CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
 BOOST_PARAMETER_FUNCTION(
   (void),
   refine_mesh_3,
@@ -378,7 +380,9 @@ BOOST_PARAMETER_FUNCTION(
                             reset_param(),
                             mesh_options_param);
 }
-  
+
+CGAL_PRAGMA_DIAG_POP
+
   
 /**
  * @brief This function refines the mesh c3t3 wrt domain & criteria


### PR DESCRIPTION
Fix warnings with pragmas, like on Windows, with gcc>=4.6.
