### PR TITLE
Fixes for Polyhedron_demo

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1069,7 +1069,7 @@ void MainWindow::selectSceneItem(int i)
       proxyModel->mapSelectionFromSource(scene->createSelection(i));
 
     sceneView->selectionModel()->select(s,
-                                        QItemSelectionModel::Select);
+                                        QItemSelectionModel::ClearAndSelect);
   }
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -38,7 +38,7 @@ public:
       this->mw = mainWindow;
       //creates and link the actions
       actionAdd_polylines= new QAction("Add Polylines", mw);
-     autoConnectActions();
+      connect(actionAdd_polylines, SIGNAL(triggered()), this, SLOT(on_actionAdd_polylines_triggered()));
       QMenu* menuFile = mw->findChild<QMenu*>("menuFile");
       if ( NULL != menuFile )
       {

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/XYZ_io_plugin.cpp
@@ -35,7 +35,7 @@ public:
       this->mw = mainWindow;
       //creates and link the actions
       actionAdd_point_set= new QAction("Add Point Sets", mw);
-      autoConnectActions();
+      connect(actionAdd_point_set, SIGNAL(triggered()), this, SLOT(on_actionAdd_point_set_triggered()));
 
       QMenu* menuFile = mw->findChild<QMenu*>("menuFile");
       if ( NULL != menuFile )

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -48,6 +48,10 @@ public:
     actionColorConnectedComponents = new QAction(tr("Color Each Connected Component"), mainWindow);
     actionColorConnectedComponents ->setProperty("subMenuName", "Polygon Mesh Processing");
     actionColorConnectedComponents->setObjectName("actionColorConnectedComponents");
+
+    connect(actionJoinPolyhedra , SIGNAL(triggered()), this, SLOT(on_actionJoinPolyhedra_triggered()));
+    connect(actionSplitPolyhedra , SIGNAL(triggered()), this, SLOT(on_actionSplitPolyhedra_triggered() ));
+    connect(actionColorConnectedComponents , SIGNAL(triggered()), this, SLOT(on_actionColorConnectedComponents_triggered()));
   }
 
   bool applicable(QAction* a) const

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
@@ -28,7 +28,7 @@ public:
     scene = scene_interface;
     actionMergePointSets = new QAction(tr("Merge"), mainWindow);
     actionMergePointSets->setObjectName("actionMergePointSets");
-
+    connect(actionMergePointSets, SIGNAL(triggered()), this, SLOT(on_actionMergePointSets_triggered()));
   }
 
   QList<QAction*> actions() const {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -81,21 +81,6 @@ Scene::addItem(CGAL::Three::Scene_item* item)
             qobject_cast<CGAL::Three::Scene_group_item*>(item);
     if(group)
         addGroup(group);
-    //if group selected, add item to it
-    if(mainSelectionIndex() >=0)
-    {
-        //if new item is a group, don't do that, to avoid any ambiguity
-        if(!group)
-        {
-            CGAL::Three::Scene_group_item* selected_group =
-                    qobject_cast<CGAL::Three::Scene_group_item*>(m_entries.at(mainSelectionIndex()));
-            if(selected_group)
-            {
-                changeGroup(item,selected_group);
-                redraw_model();
-            }
-        }
-    }
     return id;
 }
 
