### PR TITLE
Mesh_3::detect_features : fix an issue with sharp edges detection.

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Detect_features_in_polyhedra.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Detect_features_in_polyhedra.h
@@ -62,7 +62,7 @@ public:
   Detect_features_in_polyhedra() : current_surface_index_(1) {}
   
   void detect_sharp_edges(Polyhedron& polyhedron,
-                          FT angle_in_deg = FT(60)) const;
+                          FT angle_in_deg = FT(120)) const;
   void detect_surface_patches(Polyhedron& polyhedron);
   void detect_vertices_incident_patches(Polyhedron& p);
   
@@ -236,7 +236,7 @@ is_sharp(const Halfedge_handle& he, FT cos_angle) const
   const Vector_3& n1 = facet_normal(f1);
   const Vector_3& n2 = facet_normal(f2);
   
-  if ( n1 * n2 <= cos_angle )
+  if ( - n1 * n2 >= cos_angle ) // cos(dihedral_angle) = - n1 * n2
     return true;
   else
     return false;


### PR DESCRIPTION
Fix a bug of dihedral angle calculation and its comparison with a threshold.
Make the default value of the threshold consistent with the documentation of
the detect_features function.