### PR TITLE
PMP::isotropic_remeshing() - improve management of constraints

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -150,6 +150,15 @@ the property map containing information about edges of the input polygon mesh be
 a default property map where no edge is constrained is provided.
 \cgalNPEnd
 
+\cgalNPBegin{ vertex_is_constrained_map } \anchor PMP_vertex_is_constrained_map
+the property map containing information about vertices of the input polygon mesh being constrained or not.\n
+\b Type : a class model of `ReadablePropertyMap` with
+`boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
+`bool` as value type. It should be default constructible.\n
+\b Default : if this parameter is omitted,
+a default property map where no vertex is constrained is provided.
+\cgalNPEnd
+
 \cgalNPBegin{protect_constraints} \anchor PMP_protect_constraints
 enables the protection of constraints listed by \ref PMP_edge_is_constrained_map "edge_is_constrained_map"
 during isotropic remeshing. If `true`, constraint edges cannot be modified at all

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -143,7 +143,7 @@ algorithm.\n
 
 \cgalNPBegin{ edge_is_constrained_map } \anchor PMP_edge_is_constrained_map
 the property map containing information about edges of the input polygon mesh being constrained or not.\n
-\b Type : a class model of `ReadablePropertyMap` with
+\b Type : a class model of `ReadWritePropertyMap` with
 `boost::graph_traits<PolygonMesh>::%edge_descriptor` as key type and
 `bool` as value type. It should be default constructible.\n
 \b Default : if this parameter is omitted,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -86,10 +86,10 @@ namespace internal {
     typedef value_type&                         reference;
     typedef boost::read_write_property_map_tag  category;
 
-    friend bool get(const No_constraint_pmap& map, const key_type& e) {
+    friend bool get(const No_constraint_pmap& , const key_type& ) {
       return false;
     }
-    friend void put(No_constraint_pmap& map, const key_type& e, const bool is) {}
+    friend void put(No_constraint_pmap& , const key_type& , const bool ) {}
   };
 
   template <typename PM, typename FaceRange>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1178,6 +1178,8 @@ private:
           halfedge_descriptor hopp = opposite(h, mesh_);
           if (halfedge_status_map_[hopp] == PATCH)
             halfedge_status_map_[hopp] = PATCH_BORDER;
+
+          put(ecmap_, e, false);
         }
       }
 
@@ -1512,6 +1514,18 @@ private:
 
     const Patch_id_list& input_patch_ids() const {
       return input_patch_ids_;
+    }
+
+    void update_constraints_property_map()
+    {
+      BOOST_FOREACH(edge_descriptor e, edges(mesh_))
+      {
+        if (is_on_patch_border(halfedge(e, mesh_))
+          || is_on_patch_border(opposite(halfedge(e, mesh_), mesh_)))
+          put(ecmap_, e, true);
+        else
+          put(ecmap_, e, false);
+      }
     }
 
   private:

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
@@ -35,6 +35,7 @@ namespace CGAL{
   enum geom_traits_t                { geom_traits };
   enum number_of_iterations_t       { number_of_iterations };
   enum protect_constraints_t        { protect_constraints };
+  enum vertex_is_constrained_t      { vertex_is_constrained };
 
   //to be documented
   enum smooth_along_features_t      { smooth_along_features };
@@ -148,6 +149,14 @@ namespace CGAL{
     {
       typedef pmp_bgl_named_params<Boolean, smooth_along_features_t, self> Params;
       return Params(b, *this);
+    }
+
+    template <typename VertexIsConstrained>
+    pmp_bgl_named_params<VertexIsConstrained, vertex_is_constrained_t, self>
+    vertex_is_constrained_map(const VertexIsConstrained& vm) const
+    {
+      typedef pmp_bgl_named_params<VertexIsConstrained, vertex_is_constrained_t, self> Params;
+      return Params(vm, *this);
     }
 
     //overload
@@ -286,6 +295,14 @@ namespace parameters{
   {
     typedef pmp_bgl_named_params<Boolean, smooth_along_features_t> Params;
     return Params(b);
+  }
+
+  template <typename VertexIsConstrained>
+  pmp_bgl_named_params<VertexIsConstrained, vertex_is_constrained_t>
+  vertex_is_constrained_map(const VertexIsConstrained& vm)
+  {
+    typedef pmp_bgl_named_params<VertexIsConstrained, vertex_is_constrained_t> Params;
+    return Params(vm);
   }
 
   //overload

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -124,9 +124,9 @@ void isotropic_remeshing(const FaceRange& faces
       msg.c_str());
   }
 
-  typename internal::Incremental_remesher<PM, VPMap, GT>
-    remesher(pmesh, vpmap, protect);
-  remesher.init_remeshing(faces, ecmap);
+  typename internal::Incremental_remesher<PM, VPMap, ECMap, GT>
+    remesher(pmesh, vpmap, protect, ecmap);
+  remesher.init_remeshing(faces);
 
   unsigned int nb_iterations = choose_param(get_param(np, number_of_iterations), 1);
   bool smoothing_1d = choose_param(get_param(np, smooth_along_features), false);
@@ -214,6 +214,7 @@ void split_long_edges(const EdgeRange& edges
                     , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
+  typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
   using boost::choose_pmap;
   using boost::get_param;
 
@@ -223,8 +224,11 @@ void split_long_edges(const EdgeRange& edges
                             pmesh,
                             boost::vertex_point);
 
-  typename internal::Incremental_remesher<PM, VPMap, GT>
-    remesher(pmesh, vpmap, false/*protect constraints*/, false/*need aabb_tree*/);
+  typedef std::vector<face_descriptor>                     FaceRange;
+  typedef internal::Border_constraint_pmap<PM, FaceRange>  ECMap;
+
+  typename internal::Incremental_remesher<PM, VPMap, ECMap, GT>
+    remesher(pmesh, vpmap, false/*protect constraints*/, ECMap(), false/*need aabb_tree*/);
 
   remesher.split_long_edges(edges, max_length, Emptyset_iterator());
 }
@@ -253,6 +257,7 @@ void split_long_edges(
         , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
+  typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
   using boost::choose_pmap;
   using boost::get_param;
 
@@ -261,9 +266,11 @@ void split_long_edges(
   VPMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
                             pmesh,
                             boost::vertex_point);
+  typedef std::vector<face_descriptor>                     FaceRange;
+  typedef internal::Border_constraint_pmap<PM, FaceRange>  ECMap;
 
-  typename internal::Incremental_remesher<PM, VPMap, GT>
-    remesher(pmesh, vpmap, false/*protect constraints*/, false/*need aabb_tree*/);
+  typename internal::Incremental_remesher<PM, VPMap, ECMap, GT>
+    remesher(pmesh, vpmap, false/*protect constraints*/, ECMap(), false/*need aabb_tree*/);
 
   remesher.split_long_edges(edge_range, max_length, out);
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -229,7 +229,6 @@ void split_long_edges(const EdgeRange& edges
                     , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
-  typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
   using boost::choose_pmap;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -154,6 +154,8 @@ void isotropic_remeshing(const FaceRange& faces
 #endif
   }
 
+  remesher.update_constraints_property_map();
+
 #ifdef CGAL_PMP_REMESHING_VERBOSE
   std::cout << "Remeshing done (size = " << target_edge_length;
   std::cout << ", #iter = " << nb_iterations << ")." << std::endl;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -94,7 +94,7 @@ void isotropic_remeshing(const FaceRange& faces
                        , const NamedParameters& np)
 {
   typedef PolygonMesh PM;
-  typedef boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
   using boost::choose_pmap;
   using boost::get_param;
   using boost::choose_param;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -181,7 +181,8 @@ public Q_SLOTS:
          , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
          .protect_constraints(protect)
          .edge_is_constrained_map(selection_item->constrained_edges_pmap())
-         .smooth_along_features(smooth_features));
+         .smooth_along_features(smooth_features)
+         .vertex_is_constrained_map(selection_item->constrained_vertices_pmap()));
         }
         selection_item->poly_item_changed();
         selection_item->clear<face_descriptor>();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -142,7 +142,6 @@ public Q_SLOTS:
 
       if (selection_item)
       {
-        std::vector<edge_descriptor> updated_selected_edges;
         if (edges_only)
         {
           std::vector<edge_descriptor> edges;
@@ -163,12 +162,15 @@ public Q_SLOTS:
               edges.push_back(edge(he, pmesh));
             }
           }
-          CGAL::Polygon_mesh_processing::split_long_edges(
+          if (!edges.empty())
+            CGAL::Polygon_mesh_processing::split_long_edges(
               edges
-            , target_length
-            , *selection_item->polyhedron()
-            , std::back_inserter(updated_selected_edges)
-            , PMP::parameters::geom_traits(Kernel()));
+              , target_length
+              , *selection_item->polyhedron()
+              , PMP::parameters::geom_traits(Kernel())
+              .edge_is_constrained_map(selection_item->constrained_edges_pmap()));
+          else
+            std::cout << "No selected or boundary edges to be split" << std::endl;
         }
         else
         {
@@ -198,10 +200,14 @@ public Q_SLOTS:
           BOOST_FOREACH(halfedge_descriptor h, border)
             border_edges.push_back(edge(h, pmesh));
 
-          CGAL::Polygon_mesh_processing::split_long_edges(
+          if (!border_edges.empty())
+            CGAL::Polygon_mesh_processing::split_long_edges(
               border_edges
-            , target_length
-            , *poly_item->polyhedron());
+              , target_length
+              , *poly_item->polyhedron()
+              , PMP::parameters::geom_traits(Kernel()));
+          else
+            std::cout << "No border to be split" << std::endl;
         }
         else
         {
@@ -454,6 +460,8 @@ private:
     connect(ui.splitEdgesOnly_checkbox, SIGNAL(toggled(bool)),
             ui.protect_checkbox, SLOT(setDisabled(bool)));
     connect(ui.protect_checkbox, SIGNAL(toggled(bool)),
+            ui.smooth1D_checkbox, SLOT(setDisabled(bool)));
+    connect(ui.splitEdgesOnly_checkbox, SIGNAL(toggled(bool)),
             ui.smooth1D_checkbox, SLOT(setDisabled(bool)));
 
     //Set default parameters

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -172,33 +172,17 @@ public Q_SLOTS:
         }
         else
         {
-        std::vector<bool> selected(
-          selection_item->polyhedron()->size_of_halfedges()/2,
-          false);
-
-        if (selection_item->selected_edges.empty())
-          CGAL::Polygon_mesh_processing::isotropic_remeshing(
-            selection_item->selected_facets
-          , target_length
-          , *selection_item->polyhedron()
-          , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
-          .protect_constraints(protect)
-          .smooth_along_features(smooth_features));
-        else
-          CGAL::Polygon_mesh_processing::isotropic_remeshing(
+         CGAL::Polygon_mesh_processing::isotropic_remeshing(
            selection_item->selected_facets
          , target_length
          , *selection_item->polyhedron()
          , CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
          .protect_constraints(protect)
-         .edge_is_constrained_map(selection_item->selected_edges_pmap(selected))
+         .edge_is_constrained_map(selection_item->constrained_edges_pmap())
          .smooth_along_features(smooth_features));
-
         }
         selection_item->poly_item_changed();
-        selection_item->clear_all();
-        selection_item->selected_edges.insert(updated_selected_edges.begin(),
-                                              updated_selected_edges.end());
+        selection_item->clear<face_descriptor>();
         selection_item->changed_with_poly_item();
       }
       else if (poly_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -34,6 +34,7 @@ typedef boost::graph_traits<Polyhedron>::vertex_descriptor		vertex_descriptor;
 typedef boost::graph_traits<Polyhedron>::vertex_iterator		  vertex_iterator;
 typedef boost::graph_traits<Polyhedron>::face_descriptor      face_descriptor;
 typedef boost::graph_traits<Polyhedron>::halfedge_descriptor  halfedge_descriptor;
+typedef boost::graph_traits<Polyhedron>::edge_descriptor      edge_descriptor;
 
 struct Array_based_vertex_point_map
 {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -552,6 +552,29 @@ public:
     }
   };
 
+  struct Is_constrained_map
+  {
+    Selection_set_edge& m_set;
+
+    typedef edge_descriptor                    key_type;
+    typedef bool                               value_type;
+    typedef bool                               reference;
+    typedef boost::read_write_property_map_tag category;
+
+    Is_constrained_map(Selection_set_edge& set_)
+      : m_set(set_)
+    {}
+    friend bool get(const Is_constrained_map& map, const key_type& k)
+    {
+      return map.m_set.count(k);
+    }
+    friend void put(Is_constrained_map& map, const key_type& k, const value_type b)
+    {
+      if (b)  map.m_set.insert(k);
+      else    map.m_set.erase(k);
+    }
+  };
+
   template <class Handle>
   struct Index_map
   {
@@ -854,6 +877,11 @@ public:
       mark[tr.id(e)] = true;
 
     return Is_selected_property_map<edge_descriptor>(mark);
+  }
+
+  Is_constrained_map constrained_edges_pmap()
+  {
+    return Is_constrained_map(selected_edges);
   }
 
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -552,16 +552,17 @@ public:
     }
   };
 
+  template <typename SelectionSet>
   struct Is_constrained_map
   {
-    Selection_set_edge& m_set;
+    SelectionSet& m_set;
 
-    typedef edge_descriptor                    key_type;
+    typedef typename SelectionSet::key_type    key_type;
     typedef bool                               value_type;
     typedef bool                               reference;
     typedef boost::read_write_property_map_tag category;
 
-    Is_constrained_map(Selection_set_edge& set_)
+    Is_constrained_map(SelectionSet& set_)
       : m_set(set_)
     {}
     friend bool get(const Is_constrained_map& map, const key_type& k)
@@ -879,9 +880,14 @@ public:
     return Is_selected_property_map<edge_descriptor>(mark);
   }
 
-  Is_constrained_map constrained_edges_pmap()
+  Is_constrained_map<Selection_set_edge> constrained_edges_pmap()
   {
-    return Is_constrained_map(selected_edges);
+    return Is_constrained_map<Selection_set_edge>(selected_edges);
+  }
+
+  Is_constrained_map<Selection_set_vertex> constrained_vertices_pmap()
+  {
+    return Is_constrained_map<Selection_set_vertex>(selected_vertices);
   }
 
 protected:


### PR DESCRIPTION
This PR makes 3 improvements to the management of constraints in `PMP::isotropic_remeshing`

- fix a bug that was loosing the corner vertices (incident to more than 2 constraints) during the remeshing process (because of some wrong collapse and relaxation steps)
- introduce the ability to choose constrained vertices, that are not allowed to be modified by remeshing
- keep the selection_item valid by updating the selection of constrained edges after remeshing (i.e. resampling for edges) 

edit : the deformation plugin also benefits of keeping its selection valid after remeshing