### PR TITLE
Set CMP0056 if CMake>=3.2

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -27,6 +27,17 @@ if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+if(POLICY CMP0056)
+  # http://www.cmake.org/cmake/help/v3.2/policy/CMP0056.html
+  #
+  # Fix a bug: `try_compile` should use `CMAKE_EXE_LINKER_FLAGS`.
+  # That variable can contain important flags like
+  #
+  #     -static-libstdc++ -static-libgcc
+  #
+  cmake_policy(SET CMP0056 NEW)
+endif()
+
 # Use GNUInstallDirst to get canonical paths
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Fix the [CMake bug #14006][bug]. It has been "fixed" in CMake>=3.2, with the [policy CMP0056][cmp]. If we want the bug be fixed in CGAL, we must set the policy because we use `cmake_policy(VERSION 2.8.11)`.

[bug]: https://cmake.org/Bug/view.php?id=14066
[cmp]: https://cmake.org/cmake/help/v3.2/policy/CMP0056.html
