### PR TITLE
Polyhedron demo : fix a typo in selection widget

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -90,7 +90,7 @@
                   </item>
                   <item>
                    <property name="text">
-                    <string>Selected Components (facet)</string>
+                    <string>Connected Component (Facet)</string>
                    </property>
                   </item>
                   <item>


### PR DESCRIPTION
selection type is "connected component", not "selected components"