### PR TITLE
Fix CGAL_BRANCH_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,7 @@ project(CGAL CXX C)
 # Minimal version of CMake:
 cmake_minimum_required(VERSION 2.8.11)
 
-# option for branch build
-
-option( CGAL_BRANCH_BUILD "Create CGAL from branch" ON)
-mark_as_advanced( CGAL_BRANCH_BUILD )
+set( CGAL_BRANCH_BUILD ON CACHE INTERNAL "Create CGAL from a Git branch" FORCE)
 
 include(${CMAKE_SOURCE_DIR}/Installation/cmake/modules/CGAL_SCM.cmake)
 


### PR DESCRIPTION
The CMake variable `CGAL_BRANCH_BUILD` was an option. But if
the variable was set to `FALSE`, that lead to a CMake error
automatically. This commit fixes that situation by turning the
option into an internal cache value, that cannot be set to `FALSE`.