### PR TITLE
BGL convert_surface_mesh : convert also boundary halfedges

### DIFF
--- a/BGL/include/CGAL/boost/graph/convert_surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/convert_surface_mesh.h
@@ -70,6 +70,10 @@ namespace CGAL {
     }
     do {
       h2h.insert(std::make_pair(shd, thd));
+
+      if (face(opposite(shd, sm), sm) == boost::graph_traits<SourceMesh>::null_face())
+        h2h.insert(std::make_pair(opposite(shd, sm), opposite(thd, tm)));
+
       shd = next(shd,sm);
       thd = next(thd,tm);
     }while(shd != done);


### PR DESCRIPTION
Until that PR, the code of convert_surface_mesh forgot to map boundary halfedges (incident to `null_face()`) and store them in the `h2h` map
Fixed.

