### PR TITLE
Polyhedron_demo: Display distance between points

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -239,6 +239,8 @@ MainWindow::MainWindow(QWidget* parent)
 
   connect(viewer, SIGNAL(requestContextMenu(QPoint)),
           this, SLOT(contextMenuRequested(QPoint)));
+  connect(viewer, SIGNAL(sendMessage(QString)),
+          this, SLOT(information(QString)));
 
   // The contextMenuPolicy of infoLabel is now the default one, so that one
   // can easily copy-paste its text.

--- a/Polyhedron/demo/Polyhedron/TextRenderer.cpp
+++ b/Polyhedron/demo/Polyhedron/TextRenderer.cpp
@@ -38,7 +38,7 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
       qglviewer::Vec src(item->position().x(), item->position().y(),item->position().z());
       if(item->is_3D())
       {
-        if(viewer->testDisplayId(src.x, src.y, src.z))
+        if(item->is_always_visible() || viewer->testDisplayId(src.x, src.y, src.z))
         {
             rect = QRect(camera->projectedCoordinatesOf(src).x-item->width()/2,
                        camera->projectedCoordinatesOf(src).y-item->height()/2,

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -199,34 +199,34 @@ void Viewer::initializeGL()
   //Fragment source code
   const char fragment_source[] =
   {
-          "#version 120 \n"
-          "varying highp vec4 color; \n"
-          "varying highp vec4 fP; \n"
-          "varying highp vec3 fN; \n"
-          "uniform highp vec4 light_pos;  \n"
-          "uniform highp vec4 light_diff; \n"
-          "uniform highp vec4 light_spec; \n"
-          "uniform highp vec4 light_amb;  \n"
-          "uniform highp float spec_power ; \n"
+      "#version 120 \n"
+      "varying highp vec4 color; \n"
+      "varying highp vec4 fP; \n"
+      "varying highp vec3 fN; \n"
+      "uniform highp vec4 light_pos;  \n"
+      "uniform highp vec4 light_diff; \n"
+      "uniform highp vec4 light_spec; \n"
+      "uniform highp vec4 light_amb;  \n"
+      "uniform highp float spec_power ; \n"
 
-          "void main(void) { \n"
+      "void main(void) { \n"
 
-          "   vec3 L = light_pos.xyz - fP.xyz; \n"
-          "   vec3 V = -fP.xyz; \n"
-          "   vec3 N; \n"
-          "   if(fN == vec3(0.0,0.0,0.0)) \n"
-          "       N = vec3(0.0,0.0,0.0); \n"
-          "   else \n"
-          "       N = normalize(fN); \n"
-          "   L = normalize(L); \n"
-          "   V = normalize(V); \n"
-          "   vec3 R = reflect(-L, N); \n"
-          "   vec4 diffuse = max(abs(dot(N,L)),0.0) * light_diff*color; \n"
-          "   vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
+      "   vec3 L = light_pos.xyz - fP.xyz; \n"
+      "   vec3 V = -fP.xyz; \n"
+      "   vec3 N; \n"
+      "   if(fN == vec3(0.0,0.0,0.0)) \n"
+      "       N = vec3(0.0,0.0,0.0); \n"
+      "   else \n"
+      "       N = normalize(fN); \n"
+      "   L = normalize(L); \n"
+      "   V = normalize(V); \n"
+      "   vec3 R = reflect(-L, N); \n"
+      "   vec4 diffuse = max(abs(dot(N,L)),0.0) * light_diff*color; \n"
+      "   vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-          "gl_FragColor = color*light_amb + diffuse + specular; \n"
-          "} \n"
-          "\n"
+      "gl_FragColor = color*light_amb + diffuse + specular; \n"
+      "} \n"
+      "\n"
       };
 
       QOpenGLShader *vertex_shader = new QOpenGLShader(QOpenGLShader::Vertex);
@@ -383,13 +383,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
         }
         if(!is_d_pressed)
         {
-            distance_is_displayed = false;
-            Q_FOREACH(TextItem* ti, distance_text)
-            {
-              textRenderer->removeText(ti);
-              delete ti;
-              distance_text.removeOne(ti);
-            }
+            clearDistancedisplay();
         }
         is_d_pressed = true;
         updateGL();
@@ -836,7 +830,6 @@ void Viewer::drawVisualHints()
         QMatrix4x4 mvpMatrix;
         double mat[16];
         QMatrix4x4 mvMatrix;
-        //camera()->frame()->rotation().getMatrix(mat);
         camera()->getModelViewProjectionMatrix(mat);
         //nullifies the translation
         mat[12]=0;
@@ -896,7 +889,9 @@ void Viewer::drawVisualHints()
     if(distance_is_displayed)
     {
         glDisable(GL_DEPTH_TEST);
-        glPointSize(5.0f);
+
+        glLineWidth(3.0f);
+        glPointSize(6.0f);
         //draws the distance
         QMatrix4x4 mvpMatrix;
         double mat[16];
@@ -916,6 +911,7 @@ void Viewer::drawVisualHints()
         rendering_program_dist.release();
         glEnable(GL_DEPTH_TEST);
         glPointSize(1.0f);
+        glLineWidth(1.0f);
 
     }
     if (!d->painter->isActive())
@@ -1394,7 +1390,7 @@ void Viewer::showDistance(QPoint pixel)
         //set APoint
         APoint = point;
         isAset = true;
-        distance_is_displayed = false;
+        clearDistancedisplay();
     }
     else if (found)
     {
@@ -1440,4 +1436,15 @@ void Viewer::showDistance(QPoint pixel)
                   .arg(dist)));
     }
 
