### PR TITLE
Polyhedron demo : vtk_io_plugin can save

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -31,14 +31,15 @@ polyhedron_demo_plugin(stl_plugin STL_io_plugin)
 target_link_libraries(stl_plugin scene_polyhedron_item scene_polygon_soup_item)
 
 find_package(VTK QUIET COMPONENTS
-                         vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML)
+  vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML vtkFiltersCore vtkFiltersSources)
 if (VTK_FOUND)
   include(${VTK_USE_FILE})
   if ("${VTK_VERSION_MAJOR}" GREATER "5")
     if(VTK_LIBRARIES)
       polyhedron_demo_plugin(vtk_plugin VTK_io_plugin)
       target_link_libraries(vtk_plugin scene_polyhedron_item
-                                        vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML)
+                                        vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML
+                                        vtkFiltersCore vtkFiltersSources)
     else()
       message(STATUS "NOTICE : the vtk IO plugin needs VTK libraries and will not be compiled.")
     endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -37,7 +37,7 @@ if (VTK_FOUND)
   if ("${VTK_VERSION_MAJOR}" GREATER "5")
     if(VTK_LIBRARIES)
       polyhedron_demo_plugin(vtk_plugin VTK_io_plugin)
-      target_link_libraries(vtk_plugin scene_polyhedron_item
+      target_link_libraries(vtk_plugin scene_polyhedron_item scene_polylines_item
                                         vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML
                                         vtkFiltersCore vtkFiltersSources)
     else()

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -45,6 +45,8 @@
 #include <vtkSmartPointer.h>
 #include <vtkPolyDataReader.h>
 #include <vtkXMLPolyDataReader.h>
+#include <vtkPolyDataWriter.h>
+#include <vtkXMLPolyDataWriter.h>
 #include <vtkPolyData.h>
 #include <vtkIdTypeArray.h>
 #include <vtkFieldData.h>
@@ -55,10 +57,7 @@
 #include <vtkIdList.h>
 #include <vtkAppendFilter.h>
 #include <vtkSphereSource.h>
-#include <vtkUnstructuredGrid.h>
 #include <vtkVersion.h>
-#include <vtkUnstructuredGridWriter.h>
-#include <vtkXMLUnstructuredGridWriter.h>
 #include <vtkPoints.h>
 #include <vtkCellArray.h>
 #include <vtkType.h>
@@ -155,7 +154,8 @@ namespace CGAL{
       cell->Delete();
     }
 
-    vtkPolyData* polydata = vtkPolyData::New();
+    vtkSmartPointer<vtkPolyData> polydata =
+      vtkSmartPointer<vtkPolyData>::New();
 
     polydata->SetPoints(vtk_points);
     vtk_points->Delete();
@@ -164,20 +164,20 @@ namespace CGAL{
     vtk_cells->Delete();
 
     // Combine the two data sets
-    vtkSmartPointer<vtkAppendFilter> appendFilter =
-      vtkSmartPointer<vtkAppendFilter>::New();
-    appendFilter->AddInputData(polydata);
-    appendFilter->Update();
+    //vtkSmartPointer<vtkAppendFilter> appendFilter =
+    //  vtkSmartPointer<vtkAppendFilter>::New();
+    //appendFilter->AddInputData(polydata);
+    //appendFilter->Update();
 
-    vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid =
-      vtkSmartPointer<vtkUnstructuredGrid>::New();
-    unstructuredGrid->ShallowCopy(appendFilter->GetOutput());
+    //vtkSmartPointer<vtkPolyData> unstructuredGrid =
+    //  vtkSmartPointer<vtkPolyData>::New();
+    //unstructuredGrid->ShallowCopy(appendFilter->GetOutput());
 
     // Write the unstructured grid
     vtkSmartPointer<VtkWriter> writer =
       vtkSmartPointer<VtkWriter>::New();
     writer->SetFileName(filename);
-    writer->SetInputData(unstructuredGrid);
+    writer->SetInputData(polydata);
     writer->Write();
   }
 }//end namespace CGAL
@@ -195,7 +195,8 @@ public:
   typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
   typedef boost::graph_traits<Polyhedron>::face_descriptor face_descriptor;
 
-  QString nameFilters() const { return "VTK PolyData files (*.vtk, *.vtp)"; }
+  QString nameFilters() const { 
+    return "VTK PolyData files (*.vtk);; VTK XML PolyData (*.vtp)"; }
   QString name() const { return "vtk_plugin"; }
 
   bool canSave(const CGAL::Three::Scene_item* item)
@@ -219,11 +220,11 @@ public:
     {
       char last_char = output_filename.back();
       if (last_char != 'p' && last_char != 'P')
-        CGAL::polygon_mesh_to_vtkUnstructured<vtkUnstructuredGridWriter>(
+        CGAL::polygon_mesh_to_vtkUnstructured<vtkPolyDataWriter>(
           *poly_item->polyhedron(),
           output_filename.data());
       else
-        CGAL::polygon_mesh_to_vtkUnstructured<vtkXMLUnstructuredGridWriter>(
+        CGAL::polygon_mesh_to_vtkUnstructured<vtkXMLPolyDataWriter>(
         *poly_item->polyhedron(),
         output_filename.data());
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -265,7 +265,7 @@ public:
       return false;
     else
     {
-      char last_char = output_filename.back();
+      char last_char = output_filename[output_filename.size()-1];
       if (last_char != 'p' && last_char != 'P')
         CGAL::polygon_mesh_to_vtkUnstructured<vtkPolyDataWriter>(
           *poly_item->polyhedron(),
@@ -297,14 +297,13 @@ public:
     vtkSmartPointer<CGAL::ErrorObserverVtk> errorObserver =
       vtkSmartPointer<CGAL::ErrorObserverVtk>::New();
 
-    data->AddObserver(vtkCommand::ErrorEvent, errorObserver);
-    data->AddObserver(vtkCommand::WarningEvent, errorObserver);
-
     char last_char = input_filename[input_filename.size() - 1];
     if (last_char != 'p' && last_char != 'P')
     {
       vtkSmartPointer<vtkPolyDataReader> reader =
         vtkSmartPointer<vtkPolyDataReader>::New();
+      reader->AddObserver(vtkCommand::ErrorEvent, errorObserver);
+      reader->AddObserver(vtkCommand::WarningEvent, errorObserver);
       reader->SetFileName(input_filename.data());
       reader->Update();
       data = reader->GetOutput();
@@ -313,6 +312,8 @@ public:
     {
       vtkSmartPointer<vtkXMLPolyDataReader> reader =
         vtkSmartPointer<vtkXMLPolyDataReader>::New();
+      reader->AddObserver(vtkCommand::ErrorEvent, errorObserver);
+      reader->AddObserver(vtkCommand::WarningEvent, errorObserver);
       reader->SetFileName(input_filename.data());
       reader->Update();
       data = reader->GetOutput();
@@ -326,7 +327,7 @@ public:
       msgBox.setStandardButtons(QMessageBox::Ok);
       msgBox.setIcon(QMessageBox::Critical);
       msgBox.exec();
-      return new Scene_polyhedron_item();
+      return NULL;
     }
     if (errorObserver->GetWarning())
     {
@@ -345,7 +346,7 @@ public:
       poly_item->setName(fileinfo.fileName());
       return poly_item;
     }
-    return new Scene_polyhedron_item();
+    return NULL;
   }
 
 }; // end Polyhedron_demo_vtk_plugin


### PR DESCRIPTION
This PR adds the ability to save a Polyhedron_item as .vtk and .vtp file,
for the vtkPolyData and vtkXMLPolyData types
to be consistent with the types available in `load()`