### PR TITLE
Polyhedron demo : add remeshing of a Polyhedron with Mesh_3

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
@@ -88,7 +88,7 @@ struct Polyhedron_tester : public Tester<K>
     if (boost::is_convertible<Concurrency_tag, CGAL::Parallel_tag>::value)
     {
       this->verify(c3t3, domain, criteria, Polyhedral_tag(),
-                   110, 140, 190, 230, 350, 420); 
+                   110, 140, 190, 235, 350, 420); 
     }
     else
 #endif //CGAL_LINKED_WITH_TBB

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -25,7 +25,7 @@ public:
   }
   QString name() const { return "C3t3_io_plugin"; }
   QString nameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma)"; }
-  QString saveNameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma);;avizo (*.am)"; }
+  QString saveNameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma);;avizo (*.am);;OFF files (*.off)"; }
   QString loadNameFilters() const { return "binary files (*.cgal)" ; }
   QList<QAction*> actions() const
   {
@@ -143,6 +143,12 @@ save(const CGAL::Three::Scene_item* item, QFileInfo fileinfo)
     {
       std::ofstream avizo_file (qPrintable(path));
       CGAL::output_to_avizo(avizo_file, c3t3_item->c3t3());
+      return true;
+    }
+    else if (fileinfo.suffix() == "off")
+    {
+      std::ofstream off_file(qPrintable(path));
+      c3t3_item->c3t3().output_facets_in_complex_to_off(off_file);
       return true;
     }
     else

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
@@ -28,6 +28,7 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
                                  const double tet_shape,
                                  bool protect_features,
                                  const int manifold,
+                                 const bool surface_only,
                                  CGAL::Three::Scene_interface* scene);
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
@@ -250,7 +250,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="volumeGroup">
      <property name="title">
       <string>Volume</string>
      </property>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
@@ -87,8 +87,16 @@ public:
   virtual void init(QMainWindow*, Scene_interface*, Messages_interface*);
   inline virtual QList<QAction*> actions() const;
   
