### PR TITLE
Polyhedron demo : Create new items for the spheres and the intersection of the c3t3_item 

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -208,6 +208,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
 
   add_library(scene_basic_objects SHARED
     Scene_plane_item.cpp
+    Scene_spheres_item.cpp
 )
   target_link_libraries(scene_basic_objects 
     demo_framework
@@ -225,10 +226,9 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     target_link_libraries(${item_name} demo_framework ${CGAL_LIBRARIES} ${Boost_LIBRARIES})
   endmacro(add_item)
 
-  add_item(scene_spheres_item Scene_spheres_item)
   add_item(scene_c2t3_item Scene_c2t3_item.cpp)
   add_item(scene_c3t3_item Scene_c3t3_item.cpp)
-  target_link_libraries(scene_c3t3_item scene_polyhedron_item scene_polygon_soup_item scene_spheres_item ${TBB_LIBRARIES})
+  target_link_libraries(scene_c3t3_item scene_polyhedron_item scene_polygon_soup_item scene_basic_objects ${TBB_LIBRARIES})
   add_item(scene_polyhedron_item Scene_polyhedron_item.cpp)
   add_item(scene_polyhedron_transform_item Plugins/PCA/Scene_polyhedron_transform_item.cpp )
 
@@ -242,7 +242,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   target_link_libraries(scene_combinatorial_map_item scene_polyhedron_item)
 
   add_item(scene_polylines_item Scene_polylines_item.cpp)
-  target_link_libraries(scene_polylines_item scene_spheres_item)
+  target_link_libraries(scene_polylines_item scene_basic_objects)
 
   add_item(scene_polyhedron_item_decorator Scene_polyhedron_item_decorator.cpp )
   target_link_libraries(scene_polyhedron_item_decorator scene_polyhedron_item)
@@ -262,7 +262,8 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     add_item(scene_textured_polyhedron_item Scene_textured_polyhedron_item.cpp texture.cpp)
     add_item(scene_edit_polyhedron_item Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
            ${editionUI_FILES})
-    target_link_libraries(scene_edit_polyhedron_item scene_polyhedron_item scene_polyhedron_item_k_ring_selection scene_spheres_item)
+           target_link_libraries(scene_edit_polyhedron_item scene_polyhedron_item scene_polyhedron_item_k_ring_selection
+               scene_basic_objects)
   endif()
 
   add_item(scene_implicit_function_item Scene_implicit_function_item.cpp  Color_ramp.cpp )
@@ -345,7 +346,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     scene_points_with_normal_item
     scene_implicit_function_item
     scene_polylines_item
-    scene_spheres_item
+    scene_basic_objects
     NAMESPACE Polyhedron_
     APPEND FILE polyhedron_demo_targets.cmake)
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -242,6 +242,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   target_link_libraries(scene_combinatorial_map_item scene_polyhedron_item)
 
   add_item(scene_polylines_item Scene_polylines_item.cpp)
+  target_link_libraries(scene_polylines_item scene_spheres_item)
 
   add_item(scene_polyhedron_item_decorator Scene_polyhedron_item_decorator.cpp )
   target_link_libraries(scene_polyhedron_item_decorator scene_polyhedron_item)
@@ -344,6 +345,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     scene_points_with_normal_item
     scene_implicit_function_item
     scene_polylines_item
+    scene_spheres_item
     NAMESPACE Polyhedron_
     APPEND FILE polyhedron_demo_targets.cmake)
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -225,9 +225,10 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     target_link_libraries(${item_name} demo_framework ${CGAL_LIBRARIES} ${Boost_LIBRARIES})
   endmacro(add_item)
 
+  add_item(scene_spheres_item Scene_spheres_item)
   add_item(scene_c2t3_item Scene_c2t3_item.cpp)
   add_item(scene_c3t3_item Scene_c3t3_item.cpp)
-  target_link_libraries(scene_c3t3_item scene_polyhedron_item scene_polygon_soup_item ${TBB_LIBRARIES})
+  target_link_libraries(scene_c3t3_item scene_polyhedron_item scene_polygon_soup_item scene_spheres_item ${TBB_LIBRARIES})
   add_item(scene_polyhedron_item Scene_polyhedron_item.cpp)
   add_item(scene_polyhedron_transform_item Plugins/PCA/Scene_polyhedron_transform_item.cpp )
 
@@ -272,8 +273,9 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   target_link_libraries(scene_nef_polyhedron_item scene_polyhedron_item)
   add_item(scene_points_with_normal_item Scene_points_with_normal_item.cpp)
   target_link_libraries( scene_points_with_normal_item gl_splat)
+
   target_link_libraries( demo_framework gl_splat)
-  
+
   
 
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -262,7 +262,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     add_item(scene_textured_polyhedron_item Scene_textured_polyhedron_item.cpp texture.cpp)
     add_item(scene_edit_polyhedron_item Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
            ${editionUI_FILES})
-    target_link_libraries(scene_edit_polyhedron_item scene_polyhedron_item scene_polyhedron_item_k_ring_selection)
+    target_link_libraries(scene_edit_polyhedron_item scene_polyhedron_item scene_polyhedron_item_k_ring_selection scene_spheres_item)
   endif()
 
   add_item(scene_implicit_function_item Scene_implicit_function_item.cpp  Color_ramp.cpp )

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1745,7 +1745,7 @@ void MainWindow::restoreCollapseState()
 void MainWindow::make_new_group()
 {
     Scene_group_item * group = new Scene_group_item("New group");
-    scene->add_group(group);
+    scene->addItem(group);
 }
 
 void MainWindow::on_upButton_pressed()

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -70,7 +70,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
 
         Scene_c3t3_item* item = new Scene_c3t3_item();
         item->setName(fileinfo.baseName());
-        item->set_scene(scene);
+        item->setScene(scene);
 
 
         if(item->load_binary(in)) {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -2,6 +2,7 @@
 #include "Scene_c3t3_item.h"
 
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
 #include <CGAL/IO/File_avizo.h>
 #include <iostream>
 #include <fstream>
@@ -9,18 +10,31 @@
 
 class Polyhedron_demo_c3t3_binary_io_plugin :
   public QObject,
-  public CGAL::Three::Polyhedron_demo_io_plugin_interface
+  public CGAL::Three::Polyhedron_demo_io_plugin_interface,
+  public CGAL::Three::Polyhedron_demo_plugin_interface
 {
     Q_OBJECT
     Q_INTERFACES(CGAL::Three::Polyhedron_demo_io_plugin_interface)
+    Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
     Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
 
 public:
+  void init(QMainWindow*, CGAL::Three::Scene_interface* sc )
+  {
+    this->scene = sc;
+  }
   QString name() const { return "C3t3_io_plugin"; }
   QString nameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma)"; }
   QString saveNameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma);;avizo (*.am)"; }
   QString loadNameFilters() const { return "binary files (*.cgal)" ; }
-
+  QList<QAction*> actions() const
+  {
+    return QList<QAction*>();
+  }
+  bool applicable(QAction*) const
+  {
+    return false;
+  }
   bool canLoad() const;
   CGAL::Three::Scene_item* load(QFileInfo fileinfo);
 
@@ -30,6 +44,7 @@ public:
 private:
   bool try_load_other_binary_format(std::istream& in, C3t3& c3t3);
   bool try_load_a_cdt_3(std::istream& in, C3t3& c3t3);
+  CGAL::Three::Scene_interface* scene;
 };
 
 
@@ -55,6 +70,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
 
         Scene_c3t3_item* item = new Scene_c3t3_item();
         item->setName(fileinfo.baseName());
+        item->set_scene(scene);
 
 
         if(item->load_binary(in)) {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -439,7 +439,7 @@ treat_result(Scene_item& source_item,
 
   const Scene_interface::Item_id index = scene->mainSelectionIndex();
   scene->itemChanged(index);
-
+  scene->setSelectedItem(-1);
   Scene_interface::Item_id new_item_id = scene->addItem(&result_item);
   scene->setSelectedItem(new_item_id);
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -52,7 +52,7 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
   std::cerr << "done (" << timer.time() << " ms)" << std::endl;
 
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
-  p_new_item->set_scene(scene);
+  p_new_item->setScene(scene);
 
   Mesh_parameters param;
   param.facet_angle = facet_angle;
@@ -93,7 +93,7 @@ Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
     new Function_mesh_domain(Function_wrapper(*pfunction), domain_bbox, 1e-7);
 
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
-  p_new_item->set_scene(scene);
+  p_new_item->setScene(scene);
 
   Mesh_parameters param;
   param.protect_features = false;
@@ -143,7 +143,7 @@ Meshing_thread* cgal_code_mesh_3(const Image* pImage,
   CGAL::Timer timer;
   timer.start();
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
-  p_new_item->set_scene(scene);
+  p_new_item->setScene(scene);
 
   Mesh_parameters param;
   param.protect_features = protect_features;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -512,6 +512,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
                                       CGAL::internal::IsTerminalDefault() );
 
     skeleton_item->setName(QString("Medial skeleton curve of %1").arg(item->name()));
+    scene->setSelectedItem(-1);
     scene->addItem(skeleton_item);
     skeleton_item->invalidateOpenGLBuffers();
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -225,17 +225,19 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ShowROICheckBox_stateChanged(int
   {
     Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(i));
     if(!edit_item) { continue; }
-    
     scene->itemChanged(edit_item);  // just for redraw   
   }  
 }
-void Polyhedron_demo_edit_polyhedron_plugin::on_ShowAsSphereCheckBox_stateChanged(int /*state*/)
+void Polyhedron_demo_edit_polyhedron_plugin::on_ShowAsSphereCheckBox_stateChanged(int state)
 {
   for(CGAL::Three::Scene_interface::Item_id i = 0, end = scene->numberOfEntries(); i < end; ++i)
   {
     Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(i));
     if(!edit_item) { continue; }
-    
+    if(state == 0)
+      edit_item->ShowAsSphere(false);
+    else
+      edit_item->ShowAsSphere(true);
     scene->itemChanged(edit_item);  // just for redraw   
   }  
 }
@@ -334,8 +336,10 @@ void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool
     Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(i));
 
     if(visible && poly_item) {
+      ui_widget.ShowAsSphereCheckBox->setChecked(false);
       convert_to_edit_polyhedron(i, poly_item);
     } else if(!visible && edit_item) {
+      edit_item->ShowAsSphere(false);
       convert_to_plain_polyhedron(i, edit_item);
     }
   }
