### PR TITLE
Polyhedron_demo: Fix Point_set_smoothing_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -33,6 +33,7 @@ class Polyhedron_demo_point_set_smoothing_plugin :
 public:
   void init(QMainWindow* mainWindow, CGAL::Three::Scene_interface* scene_interface, Messages_interface*) {
     scene = scene_interface;
+    mw = mainWindow;
     actionJetSmoothing = new QAction(tr("Point Set Jet Smoothing"), mainWindow);
     actionJetSmoothing->setObjectName("actionJetSmoothing");
     autoConnectActions();


### PR DESCRIPTION
Fixes the SEGFAULT by defining mw in the plugin's `init()` function, as it was missing.