### PR TITLE
Clean up scene item API

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -868,7 +868,7 @@ void MainWindow::reload_item() {
   new_item->setColor(item->color());
   new_item->setRenderingMode(item->renderingMode());
   new_item->setVisible(item->visible());
-  new_item->invalidate_buffers();
+  new_item->invalidate_OpenGLBuffers();
   scene->replaceItem(item_index, new_item, true);
   item->deleteLater();
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -868,7 +868,7 @@ void MainWindow::reload_item() {
   new_item->setColor(item->color());
   new_item->setRenderingMode(item->renderingMode());
   new_item->setVisible(item->visible());
-  new_item->invalidate_OpenGLBuffers();
+  new_item->invalidateOpenGLBuffers();
   scene->replaceItem(item_index, new_item, true);
   item->deleteLater();
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -82,7 +82,7 @@ public:
   }
 
   // Wireframe OpenGL drawing in a display list
-  void invalidate_OpenGLBuffers()
+  void invalidateOpenGLBuffers()
   {
       compute_elements();
       are_buffers_filled = false;
@@ -167,7 +167,7 @@ public:
                 bbox.ymax(),
                 bbox.zmax());
   }
-  void invalidate_OpenGLBuffers()
+  void invalidateOpenGLBuffers()
   {
       compute_elements();
       are_buffers_filled = false;
@@ -480,7 +480,7 @@ void Polyhedron_demo_cut_plugin::cut() {
   }
 
   messages->information(QString("cut (%1 ms). %2 edges.").arg(time.elapsed()).arg(edges_item->edges.size()));
-  edges_item->invalidate_OpenGLBuffers();
+  edges_item->invalidateOpenGLBuffers();
   scene->itemChanged(edges_item);
   }
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -82,7 +82,7 @@ public:
   }
 
   // Wireframe OpenGL drawing in a display list
-  void invalidate_buffers()
+  void invalidate_OpenGLBuffers()
   {
       compute_elements();
       are_buffers_filled = false;
@@ -167,7 +167,7 @@ public:
                 bbox.ymax(),
                 bbox.zmax());
   }
-  void invalidate_buffers()
+  void invalidate_OpenGLBuffers()
   {
       compute_elements();
       are_buffers_filled = false;
@@ -480,7 +480,7 @@ void Polyhedron_demo_cut_plugin::cut() {
   }
 
   messages->information(QString("cut (%1 ms). %2 edges.").arg(time.elapsed()).arg(edges_item->edges.size()));
-  edges_item->invalidate_buffers();
+  edges_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edges_item);
   }
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
@@ -117,7 +117,7 @@ Polyhedron_demo_nef_plugin::on_actionToNef_triggered()
     new_nef_item->setRenderingMode(item->renderingMode());
     item->setVisible(false);
     scene->itemChanged(index);
-    new_nef_item->invalidate_buffers();
+    new_nef_item->invalidate_OpenGLBuffers();
     scene->addItem(new_nef_item);
     std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
@@ -117,7 +117,7 @@ Polyhedron_demo_nef_plugin::on_actionToNef_triggered()
     new_nef_item->setRenderingMode(item->renderingMode());
     item->setVisible(false);
     scene->itemChanged(index);
-    new_nef_item->invalidate_OpenGLBuffers();
+    new_nef_item->invalidateOpenGLBuffers();
     scene->addItem(new_nef_item);
     std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
@@ -73,7 +73,7 @@ Polyhedron_demo_gocad_plugin::load(QFileInfo fileinfo) {
   if(qcolor.isValid()) 
   {  
     item->setColor(qcolor);
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
   }
   
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
@@ -73,7 +73,7 @@ Polyhedron_demo_gocad_plugin::load(QFileInfo fileinfo) {
   if(qcolor.isValid()) 
   {  
     item->setColor(qcolor);
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
   }
   
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -146,7 +146,7 @@ Polyhedron_demo_polylines_io_plugin::load(QFileInfo fileinfo) {
   item->setColor(Qt::black);
   item->setProperty("polylines metadata", polylines_metadata);
   std::cerr << "Number of polylines in item: " << item->polylines.size() << std::endl;
-  item->invalidate_OpenGLBuffers();
+  item->invalidateOpenGLBuffers();
   return item;
 }
 
@@ -259,7 +259,7 @@ void Polyhedron_demo_polylines_io_plugin::addPolylineButton_clicked()
         item->setName(name);
         item->setColor(Qt::black);
         item->setProperty("polylines metadata", polylines_metadata);
-        item->invalidate_OpenGLBuffers();
+        item->invalidateOpenGLBuffers();
         scene->addItem(item);
     }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -146,7 +146,7 @@ Polyhedron_demo_polylines_io_plugin::load(QFileInfo fileinfo) {
   item->setColor(Qt::black);
   item->setProperty("polylines metadata", polylines_metadata);
   std::cerr << "Number of polylines in item: " << item->polylines.size() << std::endl;
-  item->invalidate_buffers();
+  item->invalidate_OpenGLBuffers();
   return item;
 }
 
@@ -259,7 +259,7 @@ void Polyhedron_demo_polylines_io_plugin::addPolylineButton_clicked()
         item->setName(name);
         item->setColor(Qt::black);
         item->setProperty("polylines metadata", polylines_metadata);
-        item->invalidate_buffers();
+        item->invalidate_OpenGLBuffers();
         scene->addItem(item);
     }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -209,7 +209,7 @@ void Polyhedron_demo_xyz_plugin::addPointSetButton_clicked()
         QString name = QString("Point_set #%1").arg(QString::number(nb_of_point_set));
         item->setName(name);
         item->setColor(Qt::black);
-        item->invalidate_buffers();
+        item->invalidate_OpenGLBuffers();
         scene->addItem(item);
     }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -209,7 +209,7 @@ void Polyhedron_demo_xyz_plugin::addPointSetButton_clicked()
         QString name = QString("Point_set #%1").arg(QString::number(nb_of_point_set));
         item->setName(name);
         item->setColor(Qt::black);
-        item->invalidate_OpenGLBuffers();
+        item->invalidateOpenGLBuffers();
         scene->addItem(item);
     }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Detect_sharp_edges_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Detect_sharp_edges_plugin.cpp
@@ -111,7 +111,7 @@ void Polyhedron_demo_detect_sharp_edges_plugin::detectSharpEdges(bool input_dial
     CGAL::detect_sharp_edges(pMesh, angle);
 
     //update item
-    scene->item(tuple.first)->invalidate_OpenGLBuffers();
+    scene->item(tuple.first)->invalidateOpenGLBuffers();
 
     // update scene
     scene->itemChanged(tuple.first);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Detect_sharp_edges_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Detect_sharp_edges_plugin.cpp
@@ -111,7 +111,7 @@ void Polyhedron_demo_detect_sharp_edges_plugin::detectSharpEdges(bool input_dial
     CGAL::detect_sharp_edges(pMesh, angle);
 
     //update item
-    scene->item(tuple.first)->invalidate_buffers();
+    scene->item(tuple.first)->invalidate_OpenGLBuffers();
 
     // update scene
     scene->itemChanged(tuple.first);

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -198,11 +198,11 @@ public Q_SLOTS:
             new_item->setColor(poly->color());
             new_item->setRenderingMode(poly->renderingMode());
             new_item->setVisible(poly->visible());
-            new_item->invalidate_OpenGLBuffers();
+            new_item->invalidateOpenGLBuffers();
             new_item->setProperty("source filename", poly->property("source filename"));
             scene->replaceItem(scene->item_id(poly),new_item);
             delete poly;
-            new_item->invalidate_OpenGLBuffers();
+            new_item->invalidateOpenGLBuffers();
             viewer->updateGL();
             messages->information(QString("%1 clipped").arg(new_item->name()));
           }
@@ -215,7 +215,7 @@ public Q_SLOTS:
         else
         {
           CGAL::corefinement::inplace_clip_open_polyhedron(*(poly->polyhedron()),plane->plane());
-          poly->invalidate_OpenGLBuffers();
+          poly->invalidateOpenGLBuffers();
           viewer->updateGL();
           messages->information(QString("%1 clipped").arg(poly->name()));
         }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -198,11 +198,11 @@ public Q_SLOTS:
             new_item->setColor(poly->color());
             new_item->setRenderingMode(poly->renderingMode());
             new_item->setVisible(poly->visible());
-            new_item->invalidate_buffers();
+            new_item->invalidate_OpenGLBuffers();
             new_item->setProperty("source filename", poly->property("source filename"));
             scene->replaceItem(scene->item_id(poly),new_item);
             delete poly;
-            new_item->invalidate_buffers();
+            new_item->invalidate_OpenGLBuffers();
             viewer->updateGL();
             messages->information(QString("%1 clipped").arg(new_item->name()));
           }
@@ -215,7 +215,7 @@ public Q_SLOTS:
         else
         {
           CGAL::corefinement::inplace_clip_open_polyhedron(*(poly->polyhedron()),plane->plane());
-          poly->invalidate_buffers();
+          poly->invalidate_OpenGLBuffers();
           viewer->updateGL();
           messages->information(QString("%1 clipped").arg(poly->name()));
         }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
@@ -170,7 +170,7 @@ void Polyhedron_demo_corefinement_plugin::corefinement()
     new_item->setColor(Qt::green);
     new_item->setRenderingMode(Wireframe);
     scene->addItem(new_item);  
-    new_item->invalidate_buffers();
+    new_item->invalidate_OpenGLBuffers();
     std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
       
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Corefinement_plugin.cpp
@@ -170,7 +170,7 @@ void Polyhedron_demo_corefinement_plugin::corefinement()
     new_item->setColor(Qt::green);
     new_item->setRenderingMode(Wireframe);
     scene->addItem(new_item);  
-    new_item->invalidate_OpenGLBuffers();
+    new_item->invalidateOpenGLBuffers();
     std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
       
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
@@ -212,7 +212,7 @@ void Polyhedron_demo_intersection_plugin::intersection()
   new_item->setColor(Qt::green);
   new_item->setRenderingMode(Wireframe);
   scene->addItem(new_item);
-  new_item->invalidate_OpenGLBuffers();
+  new_item->invalidateOpenGLBuffers();
 
   QApplication::restoreOverrideCursor();
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Intersection_plugin.cpp
@@ -212,7 +212,7 @@ void Polyhedron_demo_intersection_plugin::intersection()
   new_item->setColor(Qt::green);
   new_item->setRenderingMode(Wireframe);
   scene->addItem(new_item);
