### PR TITLE
Fix warning in NewKernel_d: use boost::mlp::if_

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/KernelD_converter.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/KernelD_converter.h
@@ -85,11 +85,14 @@ class KernelD_converter_
 
 	// Disable the conversion in some cases:
 	struct Do_not_use{};
-	typedef typename boost::mpl::if_c <
-	  // If Point==Vector, keep only one conversion
-	  duplicate::value ||
-	  // For iterator objects, the default is make_transforming_iterator
-	  (iterator_tag_traits<Tag_>::is_iterator && no_converter::value),
+
+        // Explicit calls to boost::mpl functions to avoid parenthesis
+        // warning on some versions of GCC
+	typedef typename boost::mpl::if_ <
+                          // If Point==Vector, keep only one conversion
+          boost::mpl::or_<boost::mpl::bool_<duplicate::value>,
+                          // For iterator objects, the default is make_transforming_iterator
+                          boost::mpl::bool_<(iterator_tag_traits<Tag_>::is_iterator && no_converter::value)> >,
 	  Do_not_use,K1_Obj>::type argument_type;
 	//typedef typename KOC::argument_type K1_Obj;
 	//typedef typename KOC::result_type K2_Obj;


### PR DESCRIPTION
For unknown reasons, computing directly the boolean expression inside the template of `boost::mpl::if_c` leads to warnings in some platforms ([CentOS](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-118/NewKernel_d/TestReport_lrineau_CentOS6-32.gz) for example). Adding parenthesis doesn't change anything (and is pointless as the right parenthesis are already there).

The only way to remove this warning seems to be using the expression `boost::mpl::if_<boost::mpl::bool_<>,,>` instead and computing the expression with `boost::mpl::or_`. The warning is gone, the test compiles and runs fine.