### PR TITLE
Fix for Scene_polyhedron_item::setColor.

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -265,6 +265,10 @@ Scene_polyhedron_item::initialize_buffers(CGAL::Three::Viewer_interface* viewer)
             program->setAttributeBuffer("colors",GL_FLOAT,0,3);
             buffers[Facets_color].release();
         }
+        else
+        {
+          program->disableAttributeArray("colors");
+        }
         vaos[Facets]->release();
         //gouraud
         vaos[Gouraud_Facets]->bind();
@@ -982,9 +986,8 @@ Scene_polyhedron_item::setColor(QColor c)
   // reset patch ids
   if (colors_.size()>2 || plugin_has_set_color_vector_m)
   {
-    BOOST_FOREACH(Polyhedron::Facet_handle fh, faces(*poly))
-      fh->set_patch_id(1);
-    colors_[1]=c;
+   colors_.clear();
+   is_monochrome = true;
   }
   Scene_item::setColor(c);
 }


### PR DESCRIPTION
This PR modifies the function setColor() of the polyhedron_item, so it does not corrupt colors_ anymore, which fixes the segfault that currently occurs when using the Edit_polyhedron_plugin.