### PR TITLE
Set Eigen3 use file name in CGAL common

### DIFF
--- a/Installation/cmake/modules/CGAL_Common.cmake
+++ b/Installation/cmake/modules/CGAL_Common.cmake
@@ -54,5 +54,8 @@ if( NOT CGAL_COMMON_FILE_INCLUDED )
 
   # set minimal version of some optional libraries:
   set( Eigen3_FIND_VERSION "3.1.0")
-  
+  # set use-file for Eigen3 (needed to have default solvers)
+  set(EIGEN3_USE_FILE "UseEigen3")
+
+
 endif()

--- a/Installation/cmake/modules/FindEigen3.cmake
+++ b/Installation/cmake/modules/FindEigen3.cmake
@@ -44,8 +44,6 @@ macro(_eigen3_get_version)
   set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
 endmacro(_eigen3_get_version)
 
-set(EIGEN3_USE_FILE "UseEigen3")
-
 if (EIGEN3_INCLUDE_DIR)
 
   if (EXISTS ${EIGEN3_INCLUDE_DIR}/signature_of_eigen3_matrix_library)


### PR DESCRIPTION
ensure the use file is known even if the FindEigen3.cmake
shipped with Eigen is used

