### PR TITLE
Mesh_2 suppress an "unused parameter" warning concerning boost

### DIFF
--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -31,7 +31,7 @@
 
 #include <fstream>
 
-#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#if ( defined( __clang__ ) || (BOOST_GCC >= 40600 ) ) && (BOOST_VERSION < 106000)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -169,7 +169,7 @@ namespace CGAL
 } //end namespace CGAL
 
 //CGAL_PRAGMA_DIAG_POP
-#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#if ( defined( __clang__ ) || (BOOST_GCC >= 40600 ) ) && (BOOST_VERSION < 106000)
 #pragma GCC diagnostic pop
 #endif
 

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -44,10 +44,11 @@ namespace CGAL
 {
 namespace parameters
 {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-parameter"
+#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #endif
 
 BOOST_PARAMETER_NAME( cdt )
@@ -60,8 +61,8 @@ BOOST_PARAMETER_NAME( (seeds_end, tag) seeds_end_)
 BOOST_PARAMETER_NAME( (mark, tag) mark_)
 
 //CGAL_PRAGMA_DIAG_POP
-#ifdef __clang__
-#pragma clang diagnostic pop
+#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#pragma GCC diagnostic pop
 #endif
 
 }//end namespace parameters

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -21,6 +21,8 @@
 #ifndef CGAL_LLOYD_OPTIMIZE_MESH_2_H
 #define CGAL_LLOYD_OPTIMIZE_MESH_2_H
 
+
+
 #include <CGAL/Mesh_2/Mesh_global_optimizer_2.h>
 #include <CGAL/Mesh_2/Lloyd_move_2.h>
 #include <CGAL/Mesh_2/Mesh_sizing_field.h>
@@ -28,6 +30,12 @@
 #include <CGAL/iterator.h>
 
 #include <fstream>
+
+#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 
 #ifdef BOOST_PARAMETER_MAX_ARITY
 #  if (BOOST_PARAMETER_MAX_ARITY < 8)
@@ -44,12 +52,7 @@ namespace CGAL
 {
 namespace parameters
 {
-#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
-#endif
+  
 
 BOOST_PARAMETER_NAME( cdt )
 BOOST_PARAMETER_NAME( (max_iteration_number, tag) max_iteration_number_ )
@@ -59,11 +62,6 @@ BOOST_PARAMETER_NAME( (freeze_bound, tag) freeze_bound_)
 BOOST_PARAMETER_NAME( (seeds_begin, tag) seeds_begin_)
 BOOST_PARAMETER_NAME( (seeds_end, tag) seeds_end_)
 BOOST_PARAMETER_NAME( (mark, tag) mark_)
-
-//CGAL_PRAGMA_DIAG_POP
-#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
-#pragma GCC diagnostic pop
-#endif
 
 }//end namespace parameters
 }//end namespace CGAL
@@ -169,5 +167,12 @@ namespace CGAL
   }
 
 } //end namespace CGAL
+
+//CGAL_PRAGMA_DIAG_POP
+#if defined( __clang__ ) || (BOOST_GCC >= 40600 )
+#pragma GCC diagnostic pop
+#endif
+
+
 
 #endif


### PR DESCRIPTION
This should fix this [testcase](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-118/Mesh_2/TestReport_lrineau_Fedora-strict-ansi.gz)