### PR TITLE
Polyhedron_demo : selection tool enhancement

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -85,6 +85,7 @@ public:
     connect(ui_widget.Select_all_button,  SIGNAL(clicked()), this, SLOT(on_Select_all_button_clicked()));
     connect(ui_widget.Clear_button,  SIGNAL(clicked()), this, SLOT(on_Clear_button_clicked()));
     connect(ui_widget.Clear_all_button,  SIGNAL(clicked()), this, SLOT(on_Clear_all_button_clicked()));
+    connect(ui_widget.Inverse_selection_button,  SIGNAL(clicked()), this, SLOT(on_Inverse_selection_button_clicked()));
     connect(ui_widget.Select_isolated_components_button,  SIGNAL(clicked()), this, SLOT(on_Select_isolated_components_button_clicked()));
     connect(ui_widget.Get_minimum_button,  SIGNAL(clicked()), this, SLOT(on_Get_minimum_button_clicked()));
     connect(ui_widget.Create_selection_item_button,  SIGNAL(clicked()), this, SLOT(on_Create_selection_item_button_clicked()));    
@@ -153,6 +154,15 @@ public Q_SLOTS:
     }
 
     selection_item->clear_all();
+  }
+  void on_Inverse_selection_button_clicked()
+  {
+    Scene_polyhedron_selection_item* selection_item = get_selected_item<Scene_polyhedron_selection_item>();
+    if(!selection_item) {
+      print_message("Error: there is no selected polyhedron selection item!");
+      return;
+    }
+    selection_item->inverse_selection();
   }
   // Isolated component related functions
   void on_Select_isolated_components_button_clicked() {

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -84,6 +84,7 @@ public:
 
     connect(ui_widget.Select_all_button,  SIGNAL(clicked()), this, SLOT(on_Select_all_button_clicked()));
     connect(ui_widget.Clear_button,  SIGNAL(clicked()), this, SLOT(on_Clear_button_clicked()));
+    connect(ui_widget.Clear_all_button,  SIGNAL(clicked()), this, SLOT(on_Clear_all_button_clicked()));
     connect(ui_widget.Select_isolated_components_button,  SIGNAL(clicked()), this, SLOT(on_Select_isolated_components_button_clicked()));
     connect(ui_widget.Get_minimum_button,  SIGNAL(clicked()), this, SLOT(on_Get_minimum_button_clicked()));
     connect(ui_widget.Create_selection_item_button,  SIGNAL(clicked()), this, SLOT(on_Create_selection_item_button_clicked()));    
@@ -143,6 +144,15 @@ public Q_SLOTS:
     }
 
     selection_item->clear();
