### PR TITLE
Polyhedron_demo : New picking

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -331,10 +331,10 @@ Scene::drawWithNames(CGAL::Three::Viewer_interface* viewer)
 {
     draw_aux(true, viewer);
 }
-
 void 
 Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
 {
+    QMap<float, int> picked_item_IDs;
     if(!ms_splatting->viewer_is_set)
         ms_splatting->setViewer(viewer);
     if(!gl_init)
@@ -343,7 +343,8 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
     for(int index = 0; index < m_entries.size(); ++index)
     {
         if(with_names) {
-            viewer->glPushName(index);
+            glClearDepth(1.0);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         }
         CGAL::Three::Scene_item& item = *m_entries[index];
         if(item.visible())
@@ -375,140 +376,151 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
             }
         }
         if(with_names) {
-            viewer->glPopName();
+
+            //    read depth buffer at pick location;
+            float depth = 1.0;
+            glReadPixels(picked_pixel.x(),picked_pixel.y(),1,1,GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
+            if (depth != 1.0)
+            {
+                //add object to list of picked objects;
+                picked_item_IDs[depth] = index;
+            }
         }
     }
-glDepthFunc(GL_LEQUAL);
-    // Wireframe OpenGL drawing
-    for(int index = 0; index < m_entries.size(); ++index)
+    if(!with_names)
     {
-        if(with_names) {
-            viewer->glPushName(index);
-        }
-        CGAL::Three::Scene_item& item = *m_entries[index];
-        if(item.visible())
+        glDepthFunc(GL_LEQUAL);
+        // Wireframe OpenGL drawing
+        for(int index = 0; index < m_entries.size(); ++index)
         {
-            if(item.renderingMode() == FlatPlusEdges || item.renderingMode() == Wireframe)
+            CGAL::Three::Scene_item& item = *m_entries[index];
+            if(item.visible())
             {
-                viewer->glDisable(GL_LIGHTING);
-                viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
-                viewer->glPointSize(2.f);
-                viewer->glLineWidth(1.0f);
-                if(index == selected_item || selected_items_list.contains(index))
+                if(item.renderingMode() == FlatPlusEdges || item.renderingMode() == Wireframe)
                 {
-                      item.selection_changed(true);
-                }
-                else
-                {
-                      item.selection_changed(false);
-                }
-
-
-
-                if(viewer)
-                    item.draw_edges(viewer);
-                else
-                    item.draw_edges();
-            }
-            else{
-                if( item.renderingMode() == PointsPlusNormals ){
                     viewer->glDisable(GL_LIGHTING);
                     viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
                     viewer->glPointSize(2.f);
                     viewer->glLineWidth(1.0f);
                     if(index == selected_item || selected_items_list.contains(index))
                     {
-
                         item.selection_changed(true);
                     }
                     else
                     {
-
                         item.selection_changed(false);
                     }
+
+
+
                     if(viewer)
                         item.draw_edges(viewer);
                     else
                         item.draw_edges();
                 }
+                else{
+                    if( item.renderingMode() == PointsPlusNormals ){
+                        viewer->glDisable(GL_LIGHTING);
+                        viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
+                        viewer->glPointSize(2.f);
+                        viewer->glLineWidth(1.0f);
+                        if(index == selected_item || selected_items_list.contains(index))
+                        {
+
+                            item.selection_changed(true);
+                        }
+                        else
+                        {
+
+                            item.selection_changed(false);
+                        }
+                        if(viewer)
+                            item.draw_edges(viewer);
+                        else
+                            item.draw_edges();
+                    }
+                }
             }
         }
-        if(with_names) {
-            viewer->glPopName();
-        }
-    }
 
 
-    // Points OpenGL drawing
-    for(int index = 0; index < m_entries.size(); ++index)
-    {
-        if(with_names) {
-            viewer->glPushName(index);
-        }
-        CGAL::Three::Scene_item& item = *m_entries[index];
-        if(item.visible())
-        {
-            if(item.renderingMode() == Points  || item.renderingMode() == PointsPlusNormals)
-            {
-                viewer->glDisable(GL_LIGHTING);
-                viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_POINT);
-                viewer->glPointSize(2.f);
-                viewer->glLineWidth(1.0f);
-
-                if(viewer)
-                    item.draw_points(viewer);
-                else
-                    item.draw_points();
-            }
-        }
-        if(with_names) {
-            viewer->glPopName();
-        }
-    }
-    glDepthFunc(GL_LESS);
-    // Splatting
-    if(!with_names && ms_splatting->isSupported())
-    {
-
-        ms_splatting->beginVisibilityPass();
+        // Points OpenGL drawing
         for(int index = 0; index < m_entries.size(); ++index)
         {
             CGAL::Three::Scene_item& item = *m_entries[index];
-            if(item.visible() && item.renderingMode() == Splatting)
+            if(item.visible())
             {
-
-                if(viewer)
+                if(item.renderingMode() == Points  || item.renderingMode() == PointsPlusNormals)
                 {
-                    item.draw_splats(viewer);
+                    viewer->glDisable(GL_LIGHTING);
+                    viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_POINT);
+                    viewer->glPointSize(2.f);
+                    viewer->glLineWidth(1.0f);
+
+                    if(viewer)
+                        item.draw_points(viewer);
+                    else
+                        item.draw_points();
                 }
-                else
-                    item.draw_splats();
             }
-
         }
