### PR TITLE
Voronoi_2  Switch to transform_iterator

### DIFF
--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
@@ -27,6 +27,7 @@
 #include <CGAL/circulator.h>
 #include <CGAL/tags.h>
 #include <CGAL/use.h>
+#include <CGAL/assertions.h>
 
 #include <iostream>
 #include <iterator>
@@ -625,14 +626,7 @@ public:
   //---------------
  private:
   Locate_result locate(const Point_2& , const Tag_false&) const {
-    static unsigned int i = 0;
-    if ( i == 0 ) {
-      i++;
-      std::cerr << "Point location is not supported..." << std::endl;
-    }
-
-    // to avoid warnings/errors...
-    //    Face_handle f;
+    CGAL_assertion_msg(false, "Point location is not supported");
     return Locate_result();
   }
 

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2.h
@@ -23,7 +23,6 @@
 
 #include <CGAL/Voronoi_diagram_2/basic.h>
 #include <CGAL/iterator.h>
-#include <CGAL/Iterator_project.h>
 #include <CGAL/circulator.h>
 #include <CGAL/tags.h>
 #include <CGAL/use.h>
@@ -48,6 +47,7 @@
 #include <CGAL/Identity_policy_2.h>
 
 #include <boost/variant.hpp>
+#include <boost/iterator/transform_iterator.hpp>
 
 namespace CGAL {
 
@@ -253,18 +253,16 @@ class Voronoi_diagram_2
     typedef Face                                argument_type;
     typedef Site_2                              result_type;
 
-    Site_2& operator()(const Face& f) const {
-      static Site_2 s;
+    Site_2 operator()(const Face& f) const {
       // here we construct an adaptation traits; ideally we should get
       // the adaptation traits from the outer class
-      s = Adaptation_traits().access_site_2_object()(f.dual());
-      return s;
+      return Adaptation_traits().access_site_2_object()(f.dual());
     }
   };
 
  public:
-  typedef Iterator_project<Face_iterator,Project_site_2>
-  Site_iterator;
+
+  typedef boost::transform_iterator<Project_site_2, Face_iterator> Site_iterator;
 
   // ACCESSOR
   typedef CGAL_VORONOI_DIAGRAM_2_INS::Accessor<Self>  Accessor;

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Dummy_iterator.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Dummy_iterator.h
@@ -35,13 +35,14 @@ class Dummy_iterator : public Emptyset_iterator
   typedef Dummy_iterator<Value_t>  Self;
 
  public:
-  typedef Value_t            value_type;
-  typedef value_type&        reference;
-  typedef value_type*        pointer;
-  typedef const value_type&  const_reference;
-  typedef const value_type*  const_pointer;
-  typedef std::size_t        size_type;
-  typedef std::ptrdiff_t     difference_type;
+  typedef Value_t                         value_type;
+  typedef value_type&                     reference;
+  typedef value_type*                     pointer;
+  typedef const value_type&               const_reference;
+  typedef const value_type*               const_pointer;
+  typedef std::size_t                     size_type;
+  typedef std::ptrdiff_t                  difference_type;
+  typedef std::bidirectional_iterator_tag iterator_category;
 
   Dummy_iterator() {}
   Dummy_iterator(const Dummy_iterator&) {}


### PR DESCRIPTION
The usage of static was necessary for CGAL::Iterator_project
Dummy_iterator keeps its static, as the class is only used for concept checking

This solves Issue #1398
