### PR TITLE
When opening a binary ply file  we have to use std::ios_base::binary

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
@@ -27,7 +27,7 @@ bool Polyhedron_demo_ply_to_xyz_plugin::canLoad() const {
 
 CGAL::Three::Scene_item*
 Polyhedron_demo_ply_to_xyz_plugin::load(QFileInfo fileinfo) {
-  std::ifstream in(fileinfo.filePath().toUtf8());
+  std::ifstream in(fileinfo.filePath().toUtf8(), std::ios_base::binary);
 
   if(!in)
     std::cerr << "Error!\n";


### PR DESCRIPTION
@sgiraudot  We have to check that with an Ascii file 