### PR TITLE
Always include <boost/static_assert.hpp>

### DIFF
--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -52,10 +52,8 @@
 #  define CGAL_NO_WARNINGS
 #endif
 
-#ifndef CGAL_NO_ASSERTIONS 
 #ifdef CGAL_CFG_NO_CPP0X_STATIC_ASSERT
 #include <boost/static_assert.hpp>
-#endif
 #endif
 
 namespace CGAL {


### PR DESCRIPTION
If C++11 `static_assert` cannot be used, `BOOST_STATIC_ASSERT` is used
instead *even with `CGAL_NO_ASSERTIONS`*.