### PR TITLE
Polyhedron_demo: Fix triangulate primitive

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -229,12 +229,11 @@ bool CGAL::Three::Scene_item::testDisplayId(double, double, double, CGAL::Three:
 
 void CGAL::Three::Scene_item::compute_diag_bbox()const
 {
-  if(!is_bbox_computed)
-    compute_bbox();
+  Bbox b_box = bbox();
   _diag_bbox = CGAL::sqrt(
-        CGAL::square(_bbox.xmax() - _bbox.xmin())
-        + CGAL::square(_bbox.ymax() - _bbox.ymin())
-        + CGAL::square(_bbox.zmax() - _bbox.zmin())
+        CGAL::square(b_box.xmax() - b_box.xmin())
+        + CGAL::square(b_box.ymax() - b_box.ymin())
+        + CGAL::square(b_box.zmax() - b_box.zmin())
         );
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -19,6 +19,7 @@ CGAL::Three::Scene_item::Scene_item(int buffers_size, int vaos_size)
     vaos(vaos_size)
 {
   is_bbox_computed = false;
+  is_diag_bbox_computed = false;
   for(int i=0; i<vaosSize; i++)
   {
     addVaos(i);

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -229,7 +229,7 @@ bool CGAL::Three::Scene_item::testDisplayId(double, double, double, CGAL::Three:
 
 void CGAL::Three::Scene_item::compute_diag_bbox()const
 {
-  Bbox b_box = bbox();
+ const Bbox& b_box = bbox();
   _diag_bbox = CGAL::sqrt(
         CGAL::square(b_box.xmax() - b_box.xmin())
         + CGAL::square(b_box.ymax() - b_box.ymin())

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -228,6 +228,7 @@ QList<Kernel::Triangle_3> Scene_polyhedron_item_priv::triangulate_primitive(Poly
 }
 
 
+
 void* Scene_polyhedron_item_priv::get_aabb_tree()
 {
   QVariant aabb_tree_property = item->property(aabb_property_name);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -228,7 +228,6 @@ QList<Kernel::Triangle_3> Scene_polyhedron_item_priv::triangulate_primitive(Poly
 }
 
 
-
 void* Scene_polyhedron_item_priv::get_aabb_tree()
 {
   QVariant aabb_tree_property = item->property(aabb_property_name);

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -51,6 +51,7 @@ public:
 
   SMesh* polyhedron();
   const SMesh* polyhedron() const;
+  void compute_bbox()const;
 public Q_SLOTS:
   virtual void selection_changed(bool);
 protected:

--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -64,7 +64,6 @@ public:
       idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly));
       idPoint.id = source(he_circ, *poly);
       idPoints.push_back(idPoint);
-
     }
     triangulate(idPoints, normal, item_diag);
   }
@@ -73,7 +72,7 @@ public:
                   const Vector& normal,
                   const double item_diag)
   {
-   triangulate(idPoints, normal, item_diag);
+    triangulate(idPoints, normal, item_diag);
   }
 
 private:
@@ -92,22 +91,41 @@ private:
     // Iterate the points of the facet and decide if they must be inserted in the CDT
     BOOST_FOREACH(PointAndId idPoint, idPoints)
     {
-     typename CDT::Vertex_handle vh = cdt->insert(idPoint.point);
-     v2v[vh] = idPoint.id;
-     if(first == 0) {
-      first = vh;
-     }
-     if(previous != 0 && previous != vh) {
-      cdt->insert_constraint(previous, vh);
-      last_inserted = previous;
-     }
+     typename CDT::Vertex_handle vh;
+     //Always insert the first point, then only insert
+     // if the distance with the precedent is reasonable.
+     if(first == 0 || CGAL::squared_distance(idPoint.point, previous->point()) > min_sq_dist)
+     {
+       vh = cdt->insert(idPoint.point);
+       v2v[vh] = idPoint.id;
+       if(first == 0) {
+         first = vh;
+       }
+       if(previous != 0 && previous != vh) {
+         double sq_dist = CGAL::squared_distance(previous->point(), vh->point());
+         if(sq_dist > min_sq_dist)
+         {
+           cdt->insert_constraint(previous, vh);
+           sq_dist = CGAL::squared_distance(previous->point(), first->point());
+           if(sq_dist > min_sq_dist)
+           {
+             last_inserted = previous;
+           }
+         }
+       }
      previous = vh;
+     }
     }
     double sq_dist = CGAL::squared_distance(previous->point(), first->point());
+
     if(sq_dist > min_sq_dist)
-     cdt->insert_constraint(previous, first);
+    {
+      cdt->insert_constraint(previous, first);
+    }
     else
-     cdt->insert_constraint(last_inserted, first);
+    {
+      cdt->insert_constraint(last_inserted, first);
+    }
     // sets mark is_external
     for(typename CDT::All_faces_iterator
         fit2 = cdt->all_faces_begin(),
@@ -119,17 +137,19 @@ private:
     //check if the facet is external or internal
     std::queue<typename CDT::Face_handle> face_queue;
     face_queue.push(cdt->infinite_vertex()->face());
-    while(! face_queue.empty() ) {
-     typename CDT::Face_handle fh = face_queue.front();
-     face_queue.pop();
-     if(fh->info().is_external) continue;
-     fh->info().is_external = true;
-     for(int i = 0; i <3; ++i) {
-      if(!cdt->is_constrained(std::make_pair(fh, i)))
+    while(! face_queue.empty() )
+    {
+      typename CDT::Face_handle fh = face_queue.front();
+      face_queue.pop();
+      if(fh->info().is_external) continue;
+      fh->info().is_external = true;
+      for(int i = 0; i <3; ++i)
       {
-       face_queue.push(fh->neighbor(i));
+        if(!cdt->is_constrained(std::make_pair(fh, i)))
+        {
+          face_queue.push(fh->neighbor(i));
+        }
       }
-     }
     }
   }
 };

--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -64,6 +64,7 @@ public:
       idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly));
       idPoint.id = source(he_circ, *poly);
       idPoints.push_back(idPoint);
+
     }
     triangulate(idPoints, normal, item_diag);
   }
@@ -132,19 +133,17 @@ private:
         end = cdt->all_faces_end();
         fit2 != end; ++fit2)
     {
-     fit2->info().is_external = false;
+      fit2->info().is_external = false;
     }
     //check if the facet is external or internal
     std::queue<typename CDT::Face_handle> face_queue;
     face_queue.push(cdt->infinite_vertex()->face());
-    while(! face_queue.empty() )
-    {
+    while(! face_queue.empty() ) {
       typename CDT::Face_handle fh = face_queue.front();
       face_queue.pop();
       if(fh->info().is_external) continue;
       fh->info().is_external = true;
-      for(int i = 0; i <3; ++i)
-      {
+      for(int i = 0; i <3; ++i) {
         if(!cdt->is_constrained(std::make_pair(fh, i)))
         {
           face_queue.push(fh->neighbor(i));


### PR DESCRIPTION
This PR fixes some bug in the triangulate_primitive.h file, in the workaround for the meshes with very close points.
 @janetournois  can you please check my algorithm is right? 