### PR TITLE
Polyhedron demo: fix c3t3 item, again

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -930,6 +930,7 @@ template <typename Tr, typename Ct>
 void
 Mesh_complex_3_in_triangulation_3_base<Tr,Ct>::
 rescan_after_load_of_triangulation() {
+  this->number_of_facets_ = 0;
   for(typename Tr::Finite_facets_iterator
         fit = this->triangulation().finite_facets_begin(),
         end = this->triangulation().finite_facets_end();
@@ -940,6 +941,7 @@ rescan_after_load_of_triangulation() {
     }
   }
 
+  this->number_of_cells_ = 0;
   for(typename Tr::Finite_cells_iterator
         cit = this->triangulation().finite_cells_begin(),
         end = this->triangulation().finite_cells_end();

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -284,6 +284,8 @@ public:
     return corners_.size();
   }
 
+  void rescan_after_load_of_triangulation();
+
   /**
    * Returns true if edge \c e is in complex
    */
@@ -725,6 +727,21 @@ is_valid(bool verbose) const
   return true;
 }
 
+template <typename Tr, typename CI_, typename CSI_>
+void
+Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_>::
+rescan_after_load_of_triangulation() {
+  corners_.clear();
+  for(typename Tr::Finite_vertices_iterator
+        vit = this->triangulation().finite_vertices_begin(),
+        end = this->triangulation().finite_vertices_end();
+      vit != end; ++vit)
+  {
+    if ( vit->in_dimension() == 0 ) {
+      add_to_complex(vit, Corner_index(1));
+    }
+  }
+}
 
 template <typename Tr, typename CI_, typename CSI_>
 std::ostream &
@@ -747,6 +764,7 @@ operator>> (std::istream& is,
   typedef typename Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_>::Concurrency_tag Concurrency_tag;
   is >> static_cast<
     Mesh_3::Mesh_complex_3_in_triangulation_3_base<Tr, Concurrency_tag>&>(c3t3);
+  c3t3.rescan_after_load_of_triangulation();
   return is;
 }
 

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -741,6 +741,7 @@ rescan_after_load_of_triangulation() {
       add_to_complex(vit, Corner_index(1));
     }
   }
+  Base::rescan_after_load_of_triangulation();
 }
 
 template <typename Tr, typename CI_, typename CSI_>

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -460,8 +460,10 @@ void refine_mesh_3_impl(C3T3& c3t3,
                           parameters::convergence = lloyd.convergence(),
                           parameters::freeze_bound = lloyd.bound());
   }
-    
-  dump_c3t3(c3t3, mesh_options.dump_after_glob_opt_prefix);
+
+  if( odt || lloyd) {
+    dump_c3t3(c3t3, mesh_options.dump_after_glob_opt_prefix);
+  }
 
   // Perturbation
   if ( perturb )
@@ -475,9 +477,9 @@ void refine_mesh_3_impl(C3T3& c3t3,
                    domain,
                    parameters::time_limit = perturb_time_limit,
                    parameters::sliver_bound = perturb.bound());
+
+    dump_c3t3(c3t3, mesh_options.dump_after_perturb_prefix);
   }
-  
-  dump_c3t3(c3t3, mesh_options.dump_after_perturb_prefix);
 
   // Exudation
   if ( exude )
@@ -490,9 +492,9 @@ void refine_mesh_3_impl(C3T3& c3t3,
     exude_mesh_3(c3t3,
                  parameters::time_limit = exude_time_limit,
                  parameters::sliver_bound = exude.bound());
+
+    dump_c3t3(c3t3, mesh_options.dump_after_exude_prefix);
   }
-  
-  dump_c3t3(c3t3, mesh_options.dump_after_exude_prefix);
 
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -1,6 +1,7 @@
 #include "Scene_polyhedron_transform_item.h"
 #include "Kernel_type.h"
 #include "Polyhedron_type.h"
+#include <CGAL/Three/Viewer_interface.h>
 
 Scene_polyhedron_transform_item::Scene_polyhedron_transform_item(const qglviewer::Vec& pos,const Scene_polyhedron_item* poly_item_,const CGAL::Three::Scene_interface*):
     Scene_item(NbOfVbos,NbOfVaos),

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -3,6 +3,7 @@
 #include "opengl_tools.h"
 #include "create_sphere.h"
 #include "Scene_edit_polyhedron_item.h"
+#include <CGAL/Three/Viewer_interface.h>
 #include <boost/foreach.hpp>
 #include <algorithm>
 #include <QTime>

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -23,7 +23,6 @@
     </qresource>
     <qresource prefix="/cgal/Polyhedron_3">
         <file alias="about.html">resources/about.html</file>
-        <file>resources/shader_c3t3.v</file>
         <file>resources/shader_with_light.v</file>
         <file>resources/shader_with_light.f</file>
         <file>resources/shader_without_light.f</file>
@@ -34,9 +33,11 @@
         <file>resources/shader_with_texture.v</file>
         <file>resources/shader_instanced.v</file>
         <file>resources/shader_no_light_no_selection.f</file>
