### PR TITLE
Ex-filtrate Compare_{x,y}_2::operator(Point_2,Point_2) and (re-gain) a factor of 2 in speed

### DIFF
--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Compare_x_2.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Compare_x_2.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2011 GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+//
+// Author(s)     : Andreas Fabri
+
+
+#ifndef CGAL_INTERNAL_STATIC_FILTERS_COMPARE_X_2_H
+#define CGAL_INTERNAL_STATIC_FILTERS_COMPARE_X_2_H
+
+#include <CGAL/Bbox_2.h>
+#include <CGAL/Profile_counter.h>
+#include <CGAL/internal/Static_filters/tools.h>
+#include <cmath>
+#include <iostream>
+
+namespace CGAL {
+
+namespace internal {
+
+namespace Static_filters_predicates {
+
+
+template < typename K_base >
+class Compare_x_2
+  : public K_base::Compare_x_2
+{
+  typedef typename K_base::Point_2   Point_2;
+  typedef typename K_base::Line_2    Line_2;
+  typedef typename K_base::Compare_x_2   Base;
+
+public:
+
+  typedef typename Base::result_type  result_type;
+
+
+#ifndef CGAL_CFG_MATCHING_BUG_6
+  using Base::operator();
+#else // CGAL_CFG_MATCHING_BUG_6
+  template <typename T>
+  result_type
+  operator()(const T& t1, const T& t2, const T& t3) const
+  {
+    return Base()(t1,t2,t3);
+  }
+
+  template <typename T>
+  result_type
+  operator()(const T& t1, const T& t2, const T& t3, const T& t4) const
+  {
+    return Base()(t1,t2,t3, t4);
+  } 
+  
+  result_type
+  operator()(const Point_2& p, const Line_2& l1, const Line_2& l2) const
+  {
+    return Base()(p,l1,l2);
+  } 
+#endif // CGAL_CFG_MATCHING_BUG_6
+
+
+  result_type operator()(const Point_2 &p, const Point_2& q) const
+  {
+    CGAL_BRANCH_PROFILER(std::string("semi-static attempts/calls to   : ") +
+                         std::string(CGAL_PRETTY_FUNCTION), tmp);
+
+    Get_approx<Point_2> get_approx; // Identity functor for all points
+                                    // but lazy points
+    double px, qx;
+
+    if (fit_in_double(get_approx(p).x(), px) && fit_in_double(get_approx(q).x(), qx) )
+    {
+      CGAL_BRANCH_PROFILER_BRANCH(tmp);
+      return compare(px, qx);
+    }
+    return Base::operator()(p, q);
+  }
+
+
+
+}; // end class Compare_x_2
+
+} // end namespace Static_filters_predicates
+
+} // end namespace internal
+
+} // end namespace CGAL
+
+#endif  // CGAL_INTERNAL_STATIC_FILTERS_COMPARE_X_2_H

--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Compare_y_2.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Compare_y_2.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2011 GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+//
+// Author(s)     : Andreas Fabri
+
+
+#ifndef CGAL_INTERNAL_STATIC_FILTERS_COMPARE_Y_2_H
+#define CGAL_INTERNAL_STATIC_FILTERS_COMPARE_Y_2_H
+
+#include <CGAL/Bbox_2.h>
+#include <CGAL/Profile_counter.h>
+#include <CGAL/internal/Static_filters/tools.h>
+#include <cmath>
+#include <iostream>
+
+namespace CGAL {
+
+namespace internal {
+
+namespace Static_filters_predicates {
+
+
+template < typename K_base >
+class Compare_y_2
+  : public K_base::Compare_y_2
+{
+  typedef typename K_base::Point_2   Point_2;
+  typedef typename K_base::Line_2    Line_2;
+  typedef typename K_base::Compare_y_2   Base;
+
+public:
+
+  typedef typename Base::result_type  result_type;
+
+
+#ifndef CGAL_CFG_MATCHING_BUG_6
+  using Base::operator();
+#else // CGAL_CFG_MATCHING_BUG_6
+  template <typename T>
+  result_type
+  operator()(const T& t1, const T& t2, const T& t3) const
+  {
+    return Base()(t1,t2,t3);
+  }
+
+  template <typename T>
+  result_type
+  operator()(const T& t1, const T& t2, const T& t3, const T& t4) const
+  {
+    return Base()(t1,t2,t3, t4);
+  } 
+  
+  result_type
+  operator()(const Point_2& p, const Line_2& l1, const Line_2& l2) const
+  {
+    return Base()(p,l1,l2);
+  } 
+#endif // CGAL_CFG_MATCHING_BUG_6
+
+
+  result_type operator()(const Point_2 &p, const Point_2& q) const
+  {
+    CGAL_BRANCH_PROFILER(std::string("semi-static attempts/calls to   : ") +
+                         std::string(CGAL_PRETTY_FUNCTION), tmp);
+
+    Get_approx<Point_2> get_approx; // Identity functor for all points
+                                    // but lazy points
+    double py, qy;
+
+    if (fit_in_double(get_approx(p).y(), py) && fit_in_double(get_approx(q).y(), qy) )
+    {
+      CGAL_BRANCH_PROFILER_BRANCH(tmp);
+      return compare(py, qy);
+    }
+    return Base::operator()(p, q);
+  }
+
+
+
+}; // end class Compare_y_2
+
+} // end namespace Static_filters_predicates
+
+} // end namespace internal
+
+} // end namespace CGAL
+
+#endif  // CGAL_INTERNAL_STATIC_FILTERS_COMPARE_Y_2_H

