### PR TITLE
Hack to fix a bug with CGAL_HEADER_ONLY

### DIFF
--- a/Installation/src/CMakeLists.txt
+++ b/Installation/src/CMakeLists.txt
@@ -56,6 +56,11 @@ function (collect_cgal_library LIBRARY_NAME ADDITIONAL_FILES)
         SOVERSION "${CGAL_SONAME_VERSION}")
     endif()
   else()
+    if(${LIBRARY_NAME}_LIB_DEPENDS)
+      # Fix a bug when CGAL is configured first without `CGAL_HEADER_ONLY`
+      # and then `CGAL_HEADER_ONLY` is set without cleaning the cache.
+      unset(${LIBRARY_NAME}_LIB_DEPENDS CACHE)
+    endif()
     add_library(${LIBRARY_NAME} INTERFACE)
   endif()
 

--- a/Installation/src/CMakeLists.txt
+++ b/Installation/src/CMakeLists.txt
@@ -45,18 +45,18 @@ function (collect_cgal_library LIBRARY_NAME ADDITIONAL_FILES)
   endif()
 
   if (NOT CGAL_HEADER_ONLY)
-     add_library (${LIBRARY_NAME}
-       ${CMAKE_CURRENT_BINARY_DIR}/all_files.cpp
-       ${rc_file}
-       ${ADDITIONAL_FILES})
-   #  add_library (${LIBRARY_NAME} ${CGAL_LIBRARY_SOURCE_FILES} ${rc_file} ${ADDITIONAL_FILES}) # builing not creating temporary all_files.cpp
-   if(CGAL_SOVERSION AND CGAL_SONAME_VERSION)
-     set_target_properties(${LIBRARY_NAME} PROPERTIES
-       VERSION "${CGAL_SOVERSION}"
-       SOVERSION "${CGAL_SONAME_VERSION}")
-   endif()
+    add_library (${LIBRARY_NAME}
+      ${CMAKE_CURRENT_BINARY_DIR}/all_files.cpp
+      ${rc_file}
+      ${ADDITIONAL_FILES})
+    #  add_library (${LIBRARY_NAME} ${CGAL_LIBRARY_SOURCE_FILES} ${rc_file} ${ADDITIONAL_FILES}) # builing not creating temporary all_files.cpp
+    if(CGAL_SOVERSION AND CGAL_SONAME_VERSION)
+      set_target_properties(${LIBRARY_NAME} PROPERTIES
+        VERSION "${CGAL_SOVERSION}"
+        SOVERSION "${CGAL_SONAME_VERSION}")
+    endif()
   else()
-      add_library(${LIBRARY_NAME} INTERFACE)
+    add_library(${LIBRARY_NAME} INTERFACE)
   endif()
 
   if(CGAL_AUTO_LINK_ENABLED)


### PR DESCRIPTION
(I copy the text from acf339d27f708d14e4569e25b4a648501a8d15c6. The other commit is just a fix of the indentation.)

If a `CMakeCache.txt ` is first created without `CGAL_HEADER_ONLY`, and
then `CGAL_HEADER_ONLY` is set, then CMake displays error messages like:
```
CMake Error: Target CGAL has dependency information when it shouldn't.
Your cache is probably stale. Please remove the entry
  CGAL_LIB_DEPENDS
from the cache.
```

The problem comes from the fact that the target `CGAL` was first created as
a library target, and then turned into an "interface library" target.

This patch fixes the error the simplest way: remove the aforementioned
variable from the cache if it is present.