### PR TITLE
Print the seed of CGAL::default_random

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -341,11 +341,11 @@ endif()
 #   CGAL-4.6   : 11.0.0 (int->size_t in CGAL_ImageIO)
 #   CGAL-4.7   : 11.0.1 (Nothing different in CGAL compiled libraries.)
 #   CGAL-4.8   : 11.0.2 (Nothing different in CGAL compiled libraries.)
-#   CGAL-4.9   : 11.1.0 (Add Random::Random(char*) to Random.cpp.)
+#   CGAL-4.9   : 11.0.3 (Nothing different in CGAL compiled libraries.)
 # ¹) According to http://upstream-tracker.org/versions/cgal.html
 
 set( CGAL_SONAME_VERSION "11" )
-set( CGAL_SOVERSION      "11.1.0" )
+set( CGAL_SOVERSION      "11.0.3" )
 
 message( STATUS "CGAL_SONAME_VERSION=${CGAL_SONAME_VERSION}" )
 message( STATUS "CGAL_SOVERSION     =${CGAL_SOVERSION}" )

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -340,10 +340,12 @@ endif()
 #   CGAL-4.5   : 10.0.4 (Nothing different in CGAL compiled libraries¹.)
 #   CGAL-4.6   : 11.0.0 (int->size_t in CGAL_ImageIO)
 #   CGAL-4.7   : 11.0.1 (Nothing different in CGAL compiled libraries.)
+#   CGAL-4.8   : 11.0.2 (Nothing different in CGAL compiled libraries.)
+#   CGAL-4.9   : 11.1.0 (Add Random::Random(char*) to Random.cpp.)
 # ¹) According to http://upstream-tracker.org/versions/cgal.html
 
 set( CGAL_SONAME_VERSION "11" )
-set( CGAL_SOVERSION      "11.0.1" )
+set( CGAL_SOVERSION      "11.1.0" )
 
 message( STATUS "CGAL_SONAME_VERSION=${CGAL_SONAME_VERSION}" )
 message( STATUS "CGAL_SOVERSION     =${CGAL_SOVERSION}" )

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -237,7 +237,7 @@ CGAL_EXPORT extern  Random  default_random;
 #ifdef CGAL_HEADER_ONLY
 inline Random& get_default_random()
 {
-  static Random default_random("default");
+  static Random default_random;
   return default_random;
 }
 #else // CGAL_HEADER_ONLY

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -66,7 +66,6 @@ public:
   // creation
   CGAL_EXPORT Random( );
   CGAL_EXPORT Random( unsigned int  seed);
-  CGAL_EXPORT Random(char*);
   
   // seed
   CGAL_EXPORT unsigned int get_seed ( ) const;

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -239,7 +239,6 @@ CGAL_EXPORT extern  Random  default_random;
 inline Random& get_default_random()
 {
   static Random default_random("default");
-  std::cerr << "get_default_random()" << std::endl;
   return default_random;
 }
 #else // CGAL_HEADER_ONLY

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -66,6 +66,7 @@ public:
   // creation
   CGAL_EXPORT Random( );
   CGAL_EXPORT Random( unsigned int  seed);
+  CGAL_EXPORT Random(char*);
   
   // seed
   CGAL_EXPORT unsigned int get_seed ( ) const;
@@ -237,7 +238,8 @@ CGAL_EXPORT extern  Random  default_random;
 #ifdef CGAL_HEADER_ONLY
 inline Random& get_default_random()
 {
-  static Random default_random;
+  static Random default_random("default");
+  std::cerr << "get_default_random()" << std::endl;
   return default_random;
 }
 #else // CGAL_HEADER_ONLY

--- a/Random_numbers/include/CGAL/Random_impl.h
+++ b/Random_numbers/include/CGAL/Random_impl.h
@@ -46,7 +46,11 @@ Random( )
     std::time_t s;
     std::time( &s);
     seed = (unsigned int)s;
-
+#if defined( CGAL_TEST_SUITE ) || defined( CGAL_PRINT_SEED )
+    if(this == & get_default_random()){
+      std::cerr << "default_random::get_seed() = " << seed << std::endl;
+    }
+#endif
     // initialize random numbers generator
     rng.seed(static_cast<boost::int32_t>(seed));
     random_value = get_int(0, 1<<15);