@@ -401,7 +405,9 @@ Polyhedron_demo_edit_polyhedron_plugin::convert_to_edit_polyhedron(Item_id i,
   int k_ring = ui_widget.ROIRadioButton->isChecked() ? ui_widget.BrushSpinBoxRoi->value() : 
                                                        ui_widget.BrushSpinBoxCtrlVert->value();
   edit_poly->set_k_ring(k_ring);
+  scene->setSelectedItem(-1);
   scene->replaceItem(i, edit_poly);
+  scene->setSelectedItem(i);
   return edit_poly;
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -2,6 +2,7 @@
 
 #include "opengl_tools.h"
 #include "Scene_edit_polyhedron_item.h"
+#include "Scene_spheres_item.h"
 #include <CGAL/Three/Viewer_interface.h>
 #include <boost/foreach.hpp>
 #include <algorithm>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -3,7 +3,7 @@
 //#define CGAL_PROFILE 
 #include "Scene_edit_polyhedron_item_config.h"
 #include "Scene_polyhedron_item.h"
-#include "Scene_spheres_item.h"
+
 
 #include <CGAL/Three/Scene_group_item.h>
 
@@ -39,7 +39,7 @@ typedef boost::graph_traits<Polyhedron>::vertex_iterator		  vertex_iterator;
 typedef boost::graph_traits<Polyhedron>::face_descriptor      face_descriptor;
 typedef boost::graph_traits<Polyhedron>::halfedge_descriptor  halfedge_descriptor;
 typedef boost::graph_traits<Polyhedron>::edge_descriptor      edge_descriptor;
-
+class Scene_spheres_item;
 struct Array_based_vertex_point_map
 {
 public:

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -3,6 +3,10 @@
 //#define CGAL_PROFILE 
 #include "Scene_edit_polyhedron_item_config.h"
 #include "Scene_polyhedron_item.h"
+#include "Scene_spheres_item.h"
+
+#include <CGAL/Three/Scene_group_item.h>
+
 #include "Scene_polyhedron_item_k_ring_selection.h"
 #include "Travel_isolated_components.h"
 
@@ -191,7 +195,7 @@ struct Mouse_keyboard_state_deformation
 
 // This class represents a polyhedron in the OpenGL scene
 class SCENE_EDIT_POLYHEDRON_ITEM_EXPORT Scene_edit_polyhedron_item 
-  : public CGAL::Three::Scene_item {
+  : public CGAL::Three::Scene_group_item {
   Q_OBJECT
 public:  
   /// Create an Scene_edit_polyhedron_item from a Scene_polyhedron_item.
@@ -236,6 +240,7 @@ public:
   bool isFinite() const { return true; }
   bool isEmpty() const;
   void compute_bbox() const;
+  Bbox bbox() const{return Scene_item::bbox();}
 
   int get_k_ring()       { return k_ring_selector.k_ring; }
   void set_k_ring(int v) { k_ring_selector.k_ring = v; }
@@ -244,12 +249,17 @@ public:
   // take keyboard events from main-window, which is more stable
   bool eventFilter(QObject *target, QEvent *event);
   void update_frame_plane();
+  void ShowAsSphere(bool b);
   
 protected:
   void timerEvent(QTimerEvent *event);
 
 
 public Q_SLOTS:
+  void reset_spheres()
+  {
+    spheres = NULL;
+  }
   void invalidateOpenGLBuffers();
   void selected(const std::set<Polyhedron::Vertex_handle>& m)
   {
@@ -259,7 +269,7 @@ public Q_SLOTS:
       vertex_descriptor vh = *it;
       bool changed = false;
       if(ui_widget->ROIRadioButton->isChecked()) {
-        if(ui_widget->InsertRadioButton->isChecked()) { changed = insert_roi_vertex(vh); }
+        if(ui_widget->InsertRadioButton->isChecked()) { changed = insert_roi_vertex(vh);}
         else          { changed = erase_roi_vertex(vh);  }
       }
       else {
@@ -298,16 +308,14 @@ private:
   mutable std::vector<GLdouble> normals;
   mutable std::vector<GLdouble> pos_bbox;
   mutable std::vector<GLdouble> pos_axis;
-  mutable std::vector<GLdouble> pos_sphere;
-  mutable std::vector<GLdouble> normals_sphere;
   mutable std::vector<GLdouble> pos_frame_plane;
   mutable QOpenGLShaderProgram *program;
   mutable QOpenGLShaderProgram bbox_program;
   mutable std::size_t nb_ROI;
-  mutable std::size_t nb_sphere;
   mutable std::size_t nb_control;
   mutable std::size_t nb_axis;
   mutable std::size_t nb_bbox;
+  mutable Scene_spheres_item* spheres;
 
   enum Buffer
   {
@@ -315,8 +323,6 @@ private:
       Facet_normals,
       Roi_vertices,
       Control_vertices,
-      Sphere_vertices,
-      Sphere_normals,
       Bbox_vertices,
       Axis_vertices,
       Axis_colors,
@@ -328,10 +334,8 @@ private:
       Facets=0,
       Roi_points,
       Edges,
-      ROI_spheres,
       BBox,
       Control_points,
-      Control_spheres,
       Axis,
       Frame_plane,
       NumberOfVaos
@@ -341,7 +345,6 @@ private:
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer) const;
   void compute_normals_and_vertices(void);
   void compute_bbox(const CGAL::Three::Scene_interface::Bbox&);
-  void create_Sphere(double);
   void reset_drawing_data();
 
   Deform_mesh* deform_mesh;

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -39,5 +39,6 @@
         <file>resources/shader_c3t3.v</file>
         <file>resources/shader_c3t3.f</file>
         <file>resources/shader_plane_two_faces.f</file>
+        <file>resources/shader_spheres.v</file>
     </qresource>
 </RCC>

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -177,7 +177,8 @@ Scene::erase(QList<int> indices)
     CGAL::Three::Scene_item* item = m_entries[index];
     if(item->parentGroup()
        && item->parentGroup()->isChildLocked(item))
-      continue;
+      if(!indices.contains(item_id(item->parentGroup())))
+        continue;
     if(!to_be_removed.contains(item))
       to_be_removed.push_back(item);
   }
@@ -1253,6 +1254,7 @@ void Scene::add_group(Scene_group_item* group)
         redraw_model();
     }
     connect(this, SIGNAL(drawFinished()), group, SLOT(resetDraw()));
+    group->setScene(this);
 }
 
 namespace scene { namespace details {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -139,11 +139,9 @@ Scene::erase(Scene::Item_id index)
   {
       m_group_entries.removeAll(group);
   }
-    Q_FOREACH(CGAL::Three::Scene_group_item* group, m_group_entries)
-    {
-        if(group->getChildren().contains(item))
-            group->removeChild(item);
-    }
+  if(item->parentGroup())
+    item->parentGroup()->removeChild(item);
+
   Q_EMIT itemAboutToBeDestroyed(item);
     item->deleteLater();
     m_entries.removeAll(item);
@@ -186,9 +184,8 @@ Scene::erase(QList<int> indices)
     {
       m_group_entries.removeAll(group);
     }
-    Q_FOREACH(CGAL::Three::Scene_group_item* group_item, m_group_entries)
-      if(group_item->getChildren().contains(item))
-        group_item->removeChild(item);
+      if(item->parentGroup())
+        item->parentGroup()->removeChild(item);
     Q_EMIT itemAboutToBeDestroyed(item);
     item->deleteLater();
     m_entries.removeAll(item);

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -352,7 +352,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
                 }
                 viewer->glEnable(GL_LIGHTING);
-                viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_FILL);
                 viewer->glPointSize(2.f);
                 viewer->glLineWidth(1.0f);
                 if(index == selected_item || selected_items_list.contains(index))
@@ -406,7 +405,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                     || item.renderingMode() == Wireframe)
             {
                 viewer->glDisable(GL_LIGHTING);
-                viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
                 viewer->glPointSize(2.f);
                 viewer->glLineWidth(1.0f);
                 if(index == selected_item || selected_items_list.contains(index))
@@ -428,7 +426,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
             else{
                 if( item.renderingMode() == PointsPlusNormals ){
                     viewer->glDisable(GL_LIGHTING);
-                    viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
                     viewer->glPointSize(2.f);
                     viewer->glLineWidth(1.0f);
                     if(index == selected_item || selected_items_list.contains(index))
@@ -477,7 +474,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                     (!with_names && item.renderingMode() == PointsPlusNormals))
             {
                 viewer->glDisable(GL_LIGHTING);
-                viewer->glPolygonMode(GL_FRONT_AND_BACK,GL_POINT);
                 viewer->glPointSize(2.0f);
                 viewer->glLineWidth(1.0f);
 
@@ -558,7 +554,7 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
     {
         Q_EMIT(itemPicked(index_map.key(mainSelectionIndex())));
     }
-
+    Q_EMIT drawFinished();
 }
 
 // workaround for Qt-4.2 (see above)
@@ -1245,6 +1241,7 @@ void Scene::add_group(Scene_group_item* group)
             changeGroup(item(id),group);
         redraw_model();
     }
+    connect(this, SIGNAL(drawFinished()), group, SLOT(resetDraw()));
 }
 
 namespace scene { namespace details {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -742,41 +742,41 @@ bool Scene::dropMimeData(const QMimeData * /*data*/,
                          int /*column*/,
                          const QModelIndex &parent)
 {
-  //gets the moving items
-  QList<Scene_item*> items;
-  QList<int> groups_children;
+    //gets the moving items
+    QList<Scene_item*> items;
+    QList<int> groups_children;
 
-  //get IDs of all children of selected groups
-  Q_FOREACH(int i, selected_items_list)
-  {
-    CGAL::Three::Scene_group_item* group =
-        qobject_cast<CGAL::Three::Scene_group_item*>(item(i));
-    if(group)
-      Q_FOREACH(Scene_item* child, group->getChildren())
-        groups_children << item_id(child);
-  }
-  // Insure that children of selected groups will not be added twice
-  Q_FOREACH(int i, selected_items_list)
-  {
-    if(!groups_children.contains(i))
+    //get IDs of all children of selected groups
+    Q_FOREACH(int i, selected_items_list)
     {
-      items << item(i);
+      CGAL::Three::Scene_group_item* group =
+          qobject_cast<CGAL::Three::Scene_group_item*>(item(i));
+      if(group)
+        Q_FOREACH(Scene_item* child, group->getChildren())
+          groups_children << item_id(child);
     }
-  }
-  //Gets the group at the drop position
-  CGAL::Three::Scene_group_item* group =
-      qobject_cast<CGAL::Three::Scene_group_item*>(this->item(index_map[parent]));
-  bool one_contained = false;
-  if(group)
-  {
-    Q_FOREACH(int id, selected_items_list)
-      if(group->getChildren().contains(item(id)))
+    // Insure that children of selected groups will not be added twice
+    Q_FOREACH(int i, selected_items_list)
+    {
+      if(!groups_children.contains(i))
       {
-        one_contained = true;
-        break;
-
+        items << item(i);
       }
-  }
+    }
+    //Gets the group at the drop position
+    CGAL::Three::Scene_group_item* group =
+        qobject_cast<CGAL::Three::Scene_group_item*>(this->item(index_map[parent]));
+    bool one_contained = false;
+    if(group)
+    {
+      Q_FOREACH(int id, selected_items_list)
+        if(group->getChildren().contains(item(id)))
+        {
+          one_contained = true;
+          break;
+
+        }
+    }
     //if the drop item is not a group_item or if it already contains the item, then the drop action must be ignored
     if(!group ||one_contained)
     {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -118,6 +118,12 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
     Q_EMIT updated_bbox();
     }
   Q_EMIT updated();
+    CGAL::Three::Scene_group_item* group =
+            qobject_cast<CGAL::Three::Scene_group_item*>(m_entries[index]);
+    if(group)
+    {
+        add_group(group);
+    }
     itemChanged(index);
     Q_EMIT restoreCollapsedState();
     redraw_model();

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -244,6 +244,7 @@ Q_SIGNALS:
   void selectionRay(double, double, double, double, double, double);
   void selectionChanged(int i);
   void restoreCollapsedState();
+  void drawFinished();
 private Q_SLOTS:
   //! Casts a selection ray and calls the item function select.
   void setSelectionRay(double, double, double, double, double, double);

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -178,9 +178,8 @@ public Q_SLOTS:
   //!Removes item from all the groups of the scene.
   void remove_item_from_groups(CGAL::Three::Scene_item* item);
 
-  void add_group(Scene_group_item* group);
   //!Re-organizes the sceneView.
-  void group_added();
+  void redraw_model();
   //! Sets the selected item to the target index.
   void setSelectedItemIndex(int i)
   {
@@ -249,7 +248,7 @@ private Q_SLOTS:
   //! Casts a selection ray and calls the item function select.
   void setSelectionRay(double, double, double, double, double, double);
   void callDraw(){  QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin(); viewer->update();}
-
+  void add_group(Scene_group_item* group);
 private:
   /*! Calls the drawing functions of each visible item according
    * to its current renderingMode. If with_names is true, uses

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -647,6 +647,12 @@ void Scene_c3t3_item::draw_points(CGAL::Three::Viewer_interface * viewer) const
   viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(positions_grid.size() / 3));
   program->release();
   vaos[Grid]->release();
+  if(spheres_are_shown)
+  {
+    spheres->setPlane(this->plane());
+  }
+  Scene_group_item::draw_edges(viewer);
+
 }
 
 void Scene_c3t3_item::draw_triangle(const Kernel::Point_3& pa,
@@ -1154,6 +1160,8 @@ void Scene_c3t3_item::show_spheres(bool b)
   if(b && !spheres)
   {
     spheres = new Scene_spheres_item(this, true);
+    spheres->setName("Protecting spheres");
+    spheres->setRenderingMode(Gouraud);
     connect(spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
     last_known_scene->addItem(spheres);
     last_known_scene->changeGroup(spheres, this);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1154,15 +1154,14 @@ void Scene_c3t3_item::show_spheres(bool b)
   if(b && !spheres)
   {
     spheres = new Scene_spheres_item(this, true);
-    connect(spheres, SIGNAL(aboutToBeDestroyed()), this, SLOT(reset_spheres()));
+    connect(spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
     last_known_scene->addItem(spheres);
     last_known_scene->changeGroup(spheres, this);
     compute_spheres();
   }
-  else if (!b)
+  else if (!b && spheres!=NULL)
   {
     last_known_scene->erase(last_known_scene->item_id(spheres));
-    spheres = NULL;
   }
   Q_EMIT redraw();
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1165,10 +1165,12 @@ void Scene_c3t3_item::show_spheres(bool b)
     connect(spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
     last_known_scene->addItem(spheres);
     last_known_scene->changeGroup(spheres, this);
+    lockChild(spheres);
     compute_spheres();
   }
   else if (!b && spheres!=NULL)
   {
+    unlockChild(spheres);
     last_known_scene->erase(last_known_scene->item_id(spheres));
   }
   Q_EMIT redraw();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -116,7 +116,6 @@ Scene_c3t3_item::Scene_c3t3_item()
   : Scene_group_item("unnamed", NumberOfBuffers, NumberOfVaos)
   , d(new Scene_c3t3_item_priv(this))
   , frame(new ManipulatedFrame())
-  , last_known_scene(NULL)
   , data_item_(NULL)
   , histogram_()
   , indices_()
@@ -144,7 +143,6 @@ Scene_c3t3_item::Scene_c3t3_item(const C3t3& c3t3)
   : Scene_group_item("unnamed", NumberOfBuffers, NumberOfVaos)
   , d(new Scene_c3t3_item_priv(c3t3, this))
   , frame(new ManipulatedFrame())
-  , last_known_scene(NULL)  
   , data_item_(NULL)  
   , histogram_()
   , indices_()
@@ -749,11 +747,11 @@ void Scene_c3t3_item::export_facets_in_complex()
     }
 
     soup_item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
-    last_known_scene->addItem(soup_item);
+    scene->addItem(soup_item);
   }
   else{
     item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
-    last_known_scene->addItem(item);
+    scene->addItem(item);
   }
 }
 
@@ -1163,15 +1161,15 @@ void Scene_c3t3_item::show_spheres(bool b)
     spheres->setName("Protecting spheres");
     spheres->setRenderingMode(Gouraud);
     connect(spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
-    last_known_scene->addItem(spheres);
-    last_known_scene->changeGroup(spheres, this);
+    scene->addItem(spheres);
+    scene->changeGroup(spheres, this);
     lockChild(spheres);
     compute_spheres();
   }
   else if (!b && spheres!=NULL)
   {
     unlockChild(spheres);
-    last_known_scene->erase(last_known_scene->item_id(spheres));
+    scene->erase(scene->item_id(spheres));
   }
   Q_EMIT redraw();
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -214,7 +214,6 @@ private:
   mutable std::vector<float> *normals;
   mutable std::vector<float> *edges;
   mutable std::vector<float> *colors;
-  mutable int nb_pos;
   mutable QOpenGLShaderProgram *program;
 }; //end of class Scene_triangle_item
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -154,8 +154,6 @@ private:
 public:
   QMenu* contextMenu();
 
-  void set_scene(CGAL::Three::Scene_interface* scene){ last_known_scene = scene; }
-
 protected:
   friend struct Scene_c3t3_item_priv;
 
@@ -189,7 +187,6 @@ private:
       NumberOfVaos
   };
   qglviewer::ManipulatedFrame* frame;
-  CGAL::Three::Scene_interface* last_known_scene;
 
   Scene_spheres_item *spheres;
   bool spheres_are_shown;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -106,7 +106,7 @@ public:
 
   // Indicate if rendering mode is supported
   bool supportsRenderingMode(RenderingMode m) const {
-    return (m != Gouraud && m != PointsPlusNormals && m != Splatting);
+    return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points);
   }
 
   void draw(CGAL::Three::Viewer_interface* viewer) const;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -3,7 +3,6 @@
 
 #include "Scene_c3t3_item_config.h"
 #include "C3t3_type.h"
-#include "Scene_spheres_item.h"
 
 #include <QVector>
 #include <QColor>
@@ -26,7 +25,8 @@
 #include <CGAL/IO/File_binary_mesh_3.h>
 
 struct Scene_c3t3_item_priv;
-
+class Scene_spheres_item;
+class Scene_intersection_item;
 using namespace CGAL::Three;
   class SCENE_C3T3_ITEM_EXPORT Scene_c3t3_item
   : public Scene_group_item
@@ -118,7 +118,7 @@ private:
   void reset_cut_plane();
   void draw_triangle(const Kernel::Point_3& pa,
     const Kernel::Point_3& pb,
-    const Kernel::Point_3& pc, bool /* is_cut */) const;
+    const Kernel::Point_3& pc) const;
 
   void draw_triangle_edges(const Kernel::Point_3& pa,
     const Kernel::Point_3& pb,
@@ -137,7 +137,13 @@ private:
   {
     spheres = NULL;
   }
+
+  void reset_intersection_item()
+  {
+    intersection = NULL;
+  }
   void show_spheres(bool b);
+  void show_intersection(bool b);
   virtual QPixmap graphicalToolTip() const;
 
   void update_histogram();
@@ -189,6 +195,7 @@ private:
   qglviewer::ManipulatedFrame* frame;
 
   Scene_spheres_item *spheres;
+  Scene_intersection_item *intersection;
   bool spheres_are_shown;
   const Scene_item* data_item_;
   QPixmap histogram_;
@@ -219,7 +226,6 @@ private:
   mutable std::vector<float> s_radius;
   mutable std::vector<float> s_center;
   mutable QOpenGLShaderProgram *program;
-
 
   using Scene_item::initialize_buffers;
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -3,6 +3,7 @@
 
 #include "Scene_c3t3_item_config.h"
 #include "C3t3_type.h"
+#include "Scene_spheres_item.h"
 
 #include <QVector>
 #include <QColor>
@@ -19,8 +20,7 @@
 #include <QOpenGLShaderProgram>
 
 #include <CGAL/Three/Viewer_interface.h>
-
-#include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_group_item.h>
 #include <Scene_polyhedron_item.h>
 #include <Scene_polygon_soup_item.h>
 #include <CGAL/IO/File_binary_mesh_3.h>
@@ -29,7 +29,7 @@ struct Scene_c3t3_item_priv;
 
 using namespace CGAL::Three;
   class SCENE_C3T3_ITEM_EXPORT Scene_c3t3_item
-  : public Scene_item
+  : public Scene_group_item
 {
   Q_OBJECT
 public:
@@ -86,8 +86,12 @@ public:
            && c3t3().number_of_cells_in_complex()    == 0  );
   }
 
-  void compute_bbox() const;
 
+  void compute_bbox() const;
+  Scene_item::Bbox bbox() const
+  {
+      return Scene_item::bbox();
+  }
   Scene_c3t3_item* clone() const {
     return 0;
   }
@@ -129,12 +133,11 @@ private:
 
   void data_item_destroyed();
 
-  void show_spheres(bool b)
+  void reset_spheres()
   {
-    spheres_are_shown = b;
-    Q_EMIT redraw();
-
+    spheres = NULL;
   }
+  void show_spheres(bool b);
   virtual QPixmap graphicalToolTip() const;
 
   void update_histogram();
@@ -170,12 +173,6 @@ private:
       Facet_colors,
       Edges_vertices,
       Grid_vertices,
-      Sphere_vertices,
-      Sphere_normals,
-      Sphere_colors,
-      Sphere_radius,
-      Sphere_center,
-      Wired_spheres_vertices,
       iEdges_vertices,
       iFacet_vertices,
       iFacet_normals,
@@ -187,8 +184,6 @@ private:
       Facets=0,
       Edges,
       Grid,
-      Spheres,
-      Wired_spheres,
       iEdges,
       iFacets,
       NumberOfVaos
@@ -196,6 +191,7 @@ private:
   qglviewer::ManipulatedFrame* frame;
   CGAL::Three::Scene_interface* last_known_scene;
 
+  Scene_spheres_item *spheres;
   bool spheres_are_shown;
   const Scene_item* data_item_;
   QPixmap histogram_;
@@ -226,14 +222,14 @@ private:
   mutable std::vector<float> s_radius;
   mutable std::vector<float> s_center;
   mutable QOpenGLShaderProgram *program;
-  mutable QOpenGLShaderProgram *program_sphere;
+
 
   using Scene_item::initialize_buffers;
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer);
   void initialize_intersection_buffers(CGAL::Three::Viewer_interface *viewer);
+  void compute_spheres();
   void compute_elements();
   void compute_intersections();
-  void compile_shaders();
 };
 
 #endif // SCENE_C3T3_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -8,6 +8,7 @@ Scene_group_item::Scene_group_item(QString name, int nb_vbos, int nb_vaos )
 {
     this->name_ = name;
     expanded = true;
+    already_drawn = false;
 }
 
 bool Scene_group_item::isFinite() const
@@ -82,7 +83,8 @@ void Scene_group_item::setRenderingMode(RenderingMode m)
   Scene_item::setRenderingMode(m);
   Q_FOREACH(Scene_item* child, children)
   {
-    child->setRenderingMode(m);
+    if(child->supportsRenderingMode(m))
+      child->setRenderingMode(m);
   }
 }
 
@@ -118,7 +120,7 @@ void Scene_group_item::moveUp(int i)
 }
 
 void Scene_group_item::draw(CGAL::Three::Viewer_interface* viewer) const {
-  if(viewer->inDrawWithNames()) return;
+  if(viewer->inDrawWithNames() || already_drawn ) return;
   Q_FOREACH(Scene_item* child, children) {
     if(!child->visible()) continue;
     switch(child->renderingMode()) {
@@ -128,12 +130,26 @@ void Scene_group_item::draw(CGAL::Three::Viewer_interface* viewer) const {
       child->draw(viewer); break;
     default: break;
     }
+    switch(child->renderingMode()) {
+    case FlatPlusEdges:
+    case Wireframe:
+    case PointsPlusNormals:
+      child->draw_edges(viewer); break;
+    default: break;
+    }
+    switch(child->renderingMode()) {
+    case Points:
+    case PointsPlusNormals:
+      child->draw_points(viewer); break;
+    default: break;
+    }
   }
+  already_drawn = true;
 }
 
 void Scene_group_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
 {
-  if(viewer->inDrawWithNames()) return;
+  if(viewer->inDrawWithNames() || already_drawn ) return;
   Q_FOREACH(Scene_item* child, children) {
     if(!child->visible()) continue;
     switch(child->renderingMode()) {
@@ -143,12 +159,26 @@ void Scene_group_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const
       child->draw_edges(viewer); break;
     default: break;
     }
+    switch(child->renderingMode()) {
+    case Flat:
+    case FlatPlusEdges:
+    case Gouraud:
+      child->draw(viewer); break;
+    default: break;
+    }
+    switch(child->renderingMode()) {
+    case Points:
+    case PointsPlusNormals:
+      child->draw_points(viewer); break;
+    default: break;
+    }
   }
+  already_drawn = true;
 }
 
 void Scene_group_item::draw_points(CGAL::Three::Viewer_interface* viewer) const
 {
-  if(viewer->inDrawWithNames()) return;
+  if(viewer->inDrawWithNames() || already_drawn ) return;
   Q_FOREACH(Scene_item* child, children) {
     if(!child->visible()) continue;
     switch(child->renderingMode()) {
@@ -157,7 +187,22 @@ void Scene_group_item::draw_points(CGAL::Three::Viewer_interface* viewer) const
       child->draw_points(viewer); break;
     default: break;
     }
+    switch(child->renderingMode()) {
+    case Flat:
+    case FlatPlusEdges:
+    case Gouraud:
+      child->draw(viewer); break;
+    default: break;
+    }
+    switch(child->renderingMode()) {
+    case FlatPlusEdges:
+    case Wireframe:
+    case PointsPlusNormals:
+      child->draw_edges(viewer); break;
+    default: break;
+    }
   }
+  already_drawn = true;
 }
 
 void Scene_group_item::draw_splats(CGAL::Three::Viewer_interface* viewer) const

--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -213,3 +213,23 @@ void Scene_group_item::draw_splats(CGAL::Three::Viewer_interface* viewer) const
       child->draw_splats(viewer);
   }
 }
