### PR TITLE
Improve the CDT constructors

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -108,9 +108,9 @@ Constrained_Delaunay_triangulation_2(const
 Constrained_Delaunay_triangulation_2& cdt1); 
 
 /*!
-A templated constructor which introduces and builds 
-a constrained triangulation with constraints in the range 
-`[first,last)`. 
+Builds a constrained triangulation with constraints
+in the range `[first,last)` by calling
+`insert_constraints(first, last)`.
 \tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`. 
 */ 
 template<class ConstraintIterator> Constrained_Delaunay_triangulation_2( 

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -120,14 +120,11 @@ public:
   Constrained_Delaunay_triangulation_2(const CDt& cdt)
     : Ctr(cdt) {}
 
-  Constrained_Delaunay_triangulation_2(List_constraints& lc, 
+  Constrained_Delaunay_triangulation_2(const List_constraints& lc,
 				       const Geom_traits& gt=Geom_traits())
     : Ctr(gt) 
-    {   
-      typename List_constraints::iterator itc = lc.begin();
-      for( ; itc != lc.end(); ++itc) {
-	insert((*itc).first, (*itc).second);
-      }
+    {
+      insert_constraints(lc.begin(), lc.end());
       CGAL_triangulation_postcondition( is_valid() );
     }
 
@@ -137,9 +134,7 @@ public:
 				       const Geom_traits& gt=Geom_traits() )
     : Ctr(gt) 
     {
-      for ( ; it != last; it++) {
-      	insert((*it).first, (*it).second);
-      }
+      insert_constraints(it, last);
       CGAL_triangulation_postcondition( is_valid() );
     }
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -222,7 +222,7 @@ public:
   }
 
 
-  Constrained_triangulation_plus_2(std::list<std::pair<Point,Point> > constraints,
+  Constrained_triangulation_plus_2(const std::list<std::pair<Point,Point> > &constraints,
 				   const Geom_traits& gt=Geom_traits() )
     : Triangulation(gt)
      , hierarchy(Vh_less_xy(this))


### PR DESCRIPTION
(fixes #511 )
This PR Updates the CDT constructors to use insert() with a range of iterators instead of a for-loop. 
It also updates  the tests and the doc.