### PR TITLE
Polyhedron_demo : Optimize the point_set visualization

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -28,6 +28,8 @@
 #include <algorithm>
 #include <boost/array.hpp>
 
+const std::size_t limit_fast_drawing = 300000; //arbitraty large valu
+
 struct Scene_points_with_normal_item_priv
 {
   Scene_points_with_normal_item_priv(Scene_points_with_normal_item* parent)
@@ -580,8 +582,8 @@ void Scene_points_with_normal_item::drawEdges(CGAL::Three::Viewer_interface* vie
 {
     double ratio_displayed = 1.0;
     if (viewer->inFastDrawing () &&
-        (d->nb_lines/6 > 300000)) // arbitrary large value
-      ratio_displayed = 6 * 300000. / (double)(d->nb_lines);
+        (d->nb_lines/6 > limit_fast_drawing)) // arbitrary large value
+      ratio_displayed = 6 * limit_fast_drawing / (double)(d->nb_lines);
 
     if(!are_buffers_filled)
         d->initializeBuffers(viewer);
@@ -605,8 +607,8 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
     viewer->glPointSize(d->point_Slider->value());
     double ratio_displayed = 1.0;
     if ((viewer->inFastDrawing () || d->isPointSliderMoving())
-        &&((d->nb_points + d->nb_selected_points)/3 > 300000)) // arbitrary large value
-      ratio_displayed = 3 * 300000. / (double)(d->nb_points + d->nb_selected_points);
+        &&((d->nb_points + d->nb_selected_points)/3 > limit_fast_drawing)) // arbitrary large value
+      ratio_displayed = 3 * limit_fast_drawing / (double)(d->nb_points + d->nb_selected_points);
 
     vaos[Scene_points_with_normal_item_priv::ThePoints]->bind();
     if(has_normals())
@@ -716,7 +718,7 @@ QMenu* Scene_points_with_normal_item::contextMenu()
       {
         QMenu *container = new QMenu(tr("Normals Length"));
         QWidgetAction *sliderAction = new QWidgetAction(0);
-        if((d->nb_points + d->nb_selected_points)/3 <= 300000)
+        if((d->nb_points + d->nb_selected_points)/3 <= limit_fast_drawing)
         {
           connect(d->normal_Slider, &QSlider::valueChanged, this, &Scene_points_with_normal_item::invalidateOpenGLBuffers);
           connect(d->normal_Slider, &QSlider::valueChanged, this, &Scene_points_with_normal_item::itemChanged);

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -84,6 +84,10 @@ public Q_SLOTS:
   void resetSelection();
   //Select duplicated points
   void selectDuplicates();
+  //Set the status of the slider as `pressed`
+  void pointSliderPressed();
+  //Set the status of the slider as `released`
+  void pointSliderReleased();
 
 // Data
 protected:


### PR DESCRIPTION
This PR 
- Makes the resizing of the points real fast
- Makes the resizing of the normals applied on slider released instead of every tick when the point set size is bigger than 300 000
- sets the initial value of the point size to 2 instead of 5