### PR TITLE
use the boolean are_buffers_filled from Scene_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -18,7 +18,7 @@ struct Scene_combinatorial_map_item_priv
   :last_known_scene(scene),volume_to_display(0),exportSelectedVolume(NULL),address_of_A(ad_A)
   {
     item = parent;
-    are_buffers_filled = false;
+    item->are_buffers_filled = false;
     nb_points = 0;
     nb_lines =0;
     nb_facets =0;
@@ -52,7 +52,6 @@ struct Scene_combinatorial_map_item_priv
   void* address_of_A;
 
   mutable QOpenGLShaderProgram *program;
-  mutable bool are_buffers_filled;
   mutable std::vector<double> positions_lines;
   mutable std::vector<double> positions_points;
   mutable std::vector<double> positions_facets;
@@ -456,7 +455,7 @@ void Scene_combinatorial_map_item_priv::initialize_buffers(CGAL::Three::Viewer_i
         item->vaos[Scene_combinatorial_map_item_priv::Facets]->release();
         program->release();
     }
-    are_buffers_filled = true;
+    item->are_buffers_filled = true;
 
 
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -97,7 +97,6 @@ struct Scene_polyhedron_shortest_path_item_priv
 
   mutable std::vector<float> vertices;
   mutable QOpenGLShaderProgram *program;
-  mutable bool are_buffers_filled;
 };
 Scene_polyhedron_shortest_path_item::Scene_polyhedron_shortest_path_item()
    :Scene_polyhedron_item_decorator(NULL, false)
@@ -146,7 +145,7 @@ void Scene_polyhedron_shortest_path_item_priv::initialize_buffers(CGAL::Three::V
         item->buffers[Vertices].release();
         item->vaos[Selected_Edges]->release();
     }
-    are_buffers_filled = true;
+    item->are_buffers_filled = true;
 }
 bool Scene_polyhedron_shortest_path_item::supportsRenderingMode(RenderingMode m) const
 {

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -95,8 +95,6 @@ protected:
 
   void initializeBuffers(CGAL::Three::Viewer_interface*)const;
   void compute_normals_and_vertices(void) const;
-  mutable bool are_buffers_filled;
-
 };
 
 #endif // SCENE_PLANE_ITEM_H


### PR DESCRIPTION
this was preventing the buffer to be marked as initialized
(in Scene_combinatorial_map_item and Scene_polyhedron_shortest_path_item)