### PR TITLE
OT reconstruction: improve verbosity

### DIFF
--- a/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
@@ -949,7 +949,7 @@ public:
   // (a,b,c) + (c,b,a) + (a,c,i) + (c,a,j) ->
   // (a,c,i) + (c,a,j)
   void collapse_cyclic_edge(const Edge& bc, int verbose = 0) {
-    if (verbose > 0)
+    if (verbose > 1)
       std::cout << "collapse_cyclic_edge ... ";
 
     Edge cb = twin_edge(bc);
@@ -972,7 +972,7 @@ public:
     this->delete_face(cba);
     this->delete_vertex(b);
 
-    if (verbose > 0)
+    if (verbose > 1)
       std::cout << "done" << std::endl;
   }
 
@@ -1050,7 +1050,7 @@ public:
 
       if ( is_m_infinity(Dac) && is_m_infinity(Dbd) )
       {
-        if (verbose > 0)
+        if (verbose > 1)
           std::cerr << "--- No flips available ---"  << std::endl;
         return false;
       }
@@ -1109,7 +1109,7 @@ public:
       nb_flips++;
     }
 
-    if (verbose > 0)
+    if (verbose > 1)
       std::cerr  << "Nb flips: "  << nb_flips << std::endl;
 
     return true;

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -532,7 +532,7 @@ public:
     Vertex_handle s = m_dt.source_vertex(edge);
     Vertex_handle t = m_dt.target_vertex(edge);
 
-    if (m_verbose > 0) {
+    if (m_verbose > 1) {
       std::cerr << std::endl << "do collapse ("
           << s->id() << "->" << t->id() << ") ... " << std::endl;
     }
@@ -552,7 +552,8 @@ public:
     // debug test
     bool ok = m_dt.check_kernel_test(edge);
     if (!ok) {
-      std::cerr << "do_collapse: kernel test failed: " << std::endl;
+      if (m_verbose > 1)
+        std::cerr << "do_collapse: kernel test failed: " << std::endl;
       return false;
     }
     //
@@ -570,7 +571,7 @@ public:
       relocate_one_ring(hull.begin(), hull.end());
     }
 
-    if (m_verbose > 0) {
+    if (m_verbose > 1) {
       std::cerr << "done" << std::endl;
     }
 


### PR DESCRIPTION
There are currently 3 levels of verbosity:
* 0 = nothing is displayed
* 1
* >1

The level 1 is currently a bit too verbose, as some functions which are called several times per iteration display messages. Level 1 verbosity should only display state messages (initalization, preprocessing, etc.), extensive debug information should be reserved to level >1.