### PR TITLE
BGL : detect internal property maps, and use it in PMP isotropic remeshing

### DIFF
--- a/BGL/include/CGAL/boost/graph/internal/Has_member_id.h
+++ b/BGL/include/CGAL/boost/graph/internal/Has_member_id.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 GeometryFactory (France).  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s) : Jane Tournois
+
+
+#ifndef CGAL_HAS_MEMBER_ID_H
+#define CGAL_HAS_MEMBER_ID_H
+
+namespace CGAL {
+namespace internal {
+
+  template <typename Type>
+  class Has_member_id
+  {
+    typedef char yes[1];
+    typedef char no[2];
+
+    struct BaseWithId
+    {
+      void id(){}
+    };
+    struct Base : public Type, public BaseWithId {};
+
+    template <typename T, T t>
+    class Helper{};
+
+    template <typename U>
+    static no &check(U*, Helper<void (BaseWithId::*)(), &U::id>* = 0);
+
+    static yes &check(...);
+
+  public:
+    static const bool value = (sizeof(yes) == sizeof(check((Base*)(0))));
+  };
+
+}  // internal
+}  // cgal
+
+#endif /* CGAL_HAS_MEMBER_ID_H */

--- a/BGL/include/CGAL/boost/graph/properties.h
+++ b/BGL/include/CGAL/boost/graph/properties.h
@@ -60,8 +60,16 @@ enum face_external_index_t   { face_external_index   } ;
     {}
     std::string s;
     T t;
-        
   };
+
+template<typename Graph, typename PropertyTag>
+struct graph_has_property : CGAL::Tag_false {};
+  
+struct cgal_no_property
+{
+  typedef bool type;
+  typedef const bool const_type;
+};
 
 /// @}
 

--- a/BGL/include/CGAL/boost/graph/properties_CombinatorialMap.h
+++ b/BGL/include/CGAL/boost/graph/properties_CombinatorialMap.h
@@ -270,6 +270,23 @@ void put(PropertyTag p, CGAL_LCC_TYPE& g, const Key& key, const Value& value)
   put(pmap, key, value);
 }
 
+// graph has internal property map
+template<CGAL_LCC_ARGS>
+struct graph_has_property<CGAL_LCC_TYPE, edge_weight_t>
+  : CGAL::Tag_true{};
+
+template<CGAL_LCC_ARGS>
+struct graph_has_property<CGAL_LCC_TYPE, edge_index_t>
+  : CGAL::Tag_true{};
+
+template<CGAL_LCC_ARGS>
+struct graph_has_property<CGAL_LCC_TYPE, vertex_index_t>
+  : CGAL::Tag_true{};
+
+template<CGAL_LCC_ARGS>
+struct graph_has_property<CGAL_LCC_TYPE, vertex_point_t>
+  : CGAL::Tag_true{};
+
 } // namespace boost
 
 #undef CGAL_LCC_ARGS

--- a/BGL/include/CGAL/boost/graph/properties_PolyMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/properties_PolyMesh_ArrayKernelT.h
@@ -268,6 +268,25 @@ struct property_map<OpenMesh::PolyMesh_ArrayKernelT<K>, boost::vertex_point_t >
   typedef type const_type;
 };
 
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, edge_weight_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, vertex_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, face_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, edge_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, halfedge_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::PolyMesh_ArrayKernelT<K>, vertex_point_t>
+  : CGAL::Tag_true{};
+
 } // namespace boost
 
 namespace OpenMesh {

--- a/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -26,6 +26,7 @@
 #include <CGAL/squared_distance_2_1.h>
 #include <CGAL/number_utils.h>
 #include <boost/shared_ptr.hpp>
+#include <CGAL/boost/graph/internal/Has_member_id.h>
 
 #define CGAL_HDS_PARAM_ template < class Traits, class Items, class Alloc> class HDS
 
@@ -435,6 +436,29 @@ struct vertex_property_type<const CGAL::Polyhedron_3<Gt,I,HDS,A> >
 {
   typedef CGAL::vertex_point_t type;
 };
+
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, vertex_point_t>
+  : CGAL::Tag_true {};
+
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, edge_weight_t>
+  : CGAL::Tag_true {};
+
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, edge_index_t>
+  : CGAL::Tag_true {};
+
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, face_index_t>
+  : CGAL::Boolean_tag<
+      CGAL::internal::Has_member_id<
+        typename CGAL::Polyhedron_3<Gt, I, HDS, A>::Facet
+      >::value
+    >
+{};
+
+
 } // namespace boost
 
 

--- a/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/BGL/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -447,7 +447,12 @@ struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, edge_weight_t>
 
 template<class Gt, class I, CGAL_HDS_PARAM_, class A>
 struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, edge_index_t>
-  : CGAL::Tag_true {};
+  : CGAL::Boolean_tag<
+      CGAL::internal::Has_member_id<
+        typename graph_traits<CGAL::Polyhedron_3<Gt, I, HDS, A> >::edge_descriptor
+      >::value
+    >
+{};
 
 template<class Gt, class I, CGAL_HDS_PARAM_, class A>
 struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, face_index_t>
@@ -458,6 +463,23 @@ struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, face_index_t>
     >
 {};
 
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, halfedge_index_t>
+  : CGAL::Boolean_tag<
+      CGAL::internal::Has_member_id<
+        typename CGAL::Polyhedron_3<Gt, I, HDS, A>::Halfedge
+      >::value
+    >
+{};
+
+template<class Gt, class I, CGAL_HDS_PARAM_, class A>
+struct graph_has_property<CGAL::Polyhedron_3<Gt, I, HDS, A>, vertex_index_t>
+  : CGAL::Boolean_tag<
+      CGAL::internal::Has_member_id<
+        typename CGAL::Polyhedron_3<Gt, I, HDS, A>::Vertex
+      >::value
+    >
+{};
 
 } // namespace boost
 

--- a/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -266,7 +266,6 @@ namespace internal {
      const TYPE& x)                                                \
  { return get(get(p, sm), x); }                                        \
 
-
 CGAL_SM_INTRINSIC_PROPERTY(boost::uint32_t, boost::vertex_index_t,
 SM_Vertex_index)
 CGAL_SM_INTRINSIC_PROPERTY(boost::uint32_t, boost::edge_index_t,
@@ -294,6 +293,26 @@ put(CGAL::vertex_point_t p, const CGAL::Surface_mesh<Point>& g,
 }
 
 } // CGAL
+
+namespace boost
+{
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, vertex_index_t>
+    : CGAL::Tag_true {};
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, edge_index_t>
+    : CGAL::Tag_true {};
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, halfedge_index_t>
+    : CGAL::Tag_true {};
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, face_index_t>
+    : CGAL::Tag_true {};
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, CGAL::vertex_point_t>
+    : CGAL::Tag_true {};
+
+} //boost
 
 #if 0
 //

--- a/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/BGL/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -311,6 +311,9 @@ namespace boost
   template<typename Point>
   struct graph_has_property<CGAL::Surface_mesh<Point>, CGAL::vertex_point_t>
     : CGAL::Tag_true {};
+  template<typename Point>
+  struct graph_has_property<CGAL::Surface_mesh<Point>, edge_weight_t>
+    : CGAL::Tag_true {};
 
 } //boost
 

--- a/BGL/include/CGAL/boost/graph/properties_TriMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/properties_TriMesh_ArrayKernelT.h
@@ -99,6 +99,25 @@ struct property_map<OpenMesh::TriMesh_ArrayKernelT<K>, boost::vertex_point_t >
   typedef type const_type;
 };
 
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, edge_weight_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, vertex_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, face_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, edge_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, halfedge_index_t>
+  : CGAL::Tag_true{};
+template<typename K>
+struct graph_has_property<OpenMesh::TriMesh_ArrayKernelT<K>, vertex_point_t>
+  : CGAL::Tag_true{};
+
 } // namespace boost
 
 namespace OpenMesh {

--- a/BGL/test/BGL/CMakeLists.txt
+++ b/BGL/test/BGL/CMakeLists.txt
@@ -79,6 +79,8 @@ create_single_source_cgal_program( "test_helpers.cpp" )
 
 create_single_source_cgal_program( "test_Has_member_clear.cpp" )
 
+create_single_source_cgal_program( "test_Has_member_id.cpp" )
+
 create_single_source_cgal_program( "test_cgal_bgl_named_params.cpp" )
 
 if(OpenMesh_FOUND)

--- a/BGL/test/BGL/test_Has_member_id.cpp
+++ b/BGL/test/BGL/test_Has_member_id.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <CGAL/assertions.h>
 #include <CGAL/boost/graph/internal/Has_member_id.h>
 
@@ -30,11 +29,8 @@ int main()
   CGAL_static_assertion(!Has_member_id<Polyhedron::Face>::value);
   CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::Facet>::value);
   CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::FBase>::value);