-  new_item->invalidate_buffers();
+  new_item->invalidate_OpenGLBuffers();
 
   QApplication::restoreOverrideCursor();
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -52,7 +52,7 @@ void Scene_combinatorial_map_item::set_next_volume(){
     ++volume_to_display;
     volume_to_display=volume_to_display%(combinatorial_map().attributes<3>().size()+1);
   are_buffers_filled = false;
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 
     if (exportSelectedVolume!=NULL && ( volume_to_display==1 || volume_to_display==0 ) )

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -52,7 +52,7 @@ void Scene_combinatorial_map_item::set_next_volume(){
     ++volume_to_display;
     volume_to_display=volume_to_display%(combinatorial_map().attributes<3>().size()+1);
   are_buffers_filled = false;
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 
     if (exportSelectedVolume!=NULL && ( volume_to_display==1 || volume_to_display==0 ) )

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -13,7 +13,7 @@ Scene_polyhedron_transform_item::Scene_polyhedron_transform_item(const qglviewer
 {
     frame->setPosition(pos);
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 void Scene_polyhedron_transform_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =0) const
@@ -115,7 +115,7 @@ Scene_polyhedron_transform_item::compute_bbox() const {
 }
 
 
-void Scene_polyhedron_transform_item::invalidate_buffers()
+void Scene_polyhedron_transform_item::invalidate_OpenGLBuffers()
 {
     compute_elements();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -13,7 +13,7 @@ Scene_polyhedron_transform_item::Scene_polyhedron_transform_item(const qglviewer
 {
     frame->setPosition(pos);
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 void Scene_polyhedron_transform_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =0) const
@@ -115,7 +115,7 @@ Scene_polyhedron_transform_item::compute_bbox() const {
 }
 
 
-void Scene_polyhedron_transform_item::invalidate_OpenGLBuffers()
+void Scene_polyhedron_transform_item::invalidateOpenGLBuffers()
 {
     compute_elements();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
@@ -27,7 +27,7 @@ public:
     const Scene_polyhedron_item* getBase() const{ return poly_item;  };
     const qglviewer::Vec& center() const { return center_; }
     virtual bool supportsRenderingMode(RenderingMode m) const { return m==Wireframe ; }
-    virtual void invalidate_buffers();
+    virtual void invalidate_OpenGLBuffers();
     virtual bool keyPressEvent(QKeyEvent*);
 
 private:

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.h
@@ -27,7 +27,7 @@ public:
     const Scene_polyhedron_item* getBase() const{ return poly_item;  };
     const qglviewer::Vec& center() const { return center_; }
     virtual bool supportsRenderingMode(RenderingMode m) const { return m==Wireframe ; }
-    virtual void invalidate_OpenGLBuffers();
+    virtual void invalidateOpenGLBuffers();
     virtual bool keyPressEvent(QKeyEvent*);
 
 private:

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
@@ -62,7 +62,7 @@ public:
 
     }
 
-    void invalidate_OpenGLBuffers()
+    void invalidateOpenGLBuffers()
     {
         compute_elements();
         are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Trivial_plugin.cpp
@@ -62,7 +62,7 @@ public:
 
     }
 
-    void invalidate_buffers()
+    void invalidate_OpenGLBuffers()
     {
         compute_elements();
         are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -341,7 +341,7 @@ protected:
 
   void change_poly_item_by_blocking(Scene_polyhedron_item* poly_item, Scene_hole_visualizer* collection) {
     if(collection) collection->block_poly_item_changed = true;
-    poly_item->invalidate_OpenGLBuffers();
+    poly_item->invalidateOpenGLBuffers();
     scene->itemChanged(poly_item);
     if(collection) collection->block_poly_item_changed = false;
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -341,7 +341,7 @@ protected:
 
   void change_poly_item_by_blocking(Scene_polyhedron_item* poly_item, Scene_hole_visualizer* collection) {
     if(collection) collection->block_poly_item_changed = true;
-    poly_item->invalidate_buffers();
+    poly_item->invalidate_OpenGLBuffers();
     scene->itemChanged(poly_item);
     if(collection) collection->block_poly_item_changed = false;
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Inside_out_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Inside_out_plugin.cpp
@@ -65,11 +65,11 @@ void Polyhedron_demo_inside_out_plugin::on_actionInsideOut_triggered()
   
       // inside out
       CGAL::Polygon_mesh_processing::reverse_face_orientations(*pMesh);
-      poly_item->invalidate_OpenGLBuffers();
+      poly_item->invalidateOpenGLBuffers();
     }
     else {
       soup_item->inside_out();
-      soup_item->invalidate_OpenGLBuffers();
+      soup_item->invalidateOpenGLBuffers();
     }
 
     // update scene

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Inside_out_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Inside_out_plugin.cpp
@@ -65,11 +65,11 @@ void Polyhedron_demo_inside_out_plugin::on_actionInsideOut_triggered()
   
       // inside out
       CGAL::Polygon_mesh_processing::reverse_face_orientations(*pMesh);
-      poly_item->invalidate_buffers();
+      poly_item->invalidate_OpenGLBuffers();
     }
     else {
       soup_item->inside_out();
-      soup_item->invalidate_buffers();
+      soup_item->invalidate_OpenGLBuffers();
     }
 
     // update scene

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -229,7 +229,7 @@ public Q_SLOTS:
          .protect_constraints(protect)
          .smooth_along_features(smooth_features));
         }
-        poly_item->invalidate_buffers();
+        poly_item->invalidate_OpenGLBuffers();
         Q_EMIT poly_item->itemChanged();
       }
       else{
@@ -329,7 +329,7 @@ public Q_SLOTS:
 
     BOOST_FOREACH(Scene_polyhedron_item* poly_item, selection)
     {
-      poly_item->invalidate_buffers();
+      poly_item->invalidate_OpenGLBuffers();
       Q_EMIT poly_item->itemChanged();
     }
     

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -229,7 +229,7 @@ public Q_SLOTS:
          .protect_constraints(protect)
          .smooth_along_features(smooth_features));
         }
-        poly_item->invalidate_OpenGLBuffers();
+        poly_item->invalidateOpenGLBuffers();
         Q_EMIT poly_item->itemChanged();
       }
       else{
@@ -329,7 +329,7 @@ public Q_SLOTS:
 
     BOOST_FOREACH(Scene_polyhedron_item* poly_item, selection)
     {
-      poly_item->invalidate_OpenGLBuffers();
+      poly_item->invalidateOpenGLBuffers();
       Q_EMIT poly_item->itemChanged();
     }
     

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Jet_fitting_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Jet_fitting_plugin.cpp
@@ -132,8 +132,8 @@ void Polyhedron_demo_jet_fitting_plugin::on_actionEstimateCurvature_triggered()
 
   scene->addItem(max_curv);
   scene->addItem(min_curv);
-  max_curv->invalidate_OpenGLBuffers();
-  min_curv->invalidate_OpenGLBuffers();
+  max_curv->invalidateOpenGLBuffers();
+  min_curv->invalidateOpenGLBuffers();
   
   // default cursor
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Jet_fitting_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Jet_fitting_plugin.cpp
@@ -132,8 +132,8 @@ void Polyhedron_demo_jet_fitting_plugin::on_actionEstimateCurvature_triggered()
 
   scene->addItem(max_curv);
   scene->addItem(min_curv);
-  max_curv->invalidate_buffers();
-  min_curv->invalidate_buffers();
+  max_curv->invalidate_OpenGLBuffers();
+  min_curv->invalidate_OpenGLBuffers();
   
   // default cursor
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -84,7 +84,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionJoinPolyhedra_tri
     }
   }
 
-  mainSelectionItem->invalidate_buffers();
+  mainSelectionItem->invalidate_OpenGLBuffers();
   scene->itemChanged(mainSelectionIndex);
 
   //remove the other items
@@ -166,7 +166,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionColorConnectedCom
         CGAL::internal::corefinement::Dummy_true(),
         marker
       );
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -84,7 +84,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionJoinPolyhedra_tri
     }
   }
 
-  mainSelectionItem->invalidate_OpenGLBuffers();
+  mainSelectionItem->invalidateOpenGLBuffers();
   scene->itemChanged(mainSelectionIndex);
 
   //remove the other items
@@ -166,7 +166,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionColorConnectedCom
         CGAL::internal::corefinement::Dummy_true(),
         marker
       );
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -333,7 +333,7 @@ public:
   {
     CGAL::Polyhedron_copy_3<Mean_curvature_skeleton::Meso_skeleton, Polyhedron::HalfedgeDS> modifier(mcs->meso_skeleton());
     meso_skeleton->delegate(modifier);
-    scene->item(contractedItemIndex)->invalidate_buffers();
+    scene->item(contractedItemIndex)->invalidate_OpenGLBuffers();
     scene->itemChanged(contractedItemIndex);
   }
 
@@ -513,7 +513,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
 
     skeleton_item->setName(QString("Medial skeleton curve of %1").arg(item->name()));
     scene->addItem(skeleton_item);
-    skeleton_item->invalidate_buffers();
+    skeleton_item->invalidate_OpenGLBuffers();
 
     item->setPointsMode();
 
@@ -664,7 +664,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   }
   // update scene
   update_meso_skeleton();
-  scene->item(fixedPointsItemIndex)->invalidate_buffers();
+  scene->item(fixedPointsItemIndex)->invalidate_OpenGLBuffers();
   scene->itemChanged(fixedPointsItemIndex);
   scene->setSelectedItem(index);
   QApplication::restoreOverrideCursor();
@@ -828,7 +828,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
 
   skeleton->setName(QString("skeleton curve of %1").arg(item->name()));
   scene->addItem(skeleton);
-  skeleton->invalidate_buffers();
+  skeleton->invalidate_OpenGLBuffers();
 
   // set the fixed points and contracted mesh as invisible
   if (fixedPointsItemIndex >= 0)
@@ -900,7 +900,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
     delete temp;
   }
 
-  scene->item(fixedPointsItemIndex)->invalidate_buffers();
+  scene->item(fixedPointsItemIndex)->invalidate_OpenGLBuffers();
   scene->itemChanged(fixedPointsItemIndex);
   update_meso_skeleton();
   scene->setSelectedItem(index);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -333,7 +333,7 @@ public:
   {
     CGAL::Polyhedron_copy_3<Mean_curvature_skeleton::Meso_skeleton, Polyhedron::HalfedgeDS> modifier(mcs->meso_skeleton());
     meso_skeleton->delegate(modifier);
-    scene->item(contractedItemIndex)->invalidate_OpenGLBuffers();
+    scene->item(contractedItemIndex)->invalidateOpenGLBuffers();
     scene->itemChanged(contractedItemIndex);
   }
 
@@ -513,7 +513,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
 
     skeleton_item->setName(QString("Medial skeleton curve of %1").arg(item->name()));
     scene->addItem(skeleton_item);
-    skeleton_item->invalidate_OpenGLBuffers();
+    skeleton_item->invalidateOpenGLBuffers();
 
     item->setPointsMode();
 
@@ -664,7 +664,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   }
   // update scene
   update_meso_skeleton();
-  scene->item(fixedPointsItemIndex)->invalidate_OpenGLBuffers();
+  scene->item(fixedPointsItemIndex)->invalidateOpenGLBuffers();
   scene->itemChanged(fixedPointsItemIndex);
   scene->setSelectedItem(index);
   QApplication::restoreOverrideCursor();
@@ -828,7 +828,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
 
   skeleton->setName(QString("skeleton curve of %1").arg(item->name()));
   scene->addItem(skeleton);
-  skeleton->invalidate_OpenGLBuffers();
+  skeleton->invalidateOpenGLBuffers();
 
   // set the fixed points and contracted mesh as invisible
   if (fixedPointsItemIndex >= 0)
@@ -900,7 +900,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
     delete temp;
   }
 
-  scene->item(fixedPointsItemIndex)->invalidate_OpenGLBuffers();
+  scene->item(fixedPointsItemIndex)->invalidateOpenGLBuffers();
   scene->itemChanged(fixedPointsItemIndex);
   update_meso_skeleton();
   scene->setSelectedItem(index);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -109,12 +109,12 @@ void Polyhedron_demo_orient_soup_plugin::orient()
         poly_item->setColor(item->color());
         poly_item->setRenderingMode(item->renderingMode());
         poly_item->setVisible(item->visible());
-        poly_item->invalidate_OpenGLBuffers();
+        poly_item->invalidateOpenGLBuffers();
         poly_item->setProperty("source filename", item->property("source filename"));
         scene->replaceItem(index, poly_item);
         delete item;
       } else {
-        item->invalidate_OpenGLBuffers();
+        item->invalidateOpenGLBuffers();
         scene->itemChanged(item);
       }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -109,12 +109,12 @@ void Polyhedron_demo_orient_soup_plugin::orient()
         poly_item->setColor(item->color());
         poly_item->setRenderingMode(item->renderingMode());
         poly_item->setVisible(item->visible());
-        poly_item->invalidate_buffers();
+        poly_item->invalidate_OpenGLBuffers();
         poly_item->setProperty("source filename", item->property("source filename"));
         scene->replaceItem(index, poly_item);
         delete item;
       } else {
-        item->invalidate_buffers();
+        item->invalidate_OpenGLBuffers();
         scene->itemChanged(item);
       }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
