### PR TITLE
bugfix for master: used the copied polyhedron

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -189,7 +189,7 @@ Polyhedral_mesh_domain_with_features_3(const Polyhedron& p,
 {
   poly_.resize(1);
   poly_[0] = p;
-  this->add_primitives(p);
+  this->add_primitives(poly_[0]);
   this->set_random_generator(p_rng);
 }
 


### PR DESCRIPTION
As `Polyhedral_mesh_domain_with_features_3` copies the polyhedra, the
aabb tree should used the copy (with the assigned patch ids!)

cc @janetournois 
