### PR TITLE
Add minimal support for CTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ Kernel_23/test/Kernel_23/Makefile
 Kernel_23/test/Kernel_23/Simple_cartesian
 Kernel_23/test/Kernel_23/Simple_homogeneous
 Kernel_23/test/Kernel_23/Test_IO.out
+/Kernel_23/test/Kernel_23/Test-*IO.out
 Kernel_23/test/Kernel_23/cgal_test_with_cmake
 Kernel_23/test/Kernel_23/test_kernel__
 Kinetic_data_structures/demo/Kinetic_data_structures/Delaunay_triangulation_2

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -741,6 +741,11 @@ message("== Write compiler_config.h (DONE) ==\n")
 #
 #--------------------------------------------------------------------------------------------------
 
+
+# Enable testing with BUILD_TESTING
+option(BUILD_TESTING "Build the testing tree." OFF)
+include(CTest)
+
 message("== Generating build files ==")
 
 set(CGAL_LIBRARIES_DIR ${CMAKE_BINARY_DIR}/lib)

--- a/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
+++ b/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
@@ -28,6 +28,8 @@ function(create_single_source_cgal_program firstfile )
       add_test(NAME ${exe_name}
         COMMAND ${exe_name} ${ARGS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      set_property(TEST "${exe_name}"
+        APPEND PROPERTY LABELS "${PROJECT_NAME}")
     endif(BUILD_TESTING)
 
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS ${exe_name} )

--- a/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
+++ b/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
@@ -18,6 +18,18 @@ function(create_single_source_cgal_program firstfile )
 
     add_executable(${exe_name} ${all})
 
+    if(BUILD_TESTING)
+      if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cin")
+        set(ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cin")
+      elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cmd")
+        file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cmd" ARGS LIMIT_COUNT 1)
+      endif()
+      message(STATUS "add test for ${exe_name}")
+      add_test(NAME ${exe_name}
+        COMMAND ${exe_name} ${ARGS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    endif(BUILD_TESTING)
+
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS ${exe_name} )
 
     # Link the executable to CGAL and third-party libraries

--- a/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
+++ b/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
@@ -23,6 +23,8 @@ function(create_single_source_cgal_program firstfile )
         set(ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cin")
       elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cmd")
         file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cmd" ARGS LIMIT_COUNT 1)
+        # TODO: handle multi-lines .cmd files
+        # see https://github.com/CGAL/cgal/pull/1295/files/c65d3abe17bb3e677b8077996cdaf8672f9c4c6f#r71705451
       endif()
       message(STATUS "add test for ${exe_name}")
       add_test(NAME ${exe_name}

--- a/Kernel_23/test/Kernel_23/Cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Cartesian.cpp
@@ -26,6 +26,7 @@
 
 #include "CGAL/Precise_numbers.h"
 #include "CGAL/_test_cls_kernel.h"
+#define TEST_FILENAME "Test-Cartesian-IO.out"
 #include "CGAL/_test_io.h"
 #include "CGAL/_test_2.h"
 #include "CGAL/_test_3.h"

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -31,6 +31,7 @@
 
 #include "CGAL/Precise_numbers.h"
 
+#define TEST_FILENAME "Test-Filtered_cartesian-IO.out"
 #include "CGAL/_test_io.h"
 
 #include "CGAL/_test_2.h"

--- a/Kernel_23/test/Kernel_23/Filtered_homogeneous.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_homogeneous.cpp
@@ -29,6 +29,7 @@
 
 #include "CGAL/Precise_numbers.h"
 
+#define TEST_FILENAME "Test-Filtered_homogeneous-IO.out"
 #include "CGAL/_test_io.h"
 
 #include "CGAL/_test_2.h"

--- a/Kernel_23/test/Kernel_23/Homogeneous.cpp
+++ b/Kernel_23/test/Kernel_23/Homogeneous.cpp
@@ -25,6 +25,7 @@
 #include <CGAL/intersection_3.h>
 
 #include "CGAL/Precise_numbers.h"
+#define TEST_FILENAME "Test-Homogeneous-IO.out"
 #include "CGAL/_test_io.h"
 #include "CGAL/_test_2.h"
 #include "CGAL/_test_3.h"

--- a/Kernel_23/test/Kernel_23/Lazy_kernel.cpp
+++ b/Kernel_23/test/Kernel_23/Lazy_kernel.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 
 #include "CGAL/Precise_numbers.h"
+#define TEST_FILENAME "Test-Lazy_kernel-IO.out"
 #include "CGAL/_test_io.h"
 #include "CGAL/_test_2.h"
 #include "CGAL/_test_3.h"

--- a/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 
 #include "CGAL/Precise_numbers.h"
+#define TEST_FILENAME "Test-Simple_cartesian-IO.out"
 #include "CGAL/_test_io.h"
 
 #include "CGAL/_test_2.h"

--- a/Kernel_23/test/Kernel_23/Simple_homogeneous.cpp
+++ b/Kernel_23/test/Kernel_23/Simple_homogeneous.cpp
@@ -27,6 +27,7 @@
 #include <CGAL/intersection_3.h>
 
 #include "CGAL/Precise_numbers.h"
+#define TEST_FILENAME "Test-Simple_homogeneous-IO.out"
 #include "CGAL/_test_io.h"
 #include "CGAL/_test_2.h"
 #include "CGAL/_test_3.h"

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_io.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_io.h
@@ -25,16 +25,20 @@
 #include <fstream>
 #include <cassert>
 
+#ifndef TEST_FILENAME
+#  define TEST_FILENAME "Test_IO.out"
+#endif
+
 template <class T>
 void
 _test_io_for(const T& t)
 {
     {
-        std::ofstream oFile("Test_IO.out", std::ios::out);
+        std::ofstream oFile(TEST_FILENAME, std::ios::out);
         oFile << t << std::endl;
     }
 
-    std::ifstream iFile("Test_IO.out", std::ios::in);
+    std::ifstream iFile(TEST_FILENAME, std::ios::in);
     T u;
     iFile >> u;
     assert(!iFile.fail());


### PR DESCRIPTION
With that patch, that is so simple to build and run tests (in parallel) for a package.

From the build directory configured in CMake with `WITH_tests=ON` and/or `WITH_examples=ON`, that is as simple as:
```shell
  cd test/Kernel_23
  make -j6
  ctest -j6
```
