### PR TITLE
Polyhedron demo : fix the item's Info

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1273,8 +1273,6 @@ void MainWindow::updateInfo() {
             .arg(item->bbox().xmax)
             .arg(item->bbox().ymax)
             .arg(item->bbox().zmax);
-    if(item->getNbIsolatedvertices() > 0)
-    item_text += QString("<br />Number of isolated vertices : %1<br />").arg(item->getNbIsolatedvertices());
     if(!item_filename.isEmpty()) {
       item_text += QString("<br />File:<i> %1").arg(item_filename);
     }


### PR DESCRIPTION
When a Polyhedron_item has isolated vertices, the line "Number of isolated vertices" appears twice : once in the item all the time, and one in the MainWindow only when this number is positive.

This PR removes the one added by the MainWindow , but I wonder if it would be better to remove the one from the item and make the one from the MainWindow permanent, so all kinds of items can write their isolated vertices.
 @sloriot is not sure if it makes sense for non Polyhedron_items to indicate that. @janetournois what do you think ?