### PR TITLE
Polyhedron_demo : Fix the menu bug with Unity

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -524,7 +524,10 @@ void MainWindow::setMenus(QString name, QString parentName, QAction* a )
     if(a->property("added").toBool())
       hasAction = true;
   if(!hasAction)
+  {
+    ui->menuOperations->removeAction(a);
     menu->addAction(a);
+  }
   a->setProperty("added", true);
   //If the parent menu already exists, don't create a new one.
   if(menu_map.contains(parentName))
@@ -540,7 +543,6 @@ void MainWindow::setMenus(QString name, QString parentName, QAction* a )
     menu_map[parentName] = parentMenu;
   }
   parentMenu->addMenu(menu);
-  ui->menuOperations->removeAction(a);
 }
 
 void MainWindow::load_plugin(QString fileName, bool blacklisted)


### PR DESCRIPTION
This fixes #909 

With this PR, when a plugin is loaded, an action is removed from the Operations root menu before it is added to a submenu.
This way, it is not "already tracked" and unity does not discard it. (I guess it is unity that does it as the bug only appears when Unity is used)