### PR TITLE
Produce a smaller output to allow the VC++ testsuite to finish

### DIFF
--- a/Point_set_processing_3/test/Point_set_processing_3/edge_aware_upsample_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/edge_aware_upsample_test.cpp
@@ -106,7 +106,7 @@ int main(int argc, char * argv[])
   const double sharpness_sigma = 25;   //control sharpness of the result.
   const double edge_sensitivity = 0;    // more points will up-sample on edge.
   const double neighbor_radius = 0.2;      // initial neighbors size.
-  const unsigned int times_of_output_points = 40;
+  const unsigned int times_of_output_points = 4;
 
   // Accumulated errors
   int accumulated_fatal_err = EXIT_SUCCESS;


### PR DESCRIPTION

It is slow, because it uses ITERATOR_DEBUGGING, and because it is rather slow