### PR TITLE
Add specializations for Compare_distance_3::operator() for points/segments

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -489,7 +489,7 @@ namespace CartesianKernelFunctors {
     result_type
     operator()(const Point_3& p1, const Segment_3& s2, const Point_3& p2) const
     {
-      return CGAL::internal::compare_distance_ppsC3(p1,p2,s2, K());
+      return opposite(CGAL::internal::compare_distance_ppsC3(p1,p2,s2, K()));
     }
 
     template <class T1, class T2, class T3>

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -462,6 +462,7 @@ namespace CartesianKernelFunctors {
   class Compare_distance_3
   {
     typedef typename K::Point_3            Point_3;
+    typedef typename K::Segment_3          Segment_3;
   public:
     typedef typename K::Comparison_result  result_type;
 
@@ -471,6 +472,25 @@ namespace CartesianKernelFunctors {
       return cmp_dist_to_pointC3(p.x(), p.y(), p.z(),
 				 q.x(), q.y(), q.z(),
 				 r.x(), r.y(), r.z());
+    }
+
+
+    result_type
+    operator()(const Point_3& p1, const Segment_3& s1, const Segment_3& s2) const
+    {
+      return CGAL::compare_distance(p1,s1,s2);
+    }
+
+    result_type
+    operator()(const Point_3& p1, const Point_3& p2, const Segment_3& s2) const
+    {
+      return CGAL::compare_distance(p1,p2,s2);
+    }
+
+    result_type
+    operator()(const Point_3& p1, const Segment_3& s2, const Point_3& p2) const
+    {
+      return CGAL::compare_distance(p1,p2,s2);
     }
 
     template <class T1, class T2, class T3>

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -474,23 +474,22 @@ namespace CartesianKernelFunctors {
 				 r.x(), r.y(), r.z());
     }
 
-
     result_type
     operator()(const Point_3& p1, const Segment_3& s1, const Segment_3& s2) const
     {
-      return CGAL::compare_distance(p1,s1,s2);
+      return CGAL::internal::compare_distance_pssC3(p1,s1,s2, K());
     }
 
     result_type
     operator()(const Point_3& p1, const Point_3& p2, const Segment_3& s2) const
     {
-      return CGAL::compare_distance(p1,p2,s2);
+      return CGAL::internal::compare_distance_ppsC3(p1,p2,s2, K());
     }
 
     result_type
     operator()(const Point_3& p1, const Segment_3& s2, const Point_3& p2) const
     {
-      return CGAL::compare_distance(p1,p2,s2);
+      return CGAL::internal::compare_distance_ppsC3(p1,p2,s2, K());
     }
 
     template <class T1, class T2, class T3>

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -174,6 +174,125 @@ squared_distance(
     return squared_distance(pt, seg, k);
 }
 
+template <class K>
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 &pt,
+    const typename K::Segment_3 &seg1,
+    const typename K::Segment_3 &seg2,
+    const K& k,
+    const Cartesian_tag&)
+{
+    typename K::Construct_vector_3 construct_vector;
+    typedef typename K::Vector_3 Vector_3;
+    typedef typename K::RT RT;
+    typedef typename K::FT FT;
+    FT d1=FT(0), d2=FT(0);
+    RT e1 = RT(1), e2 = RT(1);
+    // assert that the segment is valid (non zero length).
+    {
+      Vector_3 diff = construct_vector(seg1.source(), pt);
+      Vector_3 segvec = construct_vector(seg1.source(), seg1.target());
+      RT d = wdot(diff,segvec, k);
+      if (d <= (RT)0){
+        d1 = (FT(diff*diff));
+      }else{
+        RT e = wdot(segvec,segvec, k);
+        if (d > e){
+          d1 = squared_distance(pt, seg1.target(), k);
+        } else{
+          Vector_3 wcr = wcross(segvec, diff, k);
+          d1 = FT(wcr*wcr);
+          e1 = e;
+        }
+      }
+    }
+    {
+      Vector_3 diff = construct_vector(seg2.source(), pt);
+      Vector_3 segvec = construct_vector(seg2.source(), seg2.target());
+      RT d = wdot(diff,segvec, k);
+      if (d <= (RT)0){
+        d2 = (FT(diff*diff));
+      }else{
+        RT e = wdot(segvec,segvec, k);
+        if (d > e){
+          d2 = squared_distance(pt, seg2.target(), k);
+        } else{
+          Vector_3 wcr = wcross(segvec, diff, k);
+          d2 = FT(wcr*wcr);
+          e2 = e;
+        }
+      }
+    }
+    return compare(d1*e2, d2*e1);
+}
+
+template <class K>
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 &pt,
+    const typename K::Point_3 &pt2,
+    const typename K::Segment_3 &seg,
+    const K& k,
+    const Cartesian_tag&)
+{
+    typename K::Construct_vector_3 construct_vector;
+    typedef typename K::Vector_3 Vector_3;
+    typedef typename K::RT RT;
+    typedef typename K::FT FT;
+    RT e2 = RT(1);
+    // assert that the segment is valid (non zero length).
+    FT d1 = squared_distance(pt, pt2, k);
+    FT d2 = FT(0);
+    {
+      Vector_3 diff = construct_vector(seg.source(), pt);
+      Vector_3 segvec = construct_vector(seg.source(), seg.target());
+      RT d = wdot(diff,segvec, k);
+      if (d <= (RT)0){
+        d2 = (FT(diff*diff));
+      }else{
+        RT e = wdot(segvec,segvec, k);
+        if (d > e){
+          d2 = squared_distance(pt, seg.target(), k);
+        } else{
+          Vector_3 wcr = wcross(segvec, diff, k);
+          d2 = FT(wcr*wcr);
+          e2 = e;
+        }
+      }
+    }
+    return compare(d1*e2, d2);
+}
+
+template <class K>
+inline
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 & pt,
+    const typename K::Point_3 & pt2,
+    const typename K::Segment_3 & seg2,
+    const K& k)
+{
+  typedef typename K::Kernel_tag Tag;
+  Tag tag;
+  return compare_distance(pt, pt2, seg2, k, tag);
+}
+
+
+template <class K>
+inline
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 & pt,
+    const typename K::Segment_3 & seg1,
+    const typename K::Segment_3 & seg2,
+    const K& k)
+{
+  typedef typename K::Kernel_tag Tag;
+  Tag tag;
+  return compare_distance(pt, seg1, seg2, k, tag);
+}
+
 
 
 