@@ -177,7 +177,7 @@ public Q_SLOTS:
     Q_FOREACH(CGAL::Three::Scene_interface::Item_id id, scene->selectionIndices()) {
       Scene_points_with_normal_item* point_item = qobject_cast<Scene_points_with_normal_item*>(scene->item(id));
       if(point_item) { 
-        point_item->invalidate_buffers();
+        point_item->invalidate_OpenGLBuffers();
         scene->itemChanged(point_item);
       }
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
@@ -177,7 +177,7 @@ public Q_SLOTS:
     Q_FOREACH(CGAL::Three::Scene_interface::Item_id id, scene->selectionIndices()) {
       Scene_points_with_normal_item* point_item = qobject_cast<Scene_points_with_normal_item*>(scene->item(id));
       if(point_item) { 
-        point_item->invalidate_OpenGLBuffers();
+        point_item->invalidateOpenGLBuffers();
         scene->itemChanged(point_item);
       }
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
@@ -311,7 +311,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
       new_polylines_item->setColor(Qt::green);
       new_polylines_item->setRenderingMode(Wireframe);
       scene->addItem(new_polylines_item);
-      new_polylines_item->invalidate_buffers();
+      new_polylines_item->invalidate_OpenGLBuffers();
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
@@ -311,7 +311,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
       new_polylines_item->setColor(Qt::green);
       new_polylines_item->setRenderingMode(Wireframe);
       scene->addItem(new_polylines_item);
-      new_polylines_item->invalidate_OpenGLBuffers();
+      new_polylines_item->invalidateOpenGLBuffers();
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_stitching_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_stitching_plugin.cpp
@@ -141,7 +141,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionDetectBorders_trigger
         new_item->setName(tr("Boundary of %1").arg(item->name()));
         new_item->setColor(Qt::red);
         scene->addItem(new_item);
-        new_item->invalidate_OpenGLBuffers();
+        new_item->invalidateOpenGLBuffers();
       }
     }
   }
@@ -158,7 +158,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionStitchBorders_trigger
     {
       Polyhedron* pMesh = item->polyhedron();
       CGAL::Polygon_mesh_processing::stitch_borders(*pMesh);
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_stitching_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_stitching_plugin.cpp
@@ -141,7 +141,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionDetectBorders_trigger
         new_item->setName(tr("Boundary of %1").arg(item->name()));
         new_item->setColor(Qt::red);
         scene->addItem(new_item);
-        new_item->invalidate_buffers();
+        new_item->invalidate_OpenGLBuffers();
       }
     }
   }
@@ -158,7 +158,7 @@ void Polyhedron_demo_polyhedron_stitching_plugin::on_actionStitchBorders_trigger
     {
       Polyhedron* pMesh = item->polyhedron();
       CGAL::Polygon_mesh_processing::stitch_borders(*pMesh);
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(item);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -88,7 +88,7 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveIsolatedVertices_t
         *poly_item->polyhedron());
     messages->information(tr(" %1 isolated vertices have been removed.")
       .arg(nbv));
-    poly_item->invalidate_OpenGLBuffers();
+    poly_item->invalidateOpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
   }
 }
@@ -106,7 +106,7 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveDegenerateFaces_tr
       *poly_item->polyhedron());
     messages->information(tr(" %1 degenerate faces have been removed.")
       .arg(nbv));
-    poly_item->invalidate_OpenGLBuffers();
+    poly_item->invalidateOpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -88,7 +88,7 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveIsolatedVertices_t
         *poly_item->polyhedron());
     messages->information(tr(" %1 isolated vertices have been removed.")
       .arg(nbv));
-    poly_item->invalidate_buffers();
+    poly_item->invalidate_OpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
   }
 }
@@ -106,7 +106,7 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveDegenerateFaces_tr
       *poly_item->polyhedron());
     messages->information(tr(" %1 degenerate faces have been removed.")
       .arg(nbv));
-    poly_item->invalidate_buffers();
+    poly_item->invalidate_OpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -305,7 +305,7 @@ public Q_SLOTS:
     Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
     if(selection_item->export_selected_facets_as_polyhedron(poly_item->polyhedron())) {
       poly_item->setName(QString("%1-facets").arg(selection_item->name()));
-      poly_item->invalidate_OpenGLBuffers(); // for init()
+      poly_item->invalidateOpenGLBuffers(); // for init()
       scene->setSelectedItem( scene->addItem(poly_item) );
       scene->itemChanged(poly_item);
     }
@@ -358,7 +358,7 @@ public Q_SLOTS:
         scene->erase(item_id);
         return;
       }
-      selection_item->invalidate_OpenGLBuffers();
+      selection_item->invalidateOpenGLBuffers();
       scene->itemChanged(selection_item);
     }
     // now set default params both for selection items coming from selection_io, or on_Create_selection_item_button_clicked

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -305,7 +305,7 @@ public Q_SLOTS:
     Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
     if(selection_item->export_selected_facets_as_polyhedron(poly_item->polyhedron())) {
       poly_item->setName(QString("%1-facets").arg(selection_item->name()));
-      poly_item->invalidate_buffers(); // for init()
+      poly_item->invalidate_OpenGLBuffers(); // for init()
       scene->setSelectedItem( scene->addItem(poly_item) );
       scene->itemChanged(poly_item);
     }
@@ -358,7 +358,7 @@ public Q_SLOTS:
         scene->erase(item_id);
         return;
       }
-      selection_item->invalidate_buffers();
+      selection_item->invalidate_OpenGLBuffers();
       scene->itemChanged(selection_item);
     }
     // now set default params both for selection items coming from selection_io, or on_Create_selection_item_button_clicked

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
@@ -84,7 +84,7 @@ void Polyhedron_demo_self_intersection_plugin::on_actionSelfIntersection_trigger
         selection_item->selected_facets.insert(fb->first);
         selection_item->selected_facets.insert(fb->second);
       }
-      selection_item->invalidate_OpenGLBuffers();
+      selection_item->invalidateOpenGLBuffers();
       selection_item->setName(tr("%1 (selection) (intersecting triangles)").arg(item->name()));
       scene->addItem(selection_item);
       item->setRenderingMode(Wireframe);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
@@ -84,7 +84,7 @@ void Polyhedron_demo_self_intersection_plugin::on_actionSelfIntersection_trigger
         selection_item->selected_facets.insert(fb->first);
         selection_item->selected_facets.insert(fb->second);
       }
-      selection_item->invalidate_buffers();
+      selection_item->invalidate_OpenGLBuffers();
       selection_item->setName(tr("%1 (selection) (intersecting triangles)").arg(item->name()));
       scene->addItem(selection_item);
       item->setRenderingMode(Wireframe);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
@@ -97,7 +97,7 @@ public Q_SLOTS:
       }
       CGAL_assertion_code(pMesh->normalize_border());
       // CGAL_assertion(pMesh->is_valid(true, 3));
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();
@@ -127,7 +127,7 @@ public Q_SLOTS:
       CGAL_assertion_code(pMesh->normalize_border());
       CGAL_assertion(pMesh->is_valid(false, 3));
 
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
@@ -97,7 +97,7 @@ public Q_SLOTS:
       }
       CGAL_assertion_code(pMesh->normalize_border());
       // CGAL_assertion(pMesh->is_valid(true, 3));
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();
@@ -127,7 +127,7 @@ public Q_SLOTS:
       CGAL_assertion_code(pMesh->normalize_border());
       CGAL_assertion(pMesh->is_valid(false, 3));
 
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(item);
       // default cursor
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
@@ -77,7 +77,7 @@ void Polyhedron_demo_merge_point_sets_plugin::on_actionMergePointSets_triggered(
     }
   
 
-  mainSelectionItem->invalidate_buffers();
+  mainSelectionItem->invalidate_OpenGLBuffers();
   scene->itemChanged(mainSelectionIndex);
 
   //remove the other items

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
@@ -77,7 +77,7 @@ void Polyhedron_demo_merge_point_sets_plugin::on_actionMergePointSets_triggered(
     }
   
 
-  mainSelectionItem->invalidate_OpenGLBuffers();
+  mainSelectionItem->invalidateOpenGLBuffers();
   scene->itemChanged(mainSelectionIndex);
 
   //remove the other items

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
@@ -117,7 +117,7 @@ void Polyhedron_demo_point_set_bilateral_smoothing_plugin::on_actionBilateralSmo
 	      << std::endl;
 
     // Updates scene
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
@@ -117,7 +117,7 @@ void Polyhedron_demo_point_set_bilateral_smoothing_plugin::on_actionBilateralSmo
 	      << std::endl;
 
     // Updates scene
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -131,7 +131,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalInversio
     for(Point_set::iterator it = points->begin(); it != points->end(); ++it){
       it->normal() = -1 * it->normal();
     }
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(item);
   }
 }
@@ -259,7 +259,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
         points->set_first_selected (first_unoriented_point);
 
         // Updates scene
-        item->invalidate_OpenGLBuffers();
+        item->invalidateOpenGLBuffers();
         scene->itemChanged(index);
 
         QApplication::restoreOverrideCursor();
@@ -276,7 +276,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
     else
       {
         // Updates scene
-        item->invalidate_OpenGLBuffers();
+        item->invalidateOpenGLBuffers();
         scene->itemChanged(index);
 
         QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -131,7 +131,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalInversio
     for(Point_set::iterator it = points->begin(); it != points->end(); ++it){
       it->normal() = -1 * it->normal();
     }
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(item);
   }
 }
@@ -259,7 +259,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
         points->set_first_selected (first_unoriented_point);
 
         // Updates scene
-        item->invalidate_buffers();
+        item->invalidate_OpenGLBuffers();
         scene->itemChanged(index);
 
         QApplication::restoreOverrideCursor();
@@ -276,7 +276,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
     else
       {
         // Updates scene
-        item->invalidate_buffers();
+        item->invalidate_OpenGLBuffers();
         scene->itemChanged(index);
 
         QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
@@ -106,7 +106,7 @@ void Polyhedron_demo_point_set_outliers_removal_plugin::on_actionOutlierRemoval_
     points->set_first_selected (first_point_to_remove);
 
     // Updates scene
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
@@ -106,7 +106,7 @@ void Polyhedron_demo_point_set_outliers_removal_plugin::on_actionOutlierRemoval_
     points->set_first_selected (first_point_to_remove);
 
     // Updates scene
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -391,7 +391,7 @@ protected:
 	point_set_item->point_set()->set_first_selected
 	  (point_set_item->point_set()->begin() + size);
       } 
-    point_set_item->invalidate_OpenGLBuffers();
+    point_set_item->invalidateOpenGLBuffers();
   }
 
   
@@ -475,7 +475,7 @@ public Q_SLOTS:
 	new_item->point_set()->push_back(*it);
     }
     new_item->resetSelection();
-    new_item->invalidate_OpenGLBuffers();
+    new_item->invalidateOpenGLBuffers();
 
     scene->addItem(new_item);
  }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -391,7 +391,7 @@ protected:
 	point_set_item->point_set()->set_first_selected
 	  (point_set_item->point_set()->begin() + size);
       } 
-    point_set_item->invalidate_buffers();
+    point_set_item->invalidate_OpenGLBuffers();
   }
 
   
@@ -475,7 +475,7 @@ public Q_SLOTS:
 	new_item->point_set()->push_back(*it);
     }
     new_item->resetSelection();
-    new_item->invalidate_buffers();
+    new_item->invalidate_OpenGLBuffers();
 
     scene->addItem(new_item);
  }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
@@ -182,7 +182,7 @@ void Polyhedron_demo_point_set_simplification_plugin::on_actionSimplify_triggere
     points->set_first_selected(first_point_to_remove);
 
     // Updates scene
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
@@ -182,7 +182,7 @@ void Polyhedron_demo_point_set_simplification_plugin::on_actionSimplify_triggere
     points->set_first_selected(first_point_to_remove);
 
     // Updates scene
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -87,7 +87,7 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
     item->set_has_normals(false);
 
     // update scene
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -87,7 +87,7 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
     item->set_has_normals(false);
 
     // update scene
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(index);
 
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -135,7 +135,7 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
 		<< std::endl;
 
       // Updates scene
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(index);
 
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -135,7 +135,7 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
 		<< std::endl;
 
       // Updates scene
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(index);
 
       QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -565,7 +565,7 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	  new_item->setRenderingMode(pts_item->renderingMode());
 	  new_item->setVisible(pts_item->visible());
 	  new_item->resetSelection();