@@ -62,24 +66,6 @@ Random( unsigned int  seed)
     random_value = get_int(0, 1<<15);
 }
 
-
-CGAL_INLINE_FUNCTION
-Random::
-Random(char* )
-    :  val(0)
-{
-    // get system's time
-    std::time_t s;
-    std::time( &s);
-    seed = (unsigned int)s;
-
-#if defined( CGAL_TEST_SUITE ) || defined( CGAL_PRINT_SEED )
-    std::cerr << "default_random::get_seed() = " << seed << std::endl;
-#endif
-    // initialize random numbers generator
-    rng.seed(static_cast<boost::int32_t>(seed));
-    random_value = get_int(0, 1<<15);
-}
 
 // seed
 CGAL_INLINE_FUNCTION

--- a/Random_numbers/include/CGAL/Random_impl.h
+++ b/Random_numbers/include/CGAL/Random_impl.h
@@ -62,6 +62,25 @@ Random( unsigned int  seed)
     random_value = get_int(0, 1<<15);
 }
 
+
+CGAL_INLINE_FUNCTION
+Random::
+Random(char* )
+    :  val(0)
+{
+    // get system's time
+    std::time_t s;
+    std::time( &s);
+    seed = (unsigned int)s;
+
+#if defined( CGAL_TEST_SUITE ) || defined( CGAL_PRINT_SEED )
+    std::cerr << "default_random::get_seed() = " << seed << std::endl;
+#endif
+    // initialize random numbers generator
+    rng.seed(static_cast<boost::int32_t>(seed));
+    random_value = get_int(0, 1<<15);
+}
+
 // seed
 CGAL_INLINE_FUNCTION
 unsigned int

--- a/Random_numbers/src/CGAL/Random.cpp
+++ b/Random_numbers/src/CGAL/Random.cpp
@@ -29,7 +29,7 @@
 
 namespace CGAL {
 
-  Random  default_random = Random("default");
+  Random  default_random;
 
 } //namespace CGAL
 

--- a/Random_numbers/src/CGAL/Random.cpp
+++ b/Random_numbers/src/CGAL/Random.cpp
@@ -29,7 +29,7 @@
 
 namespace CGAL {
 
-Random  default_random;
+  Random  default_random = Random("default");
 
 } //namespace CGAL
 

--- a/Random_numbers/test/Random_numbers/test_Random-CGAL_TEST_SUITE.cpp
+++ b/Random_numbers/test/Random_numbers/test_Random-CGAL_TEST_SUITE.cpp
@@ -1,0 +1,14 @@
+#ifndef CGAL_TEST_SUITE
+#  define CGAL_TEST_SUITE 1
+#endif
+
+#include <CGAL/Random.h>
+
+int main()
+{
+  int  u = CGAL::get_default_random().get_int( 0, 1000);
+  if(u >= 0 || u <= 1000)
+    return 0;
+  else
+    return 1;
+}

--- a/Random_numbers/test/Random_numbers/test_Random-no-CGAL_TEST_SUITE.cpp
+++ b/Random_numbers/test/Random_numbers/test_Random-no-CGAL_TEST_SUITE.cpp
@@ -1,0 +1,14 @@
+#ifdef CGAL_TEST_SUITE
+#  undef CGAL_TEST_SUITE
+#endif
+
+#include <CGAL/Random.h>
+
+int main()
+{
+  int  u = CGAL::get_default_random().get_int( 0, 1000);
+  if(u >= 0 || u <= 1000)
+    return 0;
+  else
+    return 1;
+}


### PR DESCRIPTION
when CGAL_TEST_SUITE   or CGAL_PRINT_SEED is defined

Rationale: Again and again we get timeouts in the [testsuite](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-4.8-Ic-145/Point_set_shape_detection_3_Examples/TestReport_lrineau_CentOS5.gz),  and cannot reproduce them as we do not know the seed of `CGAL::default_random`.    

With this PR we dump the seed in the testsuite, and can advice users with a bug report to add a define.