### PR TITLE
operator>>(Lazy_exac_nt) calls new function read_float_or_quotient()

### DIFF
--- a/Number_types/include/CGAL/GMP/Gmpfi_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfi_type.h
@@ -27,6 +27,7 @@
 #include <boost/operators.hpp>
 #include <CGAL/Uncertain.h>
 #include <CGAL/tss.h>
+#include <CGAL/IO/io.h>
 
 #include <limits>
 #include <algorithm>
@@ -818,7 +819,7 @@ std::istream& operator>>(std::istream& is,Gmpfi &f){
         std::istream::int_type c;
         std::ios::fmtflags old_flags = is.flags();
         is.unsetf(std::ios::skipws);
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
         c=is.get();
         if(c!='['){
                 invalid_number:
@@ -826,13 +827,13 @@ std::istream& operator>>(std::istream& is,Gmpfi &f){
                 is.flags(old_flags);
                 return is;
         }
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
         is>>left;
         c=is.get();
         if(c!=',')
                 goto invalid_number;
         is>>right;
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
         c=is.get();
         if(c!=']')
                 goto invalid_number;

--- a/Number_types/include/CGAL/GMP/Gmpfr_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfr_type.h
@@ -28,6 +28,7 @@
 #include <limits>
 #include <CGAL/Uncertain.h>
 #include <CGAL/ipower.h>
+#include <CGAL/IO/io.h>
 
 #if MPFR_VERSION_MAJOR < 3
         typedef mp_rnd_t mpfr_rnd_t;
@@ -1030,7 +1031,7 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
         std::ios::fmtflags old_flags = is.flags();
 
         is.unsetf(std::ios::skipws);
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
 
         // 1. read the mantissa, it starts in +, - or a digit and ends in e
         Gmpz mant(0);           // the mantissa of the number
@@ -1042,11 +1043,11 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
                 case '-':
                         neg_mant=true;
                         is.get();
-                        gmpz_eat_white_space(is);
+                        internal::eat_white_space(is);
                         break;
                 case '+':
                         is.get();
-                        gmpz_eat_white_space(is);
+                        internal::eat_white_space(is);
                         break;
                 case 'n':       // this is NaN
                         is.get();
@@ -1088,7 +1089,7 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
                 mant=-mant;
 
         is.putback(c);
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
 
         switch(c=is.get()){
                 case 'e':
@@ -1103,17 +1104,17 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
                 case '-':
                         neg_exp=true;
                         is.get();
-                        gmpz_eat_white_space(is);
+                        internal::eat_white_space(is);
                         break;
                 case '+':
                         is.get();
-                        gmpz_eat_white_space(is);
+                        internal::eat_white_space(is);
                         break;
                 default:
                         if(c<'0'||c>'9')
                                 goto invalid_number;
         }
-        gmpz_eat_white_space(is);
+        internal::eat_white_space(is);
         while((c=is.get())>='0'&&c<='9')
                 exp=10*exp+(c-'0');
         is.putback(c);

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -27,7 +27,7 @@
 #define CGAL_GMPQ_TYPE_H
 
 #include <CGAL/basic.h>
-#include <CGAL/Io/io.h>
+#include <CGAL/IO/io.h>
 
 #include <CGAL/GMP/Gmpz_type.h>
 #include <CGAL/GMP/Gmpfr_type.h>

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -27,6 +27,8 @@
 #define CGAL_GMPQ_TYPE_H
 
 #include <CGAL/basic.h>
+#include <CGAL/Io/io.h>
+
 #include <CGAL/GMP/Gmpz_type.h>
 #include <CGAL/GMP/Gmpfr_type.h>
 
@@ -486,136 +488,16 @@ operator<<(std::ostream& os, const Gmpq &z)
 //   return is;
 // }
 
-namespace Gmpq_detail {
-  inline
-  bool is_space (const std::istream& /*is*/, std::istream::int_type c)
-  {
-    std::istream::char_type cc= c;
-    return (c == std::istream::traits_type::eof()) ||
-           std::isspace(cc, std::locale::classic() );
-  }
 
-  inline
-  bool is_eof (const std::istream& /*is*/, std::istream::int_type c)
-  {
-    return c == std::istream::traits_type::eof();
-  }
-
-  inline
-  bool is_digit (const std::istream& /*is*/, std::istream::int_type c)
-  {
-    std::istream::char_type cc= c;
-    return std::isdigit(cc, std::locale::classic() );
-  }
-
-  inline std::istream::int_type peek(std::istream& is)
-  {
-    // Workaround for a bug in the version of libc++ that is shipped with
-    // Apple-clang-3.2. See the long comment in the function
-    // gmpz_new_read() in <CGAL/GMP/Gmpz_type.h>.
-
-    if(is.eof())
-      return std::istream::traits_type::eof();
-    else
-      return is.peek();
-  }
-}
 
 inline
 std::istream&
 operator>>(std::istream& is, Gmpq &z)
 {
-  // reads rational and floating point literals.
-  const std::istream::char_type zero = '0';
-  std::istream::int_type c;
-  std::ios::fmtflags old_flags = is.flags();
-
-  is.unsetf(std::ios::skipws);
-  gmpz_eat_white_space(is);
-
-  Gmpz n(0);             // unsigned number before '/' or '.'
-  Gmpz d(1);             // number after '/', or denominator (fp-case)
-  bool negative = false; // do we have a leading '-'?
-  bool digits = false;   // for fp-case: are there any digits at all?
-
-  c = Gmpq_detail::peek(is);
-  if (c != '.') {
-    // is there a sign?
-    if (c == '-' || c == '+') {
-      is.get();
-      negative = (c == '-');
-      gmpz_eat_white_space(is);
-      c=Gmpq_detail::peek(is);
-    }
-    // read n (could be empty)
-    while (!Gmpq_detail::is_eof(is, c) && Gmpq_detail::is_digit(is, c)) {
-      digits = true;
-      n = n*10 + (c-zero);
-      is.get();
-      c = Gmpq_detail::peek(is);
-    }
-    // are we done?
-    if (Gmpq_detail::is_eof(is, c) || Gmpq_detail::is_space(is, c)) {
-      is.flags(old_flags);
-      if (digits && !is.fail())
-        z = negative? Gmpq(-n,1): Gmpq(n,1);
-      return is;
-    }
-  } else
-    n = 0;
-
-  // now we have read n, we are not done, and c is the next character
-  // in the stream
-  if (c == '/' || c == '.') {
-    is.get();
-    if (c == '/') {
-      // rational case
-      is >> d;
-      is.flags(old_flags);
-      if (!is.fail())
-        z = negative? Gmpq(-n,d): Gmpq(n,d);
-      return is;
-    }
-
-    // floating point case; read number after '.' (may be empty)
-    while (true) {
-      c = Gmpq_detail::peek(is);
-      if (Gmpq_detail::is_eof(is, c) || !Gmpq_detail::is_digit(is, c))
-        break;
-      // now we have a digit
-      is.get();
-      digits = true;
-      d *= 10;
-      n = n*10 + (c-zero);
-    }
-  }
-
-  // now we have read all digits after '.', and c is the next character;
-  // read the exponential part (optional)
-  int e = 0;
-  if (c == 'e' || c == 'E') {
-    is.get();
-    is >> e;
-  }
-
-  // now construct the Gmpq
-  if (!digits) {
-    // illegal floating-point number
-    is.setstate(std::ios_base::failbit);
-    is.flags(old_flags);
-    return is;
-  }
-
-  // handle e
-  if (e > 0)
-    while (e--) n *= 10;
-  else
-    while (e++) d *= 10;
-  is.flags(old_flags);
-  if (!is.fail())
-    z = (negative ? Gmpq(-n,d) : Gmpq(n,d));
+  internal::read_float_or_quotient<Gmpz,Gmpq>(is, z);
   return is;
 }
+
 
 inline Gmpq min BOOST_PREVENT_MACRO_SUBSTITUTION(const Gmpq& x,const Gmpq& y){
   return (x<=y)?x:y;

--- a/Number_types/include/CGAL/GMP/Gmpz_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpz_type.h
@@ -27,6 +27,8 @@
 #define CGAL_GMPZ_TYPE_H
 
 #include <CGAL/basic.h>
+#include <CGAL/Io/io.h>
+
 #include <CGAL/gmp.h>
 #include <mpfr.h>
 
@@ -282,27 +284,6 @@ operator<<(std::ostream& os, const Gmpz &z)
   return os;
 }
 
-inline
-void gmpz_eat_white_space(std::istream &is)
-{
-  std::istream::int_type c;
-  do {
-    c= is.peek();
-    if (c== std::istream::traits_type::eof())
-      return;
-    else {
-      std::istream::char_type cc= c;
-      if ( std::isspace(cc, std::locale::classic()) ) {
-        is.get();
-        // since peek succeeded, this should too
-        CGAL_assertion(!is.fail());
-      } else {
-        return;
-      }
-    }
-  } while (true);
-}
-
 
 inline
 std::istream &
@@ -315,14 +296,14 @@ gmpz_new_read(std::istream &is, Gmpz &z)
   std::ios::fmtflags old_flags = is.flags();
 
   is.unsetf(std::ios::skipws);
-  gmpz_eat_white_space(is);
+  internal::eat_white_space(is);
 
   c=is.peek();
   if (c=='-' || c=='+'){
       is.get();
       CGAL_assertion(!is.fail());
       negative=(c=='-');
-      gmpz_eat_white_space(is);
+      internal::eat_white_space(is);
       c=is.peek();
   }
 

--- a/Number_types/include/CGAL/GMP/Gmpz_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpz_type.h
@@ -27,7 +27,7 @@
 #define CGAL_GMPZ_TYPE_H
 
 #include <CGAL/basic.h>
-#include <CGAL/Io/io.h>
+#include <CGAL/IO/io.h>
 
 #include <CGAL/gmp.h>
 #include <mpfr.h>

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -48,7 +48,7 @@
 #include <CGAL/Sqrt_extension_fwd.h>
 #include <CGAL/Kernel/mpl.h>
 
-#include <CGAL/Io/io.h>
+#include <CGAL/IO/io.h>
 
 
 /*

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -48,6 +48,9 @@
 #include <CGAL/Sqrt_extension_fwd.h>
 #include <CGAL/Kernel/mpl.h>
 
+#include <CGAL/Io/io.h>
+
+
 /*
  * This file contains the definition of the number type Lazy_exact_nt<ET>,
  * where ET is an exact number type (must provide the exact operations needed).
@@ -1302,7 +1305,7 @@ std::istream &
 operator>> (std::istream & is, Lazy_exact_nt<ET> & a)
 {
   ET e;
-  is >> e;
+  internal::read_float_or_quotient(is, e);
   if (is)
     a = e;
   return is;

--- a/Number_types/include/CGAL/leda_rational.h
+++ b/Number_types/include/CGAL/leda_rational.h
@@ -25,6 +25,7 @@
 #ifndef CGAL_LEDA_RATIONAL_H
 #define CGAL_LEDA_RATIONAL_H
 
+#include <CGAL/IO/io.h>
 #include <CGAL/number_type_basic.h>
 
 #include <CGAL/leda_coercion_traits.h>
@@ -278,6 +279,17 @@ public:
     }
 
 };
+
+  namespace internal {
+    template <typename ET>
+    void read_float_or_quotient(std::istream & is, ET& et);
+
+      template <>
+    void read_float_or_quotient(std::istream & is, leda_rational& et)
+    {
+      internal::read_float_or_quotient<leda_integer,leda_rational>(is, et);
+    }
+  }
 
 
 } //namespace CGAL

--- a/Number_types/include/CGAL/leda_rational.h
+++ b/Number_types/include/CGAL/leda_rational.h
@@ -280,17 +280,17 @@ public:
 
 };
 
-  namespace internal {
-    template <typename ET>
-    void read_float_or_quotient(std::istream & is, ET& et);
+namespace internal {
+  // See: Stream_support/include/CGAL/IO/io.h
+  template <typename ET>
+  void read_float_or_quotient(std::istream & is, ET& et);
 
-      template <>
-    void read_float_or_quotient(std::istream & is, leda_rational& et)
-    {
-      internal::read_float_or_quotient<leda_integer,leda_rational>(is, et);
-    }
+  template <>
+  inline void read_float_or_quotient(std::istream & is, leda_rational& et)
+  {
+    internal::read_float_or_quotient<leda_integer,leda_rational>(is, et);
   }
-
+} // namespace internal
 
 } //namespace CGAL
 

--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -30,6 +30,7 @@
 #include <cstdio>
 #include <cctype>
 #include <string>
+#include <locale>
 #include <iostream>
 #include <CGAL/tags.h>
 #include <CGAL/IO/io_tags.h>
@@ -358,6 +359,170 @@ void swallow(std::istream &is, char d);
 
 CGAL_EXPORT
 void swallow(std::istream &is, const std::string& s );
+
+
+  namespace internal {
+inline
+void eat_white_space(std::istream &is)
+{
+  std::istream::int_type c;
+  do {
+    c= is.peek();
+    if (c== std::istream::traits_type::eof())
+      return;
+    else {
+      std::istream::char_type cc= c;
+      if ( std::isspace(cc, std::locale::classic()) ) {
+        is.get();
+        // since peek succeeded, this should too
+        CGAL_assertion(!is.fail());
+      } else {
+        return;
+      }
+    }
+  } while (true);
+}
+ 
+
+  inline
+  bool is_space (const std::istream& /*is*/, std::istream::int_type c)
+  {
+    std::istream::char_type cc= c;
+    return (c == std::istream::traits_type::eof()) ||
+           std::isspace(cc, std::locale::classic() );
+  }
+
+  inline
+  bool is_eof (const std::istream& /*is*/, std::istream::int_type c)
+  {
+    return c == std::istream::traits_type::eof();
+  }
+
+  inline
+  bool is_digit (const std::istream& /*is*/, std::istream::int_type c)
+  {
+    std::istream::char_type cc= c;
+    return std::isdigit(cc, std::locale::classic() );
+  }
+
+  inline std::istream::int_type peek(std::istream& is)
+  {
+    // Workaround for a bug in the version of libc++ that is shipped with
+    // Apple-clang-3.2. See the long comment in the function
+    // gmpz_new_read() in <CGAL/GMP/Gmpz_type.h>.
+
+    if(is.eof())
+      return std::istream::traits_type::eof();
+    else
+      return is.peek();
+  }
+   
+    
+template <typename ET>
+void read_float_or_quotient(std::istream & is, ET& et)
+{
+  is >> et;
+}   
+
+
+
+template <typename Int, typename Rat>
+void read_float_or_quotient(std::istream& is, Rat &z)
+{
+  // reads rational and floating point literals.
+  const std::istream::char_type zero = '0';
+  std::istream::int_type c;
+  std::ios::fmtflags old_flags = is.flags();
+
+  is.unsetf(std::ios::skipws);
+  internal::eat_white_space(is);
+
+  Int n(0);             // unsigned number before '/' or '.'
+  Int d(1);             // number after '/', or denominator (fp-case)
+  bool negative = false; // do we have a leading '-'?
+  bool digits = false;   // for fp-case: are there any digits at all?
+
+  c = internal::peek(is);
+  if (c != '.') {
+    // is there a sign?
+    if (c == '-' || c == '+') {
+      is.get();
+      negative = (c == '-');
+      internal::eat_white_space(is);
+      c=internal::peek(is);
+    }
+    // read n (could be empty)
+    while (!internal::is_eof(is, c) && internal::is_digit(is, c)) {
+      digits = true;
+      n = n*10 + (c-zero);
+      is.get();
+      c = internal::peek(is);
+    }
+    // are we done?
+    if (internal::is_eof(is, c) || internal::is_space(is, c)) {
+      is.flags(old_flags);
+      if (digits && !is.fail())
+        z = negative? Rat(-n,1): Rat(n,1);
+      return;
+    }
+  } else
+    n = 0;
+
+  // now we have read n, we are not done, and c is the next character
+  // in the stream
+  if (c == '/' || c == '.') {
+    is.get();
+    if (c == '/') {
+      // rational case
+      is >> d;
+      is.flags(old_flags);
+      if (!is.fail())
+        z = negative? Rat(-n,d): Rat(n,d);
+      return;
+    }
+
+    // floating point case; read number after '.' (may be empty)
+    while (true) {
+      c = internal::peek(is);
+      if (internal::is_eof(is, c) || !internal::is_digit(is, c))
+        break;
+      // now we have a digit
+      is.get();
+      digits = true;
+      d *= 10;
+      n = n*10 + (c-zero);
+    }
+  }
+
+  // now we have read all digits after '.', and c is the next character;
+  // read the exponential part (optional)
+  int e = 0;
+  if (c == 'e' || c == 'E') {
+    is.get();
+    is >> e;
+  }
+
+  // now construct the Gmpq
+  if (!digits) {
+    // illegal floating-point number
+    is.setstate(std::ios_base::failbit);
+    is.flags(old_flags);
+    return;
+  }
+
+  // handle e
+  if (e > 0)
+    while (e--) n *= 10;
+  else
+    while (e++) d *= 10;
+  is.flags(old_flags);
+  if (!is.fail())
+    z = (negative ? Rat(-n,d) : Rat(n,d));
+
+} 
+    
+    
+  } // namespace internal
 
 } //namespace CGAL
 

