### PR TITLE
Polyhedron_demo : Fix for the c3t3_items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3_plugin/C3t3_io_plugin.cpp
@@ -58,6 +58,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
 
 
         if(item->load_binary(in)) {
+          item->c3t3_changed();
           item->changed();
           return item;
         }
@@ -65,6 +66,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
         item->c3t3().clear();
         in.seekg(0);
         if(try_load_other_binary_format(in, item->c3t3())) {
+          item->c3t3_changed();
           item->changed();
           return item;
         }
@@ -72,6 +74,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
         item->c3t3().clear();
         in.seekg(0);
         if(try_load_a_cdt_3(in, item->c3t3())) {
+          item->c3t3_changed();
           item->changed();
           return item;
         }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1146,7 +1146,6 @@ void Scene_c3t3_item::compute_elements()
   if (isEmpty()){
     return;
   }
-
   for (Tr::Finite_facets_iterator
          fit = c3t3().triangulation().finite_facets_begin(),
          end = c3t3().triangulation().finite_facets_end();
@@ -1165,7 +1164,6 @@ void Scene_c3t3_item::compute_elements()
       }
     }
     tree.build();
-
 
   //The facets
   {  


### PR DESCRIPTION
This is a fix for #851.

- A call to c3t3_changed() was missing in the end of the loading function.