### PR TITLE
Polyhedron_demo : fix the WaitCursor in the Mesh_3 script

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -312,6 +312,9 @@ void Mesh_3_plugin::mesh_3(const bool surface_only)
   // -----------------------------------
   // Get values
   // -----------------------------------
+
+  //reset cursor from the code for the scripts
+  QApplication::restoreOverrideCursor();
   int i = dialog.exec();
   if( i == QDialog::Rejected ) { return; }
 


### PR DESCRIPTION
This fixes #1302. 
This PR restores the overridecursor before the meshing dialog appears so the Waitcursor set by the Mainwindow's code for loading a script disappears.