### PR TITLE
Fix a test

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
@@ -100,6 +100,8 @@ public:
 
     // Mesh generation
     C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
+                                        no_perturb(),
+                                        no_exude(),
       mesh_3_options(number_of_initial_points = 30));
 
     // Verify


### PR DESCRIPTION
One cannot run `make_mesh_3` without `no_exude()`, and then use
`verify_c3t3`, that runs `refine_mesh_3`.

Fixes that error:
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.9-I-14/Mesh_3/TestReport_lrineau_ArchLinux-clang-Release.gz