### PR TITLE
PMP isotropic remeshing : reduce the internal aabb_tree to the input face_range

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -204,7 +204,7 @@ namespace internal {
         boost::make_assoc_property_map(patch_ids_map_),// set patch_id() for each face
         PMP::parameters::edge_is_constrained_map(cpmap));
 
-      BOOST_FOREACH(face_descriptor f, faces(mesh_))
+      BOOST_FOREACH(face_descriptor f, face_range)
       {
         input_triangles_.push_back(triangle(f));
         input_patch_ids_.push_back(get_patch_id(f));


### PR DESCRIPTION
The input triangles are only composed of the face_range to remesh.

This reduces the size of the aabb_tree for projection
and fixes the fact that the face range only should be triangulated, not the
entire polygon mesh.

This PR is a bug fix for 4.8
@sloriot can you please test it on the data on which you got issues with projections in the past?