### PR TITLE
PMP isotropic remeshing : fix collapse step with inside borders

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1045,7 +1045,7 @@ private:
         return is_collapse_allowed_on_patch_border(he);
       else if (is_on_patch_border(hopp))
         return is_collapse_allowed_on_patch_border(hopp);
-      return true;
+      return false;
     }
 
     bool is_collapse_allowed_on_patch_border(const halfedge_descriptor& h) const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -678,7 +678,7 @@ namespace internal {
 
         //check that mesh does not become non-triangle,
         //nor has inverted faces
-        if (deviation_pre < deviation_post
+        if (deviation_pre <= deviation_post
           || !check_normals(he)
           || incident_to_degenerate(he)
           || incident_to_degenerate(opposite(he, mesh_))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1031,16 +1031,41 @@ private:
 
       if (protect_constraints_ && is_constrained(e))
         return false;
-      else if (!is_on_patch(he)) //hopp is also on patch
+      if (is_on_patch(he)) //hopp is also on patch
+      {
+        if (is_on_patch_border(next(he, mesh_)) && is_on_patch_border(prev(he, mesh_)))
+          return false;//too many cases to be handled
+        else if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
+          return false;//too many cases to be handled
+        else if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
+          return false;//collapse would induce pinching the selection
+        else return true;
+      }
+      else if (is_on_patch_border(he))
+        return is_collapse_allowed_on_patch_border(he);
+      else if (is_on_patch_border(hopp))
+        return is_collapse_allowed_on_patch_border(hopp);
+      return true;
+    }
+
+    bool is_collapse_allowed_on_patch_border(const halfedge_descriptor& h) const
+    {
+      CGAL_precondition(is_on_patch_border(h));
+      halfedge_descriptor hopp = opposite(h, mesh_);
+
+      if (is_on_patch_border(next(h, mesh_)) && is_on_patch_border(prev(h, mesh_)))
         return false;
-      else if (is_on_patch_border(next(he, mesh_)) && is_on_patch_border(prev(he, mesh_)))
-        return false;//too many cases to be handled
-      else if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
-        return false;//too many cases to be handled
-      if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
-        return false;//collapse would induce pinching the selection
-      else
-        return true;
+
+      if (is_on_patch_border(hopp))
+      {
+        if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
+          return false;
+        else
+          return true;
+      }
+      CGAL_assertion(is_on_mesh(hopp));
+
+      return true;//we already checked we're not pinching a hole in the patch
     }
 
     bool collapse_does_not_invert_face(const halfedge_descriptor& h) const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -998,10 +998,7 @@ private:
 
     bool is_constrained(const edge_descriptor& e) const
     {
-      if (protect_constraints_)
-        return false;
-      else
-        return get(Constraint_property_map(*this), e);
+      return get(Constraint_property_map(*this), e);
     }
 
     bool is_split_allowed(const edge_descriptor& e) const
@@ -1063,8 +1060,7 @@ private:
         else
           return true;
       }
-      CGAL_assertion(is_on_mesh(hopp));
-
+      CGAL_assertion(is_on_mesh(hopp) || is_on_border(hopp));
       return true;//we already checked we're not pinching a hole in the patch
     }
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
   }
 
   double target_edge_length = (argc > 2) ? atof(argv[2]) : 0.079;
-  unsigned int nb_iter = (argc > 3) ? atoi(argv[3]) : 1;
+  unsigned int nb_iter = (argc > 3) ? atoi(argv[3]) : 2;
   const char* selection_file = (argc > 4) ? argv[4]
     : "data/joint-patch.selection.txt";
 
@@ -155,25 +155,21 @@ int main(int argc, char* argv[])
 
   std::cout << "done." << std::endl;
 
-  std::set<face_descriptor> patch;
-  std::copy(pre_patch.begin(), pre_patch.end(),
-            std::inserter(patch, patch.begin()));
-
-  std::cout << "Start remeshing of " << selection_file
-    << " (" << patch.size() << " faces)..." << std::endl;
+  //std::cout << "Start remeshing of " << selection_file
+  //  << " (" << patch.size() << " faces)..." << std::endl;
 
   CGAL::Timer t;
-  t.start();
+  //t.start();
 
-  PMP::isotropic_remeshing(
-    patch,
-    target_edge_length,
-    m,
-    PMP::parameters::number_of_iterations(nb_iter)
-    .protect_constraints(false)
-    );
-  t.stop();
-  std::cout << "Remeshing patch took " << t.time() << std::endl;
+  //PMP::isotropic_remeshing(
+  //  patch,
+  //  target_edge_length,
+  //  m,
+  //  PMP::parameters::number_of_iterations(nb_iter)
+  //  .protect_constraints(false)
+  //  );
+  //t.stop();
+  //std::cout << "Remeshing patch took " << t.time() << std::endl;
 
   t.start();
   PMP::isotropic_remeshing(faces(m),


### PR DESCRIPTION
This PR fixes a bug in the isotropic remeshing edge collapse step.

The conditions under which patch border edges can be collapsed
are more the complicated than the conditions for inside-patch edges 