### PR TITLE
Bugfix: color map with empty Polyhedron

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -636,7 +636,7 @@ init()
     }
     
     colors_.clear();
-    compute_color_map(this->color(), max + 1 - min,
+    compute_color_map(this->color(), (std::max)(0, max + 1 - min),
                       std::back_inserter(colors_));
     m_min_patch_id=min;
   }


### PR DESCRIPTION
If the Polyhedron item is initialized with an empty Polyhedron object, then the values `min` and `max` in the test to compute color map keep their initial values (INT_MAX and 0), which leads to `(max+1-min)` being a negative number which leads to an overly large signed number which leads to allocating a huge number of colors which leads to a `std::bad_alloc`.

(This happened with the `Surface_reconstruction_plugin` for example.)