### PR TITLE
Polyhedron_demo:  Trivial fixes

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1002,9 +1002,7 @@ void MainWindow::open(QString filename)
   settings.setValue("OFF open directory",
                     fileinfo.absoluteDir().absolutePath());
 
-  QApplication::setOverrideCursor(Qt::WaitCursor);
   CGAL::Three::Scene_item* scene_item = load_item(fileinfo, find_loader(load_pair.first));
-  QApplication::restoreOverrideCursor();
 
   if(scene_item != 0) {
     this->addToRecentFiles(fileinfo.absoluteFilePath());

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1187,11 +1187,14 @@ void MainWindow::showSceneContextMenu(int selectedItemIndex,
   if(menu) {
     bool menuChanged = menu->property(prop_name).toBool();
     if(!menuChanged) {
-      QAction* actionStatistics =
-      menu->addAction(tr("Statistics..."));
-      actionStatistics->setObjectName("actionStatisticsOnPolyhedron");
-      connect(actionStatistics, SIGNAL(triggered()),
-              this, SLOT(statistics_on_item()));
+      if(item->has_stats())
+      {
+        QAction* actionStatistics =
+            menu->addAction(tr("Statistics..."));
+        actionStatistics->setObjectName("actionStatisticsOnPolyhedron");
+        connect(actionStatistics, SIGNAL(triggered()),
+                this, SLOT(statistics_on_item()));
+      }
       menu->addSeparator();
       if(!item->property("source filename").toString().isEmpty()) {
         QAction* reload = menu->addAction(tr("&Reload Item from File"));

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -81,8 +81,9 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
   else
     if( total_nb_of_vertices!= item->polyhedron()->size_of_vertices())
     {
-      QApplication::restoreOverrideCursor();
       item->setNbIsolatedvertices(total_nb_of_vertices - item->polyhedron()->size_of_vertices());
+      //needs two restore, it's not a typo
+      QApplication::restoreOverrideCursor();
       QMessageBox::warning((QWidget*)NULL,
                      tr("Isolated vertices found"),
                      tr("%1 isolated vertices ignored")

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -45,6 +45,7 @@ public:
       MEAN_ANGLE
     };
     QString compute_stats(int type);
+     bool has_stats()const {return true;}
     CGAL::Three::Scene_item::Header_data header() const;
     Scene_polyhedron_item();
     //   Scene_polyhedron_item(const Scene_polyhedron_item&);

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -427,12 +427,7 @@ protected:
       vaos[i] = n_vao;
   }
 
-  //! Used pass data to the shader.
-  int vertexLoc;
-  //! Used pass data to the shader.
-  int normalLoc;
-  //! Used pass data to the shader.
-  int colorLoc;
+
   /*! Fills the VBOs with data. Must be called after each call to #compute_elements().
    * @see compute_elements()
    */

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -271,6 +271,8 @@ public:
   };
   //!Returns a Header_data struct containing the header information.
   virtual Header_data header()const;
+  //!Returns true if the item has statistics.
+  virtual bool has_stats()const{return false;}
   //!Returns a QString containing the requested value for the the table in the statistics dialog
   /*!
    * Example :


### PR DESCRIPTION
This PR fixes two minor problems :

- It does some clean-up in Scene_item.h
- It fixes #864 by introducing a boolean function called has_stats(), which returns false by default. An item will not have an "Statistics" option displayed in its context menu if has_stats doesn't return true.