--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -419,7 +419,7 @@ void eat_white_space(std::istream &is)
    
     
 template <typename ET>
-void read_float_or_quotient(std::istream & is, ET& et)
+inline void read_float_or_quotient(std::istream & is, ET& et)
 {
   is >> et;
 }   
@@ -427,7 +427,7 @@ void read_float_or_quotient(std::istream & is, ET& et)
 
 
 template <typename Int, typename Rat>
-void read_float_or_quotient(std::istream& is, Rat &z)
+inline void read_float_or_quotient(std::istream& is, Rat &z)
 {
   // reads rational and floating point literals.
   const std::istream::char_type zero = '0';

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -17,6 +17,7 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  create_single_source_cgal_program( "read.cpp" )
   create_single_source_cgal_program( "sm_join.cpp" )
   create_single_source_cgal_program( "sm_aabbtree.cpp" )
   create_single_source_cgal_program( "sm_bgl.cpp" )

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -17,7 +17,6 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
-  create_single_source_cgal_program( "read.cpp" )
   create_single_source_cgal_program( "sm_join.cpp" )
   create_single_source_cgal_program( "sm_aabbtree.cpp" )
   create_single_source_cgal_program( "sm_bgl.cpp" )


### PR DESCRIPTION
The function `read_float_or_quotient() ` existed in non-template form as `operator(istream&, Gmpq&)` in Number_types/include/GMP/Gmpq_type.h and it is now as function template in CGAL/IO/io.h.

This PR should partially fix the issue #813. Partially, because it does not fix `operator(istream&, leda_real&)`   but `operator(istream&, Lazy_exact_nt<leda_real>&)`  as number type of EPEC 