### PR TITLE
Fix memory leak in CORE

### DIFF
--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories( BEFORE ../../include )
 
 include( CGAL_CreateSingleSourceCGALProgram )
 
+create_single_source_cgal_program( "cyclic.cpp" )
 create_single_source_cgal_program( "Algebraic_curve_kernel_2.cpp" )
 create_single_source_cgal_program( "algebraic_curve_kernel_2_tools.cpp" )
 create_single_source_cgal_program( "Algebraic_kernel_d_1_LEDA.cpp" )

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/cyclic.cpp
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/cyclic.cpp
@@ -1,4 +1,9 @@
 
+#include <CGAL/basic.h>
+#include <iostream>
+
+#ifdef CGAL_HAS_CORE_ARITHMETIC_KERNEL
+
 #define CGAL_ACK_DEBUG_FLAG 0
 
 //#define CGAL_AK_ENABLE_DEPRECATED_INTERFACE 1
@@ -12,8 +17,6 @@ static const char *ACK_2_ascii_polys[] = {
 };
 
 static const int ACK_2_n_polys = 2;
-
-#include <CGAL/basic.h>
 
 #include <CGAL/Arithmetic_kernel.h>
 
@@ -62,3 +65,13 @@ int main()
 
     return 0;
 }
+
+#else
+
+int main()
+{
+  std::cerr << "Needs CGAL_HAS_CORE_ARITHMETIC_KERNEL" << std::endl;
+  return 0;
+}
+
+#endif

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/cyclic.cpp
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/cyclic.cpp
@@ -1,0 +1,64 @@
+
+#define CGAL_ACK_DEBUG_FLAG 0
+
+//#define CGAL_AK_ENABLE_DEPRECATED_INTERFACE 1
+
+
+static const char *ACK_2_ascii_polys[] = {
+    
+    "P[2(0,P[2(2,1)])(2,P[0(0,-1)])]", // x^2-y^2 
+
+    "P[1(0,P[2(2,1)])(1,P[0(0,1)])]", // x^2+y7 
+};
+
+static const int ACK_2_n_polys = 2;
+
+#include <CGAL/basic.h>
+
+#include <CGAL/Arithmetic_kernel.h>
+
+#include <CGAL/Algebraic_kernel_d_1.h>
+#include <CGAL/Algebraic_kernel_d/Algebraic_real_quadratic_refinement_rep_bfi.h>
+#include <CGAL/Algebraic_kernel_d/Bitstream_descartes.h>
+#include <CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h>
+
+
+int main()
+{
+  typedef CGAL::CORE_arithmetic_kernel AT;
+    typedef AT::Integer Coefficient;
+    typedef AT::Rational Rational;
+      
+    typedef CGAL::internal::Algebraic_real_quadratic_refinement_rep_bfi
+        < Coefficient, Rational > Rep_class;
+    typedef CGAL::internal::Bitstream_descartes< 
+        CGAL::internal::Bitstream_descartes_rndl_tree_traits<
+        CGAL::internal::Bitstream_coefficient_kernel<Coefficient > > > 
+        Isolator;
+    
+    typedef CGAL::Algebraic_kernel_d_1<Coefficient,Rational,Rep_class, Isolator> 
+        Algebraic_kernel_d_1;
+
+  
+    typedef CGAL::Algebraic_curve_kernel_2<Algebraic_kernel_d_1>  AK_2;
+ 
+    typedef  AK_2::Polynomial_2 Poly_2;
+    typedef  AK_2::Curve_analysis_2 Curve_analysis_2;
+    typedef  Curve_analysis_2::Status_line_1 Status_line_1;
+
+    Poly_2 polys[ACK_2_n_polys];
+    
+    for(int i = 0; i < ACK_2_n_polys; i++) {
+      std::istringstream in(ACK_2_ascii_polys[i]);
+        in >> polys[i];    
+    }
+    
+    AK_2 kernel_2;
+     
+    Curve_analysis_2 c7_c6 =
+      kernel_2.construct_curve_2_object()(polys[0]*polys[1]); 
+    
+    Status_line_1 line = c7_c6.status_line_at_event(0);
+
+    return 0;
+}

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 #include <cassert>
 
-
 #if defined CGAL_USE_LEDA
 #  include <CGAL/leda_real.h>
 #elif defined CGAL_USE_CORE

