### PR TITLE
Use boost::math::float_next() to compute ulp

### DIFF
--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filter_error.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filter_error.h
@@ -37,6 +37,8 @@
 #include <CGAL/basic.h>
 #include <CGAL/FPU.h>
 
+#include <boost/math/special_functions/next.hpp>
+
 namespace CGAL { namespace internal {
 
 struct Static_filter_error
@@ -66,15 +68,8 @@ struct Static_filter_error
       d = CGAL_IA_FORCE_TO_DOUBLE(d); // stop constant propagation.
       CGAL_assertion(d>=0);
       double u;
-      if (d == 1) // I need to special case to prevent infinite recursion.
-          u = (d + CGAL_IA_MIN_DOUBLE) - d;
-      else {
-          // We need to use the d*ulp formula, in order for the formal proof
-          // of homogeneisation to work.
-          // u = (d + CGAL_IA_MIN_DOUBLE) - d;
-          u = d * ulp();
-      }
-
+      double nd = boost::math::float_next(d);
+      u = nd - d;
       // Then add extra bonus, because of Intel's extended precision feature.
       // (ulp can be 2^-53 + 2^-64)
       u += u / (1<<11);


### PR DESCRIPTION
The clang testsuite on OSX has an assertion with our self written  ` ulp()`  function. Let's see if boost does it better.