-       ms_splatting->beginAttributePass();
-         for(int index = 0; index < m_entries.size(); ++index)
-        {  CGAL::Three::Scene_item& item = *m_entries[index];
-            if(item.visible() && item.renderingMode() == Splatting)
+        glDepthFunc(GL_LESS);
+        // Splatting
+        if(!with_names && ms_splatting->isSupported())
+        {
+
+            ms_splatting->beginVisibilityPass();
+            for(int index = 0; index < m_entries.size(); ++index)
             {
-                viewer->glColor4d(item.color().redF(), item.color().greenF(), item.color().blueF(), item.color().alphaF());
-                if(viewer)
-                    item.draw_splats(viewer);
-                else
-                    item.draw_splats();
+                CGAL::Three::Scene_item& item = *m_entries[index];
+                if(item.visible() && item.renderingMode() == Splatting)
+                {
+
+                    if(viewer)
+                    {
+                        item.draw_splats(viewer);
+                    }
+                    else
+                        item.draw_splats();
+                }
+
             }
+            ms_splatting->beginAttributePass();
+            for(int index = 0; index < m_entries.size(); ++index)
+            {  CGAL::Three::Scene_item& item = *m_entries[index];
+                if(item.visible() && item.renderingMode() == Splatting)
+                {
+                    viewer->glColor4d(item.color().redF(), item.color().greenF(), item.color().blueF(), item.color().alphaF());
+                    if(viewer)
+                        item.draw_splats(viewer);
+                    else
+                        item.draw_splats();
+                }
+            }
+            ms_splatting->finalize();
+
         }
-        ms_splatting->finalize();
-
     }
-
-    //scrolls the sceneView to the selected item's line.
-    if(picked)
-        Q_EMIT(itemPicked(index_map.key(mainSelectionIndex())));
+    else
+    {
+        QList<float> depths = picked_item_IDs.keys();
+        if(!depths.isEmpty())
+        {
+            qSort(depths);
+            int id = picked_item_IDs[depths.first()];
+            setSelectedItemIndex(id);
+            viewer->setSelectedName(id);
+        }
+    }
     if(with_names)
         picked = true;
     else
         picked = false;
+    //scrolls the sceneView to the selected item's line.
+    if(picked)
+    {
+        Q_EMIT(itemPicked(index_map.key(mainSelectionIndex())));
+    }
 
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -112,6 +112,8 @@ public:
   void initializeGL();
   /*! Is called by Viewer::draw(). Is deprecated and does nothing.*/
   void draw();
