### PR TITLE
Polyhedron_demo: Snapshot to clipboard

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -578,6 +578,9 @@
    <property name="text">
     <string>Re&amp;center Scene</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+R</string>
+   </property>
   </action>
   <action name="actionSetBackgroundColor">
    <property name="text">

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -578,9 +578,6 @@
    <property name="text">
     <string>Re&amp;center Scene</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+C</string>
-   </property>
   </action>
   <action name="actionSetBackgroundColor">
    <property name="text">

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -405,7 +405,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     d->scene->printPrimitiveIds(this);
     update();
     return;
-      }
+  }
 
   else if(e->key() == Qt::Key_C && e->modifiers() & Qt::ControlModifier){
     d->sendSnapshotToClibboard(this);
@@ -413,7 +413,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
   }
 
   else if(e->key() == Qt::Key_S && e->modifiers() & Qt::ControlModifier){
-    saveSnapshot(true);
+    this->saveSnapshot(true,true);
     return;
   }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -161,6 +161,7 @@ protected:
   bool is_d_pressed;
 
 protected:
+  friend class Viewer_impl;
   Viewer_impl* d;
   double prev_radius;
 


### PR DESCRIPTION
Fixes #1314.
This PR implements a way to take a snapshot and send it to the clipboard. 
It uses arbitrary values for every quality parameters that are supposed to be given through the Dialog when a snapshot is taken in the regular way. 

**Question :** Would it  be better to keep the dialog for those parameters ? IMHO this shortcut is supposed to be quick, so keeping a dialog makes no sense and if the user needs some specifics parameters, then he/she can use the regular snapshot feature.

The function is bound to "Ctrl+Print Screen".
Once coupled with #1338, it will be able to use a transparent background.

@lrineau This PR makes the Viewer_impl a friend class of the viewer, as I needed access to some protected functions and I found it curious that a D pointer was not a "friend" of its original class. Is this OK for you ?