### PR TITLE
Point set shape detection: bugfix default property maps

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -298,12 +298,14 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
           m_direct_octrees[s] = new Direct_octree(
             m_traits, last + 1,
             last + subsetSize + 1,
+            m_point_pmap, m_normal_pmap,
             remainingPoints - subsetSize);
         }
         else
           m_direct_octrees[0] = new Direct_octree(
             m_traits, m_input_iterator_first,
-            m_input_iterator_first + (subsetSize), 
+            m_input_iterator_first + (subsetSize),
+            m_point_pmap, m_normal_pmap,
           0);
 
         m_available_octree_sizes[s] = subsetSize;
@@ -313,7 +315,8 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
       }
 
       m_global_octree = new Indexed_octree(
-        m_traits, m_input_iterator_first, m_input_iterator_beyond);
+        m_traits, m_input_iterator_first, m_input_iterator_beyond,
+        m_point_pmap, m_normal_pmap);
       m_global_octree->createTree();
 
       return true;

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
@@ -235,6 +235,8 @@ namespace CGAL {
       Octree(Sd_traits const& traits,
              const Input_iterator &first,
              const Input_iterator &beyond,
+             Point_map& point_pmap,
+             Normal_map& normal_pmap,
              std::size_t offset = 0,
              std::size_t bucketSize = 20, 
              std::size_t maxLevel = 10)
@@ -242,7 +244,9 @@ namespace CGAL {
                m_traits(traits),
                m_root(NULL),
                m_bucket_size(bucketSize),
-               m_set_max_level(maxLevel) {}
+               m_set_max_level(maxLevel),
+               m_point_pmap (point_pmap),
+               m_normal_pmap (normal_pmap) {}
 
       ~Octree() {
         if (!m_root)


### PR DESCRIPTION
The `Efficient_RANSAC` algorithm in CGAL uses property maps to access points and normals from a container. But currently, there is a bug if the property maps use a resource (for example an index property map with an internal `std::vector`) that can lead to a segmentation fault.

The reason is that one of the structures used by the algorithm (the octree) is instantiated with the correct property map types _but_ without actually propagating the property maps (the default constructor of the maps is used). In practice, this works well in the examples as the property maps used are just functors (no attribute that would need copying or sharing), but crashes if the maps are more complex.

This PR corrects this. Tested on my computer (also with my own code that uses property maps with attributes that were leading to the segfault).