### PR TITLE
Use mpq_class rather than Gmpq if gmpxx is available.

### DIFF
--- a/Number_types/include/CGAL/Exact_integer.h
+++ b/Number_types/include/CGAL/Exact_integer.h
@@ -23,7 +23,9 @@
 // Author(s)     : Laurent Rineau
 
 #include <CGAL/config.h>
-#if CGAL_USE_GMP
+#if CGAL_USE_GMPXX
+#  include <CGAL/gmpxx.h>
+#elif CGAL_USE_GMP
 #  include <CGAL/Gmpz.h>
 #elif CGAL_USE_LEDA
 #  include <CGAL/leda_integer.h>
@@ -54,7 +56,11 @@ typedef unspecified_type Exact_integer;
 
 #else // not DOXYGEN_RUNNING
 
-#if CGAL_USE_GMP
+#if CGAL_USE_GMPXX
+
+typedef mpz_class Exact_integer;
+
+#elif CGAL_USE_GMP
 
 typedef Gmpz Exact_integer;
 

--- a/Number_types/include/CGAL/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/internal/Exact_type_selector.h
@@ -57,11 +57,13 @@ namespace CGAL { namespace internal {
 
 // Two classes which tell the prefered "exact number types" corresponding to a type.
 
-// The default template chooses Gmpq, or leda_rational, or Quotient<MP_Float>.
+// The default template chooses mpq_class, Gmpq, leda_rational, or Quotient<MP_Float>.
 // It should support the built-in types.
 template < typename >
 struct Exact_field_selector
-#ifdef CGAL_USE_GMP
+#ifdef CGAL_USE_GMPXX
+{ typedef mpq_class Type; };
+#elif defined(CGAL_USE_GMP)
 { typedef Gmpq Type; };
 #elif defined(CGAL_USE_LEDA)
 { typedef leda_rational Type; };


### PR DESCRIPTION
This needs testing / benchmarking before merging. Last time I tried, all examples I ran were slightly faster with `mpq_class` than `Gmpq` or the same speed. Another advantage is that with `CGAL_DONT_USE_LAZY_KERNEL` and `CGAL_USE_GMPXX`, this makes Epeck thread-safe.

TODO
--------
 - [x] benchmarks
