### PR TITLE
Minor fix in Mesh_3

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1290,8 +1290,8 @@ conflicts_zone_impl(const Point& point
     if (p_facet != 0 && !facet_is_in_its_cz)
     {
 # ifdef CGAL_MESH_3_VERBOSE
-      std::cerr << "Info: the facet is not in its conflict zone. "
-        "Switching to exact computation." << std::endl;
+      std::cerr << "Info: the facet is not in the conflict zone of (" << point
+                << "). Switching to exact computation." << std::endl;
 # endif
       
       typename Rf_base::Facet_properties properties;

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -288,7 +288,7 @@ public:
       tree_.build();
       bounding_tree_ =
         bounding_polyhedron.empty() ?
-        &tree_ :
+        0 :
         new AABB_tree_(TriangleAccessor().triangles_begin(bounding_polyhedron),
                        TriangleAccessor().triangles_end(bounding_polyhedron));
       if(!bounding_polyhedron.empty()) {


### PR DESCRIPTION
Fix an undocumented behavior of Mesh_3: when the bounding polyhedron is empty, then the bounding tree should not be initialized at all (because an AABB tree cannot be empty).
