### PR TITLE
Polyhedron demo: apply PSP algorithms to selection only

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
@@ -91,9 +91,12 @@ void Polyhedron_demo_point_set_average_spacing_plugin::on_actionAverageSpacing_t
     CGAL::Timer task_timer; task_timer.start();
     std::cerr << "Average spacing (k=" << nb_neighbors <<")...\n";
 
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
+
     // Computes average spacing
     double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(
-                                      points->begin(), points->end(),
+                                      points_begin, points->end(),
                                       nb_neighbors);
 
     // Print result

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
@@ -91,12 +91,9 @@ void Polyhedron_demo_point_set_average_spacing_plugin::on_actionAverageSpacing_t
     CGAL::Timer task_timer; task_timer.start();
     std::cerr << "Average spacing (k=" << nb_neighbors <<")...\n";
 
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-
     // Computes average spacing
     double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(
-                                      points_begin, points->end(),
+                                      points->begin_or_selection_begin(), points->end(),
                                       nb_neighbors);
 
     // Print result

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
@@ -109,12 +109,9 @@ void Polyhedron_demo_point_set_bilateral_smoothing_plugin::on_actionBilateralSmo
 
     for (unsigned int i = 0; i < dialog.iterations (); ++i)
       {
-        Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                            ? points->begin() : points->first_selected());
-
 	/* double error = */
 	CGAL::bilateral_smooth_point_set<Concurrency_tag>
