### PR TITLE
move ui files into the correct group

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ if ( Boost_VERSION GREATER 103400 )
 
     qt5_wrap_cpp( VOLUME_MOC_OUTFILES ${CMAKE_CURRENT_SOURCE_DIR}/Volume_plane_thread.h )
     qt5_wrap_cpp( VOLUME_MOC_OUTFILES ${CMAKE_CURRENT_SOURCE_DIR}/Volume_plane_interface.h )
-    qt5_wrap_ui( meshingUI_FILES  Meshing_dialog.ui Smoother_dialog.ui Local_optimizers_dialog.ui raw_image.ui )
+    qt5_wrap_ui( meshingUI_FILES  Meshing_dialog.ui Smoother_dialog.ui Local_optimizers_dialog.ui )
     qt5_generate_moc( "Polyhedron_demo_mesh_3_plugin_cgal_code.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Scene_c3t3_item.moc" )
     polyhedron_demo_plugin(mesh_3_plugin Mesh_3_plugin 
       Mesh_3_plugin_cgal_code.cpp Meshing_thread.cpp 
@@ -19,7 +19,7 @@ if ( Boost_VERSION GREATER 103400 )
       ${meshingUI_FILES})
     target_link_libraries(mesh_3_optimization_plugin scene_c3t3_item scene_polyhedron_item scene_segmented_image_item scene_implicit_function_item )
 
-  qt5_wrap_ui( imgUI_FILES Image_res_dialog.ui)
+  qt5_wrap_ui( imgUI_FILES Image_res_dialog.ui raw_image.ui)
   polyhedron_demo_plugin(io_image_plugin Io_image_plugin Raw_image_dialog.cpp ${imgUI_FILES})
   target_link_libraries(io_image_plugin scene_segmented_image_item)
   polyhedron_demo_plugin(c3t3_io_plugin C3t3_io_plugin)


### PR DESCRIPTION
This was breaking the parallel build of plugins because dependency were incorrectly encoded