+
+void Scene_group_item::lockChild(Scene_item *child)
+{
+  if(!children.contains(child))
+    return;
+  child->setProperty("lock", true);
+}
+void Scene_group_item::unlockChild(Scene_item *child)
+{
+  if(!children.contains(child))
+    return;
+  child->setProperty("lock", false);
+}
+bool Scene_group_item::isChildLocked(Scene_item *child)
+{
+  if(!children.contains(child)
+     || (!child->property("lock").toBool()) )
+    return false;
+  return true;
+}

--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -3,8 +3,8 @@
 #include <QDebug>
 
 using namespace CGAL::Three;
-Scene_group_item::Scene_group_item(QString name)
-    :  Scene_item(0,0)
+Scene_group_item::Scene_group_item(QString name, int nb_vbos, int nb_vaos )
+    :  Scene_item(nb_vbos, nb_vaos)
 {
     this->name_ = name;
     expanded = true;
@@ -53,20 +53,20 @@ void Scene_group_item::addChild(Scene_item* new_item)
     if(!children.contains(new_item))
     {
         children.append(new_item);
-        add_group_number(new_item);
+        update_group_number(new_item, has_group+1);
     }
 
 }
 
-void Scene_group_item::add_group_number(Scene_item * new_item)
+void Scene_group_item::update_group_number(Scene_item * new_item, int n)
 {
 
     Scene_group_item* group =
             qobject_cast<Scene_group_item*>(new_item);
     if(group)
       Q_FOREACH(Scene_item* child, group->getChildren())
-          add_group_number(child);
-    new_item->has_group++;
+          update_group_number(child,n+1);
+    new_item->has_group = n;
 }
 void Scene_group_item::setColor(QColor c)
 {

--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -5,6 +5,7 @@
 using namespace CGAL::Three;
 Scene_group_item::Scene_group_item(QString name, int nb_vbos, int nb_vaos )
     :  Scene_item(nb_vbos, nb_vaos)
+    , scene(NULL)
 {
     this->name_ = name;
     expanded = true;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -982,9 +982,8 @@ Scene_polyhedron_item::setColor(QColor c)
   // reset patch ids
   if (colors_.size()>2 || plugin_has_set_color_vector_m)
   {
-    BOOST_FOREACH(Polyhedron::Facet_handle fh, faces(*poly))
-      fh->set_patch_id(1);
-    colors_[1]=c;
+    colors_.clear();
+    is_monochrome = true;
   }
   Scene_item::setColor(c);
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -736,13 +736,15 @@ Scene_polyhedron_item::toolTip() const
          QObject::tr("<p>Polyhedron <b>%1</b> (mode: %5, color: %6)</p>"
                        "<p>Number of vertices: %2<br />"
                        "Number of edges: %3<br />"
-                     "Number of facets: %4")
+                     "Number of facets: %4<br />"
+                     "has_group = %7")
             .arg(this->name())
             .arg(poly->size_of_vertices())
             .arg(poly->size_of_halfedges()/2)
             .arg(poly->size_of_facets())
             .arg(this->renderingModeName())
-            .arg(this->color().name());
+            .arg(this->color().name())
+      .arg(this->has_group);
   str += QString("<br />Number of isolated vertices : %1<br />").arg(getNbIsolatedvertices());
   return str;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -736,15 +736,13 @@ Scene_polyhedron_item::toolTip() const
          QObject::tr("<p>Polyhedron <b>%1</b> (mode: %5, color: %6)</p>"
                        "<p>Number of vertices: %2<br />"
                        "Number of edges: %3<br />"
-                     "Number of facets: %4<br />"
-                     "has_group = %7")
+                     "Number of facets: %4")
             .arg(this->name())
             .arg(poly->size_of_vertices())
             .arg(poly->size_of_halfedges()/2)
             .arg(poly->size_of_facets())
             .arg(this->renderingModeName())
