### PR TITLE
Polyhedron_demo: Fix the unjustified color changes

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -36,6 +36,7 @@ CGAL::Three::Scene_item::Scene_item(int buffers_size, int vaos_size)
   nb_isolated_vertices = 0;
   has_group = 0;
   parent_group = 0;
+  is_selected = false;
 }
 
 CGAL::Three::Scene_item::~Scene_item() {


### PR DESCRIPTION
This PR initializes the boolean member `is_selected` to false in Scene_item, so that the items that do not change their color according to their selection state won't see their color randomly change.