### PR TITLE
Use double coordinates in the OpenMesh points and normals

### DIFF
--- a/Surface_mesh_deformation/test/Surface_mesh_deformation/Cactus_deformation_session_OpenMesh.cpp
+++ b/Surface_mesh_deformation/test/Surface_mesh_deformation/Cactus_deformation_session_OpenMesh.cpp
@@ -13,7 +13,14 @@
 
 #include <CGAL/Timer.h>
 
-typedef OpenMesh::PolyMesh_ArrayKernelT</* MyTraits*/>               Mesh;
+struct DoubleTraits : public OpenMesh::DefaultTraits
+{
+  typedef OpenMesh::Vec3d Point;
+  typedef OpenMesh::Vec3d Normal;
+};
+
+
+typedef OpenMesh::PolyMesh_ArrayKernelT<DoubleTraits>               Mesh;
 typedef Mesh::Point                                                 Point;
 typedef boost::graph_traits<Mesh>::vertex_descriptor    vertex_descriptor;
 typedef boost::graph_traits<Mesh>::vertex_iterator        vertex_iterator;
@@ -24,6 +31,7 @@ const double squared_threshold = 0.001; // alert if average difs between precomp
 
 double squared_length(const Point& p)
 {
+  std::cerr << typeid(p[0]).name() << std::endl;
   return p[0]*p[0]+p[1]*p[1]+p[2]*p[2];
 }
 


### PR DESCRIPTION
By default the scalar used for coordinates in OpenMesh is float. When using the deformation algorithm with the native point type of OpenMesh, and not a point property map that converts between OpenMesh and CGAL points, it is better to use an OpenMesh traits class with double coordinates.

This PR should fix [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.9-Ic-25/Surface_mesh_deformation/TestReport_jtournois_x64_Cygwin-Windows8_MSVC2015-Release-64bits.gz)