-  bool applicable(QAction*) const {
-    return qobject_cast<Scene_c3t3_item*>(scene->item(scene->mainSelectionIndex()));
+  bool applicable(QAction* a) const {
+    Scene_c3t3_item* item
+      = qobject_cast<Scene_c3t3_item*>(scene->item(scene->mainSelectionIndex()));
+    if (NULL == item)
+      return false;
+
+    if (a == actionOdt || a == actionLloyd)
+      return true;
+    else //actionPerturb or actionExude
+      return item->c3t3().number_of_cells() > 0;
   }
 
 public Q_SLOTS:

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1059,10 +1059,13 @@ void Scene_c3t3_item::export_facets_in_complex()
   namespace PMP = CGAL::Polygon_mesh_processing;
   Polyhedron outmesh;
 
-  if (PMP::orient_polygon_soup(points, polygons))
+  if (PMP::is_polygon_soup_a_polygon_mesh(polygons))
   {
-    PMP::polygon_soup_to_polygon_mesh(points, polygons, outmesh);
+    CGAL_assertion_code(bool orientable = )
+    PMP::orient_polygon_soup(points, polygons);
+    CGAL_assertion(orientable);
 
+    PMP::polygon_soup_to_polygon_mesh(points, polygons, outmesh);
     Scene_polyhedron_item* item = new Scene_polyhedron_item(outmesh);
     item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
     scene->addItem(item);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -25,6 +25,9 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_C3T3_triangle_primitive.h>
+#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
+#include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
+
 
 typedef CGAL::AABB_C3T3_triangle_primitive<Kernel,C3t3> Primitive;
 typedef CGAL::AABB_traits<Kernel, Primitive> Traits;
@@ -1020,30 +1023,56 @@ double Scene_c3t3_item_priv::complex_diag() const {
 
 void Scene_c3t3_item::export_facets_in_complex()
 {
-  std::stringstream off_sstream;
-  c3t3().output_facets_in_complex_to_off(off_sstream);
-  std::string backup = off_sstream.str();
-  // Try to read .off in a polyhedron
-  Scene_polyhedron_item* item = new Scene_polyhedron_item;
-  if (!item->load(off_sstream))
+  std::set<C3t3::Vertex_handle> vertex_set;
+  for (C3t3::Facets_in_complex_iterator fit = c3t3().facets_in_complex_begin();
+       fit != c3t3().facets_in_complex_end();
+       ++fit)
   {
-    delete item;
-    off_sstream.str(backup);
-
-    // Try to read .off in a polygon soup
-    Scene_polygon_soup_item* soup_item = new Scene_polygon_soup_item;
-
-    if (!soup_item->load(off_sstream)) {
-      delete soup_item;
-      return;
-    }
-
-    soup_item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
-    scene->addItem(soup_item);
+    vertex_set.insert(fit->first->vertex((fit->second + 1) % 4));
+    vertex_set.insert(fit->first->vertex((fit->second + 2) % 4));
+    vertex_set.insert(fit->first->vertex((fit->second + 3) % 4));
   }
-  else{
+
+  std::map<C3t3::Vertex_handle, std::size_t> indices;
+  std::vector<Kernel::Point_3> points(vertex_set.size());
+  std::vector<std::vector<std::size_t> > polygons(c3t3().number_of_facets_in_complex());
+
+  std::size_t index = 0;
+  BOOST_FOREACH(C3t3::Vertex_handle v, vertex_set)
+  {
+    points[index] = v->point();
+    indices.insert(std::make_pair(v, index));
+    index++;
+  }
+  index = 0;
+  for (C3t3::Facets_in_complex_iterator fit = c3t3().facets_in_complex_begin();
+       fit != c3t3().facets_in_complex_end();
+       ++fit, ++index)
+  {
+    std::vector<std::size_t> facet(3);
+    facet[0] = indices.at(fit->first->vertex((fit->second + 1) % 4));
+    facet[1] = indices.at(fit->first->vertex((fit->second + 2) % 4));
+    facet[2] = indices.at(fit->first->vertex((fit->second + 3) % 4));
+    polygons[index] = facet;
+  }
+
+  namespace PMP = CGAL::Polygon_mesh_processing;
+  Polyhedron outmesh;
+
+  if (PMP::orient_polygon_soup(points, polygons))
+  {
+    PMP::polygon_soup_to_polygon_mesh(points, polygons, outmesh);
+
+    Scene_polyhedron_item* item = new Scene_polyhedron_item(outmesh);
     item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
     scene->addItem(item);
+  }
+  else
+  {
+    Scene_polygon_soup_item* soup_item = new Scene_polygon_soup_item;
+    soup_item->load(points, polygons);
+    soup_item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
+    scene->addItem(soup_item);
   }
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -864,6 +864,8 @@ void Scene_polygon_soup_item::load(const std::vector<Point>& points, const std::
 // because the d-pointer forbid the definition in the .h for this function.
 template SCENE_POLYGON_SOUP_ITEM_EXPORT void Scene_polygon_soup_item::load<CGAL::cpp11::array<double, 3>, CGAL::cpp11::array<int, 3> >
 (const std::vector<CGAL::cpp11::array<double, 3> >& points, const std::vector<CGAL::cpp11::array<int, 3> >& polygons);
+template SCENE_POLYGON_SOUP_ITEM_EXPORT void Scene_polygon_soup_item::load<CGAL::Epick::Point_3, std::vector<std::size_t> >
+(const std::vector<CGAL::Epick::Point_3>& points, const std::vector<std::vector<std::size_t> >& polygons);
 
 // Local Variables:
 // c-basic-offset: 4


### PR DESCRIPTION
This PR adds to the Polyhedron demo a new operation that allows to remesh a polyhedral surface using `Mesh_3`
There are 3 ways `Mesh_3` can be called on a polyhedron in the demo now
* create a tetrahedral mesh from a closed polyhedral surface
* create a surface mesh from a closed polyhedral surface
* create a surface mesh from an open polyhedral surface
