### PR TITLE
Fix in intersection_of_Polyhedra_3: CMap default-constructor is not thread-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1233,3 +1233,7 @@ gmon.*
 /*.html
 /Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
 /Snap_rounding_2/test/Snap_rounding_2/data/out
+/Operations_on_polyhedra/examples/Operations_on_polyhedra/CMakeLists.txt
+/Operations_on_polyhedra/examples/Operations_on_polyhedra/cgal_test_with_cmake
+/Operations_on_polyhedra/test/Operations_on_polyhedra/CMakeLists.txt
+/Operations_on_polyhedra/test/Operations_on_polyhedra/cgal_test_with_cmake

--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
@@ -1242,14 +1242,16 @@ public:
       final_map_comes_from_outside=true;
       final_map_ptr=ptr;
     }
-    else{
+    else if (!do_not_build_cmap_) {
       final_map_comes_from_outside=false;
       final_map_ptr=new Combinatorial_map_3_();
     }
   }
   
   ~Node_visitor_refine_polyhedra(){
-    if(!final_map_comes_from_outside) delete final_map_ptr;
+    if(!do_not_build_cmap && !final_map_comes_from_outside) {
+      delete final_map_ptr;
+    }
   }
 
   


### PR DESCRIPTION
When `do_not_build_cmap_` is `true`, avoid even to construct the
default-constructed CMap, because that operation is not thread-safe.

See also issue #659.

CC: @sloriot, @gdamiand 
