### PR TITLE
Polyhedron demo : On the fly Selection Tool

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -81,6 +81,8 @@ public:
 
     ui_widget.setupUi(dock_widget);
     addDockWidget(dock_widget);
+    connect(dock_widget, SIGNAL(visibilityChanged(bool)),
+            this, SLOT(setItemsActive(bool)));
 
     connect(ui_widget.Select_all_button,  SIGNAL(clicked()), this, SLOT(on_Select_all_button_clicked()));
     connect(ui_widget.Add_to_selection_button,  SIGNAL(clicked()), this, SLOT(on_Add_to_selection_button_clicked()));
@@ -115,11 +117,66 @@ Q_SIGNALS:
   void save_handleType();
   void set_operation_mode(int);
 public Q_SLOTS:
+
   void setInstructions(QString s)
   {
     ui_widget.instructionsLabel->setText(s);
   }
-  void selection_action() { 
+
+  void setItemsActive(bool b)
+  {
+    for(int i=0; i<scene->numberOfEntries(); i++)
+    {
+      Scene_polyhedron_selection_item* sel_item = qobject_cast<Scene_polyhedron_selection_item*>(scene->item(i));
+      if(sel_item)
+        sel_item->setActive(b);
+    }
+  }
+  //This slot is called when a shift+click is got by a k-ring selector.
+  /*
+   * It checks if the selected poly_item has an associated selection_item.
+   * If not, it creates one and gives it the QEvent to process.
+   */
+  void checkSelectionItem(QEvent* event)
+  {
+    QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
+    CGAL::Three::Viewer_interface* viewer = dynamic_cast<CGAL::Three::Viewer_interface*>(v);
+    //If the dock widget is not visible, re-bind the viewer's selection and stop here.
+    if(!dock_widget->isVisible())
+    {
+      if(!viewer)
+          return;
+        viewer->setBindingSelect();
+      return;
+    }
+    //else unbind the viewer's selection.
+    viewer->setNoBinding();
+    int item_id = scene->mainSelectionIndex();
+    Scene_polyhedron_item* poly_item = qobject_cast<Scene_polyhedron_item*>(scene->item(item_id));
+    if(!poly_item)
+    {
+      Scene_polyhedron_selection_item* selection_item = qobject_cast<Scene_polyhedron_selection_item*>(scene->item(item_id));
+      if(!selection_item)
+        return;
+      poly_item = selection_item->polyhedron_item();
+    }
+    if(selection_item_map.find(poly_item) != selection_item_map.end())
+    {
+     selection_item_map.find(poly_item)->second->processEvent(event);
+    }
+    else{
+      Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
+      int item_id = scene->addItem(new_item);
+      QObject* scene_ptr = dynamic_cast<QObject*>(scene);
+      if (scene_ptr)
+        connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
+      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
+      scene->setSelectedItem(item_id);
+      new_item->processEvent(event);
+    }
+  }
+
+  void selection_action() {
     dock_widget->show();
     dock_widget->raise();
     if(scene->numberOfEntries() < 2) {
@@ -133,6 +190,7 @@ public Q_SLOTS:
       QObject* scene_ptr = dynamic_cast<QObject*>(scene);
       if (scene_ptr)
         connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
+      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
       scene->setSelectedItem(item_id);
       on_ModeBox_changed(ui_widget.modeBox->currentIndex());
     }
@@ -231,6 +289,7 @@ public Q_SLOTS:
     QObject* scene_ptr = dynamic_cast<QObject*>(scene);
     if (scene_ptr)
       connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
+      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
     scene->setSelectedItem(item_id);
     ui_widget.modeBox->setCurrentIndex(last_mode);
     on_ModeBox_changed(ui_widget.modeBox->currentIndex());

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -170,7 +170,7 @@ public Q_SLOTS:
       QObject* scene_ptr = dynamic_cast<QObject*>(scene);
       if (scene_ptr)
         connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
+      connect(new_item,SIGNAL(selectionRequest(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
       scene->setSelectedItem(item_id);
       new_item->processEvent(event);
     }
@@ -190,7 +190,7 @@ public Q_SLOTS:
       QObject* scene_ptr = dynamic_cast<QObject*>(scene);
       if (scene_ptr)
         connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
+      connect(new_item,SIGNAL(selectionRequest(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
       scene->setSelectedItem(item_id);
       on_ModeBox_changed(ui_widget.modeBox->currentIndex());
     }
@@ -289,7 +289,7 @@ public Q_SLOTS:
     QObject* scene_ptr = dynamic_cast<QObject*>(scene);
     if (scene_ptr)
       connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-      connect(new_item,SIGNAL(selection_request(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
+      connect(new_item,SIGNAL(selectionRequest(QEvent*)), this, SLOT(checkSelectionItem(QEvent* )));
     scene->setSelectedItem(item_id);
     ui_widget.modeBox->setCurrentIndex(last_mode);
     on_ModeBox_changed(ui_widget.modeBox->currentIndex());

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
@@ -96,8 +96,22 @@ public Q_SLOTS:
       process_selection( edge(static_cast<Polyhedron::Halfedge*>(void_ptr)->opposite()->opposite(), *poly_item->polyhedron()) );
     updateIsTreated();
   }
+  void processEvent(QEvent* event)
+  {
+    // paint with mouse move event
+    QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
+    QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+    qglviewer::Camera* camera = viewer->camera();
 
-
+    bool found = false;
+    const qglviewer::Vec& point = camera->pointUnderPixel(mouse_event->pos(), found);
+    if(found)
+    {
+      const qglviewer::Vec& orig = camera->position();
+      const qglviewer::Vec& dir = point - orig;
+      poly_item->select(orig.x, orig.y, orig.z, dir.x, dir.y, dir.z);
+    }
+  }
 Q_SIGNALS:
   void selected(const std::set<Polyhedron::Vertex_handle>&);
   void selected(const std::set<Polyhedron::Facet_handle>&);
@@ -105,6 +119,7 @@ Q_SIGNALS:
   void toogle_insert(const bool);
   void endSelection();
   void resetIsTreated();
+  void selection_request(QEvent *);
 
 protected:
 
@@ -247,6 +262,7 @@ protected:
         viewer->setFocus();
         return false;
       }
+      Q_EMIT selection_request(event);
       // paint with mouse move event
       QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
@@ -118,8 +118,9 @@ Q_SIGNALS:
   void selected(const std::set<edge_descriptor>&);
   void toogle_insert(const bool);
   void endSelection();
-  void resetIsTreated();
-  void selection_request(QEvent *);
+  void resetIsTreated(); 
+  void selectionRequest(QEvent *);
+
 
 protected:
 
@@ -262,7 +263,7 @@ protected:
         viewer->setFocus();
         return false;
       }
-      Q_EMIT selection_request(event);
+      Q_EMIT selectionRequest(event);
       // paint with mouse move event
       QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
@@ -39,12 +39,13 @@ public:
   int                    k_ring;
   Scene_polyhedron_item* poly_item;
   bool is_active;
+  bool is_current_selection;
 
   Scene_polyhedron_item_k_ring_selection() {}
 
   Scene_polyhedron_item_k_ring_selection
     (Scene_polyhedron_item* poly_item, QMainWindow* mw, Active_handle::Type aht, int k_ring)
-      :is_active(false), is_edit_mode(false)
+      :is_active(false),is_current_selection(true), is_edit_mode(false)
   {
     init(poly_item, mw, aht, k_ring);
   }
@@ -71,7 +72,10 @@ public:
     connect(poly_item, SIGNAL(selected_facet(void*)), this, SLOT(facet_has_been_selected(void*)));
     connect(poly_item, SIGNAL(selected_edge(void*)), this, SLOT(edge_has_been_selected(void*)));
   }
-
+  void setCurrentlySelected(bool b)
+  {
+    is_current_selection = b;
+  }
 public Q_SLOTS:
   // slots are called by signals of polyhedron_item
   void vertex_has_been_selected(void* void_ptr) 
@@ -120,6 +124,7 @@ Q_SIGNALS:
   void endSelection();
   void resetIsTreated(); 
   void selectionRequest(QEvent *);
+  void isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*);
 
 
 protected:
@@ -257,6 +262,9 @@ protected:
          ||
          (event->type() == QEvent::MouseButtonPress && static_cast<QMouseEvent*>(event)->button() == Qt::LeftButton && state.shift_pressing ))
     {
+      Q_EMIT isCurrentlySelected(this);
+      if(!is_current_selection)
+        return false;
       if(target == mainwindow)
       {
         QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
@@ -265,7 +273,7 @@ protected:
       }
       Q_EMIT selectionRequest(event);
       // paint with mouse move event
-      QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
+     /* QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
       qglviewer::Camera* camera = viewer->camera();
 
@@ -276,7 +284,7 @@ protected:
         const qglviewer::Vec& orig = camera->position();
         const qglviewer::Vec& dir = point - orig;
         poly_item->select(orig.x, orig.y, orig.z, dir.x, dir.y, dir.z);
-      }
+      }*/
     }//end MouseMove
     return false;
   }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -435,6 +435,7 @@ if(!poly)
         }
     }
 }