--- a/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
@@ -84,8 +84,8 @@ public:
   //  the destructor
   ~BigFloatRep(); //inline
 
-  CORE_MEMORY(BigFloatRep)    // allocate the memory pool, unless
-	                      // memory pool feature is disabled.
+  CORE_NEW(BigFloatRep)    // allocate the memory pool, unless
+  CORE_DELETE(BigFloatRep) // memory pool feature is disabled.
 
   //  approximation
   void trunc(const BigInt&, const extLong&, const extLong&);
@@ -442,6 +442,8 @@ inline void BigFloatRep::dump() const {
   std::cout << "  exp = " << exp << std::endl;
   std::cout << " -- End of BFRep " << this << " -- " << std::endl;
 }
+
+
 
 } //namespace CORE
 #endif // _CORE_BIGFLOATREP_H_

--- a/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
@@ -1322,4 +1322,6 @@ BigFloat root(const BigFloat& x, unsigned long k,
   }
 }//root
 
+  CORE_MEMORY_IMPL(BigFloatRep)
+
 } //namespace CORE

--- a/CGAL_Core/include/CGAL/CORE/BigInt.h
+++ b/CGAL_Core/include/CGAL/CORE/BigInt.h
@@ -94,7 +94,8 @@ public:
     mpz_clear(mp);
   }
 
-  CORE_MEMORY(BigIntRep)
+  CORE_NEW(BigIntRep)
+  CORE_DELETE(BigIntRep)
 
   mpz_srcptr get_mp() const {
     return mp;
@@ -557,6 +558,8 @@ inline BigInt randomize(const BigInt& a) {
   return r;
 }
 //@}
+
+  CORE_MEMORY_IMPL(BigIntRep)
 
 } //namespace CORE
 

--- a/CGAL_Core/include/CGAL/CORE/BigInt.h
+++ b/CGAL_Core/include/CGAL/CORE/BigInt.h
@@ -94,8 +94,8 @@ public:
     mpz_clear(mp);
   }
 
-  CORE_NEW(BigIntRep)
-  CORE_DELETE(BigIntRep)
+  CGAL_CORE_EXPORT CORE_NEW(BigIntRep)
+  CGAL_CORE_EXPORT CORE_DELETE(BigIntRep)
 
   mpz_srcptr get_mp() const {
     return mp;
@@ -559,7 +559,7 @@ inline BigInt randomize(const BigInt& a) {
 }
 //@}
 
-  CORE_MEMORY_IMPL(BigIntRep)
+
 
 } //namespace CORE
 

--- a/CGAL_Core/include/CGAL/CORE/BigRat.h
+++ b/CGAL_Core/include/CGAL/CORE/BigRat.h
@@ -115,8 +115,8 @@ public:
     mpq_clear(mp);
   }
 
-  CORE_NEW(BigRatRep)
-  CORE_DELETE(BigRatRep)
+  CGAL_CORE_EXPORT CORE_NEW(BigRatRep)
+  CGAL_CORE_EXPORT CORE_DELETE(BigRatRep)
 
   mpq_srcptr get_mp() const {
     return mp;
@@ -486,7 +486,6 @@ inline BigInt BigIntValue(const BigRat& a) {
   return a.BigIntValue();
 }
 
-  CORE_MEMORY_IMPL(BigRatRep)
 
 } //namespace CORE
 #endif // _CORE_BIGRAT_H_

--- a/CGAL_Core/include/CGAL/CORE/BigRat.h
+++ b/CGAL_Core/include/CGAL/CORE/BigRat.h
@@ -115,7 +115,8 @@ public:
     mpq_clear(mp);
   }
 
