### PR TITLE
Fix for gcc 4.4 with the option -std=c++0x

### DIFF
--- a/STL_Extension/include/CGAL/tuple.h
+++ b/STL_Extension/include/CGAL/tuple.h
@@ -32,6 +32,10 @@
   #if defined( _LIBCPP_VERSION ) // check if libc++ is used
     #define CGAL_CFG_NO_CPP0X_TUPLE
   #endif
+  #if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ <= 4)
+    #define CGAL_CFG_NO_CPP0X_TUPLE
+    #define CGAL_CFG_NO_CPP0X_VARIADIC_TEMPLATES
+  #endif
 #endif
 
 #ifndef CGAL_CFG_NO_CPP0X_TUPLE


### PR DESCRIPTION
Workaround for this [testcase](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-116/Voronoi_diagram_2_Examples/TestReport_lrineau_CentOS6-CXX11-Boost157.gz)
