### PR TITLE
Deal with isolated vertices when turning a polygon soup in a polyedral surface

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/polygon_soup_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/polygon_soup_example.cpp
@@ -3,7 +3,6 @@
 #include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/IO/OFF_reader.h>
-
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
@@ -39,7 +38,7 @@ int main(int argc, char* argv[])
   Polyhedron mesh;
   CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, mesh);
 
-  if (!CGAL::Polygon_mesh_processing::is_outward_oriented(mesh))
+  if (CGAL::is_closed(mesh) && (!CGAL::Polygon_mesh_processing::is_outward_oriented(mesh)))
     CGAL::Polygon_mesh_processing::reverse_face_orientations(mesh);
 
   std::ofstream out("tet-oriented1.off");

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -21,6 +21,7 @@
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <CGAL/Triangulation_face_base_with_info_2.h>
@@ -534,7 +535,9 @@ Scene_polygon_soup_item::exportAsPolyhedron(Polyhedron* out_polyhedron)
   orient();
   CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh<Polyhedron>(
     soup->points, soup->polygons, *out_polyhedron);
-
+  std::size_t rv = CGAL::Polygon_mesh_processing::remove_isolated_vertices(*out_polyhedron);
+  if(rv > 0)
+    std::cerr << "Ignore isolated vertices: " << rv << std::endl;
   if(out_polyhedron->size_of_vertices() > 0) {
     // Also check whether the consistent orientation is fine
     if(out_polyhedron->is_closed() &&


### PR DESCRIPTION
When reading a polygon soup with isolated vertices in the Polyhedron demo, it crashes on  the operation "Orient polygon soup".  The fix is to apply `remove_isolated vertices()`.  

It is maybe a mistake that the plugin tries to construct a polyhedral surface.

I fixed at the same time the example in PMP that deals with polygon soups. 