### PR TITLE
Polyhedron item : improve computation of normals

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -27,6 +27,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <CGAL/Origin.h>
 #include <CGAL/Kernel/global_functions_3.h>
+#include <CGAL/Kernel_traits.h>
 
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
@@ -34,6 +35,16 @@
 namespace CGAL{
 
 namespace Polygon_mesh_processing{
+
+namespace internal {
+
+  template<typename Point>
+  typename CGAL::Kernel_traits<Point>::Kernel::Vector_3
+  triangle_normal(const Point& p0, const Point& p1, const Point& p2)
+  {
+    return CGAL::cross_product(p2 - p1, p0 - p1);
+  }
+}
 
 template<typename Point, typename PM, typename VertexPointMap, typename Vector>
 void sum_normals(const PM& pmesh,
@@ -49,12 +60,13 @@ void sum_normals(const PM& pmesh,
     const Point& prv = get(vpmap, target(prev(he, pmesh), pmesh));
     const Point& curr = get(vpmap, target(he, pmesh));
     const Point& nxt = get(vpmap, target(next(he, pmesh), pmesh));
-    Vector n = CGAL::cross_product(nxt - curr, prv - curr);
+    Vector n = internal::triangle_normal(prv, curr, nxt);
     sum = sum + n;
 
     he = next(he, pmesh);
   } while (he != end);
 }
+
 
 /**
 * \ingroup PMP_normal_grp

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -189,12 +189,19 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Kernel;
   typedef typename Kernel::FT FT;
 
-  typedef typename GetFaceNormalMap<PolygonMesh, NamedParameters>::type FaceNormalMap;
+  typedef typename GetFaceNormalMap<PolygonMesh, NamedParameters>::NoMap DefaultMap;
+
+  typedef typename boost::lookup_named_param_def <
+    CGAL::face_normal_t,
+    NamedParameters,
+    DefaultMap> ::type FaceNormalMap;
+
   FaceNormalMap fnmap
-    = boost::choose_param(get_param(np, face_normal), FaceNormalMap());
+    = boost::choose_param(get_param(np, face_normal), DefaultMap());
+
   bool fnmap_valid
     = !boost::is_same<FaceNormalMap,
-                      typename GetFaceNormalMap<PolygonMesh, NamedParameters>::NoMap
+                      DefaultMap
                      >::value;
 
   typedef typename Kernel::Vector_3 Vector;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -55,6 +55,8 @@ void sum_normals(const PM& pmesh,
   typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
   halfedge_descriptor he = halfedge(f, pmesh);
   halfedge_descriptor end = he;
+  bool f_is_triangle = (he == next(next(next(he, pmesh), pmesh), pmesh));
+  /*it is useless to compute the normal 3 times on a triangle*/
   do
   {
     const Point& prv = get(vpmap, target(prev(he, pmesh), pmesh));
@@ -64,7 +66,7 @@ void sum_normals(const PM& pmesh,
     sum = sum + n;
 
     he = next(he, pmesh);
-  } while (he != end);
+  } while (he != end && !f_is_triangle);
 }
 
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -270,7 +270,7 @@ compute_vertex_normals(const PolygonMesh& pmesh
 * @tparam VertexNormalMap a model of `WritablePropertyMap` with
     `boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
     `Kernel::Vector_3` as value type.
-* @tparam FaceNormalMap a model of `WritablePropertyMap` with
+* @tparam FaceNormalMap a model of `ReadWritePropertyMap` with
     `boost::graph_traits<PolygonMesh>::%face_descriptor` as key type and
     `Kernel::Vector_3` as value type.
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
@@ -244,7 +244,7 @@ namespace parameters{
   face_normal_map(const FaceNormalMap& m)
   {
     typedef pmp_bgl_named_params<FaceNormalMap, face_normal_t> Params;
-    return Params(p);
+    return Params(m);
   }
 
   //overload

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
@@ -38,6 +38,7 @@ namespace CGAL{
 
   //to be documented
   enum smooth_along_features_t      { smooth_along_features };
+  enum face_normal_t                { face_normal };
 
   //internal
   enum weight_calculator_t          { weight_calculator };
@@ -98,6 +99,14 @@ namespace CGAL{
     {
       typedef pmp_bgl_named_params<WeightCalc, weight_calculator_t, self> Params;
       return Params(w, *this);
+    }
+
+    template <typename FaceNormalMap>
+    pmp_bgl_named_params<FaceNormalMap, face_normal_t, self>
+    face_normal_map(const FaceNormalMap& m) const
+    {
+      typedef pmp_bgl_named_params<FaceNormalMap, face_normal_t, self> Params;
+      return Params(m, *this);
     }
 
     //overload
@@ -228,6 +237,14 @@ namespace parameters{
   {
     typedef pmp_bgl_named_params<WeightCalc, weight_calculator_t> Params;
     return Params(w);
+  }
+
+  template <typename FaceNormalMap>
+  pmp_bgl_named_params<FaceNormalMap, face_normal_t>
+  face_normal_map(const FaceNormalMap& m)
+  {
+    typedef pmp_bgl_named_params<FaceNormalMap, face_normal_t> Params;
+    return Params(p);
   }
 
   //overload

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -100,6 +100,32 @@ public:
   > ::type  type;
 };
 
+template<typename PolygonMesh, typename NamedParameters>
+class GetFaceNormalMap
+{
+  struct DummyNormalPmap
+  {
+    typedef typename boost::graph_traits<PolygonMesh>::face_descriptor key_type;
+    typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type::Vector_3 value_type;
+    typedef value_type& reference;
+    typedef boost::lvalue_property_map_tag category;
+
+    reference operator[](key_type&) const { return CGAL::NULL_VECTOR; }
+    typedef DummyNormalPmap Self;
+    friend const value_type& get(const Self&, const key_type&) { return CGAL::NULL_VECTOR; }
+    friend         reference get(const Self&, key_type&)       { return CGAL::NULL_VECTOR; }
+    friend void put(const Self&, key_type&, const value_type&) {}
+  };
+
+public:
+  typedef DummyNormalPmap NoMap;
+  typedef typename boost::lookup_named_param_def <
+    CGAL::face_normal_t,
+    NamedParameters,
+    DummyNormalPmap//default
+  > ::type  type;
+};
+
 template<typename NamedParameters, typename DefaultSolver>
 class GetSolver
 {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -107,14 +107,11 @@ class GetFaceNormalMap
   {
     typedef typename boost::graph_traits<PolygonMesh>::face_descriptor key_type;
     typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type::Vector_3 value_type;
-    typedef value_type& reference;
-    typedef boost::lvalue_property_map_tag category;
+    typedef value_type reference;
+    typedef boost::readable_property_map_tag category;
 
-    reference operator[](key_type&) const { return CGAL::NULL_VECTOR; }
     typedef DummyNormalPmap Self;
-    friend const value_type& get(const Self&, const key_type&) { return CGAL::NULL_VECTOR; }
-    friend         reference get(const Self&, key_type&)       { return CGAL::NULL_VECTOR; }
-    friend void put(const Self&, key_type&, const value_type&) {}
+    friend reference get(const Self&, const key_type&) { return CGAL::NULL_VECTOR; }
   };
 
 public:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -167,32 +167,19 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
         if(ffit->info().is_external)
             continue;
 
-        double vertices[3][3];
-        vertices[0][0] = ffit->vertex(0)->point().x();
-        vertices[0][1] = ffit->vertex(0)->point().y();
-        vertices[0][2] = ffit->vertex(0)->point().z();
-
-        vertices[1][0] = ffit->vertex(1)->point().x();
-        vertices[1][1] = ffit->vertex(1)->point().y();
-        vertices[1][2] = ffit->vertex(1)->point().z();
-
-        vertices[2][0] = ffit->vertex(2)->point().x();
-        vertices[2][1] = ffit->vertex(2)->point().y();
-        vertices[2][2] = ffit->vertex(2)->point().z();
-
-        positions_facets.push_back( vertices[0][0]);
-        positions_facets.push_back( vertices[0][1]);
-        positions_facets.push_back( vertices[0][2]);
+        positions_facets.push_back(ffit->vertex(0)->point().x());
+        positions_facets.push_back(ffit->vertex(0)->point().y());
+        positions_facets.push_back(ffit->vertex(0)->point().z());
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back( vertices[1][0]);
-        positions_facets.push_back( vertices[1][1]);
-        positions_facets.push_back( vertices[1][2]);
+        positions_facets.push_back(ffit->vertex(1)->point().x());
+        positions_facets.push_back(ffit->vertex(1)->point().y());
+        positions_facets.push_back(ffit->vertex(1)->point().z());
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back( vertices[2][0]);
-        positions_facets.push_back( vertices[2][1]);
-        positions_facets.push_back( vertices[2][2]);
+        positions_facets.push_back(ffit->vertex(2)->point().x());
+        positions_facets.push_back(ffit->vertex(2)->point().y());
+        positions_facets.push_back(ffit->vertex(2)->point().z());
         positions_facets.push_back(1.0);
 
         typedef Kernel::Vector_3	    Vector;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -101,12 +101,15 @@ typedef CGAL::Constrained_triangulation_plus_2<CDTbase>              CDT;
 
 //Make sure all the facets are triangles
 
+template<typename FaceNormalPmap, typename VertexNormalPmap>
 void
-Scene_polyhedron_item::triangulate_facet(Facet_iterator fit) const
+Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
+                                         const FaceNormalPmap& fnmap,
+                                         const VertexNormalPmap& vnmap) const
 {
     //Computes the normal of the facet
-    Traits::Vector_3 normal =
-            CGAL::Polygon_mesh_processing::compute_face_normal(fit,*poly);
+    Traits::Vector_3 normal = get(fnmap, fit);
+
     //check if normal contains NaN values
     if (normal.x() != normal.x() || normal.y() != normal.y() || normal.z() != normal.z())
     {
@@ -593,7 +596,7 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
       }
       else
       {
-        triangulate_facet(f);
+        triangulate_facet(f, nf_pmap, nv_pmap);
       }
 
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -124,9 +124,12 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
             he_circ_end(he_circ);
 
     // Iterates on the vector of facet handles
+    typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
+    boost::unordered_map<CDT::Vertex_handle, vertex_descriptor> v2v;
     CDT::Vertex_handle previous, first;
     do {
         CDT::Vertex_handle vh = cdt.insert(he_circ->vertex()->point());
+        v2v.insert(std::make_pair(vh, he_circ->vertex()));
         if(first == 0) {
             first = vh;
         }
@@ -197,14 +200,17 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
         normals_flat.push_back(normal.y());
         normals_flat.push_back(normal.z());
 
+        Traits::Vector_3 ng = get(vnmap, v2v[ffit->vertex(0)]);
         normals_gouraud.push_back(normal.x());
         normals_gouraud.push_back(normal.y());
         normals_gouraud.push_back(normal.z());
 
+        ng = get(vnmap, v2v[ffit->vertex(1)]);
         normals_gouraud.push_back(normal.x());
         normals_gouraud.push_back(normal.y());
         normals_gouraud.push_back(normal.z());
 
+        ng = get(vnmap, v2v[ffit->vertex(2)]);
         normals_gouraud.push_back(normal.x());
         normals_gouraud.push_back(normal.y());
         normals_gouraud.push_back(normal.z());

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -379,7 +379,6 @@ Scene_polyhedron_item::compute_normals_and_vertices(const bool colors_only) cons
     typedef Polyhedron::Traits	    Kernel;
     typedef Kernel::Point_3	    Point;
     typedef Kernel::Vector_3	    Vector;
-    typedef Kernel::FT              FT;
     typedef Polyhedron::Facet_iterator Facet_iterator;
     typedef Polyhedron::Halfedge_around_facet_circulator HF_circulator;
     typedef boost::graph_traits<Polyhedron>::face_descriptor   face_descriptor;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -79,6 +79,15 @@ void delete_aabb_tree(Scene_polyhedron_item* item)
     }
 }
 
+template<typename TypeWithXYZ, typename ContainerWithPushBack>
+void push_back_xyz(const TypeWithXYZ& t,
+                   ContainerWithPushBack& vector)
+{
+  vector.push_back(t.x());
+  vector.push_back(t.y());
+  vector.push_back(t.z());
+}
+
 typedef Polyhedron::Traits Traits;
 typedef Polyhedron::Facet Facet;
 typedef CGAL::Triangulation_2_filtered_projection_traits_3<Traits>   P_traits;
@@ -173,47 +182,27 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
         if(ffit->info().is_external)
             continue;
 
-        positions_facets.push_back(ffit->vertex(0)->point().x());
-        positions_facets.push_back(ffit->vertex(0)->point().y());
-        positions_facets.push_back(ffit->vertex(0)->point().z());
+        push_back_xyz(ffit->vertex(0)->point(), positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(ffit->vertex(1)->point().x());
-        positions_facets.push_back(ffit->vertex(1)->point().y());
-        positions_facets.push_back(ffit->vertex(1)->point().z());
+        push_back_xyz(ffit->vertex(1)->point(), positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(ffit->vertex(2)->point().x());
-        positions_facets.push_back(ffit->vertex(2)->point().y());
-        positions_facets.push_back(ffit->vertex(2)->point().z());
+        push_back_xyz(ffit->vertex(3)->point(), positions_facets);
         positions_facets.push_back(1.0);
 
-        normals_flat.push_back(normal.x());
-        normals_flat.push_back(normal.y());
-        normals_flat.push_back(normal.z());
-
-        normals_flat.push_back(normal.x());
-        normals_flat.push_back(normal.y());
-        normals_flat.push_back(normal.z());
-
-        normals_flat.push_back(normal.x());
-        normals_flat.push_back(normal.y());
-        normals_flat.push_back(normal.z());
+        push_back_xyz(normal, normals_flat);
+        push_back_xyz(normal, normals_flat);
+        push_back_xyz(normal, normals_flat);
 
         Traits::Vector_3 ng = get(vnmap, v2v[ffit->vertex(0)]);
-        normals_gouraud.push_back(normal.x());
-        normals_gouraud.push_back(normal.y());
-        normals_gouraud.push_back(normal.z());
+        push_back_xyz(ng, normals_gouraud);
 
         ng = get(vnmap, v2v[ffit->vertex(1)]);
-        normals_gouraud.push_back(normal.x());
-        normals_gouraud.push_back(normal.y());
-        normals_gouraud.push_back(normal.z());
+        push_back_xyz(ng, normals_gouraud);
 
         ng = get(vnmap, v2v[ffit->vertex(2)]);
-        normals_gouraud.push_back(normal.x());
-        normals_gouraud.push_back(normal.y());
-        normals_gouraud.push_back(normal.z());
+        push_back_xyz(ng, normals_gouraud);
     }
 }
 
@@ -482,25 +471,19 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
           HF_circulator end = he;
           CGAL_For_all(he,end)
           {
-                // If Flat shading:1 normal per polygon added once per vertex
-                normals_flat.push_back(n.x());
-                normals_flat.push_back(n.y());
-                normals_flat.push_back(n.z());
+             // If Flat shading:1 normal per polygon added once per vertex
+            push_back_xyz(n, normals_flat);
 
-                //// If Gouraud shading: 1 normal per vertex
-                Vector nv = get(nv_pmap, he->vertex());
-                normals_gouraud.push_back(nv.x());
-                normals_gouraud.push_back(nv.y());
-                normals_gouraud.push_back(nv.z());
+            //// If Gouraud shading: 1 normal per vertex
+            Vector nv = get(nv_pmap, he->vertex());
+            push_back_xyz(nv, normals_gouraud);
 
-                //position
-                const Point& p = he->vertex()->point();
-                positions_facets.push_back(p.x());
-                positions_facets.push_back(p.y());
-                positions_facets.push_back(p.z());
-                positions_facets.push_back(1.0);
-                i = (i+1) %3;
-            }
+            //position
+            const Point& p = he->vertex()->point();
+            push_back_xyz(p, positions_facets);
+            positions_facets.push_back(1.0);
+            i = (i+1) %3;
+         }
       }
       else if (is_quad(f->halfedge(), *poly))
       {
@@ -511,94 +494,54 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
         Point p1 = f->halfedge()->next()->vertex()->point();
         Point p2 = f->halfedge()->next()->next()->vertex()->point();
 
-        positions_facets.push_back(p0.x());
-        positions_facets.push_back(p0.y());
-        positions_facets.push_back(p0.z());
+        push_back_xyz(p0, positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(p1.x());
-        positions_facets.push_back(p1.y());
-        positions_facets.push_back(p1.z());
+        push_back_xyz(p1, positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(p2.x());
-        positions_facets.push_back(p2.y());
-        positions_facets.push_back(p2.z());
+        push_back_xyz(p2, positions_facets);
         positions_facets.push_back(1.0);
 
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
-
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
-
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
+        push_back_xyz(nf, normals_flat);
+        push_back_xyz(nf, normals_flat);
+        push_back_xyz(nf, normals_flat);
 
         Vector nv = get(nv_pmap, f->halfedge()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
 
         nv = get(nv_pmap, f->halfedge()->next()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
 
         nv = get(nv_pmap, f->halfedge()->next()->next()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
 
         //2nd half-quad
         p0 = f->halfedge()->next()->next()->vertex()->point();
         p1 = f->halfedge()->prev()->vertex()->point();
         p2 = f->halfedge()->vertex()->point();
 
-        positions_facets.push_back(p0.x());
-        positions_facets.push_back(p0.y());
-        positions_facets.push_back(p0.z());
+        push_back_xyz(p0, positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(p1.x());
-        positions_facets.push_back(p1.y());
-        positions_facets.push_back(p1.z());
+        push_back_xyz(p1, positions_facets);
         positions_facets.push_back(1.0);
 
-        positions_facets.push_back(p2.x());
-        positions_facets.push_back(p2.y());
-        positions_facets.push_back(p2.z());
+        push_back_xyz(p2, positions_facets);
         positions_facets.push_back(1.0);
 
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
-
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
-
-        normals_flat.push_back(nf.x());
-        normals_flat.push_back(nf.y());
-        normals_flat.push_back(nf.z());
+        push_back_xyz(nf, normals_flat);
+        push_back_xyz(nf, normals_flat);
+        push_back_xyz(nf, normals_flat);
 
         nv = get(nv_pmap, f->halfedge()->next()->next()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
 
         nv = get(nv_pmap, f->halfedge()->prev()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
 
         nv = get(nv_pmap, f->halfedge()->vertex());
-        normals_gouraud.push_back(nv.x());
-        normals_gouraud.push_back(nv.y());
-        normals_gouraud.push_back(nv.z());
+        push_back_xyz(nv, normals_gouraud);
       }
       else
       {
@@ -618,27 +561,19 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
         const Point& b = he->opposite()->vertex()->point();
         if ( he->is_feature_edge())
         {
-            positions_feature_lines.push_back(a.x());
-            positions_feature_lines.push_back(a.y());
-            positions_feature_lines.push_back(a.z());
-            positions_feature_lines.push_back(1.0);
+          push_back_xyz(a, positions_feature_lines);
+          positions_feature_lines.push_back(1.0);
 
-            positions_feature_lines.push_back(b.x());
-            positions_feature_lines.push_back(b.y());
-            positions_feature_lines.push_back(b.z());
-            positions_feature_lines.push_back(1.0);
+          push_back_xyz(b, positions_feature_lines);
+          positions_feature_lines.push_back(1.0);
         }
         else
         {
-            positions_lines.push_back(a.x());
-            positions_lines.push_back(a.y());
-            positions_lines.push_back(a.z());
-            positions_lines.push_back(1.0);
+          push_back_xyz(a, positions_lines);
+          positions_lines.push_back(1.0);
 
-            positions_lines.push_back(b.x());
-            positions_lines.push_back(b.y());
-            positions_lines.push_back(b.z());
-            positions_lines.push_back(1.0);
+          push_back_xyz(b, positions_lines);
+          positions_lines.push_back(1.0);
         }
     }
     //set the colors

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -475,25 +475,21 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
       else
       {
           int i=0;
+          Vector n = PMP::compute_face_normal(f, *poly);
           HF_circulator he = f->facet_begin();
           HF_circulator end = he;
           CGAL_For_all(he,end)
           {
-
                 // If Flat shading:1 normal per polygon added once per vertex
-
-                Vector n = CGAL::Polygon_mesh_processing::compute_face_normal(f, *poly);
                 normals_flat.push_back(n.x());
                 normals_flat.push_back(n.y());
                 normals_flat.push_back(n.z());
 
-
                 //// If Gouraud shading: 1 normal per vertex
-
-                n = CGAL::Polygon_mesh_processing::compute_vertex_normal(he->vertex(), *poly);
-                normals_gouraud.push_back(n.x());
-                normals_gouraud.push_back(n.y());
-                normals_gouraud.push_back(n.z());
+                Vector nv = PMP::compute_vertex_normal(he->vertex(), *poly);
+                normals_gouraud.push_back(nv.x());
+                normals_gouraud.push_back(nv.y());
+                normals_gouraud.push_back(nv.z());
 
                 //position
                 const Point& p = he->vertex()->point();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -20,6 +20,7 @@
 #include <CGAL/Polygon_mesh_processing/repair.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
+#include <CGAL/property_map.h>
 #include <CGAL/statistics_helpers.h>
 
 #include <list>
@@ -32,7 +33,6 @@
 #include <QDialog>
 
 #include <boost/foreach.hpp>
-#include <boost/property_map/property_map.hpp>
 #include <boost/container/flat_map.hpp>
 
 namespace PMP = CGAL::Polygon_mesh_processing;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -33,7 +33,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/unordered_map.hpp>
+#include <boost/container/flat_map.hpp>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -135,7 +135,7 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
 
     // Iterates on the vector of facet handles
     typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
-    boost::unordered_map<CDT::Vertex_handle, vertex_descriptor> v2v;
+    boost::container::flat_map<CDT::Vertex_handle, vertex_descriptor> v2v;
     CDT::Vertex_handle previous, first;
     do {
         CDT::Vertex_handle vh = cdt.insert(he_circ->vertex()->point());
@@ -385,11 +385,11 @@ Scene_polyhedron_item::compute_normals_and_vertices(const bool colors_only) cons
     typedef boost::graph_traits<Polyhedron>::face_descriptor   face_descriptor;
     typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
 
-    boost::unordered_map<face_descriptor, Vector> face_normals_map;
-    boost::associative_property_map< boost::unordered_map<face_descriptor, Vector> >
+    boost::container::flat_map<face_descriptor, Vector> face_normals_map;
+    boost::associative_property_map< boost::container::flat_map<face_descriptor, Vector> >
       nf_pmap(face_normals_map);
-    boost::unordered_map<vertex_descriptor, Vector> vertex_normals_map;
-    boost::associative_property_map< boost::unordered_map<vertex_descriptor, Vector> >
+    boost::container::flat_map<vertex_descriptor, Vector> vertex_normals_map;
+    boost::associative_property_map< boost::container::flat_map<vertex_descriptor, Vector> >
       nv_pmap(vertex_normals_map);
 
     PMP::compute_normals(*poly, nv_pmap, nf_pmap);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -501,8 +501,6 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
         Point p0 = f->halfedge()->vertex()->point();
         Point p1 = f->halfedge()->next()->vertex()->point();
         Point p2 = f->halfedge()->next()->next()->vertex()->point();
-        Vector n = PMP::internal::triangle_normal(p0, p1, p2);
-        n = n / FT(CGAL::sqrt(CGAL::to_double(n * n)));
 
         positions_facets.push_back(p0.x());
         positions_facets.push_back(p0.y());
@@ -550,8 +548,6 @@ Scene_polyhedron_item::compute_normals_and_vertices(void) const
         p0 = f->halfedge()->next()->next()->vertex()->point();
         p1 = f->halfedge()->prev()->vertex()->point();
         p2 = f->halfedge()->vertex()->point();
-        n = PMP::internal::triangle_normal(p0, p1, p2);
-        n = n / FT(CGAL::sqrt(CGAL::to_double(n * n)));
 
         positions_facets.push_back(p0.x());
         positions_facets.push_back(p0.y());

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -176,7 +176,9 @@ private:
     void initialize_buffers(CGAL::Three::Viewer_interface *viewer = 0) const;
     void compute_normals_and_vertices(void) const;
     void compute_colors() const;
-    void triangulate_facet(Facet_iterator ) const;
+    template<typename FaceNormalPmap, typename VertexNormalPmap>
+    void triangulate_facet(Facet_iterator,
+      const FaceNormalPmap&, const VertexNormalPmap&) const;
     void triangulate_facet_color(Facet_iterator ) const;
     double volume, area;
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -174,12 +174,11 @@ private:
 
     using CGAL::Three::Scene_item::initialize_buffers;
     void initialize_buffers(CGAL::Three::Viewer_interface *viewer = 0) const;
-    void compute_normals_and_vertices(void) const;
-    void compute_colors() const;
+    void compute_normals_and_vertices(const bool colors_only = false) const;
     template<typename FaceNormalPmap, typename VertexNormalPmap>
     void triangulate_facet(Facet_iterator,
-      const FaceNormalPmap&, const VertexNormalPmap&) const;
-    void triangulate_facet_color(Facet_iterator ) const;
+      const FaceNormalPmap&, const VertexNormalPmap&,
+      const bool colors_only) const;
     double volume, area;
 
 }; // end class Scene_polyhedron_item


### PR DESCRIPTION
This PR removes a lot of face normal computations to display the polyhedron item.

It also fixes the display of quad meshes when the boundary edges of a quad are intersecting (I think the quad is somehow folded)

