### PR TITLE
Polyhedron_demo: Clip_polyhedron_plugin enhancement

### DIFF
--- a/Operations_on_polyhedra/include/CGAL/corefinement_operations.h
+++ b/Operations_on_polyhedra/include/CGAL/corefinement_operations.h
@@ -247,7 +247,7 @@ public:
     * @tparam Polyline_output_iterator must be an output iterator of std::vector<Kernel::Point_3>.
     * @tparam Polyhedron_ptr_and_type_output_iterator an output iterator of std::pair<Polyhedron*,int>.
     * @param P is the first input triangulated polyhedron. Note that a reference is taken and P will be updated to contain the 1D intersection between the two surfaces P and Q.
-    * @param Q is the first input triangulated polyhedron. Note that a reference is taken and Q will be updated to contain the 1D intersection between the two surfaces P and Q.
+    * @param Q is the second input triangulated polyhedron. Note that a reference is taken and Q will be updated to contain the 1D intersection between the two surfaces P and Q.
     * @param polyline_output is an output iterator that collects intersection polylines between P and Q.
     * @param poly_output is an output iterator that collects output polyhedra. Note that each polyhedron is allocated within this function (thus must be explicitly deleted when no longer used). The integer is a feature tag corresponding to the volume represented by the polyhedron of the pair.
     * @param features is an integer indicating what polyhedra the function must compute. If several kind of polyhedra are expected, feature tags must be combined by |. For example if features = Polyhedron_corefinement<Polyhedron,Kernel>::Join_tag | Polyhedron_corefinement<Polyhedron,Kernel>::Intersection_tag, then poly_output will collect two polyhedra, the union and the intersection of P and Q. 

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -188,36 +188,100 @@ public Q_SLOTS:
       //apply the clipping function
       Q_FOREACH(Scene_polyhedron_item* poly, polyhedra)
       {
+
         if(ui_widget.close_checkBox->isChecked() && poly->polyhedron()->is_closed())
         {
-          Polyhedron * polyhedron = CGAL::corefinement::clip_polyhedron(*(poly->polyhedron()),plane->plane());
-          if(polyhedron)
+          std::pair<Polyhedron*, Polyhedron*>polyhedron;
+          if(ui_widget.clip_radioButton->isChecked())
           {
-            Scene_polyhedron_item* new_item = new Scene_polyhedron_item(polyhedron);
-            new_item->setName(poly->name());
+            polyhedron.first = CGAL::corefinement::clip_polyhedron(*(poly->polyhedron()),plane->plane());
+            polyhedron.second = NULL;
+          }
+          else
+          {
+            polyhedron = CGAL::corefinement::split_polyhedron(*(poly->polyhedron()),plane->plane());
+          }
+          if(polyhedron.first != NULL)
+          {
+            Scene_polyhedron_item* new_item = new Scene_polyhedron_item(polyhedron.first);
+            if(polyhedron.second != NULL)
+              new_item->setName(QString("%1 %2").arg(poly->name()).arg("1"));
+            else
+              new_item->setName(poly->name());
             new_item->setColor(poly->color());
             new_item->setRenderingMode(poly->renderingMode());
             new_item->setVisible(poly->visible());
             new_item->invalidateOpenGLBuffers();
             new_item->setProperty("source filename", poly->property("source filename"));
             scene->replaceItem(scene->item_id(poly),new_item);
-            delete poly;
             new_item->invalidateOpenGLBuffers();
             viewer->updateGL();
-            messages->information(QString("%1 clipped").arg(new_item->name()));
+            if(ui_widget.clip_radioButton->isChecked())
+              messages->information(QString("%1 clipped").arg(new_item->name()));
           }
           else
           {
-             messages->information(QString("Could not clip %1 : returned polyhedron is null.").arg(poly->name()));
-             delete polyhedron;
+            messages->information(QString("Could not clip %1 : returned polyhedron is null.").arg(poly->name()));
+            delete polyhedron.first;
           }
+          if(polyhedron.second!= NULL)
+          {
+            Scene_polyhedron_item* new_item = new Scene_polyhedron_item(polyhedron.second);
+            new_item->setName(QString("%1 %2").arg(poly->name()).arg("2"));
+            new_item->setColor(poly->color());
+            new_item->setRenderingMode(poly->renderingMode());
+            new_item->setVisible(poly->visible());
+            new_item->invalidateOpenGLBuffers();
+            new_item->setProperty("source filename", poly->property("source filename"));
+            scene->addItem(new_item);
+            new_item->invalidateOpenGLBuffers();
+            viewer->updateGL();
+            if(!ui_widget.clip_radioButton->isChecked())
+            messages->information(QString("%1 splitted").arg(poly->name()));
+          }
+          if(polyhedron.first != NULL)
+            delete poly;
         }
+
         else
         {
-          CGAL::corefinement::inplace_clip_open_polyhedron(*(poly->polyhedron()),plane->plane());
-          poly->invalidateOpenGLBuffers();
-          viewer->updateGL();
-          messages->information(QString("%1 clipped").arg(poly->name()));
+          Scene_polyhedron_item* poly1 = new Scene_polyhedron_item(*(poly->polyhedron()));
+          poly1->setProperty("source filename", poly->property("source filename"));
+          Scene_polyhedron_item* poly2 = NULL;
+          if(!ui_widget.clip_radioButton->isChecked())
+          {
+            poly2 = new Scene_polyhedron_item(*(poly->polyhedron()));
+            poly2->setProperty("source filename", poly->property("source filename"));
+          }
+
+
+            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly1->polyhedron()),plane->plane());
+            if(poly2 != NULL)
+              poly1->setName(QString("%1 %2").arg(poly->name()).arg("1"));
+            else
+              poly1->setName(poly->name());
+            poly1->setColor(poly->color());
+            poly1->setRenderingMode(poly->renderingMode());
+            poly1->setVisible(poly->visible());
+            scene->replaceItem(scene->item_id(poly),poly1);
+            poly1->invalidateOpenGLBuffers();
+            viewer->updateGL();
+            if(ui_widget.clip_radioButton->isChecked())
+              messages->information(QString("%1 clipped").arg(poly->name()));
+
+          if(poly2 != NULL)
+          {
+            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly2->polyhedron()),plane->plane().opposite());
+            poly2->setName(QString("%1 %2").arg(poly->name()).arg("2"));
+            poly2->setColor(poly->color());
+            poly2->setRenderingMode(poly->renderingMode());
+            poly2->setVisible(poly->visible());
+            scene->addItem(poly2);
+            poly2->invalidateOpenGLBuffers();
+            viewer->updateGL();
+            messages->information(QString("%1 splitted").arg(poly->name()));
+          }
+          delete poly;
         }
       }
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -50,8 +50,8 @@ public:
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_quad.size()/3));
     program->release();
     vaos[Facets]->release();
