### PR TITLE
Replace all std::bind with boost::bind

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
@@ -43,7 +43,7 @@
 #include <CGAL/Interval_nt.h>
 #include <CGAL/Polynomial/Real_embeddable_traits.h>
 
-xs#include <CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h>
+#include <CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h>
 
 // using boost::multi_index::multi_index_container;
 // using boost::multi_index::get;

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
@@ -38,11 +38,12 @@
 // #include <boost/multi_index/member.hpp>
 // #include <boost/multi_index/hashed_index.hpp>
 // #include <boost/multi_index/sequenced_index.hpp>
+#include <boost/functional.hpp>
 
 #include <CGAL/Interval_nt.h>
 #include <CGAL/Polynomial/Real_embeddable_traits.h>
 
-#include <CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h>
+xs#include <CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h>
 
 // using boost::multi_index::multi_index_container;
 // using boost::multi_index::get;
@@ -914,9 +915,9 @@ void get_precached_poly(int var, const NT& key, int /* level */, Poly_1& poly)
     
     if(not_cached||not_found) {
         poly = Poly_1(::boost::make_transform_iterator(coeffs->begin(), 
-                            std::bind2nd(std::ptr_fun(binded_eval), key1)),
+                            boost::bind2nd(std::ptr_fun(binded_eval), key1)),
                       ::boost::make_transform_iterator(coeffs->end(),   
-                            std::bind2nd(std::ptr_fun(binded_eval), key1)));
+                            boost::bind2nd(std::ptr_fun(binded_eval), key1)));
         if(not_cached)
             return;
     // all available space consumed: drop the least recently used entry

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h
@@ -24,6 +24,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/function_objects.h>
+#include <boost/functional.hpp>
 
 /*! \file CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_traits.h
  * \brief
@@ -117,8 +118,8 @@ struct Transform {
 
         Transform<typename OutputPoly_2::NT, typename InputPoly_2::NT, Op> tr;
         return OutputPoly_2(
-            ::boost::make_transform_iterator(p.begin(), std::bind2nd(tr, op)),
-            ::boost::make_transform_iterator(p.end(), std::bind2nd(tr, op)));
+            ::boost::make_transform_iterator(p.begin(), boost::bind2nd(tr, op)),
+            ::boost::make_transform_iterator(p.end(), boost::bind2nd(tr, op)));
     }
 
     OutputPoly_2 operator()(

--- a/Bounding_volumes/include/CGAL/Min_annulus_d.h
+++ b/Bounding_volumes/include/CGAL/Min_annulus_d.h
@@ -32,6 +32,7 @@
 #include <CGAL/QP_solver/QP_full_exact_pricing.h>
 #include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/functional.hpp>
 
 // here is how it works. We have d+2 variables: 
 // R (big radius), r (small radius), c (center). The problem is
@@ -256,7 +257,7 @@ private:
   typedef  QP_access_by_index
   <typename std::vector<Point>::const_iterator, int> Point_by_index;
     
-  typedef  std::binder2nd< std::divides<int> >
+  typedef  boost::binder2nd< std::divides<int> >
   Divide;
     
   typedef  std::vector<int>           Index_vector;
@@ -331,7 +332,7 @@ public:
 				  solver->basic_original_variable_indices_begin(),
 				  CGAL::compose1_1(
 						   Point_by_index( points.begin()),
-						   std::bind2nd( std::divides<int>(), 2)));
+						   boost::bind2nd( std::divides<int>(), 2)));
   }
     
   Support_point_iterator
@@ -342,7 +343,7 @@ public:
 				  solver->basic_original_variable_indices_end(),
 				  CGAL::compose1_1(
 						   Point_by_index( points.begin()),
-						   std::bind2nd( std::divides<int>(), 2)));
+						   boost::bind2nd( std::divides<int>(), 2)));
   }
     
   int  number_of_inner_support_points() const { return static_cast<int>(inner_indices.size());}
@@ -589,7 +590,7 @@ private:
   bool
   check_dimension( std::size_t  offset = 0)
   { return ( std::find_if( points.begin()+offset, points.end(),
-			   CGAL::compose1_1( std::bind2nd(
+			   CGAL::compose1_1( boost::bind2nd(
 							  std::not_equal_to<int>(), d),
 					     tco.access_dimension_d_object()))
 	     == points.end()); }

--- a/Generator/include/CGAL/random_convex_set_2.h
+++ b/Generator/include/CGAL/random_convex_set_2.h
@@ -54,7 +54,6 @@ random_convex_set_2( std::size_t n,
   using std::less;
   using std::max_element;
   using CGAL::cpp11::copy_n;
-  using boost::bind2nd;
 
   typedef typename Traits::Point_2         Point_2;
   typedef typename Traits::FT              FT;
@@ -83,7 +82,7 @@ random_convex_set_2( std::size_t n,
     points.begin(),
     points.end(),
     points.begin(),
-    bind2nd( Sum(), scale( centroid, FT( -1))));
+    boost::bind2nd( Sum(), scale( centroid, FT( -1))));
 
   // sort them according to their direction's angle
   // w.r.t. the positive x-axis:
@@ -101,7 +100,7 @@ random_convex_set_2( std::size_t n,
     points.begin(),
     points.end(),
     points.begin(),
-    bind2nd( Sum(), sum( centroid,
+    boost::bind2nd( Sum(), sum( centroid,
                          scale( new_centroid, FT( -1)))));
 
   // compute maximal coordinate:
@@ -117,7 +116,7 @@ random_convex_set_2( std::size_t n,
     points.begin(),
     points.end(),
     o,
-    bind2nd( Scale(), FT( pg.range()) / maxcoord));
+    boost::bind2nd( Scale(), FT( pg.range()) / maxcoord));
 
 } // random_convex_set_2( n, o, pg, t)
 

--- a/Generator/include/CGAL/random_convex_set_2.h
+++ b/Generator/include/CGAL/random_convex_set_2.h
@@ -32,6 +32,7 @@
 #include <numeric>
 #include <CGAL/Random_convex_set_traits_2.h>
 #include <CGAL/centroid.h>
+#include <boost/functional.hpp>
 
 namespace CGAL {
 
@@ -48,12 +49,12 @@ random_convex_set_2( std::size_t n,
   using std::back_inserter;
   using std::accumulate;
   using std::transform;
-  using std::bind2nd;
   using std::sort;
   using std::partial_sum;
   using std::less;
   using std::max_element;
   using CGAL::cpp11::copy_n;
+  using boost::bind2nd;
 
   typedef typename Traits::Point_2         Point_2;
   typedef typename Traits::FT              FT;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Vector/determinant_of_iterator_to_points_from_iterator_to_vectors.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Vector/determinant_of_iterator_to_points_from_iterator_to_vectors.h
@@ -52,7 +52,7 @@ struct Add_determinant_of_iterator_to_points_from_iterator_to_vectors
   template<class D> struct Property<Has_determinant_of_iterator_to_points_tag, D> :
     boost::true_type {};
 
-  // TODO: use std::minus, std::bind, etc
+  // TODO: use std::minus, boost::bind, etc
   template<class T> struct Minus_fixed {
     T const& a;
     Minus_fixed(T const&a_):a(a_){}

--- a/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
+++ b/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
@@ -25,6 +25,7 @@
 // --------
 #include <CGAL/Optimisation/basic.h>
 #include <CGAL/function_objects.h>
+#include <boost/functional.hpp>
 
 #include <CGAL/QP_options.h>
 #include <CGAL/QP_solver/QP_solver.h>
@@ -665,7 +666,7 @@ private:
   { return ( std::find_if
 	     ( first, last,
 	       CGAL::compose1_1
-	       ( std::bind2nd(std::not_equal_to<int>(), d),
+	       ( boost::bind2nd(std::not_equal_to<int>(), d),
 		 tco.access_dimension_d_object()))
 	     == last); }
     

--- a/QP_solver/include/CGAL/QP_solver/QP_basis_inverse.h
+++ b/QP_solver/include/CGAL/QP_solver/QP_basis_inverse.h
@@ -415,7 +415,7 @@ class QP_basis_inverse {
 	m_it1 = M.begin()+l;
 	for ( row = 0; row < s; ++row, ++m_it1) {
 	    std::transform( m_it1->begin(), m_it1->begin()+s, m_it1->begin(),
-			    std::bind2nd( std::multiplies<ET>(), d));
+			    boost::bind2nd( std::multiplies<ET>(), d));
 	}
 
 	// new denominator: |det(A_B)|^2

--- a/QP_solver/include/CGAL/QP_solver/QP_basis_inverse_impl.h
+++ b/QP_solver/include/CGAL/QP_solver/QP_basis_inverse_impl.h
@@ -187,12 +187,12 @@ z_replace_original_by_original(ForwardIterator y_l_it,
     // tmp_l -part
     std::transform(y_l_it, (y_l_it+s), x_l.begin(), tmp_l.begin(),
         compose2_2(std::plus<ET>(), Identity<ET>(),
-        std::bind1st(std::multiplies<ET>(), s_delta)));
+        boost::bind1st(std::multiplies<ET>(), s_delta)));
     
     // tmp_x -part    
     std::transform(y_x_it, (y_x_it+b), x_x.begin(), tmp_x.begin(),
         compose2_2(std::plus<ET>(), Identity<ET>(),
-        std::bind1st(std::multiplies<ET>(), s_delta)));
+        boost::bind1st(std::multiplies<ET>(), s_delta)));
     tmp_x[k_i] -= d;
     
     // prepare \hat{k}_{2} -scalar

--- a/QP_solver/include/CGAL/QP_solver/QP_solver.h
+++ b/QP_solver/include/CGAL/QP_solver/QP_solver.h
@@ -1601,7 +1601,7 @@ ratio_test_1__q_x_S( Tag_false)
 		    q_x_S.begin(),
 		    compose2_2( std::minus<ET>(),
 				Identity<ET>(),
-				std::bind1st( std::multiplies<ET>(), d)));
+				boost::bind1st( std::multiplies<ET>(), d)));
   }
 
   // q_x_S = -+ ( A_S_BxB_O * q_x_O - A_S_Bxj)
@@ -1938,7 +1938,7 @@ compute__x_B_S( Tag_false /*has_equalities_only_and_full_rank*/,
 		  x_B_S.begin(),
 		  x_B_S.begin(),
 		  compose2_2( std::minus<ET>(),
-			      std::bind1st( std::multiplies<ET>(), d),
+			      boost::bind1st( std::multiplies<ET>(), d),
 			      Identity<ET>()));
 				
   // b_S_B - ( A_S_BxB_O * x_B_O) - r_S_B
