### PR TITLE
Use CGAL_USE to avoid g++6.0 warning

### DIFF
--- a/Bounding_volumes/include/CGAL/Approximate_min_ellipsoid_d/Khachiyan_approximation_impl.h
+++ b/Bounding_volumes/include/CGAL/Approximate_min_ellipsoid_d/Khachiyan_approximation_impl.h
@@ -28,6 +28,7 @@
 #include <numeric>
 
 #include <CGAL/tags.h>
+#include <CGAL/use.h>
 #include <CGAL/Approximate_min_ellipsoid_d/Khachiyan_approximation.h>
 
 namespace CGAL {
@@ -366,7 +367,7 @@ namespace CGAL {
     CGAL_APPEL_ASSERT(!check_tag(Exact_flag()) || tau == eps/((1+eps)*d-1));
     CGAL_APPEL_ASSERT(!check_tag(Exact_flag()) || 
 		      excess<ET>(tco.cartesian_begin(*P[k])) == (1+eps)*d);
-    
+    CGAL_USE(tau);
     const FT mu = eps / ((d-1)*(1+eps));
     const FT alpha = 1 + mu;
     const FT beta = mu / (1+eps);

--- a/Circulator/include/CGAL/Circulator/Circulator_adapters.h
+++ b/Circulator/include/CGAL/Circulator/Circulator_adapters.h
@@ -26,6 +26,7 @@
 #define CGAL_CIRCULATOR_IMPL_H 1
 
 #include <CGAL/circulator.h>
+#include <CGAL/use.h>
 
 namespace CGAL {
 
@@ -68,6 +69,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -111,6 +113,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -158,6 +161,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -210,6 +214,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -269,6 +274,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -307,6 +313,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -344,6 +351,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -393,6 +401,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return this->_ptr == NULL;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -465,6 +474,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return _i >= _size;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }
@@ -589,6 +599,7 @@ public:
 
     bool operator==( Nullptr_t p) const {
         CGAL_assertion( p == NULL);
+        CGAL_USE(p);
         return _i >= _size;
     }
     bool operator!=( Nullptr_t p) const { return !(*this == p); }

--- a/Kernel_23/include/CGAL/Kernel_checker.h
+++ b/Kernel_23/include/CGAL/Kernel_checker.h
@@ -34,6 +34,7 @@
 //   So the template parameter will be a comparator, not a converter.
 
 #include <CGAL/basic.h>
+#include <CGAL/use.h>
 #include <utility>
 #include <typeinfo>
 
@@ -52,28 +53,28 @@ template <>
 struct Pairify <bool, bool> {
   typedef bool   result_type;
   result_type operator()(const bool &t1, const bool &t2) const
-  { CGAL_kernel_assertion(t1 == t2); return t1; }
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
 };
 
 template <>
 struct Pairify <Sign, Sign> {
   typedef Sign   result_type;
   result_type operator()(const Sign &t1, const Sign &t2) const
-  { CGAL_kernel_assertion(t1 == t2); return t1; }
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
 };
 
 template <>
 struct Pairify <Bounded_side, Bounded_side> {
   typedef Bounded_side   result_type;
   result_type operator()(const Bounded_side &t1, const Bounded_side &t2) const
-  { CGAL_kernel_assertion(t1 == t2); return t1; }
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
 };
 
 template <>
 struct Pairify <Angle, Angle> {
   typedef Angle   result_type;
   result_type operator()(const Angle &t1, const Angle &t2) const
-  { CGAL_kernel_assertion(t1 == t2); return t1; }
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
 };
 
 

--- a/Kernel_d/include/CGAL/Kernel_d/Sphere_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Sphere_d.h
@@ -28,6 +28,7 @@
 #include <CGAL/basic.h>
 #include <vector>
 #include <CGAL/Dimension.h>
+#include <CGAL/use.h>
 
 namespace CGAL {
 
@@ -56,6 +57,7 @@ public:
      P(first,last), cp(0)
   { TUPLE_DIM_CHECK(P.begin(),P.end(),Sphere_d);
     CGAL_assertion(d+1==int(P.size()));
+    CGAL_USE(d);
     typename R::Orientation_d orientation_;
     orient = orientation_(P.begin(),P.end()); }
 

--- a/Kernel_d/include/CGAL/Kernel_d/Tuple_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Tuple_d.h
@@ -224,11 +224,13 @@ void Tuple_d<NT,LA>::print(std::ostream& os, const char* l) const
     case CGAL::IO::ASCII :
       os << size() << " ";
       for (i = 0; i < size(); ++i) 
-        os << v[i] << " "; break;
+        os << v[i] << " ";
+      break;
     case CGAL::IO::BINARY :
       CGAL::write(os, size()); 
       for (i = 0; i < size(); ++i) 
-        CGAL::write(os, v[i]); break;
+        CGAL::write(os, v[i]);
+      break;
     default :
       os << l << "(" << size() << ", ";
       for (i = 0; i < size(); ++i) {

--- a/Kernel_d/include/CGAL/Kernel_d/function_objectsCd.h
+++ b/Kernel_d/include/CGAL/Kernel_d/function_objectsCd.h
@@ -27,6 +27,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/enum.h>
+#include <CGAL/use.h>
 #include <CGAL/Referenced_argument.h>
 
 #undef CGAL_KD_TRACE
@@ -143,6 +144,7 @@ public:
     result_type operator()(Forward_iterator start, Forward_iterator end) const
     {
         CGAL_assertion(start!=end);
+        CGAL_USE(d);
         int d = start->dimension();
         Matrix M(d);
         Vector b(d);

--- a/Kernel_d/include/CGAL/Kernel_d/function_objectsCd.h
+++ b/Kernel_d/include/CGAL/Kernel_d/function_objectsCd.h
@@ -144,7 +144,6 @@ public:
     result_type operator()(Forward_iterator start, Forward_iterator end) const
     {
         CGAL_assertion(start!=end);
-        CGAL_USE(d);
         int d = start->dimension();
         Matrix M(d);
         Vector b(d);

--- a/Kernel_d/include/CGAL/Kernel_d/function_objectsHd.h
+++ b/Kernel_d/include/CGAL/Kernel_d/function_objectsHd.h
@@ -128,6 +128,7 @@ typedef typename R::LA LA;
 template <class Forward_iterator>
 Point_d operator()(Forward_iterator start, Forward_iterator end) const
 { CGAL_assertion(start!=end);
+  CGAL_USE(end);
   int d = start->dimension();
   typename LA::Matrix M(d);
   typename LA::Vector b(d);

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Regular_triangulation_3.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Regular_triangulation_3.h
@@ -464,6 +464,7 @@ public:
   public:
 
   void audit_move(Event_key k, Point_key pk, Cell_handle h, int) const {
+    CGAL_USE(k);
     CGAL_assertion(kdel_.vertex_handle(pk) == Vertex_handle());
     CGAL_assertion(redundant_points_.find(pk) != redundant_points_.end());
     CGAL_assertion(redundant_points_.find(pk)->second == k);
@@ -471,12 +472,15 @@ public:
   }
   
   void audit_push(Event_key k, Point_key pk, Cell_handle h) const {
+    CGAL_USE(k);
     CGAL_assertion(kdel_.vertex_handle(pk) == Vertex_handle());
     CGAL_assertion(redundant_points_.find(pk) != redundant_points_.end());
     CGAL_assertion(redundant_points_.find(pk)->second == k);
     audit_redundant(pk, h);
   }
   void audit_pop(Event_key k, Vertex_handle vh) const {
+    CGAL_USE(k);
+    CGAL_USE(vh);
     CGAL_assertion_code(if (vh->info() != k) std::cerr << vh->info() << std::endl << k << std::endl);
     CGAL_assertion(vh->info() == k);
   }

--- a/Kinetic_data_structures/include/CGAL/Kinetic/Sort.h
+++ b/Kinetic_data_structures/include/CGAL/Kinetic/Sort.h
@@ -26,6 +26,7 @@
 #include <CGAL/Kinetic/internal/debug_counters.h>
 #include <CGAL/Kinetic/Sort_visitor_base.h>
 #include <CGAL/Kinetic/Event_base.h>
+#include <CGAL/use.h>
 #include <algorithm>
 #include <iostream>
 #include <iterator>
@@ -453,15 +454,12 @@ public:
     if (s_.will_fail()) out <<  " next is " << s_.failure_time();
     else out << " out of failures";
   }
-  void audit(typename Sort::Event_key
-#ifndef NDEBUG
-	     tk
-#endif
-) const {
+  void audit(typename Sort::Event_key tk) const {
     //std::cout << "Auditing event ";
     //write(std::cout);
     //std::cout << std::endl;
     CGAL_assertion(left_object_->event() == tk);
+    CGAL_USE(tk);
   }
   Id left_object_; Solver s_;
 };

--- a/Matrix_search/include/CGAL/sorted_matrix_search.h
+++ b/Matrix_search/include/CGAL/sorted_matrix_search.h
@@ -397,7 +397,7 @@ sorted_matrix_search(InputIterator f, InputIterator l, Traits t)
     
       } // both upper_median and lower_median are infeasible
     
-      active_cells.erase( new_end, active_cells.end());
+    active_cells.erase( new_end, active_cells.end());
   } // for (;;)
 
   // there must be only one cell left:

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -174,8 +174,9 @@ public:
     Direction d_res = direction(e_res);
     Halfedge_around_vertex_const_circulator el(e_res),ee(el);
     CGAL_For_all(el,ee) {
-      if ( K.strictly_ordered_ccw(d_res, direction(el), d) )
+      if ( K.strictly_ordered_ccw(d_res, direction(el), d) ){
         e_res = el; d_res = direction(e_res);
+      }
     }
     CGAL_NEF_TRACEN("  determined "<<PE(e_res)<<" "<<d_res);
     if ( direction(cyclic_adj_succ(e_res)) == d ) {

--- a/Nef_2/include/CGAL/Nef_polyhedron_2.h
+++ b/Nef_2/include/CGAL/Nef_polyhedron_2.h
@@ -282,9 +282,17 @@ protected:
       D(d), _e(), _v(), _it(it), _m(m) {}
 
     void supporting_segment(Halfedge_handle e, ES_iterator it) 
-    { if ( it == _it ) _e = e; D.mark(e) = _m; }
+    {
+      if ( it == _it )
+        _e = e;
+      D.mark(e) = _m; 
+    }
     void trivial_segment(Vertex_handle v, ES_iterator it) 
-    { if ( it == _it ) _v = v; D.mark(v) = _m; }
+    {
+      if ( it == _it )
+        _v = v;
+      D.mark(v) = _m;
+    }
     void starting_segment(Vertex_handle v, ES_iterator) 
     { D.mark(v) = _m; }
     void passing_segment(Vertex_handle v, ES_iterator) 

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -196,7 +196,7 @@ protected:
   struct AND { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const { return b1&&b2; } };
   struct OR { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const { return b1||b2; } };
   struct DIFF { Mark operator()(const Mark& b1, const Mark& b2, bool inverted=false) const { 
-    if(inverted) return !b1&&b2; return b1&&!b2; } };
+    return (inverted) ? !b1&&b2  :  b1&&!b2 ; };
   struct XOR { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const 
     { return (b1&&!b2)||(!b1&&b2); } };
 

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -193,12 +193,25 @@ class Nef_polyhedron_3 : public CGAL::Handle_for< Nef_polyhedron_3_rep<Kernel_, 
   /*{\Menum selection flag for the point location mode.}*/
 
 protected: 
-  struct AND { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const { return b1&&b2; } };
-  struct OR { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const { return b1||b2; } };
-  struct DIFF { Mark operator()(const Mark& b1, const Mark& b2, bool inverted=false) const { 
-    return (inverted) ? !b1&&b2  :  b1&&!b2 ; };
-  struct XOR { Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const 
-    { return (b1&&!b2)||(!b1&&b2); } };
+  struct AND {
+    Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false)const 
+    { return b1&&b2; } 
+  };
+
+  struct OR {
+    Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const
+    { return b1||b2; } 
+  };
+
+  struct DIFF {
+    Mark operator()(const Mark& b1, const Mark& b2, bool inverted=false) const 
+    { return (inverted) ? !b1&&b2  :  b1&&!b2 ; }
+  };
+
+  struct XOR {
+    Mark operator()(const Mark& b1, const Mark& b2, bool /* inverted */ =false) const 
+    { return (b1&&!b2)||(!b1&&b2); } 
+  };
 
  public:
   typedef Nef_polyhedron_3_rep<Kernel,Items, Mark>    Nef_rep;

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_triangle.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_triangle.h
@@ -103,7 +103,8 @@ template <typename R>
 std::ostream& operator<<(std::ostream& os, 
                          const CGAL::Sphere_triangle<R>& t)
 { for (int i=0; i<3; ++i) os << t.point(i);
-  for (int i=0; i<3; ++i) os << t.circle(i); return os; }
+  for (int i=0; i<3; ++i) os << t.circle(i);
+  return os; }
 
 template <typename R>
 std::istream& operator>>(std::istream& is, 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Vector/array.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Vector/array.h
@@ -56,7 +56,7 @@ template<class NT_,class Dim_,class Max_dim_=Dim_> struct Array_vector {
 	struct Construct_vector {
 		struct Dimension {
 			// Initialize with NaN if possible?
-			Vector operator()(unsigned d) const {
+                  Vector operator()(unsigned CGAL_assertion_code(d)) const {
 				CGAL_assertion(d<=d_);
 				return Vector();
 			}

--- a/NewKernel_d/include/CGAL/NewKernel_d/Vector/array.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Vector/array.h
@@ -91,7 +91,7 @@ template<class NT_,class Dim_,class Max_dim_=Dim_> struct Array_vector {
 
 		struct Iterator_and_last {
 			template<typename Iter,typename T>
-				Vector operator()(unsigned d,Iter const& f,Iter const& e,CGAL_FORWARDABLE(T) t) const {
+                        Vector operator()(unsigned  CGAL_assertion_code(d),Iter const& f,Iter const& e,CGAL_FORWARDABLE(T) t) const {
 					CGAL_assertion(d==std::distance(f,e)+1);
 					CGAL_assertion(d<=d_);
 					//TODO: optimize for forward iterators

--- a/NewKernel_d/include/CGAL/NewKernel_d/Vector/vector.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Vector/vector.h
@@ -59,7 +59,7 @@ template<class NT_,class Dim_,class Max_dim_=Dim_> struct Vector_vector {
 #if 0
 		struct Iterator_add_one {
 			template<typename Iter>
-				Vector operator()(int d,Iter const& f,Iter const& e) const {
+                        Vector operator()(int  CGAL_assertion_code(d),Iter const& f,Iter const& e) const {
 					CGAL_assertion(d==std::distance(f,e)+1);
 					Vector a;
 					a.reserve(d+1);

--- a/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
+++ b/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
@@ -597,7 +597,7 @@ public:
 
     //! return \c -p if \c p.sign()<0 and \c p otherwise
     Polynomial<NT> abs() const
-    { if ( sign()<0 ) return -*this; return *this; }
+    { return ( sign()<0 )?  -*this : *this; }
 
     //! return the gcd of all coefficients
     /*! The content is defined as 1 for the zero polynomial. */

--- a/STL_Extension/include/CGAL/Circulator_identity.h
+++ b/STL_Extension/include/CGAL/Circulator_identity.h
@@ -61,6 +61,7 @@ public:
 
   bool operator==( Nullptr_t p) const {
     CGAL_assertion( p == 0);
+    CGAL_USE(p);
     return ( nt == 0);                                    //###//
   }
   bool operator!=( Nullptr_t p) const {

--- a/STL_Extension/include/CGAL/Circulator_on_node.h
+++ b/STL_Extension/include/CGAL/Circulator_on_node.h
@@ -63,6 +63,7 @@ public:
 
   bool operator==( Nullptr_t p) const {
     CGAL_assertion( p == 0);
+    CGAL_USE(p);
     return ( nt == 0);
   }
   bool  operator!=( Nullptr_t p) const { return !(*this == p); }

--- a/SearchStructures/include/CGAL/Range_tree_d.h
+++ b/SearchStructures/include/CGAL/Range_tree_d.h
@@ -399,10 +399,10 @@ public:
 
     if (v!=0)
       delete_tree(v);
-      if (header!=0)
-      	delete header;
-      if (sublayer_tree!=0)
-      	delete sublayer_tree;
+    if (header!=0)
+      delete header;
+    if (sublayer_tree!=0)
+      delete sublayer_tree;
   }
 
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1810,7 +1810,7 @@ public:
             if(!valid) {
               if (verbose)
                 std::cerr << "Integrity of opposite halfedge of " << *it << " corrupted."  << std::endl;
-                break;
+              break;
             }
 
             valid = valid && (next(prev(*it)) == *it);

--- a/Visibility_2/include/CGAL/Triangular_expansion_visibility_2.h
+++ b/Visibility_2/include/CGAL/Triangular_expansion_visibility_2.h
@@ -28,6 +28,7 @@
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Arr_observer.h>
 #include <CGAL/assertions.h>
+#include <CGAL/use.h>
 
 namespace CGAL {
 
@@ -217,6 +218,7 @@ public:
 
     out_arr.clear();
     needles.clear();
+    CGAL_USE(face);
     CGAL_assertion(!face->is_unbounded());
 
 

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
@@ -26,6 +26,7 @@
 #include <CGAL/Iterator_project.h>
 #include <CGAL/circulator.h>
 #include <CGAL/tags.h>
+#include <CGAL/use.h>
 
 #include <iostream>
 #include <iterator>
@@ -603,6 +604,7 @@ public:
   Ccb_halfedge_circulator ccb_halfedges(const Face_handle& f,
 					const Halfedge_handle& he) const {
     CGAL_precondition( he->face() == f );
+    CGAL_USE(f);
     return Ccb_halfedge_circulator(*he);
   }
 
@@ -614,7 +616,7 @@ public:
 
   Halfedge_around_vertex_circulator
   incident_halfedges(const Vertex_handle& v, const Halfedge_handle& he) const {
-    internal::use(v);
+    CGAL_USE(v);
     CGAL_precondition( he->target() == v );
     return Halfedge_around_vertex_circulator(*he);
   }


### PR DESCRIPTION
Warning issued on platform  Ubuntu-latest-GCC6-Release_? 