+
 void Scene_polyhedron_selection_item::computeElements()const
 {
   compute_any_elements(positions_facets, positions_lines, positions_points, normals,
@@ -971,6 +972,8 @@ bool Scene_polyhedron_selection_item:: treat_selection(const std::set<edge_descr
     //classic selection
     case -1:
     {
+      if(!is_active)
+        return false;
       return treat_classic_selection(selection);
       break;
     }
@@ -1290,6 +1293,8 @@ bool Scene_polyhedron_selection_item::treat_selection(const std::set<Polyhedron:
     //classic selection
     case -1:
     {
+      if(!is_active)
+        return false;
       return treat_classic_selection(selection);
       break;
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -963,6 +963,7 @@ std::size_t facet_degree(Halfedge_handle h)
 
 bool Scene_polyhedron_selection_item:: treat_selection(const std::set<edge_descriptor>& selection)
 {
+
   edge_descriptor ed =  *selection.begin();
   if(!is_treated)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -751,6 +751,8 @@ bool Scene_polyhedron_selection_item::treat_selection(const std::set<Polyhedron:
     case -2:
     case -1:
     {
+      if(!is_active)
+        return false;
       if(!is_path_selecting)
       {
         return treat_classic_selection(selection);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -268,8 +268,8 @@ protected:
 
     connect(&k_ring_selector, SIGNAL(endSelection()), this,SLOT(endSelection()));
     connect(&k_ring_selector, SIGNAL(toogle_insert(bool)), this,SLOT(toggle_insert(bool)));
-    connect(&k_ring_selector, SIGNAL(selection_request(QEvent*)), this,
-      SIGNAL(selection_request(QEvent*)));
+    connect(&k_ring_selector, SIGNAL(selectionRequest(QEvent*)), this,
+      SIGNAL(selectionRequest(QEvent*)));
     k_ring_selector.init(poly_item, mw, Active_handle::VERTEX, -1);
     connect(&k_ring_selector, SIGNAL(resetIsTreated()), this, SLOT(resetIsTreated()));
 
@@ -850,7 +850,7 @@ public:
 Q_SIGNALS:
   void updateInstructions(QString);
   void simplicesSelected(CGAL::Three::Scene_item*);
-  void selection_request(QEvent*);
+  void selectionRequest(QEvent*);
 public Q_SLOTS:
   void update_poly()
   {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -235,9 +235,12 @@ public:
         poly_need_update = false;
     }
 
-   ~Scene_polyhedron_selection_item()
-    {
-    }
+  ~Scene_polyhedron_selection_item()
+  {
+    QGLViewer* v = *QGLViewer::QGLViewerPool().begin();
+    CGAL::Three::Viewer_interface* viewer = dynamic_cast<CGAL::Three::Viewer_interface*>(v);
+    viewer->setBindingSelect();
+  }
 
   void inverse_selection();
 
@@ -270,6 +273,7 @@ protected:
     connect(&k_ring_selector, SIGNAL(toogle_insert(bool)), this,SLOT(toggle_insert(bool)));
     connect(&k_ring_selector, SIGNAL(selectionRequest(QEvent*)), this,
       SIGNAL(selectionRequest(QEvent*)));
+    connect(&k_ring_selector,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
     k_ring_selector.init(poly_item, mw, Active_handle::VERTEX, -1);
     connect(&k_ring_selector, SIGNAL(resetIsTreated()), this, SLOT(resetIsTreated()));
 
@@ -852,6 +856,7 @@ Q_SIGNALS:
   void updateInstructions(QString);
   void simplicesSelected(CGAL::Three::Scene_item*);
   void selectionRequest(QEvent*);
+  void isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*);
 public Q_SLOTS:
   void update_poly()
   {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -472,6 +472,7 @@ public:
     v->update();
     tempInstructions("Path added to selection.",
                      "Select two vertices to create the path between them. (1/2)");
+  }
 
   void processEvent(QEvent *event)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -188,7 +188,7 @@ public:
         is_active = true;
         original_sel_mode = static_cast<Active_handle::Type>(0);
         this ->operation_mode = -1;
-        for(int i=0; i<6; i++)
+        for(int i=0; i<7; i++)
         {
             addVaos(i);
             vaos[i]->create();
@@ -201,6 +201,9 @@ public:
         nb_facets = 0;
         nb_points = 0;
         nb_lines = 0;
+        are_buffers_filled = false;
+        are_temp_buffers_filled = false;
+        poly = NULL;
         this->setColor(facet_color);
         first_selected = false;
         is_treated = false;
@@ -227,6 +230,7 @@ public:
         {
             buffers[i].create();
         }
+        poly = NULL;
         init(poly_item, mw);
         this->setColor(facet_color);
         invalidateOpenGLBuffers();


### PR DESCRIPTION
This PR acts on the Selection_plugin in the Polyhedron Demo. Currently, if the user has only one item with an associated selection_item, but several scene_items, if he selects on any item, the selection is only applied in the selection_item. With this PR, a selection_item is automatically created for the item being selected if none exists.
This PR also fixes some bugs with the Selection Tool