### PR TITLE
If we are already at EOF we do nothing to skip until EOL

### DIFF
--- a/Stream_support/include/CGAL/IO/File_header_extended_OFF.h
+++ b/Stream_support/include/CGAL/IO/File_header_extended_OFF.h
@@ -108,9 +108,9 @@ std::istream& operator>>( std::istream& in, File_header_extended_OFF& h);
 
 // istream modifier skips chars until end of line.
 inline std::istream& skip_until_EOL( std::istream& in) {
-  if(in.eof()){
-    return in;
-  }
+    if(in.eof()){
+        return in;
+    }
     char c;
     while ( in.get(c) && c != '\n')
         ;

--- a/Stream_support/include/CGAL/IO/File_header_extended_OFF.h
+++ b/Stream_support/include/CGAL/IO/File_header_extended_OFF.h
@@ -108,6 +108,9 @@ std::istream& operator>>( std::istream& in, File_header_extended_OFF& h);
 
 // istream modifier skips chars until end of line.
 inline std::istream& skip_until_EOL( std::istream& in) {
+  if(in.eof()){
+    return in;
+  }
     char c;
     while ( in.get(c) && c != '\n')
         ;


### PR DESCRIPTION
This allows to load OFF files without an EOL after the last face.
Don't forget to recompile the CGAL lib after the pull.