### PR TITLE
Polyhedron_demo: Fix MFC_Skeleton_plugin 

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -472,6 +472,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
   scene->item(InputMeshItemIndex)->setVisible(false);
   Scene_polyhedron_item* item_segmentation = new Scene_polyhedron_item(segmented_polyhedron);
   item_segmentation->setItemIsMulticolor(true);
+  item_segmentation->invalidateOpenGLBuffers();
   scene->addItem(item_segmentation);
   item_segmentation->setName(QString("segmentation"));
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1195,6 +1195,7 @@ Scene_polyhedron_item::drawPoints(CGAL::Three::Viewer_interface* viewer) const {
     d->program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
     d->program->bind();
     //draw the points
+    d->program->setAttributeValue("colors", this->color());
     viewer->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(d->nb_lines/4));
     // Clean-up
     d->program->release();


### PR DESCRIPTION
Fixes #1276

This PR fixes the segfault in the mcf skeleton plugin and the bug of color of the polyhedron_item points visualization, that became magenta when the skeleton was selected.