--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filters.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Static_filters.h
@@ -41,6 +41,7 @@
 // for static filters added nov./dec. 2011
 #ifdef CGAL_DISABLE_STATIC_FILTERS_ADDED_2011
 #  define CGAL_NO_EQUAL_3_STATIC_FILTERS 1
+#  define CGAL_NO_COMPARE_X_2_STATIC_FILTERS 1
 #  define CGAL_NO_IS_DEGENERATE_3_STATIC_FILTERS 1
 #  define CGAL_NO_ANGLE_3_STATIC_FILTERS 1
 #  define CGAL_NO_DO_INTERSECT_3_STATIC_FILTERS 1
@@ -50,6 +51,11 @@
 #ifndef CGAL_NO_EQUAL_3_STATIC_FILTERS
 #  include <CGAL/internal/Static_filters/Equal_3.h>
 #endif // NOT CGAL_NO_EQUAL_3_STATIC_FILTERS
+
+#ifndef CGAL_NO_COMPARE_X_2_STATIC_FILTERS
+#  include <CGAL/internal/Static_filters/Compare_x_2.h>
+#  include <CGAL/internal/Static_filters/Compare_y_2.h>
+#endif // NOT CGAL_NO_COMPARE_X_2_STATIC_FILTERS
 
 #ifndef CGAL_NO_IS_DEGENERATE_3_STATIC_FILTERS
 #  include <CGAL/internal/Static_filters/Is_degenerate_3.h>
@@ -112,6 +118,11 @@ public:
   typedef Static_filters_predicates::Equal_3<K_base>                        Equal_3;
 #endif // NOT CGAL_NO_EQUAL_3_STATIC_FILTERS
 
+#ifndef CGAL_NO_COMPARE_X_2_STATIC_FILTERS
+  typedef Static_filters_predicates::Compare_x_2<K_base>                    Compare_x_2;
+  typedef Static_filters_predicates::Compare_y_2<K_base>                    Compare_y_2;
+#endif // NOT CGAL_NO_COMPARE_X_2_STATIC_FILTERS
+
 #ifndef CGAL_NO_IS_DEGENERATE_3_STATIC_FILTERS
   typedef Static_filters_predicates::Is_degenerate_3<K_base, Self>          Is_degenerate_3;
 #endif // NOT CGAL_NO_IS_DEGENERATE_3_STATIC_FILTERS
@@ -140,6 +151,16 @@ public:
   equal_3_object() const
   { return Equal_3(); }
 #endif // NOT CGAL_NO_EQUAL_3_STATIC_FILTERS
+
+#ifndef CGAL_NO_COMPARE_X_2_STATIC_FILTERS
+ Compare_x_2
+  compare_x_2_object() const
+  { return Compare_x_2(); }
+
+Compare_y_2
+  compare_y_2_object() const
+  { return Compare_y_2(); }
+#endif // NOT CGAL_NO_COMPARE_Y_2_STATIC_FILTERS
 
 #ifndef CGAL_NO_IS_DEGENERATE_3_STATIC_FILTERS
  Is_degenerate_3

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -3435,22 +3435,11 @@ Comparison_result
 Triangulation_2<Gt, Tds>::
 compare_xy(const Point& p, const Point& q) const
 {
-  // We do not use geom_traits().compare_x_2_object()(p,q)
-  // as it uses interval arithmetic
-  return geom_traits().compare_xy_2_object()(p,q);
-  if(geom_traits().less_x_2_object()(p,q)){
-    return SMALLER;
+  Comparison_result res = geom_traits().compare_x_2_object()(p,q);
+  if(res == EQUAL){
+    return geom_traits().compare_y_2_object()(p,q);
   }
-  if(geom_traits().less_x_2_object()(q,p)){
-    return LARGER;
-  }
-  if(geom_traits().less_y_2_object()(p,q)){
-    return SMALLER;
-  }
-  if(geom_traits().less_y_2_object()(q,p)){
-    return LARGER;
-  }
-  return EQUAL;
+  return res;
 }
 
 template <class Gt, class Tds >

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -3435,11 +3435,22 @@ Comparison_result
 Triangulation_2<Gt, Tds>::
 compare_xy(const Point& p, const Point& q) const
 {
-  Comparison_result res = geom_traits().compare_x_2_object()(p,q);
-  if(res == EQUAL){
-    return geom_traits().compare_y_2_object()(p,q);
+  // We do not use geom_traits().compare_x_2_object()(p,q)
+  // as it uses interval arithmetic
+  return geom_traits().compare_xy_2_object()(p,q);
+  if(geom_traits().less_x_2_object()(p,q)){
+    return SMALLER;
   }
-  return res;
+  if(geom_traits().less_x_2_object()(q,p)){
+    return LARGER;
+  }
+  if(geom_traits().less_y_2_object()(p,q)){
+    return SMALLER;
+  }
+  if(geom_traits().less_y_2_object()(q,p)){
+    return LARGER;
+  }
+  return EQUAL;
 }
 
 template <class Gt, class Tds >


### PR DESCRIPTION
If you look in Static_filters.h you see that less_x_2  does NOT use static filters and does not use Filtered_predicate, as all we do is to compare  two floating point numbers.   That is not the case for Compare_x_2, because this functor has an operator(Line_2,Line_2,Point_2), and hence makes constructions.

This PR first implemented `Triangulation_2::compare_xy()` with `less_x_2()` and `less_y_2()`. 
@lrineau then recalled that the proper way is to add static filters for these functors.