### PR TITLE
AABB_tree : fix doc vs code inconsistency

### DIFF
--- a/AABB_tree/doc/AABB_tree/Concepts/AABBTraits.h
+++ b/AABB_tree/doc/AABB_tree/Concepts/AABBTraits.h
@@ -145,10 +145,10 @@ A functor object to compute distance comparisons between the query and the nodes
 typedef unspecified_type Compare_distance; 
 
 /*!
-A functor object to compute closest point from the query on a primitive. Provides the operator: 
+A functor object to construct closest point from the query on a primitive. Provides the operator: 
 `Point_3 operator()(const Query& query, const Primitive& primitive, const Point_3 & closest);` which returns the closest point to `query`, among `closest` and all points of the primitive. 
 */ 
-typedef unspecified_type Closest_point; 
+typedef unspecified_type Construct_closest_point; 
 
 /*!
 A functor object to compute the squared distance between two points. Provides the operator: 
@@ -199,7 +199,7 @@ Compare_distance compare_distance_object();
 /*!
 Returns the closest point constructor. 
 */ 
-Closest_point closest_point_object(); 
+Construct_closest_point construct_closest_point_object();
 
 /*!
 Returns the squared distance functor.

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -402,8 +402,8 @@ public:
   };
   Closest_point closest_point_object() const { return Closest_point(*this); }
 
-  typedef Closest_point Compute_closest_point_3;
-  Compute_closest_point_3 compute_closest_point_3_object() const { return closest_point_object(); }
+  typedef Closest_point Construct_closest_point_3;
+  Construct_closest_point_3 construct_closest_point_3_object() const { return closest_point_object(); }
 
   // This should go down to the GeomTraits, i.e. the kernel
   // and the internal implementation should change its name from

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -400,6 +400,10 @@ public:
         return CGAL::nearest_point_3(p, internal::Primitive_helper<AT>::get_datum(pr,m_traits), bound);
     }
   };
+  Closest_point closest_point_object() const { return Closest_point(*this); }
+
+  typedef Closest_point Compute_closest_point_3;
+  Compute_closest_point_3 compute_closest_point_3_object() const { return closest_point_object(); }
 
   // This should go down to the GeomTraits, i.e. the kernel
   // and the internal implementation should change its name from
@@ -430,7 +434,6 @@ public:
       }
   };
 
-  Closest_point closest_point_object() const {return Closest_point(*this);}
   Compare_distance compare_distance_object() const {return Compare_distance();}
 
 

--- a/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
@@ -33,7 +33,7 @@ int main()
     "CGAL::Epeck should be a RayIntersectionGeomTraits");
   CGAL_static_assertion_msg(
     (Is_ray_intersection_geomtraits< CGAL::Simple_cartesian<double> >::value),
-    "CGAL::Epeck should be a RayIntersectionGeomTraits");
+    "CGAL::Simple_cartesian should be a RayIntersectionGeomTraits");
   CGAL_static_assertion_msg(
     (!Is_ray_intersection_geomtraits<AABBGeomTraits>::value),
     "Pure AABBGeomTraits shouldn't be a RayIntersectionGeomTraits");

--- a/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
@@ -11,14 +11,14 @@ struct AABBGeomTraits {
   typedef nope Do_intersect_3;
   typedef nope Intersect_3;
   typedef nope Construct_sphere_3;
-  typedef nope Compute_closest_point_3;
+  typedef nope Construct_closest_point_3;
   typedef nope Has_on_bounded_side_3;
   typedef nope Compute_squared_radius_3;
   typedef nope Compute_squared_distance_3;
   Do_intersect_3 do_intersect_3_object();
   Intersect_3 intersect_3_object();
   Construct_sphere_3 construct_sphere_3_object();
-  Compute_closest_point_3 compute_closest_point_3_object();
+  Construct_closest_point_3 construct_closest_point_3_object();
   Has_on_bounded_side_3 has_on_bounded_side_3_object();
   Compute_squared_radius_3 compute_squared_radius_3_object();
   Compute_squared_distance_3 compute_squared_distance_3_object();


### PR DESCRIPTION
partially fixes #260 

The doc mentions `Compute_closest_point_3`, and code implements `Closest_point`

<< edit
First, `Compute_closest_point_3` should be `Construct_closest_point_3`.
<< end edit

since ~~`Compute_closest_point_3`~~ `Construct_closest_point_3` should move to the Kernel at some point, I prefer to keep this option
However, for backward compatibility with possibly existing user code, I keep Closest_point
in the non-documented code.