### PR TITLE
Bilateral smoothing: use put() operator instead of using ref of get()

### DIFF
--- a/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
@@ -570,15 +570,18 @@ bilateral_smooth_point_set(
    for(unsigned int i = 0 ; it != beyond; ++it, ++i)
    {
 #ifdef CGAL_USE_PROPERTY_MAPS_API_V1
-     Point& p = get(point_pmap, it);
-     Vector& n = get(normal_pmap, it);
+     const Point& p = get(point_pmap, it);
 #else
-     Point& p = get(point_pmap, *it);
-     Vector& n = get(normal_pmap, *it);
+     const Point& p = get(point_pmap, *it);
 #endif
      sum_move_error += CGAL::squared_distance(p, update_pwns[i].position());
-     p = update_pwns[i].position();
-     n = update_pwns[i].normal();
+#ifdef CGAL_USE_PROPERTY_MAPS_API_V1
+     put (point_pmap, it, update_pwns[i].position());
+     put (normal_pmap, it, update_pwns[i].normal());
+#else
+     put (point_pmap, *it, update_pwns[i].position());
+     put (normal_pmap, *it, update_pwns[i].normal());
+#endif
    }
      
    return sum_move_error / nb_points;

--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -518,9 +518,9 @@ wlop_simplify_and_regularize_point_set(
   for (it = first_original_iter, i=0 ; it != beyond ; ++it, ++i)
   {
 #ifdef CGAL_USE_PROPERTY_MAPS_API_V1
-      Point& p0 = get(point_pmap, it);
+      const Point& p0 = get(point_pmap, it);
 #else
-      Point& p0 = get(point_pmap, *it);
+      const Point& p0 = get(point_pmap, *it);
 #endif 
     
     original_treeElements.push_back(Kd_tree_element(p0, i));


### PR DESCRIPTION
In the _bilateral smoothing_ algorithm, the points and normals are modified by getting a non-const reference through the `get()` operator. Although this is not strictly forbidden by the [Boost API](http://www.boost.org/doc/libs/1_60_0/libs/property_map/doc/ReadablePropertyMap.html), this operation is usually done using the `put()` operator (this is the case in all the other algorithms of _Point set processing_).

More specifically, some property maps might not be able to provide a `get()` operator that returns a non-const reference but still provide a `put()` operator: this PR makes _bilateral smoothing_ compatible with such property maps.