### PR TITLE
Filtered_kernel: EPECK uses static filters

### DIFF
--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filters.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filters.h
@@ -170,6 +170,8 @@ public:
   Compare_squared_radius_3
   compare_squared_radius_3_object() const
   { return Compare_squared_radius_3(); }
+
+  enum { Has_static_filters = true };
 }; // end of class template Static_filters<K_base, false>
 
 

--- a/Filtered_kernel/test/Filtered_kernel/Filtered_kernel.cpp
+++ b/Filtered_kernel/test/Filtered_kernel/Filtered_kernel.cpp
@@ -21,6 +21,9 @@
 
 #include <CGAL/Delaunay_triangulation_3.h>
 
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #if 1
 struct K : public CGAL::Filtered_kernel<CGAL::Cartesian<double> > {};
 #else
@@ -48,6 +51,11 @@ int my_rand()
 
 int main()
 {
+  assert(  CGAL::Epeck::Has_filtered_predicates);
+  assert(  CGAL::Epick::Has_filtered_predicates);
+  assert(  K::Has_filtered_predicates);
+  assert(  !CGAL::Cartesian<double>::Has_filtered_predicates);
+
   Delaunay3d D;
   for (int i=0; i<100; i++)
     D.insert(K::Point_3(NT(my_rand()), NT(my_rand()), NT(my_rand()),

--- a/Filtered_kernel/test/Filtered_kernel/Static_filters.cpp
+++ b/Filtered_kernel/test/Filtered_kernel/Static_filters.cpp
@@ -4,6 +4,8 @@
 #include <CGAL/Filtered_kernel.h>
 #include <CGAL/Kernel_checker.h>
 #include <CGAL/Random.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 typedef CGAL::Simple_cartesian<double>   K0;
 typedef CGAL::Filtered_kernel<K0, true>  K2;
@@ -300,6 +302,26 @@ int main(int argc, char **argv)
 
   std::cout.precision(20);
   std::cerr.precision(20);
+
+  #ifndef CGAL_NO_STATIC_FILTERS
+  assert(  CGAL::Epick::Has_static_filters);
+  #else
+  assert( !CGAL::Epick::Has_static_filters);
+  #endif
+
+  #ifdef CGAL_DONT_USE_LAZY_KERNEL
+    #ifdef CGAL_NO_STATIC_FILTERS
+    assert(  !CGAL::Epeck::Has_static_filters);
+    #else
+    assert(  CGAL::Epeck::Has_static_filters);
+    #endif
+  #else
+    #ifdef CGAL_LAZY_KERNEL_USE_STATIC_FILTERS_BY_DEFAULT
+    assert(  CGAL::Epeck::Has_static_filters);
+    #else
+    assert( !CGAL::Epeck::Has_static_filters);
+    #endif
+  #endif
 
   assert(  K2::Has_static_filters);
   assert(! K4::Has_static_filters);


### PR DESCRIPTION
Regular triangulation was no longer using filtered predicates...