### PR TITLE
Jet fitting 3: fix incomplete assertion

### DIFF
--- a/Jet_fitting_3/test/Jet_fitting_3/blind_1pt.cpp
+++ b/Jet_fitting_3/test/Jet_fitting_3/blind_1pt.cpp
@@ -68,7 +68,7 @@ int main()
   assert(almost_equal(monge_form.coefficients()[0], -0.2, precision)
          || almost_equal(monge_form.coefficients()[0], 0.4, precision));
   assert(almost_equal(monge_form.coefficients()[1], -0.4, precision)
-         || almost_equal(monge_form.coefficients()[0], 0.2, precision));
+         || almost_equal(monge_form.coefficients()[1], 0.2, precision));
   std::cout << "success\n";
  return 0;
 }

--- a/Jet_fitting_3/test/Jet_fitting_3/blind_1pt.cpp
+++ b/Jet_fitting_3/test/Jet_fitting_3/blind_1pt.cpp
@@ -10,6 +10,12 @@ typedef Data_Kernel::Point_3     DPoint;
 typedef CGAL::Monge_via_jet_fitting<Data_Kernel> My_Monge_via_jet_fitting;
 typedef My_Monge_via_jet_fitting::Monge_form     My_Monge_form;
 
+template <typename T>
+bool almost_equal (const T& a, const T& b, const T& precision)
+{
+  return a <= b + precision && a >= b - precision;
+}
+
 int main()
 {
   //open the input file
@@ -59,10 +65,10 @@ int main()
  
   monge_form.dump_4ogl( std::cout, 1 );
   double precision = 0.01;
-  assert(monge_form.coefficients()[0] >= -0.2 - precision);
-  assert(monge_form.coefficients()[0] <= -0.2 + precision);
-  assert(monge_form.coefficients()[1] >= -0.4 - precision);
-  assert(monge_form.coefficients()[1] <= -0.4 + precision);
+  assert(almost_equal(monge_form.coefficients()[0], -0.2, precision)
+         || almost_equal(monge_form.coefficients()[0], 0.4, precision));
+  assert(almost_equal(monge_form.coefficients()[1], -0.4, precision)
+         || almost_equal(monge_form.coefficients()[0], 0.2, precision));
   std::cout << "success\n";
  return 0;
 }


### PR DESCRIPTION
The assertion in the test `blind_1pt` is incomplete: the coefficients are computed based on a PCA with 2 equal lower eigenvalues (leading to several possible solutions for eigenvectors). Because one case only was asserted, this lead to invalid assertion in the 32bit distributions:
* [CentOS6-32](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Jet_fitting_3/TestReport_lrineau_CentOS6-32.gz)
* [Fedora-32-Release](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Jet_fitting_3/TestReport_lrineau_Fedora-32-Release.gz)
* [Fedora-32](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Jet_fitting_3/TestReport_lrineau_Fedora-32.gz)

This PR completes the assertions (and also makes them more easily readable).

Merged in [4.8-Ic-116](https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-116.shtml).