### PR TITLE
Fix memory leak in ImageIO

### DIFF
--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -70,7 +70,14 @@ static PTRIMAGE_FORMAT firstFormat=NULL;
 /** the Inrimage file format (default format) is initialized to null */
 static PTRIMAGE_FORMAT InrimageFormat=NULL;
 
+struct Remove_supported_file_format {
+  ~Remove_supported_file_format()
+  {
+    removeSupportedFileFormat();
+  }
+};
 
+static Remove_supported_file_format rsff;
 
 
 


### PR DESCRIPTION
We have memory leaks in ImageIO which are detected by the VC++ testsuite that uses VLD.

There exists a function to release memory, but we do not want to call it explicitely before ending
our test/example/demo.

In order to call it at the end, I added a static singleton that calls the function in its destructor.

Can the header-only gurus ( @cjamin @gdamiand ) please check that I did it right?