### PR TITLE
Polyhedron demo: better c3t3 item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -505,22 +505,23 @@ void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {
   vaos[Facets]->release();
 
 
- if (!are_intersection_buffers_filled)
-  {
-     ncthis->compute_intersections();
-     ncthis->initialize_intersection_buffers(viewer);
+  if(!frame->isManipulated()) {
+    if (!are_intersection_buffers_filled)
+    {
+      ncthis->compute_intersections();
+      ncthis->initialize_intersection_buffers(viewer);
+    }
+    vaos[iFacets]->bind();
+    program = getShaderProgram(PROGRAM_WITH_LIGHT);
+    attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
+    program->bind();
+
+    // positions_poly is also used for the faces in the cut plane
+    // and changes when the cut plane is moved
+    viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_poly.size() / 3));
+    program->release();
+    vaos[iFacets]->release();
   }
-  vaos[iFacets]->bind();
-  program = getShaderProgram(PROGRAM_WITH_LIGHT);
-  attrib_buffers(viewer, PROGRAM_WITH_LIGHT);
-  program->bind();
-
-  // positions_poly is also used for the faces in the cut plane
-  // and changes when the cut plane is moved
-  viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(positions_poly.size() / 3));
-  program->release();
-  vaos[iFacets]->release();
-
 
   if(spheres_are_shown)
   {
@@ -602,14 +603,21 @@ void Scene_c3t3_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
   program->release();
   vaos[Edges]->release();
 
-  vaos[iEdges]->bind();
-  program = getShaderProgram(PROGRAM_NO_SELECTION);
-  attrib_buffers(viewer, PROGRAM_NO_SELECTION);
-  program->bind();
-  program->setAttributeValue("colors", QColor(Qt::black));
-  viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size() / 3));
-  program->release();
-  vaos[iEdges]->release();
+  if(!frame->isManipulated()) {
+    if (!are_intersection_buffers_filled)
+    {
+      ncthis->compute_intersections();
+      ncthis->initialize_intersection_buffers(viewer);
+    }
+    vaos[iEdges]->bind();
+    program = getShaderProgram(PROGRAM_NO_SELECTION);
+    attrib_buffers(viewer, PROGRAM_NO_SELECTION);
+    program->bind();
+    program->setAttributeValue("colors", QColor(Qt::black));
+    viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_lines.size() / 3));
+    program->release();
+    vaos[iEdges]->release();
+  }
 
   if(spheres_are_shown)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -461,22 +461,13 @@ void Scene_c3t3_item::compute_bbox() const {
 }
 
 QString Scene_c3t3_item::toolTip() const {
-  int number_of_tets = 0;
-  for (Tr::Finite_cells_iterator
-    cit = c3t3().triangulation().finite_cells_begin(),
-    end = c3t3().triangulation().finite_cells_end();
-    cit != end; ++cit)
-  {
-    if (c3t3().is_in_complex(cit))
-      ++number_of_tets;
-  }
   return tr("<p><b>3D complex in a 3D triangulation</b></p>"
     "<p>Number of vertices: %1<br />"
     "Number of surface facets: %2<br />"
     "Number of volume tetrahedra: %3</p>")
     .arg(c3t3().triangulation().number_of_vertices())
-    .arg(c3t3().number_of_facets())
-    .arg(number_of_tets);
+    .arg(c3t3().number_of_facets_in_complex())
+    .arg(c3t3().number_of_cells_in_complex());
 }
 
 void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
@@ -10,8 +10,9 @@ uniform highp float spec_power ;
 uniform int is_two_side; 
 uniform bool is_selected;
 void main(void) {
- if(color.w>0)
+ if(color.w<0)
  {
+    vec4 my_color = vec4(color.xzy, 1.);
     highp vec3 L = light_pos.xyz - fP.xyz; 
     highp vec3 V = -fP.xyz; 
     highp vec3 N; 
@@ -24,11 +25,11 @@ void main(void) {
     highp vec3 R = reflect(-L, N); 
     vec4 diffuse; 
     if(is_two_side == 1) 
-        diffuse = abs(dot(N,L)) * light_diff * color; 
+        diffuse = abs(dot(N,L)) * light_diff * my_color; 
     else 
-        diffuse = max(dot(N,L), 0.0) * light_diff * color; 
+        diffuse = max(dot(N,L), 0.0) * light_diff * my_color; 
     highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; 
-    vec4 ret_color = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1); 
+    vec4 ret_color = vec4((my_color*light_amb).xyz + diffuse.xyz + specular.xyz,1); 
     if(is_selected)
         gl_FragColor = vec4(ret_color.r+70.0/255.0, ret_color.g+70.0/255.0, ret_color.b+70.0/255.0, 1.0);
     else

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.v
@@ -10,11 +10,7 @@ varying highp vec3 fN;
 varying highp vec4 color; 
 void main(void)
 {
-  if(vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w > 0){
-    color = vec4(0.0, 1.0, 1.0, 0.0);
-                                                                                             } else {
-    color = vec4(colors, 1.0);
-  }
+  color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
   fP = mv_matrix * vertex; 
   fN = mat3(mv_matrix)* normals; 
   gl_Position = mvp_matrix * vertex; 


### PR DESCRIPTION
This PR improve the drawing of the c3t3 item three times, with three different commits. I copy below the text of the commit messages...

@afabri @maxGimeno
(Maxime, please have a careful look at the modifications.)

Fix a critical performance issue (3c7a5dd)
----------------------

As decided by `MainWindow`, the `Scene_c3t3_item::toolTip()` method is called by `MainWindow::updateInfo()` for each `modified()` event of the manipulated frame. While the frame is manipulated, that generates a lot of events, and a lot of calls to `toolTip()`.

Before this commit, the call to `Scene_c3t3_item::toolTip()` was `O(n)`. After this commit it is `O(1)`.

That speeds up a lot the drawing of the item while the frame is manipulated!

Do not draw the intersection while the plane is manipulated (1439796)
---
... plus a fix in `draw_edges()`: missing call to `compute_intersections()`, if the item was drawn in wireframe-only.

Improve the draw of the intersection (c52758d)
---

I have tweaked the vertex and fragment shaders, to avoid the curious color interpolation for triangles of the intersection with the cutting plane.

The component `color.w` is set to the signed distance to the cutting plane (no longer any conditional in the vertex shader).

Then in the fragment shader, the drawing color is composed as such:

    if(color.w<0)
    {
      vec4 my_color = vec4(color.xzy, 1.);
      // [...]
    }
    else
      discard;
