### PR TITLE
Fix compilation errors when WITH_VTK=ON in CMake

### DIFF
--- a/CGAL_ImageIO/include/CGAL/Image_3_impl.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_impl.h
@@ -207,7 +207,6 @@ Image_3::read_vtk_image_data(vtkImageData* vtk_image)
   image->vx = spacing[0];
   image->vy = spacing[1];
   image->vz = spacing[2];
-  vtk_image->Update();
   image->endianness = ::_getEndianness();
   int vtk_type = vtk_image->GetScalarType();
   if(vtk_type == VTK_SIGNED_CHAR) vtk_type = VTK_CHAR;

--- a/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
@@ -21,7 +21,7 @@
 #ifndef CGAL_IMAGE_3_VTK_INTERFACE_H
 #define CGAL_IMAGE_3_VTK_INTERFACE_H
 
-#include "config.h"
+#include <CGAL/config.h>
 
 #ifdef CGAL_USE_VTK
 #include <CGAL/Image_3.h>


### PR DESCRIPTION
This PR fixes the compilation of CGAL libraries when `WITH_VTK:BOOL=ON` is in the CMake cache.

This re-adds the support of VTK6 that was broken by the header-only merge. Unfortunately,  `WITH_VTK:BOOL=ON` is not (yet) tested by our testsuite.

Cc: @afabri @janetournois @gdamiand
