### PR TITLE
Point set shape detection: improve example

### DIFF
--- a/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/Point_set_shape_detection_3.txt
+++ b/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/Point_set_shape_detection_3.txt
@@ -67,7 +67,10 @@ The following minimal example reads a point set from a file and detects only pla
 
 \subsection Point_set_shape_detection_3Usage_parameters Setting Parameters and Using Different Types of Shape
 
-This example illustrates the user selection of parameters using the `Shape_detection_3::Efficient_RANSAC::Parameters` struct. Shape detection is performed on five types of shapes (plane, cylinder, sphere, cone, torus). Basic information of the detected shapes is written to the standard output. The input point set is sampled on a surface mostly composed of piece-wise planar and cylindrical parts, in addition to free-form parts.
+This example illustrates the user selection of parameters using the `Shape_detection_3::Efficient_RANSAC::Parameters` struct. Shape detection is performed on five types of shapes (plane, cylinder, sphere, cone, torus). The input point set is sampled on a surface mostly composed of piece-wise planar and cylindrical parts, in addition to free-form parts.
+
+Basic information of the detected shapes is written to the standard output: if the plane is either a plane or a cylinder, specific parameters are recovered, otherwise the general method `info()` is used to get the shape parameters in a string object. Note that specific parameters can be recovered for any of the provided shape.
+
 
 \cgalExample{Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp}
 

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
@@ -99,15 +99,17 @@ int main()
   while (it != shapes.end()) {
     
     // Get specific parameters depending on detected shape.
-    if (dynamic_cast<Plane*>(it->get()))
+    if (Plane* plane = dynamic_cast<Plane*>(it->get()))
       {
-        Kernel::Vector_3 normal = dynamic_cast<Plane*>(it->get())->plane_normal();
+        Kernel::Vector_3 normal = plane->plane_normal();
         std::cout << "Plane with normal " << normal
                 << std::endl;
+        
+        // Plane shape can also be converted to Kernel::Plane_3
+        std::cout << "Kernel::Plane_3: " << static_cast<Kernel::Plane_3>(*plane) << std::endl;
       }
-    else if (dynamic_cast<Cylinder*>(it->get()))
+    else if (Cylinder* cyl = dynamic_cast<Cylinder*>(it->get()))
       {
-        Cylinder* cyl = dynamic_cast<Cylinder*>(it->get());
         Kernel::Line_3 axis = cyl->axis();
         FT radius = cyl->radius();
         std::cout << "Cylinder with axis " << axis

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
@@ -97,9 +97,30 @@ int main()
   Efficient_ransac::Shape_range::iterator it = shapes.begin();
 
   while (it != shapes.end()) {
-    // Prints the parameters of the detected shape.
-    std::cout << (*it)->info() << std::endl;
-
+    
+    // Get specific parameters depending on detected shape.
+    if (dynamic_cast<Plane*>(it->get()))
+      {
+        Kernel::Vector_3 normal = dynamic_cast<Plane*>(it->get())->plane_normal();
+        std::cout << "Plane with normal " << normal
+                << std::endl;
+      }
+    else if (dynamic_cast<Cylinder*>(it->get()))
+      {
+        Cylinder* cyl = dynamic_cast<Cylinder*>(it->get());
+        Kernel::Line_3 axis = cyl->axis();
+        FT radius = cyl->radius();
+        std::cout << "Cylinder with axis " << axis
+                  << " and radius " << radius
+                  << std::endl;
+      }
+    else
+      {
+        // Prints the parameters of the detected shape.
+        // This function is available for any type of shape.
+        std::cout << (*it)->info() << std::endl;
+      }
+    
     // Proceeds with next detected shape.
     it++;
   }


### PR DESCRIPTION
Documentation in the RANSAC package is missing an example to show how to recover specific parameters of shapes (using `dynamic_cast`).