### PR TITLE
PMP : improve remeshing_test

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -214,8 +214,12 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   halfedge_descriptor end = he;
   do
     {
-    if (!is_border(he, pmesh))
-    {
+      if (!is_border(he, pmesh)
+          && !PMP::is_degenerated(he, pmesh
+                , choose_const_pmap(get_param(np, CGAL::vertex_point), pmesh, CGAL::vertex_point)
+                , Kernel())
+          )
+      {
       Vector n = fnmap_valid ? get(fnmap, face(he, pmesh))
                              : compute_face_normal(face(he, pmesh), pmesh, np);
       normal = normal + n;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -115,7 +115,10 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
   sum_normals<Point>(pmesh, f
     , choose_const_pmap(get_param(np, CGAL::vertex_point), pmesh, CGAL::vertex_point)
     , normal);
- 
+
+  if (normal == CGAL::NULL_VECTOR)
+    return normal;
+  else
   return normal / FT( std::sqrt( to_double(normal * normal) ) );
 }
 
@@ -214,12 +217,8 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   halfedge_descriptor end = he;
   do
     {
-      if (!is_border(he, pmesh)
-          && !PMP::is_degenerated(he, pmesh
-                , choose_const_pmap(get_param(np, CGAL::vertex_point), pmesh, CGAL::vertex_point)
-                , Kernel())
-          )
-      {
+    if (!is_border(he, pmesh))
+    {
       Vector n = fnmap_valid ? get(fnmap, face(he, pmesh))
                              : compute_face_normal(face(he, pmesh), pmesh, np);
       normal = normal + n;
@@ -227,6 +226,9 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
     he = opposite(next(he, pmesh), pmesh);
   } while (he != end);
 
+  if (normal == CGAL::NULL_VECTOR)
+    return normal;
+  else
   return normal / FT( std::sqrt( to_double(normal * normal)  ) );
 }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -677,8 +677,7 @@ namespace internal {
     void equalize_valences()
     {
 #ifdef CGAL_PMP_REMESHING_VERBOSE
-      std::cout << "Equalize valences...";
-      std::cout.flush(); 
+      std::cout << "Equalize valences..." << std::endl;
 #endif
       unsigned int nb_flips = 0;
       BOOST_FOREACH(edge_descriptor e, edges(mesh_))
@@ -705,7 +704,11 @@ namespace internal {
 
         CGAL::Euler::flip_edge(he, mesh_);
         ++nb_flips;
-        
+
+#ifdef CGAL_PMP_REMESHING_VERBOSE
+        std::cout << "\r\t(" << nb_flips << " flips)";
+        std::cout.flush();
+#endif
         CGAL_assertion_code(Halfedge_status s2 = status(he));
         CGAL_assertion_code(Halfedge_status s2o = status(opposite(he, mesh_)));
         CGAL_assertion(s1 == s2   && s1 == PATCH);
@@ -746,7 +749,7 @@ namespace internal {
       }
 
 #ifdef CGAL_PMP_REMESHING_VERBOSE
-      std::cout << "done. ("<< nb_flips << " flips)" << std::endl;
+      std::cout << "\r\tdone ("<< nb_flips << " flips)" << std::endl;
 #endif
 
 #ifdef CGAL_PMP_REMESHING_DEBUG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -897,7 +897,7 @@ namespace internal {
 
       BOOST_FOREACH(vertex_descriptor v, vertices(mesh_))
       {
-        if (!is_on_patch(v) && !is_constrained(v))
+        if (!is_on_patch(v) || is_constrained(v))
           continue;
         //note if v is constrained, it has not moved
 


### PR DESCRIPTION
This PR makes the remeshing_test complete.
(we mentioned that in the comments of PR #672)

It also fixes the degenerate-case bug mentioned in PR #948 and issue #927 

This bug actually comes from the computation of normals for degenerate faces.
It was normalizing even the NULL_VECTOR, resulting in NaN coordinates for the normal vector
