### PR TITLE
PMP triangulate_hole : doc improvement

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -42,7 +42,8 @@ namespace Polygon_mesh_processing {
   /*!
   \ingroup hole_filling_grp
   triangulates a hole in a polygon mesh.
-  The hole must not contain any non-manifold vertex.
+  The hole must not contain any non-manifold vertex,
+  nor self-intersections.
   The patch generated does not introduce non-manifold edges nor degenerate triangles.
   If a hole cannot be triangulated, `pmesh` is not modified and nothing is recorded in `out`.
 


### PR DESCRIPTION
fixes #1238 
doc improvement : self-intersections are not allowed in the input