### PR TITLE
Add using get and put to help VC++; Add a testcase

### DIFF
--- a/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -150,12 +150,6 @@ struct Polyhedron_property_map {};
 
 namespace CGAL {
 
-  // Add this as VC did find the "generalized put" 
-  // when a bare pointer is used in jet_estimate_normals
-  using ::put;
-  using ::get;
-
-
 // generalized 2-ary get functions
 template<class Gt, class I, CGAL_HDS_PARAM_, class A, class PropertyTag>
 typename boost::property_map< CGAL::Polyhedron_3<Gt,I,HDS,A>, PropertyTag >::const_type
@@ -177,6 +171,13 @@ template<class Gt, class I, CGAL_HDS_PARAM_, class A, class PropertyTag, class K
 typename boost::property_traits< typename boost::property_map<CGAL::Polyhedron_3<Gt,I,HDS,A>, PropertyTag >::const_type >::reference
 get(PropertyTag p, CGAL::Polyhedron_3<Gt,I,HDS,A> const& g, const Key& key)
 { return get(get(p, g), key); }
+
+
+  
+// Add this as VC did find the "generalized put" below 
+// when a bare pointer is used in jet_estimate_normals
+using ::put;
+using ::get;
 
 // generalized put
 template<class Gt, class I, CGAL_HDS_PARAM_, class A, class PropertyTag, class Key,class Value>

--- a/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -173,11 +173,6 @@ get(PropertyTag p, CGAL::Polyhedron_3<Gt,I,HDS,A> const& g, const Key& key)
 { return get(get(p, g), key); }
 
 
-  
-// Add this as VC did find the "generalized put" below 
-// when a bare pointer is used in jet_estimate_normals
-using ::put;
-using ::get;
 
 // generalized put
 template<class Gt, class I, CGAL_HDS_PARAM_, class A, class PropertyTag, class Key,class Value>

--- a/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -150,6 +150,12 @@ struct Polyhedron_property_map {};
 
 namespace CGAL {
 
+  // Add this as VC did find the "generalized put" 
+  // when a bare pointer is used in jet_estimate_normals
+  using ::put;
+  using ::get;
+
+
 // generalized 2-ary get functions
 template<class Gt, class I, CGAL_HDS_PARAM_, class A, class PropertyTag>
 typename boost::property_map< CGAL::Polyhedron_3<Gt,I,HDS,A>, PropertyTag >::const_type

--- a/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
@@ -63,6 +63,7 @@ if ( CGAL_FOUND )
     create_single_source_cgal_program( "smoothing_test.cpp" )
     create_single_source_cgal_program( "vcm_plane_test.cpp" )
     create_single_source_cgal_program( "vcm_all_test.cpp" )
+    create_single_source_cgal_program( "jet_pointer_as_property_map.cpp" )
 
   else(EIGEN3_FOUND OR LAPACK_FOUND)
 

--- a/Point_set_processing_3/test/Point_set_processing_3/jet_pointer_as_property_map.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/jet_pointer_as_property_map.cpp
@@ -1,0 +1,47 @@
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/jet_estimate_normals.h>
+
+#include <vector>
+
+#include <iostream>
+
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+
+// Simple geometric types
+typedef Kernel::FT FT;
+typedef Kernel::Point_3 Point_3;
+typedef Kernel::Vector_3 Vector_3;
+
+
+
+
+int main()
+{  
+  std::vector<Point_3> points;
+  std::vector<size_t> indices(100);
+
+  for(int i=0; i < 100; i++){
+    indices[i] = i;
+  }
+  std::vector<Vector_3> normals(100);
+
+
+  for(int i=0; i <10; i++){
+    for(int j=0; j <10; j++){
+      points.push_back(Point_3(i,j,0));
+    }
+  }
+
+
+  CGAL::jet_estimate_normals<CGAL::Sequential_tag>(indices.begin(), indices.end(),
+                                                   &(points[0]),
+                                                   &(normals[0]),
+                                                   12);
+  
+  
+  return 0;
+}
+

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -36,6 +36,11 @@
 
 namespace CGAL {
 
+// VC++ does not consider put and get for plain pointers
+// when identifying the best match for overloads
+
+using ::put;
+using ::get;
 
 /// \cond SKIP_DOXYGEN
 


### PR DESCRIPTION
When `jet_estimate_normals()` was used with a pointer to an array as property map VC++ finds ambiguities. 