### PR TITLE
Fix for the OBJ reading.

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -852,14 +852,18 @@ Scene_polyhedron_item::load_obj(std::istream& in)
   std::size_t i, j, k;
   bool failed = false;
   while(getline(in, line)){
-    if(line[0] == 'v'){
+    if(line[0] == 'v' && line[1] == ' '){
       std::istringstream iss(line.substr(1));
       iss >> p;
       if(! iss) failed = true;
       points.push_back(p);
     } else if(line[0] == 'f'){
       std::istringstream iss(line.substr(1));
-      iss >> i >> j >> k;
+      iss >> i;
+      iss.ignore(256, ' ');
+      iss>> j;
+      iss.ignore(256, ' ');
+      iss>> k;
       if(! iss) failed = true;
       std::vector<std::size_t> face;
       face.push_back(i-1);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -5,6 +5,7 @@
 #include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/IO/File_writer_wavefront.h>
 #include <CGAL/IO/generic_copy_OFF.h>
+#include <CGAL/IO/OBJ_reader.h>
 
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
@@ -846,32 +847,8 @@ Scene_polyhedron_item::load_obj(std::istream& in)
   typedef Polyhedron::Vertex::Point Point;
   std::vector<Point> points;
   std::vector<std::vector<std::size_t> > faces;
-  
-  Point p;
-  std::string line;
-  std::size_t i, j, k;
-  bool failed = false;
-  while(getline(in, line)){
-    if(line[0] == 'v' && line[1] == ' '){
-      std::istringstream iss(line.substr(1));
-      iss >> p;
-      if(! iss) failed = true;
-      points.push_back(p);
-    } else if(line[0] == 'f'){
-      std::istringstream iss(line.substr(1));
-      iss >> i;
-      iss.ignore(256, ' ');
-      iss>> j;
-      iss.ignore(256, ' ');
-      iss>> k;
-      if(! iss) failed = true;
-      std::vector<std::size_t> face;
-      face.push_back(i-1);
-      face.push_back(j-1);
-      face.push_back(k-1);
-      faces.push_back(face);
-    }
-  }
+  bool failed = !CGAL::read_OBJ(in,points,faces);
+
   if(CGAL::Polygon_mesh_processing::orient_polygon_soup(points,faces)){
     CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh( points,faces,*poly);
   }else{

--- a/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 GeometryFactory
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Andreas Fabri and Maxime Gimeno
+
+#ifndef CGAL_IO_OBJ_READER_H
+#define CGAL_IO_OBJ_READER_H
+#include <istream>
+#include <vector>
+
+
+namespace CGAL {
+
+template <class Point_3>
+bool
+read_OBJ( std::istream& input,
+          std::vector<Point_3> &points,
+          std::vector<std::vector<std::size_t> > &faces)
+{
+  Point_3 p;
+  std::string line;
+  while(getline(input, line)) {
+    if(line[0] == 'v' && line[1] == ' ') {
+      std::istringstream iss(line.substr(1));
+      iss >> p;
+      if(!iss)
+        return false;
+      points.push_back(p);
+    }
+    else if(line[0] == 'f') {
+      std::istringstream iss(line.substr(1));
+      int i;
+      faces.push_back( std::vector<std::size_t>() );
+      while(iss >> i)
+      {
+        faces.back().push_back(i-1);
+        iss.ignore(256, ' ');
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace CGAL
+
+#endif // CGAL_IO_OBJ_READER_H


### PR DESCRIPTION
This PR fixes the Scene_polyhedron_item::Load_obj() function, that was only able to read the files with only vertex data, and no normal, texture, etc. 
Now it discards this unwanted information to avoid the crashing.