### PR TITLE
use tabs to reduce the size of the deformation widget

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
-    <height>706</height>
+    <width>553</width>
+    <height>380</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,355 +16,342 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QGroupBox" name="SelectionGroupBox">
-      <property name="title">
-       <string>Selection</string>
+     <widget class="QTabWidget" name="tabWidget">
+      <property name="currentIndex">
+       <number>0</number>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="2" column="1" rowspan="2" colspan="2">
-        <layout class="QVBoxLayout" name="RingLayout">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Brush Size ROI:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Control Vertices Brush Size:</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
-              <widget class="QSpinBox" name="BrushSpinBoxRoi"/>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="BrushSpinBoxCtrlVert"/>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item row="4" column="0" colspan="4">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QPushButton" name="SelectAllVerticesPushButton">
-           <property name="text">
-            <string>Set All Vertices as ROI</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="ClearROIPushButton">
-           <property name="text">
-            <string>Clear ROI</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="2" column="0" rowspan="2">
-        <widget class="QGroupBox" name="ROICtrlVertGroupBox">
-         <layout class="QVBoxLayout" name="CtrlVertRoiLayout">
+      <widget class="QWidget" name="tab">
+       <attribute name="title">
+        <string>Selection</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_9">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_13">
           <item>
-           <widget class="QRadioButton" name="ROIRadioButton">
+           <widget class="QGroupBox" name="RCgroup">
+            <layout class="QVBoxLayout" name="verticalLayout_7">
+             <item>
+              <widget class="QRadioButton" name="ROIRadioButton">
+               <property name="toolTip">
+                <string>Use Shift + Left Click to paint ROI vertices</string>
+               </property>
+               <property name="text">
+                <string>ROI</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="CtrlVertRadioButton">
+               <property name="toolTip">
+                <string>Use Shift + Left Click to paint control vertices</string>
+               </property>
+               <property name="text">
+                <string>Control vertices</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="RingLayout">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_5">
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>Brush Size ROI:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_2">
+                  <property name="text">
+                   <string>Control Vertices Brush Size:</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_2">
+                <item>
+                 <widget class="QSpinBox" name="BrushSpinBoxRoi"/>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="BrushSpinBoxCtrlVert"/>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="InsertEraseGroup">
+            <layout class="QVBoxLayout" name="verticalLayout_8">
+             <item>
+              <widget class="QRadioButton" name="InsertRadioButton">
+               <property name="text">
+                <string>Insertion</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="EraseRadioButton">
+               <property name="text">
+                <string>Removal</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QPushButton" name="SelectAllVerticesPushButton">
+            <property name="text">
+             <string>Set All Vertices as ROI</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ClearROIPushButton">
+            <property name="text">
+             <string>Clear ROI</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Isolated Component Size:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="Threshold_size_spin_box">
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+              <property name="value">
+               <number>8</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="Get_minimum_button">
+              <property name="text">
+               <string>Get Minimum</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="Select_isolated_components_button">
+            <property name="text">
+             <string>Select Isolated Components Below Threshold</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_2">
+       <attribute name="title">
+        <string>Remeshing</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <widget class="QCheckBox" name="RemeshingCheckBox">
             <property name="toolTip">
-             <string>Use Shift + Left Click to paint ROI vertices</string>
+             <string>Warning : after remeshing all ROI and control vertices will be unselected. &quot;Discard changes&quot; will be unavailable.</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
             </property>
             <property name="text">
-             <string>ROI</string>
+             <string>Remesh after deformation</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QCheckBox" name="remeshingEdgeLengthInput_checkBox">
+                <property name="toolTip">
+                 <string>If unchecked, automatic value is used (the average edge length at ROI boundary)</string>
+                </property>
+                <property name="layoutDirection">
+                 <enum>Qt::RightToLeft</enum>
+                </property>
+                <property name="text">
+                 <string>Target edge length</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="remeshing_edge_length_spinbox"/>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="QLabel" name="label_4">
+                <property name="layoutDirection">
+                 <enum>Qt::RightToLeft</enum>
+                </property>
+                <property name="text">
+                 <string>Nb. iterations</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="remeshing_iterations_spinbox"/>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_3">
+       <attribute name="title">
+        <string>Groups</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QPushButton" name="PrevCtrlVertPushButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&lt;&lt;</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="NextCtrlVertPushButton">
+              <property name="text">
+               <string>&gt;&gt;</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QPushButton" name="AddCtrlVertPushButton">
+              <property name="text">
+               <string>Create new</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="DeleteCtrlVertPushButton">
+              <property name="text">
+               <string>Delete </string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_4">
+       <attribute name="title">
+        <string>Display and IO</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="ShowROICheckBox">
+            <property name="text">
+             <string>Show ROI</string>
             </property>
             <property name="checked">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QRadioButton" name="CtrlVertRadioButton">
-            <property name="toolTip">
-             <string>Use Shift + Left Click to paint control vertices</string>
-            </property>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="ReadROIPushButton">
             <property name="text">
-             <string>Control vertices</string>
+             <string>Load ROI / Control Vertices</string>
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="3" rowspan="2">
-        <widget class="QGroupBox" name="InsertEraseGroupBox">
-         <layout class="QVBoxLayout" name="InsertRemoveLayout">
-          <item>
-           <widget class="QRadioButton" name="InsertRadioButton">
+          <item row="1" column="1">
+           <widget class="QPushButton" name="SaveROIPushButton">
             <property name="text">
