### PR TITLE
Mesh_3:  Remove static variables

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
@@ -785,7 +785,7 @@ operator()(Visitor visitor)
 {
   //check criterion bound
   if ( sliver_criterion_.sliver_bound() == 0 )
-    sliver_criterion_.set_sliver_bound(Sc::default_value);
+    sliver_criterion_.set_sliver_bound(sliver_criterion_.get_default_value());
 
   // Reset sliver value cache
   helper_.reset_cache();

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -589,7 +589,7 @@ private:
     if ( 0 < limit_value )
       sliver_criteria_.set_sliver_bound(limit_value);
     else
-      sliver_criteria_.set_sliver_bound(SliverCriteria::max_value);
+      sliver_criteria_.set_sliver_bound(sliver_criteria_.get_max_value());
 
     this->cells_queue_clear();
     initialize_cells_priority_queue();

--- a/Mesh_3/include/CGAL/Mesh_3/sliver_criteria.h
+++ b/Mesh_3/include/CGAL/Mesh_3/sliver_criteria.h
@@ -46,6 +46,7 @@ public:
   typedef Cell_vector_ Cell_vector;
 
 public:
+  virtual double get_default_value() const = 0;
   virtual double get_max_value() const = 0;
   //Sliver_perturber performs perturbation "unit-per-unit"
   // so it needs to know how much is a unit for each criterion
@@ -116,10 +117,7 @@ protected:
 public:
   typedef typename Base::Cell_handle    Cell_handle;
 
-  static double default_value;
-  static double max_value;
-  static double min_value;
-
+  virtual double get_default_value() const { return 90.; }
   virtual double get_max_value() const { return 90.; }
   virtual double get_perturbation_unit() const { return 1.; }
 
@@ -161,12 +159,6 @@ private:
   mutable double min_value_before_move_;
 };
 
-template<typename Tr, bool update_sliver_cache> 
-double Min_dihedral_angle_criterion<Tr, update_sliver_cache>::default_value = 12.;
-template<typename Tr, bool update_sliver_cache> 
-double Min_dihedral_angle_criterion<Tr, update_sliver_cache>::max_value = 90.; 
-template<typename Tr, bool update_sliver_cache> 
-double Min_dihedral_angle_criterion<Tr, update_sliver_cache>::min_value = 0.; 
 
 template <typename Tr,
           bool update_sliver_cache = true>
@@ -181,10 +173,8 @@ protected:
   typedef Radius_ratio_criterion<Tr, update_sliver_cache> RR_criterion;
   
 public:
-  static double default_value;
-  static double max_value;
-  static double min_value;
 
+  virtual double get_default_value() const { return 0.25; }
   virtual double get_max_value() const { return 1.; }
   virtual double get_perturbation_unit() const { return 0.05; }
 
@@ -218,13 +208,6 @@ public:
 private:
   mutable double min_value_before_move_;
 };
-
-template<typename Tr, bool update_sliver_cache> 
-double Radius_ratio_criterion<Tr, update_sliver_cache>::default_value = 0.25; 
-template<typename Tr, bool update_sliver_cache> 
-double Radius_ratio_criterion<Tr, update_sliver_cache>::max_value = 1.;
-template<typename Tr, bool update_sliver_cache> 
-double Radius_ratio_criterion<Tr, update_sliver_cache>::min_value = 0.; 
 
 
 template<typename SliverCriterion, typename Cell_vector>

--- a/Mesh_3/include/CGAL/Mesh_3/sliver_criteria.h
+++ b/Mesh_3/include/CGAL/Mesh_3/sliver_criteria.h
@@ -117,7 +117,7 @@ protected:
 public:
   typedef typename Base::Cell_handle    Cell_handle;
 
-  virtual double get_default_value() const { return 90.; }
+  virtual double get_default_value() const { return 12.; }
   virtual double get_max_value() const { return 90.; }
   virtual double get_perturbation_unit() const { return 1.; }
 

--- a/Mesh_3/test/Mesh_3/test_meshing_utilities.h
+++ b/Mesh_3/test/Mesh_3/test_meshing_utilities.h
@@ -40,6 +40,7 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 
+#include <limits>
 #include <vector>
 #include <boost/optional/optional_io.hpp>
 
@@ -224,7 +225,7 @@ struct Tester
     typedef typename CGAL::Mesh_3::Min_dihedral_angle_criterion<Tr>   Criterion;
     typedef typename C3t3::Cells_in_complex_iterator                  Cell_iterator;
     
-    double min_value = Criterion::max_value;
+    double min_value = (std::numeric_limits<double>::max)();
     Criterion criterion(min_value, c3t3.triangulation());
     
     for ( Cell_iterator cit = c3t3.cells_in_complex_begin(),

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
@@ -598,7 +598,7 @@ protected:
     perturb_->set_time_limit(p_.time_limit);
     
     // Set sliver bound (0 means no sliver bound)
-    if ( 0 == p_.sliver_bound ) { p_.sliver_bound = Sc::max_value; }
+    if ( 0 == p_.sliver_bound ) { p_.sliver_bound = criterion_.get_max_value(); }
     
     // Launch perturber
     return (*perturb_)(Visitor(&status_));


### PR DESCRIPTION
After discussion with @janetournois  we decided to remove the static variables. They are not documented.

This solves the fist six items of Issue #1391. 
The other items concern debugging and will not be made multi thread safe.