-	  new_item->invalidate_OpenGLBuffers();
+	  new_item->invalidateOpenGLBuffers();
 
 	  points = new_item->point_set();
 	  std::copy (pts_item->point_set()->begin(), pts_item->point_set()->end(),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -565,7 +565,7 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	  new_item->setRenderingMode(pts_item->renderingMode());
 	  new_item->setVisible(pts_item->visible());
 	  new_item->resetSelection();
-	  new_item->invalidate_buffers();
+	  new_item->invalidate_OpenGLBuffers();
 
 	  points = new_item->point_set();
 	  std::copy (pts_item->point_set()->begin(), pts_item->point_set()->end(),

--- a/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
@@ -76,7 +76,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionLoop_triggered()
   CGAL::Subdivision_method_3::Loop_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_buffers();
+  item->invalidate_OpenGLBuffers();
   scene->itemChanged(item);
 }
 
@@ -97,7 +97,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionCatmullClark_triggered
   CGAL::Subdivision_method_3::CatmullClark_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_buffers();
+  item->invalidate_OpenGLBuffers();
   scene->itemChanged(item);
 }
 
@@ -118,7 +118,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionSqrt3_triggered()
   CGAL::Subdivision_method_3::Sqrt3_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_buffers();
+  item->invalidate_OpenGLBuffers();
   scene->itemChanged(item);
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
@@ -76,7 +76,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionLoop_triggered()
   CGAL::Subdivision_method_3::Loop_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_OpenGLBuffers();
+  item->invalidateOpenGLBuffers();
   scene->itemChanged(item);
 }
 
@@ -97,7 +97,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionCatmullClark_triggered
   CGAL::Subdivision_method_3::CatmullClark_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_OpenGLBuffers();
+  item->invalidateOpenGLBuffers();
   scene->itemChanged(item);
 }
 
@@ -118,7 +118,7 @@ void Polyhedron_demo_subdivision_methods_plugin::on_actionSqrt3_triggered()
   CGAL::Subdivision_method_3::Sqrt3_subdivision(*poly, 1);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
   QApplication::restoreOverrideCursor();
-  item->invalidate_OpenGLBuffers();
+  item->invalidateOpenGLBuffers();
   scene->itemChanged(item);
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
@@ -205,7 +205,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_SDF_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(index);
     }
 
@@ -277,7 +277,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_Partition_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
-      item->invalidate_OpenGLBuffers();
+      item->invalidateOpenGLBuffers();
       scene->itemChanged(index);
     }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
@@ -205,7 +205,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_SDF_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(index);
     }
 
@@ -277,7 +277,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::on_Partition_button_clicked()
         scene->setSelectedItem(index);
     }
     else {
-      item->invalidate_buffers();
+      item->invalidate_OpenGLBuffers();
       scene->itemChanged(index);
     }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -88,7 +88,7 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
       << pMesh->size_of_halfedges() / 2 << " edges)" << std::endl;
 
     // update scene
-    item->invalidate_OpenGLBuffers();
+    item->invalidateOpenGLBuffers();
     scene->itemChanged(index);
     QApplication::restoreOverrideCursor();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -88,7 +88,7 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
       << pMesh->size_of_halfedges() / 2 << " edges)" << std::endl;
 
     // update scene
-    item->invalidate_buffers();
+    item->invalidate_OpenGLBuffers();
     scene->itemChanged(index);
     QApplication::restoreOverrideCursor();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -177,11 +177,11 @@ void Scene_polyhedron_shortest_path_item::ensure_shortest_paths_tree()
 void Scene_polyhedron_shortest_path_item::poly_item_changed()
 {
   recreate_shortest_path_object();
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
   
-void Scene_polyhedron_shortest_path_item::invalidate_OpenGLBuffers()
+void Scene_polyhedron_shortest_path_item::invalidateOpenGLBuffers()
 {
   compute_elements();
   compute_bbox();
@@ -383,7 +383,7 @@ bool Scene_polyhedron_shortest_path_item::run_point_select(const Ray_3& ray)
       }
       break;
     }
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     return true;
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -177,11 +177,11 @@ void Scene_polyhedron_shortest_path_item::ensure_shortest_paths_tree()
 void Scene_polyhedron_shortest_path_item::poly_item_changed()
 {
   recreate_shortest_path_object();
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
   
-void Scene_polyhedron_shortest_path_item::invalidate_buffers()
+void Scene_polyhedron_shortest_path_item::invalidate_OpenGLBuffers()
 {
   compute_elements();
   compute_bbox();
@@ -383,7 +383,7 @@ bool Scene_polyhedron_shortest_path_item::run_point_select(const Ray_3& ray)
       }
       break;
     }
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     return true;
   }
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
@@ -153,7 +153,7 @@ protected:
   
 public Q_SLOTS:
   virtual void poly_item_changed();
-  virtual void invalidate_buffers();
+  virtual void invalidate_OpenGLBuffers();
 };
 
 #endif // SCENE_POLYHEDRON_SHORTEST_PATH_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
@@ -153,7 +153,7 @@ protected:
   
 public Q_SLOTS:
   virtual void poly_item_changed();
-  virtual void invalidate_OpenGLBuffers();
+  virtual void invalidateOpenGLBuffers();
 };
 
 #endif // SCENE_POLYHEDRON_SHORTEST_PATH_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Edit_polyhedron_plugin.cpp
@@ -163,7 +163,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_PrevCtrlVertPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->prev_ctrl_vertices_group();
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_NextCtrlVertPushButton_clicked()
@@ -182,7 +182,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_SelectAllVerticesPushButton_clic
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->set_all_vertices_as_roi();
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked()
@@ -192,7 +192,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->delete_ctrl_vertices_group();
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
@@ -202,7 +202,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->clear_roi();
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ApplyAndClosePushButton_clicked()
@@ -216,7 +216,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DiscardChangesPushButton_clicked
   if (!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->reset_deform_object();
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); //for redraw
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ShowROICheckBox_stateChanged(int /*state*/)
@@ -261,7 +261,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ActivateFixedPlaneCheckBox_state
     {
         Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(i));
         if(!edit_item) { continue; }
-        edit_item->invalidate_buffers();
+        edit_item->invalidate_OpenGLBuffers();
         scene->itemChanged(edit_item);
     }
 }
@@ -319,7 +319,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ReadROIPushButton_clicked()
   if(fileName.isNull()) { return; }
 
   edit_item->read_roi(fileName.toLocal8Bit().data());
-  edit_item->invalidate_buffers();
+  edit_item->invalidate_OpenGLBuffers();
   scene->itemChanged(edit_item); 
 }
 void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool visible)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Edit_polyhedron_plugin.cpp
@@ -163,7 +163,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_PrevCtrlVertPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->prev_ctrl_vertices_group();
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_NextCtrlVertPushButton_clicked()
@@ -182,7 +182,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_SelectAllVerticesPushButton_clic
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->set_all_vertices_as_roi();
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked()
@@ -192,7 +192,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->delete_ctrl_vertices_group();
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
@@ -202,7 +202,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->clear_roi();
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); // for repaint
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ApplyAndClosePushButton_clicked()
@@ -216,7 +216,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DiscardChangesPushButton_clicked
   if (!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->reset_deform_object();
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); //for redraw
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ShowROICheckBox_stateChanged(int /*state*/)
@@ -261,7 +261,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ActivateFixedPlaneCheckBox_state
     {
         Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(i));
         if(!edit_item) { continue; }
-        edit_item->invalidate_OpenGLBuffers();
+        edit_item->invalidateOpenGLBuffers();
         scene->itemChanged(edit_item);
     }
 }
@@ -319,7 +319,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ReadROIPushButton_clicked()
   if(fileName.isNull()) { return; }
 
   edit_item->read_roi(fileName.toLocal8Bit().data());
-  edit_item->invalidate_OpenGLBuffers();
+  edit_item->invalidateOpenGLBuffers();
   scene->itemChanged(edit_item); 
 }
 void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool visible)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
@@ -28,7 +28,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
   connect(&k_ring_selector, SIGNAL(selected(const std::set<Polyhedron::Vertex_handle>&)), this,
           SLOT(selected(const std::set<Polyhedron::Vertex_handle>&)));
 