-  CORE_MEMORY(BigRatRep)
+  CORE_NEW(BigRatRep)
+  CORE_DELETE(BigRatRep)
 
   mpq_srcptr get_mp() const {
     return mp;
@@ -484,6 +485,8 @@ inline double doubleValue(const BigRat& a) {
 inline BigInt BigIntValue(const BigRat& a) {
   return a.BigIntValue();
 }
+
+  CORE_MEMORY_IMPL(BigRatRep)
 
 } //namespace CORE
 #endif // _CORE_BIGRAT_H_

--- a/CGAL_Core/include/CGAL/CORE/ExprRep.h
+++ b/CGAL_Core/include/CGAL/CORE/ExprRep.h
@@ -517,7 +517,8 @@ public:
   /// destructor
   ~ConstDoubleRep() {}
   //@}
-  CORE_MEMORY(ConstDoubleRep)
+  CGAL_CORE_EXPORT CORE_NEW(ConstDoubleRep)
+  CGAL_CORE_EXPORT CORE_DELETE(ConstDoubleRep)
 protected:
   /// compute sign and MSB
   CGAL_CORE_EXPORT void computeExactFlags();
@@ -538,7 +539,8 @@ public:
   /// destructor
   ~ConstRealRep() {}
   //@}
-  CORE_MEMORY(ConstRealRep)
+  CGAL_CORE_EXPORT CORE_NEW(ConstRealRep)
+  CGAL_CORE_EXPORT CORE_DELETE(ConstRealRep)
 private:
   Real value; ///< internal representation of node
 protected:
@@ -593,7 +595,14 @@ public:
   /// destructor
   ~ConstPolyRep() {}
   //@}
-  CORE_MEMORY(ConstPolyRep)
+  
+  CGAL_CORE_EXPORT void *operator new( size_t size){
+    return MemoryPool<ConstPolyRep>::global_allocator().allocate(size);
+  }
+ 
+   CGAL_CORE_EXPORT void operator delete( void *p, size_t ){
+    MemoryPool<ConstPolyRep>::global_allocator().free(p);
+  }
 
 private:
   Sturm<NT> ss; ///< internal Sturm sequences
@@ -696,6 +705,8 @@ protected:
     appValue() = centerize(I.first, I.second);
   }
 };
+
+
 /// \class UnaryOpRep
 /// \brief unary operator node
 class UnaryOpRep : public ExprRep {
@@ -745,7 +756,8 @@ public:
   ~NegRep() {}
   //@}
 
-  CORE_MEMORY(NegRep)
+  CGAL_CORE_EXPORT CORE_NEW(NegRep)
+  CGAL_CORE_EXPORT CORE_DELETE(NegRep)
 protected:
   /// compute sign and MSB
   CGAL_CORE_EXPORT void computeExactFlags();
@@ -775,7 +787,8 @@ public:
   ~SqrtRep() {}
   //@}
 
-  CORE_MEMORY(SqrtRep)
+  CGAL_CORE_EXPORT CORE_NEW(SqrtRep)
+  CGAL_CORE_EXPORT CORE_DELETE(SqrtRep)
 protected:
   /// compute sign and MSB
   CGAL_CORE_EXPORT void computeExactFlags();
@@ -897,7 +910,8 @@ public:
   ~AddSubRep() {}
   //@}
 
-  CORE_MEMORY(AddSubRep)
+  CGAL_CORE_EXPORT CORE_NEW(AddSubRep)
+  CGAL_CORE_EXPORT CORE_DELETE(AddSubRep)
 protected:
   /// compute sign and MSB
    void computeExactFlags();
@@ -1244,7 +1258,8 @@ public:
   ~MultRep() {}
   //@}
   
-  CORE_MEMORY(MultRep)
+  CGAL_CORE_EXPORT CORE_NEW(MultRep)
+  CGAL_CORE_EXPORT CORE_DELETE(MultRep)
   protected:
   /// compute sign and MSB
   CGAL_CORE_EXPORT void computeExactFlags();
@@ -1270,7 +1285,8 @@ public:
   ~DivRep() {}
   //@}
 
-  CORE_MEMORY(DivRep)
+  CGAL_CORE_EXPORT CORE_NEW(DivRep)
+  CGAL_CORE_EXPORT CORE_DELETE(DivRep)
 protected:
   /// compute sign and MSB
   CGAL_CORE_EXPORT void computeExactFlags();

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1210,4 +1210,41 @@ void BinOpRep::debugTree(int level, int indent, int depthLimit) const {
   second->debugTree(level, indent + 2, depthLimit - 1);
 }
 
+
+CORE_MEMORY_IMPL(ConstDoubleRep)
+CORE_MEMORY_IMPL(ConstRealRep)
+CORE_MEMORY_IMPL(NegRep)
+CORE_MEMORY_IMPL(SqrtRep)
+
+CORE_MEMORY_IMPL(MultRep)
+CORE_MEMORY_IMPL(DivRep)
+
+template <typename O>
+void * AddSubRep<O>::operator new( size_t size)
+{ return MemoryPool<AddSubRep<O> >::global_allocator().allocate(size); }
+
+template <typename O>
+void AddSubRep<O>::operator delete( void *p, size_t )
+{ MemoryPool<AddSubRep<O> >::global_allocator().free(p); }
+
+
+
+template <class T>
+void * Realbase_for<T>::operator new( size_t size)
+{ return MemoryPool<Realbase_for<T> >::global_allocator().allocate(size); }
+
+template <class T>
+void Realbase_for<T>::operator delete( void *p, size_t )
+{ MemoryPool<Realbase_for<T> >::global_allocator().free(p); }
+
+ template class AddSubRep<Add>;
+ template class AddSubRep<Sub>;
+
+template class Realbase_for<long>;
+template class Realbase_for<double>;
+template class Realbase_for<BigInt>;
+template class Realbase_for<BigRat>;
+template class Realbase_for<BigFloat>;
+
+ template class ConstPolyRep<Expr>;
 } //namespace CORE

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1210,7 +1210,7 @@ void BinOpRep::debugTree(int level, int indent, int depthLimit) const {
   second->debugTree(level, indent + 2, depthLimit - 1);
 }
 
