### PR TITLE
PMP : remove useless includes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -28,7 +28,6 @@
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/boost/graph/iterator.h>
-#include <CGAL/Kernel_traits.h>
 
 #include <boost/foreach.hpp>
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -21,8 +21,6 @@
 #ifndef CGAL_POLYGON_MESH_PROCESSING_POLYGON_SOUP_TO_POLYGON_MESH
 #define CGAL_POLYGON_MESH_PROCESSING_POLYGON_SOUP_TO_POLYGON_MESH
 
-#include <CGAL/IO/generic_print_polyhedron.h>
-#include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -22,8 +22,6 @@
 #ifndef CGAL_STITCH_POLYGON_MESH_H
 #define CGAL_STITCH_POLYGON_MESH_H
 
-#include <CGAL/Modifier_base.h>
-#include <CGAL/HalfedgeDS_decorator.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/boost/graph/properties.h>
 
@@ -105,7 +103,6 @@ detect_duplicated_boundary_edges
 
 template <class PM, typename VertexPointMap, typename HalfedgePairsRange>
 struct Naive_border_stitching_modifier
-  : CGAL::Modifier_base<PM>
 {
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -21,7 +21,6 @@
 #ifndef CGAL_POLYGON_MESH_PROCESSING_TRIANGULATE_FACES_H
 #define CGAL_POLYGON_MESH_PROCESSING_TRIANGULATE_FACES_H
 
-#include <CGAL/HalfedgeDS_decorator.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 


### PR DESCRIPTION
this PR intends to cleanup the extra "includes" that can be found in the PMP package.

