### PR TITLE
Bugfix: use property map to access content on Input_type

### DIFF
--- a/Point_set_processing_3/include/CGAL/hierarchy_simplify_point_set.h
+++ b/Point_set_processing_3/include/CGAL/hierarchy_simplify_point_set.h
@@ -242,10 +242,15 @@ namespace CGAL {
 	    while (it != current_cluster->first.end ())
 	      {
 		typename std::list<Input_type>::iterator current = it ++;
+#ifdef CGAL_USE_PROPERTY_MAPS_API_V1
+                const Point& point = get(point_pmap, current);
+#else
+                const Point& point = get(point_pmap, *current);
+#endif
 
 		// Test if point is on negative side of plane and
 		// transfer it to the negative_side cluster if it is
-		if (Vector (current_cluster->second, *current) * v < 0)
+		if (Vector (current_cluster->second, point) * v < 0)
 		  negative_side->first.splice (negative_side->first.end (),
 					       current_cluster->first, current);
 		++ current_cluster_size;


### PR DESCRIPTION
In the function `hierarchy_simplify_point_set()`, at some point, the `ForwardIterator` is dereferenced directly instead of being accessed through the property map. This works in the testsuite as the object referenced by `ForwardIterator` is a always point, but this makes the function unusable with, for example, indices as input.

This PR fixes this.