### PR TITLE
Use Boost.Config to detect a real gcc<=4.4

### DIFF
--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <boost/config.hpp>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()


### PR DESCRIPTION
... Avoids that Intel Compiler or Clang are detected as well.

Fix #1458.
