### PR TITLE
Fix CGAL_NO_ASSERTIONS

### DIFF
--- a/STL_Extension/doc/STL_Extension/STL_Extension.txt
+++ b/STL_Extension/doc/STL_Extension/STL_Extension.txt
@@ -267,12 +267,15 @@ whole \cgal library:
 - `CGAL_NDEBUG`.
 
 
-Setting the macro `CGAL_NDEBUG` disables all checks.
-Note that the standard flag `NDEBUG` sets `CGAL_NDEBUG`, but it also
-affects the standard `assert` macro.
-This way, adding `-DCGAL_NDEBUG` to your compilation flags removes
-absolutely all checks.  This is the default recommended setup for performing
-timing benchmarks for example.
+Setting the macro `CGAL_NDEBUG` disables all checks. This way, adding
+`-DCGAL_NDEBUG` to your compilation flags removes absolutely all checks.
+This is the default recommended setup for performing timing benchmarks for
+example.
+
+Note that the setting of the standard macro `NDEBUG` sets `CGAL_NDEBUG`,
+unless `CGAL_DEBUG` is also defined. If both `NDEBUG` and `CGAL_DEBUG` are
+defined, then the the standard `assert` macro is disabled, but not the CGAL
+assertions and preconditions.
 
 Not all checks are on by default.
 The first four types of checks can be marked as expensive or exactness checks

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -31,6 +31,27 @@
 
 // #include <CGAL/assertions_behaviour.h> // for backward compatibility
 
+#ifdef NDEBUG
+#  ifndef CGAL_NDEBUG
+#    define CGAL_NDEBUG
+#  endif
+#endif
+
+// The macro `CGAL_DEBUG` allows to force CGAL assertions, even if `NDEBUG`
+// is defined,
+#ifdef CGAL_DEBUG
+#  ifdef CGAL_NDEBUG
+#    undef CGAL_NDEBUG
+#  endif
+#endif
+
+#ifdef CGAL_NDEBUG
+#  define CGAL_NO_ASSERTIONS
+#  define CGAL_NO_PRECONDITIONS
+#  define CGAL_NO_POSTCONDITIONS
+#  define CGAL_NO_WARNINGS
+#endif
+
 #ifndef CGAL_NO_ASSERTIONS 
 #ifdef CGAL_CFG_NO_CPP0X_STATIC_ASSERT
 #include <boost/static_assert.hpp>
@@ -64,19 +85,6 @@ inline bool possibly(Uncertain<bool> c);
 // =================
 // assertions
 // ----------
-
-#ifdef NDEBUG
-#  ifndef CGAL_NDEBUG
-#    define CGAL_NDEBUG
-#  endif
-#endif
-
-#ifdef CGAL_NDEBUG
-#  define CGAL_NO_ASSERTIONS
-#  define CGAL_NO_PRECONDITIONS
-#  define CGAL_NO_POSTCONDITIONS
-#  define CGAL_NO_WARNINGS
-#endif
 
 #if defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_assertion(EX) (static_cast<void>(0))


### PR DESCRIPTION
- `CGAL_NO_ASSERTIONS` was used *before* it was potentially modified by
the `NDEBUG` macro.

- I have also added a macro `CGAL_DEBUG` that allows to disable `assert`
  but not CGAL assertions, using:

      -DNDEBUG -DCGAL_DEBUG