### PR TITLE
Fix the c3t3 item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -440,15 +440,14 @@ void Scene_c3t3_item::compute_bbox() const {
   if (isEmpty())
     _bbox = Bbox();
   else {
-    CGAL::Bbox_3 result =
-      c3t3().cells_in_complex_begin()->vertex(0)->point().bbox();
-    for (C3t3::Cells_in_complex_iterator
-      cit = ++c3t3().cells_in_complex_begin(),
-      cend = c3t3().cells_in_complex_end();
-      cit != cend; ++cit)
+    CGAL::Bbox_3 result;
+    for (Tr::Finite_vertices_iterator
+           vit = ++c3t3().triangulation().finite_vertices_begin(),
+           end = c3t3().triangulation().finite_vertices_end();
+         vit != end; ++vit)
     {
-      result = result + cit->vertex(0)->point().bbox();
-      //only one vertex should be a satisfactory approximation
+      if(vit->in_dimension() == -1) continue;
+      result = result + vit->point().bbox();
     }
     _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
                  result.xmax(), result.ymax(), result.zmax());

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -85,7 +85,8 @@ public:
   bool isFinite() const { return true; }
   bool isEmpty() const {
     return c3t3().triangulation().number_of_vertices() == 0
-      || c3t3().number_of_cells() == 0;
+      || (    c3t3().number_of_facets_in_complex() == 0
+           && c3t3().number_of_cells_in_complex()  == 0  );
   }
 
   void compute_bbox() const;


### PR DESCRIPTION
- The `isEmpty()` function was wrong: if the domain contains 2D surfaces
  it cannot be considered as empty, even if the 3D volume is empty.

- The computation of the bbox was wrong too.