### PR TITLE
Fix action connection

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -137,7 +137,7 @@ MainWindow::MainWindow(QWidget* parent)
   scene = new Scene(this);
   viewer->textRenderer->setScene(scene);
   viewer->setScene(scene);
-  ui->actionMax_text_items_displayed->setText(QString("Set Maximum Text Items Displayed : %1").arg(viewer->textRenderer->getMax_textItems()));
+  ui->actionMaxTextItemsDisplayed->setText(QString("Set Maximum Text Items Displayed : %1").arg(viewer->textRenderer->getMax_textItems()));
   {
     QShortcut* shortcut = new QShortcut(QKeySequence(Qt::ALT+Qt::Key_Q), this);
     connect(shortcut, SIGNAL(activated()),
@@ -269,8 +269,6 @@ MainWindow::MainWindow(QWidget* parent)
   // Connect actionQuit (Ctrl+Q) and qApp->quit()
   connect(ui->actionQuit, SIGNAL(triggered()),
           this, SLOT(quit()));
-connect(ui->actionMax_text_items_displayed, SIGNAL(triggered()),
-        this, SLOT(on_actionMaxItemsDisplayed_triggered()));
   // Connect "Select all items"
   connect(ui->actionSelect_all_items, SIGNAL(triggered()),
           this, SLOT(selectAll()));
@@ -1846,7 +1844,7 @@ void MainWindow::setExpanded(QModelIndex index)
 }
 
 
-void MainWindow::on_actionMaxItemsDisplayed_triggered()
+void MainWindow::on_actionMaxTextItemsDisplayed_triggered()
 {
   bool ok;
   bool valid;
@@ -1856,6 +1854,6 @@ void MainWindow::on_actionMaxItemsDisplayed_triggered()
   text.toInt(&valid);
   if (ok && valid){
     viewer->textRenderer->setMax(text.toInt());
-    ui->actionMax_text_items_displayed->setText(QString("Set Maximum Text Items Displayed : %1").arg(text.toInt()));
+    ui->actionMaxTextItemsDisplayed->setText(QString("Set Maximum Text Items Displayed : %1").arg(text.toInt()));
   }
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -251,9 +251,9 @@ MainWindow::MainWindow(QWidget* parent)
   connect(ui->actionAntiAliasing, SIGNAL(toggled(bool)),
           viewer, SLOT(setAntiAliasing(bool)));
 
-  connect(ui->actionDraw_two_sides, SIGNAL(toggled(bool)),
+  connect(ui->actionDrawTwoSides, SIGNAL(toggled(bool)),
           viewer, SLOT(setTwoSides(bool)));
-  connect(ui->actionQuick_camera_mode, SIGNAL(toggled(bool)),
+  connect(ui->actionQuickCameraMode, SIGNAL(toggled(bool)),
           viewer, SLOT(setFastDrawing(bool)));
 
   // add the "About CGAL..." and "About demo..." entries
@@ -270,7 +270,7 @@ MainWindow::MainWindow(QWidget* parent)
   connect(ui->actionQuit, SIGNAL(triggered()),
           this, SLOT(quit()));
   // Connect "Select all items"
-  connect(ui->actionSelect_all_items, SIGNAL(triggered()),
+  connect(ui->actionSelectAllItems, SIGNAL(triggered()),
           this, SLOT(selectAll()));
 
   // Recent files menu
@@ -1606,7 +1606,7 @@ void MainWindow::on_actionSetBackgroundColor_triggered()
   }
 }
 
-void MainWindow::on_action_Look_at_triggered()
+void MainWindow::on_actionLookAt_triggered()
 {
   Show_point_dialog dialog(this);
   dialog.setWindowTitle(tr("Look at..."));
@@ -1645,12 +1645,12 @@ void MainWindow::on_actionDumpCamera_triggered()
               .arg(cameraString()));
 }
 
-void MainWindow::on_action_Copy_camera_triggered()
+void MainWindow::on_actionCopyCamera_triggered()
 {
   qApp->clipboard()->setText(this->cameraString());
 }
 
-void MainWindow::on_action_Paste_camera_triggered()
+void MainWindow::on_actionPasteCamera_triggered()
 {
   QString s = qApp->clipboard()->text();
   viewer->moveCameraToCoordinates(s, 0.5f);
@@ -1667,7 +1667,7 @@ void MainWindow::on_actionRecenterScene_triggered()
   viewer->camera()->interpolateToFitScene();
 }
 
-void MainWindow::on_actionLoad_plugin_triggered()
+void MainWindow::on_actionLoadPlugin_triggered()
 {
     //pop a dialog of path selection, get the path and add it to plugins_directory
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -125,7 +125,7 @@ MainWindow::MainWindow(QWidget* parent)
   menu_map[ui->menuOperations->title()] = ui->menuOperations;
   // remove the Load Script menu entry, when the demo has not been compiled with QT_SCRIPT_LIB
 #if !defined(QT_SCRIPT_LIB)
-  ui->menuBar->removeAction(ui->actionloadScript);
+  ui->menuBar->removeAction(ui->actionLoadScript);
 #endif
   // Save some pointers from ui, for latter use.
   sceneView = ui->sceneView;
@@ -1361,7 +1361,7 @@ bool MainWindow::loadScript(QFileInfo info)
   return false;
 }
 
-void MainWindow::on_actionloadScript_triggered() 
+void MainWindow::on_actionLoadScript_triggered() 
 {
 #if defined(QT_SCRIPT_LIB)
   QString filename = QFileDialog::getOpenFileName(

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -270,7 +270,7 @@ protected Q_SLOTS:
   //!If QT_SCRIPT_LIB is defined, opens a dialog to choose a script.
   void on_actionLoadScript_triggered();
   //!Loads a plugin from a specified directory
-  void on_actionLoad_plugin_triggered();
+  void on_actionLoadPlugin_triggered();
   // Show/Hide
   //!Swap the visibility of the selected item(s).
   void on_actionShowHide_triggered();
@@ -298,7 +298,7 @@ protected Q_SLOTS:
    * with viewerShow.
    *@see viewerShow(float, float, float, float, float, float)
    */
-  void on_action_Look_at_triggered();
+  void on_actionLookAt_triggered();
   //!Returns the position and orientation of the current camera frame.
   QString cameraString() const;
   /*! Prints the position and orientation of the current camera frame.
@@ -306,10 +306,10 @@ protected Q_SLOTS:
    */
   void on_actionDumpCamera_triggered();
   //!Sets the coordinates of the camera in the clipboard text.
-  void on_action_Copy_camera_triggered();
+  void on_actionCopyCamera_triggered();
   //!Gets coordinates from the clipboard and sets them as the current ones for
   //!the camera.
-  void on_action_Paste_camera_triggered();
+  void on_actionPasteCamera_triggered();
   //!Hides not available operations and show available operations in all the
   //!menus.
   void filterOperations();

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -275,7 +275,7 @@ protected Q_SLOTS:
   //!Swap the visibility of the selected item(s).
   void on_actionShowHide_triggered();
   //!Pops a dialog to change the max TextItems
-  void on_actionMaxItemsDisplayed_triggered();
+  void on_actionMaxTextItemsDisplayed_triggered();
   // Select A/B
   //!Sets the selected item as item_A.
   void on_actionSetPolyhedronA_triggered();

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -268,7 +268,7 @@ protected Q_SLOTS:
   //!Duplicates the selected item and selects the new item.
   void on_actionDuplicate_triggered();
   //!If QT_SCRIPT_LIB is defined, opens a dialog to choose a script.
-  void on_actionloadScript_triggered();
+  void on_actionLoadScript_triggered();
   //!Loads a plugin from a specified directory
   void on_actionLoad_plugin_triggered();
   // Show/Hide

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -95,7 +95,7 @@
     <addaction name="actionAntiAliasing"/>
     <addaction name="actionDraw_two_sides"/>
     <addaction name="actionQuick_camera_mode"/>
-    <addaction name="actionMax_text_items_displayed"/>
+    <addaction name="actionMaxTextItemsDisplayed"/>
     <addaction name="actionSetBackgroundColor"/>
     <addaction name="menuDockWindows"/>
     <addaction name="menuCamera"/>
@@ -659,7 +659,7 @@
     <string>Quick Camera Mode</string>
    </property>
   </action>
-  <action name="actionMax_text_items_displayed">
+  <action name="actionMaxTextItemsDisplayed">
    <property name="text">
     <string>Set Maximum  Text Items Displayed :</string>
    </property>

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -51,7 +51,7 @@
     <addaction name="actionSaveAs"/>
     <addaction name="actionSaveSnapshot"/>
     <addaction name="separator"/>
-    <addaction name="actionLoad_Script"/>
+    <addaction name="actionLoadScript"/>
     <addaction name="separator"/>
     <addaction name="actionLoad_plugin"/>
     <addaction name="separator"/>
@@ -628,7 +628,7 @@
     <string>Ctrl+A</string>
    </property>
   </action>
-  <action name="actionLoad_Script">
+  <action name="actionLoadScript">
    <property name="text">
     <string>Load &amp;Script</string>
    </property>

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -53,7 +53,7 @@
     <addaction name="separator"/>
     <addaction name="actionLoadScript"/>
     <addaction name="separator"/>
-    <addaction name="actionLoad_plugin"/>
+    <addaction name="actionLoadPlugin"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
@@ -64,7 +64,7 @@
     <addaction name="actionShowHide"/>
     <addaction name="actionSetPolyhedronA"/>
     <addaction name="actionSetPolyhedronB"/>
-    <addaction name="actionSelect_all_items"/>
+    <addaction name="actionSelectAllItems"/>
     <addaction name="actionPreferences"/>
    </widget>
    <widget class="QMenu" name="menuOperations">
@@ -87,14 +87,14 @@
       <string>Ca&amp;mera</string>
      </property>
      <addaction name="actionDumpCamera"/>
-     <addaction name="action_Copy_camera"/>
-     <addaction name="action_Paste_camera"/>
+     <addaction name="actionCopyCamera"/>
+     <addaction name="actionPasteCamera"/>
     </widget>
     <addaction name="actionRecenterScene"/>
-    <addaction name="action_Look_at"/>
+    <addaction name="actionLookAt"/>
     <addaction name="actionAntiAliasing"/>
-    <addaction name="actionDraw_two_sides"/>
-    <addaction name="actionQuick_camera_mode"/>
+    <addaction name="actionDrawTwoSides"/>
+    <addaction name="actionQuickCameraMode"/>
     <addaction name="actionMaxTextItemsDisplayed"/>
     <addaction name="actionSetBackgroundColor"/>
     <addaction name="menuDockWindows"/>
@@ -563,7 +563,7 @@
     <string>Convert to Normal Polyhedron</string>
    </property>
   </action>
-  <action name="actionDraw_two_sides">
+  <action name="actionDrawTwoSides">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -595,7 +595,7 @@
     <string>Ctrl+O, M</string>
    </property>
   </action>
-  <action name="action_Look_at">
+  <action name="actionLookAt">
    <property name="text">
     <string>&amp;Look at...</string>
    </property>
@@ -610,17 +610,17 @@
     <string>&amp;Dump Camera Coordinates</string>
    </property>
   </action>
-  <action name="action_Copy_camera">
+  <action name="actionCopyCamera">
    <property name="text">
     <string>&amp;Copy Camera</string>
    </property>
   </action>
-  <action name="action_Paste_camera">
+  <action name="actionPasteCamera">
    <property name="text">
     <string>&amp;Paste Camera</string>
    </property>
   </action>
-  <action name="actionSelect_all_items">
+  <action name="actionSelectAllItems">
    <property name="text">
     <string>Select All Items</string>
    </property>
@@ -643,12 +643,12 @@
     <string>Least Square Conformal Maps</string>
    </property>
   </action>
-  <action name="actionLoad_plugin">
+  <action name="actionLoadPlugin">
    <property name="text">
     <string>Load Plugin</string>
    </property>
   </action>
-  <action name="actionQuick_camera_mode">
+  <action name="actionQuickCameraMode">
    <property name="checkable">
     <bool>true</bool>
    </property>


### PR DESCRIPTION
Fixes the following warnings at the start-up of the demo
`QMetaObject::connectSlotsByName: No matching signal for on_actionloadScript_triggered()`
`QMetaObject::connectSlotsByName: No matching signal for on_actionMaxItemsDisplayed_triggered()`

At the same time I also renamed all actions in the MainWindow to use CamelCase style

Replaces #1120 