-
   }
+  void selection_changed(bool b){is_selected = b;}
 
 private:
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer) const
@@ -163,6 +163,8 @@ public Q_SLOTS:
       plane->setName(tr("Clipping plane"));
       connect(plane, SIGNAL(destroyed()),
               this, SLOT(on_plane_destroyed()));
+      connect(ui_widget.flip_Button, SIGNAL(clicked()),
+              plane, SLOT(flipPlane()));
       scene->addItem(plane);
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>364</width>
-    <height>258</height>
+    <height>273</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -102,6 +102,30 @@
             <widget class="QPushButton" name="clipButton">
              <property name="text">
               <string>&amp;Apply</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="flip_Button">
+             <property name="text">
+              <string>Flip plane</string>
              </property>
             </widget>
            </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>346</width>
-    <height>340</height>
+    <width>444</width>
+    <height>384</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,7 +32,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This function allows to clip all the selected polyhedra by an half-space. The blue side of the clipping plane will be clipped out, and the yellow side will be kept.&lt;br/&gt;&lt;br/&gt;If the option &lt;span style=&quot; font-style:italic;&quot;&gt;keep closed&lt;/span&gt; is checked, the clipped part of each polyhedron will be closed. Otherwise, it will be left open.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This function allows to clip all the selected polyhedra by an half-space. The blue side of the clipping plane will be clipped out, and the yellow side will be kept.&lt;br/&gt;&lt;br/&gt;If the option &lt;span style=&quot; font-style:italic;&quot;&gt;keep closed&lt;/span&gt; is checked, the clipped part of each polyhedron will be closed. Otherwise, it will be left open.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>364</width>
-    <height>273</height>
+    <width>346</width>
+    <height>340</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Clip polyhedra</string>
@@ -19,6 +25,12 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This function allows to clip all the selected polyhedra by an half-space. The blue side of the clipping plane will be clipped out, and the yellow side will be kept.&lt;br/&gt;&lt;br/&gt;If the option &lt;span style=&quot; font-style:italic;&quot;&gt;keep closed&lt;/span&gt; is checked, the clipped part of each polyhedron will be closed. Otherwise, it will be left open.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
@@ -42,6 +54,12 @@
       </item>
       <item>
        <widget class="QGroupBox" name="groupBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="title">
          <string>Behavior</string>
         </property>