-
-  const bool actual_type_has_id =
-    Has_member_id<Polyhedron_with_ids::Items::Face_wrapper<Polyhedron_with_ids::HDS, K>::Face>::value;
-  CGAL_static_assertion(actual_type_has_id);
-  std::cout << "Actual type has id : " << actual_type_has_id << std::endl;
+  CGAL_static_assertion(
+    (Has_member_id<Polyhedron_with_ids::Items::Face_wrapper<Polyhedron_with_ids::HDS, K>::Face>::value));
 
   return 0;
 }

--- a/BGL/test/BGL/test_Has_member_id.cpp
+++ b/BGL/test/BGL/test_Has_member_id.cpp
@@ -1,0 +1,39 @@
+
+#include <iostream>
+#include <CGAL/assertions.h>
+#include <CGAL/boost/graph/internal/Has_member_id.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_items_with_id_3.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Polyhedron_3<K> Polyhedron;
+typedef CGAL::Polyhedron_3<K, CGAL::Polyhedron_items_with_id_3> Polyhedron_with_ids;
+
+struct StructWithId
+{
+  std::size_t m_id;
+  StructWithId() : m_id(12) {}
+  //with overload
+  const std::size_t id() const { return m_id; }
+  std::size_t& id() { return m_id; }
+};
+struct StructNoId
+{};
+
+int main(int argc, char* argv[])
+{
+  using namespace CGAL::internal;
+
+  CGAL_static_assertion(!Has_member_id<StructNoId>::value);
+  CGAL_static_assertion(Has_member_id<StructWithId>::value);
+  CGAL_static_assertion(!Has_member_id<Polyhedron::Face>::value);
+  CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::Facet>::value);
+  CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::FBase>::value);
+
+  typedef Polyhedron_with_ids::Items::Face_wrapper<Polyhedron_with_ids::HDS, K> FW;
+  CGAL_static_assertion(Has_member_id<FW::Face>::value);
+
+  return 0;
+}

--- a/BGL/test/BGL/test_Has_member_id.cpp
+++ b/BGL/test/BGL/test_Has_member_id.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <CGAL/assertions.h>
 #include <CGAL/boost/graph/internal/Has_member_id.h>
@@ -16,13 +15,13 @@ struct StructWithId
   std::size_t m_id;
   StructWithId() : m_id(12) {}
   //with overload
-  const std::size_t id() const { return m_id; }
+  std::size_t id() const { return m_id; }
   std::size_t& id() { return m_id; }
 };
 struct StructNoId
 {};
 
-int main(int argc, char* argv[])
+int main()
 {
   using namespace CGAL::internal;
 
@@ -32,8 +31,10 @@ int main(int argc, char* argv[])
   CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::Facet>::value);
   CGAL_static_assertion(Has_member_id<Polyhedron_with_ids::FBase>::value);
 
