### PR TITLE
Fix boost warning (unused typedef)

### DIFF
--- a/BGL/include/CGAL/boost/graph/Graph_geometry.h
+++ b/BGL/include/CGAL/boost/graph/Graph_geometry.h
@@ -199,7 +199,7 @@ triangle(const HalfedgeGraph& g,
          typename boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h,
          const PositionMap& pm)
 {
-  BOOST_CONCEPT_ASSERT((HalfedgeGraphConcept<HalfedgeGraph>));
+  BOOST_CONCEPT_ASSERT((HalfedgeGraphConcept<HalfedgeGraph>)) CGAL_UNUSED;
 
   typedef typename boost::graph_traits<HalfedgeGraph>::vertex_descriptor vertex_descriptor;
   

--- a/BGL/include/CGAL/boost/graph/graph_concepts.h
+++ b/BGL/include/CGAL/boost/graph/graph_concepts.h
@@ -33,9 +33,9 @@ BOOST_concept(HalfedgeGraph,(G))
 
   BOOST_CONCEPT_USAGE(HalfedgeGraph)
   {
-    BOOST_CONCEPT_ASSERT((boost::DefaultConstructible<halfedge_descriptor>));
-    BOOST_CONCEPT_ASSERT((boost::EqualityComparable<halfedge_descriptor>));
-    BOOST_CONCEPT_ASSERT((boost::Assignable<halfedge_descriptor>));
+    BOOST_CONCEPT_ASSERT((boost::DefaultConstructible<halfedge_descriptor>)) CGAL_UNUSED;
+    BOOST_CONCEPT_ASSERT((boost::EqualityComparable<halfedge_descriptor>)) CGAL_UNUSED;
+    BOOST_CONCEPT_ASSERT((boost::Assignable<halfedge_descriptor>)) CGAL_UNUSED;
 
 
     e = edge(h, g);
@@ -105,9 +105,9 @@ BOOST_concept(FaceGraph,(G))
 
   BOOST_CONCEPT_USAGE(FaceGraph)
   {
-    BOOST_CONCEPT_ASSERT((boost::DefaultConstructible<face_descriptor>));
-    BOOST_CONCEPT_ASSERT((boost::EqualityComparable<face_descriptor>));
-    BOOST_CONCEPT_ASSERT((boost::Assignable<face_descriptor>));
+    BOOST_CONCEPT_ASSERT((boost::DefaultConstructible<face_descriptor>)) CGAL_UNUSED;
+    BOOST_CONCEPT_ASSERT((boost::EqualityComparable<face_descriptor>)) CGAL_UNUSED;
+    BOOST_CONCEPT_ASSERT((boost::Assignable<face_descriptor>)) CGAL_UNUSED;
 
     f = face(h, g);
     h = halfedge(f, g);

--- a/BGL/test/BGL/test_circulator.cpp
+++ b/BGL/test/BGL/test_circulator.cpp
@@ -43,13 +43,13 @@ int main(int, char* argv[])
 
   BOOST_CONCEPT_ASSERT((CGAL::Concepts::BidirectionalCirculator<halfedge_around_source_circulator>)) CGAL_UNUSED;
 
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<face_around_face_iterator>));
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<halfedge_around_face_iterator>));
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<halfedge_around_target_iterator>));
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<vertex_around_target_iterator>));
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<face_around_face_iterator>)) CGAL_UNUSED;
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<halfedge_around_face_iterator>)) CGAL_UNUSED;
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<halfedge_around_target_iterator>)) CGAL_UNUSED;
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<vertex_around_target_iterator>)) CGAL_UNUSED;
 
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<in_edge_iterator>));
-   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<out_edge_iterator>));
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<in_edge_iterator>)) CGAL_UNUSED;
+   BOOST_CONCEPT_ASSERT((boost::BidirectionalIterator<out_edge_iterator>)) CGAL_UNUSED;
 
   std::ifstream in(argv[1]);
   Polyhedron P;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Hyperplane_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Hyperplane_d.h
