### PR TITLE
Mesh_3 - fix a memory leak in testsuite

### DIFF
--- a/Mesh_3/test/Mesh_3/test_c3t3.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3.cpp
@@ -385,10 +385,5 @@ int main()
   Tester<K_e_e> test_epec;
   test_epec();
 
-  int *p = new int;
-  *p = 18;
-  std::cout << *p << std::endl;
-  p = 0;
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
this seems to be some debug code that should not have been committed there

@cjamin do you have any clue why you added this?