-  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in invalidate_OpenGLBuffers()
+  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in invalidateOpenGLBuffers()
   poly_item->update_vertex_indices();
 
   deform_mesh = new Deform_mesh(*(poly_item->polyhedron()),
@@ -97,7 +97,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
 
     //the spheres :
     create_Sphere(length_of_axis/15.0);
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 Scene_edit_polyhedron_item::~Scene_edit_polyhedron_item()
@@ -532,7 +532,7 @@ void Scene_edit_polyhedron_item::remesh()
 void Scene_edit_polyhedron_item::timerEvent(QTimerEvent* /*event*/)
 { // just handle deformation - paint like selection is handled in eventFilter()
   if(state.ctrl_pressing && (state.left_button_pressing || state.right_button_pressing)) {
-      invalidate_OpenGLBuffers();
+      invalidateOpenGLBuffers();
     if(!ui_widget->ActivatePivotingCheckBox->isChecked()) {
         deform();
     }
@@ -821,7 +821,7 @@ void Scene_edit_polyhedron_item::compute_bbox(const CGAL::Three::Scene_interface
     
 }
 
-void Scene_edit_polyhedron_item::invalidate_OpenGLBuffers()
+void Scene_edit_polyhedron_item::invalidateOpenGLBuffers()
 {
     compute_normals_and_vertices();
     update_normals();
@@ -833,7 +833,7 @@ Scene_polyhedron_item* Scene_edit_polyhedron_item::to_polyhedron_item() {
   Scene_polyhedron_item* poly_item_tmp = poly_item;
   poly_item->set_color_vector_read_only(false);
   own_poly_item=false;
-  poly_item_tmp->invalidate_OpenGLBuffers();
+  poly_item_tmp->invalidateOpenGLBuffers();
   return poly_item_tmp;
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.cpp
@@ -28,7 +28,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
   connect(&k_ring_selector, SIGNAL(selected(const std::set<Polyhedron::Vertex_handle>&)), this,
           SLOT(selected(const std::set<Polyhedron::Vertex_handle>&)));
 
-  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in invalidate_buffers()
+  poly_item->set_color_vector_read_only(true); // to prevent recomputation of color vector in invalidate_OpenGLBuffers()
   poly_item->update_vertex_indices();
 
   deform_mesh = new Deform_mesh(*(poly_item->polyhedron()),
@@ -97,7 +97,7 @@ Scene_edit_polyhedron_item::Scene_edit_polyhedron_item
 
     //the spheres :
     create_Sphere(length_of_axis/15.0);
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 Scene_edit_polyhedron_item::~Scene_edit_polyhedron_item()
@@ -532,7 +532,7 @@ void Scene_edit_polyhedron_item::remesh()
 void Scene_edit_polyhedron_item::timerEvent(QTimerEvent* /*event*/)
 { // just handle deformation - paint like selection is handled in eventFilter()
   if(state.ctrl_pressing && (state.left_button_pressing || state.right_button_pressing)) {
-      invalidate_buffers();
+      invalidate_OpenGLBuffers();
     if(!ui_widget->ActivatePivotingCheckBox->isChecked()) {
         deform();
     }
@@ -821,7 +821,7 @@ void Scene_edit_polyhedron_item::compute_bbox(const CGAL::Three::Scene_interface
     
 }
 
-void Scene_edit_polyhedron_item::invalidate_buffers()
+void Scene_edit_polyhedron_item::invalidate_OpenGLBuffers()
 {
     compute_normals_and_vertices();
     update_normals();
@@ -833,7 +833,7 @@ Scene_polyhedron_item* Scene_edit_polyhedron_item::to_polyhedron_item() {
   Scene_polyhedron_item* poly_item_tmp = poly_item;
   poly_item->set_color_vector_read_only(false);
   own_poly_item=false;
-  poly_item_tmp->invalidate_buffers();
+  poly_item_tmp->invalidate_OpenGLBuffers();
   return poly_item_tmp;
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
@@ -248,7 +248,7 @@ protected:
 
 
 public Q_SLOTS:
-  void invalidate_OpenGLBuffers();
+  void invalidateOpenGLBuffers();
   void selected(const std::set<Polyhedron::Vertex_handle>& m)
   {
     bool any_changes = false;
@@ -266,7 +266,7 @@ public Q_SLOTS:
       }
       any_changes |= changed;
     }
-    if(any_changes) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(any_changes) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   void select(double orig_x,
@@ -439,7 +439,7 @@ public:
 
     active_group = --ctrl_vertex_frame_map.end();
 
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     Q_EMIT itemChanged();
 
     print_message("A new empty group of control vertices is created.");
@@ -642,7 +642,7 @@ public:
       (vertices(*polyhedron()).first, vertices(*polyhedron()).second,
       polyhedron()->size_of_vertices(), Is_selected(deform_mesh), visitor);
 
-    if(visitor.any_inserted) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 protected:

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_modeling/Scene_edit_polyhedron_item.h
@@ -248,7 +248,7 @@ protected:
 
 
 public Q_SLOTS:
-  void invalidate_buffers();
+  void invalidate_OpenGLBuffers();
   void selected(const std::set<Polyhedron::Vertex_handle>& m)
   {
     bool any_changes = false;
@@ -266,7 +266,7 @@ public Q_SLOTS:
       }
       any_changes |= changed;
     }
-    if(any_changes) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(any_changes) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   void select(double orig_x,
@@ -439,7 +439,7 @@ public:
 
     active_group = --ctrl_vertex_frame_map.end();
 
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     Q_EMIT itemChanged();
 
     print_message("A new empty group of control vertices is created.");
@@ -642,7 +642,7 @@ public:
       (vertices(*polyhedron()).first, vertices(*polyhedron()).second,
       polyhedron()->size_of_vertices(), Is_selected(deform_mesh), visitor);
 
-    if(visitor.any_inserted) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -355,8 +355,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                     viewer->glShadeModel(GL_SMOOTH);
                 else
                     viewer->glShadeModel(GL_FLAT);
-
-                item.contextual_changed();
                 if(viewer)
                     item.draw(viewer);
                 else
@@ -422,7 +420,6 @@ glDepthFunc(GL_LEQUAL);
                 }
             }
         }
-         item.contextual_changed();
         if(with_names) {
             viewer->glPopName();
         }
@@ -451,7 +448,6 @@ glDepthFunc(GL_LEQUAL);
                     item.draw_points();
             }
         }
-         item.contextual_changed();
         if(with_names) {
             viewer->glPopName();
         }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -54,7 +54,7 @@ public:
       return !!(os << c3t3());
   }
 
-  void invalidate_buffers()
+  void invalidate_OpenGLBuffers()
   {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -54,7 +54,7 @@ public:
       return !!(os << c3t3());
   }
 
-  void invalidate_OpenGLBuffers()
+  void invalidateOpenGLBuffers()
   {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -353,9 +353,8 @@ Scene_implicit_function_item(Implicit_function_interface* f)
     texture = new Texture(grid_size_-1,grid_size_-1);
     blue_color_ramp_.build_blue();
     red_color_ramp_.build_red();
-    //
+    startTimer(0);
     //Generates an integer which will be used as ID for each buffer
-
     compute_min_max();
     compute_function_grid();
     double offset_x = (bbox().xmin + bbox().xmax) / 2;
@@ -583,15 +582,12 @@ Scene_implicit_function_item::invalidate_buffers()
     are_buffers_filled = false;
 }
 
-void Scene_implicit_function_item::contextual_changed()
-{
-    if(!frame_->isManipulated()) {
-        if(need_update_) {
-            compute_function_grid();
-            compute_vertices_and_texmap();
-            need_update_ = false;
-        }
-    }
+
+void Scene_implicit_function_item::timerEvent(QTimerEvent* /*event*/)
+{ // just handle deformation - paint like selection is handled in eventFilter()
+  if(need_update_) {
+    compute_function_grid();
+    compute_vertices_and_texmap();
+    need_update_= false;
+  }
 }
-
-

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -364,7 +364,7 @@ Scene_implicit_function_item(Implicit_function_interface* f)
     frame_->setOrientation(1., 0, 0, 0);
     connect(frame_, SIGNAL(modified()), this, SLOT(plane_was_moved()));
 
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 
@@ -536,7 +536,7 @@ compute_function_grid() const
     }
 
     // Update
-    const_cast<Scene_implicit_function_item*>(this)->invalidate_buffers();
+    const_cast<Scene_implicit_function_item*>(this)->invalidate_OpenGLBuffers();
 
 }
 
@@ -574,9 +574,9 @@ compute_min_max()
 }
 
 void
-Scene_implicit_function_item::invalidate_buffers()
+Scene_implicit_function_item::invalidate_OpenGLBuffers()
 {
-    Scene_item::invalidate_buffers();
+    Scene_item::invalidate_OpenGLBuffers();
     compute_bbox();
     compute_vertices_and_texmap();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -364,7 +364,7 @@ Scene_implicit_function_item(Implicit_function_interface* f)
     frame_->setOrientation(1., 0, 0, 0);
     connect(frame_, SIGNAL(modified()), this, SLOT(plane_was_moved()));
 
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 
@@ -536,7 +536,7 @@ compute_function_grid() const
     }
 
     // Update
-    const_cast<Scene_implicit_function_item*>(this)->invalidate_OpenGLBuffers();
+    const_cast<Scene_implicit_function_item*>(this)->invalidateOpenGLBuffers();
 
 }
 
@@ -574,9 +574,9 @@ compute_min_max()
 }
 
 void
-Scene_implicit_function_item::invalidate_OpenGLBuffers()
+Scene_implicit_function_item::invalidateOpenGLBuffers()
 {
-    Scene_item::invalidate_OpenGLBuffers();
+    Scene_item::invalidateOpenGLBuffers();
     compute_bbox();
     compute_vertices_and_texmap();
     are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -69,7 +69,7 @@ public:
   virtual void draw_edges(CGAL::Three::Viewer_interface*) const;
 
   virtual QString toolTip() const;
-  virtual void invalidate_buffers();
+  virtual void invalidate_OpenGLBuffers();
 public Q_SLOTS:
   void plane_was_moved() { need_update_ = true; }
   void compute_function_grid() const;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -69,11 +69,11 @@ public:
   virtual void draw_edges(CGAL::Three::Viewer_interface*) const;
 
   virtual QString toolTip() const;
-  virtual void contextual_changed();
   virtual void invalidate_buffers();
 public Q_SLOTS:
   void plane_was_moved() { need_update_ = true; }
   void compute_function_grid() const;
+  void timerEvent(QTimerEvent*);
 
 private:
   typedef qglviewer::Vec                  Point;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.h
@@ -69,7 +69,7 @@ public:
   virtual void draw_edges(CGAL::Three::Viewer_interface*) const;
 
   virtual QString toolTip() const;
-  virtual void invalidate_OpenGLBuffers();
+  virtual void invalidateOpenGLBuffers();
 public Q_SLOTS:
   void plane_was_moved() { need_update_ = true; }
   void compute_function_grid() const;

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -101,7 +101,7 @@ QMenu* CGAL::Three::Scene_item::contextMenu()
     return defaultContextMenu;
 }
 
-void CGAL::Three::Scene_item::invalidate_OpenGLBuffers() {}
+void CGAL::Three::Scene_item::invalidateOpenGLBuffers() {}
 
 void CGAL::Three::Scene_item::selection_changed(bool) {}
 

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -101,7 +101,7 @@ QMenu* CGAL::Three::Scene_item::contextMenu()
     return defaultContextMenu;
 }
 
-void CGAL::Three::Scene_item::invalidate_buffers() {}
+void CGAL::Three::Scene_item::invalidate_OpenGLBuffers() {}
 
 void CGAL::Three::Scene_item::selection_changed(bool) {}
 

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -352,7 +352,7 @@ Scene_nef_polyhedron_item::load_from_off(std::istream& in)
     //   Polyhedron poly;
     //   in >> poly;
     //   *nef_poly = Nef_polyhedron(poly);
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     return (bool) in;
 }
 
@@ -367,7 +367,7 @@ bool
 Scene_nef_polyhedron_item::load(std::istream& in)
 {
     in >> *nef_poly;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     return (bool) in;
 }
 
@@ -655,17 +655,17 @@ convex_decomposition(std::list< Scene_polyhedron_item*>& convex_parts)
             from_exact(P, *poly);
             Scene_polyhedron_item *spoly = new Scene_polyhedron_item(poly);
             convex_parts.push_back(spoly);
-            spoly->invalidate_OpenGLBuffers();
+            spoly->invalidateOpenGLBuffers();
         }
     }
 }
 
 void
 Scene_nef_polyhedron_item::
-invalidate_OpenGLBuffers()
+invalidateOpenGLBuffers()
 {
     compute_bbox();
-    Base::invalidate_OpenGLBuffers();
+    Base::invalidateOpenGLBuffers();
     are_buffers_filled = false;
 }
 void

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -352,7 +352,7 @@ Scene_nef_polyhedron_item::load_from_off(std::istream& in)
     //   Polyhedron poly;
     //   in >> poly;
     //   *nef_poly = Nef_polyhedron(poly);
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     return (bool) in;
 }
 
@@ -367,7 +367,7 @@ bool
 Scene_nef_polyhedron_item::load(std::istream& in)
 {
     in >> *nef_poly;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     return (bool) in;
 }
 
@@ -655,17 +655,17 @@ convex_decomposition(std::list< Scene_polyhedron_item*>& convex_parts)
             from_exact(P, *poly);
             Scene_polyhedron_item *spoly = new Scene_polyhedron_item(poly);
             convex_parts.push_back(spoly);
-            spoly->invalidate_buffers();
+            spoly->invalidate_OpenGLBuffers();
         }
     }
 }
 
 void
 Scene_nef_polyhedron_item::
-invalidate_buffers()
+invalidate_OpenGLBuffers()
 {
     compute_bbox();
-    Base::invalidate_buffers();
+    Base::invalidate_OpenGLBuffers();
     are_buffers_filled = false;
 }
 void

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -26,7 +26,7 @@ public:
   QFont font() const;
   QString toolTip() const;
 
-  virtual void invalidate_OpenGLBuffers();
+  virtual void invalidateOpenGLBuffers();
   virtual void selection_changed(bool);
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const { return m != Gouraud && m!=Splatting; } // CHECK THIS!

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -26,7 +26,7 @@ public:
   QFont font() const;
   QString toolTip() const;
 
-  virtual void invalidate_buffers();
+  virtual void invalidate_OpenGLBuffers();
   virtual void selection_changed(bool);
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const { return m != Gouraud && m!=Splatting; } // CHECK THIS!

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -33,7 +33,7 @@ public:
   {
     setNormal(0., 0., 1.);
     //Generates an integer which will be used as ID for each buffer
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
   }
 
   ~Scene_plane_item() {
@@ -117,7 +117,7 @@ private:
   }
 
 public Q_SLOTS:
-  virtual void invalidate_buffers()
+  virtual void invalidate_OpenGLBuffers()
   {
       compute_normals_and_vertices();
       are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -33,7 +33,7 @@ public:
   {
     setNormal(0., 0., 1.);
     //Generates an integer which will be used as ID for each buffer
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
   }
 
   ~Scene_plane_item() {
@@ -117,7 +117,7 @@ private:
   }
 
 public Q_SLOTS:
-  virtual void invalidate_OpenGLBuffers()
+  virtual void invalidateOpenGLBuffers()
   {
       compute_normals_and_vertices();
       are_buffers_filled = false;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -56,7 +56,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_
     nb_points = 0;
     nb_selected_points = 0;
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 // Converts polyhedron to point set
@@ -83,7 +83,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
   nb_points = 0;
   nb_selected_points = 0;
   nb_lines = 0;
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
 }
 
 Scene_points_with_normal_item::~Scene_points_with_normal_item()
@@ -241,7 +241,7 @@ void Scene_points_with_normal_item::deleteSelection()
   std::cerr << "done: " << task_timer.time() << " seconds, "
                         << (memory>>20) << " Mb allocated"
                         << std::endl;
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -249,7 +249,7 @@ void Scene_points_with_normal_item::deleteSelection()
 void Scene_points_with_normal_item::invertSelection()
 {
   m_points->invert_selection();
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -257,7 +257,7 @@ void Scene_points_with_normal_item::invertSelection()
 void Scene_points_with_normal_item::selectAll()
 {
   m_points->select_all();
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
 // Reset selection mark
@@ -265,7 +265,7 @@ void Scene_points_with_normal_item::resetSelection()
 {
   // Un-select all points
   m_points->unselect_all();
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
   //Select duplicated points
@@ -275,7 +275,7 @@ void Scene_points_with_normal_item::selectDuplicates()
   for (Point_set::iterator ptit=m_points->begin(); ptit!=m_points->end();++ptit )
     if ( !unique_points.insert(*ptit).second )
       m_points->select(ptit);
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -303,7 +303,7 @@ bool Scene_points_with_normal_item::read_ply_point_set(std::istream& stream)
             }
         }
     }
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   return ok;
 }
 
@@ -329,7 +329,7 @@ bool Scene_points_with_normal_item::read_off_point_set(std::istream& stream)
                                               std::back_inserter(*m_points),
                                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type())) &&
             !isEmpty();
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   return ok;
 }
 
@@ -369,7 +369,7 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
       }
     }
   }
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   return ok;
 }
 
@@ -590,7 +590,7 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
   }
 }
 
-void Scene_points_with_normal_item::invalidate_OpenGLBuffers()
+void Scene_points_with_normal_item::invalidateOpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -56,7 +56,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Scene_points_
     nb_points = 0;
     nb_selected_points = 0;
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 // Converts polyhedron to point set
@@ -83,7 +83,7 @@ Scene_points_with_normal_item::Scene_points_with_normal_item(const Polyhedron& i
   nb_points = 0;
   nb_selected_points = 0;
   nb_lines = 0;
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
 }
 
 Scene_points_with_normal_item::~Scene_points_with_normal_item()
@@ -241,7 +241,7 @@ void Scene_points_with_normal_item::deleteSelection()
   std::cerr << "done: " << task_timer.time() << " seconds, "
                         << (memory>>20) << " Mb allocated"
                         << std::endl;
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -249,7 +249,7 @@ void Scene_points_with_normal_item::deleteSelection()
 void Scene_points_with_normal_item::invertSelection()
 {
   m_points->invert_selection();
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -257,7 +257,7 @@ void Scene_points_with_normal_item::invertSelection()
 void Scene_points_with_normal_item::selectAll()
 {
   m_points->select_all();
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
 // Reset selection mark
@@ -265,7 +265,7 @@ void Scene_points_with_normal_item::resetSelection()
 {
   // Un-select all points
   m_points->unselect_all();
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
   //Select duplicated points
@@ -275,7 +275,7 @@ void Scene_points_with_normal_item::selectDuplicates()
   for (Point_set::iterator ptit=m_points->begin(); ptit!=m_points->end();++ptit )
     if ( !unique_points.insert(*ptit).second )
       m_points->select(ptit);
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -303,7 +303,7 @@ bool Scene_points_with_normal_item::read_ply_point_set(std::istream& stream)
             }
         }
     }
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   return ok;
 }
 
@@ -329,7 +329,7 @@ bool Scene_points_with_normal_item::read_off_point_set(std::istream& stream)
                                               std::back_inserter(*m_points),
                                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type())) &&
             !isEmpty();
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   return ok;
 }
 
@@ -369,7 +369,7 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
       }
     }
   }
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   return ok;
 }
 
@@ -590,7 +590,7 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
   }
 }
 
-void Scene_points_with_normal_item::invalidate_buffers()
+void Scene_points_with_normal_item::invalidate_OpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -46,7 +46,7 @@ public:
   // Function for displaying meta-data of the item
   virtual QString toolTip() const;
 
-  virtual void invalidate_OpenGLBuffers();
+  virtual void invalidateOpenGLBuffers();
 
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -46,7 +46,7 @@ public:
   // Function for displaying meta-data of the item
   virtual QString toolTip() const;
 
-  virtual void invalidate_buffers();
+  virtual void invalidate_OpenGLBuffers();
 
   // Indicate if rendering mode is supported
   virtual bool supportsRenderingMode(RenderingMode m) const;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -398,7 +398,7 @@ Scene_polygon_soup_item::load(std::istream& in)
   else soup->clear();
 
     bool result = CGAL::read_OFF(in, soup->points, soup->polygons);
-    Q_EMIT invalidate_OpenGLBuffers();
+    Q_EMIT invalidateOpenGLBuffers();
     return result;
 }
 
@@ -427,7 +427,7 @@ void Scene_polygon_soup_item::load(Scene_polyhedron_item* poly_item) {
   CGAL::generic_print_polyhedron(std::cerr,
                                  *poly_item->polyhedron(),
                                  writer);
-  Q_EMIT invalidate_OpenGLBuffers();
+  Q_EMIT invalidateOpenGLBuffers();
 }
 
 void
@@ -450,7 +450,7 @@ void Scene_polygon_soup_item::shuffle_orientations()
   {
     if(std::rand() % 2 == 0) soup->inverse_orientation(i);
   }
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
 }
 
 void Scene_polygon_soup_item::inside_out()
@@ -460,7 +460,7 @@ void Scene_polygon_soup_item::inside_out()
   {
     soup->inverse_orientation(i);
   }
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
 }
 
 bool 
@@ -657,7 +657,7 @@ Scene_polygon_soup_item::isEmpty() const {
   return (soup == 0 || soup->points.empty());
 }
 void
-Scene_polygon_soup_item::invalidate_OpenGLBuffers()
+Scene_polygon_soup_item::invalidateOpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -398,7 +398,7 @@ Scene_polygon_soup_item::load(std::istream& in)
   else soup->clear();
 
     bool result = CGAL::read_OFF(in, soup->points, soup->polygons);
-    Q_EMIT invalidate_buffers();
+    Q_EMIT invalidate_OpenGLBuffers();
     return result;
 }
 
@@ -427,7 +427,7 @@ void Scene_polygon_soup_item::load(Scene_polyhedron_item* poly_item) {
   CGAL::generic_print_polyhedron(std::cerr,
                                  *poly_item->polyhedron(),
                                  writer);
-  Q_EMIT invalidate_buffers();
+  Q_EMIT invalidate_OpenGLBuffers();
 }
 
 void
@@ -450,7 +450,7 @@ void Scene_polygon_soup_item::shuffle_orientations()
   {
     if(std::rand() % 2 == 0) soup->inverse_orientation(i);
   }
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
 }
 
 void Scene_polygon_soup_item::inside_out()
@@ -460,7 +460,7 @@ void Scene_polygon_soup_item::inside_out()
   {
     soup->inverse_orientation(i);
   }
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
 }
 
 bool 
@@ -657,7 +657,7 @@ Scene_polygon_soup_item::isEmpty() const {
   return (soup == 0 || soup->points.empty());
 }
 void
-Scene_polygon_soup_item::invalidate_buffers()
+Scene_polygon_soup_item::invalidate_OpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -132,7 +132,7 @@ public:
         //soup->fill_edges();
         oriented = false;
 
-        Q_EMIT invalidate_buffers();
+        Q_EMIT invalidate_OpenGLBuffers();
     }
 
     bool save(std::ostream& out) const;
@@ -146,7 +146,7 @@ public:
     virtual void draw(CGAL::Three::Viewer_interface*) const;
     virtual void draw_points(CGAL::Three::Viewer_interface*) const;
     virtual void draw_edges(CGAL::Three::Viewer_interface* viewer) const;
-    void invalidate_buffers();
+    void invalidate_OpenGLBuffers();
     bool isFinite() const { return true; }
     bool isEmpty() const;
     void compute_bbox() const;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -132,7 +132,7 @@ public:
         //soup->fill_edges();
         oriented = false;
 
-        Q_EMIT invalidate_OpenGLBuffers();
+        Q_EMIT invalidateOpenGLBuffers();
     }
 
     bool save(std::ostream& out) const;
@@ -146,7 +146,7 @@ public:
     virtual void draw(CGAL::Three::Viewer_interface*) const;
     virtual void draw_points(CGAL::Three::Viewer_interface*) const;
     virtual void draw_edges(CGAL::Three::Viewer_interface* viewer) const;
-    void invalidate_OpenGLBuffers();
+    void invalidateOpenGLBuffers();
     bool isFinite() const { return true; }
     bool isEmpty() const;
     void compute_bbox() const;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -664,7 +664,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
     is_triangulated = true;
     nb_f_lines = 0;
     init();
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     self_intersect = false;
 }
 
@@ -685,7 +685,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
     nb_facets = 0;
     nb_lines = 0;
     nb_f_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     self_intersect = false;
 }
 
@@ -745,7 +745,7 @@ Scene_polyhedron_item::load(std::istream& in)
 
     if ( in && !isEmpty() )
     {
-        invalidate_OpenGLBuffers();
+        invalidateOpenGLBuffers();
         return true;
     }
     return false;
@@ -787,7 +787,7 @@ Scene_polyhedron_item::load_obj(std::istream& in)
   }
     if ( (! failed) && !isEmpty() )
     {
-        invalidate_buffers();
+        invalidateOpenGLBuffers();
         return true;
     }
     return false;
@@ -875,14 +875,14 @@ QMenu* Scene_polyhedron_item::contextMenu()
 void Scene_polyhedron_item::show_only_feature_edges(bool b)
 {
     show_only_feature_edges_m = b;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     Q_EMIT itemChanged();
 }
 
 void Scene_polyhedron_item::show_feature_edges(bool b)
 {
   show_feature_edges_m = b;
-  invalidate_OpenGLBuffers();
+  invalidateOpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -1020,12 +1020,12 @@ void Scene_polyhedron_item::compute_bbox() const {
 
 void
 Scene_polyhedron_item::
-invalidate_OpenGLBuffers()
+invalidateOpenGLBuffers()
 {
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();
-    Base::invalidate_OpenGLBuffers();
+    Base::invalidateOpenGLBuffers();
     are_buffers_filled = false;
 
 }
@@ -1154,7 +1154,7 @@ Scene_polyhedron_item::select(double orig_x,
                         polyhedron()->erase_facet(selected_fh->halfedge());
                         polyhedron()->normalize_border();
                         //set_erase_next_picked_facet(false);
-                        invalidate_OpenGLBuffers();
+                        invalidateOpenGLBuffers();
             Q_EMIT itemChanged();
                     }
                 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -664,7 +664,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)
     is_triangulated = true;
     nb_f_lines = 0;
     init();
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     self_intersect = false;
 }
 
@@ -685,7 +685,7 @@ Scene_polyhedron_item::Scene_polyhedron_item(const Polyhedron& p)
     nb_facets = 0;
     nb_lines = 0;
     nb_f_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     self_intersect = false;
 }
 
@@ -745,7 +745,7 @@ Scene_polyhedron_item::load(std::istream& in)
 
     if ( in && !isEmpty() )
     {
-        invalidate_buffers();
+        invalidate_OpenGLBuffers();
         return true;
     }
     return false;
@@ -875,14 +875,14 @@ QMenu* Scene_polyhedron_item::contextMenu()
 void Scene_polyhedron_item::show_only_feature_edges(bool b)
 {
     show_only_feature_edges_m = b;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     Q_EMIT itemChanged();
 }
 
 void Scene_polyhedron_item::show_feature_edges(bool b)
 {
   show_feature_edges_m = b;
-  invalidate_buffers();
+  invalidate_OpenGLBuffers();
   Q_EMIT itemChanged();
 }
 
