### PR TITLE
Add an assertion in Image_to_labeled_function_wrapper

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Image_to_labeled_function_wrapper.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Image_to_labeled_function_wrapper.h
@@ -64,7 +64,9 @@ public:
     : r_im_(image)
     , transform(transform)
     , value_outside(value_outside)
-  {}
+  {
+    CGAL_assertion(transform(value_outside) == return_type());
+  }
 
   // Default copy constructor and assignment operator are ok
 


### PR DESCRIPTION
That assertion verifies that the value `value_outside` is considered at
a value *outside* of the domain. Otherwise Mesh_3 will crash with an
assertion saying that "infinite cells should not be in the C3t3".

Relates to one of the the documentation bugs reported in #624.
