### PR TITLE
Surface mesh shortest path: fix for boost get bug

### DIFF
--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -914,7 +914,7 @@ private:
     {
       LineLineIntersectResult cgalIntersection = i2(cl2(segment), cl2(leftBoundary));
 
-      if (!cgalIntersection || !boost::get<Point_2, Point_2, Line_2>(&*cgalIntersection))
+      if (!cgalIntersection || !boost::get<Point_2>(&*cgalIntersection))
       {
         if (m_debugOutput)
         {
@@ -924,7 +924,7 @@ private:
       }
       else
       {
-        Point_2* result = boost::get<Point_2, Point_2, Line_2>(&*cgalIntersection);
+        Point_2* result = boost::get<Point_2>(&*cgalIntersection);
         FT t0 = pdas2(cs2(segment), ct2(segment), *result);
 
         if (t0 >= FT(1.00000))
@@ -974,7 +974,7 @@ private:
     {
       LineLineIntersectResult cgalIntersection = i2(cl2(segment), cl2(rightBoundary));
 
-      if (!cgalIntersection || !boost::get<Point_2, Point_2, Line_2>(&*cgalIntersection))
+      if (!cgalIntersection || !boost::get<Point_2>(&*cgalIntersection))
       {
         if (m_debugOutput)
         {
@@ -984,7 +984,7 @@ private:
       }
       else
       {
-        Point_2* result = boost::get<Point_2, Point_2, Line_2>(&*cgalIntersection);
+        Point_2* result = boost::get<Point_2>(&*cgalIntersection);
         FT t0 = pdas2(cs2(segment), ct2(segment), *result);
 
         if (t0 <= FT(0.00000))
@@ -1570,7 +1570,7 @@ private:
 
           CGAL_assertion(bool(cgalIntersection));
 
-          Point_2* result = boost::get<Point_2, Point_2, Line_2>(&*cgalIntersection);
+          Point_2* result = boost::get<Point_2>(&*cgalIntersection);
 
           CGAL_assertion(result && "Error, did not get point intersection on path walk to source");
 

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/function_objects.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/function_objects.h
@@ -457,7 +457,7 @@ public:
     CGAL_assertion(bool(intersectResult1));
     if (!intersectResult1) return CGAL::SMALLER;
 
-    const Point_2* p1_ptr = boost::get<Point_2, Point_2, Line_2>(&*intersectResult1);
+    const Point_2* p1_ptr = boost::get<Point_2>(&*intersectResult1);
 
     CGAL_assertion(p1_ptr && "Intersection should have been a point");
     if (!p1_ptr) return CGAL::SMALLER;
@@ -469,7 +469,7 @@ public:
     CGAL_assertion(bool(intersectResult2));
     if (!intersectResult2) return CGAL::SMALLER;
 
-    const Point_2* p2_ptr = boost::get<Point_2, Point_2, Line_2>(&*intersectResult2);
+    const Point_2* p2_ptr = boost::get<Point_2>(&*intersectResult2);
 
     CGAL_assertion(p2_ptr && "Intersection should have been a point");
     if (!p2_ptr) return CGAL::SMALLER;


### PR DESCRIPTION
`TestMesh` in the Surface mesh shortest path tests cannot compile on platforms with an old version of boost ([CentOS5](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Surface_mesh_shortest_path/TestReport_lrineau_CentOS5.gz), [CentOS6-32](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Surface_mesh_shortest_path/TestReport_lrineau_CentOS6-32.gz) and [CentOS6](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-I-114/Surface_mesh_shortest_path/TestReport_lrineau_CentOS6.gz)).
The reason is a bug from Boost 1.47 with `get` called with 3 template arguments that is mistaken with the `get` from adjacency list (which leads to wrong requirements on the parameter of `get`).

This is solved by calling `get` only with the first template argument (the other ones are deduced).