-  typedef Polyhedron_with_ids::Items::Face_wrapper<Polyhedron_with_ids::HDS, K> FW;
-  CGAL_static_assertion(Has_member_id<FW::Face>::value);
+  const bool actual_type_has_id =
+    Has_member_id<Polyhedron_with_ids::Items::Face_wrapper<Polyhedron_with_ids::HDS, K>::Face>::value;
+  CGAL_static_assertion(actual_type_has_id);
+  std::cout << "Actual type has id : " << actual_type_has_id << std::endl;
 
   return 0;
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -58,9 +58,8 @@ namespace CGAL {
       using boost::choose_const_pmap;
       using boost::get_param;
       typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
-        vpm = choose_const_pmap(get_param(np, CGAL::vertex_point),
-                                pmesh,
-                                CGAL::vertex_point);
+        vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(CGAL::vertex_point, pmesh));
 
       typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -39,14 +39,15 @@ namespace CGAL {
     *  computes a bounding box of a polygon mesh.
     *
     * @tparam PolygonMesh a model of `HalfedgeListGraph`
-    *   that has an internal property map for `CGAL::vertex_point_t`
     * @tparam NamedParameters a sequence of \ref namedparameters
     *
     * @param pmesh a polygon mesh
     * @param np optional sequence of \ref namedparameters among the ones listed below
     *
     * \cgalNamedParamsBegin
-    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+    *   If this parameter is omitted, an internal property map for
+    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
     * \cgalNamedParamsEnd
     *
     * @return a bounding box of `pmesh`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -55,7 +55,7 @@ namespace CGAL {
     CGAL::Bbox_3 bbox_3(const PolygonMesh& pmesh,
                         const NamedParameters& np)
     {
-      using boost::choose_const_pmap;
+      using boost::choose_param;
       using boost::get_param;
       typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
         vpm = choose_param(get_param(np, vertex_point),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -131,9 +131,10 @@ namespace Polygon_mesh_processing {
   * i.e. the collected halfedges are
   * the ones that belong to the input faces.
   *
-  * @tparam PolygonMesh model of `HalfedgeGraph`. If `PolygonMesh
-  *  `has an internal property map
-  *  for `CGAL::face_index_t`, then it should be initialized
+  * @tparam PolygonMesh model of `HalfedgeGraph`. If `PolygonMesh`
+  *  has an internal property map
+  *  for `CGAL::face_index_t` and no `face_index_map` is given
+  *  as a named parameter, then the internal one should be initialized
   * @tparam FaceRange range of
        `boost::graph_traits<PolygonMesh>::%face_descriptor`, model of `Range`.
         Its iterator type is `InputIterator`.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -167,7 +167,7 @@ namespace Polygon_mesh_processing {
                                   , const NamedParameters& np)
   {
     typedef PolygonMesh PM;
-    typedef typename GetFaceIndexMap<PM, NamedParameters>::type           FIMap;
+    typedef typename GetFaceIndexMap<PM, NamedParameters>::const_type     FIMap;
     typedef typename boost::property_map<typename internal::Dummy_PM,
                                               CGAL::face_index_t>::type   Unset_FIMap;
 
@@ -179,7 +179,7 @@ namespace Polygon_mesh_processing {
 
     //face index map given as a named parameter, or as an internal property map
     FIMap fim = choose_param(get_param(np, CGAL::face_index),
-                             get_property_map(CGAL::face_index, pmesh));
+                             get_const_property_map(CGAL::face_index, pmesh));
 
     //make a minimal check that it's properly initialized :
     //if the 2 first faces have the same id, we know the property map is not initialized

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -79,6 +79,17 @@ namespace Polygon_mesh_processing {
 
     template<typename PM
            , typename FaceRange
+           , typename HalfedgeOutputIterator>
+    HalfedgeOutputIterator border_halfedges_impl(const FaceRange& faces
+                                               , typename boost::cgal_no_property::type
+                                               , HalfedgeOutputIterator out
+                                               , const PM& pmesh)
+    {
+      return border_halfedges_impl(faces, out, pmesh);
+    }
+
+    template<typename PM
+           , typename FaceRange
            , typename FaceIndexMap
            , typename HalfedgeOutputIterator>
     HalfedgeOutputIterator border_halfedges_impl(const FaceRange& faces
@@ -167,7 +178,7 @@ namespace Polygon_mesh_processing {
 
     //face index map given as a named parameter, or as an internal property map
     FIMap fim = choose_param(get_param(np, face_index),
-                             get(CGAL::face_index, pmesh));
+                             get_property_map(face_index, pmesh));
 
     //make a minimal check that it's properly initialized :
     //if the 2 first faces have the same id, we know the property map is not initialized

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -177,8 +177,8 @@ namespace Polygon_mesh_processing {
     }
 
     //face index map given as a named parameter, or as an internal property map
-    FIMap fim = choose_param(get_param(np, face_index),
-                             get_property_map(face_index, pmesh));
+    FIMap fim = choose_param(get_param(np, CGAL::face_index),
+                             get_property_map(CGAL::face_index, pmesh));
 
     //make a minimal check that it's properly initialized :
     //if the 2 first faces have the same id, we know the property map is not initialized

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -133,7 +133,6 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   GT traits = choose_param(get_param(np, CGAL::geom_traits), GT());
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -95,8 +95,7 @@ void sum_normals(const PM& pmesh,
 /**
 * \ingroup PMP_normal_grp
 * computes the outward unit vector normal to face `f`.
-* @tparam PolygonMesh a model of `FaceGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+* @tparam PolygonMesh a model of `FaceGraph`
 * @tparam NamedParameters a sequence of \ref namedparameters
 *
 * @param f the face on which the normal is computed
@@ -104,7 +103,9 @@ void sum_normals(const PM& pmesh,
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -151,8 +152,7 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 /**
 * \ingroup PMP_normal_grp
 * computes the outward unit vector normal for all faces of the polygon mesh.
-* @tparam PolygonMesh a model of `FaceGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+* @tparam PolygonMesh a model of `FaceGraph`
 * @tparam FaceNormalMap a model of `WritablePropertyMap` with
     `boost::graph_traits<PolygonMesh>::%face_descriptor` as key type and
     `Kernel::Vector_3` as value type.
@@ -162,7 +162,9 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -190,15 +192,16 @@ compute_face_normals(const PolygonMesh& pmesh
 /**
 * \ingroup PMP_normal_grp
 * computes the unit normal at vertex `v` as the average of the normals of incident faces.
-* @tparam PolygonMesh a model of `FaceGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+* @tparam PolygonMesh a model of `FaceGraph`
 *
 * @param v the vertex at which the normal is computed
 * @param pmesh the polygon mesh containing `v`
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -266,8 +269,7 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
 /**
 * \ingroup PMP_normal_grp
 * computes the outward unit vector normal for all vertices of the polygon mesh.
-* @tparam PolygonMesh a model of `FaceListGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+* @tparam PolygonMesh a model of `FaceListGraph`
 * @tparam VertexNormalMap a model of `WritablePropertyMap` with
     `boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
     the return type of `compute_vertex_normal()` as value type.
@@ -277,7 +279,9 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -307,8 +311,7 @@ compute_vertex_normals(const PolygonMesh& pmesh
 /**
 * \ingroup PMP_normal_grp
 * computes the outward unit vector normal for all vertices and faces of the polygon mesh.
-* @tparam PolygonMesh a model of `FaceListGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+* @tparam PolygonMesh a model of `FaceListGraph`
 * @tparam VertexNormalMap a model of `WritablePropertyMap` with
     `boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
     `Kernel::Vector_3` as value type.
@@ -322,7 +325,9 @@ compute_vertex_normals(const PolygonMesh& pmesh
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -139,7 +139,7 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 
   Vector normal = traits.construct_vector_3_object()(CGAL::NULL_VECTOR);
   sum_normals<Point>(pmesh, f
-    , choose_const_pmap(get_param(np, CGAL::vertex_point), pmesh, CGAL::vertex_point)
+    , choose_param(get_param(np, vertex_point), get_const_property_map(CGAL::vertex_point, pmesh))
     , normal
     , traits);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -604,7 +604,7 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh
                                     get_property_map(boost::face_index, pmesh));
 
   //vector_property_map
-  boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);
+  boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fimap);
   std::size_t num = connected_components(pmesh, face_cc, np);
 
   // Even even we do not want to keep anything we need to first

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -430,7 +430,6 @@ connected_component(typename boost::graph_traits<PolygonMesh>::face_descriptor s
                     , const NamedParameters& np)
 {
   using boost::choose_param;
-  using boost::choose_const_pmap;
   using boost::get_param;
 
   typedef typename boost::lookup_named_param_def <
@@ -511,7 +510,6 @@ connected_components(const PolygonMesh& pmesh,
                      const NamedParameters& np)
 {
   using boost::choose_param;
-  using boost::choose_const_pmap;
   using boost::get_param;
 
   typedef typename boost::lookup_named_param_def <
@@ -596,7 +594,6 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh
 
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
@@ -680,7 +677,6 @@ std::size_t keep_large_connected_components(PolygonMesh& pmesh
 
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
@@ -735,7 +731,6 @@ void keep_or_remove_connected_components(PolygonMesh& pmesh
   typedef PolygonMesh PM;
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   typedef typename boost::graph_traits<PolygonMesh>::face_descriptor   face_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::face_iterator     face_iterator;
@@ -986,7 +981,6 @@ void remove_connected_components(PolygonMesh& pmesh
   typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, CGAL_PMP_NP_CLASS>::type FaceIndexMap;
@@ -1045,7 +1039,6 @@ void keep_connected_components(PolygonMesh& pmesh
 
   using boost::choose_param;
   using boost::get_param;
-  using boost::choose_const_pmap;
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, CGAL_PMP_NP_CLASS>::type FaceIndexMap;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -531,9 +531,9 @@ connected_components(const PolygonMesh& pmesh,
   FiniteDual finite_dual(dual,
     internal::No_border<PolygonMesh, EdgeConstraintMap>(pmesh, ecmap));
 
-  typename GetFaceIndexMap<PolygonMesh, NamedParameters>::type
+  typename GetFaceIndexMap<PolygonMesh, NamedParameters>::const_type
     fimap = choose_param(get_param(np, face_index),
-                         get_property_map(face_index, pmesh));
+                         get_const_property_map(face_index, pmesh));
 
   return boost::connected_components(finite_dual,
     fcm,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -531,13 +531,13 @@ connected_components(const PolygonMesh& pmesh,
   FiniteDual finite_dual(dual,
     internal::No_border<PolygonMesh, EdgeConstraintMap>(pmesh, ecmap));
 
+  typename GetFaceIndexMap<PolygonMesh, NamedParameters>::type
+    fimap = choose_param(get_param(np, face_index),
+                         get_property_map(face_index, pmesh));
+
   return boost::connected_components(finite_dual,
     fcm,
-    boost::vertex_index_map(
-      choose_const_pmap(get_param(np, boost::face_index),
-                        pmesh,
-                        boost::face_index)
-    )
+    boost::vertex_index_map(fimap)
   );
 }
 
@@ -600,9 +600,8 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
-  FaceIndexMap fim = choose_const_pmap(get_param(np, boost::face_index),
-                                       pmesh,
-                                       boost::face_index);
+  FaceIndexMap fimap = choose_param(get_param(np, boost::face_index),
+                                    get_property_map(boost::face_index, pmesh));
 
   //vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);
@@ -685,9 +684,8 @@ std::size_t keep_large_connected_components(PolygonMesh& pmesh
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
-  FaceIndexMap fim = choose_const_pmap(get_param(np, boost::face_index),
-                                       pmesh,
-                                       boost::face_index);
+  FaceIndexMap fim = choose_param(get_param(np, boost::face_index),
+                                  get_property_map(boost::face_index, pmesh));
 
   //vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);
@@ -993,9 +991,8 @@ void remove_connected_components(PolygonMesh& pmesh
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, CGAL_PMP_NP_CLASS>::type FaceIndexMap;
-  FaceIndexMap fim = choose_const_pmap(get_param(np, boost::face_index),
-                                       pmesh,
-                                       boost::face_index);
+  FaceIndexMap fim = choose_param(get_param(np, boost::face_index),
+                                  get_property_map(boost::face_index, pmesh));
 
   //vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);
@@ -1053,9 +1050,8 @@ void keep_connected_components(PolygonMesh& pmesh
 
   //FaceIndexMap
   typedef typename GetFaceIndexMap<PM, CGAL_PMP_NP_CLASS>::type FaceIndexMap;
-  FaceIndexMap fim = choose_const_pmap(get_param(np, boost::face_index),
-                                       pmesh,
-                                       boost::face_index);
+  FaceIndexMap fim = choose_param(get_param(np, boost::face_index),
+                                  get_property_map(boost::face_index, pmesh));
 
   //vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -747,9 +747,8 @@ void keep_or_remove_connected_components(PolygonMesh& pmesh
 
   //VertexIndexMap
   typedef typename GetVertexIndexMap<PM, NamedParameters>::type VertexIndexMap;
-  VertexIndexMap vim = choose_const_pmap(get_param(np, boost::vertex_index),
-                                         pmesh,
-                                         boost::vertex_index);
+  VertexIndexMap vim = choose_param(get_param(np, boost::vertex_index),
+                                    get_const_property_map(boost::vertex_index, pmesh));
 
   std::set<std::size_t> cc_to_keep;
   BOOST_FOREACH(std::size_t i, components_to_keep)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -80,7 +80,7 @@ namespace internal {
   fairing does not fail, but the mesh gets shrinked to `CGAL::ORIGIN`.
 
   @tparam TriangleMesh a model of `FaceGraph` and `MutableFaceGraph`
-          that has an internal property map for `CGAL::vertex_point_t`
+  that has an internal property map for `CGAL::vertex_point_t`
   @tparam VertexRange a range of vertex descriptors of `TriangleMesh`, model of `Range`.
           Its iterator type is `InputIterator`.
   @tparam NamedParameters a sequence of \ref namedparameters
@@ -143,7 +143,8 @@ namespace internal {
     typedef CGAL::internal::Cotangent_weight_with_voronoi_area_fairing<TriangleMesh, VPMap>
       Default_Weight_calculator;
 
-    VPMap vpmap_ = choose_param(get_param(np, vertex_point), get(CGAL::vertex_point, tmesh));
+    VPMap vpmap_ = choose_param(get_param(np, vertex_point),
+                                get_property_map(vertex_point, tmesh));
 
     return internal::fair(tmesh, vertices,
       choose_param(get_param(np, sparse_linear_solver), Default_solver()),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -80,7 +80,6 @@ namespace internal {
   fairing does not fail, but the mesh gets shrinked to `CGAL::ORIGIN`.
 
   @tparam TriangleMesh a model of `FaceGraph` and `MutableFaceGraph`
-  that has an internal property map for `CGAL::vertex_point_t`
   @tparam VertexRange a range of vertex descriptors of `TriangleMesh`, model of `Range`.
           Its iterator type is `InputIterator`.
   @tparam NamedParameters a sequence of \ref namedparameters
@@ -90,7 +89,9 @@ namespace internal {
   @param np optional sequence of \ref namedparameters among the ones listed below
 
   \cgalNamedParamsBegin
-    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh` \cgalParamEnd
+    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`.
+        If this parameter is omitted, an internal property map for
+      `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
     \cgalParamBegin{fairing_continuity} tangential continuity of the output surface patch. The larger `fairing_continuity` gets, the more fixed vertices are required \cgalParamEnd
     \cgalParamBegin{sparse_linear_solver} an instance of the sparse linear solver used for fairing \cgalParamEnd
   \cgalNamedParamsEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -99,11 +99,12 @@ namespace internal {
     friend void put(No_constraint_pmap& , const key_type& , const bool ) {}
   };
 
-  template <typename PM, typename FaceRange>
+  template <typename PM, typename FaceRange, typename FaceIndexMap>
   struct Border_constraint_pmap
   {
     typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
     typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
+    typedef FaceIndexMap FIMap;
 
     boost::shared_ptr< std::set<edge_descriptor> > border_edges_ptr;
     const PM* pmesh_ptr_;
@@ -118,25 +119,28 @@ namespace internal {
       : border_edges_ptr(new std::set<edge_descriptor>() )
       , pmesh_ptr_(NULL)
     {}
-    Border_constraint_pmap(const PM& pmesh, const FaceRange& faces)
+    Border_constraint_pmap(const PM& pmesh
+                         , const FaceRange& faces
+                         , const FIMap& fimap)
       : border_edges_ptr(new std::set<edge_descriptor>() )
       , pmesh_ptr_(&pmesh)
     {
       std::vector<halfedge_descriptor> border;
-      PMP::border_halfedges(faces, *pmesh_ptr_, std::back_inserter(border));
+      PMP::border_halfedges(faces, *pmesh_ptr_, std::back_inserter(border)
+        , PMP::parameters::face_index_map(fimap));
 
       BOOST_FOREACH(halfedge_descriptor h, border)
         border_edges_ptr->insert(edge(h, *pmesh_ptr_));
     }
 
-    friend bool get(const Border_constraint_pmap<PM, FaceRange>& map,
+    friend bool get(const Border_constraint_pmap<PM, FaceRange, FIMap>& map,
                     const edge_descriptor& e)
     {
       CGAL_assertion(map.pmesh_ptr_!=NULL);
       return map.border_edges_ptr->count(e)!=0;
     }
 
-    friend void put(Border_constraint_pmap<PM, FaceRange>& map,
+    friend void put(Border_constraint_pmap<PM, FaceRange, FIMap>& map,
                     const edge_descriptor& e,
                     const bool is)
     {
@@ -226,6 +230,8 @@ namespace internal {
               typename boost::graph_traits<PolygonMesh>::vertex_descriptor>
          , typename FacePatchMap = Connected_components_pmap<
               PolygonMesh, EdgeIsConstrainedMap>
+         , typename FaceIndexMap =
+              property_map_selector<PolygonMesh, CGAL::face_index_t>::type
   >
   class Incremental_remesher
   {
@@ -245,6 +251,7 @@ namespace internal {
                                , EdgeIsConstrainedMap
                                , VertexIsConstrainedMap
                                , FacePatchMap
+                               , FaceIndexMap
                                > Self;
 
   private:
@@ -264,6 +271,7 @@ namespace internal {
                        , EdgeIsConstrainedMap ecmap
                        , VertexIsConstrainedMap vcmap
                        , FacePatchMap fpmap
+                       , FaceIndexMap fimap
                        , const bool own_tree = true)//built by the remesher
       : mesh_(pmesh)
       , vpmap_(vpmap)
@@ -275,6 +283,7 @@ namespace internal {
       , patch_ids_map_(fpmap)
       , ecmap_(ecmap)
       , vcmap_(vcmap)
+      , fimap_(fimap)
     {
       CGAL_assertion(CGAL::is_triangle_mesh(mesh_));
     }
@@ -1350,7 +1359,8 @@ private:
         }
       }
 
-      internal::Border_constraint_pmap<PM, FaceRange> border_map(mesh_, face_range);
+      internal::Border_constraint_pmap<PM, FaceRange, FaceIndexMap>
+        border_map(mesh_, face_range, fimap_);
       //override the border of PATCH
       //tag PATCH_BORDER,//h belongs to the patch, hopp doesn't
       BOOST_FOREACH(edge_descriptor e, edges(mesh_))
@@ -1741,6 +1751,7 @@ private:
     FacePatchMap patch_ids_map_;
     EdgeIsConstrainedMap ecmap_;
     VertexIsConstrainedMap vcmap_;
+    FaceIndexMap fimap_;
 
   };//end class Incremental_remesher
 }//end namespace internal

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -74,7 +74,7 @@ public:
   }
 
 private:
-  type get_impl(const PropertyTag& p, const PolygonMesh& pmesh, CGAL::Tag_false)
+  type get_impl(const PropertyTag&, const PolygonMesh&, CGAL::Tag_false)
   {
     return type(); //boost::cgal_no_property::type
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -72,7 +72,7 @@ public:
                           , typename boost::cgal_no_property::const_type
   >::type const_type;
 
-  type get_pmap(const PropertyTag& p, const PolygonMesh& pmesh)
+  type get_pmap(const PropertyTag& p, PolygonMesh& pmesh)
   {
     return get_impl(p, pmesh, Has_internal_pmap());
   }
@@ -83,11 +83,11 @@ public:
   }
 
 private:
-  type get_impl(const PropertyTag&, const PolygonMesh&, CGAL::Tag_false)
+  type get_impl(const PropertyTag&, PolygonMesh&, CGAL::Tag_false)
   {
     return type(); //boost::cgal_no_property::type
   }
-  type get_impl(const PropertyTag& p, const PolygonMesh& pmesh, CGAL::Tag_true)
+  type get_impl(const PropertyTag& p, PolygonMesh& pmesh, CGAL::Tag_true)
   {
     return get(p, pmesh);
   }
@@ -106,7 +106,7 @@ private:
 
 template<typename PolygonMesh, typename PropertyTag>
 typename property_map_selector<PolygonMesh, PropertyTag>::type
-get_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
+get_property_map(const PropertyTag& p, PolygonMesh& pmesh)
 {
   property_map_selector<PolygonMesh, PropertyTag> pms;
   return pms.get_pmap(p, pmesh);
@@ -144,13 +144,20 @@ template<typename PolygonMesh, typename NamedParameters>
 class GetFaceIndexMap
 {
   typedef typename property_map_selector<PolygonMesh, boost::face_index_t>::type DefaultMap;
+  typedef typename property_map_selector<PolygonMesh, boost::face_index_t>::const_type DefaultMap_const;
 public:
   typedef typename boost::lookup_named_param_def <
     boost::face_index_t,
     NamedParameters,
     DefaultMap
   > ::type  type;
+  typedef typename boost::lookup_named_param_def <
+    boost::face_index_t,
+    NamedParameters,
+    DefaultMap_const
+  > ::type  const_type;
   typedef typename boost::is_same<type, DefaultMap>::type Is_internal_map;
+  typedef typename boost::is_same<const_type, DefaultMap_const>::type Is_internal_map_const;
 };
 
 template<typename PolygonMesh, typename NamedParameters>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -49,7 +49,15 @@ public:
 template<typename PolygonMesh, typename NamedParameters>
 class GetGeomTraits
 {
-  typedef typename GetK<PolygonMesh>::Kernel DefaultKernel;
+  typedef typename boost::graph_has_property<PolygonMesh, boost::vertex_point_t>::type
+    Has_internal_pmap;
+  struct Fake_GT {};//to be used if there is no internal vertex_point_map in PolygonMesh
+
+  typedef typename boost::mpl::if_c< Has_internal_pmap::value
+                                   , typename GetK<PolygonMesh>::Kernel
+                                   , Fake_GT
+  >::type DefaultKernel;
+
 public:
   typedef typename boost::lookup_named_param_def <
     CGAL::geom_traits_t,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_params_helper.h
@@ -67,10 +67,19 @@ public:
                           , typename boost::property_map<PolygonMesh, PropertyTag>::type
                           , typename boost::cgal_no_property::type
   >::type type;
+  typedef typename boost::mpl::if_c< Has_internal_pmap::value
+                          , typename boost::property_map<PolygonMesh, PropertyTag>::const_type
+                          , typename boost::cgal_no_property::const_type
+  >::type const_type;
 
   type get_pmap(const PropertyTag& p, const PolygonMesh& pmesh)
   {
     return get_impl(p, pmesh, Has_internal_pmap());
+  }
+
+  const_type get_const_pmap(const PropertyTag& p, const PolygonMesh& pmesh)
+  {
+    return get_const_pmap_impl(p, pmesh, Has_internal_pmap());
   }
 
 private:
@@ -79,6 +88,17 @@ private:
     return type(); //boost::cgal_no_property::type
   }
   type get_impl(const PropertyTag& p, const PolygonMesh& pmesh, CGAL::Tag_true)
+  {
+    return get(p, pmesh);
+  }
+
+  const_type get_const_pmap_impl(const PropertyTag&
+                               , const PolygonMesh&, CGAL::Tag_false)
+  {
+    return const_type(); //boost::cgal_no_property::type
+  }
+  const_type get_const_pmap_impl(const PropertyTag& p
+                               , const PolygonMesh& pmesh, CGAL::Tag_true)
   {
     return get(p, pmesh);
   }
@@ -92,12 +112,20 @@ get_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
   return pms.get_pmap(p, pmesh);
 }
 
+template<typename PolygonMesh, typename PropertyTag>
+typename property_map_selector<PolygonMesh, PropertyTag>::const_type
+get_const_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
+{
+  property_map_selector<PolygonMesh, PropertyTag> pms;
+  return pms.get_const_pmap(p, pmesh);
+}
+
 template<typename PolygonMesh, typename NamedParameters>
 class GetVertexPointMap
 {
-  typedef typename boost::property_map<PolygonMesh, boost::vertex_point_t>::const_type
+  typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::const_type
     DefaultVPMap_const;
-  typedef typename boost::property_map<PolygonMesh, boost::vertex_point_t>::type
+  typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::type
     DefaultVPMap;
 public:
   typedef typename boost::lookup_named_param_def<
@@ -128,7 +156,7 @@ public:
 template<typename PolygonMesh, typename NamedParameters>
 class GetVertexIndexMap
 {
-  typedef typename boost::property_map < PolygonMesh, boost::vertex_index_t>::type DefaultMap;
+  typedef typename property_map_selector<PolygonMesh, boost::vertex_index_t>::type DefaultMap;
 public:
   typedef typename boost::lookup_named_param_def <
     boost::vertex_index_t,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -85,9 +85,8 @@ namespace Polygon_mesh_processing {
     using boost::get_param;
 
     typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
-    vpm = choose_const_pmap(get_param(np, CGAL::vertex_point),
-                            pmesh,
-                            CGAL::vertex_point);
+    vpm = choose_param(get_param(np, vertex_point),
+                       get_const_property_map(CGAL::vertex_point, pmesh));
 
     return CGAL::approximate_sqrt(CGAL::squared_distance(get(vpm, source(h, pmesh)),
                                                          get(vpm, target(h, pmesh))));
@@ -231,9 +230,8 @@ namespace Polygon_mesh_processing {
     CGAL_precondition(boost::graph_traits<TriangleMesh>::null_face() != f);
 
     typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
-    vpm = choose_const_pmap(get_param(np, CGAL::vertex_point),
-                            tmesh,
-                            CGAL::vertex_point);
+    vpm = choose_param(get_param(np, vertex_point),
+                       get_const_property_map(CGAL::vertex_point, tmesh));
 
     typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
     halfedge_descriptor hd = halfedge(f, tmesh);
@@ -416,9 +414,8 @@ namespace Polygon_mesh_processing {
     using boost::get_param;
 
     typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
-      vpm = choose_const_pmap(get_param(np, CGAL::vertex_point),
-                              tmesh,
-                              CGAL::vertex_point);
+      vpm = choose_param(get_param(np, vertex_point),
+                         get_const_property_map(CGAL::vertex_point, tmesh));
     typename GetGeomTraits<TriangleMesh, CGAL_PMP_NP_CLASS>::type::Point_3
       origin(0, 0, 0);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -46,8 +46,7 @@ namespace Polygon_mesh_processing {
   * computes the length of an edge of a given polygon mesh.
   * The edge is given by one of its halfedges, or the edge itself.
   *
-  * @tparam PolygonMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam PolygonMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param h one halfedge of the edge to compute the length
@@ -55,7 +54,9 @@ namespace Polygon_mesh_processing {
   * @param np optional sequence of \ref namedparameters among the ones listed below
   *
   * \cgalNamedParamsBegin
-  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
   *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -126,8 +127,7 @@ namespace Polygon_mesh_processing {
   * computes the length of the border polyline
   * that contains a given halfedge.
   *
-  * @tparam PolygonMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam PolygonMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param h a halfedge of the border polyline of which the length is computed
@@ -135,8 +135,10 @@ namespace Polygon_mesh_processing {
   * @param np optional sequence of \ref namedparameters among the ones listed below
   *
   * \cgalNamedParamsBegin
-  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
-*    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
+  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
   * @return the length of the sequence of border edges of `face(h, pmesh)`.
@@ -190,8 +192,7 @@ namespace Polygon_mesh_processing {
   * computes the area of a face of a given
   * triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam TriangleMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param f the face of which the area is computed
@@ -199,7 +200,9 @@ namespace Polygon_mesh_processing {
   * @param np optional sequence of \ref namedparameters among the ones listed below
   *
   * \cgalNamedParamsBegin
-  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -263,8 +266,7 @@ namespace Polygon_mesh_processing {
   * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
           model of `Range`.
           Its iterator type is `InputIterator`.
-  * @tparam TriangleMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam TriangleMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param face_range the range of faces of which the area is computed
@@ -272,7 +274,9 @@ namespace Polygon_mesh_processing {
   * @param np optional sequence of \ref namedparameters among the ones listed below
   *
   * \cgalNamedParamsBegin
-  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel` \cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -328,15 +332,16 @@ namespace Polygon_mesh_processing {
   * \ingroup measure_grp
   * computes the surface area of a triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam TriangleMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param tmesh the triangulated surface mesh
   * @param np optional sequence of \ref namedparameters among the ones listed below
   *
   * \cgalNamedParamsBegin
-  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits}an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -378,8 +383,7 @@ namespace Polygon_mesh_processing {
   * computes the volume of the domain bounded by
   * a closed triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph` that has an internal property map
-  *         for `CGAL::vertex_point_t`
+  * @tparam TriangleMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref namedparameters
   *
   * @param tmesh the closed triangulated surface mesh bounding the volume
@@ -388,8 +392,10 @@ namespace Polygon_mesh_processing {
   * @pre `tmesh` is closed
   *
   * \cgalNamedParamsBegin
-  *  \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
-  *  \cgalParamBegin{geom_traits}an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
+  *  \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+  *   If this parameter is omitted, an internal property map for
+  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+  *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
   * @return the volume bounded by `tmesh`.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -81,7 +81,7 @@ namespace Polygon_mesh_processing {
               , const PolygonMesh& pmesh
               , const NamedParameters& np)
   {
-    using boost::choose_const_pmap;
+    using boost::choose_param;
     using boost::get_param;
 
     typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
@@ -224,7 +224,7 @@ namespace Polygon_mesh_processing {
             , const TriangleMesh& tmesh
             , const CGAL_PMP_NP_CLASS& np)
   {
-    using boost::choose_const_pmap;
+    using boost::choose_param;
     using boost::get_param;
 
     CGAL_precondition(boost::graph_traits<TriangleMesh>::null_face() != f);
@@ -410,7 +410,7 @@ namespace Polygon_mesh_processing {
     CGAL_assertion(is_triangle_mesh(tmesh));
     CGAL_assertion(is_closed(tmesh));
 
-    using boost::choose_const_pmap;
+    using boost::choose_param;
     using boost::get_param;
 
     typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -96,9 +96,8 @@ bool is_outward_oriented(const PolygonMesh& pmesh,
 
   //VertexPointMap
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type VPMap;
-  VPMap vpmap = choose_const_pmap(get_param(np, boost::vertex_point),
-                                  pmesh,
-                                  boost::vertex_point);
+  VPMap vpmap = choose_param(get_param(np, vertex_point),
+                             get_const_property_map(vertex_point, pmesh));
   //Kernel
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Kernel;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -91,7 +91,7 @@ bool is_outward_oriented(const PolygonMesh& pmesh,
   CGAL_warning(CGAL::is_closed(pmesh));
   CGAL_precondition(CGAL::is_valid(pmesh));
 
-  using boost::choose_const_pmap;
+  using boost::choose_param;
   using boost::get_param;
 
   //VertexPointMap

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -67,8 +67,7 @@ namespace internal{
  *      In other words, the answer to this predicate would be the same for each
  *      isolated connected component.
  *
- * @tparam PolygonMesh a model of `FaceListGraph` that has an internal property map
- *         for `boost::vertex_point_t`
+ * @tparam PolygonMesh a model of `FaceListGraph`
  * @tparam NamedParameters a sequence of \ref namedparameters
  *
  * @param pmesh the closed polygon mesh to be tested

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
@@ -35,7 +35,6 @@ namespace Polygon_mesh_processing {
   @brief refines a region of a triangle mesh
 
   @tparam TriangleMesh model of `MutableFaceGraph`
-          that has an internal property map for `CGAL::vertex_point_t`
   @tparam FaceRange range of face descriptors, model of `Range`.
           Its iterator type is `InputIterator`.
   @tparam FaceOutputIterator model of `OutputIterator`
@@ -52,7 +51,10 @@ namespace Polygon_mesh_processing {
 
   \cgalNamedParamsBegin
     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`
-      Instance of a class model of `ReadWritePropertyMap` \cgalParamEnd
+      Instance of a class model of `ReadWritePropertyMap`.
+      If this parameter is omitted, an internal property map for
+     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+     \cgalParamEnd
     \cgalParamBegin{density_control_factor} factor to control density of the output mesh,
       where larger values lead to denser refinements.
       The density of vertices of `faces_out` is this factor times higher than the vertices of `faces.` \cgalParamEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
@@ -77,7 +77,6 @@ namespace Polygon_mesh_processing {
            VertexOutputIterator vertices_out,
            const NamedParameters& np)
   {
-    using boost::choose_pmap;
     using boost::choose_param;
     using boost::get_param;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
@@ -84,9 +84,8 @@ namespace Polygon_mesh_processing {
     CGAL_precondition(is_triangle_mesh(tmesh) );
 
     typedef typename GetVertexPointMap<TriangleMesh,NamedParameters>::type VPmap;
-    VPmap vpm = choose_pmap(get_param(np, boost::vertex_point),
-                            tmesh,
-                            boost::vertex_point);
+    VPmap vpm = choose_param(get_param(np, vertex_point),
+                             get_property_map(vertex_point, tmesh));
 
     internal::Refine_Polyhedron_3<TriangleMesh, VPmap> refine_functor(tmesh, vpm);
     refine_functor.refine(faces,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -126,7 +126,6 @@ void isotropic_remeshing(const FaceRange& faces
 {
   typedef PolygonMesh PM;
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
-  using boost::choose_pmap;
   using boost::get_param;
   using boost::choose_param;
 
@@ -304,7 +303,6 @@ void split_long_edges(const EdgeRange& edges
   typedef PolygonMesh PM;
   typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
-  using boost::choose_pmap;
   using boost::choose_param;
   using boost::get_param;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -47,7 +47,8 @@ namespace Polygon_mesh_processing {
 *         and `boost::graph_traits<PolygonMesh>::%halfedge_descriptor` must be
 *         models of `Hashable`.
 *         If `PolygonMesh` has an internal property map for `CGAL::face_index_t`,
-*         then it should be initialized
+*         and no `face_index_map` is given
+*         as a named parameter, then the internal one should be initialized
 * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
           model of `Range`. Its iterator type is `InputIterator`.
 * @tparam NamedParameters a sequence of \ref namedparameters
@@ -66,6 +67,8 @@ namespace Polygon_mesh_processing {
 *  \cgalParamEnd
 *  \cgalParamBegin{vertex_point_map} the property map with the points associated
 *    to the vertices of `pmesh`. Instance of a class model of `ReadWritePropertyMap`.
+*  \cgalParamEnd
+*  \cgalParamBegin{face_index_map} a property map containing the index of each face of `pmesh`
 *  \cgalParamEnd
 *  \cgalParamBegin{number_of_iterations} the number of iterations for the
 *    sequence of atomic operations performed (listed in the above description)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -141,9 +141,8 @@ void isotropic_remeshing(const FaceRange& faces
   typedef typename GetGeomTraits<PM, NamedParameters>::type GT;
 
   typedef typename GetVertexPointMap<PM, NamedParameters>::type VPMap;
-  VPMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                            pmesh,
-                            boost::vertex_point);
+  VPMap vpmap = choose_param(get_param(np, vertex_point),
+                             get_property_map(vertex_point, pmesh));
 
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FIMap;
   FIMap fimap = choose_param(get_param(np, face_index),
@@ -311,13 +310,12 @@ void split_long_edges(const EdgeRange& edges
 
   typedef typename GetGeomTraits<PM, NamedParameters>::type GT;
   typedef typename GetVertexPointMap<PM, NamedParameters>::type VPMap;
-  VPMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                            pmesh,
-                            boost::vertex_point);
+  VPMap vpmap = choose_param(get_param(np, vertex_point),
+                             get_property_map(vertex_point, pmesh));
 
   typedef typename GetFaceIndexMap<PM, NamedParameters>::type FIMap;
   FIMap fimap = choose_param(get_param(np, face_index),
-    get_property_map(face_index, pmesh));
+                             get_property_map(face_index, pmesh));
 
   typedef typename boost::lookup_named_param_def <
         CGAL::edge_is_constrained_t,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -169,13 +169,13 @@ void isotropic_remeshing(const FaceRange& faces
   typedef typename boost::lookup_named_param_def <
       CGAL::face_patch_t,
       NamedParameters,
-      internal::Connected_components_pmap<PM, ECMap>//default
+      internal::Connected_components_pmap<PM, ECMap, FIMap>//default
     > ::type FPMap;
-  FPMap fpmap = (boost::is_same<FPMap, internal::Connected_components_pmap<PM, ECMap> >::value)
+  FPMap fpmap = (boost::is_same<FPMap, internal::Connected_components_pmap<PM, ECMap, FIMap> >::value)
     ? choose_param(get_param(np, face_patch),
-                   internal::Connected_components_pmap<PM, ECMap>(pmesh, ecmap))
+      internal::Connected_components_pmap<PM, ECMap, FIMap>(pmesh, ecmap, fimap))
     : choose_param(get_param(np, face_patch),
-                   internal::Connected_components_pmap<PM, ECMap>());//do not compute cc's
+      internal::Connected_components_pmap<PM, ECMap, FIMap>());//do not compute cc's
 
   double low = 4. / 5. * target_edge_length;
   double high = 4. / 3. * target_edge_length;
@@ -326,12 +326,13 @@ void split_long_edges(const EdgeRange& edges
   
   typename internal::Incremental_remesher<PM, VPMap, GT, ECMap,
     internal::No_constraint_pmap<vertex_descriptor>,
-    internal::Connected_components_pmap<PM, ECMap>
+    internal::Connected_components_pmap<PM, ECMap, FIMap>,
+    FIMap
   >
     remesher(pmesh, vpmap, false/*protect constraints*/
            , ecmap
            , internal::No_constraint_pmap<vertex_descriptor>()
-           , internal::Connected_components_pmap<PM, ECMap>()
+           , internal::Connected_components_pmap<PM, ECMap, FIMap>()
            , fimap
            , false/*need aabb_tree*/);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -151,7 +151,6 @@ std::size_t remove_null_edges(
 {
   CGAL_assertion(CGAL::is_triangle_mesh(tmesh));
 
-  using boost::choose_const_pmap;
   using boost::get_param;
   using boost::choose_param;
 
@@ -472,7 +471,6 @@ std::size_t remove_degenerate_faces(TriangleMesh& tmesh,
 {
   CGAL_assertion(CGAL::is_triangle_mesh(tmesh));
 
-  using boost::choose_const_pmap;
   using boost::get_param;
   using boost::choose_param;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -163,9 +163,8 @@ std::size_t remove_null_edges(
   typedef typename GT::vertex_descriptor vertex_descriptor;
 
   typedef typename GetVertexPointMap<TM, NamedParameters>::type VertexPointMap;
-  VertexPointMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                                     tmesh,
-                                     boost::vertex_point);
+  VertexPointMap vpmap = choose_param(get_param(np, vertex_point),
+                                      get_property_map(vertex_point, tmesh));
   typedef typename GetGeomTraits<TM, NamedParameters>::type Traits;
   Traits traits = choose_param(get_param(np, geom_traits), Traits());
 
@@ -485,9 +484,8 @@ std::size_t remove_degenerate_faces(TriangleMesh& tmesh,
   typedef typename GT::vertex_descriptor vertex_descriptor;
 
   typedef typename GetVertexPointMap<TM, NamedParameters>::type VertexPointMap;
-  VertexPointMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                                     tmesh,
-                                     boost::vertex_point);
+  VertexPointMap vpmap = choose_param(get_param(np, vertex_point),
+                                      get_property_map(vertex_point, tmesh));
   typedef typename GetGeomTraits<TM, NamedParameters>::type Traits;
   Traits traits = choose_param(get_param(np, geom_traits), Traits());
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -443,14 +443,16 @@ std::size_t remove_null_edges(
 /// @pre `CGAL::is_triangle_mesh(tmesh)`
 ///
 /// @tparam TriangleMesh a model of `FaceListGraph` and `MutableFaceGraph`
-///        that has an internal property map for `boost::vertex_point_t`
 /// @tparam NamedParameters a sequence of \ref namedparameters
 ///
 /// @param tmesh the  triangulated surface mesh to be repaired
 /// @param np optional \ref namedparameters described below
 ///
 /// \cgalNamedParamsBegin
-///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`. The type of this map is model of `ReadWritePropertyMap` \cgalParamEnd
+///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`. The type of this map is model of `ReadWritePropertyMap`. 
+/// If this parameter is omitted, an internal property map for
+/// `CGAL::vertex_point_t` should be available in `TriangleMesh`
+/// \cgalParamEnd
 ///    \cgalParamBegin{geom_traits} a geometric traits class instance.
 ///       The traits class must provide the nested type `Point_3`,
 ///       and the nested functors :

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -208,8 +208,7 @@ self_intersections( const FaceRange& face_range,
  * This function depends on the package \ref PkgBoxIntersectionDSummary
  * @pre `CGAL::is_triangle_mesh(tmesh)`
  *
- * @tparam TriangleMesh a model of `FaceListGraph` that has an internal property map
-*         for `CGAL::vertex_point_t`
+ * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam OutputIterator a model of `OutputIterator` holding objects of type 
  *   `std::pair<boost::graph_traits<TriangleMesh>::%face_descriptor, boost::graph_traits<TriangleMesh>::%face_descriptor>`
  * @tparam NamedParameters a sequence of \ref namedparameters
@@ -219,7 +218,9 @@ self_intersections( const FaceRange& face_range,
  * @param np optional sequence of \ref namedparameters among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+ *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+ *   If this parameter is omitted, an internal property map for
+ *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `SelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -265,8 +266,7 @@ self_intersections(const TriangleMesh& tmesh, OutputIterator out)
  * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
  *  model of `Range`.
  * Its iterator type is `RandomAccessIterator`.
- * @tparam TriangleMesh a model of `FaceListGraph` that has an internal property map
- *         for `CGAL::vertex_point_t`
+ * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam OutputIterator a model of `OutputIterator` holding objects of type
  *   `std::pair<boost::graph_traits<TriangleMesh>::%face_descriptor, boost::graph_traits<TriangleMesh>::%face_descriptor>`
  * @tparam NamedParameters a sequence of \ref namedparameters
@@ -277,7 +277,9 @@ self_intersections(const TriangleMesh& tmesh, OutputIterator out)
  * @param np optional sequence of \ref namedparameters among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+ *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+ *   If this parameter is omitted, an internal property map for
+ *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `SelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
 
@@ -354,15 +356,16 @@ OutputIterator self_intersections(const FaceRange& face_range,
  * This function depends on the package \ref PkgBoxIntersectionDSummary
  * @pre `CGAL::is_triangle_mesh(tmesh)`
  *
- * @tparam TriangleMesh a model of `FaceListGraph` that has an internal property map
- *         for `CGAL::vertex_point_t`
+ * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam NamedParameters a sequence of \ref namedparameters
  *
  * @param tmesh the triangulated surface mesh to be tested
  * @param np optional sequence of \ref namedparameters among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh` \cgalParamEnd
+ *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`.
+ *   If this parameter is omitted, an internal property map for
+ *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `SelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -306,9 +306,8 @@ self_intersections( const FaceRange& face_range,
   );
 
   typedef typename GetVertexPointMap<TM, NamedParameters>::const_type VertexPointMap;
-  VertexPointMap vpmap = choose_const_pmap(get_param(np, boost::vertex_point),
-                                           tmesh,
-                                           boost::vertex_point);
+  VertexPointMap vpmap = choose_param(get_param(np, vertex_point),
+                                      get_const_property_map(vertex_point, tmesh));
 
   BOOST_FOREACH(face_descriptor f, face_range)
   {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -277,7 +277,6 @@ private:
 *      edge is neither degenerated nor incident to a degenerate edge.
 *
 * @tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
-*        that has a property map for `boost::vertex_point_t`
 * @tparam HalfedgePairsRange a range of
 *         `std::pair<boost::graph_traits<PolygonMesh>::%halfedge_descriptor,
 *         boost::graph_traits<PolygonMesh>::%halfedge_descriptor>`,
@@ -290,7 +289,9 @@ private:
 * @param np optional \ref namedparameters described below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 * \cgalNamedParamsEnd
 */
 template <typename PolygonMesh,
@@ -333,14 +334,15 @@ void stitch_borders(PolygonMesh& pmesh,
 /// \pre `pmesh` does not contains any degenerate border edge.
 ///
 /// @tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
-///        that has a property map for `boost::vertex_point_t`
 /// @tparam NamedParameters a sequence of \ref namedparameters
 ///
 /// @param pmesh the polygon mesh to be modified by stitching
 /// @param np optional sequence of \ref namedparameters among the ones listed below
 ///
 /// \cgalNamedParamsBegin
-///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+/// If this parameter is omitted, an internal property map for
+/// `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 /// \cgalNamedParamsEnd
 ///
 template <typename PolygonMesh, class CGAL_PMP_NP_TEMPLATE_PARAMETERS>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -347,7 +347,6 @@ template <typename PolygonMesh, class CGAL_PMP_NP_TEMPLATE_PARAMETERS>
 void stitch_borders(PolygonMesh& pmesh, const CGAL_PMP_NP_CLASS& np)
 {
   using boost::choose_param;
-  using boost::choose_const_pmap;
   using boost::get_param;
 
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -304,9 +304,8 @@ void stitch_borders(PolygonMesh& pmesh,
   using boost::get_param;
 
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type VPMap;
-  VPMap vpm = choose_const_pmap(get_param(np, boost::vertex_point),
-                                pmesh,
-                                boost::vertex_point);
+  VPMap vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(vertex_point, pmesh));
 
   internal::Naive_border_stitching_modifier<PolygonMesh, VPMap, HalfedgePairsRange>
     modifier(hedge_pairs_to_stitch, vpm);
@@ -356,9 +355,8 @@ void stitch_borders(PolygonMesh& pmesh, const CGAL_PMP_NP_CLASS& np)
   std::vector< std::pair<halfedge_descriptor, halfedge_descriptor> > hedge_pairs_to_stitch;
 
   typedef typename GetVertexPointMap<PolygonMesh, CGAL_PMP_NP_CLASS>::const_type VPMap;
-  VPMap vpm = choose_const_pmap(get_param(np, boost::vertex_point),
-                                pmesh,
-                                boost::vertex_point);
+  VPMap vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(vertex_point, pmesh));
 
   internal::detect_duplicated_boundary_edges(pmesh,
     std::back_inserter(hedge_pairs_to_stitch),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -304,7 +304,6 @@ public:
 * \ingroup PMP_meshing_grp
 * triangulates a single face of a polygon mesh. This function depends on the package \ref PkgTriangulation2Summary
 * @tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
-*         that has an internal property map for `boost::vertex_point_t`
 * @tparam NamedParameters a sequence of \ref namedparameters
 *
 * @param f face to be triangulated
@@ -313,7 +312,9 @@ public:
 *
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -353,7 +354,6 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
           model of `Range`.
           Its iterator type is `InputIterator`.
 * @tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
-*         that has an internal property map for `boost::vertex_point_t`
 * @tparam NamedParameters a sequence of \ref namedparameters
 *
 * @param face_range the range of faces to be triangulated
@@ -361,7 +361,9 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -397,14 +399,15 @@ bool triangulate_faces(FaceRange face_range, PolygonMesh& pmesh)
 * \ingroup PMP_meshing_grp
 * triangulates all faces of a polygon mesh. This function depends on the package \ref PkgTriangulation2Summary
 * @tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
-*         that has an internal property map for `boost::vertex_point_t`
 * @tparam NamedParameters a sequence of \ref namedparameters
 *
 * @param pmesh the polygon mesh to be triangulated
 * @param np optional sequence of \ref namedparameters among the ones listed below
 *
 * \cgalNamedParamsBegin
-*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+*    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+*   If this parameter is omitted, an internal property map for
+*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -324,7 +324,7 @@ bool  triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descripto
                       PolygonMesh& pmesh,
                       const NamedParameters& np)
 {
-  using boost::choose_const_pmap;
+  using boost::choose_param;
   using boost::get_param;
 
   //VertexPointMap
@@ -373,7 +373,7 @@ bool triangulate_faces(FaceRange face_range,
                        PolygonMesh& pmesh,
                        const NamedParameters& np)
 {
-  using boost::choose_const_pmap;
+  using boost::choose_param;
   using boost::get_param;
 
   //VertexPointMap

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -329,9 +329,8 @@ bool  triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descripto
 
   //VertexPointMap
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::type VPMap;
-  VPMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                            pmesh,
-                            boost::vertex_point);
+  VPMap vpmap = choose_param(get_param(np, vertex_point),
+                             get_property_map(vertex_point, pmesh));
   //Kernel
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Kernel;
 
@@ -379,9 +378,8 @@ bool triangulate_faces(FaceRange face_range,
 
   //VertexPointMap
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::type VPMap;
-  VPMap vpmap = choose_pmap(get_param(np, boost::vertex_point),
-                            pmesh,
-                            boost::vertex_point);
+  VPMap vpmap = choose_param(get_param(np, vertex_point),
+                             get_property_map(vertex_point, pmesh));
   //Kernel
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Kernel;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -48,7 +48,6 @@ namespace Polygon_mesh_processing {
   If a hole cannot be triangulated, `pmesh` is not modified and nothing is recorded in `out`.
 
   @tparam PolygonMesh a model of `MutableFaceGraph`
-          that has an internal property map for `CGAL::vertex_point_t`
   @tparam OutputIterator a model of `OutputIterator`
     holding `boost::graph_traits<PolygonMesh>::%face_descriptor` for patch faces.
   @tparam NamedParameters a sequence of \ref namedparameters
@@ -59,7 +58,9 @@ namespace Polygon_mesh_processing {
   @param np optional sequence of \ref namedparameters among the ones listed below
 
   \cgalNamedParamsBegin
-     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+         If this parameter is omitted, an internal property map for
+         `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
      \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
   \cgalNamedParamsEnd
@@ -135,7 +136,6 @@ namespace Polygon_mesh_processing {
   @brief triangulates and refines a hole in a polygon mesh.
 
   @tparam PolygonMesh must be model of `MutableFaceGraph`
-          that has an internal property map for `CGAL::vertex_point_t`
   @tparam FacetOutputIterator model of `OutputIterator`
      holding `boost::graph_traits<PolygonMesh>::%face_descriptor` for patch faces.
   @tparam VertexOutputIterator model of `OutputIterator`
@@ -149,7 +149,9 @@ namespace Polygon_mesh_processing {
   @param np optional sequence of \ref namedparameters among the ones listed below
 
   \cgalNamedParamsBegin
-     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+         If this parameter is omitted, an internal property map for
+         `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
      \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values cause denser refinements, as in `refine()` \cgalParamEnd
      \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
@@ -201,7 +203,6 @@ namespace Polygon_mesh_processing {
   @brief triangulates, refines and fairs a hole in a polygon mesh.
 
   @tparam PolygonMesh a model of `MutableFaceGraph`
-          that has an internal property map for `CGAL::vertex_point_t`
   @tparam FaceOutputIterator model of `OutputIterator`
       holding `boost::graph_traits<PolygonMesh>::%face_descriptor` for patch faces
   @tparam VertexOutputIterator model of `OutputIterator`
@@ -215,7 +216,10 @@ namespace Polygon_mesh_processing {
   @param np optional sequence of \ref namedparameters among the ones listed below
 
   \cgalNamedParamsBegin
-     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh` \cgalParamEnd
+     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+         If this parameter is omitted, an internal property map for
+         `CGAL::vertex_point_t` should be available in `PolygonMesh`
+         \cgalParamEnd
      \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
      \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values cause denser refinements, as in `refine()` \cgalParamEnd
      \cgalParamBegin{fairing_continuity} tangential continuity of the output surface patch \cgalParamEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -98,7 +98,7 @@ namespace Polygon_mesh_processing {
     return internal::triangulate_hole_polygon_mesh(pmesh,
       border_halfedge,
       out,
-      choose_param(get_param(np, vertex_point), get(CGAL::vertex_point, pmesh)),
+      choose_param(get_param(np, vertex_point), get_property_map(vertex_point, pmesh)),
       use_dt3,
       choose_param(get_param(np, geom_traits), typename GetGeomTraits<PolygonMesh,NamedParameters>::type()))
       .first;


### PR DESCRIPTION
This PR is about internal property maps, in particular in PMP.

It implements a new tool that is able to detect whether a given BGL graph has an internal property map corresponding to a given property tag or not
 `struct graph_has_property<Graph, PropertyTag>`

We use it in `PMP::isotropic_remeshing()`, and at the same time add `face_index_map` as an optional named parameter

fixes #1256 

@sloriot we should discuss if we want to generate a compilation error or something special when there is no internal pmap, nor a pmap given as a named parameter. It should not compile already.