### PR TITLE
Fix a bug in Boost.Config<1.57 with gcc>=5.0

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -85,6 +85,14 @@
 #include <boost/config.hpp>
 #include <boost/version.hpp>
 
+// bug-fix for g++-5.x and Boost.Config<1.57
+//    https://svn.boost.org/trac/boost/ticket/10500
+#if BOOST_VERSION < 105700 && BOOST_GCC < 60000 && \
+  ! defined(__GXX_EXPERIMENTAL_CXX0X__) && defined(BOOST_HAS_VARIADIC_TMPL)
+#  undef BOOST_HAS_VARIADIC_TMPL
+#  define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+
 #include <CGAL/version.h>
 
 //----------------------------------------------------------------------//


### PR DESCRIPTION
`BOOST_HAS_VARIADIC_TMPL` and `BOOST_NO_CXX11_VARIADIC_TEMPLATES` can be
wrong, with Boost-1.57 and gcc>=5.0.

Fixes the following warnings with gcc>=5.0 in C++98 mode:
```
> CGAL-4.8-Ic-106/include/CGAL/array.h:78:31: warning: variadic templates only available with -std=c++11 or -std=gnu++11
> template< typename T, typename... Args >
>                               ^
> CGAL-4.8-Ic-106/include/CGAL/array.h:80:28: warning: variadic templates only available with -std=c++11 or -std=gnu++11
> cpp11::array< T, 1 + sizeof...(Args) >
>                            ^
> CGAL-4.8-Ic-106/include/CGAL/array.h:81:42: warning: variadic templates only available with -std=c++11 or -std=gnu++11
>  make_array(const T & t, const Args & ... args)
>                                           ^
```

Actually, I wonder if the patch should be backported to CGAL-4.7. @sloriot, what do you think?
