### PR TITLE
Demo fix for OS X (fix for #437)

### DIFF
--- a/AABB_tree/demo/AABB_tree/Scene.cpp
+++ b/AABB_tree/demo/AABB_tree/Scene.cpp
@@ -48,6 +48,7 @@ Scene::Scene()
     startTimer(0);
     ready_to_cut = false;
     are_buffers_initialized = false;
+    gl_init = false;
 
 }
 
@@ -590,6 +591,8 @@ void Scene::update_bbox()
 
 void Scene::draw(QGLViewer* viewer)
 {       
+    if(!gl_init)
+        initGL();
     if(!are_buffers_initialized)
         initialize_buffers();
     QColor color;
@@ -1314,7 +1317,7 @@ void Scene::deactivate_cutting_plane()
     disconnect(m_frame, SIGNAL(modified()), this, SLOT(cutting_plane()));
     m_view_plane = false;
 }
-void Scene::initGL(Viewer * /* viewer */)
+void Scene::initGL()
 {
     gl = new QOpenGLFunctions_2_1();
    if(!gl->initializeOpenGLFunctions())
@@ -1325,6 +1328,7 @@ void Scene::initGL(Viewer * /* viewer */)
 
     gl->glGenTextures(1, &textureId);
     compile_shaders();
+    gl_init = true;
 }
 
 void Scene::timerEvent(QTimerEvent *)

--- a/AABB_tree/demo/AABB_tree/Scene.h
+++ b/AABB_tree/demo/AABB_tree/Scene.h
@@ -82,7 +82,7 @@ public:
     void update_bbox();
     Bbox bbox() { return m_bbox; }
     ManipulatedFrame* manipulatedFrame() const { return m_frame; }
-    void initGL(Viewer *viewer);
+    void initGL();
 
 private:
     // member data
@@ -93,6 +93,7 @@ private:
     std::list<Segment> m_segments;
     std::vector<Segment> m_cut_segments;
     bool ready_to_cut;
+    bool gl_init;
 
     // distance functions (simple 2D arrays)
     Color_ramp m_red_ramp;

--- a/AABB_tree/demo/AABB_tree/Viewer.cpp
+++ b/AABB_tree/demo/AABB_tree/Viewer.cpp
@@ -31,7 +31,7 @@ void Viewer::initializeGL()
 {
   QGLViewer::initializeGL();
   setBackgroundColor(::Qt::white);
-  m_pScene->initGL(this);
+  //m_pScene->initGL(this);
 }
 
 void Viewer::mousePressEvent(QMouseEvent* e)

--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -30,7 +30,9 @@ inline QGLContext* createOpenGLContext()
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
     context->setFormat(format);
-    return QGLContext::fromOpenGLContext(context);
+    QGLContext *result = QGLContext::fromOpenGLContext(context);
+    result->create();
+    return result;
 }
 } // namespace Qt
 } // namespace CGAL

