### PR TITLE
PMP : reorder variables for API consistency

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -9,8 +9,6 @@
 /// path are not marked as constrained.
 ///
 /// \ingroup PkgPolygonMeshProcessing
-/// \defgroup remeshing_grp Isotropic remeshing
-/// \ingroup PkgPolygonMeshProcessing
 /// \defgroup reverse_face_orientations_grp CGAL::reverse_face_orientations()
 
 
@@ -76,8 +74,8 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::fair()`
 - `CGAL::Polygon_mesh_processing::refine()`
 - `CGAL::Polygon_mesh_processing::triangulate_faces()`
-- \link remeshing_grp `CGAL::Polygon_mesh_processing::isotropic_remeshing()` \endlink
-- \link remeshing_grp `CGAL::Polygon_mesh_processing::split_long_edges()` \endlink
+- \link PMP_meshing_grp `CGAL::Polygon_mesh_processing::isotropic_remeshing()` \endlink
+- \link PMP_meshing_grp `CGAL::Polygon_mesh_processing::split_long_edges()` \endlink
 
 ## Hole Filling Functions ##
 - `CGAL::Polygon_mesh_processing::triangulate_hole()`

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
     PMP::border_halfedges(faces(mesh),
       mesh,
       boost::make_function_output_iterator(halfedge2edge(mesh, border)));
-    PMP::split_long_edges(mesh, border, target_edge_length);
+    PMP::split_long_edges(border, target_edge_length, mesh);
 
   std::cout << "done." << std::endl;
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -55,9 +55,10 @@ int main(int argc, char* argv[])
   std::cout << "Start remeshing of " << filename
     << " (" << num_faces(mesh) << " faces)..." << std::endl;
 
-  PMP::isotropic_remeshing(mesh,
+  PMP::isotropic_remeshing(
       faces(mesh),
       target_edge_length,
+      mesh,
       PMP::parameters::number_of_iterations(nb_iter)
       .protect_constraints(true)//i.e. protect border, here
       );

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -46,8 +46,8 @@ int main(int argc, char* argv[])
 
     std::vector<edge_descriptor> border;
     PMP::border_halfedges(faces(mesh),
-      boost::make_function_output_iterator(halfedge2edge(mesh, border)),
-      mesh);
+      mesh,
+      boost::make_function_output_iterator(halfedge2edge(mesh, border)));
     PMP::split_long_edges(mesh, border, target_edge_length);
 
   std::cout << "done." << std::endl;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -148,8 +148,8 @@ namespace Polygon_mesh_processing {
          , typename HalfedgeOutputIterator
          , typename NamedParameters>
   HalfedgeOutputIterator border_halfedges(const FaceRange& faces
-                                  , HalfedgeOutputIterator out
                                   , const PolygonMesh& pmesh
+                                  , HalfedgeOutputIterator out
                                   , const NamedParameters& np)
   {
     typedef PolygonMesh PM;
@@ -170,8 +170,8 @@ namespace Polygon_mesh_processing {
 
   template<typename PolygonMesh
          , typename HalfedgeOutputIterator>
-  HalfedgeOutputIterator border_halfedges(HalfedgeOutputIterator out
-                                        , const PolygonMesh& pmesh)
+  HalfedgeOutputIterator border_halfedges(const PolygonMesh& pmesh
+                                        , HalfedgeOutputIterator out)
   {
     typedef PolygonMesh PM;
     typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
@@ -185,10 +185,10 @@ namespace Polygon_mesh_processing {
          , typename FaceRange
          , typename HalfedgeOutputIterator>
   HalfedgeOutputIterator border_halfedges(const FaceRange& faces
-                                        , HalfedgeOutputIterator out
-                                        , const PolygonMesh& pmesh)
+                                        , const PolygonMesh& pmesh
+                                        , HalfedgeOutputIterator out)
   {
-    return border_halfedges(faces, out, pmesh,
+    return border_halfedges(faces, pmesh, out,
       CGAL::Polygon_mesh_processing::parameters::all_default());
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/remesh_impl.h
@@ -85,7 +85,7 @@ namespace internal {
       : pmesh_(pmesh)
     {
       std::vector<halfedge_descriptor> border;
-      PMP::border_halfedges(faces, std::back_inserter(border), pmesh_);
+      PMP::border_halfedges(faces, pmesh_, std::back_inserter(border));
 
       BOOST_FOREACH(edge_descriptor e, edges(pmesh_))
         border_edges.insert(std::make_pair(e, false));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -205,7 +205,7 @@ template<typename PolygonMesh
        , typename EdgeRange
        , typename NamedParameters>
 void split_long_edges(PolygonMesh& pmesh
-                    , EdgeRange& edges
+                    , const EdgeRange& edges
                     , const double& max_length
                     , const NamedParameters& np)
 {
@@ -227,7 +227,7 @@ void split_long_edges(PolygonMesh& pmesh
 
 template<typename PolygonMesh, typename EdgeRange>
 void split_long_edges(PolygonMesh& pmesh
-                    , EdgeRange& edges
+                    , const EdgeRange& edges
                     , const double& max_length)
 {
   split_long_edges(pmesh,
@@ -242,7 +242,7 @@ template<typename PolygonMesh
        , typename OutputIterator
        , typename NamedParameters>
 void split_long_edges(PolygonMesh& pmesh
-        , EdgeRange& edge_range
+        , const EdgeRange& edge_range
         , const double& max_length
         , OutputIterator out//edges after splitting, all shorter than target_length
         , const NamedParameters& np)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -31,7 +31,7 @@ namespace CGAL {
 namespace Polygon_mesh_processing {
 
 /*!
-* \ingroup remeshing_grp
+* \ingroup PMP_meshing_grp
 * @brief remeshes a triangulated region of a polygon mesh.
 * This operation sequentially performs edge splits, edge collapses,
 * edge flips, Laplacian smoothing and projection to the initial surface
@@ -173,7 +173,7 @@ void isotropic_remeshing(
 }
 
 /*!
-* \ingroup remeshing_grp
+* \ingroup PMP_meshing_grp
 * @brief splits the edges listed in `edges` into sub-edges
 * that are not longer than the given threshold `max_length`.
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -204,9 +204,9 @@ void isotropic_remeshing(PolygonMesh& pmesh
 template<typename PolygonMesh
        , typename EdgeRange
        , typename NamedParameters>
-void split_long_edges(PolygonMesh& pmesh
-                    , const EdgeRange& edges
+void split_long_edges(const EdgeRange& edges
                     , const double& max_length
+                    , PolygonMesh& pmesh
                     , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
@@ -226,13 +226,13 @@ void split_long_edges(PolygonMesh& pmesh
 }
 
 template<typename PolygonMesh, typename EdgeRange>
-void split_long_edges(PolygonMesh& pmesh
-                    , const EdgeRange& edges
-                    , const double& max_length)
+void split_long_edges(const EdgeRange& edges
+                    , const double& max_length
+                    , PolygonMesh& pmesh)
 {
-  split_long_edges(pmesh,
-    edges,
+  split_long_edges(edges,
     max_length,
+    pmesh,
     parameters::all_default());
 }
 
@@ -241,9 +241,10 @@ template<typename PolygonMesh
        , typename EdgeRange
        , typename OutputIterator
        , typename NamedParameters>
-void split_long_edges(PolygonMesh& pmesh
-        , const EdgeRange& edge_range
+void split_long_edges(
+          const EdgeRange& edge_range
         , const double& max_length
+        , PolygonMesh& pmesh
         , OutputIterator out//edges after splitting, all shorter than target_length
         , const NamedParameters& np)
 {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -83,9 +83,9 @@ namespace Polygon_mesh_processing {
 template<typename PolygonMesh
        , typename FaceRange
        , typename NamedParameters>
-void isotropic_remeshing(PolygonMesh& pmesh
-                       , const FaceRange& faces
+void isotropic_remeshing(const FaceRange& faces
                        , const double& target_edge_length
+                       , PolygonMesh& pmesh
                        , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
@@ -160,13 +160,15 @@ void isotropic_remeshing(PolygonMesh& pmesh
 
 template<typename PolygonMesh
        , typename FaceRange>
-void isotropic_remeshing(PolygonMesh& pmesh
-  , const FaceRange& faces
-  , const double& target_edge_length)
+void isotropic_remeshing(
+    const FaceRange& faces
+  , const double& target_edge_length
+  , PolygonMesh& pmesh)
 {
-  isotropic_remeshing(pmesh,
+  isotropic_remeshing(
     faces,
     target_edge_length,
+    pmesh,
     parameters::all_default());
 }
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -83,7 +83,7 @@ void test_precondition(const char* filename,
   bool exception_caught = false;
   try
   {
-    PMP::isotropic_remeshing(m, patch, 0.079,
+    PMP::isotropic_remeshing(patch, 0.079, m,
       PMP::parameters::protect_constraints(true));
   }
   catch (const std::exception &)
@@ -165,9 +165,10 @@ int main(int argc, char* argv[])
   CGAL::Timer t;
   t.start();
 
-  PMP::isotropic_remeshing(m,
+  PMP::isotropic_remeshing(
     patch,
     target_edge_length,
+    m,
     PMP::parameters::number_of_iterations(nb_iter)
     .protect_constraints(true)
     );

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     PMP::border_halfedges(pre_patch,
       m,
       boost::make_function_output_iterator(halfedge2edge(m, border)));
-    PMP::split_long_edges(m, border, target_edge_length);
+    PMP::split_long_edges(border, target_edge_length, m);
 
   std::cout << "done." << std::endl;
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -149,8 +149,8 @@ int main(int argc, char* argv[])
 
     std::vector<edge_descriptor> border;
     PMP::border_halfedges(pre_patch,
-      boost::make_function_output_iterator(halfedge2edge(m, border)),
-      m);
+      m,
+      boost::make_function_output_iterator(halfedge2edge(m, border)));
     PMP::split_long_edges(m, border, target_edge_length);
 
   std::cout << "done." << std::endl;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -191,16 +191,16 @@ public Q_SLOTS:
 
         if (selection_item->selected_edges.empty())
           CGAL::Polygon_mesh_processing::isotropic_remeshing(
-          *selection_item->polyhedron()
-          , selection_item->selected_facets
+            selection_item->selected_facets
           , target_length
+          , *selection_item->polyhedron()
           , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
           .protect_constraints(protect));
         else
           CGAL::Polygon_mesh_processing::isotropic_remeshing(
-         *selection_item->polyhedron()
-         , selection_item->selected_facets
+           selection_item->selected_facets
          , target_length
+         , *selection_item->polyhedron()
          , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
          .protect_constraints(protect)
          .edge_is_constrained_map(selection_item->selected_edges_pmap(selected))
@@ -234,9 +234,9 @@ public Q_SLOTS:
         else
         {
         CGAL::Polygon_mesh_processing::isotropic_remeshing(
-         *poly_item->polyhedron()
-         , faces(*poly_item->polyhedron())
+           faces(*poly_item->polyhedron())
          , target_length
+         , *selection_item->polyhedron()
          , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
          .protect_constraints(protect));
         }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -177,9 +177,9 @@ public Q_SLOTS:
             }
           }
           CGAL::Polygon_mesh_processing::split_long_edges(
-            *selection_item->polyhedron()
-            , edges
+              edges
             , target_length
+            , *selection_item->polyhedron()
             , std::back_inserter(updated_selected_edges)
             , PMP::parameters::geom_traits(Kernel()));
         }
@@ -226,9 +226,10 @@ public Q_SLOTS:
           BOOST_FOREACH(halfedge_descriptor h, border)
             border_edges.push_back(edge(h, pmesh));
 
-          CGAL::Polygon_mesh_processing::split_long_edges(*poly_item->polyhedron()
-                                                        , border_edges
-                                                        , target_length);
+          CGAL::Polygon_mesh_processing::split_long_edges(
+              border_edges
+            , target_length
+            , *poly_item->polyhedron());
         }
         else
         {

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -220,8 +220,8 @@ public Q_SLOTS:
           std::vector<halfedge_descriptor> border;
           CGAL::Polygon_mesh_processing::border_halfedges(
             faces(*poly_item->polyhedron()),
-            std::back_inserter(border),
-            pmesh);
+            pmesh,
+            std::back_inserter(border));
           std::vector<edge_descriptor> border_edges;
           BOOST_FOREACH(halfedge_descriptor h, border)
             border_edges.push_back(edge(h, pmesh));

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
@@ -496,9 +496,9 @@ void Scene_edit_polyhedron_item::remesh()
 
   std::cout << "Remeshing...";
   CGAL::Polygon_mesh_processing::isotropic_remeshing(
-    *polyhedron()
-    , roi_facets
+      roi_facets
     , target_length
+    , *polyhedron()
     , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
     .protect_constraints(false) //no edge_is_constrained_map
     .vertex_point_map(vpmap)


### PR DESCRIPTION
To fit better in the PMP general framework, the order of variables in the following functions should be changed
- *border_halfedges*
- *isotropic_remeshing*
- *split_long_edges*

These functions are new in CGAL-4.8 so there is no breaking change.