### PR TITLE
Call deleteLater only if the object if not NULL

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -40,7 +40,8 @@ CGAL::Three::Scene_item::Scene_item(int buffers_size, int vaos_size)
 }
 
 CGAL::Three::Scene_item::~Scene_item() {
-  defaultContextMenu->deleteLater();
+  if(defaultContextMenu)
+    defaultContextMenu->deleteLater();
   for(int i=0; i<buffersSize; i++)
   {
     buffers[i].destroy();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -773,7 +773,8 @@ void Scene_points_with_normal_item::set_has_normals(bool b) {
   if (b!=d->m_has_normals){
     d->m_has_normals=b;
     //reset the context menu
-    defaultContextMenu->deleteLater();
+    if (defaultContextMenu)
+      defaultContextMenu->deleteLater();
     this->defaultContextMenu = 0;
   }
 }


### PR DESCRIPTION
This fixes messages `QCoreApplication::postEvent: Unexpected null receiver` when deleting an item.
