### PR TITLE
Fix bug in polyline simplification

### DIFF
--- a/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
+++ b/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
@@ -339,7 +339,7 @@ template <class Traits, class Container, class CostFunction, class StopFunction>
   typedef Vertex_base_2< K > Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb,Fb> TDS;
-  typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, CGAL::Exact_predicates_tag> CDT;
+  typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS,typename internal::Itag<K>::type>  CDT;
   typedef CGAL::Constrained_triangulation_plus_2<CDT>       PCT;
   typedef typename PCT::Constraint_id Constraint_id;
   typedef typename PCT::Vertices_in_constraint_iterator Vertices_in_constraint_iterator;
@@ -387,7 +387,7 @@ Simplifies an open or closed polyline given as an iterator range of 2D \cgal poi
   typedef Vertex_base_2< K > Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb,Fb> TDS;
-  typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, CGAL::Exact_predicates_tag> CDT;
+  typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS,typename internal::Itag<K>::type > CDT;
   typedef CGAL::Constrained_triangulation_plus_2<CDT>       PCT;
   typedef typename PCT::Constraint_id Constraint_id;
   typedef typename PCT::Vertices_in_constraint_iterator Vertices_in_constraint_iterator;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -32,12 +32,24 @@
 #include <CGAL/intersections.h>
 #include <CGAL/squared_distance_2.h>
 
+#include <boost/mpl/if.hpp>
+
 namespace CGAL {
 
 struct No_intersection_tag{};
 struct Exact_intersections_tag{}; // to be used with an exact number type
 struct Exact_predicates_tag{}; // to be used with filtered exact number
 
+namespace internal {
+
+template <typename K>
+struct Itag {
+  typedef typename boost::mpl::if_<typename Algebraic_structure_traits<typename K::FT>::Is_exact,
+                                   Exact_intersections_tag,
+                                   Exact_predicates_tag>::type type;
+};
+
+} // namespace internal
 
 template < class Gt, 
            class Tds = Triangulation_data_structure_2 <


### PR DESCRIPTION
We had hardwired that we use Exact_predicates_tag which is slow for EPEC
in particular with Quotient<MP_float> or leda::real

We determine the appropriate tag using Algebraic_structure_traits<FT>::Is_exact