-            .arg(this->color().name())
-      .arg(this->has_group);
+            .arg(this->color().name());
   str += QString("<br />Number of isolated vertices : %1<br />").arg(getNbIsolatedvertices());
   return str;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -1,11 +1,10 @@
 #include "Scene_polylines_item.h"
-#include "create_sphere.h"
+#include "Scene_spheres_item.h"
 
 #include <CGAL/bounding_box.h>
 #include <CGAL/gl.h>
 #include <QMenu>
 #include <QAction>
-
 #include <QInputDialog>
 
 class Scene_polylines_item_private {
@@ -18,18 +17,10 @@ public:
         spheres_drawn_radius(0)
     {}
 
-    void draw_sphere(const K::Point_3&, double) const;
-    void draw_spheres(const Scene_polylines_item*) const;
-
     bool draw_extremities;
     double spheres_drawn_radius;
 };
 
-void
-Scene_polylines_item::create_Sphere(float R) const
-{
-  create_flat_and_wire_sphere(R, positions_spheres, normals_spheres, positions_wire_spheres);
-}
 
 void
 Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer = 0) const
@@ -49,143 +40,17 @@ Scene_polylines_item::initialize_buffers(CGAL::Three::Viewer_interface *viewer =
         buffers[Edges_Vertices].release();
         vaos[Edges]->release();
         program->release();
+
+        nb_lines = positions_lines.size();
+        positions_lines.clear();
+        positions_lines.swap(positions_lines);
     }
