### PR TITLE
Barycentric coordinates: precision too high for 32b processors

### DIFF
--- a/Barycentric_coordinates_2/test/Barycentric_coordinates_2/MV_const_linear_precision_test.cpp
+++ b/Barycentric_coordinates_2/test/Barycentric_coordinates_2/MV_const_linear_precision_test.cpp
@@ -47,7 +47,7 @@ int main()
     const Scalar y_scale = Scalar(100);
 
     int count = 0;
-    const Scalar epsilon = Scalar(1) / Scalar(std::pow(10.0, 13.0));
+    const Scalar epsilon = Scalar(1) / Scalar(std::pow(10.0, 8.0));
 
     const Scalar limit_x = x_scale*step;
     const Scalar half    = Scalar(1) / Scalar(2);


### PR DESCRIPTION
`MV_const_linear_precision_test` is performed with a required precision too high, making the assertion fail in 32b platforms ([CentOS](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-118/Barycentric_coordinates_2/TestReport_lrineau_CentOS6-32.gz) and [Fedora](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-118/Barycentric_coordinates_2/TestReport_lrineau_Fedora-32.gz)).

This PR reduces the precision so that this assertion succeeds.