@@ -100,6 +118,12 @@
            </item>
            <item>
             <widget class="QPushButton" name="clipButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string>&amp;Apply</string>
              </property>
@@ -109,6 +133,9 @@
          </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetDefaultConstraint</enum>
+           </property>
            <item>
             <spacer name="horizontalSpacer_2">
              <property name="orientation">
@@ -124,6 +151,12 @@
            </item>
            <item>
             <widget class="QPushButton" name="flip_Button">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string>Flip plane</string>
              </property>
@@ -133,9 +166,6 @@
          </item>
         </layout>
        </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2"/>
       </item>
      </layout>
     </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -41,41 +41,74 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QCheckBox" name="close_checkBox">
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="autoFillBackground">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>&amp;Keep Closed</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="clipButton">
-          <property name="text">
-           <string>&amp;Clip</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>Behavior</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QRadioButton" name="clip_radioButton">
+             <property name="text">
+              <string>Clip</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="split_radioButton">
+             <property name="text">
+              <string>Split</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_4"/>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="close_checkBox">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>&amp;Keep Closed</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="clipButton">
+             <property name="text">
+              <string>&amp;Apply</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2"/>

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -128,3 +128,17 @@ void Scene_plane_item::draw_edges(CGAL::Three::Viewer_interface* viewer)const
     program->release();
     vaos[Edges]->release();
 }
+
+void Scene_plane_item::flipPlane()
+{
+  qglviewer::Quaternion q;
+  qglviewer::Vec axis(0,1,0);
+  if(frame->orientation().axis() == axis)
+    q.setAxisAngle(qglviewer::Vec(1,0,0), M_PI);
+  else
+    q.setAxisAngle(axis, M_PI);
+  frame->rotate(q.normalized());
+  invalidateOpenGLBuffers();
+  Q_EMIT itemChanged();
+
+}

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -44,7 +44,6 @@ public:
   bool isFinite() const { return false; }
   bool isEmpty() const { return false; }
   void compute_bbox() const { _bbox = Bbox(); }
-
   bool manipulatable() const {
     return manipulable;
   }
@@ -99,7 +98,7 @@ public:
  virtual void draw_edges(CGAL::Three::Viewer_interface* viewer)const;
   Plane_3 plane() const {
     const qglviewer::Vec& pos = frame->position();
-    const qglviewer::Vec& n = 
+    const qglviewer::Vec& n =
       frame->inverseTransformOf(qglviewer::Vec(0.f, 0.f, 1.f));
     return Plane_3(n[0], n[1],  n[2], - n * pos);
   }
@@ -134,16 +133,32 @@ public Q_SLOTS:
   
   void setNormal(float x, float y, float z) {
     QVector3D normal(x,y,z);
+    if(normal == QVector3D(0,0,0))
+      return;
     QVector3D origin(0,0,1);
-    QQuaternion q(CGAL::sqrt((normal.lengthSquared()) * (origin.lengthSquared())) + QVector3D::dotProduct(origin, normal),QVector3D::crossProduct(origin, normal));
-    q.normalize();
-    frame->setOrientation(q.x(), q.y(), q.z(), q.scalar());
+    qglviewer::Quaternion q;
+    if(origin == normal)
+    {
+      return;
+    }
+     if(origin == -normal)
+    {
+      q.setAxisAngle(qglviewer::Vec(0,1,0),M_PI);
+      frame->setOrientation(q);
+      return;
+    }
+
+    QVector3D cp = QVector3D::crossProduct(origin, normal);
+    cp.normalize();
+    q.setAxisAngle(qglviewer::Vec(cp.x(),cp.y(), cp.z()),acos(QVector3D::dotProduct(origin, normal)/(normal.length()*origin.length())));
+
+    frame->setOrientation(q.normalized());
   }
 
   void setNormal(double x, double y, double z) {
     setNormal((float)x, (float)y, (float)z);
   }
-
+  void flipPlane();
   void setClonable(bool b = true) {
     can_clone = b;
   }


### PR DESCRIPTION
This is a fix for #932 .
This PR adds :
- a button to flip the plane
- a feature to split the polyhedra instead of clipping them. The choice is made with radio buttons.