### PR TITLE
hash_value is not defined inside an #ifdef OM_HAS_HASH

### DIFF
--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -22,7 +22,7 @@
 
 #include <OpenMesh/Core/Mesh/Handles.hh>
 
-#if OMVERSION < 0x60200
+#if OM_VERSION < 0x60200
 
 namespace OpenMesh {
 

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -22,15 +22,20 @@
 
 #include <OpenMesh/Core/Mesh/Handles.hh>
 
-#ifndef OM_HAS_HASH
-
-#include <functional>
+#if OMVERSION < 0x60200
 
 namespace OpenMesh {
 
 inline std::size_t hash_value(const BaseHandle& h) { return h.idx(); }
 
 } // namespace OpenMesh
+#endif
+
+
+#ifndef OM_HAS_HASH
+
+#include <functional>
+
 
 namespace std {
 


### PR DESCRIPTION
So we have to add it for OpenMesh version < 6.2  
@janetournois can you test this please.