### PR TITLE
Polyhedron_demo : Save C3T3 items as vtu files

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -39,9 +39,9 @@ if (VTK_FOUND)
   if ("${VTK_VERSION_MAJOR}" GREATER "5")
     if(VTK_LIBRARIES)
       polyhedron_demo_plugin(vtk_plugin VTK_io_plugin)
-      target_link_libraries(vtk_plugin scene_polyhedron_item scene_polylines_item
-                                        vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML
-                                        vtkFiltersCore vtkFiltersSources)
+      target_link_libraries(vtk_plugin scene_polyhedron_item scene_polylines_item scene_c3t3_item
+                                       vtkCommonCore vtkIOCore vtkIOLegacy vtkIOXML
+                                       vtkFiltersCore vtkFiltersSources)
     else()
       message(STATUS "NOTICE : the vtk IO plugin needs VTK libraries and will not be compiled.")
     endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -18,6 +18,8 @@
 //                 Jane Tournois
 //
 
+#include <CGAL/Mesh_3/io_signature.h>
+#include "Scene_c3t3_item.h"
 #include <QtCore/qglobal.h>
 
 #include "Polyhedron_type.h"
@@ -42,6 +44,7 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/property_map.h>
+#include <CGAL/IO/Complex_3_in_triangulation_3_to_vtk.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkDataSetReader.h>
@@ -66,7 +69,7 @@
 #include <vtkCellArray.h>
 #include <vtkType.h>
 #include <vtkCommand.h>
-
+#include <vtkXMLUnstructuredGridWriter.h>
 namespace CGAL{
 
   class ErrorObserverVtk : public vtkCommand
@@ -271,17 +274,18 @@ public:
   typedef boost::graph_traits<Polyhedron>::face_descriptor face_descriptor;
 
   QString nameFilters() const {
-    return "VTK PolyData files (*.vtk);; VTK XML PolyData (*.vtp)"; }
+    return "VTK PolyData files (*.vtk);; VTK XML PolyData (*.vtp);; VTK XML UnstructuredGrid (*.vtu)"; }
   QString name() const { return "vtk_plugin"; }
 
   bool canSave(const CGAL::Three::Scene_item* item)
   {
-    return qobject_cast<const Scene_polyhedron_item*>(item);
+    return (qobject_cast<const Scene_polyhedron_item*>(item)
+            || qobject_cast<const Scene_c3t3_item*>(item));
   }
   bool save(const CGAL::Three::Scene_item* item, QFileInfo fileinfo)
   {
     std::string extension = fileinfo.suffix().toLower().toStdString();
-    if ( extension != "vtk" && extension != "vtp")
+    if ( extension != "vtk" && extension != "vtp" && extension != "vtu")
       return false;
 
     std::string output_filename = fileinfo.absoluteFilePath().toStdString();
@@ -289,9 +293,7 @@ public:
     const Scene_polyhedron_item* poly_item =
       qobject_cast<const Scene_polyhedron_item*>(item);
 
-    if (!poly_item)
-      return false;
-    else
+    if (poly_item)
     {
       if (extension != "vtp")
         CGAL::polygon_mesh_to_vtkUnstructured<vtkPolyDataWriter>(
@@ -301,6 +303,19 @@ public:
         CGAL::polygon_mesh_to_vtkUnstructured<vtkXMLPolyDataWriter>(
         *poly_item->polyhedron(),
         output_filename.data());
+    }
+    else
+    {
+      const Scene_c3t3_item* c3t3_item =
+          qobject_cast<const Scene_c3t3_item*>(item);
+      if(!c3t3_item || extension != "vtu")
+        return false;
+
+      vtkSmartPointer<vtkXMLUnstructuredGridWriter> writer =
+          vtkSmartPointer<vtkXMLUnstructuredGridWriter>::New();
+      writer->SetFileName( output_filename.data());
+      writer->SetInputData(CGAL::output_c3t3_to_vtk_unstructured_grid(c3t3_item->c3t3()));
+      writer->Write();
     }
     return true;
   }


### PR DESCRIPTION
This PR makes the VTK_IO_plugin able to save a c3t3_item as a .ctu file. 
Those files can be read by ParaView, for example.