### PR TITLE
Incremental builder: end_XXX functions now return one dart.

### DIFF
--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
@@ -47,10 +47,11 @@ namespace CGAL {
       ++new_vertices;
       return res;
     }
-    
+
     void begin_facet()
     {
-      CGAL_assertion( first_dart==lcc.null_handle && prev_dart==lcc.null_handle );
+      first_dart = lcc.null_handle;
+      prev_dart  = lcc.null_handle;
       // std::cout<<"Begin facet: "<<std::flush;
     }
 
@@ -83,7 +84,8 @@ namespace CGAL {
       prev_vertex = i;
     }
 
-    void end_facet()
+    // End of the facet. Return the first dart of this facet.
+    Dart_handle end_facet()
     {
       CGAL_assertion( first_dart!=lcc.null_handle && prev_dart!=lcc.null_handle );
       lcc.template link_beta<1>(prev_dart, first_dart);
@@ -98,8 +100,7 @@ namespace CGAL {
 
       add_dart_in_vertex_to_dart_map( prev_dart, prev_vertex );
 
-      first_dart = lcc.null_handle;
-      prev_dart = lcc.null_handle;
+      return first_dart;
       // std::cout<<"  end facet."<<std::endl;
     }
 
@@ -115,8 +116,9 @@ namespace CGAL {
       // lcc.reserve(v,h);
     }
 
-    void end_surface()
-    {}
+    // End of the surface. Return one dart of the created surface.
+    Dart_handle end_surface()
+    { return first_dart; }
 
   protected:
 


### PR DESCRIPTION
This simplifies creation and initialization of LCC.

The modified functions are undocumented.

Tested in https://cgal.geometryfactory.com/CGAL/Members/testsuite/results-4.8-Ic-145.shtml.