### PR TITLE
Add a macro to customize deprecation warnings

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -424,7 +424,7 @@ using std::max;
 
 // Macro to trigger deprecation warnings with a custom message
 #ifdef CGAL_NO_DEPRECATION_WARNINGS
-#  define CGAL_DEPRECATED_MSG
+#  define CGAL_DEPRECATED_MSG(msg)
 #elif defined(__GNUC__) || __has_attribute(__deprecated__)
 #  if BOOST_GCC >= 40500 || __has_attribute(__deprecated__)
 #    define CGAL_DEPRECATED_MSG(msg) __attribute__ ((deprecated(msg)))

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -422,6 +422,22 @@ using std::max;
 #  define CGAL_DEPRECATED
 #endif
 
+// Macro to trigger deprecation warnings with a custom message
+#ifdef CGAL_NO_DEPRECATION_WARNINGS
+#  define CGAL_DEPRECATED_MSG
+#elif defined(__GNUC__) || __has_attribute(__deprecated__)
+#  if BOOST_GCC >= 40500 || __has_attribute(__deprecated__)
+#    define CGAL_DEPRECATED_MSG(msg) __attribute__ ((deprecated(msg)))
+#  else
+#    define CGAL_DEPRECATED_MSG(msg) __attribute__ ((deprecated))
+#  endif
+#elif defined (_MSC_VER) && (_MSC_VER > 1300)
+#  define CGAL_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#elif defined(__clang__)
+#  define CGAL_DEPRECATED_MSG(msg) __attribute__ ((deprecated(msg)))
+#else
+#  define CGAL_DEPRECATED_MSG(msg)
+#endif
 
 // Macro to specify a 'noreturn' attribute.
 #if defined(__GNUG__) || __has_attribute(__noreturn__)


### PR DESCRIPTION
Fixes #1127 
This PR adds a macro : CGAL_DEPRECATED_MSG that allows to display a custom message in the deprecation warnings.