### PR TITLE
Polyhedron demo : Use maximum precision when writing files

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/GOCAD_io_plugin.cpp
@@ -96,7 +96,7 @@ bool Polyhedron_demo_gocad_plugin::save(const CGAL::Three::Scene_item* item, QFi
     return false;
 
   std::ofstream out(fileinfo.filePath().toUtf8());
-
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   Polyhedron* poly = const_cast<Polyhedron*>(poly_item->polyhedron());
 
   write_gocad(*poly, out, qPrintable(fileinfo.baseName()));

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Nef_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Nef_io_plugin.cpp
@@ -2,6 +2,8 @@
 
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
 #include <fstream>
+#include <limits>
+
 using namespace CGAL::Three;
 class Polyhedron_demo_io_nef_plugin :
   public QObject,
@@ -70,7 +72,7 @@ bool Polyhedron_demo_io_nef_plugin::save(const CGAL::Three::Scene_item* item, QF
     return false;
 
   std::ofstream out(fileinfo.filePath().toUtf8());
-
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   return (nef_item && nef_item->save(out));
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -133,7 +133,7 @@ bool Polyhedron_demo_off_plugin::save(const CGAL::Three::Scene_item* item, QFile
     return false;
 
   std::ofstream out(fileinfo.filePath().toUtf8());
-
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   return (poly_item && poly_item->save(out)) || 
     (soup_item && soup_item->save(out));
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_to_xyz_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_to_xyz_io_plugin.cpp
@@ -77,6 +77,7 @@ bool Polyhedron_demo_off_to_xyz_plugin::save(const CGAL::Three::Scene_item* item
 
   // Save point set as .xyz
   std::ofstream out(fileinfo.filePath().toUtf8().data());
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   return point_set_item->write_off_point_set(out);
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_to_xyz_io_plugin.cpp
@@ -65,6 +65,7 @@ bool Polyhedron_demo_ply_to_xyz_plugin::save(const CGAL::Three::Scene_item* item
 
   // Save point set as .xyz
   std::ofstream out(fileinfo.filePath().toUtf8().data());
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   return point_set_item->write_ply_point_set(out);
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -165,7 +165,7 @@ bool Polyhedron_demo_polylines_io_plugin::save(const CGAL::Three::Scene_item* it
 
   std::ofstream out(fileinfo.filePath().toUtf8());
 
-  out.precision(17);
+  out.precision (std::numeric_limits<double>::digits10 + 1);
 
   if(!out) {
     std::cerr << "Error! Cannot open file " << (const char*)fileinfo.filePath().toUtf8() << std::endl;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -140,6 +140,7 @@ bool Polyhedron_demo_xyz_plugin::save(const CGAL::Three::Scene_item* item, QFile
 
   // Save point set as .xyz
   std::ofstream out(fileinfo.filePath().toUtf8().data());
+  out.precision (std::numeric_limits<double>::digits10 + 1);
   return point_set_item->write_xyz_point_set(out);
 }
 


### PR DESCRIPTION
When opening geometric objects, applying operations of the Polyhedron demo and saving them back, some information may be lost: this is due to the fact the doubles are written in ASCII format without checking if the precision is high enough.

This PR increases the precision of the output stream to all IO plugins to the maximum value. The drawback is that files might get larger (as the numbers are written with additional digits) even if it is not needed, but the advantage of never losing information seems more important.