@@ -1020,12 +1020,12 @@ void Scene_polyhedron_item::compute_bbox() const {
 
 void
 Scene_polyhedron_item::
-invalidate_buffers()
+invalidate_OpenGLBuffers()
 {
   Q_EMIT item_is_about_to_be_changed();
     delete_aabb_tree(this);
     init();
-    Base::invalidate_buffers();
+    Base::invalidate_OpenGLBuffers();
     are_buffers_filled = false;
 
 }
@@ -1154,7 +1154,7 @@ Scene_polyhedron_item::select(double orig_x,
                         polyhedron()->erase_facet(selected_fh->halfedge());
                         polyhedron()->normalize_border();
                         //set_erase_next_picked_facet(false);
-                        invalidate_buffers();
+                        invalidate_OpenGLBuffers();
             Q_EMIT itemChanged();
                     }
                 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -90,7 +90,7 @@ public:
     bool self_intersected(){return !self_intersect;}
 
 public Q_SLOTS:
-    virtual void invalidate_buffers();
+    virtual void invalidate_OpenGLBuffers();
     virtual void selection_changed(bool);
     virtual void setColor(QColor c);
 	virtual void show_feature_edges(bool);
@@ -115,7 +115,7 @@ Q_SIGNALS:
     void selected_facet(void*);
     void selected_edge(void*);
     void selected_halfedge(void*);
-    void item_is_about_to_be_changed(); // emitted in invalidate_buffers()
+    void item_is_about_to_be_changed(); // emitted in invalidate_OpenGLBuffers()
 
 private:
     // Initialization

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -90,7 +90,7 @@ public:
     bool self_intersected(){return !self_intersect;}
 
 public Q_SLOTS:
-    virtual void invalidate_OpenGLBuffers();
+    virtual void invalidateOpenGLBuffers();
     virtual void selection_changed(bool);
     virtual void setColor(QColor c);
 	virtual void show_feature_edges(bool);
@@ -115,7 +115,7 @@ Q_SIGNALS:
     void selected_facet(void*);
     void selected_edge(void*);
     void selected_halfedge(void*);
-    void item_is_about_to_be_changed(); // emitted in invalidate_OpenGLBuffers()
+    void item_is_about_to_be_changed(); // emitted in invalidateOpenGLBuffers()
 
 private:
     // Initialization

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
@@ -63,10 +63,10 @@ Scene_polyhedron_item_decorator::compute_bbox() const {
 
 void
 Scene_polyhedron_item_decorator::
-invalidate_buffers()
+invalidate_OpenGLBuffers()
 {
-  poly_item->invalidate_buffers();
-  Scene_item::invalidate_buffers();
+  poly_item->invalidate_OpenGLBuffers();
+  Scene_item::invalidate_OpenGLBuffers();
   compute_bbox();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
@@ -63,10 +63,10 @@ Scene_polyhedron_item_decorator::compute_bbox() const {
 
 void
 Scene_polyhedron_item_decorator::
-invalidate_OpenGLBuffers()
+invalidateOpenGLBuffers()
 {
-  poly_item->invalidate_OpenGLBuffers();
-  Scene_item::invalidate_OpenGLBuffers();
+  poly_item->invalidateOpenGLBuffers();
+  Scene_item::invalidateOpenGLBuffers();
   compute_bbox();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
@@ -49,7 +49,7 @@ public:
   void set_delete_item(bool delete_item) { delete_poly_item = delete_item; }
 
 public Q_SLOTS:
-  void invalidate_buffers();
+  void invalidate_OpenGLBuffers();
   void select(double orig_x,
               double orig_y,
               double orig_z,

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.h
@@ -49,7 +49,7 @@ public:
   void set_delete_item(bool delete_item) { delete_poly_item = delete_item; }
 
 public Q_SLOTS:
-  void invalidate_OpenGLBuffers();
+  void invalidateOpenGLBuffers();
   void select(double orig_x,
               double orig_y,
               double orig_z,

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -207,7 +207,7 @@ public:
             buffers[i].create();
         }
         init(poly_item, mw);
-        invalidate_buffers();
+        invalidate_OpenGLBuffers();
     }
 
    ~Scene_polyhedron_selection_item()
@@ -404,7 +404,7 @@ public:
       select_all<Facet_handle>(); break;
     case Active_handle::EDGE:
       selected_edges.insert(edges(*polyhedron()).first, edges(*polyhedron()).second);
-      invalidate_buffers();
+      invalidate_OpenGLBuffers();
       QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
       v->update();
 
@@ -418,7 +418,7 @@ public:
     for(typename Tr::Iterator it = tr.iterator_begin() ; it != tr.iterator_end(); ++it) {
       tr.container().insert(*it);
     }
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     Q_EMIT itemChanged();
   }
 
@@ -440,7 +440,7 @@ public:
 
     Selection_traits<HandleType, Scene_polyhedron_selection_item> tr(this);
     tr.container().clear();
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     Q_EMIT itemChanged();
   }
 
@@ -492,7 +492,7 @@ public:
     Travel_isolated_components().travel<HandleType>
       (tr.iterator_begin(), tr.iterator_end(), tr.size(), tr.container(), visitor);
 
-    if(visitor.any_inserted) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 
@@ -596,7 +596,7 @@ public:
         any_change |= tr.container().insert(*it).second;
       }
     }
-    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   template <class Handle>
@@ -625,7 +625,7 @@ public:
         any_change |= (tr.container().erase(*it)!=0);
       }
     }
-    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   void erase_selected_facets() {
@@ -637,7 +637,7 @@ public:
       polyhedron()->erase_facet((*fb)->halfedge());
     }
     selected_facets.clear();
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     changed_with_poly_item();
   }
 
@@ -711,12 +711,12 @@ public:
       if (h->is_feature_edge())
         selected_edges.insert(e);
     }
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
   }
 
   void changed_with_poly_item() {
     // no need to update indices
-    poly_item->invalidate_buffers();
+    poly_item->invalidate_OpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
     Q_EMIT itemChanged();
   }
@@ -725,10 +725,10 @@ Q_SIGNALS:
   void simplicesSelected(CGAL::Three::Scene_item*);
 
 public Q_SLOTS:
-  void invalidate_buffers() {
+  void invalidate_OpenGLBuffers() {
 
     // do not use decorator function, which calls changed on poly_item which cause deletion of AABB
-      //  poly_item->invalidate_buffers();
+      //  poly_item->invalidate_OpenGLBuffers();
         are_buffers_filled = false;
         compute_bbox();
   }
@@ -799,7 +799,7 @@ protected:
       BOOST_FOREACH(HandleType h, selection)
         any_change |= (tr.container().erase(h)!=0);
     }
-    if(any_change) { invalidate_buffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
     return any_change;
   }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -207,7 +207,7 @@ public:
             buffers[i].create();
         }
         init(poly_item, mw);
-        invalidate_OpenGLBuffers();
+        invalidateOpenGLBuffers();
     }
 
    ~Scene_polyhedron_selection_item()
@@ -404,7 +404,7 @@ public:
       select_all<Facet_handle>(); break;
     case Active_handle::EDGE:
       selected_edges.insert(edges(*polyhedron()).first, edges(*polyhedron()).second);
-      invalidate_OpenGLBuffers();
+      invalidateOpenGLBuffers();
       QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
       v->update();
 
@@ -418,7 +418,7 @@ public:
     for(typename Tr::Iterator it = tr.iterator_begin() ; it != tr.iterator_end(); ++it) {
       tr.container().insert(*it);
     }
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     Q_EMIT itemChanged();
   }
 
@@ -440,7 +440,7 @@ public:
 
     Selection_traits<HandleType, Scene_polyhedron_selection_item> tr(this);
     tr.container().clear();
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     Q_EMIT itemChanged();
   }
 
@@ -492,7 +492,7 @@ public:
     Travel_isolated_components().travel<HandleType>
       (tr.iterator_begin(), tr.iterator_end(), tr.size(), tr.container(), visitor);
 
-    if(visitor.any_inserted) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(visitor.any_inserted) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
     return visitor.minimum_visitor.minimum;
   }
 
@@ -596,7 +596,7 @@ public:
         any_change |= tr.container().insert(*it).second;
       }
     }
-    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   template <class Handle>
@@ -625,7 +625,7 @@ public:
         any_change |= (tr.container().erase(*it)!=0);
       }
     }
-    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
   }
 
   void erase_selected_facets() {
@@ -637,7 +637,7 @@ public:
       polyhedron()->erase_facet((*fb)->halfedge());
     }
     selected_facets.clear();
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     changed_with_poly_item();
   }
 
@@ -711,12 +711,12 @@ public:
       if (h->is_feature_edge())
         selected_edges.insert(e);
     }
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
   }
 
   void changed_with_poly_item() {
     // no need to update indices
-    poly_item->invalidate_OpenGLBuffers();
+    poly_item->invalidateOpenGLBuffers();
     Q_EMIT poly_item->itemChanged();
     Q_EMIT itemChanged();
   }
@@ -725,10 +725,10 @@ Q_SIGNALS:
   void simplicesSelected(CGAL::Three::Scene_item*);
 
 public Q_SLOTS:
-  void invalidate_OpenGLBuffers() {
+  void invalidateOpenGLBuffers() {
 
     // do not use decorator function, which calls changed on poly_item which cause deletion of AABB
-      //  poly_item->invalidate_OpenGLBuffers();
+      //  poly_item->invalidateOpenGLBuffers();
         are_buffers_filled = false;
         compute_bbox();
   }
@@ -799,7 +799,7 @@ protected:
       BOOST_FOREACH(HandleType h, selection)
         any_change |= (tr.container().erase(h)!=0);
     }
-    if(any_change) { invalidate_OpenGLBuffers(); Q_EMIT itemChanged(); }
+    if(any_change) { invalidateOpenGLBuffers(); Q_EMIT itemChanged(); }
     return any_change;
   }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -331,7 +331,7 @@ Scene_polylines_item::Scene_polylines_item()
     nb_wire = 0;
     nb_centers = 0;
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 
 }
 
@@ -537,7 +537,7 @@ QMenu* Scene_polylines_item::contextMenu()
     return menu;
 }
 
-void Scene_polylines_item::invalidate_buffers()
+void Scene_polylines_item::invalidate_OpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();
@@ -575,7 +575,7 @@ void Scene_polylines_item::change_corner_radii(double r) {
     if(r >= 0) {
         d->spheres_drawn_radius = r;
         d->draw_extremities = (r > 0);
-        this->invalidate_buffers();
+        this->invalidate_OpenGLBuffers();
     Q_EMIT itemChanged();
     }
 }
@@ -677,6 +677,6 @@ Scene_polylines_item::merge(Scene_polylines_item* other_item) {
         metadata.append(other_metadata_variant.toStringList());
         setProperty("polylines metadata", metadata);
     }
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -331,7 +331,7 @@ Scene_polylines_item::Scene_polylines_item()
     nb_wire = 0;
     nb_centers = 0;
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 
 }
 
@@ -537,7 +537,7 @@ QMenu* Scene_polylines_item::contextMenu()
     return menu;
 }
 
-void Scene_polylines_item::invalidate_OpenGLBuffers()
+void Scene_polylines_item::invalidateOpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();
@@ -575,7 +575,7 @@ void Scene_polylines_item::change_corner_radii(double r) {
     if(r >= 0) {
         d->spheres_drawn_radius = r;
         d->draw_extremities = (r > 0);
-        this->invalidate_OpenGLBuffers();
+        this->invalidateOpenGLBuffers();
     Q_EMIT itemChanged();
     }
 }
@@ -677,6 +677,6 @@ Scene_polylines_item::merge(Scene_polylines_item* other_item) {
         metadata.append(other_metadata_variant.toStringList());
         setProperty("polylines metadata", metadata);
     }
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -72,7 +72,7 @@ public:
     }
 
 public Q_SLOTS:
-    virtual void invalidate_OpenGLBuffers();
+    virtual void invalidateOpenGLBuffers();
     void change_corner_radii(double);
     void change_corner_radii();
     void split_at_sharp_angles();
@@ -82,7 +82,7 @@ public Q_SLOTS:
     void smooth(){
         for (Polylines_container::iterator pit=polylines.begin(),pit_end=polylines.end();pit!=pit_end;++pit)
             smooth(*pit);
-      invalidate_OpenGLBuffers();
+      invalidateOpenGLBuffers();
       Q_EMIT itemChanged();
     }
 public:

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -72,7 +72,7 @@ public:
     }
 
 public Q_SLOTS:
