### PR TITLE
Introduce CGAL::Default for the geometric traits of Mesh_triangulation_3

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_triangulation_3.h
@@ -6,19 +6,19 @@ namespace CGAL {
 The class `Mesh_triangulation_3` is a metafunctor which provides the triangulation type to be used
 for the 3D triangulation embedding the mesh.
 
-\tparam MD stands for a model of `MeshDomain_3`.
+\tparam MD must be a model of `MeshDomain_3`.
 
-\tparam Gt stands for a model of `RegularTriangulationTraits_3`
+\tparam Gt must be a model of `RegularTriangulationTraits_3` or `Default`
 and defaults to `Kernel_traits<MD>::%Kernel`.
 
 \tparam Concurrency_tag enables sequential versus parallel meshing and optimization algorithms.
                         Possible values are `Sequential_tag` (the default) and
                         `Parallel_tag`.
 
-\tparam Vertex_base stands for a model of `MeshVertexBase_3`
+\tparam Vertex_base must be a model of `MeshVertexBase_3` or `Default`
 and defaults to `Mesh_vertex_base_3<Gt, MD>`.
 
-\tparam Cell_base stands for a model of `MeshCellBase_3`
+\tparam Cell_base must be a model of `MeshCellBase_3` or `Default`
 and defaults to `Compact_mesh_cell_base_3<Gt, MD>`.
 
 \sa `make_mesh_3()`

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image.cpp
@@ -12,16 +12,15 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_variable_size.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_variable_size.cpp
@@ -15,16 +15,15 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_implicit_sphere.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_implicit_sphere.cpp
@@ -14,16 +14,15 @@ typedef K::Point_3 Point;
 typedef FT (Function)(const Point&);
 typedef CGAL::Implicit_mesh_domain_3<Function,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_implicit_sphere_variable_size.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_implicit_sphere_variable_size.cpp
@@ -14,16 +14,15 @@ typedef K::Point_3 Point;
 typedef FT (Function)(const Point&);
 typedef CGAL::Implicit_mesh_domain_3<Function,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_optimization_example.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_optimization_example.cpp
@@ -12,16 +12,15 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Mesh Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_optimization_lloyd_example.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_optimization_lloyd_example.cpp
@@ -12,16 +12,15 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Mesh Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -16,16 +16,15 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Polyhedron_3<K> Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_3<Polyhedron, K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 // Criteria

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -11,16 +11,15 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
   Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
 

--- a/Mesh_3/examples/Mesh_3/mesh_two_implicit_spheres_with_balls.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_two_implicit_spheres_with_balls.cpp
@@ -22,16 +22,15 @@ typedef CGAL::Mesh_domain_with_polyline_features_3<
 typedef std::vector<Point>        Polyline_3;
 typedef std::list<Polyline_3>       Polylines;
 
-// Triangulation
 #ifdef CGAL_CONCURRENT_MESH_3
-  typedef CGAL::Mesh_triangulation_3<
-    Mesh_domain,
-    CGAL::Kernel_traits<Mesh_domain>::Kernel, // Same as sequential
-    CGAL::Parallel_tag                        // Tag to activate parallelism
-  >::type Tr;
+typedef CGAL::Parallel_tag Concurrency_tag;
 #else
-  typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
   Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
 

--- a/Mesh_3/include/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_triangulation_3.h
@@ -56,7 +56,7 @@ namespace CGAL {
 // Struct Mesh_triangulation_3
 //
 template<class MD,
-         class K = Default,
+         class K_ = Default,
          class Concurrency_tag = Sequential_tag,
          class Vertex_base_ = Default,
          class Cell_base_   = Default>

--- a/Mesh_3/include/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_triangulation_3.h
@@ -63,12 +63,12 @@ template<class MD,
 struct Mesh_triangulation_3;
 
 // Sequential version (default)
-template<class MD, class K, class Concurrency_tag,
+template<class MD, class K_, class Concurrency_tag,
          class Vertex_base_, class Cell_base_>
 struct Mesh_triangulation_3
 {
 private:
-  typedef typename Default::Get<K, typename Kernel_traits<MD>::Kernel>::type K;
+  typedef typename Default::Get<K_, typename Kernel_traits<MD>::Kernel>::type K;
 
   typedef typename details::Mesh_geom_traits_generator<K>::type Geom_traits;
 
@@ -90,11 +90,13 @@ public:
 #ifdef CGAL_LINKED_WITH_TBB
 // Parallel version (specialization)
 //
-template<class MD, class K,
+template<class MD, class K_,
          class Vertex_base_, class Cell_base_>
-struct Mesh_triangulation_3<MD, K, Parallel_tag, Vertex_base_, Cell_base_>
+struct Mesh_triangulation_3<MD, K_, Parallel_tag, Vertex_base_, Cell_base_>
 {
 private:
+  typedef typename Default::Get<K_, typename Kernel_traits<MD>::Kernel>::type K;
+
   typedef typename details::Mesh_geom_traits_generator<K>::type Geom_traits;
 
   typedef typename Default::Get<

--- a/Mesh_3/include/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_triangulation_3.h
@@ -56,7 +56,7 @@ namespace CGAL {
 // Struct Mesh_triangulation_3
 //
 template<class MD,
-         class K=typename Kernel_traits<MD>::Kernel,
+         class K = Default,
          class Concurrency_tag = Sequential_tag,
          class Vertex_base_ = Default,
          class Cell_base_   = Default>
@@ -68,6 +68,8 @@ template<class MD, class K, class Concurrency_tag,
 struct Mesh_triangulation_3
 {
 private:
+  typedef typename Default::Get<K, typename Kernel_traits<MD>::Kernel>::type K;
+
   typedef typename details::Mesh_geom_traits_generator<K>::type Geom_traits;
 
   typedef typename Default::Get<


### PR DESCRIPTION
[Small feature "Use Default"](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Use_Default)

This is related to #829 

I modified one example so that we can look at before/after.

@lrineau : What do you think?