### PR TITLE
Polyhedron demo : c3t3 color fix

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1055,13 +1055,13 @@ void Scene_c3t3_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer)
 
 void Scene_c3t3_item::compute_intersection(const Primitive& facet)
 {  
-
   const Kernel::Point_3& pa = facet.id().first->vertex(0)->point();
   const Kernel::Point_3& pb = facet.id().first->vertex(1)->point();
   const Kernel::Point_3& pc = facet.id().first->vertex(2)->point();
   const Kernel::Point_3& pd = facet.id().first->vertex(3)->point();
- 
+
   QColor color = d->colors[facet.id().first->subdomain_index()].darker(150);
+
   for(int i=0; i < 12;i++){
     f_colors.push_back(color.redF());f_colors.push_back(color.greenF());f_colors.push_back(color.blueF());
   }
@@ -1074,6 +1074,7 @@ void Scene_c3t3_item::compute_intersection(const Primitive& facet)
   draw_triangle_edges(pa, pb, pd);
   draw_triangle_edges(pa, pd, pc);
   draw_triangle_edges(pb, pc, pd);
+
   {
     Tr::Cell_handle nh = facet.id().first->neighbor(facet.id().second);
     if(c3t3().is_in_complex(nh)){
@@ -1113,6 +1114,9 @@ void Scene_c3t3_item::compute_intersections()
 
 void Scene_c3t3_item::compute_elements()
 {
+  positions_poly.clear();
+  normals.clear();
+  f_colors.clear();
   positions_lines.clear();
   s_colors.resize(0);
   s_center.resize(0);
@@ -1241,7 +1245,6 @@ void Scene_c3t3_item::compute_elements()
 bool Scene_c3t3_item::load_binary(std::istream& is)
 {
   if(!CGAL::Mesh_3::load_binary_file(is, c3t3())) return false;
-  // if(!c3t3().triangulation().is_valid()) std::cerr << "INVALID\n";
   if(is && frame == 0) {
     frame = new qglviewer::ManipulatedFrame();
   }
@@ -1271,5 +1274,7 @@ Scene_c3t3_item::setColor(QColor c)
   color_ = c;
   compute_color_map(c);
   invalidateOpenGLBuffers();
-  changed();
+// changed() doesn't work because the timerEvent delays it out of the draw
+// function and the intersection is not drawn before the next draw call
+  are_intersection_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -42,7 +42,7 @@ public:
   Scene_c3t3_item();
   Scene_c3t3_item(const C3t3& c3t3);
   ~Scene_c3t3_item();
-
+  void setColor(QColor c);
   bool save_binary(std::ostream& os) const
   {
     return CGAL::Mesh_3::save_binary_file(os, c3t3());
@@ -85,7 +85,8 @@ public:
   bool isFinite() const { return true; }
   bool isEmpty() const {
     return c3t3().triangulation().number_of_vertices() == 0
-      || c3t3().number_of_cells() == 0;
+        || (    c3t3().number_of_facets_in_complex() == 0
+                && c3t3().number_of_cells_in_complex()  == 0  );
   }
 
   void compute_bbox() const;


### PR DESCRIPTION
This is a fix for #869.

 The colors of a c3t3 are now computed using their facets surface patch indices in addition of their cells subdomain index. 