-    virtual void invalidate_buffers();
+    virtual void invalidate_OpenGLBuffers();
     void change_corner_radii(double);
     void change_corner_radii();
     void split_at_sharp_angles();
@@ -82,7 +82,7 @@ public Q_SLOTS:
     void smooth(){
         for (Polylines_container::iterator pit=polylines.begin(),pit_end=polylines.end();pit!=pit_end;++pit)
             smooth(*pit);
-      invalidate_buffers();
+      invalidate_OpenGLBuffers();
       Q_EMIT itemChanged();
     }
 public:

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -215,7 +215,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedron* const p)
@@ -226,7 +226,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedr
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_polyhedron& p)
@@ -237,7 +237,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_po
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::~Scene_textured_polyhedron_item()
@@ -256,7 +256,7 @@ Scene_textured_polyhedron_item::load(std::istream& in)
 {
     std::cout<<"LOAD"<<std::endl;
     in >> *poly;
-    invalidate_buffers();
+    invalidate_OpenGLBuffers();
     return in && !isEmpty();
 }
 
@@ -346,7 +346,7 @@ Scene_textured_polyhedron_item::compute_bbox() const {
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 void
-Scene_textured_polyhedron_item::invalidate_buffers()
+Scene_textured_polyhedron_item::invalidate_OpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -352,17 +352,6 @@ Scene_textured_polyhedron_item::invalidate_buffers()
     compute_bbox();
 }
 void
-Scene_textured_polyhedron_item::
-contextual_changed()
-{
-    prev_shading = cur_shading;
-    cur_shading = renderingMode();
-    if(prev_shading != cur_shading)
-    {
-        invalidate_buffers();
-    }
-}
-void
 Scene_textured_polyhedron_item::selection_changed(bool p_is_selected)
 {
     if(p_is_selected != is_selected)

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -215,7 +215,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item()
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedron* const p)
@@ -226,7 +226,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(Textured_polyhedr
     texture.GenerateCheckerBoard(2048,2048,128,0,0,0,250,250,255);
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_polyhedron& p)
@@ -237,7 +237,7 @@ Scene_textured_polyhedron_item::Scene_textured_polyhedron_item(const Textured_po
     is_selected=false;
     nb_facets = 0;
     nb_lines = 0;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
 }
 
 Scene_textured_polyhedron_item::~Scene_textured_polyhedron_item()
@@ -256,7 +256,7 @@ Scene_textured_polyhedron_item::load(std::istream& in)
 {
     std::cout<<"LOAD"<<std::endl;
     in >> *poly;
-    invalidate_OpenGLBuffers();
+    invalidateOpenGLBuffers();
     return in && !isEmpty();
 }
 
@@ -346,7 +346,7 @@ Scene_textured_polyhedron_item::compute_bbox() const {
                 bbox.xmax(),bbox.ymax(),bbox.zmax());
 }
 void
-Scene_textured_polyhedron_item::invalidate_OpenGLBuffers()
+Scene_textured_polyhedron_item::invalidateOpenGLBuffers()
 {
     are_buffers_filled = false;
     compute_bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -44,7 +44,7 @@ public:
   bool isEmpty() const;
   void compute_bbox() const;
 
-  virtual void invalidate_OpenGLBuffers();
+  virtual void invalidateOpenGLBuffers();
   virtual void selection_changed(bool);
 
 private:

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -44,7 +44,7 @@ public:
   bool isEmpty() const;
   void compute_bbox() const;
 
-  virtual void invalidate_buffers();
+  virtual void invalidate_OpenGLBuffers();
   virtual void selection_changed(bool);
 
 private:

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -28,7 +28,7 @@ public:
   virtual QString toolTip() const;
 
   // Indicate if rendering mode is supported
-  virtual bool supportsRenderingMode(RenderingMode m) const { return m != Splatting; }
+  virtual bool supportsRenderingMode(RenderingMode m) const { return (m != Splatting && m != PointsPlusNormals && m != Points && m != Gouraud ); }
   // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
    void draw() const {}
   virtual void draw(CGAL::Three::Viewer_interface*) const;
@@ -45,7 +45,6 @@ public:
   void compute_bbox() const;
 
   virtual void invalidate_buffers();
-  virtual void contextual_changed();
   virtual void selection_changed(bool);
 
 private:
@@ -55,15 +54,15 @@ private:
   enum VAOs {
       Facets=0,
       Edges,
-      NbOfVaos = Edges+1
+      NbOfVaos
   };
   enum VBOs {
-      Facets_Vertices,
+      Facets_Vertices=0,
       Facets_Normals,
       Facets_Texmap,
-      Edges_Vertices = 0,
-      Edges_Texmap= 0,
-      NbOfVbos = Edges_Texmap+1
+      Edges_Vertices,
+      Edges_Texmap,
+      NbOfVbos
   };
 
   mutable std::vector<float> positions_lines;

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -291,8 +291,6 @@ public Q_SLOTS:
   virtual void invalidate_buffers();
   //!Setter for the color of the item. Calls invalidate_buffers() so the new color is applied.
   virtual void setColor(QColor c) { color_ = c; invalidate_buffers(); }
-  //!When invalidate_buffers() is not enough.
-  virtual void contextual_changed(){}
   //!Setter for the RGB color of the item. Calls setColor(QColor).
   //!@see setColor(QColor c)
   void setRbgColor(int r, int g, int b) { setColor(QColor(r, g, b)); }
@@ -396,16 +394,14 @@ protected:
   /*! Contains the previous RenderingMode.
    * This is used to determine if invalidate_buffers should be called or not
    * in certain cases.
-   * @see invalidate_buffers()
-   * @see contextual_changed()*/
+   * @see invalidate_buffers()*/
   RenderingMode prev_shading;
   /*! \todo replace it by RenderingMode().
    * \brief
    *  Contains the current RenderingMode.
    * This is used to determine if invalidate_buffers should be called or not
    * in certain cases.
-   * @see invalidate_buffers()
-   * @see contextual_changed()*/
+   * @see invalidate_buffers()*/
   RenderingMode cur_shading;
   //!Contains the size of the vector of VBOs
   int buffersSize;

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -288,9 +288,9 @@ public Q_SLOTS:
   //! important to call this function whenever the internal data is changed,
   //! or the displayed item will not be updated.
   //!Must be overloaded.
-  virtual void invalidate_buffers();
-  //!Setter for the color of the item. Calls invalidate_buffers() so the new color is applied.
-  virtual void setColor(QColor c) { color_ = c; invalidate_buffers(); }
+  virtual void invalidate_OpenGLBuffers();
+  //!Setter for the color of the item. Calls invalidate_OpenGLBuffers() so the new color is applied.
+  virtual void setColor(QColor c) { color_ = c; invalidate_OpenGLBuffers(); }
   //!Setter for the RGB color of the item. Calls setColor(QColor).
   //!@see setColor(QColor c)
   void setRbgColor(int r, int g, int b) { setColor(QColor(r, g, b)); }
@@ -379,11 +379,11 @@ protected:
   //! file.
   std::size_t nb_isolated_vertices;
   /*! Decides if the draw function must call initialize_buffers() or not. It is set
-   * to true in the end of initialize_buffers() and to false in invalidate_buffers(). The need of
+   * to true in the end of initialize_buffers() and to false in invalidate_OpenGLBuffers(). The need of
    * this boolean comes from the need of a context from the OpenGLFunctions used in
    * initialize_buffers().
    * @see initialize_buffers()
-   * @see invalidate_buffers()
+   * @see invalidate_OpenGLBuffers()
    */
   mutable bool are_buffers_filled;
   //!The rendering mode of the item.
@@ -394,14 +394,14 @@ protected:
   /*! Contains the previous RenderingMode.
    * This is used to determine if invalidate_buffers should be called or not
    * in certain cases.
-   * @see invalidate_buffers()*/
+   * @see invalidate_OpenGLBuffers()*/
   RenderingMode prev_shading;
   /*! \todo replace it by RenderingMode().
    * \brief
    *  Contains the current RenderingMode.
    * This is used to determine if invalidate_buffers should be called or not
    * in certain cases.
-   * @see invalidate_buffers()*/
+   * @see invalidate_OpenGLBuffers()*/
   RenderingMode cur_shading;
   //!Contains the size of the vector of VBOs
   int buffersSize;
@@ -428,10 +428,10 @@ protected:
   /*! Fills the VBOs with data. Must be called after each call to #compute_elements().
    * @see compute_elements()
    */
-  virtual void initialize_buffers(){}
+  void initialize_buffers(){}
 
-  /*! Collects all the data for the shaders. Must be called in #invalidate_buffers().
-   * @see invalidate_buffers().
+  /*! Collects all the data for the shaders. Must be called in #invalidate_OpenGLBuffers().
+   * @see invalidate_OpenGLBuffers().
    */
   void compute_elements(){}
   /*! Passes all the uniform data to the shaders.

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -288,9 +288,9 @@ public Q_SLOTS:
   //! important to call this function whenever the internal data is changed,
   //! or the displayed item will not be updated.
   //!Must be overloaded.
-  virtual void invalidate_OpenGLBuffers();
-  //!Setter for the color of the item. Calls invalidate_OpenGLBuffers() so the new color is applied.
-  virtual void setColor(QColor c) { color_ = c; invalidate_OpenGLBuffers(); }
+  virtual void invalidateOpenGLBuffers();
+  //!Setter for the color of the item. Calls invalidateOpenGLBuffers() so the new color is applied.
+  virtual void setColor(QColor c) { color_ = c; invalidateOpenGLBuffers(); }
   //!Setter for the RGB color of the item. Calls setColor(QColor).
   //!@see setColor(QColor c)
   void setRbgColor(int r, int g, int b) { setColor(QColor(r, g, b)); }
@@ -379,11 +379,11 @@ protected:
   //! file.
   std::size_t nb_isolated_vertices;
   /*! Decides if the draw function must call initialize_buffers() or not. It is set
-   * to true in the end of initialize_buffers() and to false in invalidate_OpenGLBuffers(). The need of
+   * to true in the end of initialize_buffers() and to false in invalidateOpenGLBuffers(). The need of
    * this boolean comes from the need of a context from the OpenGLFunctions used in
    * initialize_buffers().
    * @see initialize_buffers()
-   * @see invalidate_OpenGLBuffers()
+   * @see invalidateOpenGLBuffers()
    */
   mutable bool are_buffers_filled;
   //!The rendering mode of the item.
@@ -392,16 +392,16 @@ protected:
   //!The default context menu.
   QMenu* defaultContextMenu;
   /*! Contains the previous RenderingMode.
-   * This is used to determine if invalidate_buffers should be called or not
+   * This is used to determine if invalidateOpenGLBuffers should be called or not
    * in certain cases.
-   * @see invalidate_OpenGLBuffers()*/
+   * @see invalidateOpenGLBuffers()*/
   RenderingMode prev_shading;
   /*! \todo replace it by RenderingMode().
    * \brief
    *  Contains the current RenderingMode.
-   * This is used to determine if invalidate_buffers should be called or not
+   * This is used to determine if invalidateOpenGLBuffers should be called or not
    * in certain cases.
-   * @see invalidate_OpenGLBuffers()*/
+   * @see invalidateOpenGLBuffers()*/
   RenderingMode cur_shading;
   //!Contains the size of the vector of VBOs
   int buffersSize;
@@ -430,8 +430,8 @@ protected:
    */
   void initialize_buffers(){}
 
-  /*! Collects all the data for the shaders. Must be called in #invalidate_OpenGLBuffers().
-   * @see invalidate_OpenGLBuffers().
+  /*! Collects all the data for the shaders. Must be called in #invalidateOpenGLBuffers().
+   * @see invalidateOpenGLBuffers().
    */
   void compute_elements(){}
   /*! Passes all the uniform data to the shaders.


### PR DESCRIPTION
This PR removes the function `contextual_changed` and renames `invalidate_buffers` into `invalidate_OpenGLBuffers`.