### PR TITLE
Polyhedron demo: robustify corefinement and intersection plugins

### DIFF
--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
@@ -656,13 +656,11 @@ namespace internal_IOP{
     
     size_t size() const {return enodes.size();}
 
-    void add_new_node(Halfedge_handle edge,Facet_handle facet)
-    {
-      enodes.push_back(compute_triangle_segment_intersection_point<Polyhedron,Kernel>(edge,facet,ek) );
-      inodes.push_back( exact_to_interval(enodes.back()) );
-    }
-
     void add_new_node(const Exact_kernel::Point_3& p){
+      const Ikernel::Point_3& p_approx=p.approx();
+      if ( !has_smaller_relative_precision(p_approx.x(),Lazy_exact_nt<typename Exact_kernel::FT>::get_relative_precision_of_to_double()) ||
+           !has_smaller_relative_precision(p_approx.y(),Lazy_exact_nt<typename Exact_kernel::FT>::get_relative_precision_of_to_double()) ||
+           !has_smaller_relative_precision(p_approx.z(),Lazy_exact_nt<typename Exact_kernel::FT>::get_relative_precision_of_to_double()) ) p.exact();
       enodes.push_back(p);
       inodes.push_back( exact_to_interval(p) );
     }

--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
@@ -567,19 +567,20 @@ namespace internal_IOP{
     
     size_t size() const {return nodes.size();}
     
+    void add_new_node(const typename Exact_kernel::Point_3& p)
+    {
+      nodes.push_back(  exact_to_double(p) );
+    }
+
     //add a new node in the final graph.
     //it is the intersection of the triangle with the segment
     void add_new_node(Halfedge_handle edge,Facet_handle facet)
     {
-      nodes.push_back (  exact_to_double(
+      add_new_node(
         compute_triangle_segment_intersection_point<Polyhedron,Kernel>(edge,facet,ek)
-      ));
+      );
     }
-    
-    void add_new_node(const typename Exact_kernel::Point_3& p)
-    {
-      nodes.push_back(  exact_to_double(p) );
-    }    
+
 
     void add_new_node(const typename Kernel::Point_3& p)
     {
@@ -663,6 +664,11 @@ namespace internal_IOP{
            !has_smaller_relative_precision(p_approx.z(),Lazy_exact_nt<typename Exact_kernel::FT>::get_relative_precision_of_to_double()) ) p.exact();
       enodes.push_back(p);
       inodes.push_back( exact_to_interval(p) );
+    }
+
+    void add_new_node(Halfedge_handle edge,Facet_handle facet)
+    {
+      add_new_node(compute_triangle_segment_intersection_point<Polyhedron,Kernel>(edge,facet,ek) );
     }
 
     //the point is an input

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
@@ -1,3 +1,4 @@
+#define CGAL_COREFINEMENT_DO_REPORT_SELF_INTERSECTIONS
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/corefinement_operations.h>
 #include <CGAL/bounding_box.h>

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
@@ -1,3 +1,4 @@
+#define CGAL_COREFINEMENT_DO_REPORT_SELF_INTERSECTIONS
 #define CGAL_USE_SEGMENT_APPROACH
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #ifdef CGAL_USE_SEGMENT_APPROACH


### PR DESCRIPTION
self-intersection tests are done prior to the call to the corefinement code, but only for faces involved in the corefinement