### PR TITLE
#define BOOST_PARAMETER_MAX_ARITY early enough

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
@@ -1,3 +1,9 @@
+
+// Needed for lloyd_optimize_mesh_2 which does it too late
+// (and we don't want to spend the time on finding out who
+// includes the header file that sets it too a value too low
+#define  BOOST_PARAMETER_MAX_ARITY 8
+
 #include <stdexcept>
 
 #define CGAL_CT2_WANTS_TO_HAVE_EXTRA_ACTION_FOR_INTERSECTING_CONSTRAINTS


### PR DESCRIPTION
CGAL/lloyd_optimize_mesh_2.h  #defines it too late.

We just set it to the value needed at the beginning of the plugin code.
The solution is not really nice, but this is just a plugin.