+  }
+  void on_Clear_all_button_clicked(){
+    Scene_polyhedron_selection_item* selection_item = get_selected_item<Scene_polyhedron_selection_item>();
+    if(!selection_item) {
+      print_message("Error: there is no selected polyhedron selection item!");
+      return;
+    }
+
+    selection_item->clear_all();
   }
   // Isolated component related functions
   void on_Select_isolated_components_button_clicked() {

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>455</width>
-    <height>684</height>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,156 +16,97 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Selection &amp;Type:</string>
-          </property>
-          <property name="buddy">
-           <cstring>Selection_type_combo_box</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="Selection_type_combo_box">
-          <item>
-           <property name="text">
-            <string>Vertex</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Facet</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Edge</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Connected component (facet)</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <spacer name="verticalSpacer_4">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>Selection by Type</string>
       </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QRadioButton" name="Insertion_radio_button">
-            <property name="text">
-             <string>Insertion</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="Removal_radio_button">
-            <property name="text">
-             <string>Removal</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Brush &amp;size:</string>
-              </property>
-              <property name="buddy">
-               <cstring>Brush_size_spin_box</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="Brush_size_spin_box"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QPushButton" name="Select_all_button">
-          <property name="toolTip">
-           <string extracomment="Select all simplices of Selection Type"/>
-          </property>
-          <property name="text">
-           <string>Select &amp;All</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="Inverse_selection_button">
-          <property name="toolTip">
-           <string extracomment="Invert selection for Selection Type"/>
-          </property>
-          <property name="text">
-           <string>Invert Selection</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="Clear_button">
-          <property name="toolTip">
-           <string extracomment="Clear selection for Selection Type"/>
-          </property>
-          <property name="text">
-           <string>&amp;Clear</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="Clear_all_button">
-          <property name="toolTip">
-           <string extracomment="Clear selection for All Types"/>
-          </property>
-          <property name="text">
-           <string>Clear All Selection</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_9" stretch=""/>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QRadioButton" name="Insertion_radio_button">
+               <property name="text">
+                <string>Insertion</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="Removal_radio_button">
+               <property name="text">
+                <string>Removal</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_7">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QLabel" name="label">
+                 <property name="text">
+                  <string>Brush &amp;size:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>Brush_size_spin_box</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="Brush_size_spin_box"/>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QPushButton" name="Select_all_button">
+             <property name="toolTip">
+              <string extracomment="Select all simplices of Selection Type"/>
+             </property>
+             <property name="text">
+              <string>Select &amp;All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="Inverse_selection_button">
+             <property name="toolTip">
+              <string extracomment="Invert selection for Selection Type"/>
+             </property>
+             <property name="text">
+              <string>Invert Selection</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="Clear_button">
+             <property name="toolTip">
+              <string extracomment="Clear selection for Selection Type"/>
+             </property>
+             <property name="text">
+              <string>&amp;Clear</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </item>
     <item>
      <spacer name="verticalSpacer_2">
@@ -378,17 +319,31 @@
      </spacer>
     </item>
     <item>
-     <widget class="QPushButton" name="Create_selection_item_button">
-      <property name="font">
-       <font>
-        <weight>75</weight>
-        <bold>true</bold>
-       </font>
-      </property>
-      <property name="text">
-       <string>Create Selection Item</string>
-      </property>
-     </widget>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QPushButton" name="Create_selection_item_button">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Create Selection Item</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="Clear_all_button">
+        <property name="toolTip">
+         <string extracomment="Clear selection for All Types"/>
+        </property>
+        <property name="text">
+         <string>Clear Selection Item</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -122,15 +122,41 @@
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QPushButton" name="Select_all_button">
+          <property name="toolTip">
+           <string extracomment="Select all simplices of Selection Type"/>
+          </property>
           <property name="text">
            <string>Select &amp;All</string>
           </property>
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="Inverse_selection_button">
+          <property name="toolTip">
+           <string extracomment="Invert selection for Selection Type"/>
+          </property>
+          <property name="text">
+           <string>Invert Selection</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="Clear_button">
+          <property name="toolTip">
+           <string extracomment="Clear selection for Selection Type"/>
+          </property>
           <property name="text">
            <string>&amp;Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="Clear_all_button">
+          <property name="toolTip">
+           <string extracomment="Clear selection for All Types"/>
+          </property>
+          <property name="text">
+           <string>Clear All Selection</string>
           </property>
          </widget>
         </item>
@@ -139,22 +165,7 @@
      </layout>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
-      <item>
-       <widget class="QPushButton" name="Inverse_selection_button">
-        <property name="text">
-         <string>Inverse selection</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="Clear_all_button">
-        <property name="text">
-         <string>Clear All</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <layout class="QHBoxLayout" name="horizontalLayout_9" stretch=""/>
     </item>
     <item>
      <spacer name="verticalSpacer_2">

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -22,6 +22,54 @@
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Selection Type :</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="Selection_type_combo_box">
+           <item>
+            <property name="text">
+             <string>Vertex</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Facet</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Edge</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Selected components (facet)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -141,17 +141,11 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
       <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="QPushButton" name="Inverse_selection_button">
+        <property name="text">
+         <string>Inverse selection</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       </widget>
       </item>
       <item>
        <widget class="QPushButton" name="Clear_all_button">

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -139,6 +139,30 @@
      </layout>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="Clear_all_button">
+        <property name="text">
+         <string>Clear All</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <spacer name="verticalSpacer_2">
       <property name="orientation">
        <enum>Qt::Vertical</enum>

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -145,7 +145,7 @@ Scene::erase(Scene::Item_id index)
             group->removeChild(item);
     }
   Q_EMIT itemAboutToBeDestroyed(item);
-    delete item;
+    item->deleteLater();
     m_entries.removeAll(item);
     selected_item = -1;
     Q_FOREACH(Scene_item* item, m_entries)
@@ -190,7 +190,7 @@ Scene::erase(QList<int> indices)
       if(group_item->getChildren().contains(item))
         group_item->removeChild(item);
     Q_EMIT itemAboutToBeDestroyed(item);
-    delete item;
+    item->deleteLater();
     m_entries.removeAll(item);
   }
   clear();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -231,3 +231,39 @@ void Scene_polyhedron_selection_item::draw_points(CGAL::Three::Viewer_interface*
     viewer->glPointSize(1.f);
 
 }
+
+void Scene_polyhedron_selection_item::inverse_selection()
+{
+  switch(k_ring_selector.active_handle_type)
+  {
+  case Active_handle::VERTEX:
+  {
+    Selection_set_vertex temp_select = selected_vertices;
+    select_all();
+    Q_FOREACH(Vertex_handle vh, temp_select)
+    {
+      selected_vertices.erase(vh);
+    }
+    break;
+  }
+  case Active_handle::EDGE:
+  {
+    Selection_set_edge temp_select = selected_edges;
+    select_all();
+    Q_FOREACH(edge_descriptor ed , temp_select)
+      selected_edges.erase(ed);
+    break;
+  }
+  default:
+  {
+    Selection_set_facet temp_select = selected_facets;
+    select_all();
+    Q_FOREACH(Facet_handle fh, temp_select)
+      selected_facets.erase(fh);
+    break;
+  }
+  }
+  invalidateOpenGLBuffers();
+  QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
+  v->update();
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -215,7 +215,7 @@ public:
    ~Scene_polyhedron_selection_item()
     {
     }
-
+  void inverse_selection();
 protected: 
   void init(Scene_polyhedron_item* poly_item, QMainWindow* mw)
   {


### PR DESCRIPTION
This PR adds two features two the selection tool :
- A Clear all button, that clears all the primitives from the selection
- A Inverse selection button, that inverse the selection of the current HandleType.