### PR TITLE
Polyhedron_demo : Add an action to hide the grid in mesh_3_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -28,7 +28,8 @@
 #include <CGAL/AABB_C3T3_triangle_primitive.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
-#include <QKeyEvent>
+
+
 typedef CGAL::AABB_C3T3_triangle_primitive<Kernel,C3t3> Primitive;
 typedef CGAL::AABB_traits<Kernel, Primitive> Traits;
 typedef CGAL::AABB_tree<Traits> Tree;
@@ -261,10 +262,7 @@ struct Scene_c3t3_item_priv {
     show_tetrahedra = false;
     is_aabb_tree_built = false;
     are_intersection_buffers_filled = false;
-    is_grid_shown = false;
-    QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
-    viewer->installEventFilter(item);
-
+    is_grid_shown = true;
   }
   void computeIntersection(const Primitive& facet);
   void fill_aabb_tree() {
@@ -843,7 +841,6 @@ void Scene_c3t3_item::drawEdges(CGAL::Three::Viewer_interface* viewer) const {
 
   if(renderingMode() == Wireframe && d->is_grid_shown)
   {
-
     vaos[Scene_c3t3_item_priv::Grid]->bind();
 
     d->program = getShaderProgram(PROGRAM_NO_SELECTION);
@@ -1141,6 +1138,14 @@ QMenu* Scene_c3t3_item::contextMenu()
     actionShowTets->setCheckable(true);
     actionShowTets->setObjectName("actionShowTets");
     connect(actionShowTets, &QAction::toggled, Set_show_tetrahedra(this->d));
+
+    QAction* actionShowGrid=
+      menu->addAction(tr("Show &grid"));
+    actionShowGrid->setCheckable(true);
+    actionShowGrid->setChecked(true);
+    actionShowGrid->setObjectName("actionShowGrid");
+    connect(actionShowGrid, SIGNAL(toggled(bool)),
+            this, SLOT(show_grid(bool)));
 
     menu->setProperty(prop_name, true);
   }
@@ -1490,6 +1495,12 @@ Scene_c3t3_item::setColor(QColor c)
   invalidateOpenGLBuffers();
   d->are_intersection_buffers_filled = false;
 }
+
+void Scene_c3t3_item::show_grid(bool b)
+{
+  d->is_grid_shown = b;
+  itemChanged();
+}
 void Scene_c3t3_item::show_spheres(bool b)
 {
   d->spheres_are_shown = b;
@@ -1564,28 +1575,4 @@ void Scene_c3t3_item::setPosition(float x, float y, float z) {
 void Scene_c3t3_item::setNormal(float x, float y, float z) {
   d->frame->setOrientation(x, y, z, 0.f);
 }
-
-bool Scene_c3t3_item::eventFilter(QObject* /*target*/, QEvent* event)
-{
-  if(event->type() == QEvent::KeyPress)
-  {
-    QKeyEvent *e = static_cast<QKeyEvent*>(event);
-    if(e->key() == Qt::Key_Control)
-    {
-      d->is_grid_shown = true;
-      itemChanged();
-    }
-  }
-  else if(event->type() == QEvent::KeyRelease)
-  {
-    QKeyEvent *e = static_cast<QKeyEvent*>(event);
-    if(e->key() == Qt::Key_Control)
-    {
-      d->is_grid_shown = false;
-      itemChanged();
-    }
-  }
-  return false;
-}
-
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -626,7 +626,7 @@ Scene_c3t3_item::build_histogram()
 
   d->histogram_ = QPixmap(width, height + text_height);
   d->histogram_.fill(QColor(192, 192, 192));
-#endif  
+#endif
 
   QPainter painter(&d->histogram_);
   painter.setPen(Qt::black);
@@ -809,18 +809,6 @@ void Scene_c3t3_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     d->spheres->setPlane(this->plane());
   }
 
-  vaos[Scene_c3t3_item_priv::Grid]->bind();
-  d->program = getShaderProgram(PROGRAM_WITHOUT_LIGHT);
-  attribBuffers(viewer, PROGRAM_WITHOUT_LIGHT);
-  d->program->bind();
-  d->program->setAttributeValue("colors", QColor(Qt::black));
-  QMatrix4x4 f_mat;
-  for (int i = 0; i<16; i++)
-    f_mat.data()[i] = d->frame->matrix()[i];
-  d->program->setUniformValue("f_matrix", f_mat);
-  viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(d->positions_grid.size() / 3));
-  d->program->release();
-  vaos[Scene_c3t3_item_priv::Grid]->release();
 
   Scene_group_item::draw(viewer);
 }
@@ -1184,7 +1172,7 @@ void Scene_c3t3_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *view
 
     item->vaos[Facets]->release();
     program->release();
-    
+
     positions_poly_size = positions_poly.size();
     positions_poly.clear();
     positions_poly.swap(positions_poly);
@@ -1213,7 +1201,7 @@ void Scene_c3t3_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *view
     positions_lines_size = positions_lines.size();
     positions_lines.clear();
     positions_lines.swap(positions_lines);
-    
+
   }
 
   // vao containing the data for the cnc
@@ -1404,7 +1392,7 @@ void Scene_c3t3_item_priv::computeElements()
     return;
   }
   //The facets
-  {  
+  {
     for (C3t3::Facet_iterator
       fit = c3t3.facets_begin(),
       end = c3t3.facets_end();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -118,7 +118,7 @@ public:
   void reset_intersection_item();
   void show_spheres(bool b);
   void show_intersection(bool b);
-
+  void show_grid(bool b);
   void show_cnc(bool b);
 
   virtual QPixmap graphicalToolTip() const;
@@ -136,7 +136,6 @@ public:
   protected:
     friend struct Scene_c3t3_item_priv;
     Scene_c3t3_item_priv* d;
-    bool eventFilter(QObject *, QEvent *);
 
 };
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -136,6 +136,7 @@ public:
   protected:
     friend struct Scene_c3t3_item_priv;
     Scene_c3t3_item_priv* d;
+    bool eventFilter(QObject *, QEvent *);
 
 };
 


### PR DESCRIPTION
This PR hides the grid when the corresponding action is checked in the context menu of a c3t3_item. This allows the taking of more beautiful screenshots.