-
+CORE_MEMORY_IMPL(BigIntRep)
 CORE_MEMORY_IMPL(BigRatRep)
 CORE_MEMORY_IMPL(ConstDoubleRep)
 CORE_MEMORY_IMPL(ConstRealRep)

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1211,6 +1211,7 @@ void BinOpRep::debugTree(int level, int indent, int depthLimit) const {
 }
 
 
+CORE_MEMORY_IMPL(BigRatRep)
 CORE_MEMORY_IMPL(ConstDoubleRep)
 CORE_MEMORY_IMPL(ConstRealRep)
 CORE_MEMORY_IMPL(NegRep)
@@ -1247,4 +1248,5 @@ template class Realbase_for<BigRat>;
 template class Realbase_for<BigFloat>;
 
  template class ConstPolyRep<Expr>;
+ template class ConstPolyRep<BigFloat>;
 } //namespace CORE

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1214,6 +1214,7 @@ CORE_MEMORY_IMPL(BigIntRep)
 CORE_MEMORY_IMPL(BigRatRep)
 CORE_MEMORY_IMPL(ConstDoubleRep)
 CORE_MEMORY_IMPL(ConstRealRep)
+
 CORE_MEMORY_IMPL(NegRep)
 CORE_MEMORY_IMPL(SqrtRep)
 
@@ -1249,4 +1250,5 @@ template class Realbase_for<BigFloat>;
 
  template class ConstPolyRep<Expr>;
  template class ConstPolyRep<BigFloat>;
+ template class ConstPolyRep<BigInt>;
 } //namespace CORE

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1251,4 +1251,5 @@ template class Realbase_for<BigFloat>;
  template class ConstPolyRep<Expr>;
  template class ConstPolyRep<BigFloat>;
  template class ConstPolyRep<BigInt>;
+ template class ConstPolyRep<BigRat>;
 } //namespace CORE

--- a/CGAL_Core/include/CGAL/CORE/Impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Impl.h
@@ -42,13 +42,18 @@
 
 // Macros for memory pool
 #ifdef CORE_DISABLE_MEMORY_POOL
-  #define CORE_MEMORY(T)
+  #define CORE_NEW(T)
+  #define CORE_DELETE(T)
+  #define CORE_MEMORY_IMPL(T)
 #else
   #include <CGAL/CORE/MemoryPool.h>
-  #define CORE_MEMORY(T)                                                 \
-    void *operator new( size_t size)                                     \
+  #define CORE_NEW(T)  void *operator new( size_t size);
+  #define CORE_DELETE(T)  void operator delete( void *p, size_t );
+
+  #define CORE_MEMORY_IMPL(T)                                            \
+    void *T::operator new( size_t size)                                  \
     { return MemoryPool<T>::global_allocator().allocate(size); }         \
-    void operator delete( void *p, size_t )                              \
+    void T::operator delete( void *p, size_t )                           \
     { MemoryPool<T>::global_allocator().free(p); }
 #endif
 

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -66,7 +66,7 @@ public:
     CGAL_assertion(count ==  nObjects * blocks.size());
 
     for(std::size_t i=0; i < blocks.size();i++){
-      :: delete blocks[i];
+      ::operator delete(blocks[i]);
     }
   }
 

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -66,7 +66,7 @@ public:
     //CGAL_warning_msg(count ==  nObjects * blocks.size(),
     //                 "Cannot delete memory as there are cyclic references");
 
