### PR TITLE
Mesh:3 improve dump_c3t3 (Parallel_tag, Polyhedra;_mesh_domain_3)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Dump_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Dump_c3t3.h
@@ -52,7 +52,9 @@ struct Dump_c3t3 {
     bin_filename += ".binary.cgal";
     std::ofstream bin_file(bin_filename.c_str(),
                            std::ios_base::binary | std::ios_base::out);
-    bin_file << "binary CGAL c3t3 " << CGAL::Get_io_signature<C3t3>()() << "\n";
+    std::string signature = CGAL::Get_io_signature<C3t3>()();
+    CGAL_assertion(signature != std::string());
+    bin_file << "binary CGAL c3t3 " << signature << "\n";
     CGAL::set_binary_mode(bin_file);
     bin_file << c3t3;
   }

--- a/Mesh_3/include/CGAL/Mesh_3/io_signature.h
+++ b/Mesh_3/include/CGAL/Mesh_3/io_signature.h
@@ -177,11 +177,11 @@ struct Get_io_signature<Weighted_point<Point, FT> >
 };
 
 #ifdef CGAL_TRIANGULATION_3_H
-template <class Gt, class Vb, class Cb>
+template <class Gt, class Vb, class Cb, class C_tag>
 struct
-Get_io_signature<Triangulation_3<Gt, Triangulation_data_structure_3<Vb, Cb> > >
+Get_io_signature<Triangulation_3<Gt, Triangulation_data_structure_3<Vb, Cb, C_tag> > >
 {
-  typedef Triangulation_data_structure_3<Vb, Cb> Tds;
+  typedef Triangulation_data_structure_3<Vb, Cb, C_tag> Tds;
 
   std::string operator()() {
     return std::string("Triangulation_3(") +

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -56,6 +56,10 @@
 # include <tbb/enumerable_thread_specific.h>
 #endif
 
+// To handle I/O for Surface_patch_index if that is a pair of `int` (the
+// default)
+#include <CGAL/internal/Mesh_3/Handle_IO_for_pair_of_int.h>
+
 namespace CGAL {
 
 namespace Mesh_3 {

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
@@ -22,9 +22,14 @@
 // File Description :
 //******************************************************************************
 
+#include <CGAL/Mesh_3/io_signature.h>
 #include "test_meshing_utilities.h"
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/IO/Polyhedron_iostream.h>
+
+#include <boost/type_traits/is_same.hpp>
+
+#include <CGAL/Mesh_3/Dump_c3t3.h>
 
 template <typename K, typename Concurrency_tag = CGAL::Sequential_tag>
 struct Polyhedron_tester : public Tester<K>
@@ -34,7 +39,12 @@ struct Polyhedron_tester : public Tester<K>
     typedef K Gt;
     typedef CGAL::Polyhedron_3<Gt> Polyhedron;
     typedef CGAL::Polyhedral_mesh_domain_3<Polyhedron, Gt> Mesh_domain;
-    
+
+    CGAL_static_assertion((boost::is_same<
+                            typename Mesh_domain::Surface_patch_index,
+                            std::pair<int, int>
+                           >::value));
+
     typedef typename CGAL::Mesh_triangulation_3<
       Mesh_domain,
       typename CGAL::Kernel_traits<Mesh_domain>::Kernel,
@@ -96,6 +106,9 @@ struct Polyhedron_tester : public Tester<K>
       this->verify(c3t3, domain, criteria, Polyhedral_tag(),
                    119, 121, 200, 204, 350, 360);  
     }
+
+    // test the dump function
+    CGAL::dump_c3t3(c3t3, "test_meshing_polyhedron-out");
   }
 };
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -291,69 +291,6 @@ typedef CGAL::Triangulation_3<Kernel, Fake_CDT_3_TDS> Fake_CDT_3;
 
 typedef Fake_mesh_domain::Surface_patch_index Fake_patch_id;
 
-#include <CGAL/Mesh_3/io_signature.h>
-
-#ifdef CGAL_MESH_3_IO_SIGNATURE_H
-namespace CGAL {
-template <>
-struct Get_io_signature<Fake_patch_id> {
-  std::string operator()() const
-  {
-    return std::string("std::pair<i,i>");
-  }
-}; // end Get_io_signature<Fake_patch_id>
-} // end namespace CGAL
-#endif
-
-namespace std {
-  inline std::ostream& operator<<(std::ostream& out, const Fake_patch_id& id) {
-    return out << id.first << " " << id.second;
-  }
-  inline std::istream& operator>>(std::istream& in, Fake_patch_id& id) {
-    return in >> id.first >> id.second;
-  }
-} // end namespace std
-
-namespace CGAL {
-template <>
-class Output_rep<Fake_patch_id> {
-  typedef Fake_patch_id T;
-  const T& t;
-public:
-  //! initialize with a const reference to \a t.
-  Output_rep( const T& tt) : t(tt) {}
-  //! perform the output, calls \c operator\<\< by default.
-  std::ostream& operator()( std::ostream& out) const {
-    if(is_ascii(out)) {
-      out << t.first << " " << t.second;
-    } else {
-      CGAL::write(out, t.first);
-      CGAL::write(out, t.second);
-    }
-    return out;
-  }
-};
-
-template <>
-class Input_rep<Fake_patch_id> {
-  typedef Fake_patch_id T;
-  T& t;
-public:
-  //! initialize with a const reference to \a t.
-  Input_rep( T& tt) : t(tt) {}
-  //! perform the output, calls \c operator\<\< by default.
-  std::istream& operator()( std::istream& in) const {
-    if(is_ascii(in)) {
-      in >> t.first >> t.second;
-    } else {
-      CGAL::read(in, t.first);
-      CGAL::read(in, t.second);
-    }
-    return in;
-  }
-};
-} // end namespace CGAL
-
 struct Update_vertex {
   typedef Fake_mesh_domain::Surface_patch_index Sp_index;
   template <typename V1, typename V2>

--- a/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
+++ b/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
@@ -98,85 +98,103 @@ else
   echo "Run all tests."
 
   for target in  \
-      Polyhedron_3 \
-      camera_positions_plugin \
-      convex_hull_plugin \
-      corefinement_plugin \
-      cut_plugin \
-      clip_polyhedron_plugin \
-      create_bbox_mesh_plugin \
-      demo_framework \
-      edit_polyhedron_plugin \
-      features_detection_plugin \
-      gocad_plugin \
-      inside_out_plugin \
-      intersection_plugin \
-      io_implicit_function_plugin \
-      isotropic_remeshing_plugin \
-      jet_fitting_plugin \
-      join_and_split_polyhedra_plugin \
-      kernel_plugin \
-      mean_curvature_flow_skeleton_plugin \
-      mesh_3_plugin \
-      mesh_segmentation_plugin \
-      mesh_simplification_plugin \
-      nef_io_plugin \
-      nef_plugin \
-      off_plugin \
-      off_to_nef_plugin \
-      off_to_xyz_plugin \
-      orient_soup_plugin \
-      parameterization_plugin \
-      pca_plugin \
-      ply_to_xyz_plugin \
-      point_dialog \
-      point_inside_polyhedron_plugin \
-      point_set_average_spacing_plugin \
-      point_set_bilateral_smoothing_plugin \
-      point_set_normal_estimation_plugin \
-      point_set_outliers_removal_plugin \
-      point_set_selection_plugin \
-      point_set_shape_detection_plugin  \
-      point_set_simplification_plugin \
-      point_set_smoothing_plugin \
-      point_set_upsampling_plugin \
-      point_set_wlop_plugin \
-      polyhedron_slicer_plugin \
-      polyhedron_stitching_plugin \
-      polylines_io_plugin \
-      remeshing_plugin \
-      scene_basic_objects \
-      scene_c2t3_item \
-      scene_combinatorial_map_item \
-      scene_edit_polyhedron_item \
-      scene_implicit_function_item \
-      scene_nef_polyhedron_item \
-      scene_points_with_normal_item \
-      scene_polygon_soup_item \
-      scene_polyhedron_item \
-      scene_polyhedron_item_decorator \
-      scene_polyhedron_item_k_ring_selection \
-      scene_polyhedron_selection_item \
-      scene_polyhedron_shortest_path_item \
-      scene_polyhedron_transform_item \
-      scene_polylines_item \
-      scene_textured_polyhedron_item \
-      selection_io_plugin \
-      selection_plugin \
-      self_intersection_plugin \
-      shortest_path_plugin \
-      stl_plugin \
-      subdivision_methods_plugin \
-      surface_reconstruction_plugin \
-      transform_polyhedron_plugin \
-      triangulate_facets_plugin \
-      trivial_plugin \
-      xyz_plugin \
-      p_klein_function_plugin \
-      p_sphere_function_plugin \
-      p_tanglecube_function_plugin \
-      shortest_path_plugin \
-      advancing_front_plugin \
+demo_framework \
+gl_splat \
+point_dialog \
+Polyhedron_3 \
+polyhedron_demo \
+scene_basic_objects \
+scene_color_ramp \
+scene_c2t3_item \
+scene_c3t3_item \
+scene_combinatorial_map_item \
+scene_edit_polyhedron_item \
+scene_image_item \
+scene_implicit_function_item \
+scene_nef_polyhedron_item \
+scene_points_with_normal_item \
+scene_polygon_soup_item \
+scene_polyhedron_item \
+scene_polyhedron_item_decorator \
+scene_polyhedron_item_k_ring_selection \
+scene_polyhedron_selection_item \
+scene_polyhedron_shortest_path_item \
+scene_polyhedron_transform_item \
+scene_polylines_item \
+scene_surface_mesh_item \
+scene_textured_polyhedron_item \
+c3t3_io_plugin \
+camera_positions_plugin \
+clip_polyhedron_plugin \
+convex_hull_plugin \
+corefinement_plugin \
+create_bbox_mesh_plugin \
+cut_plugin \
+detect_sharp_edges_plugin \
+edit_polyhedron_plugin \
+fairing_plugin \
+features_detection_plugin \
+gocad_plugin \
+hole_filling_plugin \
+hole_filling_polyline_plugin \
+inside_out_plugin \
+intersection_plugin \
+io_image_plugin \
+io_implicit_function_plugin \
+isotropic_remeshing_plugin \
+jet_fitting_plugin \
+join_and_split_polyhedra_plugin \
+kernel_plugin \
+mean_curvature_flow_skeleton_plugin \
+merge_point_sets_plugin \
+mesh_2_plugin \
+mesh_2_plugin \
+mesh_3_optimization_plugin \
+mesh_3_plugin \
+mesh_segmentation_plugin \
+mesh_simplification_plugin \
+nef_io_plugin \
+nef_plugin \
+off_plugin \
+off_to_nef_plugin \
+orient_soup_plugin \
+parameterization_plugin \
+pca_plugin \
+p_klein_function_plugin \
+ply_to_xyz_plugin \
+point_inside_polyhedron_plugin \
+point_set_average_spacing_plugin \
+point_set_bilateral_smoothing_plugin \
+point_set_from_vertices_plugin \
+point_set_interference_plugin \
+point_set_normal_estimation_plugin \
+point_set_outliers_removal_plugin \
+point_set_selection_plugin \
+point_set_shape_detection_plugin \
+point_set_simplification_plugin \
+point_set_smoothing_plugin \
+point_set_upsampling_plugin \
+point_set_wlop_plugin \
+polyhedron_slicer_plugin \
+polyhedron_stitching_plugin \
+polylines_io_plugin \
+p_sphere_function_plugin \
+p_tanglecube_function_plugin \
+remeshing_plugin \
+repair_polyhedron_plugin \
+selection_io_plugin \
+selection_plugin \
+self_intersection_plugin \
+shortest_path_plugin \
+stl_plugin \
+subdivision_methods_plugin \
+surface_mesh_io_plugin \
+surface_reconstruction_plugin \
+transform_polyhedron_plugin \
+triangulate_facets_plugin \
+trivial_plugin \
+vtk_plugin \
+xyz_plugin \
       all
   do
       if  ${MAKE_CMD} -f Makefile help | grep "$target" > /dev/null; then 


### PR DESCRIPTION
`CGAL::dump_c3t3` was not working with:
  - the parallel tag,
  - the polyhedral mesh domain with its default `Surface_patch_index` (`pair<int, int>`),

It is fixed, and I have added a test and an assertion.

