### PR TITLE
Polyhedron_demo : Add the meshing parameters to the item's tooltip

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1274,7 +1274,7 @@ void MainWindow::updateInfo() {
     QString item_text = item->toolTip();
     QString item_filename = item->property("source filename").toString();
     if(item->bbox()!=CGAL::Bbox_3())
-      item_text += QString("Bounding box: min (%1,%2,%3), max(%4,%5,%6)")
+      item_text += QString("<div>Bounding box: min (%1,%2,%3), max (%4,%5,%6)</div>")
           .arg(item->bbox().xmin())
           .arg(item->bbox().ymin())
           .arg(item->bbox().zmin())
@@ -1282,7 +1282,7 @@ void MainWindow::updateInfo() {
           .arg(item->bbox().ymax())
           .arg(item->bbox().zmax());
     if(!item_filename.isEmpty()) {
-      item_text += QString("<br />File:<i> %1").arg(item_filename);
+      item_text += QString("<div>File:<i> %1</div>").arg(item_filename);
     }
     ui->infoLabel->setText(item_text);
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -71,6 +71,20 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
   p_new_item->setScene(scene);
 
+  QString tooltip = QString(
+        "Angle: %1 \n"
+        "Edge size bound: %2 \n"
+        "Facets size bound: %3 \n"
+        "Approximation bound: %4 \n" )
+      .arg(facet_angle)
+      .arg(edge_size)
+      .arg(facet_sizing)
+      .arg(facet_approx);
+  if (pMesh->is_closed())
+    tooltip += QString("Tetrahedra size bound: %1 \n" )
+        .arg(tet_sizing);
+
+  p_new_item->setProperty("toolTip",tooltip);
   Mesh_parameters param;
   param.facet_angle = facet_angle;
   param.facet_sizing = facet_sizing;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -71,18 +71,21 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
   p_new_item->setScene(scene);
 
-  QString tooltip = QString(
-        "Angle: %1 \n"
-        "Edge size bound: %2 \n"
-        "Facets size bound: %3 \n"
-        "Approximation bound: %4 \n" )
-      .arg(facet_angle)
-      .arg(edge_size)
-      .arg(facet_sizing)
-      .arg(facet_approx);
+  QString tooltip = QString("<div>From \"") + filename +
+    QString("\" with the following mesh parameters"
+            "<ul>"
+            "<li>Angle: %1</li>"
+            "<li>Edge size bound: %2</li>"
+            "<li>Facets size bound: %3</li>"
+            "<li>Approximation bound: %4</li>")
+    .arg(facet_angle)
+    .arg(edge_size)
+    .arg(facet_sizing)
+    .arg(facet_approx);
   if (pMesh->is_closed())
-    tooltip += QString("Tetrahedra size bound: %1 \n" )
+    tooltip += QString("<li>Tetrahedra size bound: %1</li>" )
         .arg(tet_sizing);
+  tooltip += "</ul></div>";
 
   p_new_item->setProperty("toolTip",tooltip);
   Mesh_parameters param;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -743,15 +743,14 @@ void Scene_c3t3_item::compute_bbox() const {
 }
 
 QString Scene_c3t3_item::toolTip() const {
-
-  QString tooltip = property("toolTip").toString() +=QString("3D complex in a 3D triangulation \n"
-    "Number of vertices: %1 \n"
-    "Number of surface facets: %2 \n"
-    "Number of volume tetrahedra: %3 \n")
+  return tr("<p><b>3D complex in a 3D triangulation</b></p>"
+    "<p>Number of vertices: %1<br />"
+    "Number of surface facets: %2<br />"
+    "Number of volume tetrahedra: %3</p>%4")
     .arg(c3t3().triangulation().number_of_vertices())
     .arg(c3t3().number_of_facets_in_complex())
-    .arg(c3t3().number_of_cells_in_complex());
-  return tooltip;
+    .arg(c3t3().number_of_cells_in_complex())
+    .arg(property("toolTip").toString());
 }
 
 void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -743,13 +743,15 @@ void Scene_c3t3_item::compute_bbox() const {
 }
 
 QString Scene_c3t3_item::toolTip() const {
-  return tr("<p><b>3D complex in a 3D triangulation</b></p>"
-    "<p>Number of vertices: %1<br />"
-    "Number of surface facets: %2<br />"
-    "Number of volume tetrahedra: %3</p>")
+
+  QString tooltip = property("toolTip").toString() +=QString("3D complex in a 3D triangulation \n"
+    "Number of vertices: %1 \n"
+    "Number of surface facets: %2 \n"
+    "Number of volume tetrahedra: %3 \n")
     .arg(c3t3().triangulation().number_of_vertices())
     .arg(c3t3().number_of_facets_in_complex())
     .arg(c3t3().number_of_cells_in_complex());
+  return tooltip;
 }
 
 void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {


### PR DESCRIPTION
This PR fixes #1202 .

 It makes the mesh_3 plugin transmit the meshing parameters to the c3t3_item's tooltip so it is displayed in the Info widget. Those parameters are not saved by the Io_plugin.