### PR TITLE
Aos 2 fixes efif

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementGraphicsItem.h
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementGraphicsItem.h
@@ -346,8 +346,8 @@ protected:
         // Determine the direction of cv (left-to-right or right-to-left)
         Comparison_result dir = comp_end_pts(cv);
 
-        for (seg_it = cv.begin_subcurves();
-             seg_it != cv.end_subcurves() ; ++seg_it)
+        for (seg_it = cv.subcurves_begin();
+             seg_it != cv.subcurves_end() ; ++seg_it)
           {
             if (dir == SMALLER)
               {

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.h
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.h
@@ -12,9 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL: $
-// $Id: $
-//
 // Author(s)     : Alex Tsui <alextsui05@gmail.com>
 
 #ifndef CGAL_QT_ARRANGEMENT_PAINTER_OSTREAM_H
@@ -260,8 +257,8 @@ public: // methods
   ArrangementPainterOstream& operator<<( const X_monotone_curve_2& curve )
   {
     for (typename X_monotone_curve_2::Subcurve_const_iterator it =
-           curve.begin_subcurves();
-         it != curve.end_subcurves(); ++it)
+           curve.subcurves_begin();
+         it != curve.subcurves_end(); ++it)
       {
         this->painterOstream << *it;
       }

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/Utils.h
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/Utils.h
@@ -12,9 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL: $
-// $Id: $
-//
 // Author(s)     : Alex Tsui <alextsui05@gmail.com>
 
 #ifndef CGAL_ARRANGEMENTS_DEMO_UTILS_H
@@ -342,12 +339,12 @@ public:
 
   double operator() ( const Point_2& p, const X_monotone_curve_2& c ) const
   {
-    Seg_const_it seg_it_s = c.begin_subcurves();
+    Seg_const_it seg_it_s = c.subcurves_begin();
 
     bool first = true;
     FT min_dist = 0;
 
-    while (seg_it_s != c.end_subcurves())
+    while (seg_it_s != c.subcurves_end())
       {
         Segment_2 seg = *seg_it_s;
         FT dist = this->squared_distance( p, seg );

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
@@ -12,10 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-//
-//
 // Author(s)     : Efi Fogel         <efif@post.tau.ac.il>
 
 #ifndef CGAL_ARR_GEODESIC_ARC_ON_SPHERE_TRAITS_2_H
@@ -568,7 +564,8 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& xc1,
                                  const X_monotone_curve_2& xc2,
-                                 const Point_2& p) const
+                                 const Point_2&
+                                 CGAL_precondition_code(p)) const
     {
       CGAL_precondition(!xc1.is_degenerate());
       CGAL_precondition(!xc2.is_degenerate());
@@ -942,7 +939,7 @@ public:
      */
     Comparison_result operator()(const Point_2& point,
                                  const X_monotone_curve_2& xcv,
-                                 Arr_curve_end ce) const
+                                 Arr_curve_end CGAL_precondition_code(ce)) const
     {
       CGAL_precondition(point.is_no_boundary());
       CGAL_precondition_code
@@ -985,9 +982,9 @@ public:
      * \pre xcv2 does not coincide with the vertical identification curve.
      */
     Comparison_result operator()(const X_monotone_curve_2& xcv1,
-                                 Arr_curve_end ce1,
+                                 Arr_curve_end CGAL_precondition_code(ce1),
                                  const X_monotone_curve_2& xcv2,
-                                 Arr_curve_end ce2) const
+                                 Arr_curve_end CGAL_precondition_code(ce2)) const
     {
       CGAL_precondition_code
         (const Point_2& p1 = (ce1 == ARR_MIN_END) ? xcv1.left() : xcv1.right(););
@@ -1071,9 +1068,11 @@ public:
      * \pre xcv1 does not coincide with the vertical identification curve.
      * \pre xcv2 does not coincide with the vertical identification curve.
      */
-    Comparison_result operator()(const X_monotone_curve_2& xcv1,
-                                 const X_monotone_curve_2& xcv2,
-                                 Arr_curve_end ce) const
+    Comparison_result operator()(const X_monotone_curve_2&
+                                   CGAL_precondition_code(xcv1),
+                                 const X_monotone_curve_2&
+                                   CGAL_precondition_code(xcv2),
+                                 Arr_curve_end CGAL_precondition_code(ce)) const
     {
       CGAL_precondition_code
         (const Point_2& p1 = (ce == ARR_MIN_END) ? xcv1.left() : xcv1.right(););

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -12,10 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Ron Wein     <wein@post.tau.ac.il>
 //                 Iddo Hanniel <iddoh@cs.technion.ac.il>
 
@@ -100,7 +96,7 @@ private:
   {
   private:
     Bezier_cache    *p_cache;
-    
+
   public:
 
     Less_intersection_point (Bezier_cache& cache) :
@@ -605,23 +601,27 @@ private:
    *         EQUAL if p lies on the curve.
    */
   Comparison_result _exact_vertical_position (const Point_2& p,
-                                              bool force_exact) const;
+                                              bool
+#if !defined(CGAL_NO_ASSERTIONS)
+                                              force_exact
+#endif
+                                              ) const;
 
 };
 
 /*!
  * Exporter for Bezier curves.
  */
-template <class Rat_kernel, class Alg_kernel, class Nt_traits, 
+template <class Rat_kernel, class Alg_kernel, class Nt_traits,
           class Bounding_traits>
-std::ostream& 
-operator<< (std::ostream& os, 
-            const _Bezier_x_monotone_2<Rat_kernel, Alg_kernel, Nt_traits, 
+std::ostream&
+operator<< (std::ostream& os,
+            const _Bezier_x_monotone_2<Rat_kernel, Alg_kernel, Nt_traits,
                                        Bounding_traits>& cv)
 {
   os << cv.supporting_curve()
      << " [" << cv.xid()
-     << "] | " << cv.source() 
+     << "] | " << cv.source()
      << " --> " << cv.target();
 
   return (os);
@@ -645,11 +645,11 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_Bezier_x_monotone_2
 
   // Get the originators of the point that correspond to the curve B.
   Originator_iterator   ps_org = ps.get_originator (B, _xid);
-  CGAL_precondition (ps_org != ps.originators_end()); 
-  
+  CGAL_precondition (ps_org != ps.originators_end());
+
   Originator_iterator   pt_org = pt.get_originator (B, _xid);
   CGAL_precondition (pt_org != pt.originators_end());
-  
+
   // Check if the subcurve is directed left or right.
   const Comparison_result    res = _ps.compare_x (_pt, cache);
 
@@ -663,12 +663,12 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_Bezier_x_monotone_2
   {
     _dir_right = (res == SMALLER);
   }
-  
+
   // Check if the value of the parameter t increases when we traverse the
   // curve from left to right: If the curve is directed to the right, we
   // check if t_src < t_trg, otherwise we check whether t_src > t_trg.
   Comparison_result      t_res;
-  
+
   if (CGAL::compare (ps_org->point_bound().t_max,
                      pt_org->point_bound().t_min) == SMALLER ||
       CGAL::compare (ps_org->point_bound().t_min,
@@ -676,7 +676,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_Bezier_x_monotone_2
   {
     // Perform the comparison assuming that the possible parameter
     // values do not overlap.
-    t_res = CGAL::compare (ps_org->point_bound().t_min, 
+    t_res = CGAL::compare (ps_org->point_bound().t_min,
                            pt_org->point_bound().t_min);
   }
   else
@@ -684,7 +684,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_Bezier_x_monotone_2
     // In this case both exact parameter values must be known.
     // We use them to perform an exact comparison.
     CGAL_assertion (ps_org->has_parameter() && pt_org->has_parameter());
-    
+
     t_res = CGAL::compare (ps_org->parameter(), pt_org->parameter());
   }
 
@@ -700,7 +700,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_Bezier_x_monotone_2
 // Get the approximate parameter range defining the curve.
 //
 template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
-std::pair<double, double> 
+std::pair<double, double>
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::parameter_range () const
 {
   // First try to use the approximate representation of the endpoints.
@@ -728,14 +728,14 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
      Bezier_cache& cache) const
 {
   Nt_traits nt_traits;
-  
+
   //First check if the bezier is a vertical segment
   if (is_vertical())
   {
     if (! p.is_exact()) p.make_exact (cache);
-    if (! _ps.is_exact()) _ps.make_exact (cache);    
-    if (! _pt.is_exact()) _ps.make_exact (cache);    
-    
+    if (! _ps.is_exact()) _ps.make_exact (cache);
+    if (! _pt.is_exact()) _ps.make_exact (cache);
+
     if (p.is_rational() && _ps.is_rational() && _pt.is_rational())
     {
       const Rat_point_2&  rat_p = (Rat_point_2) p;
@@ -746,7 +746,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
       Comparison_result res2 = (CGAL::compare (rat_p.y(), rat_pt.y()));
       return (res1==res2 ? res1:EQUAL);
     }
-    
+
     Comparison_result res1 = (CGAL::compare (p.y(), _ps.y()));
     Comparison_result res2 = (CGAL::compare (p.y(), _pt.y()));
     return (res1==res2 ? res1:EQUAL);
@@ -755,10 +755,10 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
   if (p.identical(_ps)) {
     return EQUAL;
   }
-  
-  // Then check whether the bezier is an horizontal segment or 
+
+  // Then check whether the bezier is an horizontal segment or
   // if p has the same x-coordinate as one of the endpoint
-  
+
   const Comparison_result  res1 =  p.compare_x (_ps, cache);
 
   if (res1 == EQUAL || nt_traits.degree(_curve.y_polynomial()) <= 0)
@@ -778,13 +778,13 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
     // Compare the algebraic y-coordinates.
     return (CGAL::compare (p.y(), _ps.y()));
   }
-  
+
   if (p.identical(_pt)) {
     return EQUAL;
   }
 
   const Comparison_result  res2 = p.compare_x (_pt, cache);
-  
+
   if (res2 == EQUAL)
   {
     // In this case both points must be exact.
@@ -802,13 +802,13 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
     // Compare the algebraic y-coordinates.
     return (CGAL::compare (p.y(), _pt.y()));
   }
-  
+
   // Make sure that p is in the x-range of our subcurve.
   CGAL_precondition (res1 != res2);
-  
+
   // Check for the case when curve is an originator of the point.
   Originator_iterator   p_org = p.get_originator (_curve, _xid);
- 
+
   if (p_org != p.originators_end())
   {
     CGAL_assertion_code
@@ -838,7 +838,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
     if (in_range)
       return (EQUAL);
   }
-  
+
   // Call the vertical-position function that uses the bounding-boxes
   // to evaluate the comparsion result.
   typename Bounding_traits::Control_points  cp;
@@ -848,10 +848,10 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
 
   Originator_iterator           ps_org = _ps.get_originator (_curve, _xid);
   CGAL_assertion (ps_org != _ps.originators_end());
-  
+
   Originator_iterator           pt_org = _pt.get_originator (_curve, _xid);
   CGAL_assertion (pt_org != _pt.originators_end());
-  
+
   Comparison_result             res_bound = EQUAL;
   typename Bounding_traits::NT  x_min, y_min, x_max, y_max;
   bool                          can_refine;
@@ -949,28 +949,28 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
 
   if (res_bound != EQUAL)
     return (res_bound);
- 
-  
+
+
   if ( p.is_rational() ){
     const Rational& px = ((Rat_point_2) p).x();
-    
+
     Integer denom_px=nt_traits.denominator(px);
     Integer numer_px=nt_traits.numerator(px);
     Polynomial poly_px = CGAL::sign(numer_px) == ZERO ? Polynomial() : nt_traits.construct_polynomial(&numer_px,0);
     Polynomial poly_x = nt_traits.scale(_curve.x_polynomial(),denom_px) - poly_px;
-    
+
     std::vector <Algebraic> roots;
     std::pair<double,double> prange = parameter_range();
     nt_traits.compute_polynomial_roots (poly_x,prange.first,prange.second,std::back_inserter(roots));
-    
+
     CGAL_assertion(roots.size()==1); //p is in the range and the curve is x-monotone
-    
+
     return CGAL::compare(
       ((Rat_point_2) p).y(),
       nt_traits.evaluate_at (_curve.y_polynomial(), *roots.begin())
     );
   }
-  
+
   // In this case we have to switch to exact computations and check whether
   // p lies of the given subcurve. We take one of p's originating curves and
   // compute its intersections with our x-monotone curve.
@@ -978,7 +978,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
     p.make_exact (cache);
 
   CGAL_assertion (p.originators_begin() != p.originators_end());
-    
+
   Originator   org = *(p.originators_begin());
   bool         do_ovlp;
   bool         swap_order = (_curve.id() > org.curve().id());
@@ -1000,20 +1000,20 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
 
   if (do_ovlp)
     return (EQUAL);
-    
+
   // Go over the intersection points and look for p there.
   Intersect_iter       iit;
-    
+
   for (iit = inter_list.begin(); iit != inter_list.end(); ++iit)
   {
     // Get the parameter of the originator and compare it to p's parameter.
     const Algebraic&  s = swap_order ? iit->s : iit->t;
-      
+
     if (CGAL::compare (s, org.parameter()) == EQUAL)
     {
       // Add this curve as an originator for p.
       const Algebraic&  t = swap_order ? iit->t : iit->s;
-    
+
       CGAL_assertion (_is_in_range (t, cache));
 
       Point_2&  pt = const_cast<Point_2&> (p);
@@ -1023,7 +1023,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
       return (EQUAL);
     }
   }
-  
+
   // We now know that p is not on the subcurve. We therefore subdivide the
   // curve using exact rational arithmetic, until we reach a separation
   // between the curve and the point. (This case should be very rare.)
@@ -1039,7 +1039,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
 
   if (! _ps.is_exact())
     _ps.make_exact (cache);
-  
+
   if (! _pt.is_exact())
     _pt.make_exact (cache);
 
@@ -1074,7 +1074,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
       CGAL_precondition_msg (false, "p is not on cv1");
     }
   }
-  
+
   if (! p.equals (cv.left(), cache))
   {
     if (cv.point_position (p, cache) != EQUAL)
@@ -1090,14 +1090,14 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
     if (cv.is_vertical())
       // Both are vertical segments with a common endpoint, so they overlap:
       return (EQUAL);
-    
+
     return (LARGER);
   }
   else if (cv.is_vertical())
   {
     return (SMALLER);
   }
-    
+
   // Check if both subcurves originate from the same Bezier curve.
   Nt_traits       nt_traits;
 
@@ -1118,7 +1118,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
       {
         // Comparison based on the control polygon of the bounded vertical
         // tangency point, using the fact this polygon is y-monotone.
-        const typename Bounding_traits::Control_points& cp = 
+        const typename Bounding_traits::Control_points& cp =
           org->point_bound().ctrl;
 
         if (_inc_to_right)
@@ -1130,21 +1130,21 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
           return (CGAL::compare (cp.front().y(), cp.back().y()));
         }
       }
-    
+
       // Iddo: Handle rational points (using de Casteljau derivative)?
-    
+
       // In this case we know that we have a vertical tangency at t0, so
       // X'(t0) = 0. We evaluate the sign of Y'(t0) in order to find the
       // vertical position of the two subcurves to the right of this point.
       CGAL_assertion (org->has_parameter());
-    
+
       const Algebraic&  t0 = org->parameter();
       Polynomial        polyY_der = nt_traits.derive (_curve.y_polynomial());
       const CGAL::Sign  sign_der =
         CGAL::sign (nt_traits.evaluate_at (polyY_der, t0));
-    
+
       CGAL_assertion (sign_der != CGAL::ZERO);
-    
+
       if (_inc_to_right)
         return ((sign_der == CGAL::POSITIVE) ? LARGER : SMALLER);
       else
@@ -1163,7 +1163,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
   // Compare the two subcurves by choosing some point to the right of p
   // and comparing the vertical position there.
   Comparison_result   right_res;
-  
+
   if (right().compare_x (cv.right(), cache) != LARGER)
   {
     right_res = _compare_to_side (cv, p,
@@ -1175,10 +1175,10 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_right
     right_res = cv._compare_to_side (*this, p,
                                      true,        // Compare to p's right.
                                      cache);
-    
+
     right_res = CGAL::opposite (right_res);
   }
-  
+
   return (right_res);
 }
 
@@ -1218,7 +1218,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
       CGAL_precondition_msg (false, "p is not on cv2");
     }
   }
-  
+
   // Check for vertical subcurves. A vertical segment is below any other
   // x-monotone subcurve to the left of their common endpoint.
   if (is_vertical())
@@ -1226,14 +1226,14 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
     if (cv.is_vertical())
       // Both are vertical segments with a common endpoint, so they overlap:
       return (EQUAL);
-    
+
     return (SMALLER);
   }
   else if (cv.is_vertical())
   {
     return (LARGER);
   }
-    
+
   // Check if both subcurves originate from the same Bezier curve.
   Nt_traits       nt_traits;
 
@@ -1246,16 +1246,16 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
 
     CGAL_assertion (org != p.originators_end());
     CGAL_assertion (_inc_to_right != cv._inc_to_right);
-    
+
     if (org->point_bound().type == Bez_point_bound::VERTICAL_TANGENCY_PT)
     {
       if (! p.is_exact())
       {
         // Comparison based on the control polygon of the bounded vertical
         // tangency point, using the fact this polygon is y-monotone.
-        const typename Bounding_traits::Control_points& cp = 
+        const typename Bounding_traits::Control_points& cp =
           org->point_bound().ctrl;
-      
+
         if (_inc_to_right)
         {
           return (CGAL::compare(cp.front().y(), cp.back().y()));
@@ -1265,21 +1265,21 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
           return (CGAL::compare(cp.back().y(), cp.front().y()));
         }
       }
-    
+
       // Iddo: Handle rational points (using de Casteljau derivative)?
-    
+
       // In this case we know that we have a vertical tangency at t0, so
       // X'(t0) = 0. We evaluate the sign of Y'(t0) in order to find the
       // vertical position of the two subcurves to the right of this point.
       CGAL_assertion (org->has_parameter());
-    
+
       const Algebraic&  t0 = org->parameter();
       Polynomial        polyY_der = nt_traits.derive (_curve.y_polynomial());
       const CGAL::Sign  sign_der =
         CGAL::sign (nt_traits.evaluate_at (polyY_der, t0));
-    
+
       CGAL_assertion (sign_der != CGAL::ZERO);
-      
+
       if (_inc_to_right)
         return ((sign_der == CGAL::NEGATIVE) ? LARGER : SMALLER);
       else
@@ -1292,14 +1292,14 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
   // vertical order to p's right; note that we swap the order of the curves
   // to obtains their position to the left.
   Comparison_result   slope_res = cv._compare_slopes (*this, p, cache);
-    
+
   if (slope_res != EQUAL)
     return (slope_res);
 
   // Compare the two subcurves by choosing some point to the left of p
   // and compareing the vertical position there.
   Comparison_result   left_res;
-  
+
   if (left().compare_x (cv.left(), cache) != SMALLER)
   {
     left_res = _compare_to_side (cv, p,
@@ -1313,7 +1313,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
                                     cache);
     left_res = CGAL::opposite (left_res);
   }
-  
+
   return (left_res);
 }
 
@@ -1334,11 +1334,11 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::equals
         return compare(left().x(),cv.left().x())==EQUAL;
       return false;
     }
-    
+
     // Check whether the two curves have the same support:
     if (! _curve.has_same_support (cv._curve))
       return (false);
-    
+
     // Mark that the two curves overlap in the cache.
     const Curve_id               id1 = _curve.id();
     const Curve_id               id2 = cv._curve.id();
@@ -1378,13 +1378,13 @@ split(const Point_2& p, Self& c1, Self& c2) const
     CGAL_assertion(sols.size() == 1);
     p.add_originator(Originator(_curve, _xid,*sols.begin()) );
   }
-  
+
   CGAL_precondition(p.get_originator(_curve, _xid) != p.originators_end() ||
                     p.is_rational());
 
   // Duplicate the curve.
   c1 = c2 = *this;
-    
+
   // Perform the split.
   if (_dir_right)
   {
@@ -1410,7 +1410,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::can_merge_with
   return (_curve.is_same (cv._curve) &&
           _xid == cv._xid &&
           (right().is_same (cv.left()) || left().is_same (cv.right())));
-  
+
   return (false);
 }
 
@@ -1438,7 +1438,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::merge
   else
   {
     CGAL_precondition (left().is_same (cv.right()));
-    
+
     // Extend the subcurve to the left.
     if (_dir_right)
       res._ps = cv.left();
@@ -1467,7 +1467,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
   Nt_traits            nt_traits;
 
   bool  p_lt_ps =
-      (CGAL::compare (t, nt_traits.convert (s_org->point_bound().t_min)) == 
+      (CGAL::compare (t, nt_traits.convert (s_org->point_bound().t_min)) ==
        SMALLER);
   bool  p_gt_ps =
       (CGAL::compare (t, nt_traits.convert (s_org->point_bound().t_max)) ==
@@ -1485,7 +1485,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
     // parameter is between the source and target parameters.
     return (true);
   }
-  
+
   if ((p_lt_ps && p_lt_pt) || (p_gt_ps && p_gt_pt))
   {
     // The point p is definately not in the x-range of the subcurve,
@@ -1493,15 +1493,15 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
     // (or greater than both of them).
     return (false);
   }
-  
+
   // Obtain the exact t-range of the curve and peform an exact comparison.
   std::pair<Algebraic, Algebraic> range = _t_range (cache);
   const Algebraic&                t_src = range.first;
   const Algebraic&                t_trg = range.second;
-  
+
   const Comparison_result  res1 = CGAL::compare (t, t_src);
   const Comparison_result  res2 = CGAL::compare (t, t_trg);
-  
+
   return (res1 == EQUAL || res2 == EQUAL || res1 != res2);
 }
 
@@ -1514,7 +1514,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
          bool& is_certain) const
 {
   is_certain = true;
-  
+
   // Check the easy case that p is one of the subcurve endpoints.
   if (p.is_same(_ps) || p.is_same(_pt))
     return true;
@@ -1534,14 +1534,14 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
 
   Originator_iterator  s_org = _ps.get_originator (_curve, _xid);
   CGAL_assertion (s_org != _ps.originators_end());
-  
+
   Originator_iterator  t_org = _pt.get_originator (_curve, _xid);
   CGAL_assertion (t_org != _pt.originators_end());
-  
+
   bool      can_refine_p = ! p.is_exact();
   bool      can_refine_s = ! _ps.is_exact();
   bool      can_refine_t = ! _pt.is_exact();
-  
+
   while (can_refine_p || can_refine_s || can_refine_t)
   {
     bool  p_lt_ps = (CGAL::compare (p_org->point_bound().t_max,
@@ -1567,14 +1567,14 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
       // (or greater than both of them).
       return (false);
     }
-    
+
     // Try to refine the points.
     if (can_refine_p)
       can_refine_p = p.refine();
-    
+
     if (can_refine_s)
       can_refine_s = _ps.refine();
-    
+
     if (can_refine_t)
       can_refine_t = _pt.refine();
   }
@@ -1634,7 +1634,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
   if ( is_vertical() ){
     if ( compare(rat_p.x(),left().x())==EQUAL ){
       _curve.get_t_at_y (rat_p.y(), std::back_inserter(t_vals));
-      
+
       for (t_iter = t_vals.begin(); t_iter != t_vals.end(); ++t_iter)
       {
         // Compare the current t-value with t_min.
@@ -1670,9 +1670,9 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_is_in_range
       }
     }
     is_endpoint = false;
-    return (false);          
+    return (false);
   }
-  
+
   _curve.get_t_at_x (rat_p.x(), std::back_inserter(t_vals));
   CGAL_assertion (! t_vals.empty() );
 
@@ -1745,7 +1745,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_get_y
   const Algebraic&                         t_src = t_range.first;
   const Algebraic&                         t_trg = t_range.second;
   Comparison_result                        res1, res2;
-  
+
   for (t_iter = t_vals.begin(); t_iter != t_vals.end(); ++t_iter)
   {
     res1 = CGAL::compare (*t_iter, t_src);
@@ -1772,7 +1772,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_get_y
               nt_traits.convert (_curve.y_norm()));
     }
   }
-  
+
   // If we reached here, x0 is not in the x-range of our subcurve.
   CGAL_error();
   return (0);
@@ -1808,7 +1808,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_slopes
     const Bez_point_bound&  bound1 = org1->point_bound();
     const Bez_point_bound&  bound2 = org2->point_bound();
     Bounding_traits         bound_tr;
-    
+
     return (bound_tr.compare_slopes_at_intersection_point (bound1,
                                                            bound2));
   }
@@ -1903,7 +1903,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_slopes
   // Handle the comparison when one slope (or both) is +/- oo.
   if (inf_slope1 == CGAL::POSITIVE)
     return (inf_slope2 == CGAL::POSITIVE ? EQUAL : LARGER);
-  
+
   if (inf_slope1 == CGAL::NEGATIVE)
     return (inf_slope2 == CGAL::NEGATIVE ? EQUAL : SMALLER);
 
@@ -1922,7 +1922,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_slopes
 //
 template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
 std::pair<typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt,
-                                        BndTrt>::Algebraic, 
+                                        BndTrt>::Algebraic,
           typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt,
                                         BndTrt>::Algebraic>
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_t_range
@@ -1930,17 +1930,17 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_t_range
 {
   Originator_iterator  ps_org = _ps.get_originator (_curve, _xid);
   CGAL_assertion(ps_org != _ps.originators_end());
-  
+
   Originator_iterator  pt_org = _pt.get_originator (_curve, _xid);
   CGAL_assertion(pt_org != _pt.originators_end());
-  
+
   // Make sure that the two endpoints are exact.
   if (! ps_org->has_parameter())
     _ps.make_exact (cache);
-  
+
   if (! pt_org->has_parameter())
     _pt.make_exact (cache);
-  
+
   return (std::make_pair (ps_org->parameter(),
                           pt_org->parameter()));
 }
@@ -1981,10 +1981,10 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_to_side
 
   // Get the parameter value for the point p.
   Originator_iterator          org = p.get_originator (_curve, _xid);
-  
+
   CGAL_assertion (org != p.originators_end());
   CGAL_assertion (org->has_parameter());
-  
+
   const Algebraic&             t0 = org->parameter();
 
   // Get the parameter range of the curve.
@@ -1998,14 +1998,14 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_to_side
   Algebraic                    next_t;
   Comparison_result            res = CGAL::EQUAL;
   bool                         found = false;
-  
+
   for (iit = inter_list.begin(); iit != inter_list.end(); ++iit)
   {
     // Check if the current point lies to the right (left) of p. We do so by
     // considering its originating parameter value s (or t, if we swapped
     // the curves).
     const Algebraic&     t = (no_swap_curves ? (iit->s) : iit->t);
-    
+
     res = CGAL::compare (t, t0);
     if ((to_right && ((_inc_to_right && res == LARGER) ||
                       (! _inc_to_right && res == SMALLER))) ||
@@ -2032,7 +2032,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_to_side
       }
     }
   }
-  
+
   // If the next intersection point occurs before the right (left) endpoint
   // of the subcurve, keep it. Otherwise, take the parameter value at
   // the endpoint.
@@ -2043,7 +2043,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_to_side
     else
       res = CGAL::compare (t_src, next_t);
   }
