### PR TITLE
PMP isotropic remeshing does not support exact constructions

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -56,14 +56,17 @@
 #ifdef CGAL_PMP_REMESHING_DEBUG
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #define CGAL_DUMP_REMESHING_STEPS
+#define CGAL_PMP_REMESHING_VERBOSE_PROGRESS
 #endif
 
 #ifdef CGAL_PMP_REMESHING_VERY_VERBOSE
 #define CGAL_PMP_REMESHING_VERBOSE
+#define CGAL_PMP_REMESHING_VERBOSE_PROGRESS
 #endif
 
-
-
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
+#define CGAL_PMP_REMESHING_VERBOSE
+#endif
 
 
 namespace CGAL {
@@ -424,7 +427,7 @@ namespace internal {
         double sqlen = eit->first;
         long_edges.right.erase(eit);
 
-#ifdef CGAL_PMP_REMESHING_VERBOSE
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
         std::cout << "\r\t(" << long_edges.left.size() << " long edges, ";
         std::cout << nb_splits << " splits)";
         std::cout.flush();
@@ -559,7 +562,7 @@ namespace internal {
         halfedge_descriptor he = eit->second;
         short_edges.right.erase(eit);
 
-#ifdef CGAL_PMP_REMESHING_VERBOSE
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
         std::cout << "\r\t(" << short_edges.left.size() << " short edges, ";
         std::cout << nb_collapses << " collapses)";
         std::cout.flush();
@@ -760,7 +763,7 @@ namespace internal {
         CGAL::Euler::flip_edge(he, mesh_);
         ++nb_flips;
 
-#ifdef CGAL_PMP_REMESHING_VERBOSE
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
         std::cout << "\r\t(" << nb_flips << " flips)";
         std::cout.flush();
 #endif
@@ -836,7 +839,7 @@ namespace internal {
 #endif
       for (unsigned int nit = 0; nit < nb_iterations; ++nit)
       {
-#ifdef CGAL_PMP_REMESHING_VERBOSE
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
         std::cout << "\r\t(iteration " << (nit + 1) << " / ";
         std::cout << nb_iterations << ") ";
         std::cout.flush();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -61,7 +61,8 @@ namespace Polygon_mesh_processing {
 * not be longer than 4/3*`target_edge_length`
 *
 * \cgalNamedParamsBegin
-*  \cgalParamBegin{geom_traits} a geometric traits class instance, model of `Kernel`
+*  \cgalParamBegin{geom_traits} a geometric traits class instance, model of `Kernel`.
+*    Exact constructions kernels are not supported by this function.
 *  \cgalParamEnd
 *  \cgalParamBegin{vertex_point_map} the property map with the points associated
 *    to the vertices of `pmesh`. Instance of a class model of `ReadWritePropertyMap`.
@@ -103,6 +104,14 @@ namespace Polygon_mesh_processing {
 * @sa `split_long_edges()`
 *
 *@todo add possibility to provide a functor that projects to a prescribed surface
+*@todo Deal with exact constructions Kernel. The only thing that makes sense is to
+*      guarantee that the output vertices are exactly on the input surface.
+*      To do so, we can do every construction in `double`, and use an exact process for
+*      projection. For each vertex, the `AABB_tree` would be used in an inexact manner
+*      to find the triangle on which projection has to be done. Then, use
+*      `CGAL::intersection(triangle, line)` in the exact constructions kernel to
+*      get a point which is exactly on the surface.
+*
 */
 template<typename PolygonMesh
        , typename FaceRange

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -25,7 +25,7 @@
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic;
-typedef CGAL::Exact_predicates_inexact_constructions_kernel Epec;
+typedef CGAL::Exact_predicates_exact_constructions_kernel Epec;
 
 template <class K>
 struct Main {

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -3,10 +3,10 @@
 //#define CGAL_PMP_REMESHING_DEBUG
 //#define CGAL_DUMP_REMESHING_STEPS
 #define CGAL_PMP_REMESHING_VERBOSE
+//#define CGAL_PMP_REMESHING_VERY_VERBOSE
 //#define CGAL_PMP_REMESHING_EXPENSIVE_DEBUG
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
@@ -25,7 +25,6 @@
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic;
-typedef CGAL::Exact_predicates_exact_constructions_kernel Epec;
 
 template <class K>
 struct Main {
@@ -251,7 +250,6 @@ Main(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
   Main<Epic> m(argc,argv);
-  Main<Epec> m2(argc,argv);
 
   return 0;
 }


### PR DESCRIPTION
We were testing Epic twice instead of Epic and Epec.

**Edit** : it does not seem very useful to make isotropic remeshing work with an exact constructions kernel.
So, we have decided to remove support of those kernels for this function, at least for the moment.
Later, we could modify `isotropic_remeshing` so that it guarantees that output vertices lie exactly on the input surface. A `@todo` has been added to the doxygen comments to detail how to do that