@@ -1192,62 +1177,6 @@ QList<QModelIndex> Scene::getModelIndexFromId(int id) const
 
 void Scene::addGroup(Scene_group_item* group)
 {
-    //Find the indices of the selected items
-    QList<int> indices;
-    QList<int> blacklist;
-    Q_FOREACH(int id, selectionIndices()){
-        CGAL::Three::Scene_group_item* group =
-                qobject_cast<CGAL::Three::Scene_group_item*>(item(id));
-        if(group)
-            Q_FOREACH(CGAL::Three::Scene_item *item, group->getChildren())
-                blacklist<<item_id(item);
-
-        if(!indices.contains(id) && !blacklist.contains(id))
-            indices<<id;
-}
-    //checks if all the selected items are in the same group
-    bool all_in_one = true;
-    if(indices.isEmpty())
-        all_in_one = false;
-    //group containing the selected item
-    CGAL::Three::Scene_group_item * existing_group = 0;
-    //for each selected item
-    Q_FOREACH(int id, indices){
-        //if the selected item is in a group
-        if(item(id)->has_group!=0){
-            //for each group
-            CGAL::Three::Scene_group_item *group = item(id)->parentGroup();
-            //if it is the first pass, we initialize existing_group
-            if(existing_group == 0)
-                existing_group = group;
-            //else we check if it is the same group as before.
-            //If not, all selected items are not in the same group
-            else if(existing_group != group)
-                all_in_one = false;
-            break;
-        }
-        //else it is impossible that all the selected items are in the same group
-        else{
-            all_in_one = false;
-            break;
-        }
-    }//end foreach selected item
-
-    //If all the selected items are in the same group, we put them in a sub_group of this group
-    if(all_in_one)
-    {
-        Q_FOREACH(int id, indices)
-            changeGroup(item(id),group);
-        changeGroup(group, existing_group);
-        redraw_model();
-    }
-    //else we create a new group
-    else
-    {
-        Q_FOREACH(int id, indices)
-            changeGroup(item(id),group);
-        redraw_model();
-    }
     connect(this, SIGNAL(drawFinished()), group, SLOT(resetDraw()));
     group->setScene(this);
 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -337,6 +337,15 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
     for(int index = 0; index < m_entries.size(); ++index)
     {
         CGAL::Three::Scene_item& item = *m_entries[index];
+        if(index == selected_item || selected_items_list.contains(index))
+        {
+            item.selection_changed(true);
+        }
+        else
+
+        {
+            item.selection_changed(false);
+        }
         if(!with_names && item_should_be_skipped_in_draw(&item)) continue;
         if(item.visible())
         {
@@ -349,16 +358,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                 viewer->glEnable(GL_LIGHTING);
                 viewer->glPointSize(2.f);
                 viewer->glLineWidth(1.0f);
-                if(index == selected_item || selected_items_list.contains(index))
-                {
-                    item.selection_changed(true);
-                }
-                else
-
-                {
-                    item.selection_changed(false);
-                }
-
                 if(item.renderingMode() == Gouraud)
                     viewer->glShadeModel(GL_SMOOTH);
                 else
@@ -387,6 +386,15 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
     for(int index = 0; index < m_entries.size(); ++index)
     {
         CGAL::Three::Scene_item& item = *m_entries[index];
+        if(index == selected_item || selected_items_list.contains(index))
+        {
+            item.selection_changed(true);
+        }
+        else
+        {
+            item.selection_changed(false);
+        }
+
         if(!with_names && item_should_be_skipped_in_draw(&item)) continue;
         if(item.visible())
         {
@@ -402,16 +410,6 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                 viewer->glDisable(GL_LIGHTING);
                 viewer->glPointSize(2.f);
                 viewer->glLineWidth(1.0f);
-                if(index == selected_item || selected_items_list.contains(index))
-                {
-                    item.selection_changed(true);
-                }
-                else
-                {
-                    item.selection_changed(false);
-                }
-
-
 
                 if(viewer)
                     item.drawEdges(viewer);

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -184,9 +184,8 @@ public Q_SLOTS:
   void setSelectedItemIndex(int i)
   {
     selected_item = i;
-    Q_EMIT selectionChanged(i);
   }
-  //! Same as setSelectedItemIndex.
+  //! Clears the current selection then sets the selected item to the target index.
   void setSelectedItem(int i )
   {
     selected_item = i;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -226,6 +226,13 @@ Scene_polylines_item::compute_bbox() const {
                 bbox.zmax());
 }
 
+Scene_item::Bbox Scene_polylines_item::bbox() const
+{
+  if(!is_bbox_computed)
+      compute_bbox();
+  is_bbox_computed = true;
+  return _bbox;
+}
 Scene_polylines_item* 
 Scene_polylines_item::clone() const {
     Scene_polylines_item* item = new Scene_polylines_item;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.h
@@ -29,6 +29,7 @@ public:
     bool isFinite() const { return true; }
     bool isEmpty() const;
     void compute_bbox() const;
+    Bbox bbox() const;
 
     Scene_polylines_item* clone() const;
 


### PR DESCRIPTION
Fixes  #1084 

This PR fixes :
- The multi selection that was broken for some time
- The polyline_items that had problems with their BBox
- Re-connects some actions that were broken in plugins not inheriting from the plugin helper.
- The color of items in a group when they are selected.

Plus, after this PR, when a group is added to the scene, no matter the selection, no item will be added as a child, which will avoid problems with several plugins and all the scene_items that recently inherited from Scene_group_item, such as the polylines_item or the c3t3_item.
