### PR TITLE
Mesh 3 - Improve Gray level images domain and fix warnings

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Gray_image_mesh_domain_3.h
@@ -8,7 +8,8 @@ gray image. A 3D gray image is a grid of voxels,
 where each voxel is associated with a gray level value.
 This class is a model of the concept `MeshDomain_3`.
 The domain to be discretized is the union of voxels that lie inside a surface
-described by an isolevel value, called \a isovalue.
+described by an isolevel value, called \a isovalue. The voxels lying inside the
+domain have gray level values that are larger than the isovalue.
 
 This class includes a member function that provides, by interpolation,
 a gray level value at any query point.
@@ -19,7 +20,7 @@ The intersection is then constructed by bisection.
 The bisection stops when the query segment is shorter than a given error bound 
 `e`. This error bound is given by `e=d`\f$ \times\f$`bound` where `d` is the 
 length of the diagonal of the bounding box (in world coordinates) and 
-`bound` is the argument passed to the constructor of `Labeled_image_mesh_domain_3`. 
+`bound` is the argument passed to the constructor of `Labeled_image_mesh_domain_3`.
 
 
 \tparam Image is the type of the input image. 
@@ -54,18 +55,19 @@ public:
 
 /*!
 Construction from an image.
+The object to be meshed is described by the voxels that have a gray-level
+value higher than the input isovalue.
 @param image the input image
 @param iso_value the isovalue, inside `image`,
-       of the surface describing the boundary of the object to be meshed
+       of the surface describing the boundary of the object to be meshed.
 @param value_outside the value attached to voxels outside of the domain
-       to be meshed
+       to be meshed. It should be lower than `iso_value`
 @param error_bound is relative to the size of the image. 
 */ 
   Gray_image_mesh_domain_3(
       const Image& image,
       const Image_word_type iso_value,
-      const Image_word_type value_outside =
-            std::numeric_limits<ImageWordType>::max(),
+      const Image_word_type value_outside = 0.,
       const BGT::FT& error_bound = BGT::FT(1e-3));
 
 /// @}

--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -565,6 +565,7 @@ for more details.
 
 \subsection Mesh_33DDomainsBoundedbyIsosurfaces 3D Domains Bounded by Isosurfaces
 
+\subsubsection Mesh_33DDomainsImplicitIsosurfaces 3D Domains Bounded by Implicit Isosurfaces
 The following code produces a 3D mesh for a domain whose boundary surface
 is an isosurface defined by an implicit
 function. \cgalFigureRef{figureimplicit_domain} shows a cut view of the
@@ -578,6 +579,14 @@ constructor of the `Mesh_criteria` instance.
 \cgalFigureBegin{figureimplicit_domain,implicit_domain.jpg}
 Cut view of a 3D mesh produced from an implicit domain
 \cgalFigureEnd
+
+\subsubsection Mesh_33DDomainsGrayImageIsosurfaces 3D Domains Bounded by Isosurfaces in 3D Gray-Level Images
+
+The following example produces a 3D mesh for a domain whose boundary surface
+is the isosurface associated to an isovalue inside the input gray-level
+3D image.
+
+\cgalExample{Mesh_3/mesh_3D_gray_image.cpp}
 
 \subsection Mesh_3MeshingMultipleDomains Meshing Multiple Domains
 

--- a/Mesh_3/doc/Mesh_3/examples.txt
+++ b/Mesh_3/doc/Mesh_3/examples.txt
@@ -12,4 +12,5 @@
 \example Mesh_3/mesh_polyhedral_domain.cpp
 \example Mesh_3/mesh_polyhedral_domain_with_features.cpp
 \example Mesh_3/mesh_two_implicit_spheres_with_balls.cpp
+\example Mesh_3/mesh_3D_gray_image.cpp
 */

--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -36,7 +36,8 @@
 typedef float Image_word_type;
 
 template<typename T>
