### PR TITLE
Mesh 3 - doc fix for facet_distance criterion

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_criteria_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_criteria_3.h
@@ -125,7 +125,8 @@ surface mesh facets.
 a space varying (resp. a uniform) upper-bound or for the radii of the surface Delaunay balls. 
 
 - `facet_distance`: a scalar field (resp. a constant) describing a space varying (resp. a uniform) 
-upper bound for the same distance. 
+upper bound for the distance between the facet circumcenter and the center of its surface
+Delaunay ball.
 
 - `facet_topology`: the set of topological constraints 
 which have to be verified by each surface facet. The default value is 
@@ -138,10 +139,10 @@ get all possible values.
 a space varying (resp. a uniform) upper-bound for the circumradii of the mesh tetrahedra. 
 
 Note that each size or distance parameter can be specified using two ways: either as 
-scalar field or as a numerical value when the field is uniform. 
+a scalar field or as a numerical value when the field is uniform. 
 
 Each parameter has a special default value `ignored` which means that the 
-corresponding criteria will be ignored. 
+corresponding criterion will be ignored. 
 Numerical sizing or distance values, as well as scalar fields 
 should be given in the unit used for coordinates of points in the mesh domain class 
 of the mesh generation process. 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_criteria_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_criteria_3.h
@@ -51,7 +51,7 @@ for the radius of the surface Delaunay balls.
 of the surface mesh facets.
 \param topology is the set of topological constraints 
 which have to be verified by each surface facet. See 
-section \ref introsecparam for further details. 
+section \ref Mesh_3DelaunayRefinement for further details. 
 Note that if one parameter is set to 0, then its corresponding criteria is ignored. 
 */ 
 Mesh_facet_criteria_3( 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_criteria_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_criteria_3.h
@@ -42,12 +42,14 @@ typedef Tr::Geom_traits::FT FT;
 /// @{
 
 /*!
-Returns an object to serve as criteria for facets. The argument 
-`angle_bound` is the lower bound for the angle in degrees of the 
-surface mesh facets. The argument `radius_bound` is a uniform upper bound 
-for the radius of the surface Delaunay balls. The argument 
-`distance_bound` is an upper bound for the center-center distances 
-of the surface mesh facets. `topology` is the set of topological constraints 
+Returns an object to serve as criteria for facets.
+\param angle_bound is the lower bound for the angle in degrees of the 
+surface mesh facets.
+\param radius_bound is a uniform upper bound 
+for the radius of the surface Delaunay balls.
+\param distance_bound is an upper bound for the center-center distances 
+of the surface mesh facets.
+\param topology is the set of topological constraints 
 which have to be verified by each surface facet. See 
 section \ref introsecparam for further details. 
 Note that if one parameter is set to 0, then its corresponding criteria is ignored. 


### PR DESCRIPTION
This PR fixes the documentation of the meshing criterion `facet_distance`
fixes #1250 