### PR TITLE
Adds CMake package version file generation

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -891,7 +891,10 @@ if ( ZLIB_IN_AUXILIARY )
 endif()
 
 
-install(FILES ${CMAKE_BINARY_DIR}/config/CGALConfig.cmake DESTINATION ${CGAL_INSTALL_CMAKE_DIR} )
+install(FILES
+  ${CMAKE_BINARY_DIR}/config/CGALConfig.cmake
+  ${CMAKE_BINARY_DIR}/config/CGALConfigVersion.cmake
+  DESTINATION ${CGAL_INSTALL_CMAKE_DIR} )
 
 if(CGAL_INSTALL_MAN_DIR)
   install(FILES auxiliary/cgal_create_cmake_script.1 DESTINATION ${CGAL_INSTALL_MAN_DIR} )

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -892,8 +892,8 @@ endif()
 
 
 install(FILES
+  ${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake
   ${CMAKE_BINARY_DIR}/config/CGALConfig.cmake
-  ${CMAKE_BINARY_DIR}/config/CGALConfigVersion.cmake
   DESTINATION ${CGAL_INSTALL_CMAKE_DIR} )
 
 if(CGAL_INSTALL_MAN_DIR)

--- a/Installation/cmake/modules/CGAL_Macros.cmake
+++ b/Installation/cmake/modules/CGAL_Macros.cmake
@@ -411,11 +411,20 @@ if( NOT CGAL_MACROS_FILE_INCLUDED )
 
   macro( create_CGALconfig_files )
 
+    include(CMakePackageConfigHelpers)
+
     # CGALConfig.cmake is platform specific so it is generated and stored in the binary folder.
     configure_file("${CGAL_MODULES_DIR}/CGALConfig_binary.cmake.in"  "${CMAKE_BINARY_DIR}/CGALConfig.cmake"        @ONLY)
+    write_basic_package_version_file("${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake"
+      VERSION "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}.${CGAL_BUILD_VERSION}"
+      COMPATIBILITY AnyNewerVersion)
 
     # There is also a version of CGALConfig.cmake that is prepared in case CGAL in installed in CMAKE_INSTALL_PREFIX.
     configure_file("${CGAL_MODULES_DIR}/CGALConfig_install.cmake.in" "${CMAKE_BINARY_DIR}/config/CGALConfig.cmake" @ONLY)
+    configure_file(
+      "${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake"
+      "${CMAKE_BINARY_DIR}/config/CGALConfigVersion.cmake"
+      COPYONLY)
 
     #write prefix exceptions
     file( APPEND ${CMAKE_BINARY_DIR}/CGALConfig.cmake "${SPECIAL_PREFIXES}\n")

--- a/Installation/cmake/modules/CGAL_Macros.cmake
+++ b/Installation/cmake/modules/CGAL_Macros.cmake
@@ -417,7 +417,7 @@ if( NOT CGAL_MACROS_FILE_INCLUDED )
     configure_file("${CGAL_MODULES_DIR}/CGALConfig_binary.cmake.in"  "${CMAKE_BINARY_DIR}/CGALConfig.cmake"        @ONLY)
     write_basic_package_version_file("${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake"
       VERSION "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}.${CGAL_BUILD_VERSION}"
-      COMPATIBILITY AnyNewerVersion)
+      COMPATIBILITY SameMajorVersion)
 
     # There is also a version of CGALConfig.cmake that is prepared in case CGAL in installed in CMAKE_INSTALL_PREFIX.
     configure_file("${CGAL_MODULES_DIR}/CGALConfig_install.cmake.in" "${CMAKE_BINARY_DIR}/config/CGALConfig.cmake" @ONLY)

--- a/Installation/cmake/modules/CGAL_Macros.cmake
+++ b/Installation/cmake/modules/CGAL_Macros.cmake
@@ -421,10 +421,6 @@ if( NOT CGAL_MACROS_FILE_INCLUDED )
 
     # There is also a version of CGALConfig.cmake that is prepared in case CGAL in installed in CMAKE_INSTALL_PREFIX.
     configure_file("${CGAL_MODULES_DIR}/CGALConfig_install.cmake.in" "${CMAKE_BINARY_DIR}/config/CGALConfig.cmake" @ONLY)
-    configure_file(
-      "${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake"
-      "${CMAKE_BINARY_DIR}/config/CGALConfigVersion.cmake"
-      COPYONLY)
 
     #write prefix exceptions
     file( APPEND ${CMAKE_BINARY_DIR}/CGALConfig.cmake "${SPECIAL_PREFIXES}\n")


### PR DESCRIPTION
This allows clients to specify a minimum CGAL version in their CMake list files.
Eg.:

    find_package(CGAL 4.9)

More info: https://cmake.org/cmake/help/v3.6/manual/cmake-packages.7.html#package-version-file