### PR TITLE
Polyhedron_demo: Transparent background for snapshots

### DIFF
--- a/Polyhedron/demo/Polyhedron/ImageInterface.ui
+++ b/Polyhedron/demo/Polyhedron/ImageInterface.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>305</width>
-    <height>234</height>
+    <width>484</width>
+    <height>447</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -231,13 +231,22 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="whiteBackground">
-     <property name="toolTip">
-      <string>Use white as background color</string>
-     </property>
-     <property name="text">
-      <string>Use White Background</string>
-     </property>
+    <widget class="QComboBox" name="color_comboBox">
+     <item>
+      <property name="text">
+       <string>Use current background color</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Use transparent background</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Choose background color</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item>

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -10,7 +10,7 @@
 #include <QOpenGLShaderProgram>
 #include <QOpenGLFramebufferObject>
 #include <QMessageBox>
-
+#include <QColorDialog>
 #include <QInputDialog>
 #include <cmath>
 #include <QApplication>
@@ -1539,9 +1539,23 @@ void Viewer::saveSnapshot(bool, bool)
   setSnapshotQuality(imageInterface->imgQuality->value());
 
   QColor previousBGColor = backgroundColor();
-  if (imageInterface->whiteBackground->isChecked())
-    setBackgroundColor(Qt::white);
+ switch(imageInterface->color_comboBox->currentIndex())
+ {
+ case 0:
+   break;
+ case 1:
+   this->setBackgroundColor(QColor(Qt::transparent));
+   break;
+ case 2:
+   QColor c =  QColorDialog::getColor();
+   if(c.isValid()) {
+     setBackgroundColor(c);
+     this->setBackgroundColor(c);
+   }
+   else return;
+   break;
 
+ }
   QSize finalSize(imageInterface->imgWidth->value(), imageInterface->imgHeight->value());
 
   qreal oversampling = imageInterface->oversampling->value();
@@ -1636,8 +1650,7 @@ void Viewer::saveSnapshot(bool, bool)
     }
 
   image.save(fileName);
-  if (imageInterface->whiteBackground->isChecked())
-    setBackgroundColor(previousBGColor);
+  setBackgroundColor(previousBGColor);
 
 }
  #include "Viewer.moc"


### PR DESCRIPTION
Fixes #1313.
This PR gives the possibility to choose if the background of the snapshot  will be of the same color as the scene, transparent, or of the chosen color. In the latter case, when the user confirms his/her choices and closes the dialog, a color dialog opens and let him/her choose the wanted color.