### PR TITLE
Fix for 761

### DIFF
--- a/AABB_tree/demo/AABB_tree/Viewer.cpp
+++ b/AABB_tree/demo/AABB_tree/Viewer.cpp
@@ -5,7 +5,7 @@
 #include <CGAL/Qt/CreateOpenGLContext.h>
 
 Viewer::Viewer(QWidget* parent)
-  : QGLViewer(CGAL::Qt::createOpenGLContext(parent),parent),
+  : QGLViewer(CGAL::Qt::createOpenGLContext(),parent),
     m_pScene(NULL),
     m_custom_mouse(false)
 {

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.cpp
@@ -5,7 +5,7 @@
 #include "CGAL/Qt/CreateOpenGLContext.h"
 
 Viewer::Viewer(QWidget* parent)
-  : QGLViewer(CGAL::Qt::createOpenGLContext(parent),parent)
+  : QGLViewer(CGAL::Qt::createOpenGLContext(),parent)
 {
   are_buffers_initialized = false;
 }

--- a/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
@@ -7,7 +7,7 @@
 
 
 Viewer::Viewer(QWidget* parent )
-  : QGLViewer(CGAL::Qt::createOpenGLContext(parent),parent)
+  : QGLViewer(CGAL::Qt::createOpenGLContext(),parent)
 {
     extension_is_found = false;
 }

--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -23,9 +23,9 @@
 #include <QGLContext>
 namespace CGAL{
 namespace Qt{
-inline QGLContext* createOpenGLContext(QObject* parent)
+inline QGLContext* createOpenGLContext()
 {
-    QOpenGLContext *context = new QOpenGLContext(parent);
+    QOpenGLContext *context = new QOpenGLContext();
     QSurfaceFormat format;
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
@@ -35,9 +35,9 @@ inline QGLContext* createOpenGLContext(QObject* parent)
     return result;
 }
 
-inline QGLContext* createOpenGLMSAAContext(QObject* parent)
+inline QGLContext* createOpenGLMSAAContext()
 {
-    QOpenGLContext *context = new QOpenGLContext(parent);
+    QOpenGLContext *context = new QOpenGLContext();
     QSurfaceFormat format;
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);

--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -30,8 +30,10 @@ inline QGLContext* createOpenGLContext()
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
     context->setFormat(format);
+    context->create();
     QGLContext *result = QGLContext::fromOpenGLContext(context);
     result->create();
+    delete context;
     return result;
 }
 

--- a/Linear_cell_complex/demo/Linear_cell_complex/Viewer.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Viewer.cpp
@@ -28,7 +28,7 @@
 #include <QDebug>
 
 Viewer::Viewer(QWidget* parent)
-  : QGLViewer(CGAL::Qt::createOpenGLMSAAContext(parent),parent), wireframe(false),
+  : QGLViewer(CGAL::Qt::createOpenGLMSAAContext(),parent), wireframe(false),
     flatShading(true), edges(true), vertices(true),
     m_previous_scene_empty(true), are_buffers_initialized(false)
 {

--- a/Linear_cell_complex/examples/Linear_cell_complex/linear_cell_complex_3_viewer_qt.h
+++ b/Linear_cell_complex/examples/Linear_cell_complex/linear_cell_complex_3_viewer_qt.h
@@ -153,8 +153,8 @@ class SimpleLCCViewerQt : public QGLViewer, public QOpenGLFunctions_2_1
 
 public:
   // Constructor/Destructor
-  SimpleLCCViewerQt(LCC& alcc, QObject* parent) :
-    QGLViewer(CGAL::Qt::createOpenGLContext(parent)),
+  SimpleLCCViewerQt(LCC& alcc) :
+    QGLViewer(CGAL::Qt::createOpenGLContext()),
     lcc(alcc),
     wireframe(false),
     flatShading(true),

--- a/Mesh_3/demo/Mesh_3/src/CGAL_demo/Viewer.cpp
+++ b/Mesh_3/demo/Mesh_3/src/CGAL_demo/Viewer.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/Qt/CreateOpenGLContext.h>
 
 Viewer::Viewer(QWidget* parent, bool antialiasing)
-  : QGLViewer(CGAL::Qt::createOpenGLContext(parent), parent),
+  : QGLViewer(CGAL::Qt::createOpenGLContext(), parent),
     scene(0),
     antialiasing(antialiasing),
     twosides(false),

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Viewer.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Viewer.cpp
@@ -2,7 +2,7 @@
  #include <CGAL/Qt/CreateOpenGLContext.h>
 
 Viewer::Viewer(QWidget *parent)
-: QGLViewer(CGAL::Qt::createOpenGLContext(parent),parent)
+: QGLViewer(CGAL::Qt::createOpenGLContext(),parent)
 {}
 Viewer::~Viewer()
 {}

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Viewer.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Viewer.h
@@ -22,7 +22,7 @@ class Viewer : public QGLViewer, QOpenGLFunctions_2_1 {
   int nr_of_facets;
 public:
   Viewer(QWidget* parent)
-    : QGLViewer(CGAL::Qt::createOpenGLContext(parent), parent)
+    : QGLViewer(CGAL::Qt::createOpenGLContext(), parent)
   {}
   ~Viewer()
   {

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -64,7 +64,7 @@ public:
    NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
   };
 
-  Viewer_interface(QWidget* parent) : QGLViewer(CGAL::Qt::createOpenGLContext(parent), parent) {}
+  Viewer_interface(QWidget* parent) : QGLViewer(CGAL::Qt::createOpenGLContext(), parent) {}
   virtual ~Viewer_interface() {}
 
   //! Sets the scene for the viewer.

--- a/Triangulation_3/demo/Triangulation_3/Viewer.h
+++ b/Triangulation_3/demo/Triangulation_3/Viewer.h
@@ -24,7 +24,7 @@ class Viewer : public QGLViewer, QOpenGLFunctions_2_1 {
 
 public:
   Viewer(QWidget* parent)
-    : QGLViewer(CGAL::Qt::createOpenGLContext(parent),parent)
+    : QGLViewer(CGAL::Qt::createOpenGLContext(),parent)
     , m_showAxis(false)
     , m_showVertex(true)
     , m_showDEdge(true)


### PR DESCRIPTION
This reverts commit 552aaa159f50b34506bae97cb5afcd9fc3d79a9e to fix #761 

- The use of a parent induced a double delete of the context, which cannot be fixed.
- There were a missing call to create() front the QOpenGLContext, before it was passed to QGLContext::fromOpenGLContext, which made the application segfault when deleting the QOpenGLContext. 
- Now that create is called, it is possible to delete "context" after the QGLContext is created, which should fix the memory leak.