### PR TITLE
Replace deprecated binder2nd

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -36,7 +36,8 @@
 typedef float Image_word_type;
 
 template<typename T>
-struct Greater_than : public std::unary_function<T, bool> {
+struct Greater_than {
+  typedef T argument_type;
   Greater_than(const T& second) : second(second) {}
   bool operator()(const T& first) const {
     return std::greater<T>()(first, second);

--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -35,11 +35,20 @@
 
 typedef float Image_word_type;
 
+template<typename T>
+struct Greater_than : public std::unary_function<T, bool> {
+  Greater_than(const T& second) : second(second) {}
+  bool operator()(const T& first) const {
+    return std::greater<T>()(first, second);
+  }
+  T second;
+};
+
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-typedef CGAL::Gray_image_mesh_domain_3<CGAL::Image_3,K, 
+typedef CGAL::Gray_image_mesh_domain_3<CGAL::Image_3, K,
                                        Image_word_type,
-                                       std::binder1st< std::less<Image_word_type> > > Mesh_domain;
+                                       Greater_than<Image_word_type> > Mesh_domain;
 
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
@@ -58,7 +67,7 @@ int main()
   if(!image.read("data/skull_2.9.inr")) return 1;
 
   // Domain
-  Mesh_domain domain(image, std::bind1st(std::less<Image_word_type>(), 2.9f), 0.f);
+  Mesh_domain domain(image, 2.9f, 0.f);
 
   // Mesh criteria
   Mesh_criteria criteria(facet_angle=30, facet_size=6, facet_distance=2,

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -32,6 +32,17 @@
 
 namespace CGAL {
 
+namespace internal {
+
+template<typename T>
+struct Less_than {
+  Less_than(const T& second) : second(second) {}
+  bool operator()(const T& first) const { return std::less<T>()(first, second); }
+  T second;
+};
+
+}
+
 /**
  * @class Gray_image_mesh_domain_3
  *
@@ -40,7 +51,7 @@ namespace CGAL {
 template<class Image,
          class BGT,
          typename Image_word_type = float,
-         typename Transform = std::binder2nd<std::less<Image_word_type> >,
+         typename Transform = internal::Less_than<Image_word_type>,
          typename Subdomain_index = int>
 class Gray_image_mesh_domain_3
   : public Labeled_mesh_domain_3<
@@ -73,7 +84,7 @@ public:
                            const FT& error_bound = FT(1e-3),
                            CGAL::Random* p_rng = NULL)
     : Base(Wrapper(image, 
-                   Transform(std::less<Image_word_type>(), iso_value),
+                   Transform(iso_value),
                    value_outside),
            compute_bounding_box(image),
            error_bound,

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -35,7 +35,7 @@ namespace CGAL {
 namespace internal {
 
 template<typename T>
-struct Less_than {
+struct Less_than : public std::unary_function<T, bool> {
   Less_than(const T& second) : second(second) {}
   bool operator()(const T& first) const { return std::less<T>()(first, second); }
   T second;

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -35,7 +35,8 @@ namespace CGAL {
 namespace internal {
 
 template<typename T>
-struct Less_than : public std::unary_function<T, bool> {
+struct Less_than {
+  typedef T argument_type;
   Less_than(const T& second) : second(second) {}
   bool operator()(const T& first) const { return std::less<T>()(first, second); }
   T second;


### PR DESCRIPTION
We cannot just use `boost::bind` or similar, since we need to get the type
of the binder (which is not easily possible without decltype).