### PR TITLE
Allow building the doc without configuring CGAL

### DIFF
--- a/Documentation/conversion_tools/split_doxyassist.py
+++ b/Documentation/conversion_tools/split_doxyassist.py
@@ -147,11 +147,11 @@ for p in tree.iter(tag='{http://simply-life.net/doxyassist/doxyassist.xsd}projec
         for this_input in package_inputs:
             if ('include' in this_input):
                 new_input = this_input.split('include')[1]            
-                new_input = "${CMAKE_SOURCE_DIR}/"+this_input.split('/')[1]+"/include"+new_input
+                new_input = "${CGAL_ROOT}/"+this_input.split('/')[1]+"/include"+new_input
                 clean_package_inputs.append(new_input)
             else:
                 new_input = this_input.split('doc')[1]            
-                new_input = "${CMAKE_SOURCE_DIR}/"+ this_input.split('/')[1] +"/doc"+new_input
+                new_input = "${CGAL_ROOT}/"+ this_input.split('/')[1] +"/doc"+new_input
                 clean_package_inputs.append(new_input)            
 
         # This will include the default paramters for the configuration.

--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -1,8 +1,27 @@
 project(Documentation NONE)
 
-option(BUILD_DOC "Build the doxygen documentation" OFF)
-if(NOT BUILD_DOC)
-  return()
+# Minimal version of CMake:
+cmake_minimum_required(VERSION 2.8.11)
+
+# Check whether this cmake script is the top level one
+if ( ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  # decide if this is a branch build
+  if ( NOT EXISTS "${CMAKE_SOURCE_DIR}/../VERSION")
+    set(CGAL_BRANCH_BUILD ON CACHE INTERNAL "CGAL Branch build")
+  endif()
+
+  if (CGAL_BRANCH_BUILD)
+    set(CGAL_ROOT "${CMAKE_SOURCE_DIR}/../..")
+  else()
+    set(CGAL_ROOT "${CMAKE_SOURCE_DIR}/..")
+  endif()
+  get_filename_component(CGAL_ROOT ${CGAL_ROOT} REALPATH)
+else()
+  option(BUILD_DOC "Build the doxygen documentation" OFF)
+  if(NOT BUILD_DOC)
+    return()
+  endif()
+  set(CGAL_ROOT "${CMAKE_SOURCE_DIR}")
 endif()
 
 find_package(Doxygen)
@@ -29,9 +48,9 @@ endmacro()
 
 function(configure_doxygen_package CGAL_PACKAGE_NAME)
   if(CGAL_BRANCH_BUILD)
-    set(CGAL_PACKAGE_DIR ${CMAKE_SOURCE_DIR}/${CGAL_PACKAGE_NAME})
+    set(CGAL_PACKAGE_DIR ${CGAL_ROOT}/${CGAL_PACKAGE_NAME})
   else()
-    set(CGAL_PACKAGE_DIR ${CMAKE_SOURCE_DIR})
+    set(CGAL_PACKAGE_DIR ${CGAL_ROOT})
   endif()
 
   set(CGAL_PACKAGE_DOC_DIR ${CGAL_PACKAGE_DIR}/doc/${CGAL_PACKAGE_NAME})
@@ -93,9 +112,9 @@ function(configure_doxygen_package CGAL_PACKAGE_NAME)
       list(APPEND DEPENDENCIES ${PKG})
 
       if(CGAL_BRANCH_BUILD)
-        SET(IMG_DIR "${CMAKE_SOURCE_DIR}/${PKG}/doc/${PKG}/fig")
+        SET(IMG_DIR "${CGAL_ROOT}/${PKG}/doc/${PKG}/fig")
       else()
-        SET(IMG_DIR "${CMAKE_SOURCE_DIR}/doc/${PKG}/fig")
+        SET(IMG_DIR "${CGAL_ROOT}/doc/${PKG}/fig")
       endif()
 
       if(EXISTS ${IMG_DIR})
@@ -209,7 +228,7 @@ set(CGAL_DOC_VERSION ${CGAL_CREATED_VERSION_NUM})
 if(PYTHONINTERP_FOUND)
   execute_process(COMMAND ${PYTHON_EXECUTABLE}
                           ${CGAL_DOC_SCRIPT_DIR}/generate_how_to_cite.py
-                          ${CMAKE_SOURCE_DIR}
+                          ${CGAL_ROOT}
                           ${CMAKE_BINARY_DIR}
                           "${CGAL_BRANCH_BUILD}"
                   RESULT_VARIABLE GENERATE_HOW_TO_CITE_RESULT)
@@ -236,41 +255,46 @@ configure_file(${CGAL_DOC_SCRIPT_DIR}/pkglist_filter.py ${CMAKE_BINARY_DIR}/pkgl
 
 set(CGAL_DOC_PACKAGES "")
 if(CGAL_BRANCH_BUILD)
-  foreach(pkg ${CGAL_CONFIGURED_PACKAGES_NAMES} "Miscellany")
-    if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${pkg}/doc/${pkg})
-      list(APPEND CGAL_DOC_PACKAGES ${pkg})
+  file(GLOB CGAL_ALL_PACKAGES RELATIVE ${CGAL_ROOT} "${CGAL_ROOT}/*")
+  foreach (pkg ${CGAL_ALL_PACKAGES})
+    #detect packages with documentation to process
+    if (IS_DIRECTORY ${CGAL_ROOT}/${pkg})
+      if(EXISTS "${CGAL_ROOT}/${pkg}/doc/${pkg}/PackageDescription.txt")
+        list(APPEND CGAL_DOC_PACKAGES ${pkg})
+      endif()
     endif()
-    if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${pkg}/examples)
-      set(CGAL_${pkg}_EXAMPLE_DIR "${CMAKE_SOURCE_DIR}/${pkg}/examples")
+    #set up directories of packages
+    if(IS_DIRECTORY ${CGAL_ROOT}/${pkg}/examples)
+      set(CGAL_${pkg}_EXAMPLE_DIR "${CGAL_ROOT}/${pkg}/examples")
     endif()
-    if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${pkg}/include)
-      set(CGAL_${pkg}_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/${pkg}/include")
+    if(IS_DIRECTORY ${CGAL_ROOT}/${pkg}/include)
+      set(CGAL_${pkg}_INCLUDE_DIR "${CGAL_ROOT}/${pkg}/include")
     endif()
-    if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${pkg}/include)
-      set(CGAL_${pkg}_DEMO_DIR "${CMAKE_SOURCE_DIR}/${pkg}/demo")
+    if(IS_DIRECTORY ${CGAL_ROOT}/${pkg}/demo)
+      set(CGAL_${pkg}_DEMO_DIR "${CGAL_ROOT}/${pkg}/demo")
     endif()
   endforeach()
 else()
