### PR TITLE
Mesh_3 - fix documentation about detection of sharp features

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -79,9 +79,11 @@ Polyhedral_mesh_domain_with_features_3(Polyhedron polyhedron,
 
 /*!
 Detects sharp features of the internal bounding polyhedron (and the potential internal polyhedron) 
-and inserts them in as features of the domain. `angle_bound` gives the maximum dihedral angle 
-(in degrees) between two triangles of the input polyhedron/a which is used to consider that the edge between 
-those triangles is a feature edge. 
+and inserts them as features of the domain. `angle_bound` gives the maximum
+angle (in degrees) between the two normal vectors of adjacent triangles.
+For an edge of the polyhedron, if the angle between the two normal vectors of its
+incident facets is bigger than the given bound, then the edge is considered as
+a feature edge.
 */ 
 void detect_features(FT angle_bound=120); 
 


### PR DESCRIPTION
The angle bound for sharp features detection is a bound on facets normals, and not on the dihedral angle itself.

This PR fixes issue #747