### PR TITLE
Polyhedron_demo: Fix images issues in mesh 3 plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -893,7 +893,7 @@ Io_image_plugin::load(QFileInfo fileinfo) {
   if(type == "Gray-level image")
   {
     //Create planes
-    image_item = new Scene_image_item(image,125, true);
+    image_item = new Scene_image_item(image,0, true);
     image_item->setName(fileinfo.baseName());
     msgBox.setText("Planes created : 0/3");
     msgBox.setStandardButtons(QMessageBox::NoButton);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -388,7 +388,7 @@ public Q_SLOTS:
     threads.erase(it);
 
     update_msgBox();
-    Volume_plane_intersection* intersection = dynamic_cast<Volume_plane_intersection*>(scene->item(intersectionId));
+    Volume_plane_intersection* intersection = dynamic_cast<Volume_plane_intersection*>(scene->item(intersection_id));
     if(!intersection) {
       // the intersection is gone before it was initialized
       return;
@@ -451,18 +451,18 @@ private:
 
   CGAL::Three::Scene_group_item* group;
   std::vector<Volume_plane_thread*> threads;
-  struct controls{
+  struct Controls{
     CGAL::Three::Scene_item* group;
-    CGAL::Three::Scene_item* xitem;
-    CGAL::Three::Scene_item* yitem;
-    CGAL::Three::Scene_item* zitem;
-    int xvalue;
-    int yvalue;
-    int zvalue;
+    CGAL::Three::Scene_item* x_item;
+    CGAL::Three::Scene_item* y_item;
+    CGAL::Three::Scene_item* z_item;
+    int x_value;
+    int y_value;
+    int z_value;
   };
-  controls *current_control;
-  QMap<CGAL::Three::Scene_item*, controls> group_map;
-  unsigned int intersectionId;
+  Controls *current_control;
+  QMap<CGAL::Three::Scene_item*, Controls> group_map;
+  unsigned int intersection_id;
   bool loadDCM(QString filename);
   Image* createDCMImage(QString dirname);
   QLayout* createOrGetDockLayout() {
@@ -579,7 +579,7 @@ private:
           = new Volume_plane_intersection(img->xdim() * img->vx(),
                                           img->ydim() * img->vy(),
                                           img->zdim() * img->vz());
-      this->intersectionId = scene->addItem(i);
+      this->intersection_id = scene->addItem(i);
       scene->changeGroup(i, group);
       group->lockChild(i);
     } else {
@@ -601,37 +601,37 @@ private:
 
     switchReaderConverter< Word >(minmax);
 
-    Volume_plane<x_tag> *xitem = new Volume_plane<x_tag>();
-    Volume_plane<y_tag> *yitem = new Volume_plane<y_tag>();
-    Volume_plane<z_tag> *zitem = new Volume_plane<z_tag>();
+    Volume_plane<x_tag> *x_item = new Volume_plane<x_tag>();
+    Volume_plane<y_tag> *y_item = new Volume_plane<y_tag>();
+    Volume_plane<z_tag> *z_item = new Volume_plane<z_tag>();
     scene->setSelectedItem(-1);
     group = new Scene_group_item(QString("Planes for %1").arg(seg_img->name()));
     connect(group, SIGNAL(aboutToBeDestroyed()),
             this, SLOT(erase_group()));
     scene->addItem(group);
-    controls c;
+    Controls c;
     c.group = group;
-    c.xitem = xitem;
-    c.yitem = yitem;
-    c.zitem = zitem;
-    c.xvalue = 0;
-    c.yvalue = 0;
-    c.zvalue = 0;
+    c.x_item = x_item;
+    c.y_item = y_item;
+    c.z_item = z_item;
+    c.x_value = 0;
+    c.y_value = 0;
+    c.z_value = 0;
     group_map[seg_img] = c;
     current_control = &group_map[seg_img];
     connect(seg_img, SIGNAL(aboutToBeDestroyed()),
             this, SLOT(erase_group()));
 
-    threads.push_back(new X_plane_thread<Word>(xitem, img, clamper, name));
+    threads.push_back(new X_plane_thread<Word>(x_item, img, clamper, name));
 
     connect(threads.back(), SIGNAL(finished(Volume_plane_thread*)), this, SLOT(addVP(Volume_plane_thread*)));
     threads.back()->start();
 
-    threads.push_back(new Y_plane_thread<Word>(yitem,img, clamper, name));
+    threads.push_back(new Y_plane_thread<Word>(y_item,img, clamper, name));
     connect(threads.back(), SIGNAL(finished(Volume_plane_thread*)), this, SLOT(addVP(Volume_plane_thread*)));
     threads.back()->start();
 
-    threads.push_back(new Z_plane_thread<Word>(zitem,img, clamper, name));
+    threads.push_back(new Z_plane_thread<Word>(z_item,img, clamper, name));
     connect(threads.back(), SIGNAL(finished(Volume_plane_thread*)), this, SLOT(addVP(Volume_plane_thread*)));
     threads.back()->start();
 
@@ -678,9 +678,9 @@ private Q_SLOTS:
       {
         if(group_map[key].group == group_item)
         {
-          group_map[key].xitem = NULL;
-          group_map[key].yitem = NULL;
-          group_map[key].zitem = NULL;
+          group_map[key].x_item = NULL;
+          group_map[key].y_item = NULL;
+          group_map[key].z_item = NULL;
           group_map.remove(key);
           break;
         }
@@ -701,12 +701,12 @@ private Q_SLOTS:
     {
       return;
     }
-    controls c = group_map[sel_itm];
+    Controls c = group_map[sel_itm];
     current_control = &group_map[sel_itm];
     // x line
-    if(c.xitem != NULL)
+    if(c.x_item != NULL)
     {
-      Volume_plane_interface* x_plane = qobject_cast<Volume_plane_interface*>(c.xitem);
+      Volume_plane_interface* x_plane = qobject_cast<Volume_plane_interface*>(c.x_item);
       if(x_slider)
         delete x_slider;
       x_slider = new Plane_slider(x_plane->translationVector(), scene->item_id(x_plane), scene, x_plane->manipulatedFrame(),
@@ -716,15 +716,15 @@ private Q_SLOTS:
       connect(x_plane, SIGNAL(manipulated(int)), x_cubeLabel, SLOT(setNum(int)));
       connect(x_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_x_item()));
       connect(x_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
-      x_slider->setValue(c.xvalue);
+      x_slider->setValue(c.x_value);
 
       x_box->addWidget(x_slider);
       x_box->addWidget(x_cubeLabel);
     }
     //y line
-    if(c.yitem != NULL)
+    if(c.y_item != NULL)
     {
-      Volume_plane_interface* y_plane = qobject_cast<Volume_plane_interface*>(c.yitem);
+      Volume_plane_interface* y_plane = qobject_cast<Volume_plane_interface*>(c.y_item);
       if(y_slider)
         delete y_slider;
       y_slider = new Plane_slider(y_plane->translationVector(), scene->item_id(y_plane), scene, y_plane->manipulatedFrame(),
@@ -734,14 +734,14 @@ private Q_SLOTS:
       connect(y_plane, SIGNAL(manipulated(int)), y_cubeLabel, SLOT(setNum(int)));
       connect(y_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_y_item()));
       connect(y_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
-      y_slider->setValue(c.yvalue);
+      y_slider->setValue(c.y_value);
       y_box->addWidget(y_slider);
       y_box->addWidget(y_cubeLabel);
     }
     // z line
-    if(c.zitem != NULL)
+    if(c.z_item != NULL)
     {
-      Volume_plane_interface* z_plane = qobject_cast<Volume_plane_interface*>(c.zitem);
+      Volume_plane_interface* z_plane = qobject_cast<Volume_plane_interface*>(c.z_item);
       if(z_slider)
         delete z_slider;
       z_slider = new Plane_slider(z_plane->translationVector(), scene->item_id(z_plane), scene, z_plane->manipulatedFrame(),
@@ -751,7 +751,7 @@ private Q_SLOTS:
       connect(z_plane, SIGNAL(manipulated(int)), z_cubeLabel, SLOT(setNum(int)));
       connect(z_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_z_item()));
       connect(z_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
-      z_slider->setValue(c.zvalue);
+      z_slider->setValue(c.z_value);
       z_box->addWidget(z_slider);
       z_box->addWidget(z_cubeLabel);
     }
@@ -759,26 +759,26 @@ private Q_SLOTS:
 //Keeps the position of the planes for the next time
   void set_value()
   {
-    current_control->xvalue = x_slider->value();
-    current_control->yvalue = y_slider->value();
-    current_control->zvalue = z_slider->value();
+    current_control->x_value = x_slider->value();
+    current_control->y_value = y_slider->value();
+    current_control->z_value = z_slider->value();
   }
 
   void destroy_x_item()
   {
-    current_control->xitem = NULL; 
+    current_control->x_item = NULL;
     if(group_map.isEmpty())
       x_control->hide();
   }
   void destroy_y_item()
   {
-    current_control->yitem = NULL;
+    current_control->y_item = NULL;
     if(group_map.isEmpty())
       y_control->hide();
   }
   void destroy_z_item()
   {
-    current_control->zitem = NULL;
+    current_control->z_item = NULL;
     if(group_map.isEmpty())
       z_control->hide();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -503,6 +503,7 @@ private:
   }
 
   void createPlanes(Scene_image_item* seg_img) {
+    QApplication::setOverrideCursor(Qt::WaitCursor);
     //Control widgets creation
     QLayout* layout = createOrGetDockLayout();
     if(x_control == NULL)
@@ -664,6 +665,7 @@ private Q_SLOTS:
     {
       msgBox.hide();
       nbPlanes = 0;
+      QApplication::restoreOverrideCursor();
     }
   }
   // Avoids the segfault after the deletion of an item

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
@@ -58,6 +58,30 @@ template<typename Tag>
 class Volume_plane : public Volume_plane_interface, public Tag {
 public:
  Volume_plane();
+
+ void compute_bbox()const
+ {
+   compute_bbox(*this);
+ }
+
+ void compute_bbox(x_tag)const
+ {
+   _bbox = Bbox(0,0,0,
+               0, (adim_ - 1) * yscale_, (bdim_ - 1) * zscale_);
+ }
+
+ void compute_bbox(y_tag)const
+ {
+   _bbox = Bbox(0,0,0,
+               (adim_ - 1) * xscale_, 0, (bdim_ - 1) * zscale_);
+ }
+
+ void compute_bbox(z_tag)const
+ {
+   _bbox = Bbox(0,0,0,
+               (adim_ - 1) * xscale_, (bdim_ - 1) * yscale_, 0);
+ }
+
  void setData(unsigned int adim, unsigned int bdim, unsigned int cdim,
                  float xscale, float yscale, float zscale, std::vector<float>& colors);
 

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -654,15 +654,33 @@ Scene_image_item::draw(Viewer_interface* viewer) const
   }
 }
 
+template <typename T> const char* whatType(T) { return "unknown"; }    // default
+template <> const char* whatType(float) { return "float"; }    // default
+template <> const char* whatType(double) { return "double"; }    // default
+template <> const char* whatType(char) { return "char"; }    // default
+template <> const char* whatType(boost::uint8_t) { return "uint8 "; }    // default
+template <> const char* whatType(boost::int16_t) { return "uint16"; }    // default
+template <> const char* whatType(boost::uint16_t type) { return "uint16_t"; }    // default
+template <> const char* whatType(boost::int32_t) { return "int32_t"; }    // default
+template <> const char* whatType(boost::uint32_t) { return "uint32_t"; }    // default
+
+template<typename Word>
+QString explicitWordType()
+{
+  return QString(whatType(Word(0)));
+}
+
 QString
 Scene_image_item::toolTip() const
 {
+  QString w_type;
+  CGAL_IMAGE_IO_CASE(image()->image(), w_type = explicitWordType<Word>())
   return tr("<p>Image <b>%1</b></p>"
             "<p>Word type: %2</p>"
             "<p>Dimensions: %3 x %4 x %5</p>"
             "<p>Spacings: ( %6 , %7 , %8 )</p>")
     .arg(this->name())
-    .arg("...")
+    .arg(w_type)
     .arg(m_image->xdim()) 
     .arg(m_image->ydim())
     .arg(m_image->zdim())

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -658,11 +658,11 @@ template <typename T> const char* whatType(T) { return "unknown"; }    // defaul
 template <> const char* whatType(float) { return "float"; }
 template <> const char* whatType(double) { return "double"; }
 template <> const char* whatType(char) { return "int8_t (char)"; }
-template <> const char* whatType(boost::uint8_t) { return "uint8_t"; }
-template <> const char* whatType(boost::int16_t) { return "uint16_t"; }
-template <> const char* whatType(boost::uint16_t type) { return "uint16_t"; }
-template <> const char* whatType(boost::int32_t) { return "int32_t"; }
-template <> const char* whatType(boost::uint32_t) { return "uint32_t"; }
+template <> const char* whatType(boost::uint8_t) { return "uint8_t (unsigned char)"; }
+template <> const char* whatType(boost::int16_t) { return "int16_t (short)"; }
+template <> const char* whatType(boost::uint16_t) { return "uint16_t (unsigned short)"; }
+template <> const char* whatType(boost::int32_t) { return "int32_t (int)"; }
+template <> const char* whatType(boost::uint32_t) { return "uint32_t (unsigned int)"; }
 
 template<typename Word>
 QString explicitWordType()

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -713,47 +713,51 @@ Scene_image_item::supportsRenderingMode(RenderingMode m) const
 void
 Scene_image_item_priv::initializeBuffers()
 {
-  internal::Image_accessor image_data_accessor (*item->m_image,
-                                                m_voxel_scale,
-                                                m_voxel_scale,
-                                                m_voxel_scale);
-  internal::Vertex_buffer_helper helper (image_data_accessor);
-  helper.fill_buffer_data();
   draw_Bbox(item->bbox(), v_box);
   std::vector<float> nul_vec(0);
   for(std::size_t i=0; i<v_box->size(); i++)
-      nul_vec.push_back(0.0);
-  rendering_program.bind();
-  vao[0].bind();
-  m_vbo[0].bind();
-  m_vbo[0].allocate(helper.vertices(), static_cast<int>(helper.vertex_size()));
-  poly_vertexLocation[0] = rendering_program.attributeLocation("vertex");
-  rendering_program.enableAttributeArray(poly_vertexLocation[0]);
-  rendering_program.setAttributeBuffer(poly_vertexLocation[0],GL_FLOAT,0,3);
-  m_vbo[0].release();
+    nul_vec.push_back(0.0);
+  if(!is_hidden)
+  {
+    internal::Image_accessor image_data_accessor (*item->m_image,
+                                                  m_voxel_scale,
+                                                  m_voxel_scale,
+                                                  m_voxel_scale);
+    internal::Vertex_buffer_helper helper (image_data_accessor);
+    helper.fill_buffer_data();
+    rendering_program.bind();
+    vao[0].bind();
+    m_vbo[0].bind();
+    m_vbo[0].allocate(helper.vertices(), static_cast<int>(helper.vertex_size()));
+    poly_vertexLocation[0] = rendering_program.attributeLocation("vertex");
+    rendering_program.enableAttributeArray(poly_vertexLocation[0]);
+    rendering_program.setAttributeBuffer(poly_vertexLocation[0],GL_FLOAT,0,3);
+    m_vbo[0].release();
 
-  m_vbo[1].bind();
-  m_vbo[1].allocate(helper.normals(), static_cast<int>(helper.normal_size()));
-  normalsLocation[0] = rendering_program.attributeLocation("normal");
-  rendering_program.enableAttributeArray(normalsLocation[0]);
-  rendering_program.setAttributeBuffer(normalsLocation[0],GL_FLOAT,0,3);
-  m_vbo[1].release();
+    m_vbo[1].bind();
+    m_vbo[1].allocate(helper.normals(), static_cast<int>(helper.normal_size()));
+    normalsLocation[0] = rendering_program.attributeLocation("normal");
+    rendering_program.enableAttributeArray(normalsLocation[0]);
+    rendering_program.setAttributeBuffer(normalsLocation[0],GL_FLOAT,0,3);
+    m_vbo[1].release();
 
-  m_vbo[2].bind();
-  m_vbo[2].allocate(helper.colors(), static_cast<int>(helper.color_size()));
-  colorLocation[0] = rendering_program.attributeLocation("inColor");
-  rendering_program.enableAttributeArray(colorLocation[0]);
-  rendering_program.setAttributeBuffer(colorLocation[0],GL_FLOAT,0,3);
-  m_vbo[2].release();
+    m_vbo[2].bind();
+    m_vbo[2].allocate(helper.colors(), static_cast<int>(helper.color_size()));
+    colorLocation[0] = rendering_program.attributeLocation("inColor");
+    rendering_program.enableAttributeArray(colorLocation[0]);
+    rendering_program.setAttributeBuffer(colorLocation[0],GL_FLOAT,0,3);
+    m_vbo[2].release();
 
-  m_ibo->bind();
-  m_ibo->allocate(helper.quads(), static_cast<int>(helper.quad_size()));
-  vao[0].release();
+    m_ibo->bind();
+    m_ibo->allocate(helper.quads(), static_cast<int>(helper.quad_size()));
+    vao[0].release();
 
-  color.resize(0);
-  for(std::size_t i=0; i<helper.color_size()/sizeof(GLuint); i++)
+    color.resize(0);
+    for(std::size_t i=0; i<helper.color_size()/sizeof(GLuint); i++)
       color.push_back(0.0);
-
+    rendering_program.release();
+  }
+  rendering_program.bind();
   vao[1].bind();
   m_vbo[3].bind();
   m_vbo[3].allocate(v_box->data(), static_cast<int>(v_box->size()*sizeof(float)));

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -655,14 +655,14 @@ Scene_image_item::draw(Viewer_interface* viewer) const
 }
 
 template <typename T> const char* whatType(T) { return "unknown"; }    // default
-template <> const char* whatType(float) { return "float"; }    // default
-template <> const char* whatType(double) { return "double"; }    // default
-template <> const char* whatType(char) { return "char"; }    // default
-template <> const char* whatType(boost::uint8_t) { return "uint8 "; }    // default
-template <> const char* whatType(boost::int16_t) { return "uint16"; }    // default
-template <> const char* whatType(boost::uint16_t type) { return "uint16_t"; }    // default
-template <> const char* whatType(boost::int32_t) { return "int32_t"; }    // default
-template <> const char* whatType(boost::uint32_t) { return "uint32_t"; }    // default
+template <> const char* whatType(float) { return "float"; }
+template <> const char* whatType(double) { return "double"; }
+template <> const char* whatType(char) { return "int8_t (char)"; }
+template <> const char* whatType(boost::uint8_t) { return "uint8_t"; }
+template <> const char* whatType(boost::int16_t) { return "uint16_t"; }
+template <> const char* whatType(boost::uint16_t type) { return "uint16_t"; }
+template <> const char* whatType(boost::int32_t) { return "int32_t"; }
+template <> const char* whatType(boost::uint32_t) { return "uint32_t"; }
 
 template<typename Word>
 QString explicitWordType()


### PR DESCRIPTION
This PR fixes #1182.

This is a fix for the Io_image_plugin:
- This corrects the naming style
- This fixes the Word type in the toolTip()
- This adds a waitCursor during the creation of the planes
- This adds a bbox to the volume planes
- This keeps the item from computing useless data for the gray-images display.