### PR TITLE
Polyhedron_demo : Fix for 753

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -785,51 +785,57 @@ Scene_polyhedron_item::toolTip() const
 
 QMenu* Scene_polyhedron_item::contextMenu()
 {
-    const char* prop_name = "Menu modified by Scene_polyhedron_item.";
+  const char* prop_name = "Menu modified by Scene_polyhedron_item.";
 
-    QMenu* menu = Scene_item::contextMenu();
+  QMenu* menu = Scene_item::contextMenu();
 
-    // Use dynamic properties:
-    // http://doc.qt.io/qt-5/qobject.html#property
-    bool menuChanged = menu->property(prop_name).toBool();
+  // Use dynamic properties:
+  // http://doc.qt.io/qt-5/qobject.html#property
+  bool menuChanged = menu->property(prop_name).toBool();
 
-    if(!menuChanged) {
+  if(!menuChanged) {
 
-        QAction* actionShowOnlyFeatureEdges =
-                menu->addAction(tr("Show only &feature edges"));
-        actionShowOnlyFeatureEdges->setCheckable(true);
-        actionShowOnlyFeatureEdges->setObjectName("actionShowOnlyFeatureEdges");
-        connect(actionShowOnlyFeatureEdges, SIGNAL(toggled(bool)),
-                this, SLOT(show_only_feature_edges(bool)));
+    QAction* actionShowOnlyFeatureEdges =
+        menu->addAction(tr("Show only &feature edges"));
+    actionShowOnlyFeatureEdges->setCheckable(true);
+    actionShowOnlyFeatureEdges->setChecked(show_only_feature_edges_m);
+    actionShowOnlyFeatureEdges->setObjectName("actionShowOnlyFeatureEdges");
+    connect(actionShowOnlyFeatureEdges, SIGNAL(toggled(bool)),
+            this, SLOT(show_only_feature_edges(bool)));
 
     QAction* actionShowFeatureEdges =
-      menu->addAction(tr("Show feature edges"));
+        menu->addAction(tr("Show feature edges"));
     actionShowFeatureEdges->setCheckable(true);
     actionShowFeatureEdges->setChecked(show_feature_edges_m);
     actionShowFeatureEdges->setObjectName("actionShowFeatureEdges");
     connect(actionShowFeatureEdges, SIGNAL(toggled(bool)),
-      this, SLOT(show_feature_edges(bool)));
+            this, SLOT(show_feature_edges(bool)));
 
-    QAction* actionPickFacets = 
-      menu->addAction(tr("Facets picking"));
+    QAction* actionPickFacets =
+        menu->addAction(tr("Facets picking"));
     actionPickFacets->setCheckable(true);
     actionPickFacets->setObjectName("actionPickFacets");
     connect(actionPickFacets, SIGNAL(toggled(bool)),
             this, SLOT(enable_facets_picking(bool)));
 
-        QAction* actionEraseNextFacet =
-                menu->addAction(tr("Erase next picked facet"));
-        actionEraseNextFacet->setCheckable(true);
-        actionEraseNextFacet->setObjectName("actionEraseNextFacet");
-        connect(actionEraseNextFacet, SIGNAL(toggled(bool)),
-                this, SLOT(set_erase_next_picked_facet(bool)));
-        menu->setProperty(prop_name, true);
-    }
-    QAction* action = menu->findChild<QAction*>("actionPickFacets");
-    if(action) action->setChecked(facet_picking_m);
-    action = menu->findChild<QAction*>("actionEraseNextFacet");
-    if(action) action->setChecked(erase_next_picked_facet_m);
-    return menu;
+    QAction* actionEraseNextFacet =
+        menu->addAction(tr("Erase next picked facet"));
+    actionEraseNextFacet->setCheckable(true);
+    actionEraseNextFacet->setObjectName("actionEraseNextFacet");
+    connect(actionEraseNextFacet, SIGNAL(toggled(bool)),
+            this, SLOT(set_erase_next_picked_facet(bool)));
+    menu->setProperty(prop_name, true);
+  }
+
+  QAction* action = menu->findChild<QAction*>("actionShowOnlyFeatureEdges");
+  if(action) action->setChecked(show_only_feature_edges_m);
+  action = menu->findChild<QAction*>("actionShowFeatureEdges");
+  if(action) action->setChecked(show_feature_edges_m);
+  action = menu->findChild<QAction*>("actionPickFacets");
+  if(action) action->setChecked(facet_picking_m);
+  action = menu->findChild<QAction*>("actionEraseNextFacet");
+  if(action) action->setChecked(erase_next_picked_facet_m);
+  return menu;
 }
 
 void Scene_polyhedron_item::show_only_feature_edges(bool b)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -926,19 +926,24 @@ void Scene_polyhedron_item::draw_edges(CGAL::Three::Viewer_interface* viewer) co
         program->release();
         vaos[Edges]->release();
     }
-    if(show_feature_edges_m || show_only_feature_edges_m)
-    {
-        vaos[Feature_edges]->bind();
 
-        attrib_buffers(viewer, PROGRAM_NO_SELECTION);
-        program = getShaderProgram(PROGRAM_NO_SELECTION);
-        program->bind();
-        //draw the edges
+    //draw the feature edges
+    vaos[Feature_edges]->bind();
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    program->bind();
+    if(show_feature_edges_m || show_only_feature_edges_m)
         program->setAttributeValue("colors", Qt::red);
-        viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_f_lines/4));
-        program->release();
-        vaos[Feature_edges]->release();
-        }
+    else
+    {
+        if(!is_selected)
+            program->setAttributeValue("colors", this->color().lighter(50));
+        else
+            program->setAttributeValue("colors",QColor(0,0,0));
+    }
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(nb_f_lines/4));
+    program->release();
+    vaos[Feature_edges]->release();
     }
 
 void


### PR DESCRIPTION
This is a fix for #753.

- The checkboxes are updated when the menu is opened, not when it is created like before.
- The feature edges are always displayed, only their color change.