### PR TITLE
Introduce CGAL::Default for the TDS of 2D constrained triangulations

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -31,7 +31,7 @@ to compute the intersection of two segments.
 and has then to be also a model of the concept 
 `ConstrainedTriangulationTraits_2`. 
 
-\tparam Tds must be a model of `TriangulationDataStructure_2`. 
+\tparam Tds must be a model of `TriangulationDataStructure_2`or `Default`.
 
 \tparam Itag allows to select if intersecting constraints are supported and how they are handled.
 - `No_intersection_tag` if intersections of 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -90,7 +90,7 @@ It has then to be a model of the concept
 
 
 \tparam Tds must be a model 
-of the concept `TriangulationDataStructure_2`. 
+of the concept `TriangulationDataStructure_2` or `Default`.
 
 \tparam Itag is the intersection tag 
 which serves to choose between the different 
@@ -127,7 +127,7 @@ the default for
 and the default for the 
 triangulation data structure parameter is the class 
 `Triangulation_data_structure_2 < Triangulation_vertex_base_2<Gt>, Constrained_triangulation_face_base_2<Gt> >`. 
-The default intersection tag is `No_intersection_tag`. 
+The default intersection tag is `No_intersection_tag`.
 
 \sa `CGAL::Triangulation_2<Traits,Tds>`
 \sa `TriangulationDataStructure_2`

--- a/Triangulation_2/examples/Triangulation_2/constrained.cpp
+++ b/Triangulation_2/examples/Triangulation_2/constrained.cpp
@@ -6,11 +6,8 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
-typedef CGAL::Triangulation_vertex_base_2<K>                     Vb;
-typedef CGAL::Constrained_triangulation_face_base_2<K>           Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb,Fb>              TDS;
 typedef CGAL::Exact_predicates_tag                               Itag;
-typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, Itag> CDT;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K, CGAL::Default, Itag> CDT;
 typedef CDT::Point          Point;
 
 int

--- a/Triangulation_2/examples/Triangulation_2/constrained_plus.cpp
+++ b/Triangulation_2/examples/Triangulation_2/constrained_plus.cpp
@@ -8,11 +8,8 @@
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel K;
 
-typedef CGAL::Triangulation_vertex_base_2<K>              Vb;
-typedef CGAL::Constrained_triangulation_face_base_2<K>    Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb,Fb>       TDS;
 typedef CGAL::Exact_intersections_tag                     Itag;
-typedef CGAL::Constrained_Delaunay_triangulation_2<K,TDS,Itag> CDT;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K,CGAL::Default,Itag> CDT;
 typedef CGAL::Constrained_triangulation_plus_2<CDT>       CDTplus;
 typedef CDTplus::Point                                    Point;
 

--- a/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
+++ b/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
@@ -5,18 +5,15 @@
 
 #include <vector>
 
-typedef CGAL::Exact_predicates_exact_constructions_kernel        K;
-typedef CGAL::Polygon_2<K>                                       Polygon_2;
-typedef CGAL::Triangulation_vertex_base_2<K>                     Vb;
-typedef CGAL::Constrained_triangulation_face_base_2<K>           Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb,Fb>              TDS;
-typedef CGAL::Exact_intersections_tag                            Itag;
-typedef CGAL::Constrained_Delaunay_triangulation_2<K,TDS, Itag>  CDT;
-typedef CGAL::Constrained_triangulation_plus_2<CDT>              CDTP;
+typedef CGAL::Exact_predicates_exact_constructions_kernel                 K;
+typedef CGAL::Polygon_2<K>                                                Polygon_2;
+typedef CGAL::Exact_intersections_tag                                     Itag;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K,CGAL::Default, Itag> CDT;
+typedef CGAL::Constrained_triangulation_plus_2<CDT>                       CDTP;
 
