### PR TITLE
Polyhedron demo: add cdt2 mesher

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/CMakeLists.txt
@@ -1,0 +1,6 @@
+include( polyhedron_demo_macros )
+#if the plugin has a UI file
+qt5_wrap_ui( mesh_2UI_FILES mesh_2_dialog.ui)
+polyhedron_demo_plugin(mesh_2_plugin Mesh_2_plugin ${mesh_2UI_FILES})
+#if the plugin uses external libraries like scene_items
+target_link_libraries(mesh_2_plugin scene_polyhedron_item scene_polylines_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/CMakeLists.txt
@@ -3,4 +3,6 @@ include( polyhedron_demo_macros )
 qt5_wrap_ui( mesh_2UI_FILES mesh_2_dialog.ui)
 polyhedron_demo_plugin(mesh_2_plugin Mesh_2_plugin ${mesh_2UI_FILES})
 #if the plugin uses external libraries like scene_items
-target_link_libraries(mesh_2_plugin scene_polyhedron_item scene_polylines_item)
+target_link_libraries(mesh_2_plugin scene_polyhedron_item
+                                    scene_polylines_item
+                                    scene_points_with_normal_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/Mesh_2_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/Mesh_2_plugin.cpp
@@ -1,0 +1,373 @@
+#include <stdexcept>
+
+#define CGAL_CT2_WANTS_TO_HAVE_EXTRA_ACTION_FOR_INTERSECTING_CONSTRAINTS
+#define CGAL_CDT2_EXTRA_ACTION_FOR_INTERSECTING_CONSTRAINTS \
+  throw std::runtime_error("This plugin does not deal with intersecting edges");
+
+#include <QtCore/qglobal.h>
+
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
+
+#include "Scene_polyhedron_item.h"
+#include "Scene_polylines_item.h"
+#include "Polyhedron_type.h"
+
+#include <CGAL/iterator.h>
+
+#include <CGAL/Projection_traits_xy_3.h>
+#include <CGAL/Projection_traits_yz_3.h>
+#include <CGAL/Projection_traits_xz_3.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Delaunay_mesh_vertex_base_2.h>
+#include <CGAL/Delaunay_mesh_face_base_2.h>
+#include <CGAL/Delaunay_mesher_2.h>
+#include <CGAL/Delaunay_mesh_size_criteria_2.h>
+#include <CGAL/Triangulation_face_base_with_info_2.h>
+#include <CGAL/lloyd_optimize_mesh_2.h>
+
+#include <CGAL/boost/graph/Euler_operations.h>
+
+#include <QTime>
+#include <QAction>
+#include <QMainWindow>
+#include <QApplication>
+#include <QString>
+#include <QDialog>
+#include <QMessageBox>
+#include <QtPlugin>
+
+#include <vector>
+#include <algorithm>
+#include <queue>
+#include <sstream>
+
+#include "ui_mesh_2_dialog.h"
+
+struct FaceInfo2
+{
+  FaceInfo2(){}
+  int nesting_level;
+  bool in_domain(){
+    return nesting_level%2 == 1;
+  }
+};
+
+template <class CDT>
+void
+mark_domains(CDT& ct,
+             typename CDT::Face_handle start,
+             int index,
+             std::list<typename CDT::Edge>& border )
+{
+  if(start->info().nesting_level != -1){
+    return;
+  }
+  std::list<typename CDT::Face_handle> queue;
+  queue.push_back(start);
+  while(! queue.empty()){
+    typename CDT::Face_handle fh = queue.front();
+    queue.pop_front();
+    if(fh->info().nesting_level == -1){
+      fh->info().nesting_level = index;
+      for(int i = 0; i < 3; i++){
+        typename CDT::Edge e(fh,i);
+        typename CDT::Face_handle n = fh->neighbor(i);
+        if(n->info().nesting_level == -1){
+          if(ct.is_constrained(e)) border.push_back(e);
+          else queue.push_back(n);
+        }
+      }
+    }
+  }
+}
+
+template <class CDT>
+void
+mark_domains(CDT& cdt)
+{
+  for(typename CDT::All_faces_iterator it = cdt.all_faces_begin(); it != cdt.all_faces_end(); ++it){
+    it->info().nesting_level = -1;
+  }
+  std::list<typename CDT::Edge> border;
+  mark_domains(cdt, cdt.infinite_face(), 0, border);
+  while(! border.empty()){
+    typename CDT::Edge e = border.front();
+    border.pop_front();
+    typename CDT::Face_handle n = e.first->neighbor(e.second);
+    if(n->info().nesting_level == -1){
+      mark_domains(cdt, n, e.first->info().nesting_level+1, border);
+    }
+  }
+}
+
+template <class CDT, class TriangleMesh>
+void cdt2_to_face_graph(const CDT& cdt, TriangleMesh& tm)
+{
+  typedef typename boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
+
+  typedef std::map<typename CDT::Vertex_handle, vertex_descriptor> Map;
+  Map descriptors;
+  for (typename CDT::Finite_faces_iterator fit=cdt.finite_faces_begin(),
+                                           fit_end=cdt.finite_faces_end();
+                                           fit!=fit_end; ++fit)
+  {
+    if (!fit->info().in_domain()) continue;
+    CGAL::cpp11::array<vertex_descriptor,3> vds;
+    for(int i=0; i<3; ++i)
+    {
+      typename Map::iterator it;
+      bool insert_ok;
+      boost::tie(it,insert_ok) =
+        descriptors.insert(std::make_pair(fit->vertex(i),vertex_descriptor()));
+      if (insert_ok)
+        it->second = add_vertex(fit->vertex(i)->point(),tm);
+      vds[i]=it->second;
+    }
+
+    CGAL::Euler::add_face(vds, tm);
+  }
+}
+
+class Polyhedron_demo_mesh_2_plugin :
+  public QObject,
+  public CGAL::Three::Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+
+public:
+  void init(QMainWindow* mainWindow,
+            CGAL::Three::Scene_interface* scene_interface)
+  {
+    this->scene = scene_interface;
+    this->mw = mainWindow;
+
+    actionMesh_2_ = new QAction("Mesh_2", mw);
+    // actionMesh_2_->setProperty("subMenuName", "Polygon Mesh Processing");
+    if (actionMesh_2_) {
+      connect(actionMesh_2_, SIGNAL(triggered()),
+        this, SLOT(run()));
+    }
+  }
+
+  QList<QAction*> actions() const {
+    return QList<QAction*>() << actionMesh_2_;
+  }
+
+  bool applicable(QAction*) const
+  {
+    Q_FOREACH(int index, scene->selectionIndices())
+    {
+      //if one polyhedron is found in the selection, it's fine
+      if (qobject_cast<Scene_polylines_item*>(scene->item(index)))
+        return true;
+    }
+    return false;
+  }
+
+private:
+  Ui::mesh_2_dialog
+  create_dialog(QDialog* dialog, double diag_length)
+  {
+    Ui::mesh_2_dialog ui;
+    ui.setupUi(dialog);
+    connect(ui.buttonBox, SIGNAL(accepted()), dialog, SLOT(accept()));
+    connect(ui.buttonBox, SIGNAL(rejected()), dialog, SLOT(reject()));
+
+    //connect checkbox to spinbox
+    connect(ui.runLloyd_checkbox, SIGNAL(toggled(bool)),
+            ui.nbIterations_spinbox, SLOT(setEnabled(bool)));
+    connect(ui.runMesh2_checkbox, SIGNAL(toggled(bool)),
+            ui.edgeLength_dspinbox, SLOT(setEnabled(bool)));
+
+    //Set default parameters
+    ui.edgeLength_dspinbox->setDecimals(3);
+    ui.edgeLength_dspinbox->setSingleStep(0.001);
+    ui.edgeLength_dspinbox->setRange(1e-6 * diag_length, //min
+                                     2.   * diag_length);//max
+    ui.edgeLength_dspinbox->setValue(0.05 * diag_length);
+
+    std::ostringstream oss;
+    oss << "Diagonal length of the Bbox of the selection to mesh is ";
+    oss << diag_length << "." << std::endl;
+    oss << "Default is 5% of it" << std::endl;
+    ui.edgeLength_dspinbox->setToolTip(
+      "Diagonal length of the Bbox of the selection to mesh is "+
+      QString::number(diag_length)+" - default is 5% of it");
+
+    ui.nbIterations_spinbox->setSingleStep(1);
+    ui.nbIterations_spinbox->setRange(1/*min*/, 1000/*max*/);
+    ui.nbIterations_spinbox->setValue(1);
+
+    ui.runLloyd_checkbox->setChecked(false);
+    ui.runMesh2_checkbox->setChecked(true);
+
+    return ui;
+  }
+
+  template <class ProjectionTraits>
+  void mesh(std::vector<Scene_polylines_item*>& polylines_items,
+            double diagonal_length)
+  {
+    // Create dialog box
+    QDialog dialog(mw);
+    Ui::mesh_2_dialog ui =
+      create_dialog(&dialog, diagonal_length);
+
+    // Get values
+    int i = dialog.exec();
+    if (i == QDialog::Rejected)
+    {
+      std::cout << "2D Meshing aborted" << std::endl;
+      return;
+    }
+    bool runMesh2 = ui.runMesh2_checkbox->isChecked();
+    double target_length = ui.edgeLength_dspinbox->value();
+    unsigned int nb_iter = ui.nbIterations_spinbox->value();
+    bool runLloyd = ui.runLloyd_checkbox->isChecked();
+
+
+    // wait cursor
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    typedef ProjectionTraits                                             Gt;
+    typedef CGAL::Delaunay_mesh_vertex_base_2<Gt>                        Vb;
+    typedef CGAL::Delaunay_mesh_face_base_2<Gt>                          Fm;
+    typedef CGAL::Triangulation_face_base_with_info_2<FaceInfo2,Gt,Fm>   Fb;
+    typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                TDS;
+    typedef CGAL::No_intersection_tag                                   Tag;
+    typedef CGAL::Constrained_Delaunay_triangulation_2<Gt, TDS, Tag>    CDT;
+    typedef CGAL::Delaunay_mesh_size_criteria_2<CDT>               Criteria;
+
+    QTime time; // global timer
+    time.start();
+
+    std::cout << " Building Constrained_Delaunay_triangulation_2..."
+              << std::flush;
+    CDT cdt;
+
+    QTime ltime; //local timer
+    ltime.start();
+    try{
+      Q_FOREACH(Scene_polylines_item* polylines_item, polylines_items)
+        Q_FOREACH(const std::vector<Kernel::Point_3>& points,
+                    polylines_item->polylines)
+          cdt.insert_constraint(points.begin(),points.end());
+    }catch(std::runtime_error)
+    {
+      QApplication::restoreOverrideCursor();
+      throw;
+    }
+    std::cout << " done (" << ltime.elapsed() << " ms)" << std::endl;
+
+    if (cdt.dimension()!=2){
+      QApplication::restoreOverrideCursor();
+      std::cout << "Triangulation is not of dimension 2" << std::endl;
+      return;
+    }
+
+    if (runMesh2){
+      ltime.restart();
+      std::cout << " Running refine_Delaunay_mesh_2 ..." << std::flush;
+      CGAL::refine_Delaunay_mesh_2(cdt, Criteria(0.125, target_length));
+      std::cout << " done (" << ltime.elapsed() << " ms)" << std::endl;
+    }
+
+    if (runLloyd){
+      ltime.restart();
+      std::cout << " Running lloyd_optimize_mesh_2..." << std::flush;
+      CGAL::lloyd_optimize_mesh_2(cdt,
+        CGAL::parameters::max_iteration_number = nb_iter);
+      std::cout << " done (" << ltime.elapsed() << " ms)" << std::endl;
+    }
+
+    // export result as a polyhedron item
+    mark_domains(cdt);
+    QString iname =
+      polylines_items.size()==1?
+      polylines_items.front()->name()+QString("_meshed_"):
+      QString("2dmesh_");
+    iname+=QString::number(target_length);
+    if (runLloyd) iname+=QString("_Lloyd_")+QString::number(nb_iter);
+    Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
+    poly_item->setName(iname);
+    cdt2_to_face_graph(cdt,*poly_item->polyhedron());
+    scene->addItem(poly_item);
+    poly_item->invalidateOpenGLBuffers();
+
+    std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
+    // default cursor
+    QApplication::restoreOverrideCursor();
+  }
+
+  int detect_constant_coordinate(
+    const std::vector<Scene_polylines_item*>& polylines_items)
+  {
+    int res=-1;
+    Kernel::Point_3 ref = polylines_items.front()->polylines.front().front();
+    Q_FOREACH(Scene_polylines_item* polylines_item, polylines_items)
+      Q_FOREACH(const std::vector<Kernel::Point_3>& points,
+                  polylines_item->polylines)
+        Q_FOREACH(const Kernel::Point_3& pt, points)
+        {
+          int nbe=0, candidate=-1;
+          for (int i=0; i<3; ++i)
+            if (ref[i]==pt[i]){
+              ++nbe;
+              candidate=i;
+            }
+          if (nbe==0) return -1;
+          if (nbe==1){
+            if (res==-1)
+              res=candidate;
+            else
+              if(res!=candidate) return -1;
+          }
+        }
+    return res;
+  }
+
+public Q_SLOTS:
+
+  void run()
+  {
+    //collect input polylines
+    std::vector<Scene_polylines_item*> polylines_items;
+    double inf = std::numeric_limits<double>::infinity();
+    CGAL::Three::Scene_interface::Bbox bbox(inf,inf,inf,-inf,-inf,-inf);
+    Q_FOREACH(int index, scene->selectionIndices())
+    {
+      Scene_polylines_item* polylines_item =
+        qobject_cast<Scene_polylines_item*>(scene->item(index));
+      if (polylines_item){
+        polylines_items.push_back(polylines_item);
+        bbox=bbox+polylines_item->bbox();
+      }
+    }
+
+    double diag = bbox.diagonal_length();
+    switch( detect_constant_coordinate(polylines_items) )
+    {
+      case 0:
+        mesh<CGAL::Projection_traits_yz_3<Kernel> >(polylines_items, diag);
+      break;
+      case 1:
+        mesh<CGAL::Projection_traits_xz_3<Kernel> >(polylines_items, diag);
+      break;
+      case 2:
+        mesh<CGAL::Projection_traits_xy_3<Kernel> >(polylines_items, diag);
+      break;
+      default:
+        QMessageBox::critical(mw,
+                              "Invalid Input Data",
+                              "Polylines must all be in the xy, yz or xz plane");
+    }
+  }
+
+private:
+  QAction* actionMesh_2_;
+
+}; // end Mesh_2_plugin
+
+#include "Mesh_2_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/mesh_2_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/mesh_2_dialog.ui
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>mesh_2_dialog</class>
+ <widget class="QDialog" name="mesh_2_dialog">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>310</width>
+    <height>233</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>2D Mesh Criteria</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Mesh_2</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0" columnstretch="2,0">
+      <item row="2" column="0">
+       <widget class="QLabel" name="edgeLength_label">
+        <property name="text">
+         <string>Maximum edge length</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>edgeLength_dspinbox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="edgeLength_dspinbox">
+        <property name="minimumSize">
+         <size>
+          <width>110</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="runLloyd_checkbox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="runLloyd_label">
+        <property name="text">
+         <string>Run Lloyd Optimisation</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="runMesh2_label">
+        <property name="text">
+         <string>Run Mesh Refinement</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="runMesh2_checkbox">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="nbIterations_label">
+        <property name="text">
+         <string>Number of iterations</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>nbIterations_spinbox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QSpinBox" name="nbIterations_spinbox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>110</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>edgeLength_dspinbox</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>mesh_2_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>388</x>
+     <y>288</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>mesh_2_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>388</x>
+     <y>288</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/mesh_2_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2_plugin/mesh_2_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>310</width>
-    <height>233</height>
+    <width>408</width>
+    <height>357</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,98 +22,157 @@
      <property name="title">
       <string>Mesh_2</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0" columnstretch="2,0">
-      <item row="2" column="0">
-       <widget class="QLabel" name="edgeLength_label">
-        <property name="text">
-         <string>Maximum edge length</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>edgeLength_dspinbox</cstring>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="runMesh2_label">
+          <property name="text">
+           <string>Run Mesh Refinement</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="runMesh2_checkbox">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="edgeLength_dspinbox">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>1000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="edgeLength_label">
+          <property name="text">
+           <string>Maximum edge length</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>edgeLength_dspinbox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="edgeLength_dspinbox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximum">
+           <double>1000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="5" column="1">
-       <widget class="QCheckBox" name="runLloyd_checkbox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Domain Definition:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QRadioButton" name="radioAll">
+            <property name="text">
+             <string>Whole Domain</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioNesting">
+            <property name="text">
+             <string>Use Nesting Number</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioSeedsIn">
+            <property name="text">
+             <string>With Seeds Inside the Domain</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioSeedsOut">
+            <property name="text">
+             <string>With Seeds Outside the Domain</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="runLloyd_label">
-        <property name="text">
-         <string>Run Lloyd Optimisation</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="runLloyd_label">
+          <property name="text">
+           <string>Run Lloyd Optimisation</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="runLloyd_checkbox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="runMesh2_label">
-        <property name="text">
-         <string>Run Mesh Refinement</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="runMesh2_checkbox">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="nbIterations_label">
-        <property name="text">
-         <string>Number of iterations</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>nbIterations_spinbox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QSpinBox" name="nbIterations_spinbox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="nbIterations_label">
+          <property name="text">
+           <string>Number of iterations</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>nbIterations_spinbox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="nbIterations_spinbox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This plugin enables the meshing of polylines (not necessarily in the same item) that are in the xy, yz or xz plane. Seeds are handled as well as nested domain definition.

Minor know issue: if run mesh_2 is switch off but run Lloyd was switch on, the spinbox for the number of iteration is not disabled.

cc @afabri @janetournois 