### PR TITLE
Polyhedron demo: fix select one point

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
@@ -189,10 +189,10 @@ public Q_SLOTS:
         scene->itemChanged(point_item);
       }
     }
-    if(!found && !generated_points.empty())
+    if(!found && !generated_points.empty()) {
       generated_points.last()->invalidateOpenGLBuffers();
       scene->itemChanged(generated_points.last());
-
+    }
   }
 
   void on_Sample_random_points_from_bbox() {

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -150,7 +150,7 @@ public:
       }
     else if (!currently && selected)
       {
-        std::swap (*it, *first);
+        std::swap (*it, *(-- first));
         ++ m_nb_selected;
       }
   }


### PR DESCRIPTION
There was a bug in the selection mechanism of the point set item that created a memory corruption (`std::swap` applied on `end()`), spotted in issue https://github.com/CGAL/cgal/issues/1049.

This PR also fixes another bug if no point was selected (missing brackets).