-    if(count !=  nObjects * blocks.size()){
+    if(count ==  nObjects * blocks.size()){
       for(std::size_t i=0; i < blocks.size();i++){
         ::operator delete(blocks[i]);
       }

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -55,16 +55,16 @@ public:
 
   ~MemoryPool()
   {
-    CGAL_warning_code(
+    //CGAL_warning_code(
       std::size_t count = 0;
       Thunk* t = head;
       while(t!=0){
 	++count;
 	t = t->next;
       }
-			);
-    CGAL_warning_msg(count ==  nObjects * blocks.size(),
-                     "Cannot delete memory as there are cyclic references");
+    //);
+    //CGAL_warning_msg(count ==  nObjects * blocks.size(),
+    //                 "Cannot delete memory as there are cyclic references");
 
     if(count !=  nObjects * blocks.size()){
       for(std::size_t i=0; i < blocks.size();i++){

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -56,7 +56,7 @@ public:
   ~MemoryPool()
   {
     CGAL_assertion_code(
-      int count = 0;
+                        std::size_t count = 0;
       Thunk* t = head;
       while(t!=0){
 	++count;

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -63,10 +63,13 @@ public:
 	t = t->next;
       }
 			);
-    CGAL_warning(count ==  nObjects * blocks.size());
+    CGAL_warning_msg(count ==  nObjects * blocks.size(),
+                     "Cannot delete memory as there are cyclic references");
 
-    for(std::size_t i=0; i < blocks.size();i++){
-      ::operator delete(blocks[i]);
+    if(count !=  nObjects * blocks.size()){
+      for(std::size_t i=0; i < blocks.size();i++){
+        ::operator delete(blocks[i]);
+      }
     }
   }
 

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -55,15 +55,15 @@ public:
 
   ~MemoryPool()
   {
-    CGAL_assertion_code(
-                        std::size_t count = 0;
+    CGAL_warning_code(
+      std::size_t count = 0;
       Thunk* t = head;
       while(t!=0){
 	++count;
 	t = t->next;
       }
 			);
-    CGAL_assertion(count ==  nObjects * blocks.size());
+    CGAL_warning(count ==  nObjects * blocks.size());
 
     for(std::size_t i=0; i < blocks.size();i++){
       ::operator delete(blocks[i]);

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -66,7 +66,7 @@ public:
     CGAL_assertion(count ==  nObjects * blocks.size());
 
     for(std::size_t i=0; i < blocks.size();i++){
-      delete blocks[i];
+      :: delete blocks[i];
     }
   }
 
@@ -120,6 +120,9 @@ template< class T, int nObjects >
 void MemoryPool< T, nObjects >::free(void* t) {
    CGAL_assertion(t != 0);     
    if (t == 0) return; // for safety
+   if(blocks.empty()){
+     std::cerr << typeid(T).name() << std::endl;
+   }
    assert (! blocks.empty());
 
    // recycle the object memory, by putting it back into the chain

--- a/CGAL_Core/include/CGAL/CORE/RealRep.h
+++ b/CGAL_Core/include/CGAL/CORE/RealRep.h
@@ -93,7 +93,10 @@ private:
 template <class T>
 class Realbase_for : public RealRep {
 public:
-  CORE_MEMORY(Realbase_for)
+
+  CGAL_CORE_EXPORT CORE_NEW(Realbase_for)
+  CGAL_CORE_EXPORT CORE_DELETE(Realbase_for)
+
   Realbase_for(const T& k);
   ~Realbase_for() {}
   int ID() const;

--- a/CGAL_Core/include/CGAL/CORE/Real_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Real_impl.h
@@ -288,4 +288,5 @@ std::istream& operator >>(std::istream& i, Real& x) {
   return i;
 }//operator >> (std::istream&, Real&)
 
+
 } //namespace CORE


### PR DESCRIPTION
The class `CORE::MemoryPool` now keeps track of allocated blocks and deletes them in `~MemoryPool()`.

This is stil a rather lazy approach, as memory gets only deleted when the program ends.