### PR TITLE
Add <CGAL/atomic.h> and CGAL_CAN_USE_CXX11_ATOMIC

### DIFF
--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -31,6 +31,9 @@
      }
 
 #  else // not CGAL_CAN_USE_CXX11_ATOMIC
+#    if BOOST_VERSION < 105300
+#      error Boost.Atomic was introduced in Boost-1.53
+#    endif
 #    include <boost/thread/atomic.hpp>
 
      namespace CGAL {

--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 GeometryFactory (France)
+// Copyright (c) 2016 GeometryFactory Sarl (France)
 //  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org); you can redistribute it and/or
@@ -21,29 +21,36 @@
 #include <CGAL/config.h>
 
 #ifdef CGAL_HAS_THREADS
+
 #  ifdef CGAL_CAN_USE_CXX11_ATOMIC
 #    include <atomic>
-
-     namespace CGAL {
-       namespace cpp11 {
-         using std::atomic;
-       }
-     }
-
+#    define CGAL_ATOMIC_NS std
 #  else // not CGAL_CAN_USE_CXX11_ATOMIC
-#    if BOOST_VERSION < 105300
-#      error Boost.Atomic was introduced in Boost-1.53
-#    endif
-#    include <boost/thread/atomic.hpp>
-
-     namespace CGAL {
-       namespace cpp11 {
-         using boost::atomic;
-       }
-     }
-
+#    if BOOST_VERSION >= 105300
+#      include <boost/thread/atomic.hpp>
+#      define CGAL_ATOMIC_NS boost
+#    else // BOOST_VERSION < 105300
+#      define CGAL_NO_ATOMIC "Boost.Atomic was introduced in Boost-1.53"
+#    endif // BOOST_VERSION < 105300
 #  endif // not CGAL_CAN_USE_CXX11_ATOMIC
+
+#  ifndef CGAL_NO_ATOMIC
+   namespace CGAL {
+     namespace cpp11 {
+       using CGAL_ATOMIC_NS ::atomic;
+
+       using CGAL_ATOMIC_NS ::memory_order_relaxed;
+       using CGAL_ATOMIC_NS ::memory_order_consume;
+       using CGAL_ATOMIC_NS ::memory_order_acquire;
+       using CGAL_ATOMIC_NS ::memory_order_release;
+       using CGAL_ATOMIC_NS ::memory_order_acq_rel;
+       using CGAL_ATOMIC_NS ::memory_order_seq_cst;
+
+       using CGAL_ATOMIC_NS ::atomic_thread_fence;
+     }
+   }
+#  endif // CGAL_ATOMIC_NS
+
 #endif // CGAL_HAS_THREADS
 
 #endif // CGAL_ATOMIC_H
-

--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 GeometryFactory (France)
+//  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+
+#ifndef CGAL_ATOMIC_H
+#define CGAL_ATOMIC_H
+
+#include <CGAL/config.h>
+
+#ifdef CGAL_HAS_THREADS
+#  ifdef CGAL_CAN_USE_CXX11_ATOMIC
+#    include <atomic>
+
+     namespace CGAL {
+       namespace cpp11 {
+         using std::atomic;
+       }
+     }
+
+#  else // not CGAL_CAN_USE_CXX11_ATOMIC
+#    include <boost/thread/atomic.hpp>
+
+     namespace CGAL {
+       namespace cpp11 {
+         using boost::atomic;
+       }
+     }
+
+#  endif // not CGAL_CAN_USE_CXX11_ATOMIC
+#endif // CGAL_HAS_THREADS
+
+#endif // CGAL_ATOMIC_H
+

--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -27,7 +27,7 @@
 #    define CGAL_ATOMIC_NS std
 #  else // not CGAL_CAN_USE_CXX11_ATOMIC
 #    if BOOST_VERSION >= 105300
-#      include <boost/thread/atomic.hpp>
+#      include <boost/atomic.hpp>
 #      define CGAL_ATOMIC_NS boost
 #    else // BOOST_VERSION < 105300
 #      define CGAL_NO_ATOMIC "Boost.Atomic was introduced in Boost-1.53"

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -374,6 +374,9 @@ using std::max;
 #ifndef __has_feature
   #define __has_feature(x) 0  // Compatibility with non-clang compilers.
 #endif
+#ifndef __has_include
+  #define __has_include(x) 0  // Compatibility with non-clang compilers.
+#endif
 #ifndef __has_extension
   #define __has_extension __has_feature // Compatibility with pre-3.0 compilers.
 #endif
@@ -434,16 +437,23 @@ using std::max;
 #  endif
 #endif
 
-#if ( defined(__GNUC__) && defined(__GNUC_MINOR__)       \
-      && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 \
-      && __cplusplus >= 201103L ) || ( _MSC_VER >= 1900 )
+#if __has_feature(cxx_thread_local) || \
+    ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L ) || \
+    ( _MSC_VER >= 1900 )
 #define CGAL_CAN_USE_CXX11_THREAD_LOCAL
 #endif
 
-#if ( defined(__GNUC__) && defined(__GNUC_MINOR__)       \
-      && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 \
-      && __cplusplus >= 201103L ) || ( _MSC_VER >= 1700 )
+#if ( BOOST_VERSION >= 105000 && ! defined(BOOST_NO_CXX11_HDR_MUTEX) ) || \
+    (__has_include(<mutex>) && __cplusplus >= 201103L ) | \
+    ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L ) || \
+    ( _MSC_VER >= 1700 )
 #define CGAL_CAN_USE_CXX11_MUTEX
+#endif
+
+#if (__has_include(<atomic>) && __cplusplus >= 201103L ) || \
+    ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L ) || \
+    ( _MSC_VER >= 1700 )
+#define CGAL_CAN_USE_CXX11_ATOMIC
 #endif
 
 // Support for LEDA with threads

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -450,7 +450,8 @@ using std::max;
 #define CGAL_CAN_USE_CXX11_MUTEX
 #endif
 
-#if (__has_include(<atomic>) && __cplusplus >= 201103L ) || \
+#if ( BOOST_VERSION >= 105600 && ! defined(BOOST_NO_CXX11_HDR_ATOMIC) ) || \
+    (__has_include(<atomic>) && __cplusplus >= 201103L ) || \
     ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L ) || \
     ( _MSC_VER >= 1700 )
 #define CGAL_CAN_USE_CXX11_ATOMIC


### PR DESCRIPTION
- Change the way the macros `CGAL_CAN_USE_CXX11_THREAD_LOCAL` and
  `CGAL_CAN_USE_CXX11_MUTEX` are defined, so that other compilers are
  also supported.

- Add the macro `CGAL_CAN_USE_CXX11_ATOMIC` and the header
  `<CGAL/atomic.h>`.