### PR TITLE
Polyhedron_demo : fix the transparency in snapshots taken with Ctrl+C on Windows

### DIFF
--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1680,8 +1680,23 @@ void Viewer_impl::sendSnapshotToClipboard(Viewer *viewer)
   QImage * snap = takeSnapshot(viewer, 95, 1, 2*viewer->size(), 1, true);
   if(snap)
   {
+#if defined(_WIN32)
     QApplication::clipboard()->setImage(*snap);
-    delete snap;
+    QMimeData *mimeData = new QMimeData();
+    QByteArray ba;
+    QBuffer buffer(&ba);
+    buffer.open(QIODevice::WriteOnly);
+    snap->save(&buffer, "PNG"); // writes image into ba in PNG format
+    buffer.close();
+    mimeData->setData("PNG", ba);
+    //According to the doc, the ownership of mime_data is transferred to
+    //clipboard, so this is not a memory leak.
+    QApplication::clipboard()->setMimeData(mimeData);
+#else
+QApplication::clipboard()->setImage(*snap);
+#endif
+delete snap;
+
   }
 
 }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1693,7 +1693,7 @@ void Viewer_impl::sendSnapshotToClipboard(Viewer *viewer)
     //clipboard, so this is not a memory leak.
     QApplication::clipboard()->setMimeData(mimeData);
 #else
-QApplication::clipboard()->setImage(*snap);
+    QApplication::clipboard()->setImage(*snap);
 #endif
 delete snap;
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -15,6 +15,11 @@
 #include <cmath>
 #include <QApplication>
 
+#if defined(_WIN32)
+#include <QMimeData>
+#include <QByteArray>
+#include <QBuffer>
+#endif
 
 class Viewer_impl {
 public:

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1695,8 +1695,7 @@ void Viewer_impl::sendSnapshotToClipboard(Viewer *viewer)
 #else
     QApplication::clipboard()->setImage(*snap);
 #endif
-delete snap;
-
+    delete snap;
   }
 
 }


### PR DESCRIPTION
This PR fixes the transparency of the snapshots taken with Ctrl+C on Windows.
As the solutions for Linux and Windows are not compatible, it uses a #if defined.

 @janetournois @afabri please test this PR and tell me if this works.
Steps to test : 
- open any kind of item in the demo
- press Control + C
- paste in Gimp and check if the background is transparent