### PR TITLE
Polyhedron demo : clean up for plugin loader and fix for menus segfault

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -344,7 +344,10 @@ protected:
   //! Returns a list of the selected items in the sceneView.
   QList<int> getSelectedSceneItemIndices() const;
 private:
+  void updateMenus();
+  void load_plugin(QString names, bool blacklisted);
   void recurseExpand(QModelIndex index);
+  QMap<QString, QMenu*> menu_map;
   QString get_item_stats();
   QString strippedName(const QString &fullFileName);
   void setMenus(QString, QString, QAction *a);


### PR DESCRIPTION
This is a fix for #911 (fixes #911).
- Moved the shared code between `loadPlugins` and `on_actionLoad_plugin_triggered` in a separate function
- Fixed the segfault when menus and submenus have the same name