-struct Greater_than : public std::unary_function<T, bool> {
+struct Greater_than {
+  typedef T argument_type;
   Greater_than(const T& second) : second(second) {}
   bool operator()(const T& first) const {
     return std::greater<T>()(first, second);

--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -35,11 +35,20 @@
 
 typedef float Image_word_type;
 
+template<typename T>
+struct Greater_than : public std::unary_function<T, bool> {
+  Greater_than(const T& second) : second(second) {}
+  bool operator()(const T& first) const {
+    return std::greater<T>()(first, second);
+  }
+  T second;
+};
+
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-typedef CGAL::Gray_image_mesh_domain_3<CGAL::Image_3,K, 
+typedef CGAL::Gray_image_mesh_domain_3<CGAL::Image_3, K,
                                        Image_word_type,
-                                       std::binder1st< std::less<Image_word_type> > > Mesh_domain;
+                                       Greater_than<Image_word_type> > Mesh_domain;
 
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
@@ -58,7 +67,7 @@ int main()
   if(!image.read("data/skull_2.9.inr")) return 1;
 
   // Domain
-  Mesh_domain domain(image, std::bind1st(std::less<Image_word_type>(), 2.9f), 0.f);
+  Mesh_domain domain(image, 2.9f, 0.f);
 
   // Mesh criteria
   Mesh_criteria criteria(facet_angle=30, facet_size=6, facet_distance=2,

--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -35,21 +35,10 @@
 
 typedef float Image_word_type;
 
-template<typename T>
-struct Greater_than {
-  typedef T argument_type;
-  Greater_than(const T& second) : second(second) {}
-  bool operator()(const T& first) const {
-    return std::greater<T>()(first, second);
-  }
-  T second;
-};
-
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Gray_image_mesh_domain_3<CGAL::Image_3, K,
-                                       Image_word_type,
-                                       Greater_than<Image_word_type> > Mesh_domain;
+                                       Image_word_type> Mesh_domain;
 
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -32,6 +32,17 @@
 
 namespace CGAL {
 
+namespace internal {
+
+template<typename T>
+struct Less_than {
+  Less_than(const T& second) : second(second) {}
+  bool operator()(const T& first) const { return std::less<T>()(first, second); }
+  T second;
+};
+
+}
+
 /**
  * @class Gray_image_mesh_domain_3
  *
@@ -40,7 +51,7 @@ namespace CGAL {
 template<class Image,
          class BGT,
          typename Image_word_type = float,
-         typename Transform = std::binder2nd<std::less<Image_word_type> >,
+         typename Transform = internal::Less_than<Image_word_type>,
          typename Subdomain_index = int>
 class Gray_image_mesh_domain_3
   : public Labeled_mesh_domain_3<
@@ -73,7 +84,7 @@ public:
                            const FT& error_bound = FT(1e-3),
                            CGAL::Random* p_rng = NULL)
     : Base(Wrapper(image, 
-                   Transform(std::less<Image_word_type>(), iso_value),
+                   Transform(iso_value),
                    value_outside),
            compute_bounding_box(image),
            error_bound,

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -28,19 +28,20 @@
 #include <CGAL/Mesh_3/Image_to_labeled_function_wrapper.h>
 
 #include <functional>
-#include <limits>
 
 namespace CGAL {
 
 namespace internal {
 
-template<typename T>
-struct Less_than {
-  typedef T argument_type;
-  Less_than(const T& second) : second(second) {}
-  bool operator()(const T& first) const { return std::less<T>()(first, second); }
-  T second;
-};
+  template<typename T>
+  struct Greater_than {
+    typedef T argument_type;
+    Greater_than(const T& second) : second(second) {}
+    bool operator()(const T& first) const {
+      return std::greater<T>()(first, second);
+    }
+    T second;
+  };
 
 }
 
@@ -52,7 +53,7 @@ struct Less_than {
 template<class Image,
          class BGT,
          typename Image_word_type = float,
-         typename Transform = internal::Less_than<Image_word_type>,
+         typename Transform = internal::Greater_than<Image_word_type>,
          typename Subdomain_index = int>
 class Gray_image_mesh_domain_3
   : public Labeled_mesh_domain_3<
@@ -80,8 +81,7 @@ public:
   /// Constructor
   Gray_image_mesh_domain_3(const Image& image,
                            const Image_word_type iso_value,
-                           const Image_word_type value_outside = 
-                             (std::numeric_limits<Image_word_type>::max)(),
+                           const Image_word_type value_outside = 0.,
                            const FT& error_bound = FT(1e-3),
                            CGAL::Random* p_rng = NULL)
     : Base(Wrapper(image, 
@@ -94,8 +94,7 @@ public:
 
   Gray_image_mesh_domain_3(const Image& image,
                            const Transform& transform,
-                           const Image_word_type value_outside = 
-                             (std::numeric_limits<Image_word_type>::max)(),
+                           const Image_word_type value_outside = 0.,
                            const FT& error_bound = FT(1e-3),
                            CGAL::Random* p_rng = NULL)
     : Base(Wrapper(image, transform, value_outside),

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -35,7 +35,7 @@ namespace CGAL {
 namespace internal {
 
 template<typename T>
-struct Less_than {
+struct Less_than : public std::unary_function<T, bool> {
   Less_than(const T& second) : second(second) {}
   bool operator()(const T& first) const { return std::less<T>()(first, second); }
   T second;

--- a/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Gray_image_mesh_domain_3.h
@@ -35,7 +35,8 @@ namespace CGAL {
 namespace internal {
 
 template<typename T>
-struct Less_than : public std::unary_function<T, bool> {
+struct Less_than {
+  typedef T argument_type;
   Less_than(const T& second) : second(second) {}
   bool operator()(const T& first) const { return std::less<T>()(first, second); }
   T second;

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
@@ -32,6 +32,16 @@
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
+template<typename T>
+struct Greater_than {
+  typedef T argument_type;
+  Greater_than(const T& second) : second(second) {}
+  bool operator()(const T& first) const {
+    return std::greater<T>()(first, second);
+  }
+  T second;
+};
+
 template <typename Concurrency_tag = CGAL::Sequential_tag>
 struct Image_tester : public Tester<K_e_i>
 {
@@ -44,7 +54,7 @@ public:
       Image,
       K_e_i,
       Image_word_type,
-      std::binder1st< std::less<Image_word_type> > >    Mesh_domain;
+      Greater_than<Image_word_type> >                   Mesh_domain;
 
     typedef typename CGAL::Mesh_triangulation_3<
       Mesh_domain,
@@ -70,7 +80,7 @@ public:
 
     // Domain
     Mesh_domain domain(image,
-      std::bind1st(std::less<Image_word_type>(), 2.9f),//transform
+      2.9f, //isovalue
       0.f,  //value_outside
       1e-3, //error_bound
       &CGAL::default_random);//random generator for determinism


### PR DESCRIPTION
This PR improves the gray level images oracle of Mesh_3, and its documentation.

In particular, the "inside" of the domain is now considered to be the side where the voxel values are higher than the isovalue. This makes more sense because it is intended to be used with medical images, where the "white" area is the area of interest.

This PR solves issue #624
This PR ships pull request #633 