+}
+
+void Viewer::clearDistancedisplay()
+{
+  distance_is_displayed = false;
+  Q_FOREACH(TextItem* ti, distance_text)
+  {
+    textRenderer->removeText(ti);
+    delete ti;
+  }
+  distance_text.clear();
 }

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -70,6 +70,8 @@ public:
   QOpenGLShaderProgram* getShaderProgram(int name) const;
   QPainter* getPainter();
 
+Q_SIGNALS:
+  void sendMessage(QString);
 public Q_SLOTS:
   //! Sets the antialiasing to true or false.
   void setAntiAliasing(bool b);
@@ -105,11 +107,14 @@ protected:
   };
 
   //! The buffers used to draw the axis system
-  QOpenGLBuffer buffers[3];
+  QOpenGLBuffer buffers[4];
   //! The VAO used to draw the axis system
-  QOpenGLVertexArrayObject vao[1];
+  QOpenGLVertexArrayObject vao[2];
   //! The rendering program used to draw the axis system
   QOpenGLShaderProgram rendering_program;
+  //! The rendering program used to draw the distance
+  QOpenGLShaderProgram rendering_program_dist;
+
   //! Holds the vertices data for the axis system
   std::vector<float> v_Axis;
   //! Holds the normals data for the axis system
@@ -120,6 +125,8 @@ protected:
   bool axis_are_displayed;
   //! Decides if the text is displayed in the drawVisualHints function.
   bool has_text;
+  //! Decides if the distance between APoint and BPoint must be drawn;
+  bool distance_is_displayed;
   //!Defines the behaviour for the mouse press events
   void mousePressEvent(QMouseEvent*);
   void wheelEvent(QWheelEvent *);
@@ -144,6 +151,11 @@ protected:
   void resizeGL(int w, int h);
   bool i_is_pressed;
 
+  //!Draws the distance between two selected points.
+  void showDistance(QPoint);
+  qglviewer::Vec APoint;
+  qglviewer::Vec BPoint;
+  bool is_d_pressed;
 
 protected:
   Viewer_impl* d;

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -136,6 +136,8 @@ protected:
   void contextMenuEvent(QContextMenuEvent*);
   //!Defines the behaviour for the key release events
   void keyReleaseEvent(QKeyEvent *);
+  //!Clears the distance display
+  void clearDistancedisplay();
   /*!
    * \brief makeArrow creates an arrow and stores it in a struct of vectors.
    * \param R the radius of the arrow.

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -14,7 +14,7 @@
 #include <QPoint>
 #include <QFont>
 #include <QOpenGLFramebufferObject>
-
+#include <CGAL/Three/TextRenderer.h>
 // forward declarations
 class QWidget;
 namespace CGAL{
@@ -114,7 +114,7 @@ protected:
   QOpenGLShaderProgram rendering_program;
   //! The rendering program used to draw the distance
   QOpenGLShaderProgram rendering_program_dist;
-
+  QList<TextItem*>  distance_text;
   //! Holds the vertices data for the axis system
   std::vector<float> v_Axis;
   //! Holds the normals data for the axis system

--- a/Three/include/CGAL/Three/TextRenderer.h
+++ b/Three/include/CGAL/Three/TextRenderer.h
@@ -53,8 +53,8 @@ public :
      * \param font the font used for the rendering.
      * \param p_color the color of the text.
      */
-    TextItem(float p_x, float p_y, float p_z, QString p_text, bool p_3D = true, QFont font = QFont(), QColor p_color = Qt::black)
-        :x(p_x), y(p_y), z(p_z),_3D(p_3D), m_text(p_text), m_font(font), m_color(p_color)
+    TextItem(float p_x, float p_y, float p_z, QString p_text, bool p_3D = true, QFont font = QFont(), QColor p_color = Qt::black, bool always_visible = false)
+        :x(p_x), y(p_y), z(p_z),_3D(p_3D), m_text(p_text), m_font(font), m_color(p_color), _is_always_visible(always_visible)
     {
        QFontMetrics fm(m_font);
        _width = fm.width(m_text);
@@ -68,6 +68,7 @@ public :
     QFont font(){return m_font;}
     QColor color() {return m_color;}
     bool is_3D()const{return _3D;}
+    bool is_always_visible(){return _is_always_visible;}
 private:
     float x;
     float y;
@@ -75,6 +76,7 @@ private:
     float _width;
     float _height;
     bool _3D;
+    bool _is_always_visible;
     QString m_text;
     QFont m_font;
     QColor m_color;

--- a/Three/include/CGAL/Three/TextRenderer.h
+++ b/Three/include/CGAL/Three/TextRenderer.h
@@ -54,7 +54,7 @@ public :
      * \param p_color the color of the text.
      */
     TextItem(float p_x, float p_y, float p_z, QString p_text, bool p_3D = true, QFont font = QFont(), QColor p_color = Qt::black, bool always_visible = false)
-        :x(p_x), y(p_y), z(p_z),_3D(p_3D), m_text(p_text), m_font(font), m_color(p_color), _is_always_visible(always_visible)
+        :x(p_x), y(p_y), z(p_z),_3D(p_3D), _is_always_visible(always_visible), m_text(p_text), m_font(font), m_color(p_color)
     {
        QFontMetrics fm(m_font);
        _width = fm.width(m_text);


### PR DESCRIPTION
This PR allows the user to display the distance between two points in the scene by pressing D and clicking on the scene. It will display a line between the two points, print their coordinates on their position and the distance in the middle of the segment. Press D alone to erase it.

![screen](https://cloud.githubusercontent.com/assets/11310805/15652001/887fdeaa-2683-11e6-819e-148fcb0e8f2a.png)
