### PR TITLE
Polyhedron demo - various small fixes for Mesh_3 plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -77,7 +77,8 @@ public:
 
   bool applicable(QAction* a) const {
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
-    if(qobject_cast<Scene_implicit_function_item*>(scene->item(scene->mainSelectionIndex())))
+    if(qobject_cast<Scene_implicit_function_item*>(scene->item(scene->mainSelectionIndex())) != NULL
+      && a == actionMesh_3)
       return true;
 #endif
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -298,8 +298,10 @@ void Mesh_3_plugin::mesh_3(const bool surface_only)
   ui.protect->setChecked(features_protection_available);
 
   ui.grayImgGroup->setVisible(image_item != NULL && image_item->isGray());
-  ui.volumeGroup->setVisible(!surface_only && poly_item != NULL
-                             && poly_item->polyhedron()->is_closed());
+  if (poly_item != NULL)
+    ui.volumeGroup->setVisible(!surface_only && poly_item->polyhedron()->is_closed());
+  else
+    ui.volumeGroup->setVisible(!surface_only);
   ui.noEdgeSizing->setChecked(ui.protect->isChecked());
   ui.edgeLabel->setEnabled(ui.noEdgeSizing->isChecked());
   ui.edgeSizing->setEnabled(ui.noEdgeSizing->isChecked());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -60,7 +60,7 @@ public:
               this, SLOT(mesh_3_volume()));
     }
 
-    actionMesh_3_remesh = new QAction("Remesh a polyhedral surface", mw);
+    actionMesh_3_remesh = new QAction("Create a Surface Triangle Mesh", mw);
     if (actionMesh_3_remesh){
       actionMesh_3_remesh->setProperty("subMenuName", "Tetrahedral Mesh Generation");
       connect(actionMesh_3_remesh, SIGNAL(triggered()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -60,10 +60,10 @@ public:
               this, SLOT(mesh_3_volume()));
     }
 
-    actionMesh_3_remesh = new QAction("Create a Surface Triangle Mesh", mw);
-    if (actionMesh_3_remesh){
-      actionMesh_3_remesh->setProperty("subMenuName", "Tetrahedral Mesh Generation");
-      connect(actionMesh_3_remesh, SIGNAL(triggered()),
+    actionMesh_3_surface = new QAction("Create a Surface Triangle Mesh", mw);
+    if (actionMesh_3_surface){
+      actionMesh_3_surface->setProperty("subMenuName", "Tetrahedral Mesh Generation");
+      connect(actionMesh_3_surface, SIGNAL(triggered()),
               this, SLOT(mesh_3_surface()));
     }
 
@@ -71,7 +71,7 @@ public:
   }
 
   QList<QAction*> actions() const {
-    return QList<QAction*>() << actionMesh_3 << actionMesh_3_remesh;
+    return QList<QAction*>() << actionMesh_3 << actionMesh_3_surface;
   }
 
 
@@ -110,7 +110,7 @@ private:
 
 private:
   QAction* actionMesh_3;
-  QAction* actionMesh_3_remesh;
+  QAction* actionMesh_3_surface;
   Messages_interface* msg;
   QMessageBox* message_box_;
   Scene_item* source_item_;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1076,6 +1076,7 @@ void Scene_c3t3_item::export_facets_in_complex()
     soup_item->setName(QString("%1_%2").arg(this->name()).arg("facets"));
     scene->addItem(soup_item);
   }
+  this->setVisible(false);
 }
 
 QMenu* Scene_c3t3_item::contextMenu()


### PR DESCRIPTION
This PR makes the `volumeGroup` visible for meshing segmented images, and renames the surface meshing operation.

fixes #1185 and implements @lrineau comment about action name of #1154 

the fix of @maxGimeno in `Fix_bug_display-GF` is necessary to have this PR working