### PR TITLE
Polyhedron demo : fix deformation plugin

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -45,6 +45,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/range.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <map>
 #include <list>
@@ -101,7 +102,7 @@ namespace internal {
     typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
     typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
 
-    std::set<edge_descriptor> border_edges;
+    boost::shared_ptr< std::set<edge_descriptor> > border_edges_ptr;
     const PM* pmesh_ptr_;
 
   public:
@@ -110,22 +111,26 @@ namespace internal {
     typedef value_type&                         reference;
     typedef boost::read_write_property_map_tag  category;
 
-    Border_constraint_pmap():pmesh_ptr_(NULL) {}
+    Border_constraint_pmap()
+      : border_edges_ptr(new std::set<edge_descriptor>() )
+      , pmesh_ptr_(NULL)
+    {}
     Border_constraint_pmap(const PM& pmesh, const FaceRange& faces)
-      : pmesh_ptr_(&pmesh)
+      : border_edges_ptr(new std::set<edge_descriptor>() )
+      , pmesh_ptr_(&pmesh)
     {
       std::vector<halfedge_descriptor> border;
       PMP::border_halfedges(faces, *pmesh_ptr_, std::back_inserter(border));
 
       BOOST_FOREACH(halfedge_descriptor h, border)
-        border_edges.insert(edge(h, *pmesh_ptr_));
+        border_edges_ptr->insert(edge(h, *pmesh_ptr_));
     }
 
     friend bool get(const Border_constraint_pmap<PM, FaceRange>& map,
                     const edge_descriptor& e)
     {
       CGAL_assertion(map.pmesh_ptr_!=NULL);
-      return map.border_edges.count(e)!=0;
+      return map.border_edges_ptr->count(e)!=0;
     }
 
     friend void put(Border_constraint_pmap<PM, FaceRange>& map,
@@ -134,9 +139,9 @@ namespace internal {
     {
       CGAL_assertion(map.pmesh_ptr_ != NULL);
       if (is)
-        map.border_edges.insert(e);
+        map.border_edges_ptr->insert(e);
       else
-        map.border_edges.erase(e);
+        map.border_edges_ptr->erase(e);
     }
   };
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -486,11 +486,23 @@ void Scene_edit_polyhedron_item::remesh()
 
   std::set<face_descriptor> roi_facets;
   std::set<halfedge_descriptor> roi_border_halfedges;
+
+  std::set<vertex_descriptor> roi_vertices(
+    deform_mesh->roi_vertices().begin(),deform_mesh->roi_vertices().end());
+
   BOOST_FOREACH(vertex_descriptor v, deform_mesh->roi_vertices())
   {
     BOOST_FOREACH(face_descriptor fv, CGAL::faces_around_target(halfedge(v, g), g))
-      roi_facets.insert(fv);
+    {
+      bool add_face=true;
+      BOOST_FOREACH(vertex_descriptor vfd, CGAL::vertices_around_face(halfedge(fv,g),g))
+        if (roi_vertices.count(vfd)==0)
+          add_face=false;
+      if(add_face)
+        roi_facets.insert(fv);
+    }
   }
+
   CGAL::Polygon_mesh_processing::border_halfedges(roi_facets, g,
     std::inserter(roi_border_halfedges, roi_border_halfedges.begin()));
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -613,7 +613,9 @@ bool Scene_edit_polyhedron_item::eventFilter(QObject* /*target*/, QEvent *event)
     const QPoint& p = viewer->mapFromGlobal(QCursor::pos());
     bool need_repaint = activate_closest_manipulated_frame(p.x(), p.y());
 
-    if (ctrl_released_now && ui_widget->RemeshingCheckBox->isChecked()){
+    if (!ui_widget->ActivatePivotingCheckBox->isChecked() &&
+        ctrl_released_now && ui_widget->RemeshingCheckBox->isChecked())
+    {
       remesh();
     }
 

--- a/Surface_mesh_deformation/include/CGAL/Surface_mesh_deformation.h
+++ b/Surface_mesh_deformation/include/CGAL/Surface_mesh_deformation.h
@@ -857,7 +857,7 @@ public:
   /**
    * Returns the range of vertices in the region-of-interest.
    */
-  Roi_vertex_range roi_vertices() const
+  const Roi_vertex_range& roi_vertices() const
   {
     return roi;
   }


### PR DESCRIPTION
This PR fixes the list of roi_border edges collected before deformation.

The result is that the ROI area does not get wrong after isotropic remeshing

and adds a default constructor to ROI_border_pmap (will be needed by isotropic remeshing soon)
