### PR TITLE
Fix -Wconversion warnings, and issues detected by those warnings

### DIFF
--- a/Algebraic_foundations/include/CGAL/ipower.h
+++ b/Algebraic_foundations/include/CGAL/ipower.h
@@ -65,12 +65,12 @@ NT ipower(const NT& base, long expn) {
     if (expn == 1) return base;
     
     // find the most significant non-zero bit of expn
-    int e = expn, msb = 0;
+    long e = expn, msb = 0;
     while (e >>= 1) msb++;
     
     // computing base^expn by square-and-multiply
     NT res = base;
-    int b = 1<<msb;
+    long b = 1<<msb;
     while (b >>= 1) { // is there another bit right of what we saw so far?
         res *= res;
         if (expn & b) res *= base;

--- a/Algebraic_foundations/include/CGAL/ipower.h
+++ b/Algebraic_foundations/include/CGAL/ipower.h
@@ -70,7 +70,7 @@ NT ipower(const NT& base, long expn) {
     
     // computing base^expn by square-and-multiply
     NT res = base;
-    long b = 1<<msb;
+    long b = 1L<<msb;
     while (b >>= 1) { // is there another bit right of what we saw so far?
         res *= res;
         if (expn & b) res *= base;

--- a/CGAL_ImageIO/include/CGAL/ImageIO.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO.h
@@ -516,7 +516,7 @@ CGAL_IMAGEIO_EXPORT char *ImageIO_gets( const _image *im, char *str, int size );
 
 /** replaces fseek function
  */
-CGAL_IMAGEIO_EXPORT int ImageIO_seek( const _image *im, long offset, int whence );
+CGAL_IMAGEIO_EXPORT long ImageIO_seek( const _image *im, long offset, int whence );
 
 /** replaces ferror function
  */

--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -608,9 +608,9 @@ void _get_image_bounding_box(_image* im,
   *x_min = im->tx;
   *y_min = im->ty;
   *z_min = im->tz;
-  *x_max = (im->xdim - 1.0f)*(im->vx) + *x_min ;
-  *y_max = (im->ydim - 1.0f)*(im->vy) + *y_min ;
-  *z_max = (im->zdim - 1.0f)*(im->vz) + *z_min ;
+  *x_max = (double(im->xdim) - 1.0)*(im->vx) + *x_min ;
+  *y_max = (double(im->ydim) - 1.0)*(im->vy) + *y_min ;
+  *z_max = (double(im->zdim) - 1.0)*(im->vz) + *z_min ;
 }
 
 /* Free an image descriptor */
@@ -1102,7 +1102,7 @@ static void _swapImageData( _image *im )
       ptr3 = ptr4 = (unsigned short int *) im->data;
       while( length-- ) {
 	si = *ptr3++;
-	*ptr4++ = ((si >> 8) & 0xff) | (si << 8);
+	*ptr4++ = (unsigned short int)(((si >> 8) & 0xff) | (si << 8));
       }
     }
     
@@ -1570,10 +1570,10 @@ float triLinInterp(const _image* image,
                    float posz,
                    float value_outside /*= 0.f */)
 {
-  const int dimx = image->xdim;
-  const int dimy = image->ydim;
-  const int dimz = image->zdim;
-  const int dimxy = dimx*dimy;
+  const std::size_t dimx = image->xdim;
+  const std::size_t dimy = image->ydim;
+  const std::size_t dimz = image->zdim;
+  const std::size_t dimxy = dimx*dimy;
   
   if(posx < 0.f || posy < 0.f || posz < 0.f )
     return value_outside;
@@ -1594,10 +1594,10 @@ float triLinInterp(const _image* image,
   const int j2 = j1 + 1;
   const int k2 = k1 + 1;
 
-  const float KI2 = i2-posz;
-  const float KI1 = posz-i1;
-  const float KJ2 = j2-posy;
-  const float KJ1 = posy-j1;
+  const float KI2 = float(i2)-posz;
+  const float KI1 = posz-float(i1);
+  const float KJ2 = float(j2)-posy;
+  const float KJ1 = posy-float(j1);
 
   CGAL_IMAGE_IO_CASE
     (image,
@@ -1605,11 +1605,11 @@ float triLinInterp(const _image* image,
      return (((float)array[i1 * dimxy + j1 * dimx + k1] * KI2 +
               (float)array[i2 * dimxy + j1 * dimx + k1] * KI1) * KJ2 +
              ((float)array[i1 * dimxy + j2 * dimx + k1] * KI2 +
-              (float)array[i2 * dimxy + j2 * dimx + k1] * KI1) * KJ1) * (k2-posx)+
+              (float)array[i2 * dimxy + j2 * dimx + k1] * KI1) * KJ1) * (float(k2)-posx)+
      (((float)array[i1 * dimxy + j1 * dimx + k2] * KI2 +
        (float)array[i2 * dimxy + j1 * dimx + k2] * KI1) * KJ2 +
       ((float)array[i1 * dimxy + j2 * dimx + k2] * KI2 +
-       (float)array[i2 * dimxy + j2 * dimx + k2] * KI1) * KJ1) * (posx-k1);
+       (float)array[i2 * dimxy + j2 * dimx + k2] * KI1) * KJ1) * (posx-float(k1));
      );
   return 0.f;
 }
@@ -1635,9 +1635,9 @@ void convertImageTypeToFloat(_image* image){
   if(image->wordKind == WK_FLOAT && image->wdim == 4)
     return;
 
-  const unsigned int dimx = image->xdim;
-  const unsigned int dimy = image->ydim;
-  const unsigned int dimz = image->zdim;
+  const std::size_t dimx = image->xdim;
+  const std::size_t dimy = image->ydim;
+  const std::size_t dimz = image->zdim;
   
   float * array = (float*)ImageIO_alloc (dimx * dimy * dimz *sizeof(float));
   if (array == NULL ) {

--- a/CGAL_ImageIO/include/CGAL/Image_3_impl.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_impl.h
@@ -103,9 +103,9 @@ void Image_3::gl_draw_bbox(const float line_width,
     double z() const { return z_; }
   };
 
-  const double xmax = (image_ptr->xdim - 1.0)*(image_ptr->vx);
-  const double ymax = (image_ptr->ydim - 1.0)*(image_ptr->vy);
-  const double zmax = (image_ptr->zdim - 1.0)*(image_ptr->vz);
+  const double xmax = (double(image_ptr->xdim) - 1.0)*(image_ptr->vx);
+  const double ymax = (double(image_ptr->ydim) - 1.0)*(image_ptr->vy);
+  const double zmax = (double(image_ptr->zdim) - 1.0)*(image_ptr->vz);
 
   Point a(0.0, 0.0,    0.0);
   Point b(0.0, ymax, 0.0);

--- a/CGAL_ImageIO/include/CGAL/Image_3_impl.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_impl.h
@@ -61,7 +61,7 @@ void Image_3::gl_draw(const float point_size,
   glColor3ub(r,g,b);
   glBegin(GL_POINTS);
   unsigned char *pData = (unsigned char*)image_ptr->data;
-  unsigned int xy = image_ptr->xdim * image_ptr->ydim;
+  std::size_t xy = image_ptr->xdim * image_ptr->ydim;
   for(unsigned int i=0;i<image_ptr->xdim;i+=5)
     for(unsigned int j=0;j<image_ptr->ydim;j+=5)
       for(unsigned int k=0;k<image_ptr->zdim;k+=5)

--- a/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
@@ -220,7 +220,7 @@ int testAnalyzeHeader(char *magic,const char *) {
 CGAL_INLINE_FUNCTION
 int writeAnalyze( char *name, _image* im) {
   char *outputName;
-  int length, extLength=0, res;
+  std::size_t length, extLength=0;
 
 
   length=strlen(name);
@@ -252,7 +252,7 @@ int writeAnalyze( char *name, _image* im) {
     return ImageIO_OPENING;
   }
 
-  res = writeAnalyzeHeader(im);
+  int res = writeAnalyzeHeader(im);
   if ( res < 0 ) {
     fprintf(stderr, "writeAnalyze: error: unable to write header of \'%s\'\n",
 	    outputName);
@@ -530,7 +530,7 @@ int _readAnalyzeHeader( _image* im, const char* name,
       /* header is read. close header file and open data file. */
       if( name != NULL ) {
 
-	int length = strlen(name) ;
+        std::size_t length = strlen(name) ;
 	char* data_filename = (char *) ImageIO_alloc(length+4) ;
 	
 	if( strcmp( name+length-4, ".hdr" ) )
@@ -612,9 +612,9 @@ writeAnalyzeHeader( const _image* im )
    hdr.dime.cal_min     = 0.0;
 
    hdr.dime.dim[0] = 4;
-   hdr.dime.dim[1] = im->xdim;
-   hdr.dime.dim[2] = im->ydim;
-   hdr.dime.dim[3] = im->zdim;
+   hdr.dime.dim[1] = short(im->xdim);
+   hdr.dime.dim[2] = short(im->ydim);
+   hdr.dime.dim[3] = short(im->zdim);
    hdr.dime.dim[4] = 1 ;
 
    if ( im->wordKind == WK_FIXED && im->sign == SGN_UNSIGNED ) {
@@ -633,9 +633,9 @@ writeAnalyzeHeader( const _image* im )
 	
 	{
 	  unsigned char *buf = (unsigned char *)im->data;
-	  int size = im->xdim * im->ydim * im->zdim * im->vdim;
+          std::size_t size = std::size_t(im->xdim) * im->ydim * im->zdim * im->vdim;
 	  imin = imax = *buf;
-	  for (i=0; i<size; i++, buf++) {
+	  for (std::size_t i=0; i<size; i++, buf++) {
 	    if ( imax < *buf ) imax = *buf;
 	    if ( imin > *buf ) imin = *buf;
 	  }
@@ -645,10 +645,9 @@ writeAnalyzeHeader( const _image* im )
       else if ( im->wdim == 2 ) {
 	if ( im->vdim == 1 ) {
 	  unsigned short int *buf = (unsigned short int*)im->data;
-	  int size = im->xdim * im->ydim *im->zdim;
-	  int i;
+          std::size_t size = std::size_t(im->xdim) * im->ydim *im->zdim;
 	  imin = imax = *buf;
-	  for (i=0; i<size; i++, buf++) {
+	  for (std::size_t i=0; i<size; i++, buf++) {
 	    if ( imax < *buf ) imax = *buf;
 	    if ( imin > *buf ) imin = *buf;
 	  }
@@ -680,10 +679,9 @@ writeAnalyzeHeader( const _image* im )
      }
      if( im->wdim == 2 ) {
        short int *buf = (short int*)im->data;
-       int size = im->xdim * im->ydim *im->zdim;
-       int i;
+       std::size_t size = std::size_t(im->xdim) * im->ydim *im->zdim;
        imin = imax = *buf;
-       for (i=0; i<size; i++, buf++) {
+       for (std::size_t i=0; i<size; i++, buf++) {
 	 if ( imax < *buf ) imax = *buf;
 	 if ( imin > *buf ) imin = *buf;
        }
@@ -691,10 +689,9 @@ writeAnalyzeHeader( const _image* im )
      }
      else if( im->wdim == 4 ) {
        int *buf = (int*)im->data;
-       int size = im->xdim * im->ydim *im->zdim;
-       int i;
+       std::size_t size = std::size_t(im->xdim) * im->ydim *im->zdim;
        imin = imax = *buf;
-       for (i=0; i<size; i++, buf++) {
+       for (std::size_t i=0; i<size; i++, buf++) {
 	 if ( imax < *buf ) imax = *buf;
 	 if ( imin > *buf ) imin = *buf;
        }
@@ -727,7 +724,7 @@ writeAnalyzeHeader( const _image* im )
       return -1;
    }
 	 
-   hdr.dime.bitpix = 8*im->wdim*im->vdim ;
+   hdr.dime.bitpix = short(8*im->wdim*im->vdim) ;
 
    hdr.hk.regular = 'r';
    hdr.hk.sizeof_hdr = sizeof(struct dsr);

--- a/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/analyze_impl.h
@@ -790,9 +790,9 @@ writeAnalyzeHeader( const _image* im )
 /* Writes the given image body in an already opened file.*/
 CGAL_INLINE_FUNCTION
 int writeAnalyzeData(const _image *im) {
-  unsigned int lineSize = im->wdim * im->xdim * im->vdim ;
-  unsigned long size = lineSize * im->ydim * im->zdim;
-  unsigned int nwrt ;
+  std::size_t lineSize = std::size_t(im->wdim) * im->xdim * im->vdim ;
+  std::size_t size = lineSize * im->ydim * im->zdim;
+  std::size_t nwrt ;
 
   if(im->openMode != OM_CLOSE) {
 

--- a/CGAL_ImageIO/src/CGAL_ImageIO/bmp_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/bmp_impl.h
@@ -341,8 +341,8 @@ void *_readBmpImage( const char *name,
 	myBuf[i+2] = argbs[0][row * widths[0] + col].blue;
       }
       
-      *dimx = widths[0];
-      *dimy = heights[0];
+      *dimx = int(widths[0]);
+      *dimy = int(heights[0]);
       *dimz = 3;
 
     } else {

--- a/CGAL_ImageIO/src/CGAL_ImageIO/bmpendian_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/bmpendian_impl.h
@@ -57,7 +57,7 @@ int readINT8little(FILE *f, CGAL_INT8 *i)
     if (rc == EOF)
 	return rc;
     
-    *i = (rc & 0xff);
+    *i = CGAL_INT8(rc & 0xff);
     return 0;
 }
 
@@ -70,7 +70,7 @@ int readUINT8little(FILE *f, CGAL_UINT8 *i)
     if (rc == EOF)
 	return rc;
     
-    *i = (rc & 0xff);
+    *i = CGAL_UINT8(rc & 0xff);
     return 0;
 }
 
@@ -92,7 +92,7 @@ int readINT16little(FILE *f, CGAL_INT16 *i)
     if (rc == EOF)
 	return rc;
     
-    temp |= ((rc & 0xff) << 8);
+    temp = temp | CGAL_INT16((rc & 0xff) << 8);
     *i = temp;
     return 0;
 }
@@ -109,7 +109,7 @@ int readUINT16little(FILE *f, CGAL_UINT16 *i)
     if (rc == EOF)
 	return rc;
     
-    temp |= ((rc & 0xff) << 8);
+    temp = CGAL_INT16(temp | ((rc & 0xff) << 8));
     *i = temp;
     return 0;
 }
@@ -126,14 +126,14 @@ int readINT32little(FILE *f, CGAL_INT32 *i)
     CGAL_INT32 temp = 0;
     
     temp = ((long)fgetc(f) & 0xff);
-    temp |= (((long)fgetc(f) & 0xff) << 8);
-    temp |= (((long)fgetc(f) & 0xff) << 16);
+    temp = CGAL_INT32(temp | (((long)fgetc(f) & 0xff) << 8));
+    temp = CGAL_INT32(temp | (((long)fgetc(f) & 0xff) << 16));
     
     rc = fgetc(f);
     if (rc == EOF)
 	return rc;
     
-    temp |= (((long)rc & 0xff) << 24);
+    temp = CGAL_INT32(temp | (((long)rc & 0xff) << 24));
     *i = temp;
     return 0;
 }
@@ -145,14 +145,14 @@ int readUINT32little(FILE *f, CGAL_UINT32 *i)
     CGAL_UINT32 temp = 0;
     
     temp = ((long)fgetc(f) & 0xff);
-    temp |= (((long)fgetc(f) & 0xff) << 8);
-    temp |= (((long)fgetc(f) & 0xff) << 16);
+    temp = CGAL_UINT32(temp | (((long)fgetc(f) & 0xff) << 8));
+    temp = CGAL_UINT32(temp | (((long)fgetc(f) & 0xff) << 16));
     
     rc = fgetc(f);
     if (rc == EOF)
 	return rc;
     
-    temp |= (((long)rc & 0xff) << 24);
+    temp = CGAL_UINT32(temp | (((long)rc & 0xff) << 24));
     *i = temp;
     return 0;
 }

--- a/CGAL_ImageIO/src/CGAL_ImageIO/bmpread_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/bmpread_impl.h
@@ -743,7 +743,8 @@ int readSingleImageBMP(FILE *fp, RGB **argb, CGAL_UINT32 *width, CGAL_UINT32 *he
     RGB              *colorTable = (RGB*)NULL;
     RGB              *image = (RGB*)NULL;
     int               rc, depth, inverted;
-    long              numColors, numPixels, endPos;
+    int               numColors;
+    long              numPixels, endPos;
     
     /*
      * First, get the file header and sanity check it.  The type field must be

--- a/CGAL_ImageIO/src/CGAL_ImageIO/bmptypes.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/bmptypes.h
@@ -44,12 +44,14 @@
 * CGAL_UINT32 is an unsigned CGAL_INT32
 */
 
-typedef char           CGAL_INT8;
-typedef short          CGAL_INT16;
-typedef long           CGAL_INT32;
-typedef unsigned char  CGAL_UINT8;
-typedef unsigned short CGAL_UINT16;
-typedef unsigned long  CGAL_UINT32;
+#include <boost/cstdint.hpp>
+
+typedef char            CGAL_INT8;
+typedef short           CGAL_INT16;
+typedef boost::int32_t  CGAL_INT32;
+typedef unsigned char   CGAL_UINT8;
+typedef unsigned short  CGAL_UINT16;
+typedef boost::uint32_t CGAL_UINT32;
 
 /*****************************************************************************
 *

--- a/CGAL_ImageIO/src/CGAL_ImageIO/convert_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/convert_impl.h
@@ -55,7 +55,7 @@ void ConvertBuffer( void *bufferIn,
 		    int bufferLength )
 {
   const char *proc = "ConvertBuffer";
-  int i, min, max;
+  int i;
   u8 *u8buf;
   s8 *s8buf;
   u16 *u16buf;
@@ -79,9 +79,9 @@ void ConvertBuffer( void *bufferIn,
   }
   
   switch ( typeOut ) {
-  case CGAL_SCHAR :
+  case CGAL_SCHAR : {
     s8buf = (s8*)bufferOut;
-    min = -128; max = 127;
+    s8 min = -128, max = 127;
     switch( typeIn ) {
     case CGAL_SCHAR :
       if ( bufferOut == bufferIn ) return;
@@ -91,8 +91,8 @@ void ConvertBuffer( void *bufferIn,
       r32buf = (r32*)bufferIn;
       for (i=bufferLength; i>0; i--, s8buf++, r32buf++ ) {
 	if ( *r32buf < min ) *s8buf = min;
-	else if ( *r32buf < 0.0 ) *s8buf = (int)(*r32buf - 0.5);
-	else if ( *r32buf < max ) *s8buf = (int)(*r32buf + 0.5);
+	else if ( *r32buf < 0.0 ) *s8buf = (s8)(*r32buf - 0.5);
+	else if ( *r32buf < max ) *s8buf = (s8)(*r32buf + 0.5);
 	else *s8buf = max;
       }
       break;
@@ -100,8 +100,8 @@ void ConvertBuffer( void *bufferIn,
       r64buf = (r64*)bufferIn;
       for (i=bufferLength; i>0; i--, s8buf++, r64buf++ ) {
 	if ( *r64buf < min ) *s8buf = min;
-	else if ( *r64buf < 0.0 ) *s8buf = (int)(*r64buf - 0.5);
-	else if ( *r64buf < max ) *s8buf = (int)(*r64buf + 0.5);
+	else if ( *r64buf < 0.0 ) *s8buf = (s8)(*r64buf - 0.5);
+	else if ( *r64buf < max ) *s8buf = (s8)(*r64buf + 0.5);
 	else *s8buf = max;
       }
       break;
@@ -111,14 +111,14 @@ void ConvertBuffer( void *bufferIn,
       return;
     }
     break; /* end case typeOut = CGAL_SCHAR */
-
+  }
 
 
 
     
-  case CGAL_UCHAR :
+  case CGAL_UCHAR : {
     u8buf = (u8*)bufferOut;
-    min = 0; max = 255;
+    u8 min = 0, max = 255;
     switch( typeIn ) {
     case CGAL_UCHAR :
       if ( bufferOut == bufferIn ) return;
@@ -135,7 +135,7 @@ void ConvertBuffer( void *bufferIn,
       r32buf = (r32*)bufferIn;
       for (i=bufferLength; i>0; i--, u8buf++, r32buf++ ) {
 	if ( *r32buf < min ) *u8buf = min;
-	else if ( *r32buf < max ) *u8buf = (int)(*r32buf + 0.5);
+	else if ( *r32buf < max ) *u8buf = (u8)(*r32buf + 0.5);
 	else *u8buf = max;
       }
       break;
@@ -143,7 +143,7 @@ void ConvertBuffer( void *bufferIn,
       r64buf = (r64*)bufferIn;
       for (i=bufferLength; i>0; i--, u8buf++, r64buf++ ) {
 	if ( *r64buf < min ) *u8buf = min;
-	else if ( *r64buf < max ) *u8buf = (int)(*r64buf + 0.5);
+	else if ( *r64buf < max ) *u8buf = (u8)(*r64buf + 0.5);
 	else *u8buf = max;
       }
       break;
@@ -153,15 +153,15 @@ void ConvertBuffer( void *bufferIn,
       return;
     }
     break; /* end case typeOut = CGAL_UCHAR */
-
+  }
 
 
 
 
     
-  case CGAL_SSHORT :
+  case CGAL_SSHORT : {
     s16buf = (s16*)bufferOut;
-    min = -32768; max = 32767;
+    s16 min = -32768, max = 32767;
     switch( typeIn ) {
     case CGAL_SSHORT :
       if ( bufferOut == bufferIn ) return;
@@ -178,8 +178,8 @@ void ConvertBuffer( void *bufferIn,
       r32buf = (r32*)bufferIn;
       for (i=bufferLength; i>0; i--, s16buf++, r32buf++ ) {
 	if ( *r32buf < min ) *s16buf = min;
-	else if ( *r32buf < 0.0 ) *s16buf = (int)(*r32buf - 0.5);
-	else if ( *r32buf < max ) *s16buf = (int)(*r32buf + 0.5);
+	else if ( *r32buf < 0.0 ) *s16buf = (s16)(*r32buf - 0.5);
+	else if ( *r32buf < max ) *s16buf = (s16)(*r32buf + 0.5);
 	else *s16buf = max;
       }
       break;
@@ -187,8 +187,8 @@ void ConvertBuffer( void *bufferIn,
       r64buf = (r64*)bufferIn;
       for (i=bufferLength; i>0; i--, s16buf++, r64buf++ ) {
 	if ( *r64buf < min ) *s16buf = min;
-	else if ( *r64buf < 0.0 ) *s16buf = (int)(*r64buf - 0.5);
-	else if ( *r64buf < max ) *s16buf = (int)(*r64buf + 0.5);
+	else if ( *r64buf < 0.0 ) *s16buf = (s16)(*r64buf - 0.5);
+	else if ( *r64buf < max ) *s16buf = (s16)(*r64buf + 0.5);
 	else *s16buf = max;
       }
       break;
@@ -198,14 +198,14 @@ void ConvertBuffer( void *bufferIn,
       return;
     }
     break; /* end case typeOut = CGAL_SSHORT */
-
+  }
 
 
 
     
-  case CGAL_USHORT :
+  case CGAL_USHORT : {
     u16buf = (u16*)bufferOut;
-    min = 0; max = 65535;
+    u16 min = 0, max = 65535;
     switch( typeIn ) {
     case CGAL_USHORT :
       if ( bufferOut == bufferIn ) return;
@@ -215,8 +215,8 @@ void ConvertBuffer( void *bufferIn,
       r32buf = (r32*)bufferIn;
       for (i=bufferLength; i>0; i--, u16buf++, r32buf++ ) {
 	if ( *r32buf < min ) *u16buf = min;
-	else if ( *r32buf < 0.0 ) *u16buf = (int)(*r32buf - 0.5);
-	else if ( *r32buf < max ) *u16buf = (int)(*r32buf + 0.5);
+	else if ( *r32buf < 0.0 ) *u16buf = (u16)(*r32buf - 0.5);
+	else if ( *r32buf < max ) *u16buf = (u16)(*r32buf + 0.5);
 	else *u16buf = max;
       }
       break;
@@ -224,8 +224,8 @@ void ConvertBuffer( void *bufferIn,
       r64buf = (r64*)bufferIn;
       for (i=bufferLength; i>0; i--, u16buf++, r64buf++ ) {
 	if ( *r64buf < min ) *u16buf = min;
-	else if ( *r64buf < 0.0 ) *u16buf = (int)(*r64buf - 0.5);
-	else if ( *r64buf < max ) *u16buf = (int)(*r64buf + 0.5);
+	else if ( *r64buf < 0.0 ) *u16buf = (u16)(*r64buf - 0.5);
+	else if ( *r64buf < max ) *u16buf = (u16)(*r64buf + 0.5);
 	else *u16buf = max;
       }
       break;
@@ -235,7 +235,7 @@ void ConvertBuffer( void *bufferIn,
       return;
     }
     break; /* end case typeOut = CGAL_USHORT */
-
+  }
 
 
 
@@ -403,9 +403,9 @@ void Convert_r32_to_s8( r32 *theBuf,
     if ( *tb < -128.0 ) {
       *rb = -128;
     } else if ( *tb < 0.0 ) {
-      *rb = (int)(*tb - 0.5);
+      *rb = (s8)(*tb - 0.5);
     } else if ( *tb < 127.0 ) {
-      *rb = (int)(*tb + 0.5);
+      *rb = (s8)(*tb + 0.5);
     } else {
       *rb = 127;
     }
@@ -429,7 +429,7 @@ void Convert_r32_to_u8( r32 *theBuf,
     if ( *tb < 0.0 ) {
       *rb = 0;
     } else if ( *tb < 255.0 ) {
-      *rb = (int)(*tb + 0.5);
+      *rb = (u8)(*tb + 0.5);
     } else {
       *rb = 255;
     }
@@ -453,9 +453,9 @@ void Convert_r32_to_s16( r32 *theBuf,
     if ( *tb < -32768.0 ) {
       *rb = -32768;
     } else if ( *tb < 0.0 ) {
-      *rb = (int)(*tb - 0.5);
+      *rb = (s16)(*tb - 0.5);
     } else if ( *tb < 32767.0 ) {
-      *rb = (int)(*tb + 0.5);
+      *rb = (s16)(*tb + 0.5);
     } else {
       *rb = 32767;
     }
@@ -479,7 +479,7 @@ void Convert_r32_to_u16( r32 *theBuf,
     if ( *tb < 0.0 ) {
       *rb = 0;
     } else if ( *tb < 65535.0 ) {
-      *rb = (int)(*tb + 0.5);
+      *rb = (u16)(*tb + 0.5);
     } else {
       *rb = 65535;
     }

--- a/CGAL_ImageIO/src/CGAL_ImageIO/fgetns_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/fgetns_impl.h
@@ -31,15 +31,12 @@
    if any */
 CGAL_INLINE_FUNCTION
 char *fgetns(char *str, int n,  _image *im ) {
-  char *ret;
-  int l;
-
   memset( str, 0, n );
-  ret = ImageIO_gets( im, str, n );
+  char* ret = ImageIO_gets( im, str, n );
 
   if(!ret) return NULL;
 
-  l = strlen(str);
+  std::size_t l = strlen(str);
   if(l > 0 && str[l-1] == '\n') str[l-1] = '\0';
   return ret;
 }

--- a/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
@@ -255,9 +255,9 @@ int   gif89 = 0;
     get_static_b() = (byte *) ImageIO_alloc(256 * sizeof(byte));
    
     for (i = 0; i < 256; i++) {
-      get_static_r()[i] = EGApalette[i&15][0];
-      get_static_g()[i] = EGApalette[i&15][1];
-      get_static_b()[i] = EGApalette[i&15][2];
+      get_static_r()[i] = byte(EGApalette[i&15][0]);
+      get_static_g()[i] = byte(EGApalette[i&15][1]);
+      get_static_b()[i] = byte(EGApalette[i&15][2]);
     }
   }
 

--- a/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/gif_impl.h
@@ -134,7 +134,7 @@ int   gif89 = 0;
   byte ch, ch1;
   byte *ptr, *ptr1;
   int i, block;
-  int npixels, maxpixels, aspect, filesize;
+  int npixels, maxpixels, aspect;
   float normaspect;
   int OutCount = 0,		/* Decompressor output 'stack count' */
     RWidth, RHeight,		/* screen dimensions */
@@ -186,7 +186,7 @@ int   gif89 = 0;
   }
   /* find the size of the file */
   fseek(fp, 0L, 2);
-  filesize = ftell(fp);
+  long filesize = ftell(fp);
   fseek(fp, 0L, 0);
 
  /* the +256's are so we can read truncated GIF files without fear of 

--- a/CGAL_ImageIO/src/CGAL_ImageIO/gis_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/gis_impl.h
@@ -48,8 +48,9 @@ PTRIMAGE_FORMAT createGisFormat() {
 CGAL_INLINE_FUNCTION
 int writeGis( char *name, _image* im) {
   char *outputName;
-  int length, extLength=0, res;
-
+  std::size_t length, extLength=0;
+  int res;
+  std::size_t done;
 
   length=strlen(name);
   outputName= (char *)ImageIO_alloc(length+8);
@@ -110,7 +111,7 @@ int writeGis( char *name, _image* im) {
   }
 
   if ( im->dataMode == DM_ASCII ) {
-    int i, j, n, size;
+    std::size_t i, j, n, size;
     char *str = (char*)ImageIO_alloc( _LGTH_STRING_+1 );
     size = im->xdim * im->ydim * im->zdim * im->vdim;
     n = ( im->xdim < 16 ) ? im->xdim : 16;
@@ -143,7 +144,8 @@ int writeGis( char *name, _image* im) {
 		if ( j<n && i<size ) sprintf( str+strlen(str), " " );
 	      }
 	      sprintf( str+strlen(str), "\n" );
-	      res = ImageIO_write( im, str, strlen( str )  );
+              done = ImageIO_write( im, str, strlen( str )  );
+              res = (done == strlen( str )) ? int(done) : -1;
 	      if ( res  <= 0 ) {
 		fprintf(stderr, "writeGis: error when writing data in \'%s\'\n", outputName);
 		if ( outputName != NULL ) ImageIO_free( outputName );
@@ -162,7 +164,8 @@ int writeGis( char *name, _image* im) {
 		if ( j<n && i<size ) sprintf( str+strlen(str), " " );
 	      }
 	      sprintf( str+strlen(str), "\n" );
-	      res = ImageIO_write( im, str, strlen( str )  );
+              done = ImageIO_write( im, str, strlen( str )  );
+              res = (done == strlen( str )) ? int(done) : -1;
 	      if ( res  <= 0 ) {
 		fprintf(stderr, "writeGis: error when writing data in \'%s\'\n", outputName);
 		if ( outputName != NULL ) ImageIO_free( outputName );
@@ -189,7 +192,8 @@ int writeGis( char *name, _image* im) {
 		if ( j<n && i<size ) sprintf( str+strlen(str), " " );
 	      }
 	      sprintf( str+strlen(str), "\n" );
-	      res = ImageIO_write( im, str, strlen( str )  );
+	      done = ImageIO_write( im, str, strlen( str )  );
+              res = (done == strlen( str )) ? int(done) : -1;
 	      if ( res  <= 0 ) {
 		fprintf(stderr, "writeGis: error when writing data in \'%s\'\n", outputName);
 		if ( outputName != NULL ) ImageIO_free( outputName );
@@ -208,7 +212,8 @@ int writeGis( char *name, _image* im) {
 		if ( j<n && i<size ) sprintf( str+strlen(str), " " );
 	      }
 	      sprintf( str+strlen(str), "\n" );
-	      res = ImageIO_write( im, str, strlen( str )  );
+	      done = ImageIO_write( im, str, strlen( str )  );
+              res = (done == strlen( str )) ? int(done) : -1;
 	      if ( res  <= 0 ) {
 		fprintf(stderr, "writeGis: error when writing data in \'%s\'\n", outputName);
 		if ( outputName != NULL ) ImageIO_free( outputName );
@@ -261,7 +266,7 @@ int readGisHeader( const char* name,_image* im)
   iss.str(str);
   iss >> im->xdim >> im->ydim >> im->zdim >> im->vdim;
 
-  status = iss.str().length();
+  status = (int)iss.str().length();
   switch ( status ) {
   case 2 :    im->zdim = 1;
   case 3 :    im->vdim = 1;
@@ -468,7 +473,7 @@ int readGisHeader( const char* name,_image* im)
   /* header is read. close header file and open data file. */
   if( name != NULL ) {
     
-    int length = strlen(name) ;
+    std::size_t length = strlen(name) ;
     char* data_filename = (char *) ImageIO_alloc(length+4) ;
     
     if( strcmp( name+length-4, ".dim" ) ) {
@@ -510,7 +515,7 @@ int readGisHeader( const char* name,_image* im)
        only U8 and S8
      */
     if ( im->dataMode == DM_ASCII ) {
-      int size = im->xdim * im->ydim * im->zdim * im->vdim * im->wdim;
+      std::size_t size = std::size_t(im->xdim) * im->ydim * im->zdim * im->vdim * im->wdim;
       unsigned int n;
       char *tmp;
       int ret, iv=0;

--- a/CGAL_ImageIO/src/CGAL_ImageIO/inr_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/inr_impl.h
@@ -75,7 +75,7 @@ static void concatStringElement(const stringListHead *strhead,
 /* Writes the given inrimage header in an already opened file.*/
 CGAL_INLINE_FUNCTION
 int _writeInrimageHeader(const _image *im, ENDIANNESS end) {
-  unsigned int pos, i;
+  std::size_t pos, i;
   char type[30], endianness[5], buf[257], scale[20];
   std::ostringstream oss;
 

--- a/CGAL_ImageIO/src/CGAL_ImageIO/iris_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/iris_impl.h
@@ -139,7 +139,7 @@ static void expandrow(byte *optr, byte *iptr, int z)
 	optr[7*4] = iptr[7];
 	optr += 8*4;
 	iptr += 8;
-	count -= 8;
+	count = byte(count - 8);
       }
       while(count--) {
 	*optr = *iptr++;
@@ -158,7 +158,7 @@ static void expandrow(byte *optr, byte *iptr, int z)
 	optr[6*4] = pixel;
 	optr[7*4] = pixel;
 	optr += 8*4;
-	count -= 8;
+	count = byte(count - 8);
       }
       while(count--) {
 	*optr = pixel;
@@ -194,16 +194,16 @@ static void addimgtag(byte *dptr, int xsize, int ysize)
   dptr[0] = 0x69;  dptr[1] = 0x43;  dptr[2] = 0x42;  dptr[3] = 0x22;
   dptr += 4;
 
-  dptr[0] = (xsize>>24)&0xff;
-  dptr[1] = (xsize>>16)&0xff;
-  dptr[2] = (xsize>> 8)&0xff;
-  dptr[3] = (xsize    )&0xff;
+  dptr[0] = byte((xsize>>24)&0xff);
+  dptr[1] = byte((xsize>>16)&0xff);
+  dptr[2] = byte((xsize>> 8)&0xff);
+  dptr[3] = byte((xsize    )&0xff);
   dptr += 4;
 
-  dptr[0] = (ysize>>24)&0xff;
-  dptr[1] = (ysize>>16)&0xff;
-  dptr[2] = (ysize>> 8)&0xff;
-  dptr[3] = (ysize    )&0xff;
+  dptr[0] = byte((ysize>>24)&0xff);
+  dptr[1] = byte((ysize>>16)&0xff);
+  dptr[2] = byte((ysize>> 8)&0xff);
+  dptr[3] = byte((ysize    )&0xff);
 }
 
 /* byte order independent read/write of shorts and longs. */
@@ -212,7 +212,7 @@ static unsigned short getshort( const _image *im)
 {
   byte buf[2];
   ImageIO_read( im, buf, (size_t) 2);
-  return (buf[0]<<8)+(buf[1]<<0);
+  return (unsigned short)((buf[0]<<8)+(buf[1]<<0));
 }
 
 /*****************************************************/
@@ -229,9 +229,9 @@ CGAL_INLINE_FUNCTION
 int readIrisImage( const char *, _image *im ) {
   byte   *rawdata, *rptr;
   byte   *pic824,  *bptr, *iptr;
-  int     i, j, size;
+  std::size_t     i, j, size;
   unsigned short imagic, type;
-  int xsize, ysize, zsize;
+  unsigned int xsize, ysize, zsize;
 
 
   /* read header information from file */
@@ -277,10 +277,10 @@ int readIrisImage( const char *, _image *im ) {
       if (!pic824) exit(-1);
       
       /* copy plane 3 from rawdata into pic824, inverting pic vertically */
-      for (i = 0, bptr = pic824; i < (int) ysize; i++) 
+      for (i = 0, bptr = pic824; i < ysize; i++)
 	{
 	  rptr = rawdata + 3 + ((ysize - 1) - i) * (xsize * 4);
-	  for (j = 0; j < (int) xsize; j++, bptr++, rptr += 4)
+	  for (j = 0; j < xsize; j++, bptr++, rptr += 4)
 	    *bptr = *rptr;
 	}
       
@@ -311,11 +311,11 @@ int readIrisImage( const char *, _image *im ) {
       exit(1);
     
     /* copy plane 3 from rawdata into pic824, inverting pic vertically */
-    for (i = 0, bptr = pic824; i<(int) ysize; i++) 
+    for (i = 0, bptr = pic824; i< ysize; i++)
       {
 	rptr = rawdata + ((ysize - 1) - i) * (xsize * 4);
 
-	for (j=0; j<(int) xsize; j++, rptr += 4) {
+	for (j=0; j< xsize; j++, rptr += 4) {
 	  *bptr++ = rptr[3];
 	  *bptr++ = rptr[2];
 	  *bptr++ = rptr[1];

--- a/CGAL_ImageIO/src/CGAL_ImageIO/pnm_impl.h
+++ b/CGAL_ImageIO/src/CGAL_ImageIO/pnm_impl.h
@@ -565,9 +565,9 @@ int writePgmImage(char *name,_image *im  )
   ImageIO_write( im, string, strlen( string ) );
 
   if ( im->dataMode == DM_ASCII ) {
-    int i, j, n, size;
+    std::size_t i, j, n, size;
     char *str = (char*)ImageIO_alloc( _LGTH_STRING_+1 );
-    size = im->xdim * im->ydim * im->zdim * im->vdim;
+    size = std::size_t(im->xdim) * im->ydim * im->zdim * im->vdim;
     n = ( im->xdim < 16 ) ? im->xdim : 16;
     i = 0;
     switch( im->wdim ) {

--- a/Geomview/include/CGAL/IO/Geomview_stream_impl.h
+++ b/Geomview/include/CGAL/IO/Geomview_stream_impl.h
@@ -297,9 +297,9 @@ CGAL_INLINE_FUNCTION
 Geomview_stream&
 Geomview_stream::operator<<(double d)
 {
-    float f = d;
+    float f = float(d);
     if (get_binary_mode()) {
-        float num = d;
+        float num = float(d);
         I_swap_to_big_endian(num);
         std::size_t retwrite= ::write(out, (char*)&num, sizeof(num));
         (void)retwrite;

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -343,11 +343,11 @@ endif()
 #   CGAL-4.6   : 11.0.0 (int->size_t in CGAL_ImageIO)
 #   CGAL-4.7   : 11.0.1 (Nothing different in CGAL compiled libraries.)
 #   CGAL-4.8   : 11.0.2 (Nothing different in CGAL compiled libraries.)
-#   CGAL-4.9   : 11.0.3 (Nothing different in CGAL compiled libraries.)
+#   CGAL-4.9   : 12.0.0 (Change the API/ABI in CGAL_ImageIO, but issue with 4GB images.)
 # ¹) According to http://upstream-tracker.org/versions/cgal.html
 
-set( CGAL_SONAME_VERSION "11" )
-set( CGAL_SOVERSION      "11.0.3" )
+set( CGAL_SONAME_VERSION "12" )
+set( CGAL_SOVERSION      "12.0.0" )
 
 message( STATUS "CGAL_SONAME_VERSION=${CGAL_SONAME_VERSION}" )
 message( STATUS "CGAL_SOVERSION     =${CGAL_SOVERSION}" )

--- a/Kinetic_data_structures/include/CGAL/Polynomial/internal/Turkowski_numeric_solvers_impl.h
+++ b/Kinetic_data_structures/include/CGAL/Polynomial/internal/Turkowski_numeric_solvers_impl.h
@@ -150,8 +150,8 @@ FindPolynomialRoots(
   int number_of_ITERATE=0;
   int number_of_INIT=0;
   CGAL_precondition(static_cast<unsigned int>(fig) < MAXN);
-  int i;
-  int j;
+  long i;
+  long j;
   FLOAT h[MAXN + 3], b[MAXN + 3], c[MAXN + 3], d[MAXN + 3], e[MAXN + 3];
   /* [-2 : n] */
   FLOAT K, ps, qs, pt, qt, s, rev, r= std::numeric_limits<double>::infinity();
@@ -200,7 +200,7 @@ FindPolynomialRoots(
   for (j = n; j >= 0; j--)                      /* Find geometric mean of coeff's */
     if (h[2 + j] != 0.0)
       s += std::log( ::CGAL::abs(h[2 + j]));
-  s = std::exp(s / (n + 1));
+  s = std::exp(s / double(n + 1));
 
   for (j = n; j >= 0; j--)                      /* Normalize coeff's by mean */
     h[2 + j] /= s;
@@ -413,8 +413,8 @@ void Turkowski_polynomial_compute_roots(const double *begin, const double *end,
   case 3:
     {
       double rd[3];
-      int numr= FindCubicRoots(begin, rd);
-      for (int i=numr-1; i>=0; --i) {
+      long numr= FindCubicRoots(begin, rd);
+      for (long i=numr-1; i>=0; --i) {
 	if (rd[i] >= lb && rd[i] < ub) roots.push_back(rd[i]);
       }
       std::sort(roots.begin(), roots.end(), std::greater<double>());
@@ -446,9 +446,9 @@ void Turkowski_polynomial_compute_cleaned_roots(const double *begin, const doubl
   case 3:
     {
       double rd[3];
-      int numr= FindCubicRoots(begin, rd);
+      long numr= FindCubicRoots(begin, rd);
       double last=-std::numeric_limits<double>::infinity();
-      for (int i=numr-1; i>=0; --i) {
+      for (long i=numr-1; i>=0; --i) {
 	if (rd[i]< ub && rd[i] >= lb) roots.push_back(rd[i]);
 	if (rd[i] < lb && rd[i] > last){
 	  last=rd[i];

--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -68,6 +68,7 @@ namespace CGAL {
 
           using CGAL::cpp11::array;
           using CGAL::cpp11::tuple;
+          using CGAL::cpp11::get;
 
           typedef array<int, 3> Pixel;
 

--- a/Number_types/include/CGAL/GMP/Gmpfr_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfr_type.h
@@ -1088,7 +1088,7 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
         if(neg_mant)
                 mant=-mant;
 
-        is.putback(c);
+        is.putback(static_cast<std::istream::char_type>(c));
         internal::eat_white_space(is);
 
         switch(c=is.get()){
@@ -1117,7 +1117,7 @@ std::istream& operator>>(std::istream& is,Gmpfr &f){
         internal::eat_white_space(is);
         while((c=is.get())>='0'&&c<='9')
                 exp=10*exp+(c-'0');
-        is.putback(c);
+        is.putback(static_cast<std::istream::char_type>(c));
         if(exp.bit_size()>8*sizeof(mpfr_exp_t))
                 mpfr_set_erangeflag();
 

--- a/Number_types/include/CGAL/GMP/Gmpz_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpz_type.h
@@ -307,7 +307,7 @@ gmpz_new_read(std::istream &is, Gmpz &z)
       c=is.peek();
   }
 
-  std::istream::char_type cc= c;
+  std::istream::char_type cc= static_cast<std::istream::char_type>(c);
 
   if (c== std::istream::traits_type::eof() ||
       !std::isdigit(cc, std::locale::classic() ) ){
@@ -342,7 +342,7 @@ gmpz_new_read(std::istream &is, Gmpz &z)
       if (c== std::istream::traits_type::eof()) {
         break;
       }
-      cc=c;
+      cc=static_cast<std::istream::char_type>(c);
       if  ( !std::isdigit(cc, std::locale::classic() )) {
         break;
       }

--- a/Number_types/include/CGAL/GMP/Gmpzf_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpzf_type.h
@@ -401,7 +401,7 @@ double Gmpzf::to_double() const
 {
   Exponent k;                                 // exponent
   double l = mpz_get_d_2exp (&k, man());      // mantissa in [0.5,1)
-  return std::ldexp(l, k+exp());
+  return std::ldexp(l, static_cast<int>(k+exp()));
 }
 
 
@@ -447,7 +447,7 @@ std::pair<double, double> Gmpzf::to_interval() const
   std::pair<std::pair<double, double>, long> lue = to_interval_exp();
   double l = lue.first.first;
   double u = lue.first.second;
-  long k = lue.second;
+  int k = static_cast<int>(lue.second);
   return std::pair<double,double> (std::ldexp (l, k), std::ldexp (u, k));
 }
 

--- a/Number_types/include/CGAL/Gmpzf.h
+++ b/Number_types/include/CGAL/Gmpzf.h
@@ -151,7 +151,8 @@ public:
         double operator()(const Quotient<Gmpzf>& q) const {
 	  std::pair<double, long> n = q.numerator().to_double_exp();
 	  std::pair<double, long> d = q.denominator().to_double_exp();
-	  double scale = std::ldexp(1.0, n.second - d.second);
+	  double scale = std::ldexp(1.0,
+                                    static_cast<int>(n.second - d.second));
 	  return (n.first / d.first) * scale;
 	}
     };
@@ -165,10 +166,10 @@ public:
 	  std::pair<std::pair<double, double>, long> d =
 	    q.denominator().to_interval_exp();
 
-	  CGAL_assertion_msg(CGAL::abs(1.0*n.second - d.second) < (1<<30)*2.0,
+	  CGAL_assertion_msg(CGAL::abs((double)(n.second - d.second)) < (1<<30)*2.0,
                      "Exponent overflow in Quotient<MP_Float> to_interval");
 	  return ldexp(Interval_nt<>(n.first) / Interval_nt<>(d.first),
-               n.second - d.second).pair();
+                       static_cast<int>(n.second - d.second)).pair();
         }
     };
 };

--- a/Number_types/include/CGAL/Gmpzf.h
+++ b/Number_types/include/CGAL/Gmpzf.h
@@ -166,7 +166,7 @@ public:
 	  std::pair<std::pair<double, double>, long> d =
 	    q.denominator().to_interval_exp();
 
-	  CGAL_assertion_msg(CGAL::abs((double)(n.second - d.second)) < (1<<30)*2.0,
+	  CGAL_assertion_msg(CGAL::abs(double(n.second) - double(d.second)) < (1<<30)*2.0,
                      "Exponent overflow in Quotient<MP_Float> to_interval");
 	  return ldexp(Interval_nt<>(n.first) / Interval_nt<>(d.first),
                        static_cast<int>(n.second - d.second)).pair();

--- a/Number_types/include/CGAL/MP_Float.h
+++ b/Number_types/include/CGAL/MP_Float.h
@@ -141,7 +141,7 @@ private:
     iterator i = v.begin();
     for (++i; *i == 0; ++i)
       ;
-    exp += i-v.begin();
+    exp += static_cast<exponent_type>(i-v.begin());
     v.erase(v.begin(), i);
   }
 
@@ -164,8 +164,8 @@ public:
    
     //Note: For Integer type, if the destination type is signed, the value is unchanged 
     //if it can be represented in the destination type)
-    low=static_cast<limb>(l & mask); //extract low bits from l 
-    high = (l - low) >> sizeof_limb; //extract high bits from l
+    low = static_cast<limb>(l & mask); //extract low bits from l
+    high= static_cast<limb>((l - low) >> sizeof_limb); //extract high bits from l
     
     CGAL_postcondition ( l == low + ( static_cast<limb2>(high) << sizeof_limb ) );
   }
@@ -232,7 +232,7 @@ public:
 
   exponent_type max_exp() const
   {
-    return v.size() + exp;
+    return exponent_type(v.size()) + exp;
   }
 
   exponent_type min_exp() const
@@ -305,7 +305,7 @@ public:
   // a value with an exponent close to 0.
   exponent_type find_scale() const
   {
-    return exp + v.size();
+    return exp + exponent_type(v.size());
   }
 
   // Rescale the value by some factor (in limbs).  (substract the exponent)
@@ -320,7 +320,7 @@ public:
   lsb(limb l)
   {
     unsigned short nb = 0;
-    for (; (l&1)==0; ++nb, l>>=1)
+    for (; (l&1)==0; ++nb, l=(limb)(l>>1) )
       ;
     return nb;
   }
@@ -350,7 +350,7 @@ public:
     CGAL_assertion(r.v.begin() != r.v.end());
     unsigned short nb = lsb(r.v[0]);
     r.v.clear();
-    r.v.push_back(1<<nb);
+    r.v.push_back((limb)(1<<nb));
     return (sign() > 0) ? r : -r;
   }
 

--- a/Number_types/include/CGAL/MP_Float_impl.h
+++ b/Number_types/include/CGAL/MP_Float_impl.h
@@ -46,7 +46,7 @@ inline
 int my_nearbyint(const T& d)
 {
   int z = int(d);
-  T frac = d - z;
+  T frac = d - T(z);
 
   CGAL_assertion(CGAL::abs(frac) < T(1.0));
 
@@ -95,9 +95,9 @@ void MP_Float::construct_from_builtin_fp_type(T d)
     T orig = d, sum = 0;
     while (true) {
       int r = my_nearbyint(d);
-      if (d-r >= T( INTERN_MP_FLOAT::base/2-1)/( INTERN_MP_FLOAT::base-1))
+      if (d-double(r) >= T( INTERN_MP_FLOAT::base/2-1)/( INTERN_MP_FLOAT::base-1))
         ++r;
-      v.push_back(r);
+      v.push_back(limb(r));
       // We used to do simply "d -= v.back();", but when the most significant
       // limb is 1 and the second is -32768, then it can happen that
       // |d - v.back()| > |d|, hence a bit of precision can be lost.

--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -274,6 +274,8 @@ struct Mpzf {
 #endif
   int size; /* Number of relevant limbs in data_. */
   int exp; /* The number is data_ (an integer) * 2 ^ (64 * exp). */
+  typedef int Exponent_type;
+  typedef int Size_type;
 
   struct allocate{};
   struct noalloc{};
@@ -471,8 +473,8 @@ struct Mpzf {
     init_from_mpz_t(z.mpz());
   }
   void init_from_mpz_t(mpz_t const z){
-    exp=mpz_scan1(z,0)/GMP_NUMB_BITS;
-    size=mpz_size(z)-exp;
+    exp=Exponent_type(mpz_scan1(z,0)/GMP_NUMB_BITS);
+    size=Size_type(mpz_size(z)-exp);
     init(size);
     mpn_copyi(data(),z->_mp_d+exp,size);
   }
@@ -800,9 +802,9 @@ struct Mpzf {
     else { mpn_copyi(res.data(), b.data(), bsize); }
     res.exp = 0; // Pick b.exp? or the average? 0 helps return 1 more often.
     if (asize < bsize)
-      res.size = mpn_gcd(res.data(), res.data(), bsize, tmp.data(), asize);
+      res.size = Size_type(mpn_gcd(res.data(), res.data(), bsize, tmp.data(), asize));
     else
-      res.size = mpn_gcd(res.data(), tmp.data(), asize, res.data(), bsize);
+      res.size = Size_type(mpn_gcd(res.data(), tmp.data(), asize, res.data(), bsize));
     if(rtz!=0) {
       mp_limb_t c = mpn_lshift(res.data(), res.data(), res.size, rtz);
       if(c) { res.data()[res.size]=c; ++res.size; }
@@ -884,7 +886,7 @@ struct Mpzf {
     if(size==0) return 0;
     int asize = std::abs(size);
     mp_limb_t top = data()[asize-1];
-    double dtop = top;
+    double dtop = (double)top;
     if(top >= (1LL<<53) || asize == 1) /* ok */ ;
     else { dtop += (double)data()[asize-2] * ldexp(1.,-GMP_NUMB_BITS); }
     return ldexp( (size<0) ? -dtop : dtop, (asize-1+exp) * GMP_NUMB_BITS);
@@ -903,13 +905,13 @@ struct Mpzf {
 	e += (11 - lz);
 	x >>= (11 - lz);
       }
-      dl = x;
-      dh = x + 1;
+      dl = double(x);
+      dh = double(x + 1);
       // Check for the few cases where dh=x works (asize==1 and the evicted
       // bits from x were 0s)
     }
     else if (asize == 1) {
-      dl = dh = x; // conversion is exact
+      dl = dh = double(x); // conversion is exact
     }
     else {
       mp_limb_t y = data()[asize-2];
@@ -917,8 +919,8 @@ struct Mpzf {
       x <<= (lz - 11);
       y >>= (75 - lz);
       x |= y;
-      dl = x;
-      dh = x + 1;
+      dl = double(x);
+      dh = double(x + 1);
       // Check for the few cases where dh=x works (asize==2 and the evicted
       // bits from y were 0s)
     }

--- a/Number_types/include/CGAL/int.h
+++ b/Number_types/include/CGAL/int.h
@@ -230,8 +230,9 @@ template<> class Algebraic_structure_traits< short int >
         void operator()( const Type& x,
                          const Type& y,
                          Type& q, Type& r) const {
-          q = x / y;
-          r = x % y;
+          q = Type(x / y);
+          r = Type(x % y);
+          CGAL_assertion(x == q * y + r);
           return;
         }
     };
@@ -242,8 +243,8 @@ template<> class Algebraic_structure_traits< short int >
                                 Type > {
       public:
         Type operator()( const Type& x,
-                                        const Type& y) const {
-          return x / y;
+                         const Type& y) const {
+          return Type(x / y);
         };
     };
 
@@ -253,8 +254,8 @@ template<> class Algebraic_structure_traits< short int >
                                 Type > {
       public:
         Type operator()( const Type& x,
-                                        const Type& y) const {
-          return x % y;
+                         const Type& y) const {
+          return Type(x % y);
         };
     };
 

--- a/Spatial_sorting/include/CGAL/Multiscale_sort.h
+++ b/Spatial_sorting/include/CGAL/Multiscale_sort.h
@@ -46,7 +46,7 @@ public:
 	typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
         RandomAccessIterator middle = begin;
         if (end - begin >= _threshold) {
-            middle = begin + difference_type ((end - begin) * _ratio);
+            middle = begin + difference_type (double(end - begin) * _ratio);
             this->operator() (begin, middle);
         }
         _sort (middle, end);

--- a/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
+++ b/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
@@ -393,13 +393,15 @@ std::istream& operator>>( std::istream& in, File_header_OFF& h) {
         // facets and we do not know the genus of the surface.
         // So we add 12 and a factor of 5 percent.
         if (    h.size_of_halfedges() == 0
-             || h.size_of_halfedges() > (h.size_of_vertices()
+             || h.size_of_halfedges() > double(h.size_of_vertices()
                 + h.size_of_facets() - 2 + 12) * 2.1
              || h.size_of_halfedges() < (h.size_of_vertices()
                 + h.size_of_facets() - 2) * 2
         )
-            h.set_halfedges( int((h.size_of_vertices() +
-                                  h.size_of_facets() - 2 + 12) * 2.1));
+            h.set_halfedges( int( double(h.size_of_vertices() +
+                                         h.size_of_facets() - 2 + 12) * 2.1
+                                 )
+                            );
     }
     h.set_off_header( h.off());
     return in;

--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -371,7 +371,7 @@ void eat_white_space(std::istream &is)
     if (c== std::istream::traits_type::eof())
       return;
     else {
-      std::istream::char_type cc= c;
+      std::istream::char_type cc= static_cast<std::istream::char_type>(c);
       if ( std::isspace(cc, std::locale::classic()) ) {
         is.get();
         // since peek succeeded, this should too
@@ -387,9 +387,9 @@ void eat_white_space(std::istream &is)
   inline
   bool is_space (const std::istream& /*is*/, std::istream::int_type c)
   {
-    std::istream::char_type cc= c;
     return (c == std::istream::traits_type::eof()) ||
-           std::isspace(cc, std::locale::classic() );
+      std::isspace(static_cast<std::istream::char_type>(c),
+                   std::locale::classic() );
   }
 
   inline
@@ -401,8 +401,9 @@ void eat_white_space(std::istream &is)
   inline
   bool is_digit (const std::istream& /*is*/, std::istream::int_type c)
   {
-    std::istream::char_type cc= c;
-    return std::isdigit(cc, std::locale::classic() );
+    CGAL_assertion(c != std::istream::traits_type::eof());
+    return std::isdigit(static_cast<std::istream::char_type>(c),
+                        std::locale::classic() );
   }
 
   inline std::istream::int_type peek(std::istream& is)


### PR DESCRIPTION
I have used the warning flag `-Wconversion` from g++ (see [doc][d]) to compile `Mesh_3/test/Mesh_3/`.

[d]: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

That triggered *a lot* of warnings. A few of those warnings were actual bugs, most of them related to the fact that `int` is 32bits on Windows, even on a 64bits machine.

I have decided to fix all bugs I have detected, and "fix" all other `-Wconversion` warnings by adding the explicit casts when needed. The objective is to make `-Wconversion` a useful tool to detected issues.

The flaw in that approach is that I may have "quieted" warnings that actually pointed to bugs. That is why this PR needs a careful review.

- @mglisse Can you please review the diffs in `Number_types`, in commit 8755b6f514647eeb7608768aaef13f46a01e1592?
- For `CGAL_ImageIO`, I am confident of my patch, but will run more tests anyway.
- The warnings in `Stream_support` were harmless: 
73e2ccae6421dacd1081995dd4058a73e2da6b43 and ff63d8eb26278a611afad4134cee301bf137a983. It is important to understand that `char_type` and `int_type` differ only because in case of `EOF`, a [`istream::get()`](http://en.cppreference.com/w/cpp/io/basic_istream/get) will return a `Traits::eof()` that cannot be encoded in `char_type` (on purpose).
- Please also review 4c97ab6c96a5fda0f258d8d44dcdf4690bcd2e8b, in case I am wrong.

Cc: @CGAL/geometryfactory @mglisse (I would Cc Sylvain Pion if I could... and actually I can! @sylvainpion).

A final note: I would have preferred to include the fixes for 32bits issues of CGAL_ImageIO in CGAL-4.8.1, but I cannot because that would bump the SONAME of the library, and that is a bad idea for a bug-fix release.
