### PR TITLE
Add index function in Compact container

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -1239,11 +1239,11 @@ namespace CGAL {
       for ( typename Dart_range::const_iterator it=darts().begin();
            it!=darts().end(); ++it)
       {
-        os << " dart " << &(*it) << "; beta[i]=";
+        os << " dart " << darts().index(it)<<"; beta[i]=";
         for ( unsigned int i=0; i<=dimension; ++i)
         {
-          os << &(*it->beta(i)) << ",\t";
-          if (it->is_free(i)) os << "\t";
+          if (is_free(it, i)) os << " - \t";
+          else os << darts().index(beta(it, i)) << ",\t";
         }
         if ( attribs )
         {

--- a/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_2_test.h
+++ b/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_2_test.h
@@ -79,7 +79,8 @@ bool test2D()
 
     dh = map.make_combinatorial_tetrahedron();
     cout << "Nombre de brins : " << map.number_of_darts() << endl;
-
+    map.display_darts(std::cout, true);
+    
     cout << "Parcours de CC : ";
     for ( typename Map::template Dart_of_orbit_range<1,2>::iterator it ( map, dh );
             it.cont();++it )

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -664,11 +664,11 @@ public:
       // elements) ?
       if ( p<c && c<(p+s-1) )
       {
+        CGAL_assertion_msg( (c-p)+p == c, "wrong alignment of iterator");
         return res+(c-p-1);
       }
 
       res += s-2;
-      CGAL_assertion_msg( (c-p)+p == c, "wrong alignment of iterator");
     }
 
     return (size_type)-1; // cit does not belong to this compact container

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -640,6 +640,40 @@ public:
     return alloc;
   }
 
+  // Returns the index of the iterator "cit", i.e. the number n so that
+  // operator[](n)==*cit.
+  // Complexity : O(#blocks) = O(sqrt(capacity())).
+  // This function is mostly useful for purposes of efficient debugging at
+  // higher levels.
+  size_type index(const_iterator cit) const
+  {
+    // We use the block structure to provide an efficient version :
+    // we check if the address is in the range of each block.
+
+    assert(cit != end());
+
+    const_pointer c = &*cit;
+    size_type res=0;
+
+    for (typename All_items::const_iterator it = all_items.begin(), itend = all_items.end();
+         it != itend; ++it) {
+      const_pointer p = it->first;
+      size_type s = it->second;
+
+      // Are we in the address range of this block (excluding first and last
+      // elements) ?
+      if ( p<c && c<(p+s-1) )
+      {
+        return res+(c-p-1);
+      }
+
+      res += s-2;
+      CGAL_assertion_msg( (c-p)+p == c, "wrong alignment of iterator");
+    }
+
+    return (size_type)-1; // cit does not belong to this compact container
+  }
+
   // Returns whether the iterator "cit" is in the range [begin(), end()].
   // Complexity : O(#blocks) = O(sqrt(capacity())).
   // This function is mostly useful for purposes of efficient debugging at

--- a/STL_Extension/test/STL_Extension/test_Compact_container_is_used.cpp
+++ b/STL_Extension/test/STL_Extension/test_Compact_container_is_used.cpp
@@ -43,6 +43,16 @@ int main()
       std::cout<<"PB new emplace element is not used (2)."<<std::endl;
       return EXIT_FAILURE;
     }
+    if ( c1.index(it)!=nb )
+    {
+      std::cout<<"PB index of new emplace element is not correct."<<std::endl;
+      return EXIT_FAILURE;
+    }
+    if ( &(c1[nb])!=&*it )
+    {
+      std::cout<<"PB operator[] gives a wrong result."<<std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   nb=0;


### PR DESCRIPTION
This function allows to retreive the index of a given handle. This is particularly usefull to debug code based on compact container. This allows to write index (small numbers) instead of pointers.

This function is undocumented because it is mainly for cgal developers; and thus there is no modification of api, and thus no small feature.

I used this function in CMap test in order to test it.