### PR TITLE
Bugfix: check if polygon soup is not empty before attempting BBox computation

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -665,6 +665,8 @@ Scene_polygon_soup_item::invalidateOpenGLBuffers()
 
 void Scene_polygon_soup_item::compute_bbox() const {
 
+  if (isEmpty())
+    return;
   const Point_3& p = *(soup->points.begin());
   CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
   for(Polygon_soup::Points::const_iterator it = soup->points.begin();


### PR DESCRIPTION
When calling `setColor` on a polygon soup item, the Polyhedron demo segfaults: `setColor` calls `invalidateOpenGlBuffers` which calls `compute_bbox`. This function computes the bounding box on points without checking if the container has been allocated (which is not the case if it is called before `init_polygon_soup`).

This bugfix adds a safety test at the beginning of `compute_bbox`.