### PR TITLE
Remove useless copy constructor

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -47,7 +47,6 @@ class LineC3
     Vector_3 second;
     Rep () : first(), second() { }
     Rep (const Point_3& p, const Vector_3& v) : first(p), second(v) { }
-    Rep (const Rep& r) : first(r.first), second(r.second) { }
   };
 
   typedef typename R_::template Handle<Rep>::type  Base;


### PR DESCRIPTION
This copy constructor is useless as noted by this comment: https://github.com/CGAL/cgal/commit/0e1c69619209041f9f5c577170bbe32bd80f04fb#commitcomment-15267864

This PR removes it.

Merged in [4.8-Ic-94](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-94.shtml).