### PR TITLE
Check that the input can be read in the Mesh_3 examples

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image.cpp
@@ -1,26 +1,3 @@
-// Copyright (c) 2012 GeometryFactory (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Laurent Rineau
-//
-//******************************************************************************
-// File Description :
-//***************************************************************************
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -50,12 +27,15 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char*argv[])
 {
-  // Loads image
+  const char* fname = (argc>1)?argv[1]:"data/skull_2.9.inr";
+  // Load image
   CGAL::Image_3 image;
-  if(!image.read("data/skull_2.9.inr")) return 1;
-
+  if(!image.read(fname)){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
   // Domain
   Mesh_domain domain(image, 2.9f, 0.f);
 

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image.cpp
@@ -1,3 +1,4 @@
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -30,11 +31,15 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char* argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/liver.inr.gz";
   // Loads image
   CGAL::Image_3 image;
-  image.read("data/liver.inr.gz");
+  if(!image.read(fname)){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Domain
   Mesh_domain domain(image);

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_variable_size.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_variable_size.cpp
@@ -35,11 +35,15 @@ typedef CGAL::Mesh_constant_domain_field_3<Mesh_domain::R,
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char* argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/liver.inr.gz";
   // Loads image
   CGAL::Image_3 image;
-  image.read("data/liver.inr.gz");
+  if(!image.read(fname)){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Domain
   Mesh_domain domain(image);

--- a/Mesh_3/examples/Mesh_3/mesh_optimization_example.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_optimization_example.cpp
@@ -30,11 +30,16 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char* argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/liver.inr.gz";
   // Domain
   CGAL::Image_3 image;
-  image.read("data/liver.inr.gz");
+  if(!image.read(fname)){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
+
   Mesh_domain domain(image);
 
   // Mesh criteria

--- a/Mesh_3/examples/Mesh_3/mesh_optimization_lloyd_example.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_optimization_lloyd_example.cpp
@@ -30,11 +30,15 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/liver.inr.gz";
   // Domain
   CGAL::Image_3 image;
-  image.read("data/liver.inr.gz");
+  if(!image.read(fname)){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
   Mesh_domain domain(image);
 
   // Mesh criteria

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -43,6 +43,7 @@ int main(int argc, char*argv[])
   input >> polyhedron;
   if(input.bad()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
   }
   input.close();
    

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -34,12 +34,17 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/elephant.off";
   // Create input polyhedron
   Polyhedron polyhedron;
-  std::ifstream input("data/elephant.off");
+  std::ifstream input(fname);
   input >> polyhedron;
+  if(input.bad()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+  }
+  input.close();
    
   // Create domain
   Mesh_domain domain(polyhedron);

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -30,10 +30,11 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/fandisk.off";
   // Create domain
-  Mesh_domain domain("data/fandisk.off");
+  Mesh_domain domain(fname);
   
   // Get sharp features
   domain.detect_features();

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_edge_tolerance_region.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_edge_tolerance_region.cpp
@@ -1,14 +1,6 @@
 
-//******************************************************************************
-// File Description :
-//
-//******************************************************************************
-
-
-
 #include <CGAL/AABB_intersections.h>
 
-#include <debug.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -41,12 +33,16 @@ typedef Mesh_criteria::Cell_criteria Cell_criteria;
 
 
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/star.off";
   // Create polyhedron
   Polyhedron polyhedron;
-  std::ifstream input("data/star.off");
+  std::ifstream input(fname);
   input >> polyhedron;
+  if(input.bad()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+  }
   input.close();
 
   // Implicit function built by AABB_tree projection queries

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_edge_tolerance_region.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_edge_tolerance_region.cpp
@@ -42,6 +42,7 @@ int main(int argc, char*argv[])
   input >> polyhedron;
   if(input.bad()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
   }
   input.close();
 

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_implicit_function.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_implicit_function.cpp
@@ -1,12 +1,6 @@
-//******************************************************************************
-// File Description :
-//
-//******************************************************************************
-
 
 #include <CGAL/AABB_intersections.h>
 
-#include <debug.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -38,12 +32,16 @@ typedef Mesh_criteria::Facet_criteria Facet_criteria;
 typedef Mesh_criteria::Cell_criteria Cell_criteria;
 
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/elephant.off";
   // Create and fill polyhedron
   Polyhedron polyhedron;
-  std::ifstream input("data/elephant.off");
+  std::ifstream input(fname);
   input >> polyhedron;
+  if(input.bad()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+  }
   input.close();
 
   // Implicit function built by AABB_tree projection queries

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_implicit_function.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_implicit_function.cpp
@@ -41,6 +41,7 @@ int main(int argc, char*argv[])
   input >> polyhedron;
   if(input.bad()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
   }
   input.close();
 

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_surface_tolerance_region.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_surface_tolerance_region.cpp
@@ -40,6 +40,7 @@ int main(int argc, char*argv[])
   input >> polyhedron;
   if(input.bad()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
   }
   input.close();
 

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_surface_tolerance_region.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_surface_tolerance_region.cpp
@@ -1,13 +1,5 @@
-
-//******************************************************************************
-// File Description :
-//
-//******************************************************************************
-
-
 #include <CGAL/AABB_intersections.h>
 
-#include <debug.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -39,12 +31,16 @@ typedef Mesh_criteria::Facet_criteria Facet_criteria;
 typedef Mesh_criteria::Cell_criteria Cell_criteria;
 
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/elephant.off";
   // Create and fill polyhedron
   Polyhedron polyhedron;
-  std::ifstream input("data/elephant.off");
+  std::ifstream input(fname);
   input >> polyhedron;
+  if(input.bad()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+  }
   input.close();
 
   // Implicit function built by AABB_tree projection queries


### PR DESCRIPTION
At the same time allow to process argc[1] if present. 

This should fix #800 
Almost, as there is still an example with a domain where we call the constructor with a file name. See also  #488