### PR TITLE
Fix warnings instead of suppressing them; cleanup of the CMakeLists.txt

### DIFF
--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -5,17 +5,8 @@ project( Poisson_surface_reconstruction_3_example )
 cmake_minimum_required(VERSION 2.8.11)
 
 
-# Require packages new or improved since CGAL 3.5 beta 1
-include_directories (BEFORE ../../../Installation/include)
-include_directories (BEFORE ../../../Point_set_processing_3/include)
-include_directories (BEFORE ../../../Surface_mesher/include)
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../Installation/cmake/modules ${CMAKE_MODULE_PATH})
-
-# Include this package's headers first
-include_directories (BEFORE . include ../../include)
-
 # Find CGAL
-find_package(CGAL)
+find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
@@ -24,14 +15,8 @@ if ( CGAL_FOUND )
 
   # VisualC++ optimization for applications dealing with large data
   if (MSVC)
-    # Use /FR to turn on IntelliSense
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FR")
-
-    # Allow Windows applications to use up to 3GB of RAM
+    # Allow Windows 32bit applications to use up to 3GB of RAM
     SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-
-    # Turn off stupid VC++ warnings
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4311 /wd4800 /wd4503 /wd4244 /wd4345 /wd4996 /wd4396 /wd4018")
 
     # Print new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )
@@ -39,9 +24,6 @@ if ( CGAL_FOUND )
     message( STATUS "USING RELEASE CXXFLAGS = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}'" )
     message( STATUS "USING RELEASE EXEFLAGS = '${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_RELEASE}'" )
   endif()
-
-  # Temporary debugging stuff
-  ADD_DEFINITIONS( "-DDEBUG_TRACE" ) # turn on traces
 
   # Find Eigen3 (requires 3.1.0 or greater)
   find_package(Eigen3 3.1.0)

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
@@ -65,8 +65,8 @@ typedef CGAL::AABB_traits<Kernel, Primitive> AABB_traits;
 typedef CGAL::AABB_tree<AABB_traits> AABB_tree;
 
 struct Counter {
-  int i, N;
-  Counter(int N)
+  std::size_t i, N;
+  Counter(std::size_t N)
     : i(0), N(N)
   {}
 
@@ -210,7 +210,7 @@ int main(int argc, char * argv[])
     }
 
     // Prints status
-    int nb_points = points.size();
+    std::size_t nb_points = points.size();
     std::cerr << "Reads file " << input_filename << ": " << nb_points << " points, "
                                                         << task_timer.time() << " seconds"
                                                         << std::endl;

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -5,16 +5,8 @@ project( Poisson_surface_reconstruction_3_test )
 cmake_minimum_required(VERSION 2.8.11)
 
 
-# Require packages new or improved since CGAL 3.5 beta 1
-include_directories (BEFORE ../../../Installation/include/)
-include_directories (BEFORE ../../../Point_set_processing_3/include)
-include_directories (BEFORE ../../../Surface_mesher/include)
-
-# Include this package's headers first
-include_directories (BEFORE . include ../../include)
-
 # Find CGAL
-find_package(CGAL QUIET COMPONENTS Core )
+find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
@@ -23,14 +15,8 @@ if ( CGAL_FOUND )
 
   # VisualC++ optimization for applications dealing with large data
   if (MSVC)
-    # Use /FR to turn on IntelliSense
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FR")
-
-    # Allow Windows applications to use up to 3GB of RAM
+    # Allow Windows 32bit applications to use up to 3GB of RAM
     SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-
-    # Turn off stupid VC++ warnings
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4311 /wd4800 /wd4503 /wd4244 /wd4345 /wd4996 /wd4396 /wd4018")
 
     # Prints new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )
@@ -40,7 +26,6 @@ if ( CGAL_FOUND )
   endif()
 
   # Temporary debugging stuff
-  ADD_DEFINITIONS( "-DDEBUG_TRACE" ) # turn on traces
 
   find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
   if(EIGEN3_FOUND)

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_reconstruction_test.cpp
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_reconstruction_test.cpp
@@ -165,8 +165,8 @@ int main(int argc, char * argv[])
     }
 
     // Prints status
-    long memory = CGAL::Memory_sizer().virtual_size();
-    int nb_points = points.size();
+    std::size_t memory = CGAL::Memory_sizer().virtual_size();
+    std::size_t nb_points = points.size();
     std::cerr << "Reads file " << input_filename << ": " << nb_points << " points, "
                                                         << task_timer.time() << " seconds, "
                                                         << (memory>>20) << " Mb allocated"


### PR DESCRIPTION
The include_directories are from a time before we had branch builds.