### PR TITLE
Polyhedron demo: bugfix erasing items context menu

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1110,7 +1110,7 @@ void MainWindow::selectAll()
 int MainWindow::getSelectedSceneItemIndex() const
 {
   QModelIndexList selectedRows = sceneView->selectionModel()->selectedIndexes();
-  if(selectedRows.size() != 5)
+  if(selectedRows.size() == 0)
     return -1;
   else {
     QModelIndex i = proxyModel->mapToSource(selectedRows.first());

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1225,7 +1225,10 @@ void MainWindow::showSceneContextMenu(const QPoint& p) {
           return;
       }
       else
+      {
           index = proxyModel->mapToSource(modelIndex).row();
+          scene->setSelectedItemIndex(index);
+      }
   }
   else {
     index = scene->mainSelectionIndex();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -63,18 +63,15 @@ public Q_SLOTS:
 
 void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionJoinPolyhedra_triggered()
 {
-  CGAL::Three::Scene_interface::Item_id mainSelectionIndex = -1;
-  Scene_polyhedron_item* mainSelectionItem = NULL;
-
+  CGAL::Three::Scene_interface::Item_id mainSelectionIndex
+    = scene->mainSelectionIndex();
+  Scene_polyhedron_item* mainSelectionItem
+    = qobject_cast<Scene_polyhedron_item*>(scene->item(mainSelectionIndex));
 
   QList<int> indices_to_remove;
   Q_FOREACH(int index, scene->selectionIndices()) {
-    if (mainSelectionIndex==-1){
-      mainSelectionItem =
-        qobject_cast<Scene_polyhedron_item*>(scene->item(index));
-      if(mainSelectionItem!=NULL) mainSelectionIndex=index;
+    if (index == mainSelectionIndex)
       continue;
-    }
 
     Scene_polyhedron_item* item =
       qobject_cast<Scene_polyhedron_item*>(scene->item(index));

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
@@ -54,21 +54,16 @@ public Q_SLOTS:
 
 void Polyhedron_demo_merge_point_sets_plugin::on_actionMergePointSets_triggered()
 {
-  CGAL::Three::Scene_interface::Item_id mainSelectionIndex = -1;
-  Scene_points_with_normal_item* mainSelectionItem = NULL;
+  CGAL::Three::Scene_interface::Item_id mainSelectionIndex
+    = scene->mainSelectionIndex();
+  Scene_points_with_normal_item* mainSelectionItem
+    = qobject_cast<Scene_points_with_normal_item*>(scene->item(mainSelectionIndex));
 
   QList<int> indices_to_remove;
   Q_FOREACH(int index, scene->selectionIndices())
     {
-      if (mainSelectionIndex == -1)
-        {
-          mainSelectionItem =
-            qobject_cast<Scene_points_with_normal_item*>(scene->item(index));
-          if (mainSelectionItem != NULL)
-            mainSelectionIndex = index;
-          mainSelectionItem->point_set()->unselect_all();
-          continue;
-        }
+      if (index == mainSelectionIndex)
+        continue;
 
       Scene_points_with_normal_item* item =
         qobject_cast<Scene_points_with_normal_item*>(scene->item(index));


### PR DESCRIPTION
I found out that my [recently merged](https://github.com/CGAL/cgal/pull/605) plugin for merging point set items was generating a segfault when applied from a context menu (when right-clicking on one of the selected items to access the operation menu). The reason was that all items were merged in the first one (which was not necessarily the "main" selected) and the other ones - including the main selected - were destroyed, which caused trouble as the context menu is generated _from_ the main selected item.

This is fixed by two changes:
* Keeping track of the main selected item when calling the context menu
* Using this index inside the plugin

I also fixed a bug: when several items were selected, the function  `getSelectedSceneItemIndex` was returning -1 instead of a proper index (which doesn't make sense as -1 means no selection at all). Now the plugin to merge point set items works without trouble both from the toolbar menu and from the context menu.

I wrote this plugin by copying what was done in the plugin `join_and_split_polyhedra_plugin`, so after checking if this plugin was producing the same bug (it did), I fixed it similarly.

Merged in [4.8-Ic-99](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-99.shtml).