### PR TITLE
Polyline demo : names for items created on the fly

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
@@ -54,7 +54,7 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QLineEdit" name="name_lineEdit">
          <property name="text">
-          <string>Point_set</string>
+          <string/>
          </property>
         </widget>
        </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
@@ -53,6 +53,9 @@ p, li { white-space: pre-wrap; }
        </item>
        <item>
         <widget class="QLineEdit" name="name_lineEdit">
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
          <property name="text">
           <string/>
          </property>

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_point_set_dialog.ui
@@ -43,6 +43,24 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Item's name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="name_lineEdit">
+         <property name="text">
+          <string>Point_set</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="sizeConstraint">
         <enum>QLayout::SetMinimumSize</enum>

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
@@ -65,6 +65,9 @@ p, li { white-space: pre-wrap; }
        </item>
        <item>
         <widget class="QLineEdit" name="name_lineEdit">
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
          <property name="text">
           <string/>
          </property>

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
@@ -66,7 +66,10 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QLineEdit" name="name_lineEdit">
          <property name="text">
-          <string>Polyline</string>
+          <string/>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Add_polylines_dialog.ui
@@ -44,9 +44,33 @@ p, li { white-space: pre-wrap; }
         <bool>false</bool>
        </property>
        <property name="placeholderText">
-        <string notr="true">Polyline format:  Ax Ay A3 Bx By Bz ... Zx Zy Zz </string>
+        <string notr="true">Polyline format:  Ax Ay Az Bx By Bz ... Zx Zy Zz </string>
        </property>
       </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Item's name :</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="name_lineEdit">
+         <property name="text">
+          <string>Polyline</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -254,8 +254,15 @@ void Polyhedron_demo_polylines_io_plugin::addPolylineButton_clicked()
         add_polydiagui->textEdit->clear();
         Scene_polylines_item* item = new Scene_polylines_item;
         item->polylines = polylines;
-        nb_of_polylines++;
-        QString name = QString("%1 #%2").arg(add_polydiagui->name_lineEdit->text()).arg(QString::number(nb_of_polylines));
+        QString name;
+        if(add_polydiagui->name_lineEdit->text() != "")
+          name = add_polydiagui->name_lineEdit->text();
+        else
+        {
+          nb_of_polylines++;
+          name = QString("Polyline #%1").arg(QString::number(nb_of_polylines));
+        }
+        add_polydiagui->name_lineEdit->clear();
         item->setName(name);
         item->setColor(Qt::black);
         item->setProperty("polylines metadata", polylines_metadata);

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -255,7 +255,7 @@ void Polyhedron_demo_polylines_io_plugin::addPolylineButton_clicked()
         Scene_polylines_item* item = new Scene_polylines_item;
         item->polylines = polylines;
         nb_of_polylines++;
-        QString name = QString("Polyline #%1").arg(QString::number(nb_of_polylines));
+        QString name = QString("%1 #%2").arg(add_polydiagui->name_lineEdit->text()).arg(QString::number(nb_of_polylines));
         item->setName(name);
         item->setColor(Qt::black);
         item->setProperty("polylines metadata", polylines_metadata);

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -206,8 +206,14 @@ void Polyhedron_demo_xyz_plugin::addPointSetButton_clicked()
     {
         add_pointsetdiagui->textEdit->clear();
         item->point_set()->unselect_all();
-        nb_of_point_set++;
-        QString name = QString("%1 #%2").arg(add_pointsetdiagui->name_lineEdit->text()).arg(QString::number(nb_of_point_set));
+        QString name;
+        if(add_pointsetdiagui->name_lineEdit->text()!="")
+          name = add_pointsetdiagui->name_lineEdit->text();
+        else
+        {
+          nb_of_point_set++;
+          name = QString("Point_set #%1").arg(QString::number(nb_of_point_set));
+        }
         item->setName(name);
         item->setColor(Qt::black);
         item->invalidateOpenGLBuffers();

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -207,7 +207,7 @@ void Polyhedron_demo_xyz_plugin::addPointSetButton_clicked()
         add_pointsetdiagui->textEdit->clear();
         item->point_set()->unselect_all();
         nb_of_point_set++;
-        QString name = QString("Point_set #%1").arg(QString::number(nb_of_point_set));
+        QString name = QString("%1 #%2").arg(add_pointsetdiagui->name_lineEdit->text()).arg(QString::number(nb_of_point_set));
         item->setName(name);
         item->setColor(Qt::black);
         item->invalidateOpenGLBuffers();


### PR DESCRIPTION
This PR adds the possibility to choose the name of the point_sets and polylines created on the fly, but keeps the same counter.