### PR TITLE
Polyhedron demo: fix clip plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -150,8 +150,12 @@ public Q_SLOTS:
     //creates a new  cutting_plane;
     if(!plane)
     {
+      const Scene_interface::Bbox scene_bbox = scene->bbox();
       plane = new Scene_clipping_plane_item(scene);
       plane->setNormal(0., 0., 1.);
+      plane->setPosition((scene_bbox.xmin + scene_bbox.xmax)/2.,
+                         (scene_bbox.ymin + scene_bbox.ymax)/2.,
+                         (scene_bbox.zmin + scene_bbox.zmax)/2.);
       plane->setManipulatable(true);
       plane->setClonable(false);
       plane->setColor(QColor(0,126,255));

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -6,17 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>322</width>
-    <height>85</height>
+    <width>364</width>
+    <height>258</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>DockWidget</string>
+   <string>Clip polyhedra</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout_2">
     <item>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This function allows to clip all the selected polyhedra by an half-space. The blue side of the clipping plane will be clipped out, and the yellow side will be kept.&lt;br/&gt;&lt;br/&gt;If the option &lt;span style=&quot; font-style:italic;&quot;&gt;keep closed&lt;/span&gt; is checked, the clipped part of each polyhedron will be closed. Otherwise, it will be left open.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
@@ -41,7 +51,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Keep Closed</string>
+           <string>&amp;Keep Closed</string>
           </property>
          </widget>
         </item>
@@ -61,7 +71,7 @@
         <item>
          <widget class="QPushButton" name="clipButton">
           <property name="text">
-           <string>Clip</string>
+           <string>&amp;Clip</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
1/ Create the clipping plugin at the center of the scene, otherwise it cannot be used at all, if the scene objects are far from the origin.

2/ UI improvements:
- add a real title to the dock widget,
- add shortcuts to the checkbox and the buttons,
- and add a text explaining which side of the plane actually clip out.

CC: @maxGimeno