-  subdirlist(CGAL_DOC_PACKAGES_TMP ${CMAKE_SOURCE_DIR}/doc)
+  subdirlist(CGAL_DOC_PACKAGES_TMP ${CGAL_ROOT}/doc)
   set(CGAL_DOC_PACKAGES)
   foreach(package ${CGAL_DOC_PACKAGES_TMP})
-    if(EXISTS "${CMAKE_SOURCE_DIR}/doc/${package}/PackageDescription.txt")
+    if(EXISTS "${CGAL_ROOT}/doc/${package}/PackageDescription.txt")
       list(APPEND CGAL_DOC_PACKAGES "${package}")
     endif()
   endforeach()
 
-  subdirlist(CGAL_EXAMPLE_PACKAGES ${CMAKE_SOURCE_DIR}/examples)
-  subdirlist(CGAL_DEMO_PACKAGES ${CMAKE_SOURCE_DIR}/demo)
+  subdirlist(CGAL_EXAMPLE_PACKAGES ${CGAL_ROOT}/examples)
+  subdirlist(CGAL_DEMO_PACKAGES ${CGAL_ROOT}/demo)
   list(APPEND CGAL_EXAMPLE_PACKAGES "BGL") # manually add BGL to the list of packages
   foreach(pkg ${CGAL_EXAMPLE_PACKAGES})
-    set(CGAL_${pkg}_EXAMPLE_DIR "${CMAKE_SOURCE_DIR}/examples")
+    set(CGAL_${pkg}_EXAMPLE_DIR "${CGAL_ROOT}/examples")
     # This might not be entirely correct, but there is no reliable,
     # easy way to get a list of all package names when not in a
     # branch build.
-    set(CGAL_${pkg}_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/include")
+    set(CGAL_${pkg}_INCLUDE_DIR "${CGAL_ROOT}/include")
   endforeach()
   foreach(pkg ${CGAL_DEMO_PACKAGES})
-    set(CGAL_${pkg}_DEMO_DIR "${CMAKE_SOURCE_DIR}/demo")
+    set(CGAL_${pkg}_DEMO_DIR "${CGAL_ROOT}/demo")
   endforeach()
 endif()
 

--- a/Documentation/doc/scripts/pkglist_filter.py
+++ b/Documentation/doc/scripts/pkglist_filter.py
@@ -5,7 +5,7 @@ import re
 import os
 import sys
 
-SOURCE_DIR   = "${CMAKE_SOURCE_DIR}/"
+SOURCE_DIR   = "${CGAL_ROOT}/"
 BRANCH_BUILD = "${CGAL_BRANCH_BUILD}"
 
 def make_doc_path(pkg, arg):


### PR DESCRIPTION
Add the possibility to build the doc simply by calling cmake using the cmake script in `Documentation/doc` in branch mode and `doc` in release mode.
The way to compile the doc stays the same:
```
> make doc -j
> make doc_with_post_processing -j
```

I tested the former behavior in the branch and release modes, as well as the new behavior in both modes.