-             <string>Insertion</string>
+             <string>Save ROI / Control Vertices</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="importSelectionPushButton">
+            <property name="text">
+             <string>Import Selection from Selection_item</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="ShowAsSphereCheckBox">
+            <property name="text">
+             <string>Show As Sphere</string>
             </property>
             <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="EraseRadioButton">
-            <property name="text">
-             <string>Removal</string>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
          </layout>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="4">
-        <layout class="QGridLayout" name="gridLayout_2">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
-         </property>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="ShowROICheckBox">
-           <property name="text">
-            <string>Show ROI</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QPushButton" name="ReadROIPushButton">
-           <property name="text">
-            <string>Load ROI / Control Vertices</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QPushButton" name="SaveROIPushButton">
-           <property name="text">
-            <string>Save ROI / Control Vertices</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QPushButton" name="importSelectionPushButton">
-           <property name="text">
-            <string>Import Selection from Selection_item</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="ShowAsSphereCheckBox">
-           <property name="text">
-            <string>Show As Sphere</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="title">
-       <string/>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_8">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Isolated Component Size:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="Threshold_size_spin_box">
-             <property name="maximum">
-              <number>999999999</number>
-             </property>
-             <property name="value">
-              <number>8</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="Get_minimum_button">
-             <property name="text">
-              <string>Get Minimum</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QPushButton" name="Select_isolated_components_button">
-           <property name="text">
-            <string>Select Isolated Components Below Threshold</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="remeshing_groupBox">
-      <property name="contextMenuPolicy">
-       <enum>Qt::DefaultContextMenu</enum>
-      </property>
-      <property name="title">
-       <string>Remeshing</string>
-      </property>
-      <property name="flat">
-       <bool>false</bool>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_10">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,0,0">
-         <item>
-          <widget class="QCheckBox" name="RemeshingCheckBox">
-           <property name="toolTip">
-            <string>Warning : after remeshing all ROI and control vertices will be unselected. &quot;Discard changes&quot; will be unavailable.</string>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
-           </property>
-           <property name="text">
-            <string>Remesh after deformation</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_6">
-           <item>
-            <widget class="QCheckBox" name="remeshingEdgeLengthInput_checkBox">
-             <property name="toolTip">
-              <string>If unchecked, automatic value is used (the average edge length at ROI boundary)</string>
-             </property>
-             <property name="layoutDirection">
-              <enum>Qt::RightToLeft</enum>
-             </property>
-             <property name="text">
-              <string>Target edge length</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="layoutDirection">
-              <enum>Qt::RightToLeft</enum>
-             </property>
-             <property name="text">
-              <string>Nb. iterations</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_7">
-           <item>
-            <widget class="QDoubleSpinBox" name="remeshing_edge_length_spinbox"/>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="remeshing_iterations_spinbox"/>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="CtrlVertGroupNavigationGroupBox">
-      <property name="title">
-       <string>Group of Control Vertices Navigation</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QPushButton" name="PrevCtrlVertPushButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>&lt;&lt;</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="NextCtrlVertPushButton">
-           <property name="text">
-            <string>&gt;&gt;</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QPushButton" name="AddCtrlVertPushButton">
-           <property name="text">
-            <string>Create new</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="DeleteCtrlVertPushButton">
-           <property name="text">
-            <string>Delete </string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
-         <item>
-          <widget class="QCheckBox" name="ActivatePivotingCheckBox">
-           <property name="text">
-            <string>Activate Pivoting </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="ActivateFixedPlaneCheckBox">
-           <property name="text">
-            <string>Activate Fixed Plane Deformation</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item>
@@ -375,50 +362,60 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="ApplyAndCloseLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_11">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_10">
-        <item>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="0">
-           <widget class="QPushButton" name="DiscardChangesPushButton">
-            <property name="toolTip">
-             <string>Reset mesh to last version saved by &quot;Overwrite Initial Geometry&quot;. Not available when Remeshing is ON.</string>
-            </property>
-            <property name="text">
-             <string>Discard changes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="OverwritePushButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Overwrite Initial Geometry</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="ApplyAndClosePushButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Apply and Close</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
+       <widget class="QCheckBox" name="ActivatePivotingCheckBox">
+        <property name="text">
+         <string>Activate Pivoting </string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="ActivateFixedPlaneCheckBox">
+        <property name="text">
+         <string>Activate Fixed Plane Deformation</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_14">
+      <item>
+       <widget class="QPushButton" name="DiscardChangesPushButton">
+        <property name="toolTip">
+         <string>Reset mesh to last version saved by &quot;Overwrite Initial Geometry&quot;. Not available when Remeshing is ON.</string>
+        </property>
+        <property name="text">
+         <string>Discard changes</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="ApplyAndClosePushButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Apply and Close</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="OverwritePushButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Overwrite Initial Geometry</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>


### PR DESCRIPTION
![screenshot from 2016-06-22 11-20-35](https://cloud.githubusercontent.com/assets/1224632/16261401/acce3f14-386b-11e6-800c-183f34ceb493.png)
