### PR TITLE
Polyhedron_demo : Add a new RenderingMode for ShadedPoints

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.h
@@ -41,7 +41,7 @@ public:
     QString toolTip() const;
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const { return (m != Gouraud && m!=PointsPlusNormals && m!=Splatting); } // CHECK THIS!
+    virtual bool supportsRenderingMode(RenderingMode m) const { return (m != Gouraud && m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); } // CHECK THIS!
     //Event handling
     virtual bool keyPressEvent(QKeyEvent*);
     //drawing of the scene

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -482,7 +482,8 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
                 glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             }
             if(item.renderingMode() == Points  ||
-                    (!with_names && item.renderingMode() == PointsPlusNormals))
+                    (!with_names && item.renderingMode() == PointsPlusNormals)  ||
+                 (!with_names && item.renderingMode() == ShadedPoints))
             {
                 viewer->glDisable(GL_LIGHTING);
                 viewer->glPointSize(2.0f);

--- a/Polyhedron/demo/Polyhedron/Scene_c2t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c2t3_item.h
@@ -72,7 +72,7 @@ public:
 
   // Indicate if rendering mode is supported
   bool supportsRenderingMode(RenderingMode m) const {
-    return (m != Gouraud && m!=PointsPlusNormals && m!=Splatting); // CHECK THIS!
+    return (m != Gouraud && m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); // CHECK THIS!
   }
 
   void draw() const {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -63,7 +63,7 @@ public :
   }
   // Indicates if rendering mode is supported
   bool supportsRenderingMode(RenderingMode m) const {
-    return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points);
+    return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points && m != ShadedPoints);
   }
   void initialize_buffers(CGAL::Three::Viewer_interface *viewer)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -100,7 +100,7 @@ public:
 
   // Indicate if rendering mode is supported
   bool supportsRenderingMode(RenderingMode m) const {
-    return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points);
+    return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points && m != ShadedPoints);
   }
 
   void draw(CGAL::Three::Viewer_interface* viewer) const;

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -64,6 +64,8 @@ QString modeName(RenderingMode mode) {
     {
     case Points:
         return QObject::tr("points");
+    case ShadedPoints:
+        return QObject::tr("shaded points");
     case Wireframe:
         return QObject::tr("wire");
     case Flat:
@@ -87,6 +89,8 @@ const char* slotName(RenderingMode mode) {
     {
     case Points:
         return SLOT(setPointsMode());
+    case ShadedPoints:
+      return SLOT(setShadedPointsMode());
     case Wireframe:
         return SLOT(setWireframeMode());
     case Flat:

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.h
@@ -29,7 +29,7 @@ public:
   virtual void invalidateOpenGLBuffers();
   virtual void selection_changed(bool);
   // Indicate if rendering mode is supported
-  virtual bool supportsRenderingMode(RenderingMode m) const { return m != Gouraud && m!=Splatting; } // CHECK THIS!
+  virtual bool supportsRenderingMode(RenderingMode m) const { return m != Gouraud && m!=Splatting && m!=ShadedPoints; } // CHECK THIS!
   // OpenGL drawing in a display list
   void direct_draw() const;
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -538,7 +538,7 @@ bool Scene_points_with_normal_item::supportsRenderingMode(RenderingMode m) const
 {
     return m==Points ||
             ( has_normals() &&
-              ( m==PointsPlusNormals || m==Splatting ) );
+              ( m==PointsPlusNormals || m==ShadedPoints || m==Splatting ) );
 }
 
 void Scene_points_with_normal_item::drawSplats(CGAL::Three::Viewer_interface* viewer) const
@@ -592,7 +592,7 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
       ratio_displayed = 3 * 300000. / (double)(d->nb_points + d->nb_selected_points);
 
     vaos[Scene_points_with_normal_item_priv::ThePoints]->bind();
-    if(has_normals())
+    if(has_normals() && renderingMode() == ShadedPoints)
     {
       d->program=getShaderProgram(PROGRAM_WITH_LIGHT);
       attribBuffers(viewer,PROGRAM_WITH_LIGHT);
@@ -604,13 +604,16 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
     }
     d->program->bind();
     d->program->setAttributeValue("colors", this->color());
+    if(renderingMode() != ShadedPoints)
+      d->program->setAttributeValue("normals", QVector3D(0,0,0));
+
     viewer->glDrawArrays(GL_POINTS, 0,
                          static_cast<GLsizei>(((std::size_t)(ratio_displayed * d->nb_points)/3)));
     vaos[Scene_points_with_normal_item_priv::ThePoints]->release();
     d->program->release();
 
     vaos[Scene_points_with_normal_item_priv::Selected_points]->bind();
-    if(has_normals())
+    if(has_normals() && renderingMode() == ShadedPoints)
     {
       d->program=getShaderProgram(PROGRAM_WITH_LIGHT);
       attribBuffers(viewer,PROGRAM_WITH_LIGHT);

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -536,9 +536,17 @@ Scene_points_with_normal_item::toolTip() const
 
 bool Scene_points_with_normal_item::supportsRenderingMode(RenderingMode m) const 
 {
-    return m==Points ||
-            ( has_normals() &&
-              ( m==PointsPlusNormals || m==ShadedPoints || m==Splatting ) );
+  switch ( m )
+  {
+  case Points:
+  case ShadedPoints:
+  case PointsPlusNormals:
+  case Splatting:
+    return true;
+
+  default:
+    return false;
+  }
 }
 
 void Scene_points_with_normal_item::drawSplats(CGAL::Three::Viewer_interface* viewer) const

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -125,7 +125,7 @@ public:
     QString toolTip() const;
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const { return ( m!=PointsPlusNormals && m!=Splatting); }
+    virtual bool supportsRenderingMode(RenderingMode m) const { return ( m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); }
     // OpenGL drawing in a display list
     virtual void draw() const {}
     virtual void draw(CGAL::Three::Viewer_interface*) const;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -70,7 +70,7 @@ public:
     QMenu* contextMenu();
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const { return (m!=PointsPlusNormals && m!=Splatting); }
+    virtual bool supportsRenderingMode(RenderingMode m) const { return (m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); }
     // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
     void draw() const {}
     virtual void draw(CGAL::Three::Viewer_interface*) const;

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.h
@@ -29,7 +29,7 @@ public:
   virtual QString toolTip() const;
 
   // Indicate if rendering mode is supported
-  virtual bool supportsRenderingMode(RenderingMode m) const { return (m != Splatting && m != PointsPlusNormals && m != Points && m != Gouraud ); }
+  virtual bool supportsRenderingMode(RenderingMode m) const { return (m != Splatting && m != PointsPlusNormals && m != Points && m != Gouraud && m != ShadedPoints); }
   // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
    void draw() const {}
   virtual void draw(CGAL::Three::Viewer_interface*) const;

--- a/Three/include/CGAL/Three/Scene_interface.h
+++ b/Three/include/CGAL/Three/Scene_interface.h
@@ -45,12 +45,12 @@ class Scene_group_item;
  */
 enum RenderingMode { Points = 0,
                      PointsPlusNormals,
-                     ShadedPoints,
                      Splatting,
                      Wireframe, 
                      Flat,
                      FlatPlusEdges,
                      Gouraud,
+                     ShadedPoints,
                      NumberOfRenderingMode};
 
 

--- a/Three/include/CGAL/Three/Scene_interface.h
+++ b/Three/include/CGAL/Three/Scene_interface.h
@@ -45,13 +45,13 @@ class Scene_group_item;
  */
 enum RenderingMode { Points = 0,
                      PointsPlusNormals,
+                     ShadedPoints,
                      Splatting,
                      Wireframe, 
                      Flat,
                      FlatPlusEdges,
                      Gouraud,
-                     LastRenderingMode = Gouraud,
-                     NumberOfRenderingMode = LastRenderingMode+1 };
+                     NumberOfRenderingMode};
 
 
 namespace CGAL {

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -285,6 +285,10 @@ public Q_SLOTS:
   void setPointsMode() {
     setRenderingMode(Points);
   }
+  //!Sets the RenderingMode to Points.
+  void setShadedPointsMode() {
+    setRenderingMode(ShadedPoints);
+  }
   //!Sets the RenderingMode to Wireframe.
   void setWireframeMode() {
     setRenderingMode(Wireframe);


### PR DESCRIPTION
This PR fixes #1311.
It adds a renderingMode called ShadedPoints to distinguish between the points with lighting effects and the others.