-   //vao for the spheres
-    {
-        if(viewer->extension_is_found)
-        {
-            program = getShaderProgram(PROGRAM_INSTANCED, viewer);
-            program->bind();
-
-            vaos[Spheres]->bind();
-            buffers[Spheres_Vertices].bind();
-            buffers[Spheres_Vertices].allocate(positions_spheres.data(),
-                                static_cast<int>(positions_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("vertex");
-            program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[Spheres_Vertices].release();
-
-            buffers[Spheres_Normals].bind();
-            buffers[Spheres_Normals].allocate(normals_spheres.data(),
-                                static_cast<int>(normals_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("normals");
-            program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-            buffers[Spheres_Normals].release();
-
-            buffers[Spheres_Colors].bind();
-            buffers[Spheres_Colors].allocate(color_spheres.data(),
-                                static_cast<int>(color_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[Spheres_Colors].release();
-
-            buffers[Spheres_Center].bind();
-            buffers[Spheres_Center].allocate(positions_center.data(),
-                                static_cast<int>(positions_center.size()*sizeof(float)));
-            program->enableAttributeArray("center");
-            program->setAttributeBuffer("center",GL_FLOAT,0,3);
-            buffers[Spheres_Center].release();
-
-            viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
-            viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
-
-        }
-        else
-        {
-            program = getShaderProgram(PROGRAM_NO_SELECTION, viewer);
-            program->bind();
-
-            vaos[Spheres]->bind();
-            buffers[Spheres_Vertices].bind();
-            buffers[Spheres_Vertices].allocate(positions_center.data(),
-                                static_cast<int>(positions_center.size()*sizeof(float)));
-            program->enableAttributeArray("vertex");
-            program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[Spheres_Vertices].release();
-
-            buffers[Spheres_Normals].bind();
-            buffers[Spheres_Normals].allocate(color_spheres.data(),
-                                static_cast<int>(color_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[Spheres_Normals].release();
-        }
-        vaos[Spheres]->release();
-
-        program->release();
-    }
-
-//vao for the wired spheres
-    {
-        if(viewer->extension_is_found)
-        {
-            program = getShaderProgram(PROGRAM_INSTANCED_WIRE, viewer);
-            program->bind();
-
-            vaos[Wired_Spheres]->bind();
-            buffers[Wired_Spheres_Vertices].bind();
-            buffers[Wired_Spheres_Vertices].allocate(positions_wire_spheres.data(),
-                                static_cast<int>(positions_wire_spheres.size()*sizeof(float)));
-            program->enableAttributeArray("vertex");
-            program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-            buffers[Wired_Spheres_Vertices].release();
-
-            buffers[Spheres_Colors].bind();
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            buffers[Spheres_Colors].release();
-
-            buffers[Spheres_Normals].bind();
-            program->enableAttributeArray("normals");
-            program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-            buffers[Spheres_Normals].release();
-
-
-            buffers[Spheres_Center].bind();
-            program->enableAttributeArray("center");
-            program->setAttributeBuffer("center",GL_FLOAT,0,3);
-            buffers[Spheres_Center].release();
-
-
-            viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
-            viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
-
-            vaos[Wired_Spheres]->release();
-            program->release();
-
-            nb_lines = positions_lines.size();
-            positions_lines.resize(0);
-            std::vector<float>(positions_lines).swap(positions_lines);
-            nb_spheres = positions_spheres.size();
-            positions_spheres.resize(0);
-            std::vector<float>(positions_spheres).swap(positions_spheres);
-            normals_spheres.resize(0);
-            std::vector<float>(normals_spheres).swap(normals_spheres);
-            color_spheres.resize(0);
-            std::vector<float>(color_spheres).swap(color_spheres);
-            nb_centers = positions_center.size();
-            positions_center.resize(0);
-            std::vector<float>(positions_center).swap(positions_center);
-            nb_wire = positions_wire_spheres.size();
-            positions_wire_spheres.resize(0);
-            std::vector<float>(positions_wire_spheres).swap(positions_wire_spheres);
-        }
-    }
-
    are_buffers_filled = true;
-
 }
 void
 Scene_polylines_item::compute_elements() const
 {
-    positions_spheres.resize(0);
-    positions_wire_spheres.resize(0);
     positions_lines.resize(0);
-    color_spheres.resize(0);
-    normals_spheres.resize(0);
-    positions_center.resize(0);
-    nbSpheres = 0;
-
     //Fills the VBO with the lines
     for(std::list<std::vector<Point_3> >::const_iterator it = polylines.begin();
         it != polylines.end();
@@ -205,132 +70,115 @@ Scene_polylines_item::compute_elements() const
             positions_lines.push_back(b.y());
             positions_lines.push_back(b.z());
             positions_lines.push_back(1.0);
-
         }
-
-    }
-    //Fills the VBO with the spheres
-    if(d->draw_extremities)
-    {
-
-        // FIRST, count the number of incident cycles and polylines
-        // for all extremities.
-        typedef std::map<Point_3, int> Point_to_int_map;
-        typedef Point_to_int_map::iterator iterator;
-        Point_to_int_map corner_polyline_nb;
-
-        { // scope to fill corner_polyline_nb'
-            Point_to_int_map corner_cycles_nb;
-
-            for(std::list<std::vector<Point_3> >::const_iterator
-                it = this->polylines.begin(),
-                end = this->polylines.end();
-                it != end; ++it)
-            {
-                const K::Point_3& a = *it->begin();
-                const K::Point_3& b = *it->rbegin();
-                if(a == b) {
-                    if ( it->size()>1 )
-                        ++corner_cycles_nb[a];
-                    else
-                        ++corner_polyline_nb[a];
-                }
-                else {
-                    ++corner_polyline_nb[a];
-                    ++corner_polyline_nb[b];
-                }
-            }
-            // THEN, ignore points that are incident to one cycle only.
-            for(iterator
-                c_it = corner_cycles_nb.begin(),
-                end = corner_cycles_nb.end();
-                c_it != end; ++c_it)
-            {
-                const Point_3& a = c_it->first;
-
-                iterator p_it = corner_polyline_nb.find(a);
-
-                // If the point 'a'=c_it->first has only incident cycles...
-                if(p_it == corner_polyline_nb.end()) {
-                    // ...then count it as a corner only if it has two incident cycles
-                    // or more.
-                    if(c_it->second > 1) {
-                        corner_polyline_nb[a] = c_it->second;
-                    }
-                } else {
-                    // else add the number of cycles.
-                    p_it->second += c_it->second;
-                }
-            }
-        }
-        // At this point, 'corner_polyline_nb' gives the multiplicity of all
-        // corners.
-        //Finds the centers of the spheres and their color
-        for(iterator
-            p_it = corner_polyline_nb.begin(),
-            end = corner_polyline_nb.end();
-            p_it != end; ++p_it)
-        {
-            nbSpheres++;
-            const K::Point_3& centre = p_it->first;
-            positions_center.push_back(centre.x());
-            positions_center.push_back(centre.y());
-            positions_center.push_back(centre.z());
-
-            float colors[3];
-            switch(p_it->second) {
-            case 1:
-                colors[0] = 0.0; // black
-                colors[1] = 0.0;
-                colors[2] = 0.0;
-                break;
-            case 2:
-                colors[0] = 0.0; // green
-                colors[1] = 0.8f;
-                colors[2] = 0.0;
-                break;
-            case 3:
-                colors[0] = 0.0; // blue
-                colors[1] = 0.0;
-                colors[2] = 0.8f;
-                break;
-            case 4:
-                colors[0] = 0.8f; //red
-                colors[1] = 0.0;
-                colors[2] = 0.0;
-                break;
-            default:
-                colors[0] = 0.8f; //fuschia
-                colors[1] = 0.0;
-                colors[2] = 0.8f;
-            }
-
-            color_spheres.push_back(colors[0]);
-            color_spheres.push_back(colors[1]);
-            color_spheres.push_back(colors[2]);
-            color_wire_spheres.push_back(colors[0]);
-            color_wire_spheres.push_back(colors[1]);
-            color_wire_spheres.push_back(colors[2]);
-            color_wire_spheres.push_back(colors[0]);
-            color_wire_spheres.push_back(colors[1]);
-            color_wire_spheres.push_back(colors[2]);
-        }
-        create_Sphere(d->spheres_drawn_radius);
 
     }
 }
 
+void
+Scene_polylines_item::compute_spheres()
+{
+      // FIRST, count the number of incident cycles and polylines
+      // for all extremities.
+      typedef std::map<Point_3, int> Point_to_int_map;
+      typedef Point_to_int_map::iterator iterator;
+      Point_to_int_map corner_polyline_nb;
+
+      { // scope to fill corner_polyline_nb'
+          Point_to_int_map corner_cycles_nb;
+
+          for(std::list<std::vector<Point_3> >::const_iterator
+              it = this->polylines.begin(),
+              end = this->polylines.end();
+              it != end; ++it)
+          {
+              const K::Point_3& a = *it->begin();
+              const K::Point_3& b = *it->rbegin();
+              if(a == b) {
+                  if ( it->size()>1 )
+                      ++corner_cycles_nb[a];
+                  else
+                      ++corner_polyline_nb[a];
+              }
+              else {
+                  ++corner_polyline_nb[a];
+                  ++corner_polyline_nb[b];
+              }
+          }
+          // THEN, ignore points that are incident to one cycle only.
+          for(iterator
+              c_it = corner_cycles_nb.begin(),
+              end = corner_cycles_nb.end();
+              c_it != end; ++c_it)
+          {
+              const Point_3& a = c_it->first;
+
+              iterator p_it = corner_polyline_nb.find(a);
+
+              // If the point 'a'=c_it->first has only incident cycles...
+              if(p_it == corner_polyline_nb.end()) {
+                  // ...then count it as a corner only if it has two incident cycles
+                  // or more.
+                  if(c_it->second > 1) {
+                      corner_polyline_nb[a] = c_it->second;
+                  }
+              } else {
+                  // else add the number of cycles.
+                  p_it->second += c_it->second;
+              }
+          }
+      }
+      // At this point, 'corner_polyline_nb' gives the multiplicity of all
+      // corners.
+      //Finds the centers of the spheres and their color
+      for(iterator
+          p_it = corner_polyline_nb.begin(),
+          end = corner_polyline_nb.end();
+          p_it != end; ++p_it)
+      {
+          const K::Point_3& center = p_it->first;
+          int colors[3];
+          switch(p_it->second) {
+          case 1:
+              colors[0] = 0; // black
+              colors[1] = 0;
+              colors[2] = 0;
+              break;
+          case 2:
+              colors[0] = 0; // green
+              colors[1] = 200;
+              colors[2] = 0;
+              break;
+          case 3:
+              colors[0] = 0; // blue
+              colors[1] = 0;
+              colors[2] = 200;
+              break;
+          case 4:
+              colors[0] = 200; //red
+              colors[1] = 0;
+              colors[2] = 0;
+              break;
+          default:
+              colors[0] = 200; //fuschia
+              colors[1] = 0;
+              colors[2] = 200;
+          }
+
+          CGAL::Color c(colors[0], colors[1], colors[2]);
+
+          K::Sphere_3 *sphere = new K::Sphere_3(center, d->spheres_drawn_radius);
+          spheres->add_sphere(sphere, c);
+      }
+}
 
 Scene_polylines_item::Scene_polylines_item() 
-    :CGAL::Three::Scene_item(NbOfVbos,NbOfVaos)
+    :CGAL::Three::Scene_group_item("unnamed",NbOfVbos,NbOfVaos)
     ,d(new Scene_polylines_item_private())
-    ,nbSpheres(0)
 {
     setRenderingMode(FlatPlusEdges);
-    nb_spheres = 0;
-    nb_wire = 0;
-    nb_centers = 0;
     nb_lines = 0;
+    spheres = NULL;
     invalidateOpenGLBuffers();
 
 }
@@ -430,30 +278,7 @@ Scene_polylines_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     }
     if(d->draw_extremities)
     {
-        if(viewer->extension_is_found)
-        {
-            vaos[Spheres]->bind();
-            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_INSTANCED);
-            attrib_buffers(viewer, PROGRAM_INSTANCED);
-            program->bind();
-            viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
-                                          static_cast<GLsizei>(nb_spheres/3), nbSpheres);
-            program->release();
-            vaos[Spheres]->release();
-        }
-        else
-        {
-            vaos[Spheres]->bind();
-            QOpenGLShaderProgram* program = getShaderProgram(PROGRAM_NO_SELECTION);
-            attrib_buffers(viewer, PROGRAM_NO_SELECTION);
-            glPointSize(8.0f);
-            glEnable(GL_POINT_SMOOTH);
-            program->bind();
-            viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(nb_centers/3));
-            glDisable(GL_POINT_SMOOTH);
-            program->release();
-            vaos[Spheres]->release();
-        }
+      Scene_group_item::draw(viewer);
     }
 }
 
@@ -476,17 +301,7 @@ Scene_polylines_item::draw_edges(CGAL::Three::Viewer_interface* viewer) const {
     vaos[Edges]->release();
     if(d->draw_extremities)
     {
-        if(viewer->extension_is_found)
-        {
-            vaos[Wired_Spheres]->bind();
-            attrib_buffers(viewer, PROGRAM_INSTANCED_WIRE);
-            program = getShaderProgram(PROGRAM_INSTANCED_WIRE);
-            program->bind();
-            viewer->glDrawArraysInstanced(GL_LINES, 0,
-                                          static_cast<GLsizei>(nb_wire/3), nbSpheres);
-            program->release();
-            vaos[Wired_Spheres]->release();
-        }
+       Scene_group_item::draw_edges(viewer);
     }
 
 }
@@ -509,6 +324,10 @@ Scene_polylines_item::draw_points(CGAL::Three::Viewer_interface* viewer) const {
     // Clean-up
    vaos[Edges]->release();
    program->release();
+   if(d->draw_extremities)
+   {
+      Scene_group_item::draw_points(viewer);
+   }
 }
 
 QMenu* Scene_polylines_item::contextMenu() 
@@ -575,7 +394,23 @@ void Scene_polylines_item::change_corner_radii(double r) {
     if(r >= 0) {
         d->spheres_drawn_radius = r;
         d->draw_extremities = (r > 0);
-        this->invalidateOpenGLBuffers();
+        if(r>0 && !spheres)
+        {
+          spheres = new Scene_spheres_item(this, false);
+          spheres->setName("Corner spheres");
+          spheres->setRenderingMode(Gouraud);
+          connect(spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
+          scene->addItem(spheres);
+          scene->changeGroup(spheres, this);
+          lockChild(spheres);
+          compute_spheres();
+          spheres->invalidateOpenGLBuffers();
+        }
+        else if (r<=0 && spheres!=NULL)
+        {
+          unlockChild(spheres);
+          scene->erase(scene->item_id(spheres));
+        }
     Q_EMIT itemChanged();
     }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -80,7 +80,7 @@ public Q_SLOTS:
     void reset_spheres()
     {
       spheres = NULL;
-    }\
+    }
 
     void merge(Scene_polylines_item*);
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -3,7 +3,7 @@
 #include "Scene_polylines_item_config.h"
 #include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_group_item.h>
 
 #include <QString>
 #include <QMenu>
@@ -12,8 +12,9 @@
 #include <vector>
 
 class Scene_polylines_item_private;
+class Scene_spheres_item;
 
-class SCENE_POLYLINES_ITEM_EXPORT Scene_polylines_item : public CGAL::Three::Scene_item
+class SCENE_POLYLINES_ITEM_EXPORT Scene_polylines_item : public CGAL::Three::Scene_group_item
 {
     Q_OBJECT
 public:
@@ -76,6 +77,10 @@ public Q_SLOTS:
     void change_corner_radii(double);
     void change_corner_radii();
     void split_at_sharp_angles();
+    void reset_spheres()
+    {
+      spheres = NULL;
+    }\
 
     void merge(Scene_polylines_item*);
 
@@ -94,39 +99,24 @@ private:
 
     enum VAOs {
         Edges=0,
-        Spheres,
-        Wired_Spheres,
-        NbOfVaos = Wired_Spheres+1
+        NbOfVaos
     };
     enum VBOs {
         Edges_Vertices = 0,
-        Spheres_Vertices,
-        Spheres_Normals,
-        Spheres_Colors,
-        Spheres_Center,
-        Wired_Spheres_Vertices,
-        NbOfVbos = Wired_Spheres_Vertices+1
+        NbOfVbos
     };
 
+    mutable Scene_spheres_item *spheres;
     mutable std::vector<float> positions_lines;
-    mutable std::vector<float> positions_spheres;
-    mutable std::vector<float> positions_wire_spheres;
-    mutable std::vector<float> positions_center;
-    mutable std::vector<float> normals_spheres;
-    mutable std::vector<float> color_spheres;
-    mutable std::vector<float> color_wire_spheres;
-    mutable std::size_t nb_spheres;
-    mutable std::size_t nb_wire;
-    mutable std::size_t nb_centers;
     mutable std::size_t nb_lines;
-    mutable   GLuint nbSpheres;
     typedef std::map<Point_3, int> Point_to_int_map;
     typedef Point_to_int_map::iterator iterator;
-    void create_Sphere(float) const;
     using CGAL::Three::Scene_item::initialize_buffers;
     void initialize_buffers(CGAL::Three::Viewer_interface *viewer) const;
     using CGAL::Three::Scene_item::compute_elements;
     void compute_elements() const;
+    void compute_spheres();
+
 
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -1,0 +1,205 @@
+#include "Scene_spheres_item.h"
+
+void Scene_spheres_item::computeElements() const
+{
+  colors.clear();
+  edges_colors.clear();
+  centers.clear();
+  radius.clear();
+  Q_FOREACH(sphere_pair sp, spheres)
+  {
+    colors.push_back((float)sp.second.red()/255);
+    colors.push_back((float)sp.second.green()/255);
+    colors.push_back((float)sp.second.blue()/255);
+
+    edges_colors.push_back((float)sp.second.red()/255);
+    edges_colors.push_back((float)sp.second.green()/255);
+    edges_colors.push_back((float)sp.second.blue()/255);
+
+    centers.push_back(sp.first->center().x());
+    centers.push_back(sp.first->center().y());
+    centers.push_back(sp.first->center().z());
+
+    radius.push_back(sp.first->squared_radius());
+  }
+}
+
+void Scene_spheres_item::initializeBuffers(CGAL::Three::Viewer_interface *viewer) const
+{
+  if(has_plane)
+  {
+    program = getShaderProgram(PROGRAM_CUTPLANE_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_CUTPLANE_SPHERES);
+  }
+  else
+  {
+    program = getShaderProgram(PROGRAM_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_SPHERES);
+  }
+
+  program->bind();
+  vaos[Facets]->bind();
+  buffers[Vertices].bind();
+  buffers[Vertices].allocate(vertices.data(),
+                             static_cast<int>(vertices.size()*sizeof(float)));
+  program->enableAttributeArray("vertex");
+  program->setAttributeBuffer("vertex", GL_FLOAT, 0, 3);
+  buffers[Vertices].release();
+
+  buffers[Normals].bind();
+  buffers[Normals].allocate(normals.data(),
+                            static_cast<int>(normals.size()*sizeof(float)));
+  program->enableAttributeArray("normals");
+  program->setAttributeBuffer("normals", GL_FLOAT, 0, 3);
+  buffers[Normals].release();
+
+  buffers[Color].bind();
+  buffers[Color].allocate(colors.data(),
+                          static_cast<int>(colors.size()*sizeof(float)));
+  program->enableAttributeArray("colors");
+  program->setAttributeBuffer("colors", GL_FLOAT, 0, 3);
+  buffers[Color].release();
+
+  buffers[Radius].bind();
+  buffers[Radius].allocate(radius.data(),
+                           static_cast<int>(radius.size()*sizeof(float)));
+  program->enableAttributeArray("radius");
+  program->setAttributeBuffer("radius", GL_FLOAT, 0, 1);
+  buffers[Radius].release();
+
+  buffers[Center].bind();
+  buffers[Center].allocate(centers.data(),
+                           static_cast<int>(centers.size()*sizeof(float)));
+  program->enableAttributeArray("center");
+  program->setAttributeBuffer("center", GL_FLOAT, 0, 3);
+  buffers[Center].release();
+
+  viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
+  viewer->glVertexAttribDivisor(program->attributeLocation("radius"), 1);
+  viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
+  vaos[Facets]->release();
+
+
+  vaos[Edges]->bind();
+  buffers[Edge_vertices].bind();
+  buffers[Edge_vertices].allocate(edges.data(),
+                                  static_cast<int>(edges.size()*sizeof(float)));
+  program->enableAttributeArray("vertex");
+  program->setAttributeBuffer("vertex", GL_FLOAT, 0, 3);
+  buffers[Edge_vertices].release();
+
+  buffers[Normals].bind();
+  program->enableAttributeArray("normals");
+  program->setAttributeBuffer("normals", GL_FLOAT, 0, 3);
+  buffers[Normals].release();
+
+  buffers[Edge_color].bind();
+  buffers[Edge_color].allocate(edges_colors.data(),
+                               static_cast<int>(edges_colors.size()*sizeof(float)));
+  program->enableAttributeArray("colors");
+  program->setAttributeBuffer("colors", GL_FLOAT, 0, 3);
+  buffers[Edge_color].release();
+
+  buffers[Radius].bind();
+  program->enableAttributeArray("radius");
+  program->setAttributeBuffer("radius", GL_FLOAT, 0, 1);
+  buffers[Radius].release();
+
+  buffers[Center].bind();
+  program->enableAttributeArray("center");
+  program->setAttributeBuffer("center", GL_FLOAT, 0, 3);
+  buffers[Center].release();
+
+  viewer->glVertexAttribDivisor(program->attributeLocation("center"), 1);
+  viewer->glVertexAttribDivisor(program->attributeLocation("radius"), 1);
+  viewer->glVertexAttribDivisor(program->attributeLocation("colors"), 1);
+  vaos[Edges]->release();
+
+  program->release();
+
+  nb_centers = centers.size();
+  centers.clear();
+  centers.swap(centers);
+  colors.clear();
+  colors.swap(colors);
+  radius.clear();
+  radius.swap(radius);
+  edges_colors.clear();
+  edges_colors.swap(edges_colors);
+
+  are_buffers_filled = true;
+}
+
+void Scene_spheres_item::draw(Viewer_interface *viewer) const
+{
+  if (!are_buffers_filled)
+  {
+    computeElements();
+    initializeBuffers(viewer);
+  }
+  vaos[Facets]->bind();
+  if(has_plane)
+  {
+    program = getShaderProgram(PROGRAM_CUTPLANE_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_CUTPLANE_SPHERES);
+    program->bind();
+    QVector4D cp(plane.a(),plane.b(),plane.c(),plane.d());
+    program->setUniformValue("cutplane", cp);
+
+  }
+  else
+  {
+    program = getShaderProgram(PROGRAM_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_SPHERES);
+    program->bind();
+  }
+  viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
+                                static_cast<GLsizei>(vertices.size()/3),
+                                static_cast<GLsizei>(nb_centers));
+
+  program->release();
+  vaos[Facets]->release();
+}
+void Scene_spheres_item::draw_edges(Viewer_interface *viewer) const
+{
+  if (!are_buffers_filled)
+  {
+    computeElements();
+    initializeBuffers(viewer);
+  }
+  vaos[Edges]->bind();
+  if(has_plane)
+  {
+    program = getShaderProgram(PROGRAM_CUTPLANE_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_CUTPLANE_SPHERES);
+    program->bind();
+    QVector4D cp(plane.a(),plane.b(),plane.c(),plane.d());
+    program->setUniformValue("cutplane", cp);
+  }
+  else
+  {
+    program = getShaderProgram(PROGRAM_SPHERES, viewer);
+    attrib_buffers(viewer, PROGRAM_SPHERES);
+    program->bind();
+  }
+  viewer->glDrawArraysInstanced(GL_LINES, 0,
+                                static_cast<GLsizei>(vertices.size()/3),
+                                static_cast<GLsizei>(nb_centers));
+  program->release();
+  vaos[Edges]->release();
+}
+void Scene_spheres_item::add_sphere(CGAL::Sphere_3<Kernel> *sphere, CGAL::Color color)
+{
+  sphere_pair pair_(sphere, color);
+  spheres.append(pair_);
+}
+
+void Scene_spheres_item::remove_sphere(CGAL::Sphere_3<Kernel> *sphere)
+{
+  Q_FOREACH(sphere_pair pair_, spheres)
+    if(pair_.first == sphere)
+    {
+      spheres.removeAll(pair_);
+      break;
+    }
+}

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -2,6 +2,7 @@
 
 void Scene_spheres_item::computeElements() const
 {
+
   colors.clear();
   edges_colors.clear();
   centers.clear();
@@ -202,4 +203,9 @@ void Scene_spheres_item::remove_sphere(CGAL::Sphere_3<Kernel> *sphere)
       spheres.removeAll(pair_);
       break;
     }
+}
+
+void Scene_spheres_item::clear_spheres()
+{
+  spheres.clear();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -21,6 +21,7 @@ void Scene_spheres_item::computeElements() const
     centers.push_back(sp.first->center().z());
 
     radius.push_back(sp.first->squared_radius());
+
   }
 }
 
