### PR TITLE
Polyhedron_demo: Fixes the selection after erasing items

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1511,7 +1511,7 @@ bool MainWindow::on_actionErase_triggered()
 {
   int next_index = scene->erase(scene->selectionIndices());
   //Secure the case where erase triggers other items deletions
-  if(scene->numberOfEntries()> next_index +1 )
+  if(scene->numberOfEntries()< next_index +1 )
     next_index = -1;
   selectSceneItem(next_index);
   return next_index >= 0;


### PR DESCRIPTION
This PR restores the normal selection behavior when an item is erased from the scene.