### PR TITLE
OT reconstruction: return a boolean when running

### DIFF
--- a/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/otr2_simplest_example.cpp
+++ b/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/otr2_simplest_example.cpp
@@ -22,7 +22,11 @@ int main ()
   CGAL::cpp11::copy_n(point_generator, 100, std::back_inserter(points));
 
   Otr otr(points);
-  otr.run(100); // 100 steps
+
+  if (otr.run(100)) //100 steps
+    std::cerr << "All done." << std::endl;
+  else
+    std::cerr << "Premature ending." << std::endl;
 
   return 0;
 }

--- a/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/test_basic.cpp
+++ b/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/test_basic.cpp
@@ -22,7 +22,10 @@ int main ()
 
   CGAL::Optimal_transportation_reconstruction_2<K> otr2(points);
 
-  otr2.run(100); //100 steps
-
+  if (otr2.run(100)) //100 steps
+    std::cerr << "All done." << std::endl;
+  else
+    std::cerr << "Premature ending." << std::endl;
+      
   otr2.print_stats_debug();
 }


### PR DESCRIPTION
This PR adds 2 changes:

* Methods `run()` and `run_until()` now return a boolean instead of `void` that indicates if the required number of steps were performed or if the algorithm was prematurely ended;
* A new method `number_of_isolated_vertices()` counts vertices with mass that are not connected to any edge with mass.