-  
+
   if (! found ||
       (to_right && ((_inc_to_right && res == SMALLER) ||
                     (! _inc_to_right && res == LARGER))) ||
@@ -2052,7 +2052,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_compare_to_side
   {
     next_t = ((to_right == _dir_right) ? t_trg : t_src);
   }
-  
+
   // Find a rational value between t0 and t_next. Using this value, we
   // a point with rational coordinates on our subcurve. We also locate a point
   // on the other curve with the same x-coordinates.
@@ -2217,25 +2217,25 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt,
 
   // Construct the approximated points.
   typename std::list<Intersection_point>::const_iterator  iter;
-  
+
   for (iter = ipt_bounds.begin(); iter != ipt_bounds.end(); ++iter)
   {
-    const Bez_point_bound&  bound1 = iter->bound1; 
-    const Bez_point_bound&  bound2 = iter->bound2; 
-    const Bez_point_bbox&   bbox = iter->bbox; 
-    
+    const Bez_point_bound&  bound1 = iter->bound1;
+    const Bez_point_bound&  bound2 = iter->bound2;
+    const Bez_point_bbox&   bbox = iter->bbox;
+
     // In case it is impossible to further refine the point, stop here.
     if (! bound1.can_refine || ! bound2.can_refine)
       return (false);
-    
+
     // Create the approximated intersection point.
     Point_2                 pt;
-    
+
     if (bound1.type == Bounding_traits::Bez_point_bound::RATIONAL_PT &&
         bound2.type == Bounding_traits::Bez_point_bound::RATIONAL_PT)
     {
-      CGAL_assertion (CGAL::compare (bound1.t_min, bound1.t_max) == EQUAL); 
-      CGAL_assertion (CGAL::compare (bound2.t_min, bound2.t_max) == EQUAL); 
+      CGAL_assertion (CGAL::compare (bound1.t_min, bound1.t_max) == EQUAL);
+      CGAL_assertion (CGAL::compare (bound2.t_min, bound2.t_max) == EQUAL);
       Rational   t1 = bound1.t_min;
       Rational   t2 = bound2.t_min;
       Nt_traits  nt_traits;
@@ -2356,10 +2356,10 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_intersect
 
   if (app_ok)
   {
-    // Approximations are computed using de Casteljau subdivision and 
+    // Approximations are computed using de Casteljau subdivision and
     // filtering using skewed bounding boxes. A property of these bboxes
     // if that it can fail in the following cases: (i) there are two intersection
-    // points lying very close together, (ii) there exists an intersection point 
+    // points lying very close together, (ii) there exists an intersection point
     // whose multiplicity is greater than 1, or (iii) the curves overlap.
     // If the approximation went OK, then we know that we have a simple
     // intersection point (with multiplicity 1) if intersection point
@@ -2369,7 +2369,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_intersect
     // ranges of both curves. Note that in case of self-intersections,
     // all points we get are in the respective parameter range of the curves.
     typename std::list<Point_2>::iterator  pit;
-    
+
     for (pit = inter_pts.begin(); pit != inter_pts.end(); ++pit)
     {
       // Check if the point is in the range of this curve - first using
@@ -2388,10 +2388,10 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_intersect
       {
         if (! pit->is_exact())
           pit->make_exact (cache);
-        
+
         Originator_iterator  p_org = pit->get_originator (_curve, _xid);
         CGAL_assertion (p_org != pit->originators_end());
-        
+
         in_range1 = _is_in_range (p_org->parameter(), cache);
       }
 
@@ -2414,13 +2414,13 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_intersect
       {
         if (! pit->is_exact())
           pit->make_exact (cache);
-        
+
         Originator_iterator  p_org = pit->get_originator (cv._curve, cv._xid);
         CGAL_assertion (p_org != pit->originators_end());
-        
+
         in_range2 = cv._is_in_range (p_org->parameter(), cache);
       }
-      
+
       if (in_range1 && in_range2)
       {
         // In case the originators of the intersection point are not marked
@@ -2676,17 +2676,17 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
   Nt_traits                nt_traits;
   Originator_iterator      ps_org = _ps.get_originator (_curve, _xid);
   CGAL_assertion (ps_org != _ps.originators_end());
-  
+
   Originator_iterator      pt_org = _pt.get_originator (_curve, _xid);
   CGAL_assertion (pt_org != _pt.originators_end());
 
   Rational                 my_t_min;
   Rational                 my_t_max;
 
-  
+
   bool      can_refine_s = ! _ps.is_exact();
   bool      can_refine_t = ! _pt.is_exact();
-    
+
   do {
     if (CGAL::compare (ps_org->point_bound().t_max,
                        pt_org->point_bound().t_min) == SMALLER)
@@ -2709,9 +2709,9 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
 
     if (can_refine_s)
       can_refine_s = _ps.refine();
-    
+
     if (can_refine_t)
-      can_refine_t = _pt.refine();    
+      can_refine_t = _pt.refine();
   }
   while(can_refine_s || can_refine_t);
 
@@ -2745,7 +2745,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
         subcurves.erase(iter++);
         continue;
       }
-        
+
       // Construct the bounding box of the subcurve and compare it to
       // the bounding box of the point.
       iter->bbox (x_min, y_min, x_max, y_max);
@@ -2781,7 +2781,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
         res_y_min = CGAL::compare (p.y(), nt_traits.convert (y_min));
         res_y_max = CGAL::compare (p.y(), nt_traits.convert (y_max));
       }
-     
+
       is_fully_in_range = (CGAL::compare (iter->t_min, my_t_min) != SMALLER) &&
                           (CGAL::compare (iter->t_max, my_t_max) != LARGER);
 
@@ -2818,7 +2818,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
 
       // If we got here without entering one of the clauses above,
       // then iter has not been incremented yet.
-      ++iter; 
+      ++iter;
     }
   }
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -2662,9 +2662,13 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_intersect
 //
 template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
 Comparison_result
-_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::_exact_vertical_position
-    (const Point_2& p,
-     bool force_exact) const
+_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
+_exact_vertical_position(const Point_2& p,
+                         bool
+#if !defined(CGAL_NO_ASSERTIONS)
+                         force_exact
+#endif
+                         ) const
 {
   // If it is a rational point, obtain its rational reprsentation.
   Rat_point_2              rat_p;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/IO/Polycurve_2_iostream.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/IO/Polycurve_2_iostream.h
@@ -48,6 +48,12 @@ void write_polycurve(OutputStream& os,
                      const Polycurve_2<CGAL::Arr_segment_2<Kernel_>, PointType_2>& xcv)
 { write_polyline(os, xcv); }
 
+/*! Output operator for a polyline of type CGAL::Segment_2<Kernel_>. */
+template <typename OutputStream, typename Kernel_, typename PointType_2>
+void write_polycurve(OutputStream& os,
+                     const Polycurve_2<CGAL::Segment_2<Kernel_>, PointType_2>& xcv)
+{ write_polyline(os, xcv); }
+
 /*! Output operator for a polycurve. */
 template <typename OutputStream, typename SubcurveType_2, typename PointType_2>
 void write_polycurve(OutputStream& os,
@@ -111,6 +117,12 @@ void read_polyline(InputStream& is,
 template <typename InputStream, typename Kernel_, typename PointType_2>
 void read_polycurve(InputStream& is,
                     Polycurve_2<CGAL::Arr_segment_2<Kernel_>, PointType_2>& xcv)
+{ read_polyline(is, xcv); }
+
+/*! Input operator for a polyline of type CGAL::Segment_2<Kernel_>. */
+template <typename InputStream, typename Kernel_, typename PointType_2>
+void read_polycurve(InputStream& is,
+                    Polycurve_2<CGAL::Segment_2<Kernel_>, PointType_2>& xcv)
 { read_polyline(is, xcv); }
 
 /*! Input operator for a polycurve. */

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/IO/Polycurve_2_iostream.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/IO/Polycurve_2_iostream.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2016 Tel-Aviv University (Israel).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// Author(s)     : Efi Fogel <efifogel@gmail.com>
+
+#ifndef CGAL_POLYCURVE_2_IOSTREAM_H
+#define CGAL_POLYCURVE_2_IOSTREAM_H
+
+#include <iostream>
+
+#include <CGAL/basic.h>
+#include <CGAL/Arr_geometry_traits/Polycurve_2.h>
+#include <CGAL/Arr_segment_traits_2.h>
+
+namespace CGAL {
+namespace internal {
+
+/*! Output operator for a polyline. */
+template <typename OutputStream, typename SubcurveType_2, typename PointType_2>
+void write_polyline(OutputStream& os,
+                    const Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  typedef SubcurveType_2                                Subcurve_type_2;
+  typedef PointType_2                                   Point_type_2;
+  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
+
+  os << xcv.number_of_subcurves();       // export the number of points.
+
+  // Write the points.
+  typename Curve_2::Point_const_iterator it = xcv.points_begin();
+  while (it != xcv.points_end()) os << " " << *it++;
+}
+
+/*! Output operator for a polyline of type CGAL::Arr_segment_2<Kernel_>. */
+template <typename OutputStream, typename Kernel_, typename PointType_2>
+void write_polycurve(OutputStream& os,
+                     const Polycurve_2<CGAL::Arr_segment_2<Kernel_>, PointType_2>& xcv)
+{ write_polyline(os, xcv); }
+
+/*! Output operator for a polycurve. */
+template <typename OutputStream, typename SubcurveType_2, typename PointType_2>
+void write_polycurve(OutputStream& os,
+                     const Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  typedef SubcurveType_2                                Subcurve_type_2;
+  typedef PointType_2                                   Point_type_2;
+  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
+
+  os << xcv.number_of_subcurves();       // export the number of subcurves.
+
+  // Write the subcurves.
+  typename Curve_2::Subcurve_const_iterator it = xcv.subcurves_begin();
+  while (it != xcv.subcurves_end()) os << " " << *it++;
+}
+
+/*! Output operator for a polycurve. */
+template <typename OutputStream, typename SubcurveType_2, typename PointType_2>
+OutputStream& operator<<(OutputStream& os,
+                         const Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  write_polycurve(os, xcv);
+  return os;
+}
+
+/*! Input operator for a polyline. */
+template <typename InputStream, typename SubcurveType_2, typename PointType_2>
+void read_polyline(InputStream& is,
+                   Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  typedef SubcurveType_2                                Subcurve_type_2;
+  typedef PointType_2                                   Point_type_2;
+  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
+
+  std::size_t num;              // read the number of points.
+  is >> num;
+  if (0 == num) return;
+
+  Point_type_2 ps;
+  is >> ps;
+  if (1 == num) {
+    xcv = Curve_2(Subcurve_type_2(ps, ps));
+    return;
+  }
+
+  // Read the points.
+  Point_type_2 pt;
+  Point_type_2* ps_p = &ps;
+  Point_type_2* pt_p = &pt;
+  std::list<Subcurve_type_2> subcurves;
+  for (std::size_t i = 1; i < num; ++i) {
+    is >> *pt_p;
+    subcurves.push_back(Subcurve_type_2(*ps_p, *pt_p));
+    std::swap(ps_p, pt_p);
+  }
+
+  xcv = Curve_2(subcurves.begin(), subcurves.end());    // create the polycurve
+}
+
+/*! Input operator for a polyline of type CGAL::Arr_segment_2<Kernel_>. */
+template <typename InputStream, typename Kernel_, typename PointType_2>
+void read_polycurve(InputStream& is,
+                    Polycurve_2<CGAL::Arr_segment_2<Kernel_>, PointType_2>& xcv)
+{ read_polyline(is, xcv); }
+
+/*! Input operator for a polycurve. */
+template <typename InputStream, typename SubcurveType_2, typename PointType_2>
+void read_polycurve(InputStream& is,
+                    Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  typedef SubcurveType_2                                Subcurve_type_2;
+  typedef PointType_2                                   Point_type_2;
+  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
+
+  std::size_t num;                      // read the number of subcurves.
+  is >> num;
+
+  // Read the subcurves.
+  std::list<Subcurve_type_2> subcurves;
+  for (std::size_t i = 0; i < num; ++i) {
+    Subcurve_type_2 subcurve;
+    is >> subcurve;
+    subcurves.push_back(subcurve);
+  }
+
+  xcv = Curve_2(subcurves.begin(), subcurves.end());    // create the polycurve
+}
+
+/*! Input operator for a polycurve. */
+template <typename InputStream, typename SubcurveType_2, typename PointType_2>
+InputStream& operator>>(InputStream& is,
+                        Polycurve_2<SubcurveType_2, PointType_2>& xcv)
+{
+  read_polycurve(is, xcv);
+  return is;
+}
+
+}
+}
+
+#endif

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
@@ -224,7 +224,7 @@ public:
      * \param index The index of the subcurve.
      */
     Point_const_iterator(const Polycurve_2<Subcurve_type_2, Point_type_2>* cvP,
-                         int index) :
+                         size_type index) :
       m_cvP(cvP),
       m_index(index)
     {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <vector>
 #include <iterator>
+#include <limits>
 
 #include <CGAL/Bbox_2.h>
 
@@ -215,8 +216,8 @@ public:
   private:
     // The polycurve curve.
     const Polycurve_2<Subcurve_type_2, Point_type_2>* m_cvP;
-    int m_num_pts;                            // Its number of points.
-    int m_index;                              // The current point.
+    size_type m_num_pts;                        // Its number of points.
+    size_type m_index;                          // The current point.
 
     /*! Private constructor.
      * \param cv The scanned curve.
@@ -227,18 +228,20 @@ public:
       m_cvP(cvP),
       m_index(index)
     {
-      if (m_cvP == NULL) m_num_pts = 0;
-      else
-        m_num_pts = (m_cvP->number_of_subcurves() == 0) ?
-          0 : (m_cvP->number_of_subcurves() + 1);
+      m_num_pts = (m_cvP == NULL) ? 0 :
+        ((m_cvP->number_of_subcurves() == 0) ?
+         0 : (m_cvP->number_of_subcurves() + 1));
     }
+
+    bool is_index_valid() const
+    { return m_index != std::numeric_limits<size_type>::max(); }
 
   public:
     /*! Default constructor. */
     Point_const_iterator() :
       m_cvP(NULL),
       m_num_pts(0),
-      m_index(-1)
+      m_index(std::numeric_limits<size_type>::max())
     {}
 
     /*! Dereference operator.
@@ -247,7 +250,7 @@ public:
     const Point_type_2& operator*() const
     {
       CGAL_assertion(m_cvP != NULL);
-      CGAL_assertion((m_index >= 0) && (m_index < m_num_pts));
+      CGAL_assertion((is_index_valid()) && (m_index < m_num_pts));
 
       // First point is the source of the first subcurve.
       // Else return the target of the(i-1)'st subcurve.
@@ -277,15 +280,14 @@ public:
     /*! Decrement operators. */
     Point_const_iterator& operator--()
     {
-      if ((m_cvP != NULL) && (m_index >= 0)) --m_index;
+      if ((m_cvP != NULL) && (is_index_valid())) --m_index;
       return (*this);
     }
 
     Point_const_iterator operator--(int)
     {
-      Point_const_iterator  temp = *this;
-      if ((m_cvP != NULL) && (m_index >= 0))
-        --m_index;
+      Point_const_iterator temp = *this;
+      if ((m_cvP != NULL) && (is_index_valid())) --m_index;
       return temp;
     }
 
@@ -306,7 +308,7 @@ public:
   /*! Obtain an iterator for the polycurve points.*/
   Point_const_iterator points_begin() const
   {
-    if (number_of_subcurves() == 0) return (Point_const_iterator(NULL, -1));
+    if (number_of_subcurves() == 0) return (Point_const_iterator());
     else return (Point_const_iterator(this, 0));
   }
 
@@ -316,7 +318,7 @@ public:
   /*! Obtain a past-the-end iterator for the polycurve points.*/
   Point_const_iterator points_end() const
   {
-    if (number_of_subcurves() == 0) return (Point_const_iterator(NULL, -1));
+    if (number_of_subcurves() == 0) return (Point_const_iterator());
     else return (Point_const_iterator(this, number_of_subcurves() + 1));
   }
 
@@ -325,7 +327,7 @@ public:
 
   /*! Obtain a reverse iterator for the polycurve points. */
   Point_const_reverse_iterator points_rbegin() const
-  { return Point_const_reverse_iterator(end()); }
+  { return Point_const_reverse_iterator(points_end()); }
 
   /*! Obtain a reverse iterator for the polycurve points. */
   CGAL_DEPRECATED Point_const_reverse_iterator rbegin() const
@@ -333,7 +335,7 @@ public:
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
   Point_const_reverse_iterator points_rend() const
-  { return Point_const_reverse_iterator(begin()); }
+  { return Point_const_reverse_iterator(points_begin()); }
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
   CGAL_DEPRECATED Point_const_reverse_iterator rend() const

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
@@ -234,14 +234,14 @@ public:
     }
 
     bool is_index_valid() const
-    { return m_index != std::numeric_limits<size_type>::max(); }
+    { return m_index != std::numeric_limits<size_type>::max BOOST_PREVENT_MACRO_SUBSTITUTION (); }
 
   public:
     /*! Default constructor. */
     Point_const_iterator() :
       m_cvP(NULL),
       m_num_pts(0),
-      m_index(std::numeric_limits<size_type>::max())
+      m_index(std::numeric_limits<size_type>::max BOOST_PREVENT_MACRO_SUBSTITUTION ())
     {}
 
     /*! Dereference operator.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
@@ -349,9 +349,17 @@ public:
   Subcurve_const_iterator subcurves_begin() const
   { return m_subcurves.begin(); }
 
+  /*! Deprecated! */
+  CGAL_DEPRECATED Subcurve_const_iterator begin_subcurves() const
+  { return subcurves_begin(); }
+
   /*! Obtain a past-the-end iterator for the polycurve subcurves. */
   Subcurve_const_iterator subcurves_end() const
   { return m_subcurves.end(); }
+
+  /*! Deprecated! */
+  CGAL_DEPRECATED Subcurve_const_iterator end_subcurves() const
+  { return subcurves_end(); }
 
   /*! Obtain a reverse iterator for the polycurve subcurves. */
   Subcurve_const_reverse_iterator subcurves_rbegin() const

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polycurve_2.h
@@ -16,8 +16,8 @@
 //                 Efi Fogel <efif@post.tau.ac.il>
 //                 Dror Atariah <dror.atariah@fu-berlin.de>
 
-#ifndef CGAL_ARR_POLYCURVE_2_H
-#define CGAL_ARR_POLYCURVE_2_H
+#ifndef CGAL_POLYCURVE_2_H
+#define CGAL_POLYCURVE_2_H
 
 /*! \file
  * Header file for the polyline classes used by the
@@ -26,9 +26,9 @@
  */
 
 #include <list>
-#include <iostream>
 #include <vector>
 #include <iterator>
+
 #include <CGAL/Bbox_2.h>
 
 namespace CGAL {
@@ -196,13 +196,13 @@ public:
     return bbox;
   }
 
-  class const_iterator;
-  friend class const_iterator;
-  typedef std::reverse_iterator<const_iterator>
-  const_reverse_iterator;
+  class Point_const_iterator;
+  friend class Point_const_iterator;
+  typedef std::reverse_iterator<Point_const_iterator>
+    Point_const_reverse_iterator;
 
   /*! An iterator for the polycurve points. */
-  class CGAL_DEPRECATED const_iterator {
+  class Point_const_iterator {
   public:
     // Type definitions:
     typedef std::bidirectional_iterator_tag     iterator_category;
@@ -222,25 +222,24 @@ public:
      * \param cv The scanned curve.
      * \param index The index of the subcurve.
      */
-    const_iterator(const Polycurve_2<Subcurve_type_2, Point_type_2>* cvP,
-                   int index) :
+    Point_const_iterator(const Polycurve_2<Subcurve_type_2, Point_type_2>* cvP,
+                         int index) :
       m_cvP(cvP),
       m_index(index)
-      {
-        if (m_cvP == NULL)
-          m_num_pts = 0;
-        else
-          m_num_pts = (m_cvP->number_of_subcurves() == 0) ?
-            0 : (m_cvP->number_of_subcurves() + 1);
-      }
+    {
+      if (m_cvP == NULL) m_num_pts = 0;
+      else
+        m_num_pts = (m_cvP->number_of_subcurves() == 0) ?
+          0 : (m_cvP->number_of_subcurves() + 1);
+    }
 
   public:
     /*! Default constructor. */
-    const_iterator() :
+    Point_const_iterator() :
       m_cvP(NULL),
       m_num_pts(0),
       m_index(-1)
-      {}
+    {}
 
     /*! Dereference operator.
      * \return The current point.
@@ -262,65 +261,83 @@ public:
     const Point_type_2* operator->() const { return (&(this->operator* ())); }
 
     /*! Increment operators. */
-    const_iterator& operator++()
+    Point_const_iterator& operator++()
     {
       if ((m_cvP != NULL) && (m_index < m_num_pts)) ++m_index;
       return (*this);
     }
 
-    const_iterator operator++(int)
+    Point_const_iterator operator++(int)
     {
-      const_iterator temp = *this;
+      Point_const_iterator temp = *this;
       if ((m_cvP != NULL) && (m_index < m_num_pts)) ++m_index;
       return temp;
     }
 
     /*! Decrement operators. */
-    const_iterator& operator--()
+    Point_const_iterator& operator--()
     {
       if ((m_cvP != NULL) && (m_index >= 0)) --m_index;
       return (*this);
     }
 
-    const_iterator operator--(int)
+    Point_const_iterator operator--(int)
     {
-      const_iterator  temp = *this;
+      Point_const_iterator  temp = *this;
       if ((m_cvP != NULL) && (m_index >= 0))
         --m_index;
       return temp;
     }
 
     /*! Equality operators. */
-    bool operator==(const const_iterator& it) const
+    bool operator==(const Point_const_iterator& it) const
     { return ((m_cvP == it.m_cvP) && (m_index == it.m_index)); }
 
-    bool operator!=(const const_iterator& it) const
+    bool operator!=(const Point_const_iterator& it) const
     { return ((m_cvP != it.m_cvP) || (m_index != it.m_index)); }
 
     friend class Polycurve_2<Subcurve_type_2, Point_type_2>;
   };
 
-  /* ! Obtain an iterator for the polycurve points.*/
-  CGAL_DEPRECATED const_iterator begin() const
+  // Backward compatibility
+  typedef Point_const_iterator                  const_iterator;
+  typedef Point_const_reverse_iterator          const_reverse_iterator;
+
+  /*! Obtain an iterator for the polycurve points.*/
+  Point_const_iterator points_begin() const
   {
-    if (number_of_subcurves() == 0) return (const_iterator(NULL, -1));
-    else return (const_iterator(this, 0));
+    if (number_of_subcurves() == 0) return (Point_const_iterator(NULL, -1));
+    else return (Point_const_iterator(this, 0));
+  }
+
+  /*! Obtain an iterator for the polycurve points.*/
+  CGAL_DEPRECATED Point_const_iterator begin() const { return points_begin(); }
+
+  /*! Obtain a past-the-end iterator for the polycurve points.*/
+  Point_const_iterator points_end() const
+  {
+    if (number_of_subcurves() == 0) return (Point_const_iterator(NULL, -1));
+    else return (Point_const_iterator(this, number_of_subcurves() + 1));
   }
 
   /*! Obtain a past-the-end iterator for the polycurve points.*/
-  CGAL_DEPRECATED const_iterator end() const
-  {
-    if (number_of_subcurves() == 0) return (const_iterator(NULL, -1));
-    else return (const_iterator(this, number_of_subcurves() + 1));
-  }
+  CGAL_DEPRECATED Point_const_iterator end() const { return points_end(); }
 
   /*! Obtain a reverse iterator for the polycurve points. */
-  CGAL_DEPRECATED const_reverse_iterator rbegin() const
-  { return (const_reverse_iterator(end())); }
+  Point_const_reverse_iterator points_rbegin() const
+  { return Point_const_reverse_iterator(end()); }
+
+  /*! Obtain a reverse iterator for the polycurve points. */
+  CGAL_DEPRECATED Point_const_reverse_iterator rbegin() const
+  { return points_rbegin(); }
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
-  CGAL_DEPRECATED const_reverse_iterator rend() const
-  { return (const_reverse_iterator(begin())); }
+  Point_const_reverse_iterator points_rend() const
+  { return Point_const_reverse_iterator(begin()); }
+
+  /*! Obtain a reverse past-the-end iterator for the polycurve points. */
+  CGAL_DEPRECATED Point_const_reverse_iterator rend() const
+  { return points_rend(); }
 
   typedef typename Subcurves_container::iterator Subcurve_iterator;
   typedef typename Subcurves_container::const_iterator
@@ -329,23 +346,23 @@ public:
                                                  Subcurve_const_reverse_iterator;
 
   /*! Obtain an iterator for the polycurve subcurves. */
-  Subcurve_const_iterator begin_subcurves() const
+  Subcurve_const_iterator subcurves_begin() const
   { return m_subcurves.begin(); }
 
   /*! Obtain a past-the-end iterator for the polycurve subcurves. */
-  Subcurve_const_iterator end_subcurves() const
+  Subcurve_const_iterator subcurves_end() const
   { return m_subcurves.end(); }
 
   /*! Obtain a reverse iterator for the polycurve subcurves. */
-  Subcurve_const_reverse_iterator rbegin_subcurves() const
-  { return (Subcurve_const_reverse_iterator(end_subcurves())); }
+  Subcurve_const_reverse_iterator subcurves_rbegin() const
+  { return (Subcurve_const_reverse_iterator(subcurves_end())); }
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
-  Subcurve_const_reverse_iterator rend_subcurves() const
-  { return (Subcurve_const_reverse_iterator(begin_subcurves())); }
+  Subcurve_const_reverse_iterator subcurves_rend() const
+  { return (Subcurve_const_reverse_iterator(subcurves_begin())); }
 
   /*! Deprecated!
-   * Get the number of points contained in the polycurve.
+   * Obtain the number of points contained in the polycurve.
    * In general (for example if the polycurve is not bounded), then the
    * number of vertices cannot be read-off from the number of subcurves, and
    * the traits class is needed.
@@ -354,21 +371,17 @@ public:
   CGAL_DEPRECATED std::size_t points() const
   { return (number_of_subcurves() == 0) ? 0 : number_of_subcurves() + 1; }
 
-  /*! Deprecated! Replaced by number_of_subcurves()
-   * Get the number of subcurves that comprise the poyline.
-   * \return The number of subcurves.
-   */
-  CGAL_DEPRECATED size_type size() const
-  { return m_subcurves.size(); }
-
   /*! Obtain the number of subcurves that comprise the poyline.
    * \return The number of subcurves.
    */
   size_type number_of_subcurves() const
   { return m_subcurves.size(); }
 
+  /*! Deprecated! Replaced by number_of_subcurves(). */
+  CGAL_DEPRECATED size_type size() const { return number_of_subcurves(); }
+
   /*! Obtain the ith subcurve of the polycurve.
-   * \param i The subcurve index(from 0 to size()-1).
+   * \param[in] i The subcurve index(from 0 to size()-1).
    * \return A const reference to the subcurve.
    */
   inline const Subcurve_type_2& operator[](const std::size_t i) const
@@ -435,51 +448,6 @@ public:
                                                      boost::true_type)
   {}
 };
-
-/*! Output operator for a polycurve. */
-template <typename SubcurveType_2, typename PointType_2>
-std::ostream& operator<<(std::ostream & os,
-                         const Polycurve_2<SubcurveType_2, PointType_2>& cv)
-{
-  typedef SubcurveType_2                                Subcurve_type_2;
-  typedef PointType_2                                   Point_type_2;
-  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
-
-  // Export the number of subcurves.
-  os << cv.number_of_subcurves();
-
-  // Export the subcurves.
-  typename Curve_2::Subcurve_const_iterator iter = cv.begin_subcurves();
-  while (iter != cv.end_subcurves()) os << " " << *iter++;
-  return (os);
-}
-
-/*! Input operator for a polycurve. */
-template <typename SubcurveType_2, typename PointType_2>
-std::istream& operator>>(std::istream& is,
-                         Polycurve_2<SubcurveType_2, PointType_2>& pl)
-{
-  typedef SubcurveType_2                                Subcurve_type_2;
-  typedef PointType_2                                   Point_type_2;
-  typedef Polycurve_2<Subcurve_type_2, Point_type_2>    Curve_2;
-
-  // Import the number of curves.
-  std::size_t num;
-  is >> num;
-
-  // Import the subcurves.
-  std::list<Subcurve_type_2> subcurves;
-  for (std::size_t i = 0; i < num; ++i) {
-    Subcurve_type_2 subcurve;
-    is >> subcurve;
-    subcurves.push_back(subcurve);
-  }
-
-  // Create the polycurve curve.
-  pl = Curve_2(subcurves.begin(), subcurves.end());
-
-  return (is);
-}
 
 } // namespace polycurve
 } //namespace CGAL

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polyline_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polyline_2.h
@@ -62,19 +62,19 @@ public:
 
   /*! Obtain an iterator for the polycurve subcurves. */
   Segment_const_iterator begin_segments() const
-  { return this->begin_subcurves(); }
+  { return this->subcurves_begin(); }
 
   /*! Obtain a past-the-end iterator for the polycurve subcurves. */
   Segment_const_iterator end_segments() const
-  { return this->end_subcurves(); }
+  { return this->subcurves_end(); }
 
   /*! Obtain a reverse iterator for the polycurve subcurves. */
   Segment_const_reverse_iterator rbegin_segments() const
-  { return this->rbegin_subcurves(); }
+  { return this->subcurves_rbegin(); }
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
   Segment_const_reverse_iterator rend_segments() const
-  { this->returnrend_subcurves() ; }
+  { return this->subcurves_rend() ; }
 
   /*! Obtain the number of subcurves that comprise the poyline.
    * \return The number of subcurves.
@@ -118,19 +118,19 @@ public:
 
   /*! Obtain an iterator for the polycurve subcurves. */
   Segment_const_iterator begin_segments() const
-  { return this->begin_subcurves(); }
+  { return this->subcurves_begin(); }
 
   /*! Obtain a past-the-end iterator for the polycurve subcurves. */
   Segment_const_iterator end_segments() const
-  { return this->end_subcurves(); }
+  { return this->subcurves_end(); }
 
   /*! Obtain a reverse iterator for the polycurve subcurves. */
   Segment_const_reverse_iterator rbegin_segments() const
-  { return this->rbegin_subcurves(); }
+  { return this->subcurves_rbegin(); }
 
   /*! Obtain a reverse past-the-end iterator for the polycurve points. */
   Segment_const_reverse_iterator rend_segments() const
-  { this->returnrend_subcurves() ; }
+  { return this->subcurves_rend() ; }
 
   /*! Obtain the number of subcurves that comprise the poyline.
    * \return The number of subcurves.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
@@ -190,7 +190,7 @@ public:
 
     Comparison_result operator()(const X_monotone_curve_2 & cv1,
                                  const X_monotone_curve_2 & cv2,
-                                 const Point_2 & p) const
+                                 const Point_2 & CGAL_precondition_code(p)) const
     {
       Kernel kernel;
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
@@ -12,10 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Efi Fogel <efif@post.tau.ac.il>
 //                 Ron Wein  <wein@post.tau.ac.il>
 //                 (based on old version by: Iddo Hanniel,
@@ -58,8 +54,8 @@ public:
   typedef typename Kernel::FT                   FT;
 
 private:
-  typedef Algebraic_structure_traits<FT> AST; 
-  typedef typename AST::Is_exact FT_is_exact; 
+  typedef Algebraic_structure_traits<FT> AST;
+  typedef typename AST::Is_exact FT_is_exact;
 public:
 
   typedef Boolean_tag<FT_is_exact::value> Has_exact_division;
@@ -71,16 +67,16 @@ public:
   // Categories:
   typedef Tag_true                              Has_left_category;
   typedef Tag_false                             Has_do_intersect_category;
- 
+
   typedef Arr_oblivious_side_tag                Left_side_category;
   typedef Arr_oblivious_side_tag                Bottom_side_category;
   typedef Arr_oblivious_side_tag                Top_side_category;
   typedef Arr_oblivious_side_tag                Right_side_category;
-    
+
   /*! Default Constructor */
   Arr_non_caching_segment_basic_traits_2()
   {}
-  
+
   /// \name Types and functor inherited from the kernel
   //@{
 
@@ -100,13 +96,13 @@ public:
 
   /*! Obtain the right endpoint of a given segment */
   typedef typename Kernel::Construct_max_vertex_2  Construct_max_vertex_2;
-  
+
   /*! Check whether a given segment is vertical */
   typedef typename Kernel::Is_vertical_2           Is_vertical_2;
-  
+
   /*! Return the location of a given point with respect to an input segment */
   typedef typename Kernel::Compare_y_at_x_2        Compare_y_at_x_2;
-  
+
   /*! Check if two segments or if two points are identical */
   typedef typename Kernel::Equal_2                 Equal_2;
 
@@ -115,13 +111,13 @@ public:
   /// \name Functor introduced here (based on the kernel)
   //@{
 
-  /*! \class 
-   * A functor for comparing two segments to the left of a point 
+  /*! \class
+   * A functor for comparing two segments to the left of a point
    */
   class Compare_y_at_x_left_2 {
   public:
-    
-    /* 
+
+    /*
      * Compare the y value of two segments immediately to the left of their
      * intersection point.
      * \param cv1 The first segment.
@@ -132,9 +128,9 @@ public:
      * \return The relative position of cv1 with respect to cv2 immdiately to
      *         the left of p: SMALLER, LARGER or EQUAL.
      */
-    Comparison_result operator()(const X_monotone_curve_2 & cv1,
-                                 const X_monotone_curve_2 & cv2,
-                                 const Point_2 & p) const
+    Comparison_result operator()(const X_monotone_curve_2& cv1,
+                                 const X_monotone_curve_2& cv2,
+                                 const Point_2& CGAL_precondition_code(p)) const
     {
       Kernel kernel;
 
@@ -156,10 +152,10 @@ public:
         const Point_2 & left2 =
           (kernel.less_xy_2_object()(source2, target2)) ? source2 : target2;
         );
-      
+
       CGAL_precondition(compare_xy(left1, p) == SMALLER &&
                         compare_xy(left2, p) == SMALLER);
-    
+
       // Compare the slopes of the two segments to determine thir relative
       // position immediately to the left of q.
       // Notice that we swap the order of the curves in order to obtain the
@@ -173,14 +169,14 @@ public:
   {
     return Compare_y_at_x_left_2();
   }
-  
+
   /*! \class
-   * A functor for comparing two segments to the right of a point. 
+   * A functor for comparing two segments to the right of a point.
    */
   class Compare_y_at_x_right_2 {
   public:
-    
-    /*! 
+
+    /*!
      * Compare the y value of two segments immediately to the right of their
      * intersection point.
      * \param cv1 The first segment.
@@ -246,7 +242,7 @@ public:
      * \param p The exact point.
      * \param i The coordinate index (either 0 or 1).
      * \pre i is either 0 or 1.
-     * \return An approximation of p's x-coordinate (if i == 0), or an 
+     * \return An approximation of p's x-coordinate (if i == 0), or an
      *         approximation of p's y-coordinate (if i == 1).
      */
     Approximate_number_type operator() (const Point_2& p,

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_simple_point_location_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_simple_point_location_impl.h
@@ -14,7 +14,7 @@
 //
 // $URL$
 // $Id$
-// 
+//
 //
 // Author(s)     : Ron Wein   <wein@post.tau.ac.il>
 //                 (based on old version by Eyal Flato)
@@ -49,9 +49,9 @@ Arr_simple_point_location<Arrangement>::locate(const Point_2& p) const
 
   // Go over arrangement halfedges and check whether one of them contains
   // the query point in its interior.
-  typename Traits_adaptor_2::Is_in_x_range_2  is_in_x_range = 
+  typename Traits_adaptor_2::Is_in_x_range_2  is_in_x_range =
     m_geom_traits->is_in_x_range_2_object();
-  typename Traits_adaptor_2::Compare_y_at_x_2 cmp_y_at_x = 
+  typename Traits_adaptor_2::Compare_y_at_x_2 cmp_y_at_x =
     m_geom_traits->compare_y_at_x_2_object();
 
   typename Arrangement::Edge_const_iterator   eit;
@@ -72,10 +72,10 @@ Arr_simple_point_location<Arrangement>::locate(const Point_2& p) const
   }
 
   const Result_type& obj = optional_assign(optional_obj);
-  
+
   // In case the ray-shooting returned a vertex, we have to locate the first
   // halfedge whose source vertex is v, rotating clockwise around the vertex
-  // from "6 o'clock", and to return its incident face.   
+  // from "6 o'clock", and to return its incident face.
   const Vertex_const_handle* vh = Result().template assign<Vertex_const_handle>(obj);
   if (vh) {
     Halfedge_const_handle hh = _first_around_vertex(*vh);
@@ -120,7 +120,7 @@ _base_vertical_ray_shoot(const Point_2& p, bool shoot_up) const
   typename Traits_adaptor_2::Compare_y_at_x_left_2 compare_y_at_x_left =
     m_geom_traits->compare_y_at_x_left_2_object();
 
-  typename Dcel::Edge_const_iterator  eit = 
+  typename Dcel::Edge_const_iterator  eit =
     m_topol_traits->dcel().edges_begin();
   typename Dcel::Edge_const_iterator  e_end =
     m_topol_traits->dcel().edges_end();
@@ -128,7 +128,7 @@ _base_vertical_ray_shoot(const Point_2& p, bool shoot_up) const
   const typename Dcel::Vertex*    vs;   // The current edge source
   const typename Dcel::Vertex*    vt;   // The current edge target.
   Comparison_result               res_s;
-  Comparison_result               res;
+  Comparison_result               res = EQUAL;
   Comparison_result               y_res;
   bool                            in_x_range;
   const typename Dcel::Halfedge*  closest_he = NULL; // The closest so far.
@@ -175,12 +175,12 @@ _base_vertical_ray_shoot(const Point_2& p, bool shoot_up) const
 
           y_res = (closest_he->direction() == ARR_LEFT_TO_RIGHT) ?
             // Both curves extend to the right from a common point.
-            compare_y_at_x_right(closest_he->curve(), eit->curve(), 
+            compare_y_at_x_right(closest_he->curve(), eit->curve(),
                                  cl_vs->point()) :
             // Both curves extend to the left from a common point.
             compare_y_at_x_left(closest_he->curve(), eit->curve(),
                                 cl_vs->point());
-          
+
         }
         else if ((cl_vt == vs && closest_he->direction() != eit->direction()) ||
                  (cl_vt == vt && closest_he->direction() == eit->direction()))
@@ -189,10 +189,10 @@ _base_vertical_ray_shoot(const Point_2& p, bool shoot_up) const
 
           y_res = (closest_he->direction() == ARR_LEFT_TO_RIGHT) ?
             // Both curves extend to the left from a common point.
-            compare_y_at_x_left(closest_he->curve(), eit->curve(), 
+            compare_y_at_x_left(closest_he->curve(), eit->curve(),
                                 cl_vt->point()) :
             // Both curves extend to the right from a common point.
-            compare_y_at_x_right(closest_he->curve(), eit->curve(), 
+            compare_y_at_x_right(closest_he->curve(), eit->curve(),
                                  cl_vt->point());
         }
         else {
@@ -204,7 +204,7 @@ _base_vertical_ray_shoot(const Point_2& p, bool shoot_up) const
             ((eit->has_null_curve()) ? point_above_under :
              compare_y_position(closest_he->curve(), eit->curve()));
         }
- 
+
         // If the current edge is closer to the query point than the closest
         // edge so far, update the closest edge.
         if (y_res == curve_above_under) {
@@ -306,7 +306,7 @@ Arr_simple_point_location<Arrangement>::_vertical_ray_shoot(const Point_2& p,
       closest_he = *p_hh;
     }
   }
-  
+
   // Set the result for comparison according to the ray direction.
   const Comparison_result point_above_under = (shoot_up ? SMALLER : LARGER);
 
@@ -359,7 +359,7 @@ Arr_simple_point_location<Arrangement>::_vertical_ray_shoot(const Point_2& p,
     // If we found a valid edge, return it.
     if (! closest_he->is_fictitious())
       return make_result(closest_he);
-  
+
     // If we found a fictitious edge, we have to return a handle to its
     // incident unbounded face.
     if ((shoot_up && closest_he->direction() == ARR_LEFT_TO_RIGHT) ||
@@ -396,8 +396,8 @@ _first_around_vertex(Vertex_const_handle v) const
 
   bool found_lowest_left = false;
   bool found_top_right = false;
-  
-  typename Arrangement::Halfedge_around_vertex_const_circulator  first = 
+
+  typename Arrangement::Halfedge_around_vertex_const_circulator  first =
     v->incident_halfedges();
   typename Arrangement::Halfedge_around_vertex_const_circulator  curr = first;
 
@@ -409,7 +409,7 @@ _first_around_vertex(Vertex_const_handle v) const
       // of v.
       if (! found_lowest_left ||
           (! curr->is_fictitious() &&
-           compare_y_at_x_left(curr->curve(), lowest_left->curve(), 
+           compare_y_at_x_left(curr->curve(), lowest_left->curve(),
                                v->point()) == SMALLER))
       {
         lowest_left = curr;
@@ -421,7 +421,7 @@ _first_around_vertex(Vertex_const_handle v) const
       // of v.
       if (! found_top_right ||
           (! curr->is_fictitious() &&
-           compare_y_at_x_right(curr->curve(), top_right->curve(), 
+           compare_y_at_x_right(curr->curve(), top_right->curve(),
                                 v->point()) == LARGER))
       {
         top_right = curr;
@@ -433,7 +433,7 @@ _first_around_vertex(Vertex_const_handle v) const
   } while (curr != first);
 
   // The first halfedge we encounter is the lowest to the left, but if there
-  // is no edge to the left, we first encounter the topmost halfedge to the 
+  // is no edge to the left, we first encounter the topmost halfedge to the
   // right. Note that as the halfedge we located has v as its target, we now
   // have to return its twin.
   return (found_lowest_left) ? lowest_left->twin() : top_right->twin();

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2.h
@@ -12,17 +12,13 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Oren Nechushtan <theoren@math.tau.ac.il>
 //                 Iddo Hanniel <hanniel@math.tau.ac.il>
 
 #ifndef CGAL_TRAPEZOIDAL_DECOMPOSITION_2_H
 #define CGAL_TRAPEZOIDAL_DECOMPOSITION_2_H
 
-//#define CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION 
+//#define CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
 
 #include <CGAL/Arr_tags.h>
 #include <CGAL/basic.h>
@@ -49,7 +45,7 @@ namespace CGAL {
  * Description   Implementation for a planar trapezoidal map also known as
  *   trapezoidal decomposition and vertical decomposition.
  *
- * For requirements on Traits and X_curve classes see 
+ * For requirements on Traits and X_curve classes see
  *   Trapezoidal_decomposition_2 documentation.
  */
 template < class Td_traits>
@@ -67,7 +63,7 @@ public:
   class Base_map_item_iterator;
   class In_face_iterator;
   friend class In_face_iterator;
-  
+
   //type of trapezoidal decomposition traits
   typedef Td_traits Traits;
 
@@ -78,24 +74,24 @@ public:
   typedef typename Traits::Arrangement_on_surface_2 Arrangement_on_surface_2;
 
   //type of traits adaptor
-  typedef typename Traits::Arrangement_on_surface_2::Traits_adaptor_2		
+  typedef typename Traits::Arrangement_on_surface_2::Traits_adaptor_2
     Traits_adaptor_2;
-  
+
   //type of point
   typedef typename Traits::Point Point;
-  
+
   //!type of Halfedge_handle
   typedef typename Traits::Halfedge_handle
     Halfedge_handle;
- 
+
   //!type of Halfedge_const_handle
   typedef typename Traits::Halfedge_const_handle
     Halfedge_const_handle;
-  
+
   //!type of Vertex_const_handle
   typedef typename Traits::Vertex_const_handle
     Vertex_const_handle;
-  
+
   //type of X_monotone_curve
   typedef typename Traits::X_monotone_curve_2 X_monotone_curve_2;
 
@@ -110,7 +106,7 @@ public:
 
   //type of Td_active_trapezoid
   typedef typename Traits::Td_active_trapezoid Td_active_trapezoid;
-  
+
   //type of Td_inactive_trapezoid
   typedef typename Traits::Td_inactive_trapezoid Td_inactive_trapezoid;
 
@@ -124,14 +120,14 @@ public:
   typedef typename Traits::Td_active_vertex Td_active_vertex;
 
   //type of Td_active_fictitious_vertex
-  typedef typename Traits::Td_active_fictitious_vertex 
+  typedef typename Traits::Td_active_fictitious_vertex
     Td_active_fictitious_vertex;
 
   //type of Td_inactive_vertex
   typedef typename Traits::Td_inactive_vertex Td_inactive_vertex;
 
   //type of Td_inactive_fictitious_vertex
-  typedef typename Traits::Td_inactive_fictitious_vertex 
+  typedef typename Traits::Td_inactive_fictitious_vertex
     Td_inactive_fictitious_vertex;
 
   //type of Curve end pair
@@ -151,15 +147,15 @@ public:
   typedef std::map< int,Dag_node > Nodes_map;
 
   //type of trapezoids comparison function - for the map
-  typedef Td_map_item_handle_less<const Td_map_item* const> 
+  typedef Td_map_item_handle_less<const Td_map_item* const>
     Td_map_item_ptr_less;
-  
+
   //type of trapezoids ptr map
-  typedef std::map<const Td_map_item*, Td_map_item*, Td_map_item_ptr_less> 
+  typedef std::map<const Td_map_item*, Td_map_item*, Td_map_item_ptr_less>
     Td_map_item_ptr_map;
 
 public:
-  
+
   /*! \class Base_map_item_iterator
    * member of Trapezoidal_decomposition_2<Traits>
    * Description Implements a basic Trapezoid iterator
@@ -194,7 +190,7 @@ public:
     {
       return !operator==(it);
     }
-      
+
     Td_map_item& operator*() //const
     {
       CGAL_precondition(!traits->is_empty_item(m_cur_item));
@@ -205,7 +201,7 @@ public:
     {
       return traits->is_empty_item(m_cur_item);//!m_cur_item;
     }
-    
+
   protected:
     const Traits *traits; //pointer to the traits
     Td_map_item m_cur_item; //the current map item (or none)
@@ -230,29 +226,29 @@ public:
 
   public:
     //constructors
-    In_face_iterator(const Traits* traits_, Halfedge_const_handle sep, 
-                     boost::optional<Td_map_item&> curr = boost::none) 
-            :Base_map_item_iterator(traits_,curr), m_sep(sep->curve()) 
+    In_face_iterator(const Traits* traits_, Halfedge_const_handle sep,
+                     boost::optional<Td_map_item&> curr = boost::none)
+            :Base_map_item_iterator(traits_,curr), m_sep(sep->curve())
     { }
 
-    In_face_iterator(const Traits* traits_, const X_monotone_curve_2& sep, 
-                     boost::optional<Td_map_item&> curr = boost::none) 
-            :Base_map_item_iterator(traits_,curr), m_sep(sep) 
+    In_face_iterator(const Traits* traits_, const X_monotone_curve_2& sep,
+                     boost::optional<Td_map_item&> curr = boost::none)
+            :Base_map_item_iterator(traits_,curr), m_sep(sep)
     { }
 
 
-    In_face_iterator(const In_face_iterator &it) 
+    In_face_iterator(const In_face_iterator &it)
             :Base_map_item_iterator((Base_map_item_iterator&)it),
-              m_sep(it.m_sep)                                   
+              m_sep(it.m_sep)
     { }
 
     //operatoror overloading
     bool operator==(const In_face_iterator &it) const
     {
-      return ( Base_map_item_iterator::operator==(it) && 
+      return ( Base_map_item_iterator::operator==(it) &&
                traits->equal_2_object()(m_sep,it.m_sep));
     }
-    
+
     /*
       destription:
       advances m_cur_item to one of the right neighbours according to the relation
@@ -268,9 +264,9 @@ public:
     */
     In_face_iterator& operator++()
     {
-      if (traits->is_empty_item(m_cur_item)) 
+      if (traits->is_empty_item(m_cur_item))
         return *this;// end reached, do nothing!
-      
+
 #ifndef CGAL_TD_DEBUG
       CGAL_warning(traits != NULL);
 #else
@@ -279,10 +275,10 @@ public:
       //m_cur_item should be a trapezoid or an edge
       CGAL_assertion(!traits->is_td_vertex(m_cur_item));
 #endif
-      
+
       if (traits->is_td_trapezoid(m_cur_item))
       {
-        //if the map item is a trapezoid 
+        //if the map item is a trapezoid
         Td_active_trapezoid tr (boost::get<Td_active_trapezoid>(m_cur_item));
 
 #ifndef CGAL_TD_DEBUG
@@ -293,14 +289,14 @@ public:
         CGAL_assertion(tt);
         CGAL_assertion(!tt->is_inner_node());
 #endif
-          
+
         // handle degeneracies
-        typename Traits::Compare_curve_end_xy_2 compare_xy = 
+        typename Traits::Compare_curve_end_xy_2 compare_xy =
           traits->compare_curve_end_xy_2_object();
         if (compare_xy (traits->vtx_to_ce(tr.left()),
                         Curve_end(m_sep,ARR_MAX_END)) != SMALLER)
         {
-          //if the trapezoid's left end point is equal to or larger from the 
+          //if the trapezoid's left end point is equal to or larger from the
           //  max end of sep, we reached the end of the iterator
           m_cur_item = Td_map_item(0);
         }
@@ -308,10 +304,10 @@ public:
         {
           //if the trapezoid's left end point is smaller from the sep's max end
 
-          //comparing the y value of the trapezoid's right end point and sep 
+          //comparing the y value of the trapezoid's right end point and sep
           //   (at the trapezoid's right x value), in order to select the
           //    next trapezoid in the iterator
-          typename Traits::Compare_curve_end_y_at_x_2 compare_y_at_x = 
+          typename Traits::Compare_curve_end_y_at_x_2 compare_y_at_x =
             traits->compare_curve_end_y_at_x_2_object();
           switch (compare_y_at_x (traits->vtx_to_ce(tr.right()), m_sep))
           {
@@ -325,13 +321,13 @@ public:
             // end reached
              m_cur_item = Td_map_item(0);
             break;
-           default:       
+           default:
              m_cur_item = Td_map_item(0);
             break;
           }
         }
       }
-      else 
+      else
       {
         //if the map item is an edge
 
@@ -341,7 +337,7 @@ public:
         CGAL_assertion(tt->is_inner_node());
 
         //go to next() of the current edge.
-        // as long as there is an edge fragment of the same 
+        // as long as there is an edge fragment of the same
         //  edge - next() exists.
         // If next() does not exist we reached the last fragment of the edge
         m_cur_item = e.next();
@@ -351,18 +347,18 @@ public:
           //    (skip points)
           while(traits->is_td_vertex(m_cur_item))
           {
-            Dag_node* node = 
+            Dag_node* node =
               boost::apply_visitor(dag_node_visitor(),m_cur_item);
             m_cur_item = node->left_child().get_data();
           }
-              
+
           //make sure we stopped in an edge
           CGAL_warning(traits->is_td_edge(m_cur_item));
         }
       }
       return *this;
     }
-    
+
     In_face_iterator operator++(int)
     {
       In_face_iterator tmp = *this;
@@ -378,21 +374,21 @@ public:
     Td_active_trapezoid& trp()
     {
       CGAL_precondition (!traits->is_empty_item(m_cur_item));
-      CGAL_precondition (traits->is_active(m_cur_item) && 
+      CGAL_precondition (traits->is_active(m_cur_item) &&
                          traits->is_td_trapezoid(m_cur_item));
       return boost::get<Td_active_trapezoid>(m_cur_item);
     }
 
-    Td_active_edge& e() 
+    Td_active_edge& e()
     {
       CGAL_precondition (!traits->is_empty_item(m_cur_item));
-      CGAL_precondition (traits->is_active(m_cur_item) && 
+      CGAL_precondition (traits->is_active(m_cur_item) &&
                          traits->is_td_edge(m_cur_item));
       return boost::get<Td_active_edge>(m_cur_item);
     }
 
   };
-  
+
   /*!  Visitors for accessing td map items methods */
   class rb_visitor : public boost::static_visitor<Td_map_item>
   {
@@ -401,7 +397,7 @@ public:
     {
       return t.rb();
     }
-    
+
     template < typename T >
     Td_map_item operator()(T& /* t */) const
     {
@@ -414,19 +410,19 @@ public:
   {
   public:
     set_rb_visitor (const Td_map_item& rb) : m_rb(rb) {}
-    
-    
+
+
     void operator()(Td_active_trapezoid& t) const
     {
       t.set_rb(m_rb);
     }
-    
+
     template < typename T >
     void operator()(T& /* t */) const
     {
       CGAL_assertion(false);
     }
-    
+
   private:
     const Td_map_item& m_rb;
   };
@@ -438,7 +434,7 @@ public:
     {
       return t.rt();
     }
-    
+
     template < typename T >
     Td_map_item operator()(T& /* t */) const
     {
@@ -451,12 +447,12 @@ public:
   {
   public:
     set_rt_visitor (const Td_map_item& rt) : m_rt(rt) {}
-    
+
     void operator()(Td_active_trapezoid& t) const
     {
       t.set_rt(m_rt);
     }
-    
+
     template < typename T >
     void operator()(T& /*t*/) const
     {
@@ -466,7 +462,7 @@ public:
   private:
     const Td_map_item& m_rt;
   };
-  
+
   class lb_visitor : public boost::static_visitor<Td_map_item>
   {
   public:
@@ -487,18 +483,18 @@ public:
   {
   public:
     set_lb_visitor (const Td_map_item& lb) : m_lb(lb) {}
-    
+
     void operator()(Td_active_trapezoid& t) const
     {
       return t.set_lb(m_lb);
     }
-    
+
     template < typename T >
     void operator()(T& /* t */) const
     {
       CGAL_assertion(false);
     }
-    
+
   private:
     const Td_map_item& m_lb;
   };
@@ -512,7 +508,7 @@ public:
     {
       t.set_lt(m_lt);
     }
-    
+
     template < typename T >
     void operator()(T& /*t*/) const
     {
@@ -530,7 +526,7 @@ public:
     {
       return t.bottom();
     }
-    
+
     template < typename T >
     Halfedge_const_handle operator()(T& /*t*/) const
     {
@@ -538,17 +534,17 @@ public:
       return Halfedge_const_handle();
     }
   };
- 
+
   class set_bottom_he_visitor : public boost::static_visitor< void  >
   {
   public:
     set_bottom_he_visitor (Halfedge_const_handle he) : m_bottom_he(he) {}
-    
+
     void operator()(Td_active_trapezoid& t) const
     {
       t.set_bottom(m_bottom_he);
     }
-   
+
     template < typename T >
     void operator()(T& /*t*/) const
     {
@@ -565,7 +561,7 @@ public:
     {
       return t.top();
     }
-    
+
     template < typename T >
     Halfedge_const_handle operator()(T& /* t */) const
     {
@@ -573,17 +569,17 @@ public:
       return Halfedge_const_handle();
     }
   };
- 
+
   class set_top_he_visitor : public boost::static_visitor<void>
   {
   public:
     set_top_he_visitor (Halfedge_const_handle he) : m_top_he(he) {}
-    
+
     void operator()(Td_active_trapezoid& t) const
     {
       t.set_top(m_top_he);
     }
-    
+
     template < typename T >
     void operator()(T& /* t */) const
     {
@@ -604,7 +600,7 @@ public:
     {
       return t.cw_he();
     }
-    
+
     template < typename T >
     Halfedge_const_handle operator()(T& /*t*/) const
     {
@@ -612,12 +608,12 @@ public:
       return Halfedge_const_handle();
     }
   };
- 
+
   class set_cw_he_visitor : public boost::static_visitor<void>
   {
   public:
     set_cw_he_visitor (Halfedge_const_handle he) : m_cw_he(he) {}
-    
+
     void operator()(Td_active_vertex& t) const
     {
       t.set_cw_he(m_cw_he);
@@ -626,7 +622,7 @@ public:
     {
       t.set_cw_he(m_cw_he);
     }
-   
+
     template < typename T >
     void operator()(T& /*t*/) const
     {
@@ -661,7 +657,7 @@ public:
   {
   public:
     set_dag_node_visitor(Dag_node* node):m_node(node) {}
-    
+
     void operator()(Td_nothing& /*t*/) const
     {
       CGAL_assertion(false);
@@ -676,7 +672,7 @@ public:
     {
       t.set_dag_node(m_node);
     }
-  
+
   private:
     Dag_node* m_node;
   };
@@ -716,15 +712,15 @@ public:
     {
       return t.point();
     }
-    
+
     template < typename T >
     Point operator()(T& /* t */) const
     {
       CGAL_assertion(false);
       return Point();
-    } 
+    }
   };
-  
+
   class curve_end_for_active_vertex_visitor :
     public boost::static_visitor<boost::optional<Curve_end> >
   {
@@ -794,7 +790,7 @@ public:
   };
 
   ////MICHAL: currently not in use since split is implemented as removed and insert two
-  //struct Before_split_data 
+  //struct Before_split_data
   //{
   //  X_monotone_curve_2 m_cv_before_split;
   //  Td_map_item* m_p_old_t;
@@ -803,61 +799,61 @@ public:
   //  In_face_iterator* m_p_btm_it;
   //  In_face_iterator* m_p_mid_it;
   //  In_face_iterator* m_p_top_it;
-  //  
-  //};    
-        
+  //
+  //};
+
   //////////////////////////////////////////////
   //Trapezoidal_decomposition_2 member functions:
   //////////////////////////////////////////////
-    
-    
+
+
 protected:
-    
+
   /*!  is_edge_to_right variants:
-      returning true if the given edge is on the right side 
+      returning true if the given edge is on the right side
       of the given point / curve-end */
-    
+
   bool is_edge_to_right(Halfedge_const_handle he, const Point& p) const
   {
-    typename Traits::Equal_curve_end_2 equal = 
+    typename Traits::Equal_curve_end_2 equal =
       traits->equal_curve_end_2_object();
     //p is either min or max end of he
     CGAL_precondition(equal(Curve_end(he,ARR_MIN_END), p) ||
                       equal(Curve_end(he,ARR_MAX_END), p));
-      
+
     return equal(Curve_end(he,ARR_MIN_END), p);
   }
-    
+
   bool is_edge_to_right(Halfedge_const_handle he, const Curve_end& ce) const
   {
-    typename Traits::Equal_curve_end_2 equal = 
+    typename Traits::Equal_curve_end_2 equal =
       traits->equal_curve_end_2_object();
     //p is either min or max end of he
     CGAL_precondition(equal(Curve_end(he,ARR_MIN_END), ce) ||
                       equal(Curve_end(he,ARR_MAX_END), ce));
-      
+
     //if the curve end ce is on the right boundary - return false;
     if (traits->parameter_space_in_x_2_object()
           (ce.cv(), ce.ce()) == ARR_RIGHT_BOUNDARY)
     {
       return false;
     }
-    
+
     return equal(Curve_end(he,ARR_MIN_END), ce);
   }
-    
+
   //returns true if the given curve is on the right side of the given point
   bool is_curve_to_right(const X_monotone_curve_2& cv, const Point& p) const
   {
-    typename Traits::Equal_curve_end_2 equal = 
+    typename Traits::Equal_curve_end_2 equal =
       traits->equal_curve_end_2_object();
     //p is either min or max end of he
     CGAL_precondition(equal(Curve_end(cv,ARR_MIN_END), p) ||
                       equal(Curve_end(cv,ARR_MAX_END), p));
-      
+
     return equal(Curve_end(cv,ARR_MIN_END), p);
   }
-    
+
   /*!  is_end_point_left_low variants:
       returning true if the first curve-end is left-low
       of the second curve-end */
@@ -865,7 +861,7 @@ protected:
   {
     return (traits->compare_xy_2_object()(p1, p2) == SMALLER);
   }
-    
+
   bool is_end_point_left_low(const Point& p, const Curve_end& ce) const
   {
     return (traits->compare_curve_end_xy_2_object()(p, ce) == SMALLER);
@@ -880,25 +876,25 @@ protected:
   {
     return (traits->compare_curve_end_xy_2_object()(ce1, ce2) == SMALLER);
   }
-  
+
   template <typename T>
   bool is_end_point_left_low(const T& t, const Dag_node& node) const
   {
-    typename Traits::Compare_curve_end_xy_2 compare = 
+    typename Traits::Compare_curve_end_xy_2 compare =
       traits->compare_curve_end_xy_2_object();
     Td_map_item vtx_item (node.get_data());
     bool is_fict_vtx = traits->is_fictitious_vertex(vtx_item);
     if (is_fict_vtx) {
-      return (compare(t, 
+      return (compare(t,
                       *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),
                                              vtx_item))) == SMALLER);
     }
     else {
-      return (compare(t, boost::apply_visitor(point_for_vertex_visitor(), 
+      return (compare(t, boost::apply_visitor(point_for_vertex_visitor(),
                                               vtx_item)) == SMALLER);
     }
   }
-    
+
   /*!  is_end_point_right_top variants:
       returning true if the first curve-end is right-top
       of the second curve-end */
@@ -906,7 +902,7 @@ protected:
   {
     return (traits->compare_xy_2_object()(p1, p2) == LARGER);
   }
-    
+
   bool is_end_point_right_top(const Point& p, const Curve_end& ce) const
   {
     return (traits->compare_curve_end_xy_2_object()(p, ce) == LARGER);
@@ -916,7 +912,7 @@ protected:
   {
     return (traits->compare_curve_end_xy_2_object()(p, ce) == SMALLER);
   }
-    
+
   bool is_end_point_right_top(const Curve_end& ce1, const Curve_end& ce2) const
   {
     return (traits->compare_curve_end_xy_2_object()(ce1, ce2) == LARGER);
@@ -925,18 +921,18 @@ protected:
   template <typename T>
   bool is_end_point_right_top(const T& t, const Dag_node& node) const
   {
-    typename Traits::Compare_curve_end_xy_2 compare = 
+    typename Traits::Compare_curve_end_xy_2 compare =
       traits->compare_curve_end_xy_2_object();
     Td_map_item vtx_item (node.get_data());
     bool is_fict_vtx = traits->is_fictitious_vertex(vtx_item);
     if (is_fict_vtx) {
-      return (compare(t, 
+      return (compare(t,
                  *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),
                                         vtx_item)))  == LARGER);
     }
     else {
-      return (compare(t, 
-                  boost::apply_visitor(point_for_vertex_visitor(), 
+      return (compare(t,
+                  boost::apply_visitor(point_for_vertex_visitor(),
                                        vtx_item)) == LARGER);
     }
   }
@@ -949,47 +945,47 @@ protected:
     Td_map_item vtx_item (node.get_data());
     bool is_fict_vtx = traits->is_fictitious_vertex(vtx_item);
     if (is_fict_vtx) {
-      return equal(t, 
+      return equal(t,
                    *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),
                                           vtx_item)));
     }
     else {
-      return equal(t, 
-                   boost::apply_visitor(point_for_vertex_visitor(), 
+      return equal(t,
+                   boost::apply_visitor(point_for_vertex_visitor(),
                                         vtx_item));
     }
   }
-  
+
   /*!
    * finds the node of the leftmost trapezoid with respect to a curve.
-   * \param left_cv_end_node The dag node representing the left endpoint of 
+   * \param left_cv_end_node The dag node representing the left endpoint of
    *        the cv
    * \param cv The curve
-   * \param cres SMALLER/EQUAL/LARGER (searching for the leftmost trapezoid 
-   *        which is below/on/above cv) 
+   * \param cres SMALLER/EQUAL/LARGER (searching for the leftmost trapezoid
+   *        which is below/on/above cv)
    * \return The required DAG node
    */
-  Dag_node find_leftmost_dag_node_of_curve(const Dag_node& left_cv_end_node, 
-                                           const X_monotone_curve_2& cv, 
+  Dag_node find_leftmost_dag_node_of_curve(const Dag_node& left_cv_end_node,
+                                           const X_monotone_curve_2& cv,
                                            Comparison_result cres) const
   {
     CGAL_assertion(traits != NULL);
     Td_map_item& item = left_cv_end_node.get_data();
     CGAL_precondition(traits->is_td_vertex(item));
-    CGAL_precondition (are_equal_end_points(Curve_end(cv,ARR_MIN_END), 
+    CGAL_precondition (are_equal_end_points(Curve_end(cv,ARR_MIN_END),
                                             left_cv_end_node));
-    
+
     //if ( traits->is_fictitious_vertex(item) )
     //{
     //  CGAL_precondition(traits->equal_curve_end_2_object()
     //    (Curve_end(cv,ARR_MIN_END), *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),item))));
     //}
-    //else 
-    //{ 
+    //else
+    //{
     //  CGAL_precondition(traits->equal_curve_end_2_object()
     //     (Curve_end(cv,ARR_MIN_END), boost::apply_visitor(point_for_vertex_visitor(), item)));
     //}
-    //find the node of the curve's leftmost trapezoid 
+    //find the node of the curve's leftmost trapezoid
     Dag_node cv_leftmost_node(left_cv_end_node.right_child());
     if (traits->is_fictitious_vertex(item) )
     {
@@ -1008,10 +1004,10 @@ protected:
    /*!
    * follow_curve variants:
    * follows trapezoids along a curve (below/on/above it)
-   * \param left_cv_end_node The dag node representing the left endpoint of 
+   * \param left_cv_end_node The dag node representing the left endpoint of
    *        the cv
    * \param he/cv The halfedge / The curve
-   * \param cres SMALLER/EQUAL/LARGER (indicating the position with respect to the curve) 
+   * \param cres SMALLER/EQUAL/LARGER (indicating the position with respect to the curve)
    * \return An iterator for td map items along a curve
    */
   In_face_iterator follow_curve(const Dag_node& left_cv_end_node,
@@ -1020,7 +1016,7 @@ protected:
   {
     return follow_curve(left_cv_end_node, he->curve(), up);
   }
-      
+
   In_face_iterator follow_curve(const Dag_node& left_cv_end_node,
                                 const X_monotone_curve_2& cv,
                                 Comparison_result up) const
@@ -1030,7 +1026,7 @@ protected:
     //  and continues according to the curve cv
     return In_face_iterator(traits, cv, cv_leftmost_node.get_data());
   }
-    
+
   //-----------------------------------------------------------------------------
   // Description:
   //  Input: pointer to left trapezoid, pointer to right trapezoid
@@ -1041,16 +1037,16 @@ protected:
   //  the right trapezoid is to the right of the left one
   bool merge_if_possible(Td_map_item& left_item, Td_map_item& right_item)
   {
-    CGAL_precondition(traits->is_empty_item(left_item) || 
-                      (traits->is_active(left_item) && 
+    CGAL_precondition(traits->is_empty_item(left_item) ||
+                      (traits->is_active(left_item) &&
                        traits->is_td_trapezoid(left_item)));
-    CGAL_precondition(traits->is_empty_item(right_item) || 
-                      (traits->is_active(right_item) && 
+    CGAL_precondition(traits->is_empty_item(right_item) ||
+                      (traits->is_active(right_item) &&
                        traits->is_td_trapezoid(right_item)));
-    
+
     if (traits->is_empty_item(left_item) || traits->is_empty_item(right_item))
       return false;
-    
+
     Td_active_trapezoid& left  (boost::get<Td_active_trapezoid>(left_item));
     Td_active_trapezoid& right (boost::get<Td_active_trapezoid>(right_item));
 
@@ -1065,15 +1061,15 @@ protected:
                                             right.dag_node()->depth());
       CGAL_postcondition(
         left.is_on_right_boundary() == right.is_on_right_boundary());
-    
+
       return true;
     }
     return false;
   }
-    
+
   //---------------------------------------------------------------------------
   // Description:
-  //  splits the trapezoid with vertical line through v 
+  //  splits the trapezoid with vertical line through v
   //  assuming that he (the first cw halfedge starting at 12 o'clock) is in the
   //  desired direction, such that v is their source
   // Precondition:
@@ -1088,12 +1084,12 @@ protected:
                                     Dag_node* node);
   //---------------------------------------------------------------------------
   // Description:
-  //  the opposite operation for spliting the trapezoid with 
-  //  vertical line through ce 
+  //  the opposite operation for spliting the trapezoid with
+  //  vertical line through ce
   // Precondition:
-  //  The root trapezoid is degenerate point (ce) and is active 
+  //  The root trapezoid is degenerate point (ce) and is active
   void undo_split_trapezoid_by_vertex(Dag_node& tr_node, const Curve_end& ce);
- 
+
   void deactivate_trapezoid (Dag_node& trpz_node, Dag_node* active_node) const;
 
   void deactivate_vertex (Dag_node& vtx_node) const;
@@ -1107,10 +1103,10 @@ protected:
   // Precondition:
   //  The root trapezoid is active
   //  The root trapezoid is devided by he or is equal to it and is vertical.
-  Dag_node& split_trapezoid_by_halfedge(Dag_node& split_node, 
+  Dag_node& split_trapezoid_by_halfedge(Dag_node& split_node,
                                         Td_map_item& prev_e,
-                                        Td_map_item& prev_bottom_tr, 
-                                        Td_map_item& prev_top_tr, 
+                                        Td_map_item& prev_bottom_tr,
+                                        Td_map_item& prev_top_tr,
                                         Halfedge_const_handle he);
 
 
@@ -1121,38 +1117,38 @@ protected:
   //   vertical_ray_shoot downward from tr
   //   tr.top()
   //    vertical_ray_shoot upward from tr
-  //  update all the curves incident to the vertex that there's a new curve 
+  //  update all the curves incident to the vertex that there's a new curve
   //  starting from this vertex
   //  this point must be an interior point and not a point on the boundaries,
-  //  since a point on the boundaries is related to one curve only  
+  //  since a point on the boundaries is related to one curve only
   Td_map_item&
   update_vtx_with_new_edge(Halfedge_const_handle he,
                            const Curve_end& ce,
                            Td_map_item& vtx_item,
                            const Locate_type& CGAL_precondition_code(lt));
-  
+
   Td_map_item& insert_curve_at_vtx_using_dag(Halfedge_const_handle he,
                                              Vertex_const_handle v,
                                              Td_map_item& tr,
                                              const Locate_type&
                                              CGAL_precondition_code(lt));
-        
+
 
   //void set_trp_params_after_halfedge_update(Halfedge_const_handle old_he,
   //                                          Halfedge_const_handle new_he,
   //                                          Td_map_item& vtx_item); //MICHAL: not in use
-  
+
 
   void update_vtx_cw_he_after_merge(const X_monotone_curve_2& old_cv,
                                     Halfedge_const_handle new_he,
                                     Td_map_item& vtx_item);
-  
+
   ////MICHAL: currently not in use since split is implemented as: remove and insert two
   //void set_trp_params_after_split_halfedge_update(Halfedge_const_handle new_he,
   //                                                Td_map_item& vtx_item,
-  //                                                Halfedge_const_handle he1, 
+  //                                                Halfedge_const_handle he1,
   //                                                Halfedge_const_handle he2);
-  
+
   //-----------------------------------------------------------------------------
   // Description:
   //  update map items traveled along an iterator till end reached
@@ -1167,11 +1163,11 @@ protected:
                                     Vertex_const_handle min_v,
                                     Vertex_const_handle max_v,
                                     Td_map_item& end);
-  
+
 
   //---------------------------------------------------------------------------
   // Description:
-  //  advances input Data structure using data structure,input point p and 
+  //  advances input Data structure using data structure,input point p and
   //  possibly Halfedge p_he till
   //  p is found(if p_he hadn't been given)
   //  p_he is found(if p_he was given)
@@ -1189,7 +1185,7 @@ protected:
 
   ////-------------------------------------------------------------------------
   //// Description:
-  ////  advances input Data structure using data structure,input point p and 
+  ////  advances input Data structure using data structure,input point p and
   ////  possibly Halfedge p_he till
   ////  p is found(if p_he hadn't been given)
   ////  p_he is found(if p_he was given)
@@ -1199,16 +1195,16 @@ protected:
   ////  output is the closest active trapezoid to ce/p_he
   //// remark:
   ////  use this function with care!
-  //void search_and_print_using_dag (std::ostream& out, 
+  //void search_and_print_using_dag (std::ostream& out,
   //                                Dag_node& curr_node,
   //                                const Traits* traits,
   //                                const Point& p,
   //                                Halfedge_const_handle he,
   //                                Comparison_result up = EQUAL) const;
-    
+
   //---------------------------------------------------------------------------
   // Description:
-  //  advances input Data structure using data structure,input point ce and 
+  //  advances input Data structure using data structure,input point ce and
   //  possibly Halfedge p_he till
   //  ce is found(if p_he hadn't been given)
   //  p_he is found(if p_he was given)
@@ -1223,10 +1219,10 @@ protected:
                                 const Curve_end& ce,
                                 Halfedge_const_handle he,
                                 Comparison_result up = EQUAL) const;
-      
+
   //---------------------------------------------------------------------------
   // Description:
-  //  advances input Data structure using data structure,input point ce and 
+  //  advances input Data structure using data structure,input point ce and
   //  possibly X_monotone_curve_2 p_cv till
   //  ce is found(if p_cv hadn't been given)
   //  p_cv is found(if p_cv was given)
@@ -1241,10 +1237,10 @@ protected:
                                        const Curve_end& ce,
                                        const X_monotone_curve_2* p_cv,
                                        Comparison_result up = EQUAL) const;
-      
+
   //---------------------------------------------------------------------------
   // Description:
-  //  advances input Data structure using data structure,input point ce and 
+  //  advances input Data structure using data structure,input point ce and
   //  possibly X_monotone_curve_2 p_cv till
   //  p is found(if p_cv hadn't been given)
   //  p_cv is found(if p_cv was given)
@@ -1258,19 +1254,19 @@ protected:
                                         const Traits* traits,
                                         const Point& p,
                                         const X_monotone_curve_2* p_cv,
-                                        Comparison_result up = EQUAL) const;    
-      
-    
+                                        Comparison_result up = EQUAL) const;
+
+
   Dag_node container2dag(Nodes_map& ar, int left, int right,
                          int& num_of_new_nodes) const;
-    
+
   bool is_last_edge(Halfedge_const_handle he, Td_map_item& vtx_item);
-  
+
   /*==============================================
     Trapezoidal_decomposition_2 public member functions
     ==============================================*/
 public:
-    
+
   Trapezoidal_decomposition_2(bool with_guarantees = true) :
     m_largest_leaf_depth(0),
     m_number_of_dag_nodes(1),
@@ -1283,7 +1279,7 @@ public:
     init();
     set_with_guarantees(with_guarantees);
   }
-    
+
   Trapezoidal_decomposition_2(const double& depth_th, const double& size_th,
                               bool with_guarantees = true) :
     m_largest_leaf_depth(0),
@@ -1299,14 +1295,14 @@ public:
   }
 
   //MICHAL: problematic, should not be used
-  //Trapezoidal_decomposition_2(const Self& td) 
+  //Trapezoidal_decomposition_2(const Self& td)
   //  : m_with_guarantees(td.m_with_guarantees),
   //    m_number_of_curves(td.m_number_of_curves),
   //    m_largest_leaf_depth(td.m_largest_leaf_depth),
   //    m_number_of_dag_nodes(td.m_number_of_dag_nodes),
   //    traits(td.traits),
   //    m_arr(td.m_arr),
-  //    last_cv(Td_map_item(0)), prev_cv(Td_map_item(0)), 
+  //    last_cv(Td_map_item(0)), prev_cv(Td_map_item(0)),
   //    m_depth_threshold(td.m_depth_threshold),
   //    m_size_threshold(td.m_size_threshold)
   //{
@@ -1322,7 +1318,7 @@ public:
   //  //! \todo Reduce the 3 iterations to 1 (or 2) iterator.
   //  // First iteration: filter out the active trapezoids.
   //  typename std::vector<Td_map_item>::const_iterator it;
-  //  for (it = vtr.begin(); it != vtr.end(); ++it) 
+  //  for (it = vtr.begin(); it != vtr.end(); ++it)
   //  {
   //    Dag_node* ds_copy = new Dag_node(*it);
   //    const Td_map_item* cur = &*it;
@@ -1334,55 +1330,55 @@ public:
   //    htr.insert(typename Td_map_item_ptr_map::value_type(cur, tr_copy));
   //    // Second iteration: generate new copies of trapezoids and nodes.
   //  }
-  //    
-  //  for (it = vtr.begin(); it!=vtr.end(); ++it) 
+  //
+  //  for (it = vtr.begin(); it!=vtr.end(); ++it)
   //  {
   //    const Td_map_item* cur = &*it;
   //    Td_map_item* tr_copy = htr.find(cur)->second;
   //    const Dag_node* child;
   //    CGAL_assertion(tr_copy);
-  //    tr_copy->set_rt(cur->rt() ? 
+  //    tr_copy->set_rt(cur->rt() ?
   //                    htr.find(cur->rt())->second : NULL);
   //    tr_copy->set_rb(cur->rb() ?
   //                    htr.find(cur->rb())->second : NULL);
-  //    tr_copy->set_lt(cur->lt() ? 
+  //    tr_copy->set_lt(cur->lt() ?
   //                    htr.find(cur->lt())->second : NULL);
-  //    tr_copy->set_lb(cur->lb() ? 
+  //    tr_copy->set_lb(cur->lb() ?
   //                    htr.find(cur->lb())->second : NULL);
 
-  //    if (cur->dag_node()->is_inner_node()) 
+  //    if (cur->dag_node()->is_inner_node())
   //    {
   //      child = &cur->dag_node()->right_child();
   //      while (child && child->is_inner_node() && !pr(*(*child)))
   //        child = &child->left_child();
   //      tr_copy->dag_node()->set_right_child(*child);
   //      child = &cur->dag_node()->left_child();
-  //      while (child && child->is_inner_node() && !pr(*(*child))) 
+  //      while (child && child->is_inner_node() && !pr(*(*child)))
   //        child = &child->left_child();
   //      tr_copy->dag_node()->set_left_child(*child);
   //    }
-  //    // Third iteration: generate links in-between trapezoids 
+  //    // Third iteration: generate links in-between trapezoids
   //    //  and in-between nodes .
   //  }
   //  m_dag_root = htr.find(&*(*td.m_dag_root))->second->dag_node();
   //}
-  // 
-   
+  //
+
   /*
-    TODO: Should we add another constructor with non const argument that 
+    TODO: Should we add another constructor with non const argument that
     rebuild the trapezoidal decomposition prior to copy construction?
   */
   virtual ~Trapezoidal_decomposition_2()
   {
     CGAL_warning(m_dag_root != NULL);
     if (!m_dag_root) return;
-    
+
     delete m_dag_root;
-    
+
     if (traits)
       delete traits;
   }
-  
+
   //---------------------------------------------------------------------------
   // Description:
   //  if Halfedge or twin already inserted the latter is returned.
@@ -1393,29 +1389,29 @@ public:
   //  all the other trapezoids representing the Halfedge can be extracted
   //  via moving continously to the left and right neighbours.
   Td_map_item insert(Halfedge_const_handle he);
-    
-  
+
+
   //---------------------------------------------------------------------------
   // Description:
   // inserts a range of halfedges into the Search structure.
-  // First it randomly shuffles the container and then it inserts the Halfedges 
+  // First it randomly shuffles the container and then it inserts the Halfedges
   //  according to the new order
   // Precondition: the data structure is empty
   template <class Halfedge_iterator>
   void insert(Halfedge_iterator begin, Halfedge_iterator end)
   {
-    //Precondition: the data structure is empty 
+    //Precondition: the data structure is empty
     CGAL_precondition(m_number_of_curves == 0);
 
     if (begin == end)
       return;
-    
+
     //insert the shuffled halfedges into the search structure
-    
-    //disable the rebuild check from within the halfedge insert and check here 
+
+    //disable the rebuild check from within the halfedge insert and check here
     //  for rebuild
     bool do_rebuild = set_with_guarantees(false);
-    
+
     bool start_over = true;
     while (start_over)
     {
@@ -1423,12 +1419,12 @@ public:
 
       //random_shuffle the range
       std::random_shuffle(begin,end);
-    
+
       Halfedge_const_handle he_cst;
       Halfedge_iterator it = begin;
       for (; it < end ; ++it)
       {
-        if (do_rebuild && not_within_limits()) 
+        if (do_rebuild && not_within_limits())
         {
           std::cout << "starting over after " << number_of_curves() << std::flush;
           start_over = true;
@@ -1437,11 +1433,11 @@ public:
         }
 
         he_cst = *it;
-        insert(he_cst); 
+        insert(he_cst);
       }
       if (it != end)
         continue;
-      
+
       //after inserting the last halfedge in the range
       //  perform another rebuild check
       if (do_rebuild && not_within_limits()) //MICHAL: should I use needs_update() instead (with the random check)?
@@ -1451,18 +1447,18 @@ public:
       }
     }
 
-    //enable the rebuild from within the halfedge insert 
+    //enable the rebuild from within the halfedge insert
     set_with_guarantees(do_rebuild);
   }
-    
+
 
   // removal functions
-    
+
   //---------------------------------------------------------------------------
   // Description:
   //
   void remove(Halfedge_const_handle he);
-    
+
   ////-------------------------------------------------------------------------
   //// Description:
   ////
@@ -1471,24 +1467,24 @@ public:
   //{
   //  if(begin == end)
   //    return;
-  //  
+  //
   //  std::random_shuffle(begin,end);
-  //  
+  //
   //  curve_iterator it=begin,next=it;
-  //  while(it!=end) 
+  //  while(it!=end)
   //  {
   //    ++next;
   //    remove(*it);
   //    it=next;
   //  }
   //}
-    
+
   void clear()
   {
     delete m_dag_root;
     init();
   }
-    
+
 
 //  //-------------------------------------------------------------------------
 //  // Description:
@@ -1501,32 +1497,32 @@ public:
 //  //  locate call may change the class
 //  Td_map_item& locate_and_print(std::ostream& out, const Point& p) const
 //  {
-//    
+//
 //#ifdef CGAL_TD_DEBUG
-//    
+//
 //    CGAL_assertion(traits);
 //    CGAL_assertion(m_dag_root);
-//    
+//
 //#endif
-//    
+//
 //    Dag_node curr = *m_dag_root; //MICHAL: is it ok to add &?
-//    
+//
 //#ifdef CGAL_TD_DEBUG
-//    
+//
 //    CGAL_precondition(!!curr);
-//    
+//
 //#endif
-//    //the actual locate. curr is the DAG root, the traits, 
+//    //the actual locate. curr is the DAG root, the traits,
 //    //the point to location, and 0 - indicates point location
 //    search_and_print_using_dag(out, curr,traits,p,Halfedge_const_handle());//m_empty_he_handle);
-//    
-//    
+//
+//
 //#ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-//    
+//
 //    locate_opt_push(curr.get_data());
-//    
+//
 //#endif
-//    
+//
 //    return *curr;
 //  }
 
@@ -1543,39 +1539,39 @@ public:
   {
     //print_dag_addresses(*m_dag_root);
 #ifdef CGAL_TD_DEBUG
-    
+
     CGAL_assertion(traits);
     CGAL_assertion(m_dag_root);
-    
+
 #endif
-    
+
     Dag_node curr = *m_dag_root; //MICHAL: is it ok to add &?
-    
+
 #ifdef CGAL_TD_DEBUG
-    
+
     CGAL_precondition(!!curr);
-    
+
 #endif
-    //the actual locate. curr is the DAG root, the traits, 
+    //the actual locate. curr is the DAG root, the traits,
     //the point to location, and 0 - indicates point location
     t = search_using_dag(curr,traits,p,Halfedge_const_handle());
-    
+
 #ifdef CGAL_TD_DEBUG
-    
+
     CGAL_postcondition(t == POINT || t == CURVE || t == TRAPEZOID ||
                        t == UNBOUNDED_TRAPEZOID);
-    
+
 #endif
-    
+
 #ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-    
+
     locate_opt_push(curr.get_data());
-    
+
 #endif
-    
+
     return *curr;
   }
-    
+
   //---------------------------------------------------------------------------
   // Description:
   //  returns the active trapezoid representing the input point.
@@ -1587,37 +1583,37 @@ public:
   //  locate call may change the class
   Td_map_item& locate(const Curve_end& ce, Locate_type& lt) const
   {
-    
+
 #ifdef CGAL_TD_DEBUG
-    
+
     CGAL_assertion(traits);
     CGAL_assertion(m_dag_root);
-    
+
 #endif
-    
+
     Dag_node curr = *m_dag_root; //MICHAL: is it ok to add &?
-    
-    //the actual locate. curr is the DAG root, the traits, 
-    //the end point to locate, 
+
+    //the actual locate. curr is the DAG root, the traits,
+    //the end point to locate,
     //and NULL as cv ptr - indicates point location
     lt = search_using_dag (curr, traits, ce, Halfedge_const_handle());
-    
+
 #ifdef CGAL_TD_DEBUG
-    
+
     CGAL_postcondition(lt == POINT || lt == CURVE || lt == TRAPEZOID ||
                        lt == UNBOUNDED_TRAPEZOID);
-    
+
 #endif
-    
+
 #ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-    
+
     locate_opt_push(curr.get_data());
-    
+
 #endif
-    
+
     return curr.get_data();
   }
-  
+
   //---------------------------------------------------------------------------
   // Description:
   //  returns the active trapezoid containing the point represented by vertex.
@@ -1635,16 +1631,16 @@ public:
 
   //---------------------------------------------------------------------------
   // Description:
-  // 
+  //
   // preconditions:
   //  p is not on an edge or a vertex.
   Td_map_item& vertical_ray_shoot(const Point& p,Locate_type& t,
                                   const bool up_direction = true) const;
-  
-  
+
+
   ////MICHAL: commented due to inefficient depth update, remove and insert instead
   //void before_split_edge(const X_monotone_curve_2& cv,
-  //                       const X_monotone_curve_2& cv1, 
+  //                       const X_monotone_curve_2& cv1,
   //                       const X_monotone_curve_2& cv2);
 
   ////MICHAL: commented due to inefficient depth update, remove and insert instead
@@ -1656,53 +1652,54 @@ public:
   //// precondition:
   ////  The two halfedges are valid
   ////  The first input curve is the union of the two halfedges.
-  ////  The intersection of the latter is a point inside the 
+  ////  The intersection of the latter is a point inside the
   ////  interior of the former.
   ////  The latter are ordered from left-down to right-up
   //// postcondition:
-  ////  The first input curve is broken into two halfedges 
+  ////  The first input curve is broken into two halfedges
   ////  corresponding to the input.
-  //void split_edge(const X_monotone_curve_2& cv, Halfedge_const_handle he1, 
+  //void split_edge(const X_monotone_curve_2& cv, Halfedge_const_handle he1,
   //                Halfedge_const_handle he2);
 
- 
+
   void merge_edge(Halfedge_const_handle he1, Halfedge_const_handle he2,
                   const X_monotone_curve_2& cv);
 
-  
-  void after_merge_edge(Halfedge_const_handle merged_he, 
-                        Halfedge_const_handle before_mrg_he)
+
+  void
+  after_merge_edge(Halfedge_const_handle CGAL_precondition_code(merged_he),
+                   Halfedge_const_handle CGAL_precondition_code(before_mrg_he))
   {
     //Precondition:
     // the merge uses the suspected halfedge before the arrangement merge
-    CGAL_precondition(merged_he == before_mrg_he || 
+    CGAL_precondition(merged_he == before_mrg_he ||
                       merged_he == before_mrg_he->twin());
   }
-  
+
 
   unsigned long size() const
   {
     return m_dag_root->size();
   }
-  
+
   unsigned long number_of_curves() const
   {
     return m_number_of_curves;
   }
-  
+
   void init_arrangement_and_traits(const Arrangement_on_surface_2* arr,
                                    bool allocate_traits = true)
   {
     m_arr = arr;
-    m_trts_adaptor = 
+    m_trts_adaptor =
       static_cast<const Traits_adaptor_2*> (arr->geometry_traits());
-    
+
     if (allocate_traits)
       traits = new Td_traits(*m_trts_adaptor);
   }
-  
-  
-  
+
+
+
 #ifdef CGAL_TD_DEBUG
   /*------------------------------------------------------------------
     description:
@@ -1712,7 +1709,7 @@ public:
   {
     if ( !ds ) return true;
     if (ds->is_valid(traits) && ds->dag_node() &&
-        is_valid(ds.left_child()) && is_valid(ds.right_child())) 
+        is_valid(ds.left_child()) && is_valid(ds.right_child()))
       return true;
     CGAL_warning(ds->is_valid(traits));
     CGAL_warning(ds->dag_node());
@@ -1736,12 +1733,12 @@ public:
   //  x.debug(); //MICHAL: will not work!
   //}
 #endif
-  
+
   /*------------------------------------------------------------------
     description:
-    Rebuilds the trapezoid data structure by reinserting the curves 
+    Rebuilds the trapezoid data structure by reinserting the curves
     in a random order in an empty data structure.
-    
+
     postcondition:
     The old and new data structures agree on their member curves.
     ------------------------------------------------------------------*/
@@ -1757,17 +1754,17 @@ public:
 #ifdef CGAL_TD_DEBUG
     unsigned long rep = Halfedge_filter(container, &dag_root());
 #endif
-    
+
     clear();
-    
+
     //// initialize container to point to curves in Td_map_item Tree
     //if (rep>0)
     //{
     //  bool o = set_with_guarantees(false);
-    //  typename std::vector<Halfedge_const_handle>::iterator 
+    //  typename std::vector<Halfedge_const_handle>::iterator
     //    it = container.begin(),
     //    it_end = container.end();
-    //  while(it!=it_end) 
+    //  while(it!=it_end)
     //  {
     //    insert(*it);
     //    ++it;
@@ -1778,7 +1775,7 @@ public:
     //insert the already inserted curves from scratch in order to build a
     // search structure guaranteeing logarithmic query time and linear size
     insert(container.begin(), container.end());
-     
+
 #ifdef CGAL_TD_DEBUG
     CGAL_assertion(is_valid());
     unsigned long sz = number_of_curves();
@@ -1789,21 +1786,21 @@ public:
       CGAL_assertion(number_of_curves() == rep);
     }
 #endif
-    
+
     container.clear();
     return *this;
   }
-  
-  /* 
-     Input:  
+
+  /*
+     Input:
      a list of pointers to Td_map_items and a Td_map_item boolean predicate.
-     Output: 
+     Output:
      void
      Postcondition:
      the list pointers correspond to all the Td_map_items in the data
-     structure for which the predicate value is true. 
+     structure for which the predicate value is true.
   */
-  
+
   template <typename Container, typename Predicate>
   void filter(Container& c, const Predicate& pr, const Dag_node * ds) const
   {
@@ -1819,7 +1816,7 @@ public:
 
   ////MICHAL: not in use
   //template <class Container>
-  //unsigned long Td_map_item_filter(Container& container, 
+  //unsigned long Td_map_item_filter(Container& container,
   //                                 const Dag_node* ds) const
   ///* Return a container for all active map items */
   //{
@@ -1828,7 +1825,7 @@ public:
   //}
 
   template <typename Halfedge_container>
-  unsigned long Halfedge_filter(Halfedge_container& container, 
+  unsigned long Halfedge_filter(Halfedge_container& container,
                                 const Dag_node* ds) const
   /* Return a container for all active curves */
   {
@@ -1836,13 +1833,13 @@ public:
     std::list<Td_map_item> representatives;
     //X_trapezoid_list representatives;
     ds->filter(representatives, Td_active_edge_item(*traits));
-    
+
 #ifndef CGAL_TD_DEBUG
-    
+
     CGAL_warning(sz==representatives.size());
-    
+
 #else
-    
+
     unsigned long rep=representatives.size();
     if (sz != rep)
     {
@@ -1850,9 +1847,9 @@ public:
       std::cerr << "\nrepresentatives.size()=" << rep;
       CGAL_assertion(number_of_curves()==representatives.size());
     }
-    
+
 #endif
-    
+
     if (sz > 0)
     {
       typename std::list<Td_map_item>::iterator it = representatives.begin(),
@@ -1871,9 +1868,9 @@ public:
     }
     return sz;
   }
-  
-  
-  
+
+
+
   /*------------------------------------------------------------------
     Input: None
     Output: bool
@@ -1883,7 +1880,7 @@ public:
     Postconditions:
     The output is true iff the depth of the Trapezoidal Tree is more then
     DepthThreshold times log of the X_curve count or the Trapezoidal Tree's
-    size 
+    size
     is more then SizeThreshold times the log of the last count.
   */
   bool set_with_guarantees(bool u)
@@ -1893,14 +1890,14 @@ public:
     return old;
   }
 
-  //This method occasionaly(!) checks the guarantees 
+  //This method occasionaly(!) checks the guarantees
   // It is currently not in use, since the guarantees are constantly checked in O(1) time
-  bool needs_update() 
+  bool needs_update()
   {
     unsigned long num_of_cv = number_of_curves();
     //to avoid signed / unsigned conversion warnings
     // rand() returns an int but a non negative one.
-    if (static_cast<unsigned long>(std::rand()) > 
+    if (static_cast<unsigned long>(std::rand()) >
         RAND_MAX / ( num_of_cv + 1))
       return false;
     /*       INTERNAL COMPILER ERROR overide
@@ -1909,10 +1906,10 @@ public:
 #ifdef CGAL_TD_REBUILD_DEBUG
     std::cout << "\n|heavy!" << std::flush;
 #endif
-    
+
     return not_within_limits();
   }
-  
+
   /*------------------------------------------------------------------
     input: None
     output: bool
@@ -1926,55 +1923,55 @@ public:
   bool update()
   {
     //if the structure violates the guarantees - rebuild
-    if (not_within_limits()) //needs_update()) 
+    if (not_within_limits()) //needs_update())
     {
-      rebuild(); 
+      rebuild();
       return true;
     }
-    
+
     return false;
   }
-  
+
   bool not_within_limits()
   {
     unsigned long num_of_cv = number_of_curves();
-    
+
     //Cond 1: Depth is greater than threshold*log(number of curves)
-    bool cond1 = largest_leaf_depth() > 
+    bool cond1 = largest_leaf_depth() >
                    (depth_threshold()*(std::log(double(num_of_cv+1))));
     //Cond 2: Number of nodes is greater than threshold*number of curves
     bool cond2 = number_of_dag_nodes() > (size_threshold()*(num_of_cv + 1));
-    
+
     //return true if at least one of the conditions is true
     return cond1 || cond2;
   }
 
   /* returns a reference to the internal data structure */
   const Dag_node& dag_root() const {return *m_dag_root;}
-  
+
   /* returns a reference to the internal data structure */
   const Traits& get_traits() const {return *traits;}
-  
+
   /* returns a reference to the internal depth threshold constant */
   const double& depth_threshold() const
   {
     return m_depth_threshold;
   }
-  
-  /* sets the internal depth threshold constant to the parameter and 
+
+  /* sets the internal depth threshold constant to the parameter and
      returns its reference */
   void depth_threshold(const double& depth_th)
   {
     m_depth_threshold = depth_th;
   }
-  
+
   /* returns a reference to the internal size threshold constant */
   const double& size_threshold() const
   {
     return m_size_threshold;
   }
-  
-  /* sets the internal size threshold constant to the parameter and 
+
+  /* sets the internal size threshold constant to the parameter and
      returns its reference */
   void size_threshold(const double& size_th)
   {
@@ -2007,35 +2004,35 @@ public:
 
 
 protected:
-  
+
   //Trapezoidal Decomposition data members
   Dag_node* m_dag_root;
   unsigned long m_largest_leaf_depth; //holds the leargest depth of a leaf in the DAG
   unsigned long m_number_of_dag_nodes; //holds the number of nodes in the DAG
-  bool m_with_guarantees; //whether the structure holds logarithmic query time and linear size guarantees //m_needs_update; 
+  bool m_with_guarantees; //whether the structure holds logarithmic query time and linear size guarantees //m_needs_update;
   unsigned long m_number_of_curves;
   const Traits* traits;
   //Before_split_data m_before_split;
   const Arrangement_on_surface_2* m_arr;
   const Traits_adaptor_2* m_trts_adaptor;
-  
+
   Halfedge_const_handle m_empty_he_handle;
 
 private:
-  
+
 #ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-  
+
   mutable Td_map_item last_cv;
   mutable Td_map_item prev_cv;
-  
+
 #endif
- 
+
   unsigned long longest_query_path_length_rec(bool minus_inf,
-                                              Dag_node& min_node, 
+                                              Dag_node& min_node,
                                               bool plus_inf,
                                               Dag_node& max_node,
                                               Dag_node& node);
-    
+
   void init()
   {
     // traits may be initialized later
@@ -2043,21 +2040,21 @@ private:
     //(*m_dag_root)->set_dag_node(m_dag_root);
     boost::apply_visitor(set_dag_node_visitor(m_dag_root),
                          m_dag_root->get_data());
-    
+
     m_number_of_curves = 0;
-    m_largest_leaf_depth = 0; 
+    m_largest_leaf_depth = 0;
     m_number_of_dag_nodes = 1; //the root is the only node in the DAG
-    
+
 #ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-    
+
     locate_opt_empty();
-    
+
 #endif
-    
+
   }
-  
+
 #ifndef CGAL_NO_TRAPEZOIDAL_DECOMPOSITION_2_OPTIMIZATION
-  
+
   void locate_opt_push(Td_map_item& cv_tr) const
   {
     prev_cv = last_cv;
@@ -2091,10 +2088,10 @@ private:
       //  {
       //    res = traits->equal_curve_end_2_object()(ce, *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),item)));
       //  }
-      //  else 
-      //  { 
+      //  else
+      //  {
       //    res = traits->equal_curve_end_2_object()(ce, boost::apply_visitor(point_for_vertex_visitor(), item));
-      //  }      
+      //  }
       //}
       if (traits->is_td_trapezoid(item))
         res = traits->is_inside(item,ce);
@@ -2109,28 +2106,28 @@ private:
       //  {
       //    res = traits->equal_curve_end_2_object()(ce, *(boost::apply_visitor(curve_end_for_fict_vertex_visitor(),item)));
       //  }
-      //  else 
-      //  { 
+      //  else
+      //  {
       //    res = traits->equal_curve_end_2_object()(ce, boost::apply_visitor(point_for_vertex_visitor(), item));
-      //  }      
+      //  }
       //}
       if (traits->is_td_trapezoid(item))
         res = traits->is_inside(item,ce);
     }
     if (res)
     {
-      if (traits->is_td_vertex(item)) 
+      if (traits->is_td_vertex(item))
         lt=POINT;
       else
       {
-        Td_active_trapezoid tr (boost::get<Td_active_trapezoid>(item));       
+        Td_active_trapezoid tr (boost::get<Td_active_trapezoid>(item));
         lt = tr.is_on_boundaries()? UNBOUNDED_TRAPEZOID : TRAPEZOID;
       }
     }
     else
       item = locate(ce,lt);
   }
-  
+
 #endif
 
 
@@ -2155,7 +2152,7 @@ private:
   {
     Arr_parameter_space ps_x = traits->parameter_space_in_x_2_object()(cv, ce);
     Arr_parameter_space ps_y = traits->parameter_space_in_y_2_object()(cv, ce);
-    
+
     if (ps_x == ARR_INTERIOR && ps_y == ARR_INTERIOR)
     {
       if (ce == ARR_MIN_END)
@@ -2197,27 +2194,27 @@ private:
         out << " , y -> +oo " << std::endl;
       else
         out << " , y -> -oo " << std::endl;
-    
+
     }
   }
 
 
   void print_dag_addresses(const Dag_node& curr) const
   {
-    
+
     std::cout << "----------------- DAG ----------------" <<std::endl
               << "--------------------------------------" <<std::endl;
-    
+
     print_dag_addresses_rec(curr, 0);
     std::cout << "----------------- END OF DAG ----------------" <<std::endl
               << "---------------------------------------------" <<std::endl;
-    
+
   }
-  
+
   void print_dag_addresses_rec(const Dag_node& curr ,int level,
                                std::ostream& out = std::cout) const
   {
-    
+
     out << "------ level " << level << ", depth " << curr.depth()
         << " ------\n";
     out << " (void *)curr : " << (void *)(&curr) << std::endl;
@@ -2228,9 +2225,9 @@ private:
     //item holds the trapezoidal map item connected to curr.
     Td_map_item item = curr.get_data();
     if (traits->is_td_vertex(item))
-    { 
+    {
       out << " POINT : " ;
-      
+
       // if the map item represents a fictitious vertex
       if (traits->is_fictitious_vertex(item))
       {
@@ -2251,13 +2248,13 @@ private:
       return;
     }
     if (traits->is_td_edge(item))
-    { 
+    {
       // bool is_active = traits->is_active(item);
       // if the map item represents an edge
       const X_monotone_curve_2& he_cv = *(boost::apply_visitor(cv_for_edge_visitor(), item));
-      
+
       //   so top() is a real Halfedge with a curve() if curr is active
-      //   or curr holds the curve if curr is not active 
+      //   or curr holds the curve if curr is not active
       out << " CURVE : " ;
       print_cv_data(he_cv, out);
       out << "          (void *)left_child: " << (void*)(&(curr.left_child()))
@@ -2285,17 +2282,17 @@ private:
     }
   }
 
-public: 
+public:
   void print_dag(std::ostream& out) const
   {
-    
+
     out << "----------------- DAG ----------------" << std::endl
         << "--------------------------------------" << std::endl;
-    
+
     print_dag_addresses_rec(*m_dag_root , 0, out);
     out << "----------------- END OF DAG ----------------" << std::endl
         << "---------------------------------------------" << std::endl;
-    
+
   }
 
 protected:

--- a/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
@@ -33,6 +33,7 @@
 #include <CGAL/tags.h>
 #include <CGAL/Arr_non_caching_segment_traits_2.h>
 #include <CGAL/Arr_geometry_traits/Polycurve_2.h>
+#include <CGAL/Arr_geometry_traits/IO/Polycurve_2_iostream.h>
 #include <CGAL/Arr_tags.h>
 #include <CGAL/Arr_enums.h>
 
@@ -1058,7 +1059,7 @@ public:
       std::vector<X_monotone_subcurve_2> rev_segs(xcv.number_of_subcurves());;
       typename X_monotone_curve_2::Subcurve_const_iterator sit;
       typename X_monotone_curve_2::Subcurve_iterator tit = rev_segs.begin();
-      for (sit = xcv.begin_subcurves(); sit != xcv.end_subcurves(); ++sit)
+      for (sit = xcv.subcurves_begin(); sit != xcv.subcurves_end(); ++sit)
         *tit++ = const_op(*sit);
       return X_monotone_curve_2(rev_segs.rbegin(), rev_segs.rend());
     }
@@ -1800,7 +1801,7 @@ public:
     {
       const Subcurve_traits_2* geom_traits = m_poly_traits.subcurve_traits_2();
       typename X_monotone_curve_2::Subcurve_const_iterator it;
-      for (it = xcv.begin_subcurves(); it != xcv.end_subcurves(); ++it)
+      for (it = xcv.subcurves_begin(); it != xcv.subcurves_end(); ++it)
         if (! geom_traits->is_on_y_identification_2_object()(*it)) return false;
       return true;
     }
@@ -1845,7 +1846,7 @@ public:
     {
       const Subcurve_traits_2* geom_traits = m_poly_traits.subcurve_traits_2();
       typename X_monotone_curve_2::Subcurve_const_iterator it;
-      for (it = xcv.begin_subcurves(); it != xcv.end_subcurves(); ++it)
+      for (it = xcv.subcurves_begin(); it != xcv.subcurves_end(); ++it)
         if (! geom_traits->is_on_x_identification_2_object()(*it)) return false;
       return true;
     }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_traits_2.h
@@ -208,7 +208,7 @@ public:
       // that each Object wraps an x-monotone subcurve.
       std::vector<Object> x_seg_objects;
       const_seg_iterator it_segs;
-      for (it_segs = cv.begin_subcurves(); it_segs != cv.end_subcurves();
+      for (it_segs = cv.subcurves_begin(); it_segs != cv.subcurves_end();
            ++it_segs)
         make_seg_x_monotone(*it_segs, std::back_inserter(x_seg_objects));
       typename std::vector<Object>::iterator it = x_seg_objects.begin();
@@ -349,7 +349,7 @@ public:
       // that each Object wraps an x-monotone subcurve.
       std::vector<Object> x_seg_objects;
       const_seg_iterator it_segs;
-      for (it_segs = cv.begin_subcurves(); it_segs != cv.end_subcurves();
+      for (it_segs = cv.subcurves_begin(); it_segs != cv.subcurves_end();
            ++it_segs)
         make_seg_x_monotone(*it_segs, std::back_inserter(x_seg_objects));
       typename std::vector<Object>::iterator it = x_seg_objects.begin();

--- a/Arrangement_on_surface_2/include/CGAL/Arr_topology_traits/Arr_spherical_topology_traits_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_topology_traits/Arr_spherical_topology_traits_2_impl.h
@@ -12,9 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-//
 // Author(s)     : Efi Fogel         <efif@post.tau.ac.il>
 //                 Ron Wein          <wein@post.tau.ac.il>
 
@@ -523,7 +520,12 @@ CGAL::Object
 Arr_spherical_topology_traits_2<GeomTraits, Dcel>::
 place_boundary_vertex(Face* /* f */,
                       const X_monotone_curve_2& xc, Arr_curve_end ind,
-                      Arr_parameter_space ps_x, Arr_parameter_space ps_y)
+                      Arr_parameter_space
+#if !defined(CGAL_NO_ASSERTIONS)
+                      ps_x
+#endif
+                      ,
+                      Arr_parameter_space ps_y)
 {
   // std::cout << "place_boundary_vertex()" << std::endl;
   if (ps_y == ARR_BOTTOM_BOUNDARY) {
@@ -560,7 +562,11 @@ Arr_spherical_topology_traits_2<GeomTraits,Dcel>::
 locate_around_boundary_vertex(Vertex* v,
                               const X_monotone_curve_2& xc,
                               Arr_curve_end ind,
-                              Arr_parameter_space ps_x,
+                              Arr_parameter_space
+#if !defined(CGAL_NO_ASSERTIONS)
+                              ps_x
+#endif
+                              ,
                               Arr_parameter_space ps_y) const
 {
   // std::cout << "locate_around_boundary_vertex()" << std::endl;
@@ -583,7 +589,12 @@ locate_around_boundary_vertex(Vertex* v,
 template <typename GeomTraits, typename Dcel>
 CGAL::Object Arr_spherical_topology_traits_2<GeomTraits, Dcel>::
 locate_curve_end(const X_monotone_curve_2& xc, Arr_curve_end ind,
-                 Arr_parameter_space ps_x, Arr_parameter_space ps_y)
+                 Arr_parameter_space
+#if !defined(CGAL_NO_ASSERTIONS)
+                 ps_x
+#endif
+                 ,
+                 Arr_parameter_space ps_y)
 {
   // Act according to the boundary conditions.
   if (ps_y == ARR_TOP_BOUNDARY) {

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2007,2008,2009,2010,2011 Max-Planck-Institute Saarbruecken (Germany), 
+// Copyright (c) 2007,2008,2009,2010,2011 Max-Planck-Institute Saarbruecken (Germany),
 // and Tel-Aviv University (Israel).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org); you can redistribute it and/or
@@ -11,10 +11,6 @@
 //
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
 //
 // Author(s)     : Eric Berberich <eric@mpi-inf.mpg.de>
 //                 Pavel Emeliyanenko <asm@mpi-sb.mpg.de>
@@ -62,7 +58,7 @@ namespace internal {
  * Default representation class for Arc_2
  */
 template < class CurvedKernelViaAnalysis_2 >
-class Arc_2_rep { 
+class Arc_2_rep {
 
 public:
     //!\name Public types
@@ -70,20 +66,20 @@ public:
 
     //! this instance's first template parameter
     typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
-    
+
     //! myself
     typedef Arc_2_rep< Curved_kernel_via_analysis_2 > Self;
 
     //! type of curve kernel
     typedef typename Curved_kernel_via_analysis_2::Curve_kernel_2
     Curve_kernel_2;
-    
+
     //! type of curve that can be analzed
     typedef typename Curve_kernel_2::Curve_analysis_2 Curve_analysis_2;
-    
+
     //! type of a point on a point that can be analyzed
     typedef typename Curved_kernel_via_analysis_2::Point_2 Point_2;
-    
+
     //! type of boundary value in x-range of an arc
     typedef typename Curve_kernel_2::Bound Bound;
 
@@ -92,29 +88,29 @@ public:
 public:
     //!\name Constructors
     //!@{
-    
+
     //! default constructor
-    Arc_2_rep() : 
-        _m_arcno(-1), _m_arcno_min(-1), _m_arcno_max(-1), 
+    Arc_2_rep() :
+        _m_arcno(-1), _m_arcno_min(-1), _m_arcno_max(-1),
         _m_is_vertical(false),
         _m_left_to_right(1) {
     }
-    
+
     //! copy constructor
     Arc_2_rep(const Self& s):
         _m_min(s._m_min), _m_max(s._m_max),
         _m_support(s._m_support),
-        _m_arcno(s._m_arcno), 
-        _m_arcno_min(s._m_arcno_min), 
+        _m_arcno(s._m_arcno),
+        _m_arcno_min(s._m_arcno_min),
         _m_arcno_max(s._m_arcno_max),
         _m_is_vertical(s._m_is_vertical),
         _m_left_to_right(s._m_left_to_right) {
     }
-    
+
     //! standard constructor
-    Arc_2_rep(const Point_2& p, const Point_2& q, const Curve_analysis_2& c, 
+    Arc_2_rep(const Point_2& p, const Point_2& q, const Curve_analysis_2& c,
               int arcno = -1, int arcno_p = -1, int arcno_q = -1,
-              bool is_vertical = false) : 
+              bool is_vertical = false) :
         _m_min(p), _m_max(q),
         _m_support(c),
         _m_arcno(arcno), _m_arcno_min(arcno_p), _m_arcno_max(arcno_q),
@@ -135,13 +131,13 @@ public:
 public:
     //!\name Data members
     //!@{
-    
+
     //! minimal end-points of an arc
     mutable Point_2 _m_min;
 
     //! maximal end-points of an arc
     mutable Point_2 _m_max;
-    
+
     //! supporting curve
     mutable Curve_analysis_2 _m_support;
 
@@ -153,10 +149,10 @@ public:
 
     //! arcno at max
     mutable int _m_arcno_max;
-    
+
     //! indicates whether arc is vertical
     mutable bool _m_is_vertical;
-    
+
     //! stores a direction (left to right, right to left)
     mutable bool _m_left_to_right;
 
@@ -173,9 +169,9 @@ public:
 };
 
 
-/*!\brief 
+/*!\brief
  * Class defines an arc on a curve that can be analyzed
- * 
+ *
  * An arc is either non-vertical or vertical. If it is non-vertical,
  * we can assign a constant arc number to its interior and we may can assign
  * (non-identical) arc numbers to its end-points. It depends on whether
@@ -183,19 +179,19 @@ public:
  * If it is vertical, no arc number is available.
  *
  * We distinguish between interior arcs, rays, and branches. An interior arc
- * lies completely in the interior of the parameter space, 
- * while a ray has one end that lies on the boundary of the parameter space, 
+ * lies completely in the interior of the parameter space,
+ * while a ray has one end that lies on the boundary of the parameter space,
  * and a branch has two end that lie on the boundary.
- * 
+ *
  */
 template < class CurvedKernelViaAnalysis_2, class Rep_ >
 class Arc_2 :
         public CGAL::Handle_with_policy< Rep_ > {
-  
+
 public:
     //!\name Public types
     //!@{
-    
+
     //! this instance's first template parameter
     typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
 
@@ -204,34 +200,34 @@ public:
 
     //! this instance itself
     typedef Arc_2< Curved_kernel_via_analysis_2, Rep > Self;
-    
+
     //! type of curve kernel
     typedef typename Curved_kernel_via_analysis_2::Curve_kernel_2
     Curve_kernel_2;
-    
+
     //! type of an x-coordinate
     typedef typename Curve_kernel_2::Coordinate_1 Coordinate_1;
 
     //! type of an xy-coordinate
     typedef typename Curve_kernel_2::Coordinate_2 Coordinate_2;
-    
+
     //! type of "rational" value in x-range
     typedef typename Curve_kernel_2::Bound Bound;
-    
+
     //! type of analysis of a pair of curves
     typedef typename Curve_kernel_2::Curve_analysis_2 Curve_analysis_2;
-    
+
     //! type of analysis of a pair of curves
     typedef typename Curve_kernel_2::Curve_pair_analysis_2
     Curve_pair_analysis_2;
-    
+
     //! type of a kernel point
     typedef typename Curved_kernel_via_analysis_2::Point_2 Point_2;
     // Remark: Point_2 is already Kernel_point_2 -> no need to introduce it
 
     //! type of kernel arc
     typedef typename Curved_kernel_via_analysis_2::Arc_2 Kernel_arc_2;
-    
+
     //! the handle superclass
     typedef ::CGAL::Handle_with_policy< Rep > Base;
 
@@ -240,9 +236,9 @@ public:
 public:
     //!\name Rebind
     //!{
-    
+
     /*!\brief
-     * An auxiliary structure for rebinding the arc with a NewCKvA_2 and a 
+     * An auxiliary structure for rebinding the arc with a NewCKvA_2 and a
      * NewRep
      */
     template < typename NewCKvA_2, typename NewRep >
@@ -260,14 +256,14 @@ public:
 
         //! surface point type
         typedef typename Other::Point_2 New_point_2;
-        
+
         //! type of rebound arc
         typedef typename New_curved_kernel_via_analysis_2::Arc_2 Rebound_arc_2;
 
         /*!\brief
-         * Constructs supporting arc of type \c Rebound_arc_2 from the 
+         * Constructs supporting arc of type \c Rebound_arc_2 from the
          * (possible unbounded) \c arc
-         * of type \c Self and replaces \c min and \c max point by the 
+         * of type \c Self and replaces \c min and \c max point by the
          * given instances.
          *
          * All known items of the base class rep will be copied.
@@ -277,15 +273,15 @@ public:
          * \param max New endpoint at max
          * \return An arc of type \c Rebound_arc_2
          */
-        Rebound_arc_2 operator()(const Self& arc, 
+        Rebound_arc_2 operator()(const Self& arc,
                                  const New_point_2& min,
                                  const New_point_2& max) {
             New_rep newrep;
             newrep._m_min = min;
             newrep._m_max = max;
-            
+
             copy_members(arc, newrep);
-            
+
             return Rebound_arc_2(newrep);
         }
 
@@ -304,10 +300,10 @@ public:
             // else
             return arc._maxpoint();
         }
-        
+
         // TODO move to SfA_2l
         /*!\brief
-         * Reverse rebind, that is extracts original arc type from a 
+         * Reverse rebind, that is extracts original arc type from a
          * rebound instance
          *
          * \param arc A rebound arc
@@ -315,12 +311,12 @@ public:
          */
         Self operator()(const Rebound_arc_2& arc) {
             Rep rep;
-            
+
             rep._m_min = typename New_point_2::Rebind()(arc._minpoint());
             rep._m_max = typename New_point_2::Rebind()(arc._maxpoint());
-            
+
             rep._m_support = arc.ptr()->_m_support;
-            
+
             rep._m_arcno = arc.ptr()->_m_arcno;
             rep._m_arcno_min = arc.ptr()->_m_arcno_min;
             rep._m_arcno_max = arc.ptr()->_m_arcno_max;
@@ -330,23 +326,23 @@ public:
 
             rep._m_interval_id = arc.ptr()->_m_interval_id;
 
-            rep._m_boundary_in_interval = 
+            rep._m_boundary_in_interval =
                 arc.ptr()->_m_boundary_in_interval;
-            
+
             return Self(rep);
         }
 
     protected:
         /*!\brief
          * copies main members to a rep
-         * 
+         *
          * \param arc Source arc
          * \param newrep Destination representation
          */
         void copy_members(const Self& arc, New_rep& newrep) {
-            
+
             newrep._m_support = arc.ptr()->_m_support;
-            
+
             newrep._m_arcno = arc.ptr()->_m_arcno;
             newrep._m_arcno_min = arc.ptr()->_m_arcno_min;
             newrep._m_arcno_max = arc.ptr()->_m_arcno_max;
@@ -356,13 +352,13 @@ public:
 
             newrep._m_interval_id = arc.ptr()->_m_interval_id;
 
-            newrep._m_boundary_in_interval = 
+            newrep._m_boundary_in_interval =
                 arc.ptr()->_m_boundary_in_interval;
         }
     };
 
     //!}
-    
+
 public:
     //!\name basic constructors
     //!@{
@@ -370,26 +366,26 @@ public:
     /*!\brief
      * Default constructor
      */
-    Arc_2() : 
-        Base(Rep()) {   
+    Arc_2() :
+        Base(Rep()) {
     }
 
     /*!\brief
      * copy constructor
      */
-    Arc_2(const Self& a) : 
-        Base(static_cast<const Base&>(a)) {  
+    Arc_2(const Self& a) :
+        Base(static_cast<const Base&>(a)) {
     }
 
     //!@}
-    
+
 public:
     //!\name Constructors for non-vertical arcs
     //!@{
-    
-    /*!\brief 
+
+    /*!\brief
      * Constructs an arc with two interior end-points (segment).
-     * 
+     *
      * \param p first endpoint
      * \param q second endpoint
      * \param c The supporting curve
@@ -397,14 +393,14 @@ public:
      * \param arcno_p The arcnumber wrt \c c of the arc at \c p
      * \param arcno_q The arcnumber wrt \c c of the arc at \c q
      * \returns The constructed segment
-     * 
+     *
      * \pre p.x() != q.x()
      *
      */
     Arc_2(const Point_2& p, const Point_2& q, const Curve_analysis_2& c,
-          int arcno, int arcno_p, int arcno_q) : 
-        Base(Rep(p, q, c, arcno, arcno_p, arcno_q)) { 
-        
+          int arcno, int arcno_p, int arcno_q) :
+        Base(Rep(p, q, c, arcno, arcno_p, arcno_q)) {
+
         CGAL_precondition(!p.is_identical(q));
         CGAL_precondition(Curved_kernel_via_analysis_2::instance().
                           compare_x_2_object()(p,q) != CGAL::EQUAL);
@@ -416,10 +412,10 @@ public:
         // check end-points arcnos validity and coprimality condition
         // for supporting curves
         _check_pt_arcno_and_coprimality(p, arcno_p, c);
-        _check_pt_arcno_and_coprimality(q, arcno_q, c);    
+        _check_pt_arcno_and_coprimality(q, arcno_q, c);
         _fix_curve_ends_order(); // lexicographical order of curve ends
     }
-      
+
    /*!\brief
      * Constructs an arc with one interior end-point and another end
      * at the left or right boundary of the parameter space (ray I).
@@ -429,13 +425,13 @@ public:
      *        boundary
      * \param c The supporting curve
      * \param arcno The arcnumber wrt \c c in the interior of the arc
-     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin 
+     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
      * \return The constructed ray
      */
-    Arc_2(const Point_2& origin, CGAL::Arr_curve_end inf_end, 
+    Arc_2(const Point_2& origin, CGAL::Arr_curve_end inf_end,
           const Curve_analysis_2& c, int arcno, int arcno_o) :
         Base(Rep(origin, Point_2(inf_end, c, arcno), c, arcno, arcno_o)) {
-        
+
         CGAL_precondition(arcno >= 0);
         CGAL_precondition(arcno_o >= 0);
         // check end-points arcnos validity and coprimality condition
@@ -444,10 +440,10 @@ public:
         _check_pt_arcno_and_coprimality(origin, arcno_o, c);
         _fix_curve_ends_order(); // lexicographical order of curve ends
     }
-    
-    
+
+
     /*!\brief
-     * Constructs a non-vertical arc with one interior end-point and whose 
+     * Constructs a non-vertical arc with one interior end-point and whose
      * other end approaches a vertical asymptote (ray II)
      *
      * \param origin The interior end-point
@@ -455,19 +451,19 @@ public:
      * \param inf_end Arc is approaching the bottom or top boundary
      * \param c The supporting curve
      * \param arcno The arcnumber wrt \c c in the interior of the arc
-     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin 
+     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
      * \return The constructed ray
      *
      * \pre origin.x() != asympt_x
      */
-    Arc_2(const Point_2& origin, const Coordinate_1& asympt_x, 
+    Arc_2(const Point_2& origin, const Coordinate_1& asympt_x,
           CGAL::Arr_curve_end inf_end, const Curve_analysis_2& c, int arcno,
           int arcno_o) :
         Base(Rep(origin, Point_2(asympt_x, c, inf_end), c, arcno, arcno_o)) {
-        
+
         CGAL_precondition(
                 Curved_kernel_via_analysis_2::instance().
-                kernel().compare_1_object()(origin.x(), asympt_x) 
+                kernel().compare_1_object()(origin.x(), asympt_x)
                 != CGAL::EQUAL);
         CGAL_precondition(arcno >= 0);
         CGAL_precondition(arcno_o >= 0);
@@ -489,40 +485,40 @@ public:
                  Point_2(CGAL::ARR_MAX_END, c, arcno), c, arcno)) {
 
         CGAL_precondition(arcno >= 0);
-        _fix_curve_ends_order(); 
+        _fix_curve_ends_order();
     }
-    
+
     /*!\brief
      * Constructs a non-vertical arc with two ends approaching vertical
      * asymptotes (branch II).
      *
      * \param asympt_x1 The x-coordinate of the first asymptote
-     * \param inf_end1 Arc is approaching the bottom or top boundary at 
+     * \param inf_end1 Arc is approaching the bottom or top boundary at
      *                 \c asympt_x1
      * \param asympt_x2 The x-coordinate of the second asymptote
-     * \param inf_end2 Arc is approaching the bottom or top boundary at 
+     * \param inf_end2 Arc is approaching the bottom or top boundary at
      *                 \c asympt_x2
      * \return The constructed branch
      *
      * \pre asympt_x1 != asympt_x2
      */
-    Arc_2(const Coordinate_1& asympt_x1, CGAL::Arr_curve_end inf_end1, 
+    Arc_2(const Coordinate_1& asympt_x1, CGAL::Arr_curve_end inf_end1,
           const Coordinate_1& asympt_x2, CGAL::Arr_curve_end inf_end2,
           const Curve_analysis_2& c, int arcno) :
-        Base(Rep(Point_2(asympt_x1, c, inf_end1), 
+        Base(Rep(Point_2(asympt_x1, c, inf_end1),
                  Point_2(asympt_x2, c, inf_end2),
                  c, arcno)) {
 
         CGAL_precondition(
                 Curved_kernel_via_analysis_2::instance().
-                kernel().compare_1_object()(asympt_x1, asympt_x2) 
+                kernel().compare_1_object()(asympt_x1, asympt_x2)
                 != CGAL::EQUAL);
         CGAL_precondition(arcno >= 0);
         _fix_curve_ends_order();
     }
-    
+
     /*!\brief
-     * Construct a non-vertical arc with one left- or right-boundary end 
+     * Construct a non-vertical arc with one left- or right-boundary end
      * and one end that approaches a vertical asymptote (branch III)
      *
      * \param inf_endx Defining whether the arc emanates from the left or right
@@ -531,37 +527,37 @@ public:
      * \param inf_endy Arc is approaching the bottom or top boundary at
      *                 asympt_x
      * \return The constructed branch
-     */ 
+     */
     Arc_2(CGAL::Arr_curve_end inf_endx, const Coordinate_1& asympt_x,
           CGAL::Arr_curve_end inf_endy, const Curve_analysis_2& c, int arcno) :
-        Base(Rep(Point_2(inf_endx, c, arcno), 
+        Base(Rep(Point_2(inf_endx, c, arcno),
                  Point_2(asympt_x, c, inf_endy), c, arcno)) {
-        
-        CGAL_precondition(arcno >= 0); 
+
+        CGAL_precondition(arcno >= 0);
         _fix_curve_ends_order();
     }
-    
+
     //!@}
-    
+
 public:
     //!\name Constructors for vertical arcs
     //!@{
-    
-    /*!\brief 
-     * Constructs a vertical arc with two interior end-points 
+
+    /*!\brief
+     * Constructs a vertical arc with two interior end-points
      * (vertical segment)
      *
      * \param p The first end-point
      * \param q The second end-point
      * \param c The supporting curve
      * \return The constructed arc
-     * 
+     *
      * \pre p != q && p.x() == q.x()
      * \pre c must have a vertical component at this x
      */
-    Arc_2(const Point_2& p, const Point_2& q, const Curve_analysis_2& c) : 
-        Base(Rep(p, q, c, -1, -1, -1, true)) {  
-        
+    Arc_2(const Point_2& p, const Point_2& q, const Curve_analysis_2& c) :
+        Base(Rep(p, q, c, -1, -1, -1, true)) {
+
         CGAL_precondition(!p.is_identical(q));
         CGAL_precondition(Curved_kernel_via_analysis_2::instance().
                           compare_x_2_object()(p,q) == CGAL::EQUAL);
@@ -572,9 +568,9 @@ public:
         _check_pt_arcno_and_coprimality(p, -1, c);
         _fix_curve_ends_order();
     }
-    
+
     /*!\brief
-     * Constructs a vertical arc with one interior end-point and 
+     * Constructs a vertical arc with one interior end-point and
      * one that reaches the bottom or top boundary (vertical ray)
      *
      * \param origin The interior end-point
@@ -585,46 +581,46 @@ public:
      */
     Arc_2(const Point_2& origin, CGAL::Arr_curve_end inf_end,
           const Curve_analysis_2& c) :
-        Base(Rep(origin, Point_2(origin.x(), c, inf_end), 
+        Base(Rep(origin, Point_2(origin.x(), c, inf_end),
                  c, -1, -1, -1, true)) {
-        
+
         // check coprimality condition for supporting curves
         _check_pt_arcno_and_coprimality(origin, -1, c);
         _fix_curve_ends_order();
     }
-    
+
     /*!\brief
      * Constructs a vertical arc that connects bottom with top boundary
      * (vertical branch)
      *
      * \param x The x-coordinate of the arc
      * \return The constructed branch
-     * 
+     *
      * \pre c must have a vertical line component at this x
      */
     Arc_2(const Coordinate_1& x, const Curve_analysis_2& c) :
-        Base(Rep(Point_2(x, c, CGAL::ARR_MIN_END), 
+        Base(Rep(Point_2(x, c, CGAL::ARR_MIN_END),
                  Point_2(x, c, CGAL::ARR_MAX_END), c, -1, -1, -1, true)) {
-        
+
         _fix_curve_ends_order();
     }
-   
+
     //!@}
 
-protected:    
+protected:
     //!\name Constructor for replace endpoints + rebind
     //!@{
-    
+
     /*!\brief
      * Constructs an arc from a given representation used in rebind
      *
      * \param rep Input representation
      * \return The constructed arc
      */
-    Arc_2(Rep rep) : 
-        Base(rep) { 
+    Arc_2(Rep rep) :
+        Base(rep) {
     }
-    
+
     //!@}
 
 public:
@@ -636,7 +632,7 @@ public:
      */
     virtual ~Arc_2() {
     }
-    
+
     //!@}
 
 #define CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(X, Y) \
@@ -647,7 +643,7 @@ public:
 public:
     //!\name Parameter space
     //!@{
-    
+
     /*!\brief
      * location of arc's end
      *
@@ -660,7 +656,7 @@ public:
         }
         return _maxpoint().location();
     }
-    
+
     /*!\brief
      *  Sets boundary type for an end of an arc
      *
@@ -670,17 +666,17 @@ public:
      * \param ce The intended end
      * \param loc The location to store
      */
-    void set_location(CGAL::Arr_curve_end ce, 
+    void set_location(CGAL::Arr_curve_end ce,
                       CGAL::Arr_parameter_space loc) const {
-        (ce == CGAL::ARR_MIN_END ? 
+        (ce == CGAL::ARR_MIN_END ?
          _minpoint().set_location(loc) : _maxpoint().set_location(loc));
     }
-    
+
     //!@}
 
     //!\name Access functions
     //!@{
-    
+
     /*!\brief
      * Is a curve-end finite?
      *
@@ -688,21 +684,21 @@ public:
      * \return \c true, if finite, \c false, otherwise
      */
     bool is_finite(CGAL::Arr_curve_end ce) const {
-        const Point_2& pt = 
+        const Point_2& pt =
             (ce == CGAL::ARR_MIN_END ? _minpoint() : _maxpoint());
         return pt.is_finite();
     }
 
-    /*!\brief 
+    /*!\brief
      * returns arc's interior curve end
-     * 
+     *
      * \param ce The intended end
      * \return The minimal point of the arc, or the maximal point of the arc
      *
      *  \pre accessed curve end has finite coordinates
      */
     Point_2 curve_end(CGAL::Arr_curve_end ce) const {
-        const Point_2& pt = 
+        const Point_2& pt =
             (ce == CGAL::ARR_MIN_END ? _minpoint() : _maxpoint());
 #if !CGAL_ARRANGEMENT_ON_DUPIN_CYCLIDE
         CGAL_precondition(pt.location() == CGAL::ARR_INTERIOR ||
@@ -711,9 +707,9 @@ public:
         return pt;
     }
 
-    /*!\brief 
+    /*!\brief
      * returns x-coordinate of arc's curve end
-     * 
+     *
      * \param ce The intended end
      * \return x-coordinate of arc's end at \c ce
      *
@@ -729,28 +725,28 @@ public:
 
     /*!\brief
      * supporting curve of the arc
-     * 
+     *
      * \return supporting curve of the arc
      */
     inline
     const Curve_analysis_2& curve() const {
-        return this->ptr()->_m_support; 
+        return this->ptr()->_m_support;
     }
-  
+
     /*!\brief arc number in interior
-     * 
-     * \return arc number 
-     * 
+     *
+     * \return arc number
+     *
      * \pre !is_vertical()
      */
     inline
-    int arcno() const { 
+    int arcno() const {
         CGAL_precondition(!is_vertical());
-        return this->ptr()->_m_arcno; 
+        return this->ptr()->_m_arcno;
     }
 
     /*!\brief
-     * arc number of end of arc, which may be different from arc number in its 
+     * arc number of end of arc, which may be different from arc number in its
      * interior
      *
      * \param ce The intended end
@@ -763,8 +759,8 @@ public:
         return (ce == CGAL::ARR_MIN_END ? this->ptr()->_m_arcno_min :
                 this->ptr()->_m_arcno_max);
     }
-    
-    /*!\brief 
+
+    /*!\brief
      * arc number at given x-coordinate
      *
      * If \c x0 is equal to source's or target's x-coordinate,
@@ -781,17 +777,17 @@ public:
         CGAL_precondition(!is_vertical());
         CGAL_precondition(is_in_x_range(x0));
 
-        if (this->ptr()->_m_arcno_min != this->ptr()->_m_arcno && 
+        if (this->ptr()->_m_arcno_min != this->ptr()->_m_arcno &&
             is_finite(CGAL::ARR_MIN_END) &&
             Curved_kernel_via_analysis_2::instance().
-            kernel().compare_1_object()(x0, _minpoint().x()) == 
+            kernel().compare_1_object()(x0, _minpoint().x()) ==
             CGAL::EQUAL) {
             return this->ptr()->_m_arcno_min;
         }
-        if (this->ptr()->_m_arcno_max != this->ptr()->_m_arcno && 
+        if (this->ptr()->_m_arcno_max != this->ptr()->_m_arcno &&
             is_finite(CGAL::ARR_MAX_END) &&
             Curved_kernel_via_analysis_2::instance().
-            kernel().compare_1_object()(x0, _maxpoint().x()) == 
+            kernel().compare_1_object()(x0, _maxpoint().x()) ==
             CGAL::EQUAL) {
             return this->ptr()->_m_arcno_max;
         }
@@ -799,7 +795,7 @@ public:
     }
 
     /*!\brief
-     * checks if the arc is vertical 
+     * checks if the arc is vertical
      *
      * \return \c true, if vertical, \c false, otherwise
      */
@@ -819,7 +815,7 @@ public:
         CGAL_precondition(is_vertical());
         return _minpoint().x();
     }
-    
+
     //!@}
 
     //!\name Direction
@@ -834,13 +830,13 @@ public:
     bool is_left_to_right() const {
       return this->ptr()->_m_left_to_right;
     }
-  
+
     /*! Flip the arc . */
     Arc_2 flip () const  {
       Arc_2   opp(*this);
       opp.copy_on_write();
       opp.ptr()->_m_left_to_right = !this->ptr()->_m_left_to_right;
-      
+
       return opp;
     }
 
@@ -850,7 +846,7 @@ public:
     //!@{
 
     /*!\brief
-     * returns the index of an open interval between two events of the 
+     * returns the index of an open interval between two events of the
      * curve the arc belongs to
      *
      * \return interval id of supporting curve for this arc
@@ -859,23 +855,23 @@ public:
     inline
     int interval_id() const {
         CGAL_precondition(!is_vertical());
-        if(!this->ptr()->_m_interval_id) 
+        if(!this->ptr()->_m_interval_id)
             this->ptr()->_m_interval_id = _compute_interval_id();
         return *(this->ptr()->_m_interval_id);
     }
-    
-    
+
+
     /*!\brief
      * returns boundary value in interior of x-range of non-vertical
      * interval
-     * 
-     * \return a rational x-coordinate in the interior of the arc's x-range 
+     *
+     * \return a rational x-coordinate in the interior of the arc's x-range
      * \pre !is_vertical()
      */
     Bound boundary_in_x_range_interior() const {
         CGAL_precondition(!is_vertical());
         if(!this->ptr()->_m_boundary_in_interval) {
-            this->ptr()->_m_boundary_in_interval = 
+            this->ptr()->_m_boundary_in_interval =
                 _compute_boundary_in_interval();
             CGAL_postcondition_code(
                     typename Curve_analysis_2::Status_line_1 cv_line =
@@ -895,17 +891,17 @@ public:
 public:
     //! \name Shortcuts for code readability
     //!@{
-    
+
     //! tests whether this boundary type represents +/-oo
     inline static bool is_infinite(/*CGAL::Arr_boundary_type bnd*/) {
         return false; //(bnd == CGAL::ARR_UNBOUNDED);
     }
-    
-    //! tests whether this boundary type represents a singularity 
+
+    //! tests whether this boundary type represents a singularity
     inline static bool is_singular(/*CGAL::Arr_boundary_type bnd*/) {
         return false; //(bnd == CGAL::ARR_CONTRACTION);
     }
-    
+
     //! tests whether this boundary type represents lying on discontinuity
     inline static bool is_on_disc(/*CGAL::Arr_boundary_type bnd*/) {
         return false; //(bnd == CGAL::ARR_IDENTIFICATION);
@@ -918,26 +914,26 @@ public:
 
     //! returns true if a parameter encodes bottom or top boundary placement
     inline static bool is_on_bottom_top(CGAL::Arr_parameter_space loc) {
-        return (loc == CGAL::ARR_BOTTOM_BOUNDARY || 
+        return (loc == CGAL::ARR_BOTTOM_BOUNDARY ||
                 loc == CGAL::ARR_TOP_BOUNDARY);
     }
 
     //! returns true if a parameter encodes left or right boundary placement
     inline static bool is_on_left_right(CGAL::Arr_parameter_space loc) {
-        return (loc == CGAL::ARR_LEFT_BOUNDARY || 
+        return (loc == CGAL::ARR_LEFT_BOUNDARY ||
                 loc == CGAL::ARR_RIGHT_BOUNDARY);
     }
 
     //!@}
 
-public:    
+public:
     //! \name Predicates
     //!@{
-    
+
       /*!
      * Compare the relative x-limits of a vertical line at an interior point
      * and the arc's end on a bottom or top boundary
-     * 
+     *
      * \param p A reference point; we refer to a vertical line incident to p.
      * \param ce ARR_MIN_END if we refer to the arc's minimal end,
      *            ARR_MAX_END if we refer to its maximal end.
@@ -960,7 +956,7 @@ public:
                 p, *dynamic_cast< const Kernel_arc_2* >(this), ce
         );
     }
-    
+
 
     /*!\brief
      * Compare the relative x-limits of the curve end of \c *this
@@ -979,19 +975,19 @@ public:
     CGAL::Comparison_result compare_x_at_limit(
             CGAL::Arr_curve_end ce1,
             const Kernel_arc_2& cv2, CGAL::Arr_curve_end ce2) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Compare_x_at_limit_2,
                                             compare_x_at_limit_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return compare_x_at_limit_2(
                 *dynamic_cast< const Kernel_arc_2* >(this), ce1, cv2, ce2
         );
-    }   
+    }
 
     /*!
      * Compare the relative x-positions of an interior point
      * and the arc's end on a bottom or top boundary
-     * 
+     *
      * \param p A reference point; we refer to a vertical line incident to p.
      * \param ce ARR_MIN_END if we refer to the arc's minimal end,
      *            ARR_MAX_END if we refer to its maximal end.
@@ -1013,7 +1009,7 @@ public:
                 p, *dynamic_cast< const Kernel_arc_2* >(this), ce
         );
     }
-    
+
     /*!\brief
      * Compare the relative x-positions of the curve end of \c *this
      * and \c cv2
@@ -1028,15 +1024,15 @@ public:
      *
      * \pre the curve ends lie on the bottom or top boundary
      */
-    CGAL::Comparison_result compare_x_near_limit(const Kernel_arc_2& cv2, 
+    CGAL::Comparison_result compare_x_near_limit(const Kernel_arc_2& cv2,
                                                  CGAL::Arr_curve_end ce) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Compare_x_near_limit_2,
                                             compare_x_near_limit_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return compare_x_near_limit_2(*dynamic_cast< const Kernel_arc_2* >(this), cv2, ce);
-    }   
-  
+    }
+
     /*!\brief
      * Compare the relative y-positions of two arcs whose ends approach
      * the left or right boundary from the same side
@@ -1051,10 +1047,10 @@ public:
      * \pre The ends are defined on left or right boundary
      */
     CGAL::Comparison_result compare_y_near_boundary(
-            const Kernel_arc_2& cv2, 
+            const Kernel_arc_2& cv2,
             CGAL::Arr_curve_end ce
     ) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Compare_y_near_boundary_2,
                                             compare_y_near_boundary_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
@@ -1067,7 +1063,7 @@ public:
      * Compares the relative vertical alignment of a point with this arc
      *
      * \param p The point.
-     * \return 
+     * \return
      * CGAL::SMALLER if y(p) \< arc(x(p)), i.e. the point is below the arc;
      * CGAL::LARGER if y(p) > arc(x(p)), i.e. the point is above the arc;
      * CGAL::EQUAL if p lies on the arc.
@@ -1083,24 +1079,24 @@ public:
     }
 
     /*!\brief
-     * Compares the relative vertical aligment of this arc with a second 
-     * immediately to the left of one of their intersection points. 
-     * 
-     * If one of the curves is vertical (emanating downward from p), 
+     * Compares the relative vertical aligment of this arc with a second
+     * immediately to the left of one of their intersection points.
+     *
+     * If one of the curves is vertical (emanating downward from p),
      * it is always considered to be below the other curve.
-     * 
+     *
      * \param cv2 The second arc
      * \param p The intersection point
-     * 
+     *
      * \return The relative vertical alignment this arc with respect to cv2
      *         immediately to the left of p: SMALLER, LARGER or EQUAL.
      *
      * \pre The point p lies on both curves, and both of them must be also be
      *      defined (lexicographical) to their left.
      */
-    CGAL::Comparison_result compare_y_at_x_left(const Kernel_arc_2& cv2, 
+    CGAL::Comparison_result compare_y_at_x_left(const Kernel_arc_2& cv2,
                                                 const Point_2 &p) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Compare_y_at_x_left_2,
                                             compare_y_at_x_left_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
@@ -1108,26 +1104,26 @@ public:
                 *dynamic_cast< const Kernel_arc_2* >(this), cv2, p
         );
     }
-    
+
     /*!\brief
-     * Compares the relative vertical aligment of this arc with a second 
-     * immediately to the right of one of their intersection points. 
-     * 
-     * If one of the curves is vertical (emanating downward from p), 
+     * Compares the relative vertical aligment of this arc with a second
+     * immediately to the right of one of their intersection points.
+     *
+     * If one of the curves is vertical (emanating downward from p),
      * it is always considered to be below the other curve.
-     * 
+     *
      * \param cv2 The second arc
      * \param p The intersection point
-     * 
+     *
      * \return The relative vertical alignment this arc with respect to cv2
      *         immediately to the right of p: SMALLER, LARGER or EQUAL.
      *
      * \pre The point p lies on both curves, and both of them must be also be
      *      defined (lexicographical) to their right.
      */
-    CGAL::Comparison_result compare_y_at_x_right(const Kernel_arc_2& cv2, 
+    CGAL::Comparison_result compare_y_at_x_right(const Kernel_arc_2& cv2,
                                                  const Point_2 &p) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Compare_y_at_x_right_2,
                                             compare_y_at_x_right_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
@@ -1135,10 +1131,10 @@ public:
                 *dynamic_cast< const Kernel_arc_2* >(this), cv2, p
         );
     }
-        
+
     /*!\brief
      * Check if the given x-value is in the x-range of the arc inclusive.
-     * 
+     *
      * \param x The x-value.
      * \param *eq_min Output: Is this value equal to the x-coordinate of the
      *                       ARR_MIN_END point.
@@ -1146,9 +1142,9 @@ public:
      *                       ARR_MAX_END point.
      * \return \c true, if p.x() is in x-range of arc, \c false otherwise
      */
-    bool is_in_x_range(const Coordinate_1& x, 
+    bool is_in_x_range(const Coordinate_1& x,
                        bool *eq_min = NULL, bool *eq_max = NULL) const {
-        
+
         if (eq_min != NULL && eq_max != NULL) {
             *eq_min = *eq_max = false;
         }
@@ -1170,8 +1166,8 @@ public:
         // precomputations:
         CGAL::Comparison_result resmin = CGAL::LARGER;
         CGAL::Arr_parameter_space min_loc = location(CGAL::ARR_MIN_END);
-        bool min_has_x = 
-            (is_finite(CGAL::ARR_MIN_END) || 
+        bool min_has_x =
+            (is_finite(CGAL::ARR_MIN_END) ||
              min_loc == CGAL::ARR_BOTTOM_BOUNDARY ||
              min_loc == CGAL::ARR_TOP_BOUNDARY);
         if (min_has_x) {
@@ -1184,11 +1180,11 @@ public:
 
         CGAL::Comparison_result resmax = CGAL::SMALLER;
         CGAL::Arr_parameter_space max_loc = location(CGAL::ARR_MAX_END);
-        bool max_has_x = 
-            (is_finite(CGAL::ARR_MAX_END) || 
+        bool max_has_x =
+            (is_finite(CGAL::ARR_MAX_END) ||
              max_loc == CGAL::ARR_BOTTOM_BOUNDARY ||
              max_loc == CGAL::ARR_TOP_BOUNDARY);
-        
+
         if (max_has_x) {
             resmax = Curved_kernel_via_analysis_2::instance().
                 kernel().compare_1_object()(x, _maxpoint().x());
@@ -1197,15 +1193,15 @@ public:
             }
         }
 
-        bool res = 
+        bool res =
 	    (resmin != CGAL::SMALLER && resmax != CGAL::LARGER);
 	return res;
-    } 
-    
+    }
+
     /*!\brief
-     * Checks whether an x-coordinate lies in the interiors of this arc's 
+     * Checks whether an x-coordinate lies in the interiors of this arc's
      * x-range
-     * 
+     *
      * \param x The query coordinate
      * \return \c true, if \c x lies in the interior of this arc's x-range,
      * \c false otherwise
@@ -1219,40 +1215,40 @@ public:
         }
         return true;
     }
-    
-    /*!\brief 
+
+    /*!\brief
      * Checks whether a given arc is equal to this one
      *
      * \param cv2 The query arc
      * \return \c true iff this arc is equal to \c cv, \c false otherwise
      */
     bool is_equal(const Kernel_arc_2& cv2) const {
-        
-        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Equal_2, 
+
+        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Equal_2,
                                             equal_2)
-        
+
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return equal_2(*dynamic_cast< const Kernel_arc_2* >(this), cv2);
     }
 
     /*!\brief
      * checks whether this arcs overlaps with another
-     * 
+     *
      * \param cv2 The query arc
      * \return \c true, if both arcs have infinitely many intersection points,
      *         \c false otherwise
      */
     bool do_overlap(const Kernel_arc_2& cv2) const {
-        
-        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Do_overlap_2, 
+
+        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Do_overlap_2,
                                             do_overlap_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return do_overlap_2(*dynamic_cast< const Kernel_arc_2* >(this), cv2);
     }
 
-    /*!\brief 
+    /*!\brief
      * multiplicity of intersection
-     * 
+     *
      * The intersection multiplicity of \c *this and \c cv2 at point \c p is
      * returned.
      *
@@ -1265,12 +1261,12 @@ public:
             const Kernel_arc_2& cv2, const Point_2& p) const {
 
         // intersection point must lie in the interior of both arcs
-        CGAL_precondition_code( // because of macro stupidity one needs 
+        CGAL_precondition_code( // because of macro stupidity one needs
             bool eq_min1;       // to omit commas in declaration
             bool eq_max1;
             bool eq_min2;
             bool eq_max2;
-        );    
+        );
         CGAL_precondition(is_in_x_range(p.x(), &eq_min1, &eq_max1));
         CGAL_precondition(cv2.is_in_x_range(p.x(), &eq_min2, &eq_max2));
         CGAL_precondition(is_vertical() || (!eq_min1 && !eq_max1));
@@ -1280,14 +1276,14 @@ public:
         // internally by compare_y_at_x() ?
         CGAL_expensive_precondition(compare_y_at_x(p) == CGAL::EQUAL &&
             cv2.compare_y_at_x(p) == CGAL::EQUAL);
-            
+
         Kernel_arc_2::simplify(*dynamic_cast< const Kernel_arc_2*>(this), cv2);
         CGAL_precondition(!curve().is_identical(cv2.curve()));
         if (is_vertical() || cv2.is_vertical()) {
             CGAL_assertion(!(is_vertical() && cv2.is_vertical()));
             return 1;
         }
-        
+
         Curve_pair_analysis_2 cpa_2 =
             Curved_kernel_via_analysis_2::instance().
             kernel().construct_curve_pair_2_object()(curve(), cv2.curve());
@@ -1298,22 +1294,22 @@ public:
         CGAL_precondition(cpv_line.is_intersection());
         int j = cpv_line.event_of_curve(arcno(p.x()), curve()),
             mult = cpv_line.multiplicity_of_intersection(j);
-            
+
         CGAL_postcondition(mult > 0);
         return mult;
     }
-    
-    //!@}  
-    
+
+    //!@}
+
     //!\name Constructing functions
     //!@{
 
     /*!\brief
-     * Find all intersections of this arc with another one and 
-     * insert them to the output iterator. 
-     * 
-     * Type of output iterator is \c CGAL::Object. It either contains 
-     * an \c Arc_2 object (overlap) or a 
+     * Find all intersections of this arc with another one and
+     * insert them to the output iterator.
+     *
+     * Type of output iterator is \c CGAL::Object. It either contains
+     * an \c Arc_2 object (overlap) or a
      * <tt>std::pair\<Point_2, unsigned int></tt> (intersection point +
      * multiplicity). A past-the-end iterator is returned.
      *
@@ -1322,38 +1318,38 @@ public:
      * \return A past-the-end iterator of \c oi
      */
     template < class OutputIterator >
-    OutputIterator intersections(const Kernel_arc_2& cv2, 
+    OutputIterator intersections(const Kernel_arc_2& cv2,
                                  OutputIterator oi) const {
-        
-        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Intersect_2, 
+
+        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Intersect_2,
                                             intersect_2)
-        
+
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return intersect_2(
                 *dynamic_cast< const Kernel_arc_2* >(this), cv2, oi
         );
     }
-    
+
     /*!\brief
-     * Computes the next intersection of \c *this and \c cv2 right of \c p  
+     * Computes the next intersection of \c *this and \c cv2 right of \c p
      * in lexicographical order and returns it through \c intersection
      * argument
      *
-     * intersect_right_of_point is not called when using sweep_curves() with 
-     * intersection dictionary and without validation of internal structures 
+     * intersect_right_of_point is not called when using sweep_curves() with
+     * intersection dictionary and without validation of internal structures
      * (as is standard). Hence we can be lazy here for the moment
      * without losing performance.
      *
      * \param cv2 The second arc
      * \param p The minimal bound point
      * \param intersection The next intersection
-     * \return \c true, if there is a next intersection and 
+     * \return \c true, if there is a next intersection and
      *         \c intersection has been set properly, \c false otherwise
      * \pre The arcs are not allowed to overlap
      */
-    bool intersect_right_of_point(const Kernel_arc_2& cv2, const Point_2& p, 
+    bool intersect_right_of_point(const Kernel_arc_2& cv2, const Point_2& p,
                                   Point_2& intersection) const {
-        
+
         CGAL_precondition(!this->do_overlap(cv2));
 
         // TODO rewrite intersect_right_of_point (Pavel)
@@ -1362,7 +1358,7 @@ public:
         typedef std::vector<std::pair<Point_2, int> > Point_container;
         Point_container tmp;
         _intersection_points(
-                *dynamic_cast< const Kernel_arc_2*>(this), cv2, 
+                *dynamic_cast< const Kernel_arc_2*>(this), cv2,
                 back_inserter(tmp)
         );
         typename Point_container::const_iterator it;
@@ -1374,36 +1370,36 @@ public:
         }
         return false;
     }
-    
+
     /*!\brief
-     * Computes the next intersection of \c *this and \c cv2 left of \c p  
+     * Computes the next intersection of \c *this and \c cv2 left of \c p
      * in lexicographical order and returns it through \c intersection
      * argument
      *
-     * intersect_right_of_point is not called when using sweep_curves() with 
-     * intersection dictionary and without validation of internal structures 
+     * intersect_right_of_point is not called when using sweep_curves() with
+     * intersection dictionary and without validation of internal structures
      * (as is standard). Hence we can be lazy here for the moment
      * without losing performance.
      *
      * \param cv2 The second arc
      * \param p The maximal bound point
      * \param intersection The next intersection
-     * \return \c true, if there is a next intersection 
+     * \return \c true, if there is a next intersection
      *         and \c intersection has been set properly, \c false otherwise
      * \pre The arcs are not allowed to overlap
      */
-    bool intersect_left_of_point(const Kernel_arc_2& cv2, const Point_2& p, 
+    bool intersect_left_of_point(const Kernel_arc_2& cv2, const Point_2& p,
                                  Point_2& intersection) const {
 
         CGAL_precondition(!this->do_overlap(cv2));
-        
+
         // TODO rewrite intersect_left_of_point (Pavel)
         // use static member for Intersect, Left & Right
         // with parameters for direction and where to stop
         typedef std::vector<std::pair<Point_2, int> > Point_container;
         Point_container tmp;
         _intersection_points(
-                *dynamic_cast< const Kernel_arc_2*>(this), cv2, 
+                *dynamic_cast< const Kernel_arc_2*>(this), cv2,
                 back_inserter(tmp)
         );
         typename Point_container::const_reverse_iterator it;
@@ -1418,7 +1414,7 @@ public:
 
     /*!\brief
      * Returns a trimmed version of an arc
-     * 
+     *
      * \param p the new first endpoint
      * \param q the new second endpoint
      * \return The trimmed arc
@@ -1428,7 +1424,7 @@ public:
      */
     // do we need this method separetely ??
     Kernel_arc_2 trim(const Point_2& p, const Point_2& q) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Trim_2, trim_2)
 
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
@@ -1437,16 +1433,16 @@ public:
 
     /*!\brief
      * Split an arc at a given point into two sub-arcs
-     * 
+     *
      * \param p The split point
      * \param s1 Output: The left resulting sub-arc (p is its right endpoint)
      * \param s2 Output: The right resulting sub-arc (p is its left endpoint)
-     * 
+     *
      * \pre p lies on cv but is not one of its end-points.
      */
     void split(const Point_2& p, Kernel_arc_2& s1, Kernel_arc_2& s2) const {
-        
-        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Split_2, 
+
+        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Split_2,
                                             split_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         split_2(*dynamic_cast< const Kernel_arc_2* >(this), p, s1, s2);
@@ -1460,8 +1456,8 @@ public:
      * by the same curve and share a common endpoint; \c false otherwise.
      */
     bool are_mergeable(const Kernel_arc_2& cv2) const {
-    
-        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Are_mergeable_2, 
+
+        CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Are_mergeable_2,
                                             are_mergeable_2)
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         return are_mergeable_2(
@@ -1474,26 +1470,26 @@ public:
      *
      * \param cv2 The second arc
      * \return The resulting arc
-     * 
+     *
      * \pre The two arcs are mergeable, that is they are supported by the
      *      same curve and share a common endpoint.
-     */  
+     */
     Kernel_arc_2 merge(const Kernel_arc_2& cv2) const {
-        
+
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Merge_2, merge_2)
         Kernel_arc_2 tmp;
         CGAL_precondition(dynamic_cast< const Kernel_arc_2* >(this) != NULL);
         merge_2(*dynamic_cast< const Kernel_arc_2* >(this), cv2, tmp);
         return tmp;
     }
-    
+
     //!@}
     //!\name Simplification
-    //!@{ 
+    //!@{
 
     /*! \brief
      *  simplifies representation of \c cv and/or \c p in case they have
-     *  non-coprime supporting curves. 
+     *  non-coprime supporting curves.
      *
      *  \return \c true if simplification took place, \c false otherwise
      */
@@ -1504,14 +1500,14 @@ public:
         }
 
         std::vector<Curve_analysis_2> parts_of_f, parts_of_g, common;
-        
+
         if (Curved_kernel_via_analysis_2::instance().
             kernel().decompose_2_object()(
-                    cv.curve(), p.curve(), 
-                    std::back_inserter(parts_of_f), 
+                    cv.curve(), p.curve(),
+                    std::back_inserter(parts_of_f),
                     std::back_inserter(parts_of_g),
                     std::back_inserter(common))) {
-            
+
             CGAL_assertion((parts_of_f.size() == 1 ||
                             parts_of_g.size() == 1) && common.size() == 1);
             if (parts_of_f.size() == 1) {
@@ -1519,7 +1515,7 @@ public:
                     Curved_kernel_via_analysis_2::instance().
                         kernel().construct_curve_pair_2_object()
                             (parts_of_f[0], common[0]));
-            } 
+            }
             if (parts_of_g.size() == 1) {
                 p.simplify_by(Curved_kernel_via_analysis_2::instance().
                         kernel().construct_curve_pair_2_object()
@@ -1528,11 +1524,11 @@ public:
             return true;
         }
         return false;
-    }  
-    
+    }
+
     /*!\brief
      * simplifies representation of \c cv1 and/or \c cv2 in case they have
-     * non-coprime supporting curves. 
+     * non-coprime supporting curves.
      *
      *  \return \c true if simplification took place, \c false otherwise
      */
@@ -1543,11 +1539,11 @@ public:
         }
 
         std::vector<Curve_analysis_2> parts_of_f, parts_of_g, common;
-        
+
         if (Curved_kernel_via_analysis_2::instance().
             kernel().decompose_2_object()(
-                    cv1.curve(), cv2.curve(), 
-                    std::back_inserter(parts_of_f), 
+                    cv1.curve(), cv2.curve(),
+                    std::back_inserter(parts_of_f),
                     std::back_inserter(parts_of_g),
                     std::back_inserter(common))) {
             CGAL_assertion((parts_of_f.size() == 1 ||
@@ -1565,16 +1561,16 @@ public:
             return true;
         }
         return false;
-    }  
+    }
 
 protected:
     //!\name Trimming
     //!@{
-    
+
     /*!\brief
      * Returns a trimmed version of an arc (internal version that does not use
      * functor)
-     * 
+     *
      * \param p the new first endpoint
      * \param q the new second endpoint
      * \return The trimmed arc
@@ -1584,48 +1580,48 @@ protected:
      */
     // TODO implement in functor?
     Kernel_arc_2 _trim(const Point_2& p, const Point_2& q) const {
-        
-        if (p.location() == CGAL::ARR_INTERIOR && 
+
+        if (p.location() == CGAL::ARR_INTERIOR &&
             q.location() == CGAL::ARR_INTERIOR) {
-            
-            return _replace_endpoints(p, q, 
+
+            return _replace_endpoints(p, q,
                     (is_vertical() ? -1 : arcno(p.x())),
-                    (is_vertical() ? -1 : arcno(q.x()))).first;           
-        } 
-            
+                    (is_vertical() ? -1 : arcno(q.x()))).first;
+        }
+
         if (p.location() != CGAL::ARR_INTERIOR &&
-            q.location() != CGAL::ARR_INTERIOR) 
+            q.location() != CGAL::ARR_INTERIOR)
             return static_cast<const Kernel_arc_2&>(*this);
-        
+
         Kernel_arc_2 left_arc, right_arc;
         CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC(Split_2, split_2)
 
         if (p.location() != CGAL::ARR_INTERIOR &&
             q.location() == CGAL::ARR_INTERIOR) {
-                
+
             split_2(static_cast<const Kernel_arc_2&>(*this), q, left_arc,
                     right_arc);
             return left_arc;
         }
         // if (p.location() == CGAL::ARR_INTERIOR &&
-        //   q.location() != CGAL::ARR_INTERIOR) 
-                
+        //   q.location() != CGAL::ARR_INTERIOR)
+
         split_2(static_cast<const Kernel_arc_2&>(*this), p, left_arc,
                     right_arc);
-        return right_arc;        
+        return right_arc;
     }
-    
+
 public:
-    
+
     /*!\brief
      * Trims this arc and \c cv2 to the common x-range, if it is non-trivial
-     * 
+     *
      * \param cv2 the second arc
      * \param trimmed1 Output: trimmed version of \c *this to joint x-range of
      *                 \c *this and \c cv2
      * \param trimmed1 Output: trimmed version of \c cv2 to joint x-range of
      *                 \c *this and \c cv2
-     * \return \c true, if \c *this and \c cv2 share a non-trivial 
+     * \return \c true, if \c *this and \c cv2 share a non-trivial
      *         common x-range, \c false otherwise
      */
     bool trim_by_arc(const Kernel_arc_2& cv2, Kernel_arc_2& trimmed1,
@@ -1636,13 +1632,13 @@ public:
         const Kernel_arc_2& cv1 = static_cast< const Kernel_arc_2& >(*this);
 
         Point_2 common_left, common_right;
-        
+
         bool joint = cv1._joint_x_range(cv2, common_left, common_right);
-        
+
         if (!joint) {
             return false;
         }
-        
+
         typename Curve_kernel_2::Compare_1 compare_x(
                 Curved_kernel_via_analysis_2::instance().
                     kernel().compare_1_object());
@@ -1651,9 +1647,9 @@ public:
                                             construct_point_on_arc_2)
 
         Point_2 left1, left2;
-        
+
         if (common_left.location() != CGAL::ARR_LEFT_BOUNDARY) {
-            if ((cv1.location(CGAL::ARR_MIN_END) != 
+            if ((cv1.location(CGAL::ARR_MIN_END) !=
                  CGAL::ARR_LEFT_BOUNDARY)  &&
                 (compare_x(cv1.curve_end_x(CGAL::ARR_MIN_END),
                            common_left.x()) == CGAL::EQUAL) ) {
@@ -1664,7 +1660,7 @@ public:
                                                cv1.arcno(),
                                                cv1);
             }
-            if ((cv2.location(CGAL::ARR_MIN_END) != 
+            if ((cv2.location(CGAL::ARR_MIN_END) !=
                  CGAL::ARR_LEFT_BOUNDARY)  &&
                 (compare_x(cv2.curve_end_x(CGAL::ARR_MIN_END),
                            common_left.x()) == CGAL::EQUAL) ) {
@@ -1679,13 +1675,13 @@ public:
             left1 = cv1._minpoint();
             left2 = cv2._minpoint();
         }
-        
-        
+
+
         Point_2 right1, right2;
-        
+
         if (common_right.location() != CGAL::ARR_RIGHT_BOUNDARY) {
-            
-            if ((cv1.location(CGAL::ARR_MAX_END) != 
+
+            if ((cv1.location(CGAL::ARR_MAX_END) !=
                  CGAL::ARR_RIGHT_BOUNDARY)  &&
                 (compare_x(cv1.curve_end_x(CGAL::ARR_MAX_END),
                            common_right.x()) == CGAL::EQUAL) ) {
@@ -1696,7 +1692,7 @@ public:
                                                 cv1.arcno(),
                                                 cv1);
             }
-            if ((cv2.location(CGAL::ARR_MAX_END) != 
+            if ((cv2.location(CGAL::ARR_MAX_END) !=
                  CGAL::ARR_RIGHT_BOUNDARY)  &&
                 (compare_x(cv2.curve_end_x(CGAL::ARR_MAX_END),
                            common_right.x()) == CGAL::EQUAL) ) {
@@ -1707,31 +1703,31 @@ public:
                                                 cv2.arcno(),
                                                 cv2);
             }
-            
+
         } else {
             right1 = cv1._maxpoint();
             right2 = cv2._maxpoint();
         }
-        
+
         trimmed1 = cv1._trim(left1, right1);
-        trimmed2 = cv2._trim(left2, right2);   
+        trimmed2 = cv2._trim(left2, right2);
 
         return joint;
     }
-   
+
     //!@}
 
 protected:
     //!\name Protected helper methods
     //!@{
-    
-    /*!\brief 
+
+    /*!\brief
      * function to ensure lexicographical order of the curve ends
      *
      * must be called once from constructor
      */
     void _fix_curve_ends_order() {
-        CGAL::Comparison_result res = 
+        CGAL::Comparison_result res =
             _same_arc_compare_xy(_minpoint(), _maxpoint());
         // curve ends cannot be identical
         CGAL_precondition(res != CGAL::EQUAL);
@@ -1742,13 +1738,13 @@ protected:
         // for non-vertical arcs check arcno constancy in the arc's interior
         // for vertical arcs check that there are no intersection points
         // between curve ends
-        _check_arc_interior(); 
+        _check_arc_interior();
     }
-    
+
     // p.curve() <-> p.arcno()
     // c <-> arcno_on_c
     /*!\brief
-     * establishes preconditions that point \c pt lies on the curve 
+     * establishes preconditions that point \c pt lies on the curve
      * \c c with arc number \c arcno_on_c, also checks that point's supporting
      * curve and \c c are coprime
      *
@@ -1756,11 +1752,14 @@ protected:
      * \param arcno_on_c Arcno on curve
      * \param c Supporting curve
      */
-    void _check_pt_arcno_and_coprimality(const Point_2& pt, int arcno_on_c, 
-                                         const Curve_analysis_2& c) const {
-        
+  void _check_pt_arcno_and_coprimality(const Point_2&
+                                         CGAL_precondition_code(pt),
+                                       int CGAL_precondition_code(arcno_on_c),
+                                       const Curve_analysis_2&
+                                         CGAL_precondition_code(c)) const
+  {
         CGAL_precondition_code(
-        
+
         if (!c.is_identical(pt.curve())) {
             // -1 defines that no arcnos preconditions need to be established
             if (arcno_on_c != -1) {
@@ -1769,18 +1768,18 @@ protected:
                 Curve_pair_analysis_2 cpa_2 =
                     Curved_kernel_via_analysis_2::instance().
                       kernel().construct_curve_pair_2_object()(pt.curve(), c);
-                   
+
                 cpv_line = cpa_2.status_line_for_x(pt.x());
-                CGAL_precondition(cpv_line.event_of_curve(pt.arcno(), 
+                CGAL_precondition(cpv_line.event_of_curve(pt.arcno(),
                                                           pt.curve())
                     == cpv_line.event_of_curve(arcno_on_c, c));
-            } 
-            std::vector< Curve_analysis_2 > dummy[3]; 
+            }
+            std::vector< Curve_analysis_2 > dummy[3];
             // ensure that curves are not decomposable
             CGAL_precondition(!Curved_kernel_via_analysis_2::instance().
                               kernel().decompose_2_object()(
                                       c, pt.curve(),
-                                      std::back_inserter(dummy[0]), 
+                                      std::back_inserter(dummy[0]),
                                       std::back_inserter(dummy[1]),
                                       std::back_inserter(dummy[2]))
             );
@@ -1789,17 +1788,17 @@ protected:
         }
         );
     }
-    
-    /*!\brief 
-     * establishes preconditions to ensure that there are no event 
-     * points in the arc's interior (only at source and target) and its arc 
+
+    /*!\brief
+     * establishes preconditions to ensure that there are no event
+     * points in the arc's interior (only at source and target) and its arc
      * number is constant
-     * 
-     * \pre before calling this method source and target must be sorted 
+     *
+     * \pre before calling this method source and target must be sorted
      * using \c _fix_curve_ends_order()
      */
     void _check_arc_interior() const {
-    
+
 #if !(defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
         || defined(NDEBUG))
 
@@ -1809,12 +1808,12 @@ protected:
             cv_line = curve().status_line_for_x(x0);
             CGAL_precondition(cv_line.is_event());
             CGAL_precondition(cv_line.covers_line());
-            
+
             // check that there are no intersections between min and max
             // curve ends
-            bool inf_src = 
+            bool inf_src =
                 (_minpoint().location() == CGAL::ARR_BOTTOM_BOUNDARY);
-            bool inf_tgt = 
+            bool inf_tgt =
                 (_maxpoint().location() == CGAL::ARR_TOP_BOUNDARY);
             // either no events over this line or the vertical line has at
             // least one finite end
@@ -1824,11 +1823,11 @@ protected:
             typename Curve_kernel_2::Compare_xy_2 cmp_xy(
                 Curved_kernel_via_analysis_2::instance().
                     kernel().compare_xy_2_object());
-                    
+
             for(int k = 0; k < cv_line.number_of_events(); k++) {
             // TODO: replace by _compare_arc_numbers !! (Pavel)
           // no way since _compare_arc_numbers compares only against *this arc
-                              
+
               Coordinate_2 tmp(x0, curve(), k);
                 bool res1 = true, res2 = true;
                 if(!inf_src)
@@ -1852,19 +1851,19 @@ protected:
         tgt_line = (inf_tgt ? curve().status_line_of_interval(
             curve().number_of_status_lines_with_event()) :
             curve().status_line_for_x(_maxpoint().x()));
-        
+
         int src_idx = src_line.index(), tgt_idx = tgt_line.index(),
             diff = tgt_idx - src_idx;
         bool no_events_between = true;
         // it's supposed that arcs are not degenerate but lexicographic
         // order may not be established
-        if(src_line.is_event()) 
-            no_events_between = (tgt_line.is_event() ? (diff == 1) : 
+        if(src_line.is_event())
+            no_events_between = (tgt_line.is_event() ? (diff == 1) :
                 (diff == 0)||(diff == 1));
-        else 
+        else
             no_events_between = (tgt_line.is_event() ? (diff == 0)||
                 (diff == -1) : (diff == 0));
-        
+
         if(!no_events_between) {
             // iterate through all events between source and target
             // to check that all events points lie above our arc
@@ -1904,11 +1903,11 @@ protected:
         } else {
             CGAL_precondition(arcno() == this->ptr()->_m_arcno_max);
         }
-#endif    
+#endif
     }
-    
-    /*!\brief 
-     * compares y-coordinates of two arcs over an open (or closed) 
+
+    /*!\brief
+     * compares y-coordinates of two arcs over an open (or closed)
      * interval or at exact x-coordinate
      *
      * \c where specifies whether to compare at negative/positive boundary or
@@ -1924,21 +1923,21 @@ protected:
      * \pre !is_on_bottom_top(where)
      */
     CGAL::Comparison_result _compare_arc_numbers(
-            const Kernel_arc_2& cv2, 
-            CGAL::Arr_parameter_space where, 
-            Coordinate_1 x0 = Coordinate_1(), 
+            const Kernel_arc_2& cv2,
+            CGAL::Arr_parameter_space where,
+            Coordinate_1 x0 = Coordinate_1(),
             CGAL::Sign perturb = CGAL::ZERO) const {
 
         CGAL_precondition(!is_on_bottom_top(where));
         CGAL_assertion(dynamic_cast< const Kernel_arc_2*>(this) != NULL);
         Kernel_arc_2::simplify(*dynamic_cast< const Kernel_arc_2*>(this), cv2);
-        if(curve().is_identical(cv2.curve())) 
+        if(curve().is_identical(cv2.curve()))
             return CGAL::sign(arcno() - cv2.arcno());
         return _compare_coprime(cv2, where, x0, perturb);
     }
 
     /*!\brief
-     * computes vertical ordering of \c *this and \c cv2 
+     * computes vertical ordering of \c *this and \c cv2
      * having coprime supporting curves
      *
      * \param cv2 the second arc
@@ -1949,13 +1948,13 @@ protected:
      */
      CGAL::Comparison_result _compare_coprime(
             const Kernel_arc_2& cv2,
-            CGAL::Arr_parameter_space where, 
-            Coordinate_1 x0, 
+            CGAL::Arr_parameter_space where,
+            Coordinate_1 x0,
             CGAL::Sign perturb) const {
-        
+
 #ifdef CKvA_DEBUG_PRINT_CERR
-        CKvA_CERR("\n_compare_coprime; this: " 
-             << *dynamic_cast< const Kernel_arc_2*>(this) 
+        CKvA_CERR("\n_compare_coprime; this: "
+             << *dynamic_cast< const Kernel_arc_2*>(this)
              << "; g: " << cv2.curve().polynomial_2()
              << "; arcno_on_g: " << cv2.arcno() << "; where: " << where
         );
@@ -1964,30 +1963,30 @@ protected:
         }
         CKvA_CERR("\n");
 #endif
-        
+
         typename Curve_pair_analysis_2::Status_line_1 cpv_line;
         Curve_pair_analysis_2 cpa_2 = Curved_kernel_via_analysis_2::instance().
                         kernel().construct_curve_pair_2_object()
                             (curve(), cv2.curve());
-        
-        if(where == CGAL::ARR_INTERIOR) 
+
+        if(where == CGAL::ARR_INTERIOR)
             cpv_line = cpa_2.status_line_for_x(x0, perturb);
         else
             cpv_line = cpa_2.status_line_of_interval(
                     // TODO don't mix up location (where) and finiteness!
                     where == CGAL::ARR_LEFT_BOUNDARY ? 0 :
                     cpa_2.number_of_status_lines_with_event());
-        
-        CGAL::Sign res = 
+
+        CGAL::Sign res =
             CGAL::sign(cpv_line.event_of_curve(arcno(), curve()) -
                        cpv_line.event_of_curve(cv2.arcno(), cv2.curve()));
         CKvA_CERR("result: " << res << "\n");
         return res;
     }
-    
-    /*\brief 
+
+    /*\brief
      * internal comparison of two curve ends "lying" on the same arc
-     * 
+     *
      * since points are supposed to lie on the same arc, converging to the
      * boundary implies equality
      *
@@ -1999,30 +1998,30 @@ protected:
      */
     CGAL::Comparison_result _same_arc_compare_xy(
             const Point_2& p,
-            const Point_2& q, 
-            bool equal_x = false, 
+            const Point_2& q,
+            bool equal_x = false,
             bool only_x = false) const {
 
-        CKvA_CERR("\n_same_arc_compare_xy; this: " 
-             << *dynamic_cast< const Kernel_arc_2*>(this) 
+        CKvA_CERR("\n_same_arc_compare_xy; this: "
+             << *dynamic_cast< const Kernel_arc_2*>(this)
              << "; p: " << p
              << "; q: " << q
              << "; equal_x: " << equal_x
              << "; only_x: " << only_x
              << "\n"
         );
-        
+
         CGAL::Comparison_result res;
-        
+
         if (p.is_identical(q)) {
             res = CGAL::EQUAL;
             CKvA_CERR("result1: " << res << "\n");
             return res;
         }
-        
+
         CGAL::Arr_parameter_space locp = p.location(), locq = q.location();
         if (!equal_x || only_x) {
-          
+
             if (!p.is_on_left_right() && !q.is_on_left_right()) {
                 // both xs are finite: require x-comparisons
                 res = Curved_kernel_via_analysis_2::instance().
@@ -2065,7 +2064,7 @@ protected:
                 CKvA_CERR("result8: " << res << "\n");
                 return res;
             }
-            // compare only y-values; 
+            // compare only y-values;
             res = Curved_kernel_via_analysis_2::instance().
                 compare_xy_2_object()(p, q, true);
             CKvA_CERR("result9: " << res << "\n");
@@ -2073,38 +2072,38 @@ protected:
         }
         // here: locp != locq && one of them is at inf y
         if (locp == CGAL::ARR_INTERIOR) {
-            res = (locq == CGAL::ARR_BOTTOM_BOUNDARY ? 
+            res = (locq == CGAL::ARR_BOTTOM_BOUNDARY ?
                    CGAL::LARGER : CGAL::SMALLER);
             CKvA_CERR("result10: " << res << "\n");
             return res;
         }
         // here: locp != locq && locp is at infty
-        res = (locp == CGAL::ARR_BOTTOM_BOUNDARY ? 
+        res = (locp == CGAL::ARR_BOTTOM_BOUNDARY ?
                CGAL::SMALLER : CGAL::LARGER);
         CKvA_CERR("result11: " << res << "\n");
         return res;
     }
-    
+
     /*!\brief
      * min end-point of this arc (provided for code readability)
      *
      * \return min endpoint of arc (may lie on a boundary!)
      */
     inline
-    const Point_2& _minpoint() const { 
-        return this->ptr()->_m_min; 
+    const Point_2& _minpoint() const {
+        return this->ptr()->_m_min;
     }
-    
+
     /*!\brief
      * max end-point of this arc (provided for code readability)
      *
      * \return max endpoint of arc (may lie on a boundary!)
      */
     inline
-    const Point_2& _maxpoint() const { 
-        return this->ptr()->_m_max; 
+    const Point_2& _maxpoint() const {
+        return this->ptr()->_m_max;
     }
-    
+
     /*!\brief
      * computes this arc's interval index
      *
@@ -2114,47 +2113,47 @@ protected:
         CGAL_precondition(!is_vertical());
         // we are interested in interval "to the right"
         CGAL::Arr_parameter_space min_loc = location(CGAL::ARR_MIN_END);
-        bool min_has_x = 
-            (is_finite(CGAL::ARR_MIN_END) || 
+        bool min_has_x =
+            (is_finite(CGAL::ARR_MIN_END) ||
              min_loc == CGAL::ARR_BOTTOM_BOUNDARY ||
              min_loc == CGAL::ARR_TOP_BOUNDARY);
-        
+
         if (!min_has_x) {
             return 0;
         }
         // else
-        typename Curve_analysis_2::Status_line_1 cv_line = 
+        typename Curve_analysis_2::Status_line_1 cv_line =
             curve().status_line_for_x(_minpoint().x(), CGAL::POSITIVE);
         return cv_line.index();
     }
 
     /*!\brief
      * computes this rational value in the interiors of the arc's x-range
-     * 
+     *
      * \pre !is_vertical()
      */
     Bound _compute_boundary_in_interval() const {
         CGAL_precondition(!is_vertical());
         // a curve end at negative boundary => 0th interval
-        
+
         Bound res(0);
-        
+
         typename Curve_kernel_2::Approximate_relative_1 approx_x;
-	
+
 	typename Curve_kernel_2::Bound_between_1 bound_between_x;
-        
+
 	CGAL::Arr_parameter_space min_loc = location(CGAL::ARR_MIN_END);
-	bool min_has_x = 
-	  (is_finite(CGAL::ARR_MIN_END) || 
+	bool min_has_x =
+	  (is_finite(CGAL::ARR_MIN_END) ||
 	   min_loc == CGAL::ARR_BOTTOM_BOUNDARY ||
 	   min_loc == CGAL::ARR_TOP_BOUNDARY);
-	
+
 	CGAL::Arr_parameter_space max_loc = location(CGAL::ARR_MAX_END);
-	bool max_has_x = 
-	  (is_finite(CGAL::ARR_MAX_END) || 
+	bool max_has_x =
+	  (is_finite(CGAL::ARR_MAX_END) ||
 	   max_loc == CGAL::ARR_BOTTOM_BOUNDARY ||
 	   max_loc == CGAL::ARR_TOP_BOUNDARY);
-	
+
 	if (min_has_x) {
 	  Coordinate_1 min_x = _minpoint().x();
 	  if (max_has_x) {
@@ -2165,7 +2164,7 @@ protected:
 	    res = min_pair.second + Bound(1);
 	  }
 	} else {
-	  if (max_has_x) { 
+	  if (max_has_x) {
 	    Coordinate_1 max_x = _maxpoint().x();
 	    std::pair<Bound,Bound> max_pair=approx_x(max_x,4);
 	    res = max_pair.first - Bound(1);
@@ -2177,11 +2176,11 @@ protected:
         return res;
     }
 
-    /*!\brief 
+    /*!\brief
      * Replaces this arc's end-points by \c p1 and \c p2 with arcnos
      * \c arcno1 and \c arcno2.
-     * 
-     * new curve ends are sorted lexicographical in case of need; 
+     *
+     * new curve ends are sorted lexicographical in case of need;
      * all preconditions must be checked by the caller
      *
      * \param p1 new first endpoint
@@ -2191,13 +2190,13 @@ protected:
      * \return pair whose first entry represent the refined arc, and whose
      *         second entry reports the lexicographic comparison of p1 and p2
      */
-    std::pair< Kernel_arc_2, CGAL::Comparison_result > 
+    std::pair< Kernel_arc_2, CGAL::Comparison_result >
     _replace_endpoints(
-            const Point_2& p1, const Point_2& p2, 
+            const Point_2& p1, const Point_2& p2,
             int arcno1 = -1, int arcno2 = -1) const {
-        
-        CKvA_CERR("\n_replace_endpoints\n");    
-        
+
+        CKvA_CERR("\n_replace_endpoints\n");
+
         Rep rep(*(this->ptr()));
         rep._m_min = p1;
         rep._m_max = p2;
@@ -2209,33 +2208,33 @@ protected:
                 rep._m_arcno_max = arcno2;
             }
         }
-        
+
         CGAL::Comparison_result cmp = _same_arc_compare_xy(p1,p2);
         if (cmp == CGAL::LARGER) {
             std::swap(rep._m_min, rep._m_max);
             std::swap(rep._m_arcno_min, rep._m_arcno_max);
         }
-        /* no need to recompute location since they are set during 
+        /* no need to recompute location since they are set during
            construction of respective curve ends */
         rep._m_is_vertical = this->ptr()->_m_is_vertical;
 	rep._m_left_to_right = this->ptr()->_m_left_to_right;
-        
+
 	rep._m_interval_id = boost::none;
 	rep._m_boundary_in_interval = boost::none;
-        
+
         return std::make_pair(Kernel_arc_2(rep), cmp);
     }
-   
+
     /*!\brief
      * Simplifies representation of the arc !! DEPRECATED FUNCTION !!
-     * 
-     * Given a decomposition of the arcs's supporting curve into a pair of two 
+     *
+     * Given a decomposition of the arcs's supporting curve into a pair of two
      * curves \c cpa_2, we search for a curve this arc lies on and reset arc's
      * supporting curve and arcnos appropriately.
      *
-     * \param cpa_2 analysis of curve pair that should be used 
+     * \param cpa_2 analysis of curve pair that should be used
      *              in simplification
-     * \pre \c cpa_2 must correspond to a decomposition of this arc's 
+     * \pre \c cpa_2 must correspond to a decomposition of this arc's
      * supporting curve
      */
     void _simplify_by(const Curve_pair_analysis_2& cpa_2) const {
@@ -2252,10 +2251,10 @@ protected:
         CGAL_precondition(CGAL::resultant(mult, f).degree() < 1);
         CGAL_precondition(mult.degree() == f.degree());
         CGAL_precondition(deg(mult) == deg(f));
-        
+
         Coordinate_1 x0;
         if(is_vertical()) {
-            // processing vertical arcs: search for supporting curve which has 
+            // processing vertical arcs: search for supporting curve which has
             // vertical line at this x0 (must be exactly 1 curve)
             x0 = _minpoint().x();
             Curve_analysis_2 ca_2(cpa_2.curve_analysis(0));
@@ -2268,35 +2267,35 @@ protected:
             }
             return;
         }
-        
+
         // processing non-vertical arcs
         typename Curve_pair_analysis_2::Status_line_1 cpv_line;
         std::pair<int, int> ipair;
         // preserve original supporting curve
         Curve_analysis_2 orig_curve(curve());
-        
+
         // TODO do we mean location of is_finite?
         bool inf1_x = (_minpoint().location() == CGAL::ARR_LEFT_BOUNDARY);
-        bool curve_idx;  
+        bool curve_idx;
         if(!inf1_x) {
-            x0 = _minpoint().x(); 
+            x0 = _minpoint().x();
             cpv_line = cpa_2.status_line_for_x(x0, CGAL::POSITIVE);
-        } else 
+        } else
             cpv_line = cpa_2.status_line_of_interval(0);
-        
+
         CGAL_precondition_code(
             typename Curve_analysis_2::Status_line_1
                 cv_line = (inf1_x ? orig_curve.status_line_of_interval(0) :
                         orig_curve.status_line_for_x(x0, CGAL::POSITIVE));
         );
-        CGAL_precondition(cpv_line.number_of_events() == 
+        CGAL_precondition(cpv_line.number_of_events() ==
             cv_line.number_of_events());
-          
+
         { // search for new supporting curve and new arcno
             // since supporting curve was decomposed in two parts, arcno
             // represents y-position here
             ipair = cpv_line.curves_at_event(arcno());
-            // this must be 1-curve event 
+            // this must be 1-curve event
             CGAL_assertion(!(ipair.first != -1&&ipair.second != -1));
             this->ptr()->_m_arcno = (ipair.first != -1 ? ipair.first :
                 ipair.second);
@@ -2308,12 +2307,12 @@ protected:
         ///////////////////////////////////////////////////////////////////
         // TODO do we mean location of is_finite?
         if(_minpoint().location() == CGAL::ARR_INTERIOR)  {
-            
+
             cpv_line = cpa_2.status_line_for_x(x0);
-            CGAL_precondition(cpv_line.number_of_events() == 
+            CGAL_precondition(cpv_line.number_of_events() ==
                     orig_curve.status_line_for_x(x0).number_of_events());
             ipair = cpv_line.curves_at_event(this->ptr()->_m_arcno_min);
-            if(ipair.first != -1 && ipair.second != -1) 
+            if(ipair.first != -1 && ipair.second != -1)
                 // choose simpler supporting curve
 
               this->ptr()->_m_arcno_min = ((curve_idx) ?
@@ -2325,20 +2324,20 @@ protected:
             }
         } else // for infinite curve end arcno equals to interior arcno
             this->ptr()->_m_arcno_min = arcno();
-         
+
         // search for new target arcno
         /////////////// ATTENTION: this only holds for 2D plane topology !!
         ///////////////////////////////////////////////////////////////////
         // TODO do we mean location of is_finite?
         if(_maxpoint().location() == CGAL::ARR_INTERIOR) {
-            
-            x0 = _maxpoint().x(); 
+
+            x0 = _maxpoint().x();
             cpv_line = cpa_2.status_line_for_x(x0);
-            CGAL_precondition(cpv_line.number_of_events() == 
+            CGAL_precondition(cpv_line.number_of_events() ==
                     orig_curve.status_line_for_x(x0).number_of_events());
-                    
+
             ipair = cpv_line.curves_at_event(this->ptr()->_m_arcno_max);
-            if(ipair.first != -1 && ipair.second != -1) 
+            if(ipair.first != -1 && ipair.second != -1)
                 // choose simpler supporting curve (the one which matches
                 //  interior arcno)
                 this->ptr()->_m_arcno_max = (curve_idx ?
@@ -2361,12 +2360,12 @@ protected:
     //!\name Protected intersection methods
     //!@{
 
-    /*!\brief 
-     * returns \c true if the two arcs \c *this and \c cv2 overlap, 
+    /*!\brief
+     * returns \c true if the two arcs \c *this and \c cv2 overlap,
      * overlapping part(s) are inserted to the output iterator \c oi
-     * (of type \c Kernel_arc_2 ); if no overlapping parts found - 
+     * (of type \c Kernel_arc_2 ); if no overlapping parts found -
      * returns \c false
-     * 
+     *
      * \param cv2 The second arc
      * \param oi Report overlapping parts to this output iterator
      * \return \c true, if there was an overlap, \c false otherwise
@@ -2374,9 +2373,9 @@ protected:
     template < class OutputIterator >
     bool _trim_if_overlapped(const Kernel_arc_2& cv2, OutputIterator oi) const
     {
-               
-        CKvA_CERR("\n_trim_if_overlapped: this: " 
-             << *dynamic_cast< const Kernel_arc_2*>(this) << "; and " 
+
+        CKvA_CERR("\n_trim_if_overlapped: this: "
+             << *dynamic_cast< const Kernel_arc_2*>(this) << "; and "
              << cv2 << "\n");
         // one arc is vertical and the other one is not, or x-ranges are not
         // overlapping => quit
@@ -2396,28 +2395,28 @@ protected:
                     *dynamic_cast< const Kernel_arc_2*>(this), cv2
             );
             // coprime support => no overlaps
-            if(!curve().is_identical(cv2.curve())) 
+            if(!curve().is_identical(cv2.curve()))
                 return false;
-                
+
             // LARGER source and smaller target
             Point_2 src = (_same_arc_compare_xy(_minpoint(), cv2._minpoint(),
                  true) == CGAL::LARGER ? _minpoint() : cv2._minpoint()),
-                    tgt = (_same_arc_compare_xy(_maxpoint(), cv2._maxpoint(), 
+                    tgt = (_same_arc_compare_xy(_maxpoint(), cv2._maxpoint(),
                  true)  == CGAL::SMALLER ? _maxpoint() : cv2._maxpoint());
-            // vertical arcs do not overlap     
+            // vertical arcs do not overlap
             if(_same_arc_compare_xy(src, tgt, true) != CGAL::SMALLER)
                 return false;
             // construct a common part
             *oi++ = (_replace_endpoints(src, tgt, -1, -1).first);
             return true;
         }
-        // ask for joint x-range of two arcs 
+        // ask for joint x-range of two arcs
         // (LARGER source & smaller target curve ends)
         Point_2 src, tgt;
         if (!_joint_x_range(cv2, src, tgt)) {
             return false;
         }
-        
+
         if (curve().is_identical(cv2.curve())) {
             if(arcno() != cv2.arcno()) // arcnos are not equal => no overlaps
                 return false;
@@ -2427,18 +2426,18 @@ protected:
             *oi++ = _replace_endpoints(src, tgt, a_min, a_max).first;
             return true;
         }
-        
+
         // we are left with two non-vertical arcs whose supporting curves
         // are different => look for overlapping parts of the curves
         typedef std::vector<std::pair<Curve_analysis_2, int> >
             Curve_arcno_container;
         typedef std::vector<Curve_analysis_2> Curve_container;
         Curve_container parts_f, parts_g, common;
-                                
+
         if (!Curved_kernel_via_analysis_2::instance().
             kernel().decompose_2_object()(
-                    curve(), cv2.curve(), 
-                    std::back_inserter(parts_f), 
+                    curve(), cv2.curve(),
+                    std::back_inserter(parts_f),
                     std::back_inserter(parts_g),
                     std::back_inserter(common))) {
             return false; // supporting curves are coprime => quit
@@ -2446,20 +2445,20 @@ protected:
         Coordinate_1 x0;
         bool yes = false, inf_x = src.is_on_left_right();
         if(!inf_x) // choose a target x-coordinate from the joint x-range
-            x0 = src.x(); 
+            x0 = src.x();
         std::pair<int, int> ipair;
         Curve_pair_analysis_2 cpa_2;
         Curve_arcno_container found, overlaps;
-        
+
         CKvA_CERR("_trim_if_overlapped: non-coprime supporting curves\n");
-        
+
         typename Curve_pair_analysis_2::Status_line_1 cpv_line;
         // iterate to find all overlapping parts
         typename Curve_container::const_iterator it_parts, it_com;
         for (it_com = common.begin(); it_com != common.end(); it_com++) {
-            for(it_parts = parts_f.begin(); it_parts != parts_f.end(); 
+            for(it_parts = parts_f.begin(); it_parts != parts_f.end();
                     it_parts++) {
-               
+
                 cpa_2 = Curved_kernel_via_analysis_2::instance().
                         kernel().construct_curve_pair_2_object()
                             (*it_com, *it_parts);
@@ -2467,7 +2466,7 @@ protected:
                     cpa_2.status_line_for_x(x0, CGAL::POSITIVE));
                 // no intersections at this curve pair => skip it
                 if(arcno() >= cpv_line.number_of_events())
-                    continue; 
+                    continue;
                 ipair = cpv_line.curves_at_event(arcno(),*it_com,*it_parts);
                 // this must be 1-curve event: is this true ???
                 CGAL_assertion(!(ipair.first != -1&&ipair.second != -1));
@@ -2475,41 +2474,41 @@ protected:
                     found.push_back(std::make_pair(*it_com, ipair.first));
             }
         }
-        
+
         // now iterate over all "suspicious" common parts to find real overlaps
         typename Curve_arcno_container::const_iterator it_found;
         for (it_found = found.begin(); it_found != found.end(); it_found++) {
             for (it_parts = parts_g.begin(); it_parts != parts_g.end();
                  it_parts++) {
-                
+
                 cpa_2 = Curved_kernel_via_analysis_2::instance().
                         kernel().construct_curve_pair_2_object()
                             (it_found->first, *it_parts);
-                    
+
                 cpv_line = (inf_x ? cpa_2.status_line_of_interval(0) :
                     cpa_2.status_line_for_x(x0, CGAL::POSITIVE));
                 // no intersections at this curve pair => skip it
                 if(cv2.arcno() >= cpv_line.number_of_events())
-                    continue; 
+                    continue;
                 ipair = cpv_line.curves_at_event(cv2.arcno(),
                                                  it_found->first,
                                                  *it_parts);
                 // this must be 1-curve event: is this true ???
                 CGAL_assertion(!(ipair.first != -1&&ipair.second != -1));
-                if(ipair.first == -1 || ipair.first == it_found->second) 
+                if(ipair.first == -1 || ipair.first == it_found->second)
                     continue;
                 // lies on a common part and arcnos are the same: VUALA!!!
                 // here we need to "clip" [src.x(), tgt.x()] w.r.t. the
                 // defining x-range of a common part *it_found.. how ?
-                yes = true; // we've got it!                   
-                // now construct a common arc    
+                yes = true; // we've got it!
+                // now construct a common arc
                 Rep rep(*(this->ptr()));
                 rep._m_min = src;
                 rep._m_max = tgt;
                 rep._m_support = it_found->first;
                 rep._m_arcno = it_found->second;
                 rep._m_arcno_min = rep._m_arcno_max = rep._m_arcno;
-                
+
                 if(!inf_x) {
                     int a = arcno(src.x());
                     if(a != arcno()) {
@@ -2535,19 +2534,19 @@ protected:
                     }
                 }
                 *oi++ = Kernel_arc_2(rep);
-            }      
-        }  
+            }
+        }
         return yes;
     }
-    
+
     /*!\brief
-     * computes zero-dimensional intersections of \c cv1 with \c cv2. 
-     * 
-     * Intersection points 
-     * are inserted to the output iterator \c oi as objects of type 
+     * computes zero-dimensional intersections of \c cv1 with \c cv2.
+     *
+     * Intersection points
+     * are inserted to the output iterator \c oi as objects of type
      * <tt>std::pair<Point_2, unsigned int></tt> (intersection point +
      * multiplicity)
-     * 
+     *
      * \param cv1 the first arc
      * \param cv2 the second arc
      * \param oi reporting zero-dimensional intersections through this output
@@ -2556,12 +2555,12 @@ protected:
      */
     template < class OutputIterator >
     static OutputIterator _intersection_points(
-            const Kernel_arc_2& cv1, const Kernel_arc_2& cv2, 
+            const Kernel_arc_2& cv1, const Kernel_arc_2& cv2,
             OutputIterator oi) {
-        
-        // handle a special case when two arcs are supported by the same 
+
+        // handle a special case when two arcs are supported by the same
         // curve => only end-point intersections
-        
+
         CKvA_CERR("\nintersection_points\n");
         Kernel_arc_2::simplify(cv1, cv2);
         if (cv1.curve().is_identical(cv2.curve())) {
@@ -2574,21 +2573,21 @@ protected:
 
     /*!\brief
      * computes intersection of two arcs meeting only at their curve ends.
-     * 
+     *
      * Intersection points are returned in the output interator \c oi as object
      * of type std::pair<Point_2, int> (intersection + multiplicity)
-     * 
+     *
      * \param cv1 the first arc
      * \param cv2 the second arc
      * \param oi reporting zero-dimensional intersections through this output
      *        iterator
-     * 
+     *
      */
     template < class OutputIterator >
     static OutputIterator _intersect_at_endpoints(const Kernel_arc_2& cv1,
-                                                  const Kernel_arc_2& cv2, 
+                                                  const Kernel_arc_2& cv2,
                                                   OutputIterator oi) {
-        
+
         CKvA_CERR("\n_intersect_at_endpoints\n");
 
         CGAL_precondition(!cv1.do_overlap(cv2));
@@ -2596,83 +2595,83 @@ protected:
          * in the interior, the only remaining candidates for intersections are
          * their finite endpoints (if any), for vertical arcs as well.
          */
-        /*CGAL::Bound_type bnd_x, bnd_y, 
+        /*CGAL::Bound_type bnd_x, bnd_y,
             bnd1_x = cv2.boundary_in_x(CGAL::ARR_MIN_END),
             bnd1_y = cv2.boundary_in_y(CGAL::ARR_MIN_END),
             bnd2_x = cv2.boundary_in_x(CGAL::ARR_MAX_END),
             bnd2_y = cv2.boundary_in_y(CGAL::ARR_MAX_END);*/
-                
+
         // TODO do we mean location of is_finite?
         bool f2_min = (cv2._minpoint().location() == CGAL::ARR_INTERIOR),
              f2_max = (cv2._maxpoint().location() == CGAL::ARR_INTERIOR);
-        if(!(f2_min || f2_max)) // neither of curve ends is finite => 
+        if(!(f2_min || f2_max)) // neither of curve ends is finite =>
             return oi;          // no intersections
-            
+
         Point_2 pt;
-        
+
         CGAL::Arr_curve_end end = CGAL::ARR_MIN_END;
-        
+
         while(1) {
             CGAL::Arr_parameter_space loc = cv1.location(end);
             //bnd_x = boundary_in_x(end), bnd_y = boundary_in_y(end);
-            if(loc != CGAL::ARR_INTERIOR) 
+            if(loc != CGAL::ARR_INTERIOR)
                 goto Lendloop;
             pt = cv1.curve_end(end);
             // easy case: intersection at singularity doesn't require to
             // compare x/y-coordinates
-            /*if(is_singular(bnd_x)) { 
-                if(bnd1_x == bnd_x || bnd2_x == bnd_x) 
-                    *oi++ = std::make_pair(pt, 0); 
-                    
-            } else if(is_singular(bnd_y)) { 
-                if(bnd1_y == bnd_y || bnd2_y == bnd_y) 
-                    *oi++ = std::make_pair(pt, 0); 
-                    
+            /*if(is_singular(bnd_x)) {
+                if(bnd1_x == bnd_x || bnd2_x == bnd_x)
+                    *oi++ = std::make_pair(pt, 0);
+
+            } else if(is_singular(bnd_y)) {
+                if(bnd1_y == bnd_y || bnd2_y == bnd_y)
+                    *oi++ = std::make_pair(pt, 0);
+
             } else if(is_on_disc(bnd_x)) {
-    
+
     // CONFUSION: if bndx != bnd1_x should we compare ys at -oo
     // or at +oo ? or is this true for discontinuity:
     // 0th interval == the last interval ? (i.e. intervals are mirrored ?)
     // what if both conditions are satisfied at a time ? duplicates ?
                 if(bnd1_x == CGAL::AFTER_DISCONTINUITY &&
                     _compare_arc_numbers(cv2, bnd1_x) == CGAL::EQUAL)
-                    *oi++ = std::make_pair(pt, 0); 
-                    
+                    *oi++ = std::make_pair(pt, 0);
+
                 if(bnd2_x == CGAL::BEFORE_DISCONTINUITY &&
                     _compare_arc_numbers(cv2, bnd2_x) == CGAL::EQUAL)
-                    *oi++ = std::make_pair(pt, 0); 
-                    
+                    *oi++ = std::make_pair(pt, 0);
+
             } else if(is_on_disc(bnd_y)) {
                   // disc in y: compare only x-coordinates !
     // what if both conditions are satisfied at a time ? duplicates ?
-    
+
                 if(bnd1_y == CGAL::AFTER_DISCONTINUITY &&
                     kernel_2.compare_1_object()(pt.x(), _minpoint().x()) ==
                         CGAL::EQUAL)
                     *oi++ = std::make_pair(pt, 0);
-                    
+
                 if(bnd2_y == CGAL::BEFORE_DISCONTINUITY &&
                     kernel_2.compare_1_object()(pt.x(), _maxpoint().x()) ==
                         CGAL::EQUAL)
-                    *oi++ = std::make_pair(pt, 0);    
-              // ordinar normal case:      
+                    *oi++ = std::make_pair(pt, 0);
+              // ordinar normal case:
               // selection is exclusive since arcs cannot intersect twice
               // at the same finite end-point
               } else*/ if((f2_min && pt == cv2._minpoint()) ||
                           (f2_max && pt == cv2._maxpoint())) {
-                  *oi++ = std::make_pair(pt, 0); 
+                  *oi++ = std::make_pair(pt, 0);
               }
         Lendloop:
             if (end == CGAL::ARR_MAX_END) {
                 break;
             }
-            end = CGAL::ARR_MAX_END; 
+            end = CGAL::ARR_MAX_END;
         }
         return oi;
     }
-    
-    /*!\brief 
-     * computes a joint x-range of two arcs and returns \c true 
+
+    /*!\brief
+     * computes a joint x-range of two arcs and returns \c true
      * if arcs' x-ranges overlap; otherwise returns \c false
      *
      * \param cv2 The second arc
@@ -2684,40 +2683,40 @@ protected:
      *
      * \pre both arcs are not vertical
      */
-    bool _joint_x_range(const Kernel_arc_2& cv2, Point_2& pt_low, 
+    bool _joint_x_range(const Kernel_arc_2& cv2, Point_2& pt_low,
                         Point_2& pt_high) const {
-        
+
         CKvA_CERR("\n_joint_x_range\n");
-        
+
         CGAL_precondition(!is_vertical());
         CGAL_precondition(!cv2.is_vertical());
-        
+
         Point_2 pt1 = _minpoint(), pt2 = cv2._minpoint();
         Point_2 low = pt2, high;
         // find intersection x-range: larger source & smaller target
         if (pt1.location() != CGAL::ARR_LEFT_BOUNDARY) {
             if (pt2.location() != CGAL::ARR_LEFT_BOUNDARY) {
                 low = (Curved_kernel_via_analysis_2::instance().
-                       compare_x_2_object()(pt1, pt2) == 
-                       CGAL::LARGER ? pt1 : pt2); 
+                       compare_x_2_object()(pt1, pt2) ==
+                       CGAL::LARGER ? pt1 : pt2);
             } else {
                 low = pt1;
             }
-        } 
+        }
         pt1 = _maxpoint(), pt2 = cv2._maxpoint(), high = pt2;
         if (pt1.location() != CGAL::ARR_RIGHT_BOUNDARY) {
             if(pt2.location() != CGAL::ARR_RIGHT_BOUNDARY) {
                 high = (Curved_kernel_via_analysis_2::instance().
-                        compare_x_2_object()(pt1, pt2) == 
+                        compare_x_2_object()(pt1, pt2) ==
                         CGAL::SMALLER ? pt1 : pt2);
             } else {
                 high = pt1;
             }
-        } 
+        }
         if (!low.is_on_left_right() && !high.is_on_left_right() &&
             Curved_kernel_via_analysis_2::instance().
-            compare_x_2_object()(low, high) != 
-            CGAL::SMALLER) {// disjoint x-ranges 
+            compare_x_2_object()(low, high) !=
+            CGAL::SMALLER) {// disjoint x-ranges
             return false;
         }
         pt_low = low;
@@ -2725,13 +2724,13 @@ protected:
 
         return true;
     }
-    
+
     /*!\brief
-     * computes zero-dimensional 
+     * computes zero-dimensional
      * intersections of two arcs having coprime supporting curves
-     * 
+     *
      * intersection points are inserted to the output iterator \c oi as objects
-     * of type <tt>std::pair<Point_2, unsigned int></tt> (intersection point + 
+     * of type <tt>std::pair<Point_2, unsigned int></tt> (intersection point +
      * multiplicity)
      *
      * \param cv1 the first arc
@@ -2740,21 +2739,21 @@ protected:
      *        iterator
      */
     template <class OutputIterator>
-    static OutputIterator _intersect_coprime_support(const Kernel_arc_2& cv1, 
+    static OutputIterator _intersect_coprime_support(const Kernel_arc_2& cv1,
                                                      const Kernel_arc_2& cv2,
                                                      OutputIterator oi) {
-        // vertical arcs: the interesting case is when only one of the arcs is 
+        // vertical arcs: the interesting case is when only one of the arcs is
         // vertical - otherwise there is no intersection (different x-coords),
-        // or they overlap (not allowed), or they touch at the end-points 
+        // or they overlap (not allowed), or they touch at the end-points
         // (already tested)
-        
+
         CKvA_CERR("\n_intersect_coprime_support: " << cv1 <<
             " and " << cv2 << "\n");
-        
+
         if (cv1.is_vertical() || cv2.is_vertical()) {
             CGAL_assertion(cv1.is_vertical() != cv2.is_vertical());
             // due to coprimality condition, supporting curves are different =>
-            // they have no common vertical line therefore there is no 
+            // they have no common vertical line therefore there is no
             // intersection
             const Kernel_arc_2& vert = (cv1.is_vertical() ? cv1 : cv2),
                 nonvert = (cv1.is_vertical() ? cv2 : cv1);
@@ -2762,13 +2761,13 @@ protected:
             // vertical arc does not lie within another arc's x-range => no
             // intersections
             if (!nonvert.is_in_x_range(x)) {
-                return oi;    
+                return oi;
             }
             typename Curved_kernel_via_analysis_2:: Construct_point_on_arc_2
-                construct_point_on_arc = 
+                construct_point_on_arc =
                 Curved_kernel_via_analysis_2::instance().
                 construct_point_on_arc_2_object();
-            
+
 
             Point_2 xy = construct_point_on_arc(
                     x, nonvert.curve(), nonvert.arcno(x), nonvert
@@ -2778,7 +2777,7 @@ protected:
             }
             return oi;
         }
-        
+
         Point_2 low_x, high_x;
         // x-ranges are disjoint => nothing to do
         if (!cv1._joint_x_range(cv2, low_x, high_x)) {
@@ -2790,7 +2789,7 @@ protected:
         Curve_pair_analysis_2 cpa_2 =
             Curved_kernel_via_analysis_2::instance().
                 kernel().construct_curve_pair_2_object()(f, g);
-        int low_idx = 0,       
+        int low_idx = 0,
             high_idx = cpa_2.number_of_status_lines_with_event()-1;
 
 	bool index_at_event_min=false;
@@ -2812,7 +2811,7 @@ protected:
 		}
             }
         }
-                   
+
         if(!inf_high) {
             line = cpa_2.status_line_for_x(high_x.x());
             high_idx = line.index();
@@ -2828,8 +2827,8 @@ protected:
 	      index_at_event_max=false;
 	    }
         }
-                
-        // run over all event points within the joint x-range of two arcs 
+
+        // run over all event points within the joint x-range of two arcs
         // looking whether a particular event is made of both curves, i.e.,
         // grabbing all 2-curve events
         std::pair<int, int> ipair;
@@ -2837,26 +2836,26 @@ protected:
 
         typename CGAL::Polynomial_traits_d<
             typename Curve_kernel_2::Polynomial_2>::Total_degree deg;
-        
+
         bool which_curve = (deg(f.polynomial_2()) < deg(g.polynomial_2()));
         for(int i = low_idx; i <= high_idx; i++) {
-            typename Curve_pair_analysis_2::Status_line_1 tmp = 
+            typename Curve_pair_analysis_2::Status_line_1 tmp =
                 cpa_2.status_line_at_event(i);
-            if(!tmp.is_intersection()) 
+            if(!tmp.is_intersection())
                 continue;
 
             Coordinate_1 x0 = tmp.x();
-            if((i == low_idx && index_at_event_min) || 
+            if((i == low_idx && index_at_event_min) ||
 	       (i == high_idx && index_at_event_max)) {
                 arcno1 = cv1.arcno(x0);
                 arcno2 = cv2.arcno(x0);
-                mult = 0; // intersection at end-point 
+                mult = 0; // intersection at end-point
             } else {
                 arcno1 = cv1.arcno();
                 arcno2 = cv2.arcno();
                 mult = -1; // need to compute
             }
-            
+
             int pos = tmp.event_of_curve(arcno1, f);
             if (pos != tmp.event_of_curve(arcno2, g)) {
                 continue;
@@ -2864,13 +2863,13 @@ protected:
             if (mult == -1) {
                 mult = tmp.multiplicity_of_intersection(pos);
             }
-            
-            // pick up the curve with lower degree   
+
+            // pick up the curve with lower degree
             typename Curved_kernel_via_analysis_2::Construct_point_on_arc_2
-                construct_point_on_arc = 
+                construct_point_on_arc =
                 Curved_kernel_via_analysis_2::instance().
                 construct_point_on_arc_2_object();
-            
+
             if (which_curve) {
                 Point_2 p = construct_point_on_arc(
                         x0, cv1.curve(), arcno1, cv1
@@ -2885,45 +2884,45 @@ protected:
         }
         return oi;
     }
-    
+
     #undef CGAL_CKvA_2_GRAB_CK_FUNCTOR_FOR_ARC
     //!@}
 
-  
+
     //!\name Approximation
     //!@{
 
 private:
-  
+
   std::pair<double,double> y_interval_for_curve_end(
       const Arc_2& arc,
       CGAL::Arr_curve_end end,
-      long prec) 
+      long prec)
     const {
-    
+
     double PINF = std::numeric_limits<double>::infinity();
     double MINF = -PINF;
-    
+
     std::pair< Bound, Bound > y_approx;
-    
+
     switch (this->location(end)) {
-      
+
     case (CGAL::ARR_TOP_BOUNDARY): {
       return std::make_pair(PINF, PINF); // early exit
     }
     case (CGAL::ARR_BOTTOM_BOUNDARY): {
       return std::make_pair(MINF, MINF); // early exit
     }
-    case(CGAL::ARR_LEFT_BOUNDARY): 
+    case(CGAL::ARR_LEFT_BOUNDARY):
     case(CGAL::ARR_RIGHT_BOUNDARY): {
-      
+
       CGAL::Object obj = this->curve().asymptotic_value_of_arc(
           this->location(end), this->arcno()
       );
-      
+
       CGAL::Arr_parameter_space ps;
       Coordinate_1 asym_info;
-      
+
       if (CGAL::assign(ps, obj)) {
         if (ps == CGAL::ARR_BOTTOM_BOUNDARY) {
           return std::make_pair(MINF, MINF); // early exit
@@ -2931,10 +2930,10 @@ private:
           CGAL_assertion(ps == CGAL::ARR_TOP_BOUNDARY);
           return std::make_pair(PINF, PINF); // early exit
         }
-        
+
       } else {
-        
-        CGAL_assertion_code(bool check =) 
+
+        CGAL_assertion_code(bool check =)
           CGAL::assign(asym_info, obj);
         CGAL_assertion(check);
 
@@ -2944,31 +2943,31 @@ private:
       break;
     }
     case (CGAL::ARR_INTERIOR): {
-      
-      y_approx = 
+
+      y_approx =
         Curved_kernel_via_analysis_2::instance().
         kernel().approximate_absolute_y_2_object()(
             arc.curve_end(end).xy(), prec
         );
-      
+
     }
     } // switch
-    
+
     return std::make_pair(CGAL::to_double(y_approx.first),
                           CGAL::to_double(y_approx.second));
   }
-  
+
 public:
 
-    /*!\brief 
+    /*!\brief
      * bbounding box for arc
      */
     CGAL::Bbox_2 bbox() const {
       if (!this->ptr()->_m_bbox) {
-        
+
         double PINF = std::numeric_limits<double>::infinity();
         double MINF = -PINF;
-        
+
         double xmin;
         double xmax;
 
@@ -2986,64 +2985,64 @@ public:
         if (this->location(CGAL::ARR_MIN_END) == CGAL::ARR_INTERIOR ||
             this->location(CGAL::ARR_MIN_END) == CGAL::ARR_BOTTOM_BOUNDARY ||
             this->location(CGAL::ARR_MIN_END) == CGAL::ARR_TOP_BOUNDARY) {
-          
-          std::pair< Bound, Bound > x_approx = 
+
+          std::pair< Bound, Bound > x_approx =
             Curved_kernel_via_analysis_2::instance().
             kernel().approximate_absolute_1_object()(
                 this->curve_end_x(CGAL::ARR_MIN_END), prec
             );
-          
+
           xmin = CGAL::to_double(x_approx.first);
-          
+
         } else {
-        
+
           // left end can only lie on LEFT BOUNDARY
           xmin = MINF;
-          
+
         }
-        
+
         // ymin/ymax for left
         y_dapprox = y_interval_for_curve_end(*this, CGAL::ARR_MIN_END, prec);
-        
+
         // adapt y-interval
         ymin = CGAL::min(ymin, y_dapprox.first);
         ymax = CGAL::max(ymax, y_dapprox.second);
-        
+
         // right end
 
         // xmax for right
         if (this->location(CGAL::ARR_MAX_END) == CGAL::ARR_INTERIOR ||
             this->location(CGAL::ARR_MAX_END) == CGAL::ARR_BOTTOM_BOUNDARY ||
             this->location(CGAL::ARR_MAX_END) == CGAL::ARR_TOP_BOUNDARY) {
-          
-          std::pair< Bound, Bound > x_approx = 
+
+          std::pair< Bound, Bound > x_approx =
             Curved_kernel_via_analysis_2::instance().
             kernel().approximate_absolute_1_object()(
                 this->curve_end_x(CGAL::ARR_MAX_END), prec
             );
-          
+
           xmax = CGAL::to_double(x_approx.second);
-          
+
         } else {
-        
+
           // right end can only lie on RIGHT BOUNDARY
           xmax = PINF;
-          
+
         }
-        
+
         // ymin/ymax for right
         y_dapprox = y_interval_for_curve_end(*this, CGAL::ARR_MAX_END, prec);
-        
+
         // adapt y-interval
         ymin = CGAL::min(ymin, y_dapprox.first);
         ymax = CGAL::max(ymax, y_dapprox.second);
-        
+
         // search local extrema on a non-vertical arc
-        
+
         if (!this->is_vertical()) {
 
           // TODO remove algebraic notation (Mult, Solve_2)
-          
+
           typedef typename Curve_kernel_2::Multiplicity_type Multiplicity_type;
 
           std::vector< std::pair< Coordinate_2, Multiplicity_type > > pts;
@@ -3059,37 +3058,37 @@ public:
                 ),
                 std::back_inserter(pts)
             );
-          
+
           int n = static_cast<int>(pts.size());
           CKvA_CERR("check candidates for y-extremal points: #" << n );
           for (int i = 0; i < n; i++) {
-            
-            const Coordinate_2& curr_xy = pts[i].first; 
+
+            const Coordinate_2& curr_xy = pts[i].first;
 
 
 #if 0
-            // EBEB: Disabled this test as curr_xy's curve 
+            // EBEB: Disabled this test as curr_xy's curve
             //       is not guaranteed to be wrt this->curve()
-            
-            CKvA_CERR("check if arcnos match: " << 
-                 curr_xy << "; arc = " << *this << "\n\n"); 
+
+            CKvA_CERR("check if arcnos match: " <<
+                 curr_xy << "; arc = " << *this << "\n\n");
             // this is the simpler test, thus we evaluate it first
             if (this->arcno() == curr_xy.arcno()) {
-              CKvA_CERR("check if x-coordinate lies in interior: " << 
+              CKvA_CERR("check if x-coordinate lies in interior: " <<
                    curr_xy << "; arc = " << *this << "\n\n");
               // this is the more sophisticated test, thus second
               if (this->is_in_x_range_interior(curr_xy.x())) {
                 CKvA_CERR("update y coordinates");
-                
-                std::pair< Bound, Bound > xy_approx = 
+
+                std::pair< Bound, Bound > xy_approx =
                   Curved_kernel_via_analysis_2::instance().
                   kernel().approximate_absolute_y_2_object()
                   (curr_xy, prec);
-                
+
                 // adapt y-interval
-                ymin = CGAL::min(ymin, 
+                ymin = CGAL::min(ymin,
                                  CGAL::to_double(xy_approx.first));
-                ymax = CGAL::max(ymax, 
+                ymax = CGAL::max(ymax,
                                  CGAL::to_double(xy_approx.second));
               }
             }
@@ -3097,24 +3096,24 @@ public:
             // this is the more sophisticated test, thus second
             if (this->is_in_x_range_interior(curr_xy.x())) {
               // TODO replace with is_on
-              Point_2 curr_pt = 
+              Point_2 curr_pt =
                 Curved_kernel_via_analysis_2::instance().
-                construct_point_2_object()(curr_xy.x(), 
+                construct_point_2_object()(curr_xy.x(),
                                            curr_xy.curve(),
                                            curr_xy.arcno());
               if (this->compare_y_at_x(curr_pt) == CGAL::EQUAL) {
-                
+
                 CKvA_CERR("update y coordinates");
-                
-                std::pair< Bound, Bound > xy_approx = 
+
+                std::pair< Bound, Bound > xy_approx =
                   Curved_kernel_via_analysis_2::instance().
                   kernel().approximate_absolute_y_2_object()
                   (curr_xy, prec);
-                
+
                 // adapt y-interval
-                ymin = CGAL::min(ymin, 
+                ymin = CGAL::min(ymin,
                                  CGAL::to_double(xy_approx.first));
-                ymax = CGAL::max(ymax, 
+                ymax = CGAL::max(ymax,
                                  CGAL::to_double(xy_approx.second));
               }
             }
@@ -3126,14 +3125,14 @@ public:
 
       return *(this->ptr()->_m_bbox);
     }
-  
+
     //!}
 
 
 public:
     //!\name IO
     //!@{
-    
+
     /*!\brief
      * output operator
      *
@@ -3190,11 +3189,11 @@ public:
      * read arc from \c is
      */
     void read(std::istream& is) {
-      
+
       CGAL_precondition(CGAL::is_ascii(is));
-      
+
       Rep rep;
-      
+
       // read "Arc_2("
       swallow(is, 'A');
       swallow(is, 'r');
@@ -3202,7 +3201,7 @@ public:
       swallow(is, '_');
       swallow(is, '2');
       swallow(is, '(');
-      
+
       Point_2 min, max;
 
       // read values
@@ -3224,15 +3223,15 @@ public:
 
       // read the ')'
       swallow(is, ')');
-      
+
       *this = Arc_2< Curved_kernel_via_analysis_2, Rep >(rep);
     }
-  
+
     //!@}
 
     //! equality
     inline
-    bool operator == (const Kernel_arc_2& arc2) const { 
+    bool operator == (const Kernel_arc_2& arc2) const {
         return  is_equal(arc2);
     }
 
@@ -3261,9 +3260,9 @@ public:
         Z<Curved_kernel_via_analysis_2>
 #endif // defined(_MSC_VER) || defined(__clang__) || defined(__INTEL_COMPILER)
 
-  
-//Curved_kernel_via_analysis_2_functors<  
-  //              Curved_kernel_via_analysis_2> >; 
+
+//Curved_kernel_via_analysis_2_functors<
+  //              Curved_kernel_via_analysis_2> >;
 
     CGAL_BEFRIEND_CKvA_2_FUNCTOR(Construct_arc_2);
     CGAL_BEFRIEND_CKvA_2_FUNCTOR(Is_vertical_2);
@@ -3293,12 +3292,12 @@ public:
 #undef CGAL_BEFRIEND_CKvA_2_FUNCTOR
 
 private:
-    
+
     // type of CurveSweepTraits model
     typedef CGAL::Sweep_curves_adapter_2< Curved_kernel_via_analysis_2 > SCA_2;
     // befriend segment for Self::_intersection_points
     friend class internal::Generic_arc_2<SCA_2>;
-    
+
     /*
     // befriend all functors
 #define CGAL_BEFRIEND_SWEEP_CURVES_ADAPTER_2_FUNCTOR(Z) \
@@ -3326,7 +3325,7 @@ private:
 }; // class Arc_2
 
 /*!\relates Arc_2
- * \brief 
+ * \brief
  * output operator
  *
  * writes \c arc to \c os
@@ -3336,7 +3335,7 @@ inline
 std::ostream& operator<<(
     std::ostream& os,
     const Arc_2<CurvedKernelViaAnalysis_2, Rep_>& arc) {
-  
+
   arc.write(os);
   return os;
 }
@@ -3345,14 +3344,14 @@ std::ostream& operator<<(
 //! \brief Reads the objects from stream.
 template < class CurvedKernelViaAnalysis_2, class Rep_ >
 std::istream& operator>> (
-    std::istream& is, 
+    std::istream& is,
     Arc_2< CurvedKernelViaAnalysis_2, Rep_ >& arc) {
-  
+
   CGAL_precondition(CGAL::is_ascii(is));
-  
+
   //typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
   //typedef Rep_ Rep;
-  
+
   arc.read(is);
 
   return is;

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2007,2008,2009,2010,2011 Max-Planck-Institute Saarbruecken (Germany), 
+// Copyright (c) 2007,2008,2009,2010,2011 Max-Planck-Institute Saarbruecken (Germany),
 // and Tel-Aviv University (Israel).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org); you can redistribute it and/or
@@ -18,7 +18,7 @@
 //
 // Author(s)     : Eric Berberich <eric@mpi-inf.mpg.de>
 //                 Arno Eigenwillig <arno@mpi-inf.mpg.de>
-//                 Pavel Emeliyanenko <asm@mpi-sb.mpg.de> 
+//                 Pavel Emeliyanenko <asm@mpi-sb.mpg.de>
 //
 // ============================================================================
 
@@ -39,67 +39,67 @@ namespace CGAL {
 
 namespace internal {
 
-/*!\brief 
- * Splits a curve that can be analyzed 
+/*!\brief
+ * Splits a curve that can be analyzed
  * into connected x-monotone sweepable arcs and isolated points.
  *
  * Arcs are stored as CurvedKernelViaAnalysis_2::Arc_2 objects, and
- * each is either vertical or consists of an x-monotone piece 
+ * each is either vertical or consists of an x-monotone piece
  * of constant arc number wrt to the curve at every interior x-coordinate.
  * Isolated points are stored as \c CurvedKernelViaAnalysis_2::Point_2 objects.
- * 
+ *
  * The resulting arcs and points are written to the output iterator as
  * polymorphic \c CGAL::Object. Past-the-end value of the iterator is returned.
  */
-template < class CurvedKernelViaAnalysis_2, 
-           class ConstructArc_2 = 
+template < class CurvedKernelViaAnalysis_2,
+           class ConstructArc_2 =
            typename CurvedKernelViaAnalysis_2::Construct_arc_2 >
 struct Make_x_monotone_2 :
     public std::binary_function< typename CurvedKernelViaAnalysis_2::Curve_2,
             std::iterator<std::output_iterator_tag, CGAL::Object>,
             std::iterator<std::output_iterator_tag, CGAL::Object> > {
-            
+
     //!\name Public types
     //!@{
-    
+
     //! this instance's first template parameter
     typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
-    
+
     //! this instance's second template parameter
     typedef ConstructArc_2 Construct_arc_2;
 
     //! type of curve kernel
     typedef typename Curved_kernel_via_analysis_2::Curve_kernel_2
     Curve_kernel_2;
-    
+
     //! type of x-coordinate
     typedef typename Curve_kernel_2::Coordinate_1 Coordinate_1;
-    
+
     //! type of xy-coordinate
     typedef typename Curve_kernel_2::Coordinate_2 Coordinate_2;
-    
+
     //! type of curve analysis
     typedef typename Curve_kernel_2::Curve_analysis_2 Curve_analysis_2;
-    
+
     //! type of vertical line
     typedef typename Curve_analysis_2::Status_line_1 Status_line_1;
-    
+
     //! type of point on curve
     typedef typename Curved_kernel_via_analysis_2::Point_2 Point_2;
-    
+
     //! type of curve arc
     typedef typename Curved_kernel_via_analysis_2::Arc_2 Arc_2;
 
     //! type of not necessarily x-monotone curve arc
     typedef typename Curved_kernel_via_analysis_2::Non_x_monotone_arc_2
         Non_x_monotone_arc_2;
-    
+
     //!@}
 
     //!\name Constructors
     //!@{
 
-    /*!\brief 
+    /*!\brief
      * Standard constructor
      *
      * \param kernel The kernel instance to use
@@ -115,7 +115,7 @@ struct Make_x_monotone_2 :
     //!@{
 
     // TODO add operator for non-x-monotone arc
-    
+
     /*!\brief
      * Splits a curve into x-monotone arcs and isolated points
      *
@@ -127,21 +127,21 @@ struct Make_x_monotone_2 :
     template <class OutputIterator>
     OutputIterator operator()(Curve_analysis_2 curve, OutputIterator oi) {
 
-        Construct_arc_2 construct_arc_2 = 
+        Construct_arc_2 construct_arc_2 =
             _m_curved_kernel->construct_arc_2_object();
         // use CGAL::Total_degree ?
-        if (typename CGAL::Polynomial_traits_d< 
+        if (typename CGAL::Polynomial_traits_d<
             typename Curve_analysis_2::Polynomial_2 >::
             Total_degree()(curve.polynomial_2()) < 1) {
             return oi;
         }
-        
+
         Status_line_1 evt_line1, evt_line2,
             int_line = curve.status_line_of_interval(0);
         int total_events = curve.number_of_status_lines_with_event();
         // handle special case of a curve without any events
         if(total_events == 0) {
-            for(int k = 0; k < int_line.number_of_events(); k++) 
+            for(int k = 0; k < int_line.number_of_events(); k++)
                 *oi++ = CGAL::make_object(construct_arc_2(curve, k));
             return oi;
         }
@@ -150,8 +150,8 @@ struct Make_x_monotone_2 :
             Curve_interval_arcno_cache CIA_cache;
         const CIA_cache& map_interval_arcno =
             _m_curved_kernel->interval_arcno_cache();
-        
-        typename Curved_kernel_via_analysis_2::Construct_point_2 
+
+        typename Curved_kernel_via_analysis_2::Construct_point_2
             construct_point =
             _m_curved_kernel->construct_point_2_object();
 
@@ -163,22 +163,22 @@ struct Make_x_monotone_2 :
         // first handle segments before first event
         evt_line1 = curve.status_line_at_event(0);
         max_x = evt_line1.x();
-        
-        for(k = 0; k < evt_line1.number_of_events(); k++) 
+
+        for(k = 0; k < evt_line1.number_of_events(); k++)
             max_pts.push_back(construct_point(max_x, curve, k));
-                        
-        //std::cout << "handling events over the 1st interval\n";    
+
+        //std::cout << "handling events over the 1st interval\n";
         for(k = 0; k < int_line.number_of_events(); k++) {
-            
-            info1 = map_interval_arcno(evt_line1, 1, k); 
+
+            info1 = map_interval_arcno(evt_line1, 1, k);
             if (info1.second != CGAL::ARR_INTERIOR) {
-                arc = construct_arc_2(CGAL::ARR_MIN_END, max_x, 
-                                      (info1.second == 
+                arc = construct_arc_2(CGAL::ARR_MIN_END, max_x,
+                                      (info1.second ==
                                        CGAL::ARR_BOTTOM_BOUNDARY ?
-                                       CGAL::ARR_MIN_END : CGAL::ARR_MAX_END), 
+                                       CGAL::ARR_MIN_END : CGAL::ARR_MAX_END),
                                       curve, k);
             } else {
-                arc = construct_arc_2(max_pts[info1.first], CGAL::ARR_MIN_END, 
+                arc = construct_arc_2(max_pts[info1.first], CGAL::ARR_MIN_END,
                                       curve, k, info1.first
                 );
             }
@@ -187,42 +187,42 @@ struct Make_x_monotone_2 :
         min_pts = max_pts;
         max_pts.clear();
         min_x = max_x;
-               
+
         // next handle arcs between events, including isolated points
         for (i = 0; i < total_events-1; i++) {
             evt_line1 = curve.status_line_at_event(i);
             evt_line2 = curve.status_line_at_event(i+1);
             max_x = evt_line2.x();
             oi = _handle_vertical_and_isolated(evt_line1, min_x, min_pts, oi);
-                                
+
             n = evt_line2.number_of_events();
-            for(k = 0; k < n; k++) 
+            for(k = 0; k < n; k++)
                 max_pts.push_back(construct_point(max_x, curve, k));
-            
+
             n = curve.status_line_of_interval(i+1).number_of_events();
             CGAL::Arr_curve_end inf1_end, inf2_end;
             for (k = 0; k < n; k++) {
-                
-                info1 = map_interval_arcno(evt_line1, 0, k); 
-                info2 = map_interval_arcno(evt_line2, 1, k); 
-                inf2_end = (info2.second == CGAL::ARR_BOTTOM_BOUNDARY ? 
+
+                info1 = map_interval_arcno(evt_line1, 0, k);
+                info2 = map_interval_arcno(evt_line2, 1, k);
+                inf2_end = (info2.second == CGAL::ARR_BOTTOM_BOUNDARY ?
                     CGAL::ARR_MIN_END : CGAL::ARR_MAX_END);
-                
+
                 if (info1.second != CGAL::ARR_INTERIOR) {
-                    inf1_end = (info1.second == CGAL::ARR_BOTTOM_BOUNDARY ? 
+                    inf1_end = (info1.second == CGAL::ARR_BOTTOM_BOUNDARY ?
                         CGAL::ARR_MIN_END : CGAL::ARR_MAX_END);
                     if (info2.second != CGAL::ARR_INTERIOR) {
                         arc = construct_arc_2(min_x, inf1_end, max_x, inf2_end,
                                               curve, k);
                     } else {
-                        arc = construct_arc_2(max_pts[info2.first], min_x, 
+                        arc = construct_arc_2(max_pts[info2.first], min_x,
                                               inf1_end, curve, k, info2.first);
                     }
                 } else if (info2.second != CGAL::ARR_INTERIOR) {
                     arc = construct_arc_2(min_pts[info1.first],  max_x,
                                           inf2_end, curve, k, info1.first);
                 } else {
-                    arc = construct_arc_2(min_pts[info1.first], 
+                    arc = construct_arc_2(min_pts[info1.first],
                                           max_pts[info2.first],
                                           curve, k, info1.first, info2.first);
                 }
@@ -232,26 +232,26 @@ struct Make_x_monotone_2 :
             max_pts.clear();
             min_x = max_x;
         }
-        
+
         // here: min_x/min_pts hold information about the last event line
         // event_line2 - points to the last event line
         // vertical line or isolated points at last event?
         evt_line2 = curve.status_line_at_event(total_events-1);
         min_x = evt_line2.x();
         oi = _handle_vertical_and_isolated(evt_line2, min_x, min_pts, oi);
-        
+
         n = curve.status_line_of_interval(total_events).number_of_events();
         for (k = 0; k < n; k++) {
-        
-            info1 = map_interval_arcno(evt_line2, 0, k); 
+
+            info1 = map_interval_arcno(evt_line2, 0, k);
             if (info1.second != CGAL::ARR_INTERIOR) {
                 arc = construct_arc_2(
-                        CGAL::ARR_MAX_END, min_x, 
-                        (info1.second == CGAL::ARR_BOTTOM_BOUNDARY ? 
+                        CGAL::ARR_MAX_END, min_x,
+                        (info1.second == CGAL::ARR_BOTTOM_BOUNDARY ?
                          CGAL::ARR_MIN_END : CGAL::ARR_MAX_END), curve, k
                 );
             } else {
-                arc = construct_arc_2(min_pts[info1.first], 
+                arc = construct_arc_2(min_pts[info1.first],
                                       CGAL::ARR_MAX_END, curve, k,
                                       info1.first);
             }
@@ -264,7 +264,7 @@ struct Make_x_monotone_2 :
 private:
     //!\name Private members
     //!@{
-    
+
     /*!\brief
      * Constructs vertical arcs and isolated points at event line
      *
@@ -278,12 +278,12 @@ private:
     template <class OutputIterator>
     OutputIterator _handle_vertical_and_isolated(
             Status_line_1 cv_line,
-            Coordinate_1 x, std::vector<Point_2> pts, 
+            Coordinate_1 x, std::vector<Point_2> pts,
             OutputIterator oi) const {
-        
-        Construct_arc_2 construct_arc_2 = 
+
+        Construct_arc_2 construct_arc_2 =
             _m_curved_kernel->construct_arc_2_object();
-        
+
         int n = cv_line.number_of_events(), j;
         if(cv_line.covers_line()) { // look for vertical arcs
             if(n > 0) {
@@ -295,22 +295,23 @@ private:
                     *oi++ = CGAL::make_object(construct_arc_2(pts[j], pts[j+1],
                                                               _m_curve));
                     // the last vertical ray
-                    *oi++ = CGAL::make_object(construct_arc_2(pts[n-1], 
-                        CGAL::ARR_MAX_END, _m_curve));
+                    *oi++ = CGAL::make_object(construct_arc_2(pts[n-1],
+                                                              CGAL::ARR_MAX_END,
+                                                              _m_curve));
             } else // unbounded vertical line
                 *oi++ = CGAL::make_object(construct_arc_2(x, _m_curve));
             return oi;
-        } 
+        }
         // look for isolated points
         std::pair<int, int> ipair;
         for(j = 0; j < n; j++) {
             ipair = cv_line.number_of_incident_branches(j);
             if(ipair.first == 0&&ipair.second == 0) {
                 //std::cout << "isolated point found\n";
-                typename Curved_kernel_via_analysis_2::Construct_point_2 
+                typename Curved_kernel_via_analysis_2::Construct_point_2
                     construct_point =
                     _m_curved_kernel->construct_point_2_object();
-                
+
                 *oi++ = CGAL::make_object(construct_point(x, _m_curve, j));
             }
         }
@@ -321,13 +322,13 @@ private:
 
     //!\name Private data
     //!@{
-            
-    //! pointer to \c Curved_kernel_via_analysis_2 
+
+    //! pointer to \c Curved_kernel_via_analysis_2
     Curved_kernel_via_analysis_2 *_m_curved_kernel;
 
     //! to avoid passing curve as a parameter
     Curve_analysis_2 _m_curve;
-    
+
     //!@}
 };  // struct Make_x_monotone
 

--- a/Arrangement_on_surface_2/include/CGAL/IO/Arr_iostream.h
+++ b/Arrangement_on_surface_2/include/CGAL/IO/Arr_iostream.h
@@ -12,10 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Ron Wein           <wein@post.tau.ac.il>
 //                 (based on old version by Michal Meyerovitch and Ester Ezra)
 
@@ -44,7 +40,7 @@ namespace CGAL {
 template <class GeomTraits, class TopTraits, class Formatter>
 std::ostream&
     write (const Arrangement_on_surface_2<GeomTraits,TopTraits>& arr,
-           std::ostream& os, 
+           std::ostream& os,
            Formatter& format)
 {
   typedef Arrangement_on_surface_2<GeomTraits,TopTraits>  Arrangement_2;
@@ -64,7 +60,7 @@ std::ostream&
  */
 template <class GeomTraits, class TopTraits>
 std::ostream&
-    operator<< (std::ostream& os, 
+    operator<< (std::ostream& os,
                 const Arrangement_on_surface_2<GeomTraits,TopTraits>& arr)
 {
   typedef Arrangement_on_surface_2<GeomTraits,TopTraits>  Arrangement_2;
@@ -87,7 +83,7 @@ std::ostream&
 template <class GeomTraits, class TopTraits, class Formatter>
 std::istream&
     read (Arrangement_on_surface_2<GeomTraits,TopTraits>& arr,
-          std::istream& is, 
+          std::istream& is,
           Formatter& format)
 {
   typedef Arrangement_on_surface_2<GeomTraits,TopTraits>  Arrangement_2;
@@ -107,7 +103,7 @@ std::istream&
  */
 template <class GeomTraits, class TopTraits>
 std::istream&
-    operator>> (std::istream& is, 
+    operator>> (std::istream& is,
                 Arrangement_on_surface_2<GeomTraits,TopTraits>& arr)
 {
   typedef Arrangement_on_surface_2<GeomTraits,TopTraits>  Arrangement_2;
@@ -116,7 +112,7 @@ std::istream&
 
   Text_formatter text_format (is);
   Arr_reader      reader(arr);
-  
+
   reader (text_format);
   return (is);
 }

--- a/Arrangement_on_surface_2/include/CGAL/IO/Arrangement_2_writer.h
+++ b/Arrangement_on_surface_2/include/CGAL/IO/Arrangement_2_writer.h
@@ -12,10 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Ron Wein           <wein@post.tau.ac.il>
 //                 (based on old version by Michal Meyerovitch and Ester Ezra)
 //
@@ -197,17 +193,17 @@ namespace CGAL {
       formatter.write_edge_begin();
       formatter.write_vertex_index(_index(he_t->vertex()));
       formatter.write_vertex_index(_index(he->vertex()));
-    
+
       if (he->direction() == ARR_LEFT_TO_RIGHT)
         formatter.write_vertex_index(0);
       else
         formatter.write_vertex_index(1);
-      
+
       if (! he->has_null_curve())
       {
         // Write the associated curve.
         formatter.write_vertex_index(1);
-        formatter.write_x_monotone_curve(he->curve()); 
+        formatter.write_x_monotone_curve(he->curve());
 
         // Write additional user-defined data.
         formatter.write_halfedge_data(Halfedge_const_handle(he));
@@ -253,7 +249,7 @@ namespace CGAL {
         const std::size_t              n = _circulator_size(*oc_it);
 
         formatter.write_size("halfedges_on_outer_ccb", n);
-        _write_ccb(formatter, *oc_it);      
+        _write_ccb(formatter, *oc_it);
       }
       formatter.write_inner_ccbs_end();
 
@@ -267,7 +263,7 @@ namespace CGAL {
       {
         const std::size_t n = _circulator_size(*ic_it);
         formatter.write_size("halfedges_on_inner_ccb", n);
-        _write_ccb(formatter, *ic_it);      
+        _write_ccb(formatter, *ic_it);
       }
       formatter.write_inner_ccbs_end();
 
@@ -282,7 +278,7 @@ namespace CGAL {
           formatter.write_vertex_index(_index(&(*iso_vit)));
         formatter.write_isolated_vertices_end();
       }
-    
+
       // Write additional user-defined data associated with the face.
       if (! f->is_fictitious())
         formatter.write_face_data(Face_const_handle(f));
@@ -291,8 +287,8 @@ namespace CGAL {
     }
 
     /*! Write the edges along a given CCB. */
-    template <class Formatter>   
-    void _write_ccb(Formatter& formatter, const DHalfedge* ccb) const      
+    template <class Formatter>
+    void _write_ccb(Formatter& formatter, const DHalfedge* ccb) const
     {
       const DHalfedge* curr = ccb;
 
@@ -303,7 +299,7 @@ namespace CGAL {
       } while (curr != ccb);
       formatter.write_ccb_halfedges_end();
     }
-  
+
     /*! Get the mapped index of a given vertex. */
     int _index(const DVertex* v) const
     {
@@ -336,9 +332,9 @@ namespace CGAL {
       } while (curr != ccb);
 
       return (n);
-    }  
+    }
   };
 
 } //namespace CGAL
 
-#endif // CGAL_IO_ARRANGEMENT_2_WRITER_H 
+#endif // CGAL_IO_ARRANGEMENT_2_WRITER_H

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
@@ -1709,6 +1709,8 @@ compile_and_run test_removal
 compile_and_run test_unbounded_removal
 compile_and_run test_spherical_removal
 
+compile_and_run test_io
+
 # if any error occured then append the full error description file to error file
 
 if [ -f $FULL_ERROR_DESCRIPTION_FILE ] ; then

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_do_intersect.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_do_intersect.cpp
@@ -4,9 +4,9 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Arrangement_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 #include <list>
+#include <iostream>
 
 typedef CGAL::Quotient<int>                           Number_type;
 typedef CGAL::Simple_cartesian<Number_type>           Kernel;
@@ -32,7 +32,7 @@ int main ()
   expected_intersect[0] = false;
   expected_intersect[1] = true;
   expected_intersect[2] = true;
-  
+
   insert(arr, Segment_2(Point_2(0, 0), Point_2(2, 0)));
   insert(arr, Segment_2(Point_2(2, 0), Point_2(2, 2)));
   insert(arr, Segment_2(Point_2(2, 2), Point_2(0, 2)));
@@ -41,15 +41,14 @@ int main ()
   for (k = 0; k < N_SEGMENTS; k++)
   {
     bool do_inter = do_intersect(arr, segs[k]);
-    
+
     std::cout << "Segment: " << segs[k];
     std::cout << "        Expected: " << expected_intersect[k];
     std::cout << "        Actual: " << do_inter << std::endl;
-    
+
     if (expected_intersect[k] != do_inter)
       return (1);
   }
-  
+
   return (0);
 }
-

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_io.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_io.cpp
@@ -1,0 +1,107 @@
+#include <fstream>
+#include <list>
+
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Arr_segment_traits_2.h>
+#include <CGAL/Arr_polyline_traits_2.h>
+#include <CGAL/Arrangement_2.h>
+#include <CGAL/IO/Arr_iostream.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
+
+typedef CGAL::Arr_segment_traits_2<Kernel>              Segment_traits_2;
+typedef Segment_traits_2::Point_2                       Point_2;
+typedef Segment_traits_2::X_monotone_curve_2            Segment_2;
+typedef CGAL::Arrangement_2<Segment_traits_2>           Segment_arrangement_2;
+
+typedef CGAL::Arr_polyline_traits_2<Segment_traits_2>   Polyline_traits_2;
+typedef Polyline_traits_2::Curve_2                      Polyline_2;
+typedef CGAL::Arrangement_2<Polyline_traits_2>          Polyline_arrangement_2;
+
+typedef CGAL::Arr_polyline_traits_2<Polyline_traits_2>  Polycurve_traits_2;
+typedef Polycurve_traits_2::Curve_2                     Polycurve_2;
+typedef CGAL::Arrangement_2<Polycurve_traits_2>         Polycurve_arrangement_2;
+
+template <typename Arrangement>
+bool test_io(Arrangement& arr, const char* filename = "arr.txt")
+{
+  std::cout << "Writing an arrangement of size:" << std::endl
+            << "   V = " << arr.number_of_vertices()
+            << ",  E = " << arr.number_of_edges()
+            << ",  F = " << arr.number_of_faces() << std::endl;
+
+  // Write the arrangement to a file.
+  std::ofstream out_file(filename);
+  out_file << arr;
+  out_file.close();
+
+  // Read the arrangement from the file.
+  Arrangement arr2;
+  std::ifstream in_file(filename);
+  in_file >> arr2;
+  in_file.close();
+
+  std::cout << "Read an arrangement of size:" << std::endl
+            << "   V = " << arr2.number_of_vertices()
+            << ",  E = " << arr2.number_of_edges()
+            << ",  F = " << arr2.number_of_faces() << std::endl;
+
+  return ((arr.number_of_vertices() == arr2.number_of_vertices()) &&
+          (arr.number_of_halfedges() == arr2.number_of_halfedges()) &&
+          (arr.number_of_faces() == arr2.number_of_faces()));
+}
+
+int main()
+{
+  // Segment arrangement
+  std::list<Segment_2> segments1;
+  segments1.push_back(Segment_2(Point_2(0, 0), Point_2(1, 0)));
+  segments1.push_back(Segment_2(Point_2(1, 0), Point_2(2, 0)));
+  segments1.push_back(Segment_2(Point_2(2, 0), Point_2(3, 0)));
+
+  std::list<Segment_2> segments2;
+  segments2.push_back(Segment_2(Point_2(3, 0), Point_2(2, 1)));
+  segments2.push_back(Segment_2(Point_2(2, 1), Point_2(1, 2)));
+  segments2.push_back(Segment_2(Point_2(1, 2), Point_2(0, 3)));
+
+  std::list<Segment_2> segments3;
+  segments3.push_back(Segment_2(Point_2(0, 3), Point_2(0, 2)));
+  segments3.push_back(Segment_2(Point_2(0, 2), Point_2(0, 1)));
+  segments3.push_back(Segment_2(Point_2(0, 1), Point_2(0, 0)));
+
+  Segment_arrangement_2 segment_arr;
+  CGAL::insert(segment_arr, segments1.begin(), segments1.end());
+  CGAL::insert(segment_arr, segments2.begin(), segments2.end());
+  CGAL::insert(segment_arr, segments3.begin(), segments3.end());
+  if (! test_io(segment_arr, "arr_segments.dat")) {
+    std::cerr << "IO for segments tailed!" << std::endl;
+    return 1;
+  }
+
+  // Polyline arrangement
+  Polyline_traits_2 polyline_traits;
+  Polyline_traits_2::Construct_curve_2 polyline_ctr =
+    polyline_traits.construct_curve_2_object();
+  Polyline_2 polyline1 = polyline_ctr(segments1.begin(), segments1.end());
+  Polyline_2 polyline2 = polyline_ctr(segments2.begin(), segments2.end());
+  Polyline_2 polyline3 = polyline_ctr(segments3.begin(), segments3.end());
+  std::list<Polyline_2> polylines;
+  polylines.push_back(polyline1);
+  polylines.push_back(polyline2);
+  polylines.push_back(polyline3);
+
+  Polyline_arrangement_2 polyline_arr(&polyline_traits);
+  CGAL::insert(polyline_arr, polylines.begin(), polylines.end());
+  if (! test_io(polyline_arr, "arr_polylines.dat")) return 1;
+
+  // Poly-polyline arrangement
+  Polycurve_traits_2 polycurve_traits;
+  Polycurve_traits_2::Construct_curve_2 polycurve_ctr =
+    polycurve_traits.construct_curve_2_object();
+  Polycurve_2 polycurve = polycurve_ctr(polylines.begin(), polylines.end());
+  Polycurve_arrangement_2 polycurve_arr(&polycurve_traits);
+  CGAL::insert(polycurve_arr, polycurve);
+  if (! test_io(polycurve_arr, "arr_polycurves.dat")) return 1;
+
+  return 0;
+}

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_iso_verts.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_iso_verts.cpp
@@ -1,10 +1,11 @@
 // Testing the handling of isolated vertices.
 
+#include <iostream>
+
 #include <CGAL/Quotient.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Arrangement_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 typedef CGAL::Quotient<int>                           Number_type;
 typedef CGAL::Simple_cartesian<Number_type>           Kernel;
@@ -75,7 +76,7 @@ int main ()
   insert_non_intersecting_curve (arr,
                                  Segment_2 (Point_2 (4, 7), Point_2 (6, 6)));
   TEST_VALIDITY(7);
-  
+
   insert_non_intersecting_curve (arr,
                                  Segment_2 (Point_2 (2, 7), Point_2 (3, 3)));
   TEST_VALIDITY(8);
@@ -91,9 +92,9 @@ int main ()
   std::cout << "Arrangement size:"
             << "   V = " << arr.number_of_vertices()
             << " (" << arr.number_of_isolated_vertices() << " isolated)"
-            << ",  E = " << arr.number_of_edges() 
+            << ",  E = " << arr.number_of_edges()
             << ",  F = " << arr.number_of_faces() << std::endl;
-   
+
   // Check the validity more thoroughly.
   valid = is_valid(arr);
   std::cout << "Arrangement is "
@@ -101,4 +102,3 @@ int main ()
 
   return (0);
 }
-

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_removal.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_removal.cpp
@@ -1,10 +1,11 @@
 // Testing the removal function, covering all possible scenarios.
 
+#include <iostream>
+
 #include <CGAL/Quotient.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Arrangement_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 typedef CGAL::Quotient<int>                           Number_type;
 typedef CGAL::Simple_cartesian<Number_type>           Kernel;

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_merge.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_merge.cpp
@@ -4,13 +4,13 @@
 
 #include <string>
 #include <vector>
+#include <fstream>
 
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arr_geodesic_arc_on_sphere_traits_2.h>
 #include <CGAL/Arr_spherical_topology_traits_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 typedef CGAL::Exact_rational                                 Number_type;
 typedef CGAL::Cartesian<Number_type>                         Kernel;

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_overlay.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_overlay.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <cstring>
 #include <vector>
+#include <fstream>
 
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
@@ -13,7 +14,6 @@
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arr_overlay_2.h>
 #include <CGAL/Arr_spherical_topology_traits_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 #include <CGAL/IO/Arr_text_formatter.h>
 
 typedef CGAL::Exact_rational                              Number_type;

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_removal.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_removal.cpp
@@ -3,13 +3,13 @@
 #include <string>
 #include <cstring>
 #include <vector>
+#include <fstream>
 
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arr_geodesic_arc_on_sphere_traits_2.h>
 #include <CGAL/Arr_spherical_topology_traits_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 typedef CGAL::Exact_rational                                 Number_type;
 typedef CGAL::Cartesian<Number_type>                         Kernel;

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_unbounded_removal.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_unbounded_removal.cpp
@@ -1,12 +1,12 @@
 // Testing the removal function, covering all possible scenarios.
 
 #include <vector>
+#include <iostream>
 
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
 #include <CGAL/Arr_linear_traits_2.h>
 #include <CGAL/Arrangement_2.h>
-#include <CGAL/IO/Arr_iostream.h>
 
 typedef CGAL::Exact_rational                            Number_type;
 typedef CGAL::Cartesian<Number_type>                    Kernel;
@@ -158,4 +158,3 @@ int main()
 
   return 0;
 }
-

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_zone.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_zone.cpp
@@ -1,12 +1,12 @@
 // Testing the compute zone function
 
+#include <list>
+#include <iostream>
+
 #include <CGAL/Quotient.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Arrangement_2.h>
-#include <CGAL/IO/Arr_iostream.h>
-
-#include <list>
 
 typedef CGAL::Quotient<int>                           Number_type;
 typedef CGAL::Simple_cartesian<Number_type>           Kernel;
@@ -32,7 +32,7 @@ int main ()
   zone_expected_comp[0] = 1;
   zone_expected_comp[1] = 3;
   zone_expected_comp[2] = 4;
-  
+
   insert(arr, Segment_2(Point_2(0, 0), Point_2(2, 0)));
   insert(arr, Segment_2(Point_2(2, 0), Point_2(2, 2)));
   insert(arr, Segment_2(Point_2(2, 2), Point_2(0, 2)));
@@ -43,15 +43,14 @@ int main ()
     std::list<CGAL::Object> zone_elems;
     zone(arr, segs[k], std::back_inserter(zone_elems));
     std::size_t zone_actual_comp = zone_elems.size();
-    
+
     std::cout << "Segment: " << segs[k];
     std::cout << "        Expected: " << zone_expected_comp[k];
     std::cout << "        Actual: " << zone_actual_comp << std::endl;
-    
+
     if (zone_expected_comp[k] != zone_actual_comp)
       return (1);
   }
-  
+
   return (0);
 }
-


### PR DESCRIPTION
The fixes are described by the small feature: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Arrangement_polycurve_fixes.

I'm not even sure that it deserves a small feature.
I've de-deprecated  some member functions of Polycurve_2 and fixed their names.
I also made the stream representation of polylines and polycurves of segments match the old representation (one version back) before polylines were enhanced.

This should also take care of the false warning of certain compilers about deprecated code being used (even though the relevant templates are not instantiated).

