### PR TITLE
PMP : deal with uninitialized face_index map in border_halfedges

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -121,6 +121,7 @@ the  value type
     typename boost::property_map<PolygonMesh, CGAL::face_index_t>::type>::value_type
 \endcode
 \b Default value is \code boost::get(CGAL::face_index, pmesh)\endcode
+If this internal property map exists, its values should be initialized
 \cgalNPEnd
 
 \cgalNPBegin{vertex_index_map} \anchor PMP_vertex_index_map

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -24,6 +24,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/foreach.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/range/size.hpp>
 
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -24,7 +24,6 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/foreach.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/range/size.hpp>
 
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
@@ -160,7 +159,7 @@ namespace Polygon_mesh_processing {
     typedef typename boost::property_map<typename internal::Dummy_PM,
                                               CGAL::face_index_t>::type   Unset_FIMap;
 
-    if (boost::is_same<FIMap, Unset_FIMap>::value || boost::size(faces) == 1)
+    if (boost::is_same<FIMap, Unset_FIMap>::value || faces.size() == 1)
     {
       //face index map is not given in named parameters, nor as an internal property map
       return internal::border_halfedges_impl(faces, out, pmesh);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -159,14 +159,26 @@ namespace Polygon_mesh_processing {
     typedef typename boost::property_map<typename internal::Dummy_PM,
                                               CGAL::face_index_t>::type   Unset_FIMap;
 
-    if (boost::is_same<FIMap, Unset_FIMap>::value)
+    if (boost::is_same<FIMap, Unset_FIMap>::value || boost::size(faces) == 1)
     {
       //face index map is not given in named parameters, nor as an internal property map
       return internal::border_halfedges_impl(faces, out, pmesh);
     }
+
     //face index map given as a named parameter, or as an internal property map
     FIMap fim = choose_param(get_param(np, face_index),
                              get(CGAL::face_index, pmesh));
+
+    //make a minimal check that it's properly initialized :
+    //if the 2 first faces have the same id, we know the property map is not initialized
+    typename boost::range_iterator<const FaceRange>::type it = boost::const_begin(faces);
+    if (get(fim, *it++) == get(fim, *it))
+    {
+      std::cerr << "WARNING : the internal property map for CGAL::face_index_t" << std::endl
+                << "          is not properly initialized." << std::endl
+                << "          Initialize it before calling border_halfedges()" << std::endl;
+    }
+
     return internal::border_halfedges_impl(faces, fim, out, pmesh);
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -171,12 +171,16 @@ namespace Polygon_mesh_processing {
 
     //make a minimal check that it's properly initialized :
     //if the 2 first faces have the same id, we know the property map is not initialized
-    typename boost::range_iterator<const FaceRange>::type it = boost::const_begin(faces);
-    if (get(fim, *it++) == get(fim, *it))
+    if (boost::is_same<typename GetFaceIndexMap<PM, NamedParameters>::Is_internal_map,
+                       boost::true_type>::value)
     {
-      std::cerr << "WARNING : the internal property map for CGAL::face_index_t" << std::endl
-                << "          is not properly initialized." << std::endl
-                << "          Initialize it before calling border_halfedges()" << std::endl;
+      typename boost::range_iterator<const FaceRange>::type it = boost::const_begin(faces);
+      if (get(fim, *it++) == get(fim, *it))
+      {
+        std::cerr << "WARNING : the internal property map for CGAL::face_index_t" << std::endl
+                  << "          is not properly initialized." << std::endl
+                  << "          Initialize it before calling border_halfedges()" << std::endl;
+      }
     }
 
     return internal::border_halfedges_impl(faces, fim, out, pmesh);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -120,7 +120,9 @@ namespace Polygon_mesh_processing {
   * i.e. the collected halfedges are
   * the ones that belong to the input faces.
   *
-  * @tparam PolygonMesh model of `HalfedgeGraph`
+  * @tparam PolygonMesh model of `HalfedgeGraph`. If `PolygonMesh
+  *  `has an internal property map
+  *  for `CGAL::face_index_t`, then it should be initialized
   * @tparam FaceRange range of
        `boost::graph_traits<PolygonMesh>::%face_descriptor`, model of `Range`.
         Its iterator type is `InputIterator`.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -86,6 +86,7 @@ public:
     NamedParameters,
     DefaultMap
   > ::type  type;
+  typedef typename boost::is_same<type, DefaultMap>::type Is_internal_map;
 };
 
 template<typename PolygonMesh, typename NamedParameters>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -42,6 +42,8 @@ namespace Polygon_mesh_processing {
 *         The descriptor types `boost::graph_traits<PolygonMesh>::%face_descriptor`
 *         and `boost::graph_traits<PolygonMesh>::%halfedge_descriptor` must be
 *         models of `Hashable`.
+*         If `PolygonMesh `has an internal property map for `CGAL::face_index_t`,
+*         then it should be initialized
 * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
           model of `Range`. Its iterator type is `InputIterator`.
 * @tparam NamedParameters a sequence of \ref namedparameters


### PR DESCRIPTION
In `PMP::border_halfedges()` (and as a matter of facts `PMP::isotropic_remeshing()`,
one can provide a `face_index_map` as named parameter.

If it's not provided by the user, the internal `face_index` map (if it exists) is used.
It can happen that this internal property map exists, but is not initialized. It is for example the case for a `Polyhedron_with_items_3` for which the user does not set the face ids.

This PR
- documents the fact that the internal face index map, if it exists, should be initialized
- adds a warning (via `std::cerr`) before the face index map is used, and so before the crash happens, to help the user find the problem

See e.g. the issue #1017 
