### PR TITLE
Algebraic kernel d examples fixes akobel

### DIFF
--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
@@ -1,31 +1,60 @@
-# Created by the script cgal_create_cmake_script
-# This is the CMake script for compiling a CGAL application.
+# Created by the script cgal_create_CMakeLists
+# This is the CMake script for compiling a set of CGAL applications.
 
+project( Algebraic_kernel_d_examples )
 
-project( Algebraic_kernel_d_test )
 
 cmake_minimum_required(VERSION 2.8.11)
 
+# CGAL and its components
+find_package( CGAL QUIET COMPONENTS Core )
 
-find_package(CGAL QUIET COMPONENTS Core MPFI)
-
-if ( CGAL_FOUND )
-
-  include( ${CGAL_USE_FILE} )
-  include( CGAL_CreateSingleSourceCGALProgram )
-  include( CGAL_VersionUtils )
-
-  include_directories (BEFORE ../../include)
-
-  create_single_source_cgal_program( "Compare_1.cpp" )
-  create_single_source_cgal_program( "Construct_algebraic_real_1.cpp" )
-  create_single_source_cgal_program( "Isolate_1.cpp" )
-  create_single_source_cgal_program( "Sign_at_1.cpp" )
-  create_single_source_cgal_program( "Solve_1.cpp" )
-
-else()
-  
-    message(STATUS "This program requires the CGAL library, and will not be compiled.")
-  
+if ( NOT CGAL_FOUND )
+  message(STATUS "This project requires the CGAL library, and will not be compiled.")
+  return()  
 endif()
 