+  /*! Sets the screen coordinates of the currently picked point.*/
+  void setPickedPixel(const QPoint &p) {picked_pixel = p;}
   /*! Is deprecated and does nothing.*/
   void drawWithNames();
   /*! Is called by Viewer::draw(Viewer_interface*). Calls draw_aux(false, viewer).
@@ -274,6 +276,7 @@ private:
   //!Index of the item_B.
   int item_B;
   bool picked;
+  QPoint picked_pixel;
   bool gl_init;
   static GlSplat::SplatRenderer* ms_splatting;
   static int ms_splattingCounter;

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -55,12 +55,6 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
                              tr("Selects and display context "
                                 "menu of the selected item"));
 #endif // QGLVIEWER_VERSION >= 2.5.0
-  for(int i=0; i<16; i++)
-      pickMatrix_[i]=0;
-  pickMatrix_[0]=1;
-  pickMatrix_[5]=1;
-  pickMatrix_[10]=1;
-  pickMatrix_[15]=1;
   prev_radius = sceneRadius();
   axis_are_displayed = true;
 }
@@ -421,8 +415,7 @@ void Viewer::attrib_buffers(int program_name) const {
     QMatrix4x4 mv_mat;
     // transformation of the manipulated frame
     QMatrix4x4 f_mat;
-    // used for the picking. Is Identity except while selecting an item.
-    QMatrix4x4 pick_mat;
+
     f_mat.setToIdentity();
     //fills the MVP and MV matrices.
     GLdouble d_mat[16];
@@ -434,9 +427,6 @@ void Viewer::attrib_buffers(int program_name) const {
     this->camera()->getModelViewMatrix(d_mat);
     for (int i=0; i<16; ++i)
         mv_mat.data()[i] = GLfloat(d_mat[i]);
-    for (int i=0; i<16; ++i)
-        pick_mat.data()[i] = this->pickMatrix_[i];
-    mvp_mat = pick_mat * mvp_mat;
 
     const_cast<Viewer*>(this)->glGetIntegerv(GL_LIGHT_MODEL_TWO_SIDE,
                                              &is_both_sides);
@@ -544,63 +534,19 @@ void Viewer::attrib_buffers(int program_name) const {
     program->release();
 }
 
-
-void Viewer::pickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
-GLint viewport[4]) const
-{
- //GLfloat m[16];
- GLfloat sx, sy;
- GLfloat tx, ty;
-
- sx = viewport[2] / width;
- sy = viewport[3] / height;
- tx = (viewport[2] + 2.0 * (viewport[0] - x)) / width;
- ty = (viewport[3] + 2.0 * (viewport[1] - y)) / height;
-
- #define M(row, col) pickMatrix_[col*4+row]
-  M(0, 0) = sx;
-  M(0, 1) = 0.0;
-  M(0, 2) = 0.0;
-  M(0, 3) = tx;
-  M(1, 0) = 0.0;
-  M(1, 1) = sy;
-  M(1, 2) = 0.0;
-  M(1, 3) = ty;
-  M(2, 0) = 0.0;
-  M(2, 1) = 0.0;
-  M(2, 2) = 1.0;
-  M(2, 3) = 0.0;
-  M(3, 0) = 0.0;
-  M(3, 1) = 0.0;
-  M(3, 2) = 0.0;
-  M(3, 3) = 1.0;
- #undef M
-}
 void Viewer::beginSelection(const QPoint &point)
 {
-   // QGLViewer::beginSelection(point);
     makeCurrent();
-    //set the picking matrix to allow the picking
-    static GLint viewport[4];
-    camera()->getViewport(viewport);
-    pickMatrix(point.x(), point.y(), 1, 1, viewport);
     glEnable(GL_SCISSOR_TEST);
-    glScissor(point.x(), point.y(), 1, 1);
+    glScissor(point.x(), camera()->screenHeight()-1-point.y(), 1, 1);
     d->scene->setPickedPixel(point);
 
 }
 void Viewer::endSelection(const QPoint&)
 {
-    //QGLViewer::endSelection(point);
     glDisable(GL_SCISSOR_TEST);
-
-   //set the pick matrix to Identity
-    for(int i=0; i<16; i++)
-        pickMatrix_[i]=0;
-    pickMatrix_[0]=1;
-    pickMatrix_[5]=1;
-    pickMatrix_[10]=1;
-    pickMatrix_[15]=1;
+    //redraw thetrue scene for the glReadPixel in postSelection();
+    updateGL();
 }
 
 void Viewer::makeArrow(double R, int prec, qglviewer::Vec from, qglviewer::Vec to, qglviewer::Vec color, AxisData &data)

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -237,6 +237,7 @@ void Viewer::mousePressEvent(QMouseEvent* event)
   if(event->button() == Qt::RightButton &&
      event->modifiers().testFlag(Qt::ShiftModifier)) 
   {
+
     select(event->pos());
     requestContextMenu(event->globalPos());
     event->accept();
@@ -435,7 +436,6 @@ void Viewer::attrib_buffers(int program_name) const {
         mv_mat.data()[i] = GLfloat(d_mat[i]);
     for (int i=0; i<16; ++i)
         pick_mat.data()[i] = this->pickMatrix_[i];
-
     mvp_mat = pick_mat * mvp_mat;
 
     const_cast<Viewer*>(this)->glGetIntegerv(GL_LIGHT_MODEL_TWO_SIDE,
@@ -546,7 +546,7 @@ void Viewer::attrib_buffers(int program_name) const {
 
 
 void Viewer::pickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
-GLint viewport[4])
+GLint viewport[4]) const
 {
  //GLfloat m[16];
  GLfloat sx, sy;
@@ -575,21 +575,25 @@ GLint viewport[4])
   M(3, 2) = 0.0;
   M(3, 3) = 1.0;
  #undef M
-
- //pickMatrix_[i] = m[i];
 }
 void Viewer::beginSelection(const QPoint &point)
 {
-    QGLViewer::beginSelection(point);
+   // QGLViewer::beginSelection(point);
+    makeCurrent();
     //set the picking matrix to allow the picking
     static GLint viewport[4];
     camera()->getViewport(viewport);
-    pickMatrix(point.x(), point.y(), selectRegionWidth(), selectRegionHeight(), viewport);
+    pickMatrix(point.x(), point.y(), 1, 1, viewport);
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(point.x(), point.y(), 1, 1);
+    d->scene->setPickedPixel(point);
 
 }
-void Viewer::endSelection(const QPoint& point)
+void Viewer::endSelection(const QPoint&)
 {
-  QGLViewer::endSelection(point);
+    //QGLViewer::endSelection(point);
+    glDisable(GL_SCISSOR_TEST);
+
    //set the pick matrix to Identity
     for(int i=0; i<16; i++)
         pickMatrix_[i]=0;

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -108,14 +108,7 @@ protected:
   void wheelEvent(QWheelEvent *);
   //!Defines the behaviour for the key press events
   void keyPressEvent(QKeyEvent*);
-  /*! \brief Encapsulates the pickMatrix.
-  * Source code of gluPickMatrix slightly modified : instead of multiplying the current matrix by this value,
-  * sets the viewer's pickMatrix_ so that the drawing area is only around the cursor. This is because since CGAL 4.7,
-  * the drawing system changed to use shaders, and these need this value. pickMatrix_ is passed to the shaders in
-  * Scene_item::attrib_buffers(CGAL::Three::Viewer_interface* viewer, int program_name).*/
-  void pickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
-                  GLint viewport[4]) const;
-  /*!
+    /*!
    * \brief makeArrow creates an arrow and stores it in a struct of vectors.
    * \param R the radius of the arrow.
    * \param prec the precision of the quadric. The lower this value is, the higher precision you get.

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -114,7 +114,7 @@ protected:
   * the drawing system changed to use shaders, and these need this value. pickMatrix_ is passed to the shaders in
   * Scene_item::attrib_buffers(CGAL::Three::Viewer_interface* viewer, int program_name).*/
   void pickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
