### PR TITLE
Polyhedron_demo: On the fly selection_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -170,12 +170,35 @@ public Q_SLOTS:
     if(last_mode == 0)
       on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
   }
+  Scene_polyhedron_selection_item* onTheFlyItem() {
+    Scene_polyhedron_item* poly_item = qobject_cast<Scene_polyhedron_item*>(scene->item(scene->mainSelectionIndex()));
+    if(!poly_item)
+      return NULL;
+    Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
+    connect(this, SIGNAL(save_handleType()),new_item, SLOT(save_handleType()));
+    connect(new_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
+    connect(this, SIGNAL(set_operation_mode(int)),new_item, SLOT(set_operation_mode(int)));
+    int item_id = scene->addItem(new_item);
+    QObject* scene_ptr = dynamic_cast<QObject*>(scene);
+    if (scene_ptr)
+      connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
+    connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
+    scene->setSelectedItem(item_id);
+    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
+    if(last_mode == 0)
+      on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
+    return new_item;
+
+  }
   // Select all
   void on_Select_all_button_clicked() {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
-    if(!selection_item) {
+    if(!selection_item)
+      selection_item = onTheFlyItem();
+    if(!selection_item)
+    {
       print_message("Error: there is no selected polyhedron selection item!");
-      return; 
+      return;
     }
 
     selection_item->select_all();
@@ -184,6 +207,8 @@ public Q_SLOTS:
   void on_Select_all_NTButton_clicked()
   {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
+    if(!selection_item)
+      selection_item = onTheFlyItem();
     if(!selection_item) {
       print_message("Error: there is no selected polyhedron selection item!");
       return;
@@ -234,6 +259,8 @@ public Q_SLOTS:
   // Isolated component related functions
   void on_Select_isolated_components_button_clicked() {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
+    if(!selection_item)
+      selection_item = onTheFlyItem();
     if(!selection_item) {
       print_message("Error: there is no selected polyhedron selection item!");
       return; 
@@ -247,6 +274,8 @@ public Q_SLOTS:
   }
   void on_Get_minimum_button_clicked() {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
+    if(!selection_item)
+      selection_item = onTheFlyItem();
     if(!selection_item) {
       print_message("Error: there is no selected polyhedron selection item!");
       return; 
@@ -548,6 +577,8 @@ public Q_SLOTS:
   }
   void on_Select_sharp_edges_button_clicked() {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
+    if(!selection_item)
+      selection_item = onTheFlyItem();
     if (!selection_item) {
       print_message("Error: there is no selected polyhedron selection item!");
       return;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -134,6 +134,22 @@ public Q_SLOTS:
     else
       viewer->setNoBinding();
   }
+
+  void connectItem(Scene_polyhedron_selection_item* new_item)
+  {
+    connect(this, SIGNAL(save_handleType()),new_item, SLOT(save_handleType()));
+    connect(new_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
+    connect(this, SIGNAL(set_operation_mode(int)),new_item, SLOT(set_operation_mode(int)));
+    int item_id = scene->addItem(new_item);
+    QObject* scene_ptr = dynamic_cast<QObject*>(scene);
+    if (scene_ptr)
+      connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
+    connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
+    scene->setSelectedItem(item_id);
+    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
+    if(last_mode == 0)
+      on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
+  }
   // If the selection_item or the polyhedron_item associated to the k-ring_selector is currently selected,
   // set the k-ring_selector as currently selected. (A k-ring_selector tha tis not "currently selected" will
   // not process selection events)
@@ -157,36 +173,15 @@ public Q_SLOTS:
     Scene_polyhedron_item* poly_item = getSelectedItem<Scene_polyhedron_item>();
     if(!poly_item || selection_item_map.find(poly_item) != selection_item_map.end()) { return; }
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
-    connect(this, SIGNAL(save_handleType()),new_item, SLOT(save_handleType()));
-    connect(new_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
-    connect(this, SIGNAL(set_operation_mode(int)),new_item, SLOT(set_operation_mode(int)));
-    int item_id = scene->addItem(new_item);
-    QObject* scene_ptr = dynamic_cast<QObject*>(scene);
-    if (scene_ptr)
-      connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-    connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
-    scene->setSelectedItem(item_id);
-    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
-    if(last_mode == 0)
-      on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
+    connectItem(new_item);
   }
+
   Scene_polyhedron_selection_item* onTheFlyItem() {
     Scene_polyhedron_item* poly_item = qobject_cast<Scene_polyhedron_item*>(scene->item(scene->mainSelectionIndex()));
     if(!poly_item)
       return NULL;
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
-    connect(this, SIGNAL(save_handleType()),new_item, SLOT(save_handleType()));
-    connect(new_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
-    connect(this, SIGNAL(set_operation_mode(int)),new_item, SLOT(set_operation_mode(int)));
-    int item_id = scene->addItem(new_item);
-    QObject* scene_ptr = dynamic_cast<QObject*>(scene);
-    if (scene_ptr)
-      connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-    connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
-    scene->setSelectedItem(item_id);
-    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
-    if(last_mode == 0)
-      on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
+    connectItem(new_item);
     return new_item;
 
   }
@@ -295,20 +290,8 @@ public Q_SLOTS:
     // all other arrangements (putting inside selection_item_map), setting names etc,
     // other params (e.g. k_ring) will be set inside new_item_created
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
-    //To specify what action should be performed on shift+left-click
-    connect(this, SIGNAL(save_handleType()),new_item, SLOT(save_handleType()));
-    connect(new_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
-    connect(this, SIGNAL(set_operation_mode(int)),new_item, SLOT(set_operation_mode(int)));
-    int item_id = scene->addItem(new_item);
-    QObject* scene_ptr = dynamic_cast<QObject*>(scene);
-    if (scene_ptr)
-      connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
-    connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
-    scene->setSelectedItem(item_id);
     ui_widget.modeBox->setCurrentIndex(last_mode);
-    on_ModeBox_changed(last_mode);
-    if(last_mode == 0)
-      on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
+    connectItem(new_item);
   }
   void on_Selection_type_combo_box_changed(int index) {
     typedef Scene_polyhedron_selection_item::Active_handle Active_handle;


### PR DESCRIPTION
fixes #1210 

- Creates a scene_polyhedron_selection_item for the currently selected scene_polyhedron_item if none exists and a button is clicked in the widget.