### PR TITLE
Polyhedron_demo: Enhance deformation

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -669,11 +669,24 @@ namespace internal {
           halfedge_and_opp_removed(he);
           halfedge_and_opp_removed(prev(he, mesh_));
 
+          //constrained case
+          bool constrained_case = is_constrained(va) || is_constrained(vb);
+          if (constrained_case)
+          {
+            CGAL_assertion(is_constrained(va) ^ is_constrained(vb));//XOR
+            set_constrained(va, false);
+            set_constrained(vb, false);
+          }
+
           //perform collapse
           Point target_point = get(vpmap_, vb);
           vertex_descriptor vkept = CGAL::Euler::collapse_edge(e, mesh_);
           put(vpmap_, vkept, target_point);
           ++nb_collapses;
+
+          //fix constrained case
+          if (constrained_case)//we have made sure that collapse goes to constrained vertex
+            set_constrained(vkept, true);
 
           fix_degenerate_faces(vkept, short_edges, sq_low);
 
@@ -1271,6 +1284,10 @@ private:
     bool is_constrained(const vertex_descriptor& v) const
     {
       return get(vcmap_, v);
+    }
+    void set_constrained(const vertex_descriptor& v, const bool b)
+    {
+      put(vcmap_, v, b);
     }
 
     bool is_corner(const vertex_descriptor& v) const

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -639,7 +639,7 @@ void Scene_edit_polyhedron_item_priv::remesh()
 
   unsigned int nb_iter = ui_widget->remeshing_iterations_spinbox->value();
 
-  std::cout << "Remeshing...";
+  std::cout << "Remeshing (target edge length = " << target_length <<")...";
 
   ROI_border_pmap border_pmap(&roi_border);
   CGAL::Polygon_mesh_processing::isotropic_remeshing(

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -570,6 +570,8 @@ struct Is_constrained_map
 
 void Scene_edit_polyhedron_item_priv::remesh()
 {
+  if(deform_mesh->roi_vertices().empty())
+    return;
   boost::unordered_set<vertex_descriptor, CGAL::Handle_hash_function> constrained_set;
   const Polyhedron& g = deform_mesh->halfedge_graph();
   Array_based_vertex_point_map vpmap(&positions);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -589,6 +589,8 @@ void Scene_edit_polyhedron_item_priv::remesh()
 
     BOOST_FOREACH(face_descriptor fv, CGAL::faces_around_target(halfedge(v, g), g))
     {
+      if(fv == boost::graph_traits<Polyhedron>::null_face())
+        continue;
       bool add_face=true;
       BOOST_FOREACH(vertex_descriptor vfd, CGAL::vertices_around_face(halfedge(fv,g),g))
         if (roi_vertices.count(vfd)==0)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -603,6 +603,13 @@ void Scene_edit_polyhedron_item_priv::remesh()
       }
     }
   }
+
+  if (roi_facets.empty())
+  {
+    std::cout << "Remeshing canceled (there is no facet with "
+              << "its 3 vertices in the ROI)." << std::endl;
+    return;
+  }
   // set face_index map needed for border_halfedges and isotropic_remeshing
   boost::property_map<Polyhedron, CGAL::face_index_t>::type fim
     = get(CGAL::face_index, *item->polyhedron());

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -763,7 +763,7 @@ void Scene_edit_polyhedron_item_priv::expand_or_reduce(int steps)
 
   item->clear_roi();
   item->create_ctrl_vertices_group();
-  for(typename Polyhedron::Vertex_iterator it = poly_item->polyhedron()->vertices_begin() ; it != poly_item->polyhedron()->vertices_end(); ++it)
+  for(Polyhedron::Vertex_iterator it = poly_item->polyhedron()->vertices_begin() ; it != poly_item->polyhedron()->vertices_end(); ++it)
   {
     if(mark[it->id()]) {
       if(ctrl_active)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -9,6 +9,8 @@
 #include <QTime>
 
 #include <CGAL/Polygon_mesh_processing/border.h>
+#include <CGAL/Polygon_mesh_processing/remesh.h>
+
 struct Scene_edit_polyhedron_item_priv
 {
   Scene_edit_polyhedron_item_priv(Scene_polyhedron_item* poly_item,  Ui::DeformMesh* ui_widget, QMainWindow* mw, Scene_edit_polyhedron_item* parent)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -581,7 +581,6 @@ void Scene_edit_polyhedron_item_priv::remesh()
     deform_mesh->roi_vertices().begin(),deform_mesh->roi_vertices().end());
 
   ROI_faces_pmap roi_faces_pmap;
-  QVector<Point> controls_to_save;
   BOOST_FOREACH(vertex_descriptor v, deform_mesh->roi_vertices())
   {
     if(deform_mesh->is_control_vertex(v))
@@ -653,7 +652,9 @@ void Scene_edit_polyhedron_item_priv::remesh()
     .vertex_is_constrained_map(Is_constrained_map(&constrained_set))
     );
   std::cout << "done." << std::endl;
-
+  poly_item->update_vertex_indices();
+  poly_item->update_facet_indices();
+  poly_item->update_halfedge_indices();
   //reset ROI from its outside border roi_border
   item->clear_roi();
   do{
@@ -671,7 +672,9 @@ void Scene_edit_polyhedron_item_priv::remesh()
 
   item->create_ctrl_vertices_group();
   BOOST_FOREACH(vertex_descriptor v, constrained_set)
+  {
       item->insert_control_vertex(v);
+  }
 
   BOOST_FOREACH(face_descriptor f, faces(g))
   {
@@ -741,7 +744,7 @@ void Scene_edit_polyhedron_item_priv::expand_or_reduce(int steps)
 {
   std::vector<bool> mark(poly_item->polyhedron()->size_of_vertices(),false);
   std::size_t original_size = deform_mesh->roi_vertices().size();
-  QVector<Point> points_to_save;
+  QVector<vertex_descriptor> points_to_save;
   bool ctrl_active = ui_widget->CtrlVertRadioButton->isChecked();
   BOOST_FOREACH(vertex_descriptor v,deform_mesh->roi_vertices())
   {
@@ -749,12 +752,12 @@ void Scene_edit_polyhedron_item_priv::expand_or_reduce(int steps)
       if(ctrl_active)
       {
         if(!deform_mesh->is_control_vertex(v))
-          points_to_save.push_back(v->point());
+          points_to_save.push_back(v);
       }
       else
       {
         if(deform_mesh->is_control_vertex(v))
-          points_to_save.push_back(v->point());
+          points_to_save.push_back(v);
       }
   }
 
@@ -772,13 +775,13 @@ void Scene_edit_polyhedron_item_priv::expand_or_reduce(int steps)
     if(mark[it->id()]) {
       if(ctrl_active)
       {
-        if(points_to_save.contains(it->point()))
+        if(points_to_save.contains(it))
           item->insert_roi_vertex(it);
         else
           item->insert_control_vertex(it);
       }
       else{
-        if(points_to_save.contains(it->point()))
+        if(points_to_save.contains(it))
           item->insert_control_vertex(it);
         else
           item->insert_roi_vertex(it);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -25,7 +25,6 @@
 
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <CGAL/Surface_mesh_deformation.h>
-#include <CGAL/Polygon_mesh_processing/remesh.h>
 
 #include <boost/function_output_iterator.hpp>
 #include <QGLBuffer>


### PR DESCRIPTION
This PR is an enhancement for the Edit_polyhedron_plugin:

- It implements the propagation of the selected ROI and Control vertices
- It allows to keep the Control vertices when using remesh_after_deformation.