### PR TITLE
Polyhedron_demo: Fix for the Spheres_item and the Scene_polyline_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -97,6 +97,18 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
 
     connect(item, SIGNAL(itemChanged()),
             this, SLOT(itemChanged()));
+    CGAL::Three::Scene_group_item* group =
+            qobject_cast<CGAL::Three::Scene_group_item*>(m_entries[index]);
+    if(group)
+    {
+      QList<int> children;
+      Q_FOREACH(CGAL::Three::Scene_item* child, group->getChildren())
+      {
+        group->unlockChild(child);
+        children << item_id(child);
+      }
+      erase(children);
+    }
     std::swap(m_entries[index], item);
     if ( item->isFinite() && !item->isEmpty() &&
          m_entries[index]->isFinite() && !m_entries[index]->isEmpty() &&
@@ -105,7 +117,7 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
     Q_EMIT updated_bbox();
     }
   Q_EMIT updated();
-    CGAL::Three::Scene_group_item* group =
+    group =
             qobject_cast<CGAL::Three::Scene_group_item*>(m_entries[index]);
     if(group)
     {

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -413,6 +413,11 @@ void Scene_polylines_item::change_corner_radii(double r) {
           computeSpheres();
           spheres->invalidateOpenGLBuffers();
         }
+        else if(r>0 && spheres)
+        {
+          computeSpheres();
+          spheres->invalidateOpenGLBuffers();
+        }
         else if (r<=0 && spheres!=NULL)
         {
           unlockChild(spheres);


### PR DESCRIPTION
With this PR:
- It is possible again to change the radii of the spheres in a polyline
- Reloading a group from file won't cause the demo to crash anymore.