### PR TITLE
Advancing front: generalize filter

### DIFF
--- a/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/Advancing_front_surface_reconstruction.txt
+++ b/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/Advancing_front_surface_reconstruction.txt
@@ -202,9 +202,10 @@ reconstructed surface a triplet of point indices into an output iterator.
 The following example writes the output triangulated surface to `std::cout`
 in accordance to the OFF format.
 
-The function has an overload with an additional argument that allows to filter triangles,
-for example to avoid the generation of triangles with a perimeter larger
-than a given bound.
+The function has an overload with an additional argument that allows
+to choose how to prioritize facets. It can be written in a way to
+avoid the generation of triangles with a perimeter larger than a given
+bound.
 
 \cgalExample{Advancing_front_surface_reconstruction/reconstruction_fct.cpp}
 

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
@@ -24,8 +24,8 @@ struct Perimeter {
 
     // If perimeter > bound, return HUGE_VAL so that facet is not used
     double d  = 0;
-    sqrt(squared_distance(c->vertex((index+1)%4)->point(),
-                          c->vertex((index+2)%4)->point()));
+    d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                              c->vertex((index+2)%4)->point()));
     if(d>bound) return HUGE_VAL;
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
@@ -12,22 +12,31 @@ struct Perimeter {
     : bound(bound)
   {}
 
-  // The point type that will be injected here will be
-  // CGAL::Exact_predicates_inexact_constructions_kernel::Point_3
-  template <typename Point>
-  bool operator()(const Point& p, const Point& q, const Point& r) const
+  template <typename AdvancingFront, typename Cell_handle>
+  double operator() (const AdvancingFront& adv, Cell_handle& c,
+                     const int& index) const
   {
     // bound == 0 is better than bound < infinity
     // as it avoids the distance computations
     if(bound == 0){
-      return false;
+      return adv.smallest_radius_delaunay_sphere (c, index);
     }
-    double d  = sqrt(squared_distance(p,q));
-    if(d>bound) return true;
-    d += sqrt(squared_distance(p,r)) ;
-    if(d>bound) return true;
-    d+= sqrt(squared_distance(q,r));
-    return d>bound;
+
+    // If perimeter > bound, return HUGE_VAL so that facet is not used
+    double d  = 0;
+    sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                          c->vertex((index+2)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+    d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+    d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+
+    // Otherwise, return usual priority value: smallest radius of
+    // delaunay sphere
+    return adv.smallest_radius_delaunay_sphere (c, index);
   }
 };
 

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
@@ -22,17 +22,17 @@ struct Perimeter {
       return adv.smallest_radius_delaunay_sphere (c, index);
     }
 
-    // If perimeter > bound, return HUGE_VAL so that facet is not used
+    // If perimeter > bound, return infinity so that facet is not used
     double d  = 0;
     d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                               c->vertex((index+2)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
     d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
 
     // Otherwise, return usual priority value: smallest radius of
     // delaunay sphere

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/boundaries.cpp
@@ -26,13 +26,13 @@ struct Perimeter {
     double d  = 0;
     d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                               c->vertex((index+2)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
     d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
 
     // Otherwise, return usual priority value: smallest radius of
     // delaunay sphere

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -28,22 +28,31 @@ struct Perimeter {
     : bound(bound)
   {}
 
-  // The point type that will be injected here will be
-  // CGAL::Exact_predicates_inexact_constructions_kernel::Point_3
-  template <typename Point>
-  bool operator()(const Point& p, const Point& q, const Point& r) const
+  template <typename AdvancingFront, typename Cell_handle>
+  double operator() (const AdvancingFront& adv, Cell_handle& c,
+                     const int& index) const
   {
     // bound == 0 is better than bound < infinity
     // as it avoids the distance computations
     if(bound == 0){
-      return false;
+      return adv.smallest_radius_delaunay_sphere (c, index);
     }
-    double d  = sqrt(squared_distance(p,q));
-    if(d>bound) return true;
-    d += sqrt(squared_distance(p,r)) ;
-    if(d>bound) return true;
-    d+= sqrt(squared_distance(q,r));
-    return d>bound;
+
+    // If perimeter > bound, return HUGE_VAL so that facet is not used
+    double d  = 0;
+    sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                          c->vertex((index+2)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+    d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+    d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return HUGE_VAL;
+
+    // Otherwise, return usual priority value: smallest radius of
+    // delaunay sphere
+    return adv.smallest_radius_delaunay_sphere (c, index);
   }
 };
 

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -42,13 +42,13 @@ struct Perimeter {
     double d  = 0;
     d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                               c->vertex((index+2)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
     d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
+    if(d>bound) return adv.infinity();
 
     // Otherwise, return usual priority value: smallest radius of
     // delaunay sphere

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -38,17 +38,17 @@ struct Perimeter {
       return adv.smallest_radius_delaunay_sphere (c, index);
     }
 
-    // If perimeter > bound, return HUGE_VAL so that facet is not used
+    // If perimeter > bound, return infinity so that facet is not used
     double d  = 0;
     d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                               c->vertex((index+2)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
     d += sqrt(squared_distance(c->vertex((index+1)%4)->point(),
                                c->vertex((index+3)%4)->point()));
-    if(d>bound) return HUGE_VAL;
+    if(d>bound) return std::numeric_limits<typename AdvancingFront::coord_type>::infinity();
 
     // Otherwise, return usual priority value: smallest radius of
     // delaunay sphere

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -40,8 +40,8 @@ struct Perimeter {
 
     // If perimeter > bound, return HUGE_VAL so that facet is not used
     double d  = 0;
-    sqrt(squared_distance(c->vertex((index+1)%4)->point(),
-                          c->vertex((index+2)%4)->point()));
+    d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                              c->vertex((index+2)%4)->point()));
     if(d>bound) return HUGE_VAL;
     d += sqrt(squared_distance(c->vertex((index+2)%4)->point(),
                                c->vertex((index+3)%4)->point()));

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -186,7 +186,7 @@ namespace CGAL {
   priority of the facet `(Cell_handle,int)`. This functor enables the user to choose how candidate
   triangles are prioritized. If a facet should not appear in the output,
   `infinity()` must be returned. It defaults to a functor that returns the
-  smallest radius of the Delaunay sphere.
+  `smallest_radius_delaunay_sphere()`.
 
   */
   template <

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -159,7 +159,7 @@ namespace CGAL {
   namespace AFSR{
     struct Default_priority {
       template <typename AdvancingFront, typename Cell_handle>
-      double operator() (AdvancingFront& adv, Cell_handle& c,
+      double operator() (const AdvancingFront& adv, Cell_handle& c,
                          const int& index) const
       {
         return adv.smallest_radius_delaunay_sphere (c, index);

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -183,9 +183,10 @@ namespace CGAL {
   The default uses the `Exact_predicates_inexact_constructions_kernel` as geometric traits class.
 
   \tparam P must be a functor with `double operator()(AdvancingFront,Cell_handle,int)` returning the
-  priority of the facet `(Cell_handle,int)`. This functor enables the user to choose how candidate triangles
-  are prioritized. If a facet should not appear in the output, `HUGE_VAL` must be returned. It defaults to a
-  functor that returns the smallest radius of the Delaunay sphere.
+  priority of the facet `(Cell_handle,int)`. This functor enables the user to choose how candidate
+  triangles are prioritized. If a facet should not appear in the output,
+  `std::numeric_limits<coord_type>::infinity()` must be returned. It defaults to a functor that returns the
+  smallest radius of the Delaunay sphere.
 
   */
   template <
@@ -662,7 +663,7 @@ namespace CGAL {
     Advancing_front_surface_reconstruction(Triangulation_3& dt,
                                            Priority priority = Priority())
       : T(dt), _number_of_border(1), COS_ALPHA_SLIVER(-0.86),
-        NB_BORDER_MAX(15), DELTA(.86), min_K(HUGE_VAL),
+        NB_BORDER_MAX(15), DELTA(.86), min_K(std::numeric_limits<coord_type>::infinity()),
         eps(1e-7), inv_eps_2(coord_type(1)/(eps*eps)), eps_3(eps*eps*eps),
         STANDBY_CANDIDATE(3), STANDBY_CANDIDATE_BIS(STANDBY_CANDIDATE+1),
         NOT_VALID_CANDIDATE(STANDBY_CANDIDATE+2),
@@ -1183,7 +1184,7 @@ namespace CGAL {
                            || (c->vertex((index+2) & 3) == added_vertex)
                            || (c->vertex((index+3) & 3) == added_vertex) ))
         {
-          return HUGE_VAL;
+          return std::numeric_limits<coord_type>::infinity();
         }
       Cell_handle n = c->neighbor(index);
       // lazy evaluation ...
@@ -1210,7 +1211,7 @@ namespace CGAL {
           (c_is_plane && n_is_infinite)||
           (n_is_plane && c_is_infinite)||
           my_collinear(cp1, cp2, cp3))
-        value = HUGE_VAL;
+        value = std::numeric_limits<coord_type>::infinity();
       else
         {
           if (c_is_infinite||n_is_infinite||c_is_plane||n_is_plane)
@@ -1303,7 +1304,8 @@ namespace CGAL {
       Edge_incident_facet e_it = e, predone = previous(e);
       Cell_handle c_predone = predone.first.first;
 
-      coord_type min_valueP = NOT_VALID_CANDIDATE, min_valueA = HUGE_VAL;
+      coord_type min_valueP = NOT_VALID_CANDIDATE,
+        min_valueA = std::numeric_limits<coord_type>::infinity();
       Facet min_facet, min_facetA;
       bool border_facet(false);
 
@@ -1341,7 +1343,7 @@ namespace CGAL {
               Edge_like el1(neigh->vertex(n_i1),neigh->vertex(n_i3)),
                 el2(neigh->vertex(n_i2),neigh->vertex(n_i3));
 
-              if ((tmp != HUGE_VAL)&&
+              if ((tmp != std::numeric_limits<coord_type>::infinity())&&
                   neigh->vertex(n_i3)->not_interior()&&
                   (!is_interior_edge(el1))&&(!is_interior_edge(el2)))
                 {
@@ -1389,7 +1391,7 @@ namespace CGAL {
 
       criteria value;
 
-      if ((min_valueA == HUGE_VAL) || border_facet) // bad facets case
+      if ((min_valueA == std::numeric_limits<coord_type>::infinity()) || border_facet) // bad facets case
         {
           min_facet = Facet(c, i); // !!! sans aucune signification....
           value = NOT_VALID_CANDIDATE; // Attention a ne pas inserer dans PQ
@@ -1443,7 +1445,7 @@ namespace CGAL {
     {
       init_timer.start();
       Facet min_facet;
-      coord_type min_value = HUGE_VAL;
+      coord_type min_value = std::numeric_limits<coord_type>::infinity();
       int i1, i2, i3;
 
       if (!re_init){
@@ -1475,7 +1477,7 @@ namespace CGAL {
                     coord_type value = priority (*this, c, index);
 
                     // we might not want the triangle, for example because it is too large
-                    if(value == HUGE_VAL){
+                    if(value == std::numeric_limits<coord_type>::infinity()){
                       value = min_value;
                     }
 
@@ -1488,7 +1490,7 @@ namespace CGAL {
           }
       }
 
-      if (min_value != HUGE_VAL)
+      if (min_value != std::numeric_limits<coord_type>::infinity())
         {
           Cell_handle c_min = min_facet.first;
 
@@ -1764,7 +1766,7 @@ namespace CGAL {
                                     v1, v2, c->vertex(i),
                                     e1, e2, p1, p2);
 
-                      // if e1 contain HUGE_VAL there is no candidates to
+                      // if e1 contain infinity there is no candidates to
                       // continue: compute_value is not valid...
 
                       _ordered_border.insert(Radius_ptr_type(e1.first, p1));
@@ -1978,7 +1980,7 @@ namespace CGAL {
       }
       do
         {
-          min_K = HUGE_VAL; // pour retenir le prochain K necessaire pour progresser...
+          min_K = std::numeric_limits<coord_type>::infinity(); // pour retenir le prochain K necessaire pour progresser...
           do
             {
 
@@ -2040,10 +2042,10 @@ namespace CGAL {
           // on augmente progressivement le K mais on a deja rempli sans
           // faire des betises auparavant...
         }
-      while((!_ordered_border.empty())&&(K <= K)&&(min_K != HUGE_VAL));
+      while((!_ordered_border.empty())&&(K <= K)&&(min_K != std::numeric_limits<coord_type>::infinity()));
 
 #ifdef VERBOSE
-      if ((min_K < HUGE_VAL)&&(!_ordered_border.empty())) {
+      if ((min_K < std::numeric_limits<coord_type>::infinity())&&(!_ordered_border.empty())) {
         std::cout << "   [ next K required = " << min_K << " ]" << std::endl;
       }
 #endif // VERBOSE
@@ -2404,7 +2406,7 @@ namespace CGAL {
         return false;
       }
 
-      min_K = HUGE_VAL;
+      min_K = std::numeric_limits<coord_type>::infinity();
       // fin--
       //   if (_postprocessing_counter < 5)
       //     return true;

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -157,12 +157,12 @@ namespace CGAL {
   };
 
   namespace AFSR{
-    struct Always_false {
-
-      template <typename T>
-      bool operator()(const T&, const T&, const T&) const
+    struct Default_priority {
+      template <typename AdvancingFront, typename Cell_handle>
+      double operator() (AdvancingFront& adv, Cell_handle& c,
+                         const int& index) const
       {
-        return false;
+        return adv.smallest_radius_delaunay_sphere (c, index);
       }
     };
   } //end of namespa AFSR
@@ -183,18 +183,18 @@ namespace CGAL {
   The default uses the `Exact_predicates_inexact_constructions_kernel` as geometric traits class.
 
   \tparam F must be a functor with `bool operator()(Point,Point,Point)` returning `true` if a triangle should not appear in the output.
-          This functor enables the user to filter candidate triangles, for example based on its size.
+          This functor enables the user to priority candidate triangles, for example based on its size.
           The type `Point` must be the point type of the geometric traits class of the triangulation.
           It defaults to a functor that always returns `false`.
 
   */
   template <
     class Dt = Default,
-    class F = Default>
+    class P = Default>
   class Advancing_front_surface_reconstruction {
 
     typedef typename Default::Get<Dt,Delaunay_triangulation_3<Exact_predicates_inexact_constructions_kernel, Triangulation_data_structure_3<Advancing_front_surface_reconstruction_vertex_base_3<Exact_predicates_inexact_constructions_kernel>, Advancing_front_surface_reconstruction_cell_base_3<Exact_predicates_inexact_constructions_kernel> > > >::type Triangulation;
-    typedef typename Default::Get<F,AFSR::Always_false>::type Filter;
+    typedef typename Default::Get<P,AFSR::Default_priority>::type Priority;
   public:
 
 #ifdef DOXYGEN_RUNNING
@@ -220,9 +220,9 @@ namespace CGAL {
     typedef unspecified_type Triangulation_3;
 
   /*!
-  The type of the triangle filter functor.
+  The type of the triangle priority functor.
   */
-    typedef unspecified_type Filter;
+    typedef unspecified_type Priority;
 
   /*!
   The point type.
@@ -267,7 +267,7 @@ namespace CGAL {
 
     typedef Triangulation Triangulation_3;
     typedef typename Triangulation_3::Geom_traits Kernel;
-    typedef Advancing_front_surface_reconstruction<Dt,F> Extract;
+    typedef Advancing_front_surface_reconstruction<Dt,P> Extract;
     typedef typename Triangulation_3::Geom_traits Geom_traits;
 
     typedef typename Kernel::FT coord_type;
@@ -369,7 +369,7 @@ namespace CGAL {
 
     Vertex_handle added_vertex;
     bool deal_with_2d;
-    Filter filter;
+    Priority priority;
     int max_connected_component;
     double K_init, K_step;
     std::list<Vertex_handle> interior_edges;
@@ -660,7 +660,7 @@ namespace CGAL {
     Constructor for the unstructured point cloud given as 3D Delaunay triangulation.
     */
     Advancing_front_surface_reconstruction(Triangulation_3& dt,
-                                           Filter filter = Filter())
+                                           Priority priority = Priority())
       : T(dt), _number_of_border(1), COS_ALPHA_SLIVER(-0.86),
         NB_BORDER_MAX(15), DELTA(.86), min_K(HUGE_VAL),
         eps(1e-7), inv_eps_2(coord_type(1)/(eps*eps)), eps_3(eps*eps*eps),
@@ -668,7 +668,7 @@ namespace CGAL {
         NOT_VALID_CANDIDATE(STANDBY_CANDIDATE+2),
       _vh_number(static_cast<int>(T.number_of_vertices())), _facet_number(0),
       _postprocessing_counter(0), _size_before_postprocessing(0), _number_of_connected_components(0),
-      deal_with_2d(false), filter(filter), max_connected_component(-1), K_init(1.1), K_step(.1)
+      deal_with_2d(false), priority(priority), max_connected_component(-1), K_init(1.1), K_step(.1)
 
     {
       if(T.dimension() == 2){
@@ -1336,19 +1336,7 @@ namespace CGAL {
 
               coord_type tmp=0;
 
-              // If the triangle has a high perimeter,
-              // we do not want to consider it as a good candidate.
-
-              if(filter(facet_it.first->vertex(n_i1)->point(),
-                        facet_it.first->vertex(n_i2)->point(),
-                        facet_it.first->vertex(n_i3)->point())){
-                tmp = HUGE_VAL;
-              }
-
-
-              if(tmp != HUGE_VAL){
-                tmp = smallest_radius_delaunay_sphere(neigh, n_ind);
-              }
+              tmp = priority (*this, neigh, n_ind);
 
               Edge_like el1(neigh->vertex(n_i1),neigh->vertex(n_i3)),
                 el2(neigh->vertex(n_i2),neigh->vertex(n_i3));
@@ -1424,7 +1412,7 @@ namespace CGAL {
           else
             {
               //on refuse une trop grande non-uniformite
-              coord_type tmp = smallest_radius_delaunay_sphere(c, i);
+              coord_type tmp = priority (*this, c, i);
               if (min_valueA <= K * tmp)
                 value = - min_valueP;
               else
@@ -1464,8 +1452,8 @@ namespace CGAL {
             facet_it != end;
             ++facet_it)
           {
-            coord_type value = smallest_radius_delaunay_sphere((*facet_it).first,
-                                                               (*facet_it).second);
+            coord_type value = priority (*this, (*facet_it).first,
+                                         (*facet_it).second);
             if (value < min_value)
               {
                 min_facet = *facet_it;
@@ -1484,12 +1472,10 @@ namespace CGAL {
               if (c->vertex((index+2) & 3)->is_exterior())
                 if (c->vertex((index+3) & 3)->is_exterior())
                   {
-                    coord_type value = smallest_radius_delaunay_sphere(c, index);
+                    coord_type value = priority (*this, c, index);
 
                     // we might not want the triangle, for example because it is too large
-                    if(filter(c->vertex((index+1)&3)->point(),
-                              c->vertex((index+2)&3)->point(),
-                              c->vertex((index+3)&3)->point())){
+                    if(value == HUGE_VAL){
                       value = min_value;
                     }
 
@@ -1565,7 +1551,7 @@ namespace CGAL {
       if (v1*v2 > COS_BETA*norm)
         return 1; // label bonne pliure sinon:
 
-      if (ear_alpha <= K*smallest_radius_delaunay_sphere(neigh, n_ind))
+      if (ear_alpha <= K * priority(*this, neigh, n_ind))
         return 2; // label alpha coherent...
 
       return 0; //sinon oreille a rejeter...
@@ -1847,16 +1833,14 @@ namespace CGAL {
 			(result12.second==result_ear1.second))
 		      {
 			ear1_valid = test_merge(ear1_e, result_ear1, v1,
-						smallest_radius_delaunay_sphere(ear1_c,
-                                                                                ear1.second)) != 0;
+						priority(*this, ear1_c, ear1.second)) != 0;
 		      }
 		    if (is_border_ear2&&(e2.first < STANDBY_CANDIDATE)&&
 			(e2.first <= value)&&
 			(result12.second==result_ear2.second))
 		      {
 			ear2_valid = test_merge(ear2_e, result_ear2, v2,
-						smallest_radius_delaunay_sphere(ear2_c,
-                                                                                ear2.second)) != 0;
+						priority(*this, ear2_c, ear2.second)) != 0;
 		      }
 		    if ((!ear1_valid)&&(!ear2_valid))
 		      return NOT_VALID_CONNECTING_CASE;
@@ -2523,7 +2507,7 @@ namespace CGAL {
   be convertible to `Exact_predicates_inexact_constructions_kernel::Point_3` with the `Cartesian_converter`.
   \tparam IndicesOutputIterator must be an output iterator to which
   `CGAL::cpp11::tuple<std::size_t,std::size_t,std::size_t>` can be assigned.
-  \tparam Filter must be a functor with `bool operator()(Point,Point,Point)` where Point is `Exact_predicates_inexact_constructions_kernel::Point_3`.
+  \tparam Priority must be a functor with `bool operator()(Point,Point,Point)` where Point is `Exact_predicates_inexact_constructions_kernel::Point_3`.
 
   \param b iterator on the first point of the sequence
   \param e past the end iterator of the point sequence
@@ -2533,15 +2517,15 @@ namespace CGAL {
          Described in Section \ref AFSR_Boundaries
   \param beta half the angle of the wedge in which only the radius of triangles counts for the plausibility of candidates.
          Described in Section \ref AFSR_Selection
-  \param filter allows the user to filter candidate triangles, for example based on their size.
+  \param priority allows the user to priority candidate triangles, for example based on their size.
 
   */
-  template <typename PointInputIterator, typename IndicesOutputIterator, typename Filter>
+  template <typename PointInputIterator, typename IndicesOutputIterator, typename Priority>
   IndicesOutputIterator
   advancing_front_surface_reconstruction(PointInputIterator b,
                                          PointInputIterator e,
                                          IndicesOutputIterator out,
-                                         Filter filter,
+                                         Priority priority,
                                          double radius_ratio_bound = 5,
                                          double beta = 0.52 )
   {
@@ -2552,7 +2536,7 @@ namespace CGAL {
     typedef Triangulation_data_structure_3<LVb,LCb> Tds;
     typedef Delaunay_triangulation_3<Kernel,Tds> Triangulation_3;
 
-    typedef Advancing_front_surface_reconstruction<Triangulation_3,Filter> Reconstruction;
+    typedef Advancing_front_surface_reconstruction<Triangulation_3,Priority> Reconstruction;
     typedef typename std::iterator_traits<PointInputIterator>::value_type InputPoint;
     typedef typename Kernel_traits<InputPoint>::Kernel InputKernel;
     typedef Cartesian_converter<InputKernel,Kernel> CC;
@@ -2562,19 +2546,19 @@ namespace CGAL {
     Triangulation_3 dt( boost::make_transform_iterator(b, AFSR::Auto_count_cc<Point_3,CC>(cc)),
                         boost::make_transform_iterator(e, AFSR::Auto_count_cc<Point_3,CC>(cc) )  );
 
-    Reconstruction R(dt, filter);
+    Reconstruction R(dt, priority);
     R.run(radius_ratio_bound, beta);
     write_triple_indices(out, R);
     return out;
   }
 
 
-  template <typename PointInputIterator, typename Kernel, typename Items,  template < class T, class I, class A> class HDS, typename Alloc,typename Filter>
+  template <typename PointInputIterator, typename Kernel, typename Items,  template < class T, class I, class A> class HDS, typename Alloc,typename Priority>
   void
   advancing_front_surface_reconstruction(PointInputIterator b,
                                          PointInputIterator e,
                                          Polyhedron_3<Kernel,Items,HDS,Alloc>& polyhedron,
-                                         Filter filter,
+                                         Priority priority,
                                          double radius_ratio_bound = 5,
                                          double beta = 0.52)
   {
@@ -2584,7 +2568,7 @@ namespace CGAL {
     typedef Triangulation_data_structure_3<LVb,LCb> Tds;
     typedef Delaunay_triangulation_3<Kernel,Tds> Triangulation_3;
 
-    typedef Advancing_front_surface_reconstruction<Triangulation_3,Filter> Reconstruction;
+    typedef Advancing_front_surface_reconstruction<Triangulation_3,Priority> Reconstruction;
     typedef typename std::iterator_traits<PointInputIterator>::value_type InputPoint;
     typedef typename Kernel_traits<InputPoint>::Kernel InputKernel;
     typedef Cartesian_converter<InputKernel,Kernel> CC;
@@ -2594,7 +2578,7 @@ namespace CGAL {
     Triangulation_3 dt( boost::make_transform_iterator(b, AFSR::Auto_count_cc<Point_3,CC>(cc)),
                         boost::make_transform_iterator(e, AFSR::Auto_count_cc<Point_3,CC>(cc) )  );
 
-    Reconstruction R(dt, filter);
+    Reconstruction R(dt, priority);
     R.run(radius_ratio_bound, beta);
     AFSR::construct_polyhedron(polyhedron, R);
   }

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -1174,8 +1174,21 @@ namespace CGAL {
 
 
     //=====================================================================
-    coord_type infinity() const { return std::numeric_limits<coord_type>::infinity(); }
-    
+
+
+    /// \name Priority values
+    /// @{
+
+    /*!
+
+      computes the priority of the facet `(c,index)` such that the
+      facet with the smallest radius of Delaunay sphere has the
+      highest priority.
+
+    \param c handle to the cell containing the facet
+    \param index index of the facet in `c`
+
+    */
     coord_type
     smallest_radius_delaunay_sphere(const Cell_handle& c,
                                     const int& index) const
@@ -1290,6 +1303,12 @@ namespace CGAL {
       return value;
     }
 
+    /*!
+
+      returns the infinite floating value that prevents a facet to be used.
+    */
+    coord_type infinity() const { return std::numeric_limits<coord_type>::infinity(); }
+    /// @}      
 
     //---------------------------------------------------------------------
     // For a border edge e we determine the incident facet which has the highest

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -165,7 +165,7 @@ namespace CGAL {
         return adv.smallest_radius_delaunay_sphere (c, index);
       }
     };
-  } //end of namespa AFSR
+  } //end of namespace AFSR
 
 
   /*!
@@ -182,10 +182,10 @@ namespace CGAL {
   `Advancing_front_surface_reconstruction_vertex_base_3` and `Advancing_front_surface_reconstruction_cell_base_3` blended into the vertex and cell type.
   The default uses the `Exact_predicates_inexact_constructions_kernel` as geometric traits class.
 
-  \tparam F must be a functor with `bool operator()(Point,Point,Point)` returning `true` if a triangle should not appear in the output.
-          This functor enables the user to priority candidate triangles, for example based on its size.
-          The type `Point` must be the point type of the geometric traits class of the triangulation.
-          It defaults to a functor that always returns `false`.
+  \tparam P must be a functor with `double operator()(AdvancingFront,Cell_handle,int)` returning the
+  priority of the facet `(Cell_handle,int)`. This functor enables the user to choose how candidate triangles
+  are prioritized. If a facet should not appear in the output, `HUGE_VAL` must be returned. It defaults to a
+  functor that returns the smallest radius of the Delaunay sphere.
 
   */
   template <
@@ -220,7 +220,7 @@ namespace CGAL {
     typedef unspecified_type Triangulation_3;
 
   /*!
-  The type of the triangle priority functor.
+  The type of the facet priority functor.
   */
     typedef unspecified_type Priority;
 
@@ -2507,7 +2507,8 @@ namespace CGAL {
   be convertible to `Exact_predicates_inexact_constructions_kernel::Point_3` with the `Cartesian_converter`.
   \tparam IndicesOutputIterator must be an output iterator to which
   `CGAL::cpp11::tuple<std::size_t,std::size_t,std::size_t>` can be assigned.
-  \tparam Priority must be a functor with `bool operator()(Point,Point,Point)` where Point is `Exact_predicates_inexact_constructions_kernel::Point_3`.
+  \tparam Priority must be a functor with `double operator()(AdvancingFront,Cell_handle,int)` returning the
+  priority of the facet `(Cell_handle,int)`.
 
   \param b iterator on the first point of the sequence
   \param e past the end iterator of the point sequence
@@ -2517,7 +2518,7 @@ namespace CGAL {
          Described in Section \ref AFSR_Boundaries
   \param beta half the angle of the wedge in which only the radius of triangles counts for the plausibility of candidates.
          Described in Section \ref AFSR_Selection
-  \param priority allows the user to priority candidate triangles, for example based on their size.
+  \param priority allows the user to choose how candidate triangles are prioritized.
 
   */
   template <typename PointInputIterator, typename IndicesOutputIterator, typename Priority>

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -185,7 +185,7 @@ namespace CGAL {
   \tparam P must be a functor with `double operator()(AdvancingFront,Cell_handle,int)` returning the
   priority of the facet `(Cell_handle,int)`. This functor enables the user to choose how candidate
   triangles are prioritized. If a facet should not appear in the output,
-  `std::numeric_limits<coord_type>::infinity()` must be returned. It defaults to a functor that returns the
+  `infinity()` must be returned. It defaults to a functor that returns the
   smallest radius of the Delaunay sphere.
 
   */
@@ -663,7 +663,7 @@ namespace CGAL {
     Advancing_front_surface_reconstruction(Triangulation_3& dt,
                                            Priority priority = Priority())
       : T(dt), _number_of_border(1), COS_ALPHA_SLIVER(-0.86),
-        NB_BORDER_MAX(15), DELTA(.86), min_K(std::numeric_limits<coord_type>::infinity()),
+        NB_BORDER_MAX(15), DELTA(.86), min_K(infinity()),
         eps(1e-7), inv_eps_2(coord_type(1)/(eps*eps)), eps_3(eps*eps*eps),
         STANDBY_CANDIDATE(3), STANDBY_CANDIDATE_BIS(STANDBY_CANDIDATE+1),
         NOT_VALID_CANDIDATE(STANDBY_CANDIDATE+2),
@@ -1174,6 +1174,8 @@ namespace CGAL {
 
 
     //=====================================================================
+    coord_type infinity() const { return std::numeric_limits<coord_type>::infinity(); }
+    
     coord_type
     smallest_radius_delaunay_sphere(const Cell_handle& c,
                                     const int& index) const
@@ -1184,7 +1186,7 @@ namespace CGAL {
                            || (c->vertex((index+2) & 3) == added_vertex)
                            || (c->vertex((index+3) & 3) == added_vertex) ))
         {
-          return std::numeric_limits<coord_type>::infinity();
+          return infinity();
         }
       Cell_handle n = c->neighbor(index);
       // lazy evaluation ...
@@ -1211,7 +1213,7 @@ namespace CGAL {
           (c_is_plane && n_is_infinite)||
           (n_is_plane && c_is_infinite)||
           my_collinear(cp1, cp2, cp3))
-        value = std::numeric_limits<coord_type>::infinity();
+        value = infinity();
       else
         {
           if (c_is_infinite||n_is_infinite||c_is_plane||n_is_plane)
@@ -1305,7 +1307,7 @@ namespace CGAL {
       Cell_handle c_predone = predone.first.first;
 
       coord_type min_valueP = NOT_VALID_CANDIDATE,
-        min_valueA = std::numeric_limits<coord_type>::infinity();
+        min_valueA = infinity();
       Facet min_facet, min_facetA;
       bool border_facet(false);
 
@@ -1343,7 +1345,7 @@ namespace CGAL {
               Edge_like el1(neigh->vertex(n_i1),neigh->vertex(n_i3)),
                 el2(neigh->vertex(n_i2),neigh->vertex(n_i3));
 
-              if ((tmp != std::numeric_limits<coord_type>::infinity())&&
+              if ((tmp != infinity())&&
                   neigh->vertex(n_i3)->not_interior()&&
                   (!is_interior_edge(el1))&&(!is_interior_edge(el2)))
                 {
@@ -1391,7 +1393,7 @@ namespace CGAL {
 
       criteria value;
 
-      if ((min_valueA == std::numeric_limits<coord_type>::infinity()) || border_facet) // bad facets case
+      if ((min_valueA == infinity()) || border_facet) // bad facets case
         {
           min_facet = Facet(c, i); // !!! sans aucune signification....
           value = NOT_VALID_CANDIDATE; // Attention a ne pas inserer dans PQ
@@ -1445,7 +1447,7 @@ namespace CGAL {
     {
       init_timer.start();
       Facet min_facet;
-      coord_type min_value = std::numeric_limits<coord_type>::infinity();
+      coord_type min_value = infinity();
       int i1, i2, i3;
 
       if (!re_init){
@@ -1477,7 +1479,7 @@ namespace CGAL {
                     coord_type value = priority (*this, c, index);
 
                     // we might not want the triangle, for example because it is too large
-                    if(value == std::numeric_limits<coord_type>::infinity()){
+                    if(value == infinity()){
                       value = min_value;
                     }
 
@@ -1490,7 +1492,7 @@ namespace CGAL {
           }
       }
 
-      if (min_value != std::numeric_limits<coord_type>::infinity())
+      if (min_value != infinity())
         {
           Cell_handle c_min = min_facet.first;
 
@@ -1980,7 +1982,7 @@ namespace CGAL {
       }
       do
         {
-          min_K = std::numeric_limits<coord_type>::infinity(); // pour retenir le prochain K necessaire pour progresser...
+          min_K = infinity(); // pour retenir le prochain K necessaire pour progresser...
           do
             {
 
@@ -2042,10 +2044,10 @@ namespace CGAL {
           // on augmente progressivement le K mais on a deja rempli sans
           // faire des betises auparavant...
         }
-      while((!_ordered_border.empty())&&(K <= K)&&(min_K != std::numeric_limits<coord_type>::infinity()));
+      while((!_ordered_border.empty())&&(K <= K)&&(min_K != infinity()));
 
 #ifdef VERBOSE
-      if ((min_K < std::numeric_limits<coord_type>::infinity())&&(!_ordered_border.empty())) {
+      if ((min_K < infinity())&&(!_ordered_border.empty())) {
         std::cout << "   [ next K required = " << min_K << " ]" << std::endl;
       }
 #endif // VERBOSE
@@ -2406,7 +2408,7 @@ namespace CGAL {
         return false;
       }
 
-      min_K = std::numeric_limits<coord_type>::infinity();
+      min_K = infinity();
       // fin--
       //   if (_postprocessing_counter < 5)
       //     return true;

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -2421,21 +2421,21 @@ namespace CGAL {
   namespace AFSR {
 
     template <typename T>
-    struct Auto_count : public std::unary_function<const T&,std::pair<T,int> >{
-      mutable int i;
+    struct Auto_count : public std::unary_function<const T&,std::pair<T,std::size_t> >{
+      mutable std::size_t i;
 
       Auto_count()
         : i(0)
       {}
 
-      std::pair<T,int> operator()(const T& p) const {
+      std::pair<T,std::size_t> operator()(const T& p) const {
         return std::make_pair(p,i++);
       }
     };
 
     template <typename T, typename CC>
-    struct Auto_count_cc : public std::unary_function<const T&,std::pair<T,int> >{
-      mutable int i;
+    struct Auto_count_cc : public std::unary_function<const T&,std::pair<T,std::size_t> >{
+      mutable std::size_t i;
       CC cc;
 
       Auto_count_cc(CC cc)
@@ -2443,7 +2443,7 @@ namespace CGAL {
       {}
 
       template <typename T2>
-      std::pair<T,int> operator()(const T2& p) const {
+      std::pair<T,std::size_t> operator()(const T2& p) const {
         return std::make_pair(cc(p),i++);
       }
     };

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction_vertex_base_3.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction_vertex_base_3.h
@@ -91,10 +91,10 @@ namespace CGAL {
 
     //-------------------- DATA MEMBERS ---------------------------------
 
-    typedef int Info;  // so that we are a model of TriangulationVertexBaseWithInfo_3
+    typedef std::size_t Info;  // so that we are a model of TriangulationVertexBaseWithInfo_3
 
   private:
-    int m_id;
+    std::size_t m_id;
     int m_mark;
     int m_post_mark;
     Intern_successors_type* m_incident_border;
@@ -144,22 +144,22 @@ namespace CGAL {
 
   public:
 
-    int& id()
+    std::size_t& id()
     {
       return m_id;
     }
 
-    const int& id() const
+    const std::size_t& id() const
     {
       return m_id;
     }
 
-    int& info()
+    std::size_t& info()
     {
       return m_id;
     }
 
-    const int& info() const
+    const std::size_t& info() const
     {
       return m_id;
     }

--- a/Advancing_front_surface_reconstruction/include/CGAL/internal/AFSR/construct_polyhedron.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/internal/AFSR/construct_polyhedron.h
@@ -51,7 +51,7 @@ namespace CGAL {
 
         const TDS_2& tds = s.triangulation_data_structure_2();
 
-        int index = 0;
+        std::size_t index = 0;
         Vertex_iterator end = tds.vertices_end();
 
         for(Vertex_iterator vit = tds.vertices_begin(); vit != end; ++vit){

--- a/Advancing_front_surface_reconstruction/include/CGAL/internal/AFSR/write_triple_indices.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/internal/AFSR/write_triple_indices.h
@@ -46,9 +46,9 @@ namespace CGAL {
     for(Face_iterator fit = tds.faces_begin(); fit != tds.faces_end(); ++fit){
 
       if(fit->is_on_surface()){
-        *out++ = CGAL::make_array(std::size_t(fit->vertex(0)->vertex_3()->id()),
-                                  std::size_t(fit->vertex(1)->vertex_3()->id()),
-                                  std::size_t(fit->vertex(2)->vertex_3()->id()));
+        *out++ = CGAL::make_array(fit->vertex(0)->vertex_3()->id(),
+                                  fit->vertex(1)->vertex_3()->id(),
+                                  fit->vertex(2)->vertex_3()->id());
       }
     }
     return out;

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -161,6 +161,13 @@ and <code>src/</code> directories).
 <!-- Voronoi Diagrams -->
 <!-- Mesh Generation -->
 <!-- Surface Reconstruction -->
+  <h3>Advancing Front Surface Reconstruction</h3>
+  <ul>
+    <li>Optional template functor <code>Filter</code> is replaced by
+    another optional template functor <code>Priority</code>. This
+    allows to change the way facets are prioritized by the algorithm
+      instead of having a simple option to reject some facets.</li>
+  </ul>
 <!-- Geometry Processing -->
   <h3>Polygon Mesh Processing</h3>
   <ul>

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -166,7 +166,11 @@ and <code>src/</code> directories).
     <li>Optional template functor <code>Filter</code> is replaced by
     another optional template functor <code>Priority</code>. This
     allows to change the way facets are prioritized by the algorithm
-      instead of having a simple option to reject some facets.</li>
+    instead of having a simple option to reject some
+    facets. <b>Breaking change</b>: Programs using the
+    old <code>Filter</code> API will not compile anymore as it must be
+    replaced with the <code>Priority</code> API as described in the
+    manual. Codes using the default behavior are not impacted.</li>
   </ul>
 <!-- Geometry Processing -->
   <h3>Polygon Mesh Processing</h3>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -58,18 +58,33 @@ struct Radius {
     : bound(bound)
   {}
 
-  bool operator()(const Kernel::Point_3& p, const Kernel::Point_3& q, const Kernel::Point_3& r) const
+  template <typename AdvancingFront, typename Cell_handle>
+  double operator() (const AdvancingFront& adv, Cell_handle& c,
+                     const int& index) const
   {
+    // bound == 0 is better than bound < infinity
+    // as it avoids the distance computations
     if(bound == 0){
-      return false;
+      return adv.smallest_radius_delaunay_sphere (c, index);
     }
-    double d  = sqrt(squared_distance(p,q));
-    if(d>bound) return true;
-    d = sqrt(squared_distance(p,r)) ;
-    if(d>bound) return true;
-    d = sqrt(squared_distance(q,r));
-    return d>bound;
+
+    // If radius > bound, return infinity so that facet is not used
+    double d  = 0;
+    d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                              c->vertex((index+2)%4)->point()));
+    if(d>bound) return adv.infinity();
+    d = sqrt(squared_distance(c->vertex((index+2)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return adv.infinity();
+    d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                               c->vertex((index+3)%4)->point()));
+    if(d>bound) return adv.infinity();
+
+    // Otherwise, return usual priority value: smallest radius of
+    // delaunay sphere
+    return adv.smallest_radius_delaunay_sphere (c, index);
   }
+
 };
 
 


### PR DESCRIPTION
Small feature: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Advancing_front-Generalize_filter

Tested in [4.8-Ic-67](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-67.shtml). Warnings have been fixed and errors are not related to this PR.

Pre-approved by @afabri who asked the following question on the wiki: "_Should `HUGE_VAL` be replaced with `std::numeric_limits<double>::max()` ?_"

I kept `HUGE_VAL` because that was what was used in the first place in the _Advancing front_ package, but indeed using the STD fashion seems more consistent with what is done in CGAL usually. Any opinions? 