### PR TITLE
Fix the I/O of C3t3 in <CGAL/Mesh_vertex_base_3.h>

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
@@ -272,11 +272,11 @@ operator>>(std::istream &is, Mesh_vertex_base_3<GT,MD,Vb>& v)
   } else {
     CGAL::read(is, dimension);
   }
-  CGAL_assertion(dimension >= 0);
-  CGAL_assertion(dimension < 4);
-  typename Vertex::Index index = 
-    internal::Mesh_3::Read_mesh_domain_index<MD>()(dimension, is);
   v.set_dimension(dimension);
+  CGAL_assertion(v.in_dimension() >= -1);
+  CGAL_assertion(v.in_dimension() < 4);
+  typename Vertex::Index index =
+    internal::Mesh_3::Read_mesh_domain_index<MD>()(v.in_dimension(), is);
   v.set_index(index);
   return is;
 }


### PR DESCRIPTION
When a C3t3:
* either was created using parallel Mesh_3,
* or has "special protecting balls", 

then the `dimension` of a vertex can be negative:
* `-1` for far points,
* `dimension_ = -2-dimension_;` for special vertices.

But there was an assertion `dimension >= 0` in `Mesh_vertex_base_3::operator>>`. This commit fixes the assertion (the verification is now on `v.in_dimension()` instead of checking the internal value. And the dimension -1 is allowed, for far points.

@sloriot, in my opinion that can go to CGAL-4.8. Tell me if you disagree.

CC @cjamin (because that involves far points)