### PR TITLE
 fix polyline simplification

### DIFF
--- a/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
@@ -51,4 +51,6 @@ include( CGAL_CreateSingleSourceCGALProgram )
 
 create_single_source_cgal_program( "simplify_polygon_test.cpp" )
 
+create_single_source_cgal_program( "simplify_polyline_with_duplicate_points.cpp" )
+
 

--- a/Polyline_simplification_2/test/Polyline_simplification_2/simplify_polyline_with_duplicate_points.cpp
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/simplify_polyline_with_duplicate_points.cpp
@@ -1,0 +1,30 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polyline_simplification_2/simplify.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel           Kernel;
+typedef Kernel::Point_2                                             Point_2;
+typedef CGAL::Polyline_simplification_2::Squared_distance_cost      Cost;
+typedef CGAL::Polyline_simplification_2::Stop_above_cost_threshold  Threshold;
+
+int main(int, char**)
+{
+  std::vector<Point_2> points;
+
+  points.push_back(Point_2(0, 0));
+  points.push_back(Point_2(100, 0));
+  points.push_back(Point_2(100, 100));
+  points.push_back(Point_2(0, 100));
+  points.push_back(Point_2(0, 50));
+  points.push_back(Point_2(50, 50));
+  points.push_back(Point_2(50, 51));
+  points.push_back(Point_2(50, 49));
+  points.push_back(Point_2(70, 49));
+
+  std::vector<Point_2> output;
+  CGAL::Polyline_simplification_2::simplify(points.begin(),
+                                            points.end(),
+                                            Cost(), Threshold (5.),
+                                            std::back_inserter(output));
+  return EXIT_SUCCESS;
+}
+

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -664,13 +664,16 @@ public:
   {
     Vertices_in_constraint_iterator u = boost::prior(v);
     Vertices_in_constraint_iterator w = boost::next(v);
+    bool unew = (*u != *w);
     hierarchy.simplify(u,v,w);
     
     Triangulation::remove_incident_constraints(*v);
   
     Triangulation::remove(*v);
   
-    Triangulation::insert_constraint(*u, *w);
+    if(unew){
+      Triangulation::insert_constraint(*u, *w);
+    }
   }
 
   std::size_t remove_points_without_corresponding_vertex(Constraint_id cid)

--- a/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
@@ -612,13 +612,14 @@ void Polyline_constraint_hierarchy_2<T,Compare,Data>::simplify(Vertex_it uc,
   typename Sc_to_c_map::iterator uv_sc_iter = sc_to_c_map.find(make_edge(u, v));
   CGAL_assertion_msg( uv_sc_iter != sc_to_c_map.end(), "not a subconstraint" );
   Context_list*  uv_hcl = uv_sc_iter->second;
-  CGAL_assertion_msg(uv_hcl->size() == 1, "more than one constraint passing through the subconstraint" );
+  CGAL_assertion_msg((u == w) || (uv_hcl->size() == 1), "more than one constraint passing through the subconstraint" );
+
   if(*(uv_hcl->front().current()) != u) {
     std::swap(u,w);
     uv_sc_iter = sc_to_c_map.find(make_edge(u, v));
     CGAL_assertion_msg( uv_sc_iter != sc_to_c_map.end(), "not a subconstraint" );
     uv_hcl = (*uv_sc_iter).second;
-    CGAL_assertion_msg(uv_hcl->size() == 1, "more than one constraint passing through the subconstraint" );
+    CGAL_assertion_msg((u == w) || (uv_hcl->size() == 1), "more than one constraint passing through the subconstraint" );
   }
   // now u,v, and w are ordered along the polyline constraint
   if(vc.input()){
@@ -628,18 +629,24 @@ void Polyline_constraint_hierarchy_2<T,Compare,Data>::simplify(Vertex_it uc,
   typename Sc_to_c_map::iterator vw_sc_iter = sc_to_c_map.find(make_edge(v, w));
   CGAL_assertion_msg( vw_sc_iter != sc_to_c_map.end(), "not a subconstraint" );
   Context_list*  vw_hcl = vw_sc_iter->second;
-  CGAL_assertion_msg(vw_hcl->size() == 1, "more than one constraint passing through the subconstraint" );
+    CGAL_assertion_msg((u == w) || (vw_hcl->size() == 1), "more than one constraint passing through the subconstraint" );
+ 
   Vertex_list* vertex_list = uv_hcl->front().id().vl_ptr();
   CGAL_assertion_msg(vertex_list  == vw_hcl->front().id().vl_ptr(), "subconstraints from different polyline constraints" );
   // Remove the list item which points to v
   vertex_list->skip(vc.base());
   
-  // Remove the entries for [u,v] and [v,w]
-  sc_to_c_map.erase(uv_sc_iter);
-  sc_to_c_map.erase(vw_sc_iter);
-  delete vw_hcl;
-  // reuse other context list
-  sc_to_c_map[make_edge(u,w)] = uv_hcl;
+  if(u != w){
+    // Remove the entries for [u,v] and [v,w]
+    sc_to_c_map.erase(uv_sc_iter);
+    sc_to_c_map.erase(vw_sc_iter);
+    delete vw_hcl;
+    // reuse other context list
+    sc_to_c_map[make_edge(u,w)] = uv_hcl;
+  }else{
+    sc_to_c_map.erase(uv_sc_iter);
+    delete vw_hcl;
+  }
 }
 
 


### PR DESCRIPTION
Fixes a bug when a polyline returned on itself, that is if simplify(u,v,w) gets called with u == w.
This should go into the bug fix release of 4.9.  @sgiraudot  can you please take care of this.