@@ -529,7 +648,7 @@ squared_distance(
 
 
 template <class K>
-inline 
+inline
 typename K::FT
 squared_distance(
     const typename K::Line_3 & line,
@@ -741,7 +860,7 @@ squared_distance(
 
 
 template <class K>
-inline 
+inline
 typename K::FT
 squared_distance(
     const Ray_3<K> & ray,
@@ -763,7 +882,7 @@ squared_distance(
 
 
 template <class K>
-inline 
+inline
 typename K::FT
 squared_distance(
     const Segment_3<K> & seg,
@@ -848,7 +967,7 @@ squared_distance(
 
 
 template <class K>
-inline 
+inline
 typename K::FT
 squared_distance(
     const Line_3<K> & line,
@@ -920,6 +1039,29 @@ squared_distance(
     return internal::squared_distance(line1, line2, K());
 }
 
+
+template <class K>
+inline
+typename K::Comparison_result
+compare_distance(
+    const Point_3<K> &p,
+    const Point_3<K> &p2,
+    const Segment_3<K> &s2)
+{
+  return internal::compare_distance(p, p2, s2, K());
+}
+
+
+template <class K>
+inline
+typename K::Comparison_result
+compare_distance(
+    const Point_3<K> &p,
+    const Segment_3<K> &s1,
+    const Segment_3<K> &s2)
+{
+  return internal::compare_distance(p, s1, s2, K());
+}
 
 
 } //namespace CGAL

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -174,43 +174,15 @@ squared_distance(
     return squared_distance(pt, seg, k);
 }
 
+
+
 template <class K>
 typename K::Comparison_result
-compare_distance(
+compare_distance_pssC3(
     const typename K::Point_3 &pt,
     const typename K::Segment_3 &seg1,
     const typename K::Segment_3 &seg2,
-    const K& k,
-    const Homogeneous_tag& t)
-{
-  typename K::FT d1 = squared_distance(pt,seg1,k,t);
-  typename K::FT d2 = squared_distance(pt,seg2,k,t);
-  return compare(d1,d2);
-}
-
-template <class K>
-typename K::Comparison_result
-compare_distance(
-    const typename K::Point_3 &pt,
-    const typename K::Point_3 &pt2,
-    const typename K::Segment_3 &seg2,
-    const K& k,
-    const Homogeneous_tag& t)
-{
-  typename K::FT d1 = squared_distance(pt,pt2,k,t);
-  typename K::FT d2 = squared_distance(pt,seg2,k,t);
-  return compare(d1,d2);
-}
-
-
-template <class K>
-typename K::Comparison_result
-compare_distance(
-    const typename K::Point_3 &pt,
-    const typename K::Segment_3 &seg1,
-    const typename K::Segment_3 &seg2,
-    const K& k,
-    const Cartesian_tag&)
+    const K& k)
 {
     typename K::Construct_vector_3 construct_vector;
     typedef typename K::Vector_3 Vector_3;
@@ -258,12 +230,11 @@ compare_distance(
 
 template <class K>
 typename K::Comparison_result
-compare_distance(
+compare_distance_ppsC3(
     const typename K::Point_3 &pt,
     const typename K::Point_3 &pt2,
     const typename K::Segment_3 &seg,
-    const K& k,
-    const Cartesian_tag&)
+    const K& k)
 {
     typename K::Construct_vector_3 construct_vector;
     typedef typename K::Vector_3 Vector_3;
@@ -292,37 +263,6 @@ compare_distance(
     }
     return compare(d1*e2, d2);
 }
-
-template <class K>
-inline
-typename K::Comparison_result
-compare_distance(
-    const typename K::Point_3 & pt,
-    const typename K::Point_3 & pt2,
-    const typename K::Segment_3 & seg2,
-    const K& k)
-{
-  typedef typename K::Kernel_tag Tag;
-  Tag tag;
-  return compare_distance(pt, pt2, seg2, k, tag);
-}
-
-
-template <class K>
-inline
-typename K::Comparison_result
-compare_distance(
-    const typename K::Point_3 & pt,
-    const typename K::Segment_3 & seg1,
-    const typename K::Segment_3 & seg2,
-    const K& k)
-{
-  typedef typename K::Kernel_tag Tag;
-  Tag tag;
-  return compare_distance(pt, seg1, seg2, k, tag);
-}
-
-
 
 
 template <class K>
@@ -1066,30 +1006,6 @@ squared_distance(
     const Line_3<K> &line2)
 {  
     return internal::squared_distance(line1, line2, K());
-}
-
-
-template <class K>
-inline
-typename K::Comparison_result
-compare_distance(
-    const Point_3<K> &p,
-    const Point_3<K> &p2,
-    const Segment_3<K> &s2)
-{
-  return internal::compare_distance(p, p2, s2, K());
-}
-
-
-template <class K>
-inline
-typename K::Comparison_result
-compare_distance(
-    const Point_3<K> &p,
-    const Segment_3<K> &s1,
-    const Segment_3<K> &s2)
-{
-  return internal::compare_distance(p, s1, s2, K());
 }
 
 

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -181,6 +181,35 @@ compare_distance(
     const typename K::Segment_3 &seg1,
     const typename K::Segment_3 &seg2,
     const K& k,
+    const Homogeneous_tag& t)
+{
+  typename K::FT d1 = squared_distance(pt,seg1,k,t);
+  typename K::FT d2 = squared_distance(pt,seg2,k,t);
+  return compare(d1,d2);
+}
+
+template <class K>
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 &pt,
+    const typename K::Point_3 &pt2,
+    const typename K::Segment_3 &seg2,
+    const K& k,
+    const Homogeneous_tag& t)
+{
+  typename K::FT d1 = squared_distance(pt,pt2,k,t);
+  typename K::FT d2 = squared_distance(pt,seg2,k,t);
+  return compare(d1,d2);
+}
+
+
+template <class K>
+typename K::Comparison_result
+compare_distance(
+    const typename K::Point_3 &pt,
+    const typename K::Segment_3 &seg1,
+    const typename K::Segment_3 &seg2,
+    const K& k,
     const Cartesian_tag&)
 {
     typename K::Construct_vector_3 construct_vector;

--- a/Distance_3/test/Distance_3/compare_distance_3.cpp
+++ b/Distance_3/test/Distance_3/compare_distance_3.cpp
@@ -6,8 +6,11 @@
 template <typename K>
 void cmp(const K& k)
 {
-  typename K::Point_3 p, q;
-  typename K::Segment_3 s1, s2;
+  typedef typename K::Point_3 Point_3;
+
+  Point_3 p(0,0,0), q(1,1,1);
+  typename K::Segment_3 s1(Point_3(1,0,0),Point_3(1,1,0)),
+    s2(Point_3(1,1,1),Point_3(2,2,2));
   
   k.compare_distance_3_object()(p,s1, s2);
   k.compare_distance_3_object()(p,q, s2);

--- a/Distance_3/test/Distance_3/compare_distance_3.cpp
+++ b/Distance_3/test/Distance_3/compare_distance_3.cpp
@@ -1,0 +1,23 @@
+
+#include <CGAL/Homogeneous.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+
+template <typename K>
+void cmp(const K& k)
+{
+  typename K::Point_3 p, q;
+  typename K::Segment_3 s1, s2;
+  
+  k.compare_distance_3_object()(p,s1, s2);
+  k.compare_distance_3_object()(p,q, s2);
+}
+
+int main()
+{
+  CGAL::Exact_predicates_inexact_constructions_kernel epic;
+  CGAL::Homogeneous<int> hk;
+  cmp(epic);
+  cmp(hk);
+  return 0;
+}

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -116,8 +116,8 @@ CGAL_Kernel_pred(Compare_dihedral_angle_3,
 		 compare_dihedral_angle_3_object)
 CGAL_Kernel_pred(Compare_distance_2,
 		 compare_distance_2_object)
-CGAL_Kernel_pred(Compare_distance_3,
-		 compare_distance_3_object)
+CGAL_Kernel_pred_RT(Compare_distance_3,
+		    compare_distance_3_object)
 CGAL_Kernel_pred(Compare_slope_2,
 		 compare_slope_2_object)
 CGAL_Kernel_pred(Compare_squared_distance_2,


### PR DESCRIPTION
As `squared_distance(Point_3, Segment_3)` makes a division, we cannot perform an exact computation with a ring type.  Therefore we add low level functions `compare_distance(Point_3,Segment_3,Segment_3)` and `compare_distance(Point_3,Point_3,Segment_3)` which are called by overloaded versions of the function operator of `Compare_distance_3`.