### PR TITLE
Remove array-bounds warning also in Combinatorial_map.h

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -46,6 +46,12 @@
 #pragma warning disable 1017
 #endif
 
+#include <boost/config.hpp>
+#if  (BOOST_GCC >= 40900)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+#endif
+
 namespace CGAL {
 
   /** @file Combinatorial_map.h
@@ -4757,6 +4763,9 @@ namespace CGAL {
 
 } // namespace CGAL
 
+#if  (BOOST_GCC >= 40900)
+ _Pragma("GCC diagnostic pop")
+#endif
 
 #endif // CGAL_COMBINATORIAL_MAP_H //
 // EOF //

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -411,9 +411,9 @@ namespace CGAL {
 
 } // namespace CGAL
 
-
 #if  (BOOST_GCC >= 40900)
  _Pragma("GCC diagnostic pop")
 #endif
-#endif // CGAL_COMBINATORIAL_MAP_H //
+
+#endif // CGAL_COMBINATORIAL_MAP_STORAGES_H //
 // EOF //


### PR DESCRIPTION
same command than in Combinatorial_map_storage.h