### PR TITLE
Polyhedron_demo : Deformation use selection item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
@@ -1,7 +1,7 @@
 include( polyhedron_demo_macros )
 if ( EIGEN3_FOUND AND "${EIGEN3_VERSION}" VERSION_GREATER "3.1.90" )
   polyhedron_demo_plugin(edit_polyhedron_plugin Edit_polyhedron_plugin Deform_mesh.ui)
-  target_link_libraries(edit_polyhedron_plugin scene_polyhedron_item scene_edit_polyhedron_item)
+  target_link_libraries(edit_polyhedron_plugin scene_polyhedron_item scene_edit_polyhedron_item scene_polyhedron_selection_item)
 else()
   message(STATUS "NOTICE: The polyhedron edit plugin require Eigen 3.2 (or higher) and will not be available.")
 endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>568</width>
-    <height>588</height>
+    <height>706</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -132,23 +132,6 @@
          <property name="sizeConstraint">
           <enum>QLayout::SetDefaultConstraint</enum>
          </property>
-         <item row="0" column="1">
-          <widget class="QPushButton" name="ReadROIPushButton">
-           <property name="text">
-            <string>Load ROI / Control Vertices</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="ShowAsSphereCheckBox">
-           <property name="text">
-            <string>Show As Sphere</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QCheckBox" name="ShowROICheckBox">
            <property name="text">
@@ -159,10 +142,34 @@
            </property>
           </widget>
          </item>
+         <item row="0" column="1">
+          <widget class="QPushButton" name="ReadROIPushButton">
+           <property name="text">
+            <string>Load ROI / Control Vertices</string>
+           </property>
+          </widget>
+         </item>
          <item row="1" column="1">
           <widget class="QPushButton" name="SaveROIPushButton">
            <property name="text">
             <string>Save ROI / Control Vertices</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPushButton" name="importSelectionPushButton">
+           <property name="text">
+            <string>Import Selection from Selection_item</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="ShowAsSphereCheckBox">
+           <property name="text">
+            <string>Show As Sphere</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -352,7 +352,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool
   {
     ui_widget.ShowAsSphereCheckBox->setChecked(false);
     Scene_polyhedron_selection_item* selection_item = NULL;
-    for(std::size_t i =0; i<scene->numberOfEntries(); i++)
+    for(int i = 0; i<scene->numberOfEntries(); i++)
     {
       selection_item = qobject_cast<Scene_polyhedron_selection_item*>(scene->item(i));
       if (selection_item)
@@ -537,7 +537,7 @@ selection_item->setVisible(false);
 
 void Polyhedron_demo_edit_polyhedron_plugin::updateSelectionItems(Scene_polyhedron_item* target)
 {
-  for(std::size_t i = 0; i<scene->numberOfEntries(); i++)
+  for(int i = 0; i<scene->numberOfEntries(); i++)
   {
     Scene_polyhedron_selection_item* sel_item = qobject_cast<Scene_polyhedron_selection_item*>(scene->item(i));
     if(sel_item

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -319,13 +319,15 @@ void Viewer::mousePressEvent(QMouseEvent* event)
     requestContextMenu(event->globalPos());
     event->accept();
   }
-  else if(event->button() == Qt::LeftButton &&
-          i_is_pressed)
+  else if(!event->modifiers()
+          && event->button() == Qt::LeftButton
+          && i_is_pressed)
   {
       d->scene->printPrimitiveId(event->pos(), this);
   }
-  else if(event->button() == Qt::LeftButton &&
-          is_d_pressed)
+  else if(!event->modifiers()
+          && event->button() == Qt::LeftButton
+          && is_d_pressed)
   {
       showDistance(event->pos());
       event->accept();
@@ -411,7 +413,6 @@ void Viewer::keyReleaseEvent(QKeyEvent *e)
       return;
     }
     is_d_pressed = false;
-    return;
   }
   QGLViewer::keyReleaseEvent(e);
 }


### PR DESCRIPTION
With this PR, it is possible to import a selection_item as ROI vertices in the Edit_polyhedron_plugin.