@@ -156,7 +157,6 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
   viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                 static_cast<GLsizei>(vertices.size()/3),
                                 static_cast<GLsizei>(nb_centers));
-
   program->release();
   vaos[Facets]->release();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -7,7 +7,7 @@ void Scene_spheres_item::computeElements() const
   edges_colors.clear();
   centers.clear();
   radius.clear();
-  Q_FOREACH(sphere_pair sp, spheres)
+  Q_FOREACH(Sphere_pair sp, spheres)
   {
     colors.push_back((float)sp.second.red()/255);
     colors.push_back((float)sp.second.green()/255);
@@ -191,13 +191,13 @@ void Scene_spheres_item::draw_edges(Viewer_interface *viewer) const
 }
 void Scene_spheres_item::add_sphere(CGAL::Sphere_3<Kernel> *sphere, CGAL::Color color)
 {
-  sphere_pair pair_(sphere, color);
+  Sphere_pair pair_(sphere, color);
   spheres.append(pair_);
 }
 
 void Scene_spheres_item::remove_sphere(CGAL::Sphere_3<Kernel> *sphere)
 {
-  Q_FOREACH(sphere_pair pair_, spheres)
+  Q_FOREACH(Sphere_pair pair_, spheres)
     if(pair_.first == sphere)
     {
       spheres.removeAll(pair_);

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -183,7 +183,7 @@ void Scene_spheres_item::draw_edges(Viewer_interface *viewer) const
     program->bind();
   }
   viewer->glDrawArraysInstanced(GL_LINES, 0,
-                                static_cast<GLsizei>(vertices.size()/3),
+                                static_cast<GLsizei>(edges.size()/3),
                                 static_cast<GLsizei>(nb_centers));
   program->release();
   vaos[Edges]->release();

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -47,6 +47,7 @@ public:
   void compute_bbox() const { _bbox = Bbox(); }
   void add_sphere(CGAL::Sphere_3<Kernel>* sphere, CGAL::Color = CGAL::Color(120,120,120));
   void remove_sphere(CGAL::Sphere_3<Kernel>* sphere);
+  void clear_spheres();
   void setPrecision(int prec) { precision = prec; }
 
   void draw(CGAL::Three::Viewer_interface* viewer) const;

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -1,0 +1,96 @@
+#ifndef SCENE_SPHERES_ITEM_H
+#define SCENE_SPHERES_ITEM_H
+#include "Scene_basic_objects_config.h"
+#include "create_sphere.h"
+#include "CGAL/Three/Scene_group_item.h"
+#include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_interface.h>
+#include <CGAL/Three/Viewer_interface.h>
+#include <CGAL/Sphere_3.h>
+#include <CGAL/Plane_3.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <QOpenGLShaderProgram>
+
+#include <QList>
+#include<vector>
+
+class SCENE_BASIC_OBJECTS_EXPORT Scene_spheres_item
+    : public CGAL::Three::Scene_item
+{
+  Q_OBJECT
+public:
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+  typedef std::pair<CGAL::Sphere_3<Kernel>*, CGAL::Color> sphere_pair ;
+
+  Scene_spheres_item(Scene_group_item* parent, bool planed = false)
+    :CGAL::Three::Scene_item(NbOfVbos,NbOfVaos)
+    ,precision(36)
+    ,has_plane(planed)
+
+  {
+    setParent(parent);
+    create_flat_and_wire_sphere(1.0f,vertices,normals, edges);
+  }
+
+  ~Scene_spheres_item() {
+    Q_FOREACH(sphere_pair sphere, spheres)
+      delete sphere.first;
+  }
+
+  bool isFinite() const { return false; }
+  bool isEmpty() const { return false; }
+  Scene_item* clone() const {return 0;}
+  QString toolTip() const {return QString();}
+  bool supportsRenderingMode(RenderingMode m) const {
+    return (m == Gouraud || m == Wireframe);
+  }
+  void compute_bbox() const { _bbox = Bbox(); }
+  void add_sphere(CGAL::Sphere_3<Kernel>* sphere, CGAL::Color = CGAL::Color(120,120,120));
+  void remove_sphere(CGAL::Sphere_3<Kernel>* sphere);
+  void setPrecision(int prec) { precision = prec; }
+
+  void draw(CGAL::Three::Viewer_interface* viewer) const;
+  void draw_edges(CGAL::Three::Viewer_interface* viewer) const;
+  void invalidateOpenGLBuffers(){are_buffers_filled = false;}
+  void computeElements() const;
+  void setPlane(Kernel::Plane_3 p_plane) { plane = p_plane; }
+
+private:
+  enum Vbos
+  {
+    Vertices = 0,
+    Edge_vertices,
+    Normals,
+    Center,
+    Radius,
+    Color,
+    Edge_color,
+    NbOfVbos
+  };
+  enum Vaos
+  {
+    Facets = 0,
+    Edges,
+    NbOfVaos
+  };
+
+
+  int precision;
+  mutable CGAL::Plane_3<Kernel> plane;
+  bool has_plane;
+
+  QList<sphere_pair> spheres;
+  mutable std::vector<float> vertices;
+  mutable std::vector<float> normals;
+  mutable std::vector<float> edges;
+  mutable std::vector<float> colors;
+  mutable std::vector<float> edges_colors;
+  mutable std::vector<float> centers;
+  mutable std::vector<float> radius;
+  mutable QOpenGLShaderProgram *program;
+  mutable int nb_centers;
+  void initializeBuffers(CGAL::Three::Viewer_interface *viewer)const;
+
+};
+
+#endif // SCENE_SPHERES_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -2,7 +2,8 @@
 #define SCENE_SPHERES_ITEM_H
 #include "Scene_basic_objects_config.h"
 #include "create_sphere.h"
-#include "CGAL/Three/Scene_group_item.h"
+
+#include <CGAL/Three/Scene_group_item.h>
 #include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Scene_interface.h>
 #include <CGAL/Three/Viewer_interface.h>
@@ -12,7 +13,7 @@
 #include <QOpenGLShaderProgram>
 
 #include <QList>
-#include<vector>
+#include <vector>
 
 class SCENE_BASIC_OBJECTS_EXPORT Scene_spheres_item
     : public CGAL::Three::Scene_item

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -21,7 +21,7 @@ class SCENE_BASIC_OBJECTS_EXPORT Scene_spheres_item
   Q_OBJECT
 public:
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-  typedef std::pair<CGAL::Sphere_3<Kernel>*, CGAL::Color> sphere_pair ;
+  typedef std::pair<CGAL::Sphere_3<Kernel>*, CGAL::Color> Sphere_pair ;
 
   Scene_spheres_item(Scene_group_item* parent, bool planed = false)
     :CGAL::Three::Scene_item(NbOfVbos,NbOfVaos)
@@ -34,7 +34,7 @@ public:
   }
 
   ~Scene_spheres_item() {
-    Q_FOREACH(sphere_pair sphere, spheres)
+    Q_FOREACH(Sphere_pair sphere, spheres)
       delete sphere.first;
   }
 
