### PR TITLE
Protect polylines from Scene_polyline_item in mesh_3_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -48,8 +48,7 @@ private:
 typedef CGAL::Triangle_accessor_3<Polyhedron, Kernel> T_accessor;
 
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<
-          Kernel, Polyhedron, T_accessor, CGAL::Tag_true> Polyhedral_mesh_domain_with_features;
-typedef CGAL::Mesh_domain_with_polyline_features_3<Polyhedral_mesh_domain_with_features> Polyhedral_mesh_domain;
+          Kernel, Polyhedron, T_accessor, CGAL::Tag_true> Polyhedral_mesh_domain;
 // The last `Tag_true` says the Patch_id type will be int, and not pair<int, int>
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -23,6 +23,7 @@
 #include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
+#include <CGAL/Mesh_domain_with_polyline_features_3.h>
 
 #include <CGAL/tags.h>
 
@@ -47,7 +48,8 @@ private:
 typedef CGAL::Triangle_accessor_3<Polyhedron, Kernel> T_accessor;
 
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<
-          Kernel, Polyhedron, T_accessor, CGAL::Tag_true> Polyhedral_mesh_domain;
+          Kernel, Polyhedron, T_accessor, CGAL::Tag_true> Polyhedral_mesh_domain_with_features;
+typedef CGAL::Mesh_domain_with_polyline_features_3<Polyhedral_mesh_domain_with_features> Polyhedral_mesh_domain;
 // The last `Tag_true` says the Patch_id type will be int, and not pair<int, int>
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/CMakeLists.txt
@@ -10,7 +10,7 @@ if ( Boost_VERSION GREATER 103400 )
     polyhedron_demo_plugin(mesh_3_plugin Mesh_3_plugin 
       Mesh_3_plugin_cgal_code.cpp Meshing_thread.cpp
       ${meshingUI_FILES})
-    target_link_libraries(mesh_3_plugin scene_polyhedron_item scene_polygon_soup_item scene_implicit_function_item scene_segmented_image_item
+    target_link_libraries(mesh_3_plugin scene_polyhedron_item scene_polygon_soup_item scene_polylines_item scene_implicit_function_item scene_segmented_image_item
 	scene_c3t3_item ${QGLVIEWER_LIBRARIES} ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY})
 	 polyhedron_demo_plugin(mesh_3_volume_planes_plugin Volume_planes_plugin ${VOLUME_MOC_OUTFILES} Volume_plane_intersection.cpp)
     target_link_libraries(mesh_3_volume_planes_plugin scene_segmented_image_item)


### PR DESCRIPTION
Enable protection of polylines from a `Scene_polyline_item` for segmented image and polyhedral domains