### PR TITLE
Fix compilation error with gmpxx

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
@@ -60,7 +60,7 @@ public:
     : base(CGAL::make_array(x, y)) {}
 
   VectorC2(const FT &hx, const FT &hy, const FT &hw)
-    : base( hw != FT(1) ? CGAL::make_array(hx/hw, hy/hw)
+    : base( hw != FT(1) ? CGAL::make_array<FT>(hx/hw, hy/hw)
                         : CGAL::make_array(hx, hy) ) {}
 
   const FT & x() const


### PR DESCRIPTION
That is a follow-up to the following commit:

> commit 6b51b12ab50ae9d2c0cd7afc3ce5e2d7cbb42608
> Author: Laurent Rineau <laurent.rineau@cgal.org>
> Date:   Fri Oct 4 16:42:13 2013 +0200
>
>     Fix the case when FT is mpq_class
>
>     If x and w are mpq_class objects, then the type of x/w is not mpq_class,
>     but only a proxy type that is implicitly convertible to
>     mpq_class. With the type deduction, CGAL::make_array(x/w, y/w,
>     z/w) will not create an array<mpq_class> but an array of the proxy type.
>
>     That creates the following compilation error, in a ternary operator:
>
>     - with clang:
>     include/CGAL/Cartesian/Vector_3.h:78:25: error: incompatible operand types ('array<__gmp_expr<[...], struct __gmp_binary_expr<class __gmp_expr<mpq_t, mpq_t>, class __gmp_expr<mpq_t, mpq_t>, struct __gmp_binary_divides>>, [...]>' and 'array<__gmp_expr<[...], __mpq_struct [1]>, [...]>')
>         : base( w != FT_(1) ? CGAL::make_array(x/w, y/w, z/w)
>                             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     - with g++:
>     include/CGAL/Cartesian/Vector_3.h:78:25: error: no match for ternary 'operator?:' (operand types are 'bool', 'std::array<__gmp_expr<__mpq_struct [1], __gmp_binary_expr<__gmp_expr<__mpq_struct [1], __mpq_struct [1]>, __gmp_expr<__mpq_struct [1], __mpq_struct [1]>, __gmp_binary_divides> >, 3ul>', and 'std::array<__gmp_expr<__mpq_struct [1], __mpq_struct [1]>, 3ul>')
>          : base( w != FT_(1) ? CGAL::make_array(x/w, y/w, z/w)
>                              ^
>
>     The fix is to specify the template argument of CGAL::make_array.

The first patch in 2013 was on `Vector_3`, but `Vector_2` also suffers
from the issue.

See the PR https://github.com/CGAL/cgal/pull/1257#issuecomment-232102814. Cc @mglisse