### PR TITLE
Polyhedron_demo : Fix the update of the viewer

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -178,10 +178,10 @@ MainWindow::MainWindow(QWidget* parent)
           this, SLOT(updateDisplayInfo()));
 
   connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
-          viewer, SLOT(updateGL()));
+          viewer, SLOT(update()));
 
   connect(scene, SIGNAL(updated()),
-          viewer, SLOT(updateGL()));
+          viewer, SLOT(update()));
 
   connect(scene, SIGNAL(updated()),
           this, SLOT(selectionChanged()));
@@ -1173,7 +1173,7 @@ void MainWindow::selectionChanged()
     connect(viewer->manipulatedFrame(), SIGNAL(modified()),
             this, SLOT(updateInfo()));
   }
-  viewer->updateGL();
+  viewer->update();
 }
 
 void MainWindow::contextMenuRequested(const QPoint& global_pos) {
@@ -1510,7 +1510,7 @@ bool MainWindow::on_actionErase_triggered()
 {
   int next_index = scene->erase(scene->selectionIndices());
   //Secure the case where erase triggers other items deletions
-  if(scene->numberOfEntries()>= next_index)
+  if(scene->numberOfEntries()> next_index +1 )
     next_index = -1;
   selectSceneItem(next_index);
   return next_index >= 0;

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -106,20 +106,20 @@ bool Viewer::antiAliasing() const
 void Viewer::setAntiAliasing(bool b)
 {
   d->antialiasing = b;
-  updateGL();
+  update();
 }
 
 void Viewer::setTwoSides(bool b)
 {
   d->twosides = b;
-  updateGL();
+  update();
 }
 
 
 void Viewer::setFastDrawing(bool b)
 {
   d->inFastDrawing = b;
-  updateGL();
+  update();
 }
 
 bool Viewer::inFastDrawing() const
@@ -371,7 +371,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     }
     else if(e->key() == Qt::Key_A) {
           axis_are_displayed = !axis_are_displayed;
-          updateGL();
+          update();
         }
     else if(e->key() == Qt::Key_I) {
           i_is_pressed = true;
@@ -386,7 +386,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
             clearDistancedisplay();
         }
         is_d_pressed = true;
-        updateGL();
+        update();
         return;
     }
   }
@@ -644,7 +644,7 @@ void Viewer::endSelection(const QPoint&)
 {
     glDisable(GL_SCISSOR_TEST);
     //redraw thetrue scene for the glReadPixel in postSelection();
-    updateGL();
+    update();
 }
 
 void Viewer::makeArrow(double R, int prec, qglviewer::Vec from, qglviewer::Vec to, qglviewer::Vec color, AxisData &data)
@@ -1303,7 +1303,7 @@ void Viewer::wheelEvent(QWheelEvent* e)
         }
         else
             camera()->setZNearCoefficient(camera()->zNearCoefficient() / 1.01);
-        updateGL();
+        update();
     }
     else
         QGLViewer::wheelEvent(e);
@@ -1326,13 +1326,14 @@ void Viewer::paintGL()
   if (!d->painter->isActive())
     d->painter->begin(this);
   d->painter->beginNativePainting();
-  glClearColor(1.0, 1.0, 1.0, 1.0);
-  d->painter->endNativePainting();
+  glClearColor(backgroundColor().redF(), backgroundColor().greenF(), backgroundColor().blueF(), 1.0);
   preDraw();
   draw();
   postDraw();
+  d->painter->endNativePainting();
   d->painter->end();
 }
+
 void Viewer::postDraw()
 {
 


### PR DESCRIPTION
- Replaces updateGL() calls by update() calls. Before the viewer used a painter, updateGL() was ok, because it was the QGLViewer that painted the scene. But a QPainter can only update its painting through a paintEvent() function, which is called by update() but not by updateGL().
- Fixes the bug that made the selection empty when an item was erased.
- Fixes the background color.