### PR TITLE
Polyhedron_demo : Hides the original point set

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
@@ -105,6 +105,7 @@ void Polyhedron_demo_point_set_wlop_plugin::on_actionSimplifyAndRegularize_trigg
       = new Scene_points_with_normal_item();
     new_item->setName (tr("%1 (WLOP processed)").arg(item->name()));
     new_item->setVisible(true);
+    item->setVisible(false);
     scene->addItem(new_item);
       
     CGAL::wlop_simplify_and_regularize_point_set<Concurrency_tag>


### PR DESCRIPTION
Fixes #1274 
This PR hides the original Point Set when WLOP is called.