### PR TITLE
Polyhedron item : fix access in color map

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -188,13 +188,13 @@ Scene_polyhedron_item::triangulate_facet(Facet_iterator fit,
         {
           for (int i = 0; i<3; ++i)
           {
-            color_facets.push_back(colors_[this_patch_id].redF());
-            color_facets.push_back(colors_[this_patch_id].greenF());
-            color_facets.push_back(colors_[this_patch_id].blueF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].redF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].greenF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].blueF());
 
-            color_facets.push_back(colors_[this_patch_id].redF());
-            color_facets.push_back(colors_[this_patch_id].greenF());
-            color_facets.push_back(colors_[this_patch_id].blueF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].redF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].greenF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].blueF());
           }
         }
         if (colors_only)
@@ -412,9 +412,9 @@ Scene_polyhedron_item::compute_normals_and_vertices(const bool colors_only) cons
           {
             if (!is_monochrome)
             {
-              color_facets.push_back(colors_[this_patch_id].redF());
-              color_facets.push_back(colors_[this_patch_id].greenF());
-              color_facets.push_back(colors_[this_patch_id].blueF());
+              color_facets.push_back(colors_[this_patch_id-m_min_patch_id].redF());
+              color_facets.push_back(colors_[this_patch_id-m_min_patch_id].greenF());
+              color_facets.push_back(colors_[this_patch_id-m_min_patch_id].blueF());
             }
             if (colors_only)
               continue;
@@ -439,9 +439,9 @@ Scene_polyhedron_item::compute_normals_and_vertices(const bool colors_only) cons
           const int this_patch_id = f->patch_id();
           for (unsigned int i = 0; i < 6; ++i)
           { //6 "halfedges" for the quad, because it is 2 triangles
-            color_facets.push_back(colors_[this_patch_id].redF());
-            color_facets.push_back(colors_[this_patch_id].greenF());
-            color_facets.push_back(colors_[this_patch_id].blueF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].redF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].greenF());
+            color_facets.push_back(colors_[this_patch_id-m_min_patch_id].blueF());
           }
         }
         if (colors_only)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -626,15 +626,18 @@ init()
   {
     // Fill indices map and get max subdomain value
     int max = 0;
+    int min = (std::numeric_limits<int>::max)();
     for(Facet_iterator fit = poly->facets_begin(), end = poly->facets_end() ;
         fit != end; ++fit)
     {
       max = (std::max)(max, fit->patch_id());
+      min = (std::min)(min, fit->patch_id());
     }
-
-    colors_.resize(0);
-    compute_color_map(this->color(), max + 1,
+    
+    colors_.clear();
+    compute_color_map(this->color(), max + 1 - min,
                       std::back_inserter(colors_));
+    m_min_patch_id=min;
   }
   invalidate_stats();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -568,7 +568,7 @@ Scene_polyhedron_item::Scene_polyhedron_item()
     nb_facets = 0;
     nb_lines = 0;
     nb_f_lines = 0;
-    init();
+    invalidate_stats();
 }
 
 Scene_polyhedron_item::Scene_polyhedron_item(Polyhedron* const p)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -181,6 +181,7 @@ private:
       const bool colors_only) const;
     double volume, area;
 
+  int m_min_patch_id; // the min value of the patch ids initialized in init()
 }; // end class Scene_polyhedron_item
 
 #endif // SCENE_POLYHEDRON_ITEM_H


### PR DESCRIPTION
fix access in color map of a polyhedron item, , in case we have a single patch with index > 0

Edit
re-introduce commit [7d1b31](https://github.com/CGAL/cgal/pull/928/commits/7d1b315fab3a602304848e0f2ce94ce9c91bc752) and fix its use in the new drawing framework