### PR TITLE
Polyhedron_demo: No std::cerr in `MainWindow::message()`

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -807,7 +807,6 @@ void MainWindow::message(QString message, QString colorName, QString font) {
   if (message.endsWith('\n')) {
     message.remove(message.length()-1, 1);
   }
-  std::cerr << qPrintable(message) << std::endl;
   statusBar()->showMessage(message, 5000);
   message = "<font color=\"" + colorName + "\" style=\"font-style: " + font + ";\" >" +
     message + "</font><br>";


### PR DESCRIPTION
This PR removes the std::cerr in the function message() of the mainwindow. This way, the console will not print html messages anymore, but all the messages printed using this function will only be readable from the Console widget of the application.