+# include helper file
+include( ${CGAL_USE_FILE} )
+
+
+find_package( Boost REQUIRED )
+if ( NOT Boost_FOUND )
+  message(STATUS "This project requires the Boost library, and will not be compiled.")
+  return()  
+endif()
+
+
+find_package( MPFI REQUIRED )
+if ( NOT MPFI_FOUND )
+  message(STATUS "This project requires the MPFI library, and will not be compiled.")
+  return()  
+endif()
+include( ${MPFI_USE_FILE} )
+
+
+include_directories( BEFORE ../../include )
+
+include( CGAL_CreateSingleSourceCGALProgram )
+
+
+create_single_source_cgal_program( "Compare_1.cpp" )
+create_single_source_cgal_program( "Construct_algebraic_real_1.cpp" )
+create_single_source_cgal_program( "Isolate_1.cpp" )
+create_single_source_cgal_program( "Sign_at_1.cpp" )
+create_single_source_cgal_program( "Solve_1.cpp" )
+
+
+find_package( RS )
+find_package( RS3 )
+if ( NOT RS3_FOUND )
+  message(STATUS "Parts of this project require the RS libraries, and will not be compiled.")
+else()
+  include( ${RS_USE_FILE} )
+  include( ${RS3_USE_FILE} )
+  create_single_source_cgal_program( "RS_Compare_1.cpp" )
+  create_single_source_cgal_program( "RS_Construct_algebraic_real_1.cpp" )
+  create_single_source_cgal_program( "RS_Isolate_1.cpp" )
+  create_single_source_cgal_program( "RS_Sign_at_1.cpp" )
+  create_single_source_cgal_program( "RS_Solve_1.cpp" )
+endif()

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Compare_1.cpp
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Compare_1.cpp
@@ -1,0 +1,63 @@
+// $URL$
+// $Id$
+
+#include <CGAL/basic.h>
+#ifdef CGAL_USE_RS 
+#include <CGAL/Algebraic_kernel_rs_gmpz_d_1.h>
+#include <CGAL/Gmpz.h>
+#include <vector>
+
+typedef CGAL::Algebraic_kernel_rs_gmpz_d_1          AK;
+typedef AK::Coefficient                                 Coefficient;
+typedef AK::Polynomial_1                                Polynomial_1;
+typedef AK::Algebraic_real_1                            Algebraic_real_1;
+typedef AK::Bound                                       Bound;
+typedef std::pair<Bound,Bound>                          Interval;
+
+int main(){
+  AK ak;
+
+  AK::Construct_algebraic_real_1 construct_algebraic_real_1 = ak.construct_algebraic_real_1_object();
+  Polynomial_1 x = CGAL::shift(AK::Polynomial_1(1),1); // the monomial x
+  Algebraic_real_1 a = construct_algebraic_real_1(x*x-2,1); //  sqrt(2)
+  Algebraic_real_1 b = construct_algebraic_real_1(x*x-3,1); //  sqrt(3)
+
+  // Algebraic_real_1 is RealEmbeddable (just some functions:)
+  std::cout << "sign of a is                 : " << CGAL::sign(a)      << "\n";
+  std::cout << "double approximation of a is : " << CGAL::to_double(a) << "\n";
+  std::cout << "double approximation of b is : " << CGAL::to_double(b) << "\n";
+  std::cout << "double lower bound of a      : " << CGAL::to_interval(a).first  << "\n";
+  std::cout << "double upper bound of a      : " << CGAL::to_interval(a).second << "\n";
+  std::cout << "LessThanComparable (a<b)     : " << (a<b) << "\n\n";
+
+  // use compare_1 with int, Bound, Coefficient, Algebraic_real_1
+  AK::Compare_1 compare_1 = ak.compare_1_object();
+  std::cout << " compare with an int                  : " << compare_1(a ,int(2)) << "\n";
+  std::cout << " compare with an Coefficient          : " << compare_1(a ,Coefficient(2)) << "\n";
+  std::cout << " compare with an Bound                : " << compare_1(a ,Bound(2)) << "\n";
+  std::cout << " compare with another Algebraic_real_1: " << compare_1(a ,b) << "\n\n";
+
+  // get a value between two roots
+  AK::Bound_between_1 bound_between_1 = ak.bound_between_1_object();
+  std::cout << " value between sqrt(2) and sqrt(3) " << bound_between_1(a,b) << "\n";
+  std::cout << " is larger than sqrt(2)            " << compare_1(bound_between_1(a,b),a) << "\n";
+  std::cout << " is less   than sqrt(3)            " << compare_1(bound_between_1(a,b),b) << "\n\n";
+
+  // approximate with relative precision
+  AK::Approximate_relative_1 approx_r = ak.approximate_relative_1_object();
+  std::cout << " lower bound of a with at least 100 bits:    "<< approx_r(a,100).first  << "\n";
+  std::cout << " upper bound of a with at least 100 bits:    "<< approx_r(a,100).second << "\n\n";
+
+  // approximate with absolute error
+  AK::Approximate_absolute_1 approx_a = ak.approximate_absolute_1_object();
+  std::cout << " lower bound of b with error less than 2^-100:   "<< approx_a(b,100).first  << "\n";
+  std::cout << " upper bound of b with error less than 2^-100:   "<< approx_a(b,100).second << "\n\n";
+
+  return 0;
+  }
+#else
+int main(){
+  std::cout << "This example requires CGAL to be configured with library RS." << std::endl;
+return 0;
+}
+#endif

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Construct_algebraic_real_1.cpp
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Construct_algebraic_real_1.cpp
@@ -1,0 +1,41 @@
+// $URL$
+// $Id$
+
+#include <CGAL/basic.h>
+#ifdef CGAL_USE_RS 
+#include <CGAL/Algebraic_kernel_rs_gmpz_d_1.h>
+#include <CGAL/Gmpz.h>
+#include <vector>
+#include <iostream>
+
+typedef CGAL::Algebraic_kernel_rs_gmpz_d_1          AK;
+typedef AK::Polynomial_1                                Polynomial_1;
+typedef AK::Algebraic_real_1                            Algebraic_real_1;
+typedef AK::Coefficient                                 Coefficient;
+typedef AK::Bound                                       Bound;
+typedef AK::Multiplicity_type                           Multiplicity_type;
+
+int main(){
+  AK ak; // an object of 
+  AK::Construct_algebraic_real_1 construct_algreal_1 = ak.construct_algebraic_real_1_object();
+
+  std::cout << "Construct from int         : " << construct_algreal_1(int(2)) << "\n";
+  std::cout << "Construct from Coefficient : " << construct_algreal_1(Coefficient(2)) << "\n";
+  std::cout << "Construct from Bound       : " << construct_algreal_1(Bound(2)) << "\n\n";
+
+  Polynomial_1 x = CGAL::shift(AK::Polynomial_1(1),1); // the monomial x
+  std::cout << "Construct by index              : "
+            << construct_algreal_1(x*x-2,1) << "\n"
+            << to_double(construct_algreal_1(x*x-2,1)) << "\n";
+  std::cout << "Construct by isolating interval : "
+            << construct_algreal_1(x*x-2,Bound(0),Bound(2)) << "\n"
+            << to_double(construct_algreal_1(x*x-2,Bound(0),Bound(2))) << "\n\n";
+
+  return 0;
+}
+#else
+int main(){
+  std::cout << "This example requires CGAL to be configured with library RS." << std::endl;
+return 0;
+}
+#endif

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Isolate_1.cpp
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Isolate_1.cpp
@@ -1,0 +1,57 @@
+// $URL$
+// $Id$
+
+#include <CGAL/basic.h>
+#ifdef CGAL_USE_RS 
+#include <CGAL/Algebraic_kernel_rs_gmpz_d_1.h>
+#include <CGAL/Gmpz.h>
+#include <vector>
+
+typedef CGAL::Algebraic_kernel_rs_gmpz_d_1          AK;
+typedef AK::Polynomial_1                                Polynomial_1;
+typedef AK::Algebraic_real_1                            Algebraic_real_1;
+typedef AK::Coefficient                                 Coefficient;
+typedef AK::Bound                                       Bound;
+typedef AK::Multiplicity_type                           Multiplicity_type;
+
+int main(){
+  AK ak; // an object of 
+  AK::Construct_algebraic_real_1 construct_algreal_1 = ak.construct_algebraic_real_1_object();
+  AK::Isolate_1 isolate_1 = ak.isolate_1_object();
+  AK::Compute_polynomial_1 compute_polynomial_1 = ak.compute_polynomial_1_object();
+
+  // construct an algebraic number from an integer
+  Algebraic_real_1 frominteger=construct_algreal_1(int(2));
+  std::cout << "Construct from int: " << frominteger << "\n";
+
+  // the constructed algebraic number is root of a polynomial
+  Polynomial_1 pol=compute_polynomial_1(frominteger);
+  std::cout << "The constructed number is root of: " << pol << "\n";
+
+  // construct an algebraic number from a polynomial and an isolating interval
+  Polynomial_1 x = CGAL::shift(AK::Polynomial_1(1),1); // the monomial x
+  Algebraic_real_1 frominterval=construct_algreal_1(x*x-2,Bound(0),Bound(2));
+  std::cout << "Construct from isolating interval: " << frominterval << "\n";
+
+  // isolate the second algebraic number from the first: this is to say,
+  // isolating the second algebraic number with respect to the polynomial
+  // of which the first constructed number is root
+  std::pair<Bound,Bound> isolation1 = isolate_1(frominterval,pol);
+  std::cout << "Isolating the second algebraic number gives: ["
+            << isolation1.first << "," << isolation1.second << "]\n";
+
+  // isolate again the same algebraic number, this time with respect to
+  // the polynomial 10*x-14 (which has root 1.4, close to this algebraic
+  // number)
+  std::pair<Bound,Bound> isolation2 = isolate_1(frominterval,10*x-14);
+  std::cout << "Isolating again the second algebraic number gives: ["
+            << isolation2.first << "," << isolation2.second << "]\n";
+
+  return 0;
+}
+#else
+int main(){
+  std::cout << "This example requires CGAL to be configured with library RS." << std::endl;
+return 0;
+}
+#endif

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Sign_at_1.cpp
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Sign_at_1.cpp
@@ -1,0 +1,55 @@
+// $URL$
+// $Id$
+
+#include <CGAL/basic.h>
+#ifdef CGAL_USE_RS 
+#include <CGAL/Algebraic_kernel_rs_gmpz_d_1.h>
+#include <CGAL/Gmpz.h>
+#include <vector>
+
+typedef CGAL::Algebraic_kernel_rs_gmpz_d_1          AK;
+typedef AK::Polynomial_1                                Polynomial_1;
+typedef AK::Algebraic_real_1                            Algebraic_real_1;
+typedef AK::Coefficient                                 Coefficient;
+typedef AK::Bound                                       Bound;
+typedef AK::Multiplicity_type                           Multiplicity_type;
+
+int main(){
+  AK ak;
+  AK::Solve_1 solve_1 = ak.solve_1_object();
+  AK::Sign_at_1 sign_at_1 = ak.sign_at_1_object();
+  AK::Is_zero_at_1 is_zero_at_1 = ak.is_zero_at_1_object();
+
+  // construct the polynomials p=x^2-5 and q=x-2
+  Polynomial_1 x = CGAL::shift(AK::Polynomial_1(1),1); // the monomial x
+  Polynomial_1 p = x*x-5;
+  std::cout << "Polynomial p: " << p << "\n";
+  Polynomial_1 q = x-2;
+  std::cout << "Polynomial q: " << q << "\n";
+
+  // find the roots of p (it has two roots) and q (one root)
+  std::vector<Algebraic_real_1> roots_p,roots_q;
+  solve_1(p,true, std::back_inserter(roots_p));
+  solve_1(q,true, std::back_inserter(roots_q));
+
+  // evaluate the second root of p in q
+  std::cout << "Sign of the evaluation of root 2 of p in q: "
+            << sign_at_1(q,roots_p[1]) << "\n";
+
+  // evaluate the root of q in p
+  std::cout << "Sign of the evaluation of root 1 of q in p: "
+            << sign_at_1(p,roots_q[0]) << "\n";
+
+  // check whether the evaluation of the first root of p in p is zero
+  std::cout << "Is zero the evaluation of root 1 of p in p? "
+            << is_zero_at_1(p,roots_p[0]) << "\n";
+
+  return 0;
+}
+
+#else
+int main(){
+  std::cout << "This example requires CGAL to be configured with library RS." << std::endl;
+return 0;
+}
+#endif

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Solve_1.cpp
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/RS_Solve_1.cpp
@@ -1,0 +1,62 @@
+// $URL$
+// $Id$
+
+#include <CGAL/basic.h>
+#ifdef CGAL_USE_RS 
+#include <CGAL/Algebraic_kernel_rs_gmpz_d_1.h>
+#include <CGAL/Gmpz.h>
+#include <vector>
+
+typedef CGAL::Algebraic_kernel_rs_gmpz_d_1          AK;
+typedef AK::Polynomial_1                                Polynomial_1;
+typedef AK::Algebraic_real_1                            Algebraic_real_1;
+typedef AK::Bound                                       Bound;
+typedef AK::Multiplicity_type                           Multiplicity_type;
+
+int main(){
+  AK ak; // an object of 
+  AK::Solve_1 solve_1 = ak.solve_1_object();
+  Polynomial_1 x = CGAL::shift(AK::Polynomial_1(1),1); // the monomial x
+
+
+  // variant using a bool indicating a square free polynomial
+  // multiplicities are not computed
+  std::vector<Algebraic_real_1> roots;
+  solve_1(x*x-2,true, std::back_inserter(roots));
+  std::cout << "Number of roots is           : " << roots.size() << "\n";
+  std::cout << "First root should be -sqrt(2): " << CGAL::to_double(roots[0]) << "\n";
+  std::cout << "Second root should be sqrt(2): " << CGAL::to_double(roots[1]) << "\n\n";
+  roots.clear();
+
+  // variant for roots in a given range of a square free polynomial
+  solve_1((x*x-2)*(x*x-3),true, Bound(0),Bound(10),std::back_inserter(roots));
+  std::cout << "Number of roots is           : " << roots.size() << "\n";
+  std::cout << "First root should be  sqrt(2): " << CGAL::to_double(roots[0]) << "\n";
+  std::cout << "Second root should be sqrt(3): " << CGAL::to_double(roots[1]) << "\n\n";
+  roots.clear();
+
+  // variant computing all roots with multiplicities
+  std::vector<std::pair<Algebraic_real_1,Multiplicity_type> > mroots;
+  solve_1((x*x-2), std::back_inserter(mroots));
+  std::cout << "Number of roots is           : " << mroots.size() << "\n";
+  std::cout << "First root should be -sqrt(2): " << CGAL::to_double(mroots[0].first) << ""
+            << " with multiplicity "             << mroots[0].second << "\n";
+  std::cout << "Second root should be sqrt(2): " << CGAL::to_double(mroots[1].first) << ""
+            << " with multiplicity "             << mroots[1].second << "\n\n";
+  mroots.clear();
+
+  // variant computing roots with multiplicities for a range
+  solve_1((x*x-2)*(x*x-3),Bound(0),Bound(10),std::back_inserter(mroots));
+  std::cout << "Number of roots is           : " << mroots.size() << "\n";
+  std::cout << "First root should be  sqrt(2): " << CGAL::to_double(mroots[0].first) << ""
+            << " with multiplicity "             << mroots[0].second << "\n";
+  std::cout << "Second root should be sqrt(3): " << CGAL::to_double(mroots[1].first) << ""
+            << " with multiplicity "             << mroots[1].second << "\n\n";
+  return 0;
+}
+#else
+int main(){
+  std::cout << "This example requires CGAL to be configured with library RS." << std::endl;
+return 0;
+}
+#endif

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 2.8.11)
 
 
 # CGAL and its components
