### PR TITLE
Polyhedron demo : Activate protection of feature polylines in labeled images

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/Mesh_3_plugin_cgal_code.cpp
@@ -146,7 +146,7 @@ Meshing_thread* cgal_code_mesh_3(const Image* pImage,
   p_new_item->set_scene(scene);
 
   Mesh_parameters param;
-  param.protect_features = false;
+  param.protect_features = protect_features;
   param.facet_angle = facet_angle;
   param.facet_sizing = facet_sizing;
   param.facet_approx = facet_approx;


### PR DESCRIPTION
when needed or requested, activate protection of polylines,
either provided as input polylines, or computed as intersections with image boundary

cc @lrineau 