### PR TITLE
Polyhedron_demo : Remove an action

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -44,7 +44,9 @@ public:
   QList<QAction*> actions() const
   {
     return QList<QAction*>() << actionRemoveIsolatedVertices
-      << actionRemoveDegenerateFaces;
+                                //removed until the function is fully working;
+      //<< actionRemoveDegenerateFaces
+         ;
   }
 
   bool applicable(QAction*) const


### PR DESCRIPTION
(This is part of the #1162 resolution.)
This PR removes the action Remove_degenerate_faces from the Repair_polyhedron_plugin.
The code is still here, so we won't have to rewrite it when the function is finished and documented.