-find_package( CGAL QUIET COMPONENTS Core RS3)
+find_package( CGAL QUIET COMPONENTS Core GMP MPFR )
 
 if ( NOT CGAL_FOUND )
 
@@ -30,6 +30,16 @@ if ( NOT Boost_FOUND )
 
   return()  
 
+endif()
+
+find_package( MPFI )
+if( MPFI_FOUND )
+  include( ${MPFI_USE_FILE} )
+endif()
+
+find_package( LEDA )
+if( LEDA_FOUND )
+  include( ${LEDA_USE_FILE} )
 endif()
 
 # include for local directory
@@ -61,7 +71,14 @@ create_single_source_cgal_program( "Curve_analysis_2.cpp" )
 create_single_source_cgal_program( "Curve_pair_analysis_2.cpp" )
 create_single_source_cgal_program( "Descartes.cpp" )
 create_single_source_cgal_program( "Real_embeddable_traits_extension.cpp" )
+
+find_package( RS )
 if(RS_FOUND)
+  include( ${RS_USE_FILE} )
+  find_package( RS3 )
+  if(RS3_FOUND)
+    include( ${RS3_USE_FILE} )
+  endif()
   create_single_source_cgal_program( "Algebraic_kernel_rs_gmpq_d_1.cpp" )
   create_single_source_cgal_program( "Algebraic_kernel_rs_gmpz_d_1.cpp" )
 else()


