### PR TITLE
AABB_Tree: Fix for Source_point_from_edge_descriptor::get().

### DIFF
--- a/AABB_tree/include/CGAL/internal/AABB_tree/Halfedge_and_face_graph_property_maps.h
+++ b/AABB_tree/include/CGAL/internal/AABB_tree/Halfedge_and_face_graph_property_maps.h
@@ -192,9 +192,7 @@ struct Source_point_from_edge_descriptor{
   get(Source_point_from_edge_descriptor<HalfedgeGraph,VertexPointPMap> pmap,
       key_type h)
   {
-    return  get(vertex_point,
-                       *pmap.m_graph,
-                       source(h, *pmap.m_graph) );
+    return get(pmap.m_vppm,  source(h, *pmap.m_graph) );
   }
 };
 


### PR DESCRIPTION
This PR fixes a bug in the property maps for AABB_Tree.