### PR TITLE
Write to an ofstream and not to std::cout 

### DIFF
--- a/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
+++ b/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
@@ -80,8 +80,8 @@ run()
       DATANAME=`basename $DATAFILE`
       OUTPUTFILE=ProgramOutput.$1.$DATANAME.$PLATFORM
       rm -f $OUTPUTFILE
-      COMMAND="./$1 $DATAFILE > ${data_dir}/out"
-      echo "Executing ./$1 $DATAFILE > ${data_dir}/out"
+      COMMAND="./$1 $DATAFILE  ${data_dir}/out"
+      echo "Executing ./$1 $DATAFILE  ${data_dir}/out"
       echo
       if eval 2>&1 $COMMAND > $OUTPUTFILE ; then
 	echo "   execution of $1 ${data_dir}/$DATATFILE > ${data_dir}/out succeeded" >> $ERRORFILE

--- a/Snap_rounding_2/test/Snap_rounding_2/test_snap_rounding_2.cpp
+++ b/Snap_rounding_2/test/Snap_rounding_2/test_snap_rounding_2.cpp
@@ -16,8 +16,8 @@ typedef std::list<Point_list>                   Point_list_list;
 
 bool read_data(int argc, char *argv[], Number_Type &prec, Seg_list &seg_list)
 {
-  if (argc != 2) {
-    std::cerr << "syntex: test <input file name>\n";
+  if (argc != 3) {
+    std::cerr << "syntex: test <input file name> <output file name>\n";
     return false;
   }
 
@@ -50,19 +50,20 @@ bool read_data(int argc, char *argv[], Number_Type &prec, Seg_list &seg_list)
   return true;
 }
 
-void print_out(Point_list_list::iterator begin_iter,
+void print_out(std::ostream& out,
+               Point_list_list::iterator begin_iter,
                Point_list_list::iterator end_iter)
 {
   int counter = 0;
   std::list<std::list<Point_2> >::iterator i;
   for(i = begin_iter; i != end_iter; ++i) {
-    std::cout << "Polyline number " << ++counter << ":\n";
+    out << "Polyline number " << ++counter << ":\n";
     std::list<Point_2>::iterator i2;
     for (i2 = i->begin(); i2 != i->end(); ++i2)
-      std::cout << "    (" << CGAL::to_double(i2->x()) << ":"
-                << CGAL::to_double(i2->y()) << ")\n";
+      out << "    (" << CGAL::to_double(i2->x()) << ":"
+          << CGAL::to_double(i2->y()) << ")\n";
 
-    std::cout << std::endl;
+    out << std::endl;
   }
 }
 
@@ -75,6 +76,7 @@ int main(int argc,char *argv[])
 
   if (!read_data(argc,argv,prec,seg_list))
     return -1;
+  std::ofstream out(argv[2]);
 
   CGAL::snap_rounding_2<Sr_traits, Seg_list::const_iterator,
                         Point_list_list>(seg_list.begin(),
@@ -82,22 +84,22 @@ int main(int argc,char *argv[])
                                          output_list,
                                          prec, true, false, 3);
 
-  std::cout << "input segments" << std::endl;
+  out << "input segments" << std::endl;
   std::list<Segment_2>::iterator i1;
   for (i1 = seg_list.begin(); i1 != seg_list.end(); ++i1)
-    std::cout << *i1 << std::endl;
+    out << *i1 << std::endl;
 
-  std::cout << std::endl << "the output" << std::endl;
-  print_out(output_list.begin(),output_list.end());
+  out << std::endl << "the output" << std::endl;
+  print_out(out, output_list.begin(),output_list.end());
 
-  std::cout << std::endl << "testing sr" << std::endl;
+  out << std::endl << "testing sr" << std::endl;
   output_list.clear();
   CGAL::snap_rounding_2<Sr_traits, Seg_list::const_iterator,
                         Point_list_list>(seg_list.begin(),
                                          seg_list.end(),
                                          output_list,
                                          prec, false, false, 3);
-   print_out(output_list.begin(),output_list.end());
+  print_out(out, output_list.begin(),output_list.end());
 
-   return(0);
+  return(0);
 }


### PR DESCRIPTION
The testscript compares the generated output with an expected output.
As VLD writes there too we write directly into the file instead of redirecting from std::cout to the file in the script.