### PR TITLE
Robustify triangulate facets

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -175,6 +175,11 @@ and <code>src/</code> directories).
       Add some new features to <code>CGAL::isotropic_remeshing()</code>.
       It is now possible to select fixed vertices that survive the remeshing process,
       and to keep face attributes such as colors valid after remeshing.
+    </li> 
+     <li>
+      The functions <code>CGAL::Polygon_mesh_processing::triangulate_face()</code>
+      and <code>CGAL::Polygon_mesh_processing::triangulate_faces()</code>
+      now indicate whether some faces have not been triangulated.
     </li>
   </ul>
 <!-- Spatial Searching and Sorting -->

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -99,7 +99,7 @@ public:
       Polygon_mesh_processing::compute_face_normal(f, pmesh);
     if(normal == typename Traits::Vector_3(0,0,0))
       return false;
-    int original_size = CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh).size();
+    std::size_t original_size = CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh).size();
     if(original_size == 4)
     {
       typename Kernel::Point_3 p0, p1, p2, p3;
@@ -304,11 +304,15 @@ public:
 * @param pmesh the polygon mesh to which the face to be triangulated belongs
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
+*
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
+* @return true if the face has been triangulated. The triangulation can fail if the normal computed for the projection plane is null,
+*  if the number of points in the triangulation is different from the number of input points
+*  or if the dimension of the CDT is not 2.
 */
 template<typename PolygonMesh, typename NamedParameters>
 bool  triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor f,
@@ -357,6 +361,8 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
+* @return true if all the faces have been triangulated.
+* @see triangulate_face()
 */
 template <typename FaceRange, typename PolygonMesh, typename NamedParameters>
 bool triangulate_faces(FaceRange face_range,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -247,8 +247,9 @@ public:
   }
 
   template<typename FaceRange>
-  void operator()(FaceRange face_range, PM& pmesh)
+  bool operator()(FaceRange face_range, PM& pmesh)
   {
+   bool result = true;
     // One need to store facet handles into a vector, because the list of
     // facets of the polyhedron will be modified during the loop, and
     // that invalidates the range [facets_begin(), facets_end()[.
@@ -264,8 +265,10 @@ public:
     // Iterates on the vector of face descriptors
     BOOST_FOREACH(face_descriptor f, facets)
     {
-      this->triangulate_face(f, pmesh);
+     if(!this->triangulate_face(f, pmesh))
+       result = false;
     }
+    return result;
   }
 
   void make_hole(halfedge_descriptor h, PM& pmesh)
@@ -356,7 +359,7 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 *
 */
 template <typename FaceRange, typename PolygonMesh, typename NamedParameters>
-void triangulate_faces(FaceRange face_range,
+bool triangulate_faces(FaceRange face_range,
                        PolygonMesh& pmesh,
                        const NamedParameters& np)
 {
@@ -372,13 +375,13 @@ void triangulate_faces(FaceRange face_range,
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Kernel;
 
   internal::Triangulate_modifier<PolygonMesh, VPMap, Kernel> modifier(vpmap);
-  modifier(face_range, pmesh);
+  return modifier(face_range, pmesh);
 }
 
 template <typename FaceRange, typename PolygonMesh>
-void triangulate_faces(FaceRange face_range, PolygonMesh& pmesh)
+bool triangulate_faces(FaceRange face_range, PolygonMesh& pmesh)
 {
-  triangulate_faces(face_range, pmesh, CGAL::Polygon_mesh_processing::parameters::all_default());
+  return triangulate_faces(face_range, pmesh, CGAL::Polygon_mesh_processing::parameters::all_default());
 }
 
 /**
@@ -398,16 +401,16 @@ void triangulate_faces(FaceRange face_range, PolygonMesh& pmesh)
 *
 */
 template <typename PolygonMesh, typename NamedParameters>
-void triangulate_faces(PolygonMesh& pmesh,
+bool  triangulate_faces(PolygonMesh& pmesh,
                        const NamedParameters& np)
 {
-  triangulate_faces(faces(pmesh), pmesh, np);
+  return triangulate_faces(faces(pmesh), pmesh, np);
 }
 
 template <typename PolygonMesh>
-void triangulate_faces(PolygonMesh& pmesh)
+bool triangulate_faces(PolygonMesh& pmesh)
 {
-  triangulate_faces(faces(pmesh), pmesh, CGAL::Polygon_mesh_processing::parameters::all_default());
+  return triangulate_faces(faces(pmesh), pmesh, CGAL::Polygon_mesh_processing::parameters::all_default());
 }
 
 } // end namespace Polygon_mesh_processing

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Triangulate_facets_plugin.cpp
@@ -118,7 +118,8 @@ public Q_SLOTS:
 
       QApplication::setOverrideCursor(Qt::WaitCursor);
 
-      CGAL::Polygon_mesh_processing::triangulate_faces(*pMesh);
+      if(!CGAL::Polygon_mesh_processing::triangulate_faces(*pMesh))
+        messages->warning(tr("Some facets could not be triangulated."));
 
       CGAL_assertion_code(pMesh->normalize_border());
       CGAL_assertion(pMesh->is_valid(false, 3));


### PR DESCRIPTION
(fixes #1093 )
This PR makes triangulate_face() and triangulate_faces() boolean values, and optimizes triangulate_face() for the quads by using split_face instead of a CDT.
Small feature : https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Robustify_triangulate_facets