### PR TITLE
Point set processing : avoid using the infinite vertex as a finite vertex

### DIFF
--- a/Point_set_processing_3/include/CGAL/internal/Voronoi_covariance_3/voronoi_covariance_3.h
+++ b/Point_set_processing_3/include/CGAL/internal/Voronoi_covariance_3/voronoi_covariance_3.h
@@ -148,6 +148,8 @@ namespace CGAL {
                     for(typename std::list<Vertex_handle>::iterator it = vertices.begin();
                         it != vertices.end(); ++it)
                     {
+                        if (dt.is_infinite(*it))
+                          continue;
                         Vector p = ((*it)->point() - v->point())/2;
                         planes.push_back (Plane(CGAL::ORIGIN+p, p));
                     }


### PR DESCRIPTION
This PR fixes a hardly reproducible runtime error, spotted in issue #919

We need to skip the infinite vertex to avoid computing stuff on the associated point.
This could explain the fact that debug and release behaviour of the tests are not the same, even with the same random seed. The initialization of the infinite vertex coordinates may also be done differently depending on the platform.

it replaces PR #987