### PR TITLE
Polyhedron_demo : Fix the image_item's Bbox

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -640,9 +640,9 @@ Scene_image_item::compute_bbox() const
    _bbox = Bbox(-0.5*m_image->vx(),
                 -0.5*m_image->vy(),
                 -0.5*m_image->vz(),
-              m_image->xdim() * m_image->vx(),
-              m_image->ydim() * m_image->vy(),
-              m_image->zdim() * m_image->vz());
+              (m_image->xdim()- 0.5) * m_image->vx(),
+              (m_image->ydim()- 0.5) * m_image->vy(),
+              (m_image->zdim()- 0.5) * m_image->vz());
 }
 
 void


### PR DESCRIPTION
This PR fixes #950 :
 It fixes the Bbox that was too big for the image.