### PR TITLE
Snap roundig fix 

### DIFF
--- a/GraphicsView/include/CGAL/Qt/SegmentsGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/SegmentsGraphicsItem.h
@@ -118,7 +118,7 @@ SegmentsGraphicsItem<P>::paint(QPainter *painter,
 {
 
   painterostream = PainterOstream<Traits>(painter);
-  
+  painter->setPen(QPen(::Qt::black, 0, ::Qt::SolidLine, ::Qt::RoundCap, ::Qt::RoundJoin));
     for(typename P::iterator it = segments->begin();
         it != segments->end();
         it++){


### PR DESCRIPTION
Adds a QPen in SegmentGraphicsItem to draw the InputSegment. The default Pen has changed in Qt5 : [Qt5 :](http://doc.qt.io/qt-5/qpen.html)
"The default pen is a solid black brush with 1 width, square cap style (Qt::SquareCap), and bevel join style (Qt::BevelJoin)."
[Qt4:](http://doc.qt.io/qt-4.8/qpen.html)
The default pen is a solid black brush with 0 width, square cap style (Qt::SquareCap), and bevel join style (Qt::BevelJoin).

Making the segment extra large. Manually adding a pen in the `paint()` function allows to set the width to 0 and get back to the original behavior.