### PR TITLE
Help g++ to find the right version of next()

### DIFF
--- a/BGL/test/BGL/CMakeLists.txt
+++ b/BGL/test/BGL/CMakeLists.txt
@@ -61,6 +61,8 @@ if(OpenMesh_FOUND)
   target_link_libraries( graph_concept_OpenMesh ${OPENMESH_LIBRARIES} )
 endif()
 
+create_single_source_cgal_program( "next.cpp" )
+
 create_single_source_cgal_program( "test_circulator.cpp" )
 
 create_single_source_cgal_program( "graph_concept_Polyhedron_3.cpp" )

--- a/BGL/test/BGL/next.cpp
+++ b/BGL/test/BGL/next.cpp
@@ -1,0 +1,64 @@
+
+#include <iostream>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/helpers.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef K::Point_3 Point_3;
+typedef CGAL::Surface_mesh<Point_3> SM;
+typedef boost::graph_traits<SM>::halfedge_descriptor halfedge_descriptor;
+
+
+namespace Toto {
+
+  struct Graph {};
+
+  struct Descriptor{};
+
+  Descriptor next(const Descriptor& d, const Graph&)
+  {
+    return d;
+  }
+ 
+}
+
+namespace std {
+
+  template <>
+  struct iterator_traits<Toto::Descriptor> {
+
+  }; 
+};
+
+
+namespace Nested {
+  void 
+  gnu()
+  {
+    SM sm;
+    CGAL::make_triangle(Point_3(0,0,0), Point_3(1,0,0), Point_3(1,1,0),sm);
+    
+    halfedge_descriptor hd = *(halfedges(sm).first);
+    hd = next(hd,sm);
+    std::cout << hd;
+  }
+
+  void
+  gnats()
+  {
+    Toto::Graph g;
+    Toto::Descriptor d;
+    d = next(d,g);
+  }
+  
+}
+
+int main()
+{
+  Nested::gnu();
+
+  Nested::gnats();
+  
+  return 0;
+}

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -149,6 +149,12 @@ namespace CGAL {
     {
     public:
 
+        typedef void iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
+
         SM_Halfedge_index() : SM_Index<SM_Halfedge_index>(-1) {}
 
         explicit SM_Halfedge_index(size_type _idx) : SM_Index<SM_Halfedge_index>(_idx) {}


### PR DESCRIPTION
With the `Exact_predicates_exact_constructions_kernel` included gcc4.4 has a problem with ADL for for function `next`.  To help it we  provide the types needed for `std::iterator_traits<Surface_mesh::halfedge_index>`, although this descriptor is not an iterator. 

This should fix this [test](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-116/Surface_mesh_Examples/TestReport_lrineau_CentOS6-CXX11-Boost157.gz)