--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -29,6 +29,18 @@ inline QGLContext* createOpenGLContext()
     QSurfaceFormat format;
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
+    context->setFormat(format);
+    QGLContext *result = QGLContext::fromOpenGLContext(context);
+    result->create();
+    return result;
+}
+
+inline QGLContext* createOpenGLMSAAContext()
+{
+    QOpenGLContext *context = new QOpenGLContext();
+    QSurfaceFormat format;
+    format.setVersion(2,1);
+    format.setProfile(QSurfaceFormat::CompatibilityProfile);
     format.setSamples(16);
     context->setFormat(format);
     QGLContext *result = QGLContext::fromOpenGLContext(context);

--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -29,6 +29,7 @@ inline QGLContext* createOpenGLContext()
     QSurfaceFormat format;
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
+    format.setSamples(16);
     context->setFormat(format);
     QGLContext *result = QGLContext::fromOpenGLContext(context);
     result->create();

--- a/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
@@ -42,7 +42,6 @@ MainWindow::MainWindow (QWidget * parent):CGAL::Qt::DemosMainWindow (parent),
   dialogsierpinskitriangle(this)
 {
   setupUi (this);
-
   scene.lcc = new LCC;
   
   volumeListDock = new QDockWidget(QString(tr("Volume List")),this);
@@ -74,7 +73,6 @@ MainWindow::MainWindow (QWidget * parent):CGAL::Qt::DemosMainWindow (parent),
 
   QObject::connect(&dialogmesh, SIGNAL(accepted()),
                    this, SLOT(onCreateMeshOk()));
-
   this->viewer->setScene(&scene);
 
   connect_actions ();

--- a/Linear_cell_complex/demo/Linear_cell_complex/Viewer.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Viewer.cpp
@@ -28,7 +28,7 @@
 #include <QDebug>
 
 Viewer::Viewer(QWidget* parent)
-  : QGLViewer(CGAL::Qt::createOpenGLContext(),parent), wireframe(false),
+  : QGLViewer(CGAL::Qt::createOpenGLMSAAContext(),parent), wireframe(false),
     flatShading(true), edges(true), vertices(true),
     m_previous_scene_empty(true), are_buffers_initialized(false)
 {

--- a/Mesh_3/demo/Mesh_3/MainWindow.cpp
+++ b/Mesh_3/demo/Mesh_3/MainWindow.cpp
@@ -341,8 +341,8 @@ void MainWindow::open(QString filename)
     Q_FOREACH(Io_plugin_interface* plugin, 
               io_plugins)
     {
-      if(plugin->canLoad()) {
-          viewer->makeCurrent();
+        if(plugin->canLoad()) {
+            viewer->makeCurrent();
         item = plugin->load(fileinfo);
         if(item) break; // go out of the loop
       }

--- a/Mesh_3/demo/Mesh_3/MainWindow.cpp
+++ b/Mesh_3/demo/Mesh_3/MainWindow.cpp
@@ -342,6 +342,7 @@ void MainWindow::open(QString filename)
               io_plugins)
     {
       if(plugin->canLoad()) {
+          viewer->makeCurrent();
         item = plugin->load(fileinfo);
         if(item) break; // go out of the loop
       }

--- a/Mesh_3/demo/Mesh_3/Scene_c3t3_item.cpp
+++ b/Mesh_3/demo/Mesh_3/Scene_c3t3_item.cpp
@@ -72,7 +72,7 @@ void Scene_c3t3_item::compile_shaders()
     //Fragment source code
     const char fragment_source[] =
     {
-        "#version 330 \n"
+        "#version 120 \n"
         "varying highp vec4 fP; \n"
         "varying highp vec3 fN; \n"
         "varying vec4 color; \n"
@@ -170,6 +170,7 @@ void Scene_c3t3_item::compile_shaders()
     {
         std::cerr<<"adding fragment shader FAILED"<<std::endl;
     }
+    rendering_program_grid.bindAttributeLocation("vertex",0);
     if(!rendering_program_grid .link())
     {
         std::cerr<<"linking Program FAILED"<<std::endl;

--- a/Mesh_3/demo/Mesh_3/Scene_c3t3_item.cpp
+++ b/Mesh_3/demo/Mesh_3/Scene_c3t3_item.cpp
@@ -543,9 +543,9 @@ void Scene_c3t3_item::initialize_buffers() const
         vao[1].bind();
         buffers[3].bind();
         buffers[3].allocate(v_grid.data(), static_cast<int>(v_grid.size()*sizeof(float)));
-        poly_vertexLocation[1] = rendering_program.attributeLocation("vertex");
-        rendering_program.enableAttributeArray(poly_vertexLocation[1]);
-        rendering_program.setAttributeBuffer(poly_vertexLocation[1],GL_FLOAT,0,3);
+        poly_vertexLocation[1] = rendering_program_grid.attributeLocation("vertex");
+        rendering_program_grid.enableAttributeArray(poly_vertexLocation[1]);
+        rendering_program_grid.setAttributeBuffer(poly_vertexLocation[1],GL_FLOAT,0,3);
         buffers[3].release();
         vao[1].release();
 
@@ -660,9 +660,7 @@ Scene_c3t3_item::draw_edges(Viewer* viewer) const {
     vao[1].bind();
     attrib_buffers(viewer);
     rendering_program_grid.bind();
-    QColor color;
-    color.setRgbF(this->color().redF(), this->color().greenF(), this->color().blueF());
-    rendering_program_grid.setUniformValue(colorLocation[1], color);
+    rendering_program_grid.setUniformValue(colorLocation[1], QColor(Qt::black));
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(v_grid.size()/3));
     rendering_program_grid.release();
     vao[1].release();

--- a/Mesh_3/demo/Mesh_3/Scene_polyhedron_item.cpp
+++ b/Mesh_3/demo/Mesh_3/Scene_polyhedron_item.cpp
@@ -128,6 +128,7 @@ void Scene_polyhedron_item::compile_shaders()
     {
         std::cerr<<"adding fragment shader FAILED"<<std::endl;
     }
+    rendering_program.bindAttributeLocation("vertex", 0);
     if(!rendering_program.link())
     {
         std::cerr<<"linking Program FAILED"<<std::endl;
@@ -328,6 +329,7 @@ void Scene_polyhedron_item::attrib_buffers(Viewer* viewer) const
 
 // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
 void Scene_polyhedron_item::draw(Viewer* viewer) const {
+    viewer->makeCurrent();
     if(!are_buffers_initialized)
         initialize_buffers();
     QColor color;

--- a/Mesh_3/demo/Mesh_3/Volume_plane.h
+++ b/Mesh_3/demo/Mesh_3/Volume_plane.h
@@ -205,38 +205,38 @@ private:
 
 template<typename T>
 const char* Volume_plane<T>::vertexShader_source =
-      "#version 330 \n"
-      "in vec4 vertex; \n"
-      "in float color; \n"
+      "#version 120 \n"
+      "attribute highp vec4 vertex; \n"
+      "attribute highp float color; \n"
       "uniform highp mat4 mvp_matrix; \n"
       "uniform highp mat4 f_matrix; \n"
-      "out vec4 fullColor; \n"
+      "varying highp vec4 fullColor; \n"
       "void main() \n"
       "{ gl_Position = mvp_matrix * f_matrix * vertex; \n"
       " fullColor = vec4(color, color, color, 1.0f); } \n";
 
 template<typename T>
 const char* Volume_plane<T>::fragmentShader_source =
-      "#version 330\n"
-      "in vec4 fullColor; \n"
+      "#version 120\n"
+      "varying highp vec4 fullColor; \n"
       "void main() { gl_FragColor = fullColor; } \n";
 
 template<typename T>
 const char* Volume_plane<T>::vertexShader_bordures_source =
-      "#version 330 \n"
-      "in vec4 vertex; \n"
-      "uniform vec4 color; \n"
+      "#version 120 \n"
+      "attribute highp vec4 vertex; \n"
+      "uniform highp vec4 color; \n"
       "uniform highp mat4 mvp_matrix; \n"
       "uniform highp mat4 f_matrix; \n"
-      "out vec4 fullColor; \n"
+      "varying highp vec4 fullColor; \n"
       "void main() \n"
       "{ gl_Position = mvp_matrix * f_matrix * vertex; \n"
       " fullColor = color; } \n";
 
 template<typename T>
 const char* Volume_plane<T>::fragmentShader_bordures_source =
-      "#version 330\n"
-      "in vec4 fullColor; \n"
+      "#version 120\n"
+      "varying highp vec4 fullColor; \n"
       "void main() { gl_FragColor = fullColor; } \n";
 
 
@@ -262,6 +262,7 @@ Volume_plane<T>::~Volume_plane() {
 
 template<typename T>
 void Volume_plane<T>::draw(Viewer* viewer) const {
+    qDebug()<<"draw";
   updateCurrentCube();
 
 
@@ -338,11 +339,12 @@ void Volume_plane<T>::draw(Viewer* viewer) const {
   program.release();
 
   printGlError(__LINE__);
+  qDebug()<<"end draw";
 }
 
 template<typename T>
 void Volume_plane<T>::init() {
-  
+  qDebug()<<"init";
   initShaders();
 
   // for each vertex
@@ -419,6 +421,7 @@ void Volume_plane<T>::init() {
   cbuffer.release();
 
   printGlError(__LINE__);
+  qDebug()<<"end init";
 }
 
 template<typename T>

--- a/Mesh_3/demo/Mesh_3/Volume_plane.h
+++ b/Mesh_3/demo/Mesh_3/Volume_plane.h
@@ -262,7 +262,6 @@ Volume_plane<T>::~Volume_plane() {
 
 template<typename T>
 void Volume_plane<T>::draw(Viewer* viewer) const {
-    qDebug()<<"draw";
   updateCurrentCube();
 
 
@@ -339,12 +338,10 @@ void Volume_plane<T>::draw(Viewer* viewer) const {
   program.release();
 
   printGlError(__LINE__);
-  qDebug()<<"end draw";
 }
 
 template<typename T>
 void Volume_plane<T>::init() {
-  qDebug()<<"init";
   initShaders();
 
   // for each vertex
@@ -421,7 +418,6 @@ void Volume_plane<T>::init() {
   cbuffer.release();
 
   printGlError(__LINE__);
-  qDebug()<<"end init";
 }
 
 template<typename T>

--- a/Mesh_3/demo/Mesh_3/include/CGAL_demo/Scene.h
+++ b/Mesh_3/demo/Mesh_3/include/CGAL_demo/Scene.h
@@ -55,8 +55,6 @@ public:
   int selectionAindex() const;
   int selectionBindex() const;
 
-  // initializeGL() is called by Viewer::initializeGL()
-  void initializeGL();
   // draw() is called by Viewer::draw()
   void draw(Viewer *viewer);
   void drawWithNames(Viewer *viewer);

--- a/Mesh_3/demo/Mesh_3/include/CGAL_demo/Scene_draw_interface.h
+++ b/Mesh_3/demo/Mesh_3/include/CGAL_demo/Scene_draw_interface.h
@@ -6,7 +6,6 @@ class Viewer;
 class Scene_draw_interface {
 public:
   virtual ~Scene_draw_interface(){}
-  virtual void initializeGL() = 0;
   virtual void draw(Viewer*) = 0;
   virtual void drawWithNames(Viewer*) = 0;
 };

--- a/Mesh_3/demo/Mesh_3/src/CGAL_demo/Scene.cpp
+++ b/Mesh_3/demo/Mesh_3/src/CGAL_demo/Scene.cpp
@@ -108,9 +108,6 @@ Scene::duplicate(Item_id index)
     return -1;
 }
 
-void Scene::initializeGL()
-{
-}
 
 void 
 Scene::draw(Viewer* viewer)

--- a/Mesh_3/demo/Mesh_3/src/CGAL_demo/Viewer.cpp
+++ b/Mesh_3/demo/Mesh_3/src/CGAL_demo/Viewer.cpp
@@ -45,7 +45,6 @@ void Viewer::draw()
 void Viewer::initializeGL()
 {
   QGLViewer::initializeGL();
-  scene->initializeGL();
   initializeOpenGLFunctions();
    setBackgroundColor(::Qt::white);
 }

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
@@ -774,12 +774,14 @@ void Scene::init() {
     // Scene OpenGL state
     compile_shaders();
     init_scene(EMPTY);
-
+    gl_init = true;
 
 }
 
 // Draws the triangulation
 void Scene::draw() {
+    if(!gl_init)
+        init();
     glEnable(GL_DEPTH_TEST);
     if(!are_buffers_initialized)
         initialize_buffers();

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
@@ -31,10 +31,11 @@ private:
     CLIPPING_COLOR
   };
 
+  bool gl_init;
 public:
   Scene(Ui::MainWindow* ui_) : ui(ui_), p3dt(),
                   moving_point(Point(0.2,0.2,0.2)) {
-
+    gl_init = false;
     flying_ball = ui->actionFlying_ball->isChecked();
 
     dlocate = ui->actionPoint_location->isChecked();

--- a/Polyhedron/demo/Polyhedron/GlSplat/GlSplat.cpp
+++ b/Polyhedron/demo/Polyhedron/GlSplat/GlSplat.cpp
@@ -119,7 +119,6 @@ void SplatRenderer::init(QGLWidget *qglw)
   mBuggedAtiBlending = rendererString.startsWith("ATI") || rendererString.startsWith("AMD");
   if (mWorkaroundATI && mDummyTexId==0)
   {      
-      qDebug()<<viewer;
     viewer->glActiveTexture(GL_TEXTURE0);
     viewer->glGenTextures(1,&mDummyTexId);
     viewer->glBindTexture(GL_TEXTURE_2D, mDummyTexId);

--- a/Polyhedron/demo/Polyhedron/GlSplat/GlSplat.cpp
+++ b/Polyhedron/demo/Polyhedron/GlSplat/GlSplat.cpp
@@ -110,7 +110,6 @@ void SplatRenderer::init(QGLWidget *qglw)
   mIsSupported = true;
   if(qglw)
     qglw->makeCurrent();
-
   const char* rs = (const char*)glGetString(GL_RENDERER);
   QString rendererString("");
   if(rs)
@@ -118,15 +117,14 @@ void SplatRenderer::init(QGLWidget *qglw)
   mWorkaroundATI = rendererString.startsWith("ATI") || rendererString.startsWith("AMD");
   // FIXME: maybe some recent HW correctly supports floating point blending...
   mBuggedAtiBlending = rendererString.startsWith("ATI") || rendererString.startsWith("AMD");
-
   if (mWorkaroundATI && mDummyTexId==0)
-  {
+  {      
+      qDebug()<<viewer;
     viewer->glActiveTexture(GL_TEXTURE0);
     viewer->glGenTextures(1,&mDummyTexId);
     viewer->glBindTexture(GL_TEXTURE_2D, mDummyTexId);
     viewer->glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 4, 4, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, 0);
   }
-
   // let's check the GPU capabilities
   mSupportedMask = DEPTH_CORRECTION_BIT | BACKFACE_SHADING_BIT;
   if (!QGLFramebufferObject::hasOpenGLFramebufferObjects ())
@@ -150,7 +148,6 @@ void SplatRenderer::init(QGLWidget *qglw)
   mShaderSrcs[3] = loadSource("AttributeFP","Raycasting.glsl");
   mShaderSrcs[4] = "";
   mShaderSrcs[5] = loadSource("Finalization","Finalization.glsl");
-
   mCurrentPass = 2;
   mBindedPass = -1;
   mIsInitialized = true;

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1388,7 +1388,6 @@ void MainWindow::on_actionLoad_triggered()
   dialog.setFileMode(QFileDialog::ExistingFiles);
 
   if(dialog.exec() != QDialog::Accepted) { return; }
-  viewer->context()->makeCurrent();
   FilterPluginMap::iterator it = 
     filterPluginMap.find(dialog.selectedNameFilter());
   
@@ -1402,6 +1401,7 @@ void MainWindow::on_actionLoad_triggered()
     CGAL::Three::Scene_item* item = NULL;
     if(selectedPlugin) {
       QFileInfo info(filename);
+      viewer->context()->makeCurrent();
       item = load_item(info, selectedPlugin);
       Scene::Item_id index = scene->addItem(item);
       selectSceneItem(index);

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -129,14 +129,12 @@ MainWindow::MainWindow(QWidget* parent)
   // Save some pointers from ui, for latter use.
   sceneView = ui->sceneView;
   viewer = ui->viewer;
-
   // do not save the state of the viewer (anoying)
   viewer->setStateFileName(QString::null);
 
   // setup scene
   scene = new Scene(this);
   viewer->setScene(scene);
-
   {
     QShortcut* shortcut = new QShortcut(QKeySequence(Qt::ALT+Qt::Key_Q), this);
     connect(shortcut, SIGNAL(activated()),
@@ -1390,7 +1388,7 @@ void MainWindow::on_actionLoad_triggered()
   dialog.setFileMode(QFileDialog::ExistingFiles);
 
   if(dialog.exec() != QDialog::Accepted) { return; }
-  
+  viewer->context()->makeCurrent();
   FilterPluginMap::iterator it = 
     filterPluginMap.find(dialog.selectedNameFilter());
   

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -984,7 +984,6 @@ void MainWindow::open(QString filename)
       load_pair = File_loader_dialog::getItem(fileinfo.fileName(), selected_items, &ok);
   }
   viewer->context()->makeCurrent();
-  qDebug()<<"Current";
   if(!ok || load_pair.first.isEmpty()) { return; }
   
   if (load_pair.second)

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -983,7 +983,8 @@ void MainWindow::open(QString filename)
     default:
       load_pair = File_loader_dialog::getItem(fileinfo.fileName(), selected_items, &ok);
   }
-  
+  viewer->context()->makeCurrent();
+  qDebug()<<"Current";
   if(!ok || load_pair.first.isEmpty()) { return; }
   
   if (load_pair.second)
@@ -1401,7 +1402,6 @@ void MainWindow::on_actionLoad_triggered()
     CGAL::Three::Scene_item* item = NULL;
     if(selectedPlugin) {
       QFileInfo info(filename);
-      viewer->context()->makeCurrent();
       item = load_item(info, selectedPlugin);
       Scene::Item_id index = scene->addItem(item);
       selectSceneItem(index);

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -270,7 +270,7 @@ Scene::duplicate(Item_id index)
 
 void Scene::initializeGL()
 {
-   //ms_splatting->init();
+   ms_splatting->init();
 
     //Setting the light options
 
@@ -309,8 +309,6 @@ Scene::draw()
 void
 Scene::draw(CGAL::Three::Viewer_interface* viewer)
 {
-    if(!gl_init)
-        initializeGL();
     draw_aux(false, viewer);
 }
 void
@@ -329,6 +327,8 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
 {
     if(!ms_splatting->viewer_is_set)
         ms_splatting->setViewer(viewer);
+    if(!gl_init)
+        initializeGL();
     // Flat/Gouraud OpenGL drawing
     for(int index = 0; index < m_entries.size(); ++index)
     {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -270,7 +270,7 @@ Scene::duplicate(Item_id index)
 
 void Scene::initializeGL()
 {
-   ms_splatting->init();
+    ms_splatting->init();
 
     //Setting the light options
 

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -44,7 +44,7 @@ Scene::Scene(QObject* parent)
         ms_splatting  = new GlSplat::SplatRenderer();
     ms_splattingCounter++;
     picked = false;
-
+    gl_init = false;
 
 }
 Scene::Item_id
@@ -270,7 +270,7 @@ Scene::duplicate(Item_id index)
 
 void Scene::initializeGL()
 {
-    ms_splatting->init();
+   //ms_splatting->init();
 
     //Setting the light options
 
@@ -286,6 +286,7 @@ void Scene::initializeGL()
     glLightfv(GL_LIGHT0, GL_SPECULAR, specularLight);
     glLightfv(GL_LIGHT0, GL_POSITION, position);
 
+    gl_init = true;
 }
 
 bool
@@ -308,6 +309,8 @@ Scene::draw()
 void
 Scene::draw(CGAL::Three::Viewer_interface* viewer)
 {
+    if(!gl_init)
+        initializeGL();
     draw_aux(false, viewer);
 }
 void

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -274,6 +274,7 @@ private:
   //!Index of the item_B.
   int item_B;
   bool picked;
+  bool gl_init;
   static GlSplat::SplatRenderer* ms_splatting;
   static int ms_splattingCounter;
   QMap<QModelIndex, int> index_map;

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -144,8 +144,6 @@ void Viewer::initializeGL()
   vao[0].create();
   for(int i=0; i<3; i++)
     buffers[i].create();
- // qDebug()<<"Viewer's context : "<<context()->contextHandle()->handle();
- // d->scene->initializeGL();
 
   //Vertex source code
   const char vertex_source[] =
@@ -228,7 +226,6 @@ void Viewer::initializeGL()
   }
   if(!rendering_program.link())
   {
-      //std::cerr<<"linking Program FAILED"<<std::endl;
       qDebug() << rendering_program.log();
   }
 }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -144,7 +144,8 @@ void Viewer::initializeGL()
   vao[0].create();
   for(int i=0; i<3; i++)
     buffers[i].create();
-  d->scene->initializeGL();
+ // qDebug()<<"Viewer's context : "<<context()->contextHandle()->handle();
+ // d->scene->initializeGL();
 
   //Vertex source code
   const char vertex_source[] =
@@ -919,6 +920,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_C3T3] = program;
             return program;
@@ -942,6 +944,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_C3T3_EDGES] = program;
             return program;
@@ -965,6 +968,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_WITH_LIGHT] = program;
             return program;
@@ -986,6 +990,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_WITHOUT_LIGHT] = program;
             return program;
@@ -1007,6 +1012,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_NO_SELECTION] = program;
             return program;
@@ -1028,6 +1034,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("color_facets", 1);
             program->link();
             d->shader_programs[PROGRAM_WITH_TEXTURE] = program;
             return program;
@@ -1049,6 +1056,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("color_lines", 1);
             program->link();
             d->shader_programs[PROGRAM_WITH_TEXTURED_EDGES] = program;
             return program;
@@ -1071,6 +1079,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_INSTANCED] = program;
             return program;
@@ -1093,6 +1102,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
             {
                 std::cerr<<"adding fragment shader FAILED"<<std::endl;
             }
+            program->bindAttributeLocation("colors", 1);
             program->link();
             d->shader_programs[PROGRAM_INSTANCED_WIRE] = program;
             return program;

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
@@ -9,7 +9,7 @@ varying highp vec3 fN;
 varying highp vec4 color; 
 void main(void)
 {
-   color = vec4(colors, 1.0); 
+   color = vec4(colors, 1.0);
    fP = mv_matrix * vertex; 
    fN = mat3(mv_matrix)* normals; 
    gl_Position = mvp_matrix * vertex; 

--- a/Triangulation_3/demo/Triangulation_3/MainWindow.cpp
+++ b/Triangulation_3/demo/Triangulation_3/MainWindow.cpp
@@ -39,8 +39,6 @@ MainWindow::MainWindow(QWidget* parent)
   //   when the action is invoked, it will popup a messageBox showing the given html
   this->addAboutDemo( "documentation/about.html" );
 
-  // read last setting from .ini file
-  viewer->readSettings();
 }
 
 void MainWindow::connectActions()

--- a/Triangulation_3/demo/Triangulation_3/Viewer.cpp
+++ b/Triangulation_3/demo/Triangulation_3/Viewer.cpp
@@ -176,6 +176,8 @@ void Viewer::compile_shaders()
     for(int i=0; i< vaoSize; i++)
         vao[i].create();
 
+     // read last setting from .ini file
+    readSettings();
     draw_cylinder(m_fSizeDEdge,25,points_cylinder,normals_cylinder);
     draw_sphere(m_fSizeVertex, 15, points_sphere, normals_sphere);
     //Vertex source code


### PR DESCRIPTION
This PR repairs the 3D demos on OS X.

- Most of the problems were caused by the fact that on OS X, the paintGL function of an OpenGLWidget is called during the setupUi() call (in the MainWindow), when the viewer's scene is still pointing to NULL, which caused a segfault. 
- Some demos did not display 3D effects, this was caused by the fact that on OS X, OpenGL binds automatically the color attribute to 0 in the shaders, and OpenGL does not dipslay anything when a setAttributeValue is made on the attribute 0.
- There were some errors due to Shaders that were still written in GLSL 330 instead of 120.