@@ -21,7 +21,7 @@
 #define CGAL_WRAPPER_HYPERPLANE_D_H
 
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -44,7 +44,7 @@ class Hyperplane_d : public Get_type<typename R_::Kernel_base, Hyperplane_tag>::
   typedef typename Get_functor<Kbase, Hyperplane_translation_tag>::type			HTBase;
 
   typedef Hyperplane_d                            Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Hyperplane_tag>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Hyperplane_tag>::type>::value));
 
 public:
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
@@ -24,7 +24,7 @@
 #include <CGAL/Origin.h>
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -51,7 +51,7 @@ class Point_d : public Get_type<typename R_::Kernel_base, Point_tag>::type
 
 
   typedef Point_d                            Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Point_tag>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Point_tag>::type>::value));
 
 public:
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Ref_count_obj.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Ref_count_obj.h
@@ -24,7 +24,7 @@
 #include <CGAL/Handle_for.h>
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -45,7 +45,7 @@ class Ref_count_obj
   typedef typename Get_functor<Kbase, Construct_ttag<Tag_> >::type CBase;
 
   typedef Ref_count_obj			Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Tag_>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Tag_>::type>::value));
 
 public:
   typedef R_ R;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Segment_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Segment_d.h
@@ -23,7 +23,7 @@
 #include <CGAL/Origin.h>
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -47,7 +47,7 @@ class Segment_d : public Get_type<typename R_::Kernel_base, Segment_tag>::type
   typedef typename Get_functor<Kbase, Segment_extremity_tag>::type CSEBase;
 
   typedef Segment_d                            Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Segment_tag>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Segment_tag>::type>::value));
 
 public:
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Sphere_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Sphere_d.h
@@ -21,7 +21,7 @@
 #define CGAL_WRAPPER_SPHERE_D_H
 
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -44,7 +44,7 @@ class Sphere_d : public Get_type<typename R_::Kernel_base, Sphere_tag>::type
   typedef typename Get_functor<Kbase, Squared_radius_tag>::type			SRBase;
 
   typedef Sphere_d                            Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Sphere_tag>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Sphere_tag>::type>::value));
 
 public:
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Vector_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Vector_d.h
@@ -23,7 +23,7 @@
 #include <CGAL/Origin.h>
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/representation_tags.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits.hpp>
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
@@ -48,7 +48,7 @@ class Vector_d : public Get_type<typename R_::Kernel_base, Vector_tag>::type
   typedef typename Get_functor<Kbase, Squared_length_tag>::type SLBase;
 
   typedef Vector_d                            Self;
-  BOOST_STATIC_ASSERT((boost::is_same<Self, typename Get_type<R_, Vector_tag>::type>::value));
+  CGAL_static_assertion((boost::is_same<Self, typename Get_type<R_, Vector_tag>::type>::value));
 
 public:
 

--- a/NewKernel_d/include/CGAL/transforming_pair_iterator.h
+++ b/NewKernel_d/include/CGAL/transforming_pair_iterator.h
@@ -23,8 +23,9 @@
 // but boost's iterator_category games are a pain.
 
 #include <CGAL/transforming_iterator.h>
+#include <CGAL/assertions.h>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/static_assert.hpp>
+
 
 
 
