### PR TITLE
Replace #ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS 

### DIFF
--- a/Jet_fitting_3/examples/Jet_fitting_3/Mesh_estimation.cpp
+++ b/Jet_fitting_3/examples/Jet_fitting_3/Mesh_estimation.cpp
@@ -6,7 +6,7 @@
 
 #include <CGAL/property_map.h>
 
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -117,7 +117,7 @@ void gather_fitting_points(Vertex* v,
 }
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 int main(int argc, char *argv[])
 #else
 int main()
@@ -131,7 +131,7 @@ int main()
   std::ofstream out_4ogl, out_verbose;
 
   try {
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
     po::options_description desc("Allowed options");
     desc.add_options()
       ("help,h", "produce help message.")

--- a/Jet_fitting_3/examples/Jet_fitting_3/Mesh_estimation.cpp
+++ b/Jet_fitting_3/examples/Jet_fitting_3/Mesh_estimation.cpp
@@ -6,7 +6,7 @@
 
 #include <CGAL/property_map.h>
 
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -117,7 +117,7 @@ void gather_fitting_points(Vertex* v,
 }
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 int main(int argc, char *argv[])
 #else
 int main()
@@ -131,7 +131,7 @@ int main()
   std::ofstream out_4ogl, out_verbose;
 
   try {
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
     po::options_description desc("Allowed options");
     desc.add_options()
       ("help,h", "produce help message.")

--- a/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
+++ b/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
@@ -12,7 +12,7 @@
 
 
 
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -179,7 +179,7 @@ void compute_differential_quantities(PolyhedralSurf& P, Poly_rings& poly_rings)
 
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 int main(int argc, char *argv[])
 #else
 int main()
@@ -188,7 +188,7 @@ int main()
   std::string if_name, of_name;// of_name same as if_name with '/' -> '_'
 
   try {
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
    unsigned int int_tag;
    po::options_description desc("Allowed options");
     desc.add_options()

--- a/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
+++ b/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
@@ -12,7 +12,7 @@
 
 
 
-##if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif

--- a/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
+++ b/Ridges_3/examples/Ridges_3/Compute_Ridges_Umbilics.cpp
@@ -12,7 +12,7 @@
 
 
 
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+##if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -179,7 +179,7 @@ void compute_differential_quantities(PolyhedralSurf& P, Poly_rings& poly_rings)
 
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 int main(int argc, char *argv[])
 #else
 int main()
@@ -188,7 +188,7 @@ int main()
   std::string if_name, of_name;// of_name same as if_name with '/' -> '_'
 
   try {
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
    unsigned int int_tag;
    po::options_description desc("Allowed options");
     desc.add_options()

--- a/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
+++ b/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 #include <cassert>
 
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -168,7 +168,7 @@ void compute_differential_quantities(PolyhedralSurf& P, Poly_rings& poly_rings)
 
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 int main(int argc, char *argv[])
 #else
 int main()
@@ -177,7 +177,7 @@ int main()
   std::string if_name, of_name;// of_name same as if_name with '/' -> '_'
 
   try {
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
    unsigned int int_tag;
    po::options_description desc("Allowed options");
     desc.add_options()

--- a/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
+++ b/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 #include <cassert>
 
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 #endif
@@ -168,7 +168,7 @@ void compute_differential_quantities(PolyhedralSurf& P, Poly_rings& poly_rings)
 
 
 ///////////////MAIN///////////////////////////////////////////////////////
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 int main(int argc, char *argv[])
 #else
 int main()
@@ -177,7 +177,7 @@ int main()
   std::string if_name, of_name;// of_name same as if_name with '/' -> '_'
 
   try {
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
    unsigned int int_tag;
    po::options_description desc("Allowed options");
     desc.add_options()

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/polyhedron_ex_parameterization.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/polyhedron_ex_parameterization.cpp
@@ -46,7 +46,7 @@
 #include <fstream>
 #include <cassert>
 
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
     #include <boost/program_options.hpp>
     namespace po = boost::program_options;
 #endif
@@ -283,7 +283,7 @@ parameterize(ParameterizationMesh_3& mesh,  // Mesh parameterization adaptor
 // main()
 // ----------------------------------------------------------------------------
 
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
 int main(int argc, char * argv[])
 #else
 int main()
@@ -305,7 +305,7 @@ int main()
     std::string output;             // default: out.eps
     try
     {
-#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
         po::options_description desc("Allowed options");
         desc.add_options()
             ("help,h", "prints this help message")

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/polyhedron_ex_parameterization.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/polyhedron_ex_parameterization.cpp
@@ -46,7 +46,7 @@
 #include <fstream>
 #include <cassert>
 
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
     #include <boost/program_options.hpp>
     namespace po = boost::program_options;
 #endif
@@ -283,7 +283,7 @@ parameterize(ParameterizationMesh_3& mesh,  // Mesh parameterization adaptor
 // main()
 // ----------------------------------------------------------------------------
 
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
 int main(int argc, char * argv[])
 #else
 int main()
@@ -305,7 +305,7 @@ int main()
     std::string output;             // default: out.eps
     try
     {
-#ifdef CGAL_USE_BOOST_PROGRAM_OPTIONS
+#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS
         po::options_description desc("Allowed options");
         desc.add_options()
             ("help,h", "prints this help message")

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -1,5 +1,9 @@
-#include <iomanip>
+#include <CGAL/config.h>
 #include <iostream>
+
+#if defined(CGAL_USE_BOOST_PROGRAM_OPTIONS) && ! defined(DONT_USE_BOOST_PROGRAM_OPTIONS)
+
+#include <iomanip>
 #include <fstream>
 #include <utility>
 #include <cstdlib>
@@ -348,3 +352,12 @@ int main(int argc, char** argv)
 
   return 0;
 }
+
+
+#else 
+ int main()
+ {
+   std::cout << "TestMesh.cpp needs Boost Program Options" << std::endl;
+   return 0;
+ }
+#endif


### PR DESCRIPTION
with `#ifndef DONT_USE_BOOST_PROGRAM_OPTIONS` 

This allows us to not use boost even if it is available in a testsuite (but broken as boost was not compiled as expected)