### PR TITLE
Remove all usage of CGAL_LEDA_VERSION

### DIFF
--- a/Arrangement_on_surface_2/benchmark/Arrangement_on_surface_2/arr_bench.cpp
+++ b/Arrangement_on_surface_2/benchmark/Arrangement_on_surface_2/arr_bench.cpp
@@ -48,11 +48,7 @@ enum MaxFilesNumber {
 // Stream:
 #if BENCH_KERNEL == LEDA_KERNEL || BENCH_KERNEL == MY_KERNEL
 #if defined(USE_CGAL_WINDOW)
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/rat_window.h>
-#else
 #include <LEDA/graphics/rat_window.h>
-#endif
 #else
 #include <CGAL/IO/Qt_widget_Leda_rat.h>
 #endif

--- a/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_spherical_gaussian_map_3.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_spherical_gaussian_map_3.h
@@ -42,11 +42,7 @@
 #include <CGAL/Arr_spherical_topology_traits_2.h>
 
 #if defined(CGAL_USE_LEDA)
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/rational.h>
-#else
 #include <LEDA/numbers/rational.h>
-#endif
 #endif
 
 namespace CGAL {

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -42,11 +42,7 @@
 #include <CGAL/Kernel_d/debug.h>
 
 #ifdef CGAL_USE_LEDA
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/memory.h>
-#else
 #include <LEDA/system/memory.h>
-#endif
 #endif
 
 namespace CGAL {

--- a/Kernel_23/include/CGAL/kernel_to_kernel.h
+++ b/Kernel_23/include/CGAL/kernel_to_kernel.h
@@ -30,11 +30,7 @@
 #ifdef CGAL_USE_LEDA
 #include <CGAL/LEDA_basic.h>
 #include <CGAL/leda_integer.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/rat_point.h>
-#else
 #include <LEDA/geo/rat_point.h>
-#endif
 #endif
 
 #include <CGAL/Point_2.h>

--- a/LEDA/include/CGAL/LEDA_basic.h
+++ b/LEDA/include/CGAL/LEDA_basic.h
@@ -33,11 +33,7 @@
 // The following is needed for LEDA 4.4 due to min/max problems...
 #  define LEDA_NO_MIN_MAX_TEMPL
 
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/basic.h>
-#else
 #include <LEDA/system/basic.h>
-#endif
 
 #ifdef LEDA_NAMESPACE
 #  define CGAL_LEDA_SCOPE  leda

--- a/Nef_2/include/CGAL/IO/Nef_polyhedron_2_PS_stream.h
+++ b/Nef_2/include/CGAL/IO/Nef_polyhedron_2_PS_stream.h
@@ -22,15 +22,9 @@
 #define CGAL_NEF_POLYHEDRON_2_PS_STREAM_H
 
 #include <CGAL/Nef_polyhedron_2.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/gen_polygon.h>
-#include <LEDA/ps_file.h>
-#include <LEDA/color.h>
-#else
 #include <LEDA/geo/gen_polygon.h>
 #include <LEDA/graphics/ps_file.h>
 #include <LEDA/graphics/color.h>
-#endif
 
 namespace CGAL {
 static int frame_default = 100;

--- a/Nef_2/include/CGAL/Nef_2/gen_point_location.h
+++ b/Nef_2/include/CGAL/Nef_2/gen_point_location.h
@@ -23,11 +23,7 @@
 #define CGAL_NEF_2_GEN_POINT_LOCATION_H
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/pp_dictionary.h>
-#else
 #include <LEDA/core/pp_dictionary.h>
-#endif
 #include <sstream>
 #include <string>
 #include <list>

--- a/Nef_S2/include/CGAL/Nef_S2/leda_sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/leda_sphere_map.h
@@ -24,13 +24,8 @@
 #include <CGAL/generic_sweep.h>
 #include <CGAL/Nef_2/Segment_overlay_traits.h>
 #include <CGAL/Nef_S2/Sphere_geometry.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/graph.h>
-#include <LEDA/graph_misc.h>
-#else
 #include <LEDA/graph/graph.h>
 #include <LEDA/graph/graph_misc.h>
-#endif
 
 #undef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 211

--- a/Number_types/include/CGAL/leda_bigfloat.h
+++ b/Number_types/include/CGAL/leda_bigfloat.h
@@ -32,11 +32,7 @@
 #include <CGAL/Interval_nt.h>
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/bigfloat.h>
-#else
 #include <LEDA/numbers/bigfloat.h>
-#endif
 
 namespace CGAL {
 

--- a/Number_types/include/CGAL/leda_bigfloat_interval.h
+++ b/Number_types/include/CGAL/leda_bigfloat_interval.h
@@ -26,11 +26,7 @@
 #include <CGAL/basic.h>
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/bigfloat.h>
-#else
 #include <LEDA/numbers/bigfloat.h>
-#endif
 
 #include <boost/numeric/interval.hpp>
 

--- a/Number_types/include/CGAL/leda_coercion_traits.h
+++ b/Number_types/include/CGAL/leda_coercion_traits.h
@@ -31,17 +31,10 @@
 #ifdef CGAL_USE_LEDA
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/integer.h>
-#include <LEDA/bigfloat.h>
-#include <LEDA/rational.h>
-#include <LEDA/real.h>
-#else
 #include <LEDA/numbers/integer.h>
 #include <LEDA/numbers/bigfloat.h>
 #include <LEDA/numbers/rational.h>
 #include <LEDA/numbers/real.h>
-#endif
 
 namespace CGAL {
 
@@ -107,21 +100,7 @@ struct Coercion_traits< ::leda::bigfloat ,::leda::rational  >{
         typedef Type result_type;
         Type operator()(const ::leda::rational& x)  const { return x;}
         Type operator()(const ::leda::bigfloat& x) const {
-#if CGAL_LEDA_VERSION < 500
-            ::leda::integer e = x.get_exponent();
-            ::leda::integer s = x.get_significant();
-            if(e<0) {
-                ::leda::bigfloat b_two_to_e = ::leda::ipow2(-e);
-                ::leda::integer two_to_e = ::leda::floor(b_two_to_e);
-                return ::leda::rational(s,two_to_e);
-            }
-            // e >= 0
-            ::leda::bigfloat b_two_to_e = ::leda::ipow2(e);
-            ::leda::integer two_to_e = ::leda::floor(b_two_to_e);
-            return ::leda::rational(s * two_to_e);
-#else
             return x.to_rational();
-#endif
         }
     };
 };

--- a/Number_types/include/CGAL/leda_integer.h
+++ b/Number_types/include/CGAL/leda_integer.h
@@ -33,13 +33,8 @@
 #include <CGAL/Interval_nt.h>
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/integer.h>
-#include <LEDA/bigfloat.h>// for To_interval
-#else
 #include <LEDA/numbers/integer.h>
 #include <LEDA/numbers/bigfloat.h>// for To_interval
-#endif
 
 #include <CGAL/Residue.h>
 #include <CGAL/Modular_traits.h>
@@ -116,18 +111,6 @@ template <> class Algebraic_structure_traits< leda_integer >
 //       public:
 //         Type operator()( const Type& x, const Type& y ) const {
 //           Type m = x % y;
-// #if CGAL_LEDA_VERSION < 520
-//           // Fix wrong leda result
-//           if( x < 0 && m != 0 )
-//             m -= y;
-// #elif CGAL_LEDA_VERSION < 600
-//           // Fix another wrong leda result
-//           if( x < 0 && y > 0 && m != 0 )
-//             m -= y;
-// #else
-//           // Do nothing, it seems to work now!
-//           // TODO: be careful for future improvements of LEDA
-// #endif
 //           return m;
 //         }
 //         CGAL_IMPLICIT_INTEROPERABLE_BINARY_OPERATOR( Type )

--- a/Number_types/include/CGAL/leda_rational.h
+++ b/Number_types/include/CGAL/leda_rational.h
@@ -37,19 +37,14 @@
 #include <limits>
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#  include <LEDA/rational.h>
-#  include <LEDA/interval.h>
-#else
-#  include <LEDA/numbers/rational.h>
-#  if defined(  _MSC_VER )
-#    pragma push_macro("ERROR")  
-#    undef ERROR
-#  endif // _MSC_VER
-#  include <LEDA/numbers/interval.h>
-#  if defined(  _MSC_VER )
-#    pragma pop_macro("ERROR")  
-#  endif
+#include <LEDA/numbers/rational.h>
+#if defined(  _MSC_VER )
+#  pragma push_macro("ERROR")
+#  undef ERROR
+#endif // _MSC_VER
+#include <LEDA/numbers/interval.h>
+#if defined(  _MSC_VER )
+#  pragma pop_macro("ERROR")
 #endif
 
 #include <CGAL/leda_integer.h> // for GCD in Fraction_traits
@@ -121,35 +116,12 @@ template <> class Real_embeddable_traits< leda_rational >
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 
-#if CGAL_LEDA_VERSION >= 501
           CGAL_LEDA_SCOPE::interval temp(x);
           std::pair<double, double> result(temp.lower_bound(),temp.upper_bound());
           CGAL_assertion_code( double infinity=std::numeric_limits<double>::infinity(); )
           CGAL_postcondition(result.first  == -infinity || Type(result.first)<=x);
           CGAL_postcondition(result.second ==  infinity || Type(result.second)>=x);
           return result;
-#else
-          CGAL_LEDA_SCOPE::bigfloat xnum = x.numerator();
-          CGAL_LEDA_SCOPE::bigfloat xden = x.denominator();
-          CGAL_LEDA_SCOPE::bigfloat xupp =
-                                    div(xnum,xden,53,CGAL_LEDA_SCOPE::TO_P_INF);
-          CGAL_LEDA_SCOPE::bigfloat xlow =
-                                    div(xnum,xden,53,CGAL_LEDA_SCOPE::TO_N_INF);
-
-          // really smallest positive double
-          double MinDbl = CGAL_LEDA_SCOPE::fp::compose_parts(0,0,0,1);
-
-          double low = xlow.to_double();
-          while(Type(low) > x) low = low - MinDbl;
-
-          double upp = xupp.to_double();
-          while(Type(upp) < x) upp = upp + MinDbl;
-
-          std::pair<double, double> result(low,upp);
-          CGAL_postcondition(Type(result.first)<=x);
-          CGAL_postcondition(Type(result.second)>=x);
-          return result;
-#endif
           // Original CGAL to_interval (seemed to be inferior)
           //  // There's no guarantee about the error of to_double(), so I add
           //  //  3 ulps...

--- a/Number_types/include/CGAL/leda_real.h
+++ b/Number_types/include/CGAL/leda_real.h
@@ -35,25 +35,15 @@
 #include <utility>
 
 #include <CGAL/LEDA_basic.h>
-#if CGAL_LEDA_VERSION < 500
-#include <LEDA/real.h>
-#include <LEDA/interval.h>
-#else
 #include <LEDA/numbers/real.h>
-#endif
 
 
 namespace CGAL {
 
 template <> class Algebraic_structure_traits< leda_real >
 
-#if CGAL_LEDA_VERSION >= 500
   : public Algebraic_structure_traits_base< leda_real,
                                             Field_with_root_of_tag >  {
-#else
-  : public Algebraic_structure_traits_base< leda_real,
-                                            Field_with_kth_root_tag >  {
-#endif
 
   public:
     typedef Tag_true           Is_exact;
@@ -78,7 +68,6 @@ template <> class Algebraic_structure_traits< leda_real >
     };
 
 // Root_of is only available for LEDA versions >= 5.0
-#if CGAL_LEDA_VERSION >= 500
     class Root_of {
       public:
         typedef Type result_type;
@@ -112,7 +101,6 @@ template <> class Algebraic_structure_traits< leda_real >
         };*/
     };
 
-#endif
 
 
 };
@@ -166,7 +154,6 @@ template <> class Real_embeddable_traits< leda_real >
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 
-#if CGAL_LEDA_VERSION >= 501
             leda_bigfloat bnum = x.to_bigfloat();
             leda_bigfloat berr = x.get_bigfloat_error();
 
@@ -180,23 +167,6 @@ template <> class Real_embeddable_traits< leda_real >
             CGAL_postcondition(Type(result.first)<=x);
             CGAL_postcondition(Type(result.second)>=x);
             return result;
-#else
-            CGAL_LEDA_SCOPE::interval temp(x); //bug in leda
-            std::pair<double, double> result(temp.lower_bound(),temp.upper_bound());
-            CGAL_postcondition_msg(Type(result.first)<=x,
-                                                    "Known bug in LEDA <=5.0");
-            CGAL_postcondition_msg(Type(result.first)>=x,
-                                                    "Known bug in LEDA <=5.0");
-            return result;
-            // If x is very small and we look closer at x
-            // (i.e. comparison or to_double() or to_bigfloat())
-            // then x gets 0, which is really bad.
-            // Therefore we do not touch x.
-            // The LEDA interval above returns (-inf, inf) for
-            // very small x, which is also bad and leads to
-            // problems lateron. The postcondition fails in this
-            // situation.
-#endif
               // Original CGAL to_interval:
             //  Protect_FPU_rounding<true> P (CGAL_FE_TONEAREST);
             //  double approx = z.to_double();

--- a/Number_types/test/Number_types/leda_real.cpp
+++ b/Number_types/test/Number_types/leda_real.cpp
@@ -9,11 +9,7 @@
 int main() {
     typedef leda_real NT;
 
-#if CGAL_LEDA_VERSION >= 500 
     typedef CGAL::Field_with_root_of_tag Tag;
-#else
-    typedef CGAL::Field_with_kth_root_tag Tag;
-#endif
     typedef CGAL::Tag_true Is_exact;
 
     CGAL::test_algebraic_structure<NT,Tag, Is_exact>();

--- a/Polynomial/include/CGAL/Polynomial.h
+++ b/Polynomial/include/CGAL/Polynomial.h
@@ -48,11 +48,7 @@
 #include <CGAL/assertions.h>
 
 #ifdef CGAL_USE_LEDA
-#if CGAL_LEDA_VERSION >= 500
-#include <LEDA/core/array.h>
-#else
-#include <LEDA/array.h>
-#endif
+#  include <LEDA/core/array.h>
 #endif // CGAL_USE_LEDA
 
 #include <CGAL/Polynomial/fwd.h>

--- a/STL_Extension/include/CGAL/Handle_with_policy.h
+++ b/STL_Extension/include/CGAL/Handle_with_policy.h
@@ -34,11 +34,7 @@
 #include <cstddef>
 
 #ifdef CGAL_USE_LEDA
-#  if CGAL_LEDA_VERSION < 500
-#    include <LEDA/memory.h>
-#  else
-#    include <LEDA/system/memory.h>
-#  endif
+#  include <LEDA/system/memory.h>
 #endif
 
 


### PR DESCRIPTION
Now, LEDA version >= 6.0 is required if `CGAL_USE_LEDA` is toggled.