### PR TITLE
Fix several warnings

### DIFF
--- a/Alpha_shapes_2/examples/Alpha_shapes_2/ex_weighted_alpha_shapes_2.cpp
+++ b/Alpha_shapes_2/examples/Alpha_shapes_2/ex_weighted_alpha_shapes_2.cpp
@@ -71,7 +71,7 @@ file_input(std::list<Point>& L)
   std::cout << "Reading " << n << " points" << std::endl;
   for( ; n>0 ; n--)
     {
-      Point_base p;
+      Point_base p(0., 0.);
       is >> p;
       if(is) {
         L.push_back(Point (p, FT(10)));

--- a/Apollonius_graph_2/include/CGAL/Apollonius_site_2.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_site_2.h
@@ -75,8 +75,8 @@ template <class K>
 std::istream&
 operator>>(std::istream& is, Apollonius_site_2<K>& wp)
 {
-  typename Apollonius_site_2<K>::Weight   weight;
-  typename Apollonius_site_2<K>::Point_2  p;
+  typename Apollonius_site_2<K>::Weight   weight (0.);
+  typename Apollonius_site_2<K>::Point_2  p (0., 0.);
   is >> p >> weight;
   if(is) {
     wp = Apollonius_site_2<K>(p, weight);

--- a/Surface_mesh_parameterization/include/CGAL/LSCM_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/LSCM_parameterizer_3.h
@@ -621,7 +621,7 @@ bool LSCM_parameterizer_3<Adaptor, Border_param, Sparse_LA>::
 is_one_to_one_mapping(const Adaptor& mesh,
                       const LeastSquaresSolver& )
 {
-    Vector_3    first_triangle_normal;
+    Vector_3    first_triangle_normal(0., 0., 0.);
 
     for (Facet_const_iterator facetIt = mesh.mesh_facets_begin();
          facetIt != mesh.mesh_facets_end();

--- a/Surface_mesh_parameterization/include/CGAL/Param_mesh_patch_vertex.h
+++ b/Surface_mesh_parameterization/include/CGAL/Param_mesh_patch_vertex.h
@@ -268,9 +268,10 @@ public:
     bool operator!=(const Self& hdl) const { return ! (*this == hdl); }
 
     /// Comparison to NULL pointer
+  
     bool operator==(Nullptr_t ptr) const {
         CGAL_surface_mesh_parameterization_assertion(ptr == NULL);
-        return m_ptr == NULL;
+        return m_ptr == ptr;
     }
     bool operator!=(Nullptr_t ptr) const { return ! (*this == ptr); }
 
@@ -416,7 +417,7 @@ public:
     /// Comparison to NULL pointer
     bool operator==(Nullptr_t ptr) const {
         CGAL_surface_mesh_parameterization_assertion(ptr == NULL);
-        return m_ptr == NULL;
+        return m_ptr == ptr;
     }
     bool operator!=(Nullptr_t ptr) const { return ! (*this == ptr); }
 

--- a/Surface_mesh_segmentation/include/CGAL/internal/auxiliary/graph.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/auxiliary/graph.h
@@ -687,6 +687,8 @@ inline Graph::Graph(void (*err_function)(const char *))
   node_block_first = NULL;
   arc_for_block_first = NULL;
   arc_rev_block_first = NULL;
+  orphan_first = NULL;
+  orphan_last = NULL;
   flow = 0;
 }
 


### PR DESCRIPTION
This PR fixes several trivial warnings that pollute the testsuite every day:
* Unused parameter in _Surface mesh parameterization_ (Param mesh patch vertex)
* Uninitialized variable in _Surface mesh parameterization_ (LSCM parameterizer)
* Uninitialized attributes in _Surface mesh segmentation_ (internal auxiliary graph)
* Uninitialized variable in _Alpha shapes 2_ (ex weighted alpha shapes 2)
* Uninitialized variable in _Apollonius graph 2_ (Apollonius site 2)

Merged in [4.8-Ic-85](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-85.shtml), impacted lines are now all green (some warnings in Polyhedron demo are removed too) without visible regression (see [4.8-I-84](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-I-84.shtml) for comparison).

Remaining recurrent warnings that I could not find how to fix:
* Array subscript is above array bounds (appears a lot in [Fedora-32-Release](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-84/Installation/TestReport_lrineau_Fedora-32-Release.gz))
* Warnings from boost (unused typedef, unused _args_ argument)