### PR TITLE
Polyhedron_demo : Trivial UI change in Point_inside_polyhedron_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>542</width>
-    <height>258</height>
+    <width>340</width>
+    <height>225</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,6 +86,19 @@
        </item>
       </layout>
      </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
This PR adds a spacer to the UI of Point_inside_polyhedron_plugin, so it stays compact when the widget is resized.