### PR TITLE
Use completeBaseName() as name of items (for some file name extensions)

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -62,14 +62,14 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
 
   // Try to read .off in a polyhedron
   Scene_polyhedron_item* item = new Scene_polyhedron_item();
-  item->setName(fileinfo.baseName());
+  item->setName(fileinfo.completeBaseName());
   if(!item->load(in))
   {
     delete item;
 
     // Try to read .off in a polygon soup
     Scene_polygon_soup_item* soup_item = new Scene_polygon_soup_item;
-    soup_item->setName(fileinfo.baseName());
+    soup_item->setName(fileinfo.completeBaseName());
     in.close();
     std::ifstream in2(fileinfo.filePath().toUtf8());
     if(!soup_item->load(in2)) {
@@ -103,7 +103,7 @@ Polyhedron_demo_off_plugin::load_obj(QFileInfo fileinfo) {
 
   // Try to read .obj in a polyhedron
   Scene_polyhedron_item* item = new Scene_polyhedron_item();
-  item->setName(fileinfo.baseName());
+  item->setName(fileinfo.completeBaseName());
   if(!item->load_obj(in))
     {
       delete item;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_to_xyz_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_to_xyz_io_plugin.cpp
@@ -52,7 +52,7 @@ Polyhedron_demo_off_to_xyz_plugin::load(QFileInfo fileinfo) {
     }
   }
 
-  item->setName(fileinfo.baseName());
+  item->setName(fileinfo.completeBaseName());
   return item;
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
@@ -40,7 +40,7 @@ Polyhedron_demo_ply_to_xyz_plugin::load(QFileInfo fileinfo) {
       return 0;
     }
 
-  item->setName(fileinfo.baseName());
+  item->setName(fileinfo.completeBaseName());
   return item;
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/STL_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/STL_io_plugin.cpp
@@ -67,14 +67,14 @@ Polyhedron_demo_stl_plugin::load(QFileInfo fileinfo) {
     }
     else{
       Scene_polyhedron_item* item = new Scene_polyhedron_item(P);
-      item->setName(fileinfo.baseName());
+      item->setName(fileinfo.completeBaseName());
       return item;
     }
   }
   catch(...){}
 
   Scene_polygon_soup_item* item = new Scene_polygon_soup_item();
-  item->setName(fileinfo.baseName());
+  item->setName(fileinfo.completeBaseName());
   item->load(points, triangles);
   return item;
 }


### PR DESCRIPTION
When loading a file ~/Foo/elephant.23.3.off   the scene polyhedron item was called elephant. With `completeBaseName`  only the last suffix gets stripped. 

TODO: Something programmatically for the suffix polylines.txt    (Or we should give up such double suffixes).