@@ -32,7 +33,7 @@ namespace CGAL {
 namespace internal {
 template <class Cat1, class Cat2, bool=boost::is_convertible<Cat1,Cat2>::value>
 struct Min_category {
-	BOOST_STATIC_ASSERT((boost::is_convertible<Cat2,Cat1>::value));
+	CGAL_static_assertion((boost::is_convertible<Cat2,Cat1>::value));
 	typedef Cat1 type;
 };
 

--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -75,29 +75,10 @@
 #include <builtins.h>
 #endif
 
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/version.hpp>
-
-// Standard way to deal with clang's __has_warning
-// http://clang.llvm.org/docs/LanguageExtensions.html#feature-checking-macros
-#ifndef __has_warning
-#  define __has_warning(x) 0
-#endif
-
-// If Clang has the warning -Wunused-local-typedef, then disable it temporarily.
-#if BOOST_WORKAROUND(BOOST_VERSION, BOOST_TESTED_AT(105800)) && BOOST_CLANG && __has_warning("-Wunused-local-typedef")
-#  define CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF \
-    _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wunused-local-typedef\"")
-#  define CGAL_CLANG_POP_DIAGNOSTIC _Pragma("clang diagnostic pop")
-#else
-#  define CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
-#  define CGAL_CLANG_POP_DIAGNOSTIC
-#endif
-
-CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
 
 #if defined(BOOST_MSVC)
 #  pragma warning(push)
@@ -173,7 +154,7 @@ template <class T, class = void> struct pool2 {
   static bool empty() { return data() == 0; }
   static const int extra = 1; // TODO: handle the case where a pointer is larger than a mp_limb_t
   private:
-  BOOST_STATIC_ASSERT(sizeof(T) >= sizeof(T*));
+  CGAL_static_assertion(sizeof(T) >= sizeof(T*));
   static T& data () {
     static CGAL_MPZF_TLS T data_ = 0;
     return data_;
@@ -188,7 +169,7 @@ template <class T, class = void> struct pool3 {
   static bool empty() { return data() == 0; }
   static const int extra = 1; // TODO: handle the case where a pointer is larger than a mp_limb_t
   private:
-  BOOST_STATIC_ASSERT(sizeof(T) >= sizeof(T*));
+  CGAL_static_assertion(sizeof(T) >= sizeof(T*));
   struct cleaner {
     T data_ = 0;
     ~cleaner(){
@@ -437,7 +418,7 @@ struct Mpzf {
     }
     int e1 = (int)dexp+13;
     // FIXME: make it more general! But not slower...
-    BOOST_STATIC_ASSERT(GMP_NUMB_BITS == 64);
+    CGAL_static_assertion(GMP_NUMB_BITS == 64);
     int e2 = e1 % 64;
     exp = e1 / 64 - 17;
     // 52+1023+13==17*64 ?
@@ -1175,11 +1156,6 @@ namespace Eigen {
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)
 #endif
-
-CGAL_CLANG_POP_DIAGNOSTIC
-
-#undef CGAL_CLANG_PUSH_AND_IGNORE_UNUSED_LOCAL_TYPEDEF
-#undef CGAL_CLANG_POP_DIAGNOSTIC
 
 #endif // GMP_NUMB_BITS == 64
 #endif // CGAL_MPZF_H

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -123,15 +123,13 @@ namespace internal {
       //if no solver is provided and Eigen version < 3.2
 #endif
 
-    typedef typename GetSolver<NamedParameters, Default_solver>::type SparseLinearSolver;
-
 #if defined(CGAL_EIGEN3_ENABLED)
-    BOOST_STATIC_ASSERT_MSG(
-      (!boost::is_same<SparseLinearSolver, bool>::value) || EIGEN_VERSION_AT_LEAST(3, 2, 0),
+    CGAL_static_assertion_msg(
+      (!boost::is_same<typename GetSolver<NamedParameters, Default_solver>::type, bool>::value) || EIGEN_VERSION_AT_LEAST(3, 2, 0),
       "The function `fair` requires Eigen3 version 3.2 or later.");
 #else
-    BOOST_STATIC_ASSERT_MSG(
-      (!boost::is_same<SparseLinearSolver, bool>::value),
+    CGAL_static_assertion_msg(
+      (!boost::is_same<typename GetSolver<NamedParameters, Default_solver>::type, bool>::value),
       "The function `fair` requires Eigen3 version 3.2 or later.");
 #endif
 

--- a/STL_Extension/test/STL_Extension/test_stl_extension.cpp
+++ b/STL_Extension/test/STL_Extension/test_stl_extension.cpp
@@ -47,7 +47,7 @@
 #include <CGAL/Circulator/Circulator_adapters.h>
 #include <CGAL/function_objects.h>
 #include <CGAL/tuple.h>
-#include <boost/static_assert.hpp>
+#include <CGAL/assertions.h>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/typeof/typeof.hpp>
 
@@ -8205,15 +8205,15 @@ void test_make_sorted_pair() {
   assert(p3==p4);
   int i=2;
   assert( CGAL::make_sorted_pair(1,i) == std::make_pair(1,i) );
-  BOOST_STATIC_ASSERT( (boost::is_same<
+  CGAL_static_assertion( (boost::is_same<
                           BOOST_TYPEOF(CGAL::make_sorted_pair<long>(1L,i)),
                           std::pair<long,long> >::value) );
   assert( (CGAL::make_sorted_pair<long>(i,1L) == std::pair<long,long>(1L,2L)) );
 
-  BOOST_STATIC_ASSERT( (boost::is_same<
+  CGAL_static_assertion( (boost::is_same<
                           BOOST_TYPEOF(CGAL::make_sorted_pair<double>(1,2L)),
                           std::pair<double,double> >::value) );
-  BOOST_STATIC_ASSERT( (boost::is_same<
+  CGAL_static_assertion( (boost::is_same<
                           BOOST_TYPEOF(CGAL::make_sorted_pair<int>(1,2L)),
                           std::pair<int,int> >::value) );
 }

--- a/Spatial_searching/include/CGAL/Search_traits_adapter.h
+++ b/Spatial_searching/include/CGAL/Search_traits_adapter.h
@@ -24,9 +24,9 @@
 #include <CGAL/Kd_tree_rectangle.h>
 #include <CGAL/Euclidean_distance.h> //for default distance specialization
 #include <CGAL/property_map.h>
+#include <CGAL/assertions.h>
 
 #include <boost/mpl/has_xxx.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace CGAL{
@@ -72,7 +72,7 @@ template <class Point_with_info,class PointPropertyMap,class Base_traits>
 class Search_traits_adapter : public Base_traits{
   PointPropertyMap ppmap;
 
-  BOOST_STATIC_ASSERT( ( boost::is_same< boost::lvalue_property_map_tag,
+  CGAL_static_assertion( ( boost::is_same< boost::lvalue_property_map_tag,
                            typename boost::property_traits<PointPropertyMap>::category
                          >::value ) );
 public:
@@ -130,7 +130,7 @@ class Distance_adapter : public Base_distance {
   PointPropertyMap ppmap;
   typedef typename Base_distance::FT FT;
 
-  BOOST_STATIC_ASSERT( ( boost::is_same< boost::lvalue_property_map_tag,
+  CGAL_static_assertion( ( boost::is_same< boost::lvalue_property_map_tag,
                            typename boost::property_traits<PointPropertyMap>::category
                          >::value ) );
 public:


### PR DESCRIPTION
Using `BOOST_STATIC_ASSERT` and `BOOST_CONCEPT_ASSERT` generates warning about unused typedef in many packages and platforms in the testsuite (example on [Point set processing](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Point_set_processing_3/TestReport_cgaltester_x86-64_Darwin-13.0_Apple-clang-5.0_Release-cpp11.gz)).

One way to remove this warning is to append `__attribute__((unused))` after the assertion (as described [here](https://svn.boost.org/trac/boost/ticket/7242)). That was actually already included in CGAL with the macro `CGAL_UNUSED` (which is called when using `CGAL_static_assertion` instead of `BOOST_STATIC_ASSERT`). `BOOST_STATIC_ASSERT` shouldn't be used directly in CGAL code.

This PR replaces `BOOST_STATIC_ASSERT` by `CGAL_static_assertion` everywhere and adds `CGAL_UNUSED` after `BOOST_CONCEPT_ASSERT` everywhere it is used.

_(Note: if this macro is to be used more frequently, it might be a good idea to similarly create a `CGAL_concept_assertion` macro that encapsulates the Boost assertion with correct preprocessing tests, `CGAL_UNUSED`, etc.)_