### PR DESCRIPTION
Verbatim copy from my mail to Laurent:

The CMakeLists didn't include the USE_MPFI, and in the testsuite the CGAL main lib itself is configured without MPFI.

I fixed that in cgal-dev/Algebraic_kernel_d_examples-fixes-akobel, and also added equivalent examples to AK_d/examples that use the RS AK. Shouldn't affect the testsuite yet, because AFAICS RS is currently not available in any configuration; but see below.
It's been a while since I got something to integration, and you need to refresh my mind about the procedure: do you take care of that or should I push it there if I get your ack?

On the other front, I also made a pull request for the dockerfiles where I add NTL, RS and LEDA in the Arch Dockerfiles. I don't think RS and LEDA are easily available for any other platform. If you think it's worth to do so, I can try to find out the package names of NTL for other distros; I assume it's available as a mainstream package everywhere.

Note that, for the time being and due to the problem we are investigating, I expect the new RS AK examples in cgal-dev/Algebraic_kernel_d_examples-fixes-akobel to fail to execute properly.

Added second commit for enabling MPFI / LEDA / RS in the actual AK_d testsuite (not just the examples) as well.
Note: The LEDA_USE_FILE claims to add -lX11 in the linking stage but doesn't; obviously, I'm not CMan enough to fix it in a reasonable time.