@@ -1946,7 +1946,7 @@ compute__x_B_S( Tag_false /*has_equalities_only_and_full_rank*/,
 		 r_S_B.begin(), x_B_S.begin(),
 		 compose2_2(std::minus<ET>(),
 			    Identity<ET>(),
-			    std::bind1st( std::multiplies<ET>(), d)));
+			    boost::bind1st( std::multiplies<ET>(), d)));
                         
 
   // x_B_S = +- ( b_S_B - A_S_BxB_O * x_B_O)
@@ -1975,7 +1975,7 @@ compute__x_B_S( Tag_false /*has_equalities_only_and_full_rank*/,
 		  x_B_S.begin(),
 		  x_B_S.begin(),
 		  compose2_2( std::minus<ET>(),
-			      std::bind1st( std::multiplies<ET>(), d),
+			      boost::bind1st( std::multiplies<ET>(), d),
 			      Identity<ET>()));
 
   // x_B_S = +- ( b_S_B - A_S_BxB_O * x_B_O)

--- a/QP_solver/include/CGAL/QP_solver/QP_solver_impl.h
+++ b/QP_solver/include/CGAL/QP_solver/QP_solver_impl.h
@@ -2929,7 +2929,7 @@ check_basis_inverse( Tag_false)
 	    }
 	}
 	v_it = std::find_if( q_x_O.begin(), q_x_O.begin()+cols,
-			     std::bind2nd( std::not_equal_to<ET>(), et0));
+			     boost::bind2nd( std::not_equal_to<ET>(), et0));
 	if ( v_it != q_x_O.begin()+cols) {
 	    if ( ! vout4.verbose()) {
 		std::cerr << std::endl << "basis-inverse check: ";
@@ -2970,7 +2970,7 @@ check_basis_inverse( Tag_false)
 	}
 
 	v_it = std::find_if( q_lambda.begin(), q_lambda.begin()+rows,
-			     std::bind2nd( std::not_equal_to<ET>(), et0));
+			     boost::bind2nd( std::not_equal_to<ET>(), et0));
 	if ( v_it != q_lambda.begin()+rows) {
 	    if ( ! vout4.verbose()) {
 		std::cerr << std::endl << "basis-inverse check: ";

--- a/QP_solver/include/CGAL/QP_solver/basic.h
+++ b/QP_solver/include/CGAL/QP_solver/basic.h
@@ -28,6 +28,7 @@
 #include <CGAL/Quotient.h>
 #include <CGAL/QP_solver/assertions.h>
 #include <CGAL/QP_solver/debug.h>
+#include <boost/functional.hpp>
 
 #endif // CGAL_QP_SOLVER_BASIC_H
 

--- a/STL_Extension/test/STL_Extension/test_composition.cpp
+++ b/STL_Extension/test/STL_Extension/test_composition.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/basic.h>
 #include <CGAL/function_objects.h>
+#include <boost/functional.hpp>
 #include <functional>
 #include <algorithm>
 #include <numeric>
@@ -10,8 +11,8 @@ using CGAL::compose1_2;
 using CGAL::compose2_1;
 using CGAL::compose2_2;
 using CGAL::compare_to_less;
-using std::binder1st;
-using std::bind1st;
+using boost::binder1st;
+using boost::bind1st;
 using std::accumulate;
 using std::plus;
 using std::multiplies;


### PR DESCRIPTION
This should fix the deprecated warnings we get in, e.g., [this testcase](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-117/Min_annulus_d_Examples/TestReport_lrineau_Ubuntu-latest-GCC6.gz)

However I was surprised that we had other occurences of `std::bind`, e.g., in the QP_Solver package, which did not result in warnings. 