-	  (points_begin,
+	  (points->begin_or_selection_begin(),
 	   points->end(),
 	   CGAL::make_identity_property_map(Point_set::value_type()),
 	   CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
@@ -109,9 +109,12 @@ void Polyhedron_demo_point_set_bilateral_smoothing_plugin::on_actionBilateralSmo
 
     for (unsigned int i = 0; i < dialog.iterations (); ++i)
       {
+        Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                            ? points->begin() : points->first_selected());
+
 	/* double error = */
 	CGAL::bilateral_smooth_point_set<Concurrency_tag>
-	  (points->begin(), 
+	  (points_begin,
 	   points->end(),
 	   CGAL::make_identity_property_map(Point_set::value_type()),
 	   CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
@@ -67,8 +67,15 @@ private Q_SLOTS:
     flags |= Qt::CustomizeWindowHint;
     flags |= Qt::WindowCloseButtonHint;
 
+    Point_set* points = item->point_set();
+    if(points == NULL)
+      return;
+
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
+    
     double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(
-                                    item->point_set()->begin(), item->point_set()->end(),
+                                    points_begin, points->end(),
                                     6 /* knn = 1 ring */);
 
     const double max_dist =
@@ -85,7 +92,7 @@ private Q_SLOTS:
 
     CGAL::Random_points_in_sphere_3<Kernel::Point_3> generator(max_dist);
 
-    for(Point_set::iterator psit = item->point_set()->begin(); psit != item->point_set()->end(); ++psit)
+    for(Point_set::iterator psit = points_begin; psit != points->end(); ++psit)
     {
       *psit = *psit+(*generator - CGAL::ORIGIN);
       ++generator;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
@@ -71,11 +71,8 @@ private Q_SLOTS:
     if(points == NULL)
       return;
 
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-    
     double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(
-                                    points_begin, points->end(),
+                                    points->begin_or_selection_begin(), points->end(),
                                     6 /* knn = 1 ring */);
 
     const double max_dist =
@@ -92,7 +89,7 @@ private Q_SLOTS:
 
     CGAL::Random_points_in_sphere_3<Kernel::Point_3> generator(max_dist);
 
-    for(Point_set::iterator psit = points_begin; psit != points->end(); ++psit)
+    for(Point_set::iterator psit = points->begin_or_selection_begin(); psit != points->end(); ++psit)
     {
       *psit = *psit+(*generator - CGAL::ORIGIN);
       ++generator;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -130,10 +130,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalInversio
     if(points == NULL)
         return;
 
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-
-    for(Point_set::iterator it = points_begin; it != points->end(); ++it){
+    for(Point_set::iterator it = points->begin_or_selection_begin(); it != points->end(); ++it){
       it->normal() = -1 * it->normal();
     }
     item->invalidateOpenGLBuffers();
@@ -169,16 +166,13 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
     //***************************************
     // normal estimation
     //***************************************
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-
     if (dialog.method() == 0) // PCA
     {
       CGAL::Timer task_timer; task_timer.start();
       std::cerr << "Estimates normal direction by PCA (k=" << dialog.pca_neighbors() <<")...\n";
       
       // Estimates normals direction.
-      CGAL::pca_estimate_normals<Concurrency_tag>(points_begin, points->end(),
+      CGAL::pca_estimate_normals<Concurrency_tag>(points->begin_or_selection_begin(), points->end(),
                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                 dialog.pca_neighbors());
 
@@ -193,7 +187,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
       std::cerr << "Estimates normal direction by Jet Fitting (k=" << dialog.jet_neighbors() <<")...\n";
 
       // Estimates normals direction.
-      CGAL::jet_estimate_normals<Concurrency_tag>(points_begin, points->end(),
+      CGAL::jet_estimate_normals<Concurrency_tag>(points->begin_or_selection_begin(), points->end(),
                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                 dialog.jet_neighbors());
 
@@ -211,7 +205,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
           std::cerr << "Estimates Normals Direction using VCM (R="
                     << dialog.offset_radius() << " and r=" << dialog.convolution_radius() << ")...\n";
 
-          CGAL::vcm_estimate_normals(points_begin, points->end(),
+          CGAL::vcm_estimate_normals(points->begin_or_selection_begin(), points->end(),
                                      CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                      dialog.offset_radius(), dialog.convolution_radius());
         }
@@ -220,7 +214,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
           std::cerr << "Estimates Normals Direction using VCM (R="
                     << dialog.offset_radius() << " and k=" << dialog.convolution_neighbors() << ")...\n";
 
-          CGAL::vcm_estimate_normals(points->begin(), points->end(),
+          CGAL::vcm_estimate_normals(points->begin_or_selection_begin(), points->end(),
                                      CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                      dialog.offset_radius(), dialog.convolution_neighbors());
         }
@@ -245,12 +239,12 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
 
         // Tries to orient normals
         first_unoriented_point =
-          CGAL::mst_orient_normals(points_begin, points->end(),
+          CGAL::mst_orient_normals(points->begin_or_selection_begin(), points->end(),
                                    CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                    dialog.orient_neighbors());
 
         //indicates that the point set has normals
-        if (first_unoriented_point!=points_begin){
+        if (first_unoriented_point != points->begin_or_selection_begin()){
           item->set_has_normals(true);
           item->setRenderingMode(PointsPlusNormals);
         }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -170,7 +170,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
     {
       CGAL::Timer task_timer; task_timer.start();
       std::cerr << "Estimates normal direction by PCA (k=" << dialog.pca_neighbors() <<")...\n";
-      
+
       // Estimates normals direction.
       CGAL::pca_estimate_normals<Concurrency_tag>(points->begin_or_selection_begin(), points->end(),
                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -129,8 +129,11 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalInversio
     Point_set* points = item->point_set();
     if(points == NULL)
         return;
-  
-    for(Point_set::iterator it = points->begin(); it != points->end(); ++it){
+
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
+
+    for(Point_set::iterator it = points_begin; it != points->end(); ++it){
       it->normal() = -1 * it->normal();
     }
     item->invalidateOpenGLBuffers();
@@ -166,14 +169,16 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
     //***************************************
     // normal estimation
     //***************************************
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
 
     if (dialog.method() == 0) // PCA
     {
       CGAL::Timer task_timer; task_timer.start();
       std::cerr << "Estimates normal direction by PCA (k=" << dialog.pca_neighbors() <<")...\n";
-
+      
       // Estimates normals direction.
-      CGAL::pca_estimate_normals<Concurrency_tag>(points->begin(), points->end(),
+      CGAL::pca_estimate_normals<Concurrency_tag>(points_begin, points->end(),
                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                 dialog.pca_neighbors());
 
@@ -188,7 +193,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
       std::cerr << "Estimates normal direction by Jet Fitting (k=" << dialog.jet_neighbors() <<")...\n";
 
       // Estimates normals direction.
-      CGAL::jet_estimate_normals<Concurrency_tag>(points->begin(), points->end(),
+      CGAL::jet_estimate_normals<Concurrency_tag>(points_begin, points->end(),
                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                 dialog.jet_neighbors());
 
@@ -206,7 +211,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
           std::cerr << "Estimates Normals Direction using VCM (R="
                     << dialog.offset_radius() << " and r=" << dialog.convolution_radius() << ")...\n";
 
-          CGAL::vcm_estimate_normals(points->begin(), points->end(),
+          CGAL::vcm_estimate_normals(points_begin, points->end(),
                                      CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                      dialog.offset_radius(), dialog.convolution_radius());
         }
@@ -240,12 +245,12 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
 
         // Tries to orient normals
         first_unoriented_point =
-          CGAL::mst_orient_normals(points->begin(), points->end(),
+          CGAL::mst_orient_normals(points_begin, points->end(),
                                    CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                    dialog.orient_neighbors());
 
         //indicates that the point set has normals
-        if (first_unoriented_point!=points->begin()){
+        if (first_unoriented_point!=points_begin){
           item->set_has_normals(true);
           item->setRenderingMode(PointsPlusNormals);
         }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -81,7 +81,10 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    CGAL::jet_smooth_point_set<Concurrency_tag>(points->begin(), points->end(), nb_neighbors);
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
+    
+    CGAL::jet_smooth_point_set<Concurrency_tag>(points_begin, points->end(), nb_neighbors);
 
     points->invalidate_bounds();
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -81,10 +81,7 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-    
-    CGAL::jet_smooth_point_set<Concurrency_tag>(points_begin, points->end(), nb_neighbors);
+    CGAL::jet_smooth_point_set<Concurrency_tag>(points->begin_or_selection_begin(), points->end(), nb_neighbors);
 
     points->invalidate_bounds();
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -115,12 +115,10 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
                                       points->begin(), points->end(),
                                       6 /* knn = 1 ring */);
       
-      Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                          ? points->begin() : points->first_selected());
       std::size_t nb_selected = points->nb_selected_points();
       
       std::vector<std::pair<Point_set::Point, Point_set::Vector> > new_points;
-      CGAL::edge_aware_upsample_point_set<Concurrency_tag>(points_begin, 
+      CGAL::edge_aware_upsample_point_set<Concurrency_tag>(points->begin_or_selection_begin(),
 					  points->end(), 
 					  std::back_inserter(new_points),
 					  CGAL::make_identity_property_map(Point_set::value_type()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -114,9 +114,13 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
       double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(
                                       points->begin(), points->end(),
                                       6 /* knn = 1 ring */);
-
+      
+      Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                          ? points->begin() : points->first_selected());
+      std::size_t nb_selected = points->nb_selected_points();
+      
       std::vector<std::pair<Point_set::Point, Point_set::Vector> > new_points;
-      CGAL::edge_aware_upsample_point_set<Concurrency_tag>(points->begin(), 
+      CGAL::edge_aware_upsample_point_set<Concurrency_tag>(points_begin, 
 					  points->end(), 
 					  std::back_inserter(new_points),
 					  CGAL::make_identity_property_map(Point_set::value_type()),
@@ -125,10 +129,15 @@ void Polyhedron_demo_point_set_upsampling_plugin::on_actionEdgeAwareUpsampling_t
 					  dialog.edge_sensitivity(),
 					  dialog.neighborhood_radius() * average_spacing,
 					  output_size);
-
+      nb_selected += new_points.size();
+      
       for (unsigned int i = 0; i < new_points.size (); ++ i)
-	points->push_back (Point_set::Point_with_normal (new_points[i].first,
-							 new_points[i].second));
+        {
+          points->push_back (Point_set::Point_with_normal (new_points[i].first,
+                                                           new_points[i].second));
+        }
+      if (nb_selected != new_points.size())
+        points->set_first_selected (points->end() - nb_selected);
       
       std::size_t memory = CGAL::Memory_sizer().virtual_size();
       std::cerr << task_timer.time() << " seconds, "

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
@@ -98,9 +98,8 @@ void Polyhedron_demo_point_set_wlop_plugin::on_actionSimplifyAndRegularize_trigg
 	      << dialog.neighborhoodRadius() <<" * average spacing)...\n";
 
     // Computes average spacing
-    Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                        ? points->begin() : points->first_selected());
-    double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points_begin, points->end(),
+    double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points->begin_or_selection_begin(),
+                                                           points->end(),
 							   6 /* knn = 1 ring */);
 
     Scene_points_with_normal_item* new_item
@@ -110,7 +109,7 @@ void Polyhedron_demo_point_set_wlop_plugin::on_actionSimplifyAndRegularize_trigg
     scene->addItem(new_item);
     
     CGAL::wlop_simplify_and_regularize_point_set<Concurrency_tag>
-      (points_begin,
+      (points->begin_or_selection_begin(),
        points->end(),
        std::back_inserter(*(new_item->point_set ())),
        dialog.retainedPercentage (),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
@@ -98,7 +98,9 @@ void Polyhedron_demo_point_set_wlop_plugin::on_actionSimplifyAndRegularize_trigg
 	      << dialog.neighborhoodRadius() <<" * average spacing)...\n";
 
     // Computes average spacing
-    double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points->begin(), points->end(),
+    Point_set::iterator points_begin = (points->nb_selected_points() == 0
+                                        ? points->begin() : points->first_selected());
+    double average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points_begin, points->end(),
 							   6 /* knn = 1 ring */);
 
     Scene_points_with_normal_item* new_item
@@ -106,9 +108,9 @@ void Polyhedron_demo_point_set_wlop_plugin::on_actionSimplifyAndRegularize_trigg
     new_item->setName (tr("%1 (WLOP processed)").arg(item->name()));
     new_item->setVisible(true);
     scene->addItem(new_item);
-      
+    
     CGAL::wlop_simplify_and_regularize_point_set<Concurrency_tag>
-      (points->begin(),
+      (points_begin,
        points->end(),
        std::back_inserter(*(new_item->point_set ())),
        dialog.retainedPercentage (),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -123,10 +123,7 @@ namespace SurfaceReconstruction
   
   unsigned int scale_of_anisotropy (const Point_set& points, double& size)
   {
-    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
-                                              ? points.begin() : points.first_selected());
-    
-    Tree tree(points_begin, points.end());
+    Tree tree(points.begin_or_selection_begin(), points.end());
     
     double ratio_kept = (points.size() < 1000)
       ? 1. : 1000. / (points.size());
@@ -194,10 +191,7 @@ namespace SurfaceReconstruction
   
   unsigned int scale_of_noise (const Point_set& points, double& size)
   {
-    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
-                                              ? points.begin() : points.first_selected());
-    
-    Tree tree(points.begin(), points.end());
+    Tree tree(points.begin_or_selection_begin(), points.end());
     
     double ratio_kept = (points.size() < 1000)
       ? 1. : 1000. / (points.size());
@@ -278,11 +272,8 @@ namespace SurfaceReconstruction
                     bool separate_shells = false, bool force_manifold = true,
                     unsigned int samples = 300, unsigned int iterations = 4)
   {
-    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
-                                              ? points.begin() : points.first_selected());
-
     ScaleSpace reconstruct (scale, samples);
-    reconstruct.reconstruct_surface(points_begin, points.end (), iterations,
+    reconstruct.reconstruct_surface(points.begin_or_selection_begin(), points.end (), iterations,
                                     separate_shells, force_manifold);
 
     for( unsigned int sh = 0; sh < reconstruct.number_of_shells(); ++sh )
@@ -313,7 +304,7 @@ namespace SurfaceReconstruction
                 if (map_i2i.find ((*it)[ind]) == map_i2i.end ())
                   {
                     map_i2i.insert (std::make_pair ((*it)[ind], current_index ++));
-                    Point p = (points_begin + (*it)[ind])->position();
+                    Point p = (points.begin_or_selection_begin() + (*it)[ind])->position();
                     new_item->new_vertex (p.x (), p.y (), p.z ());
                     
                     if (generate_smooth)
@@ -369,7 +360,7 @@ namespace SurfaceReconstruction
                 if (map_i2i.find ((*it)[ind]) == map_i2i.end ())
                   {
                     map_i2i.insert (std::make_pair ((*it)[ind], current_index ++));
-                    Point p = (points_begin + (*it)[ind])->position();
+                    Point p = (points.begin_or_selection_begin() + (*it)[ind])->position();
                     new_item->new_vertex (p.x (), p.y (), p.z ());
                     
                     if (generate_smooth)
@@ -401,20 +392,14 @@ namespace SurfaceReconstruction
   {
     Polyhedron& P = * const_cast<Polyhedron*>(new_item->polyhedron());
     Radius filter (size);
-    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
-                                              ? points.begin() : points.first_selected());
-
-    CGAL::advancing_front_surface_reconstruction (points_begin, points.end (), P, filter,
+    CGAL::advancing_front_surface_reconstruction (points.begin_or_selection_begin(), points.end (), P, filter,
                                                   radius_ratio_bound, beta);
 						  
   }
 
   void compute_normals (Point_set& points, unsigned int neighbors)
   {
-    Point_set::iterator points_begin = (points.nb_selected_points() == 0
-                                        ? points.begin() : points.first_selected());
-
-    CGAL::jet_estimate_normals<Concurrency_tag>(points_begin, points.end(),
+    CGAL::jet_estimate_normals<Concurrency_tag>(points.begin_or_selection_begin(), points.end(),
                                                 CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()),
                                                 2 * neighbors);
   }
@@ -555,9 +540,6 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
     {
       // Gets point set
       Point_set* points = pts_item->point_set();
-      Point_set::iterator points_begin = (points->nb_selected_points() == 0
-                                          ? points->begin() : points->first_selected());
-
       // wait cursor
       QApplication::setOverrideCursor(Qt::WaitCursor);
 
@@ -580,9 +562,8 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	  new_item->invalidateOpenGLBuffers();
 
 	  points = new_item->point_set();
-	  std::copy (points_begin, pts_item->point_set()->end(),
+	  std::copy (points->begin_or_selection_begin(), pts_item->point_set()->end(),
 		     std::back_inserter (*points));
-          points_begin = points->begin();
 	}
 
       std::cerr << "Analysing isotropy of point set... ";

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin_impl.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin_impl.cpp
@@ -71,16 +71,6 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
       return NULL;
     }
 
-    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
-                                              ? points.begin() : points.first_selected());
-
-    bool points_have_normals = (points_begin->normal() != CGAL::NULL_VECTOR);
-    if ( ! points_have_normals )
-    {
-      std::cerr << "Input point set not supported: this reconstruction method requires oriented normals" << std::endl;
-      return NULL;
-    }
-
     CGAL::Timer reconstruction_timer; reconstruction_timer.start();
 
     //***************************************
@@ -97,7 +87,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
     // + property maps to access each point's position and normal.
     // The position property map can be omitted here as we use iterators over Point_3 elements.
     Poisson_reconstruction_function function(
-                              points_begin, points.end(),
+                              points.begin_or_selection_begin(), points.end(),
                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()));
 
     bool ok = false;    
@@ -135,7 +125,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
     std::cerr << "Surface meshing...\n";
 
     // Computes average spacing
-    Kernel::FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points_begin, points.end(),
+    Kernel::FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points.begin_or_selection_begin(), points.end(),
                                                        6 /* knn = 1 ring */);
 
     // Gets one point inside the implicit surface
@@ -211,7 +201,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
 
     std::set<Polyhedron::Face_handle> faces_to_keep;
     
-    for (Point_set::const_iterator p=points_begin; p!=points.end(); p++)
+    for (Point_set::const_iterator p=points.begin_or_selection_begin(); p!=points.end(); p++)
     {
       AABB_traits::Point_and_primitive_id pap = tree.closest_point_and_primitive (*p);
       double distance = std::sqrt(CGAL::squared_distance (pap.first, *p));

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin_impl.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin_impl.cpp
@@ -71,7 +71,10 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
       return NULL;
     }
 
-    bool points_have_normals = (points.begin()->normal() != CGAL::NULL_VECTOR);
+    Point_set::const_iterator points_begin = (points.nb_selected_points() == 0
+                                              ? points.begin() : points.first_selected());
+
+    bool points_have_normals = (points_begin->normal() != CGAL::NULL_VECTOR);
     if ( ! points_have_normals )
     {
       std::cerr << "Input point set not supported: this reconstruction method requires oriented normals" << std::endl;
@@ -94,7 +97,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
     // + property maps to access each point's position and normal.
     // The position property map can be omitted here as we use iterators over Point_3 elements.
     Poisson_reconstruction_function function(
-                              points.begin(), points.end(),
+                              points_begin, points.end(),
                               CGAL::make_normal_of_point_with_normal_pmap(Point_set::value_type()));
 
     bool ok = false;    
@@ -132,7 +135,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
     std::cerr << "Surface meshing...\n";
 
     // Computes average spacing
-    Kernel::FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points.begin(), points.end(),
+    Kernel::FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>(points_begin, points.end(),
                                                        6 /* knn = 1 ring */);
 
     // Gets one point inside the implicit surface
@@ -208,7 +211,7 @@ Polyhedron* poisson_reconstruct(const Point_set& points,
 
     std::set<Polyhedron::Face_handle> faces_to_keep;
     
-    for (Point_set::const_iterator p=points.begin(); p!=points.end(); p++)
+    for (Point_set::const_iterator p=points_begin; p!=points.end(); p++)
     {
       AABB_traits::Point_and_primitive_id pap = tree.closest_point_and_primitive (*p);
       double distance = std::sqrt(CGAL::squared_distance (pap.first, *p));

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -126,6 +126,15 @@ public:
     m_nb_selected = static_cast<std::size_t>(std::distance (it, end()));
   }
 
+  const_iterator begin_or_selection_begin() const
+  {
+    return (m_nb_selected == 0 ? begin() : first_selected());
+  }
+  iterator begin_or_selection_begin()
+  {
+    return (m_nb_selected == 0 ? begin() : first_selected());
+  }
+
   // Test if point is selected
   bool is_selected(const_iterator it) const
   {


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/CGAL/cgal/issues/1230

Point set processing algorithms are applied to the selection (or to the whole point set if the selection is empty), with the exception of algorithms that specifically use selection in a select/remove fashion (simplification algorithms) as this would most certainly add confusion.