### PR TITLE
CMap make null_handle const

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -100,8 +100,8 @@ namespace CGAL {
     static const unsigned int dimension = Base::dimension;
 
     typedef typename Base::Null_handle_type Null_handle_type;
-    static Null_handle_type null_handle;
 
+    using Base::null_handle;
     using Base::null_dart_handle;
     using Base::mdarts;
     using Base::get_beta;
@@ -3759,13 +3759,6 @@ namespace CGAL {
     typename Helper::Split_functors m_onsplit_functors;
     typename Helper::Merge_functors m_onmerge_functors;
   };
-
-  template < unsigned int d_, class Refs, class Items_, class Alloc_,
-             class Storage_ >
-  typename Combinatorial_map_base<d_,Refs,Items_,Alloc_,Storage_>::
-     Base::Null_handle_type
-     Combinatorial_map_base<d_,Refs,Items_,Alloc_,Storage_>::null_handle =
-     Combinatorial_map_base<d_,Refs,Items_,Alloc_,Storage_>::Base::null_handle;
 
   template < unsigned int d_,
              class Items_=Combinatorial_map_min_items<d_>,

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -59,7 +59,7 @@ namespace CGAL {
     typedef typename Dart_container::size_type      size_type;
 
     typedef CGAL::Void* Null_handle_type;
-    static Null_handle_type null_handle;
+    static const Null_handle_type null_handle;
 
     typedef Items_ Items;
     typedef Alloc_ Alloc;
@@ -384,7 +384,7 @@ namespace CGAL {
 
   /// null_handle
   template < unsigned int d_, class Items_, class Alloc_ >
-  typename Combinatorial_map_storage_1<d_, Items_, Alloc_>::Null_handle_type
+  const typename Combinatorial_map_storage_1<d_, Items_, Alloc_>::Null_handle_type
   Combinatorial_map_storage_1<d_, Items_, Alloc_>::null_handle = NULL;
 
 #ifdef CGAL_CMAP_DEPRECATED


### PR DESCRIPTION
Make the (internal and undocumented) variable null_handle const.

It is a bug fix (because the fact that this variable was non cost was a bug).

Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-113.shtml.