### PR TITLE
Spatial searching: fix misleading typedef in examples

### DIFF
--- a/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_inplace.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_inplace.cpp
@@ -9,8 +9,6 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point_3;
 
-typedef std::size_t Point;
-
 //definition of a non-mutable lvalue property map,
 //with the get function as a friend function to give it
 //access to the private member
@@ -19,7 +17,7 @@ class My_point_property_map{
 public:
   typedef Point_3 value_type;
   typedef const value_type& reference;
-  typedef Point key_type;
+  typedef std::size_t key_type;
   typedef boost::lvalue_property_map_tag category;  
 
   My_point_property_map(const std::vector<Point_3>& pts):points(pts){}
@@ -33,7 +31,7 @@ public:
 
 typedef CGAL::Random_points_in_cube_3<Point_3>                               Random_points_iterator;
 typedef CGAL::Search_traits_3<Kernel>                                        Traits_base;
-typedef CGAL::Search_traits_adapter<Point,My_point_property_map,Traits_base> Traits;
+typedef CGAL::Search_traits_adapter<std::size_t,My_point_property_map,Traits_base> Traits;
 
 
 typedef CGAL::Orthogonal_k_neighbor_search<Traits>                      K_neighbor_search;

--- a/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_pmap.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_pmap.cpp
@@ -9,13 +9,11 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point_3;
 
-typedef std::size_t Point;
-
-typedef boost::const_associative_property_map<std::map<Point,Point_3> >                 My_point_property_map;
+typedef boost::const_associative_property_map<std::map<std::size_t,Point_3> >           My_point_property_map;
   
 typedef CGAL::Random_points_in_cube_3<Point_3>                                          Random_points_iterator;
 typedef CGAL::Search_traits_3<Kernel>                                                   Traits_base;
-typedef CGAL::Search_traits_adapter<Point,My_point_property_map,Traits_base>            Traits;
+typedef CGAL::Search_traits_adapter<std::size_t,My_point_property_map,Traits_base>      Traits;
 
 
 typedef CGAL::Orthogonal_k_neighbor_search<Traits>                      K_neighbor_search;
@@ -27,7 +25,7 @@ int main() {
   const unsigned int K = 5;
   // generator for random data points in the cube ( (-1,-1,-1), (1,1,1) )
   Random_points_iterator rpit( 1.0);
-  std::map<Point,Point_3> points;
+  std::map<std::size_t,Point_3> points;
   
   points[0]=Point_3(*rpit++);
   points[1]=Point_3(*rpit++);


### PR DESCRIPTION
In some examples of the `Spatial Searching` package, there is a `typedef std::size_t Point`. This is extremely misleading and makes the example hard to understand (there is also a `typedef Kernel::Point_3 Point_3` which makes sense). That actually lead me to make some errors when writing my own property map, taking inspiration on this piece of code…

I suggest to simply remove this typedef (`std::size_t` is short and clear).