### PR TITLE
Polyhedron demo : isotropic remeshing of several items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -247,6 +247,7 @@ public Q_SLOTS:
     unsigned int nb_iter = 1;
     bool protect = false;
 
+    std::vector<Scene_polyhedron_item*> selection;
     BOOST_FOREACH(int index, scene->selectionIndices())
     {
       Scene_polyhedron_item* poly_item =
@@ -258,8 +259,12 @@ public Q_SLOTS:
           << " is not a Polyhedron, remeshing skipped\n";
         continue;
       }
-      else if (target_length == 0.)
+      else
       {
+        selection.push_back(poly_item);
+
+        if (target_length == 0.)//parameters have not been set yet
+        {
         QDialog dialog(mw);
         Ui::Isotropic_remeshing_dialog ui = remeshing_dialog(&dialog, poly_item);
         ui.objectName->setText(QString::number(scene->selectionIndices().size())
@@ -275,12 +280,12 @@ public Q_SLOTS:
         target_length = ui.edgeLength_dspinbox->value();
         nb_iter = ui.nbIterations_spinbox->value();
         protect = ui.protect_checkbox->isChecked();
-
-        break;
+        }
       }
     }
-    if(target_length == 0.)
-    {
+
+    if(target_length == 0.)//parameters have not been set
+    {                      // i.e. no item is a polyhedron
       std::cout << "Remeshing aborted" << std::endl;
       return;
     }
@@ -288,18 +293,6 @@ public Q_SLOTS:
     // wait cursor
     QApplication::setOverrideCursor(Qt::WaitCursor);
     int total_time = 0;
-
-    std::vector<Scene_polyhedron_item*> selection;
-    Q_FOREACH(int sel_i, scene->selectionIndices())
-    {
-      Scene_polyhedron_item* poly_item =
-        qobject_cast<Scene_polyhedron_item*>(scene->item(sel_i));
-      if (poly_item == NULL)
-        std::cout << "Item " << scene->item(sel_i)->name().data()
-                  << " is not a Polyhedron, remeshing skipped\n";
-      else
-        selection.push_back(poly_item);
-    }
 
 #ifdef CGAL_LINKED_WITH_TBB
     QTime time;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -294,7 +294,8 @@ public Q_SLOTS:
       Scene_polyhedron_item* poly_item =
         qobject_cast<Scene_polyhedron_item*>(scene->item(sel_i));
       if (poly_item == NULL)
-        std::cout << "Item " << sel_i << " is not a Polyhedron, remeshing skipped\n";
+        std::cout << "Item " << scene->item(sel_i)->name().data()
+                  << " is not a Polyhedron, remeshing skipped\n";
       else
         selection.push_back(poly_item);
     }
@@ -316,11 +317,11 @@ public Q_SLOTS:
       QTime time;
       time.start();
 
-        remesher.remesh(poly_item);
+        remesher(poly_item);
 
       total_time += time.elapsed();
-      std::cout << "Remeshing of item "<< index << " done in "
-                << time.elapsed() << " ms" << std::endl;
+      std::cout << "Remeshing of " << poly_item->name().data()
+                << " done in " << time.elapsed() << " ms" << std::endl;
     }
 #endif
     std::cout << "Remeshing of all selected items done in "

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -242,11 +242,10 @@ public Q_SLOTS:
   void isotropic_remeshing_of_several_polyhedra()
   {
     // Remeshing parameters
-    bool parameters_set = false;
-    bool edges_only;
-    double target_length;
-    unsigned int nb_iter;
-    bool protect;
+    bool edges_only = false;
+    double target_length = 0.;
+    unsigned int nb_iter = 1;
+    bool protect = false;
 
     BOOST_FOREACH(int index, scene->selectionIndices())
     {
@@ -259,7 +258,7 @@ public Q_SLOTS:
           << " is not a Polyhedron, remeshing skipped\n";
         continue;
       }
-      else if (!parameters_set)
+      else if (target_length == 0.)
       {
         QDialog dialog(mw);
         Ui::Isotropic_remeshing_dialog ui = remeshing_dialog(&dialog, poly_item);
@@ -277,12 +276,14 @@ public Q_SLOTS:
         nb_iter = ui.nbIterations_spinbox->value();
         protect = ui.protect_checkbox->isChecked();
 
-        parameters_set = true;
         break;
       }
     }
-    if(!parameters_set)
+    if(target_length == 0.)
+    {
       std::cout << "Remeshing aborted" << std::endl;
+      return;
+    }
 
     // wait cursor
     QApplication::setOverrideCursor(Qt::WaitCursor);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -248,7 +248,6 @@ public Q_SLOTS:
     unsigned int nb_iter;
     bool protect;
 
-    const QList<int> indices = scene->selectionIndices();
     BOOST_FOREACH(int index, scene->selectionIndices())
     {
       Scene_polyhedron_item* poly_item =
@@ -264,7 +263,7 @@ public Q_SLOTS:
       {
         QDialog dialog(mw);
         Ui::Isotropic_remeshing_dialog ui = remeshing_dialog(&dialog, poly_item);
-        ui.objectName->setText(QString::number(indices.size())
+        ui.objectName->setText(QString::number(scene->selectionIndices().size())
           .append(QString(" items to be remeshed")));
         int i = dialog.exec();
         if (i == QDialog::Rejected)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -256,7 +256,8 @@ public Q_SLOTS:
 
       if (poly_item == NULL)
       {
-        std::cout << "Item " << index << " is not a Polyhedron, remeshing skipped\n";
+        std::cout << scene->item(index)->name().data()
+          << " is not a Polyhedron, remeshing skipped\n";
         continue;
       }
       else if (!parameters_set)

--- a/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
+++ b/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
@@ -110,6 +110,7 @@ else
       inside_out_plugin \
       intersection_plugin \
       io_implicit_function_plugin \
+      isotropic_remeshing_plugin \
       jet_fitting_plugin \
       join_and_split_polyhedra_plugin \
       kernel_plugin \


### PR DESCRIPTION
This PR introduces the following functionality

when more than one Scene_polyhedron_items are selected, they are all meshed with *PMP::split_long_edges()* or *PMP::isotropic_remeshing()* following the common parameters chosen in the remeshing widget.

The branch is ready for testing