@@ -81,7 +81,7 @@ private:
   mutable CGAL::Plane_3<Kernel> plane;
   bool has_plane;
 
-  QList<sphere_pair> spheres;
+  QList<Sphere_pair> spheres;
   mutable std::vector<float> vertices;
   mutable std::vector<float> normals;
   mutable std::vector<float> edges;

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -458,96 +458,47 @@ void Viewer::attrib_buffers(int program_name) const {
     QVector4D specular(0.0f, 0.0f, 0.0f, 1.0f);
     QOpenGLShaderProgram* program = getShaderProgram(program_name);
     program->bind();
+    program->setUniformValue("mvp_matrix", mvp_mat);
     switch(program_name)
     {
-    case PROGRAM_NO_SELECTION:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-
-        program->setUniformValue("f_matrix",f_mat);
-        break;
     case PROGRAM_WITH_LIGHT:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-        program->setUniformValue("light_pos", position);
-        program->setUniformValue("light_diff",diffuse);
-        program->setUniformValue("light_spec", specular);
-        program->setUniformValue("light_amb", ambient);
-        program->setUniformValue("spec_power", 51.8f);
-        program->setUniformValue("is_two_side", is_both_sides);
-        break;
     case PROGRAM_C3T3:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-        program->setUniformValue("light_pos", position);
-        program->setUniformValue("light_diff",diffuse);
-        program->setUniformValue("light_spec", specular);
-        program->setUniformValue("light_amb", ambient);
-        program->setUniformValue("spec_power", 51.8f);
-        program->setUniformValue("is_two_side", is_both_sides);
-        break;
-    case PROGRAM_C3T3_EDGES:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        break;
-    case PROGRAM_WITHOUT_LIGHT:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-
-        program->setUniformValue("light_pos", position);
-        program->setUniformValue("light_diff", diffuse);
-        program->setUniformValue("light_spec", specular);
-        program->setUniformValue("light_amb", ambient);
-        program->setUniformValue("spec_power", 51.8f);
-        program->setUniformValue("is_two_side", is_both_sides);
-        program->setAttributeValue("normals", 0.0,0.0,0.0);
-        program->setUniformValue("f_matrix",f_mat);
-
-
-        break;
-    case PROGRAM_WITH_TEXTURE:
-
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-        program->setUniformValue("light_pos", position);
-        program->setUniformValue("light_diff",diffuse);
-        program->setUniformValue("light_spec", specular);
-        program->setUniformValue("light_amb", ambient);
-        program->setUniformValue("spec_power", 51.8f);
-        program->setUniformValue("s_texture",0);
-        program->setUniformValue("f_matrix",f_mat);
-
-        break;
     case PROGRAM_PLANE_TWO_FACES:
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-        program->setUniformValue("light_pos", position);
-        program->setUniformValue("light_diff",diffuse);
-        program->setUniformValue("light_spec", specular);
-        program->setUniformValue("light_amb", ambient);
-        program->setUniformValue("spec_power", 51.8f);
-        program->setUniformValue("is_two_side", is_both_sides);
-        break;
-
-    case PROGRAM_WITH_TEXTURED_EDGES:
-
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("s_texture",0);
-
-        break;
     case PROGRAM_INSTANCED:
-
-        program->setUniformValue("mvp_matrix", mvp_mat);
-        program->setUniformValue("mv_matrix", mv_mat);
-
+    case PROGRAM_WITH_TEXTURE:
+    case PROGRAM_CUTPLANE_SPHERES:
+    case PROGRAM_SPHERES:
         program->setUniformValue("light_pos", position);
         program->setUniformValue("light_diff",diffuse);
         program->setUniformValue("light_spec", specular);
         program->setUniformValue("light_amb", ambient);
         program->setUniformValue("spec_power", 51.8f);
         program->setUniformValue("is_two_side", is_both_sides);
-
         break;
-    case PROGRAM_INSTANCED_WIRE:
-        program->setUniformValue("mvp_matrix", mvp_mat);
+    }
+    switch(program_name)
+    {
+    case PROGRAM_WITH_LIGHT:
+    case PROGRAM_C3T3:
+    case PROGRAM_PLANE_TWO_FACES:
+    case PROGRAM_INSTANCED:
+    case PROGRAM_CUTPLANE_SPHERES:
+    case PROGRAM_SPHERES:
+      program->setUniformValue("mv_matrix", mv_mat);
+      break;
+    case PROGRAM_WITHOUT_LIGHT:
+      program->setUniformValue("f_matrix",f_mat);
+      break;
+    case PROGRAM_WITH_TEXTURE:
+      program->setUniformValue("mv_matrix", mv_mat);
+      program->setUniformValue("s_texture",0);
+      program->setUniformValue("f_matrix",f_mat);
+      break;
+    case PROGRAM_WITH_TEXTURED_EDGES:
+        program->setUniformValue("s_texture",0);
+        break;
+    case PROGRAM_NO_SELECTION:
+        program->setUniformValue("f_matrix",f_mat);
         break;
     }
     program->release();
@@ -1110,6 +1061,51 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
 
         }
         break;
