### PR TITLE
initialize to avoid a warning

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -159,7 +159,7 @@ private:
     Vertex_handle v1 = arete.first;
     Vertex_handle v2 = arete.second;
     Cell_handle c;
-    int index1, index2;
+    int index1=0, index2=0; // initialize to avoid g++ 4.8 -Wmaybe-uninitialized
 
     CGAL_assume_code(bool is_edge =)
     this->r_tr_.is_edge(v1, v2, c, index1, index2);


### PR DESCRIPTION
The compiler does not realize that the edge exists.
CGAL_assume does not help so let's initialize the variables.
I can't reproduce the error with g++ 4.9.3

This should fix this [test](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-116/Mesh_3/TestReport_lrineau_CentOS7-Release.gz)
