### PR TITLE
Adding moc files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1133,6 +1133,8 @@ semantic.cache
 ui_*.h
 qrc_*.cxx
 *.qrc.depends
+moc_*.cpp
+*automoc.cpp
 
 # Emacs file
 .dir-locals.el


### PR DESCRIPTION
Just adding two rules in the .gitignore file to ignore moc files from Qt compilation.