+    case PROGRAM_CUTPLANE_SPHERES:
+      if( d->shader_programs[PROGRAM_CUTPLANE_SPHERES])
+      {
+          return d->shader_programs[PROGRAM_CUTPLANE_SPHERES];
+      }
+      else
+      {
+        QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+        if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.v"))
+        {
+            std::cerr<<"adding vertex shader FAILED"<<std::endl;
+        }
+        if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_c3t3.f" ))
+        {
+            std::cerr<<"adding fragment shader FAILED"<<std::endl;
+        }
+        program->bindAttributeLocation("colors", 1);
+        program->link();
+        d->shader_programs[PROGRAM_CUTPLANE_SPHERES] = program;
+        return program;
+      }
+    case PROGRAM_SPHERES:
+        if( d->shader_programs[PROGRAM_SPHERES])
+        {
+            return d->shader_programs[PROGRAM_SPHERES];
+        }
+        else
+        {
+            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_spheres.v" ))
+            {
+                std::cerr<<"adding vertex shader FAILED"<<std::endl;
+            }
+            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f" ))
+            {
+                std::cerr<<"adding fragment shader FAILED"<<std::endl;
+            }
+            program->bindAttributeLocation("colors", 1);
+            program->link();
+            d->shader_programs[PROGRAM_SPHERES] = program;
+            return program;
+
+        }
+      break;
+
     default:
         std::cerr<<"ERROR : Program not found."<<std::endl;
         return 0;

--- a/Polyhedron/demo/Polyhedron/resources/shader_spheres.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_spheres.v
@@ -1,0 +1,21 @@
+#version 120
+attribute highp vec4 vertex;
+attribute highp vec3 normals;
+attribute highp vec3 colors;
+attribute highp vec3 center;
+attribute highp float radius;
+uniform highp mat4 mvp_matrix;
+uniform highp mat4 mv_matrix;
+varying highp vec4 fP;
+varying highp vec3 fN;
+varying highp vec4 color;
+
+
+void main(void)
+{
+  color = vec4(colors, 1.0);
+  fP = mv_matrix * vertex;
+  fN = mat3(mv_matrix)* normals;
+  gl_Position =  mvp_matrix *
+  vec4(radius*vertex.x + center.x, radius* vertex.y + center.y, radius*vertex.z + center.z, 1.0) ;
+}

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -46,6 +46,22 @@ public :
     bool isFinite() const;
     //!Returns true to avoid disturbing the BBox of the scene.
     bool isEmpty() const ;
+    /*!
+     * \brief Locks a child
+     * A locked child cannot be moved out of the group nor can it be deleted.
+     */
+    void lockChild(CGAL::Three::Scene_item*);
+    /*!
+     * \brief Unlocks a child
+     * @see lockChild()
+     */
+    void unlockChild(CGAL::Three::Scene_item*);
+    /*!
+     * \brief Tells if a child is locked.
+     * \return true if the child is locked.
+     * @see lockChild()
+     */
+    bool isChildLocked(CGAL::Three::Scene_item*);
     //!Returns if the group_item is currently expanded or collapsed in the view.
     //! True means expanded, false means collapsed.
     //! @see setExpanded.
@@ -122,6 +138,8 @@ public :
     //!@see getChildren @see addChild
     void removeChild( Scene_item* item)
     {
+     if(isChildLocked(item))
+      return;
       update_group_number(item,0);
       children.removeOne(item);
     }

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -23,6 +23,7 @@
 #define SCENE_GROUP_ITEM_H
 
 #include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_interface.h>
 using namespace CGAL::Three;
 
 #include <QtCore/qglobal.h>
@@ -42,6 +43,8 @@ class DEMO_FRAMEWORK_EXPORT Scene_group_item : public Scene_item
 public :
     Scene_group_item(QString name = QString("New group"), int nb_vbos = 0, int nb_vaos = 0);
     ~Scene_group_item() {}
+    //!Sets the scene;
+    void setScene(Scene_interface* s) { scene = s; }
     //!Returns false to avoid disturbing the BBox of the scene.
     bool isFinite() const;
     //!Returns true to avoid disturbing the BBox of the scene.
@@ -151,13 +154,16 @@ public :
 public Q_SLOTS:
     void resetDraw() { already_drawn = false;}
 private:
-    //!Contains a reference to all the children of this group.
-    QList<Scene_item*> children;
     //!Updates the property has_group for each group and sub-groups containing new_item.
     void update_group_number(Scene_item*new_item, int n);
 
     bool expanded;
     mutable bool already_drawn;
+protected:
+    Scene_interface *scene;
+    //!Contains a reference to all the children of this group.
+    QList<Scene_item*> children;
+
 
 }; //end of class Scene_group_item
 

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -40,7 +40,7 @@ class DEMO_FRAMEWORK_EXPORT Scene_group_item : public Scene_item
 {
     Q_OBJECT
 public :
-    Scene_group_item(QString name = QString("New group"));
+    Scene_group_item(QString name = QString("New group"), int nb_vbos = 0, int nb_vaos = 0);
     ~Scene_group_item() {}
     //!Returns false to avoid disturbing the BBox of the scene.
     bool isFinite() const;
@@ -122,12 +122,7 @@ public :
     //!@see getChildren @see addChild
     void removeChild( Scene_item* item)
     {
-      Scene_group_item* group =
-              qobject_cast<Scene_group_item*>(item);
-      if(group)
-        Q_FOREACH(Scene_item* child, group->getChildren())
-            removeChild(child);
-      item->has_group=0;
+      update_group_number(item,0);
       children.removeOne(item);
     }
     //!Moves a child up in the list.
@@ -139,7 +134,8 @@ private:
     //!Contains a reference to all the children of this group.
     QList<Scene_item*> children;
     //!Updates the property has_group for each group and sub-groups containing new_item.
-    void add_group_number(Scene_item*new_item);
+    void update_group_number(Scene_item*new_item, int n);
+
     bool expanded;
 
 }; //end of class Scene_group_item

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -130,6 +130,8 @@ public :
     //!Moves a child down in the list.
     void moveDown(int);
 
+public Q_SLOTS:
+    void resetDraw() { already_drawn = false;}
 private:
     //!Contains a reference to all the children of this group.
     QList<Scene_item*> children;
@@ -137,6 +139,7 @@ private:
     void update_group_number(Scene_item*new_item, int n);
 
     bool expanded;
+    mutable bool already_drawn;
 
 }; //end of class Scene_group_item
 

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -72,6 +72,8 @@ public:
   PROGRAM_INSTANCED_WIRE,      /** Used to display instanced rendered wired spheres. Not affected by light.*/
   PROGRAM_C3T3,                /** Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.*/
   PROGRAM_C3T3_EDGES,          /** Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.*/
+  PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
+  PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
   NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
  };
   typedef CGAL::Three::Scene_interface::Bbox Bbox;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -61,6 +61,8 @@ public:
    PROGRAM_INSTANCED_WIRE,      /** Used to display instanced rendered wired spheres. Not affected by light.*/
    PROGRAM_C3T3,                /** Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.*/
    PROGRAM_C3T3_EDGES,          /** Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.*/
+   PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
+   PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
    NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
   };
 


### PR DESCRIPTION
This PR transforms the c3t3_item, the polylines_item and the edit_item :
- They are now group_items
- When the user asks to draw the spheres of these items, a new item is created and added as a child to the item, that cannot be moved or suppressed like a normal group's child, but only with the contextual menu. 
- The same principle is applied to the intersection tetrahedra of the c3t3
- The way these items are displayed or hidden does not change, but this PR allows for example to change the renderingMode of these sub-items without altering the one from the original item.
- This PR also fixes some bugs and errors from the group_items and simplifies there API (for exemple, it is not necessary to call add_group() anymore).