-        <file>resources/shader_c3t3_edges.f</file>
-        <file>resources/shader_c3t3.f</file>
+        <file>resources/shader_c3t3_spheres.v</file>
         <file>resources/shader_c3t3_edges.v</file>
+        <file>resources/shader_c3t3_edges.f</file>
+        <file>resources/shader_c3t3.v</file>
+        <file>resources/shader_c3t3.f</file>
         <file>resources/shader_plane_two_faces.f</file>
     </qresource>
 </RCC>

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -32,43 +32,7 @@ void Scene_c3t3_item::compile_shaders()
 {
     program_sphere = new QOpenGLShaderProgram();
 
-    //Source code
-    const char vertex_source[] =
-    {
-        "#version 120                                                                                             \n"
-        "attribute highp vec4 vertex;                                                                             \n"
-        "attribute highp vec3 normals;                                                                            \n"
-        "attribute highp vec3 colors;                                                                             \n"
-        "attribute highp vec3 center;                                                                             \n"
-        "attribute highp float radius;                                                                            \n"
-        "uniform highp vec4 cutplane;                                                                             \n"
-        "uniform highp mat4 mvp_matrix;                                                                           \n"
-        "uniform highp mat4 mv_matrix;                                                                            \n"
-        "varying highp vec4 fP;                                                                                   \n"
-        "varying highp vec3 fN;                                                                                   \n"
-        "varying highp vec4 color;                                                                                \n"
-        "                                                                                                         \n"
-        "                                                                                                         \n"
-        "void main(void)                                                                                          \n"
-        "{                                                                                                        \n"
-        " if(center.x * cutplane.x  + center.y * cutplane.y  + center.z * cutplane.z  +  cutplane.w > 0){         \n"
-        "    color = vec4(colors,0.0);                                                                            \n"
-        " }else{                                                                                                  \n"
-        "  color = vec4(colors,1.0);}                                                                             \n"
-        "  fP = mv_matrix * vertex;                                                                               \n"
-        "  fN = mat3(mv_matrix)* normals;                                                                         \n"
-        "  gl_Position =  mvp_matrix *                                                                            \n"
-        "  vec4(radius*vertex.x + center.x, radius* vertex.y + center.y, radius*vertex.z + center.z, 1.0) ;       \n"
-        "}                                                                                                        \n"
-    };
-    QOpenGLShader *vertex_shader = new QOpenGLShader(QOpenGLShader::Vertex);
-    if(!vertex_shader->compileSourceCode(vertex_source))
-    {
-        std::cerr<<"Compiling vertex source FAILED"<<std::endl;
-    }
-
-
-    if(!program_sphere->addShader(vertex_shader))
+    if(!program_sphere->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.v"))
     {
         std::cerr<<"adding vertex shader FAILED"<<std::endl;
     }
@@ -570,6 +534,12 @@ void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {
 }
 
 void Scene_c3t3_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
+  if(renderingMode() == FlatPlusEdges)
+  {
+    GLint renderMode;
+    glGetIntegerv(GL_RENDER_MODE, &renderMode);
+    if(renderMode == GL_SELECT) return;
+  }
   Scene_c3t3_item* ncthis = const_cast<Scene_c3t3_item*>(this);
   if (!are_buffers_filled)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -30,7 +30,7 @@ struct Scene_c3t3_item_priv {
 
 void Scene_c3t3_item::compile_shaders()
 {
-    program_sphere = new QOpenGLShaderProgram();
+    program_sphere = new QOpenGLShaderProgram(this);
 
     if(!program_sphere->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.v"))
     {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -85,8 +85,9 @@ public:
   bool isFinite() const { return true; }
   bool isEmpty() const {
     return c3t3().triangulation().number_of_vertices() == 0
-      || (    c3t3().number_of_facets_in_complex() == 0
-           && c3t3().number_of_cells_in_complex()  == 0  );
+      || (    c3t3().number_of_vertices_in_complex() == 0
+           && c3t3().number_of_facets_in_complex()   == 0
+           && c3t3().number_of_cells_in_complex()    == 0  );
   }
 
   void compute_bbox() const;

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -1,4 +1,5 @@
 #include "Scene_nef_polyhedron_item.h"
+#include <CGAL/Three/Viewer_interface.h>
 #include "Scene_polyhedron_item.h"
 #include "Nef_type.h"
 #include "Polyhedron_type.h"

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -3,6 +3,7 @@
 
 #include "Scene_polygon_soup_item.h"
 #include "Scene_polyhedron_item.h"
+#include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -2,7 +2,6 @@
 #define SCENE_POLYGON_SOUP_ITEM_H
 #include "Scene_polygon_soup_item_config.h"
 #include  <CGAL/Three/Scene_item.h>
-#include "Viewer.h"
 #include "Polyhedron_type.h"
 
 #include <boost/foreach.hpp>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1,4 +1,5 @@
 #include "Scene_polyhedron_item.h"
+#include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/AABB_intersections.h>
 #include "Kernel_type.h"
 #include <CGAL/IO/Polyhedron_iostream.h>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -5,7 +5,6 @@
 #include  <CGAL/Three/Scene_item.h> //<- modif ?
 #include "Polyhedron_type_fwd.h"
 #include "Polyhedron_type.h"
-#include "Viewer.h"
 #include <iostream>
 #include <QOpenGLVertexArrayObject>
 #include <QOpenGLBuffer>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -14,6 +14,11 @@
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
 #include "Polyhedron_demo_detect_sharp_edges.h"
 
+// Laurent Rineau, 2016/04/07: that header should not be included here, but
+// only in the .cpp file. But that header file does contain the body of a
+// few member functions.
+#include <CGAL/Three/Viewer_interface.h>
+
 #include <fstream>
 #include <boost/foreach.hpp>
 #include <boost/unordered_set.hpp>

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -246,6 +246,18 @@ void Viewer::mousePressEvent(QMouseEvent* event)
   }
 }
 
+#include <QContextMenuEvent>
+void Viewer::contextMenuEvent(QContextMenuEvent* event)
+{
+  if(event->reason() != QContextMenuEvent::Mouse) {
+    requestContextMenu(event->globalPos());
+    event->accept();
+  }
+  else {
+    QGLViewer::contextMenuEvent(event);
+  }
+}
+
 void Viewer::keyPressEvent(QKeyEvent* e)
 {
   if(!e->modifiers()) {

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -307,7 +307,7 @@ void Viewer_impl::draw_aux(bool with_names, Viewer* viewer)
   else
     viewer->glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_FALSE);
 
-  if(antialiasing)
+  if(!with_names && antialiasing)
   {
     viewer->glEnable(GL_BLEND);
     viewer->glEnable(GL_LINE_SMOOTH);

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -21,6 +21,7 @@ class Scene_draw_interface;
 }
 class QMouseEvent;
 class QKeyEvent;
+class QContextMenuEvent;
 
 class Viewer_impl;
 //!The viewer class. Deals with all the openGL rendering and the mouse/keyboard events.
@@ -108,6 +109,8 @@ protected:
   void wheelEvent(QWheelEvent *);
   //!Defines the behaviour for the key press events
   void keyPressEvent(QKeyEvent*);
+  //!Deal with context menu events
+  void contextMenuEvent(QContextMenuEvent*);
   /*! \brief Encapsulates the pickMatrix.
   * Source code of gluPickMatrix slightly modified : instead of multiplying the current matrix by this value,
   * sets the viewer's pickMatrix_ so that the drawing area is only around the cursor. This is because since CGAL 4.7,

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.f
@@ -2,7 +2,7 @@
 varying highp vec4 color;
 void main(void) 
 { 
-  if(color.w>0)
+  if(color.w<0)
     gl_FragColor = vec4(0,0,0,1.0); 
   else
     discard;

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.v
@@ -6,14 +6,6 @@ uniform highp vec4 cutplane;
 varying highp vec4 color; 
 void main(void)
 {
-  if(vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w > 0)
-  {
-    color = vec4(0.0, 1.0, 1.0, 0.0);
-  } 
-  else 
-  {
-    color = vec4(colors, 1.0);
-  }
+  color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
   gl_Position = mvp_matrix * vertex;
 }
- 

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_spheres.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_spheres.v
@@ -1,0 +1,22 @@
+#version 120
+attribute highp vec4 vertex;
+attribute highp vec3 normals;
+attribute highp vec3 colors;
+attribute highp vec3 center;
+attribute highp float radius;
+uniform highp vec4 cutplane;
+uniform highp mat4 mvp_matrix;
+uniform highp mat4 mv_matrix;
+varying highp vec4 fP;
+varying highp vec3 fN;
+varying highp vec4 color;
+
+
+void main(void)
+{
+  color = vec4(colors, center.x * cutplane.x  + center.y * cutplane.y  + center.z * cutplane.z  +  cutplane.w);
+  fP = mv_matrix * vertex;
+  fN = mat3(mv_matrix)* normals;
+  gl_Position =  mvp_matrix *
+  vec4(radius*vertex.x + center.x, radius* vertex.y + center.y, radius*vertex.z + center.z, 1.0) ;
+}


### PR DESCRIPTION
Followup to PR #962, in  	5a9d82e:

 - the display of spheres was no longer correct,
 - allow loading of c3t3 without any facets and cells (only vertices
   with weights),
 - fix the display of spheres, with better shaders,
 - `Scene_c3t3_item`: do not draw edges, in FlatPlusEdges, during a
   `drawWithNames()`, to optimize speed,
 - `Viewer`: do not use anti-aliasing during `drawWithNames()`
Plus:
 - Allow to pop the context menu with `Key_Menu` (910f17c), faster than shift+rightbutton
 - Do not depend on `Viewer.h` (f267cfb)

Cc: @maxGimeno, have a look at the modifications please.
