### PR TITLE
Adding less-than operator (<) to Point_d

### DIFF
--- a/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Point_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Point_d.h
@@ -3,243 +3,252 @@ namespace CGAL {
 /*!
 \ingroup PkgKernelDKernelObjs
 
-An instance of data type `Point_d<Kernel>` is a point of Euclidean 
-space in dimension \f$ d\f$. A point \f$ p = (p_0,\ldots,p_{ d - 1 })\f$ in 
-\f$ d\f$-dimensional space can be represented by homogeneous coordinates 
-\f$ (h_0,h_1,\ldots,h_d)\f$ of number type `RT` such that \f$ p_i = 
-h_i/h_d\f$, which is of type `FT`. The homogenizing coordinate \f$ h_d\f$ 
-is positive. 
+An instance of data type `Point_d<Kernel>` is a point of Euclidean
+space in dimension \f$ d\f$. A point \f$ p = (p_0,\ldots,p_{ d - 1 })\f$ in
+\f$ d\f$-dimensional space can be represented by homogeneous coordinates
+\f$ (h_0,h_1,\ldots,h_d)\f$ of number type `RT` such that \f$ p_i =
+h_i/h_d\f$, which is of type `FT`. The homogenizing coordinate \f$ h_d\f$
+is positive.
 
-We call \f$ p_i\f$, \f$ 0 \leq i < d\f$ the \f$ i\f$-th %Cartesian coordinate and 
-\f$ h_i\f$, \f$ 0 \le i \le d\f$, the \f$ i\f$-th homogeneous coordinate. We call \f$ d\f$ 
-the dimension of the point. 
+We call \f$ p_i\f$, \f$ 0 \leq i < d\f$ the \f$ i\f$-th %Cartesian coordinate and
+\f$ h_i\f$, \f$ 0 \le i \le d\f$, the \f$ i\f$-th homogeneous coordinate. We call \f$ d\f$
+the dimension of the point.
 
 \cgalHeading{Downward compatibility}
 
-We provide operations of the lower 
-dimensional interface `x()`, `y()`, `z()`, `hx()`, 
-`hy()`, `hz()`, `hw()`. 
+We provide operations of the lower
+dimensional interface `x()`, `y()`, `z()`, `hx()`,
+`hy()`, `hz()`, `hw()`.
 
 \cgalHeading{Implementation}
 
-Points are implemented by arrays of `RT` items. All operations 
-like creation, initialization, tests, point - vector arithmetic, input 
-and output on a point \f$ p\f$ take time \f$ O(p.dimension())\f$. 
-`dimension()`, coordinate access and conversions take constant 
-time. The space requirement for points is \f$ O(p.dimension())\f$. 
+Points are implemented by arrays of `RT` items. All operations
+like creation, initialization, tests, point - vector arithmetic, input
+and output on a point \f$ p\f$ take time \f$ O(p.dimension())\f$.
+`dimension()`, coordinate access and conversions take constant
+time. The space requirement for points is \f$ O(p.dimension())\f$.
 
 */
 template< typename Kernel >
 class Point_d {
 public:
 
-/// \name Types 
+/// \name Types
 /// @{
 
 /*!
-the linear algebra layer. 
-*/ 
-typedef unspecified_type LA; 
+the linear algebra layer.
+*/
+typedef unspecified_type LA;
 
 /*!
-a read-only iterator for the 
-%Cartesian coordinates. 
-*/ 
-typedef unspecified_type Cartesian_const_iterator; 
+a read-only iterator for the
+%Cartesian coordinates.
+*/
+typedef unspecified_type Cartesian_const_iterator;
 
 /*!
-a read-only iterator for the 
-homogeneous coordinates. 
-*/ 
-typedef unspecified_type Homogeneous_const_iterator; 
+a read-only iterator for the
+homogeneous coordinates.
+*/
+typedef unspecified_type Homogeneous_const_iterator;
 
-/// @} 
+/// @}
 
-/// \name Creation 
+/// \name Creation
 /// @{
 
 /*!
-introduces a variable `p` of 
-type `Point_d<Kernel>`. 
-*/ 
-Point_d<Kernel>(); 
+introduces a variable `p` of
+type `Point_d<Kernel>`.
+*/
+Point_d<Kernel>();
 
 /*!
-introduces a variable 
-`p` of type `Point_d<Kernel>` in \f$ d\f$-dimensional space, 
-initialized to the origin. 
-*/ 
-Point_d<Kernel>(int d, Origin); 
+introduces a variable
+`p` of type `Point_d<Kernel>` in \f$ d\f$-dimensional space,
+initialized to the origin.
+*/
+Point_d<Kernel>(int d, Origin);
 
 /*!
-introduces a variable 
-`p` of type `Point_d<Kernel>` in dimension `d`. If `size [first,last) == d` this creates a point with %Cartesian coordinates 
-`set [first,last)`. If `size [first,last) == d+1` the range 
-specifies the homogeneous coordinates 
+introduces a variable
+`p` of type `Point_d<Kernel>` in dimension `d`. If `size [first,last) == d` this creates a point with %Cartesian coordinates
+`set [first,last)`. If `size [first,last) == d+1` the range
+specifies the homogeneous coordinates
 \f$ H = set [first,last) = (\pm h_0, \pm h_1, \ldots, \pm h_d)\f$
 where the sign chosen is the sign of \f$ h_d\f$.
 
-\pre `d` is nonnegative, `[first,last)` has `d` or `d+1` elements where the last has to be non-zero. 
+\pre `d` is nonnegative, `[first,last)` has `d` or `d+1` elements where the last has to be non-zero.
 \tparam InputIterator has `RT` as value type.
-*/ 
-template <class InputIterator> Point_d<Kernel>(int d, 
-InputIterator first, InputIterator last); 
+*/
+template <class InputIterator> Point_d<Kernel>(int d,
+InputIterator first, InputIterator last);
 
 /*!
-introduces a 
-variable `p` of type `Point_d<Kernel>` in dimension `d` 
-initialized to the point with homogeneous coordinates as defined by 
-`H = set [first,last)` and `D`: \f$ (\pm H[0], 
-\pm H[1], \ldots, \pm H[d-1], \pm D)\f$. 
+introduces a
+variable `p` of type `Point_d<Kernel>` in dimension `d`
+initialized to the point with homogeneous coordinates as defined by
+`H = set [first,last)` and `D`: \f$ (\pm H[0],
+\pm H[1], \ldots, \pm H[d-1], \pm D)\f$.
 The sign  chosen is the sign of \f$ D\f$.
 
-\pre `D` is non-zero, the iterator range defines a \f$ d\f$-tuple of `RT`. 
+\pre `D` is non-zero, the iterator range defines a \f$ d\f$-tuple of `RT`.
 \tparam InputIterator has `RT` as value type.
-*/ 
-template <class InputIterator> Point_d<Kernel>(int d, 
-InputIterator first, InputIterator last, RT D); 
+*/
+template <class InputIterator> Point_d<Kernel>(int d,
+InputIterator first, InputIterator last, RT D);
 
 /*!
-introduces a variable 
-`p` of type `Point_d<Kernel>` in \f$ 2\f$-dimensional space. 
-\pre \f$ w \neq0\f$. 
-*/ 
-Point_d<Kernel>(RT x, RT y, RT w = 1); 
+introduces a variable
+`p` of type `Point_d<Kernel>` in \f$ 2\f$-dimensional space.
+\pre \f$ w \neq0\f$.
+*/
+Point_d<Kernel>(RT x, RT y, RT w = 1);
 
 /*!
-introduces a 
-variable `p` of type `Point_d<Kernel>` in \f$ 3\f$-dimensional 
+introduces a
+variable `p` of type `Point_d<Kernel>` in \f$ 3\f$-dimensional
 space.
 
-\pre \f$ w \neq0\f$. 
-*/ 
-Point_d<Kernel>(RT x, RT y, RT z, RT w); 
+\pre \f$ w \neq0\f$.
+*/
+Point_d<Kernel>(RT x, RT y, RT z, RT w);
 
-/// @} 
+/// @}
 
-/// \name Operations 
+/// \name Operations
 /// @{
 
 /*!
-returns the dimension of `p`. 
+returns the dimension of `p`.
 
-*/ 
-int dimension() ; 
+*/
+int dimension() ;
 
 /*!
-returns the \f$ i\f$-th %Cartesian 
+returns the \f$ i\f$-th %Cartesian
 coordinate of `p`.
 
-\pre \f$ 0 \leq i < d\f$. 
-*/ 
-FT cartesian(int i) ; 
+\pre \f$ 0 \leq i < d\f$.
+*/
+FT cartesian(int i) ;
 
 /*!
-returns the \f$ i\f$-th %Cartesian 
+returns the \f$ i\f$-th %Cartesian
 coordinate of `p`.
 
-\pre \f$ 0 \leq i < d\f$. 
-*/ 
-FT operator[](int i) ; 
+\pre \f$ 0 \leq i < d\f$.
+*/
+FT operator[](int i) ;
 
 /*!
-returns the \f$ i\f$-th homogeneous 
+returns the \f$ i\f$-th homogeneous
 coordinate of `p`.
 
-\pre \f$ 0 \leq i \leq d\f$. 
-*/ 
-RT homogeneous(int i) ; 
+\pre \f$ 0 \leq i \leq d\f$.
+*/
+RT homogeneous(int i) ;
 
 /*!
-returns an 
-iterator pointing to the zeroth %Cartesian coordinate \f$ p_0\f$ of 
-`p`. 
-*/ 
-Cartesian_const_iterator cartesian_begin() ; 
+returns an
+iterator pointing to the zeroth %Cartesian coordinate \f$ p_0\f$ of
+`p`.
+*/
+Cartesian_const_iterator cartesian_begin() ;
 
 /*!
-returns an 
-iterator pointing beyond the last %Cartesian coordinate of `p`. 
+returns an
+iterator pointing beyond the last %Cartesian coordinate of `p`.
 
-*/ 
-Cartesian_const_iterator cartesian_end() ; 
-
-/*!
-returns 
-an iterator pointing to the zeroth homogeneous coordinate \f$ h_0\f$ of 
-`p`. 
-*/ 
-Homogeneous_const_iterator homogeneous_begin() ; 
+*/
+Cartesian_const_iterator cartesian_end() ;
 
 /*!
-returns an 
-iterator pointing beyond the last homogeneous coordinate of 
-`p`. 
-*/ 
-Homogeneous_const_iterator homogeneous_end() ; 
+returns
+an iterator pointing to the zeroth homogeneous coordinate \f$ h_0\f$ of
+`p`.
+*/
+Homogeneous_const_iterator homogeneous_begin() ;
 
 /*!
-returns \f$ t(p)\f$. 
-*/ 
-Point_d<Kernel> transform(const Aff_transformation_d<Kernel>& t) 
-; 
+returns an
+iterator pointing beyond the last homogeneous coordinate of
+`p`.
+*/
+Homogeneous_const_iterator homogeneous_end() ;
 
-/// @} 
+/*!
+returns \f$ t(p)\f$.
+*/
+Point_d<Kernel> transform(const Aff_transformation_d<Kernel>& t)
+;
 
-/// \name Arithmetic Operators, Tests and IO 
+/// @}
+
+/// \name Arithmetic Operators, Tests and IO
 /// @{
 
 /*!
-returns the 
-vector \f$ p-O\f$. 
-*/ 
-Vector_d<Kernel> operator-(const Origin& o) ; 
+returns the
+vector \f$ p-O\f$.
+*/
+Vector_d<Kernel> operator-(const Origin& o) ;
 
 /*!
-returns \f$ p - 
+returns \f$ p -
 q\f$.
 
-\pre `p.dimension() == q.dimension()`. 
-*/ 
-Vector_d<Kernel> operator-(const Point_d<Kernel>& q) ; 
+\pre `p.dimension() == q.dimension()`.
+*/
+Vector_d<Kernel> operator-(const Point_d<Kernel>& q) ;
 
 /*!
-returns \f$ p + 
+returns \f$ p +
 v\f$.
 
-\pre `p.dimension() == v.dimension()`. 
-*/ 
-Point_d<Kernel> operator+(const Vector_d<Kernel>& v) ; 
+\pre `p.dimension() == v.dimension()`.
+*/
+Point_d<Kernel> operator+(const Vector_d<Kernel>& v) ;
 
 /*!
-returns \f$ p - 
+returns \f$ p -
 v\f$.
 
-\pre `p.dimension() == v.dimension()`. 
-*/ 
-Point_d<Kernel> operator-(const Vector_d<Kernel>& v) ; 
+\pre `p.dimension() == v.dimension()`.
+*/
+Point_d<Kernel> operator-(const Vector_d<Kernel>& v) ;
 
 /*!
-adds `v` 
+adds `v`
 to `p`.
 
-\pre `p.dimension() == v.dimension()`. 
-*/ 
-Point_d<Kernel>& operator+=(const Vector_d<Kernel>& v); 
+\pre `p.dimension() == v.dimension()`.
+*/
+Point_d<Kernel>& operator+=(const Vector_d<Kernel>& v);
 
 /*!
-subtracts 
+subtracts
 `v` from `p`.
 
-\pre `p.dimension() == v.dimension()`. 
-*/ 
-Point_d<Kernel>& operator-=(const Vector_d<Kernel>& v); 
+\pre `p.dimension() == v.dimension()`.
+*/
+Point_d<Kernel>& operator-=(const Vector_d<Kernel>& v);
 
 /*!
-returns true if `p` is 
-the origin. 
-*/ 
-bool operator==(const Origin&) ; 
+returns true if `p` is
+the origin.
+*/
+bool operator==(const Origin&) ;
+
+/*!
+returns true iff `p` is lexicographically
+smaller than `q` with respect to %Cartesian
+lexicographic order of points.
+
+\pre `p.dimension() == q.dimension()`.
+*/
+bool operator<(const Point_d<Kernel>& q);
 
 /// @}
 

--- a/Kernel_d/include/CGAL/Kernel_d/Point_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Point_d.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2000,2001  
+// Copyright (c) 2000,2001
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
 // Max-Planck-Institute Saarbruecken (Germany),
-// and Tel-Aviv University (Israel).  All rights reserved. 
+// and Tel-Aviv University (Israel).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org); you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public License as
@@ -18,7 +18,7 @@
 //
 // $URL$
 // $Id$
-// 
+//
 //
 // Author(s)     : Michael Seel
 
@@ -61,11 +61,11 @@ public:
   Point_d(int d=0) : Base(d) {}
   Point_d(int d, const Origin &o) : Base(d,o) {}
 
-  Point_d(int a, int b, int c = 1) : 
-    Base(RT(a),RT(b),RT(c)) {} 
+  Point_d(int a, int b, int c = 1) :
+    Base(RT(a),RT(b),RT(c)) {}
   Point_d(const RT& a, const RT& b, const RT& c = 1) :
-    Base(a,b,c) {}  
-  Point_d(int a, int b, int c, int d) : 
+    Base(a,b,c) {}
+  Point_d(int a, int b, int c, int d) :
     Base(RT(a),RT(b),RT(c),RT(d)) {}
   Point_d(const RT& a, const RT& b, const RT& c, const RT& d) :
     Base(a,b,c,d) {}
@@ -79,8 +79,8 @@ public:
 
   Point_d(const Self &p) : Base(p) {}
   Point_d(const Base& p) : Base(p) {}
- 
-  Vector_d<R> operator-(const Origin& o) const 
+
+  Vector_d<R> operator-(const Origin& o) const
   { return Base::operator-(o); }
   Vector_d<R> operator-(const Self& q) const
   { return Base::operator-(q); }
@@ -88,11 +88,19 @@ public:
   { return Base::operator+(v); }
   Self operator-(const Vector_d<R>& v) const
   { return Base::operator-(v); }
-  Self& operator+=(const Vector_d<R>& v) 
+  Self& operator+=(const Vector_d<R>& v)
   { return static_cast<Self&>(Base::operator+=(v)); }
   Self& operator-=(const Vector_d<R>& v)
   { return static_cast<Self&>(Base::operator-=(v)); }
-  
+
+  inline bool operator<(const Self& q) const
+  { return R().less_lexicographically_d_object()(*this, q); }
+  inline bool operator>(const Self& q) const
+  { return R().less_lexicographically_d_object()(q, *this); }
+  inline bool operator<=(const Self& q) const
+  { return ! R().less_lexicographically_d_object()(q, *this); }
+  inline bool operator>=(const Self& q) const
+  { return ! R().less_lexicographically_d_object()(*this, q); }
 };
 
 } //namespace CGAL


### PR DESCRIPTION
My editor removed useless space a the end of lines. I hope that it is fine. I did not know very well where to put the implementation of the operators. In Kernel_23, all the implementation of the operators is in two header files but it seems that in Kernel_d, it is in the specific object classes so I put the implementation there.