### PR TITLE
Polyhedron_demo : Fix for the Scene Bbox

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1026,7 +1026,7 @@ Scene::Bbox Scene::bbox() const
     Bbox bbox = Bbox(0,0,0,0,0,0);
     Q_FOREACH(CGAL::Three::Scene_item* item, m_entries)
     {
-        if(item->isFinite() && !item->isEmpty() && item->visible()) {
+        if(item->isFinite() && !item->isEmpty()) {
             if(bbox_initialized) {
 
                 bbox = bbox + item->bbox();


### PR DESCRIPTION
 When an item's visibility changes, it changes the Viewer's Frustum.