-typedef CDTP::Point                                              Point;
-typedef CDTP::Constraint_id                                      Cid;
-typedef CDTP::Vertex_handle                                      Vertex_handle;
+typedef CDTP::Point                                                       Point;
+typedef CDTP::Constraint_id                                               Cid;
+typedef CDTP::Vertex_handle                                               Vertex_handle;
 
 void 
 print(const CDTP& cdtp, Cid cid)

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -56,24 +56,17 @@ namespace CGAL {
 
 
 template <class Gt,
-          class Tds_ = Triangulation_data_structure_2 <
-                                                       Triangulation_vertex_base_2<Gt>,
-                                                       Constrained_triangulation_face_base_2<Gt> >,
-	  class Itag_ = No_intersection_tag>
+          class Tds_ = Default ,
+	  class Itag_ = Default>
 class Constrained_Delaunay_triangulation_2
-  : public  Constrained_triangulation_2<Gt, typename Default::Get< Tds_,
-                                                     Triangulation_data_structure_2 <
-                                                       Triangulation_vertex_base_2<Gt>,
-                                                       Constrained_triangulation_face_base_2<Gt> > >::type, Itag_>
+  : public  Constrained_triangulation_2<Gt, Tds_, Itag_>
 {
-public:  typedef typename Default::Get<Tds_, Triangulation_data_structure_2 <
-                                        Triangulation_vertex_base_2<Gt>,
-                                        Constrained_triangulation_face_base_2<Gt> > >::type Tds;
-  typedef typename Default::Get<Itag_, No_intersection_tag>::type Itag;
+public:
+  typedef Constrained_triangulation_2<Gt,Tds_,Itag_>            Ctr;
+  typedef typename Ctr::Tds Tds;
+  typedef typename Ctr::Itag Itag;
 
-  typedef Constrained_triangulation_2<Gt,Tds,Itag>            Ctr;
-
-  typedef Constrained_Delaunay_triangulation_2<Gt,Tds,Itag>    CDt;
+  typedef Constrained_Delaunay_triangulation_2<Gt,Tds_,Itag_>    CDt;
   typedef typename Ctr::Geom_traits      Geom_traits;
   typedef typename Ctr::Intersection_tag Intersection_tag;
 

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -56,15 +56,23 @@ namespace CGAL {
 
 
 template <class Gt,
-          class Tds_ = Default,
-	  class Itag_ = Default>
+          class Tds_ = Triangulation_data_structure_2 <
+                                                       Triangulation_vertex_base_2<Gt>,
+                                                       Constrained_triangulation_face_base_2<Gt> >,
+	  class Itag_ = No_intersection_tag>
 class Constrained_Delaunay_triangulation_2
-  : public  Constrained_triangulation_2<Gt, Tds_, Itag_>
+  : public  Constrained_triangulation_2<Gt, typename Default::Get< Tds_,
+                                                     Triangulation_data_structure_2 <
+                                                       Triangulation_vertex_base_2<Gt>,
+                                                       Constrained_triangulation_face_base_2<Gt> > >::type, Itag_>
 {
-public:
-  typedef Constrained_triangulation_2<Gt,Tds_,Itag_>            Ctr;
-  typedef typename Ctr::Tds Tds;
-  typedef typename Ctr::Itag Itag;
+public:  typedef typename Default::Get<Tds_, Triangulation_data_structure_2 <
+                                        Triangulation_vertex_base_2<Gt>,
+                                        Constrained_triangulation_face_base_2<Gt> > >::type Tds;
+  typedef typename Default::Get<Itag_, No_intersection_tag>::type Itag;
+
+  typedef Constrained_triangulation_2<Gt,Tds,Itag>            Ctr;
+
   typedef Constrained_Delaunay_triangulation_2<Gt,Tds,Itag>    CDt;
   typedef typename Ctr::Geom_traits      Geom_traits;
   typedef typename Ctr::Intersection_tag Intersection_tag;

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -55,17 +55,16 @@ struct Get_iterator_value_type<T,true>{
 namespace CGAL {
 
 
-template <class Gt, 
-          class Tds_ = Triangulation_data_structure_2 <
-                      Triangulation_vertex_base_2<Gt>,
-		      Constrained_triangulation_face_base_2<Gt> >,
-	  class Itag = No_intersection_tag >		
+template <class Gt,
+          class Tds_ = Default,
+	  class Itag_ = Default>
 class Constrained_Delaunay_triangulation_2
-  : public  Constrained_triangulation_2<Gt, Tds_, Itag>
+  : public  Constrained_triangulation_2<Gt, Tds_, Itag_>
 {
 public:
-  typedef Constrained_triangulation_2<Gt,Tds_,Itag>            Ctr;
+  typedef Constrained_triangulation_2<Gt,Tds_,Itag_>            Ctr;
   typedef typename Ctr::Tds Tds;
+  typedef typename Ctr::Itag Itag;
   typedef Constrained_Delaunay_triangulation_2<Gt,Tds,Itag>    CDt;
   typedef typename Ctr::Geom_traits      Geom_traits;
   typedef typename Ctr::Intersection_tag Intersection_tag;

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -56,15 +56,16 @@ namespace CGAL {
 
 
 template <class Gt, 
-          class Tds = Triangulation_data_structure_2 <
+          class Tds_ = Triangulation_data_structure_2 <
                       Triangulation_vertex_base_2<Gt>,
 		      Constrained_triangulation_face_base_2<Gt> >,
 	  class Itag = No_intersection_tag >		
 class Constrained_Delaunay_triangulation_2
-  : public  Constrained_triangulation_2<Gt, Tds, Itag> 
+  : public  Constrained_triangulation_2<Gt, Tds_, Itag>
 {
 public:
-  typedef Constrained_triangulation_2<Gt,Tds,Itag>             Ctr;
+  typedef Constrained_triangulation_2<Gt,Tds_,Itag>            Ctr;
+  typedef typename Ctr::Tds Tds;
   typedef Constrained_Delaunay_triangulation_2<Gt,Tds,Itag>    CDt;
   typedef typename Ctr::Geom_traits      Geom_traits;
   typedef typename Ctr::Intersection_tag Intersection_tag;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -40,10 +40,8 @@ struct Exact_predicates_tag{}; // to be used with filtered exact number
 
 
 template < class Gt, 
-           class Tds_ = Triangulation_data_structure_2 <
-                                                       Triangulation_vertex_base_2<Gt>,
-                                                       Constrained_triangulation_face_base_2<Gt> >,
-           class Itag_ = No_intersection_tag>
+           class Tds_ = Default ,
+           class Itag_ = Default >
 class Constrained_triangulation_2  
   : public Triangulation_2<Gt,typename Default::Get< Tds_,
                                                      Triangulation_data_structure_2 <
@@ -55,10 +53,11 @@ public:
   typedef typename Default::Get<Tds_, Triangulation_data_structure_2 <
                                         Triangulation_vertex_base_2<Gt>,
                                         Constrained_triangulation_face_base_2<Gt> > >::type Tds;
+
   typedef typename Default::Get<Itag_, No_intersection_tag>::type Itag;
 
   typedef Triangulation_2<Gt,Tds> Triangulation;
-  typedef Constrained_triangulation_2<Gt,Tds_,Itag>  Constrained_triangulation;
+  typedef Constrained_triangulation_2<Gt,Tds_,Itag_>  Constrained_triangulation;
   
   typedef typename Triangulation::Edge Edge;
   typedef typename Triangulation::Vertex Vertex;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -28,7 +28,7 @@
 #include <CGAL/Triangulation_2.h> 
 #include <CGAL/Constrained_triangulation_face_base_2.h>
 #include <CGAL/iterator.h>
-
+#include <CGAL/Default.h>
 #include <CGAL/intersections.h>
 #include <CGAL/squared_distance_2.h>
 
@@ -40,16 +40,23 @@ struct Exact_predicates_tag{}; // to be used with filtered exact number
 
 
 template < class Gt, 
-           class Tds = Triangulation_data_structure_2 <
-                       Triangulation_vertex_base_2<Gt>,
-		       Constrained_triangulation_face_base_2<Gt> >, 
+           class Tds_ = Triangulation_data_structure_2 <
+                          Triangulation_vertex_base_2<Gt>,
+                          Constrained_triangulation_face_base_2<Gt> >, 
            class Itag = No_intersection_tag >
-class Constrained_triangulation_2  : public Triangulation_2<Gt,Tds>
+class Constrained_triangulation_2  
+  : public Triangulation_2<Gt,typename Default::Get< Tds_,
+                                                     Triangulation_data_structure_2 <
+                                                       Triangulation_vertex_base_2<Gt>,
+                                                       Constrained_triangulation_face_base_2<Gt> > >::type >
 {
 
 public:
+  typedef typename Default::Get<Tds_, Triangulation_data_structure_2 <
+                                        Triangulation_vertex_base_2<Gt>,
+                                        Constrained_triangulation_face_base_2<Gt> > >::type Tds;
   typedef Triangulation_2<Gt,Tds> Triangulation;
-  typedef Constrained_triangulation_2<Gt,Tds,Itag>  Constrained_triangulation;
+  typedef Constrained_triangulation_2<Gt,Tds_,Itag>  Constrained_triangulation;
   
   typedef typename Triangulation::Edge Edge;
   typedef typename Triangulation::Vertex Vertex;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -40,10 +40,8 @@ struct Exact_predicates_tag{}; // to be used with filtered exact number
 
 
 template < class Gt, 
-           class Tds_ = Triangulation_data_structure_2 <
-                          Triangulation_vertex_base_2<Gt>,
-                          Constrained_triangulation_face_base_2<Gt> >, 
-           class Itag = No_intersection_tag >
+           class Tds_ = Default,
+           class Itag_ = Default>
 class Constrained_triangulation_2  
   : public Triangulation_2<Gt,typename Default::Get< Tds_,
                                                      Triangulation_data_structure_2 <
@@ -55,6 +53,8 @@ public:
   typedef typename Default::Get<Tds_, Triangulation_data_structure_2 <
                                         Triangulation_vertex_base_2<Gt>,
                                         Constrained_triangulation_face_base_2<Gt> > >::type Tds;
+  typedef typename Default::Get<Itag_, No_intersection_tag>::type Itag;
+
   typedef Triangulation_2<Gt,Tds> Triangulation;
   typedef Constrained_triangulation_2<Gt,Tds_,Itag>  Constrained_triangulation;
   

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -40,8 +40,10 @@ struct Exact_predicates_tag{}; // to be used with filtered exact number
 
 
 template < class Gt, 
-           class Tds_ = Default,
-           class Itag_ = Default>
+           class Tds_ = Triangulation_data_structure_2 <
+                                                       Triangulation_vertex_base_2<Gt>,
+                                                       Constrained_triangulation_face_base_2<Gt> >,
+           class Itag_ = No_intersection_tag>
 class Constrained_triangulation_2  
   : public Triangulation_2<Gt,typename Default::Get< Tds_,
                                                      Triangulation_data_structure_2 <

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
@@ -11,7 +11,8 @@ Delaunay triangulation.
 
 \tparam TriangulationDataStructure_3 is the triangulation data structure. 
 It has the default value `Triangulation_data_structure_3<Triangulation_vertex_base_3<DelaunayTriangulationTraits_3>, 
-								  Delaunay_triangulation_cell_base_3<DelaunayTriangulationTraits_3> >`. 
+								  Delaunay_triangulation_cell_base_3<DelaunayTriangulationTraits_3> >`.
+`Default` may be used.
 
 \tparam LocationPolicy is a tag which must be a `Location_policy<Tag>`: 
 either `Fast_location` or `Compact_location`. 
@@ -35,7 +36,7 @@ manual \ref Triangulation3exfastlocation.
 
 \tparam SurjectiveLockDataStructure is an optional parameter to specify the type of the spatial lock data structure.
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when 
-        TriangulationDataStructure_3::Concurrency_tag is Parallel_tag).
+        `TriangulationDataStructure_3::Concurrency_tag` is `Parallel_tag`).
         It must be a model of the `SurjectiveLockDataStructure` concept,
         with `Object` being a `Point`.
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
@@ -31,10 +31,11 @@ of all simplices are regular.
 
 \tparam TriangulationDataStructure_3 is the triangulation data structure. 
 It has the default value `Triangulation_data_structure_3<Triangulation_vertex_base_3<RegularTriangulationTraits_3>, Regular_triangulation_cell_base_3<RegularTriangulationTraits_3> >`. 
+`Default` may be used.
 
 \tparam SurjectiveLockDataStructure is an optional parameter to specify the type of the spatial lock data structure.
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when 
-        TriangulationDataStructure_3::Concurrency_tag is Parallel_tag).
+        `TriangulationDataStructure_3::Concurrency_tag` is `Parallel_tag`).
         It must be a model of the `SurjectiveLockDataStructure` concept,
         with `Object` being a `Point`.
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -11,10 +11,11 @@ of points.
 
 \tparam TriangulationDataStructure_3 is the triangulation data structure.
 It has the default value `Triangulation_data_structure_3< Triangulation_vertex_base_3<TriangulationTraits_3>,Triangulation_cell_base_3<TriangulationTraits_3> >`. 
+`Default` may be used.
 
 \tparam SurjectiveLockDataStructure is an optional parameter to specify the type of the spatial lock data structure.
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when 
-        TriangulationDataStructure_3::Concurrency_tag is Parallel_tag).
+        `TriangulationDataStructure_3::Concurrency_tag` is `Parallel_tag`).
         It must be a model of the `SurjectiveLockDataStructure` concept,
         with `Object` being a `Point`.
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if


### PR DESCRIPTION
[Small feature "Use Default"](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Use_Default)

This PR makes several typedefs in examples obsolete.