### PR TITLE
Suppress warning in Combinatorial  Map for g++ >= 5

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -24,6 +24,12 @@
 
 #include <CGAL/Compact_container.h>
 
+#include <boost/config.hpp>
+#if  (BOOST_GCC >= 40800)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+#endif
+
 namespace CGAL {
 
   /** @file Combinatorial_map_storages.h
@@ -405,5 +411,9 @@ namespace CGAL {
 
 } // namespace CGAL
 
+
+#if  (BOOST_GCC >= 40800)
+ _Pragma("GCC diagnostic pop")
+#endif
 #endif // CGAL_COMBINATORIAL_MAP_H //
 // EOF //

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -412,7 +412,7 @@ namespace CGAL {
 } // namespace CGAL
 
 
-#if  (BOOST_GCC >= 40800)
+#if  (BOOST_GCC >= 50000)
  _Pragma("GCC diagnostic pop")
 #endif
 #endif // CGAL_COMBINATORIAL_MAP_H //

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -25,7 +25,7 @@
 #include <CGAL/Compact_container.h>
 
 #include <boost/config.hpp>
-#if  (BOOST_GCC >= 40800)
+#if  (BOOST_GCC >= 50000)
 _Pragma("GCC diagnostic push")
 _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
 #endif

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
@@ -22,6 +22,12 @@
 
 #include <CGAL/Combinatorial_map_storages.h>
 
+#include <boost/config.hpp>
+#if  (BOOST_GCC >= 50000)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+#endif
+
 namespace CGAL {
 
   /** @file Linear_cell_complex_storages.h
@@ -437,5 +443,8 @@ namespace CGAL {
 
 } // namespace CGAL
 
+#if  (BOOST_GCC >= 40800)
+ _Pragma("GCC diagnostic pop")
+#endif
 #endif // CGAL_LINEAR_CELL_COMPLEX_STORAGES_H //
 // EOF //

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
@@ -443,7 +443,7 @@ namespace CGAL {
 
 } // namespace CGAL
 
-#if  (BOOST_GCC >= 40800)
+#if  (BOOST_GCC >= 50000)
  _Pragma("GCC diagnostic pop")
 #endif
 #endif // CGAL_LINEAR_CELL_COMPLEX_STORAGES_H //


### PR DESCRIPTION
Fixing [these warnings](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-113/Combinatorial_map/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz)