### PR TITLE
Polyhedron_demo : Keeping colors after deformation

### DIFF
--- a/Polyhedron/demo/Polyhedron/Color_map.h
+++ b/Polyhedron/demo/Polyhedron/Color_map.h
@@ -9,7 +9,6 @@ compute_color_map(QColor base_color,
                   unsigned nb_of_colors,
                   Output_color_iterator out)
 {
- std::cerr<<"plouf \n";
   qreal hue = base_color.hueF();
   const qreal step = ((qreal)1) / nb_of_colors;
 

--- a/Polyhedron/demo/Polyhedron/Color_map.h
+++ b/Polyhedron/demo/Polyhedron/Color_map.h
@@ -9,6 +9,7 @@ compute_color_map(QColor base_color,
                   unsigned nb_of_colors,
                   Output_color_iterator out)
 {
+ std::cerr<<"plouf \n";
   qreal hue = base_color.hueF();
   const qreal step = ((qreal)1) / nb_of_colors;
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -66,6 +66,7 @@ public Q_SLOTS:
 private:
   typedef CGAL::Three::Scene_interface::Item_id Item_id;
   std::vector<QColor> saved_color;
+  bool is_color_vector_read_only;
   Scene_edit_polyhedron_item* convert_to_edit_polyhedron(Item_id, Scene_polyhedron_item*);
   Scene_polyhedron_item* convert_to_plain_polyhedron(Item_id, Scene_edit_polyhedron_item*);
   void updateSelectionItems(Scene_polyhedron_item* target);
@@ -438,6 +439,7 @@ Polyhedron_demo_edit_polyhedron_plugin::convert_to_edit_polyhedron(Item_id i,
   Scene_edit_polyhedron_item* edit_poly = new Scene_edit_polyhedron_item(poly_item, &ui_widget, mw);
   if(poly_item->isItemMulticolor())
     saved_color = poly_item->color_vector();
+  is_color_vector_read_only = poly_item->is_color_vector_read_only();
   edit_poly->setColor(poly_item->color());
   edit_poly->setName(QString("%1 (edit)").arg(poly_item->name()));
   edit_poly->setRenderingMode(Gouraud);
@@ -459,6 +461,7 @@ Polyhedron_demo_edit_polyhedron_plugin::convert_to_plain_polyhedron(Item_id i,
   Scene_polyhedron_item* poly_item = edit_item->to_polyhedron_item();
   scene->replaceItem(i, poly_item);
   delete edit_item;
+  poly_item->set_color_vector_read_only(is_color_vector_read_only);
   if(saved_color.size() >0)
   {
     poly_item->setItemIsMulticolor(true);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -65,7 +65,7 @@ public Q_SLOTS:
   void importSelection(Scene_polyhedron_selection_item*, Scene_edit_polyhedron_item*);
 private:
   typedef CGAL::Three::Scene_interface::Item_id Item_id;
-
+  std::vector<QColor> saved_color;
   Scene_edit_polyhedron_item* convert_to_edit_polyhedron(Item_id, Scene_polyhedron_item*);
   Scene_polyhedron_item* convert_to_plain_polyhedron(Item_id, Scene_edit_polyhedron_item*);
   void updateSelectionItems(Scene_polyhedron_item* target);
@@ -436,6 +436,8 @@ Polyhedron_demo_edit_polyhedron_plugin::convert_to_edit_polyhedron(Item_id i,
 {
   QString poly_item_name = poly_item->name();
   Scene_edit_polyhedron_item* edit_poly = new Scene_edit_polyhedron_item(poly_item, &ui_widget, mw);
+  if(poly_item->isItemMulticolor())
+    saved_color = poly_item->color_vector();
   edit_poly->setColor(poly_item->color());
   edit_poly->setName(QString("%1 (edit)").arg(poly_item->name()));
   edit_poly->setRenderingMode(Gouraud);
@@ -457,6 +459,13 @@ Polyhedron_demo_edit_polyhedron_plugin::convert_to_plain_polyhedron(Item_id i,
   Scene_polyhedron_item* poly_item = edit_item->to_polyhedron_item();
   scene->replaceItem(i, poly_item);
   delete edit_item;
+  if(saved_color.size() >0)
+  {
+    poly_item->setItemIsMulticolor(true);
+    poly_item->invalidateOpenGLBuffers();
+    poly_item->color_vector() = saved_color;
+    saved_color.clear();
+  }
   return poly_item;
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -139,6 +139,8 @@ struct Scene_polyhedron_item_priv{
   bool facet_picking_m;
   bool erase_next_picked_facet_m;
   //the following variable is used to indicate if the color vector must not be automatically updated.
+  // If this boolean is true, the item's color will be independant of the color's wheel, if it is false
+  // changing the color in the wheel will change the color of the item, even if it is multicolor.
   bool plugin_has_set_color_vector_m;
   bool is_multicolor;
 
@@ -1747,6 +1749,7 @@ bool Scene_polyhedron_item::testDisplayId(double x, double y, double z, CGAL::Th
 
 std::vector<QColor>& Scene_polyhedron_item::color_vector() {return d->colors_;}
 void Scene_polyhedron_item::set_color_vector_read_only(bool on_off) {d->plugin_has_set_color_vector_m=on_off;}
+bool Scene_polyhedron_item::is_color_vector_read_only() { return d->plugin_has_set_color_vector_m;}
 int Scene_polyhedron_item::getNumberOfNullLengthEdges(){return d->number_of_null_length_edges;}
 int Scene_polyhedron_item::getNumberOfDegeneratedFaces(){return d->number_of_degenerated_faces;}
 bool Scene_polyhedron_item::triangulated(){return d->poly->is_pure_triangle();}

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -88,6 +88,7 @@ public:
     void compute_bbox() const;
     std::vector<QColor>& color_vector();
     void set_color_vector_read_only(bool on_off);
+    bool is_color_vector_read_only();
     int getNumberOfNullLengthEdges();
     int getNumberOfDegeneratedFaces();
     bool triangulated();


### PR DESCRIPTION
This fixes #1203 .
This PR saves the Colors_ vector of the polyhedron_item if it exists before the conversion to edit_item and restores it after the deformation is saved.

 It also fixes a color bug in isotropic_remeshing_plugin that occurs when it is used with a polyhedron_selection_item;