### PR TITLE
Polyhedron_demo : fix context for mesa

### DIFF
--- a/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
+++ b/GraphicsView/include/CGAL/Qt/CreateOpenGLContext.h
@@ -30,10 +30,8 @@ inline QGLContext* createOpenGLContext()
     format.setVersion(2,1);
     format.setProfile(QSurfaceFormat::CompatibilityProfile);
     context->setFormat(format);
-    context->create();
     QGLContext *result = QGLContext::fromOpenGLContext(context);
     result->create();
-    delete context;
     return result;
 }
 } // namespace Qt


### PR DESCRIPTION
Restoring the memory leak in order to keep the demo running on Mesa.