### PR TITLE
Fix issues in I/O of Mesh_complex_3_in_triangulation_3

### DIFF
--- a/Mesh_3/include/CGAL/Compact_mesh_cell_base_3.h
+++ b/Mesh_3/include/CGAL/Compact_mesh_cell_base_3.h
@@ -664,7 +664,7 @@ operator>>(std::istream &is,
     {
       typename Compact_mesh_cell_base_3<GT, MT, Cb>::Surface_patch_index i2;
       if(is_ascii(is))
-        is >> i2;
+        is >> iformat(i2);
       else
       {
         read(is, i2);
@@ -687,7 +687,7 @@ operator<<(std::ostream &os,
   for(int i = 0; i < 4; ++i)
   {
     if(is_ascii(os))
-      os << ' ' << c.surface_patch_index(i);
+      os << ' ' << oformat(c.surface_patch_index(i));
     else
       write(os, c.surface_patch_index(i));
   }

--- a/Mesh_3/include/CGAL/IO/File_binary_mesh_3.h
+++ b/Mesh_3/include/CGAL/IO/File_binary_mesh_3.h
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <string>
+#include <limits>
 #include <CGAL/Mesh_3/io_signature.h>
 
 namespace CGAL {
@@ -32,10 +33,18 @@ namespace Mesh_3 {
 template <class C3T3>
 bool
 save_binary_file(std::ostream& os,
-                 const C3T3& c3t3)
+                 const C3T3& c3t3,
+                 bool binary = true)
 {
-  os << "binary CGAL c3t3 " << CGAL::Get_io_signature<C3T3>()() << "\n";
-  CGAL::set_binary_mode(os);
+  typedef typename C3T3::Triangulation::Geom_traits::FT FT;
+  if(binary) os << "binary ";
+  os << "CGAL c3t3 " << CGAL::Get_io_signature<C3T3>()() << "\n";
+  if(binary) {
+    CGAL::set_binary_mode(os);
+  } else {
+    CGAL::set_ascii_mode(os);
+    os.precision(std::numeric_limits<FT>::digits10+2);
+  }
   return !!(os << c3t3);
   // call operator!() twice, because operator bool() is C++11
 }

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -747,6 +747,8 @@ public:
   operator>> (std::istream& is,
               Mesh_complex_3_in_triangulation_3_base<Tr2,Ct2> &c3t3);
 
+  void rescan_after_load_of_triangulation();
+
   static
   std::string io_signature()
   {
@@ -920,27 +922,33 @@ operator>> (std::istream& is,
     return is;
   }
 
+  c3t3.rescan_after_load_of_triangulation();
+  return is;
+}
+
+template <typename Tr, typename Ct>
+void
+Mesh_complex_3_in_triangulation_3_base<Tr,Ct>::
+rescan_after_load_of_triangulation() {
   for(typename Tr::Finite_facets_iterator
-        fit = c3t3.triangulation().finite_facets_begin(),
-        end = c3t3.triangulation().finite_facets_end();
+        fit = this->triangulation().finite_facets_begin(),
+        end = this->triangulation().finite_facets_end();
       fit != end; ++fit)
   {
-    if ( c3t3.is_in_complex(*fit) ) {
-      ++c3t3.number_of_facets_;
+    if ( this->is_in_complex(*fit) ) {
+      ++this->number_of_facets_;
     }
   }
 
   for(typename Tr::Finite_cells_iterator
-        cit = c3t3.triangulation().finite_cells_begin(),
-        end = c3t3.triangulation().finite_cells_end();
+        cit = this->triangulation().finite_cells_begin(),
+        end = this->triangulation().finite_cells_end();
       cit != end; ++cit)
   {
-    if ( c3t3.is_in_complex(cit) ) {
-      ++c3t3.number_of_cells_;
+    if ( this->is_in_complex(cit) ) {
+      ++this->number_of_cells_;
     }
   }
-
-  return is;
 }
 
 }  // end namespace Mesh_3

--- a/Mesh_3/include/CGAL/internal/Mesh_3/get_index.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/get_index.h
@@ -115,7 +115,7 @@ struct Read_mesh_domain_index<Mesh_domain, false> {
     switch(dimension) {
     case 2: {
       typename MT::Surface_patch_index spi;
-      if(is_ascii(is)) is >> spi;
+      if(is_ascii(is)) is >> iformat(spi);
       else CGAL::read(is, spi);
       return  spi;
     }


### PR DESCRIPTION
And restore the possibility for the Polyhedron demo to load two types of
C3t3 (with `Patch_id` being `int` or `std::pair<int, int>`).