### PR TITLE
PMP doc : Isotropic remeshing requires faces and halfedges to be hashable

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -39,6 +39,9 @@ namespace Polygon_mesh_processing {
 *
 * @tparam PolygonMesh model of `MutableFaceGraph` that 
 *         has an internal property map for `CGAL::vertex_point_t`.
+*         The descriptor types `boost::graph_traits<PolygonMesh>::%face_descriptor`
+*         and `boost::graph_traits<PolygonMesh>::%halfedge_descriptor` must be
+*         models of `Hashable`.
 * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
           model of `Range`. Its iterator type is `InputIterator`.
 * @tparam NamedParameters a sequence of \ref namedparameters


### PR DESCRIPTION
This PR adds requirements to the halfedge and face descriptors types in PolygonMesh.
They should be models of `Hashable`

this PR fixes issue #806 