### PR TITLE
Fix for 539

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -17,6 +17,17 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 OLD)
 endif()
 
+#Defines flags to emulate windows behavior for warning generation
+if(CMAKE_CXX_COMPILER_ID EQUAL Clang OR CMAKE_COMPILER_IS_GNUCC  OR CMAKE_COMPILER_IS_GNUCXX)
+  if(UNIX OR APPLE)
+    SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fvisibility=hidden" )
+  endif()
+  if(UNIX AND NOT APPLE)
+    SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -z defs")
+    SET( CMAKE_MODULE_LINKER_FLAGS  "${CMAKE_MODULE_LINKER_FLAGS} -z defs")
+    SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -z defs")
+  endif()
+endif()
 # Let plugins be compiled in the same directory as the executable.
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -17,7 +17,7 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 OLD)
 endif()
 
-#Defines flags to emulate windows behavior for warning generation
+#Defines flags to emulate windows behavior for linking error generation
 if(CMAKE_CXX_COMPILER_ID EQUAL Clang OR CMAKE_COMPILER_IS_GNUCC  OR CMAKE_COMPILER_IS_GNUCXX)
   if(UNIX OR APPLE)
     SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fvisibility=hidden" )


### PR DESCRIPTION
This is a fix for #539 
- Adds the requested flags from the CMakeLists only if the compiler is CLang or gcc.