-                  GLint viewport[4]);
+                  GLint viewport[4]) const;
   /*!
    * \brief makeArrow creates an arrow and stores it in a struct of vectors.
    * \param R the radius of the arrow.

--- a/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
@@ -4,7 +4,7 @@ uniform bool is_selected;
 void main(void) 
 { 
 if(is_selected)
-  gl_FragColor = vec4(0,0,0,1.0); 
+  gl_FragColor = vec4(0,0,0,1.0);
 else
   gl_FragColor = color; 
 }  

--- a/Three/include/CGAL/Three/Scene_draw_interface.h
+++ b/Three/include/CGAL/Three/Scene_draw_interface.h
@@ -22,6 +22,7 @@
 #define SCENE_DRAW_INTERFACE_H
 
 class QKeyEvent;
+class QPoint;
 namespace CGAL
 {
 namespace Three {
@@ -36,6 +37,8 @@ public:
   virtual void draw() = 0;
   virtual void draw(CGAL::Three::Viewer_interface*) { draw(); };
   virtual void drawWithNames() = 0;
+ /*! Sets the screen coordinates of the currently picked point.*/
+  virtual void setPickedPixel(const QPoint &e) = 0;
   virtual void drawWithNames(CGAL::Three::Viewer_interface*) { drawWithNames(); }
   virtual bool keyPressEvent(QKeyEvent* e) = 0;
   virtual float get_bbox_length() const = 0;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -109,7 +109,7 @@ public:
   //! Used by the items to avoid SEGFAULT.
   bool extension_is_found;
   //!The matrix used for the picking.
-  GLfloat pickMatrix_[16];
+  mutable GLfloat pickMatrix_[16];
   //!Sets the binding for SHIFT+LEFT CLICK to SELECT (initially used in Scene_polyhedron_selection_item.h)
   void setBindingSelect()
   {


### PR DESCRIPTION
This is a fix for #976 .
- This PR replaces the QGLViewer picking, that uses the very low-performance `glPushNames` and `glRender(GL_SELECT)`, by a new one based on depth reading. This is significantly more efficient ( the old picking used on 1M facets took around 10 seconds to perform on my computer, when the new one is instant.)