### PR TITLE
use the latest CMap API

### DIFF
--- a/Operations_on_polyhedra/include/CGAL/internal/corefinement/Combinatorial_map_for_corefinement.h
+++ b/Operations_on_polyhedra/include/CGAL/internal/corefinement/Combinatorial_map_for_corefinement.h
@@ -21,8 +21,6 @@
 #ifndef CGAL_INTERNAL_COMBINATORIAL_MAP_FOR_COREFINEMENT_H
 #define CGAL_INTERNAL_COMBINATORIAL_MAP_FOR_COREFINEMENT_H
 
-#define CGAL_CMAP_DEPRECATED 1
-
 #include <CGAL/Combinatorial_map.h>
 #include <CGAL/Combinatorial_map_constructors.h>
 #include <CGAL/Cell_attribute.h>

--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3.h
@@ -21,8 +21,6 @@
 #ifndef CGAL_INTERSECTION_OF_POLYHEDRA_3_H
 #define CGAL_INTERSECTION_OF_POLYHEDRA_3_H
 
-#define CGAL_CMAP_DEPRECATED 1
-
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/box_intersection_d.h>

--- a/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
+++ b/Operations_on_polyhedra/include/CGAL/intersection_of_Polyhedra_3_refinement_visitor.h
@@ -436,7 +436,7 @@ next_marked_dart_around_target_vertex(
   CGAL_precondition(final_map.is_marked(dart,mark_index));
   typename Combinatorial_map_3::Dart_handle next=dart->beta(1);
   while ( ! final_map.is_marked(next,mark_index) ){
-    if (next->is_free(2) )//we reach a boundary
+    if (final_map.is_free(next,2) )//we reach a boundary
       return  boost::optional<typename Combinatorial_map_3::Dart_handle>();
     next=next->beta(2)->beta(1);
   }
@@ -458,7 +458,7 @@ get_next_marked_dart_around_target_vertex(
   CGAL_precondition(final_map.is_marked(dart,mark_index));
   typename Combinatorial_map_3::Dart_handle next=dart->beta(1);
   while ( !final_map.is_marked(next,mark_index) ){
-    CGAL_assertion( !next->is_free(2) );
+    CGAL_assertion( !final_map.is_free(next,2) );
     next=next->beta(2)->beta(1);
     CGAL_assertion(next != dart);
   }
@@ -478,7 +478,7 @@ get_next_marked_dart_around_source_vertex(
   CGAL_precondition(final_map.is_marked(dart,mark_index));
   typename Combinatorial_map_3::Dart_handle next=dart->beta(0);
   while ( ! final_map.is_marked(next,mark_index) ){ 
-    CGAL_assertion( !next->is_free(2) );
+    CGAL_assertion( !final_map.is_free(next,2) );
     next=next->beta(2)->beta(0);
     CGAL_assertion(next != dart);
   }
@@ -499,8 +499,8 @@ void sew_2_marked_darts( Combinatorial_map_3& final_map,
                          const std::pair<int,int>& indices,
                          const std::pair<bool,int>& polyline_info)
 {
-  CGAL_precondition( dart_1->is_free(2) );
-  CGAL_precondition( dart_2->is_free(2) );
+  CGAL_precondition( final_map.is_free(dart_1,2) );
+  CGAL_precondition( final_map.is_free(dart_2,2) );
   CGAL_precondition( final_map.is_marked(dart_1,mark_index) );
   CGAL_precondition( final_map.is_marked(dart_2,mark_index) );
   CGAL_precondition( dart_1->template attribute<0>()->point() == dart_2->beta(1)->template attribute<0>()->point() );
@@ -572,7 +572,7 @@ void sew_3_marked_darts( Combinatorial_map_3& final_map,
   typename Combinatorial_map_3::Dart_handle start=not_top;
   do
   {
-    CGAL_assertion(!not_top->is_free(3));
+    CGAL_assertion(!final_map.is_free(not_top,3));
     darts_to_remove.insert(not_top);   darts_to_remove.insert(not_top->beta(1)); darts_to_remove.insert(not_top->beta(1)->beta(1));
     darts_to_remove.insert(not_top->beta(3));   darts_to_remove.insert(not_top->beta(3)->beta(1)); darts_to_remove.insert(not_top->beta(3)->beta(1)->beta(1));
     O_Dart_handle current_1=next_marked_dart_around_target_vertex(final_map,not_top,mark_index);

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -361,7 +361,7 @@ void Scene_combinatorial_map_item_priv::compute_elements(void) const{
         typedef Combinatorial_map_3::One_dart_per_cell_range<1,3> Edge_darts;
         Edge_darts darts=item->combinatorial_map().one_dart_per_cell<1>();
         for (Edge_darts::const_iterator dit=darts.begin();dit!=darts.end();++dit){
-            CGAL_assertion(!dit->is_free(1));
+            CGAL_assertion(!item->combinatorial_map().is_free(dit,1));
             const Kernel::Point_3& a = dit->attribute<0>()->point();
             const Kernel::Point_3& b = dit->beta(1)->attribute<0>()->point();
             positions_lines.push_back(a.x());


### PR DESCRIPTION
this was responsible for bugs in the demo plugin where the cmap
is created in a library and used in another one

cc @gdamiand I think it is time to remove the old API code