### PR TITLE
Fix Compare_y_at_x_2 for polycurve traits

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
@@ -745,11 +745,22 @@ public:
         return geom_traits->compare_y_at_x_2_object()(p, xcv[i]);
       }
       // The curve is vertical
+      #ifdef CGAL_ALWAYS_LEFT_TO_RIGHT
+      const Comparison_result SMLLR = SMALLER;
+      const Comparison_result LRGR = LARGER;
+      #else
+      const bool is_left_to_right = m_poly_traits.subcurve_traits_2()->
+                                      compare_endpoints_xy_2_object()(xcv[0])
+                                        == SMALLER;
+      const Comparison_result SMLLR = is_left_to_right?SMALLER:LARGER;
+      const Comparison_result LRGR = is_left_to_right?LARGER:SMALLER;
+      #endif
+
       Comparison_result rc = geom_traits->compare_y_at_x_2_object()(p, xcv[0]);
-      if (rc == SMALLER) return SMALLER;
+      if (rc == SMLLR) return SMLLR;
       std::size_t n = xcv.number_of_subcurves();
       rc = geom_traits->compare_y_at_x_2_object()(p, xcv[n-1]);
-      if (rc == LARGER) return LARGER;
+      if (rc == LRGR) return LRGR;
       return EQUAL;
     }
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
@@ -468,7 +468,7 @@ public:
 #ifdef CGAL_ALWAYS_LEFT_TO_RIGHT
       if (this->m_poly_traits.subcurve_traits_2()->compare_xy_2_object()(p,q) ==
           LARGER)
-        seg = m_poly_traits.subcurve_traits_2()->
+        seg = this->m_poly_traits.subcurve_traits_2()->
           construct_opposite_2_object()(seg);
 #endif
 
@@ -571,11 +571,11 @@ public:
       }
 
 #ifdef CGAL_ALWAYS_LEFT_TO_RIGHT
-      if (m_poly_traits.subcurve_traits_2()->
+      if (this->m_poly_traits.subcurve_traits_2()->
           compare_endpoints_xy_2_object()(*segs.begin()) == LARGER)
       {
         X_monotone_curve_2 xcv(segs.begin(), segs.end());
-        return m_poly_traits.construct_opposite_2_object()(xcv);
+        return this->m_poly_traits.construct_opposite_2_object()(xcv);
       }
 #endif
 


### PR DESCRIPTION
The code of `Compare_y_at_x_2` was assuming that xmonotone curves was oriented from <i>left-to-right</i> (meaning endpoints are lexicographically sorted), with is not the case for example for polylines.

@efifogel Do you agree with the fix?