### PR TITLE
Polyhedron_demo : Fix for #770

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -133,11 +133,19 @@ public Q_SLOTS:
   }
   
   void setNormal(float x, float y, float z) {
-    frame->setOrientation(x, y, z, 0.f);
+    QVector3D normal(x,y,z);
+    QVector3D origin(0,0,1);
+    QQuaternion q(CGAL::sqrt((normal.lengthSquared()) * (origin.lengthSquared())) + QVector3D::dotProduct(origin, normal),QVector3D::crossProduct(origin, normal));
+    q.normalize();
+    frame->setOrientation(q.x(), q.y(), q.z(), q.scalar());
   }
 
   void setNormal(double x, double y, double z) {
-    frame->setOrientation((float)x, (float)y, (float)z, 0.f);
+    QVector3D normal(x,y,z);
+    QVector3D origin(0,0,1);
+    QQuaternion q(CGAL::sqrt((normal.lengthSquared()) * (origin.lengthSquared())) + QVector3D::dotProduct(origin, normal),QVector3D::crossProduct(origin, normal));
+    q.normalize();
+    frame->setOrientation(q.x(), q.y(), q.z(), q.scalar());
   }
 
   void setClonable(bool b = true) {

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -141,11 +141,7 @@ public Q_SLOTS:
   }
 
   void setNormal(double x, double y, double z) {
-    QVector3D normal(x,y,z);
-    QVector3D origin(0,0,1);
-    QQuaternion q(CGAL::sqrt((normal.lengthSquared()) * (origin.lengthSquared())) + QVector3D::dotProduct(origin, normal),QVector3D::crossProduct(origin, normal));
-    q.normalize();
-    frame->setOrientation(q.x(), q.y(), q.z(), q.scalar());
+    setNormal((float)x, (float)y, (float)z);
   }
 
   void setClonable(bool b = true) {


### PR DESCRIPTION
This is a fix for #770 .
- The function Scene_plane_item::setNormal(double x, double y, double z) was giving a normal instead of a quaternion to the ManipulatedFrame::setOrientation();