### PR TITLE
CGAL_ImageIO: fix missing include

### DIFF
--- a/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
@@ -52,8 +52,6 @@
 #define DT_RGB                  128 /* */
 #define DT_ALL                  255 /* */
 
-#include <string>
-
 struct header_key                       /*      header_key       */
     {                                           /* off + size*/
         int sizeof_hdr;                         /* 0 + 4     */

--- a/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
@@ -52,6 +52,8 @@
 #define DT_RGB                  128 /* */
 #define DT_ALL                  255 /* */
 
+#include <cstring>
+
 struct header_key                       /*      header_key       */
     {                                           /* off + size*/
         int sizeof_hdr;                         /* 0 + 4     */

--- a/CGAL_ImageIO/src/CGAL_ImageIO/bmpendian.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/bmpendian.h
@@ -32,6 +32,7 @@
 #ifndef __ENDIAN_H_INCLUDED__
 #define __ENDIAN_H_INCLUDED__
 
+#include <cstdio>
 #include "bmptypes.h"
 
 /*


### PR DESCRIPTION
Replace `#include <string>` by `#include <cstring>` and also add `#include<cstdio>` to avoid compilation errors on some platforms (e.g. Ubuntu 14.04).