### PR TITLE
Some bugfixes in CMap and LCC

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -84,6 +84,8 @@ namespace CGAL {
     friend struct internal::Reverse_orientation_of_connected_component_functor;
     template<typename CMap>
     friend struct internal::Init_attribute_functor;
+    template<typename CMap>
+    friend struct Swap_attributes_functor;
 
   public:
     template < unsigned int A, class B, class I, class D, class S >
@@ -203,10 +205,13 @@ namespace CGAL {
 
       this->mnb_used_marks = amap.mnb_used_marks;
       this->mmask_marks    = amap.mmask_marks;
+      this->automatic_attributes_management =
+          amap.automatic_attributes_management;
 
       for (size_type i = 0; i < NB_MARKS; ++i)
       {
         this->mfree_marks_stack[i]        = amap.mfree_marks_stack[i];
+        this->mused_marks_stack[i]        = amap.mused_marks_stack[i];
         this->mindex_marks[i]             = amap.mindex_marks[i];
         this->mnb_marked_darts[i]         = amap.mnb_marked_darts[i];
         this->mnb_times_reserved_marks[i] = amap.mnb_times_reserved_marks[i];
@@ -323,7 +328,10 @@ namespace CGAL {
     {
       if (this!=&amap)
       {
-        amap.mdarts.swap(mdarts);
+        mdarts.swap(amap.mdarts);
+
+        Helper::template Foreach_enabled_attributes
+          < internal::Swap_attributes_functor <Self> >::run(this, &amap);
 
         std::swap_ranges(mnb_times_reserved_marks,
                          mnb_times_reserved_marks+NB_MARKS,
@@ -338,9 +346,11 @@ namespace CGAL {
                          amap.mused_marks_stack);
         std::swap_ranges(mnb_marked_darts,mnb_marked_darts+NB_MARKS,
                          amap.mnb_marked_darts);
-        mattribute_containers.swap(amap.mattribute_containers);
         std::swap(null_dart_handle, amap.null_dart_handle);
         this->mnull_dart_container.swap(amap.mnull_dart_container);
+
+        std::swap(automatic_attributes_management,
+                  amap.automatic_attributes_management);
       }
     }
 
@@ -487,8 +497,11 @@ namespace CGAL {
       }
 
       // 2) We update the attribute_ref_counting.
-      Helper::template Foreach_enabled_attributes
-        <internal::Decrease_attribute_functor<Self> >::run(this,adart);
+      if ( are_attributes_automatically_managed() )
+      {
+        Helper::template Foreach_enabled_attributes
+            <internal::Decrease_attribute_functor<Self> >::run(this,adart);
+      }
 
       // 3) We erase the dart.
       mdarts.erase(adart);
@@ -2455,6 +2468,7 @@ namespace CGAL {
         if ( marks[acells[i]]==INVALID_MARK )
         {
           marks[acells[i]] = get_new_mark();
+          assert(is_whole_map_unmarked(marks[acells[i]]));
         }
       }
 
@@ -3693,7 +3707,7 @@ namespace CGAL {
               class Storage2>
     bool is_isomorphic_to(const Combinatorial_map_base
                           <d2,Refs2,Items2,Alloc2, Storage2>& map2,
-                          bool testAttributes=true)
+                          bool testAttributes=true) const
     {
       // if ( dimension!=map2.dimension ) return false;
 

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -497,11 +497,8 @@ namespace CGAL {
       }
 
       // 2) We update the attribute_ref_counting.
-      if ( are_attributes_automatically_managed() )
-      {
-        Helper::template Foreach_enabled_attributes
-            <internal::Decrease_attribute_functor<Self> >::run(this,adart);
-      }
+      Helper::template Foreach_enabled_attributes
+        <internal::Decrease_attribute_functor<Self> >::run(this,adart);
 
       // 3) We erase the dart.
       mdarts.erase(adart);
@@ -596,7 +593,8 @@ namespace CGAL {
       {
         this->template get_attribute<i>(this->template attribute<i>(dh)).
           dec_nb_refs();
-        if ( this->template get_attribute<i>(this->template attribute<i>(dh)).
+        if ( this->are_attributes_automatically_managed() &&
+             this->template get_attribute<i>(this->template attribute<i>(dh)).
              get_nb_refs()==0 )
           this->template erase_attribute<i>(this->template attribute<i>(dh));
       }
@@ -1229,6 +1227,10 @@ namespace CGAL {
           CGAL_assertion( is_whole_map_marked(marks[i]) );
           free_mark(marks[i]);
         }
+
+      Helper::template
+        Foreach_enabled_attributes<internal::Cleanup_useless_attributes<Self> >::
+          run(this);
     }
 
     /// @return the number of darts.

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -4752,17 +4752,17 @@ namespace CGAL {
     { Base::template copy<Self>(amap); }
 
     template < class CMap >
-    Combinatorial_map(const CMap & amap)
+    Combinatorial_map(const CMap & amap) : Base()
     { Base::template copy<CMap>(amap); }
 
     template < class CMap, typename Converters >
-    Combinatorial_map(const CMap & amap, const Converters& converters)
+    Combinatorial_map(const CMap & amap, const Converters& converters) : Base()
     { Base::template copy<CMap, Converters>
           (amap, converters); }
 
     template < class CMap, typename Converters, typename Pointconverter >
     Combinatorial_map(const CMap & amap, const Converters& converters,
-                      const Pointconverter& pointconverter)
+                      const Pointconverter& pointconverter) : Base()
     { Base::template copy<CMap, Converters, Pointconverter>
           (amap, converters, pointconverter); }
   };

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
@@ -34,6 +34,9 @@
  * internal/Combinatorial_map_group_functors.h. Public functions are defined
  * in Combinatorial_map_functors.h.
  *
+ * internal::Swap_attributes_functor<CMap> to swap the i-attributes between
+ *    two cmaps having same type
+ *
  * internal::Call_split_functor<CMap,i> to call the OnSplit functors on two
  *    given i-attributes.
  *
@@ -84,6 +87,20 @@ struct Is_attribute_has_point;
 // ****************************************************************************
 namespace internal
 {
+// ****************************************************************************
+/// Swap i-attribute between the two maps having same type.
+template<typename CMap>
+struct Swap_attributes_functor
+{
+  template<unsigned int i>
+  static void run( CMap* cmap1,
+                   CMap* cmap2)
+  { CGAL::cpp11::get<CMap::Helper::template Dimension_index<i>::value>
+        (cmap1->mattribute_containers).swap(
+          CGAL::cpp11::get<CMap::Helper::template Dimension_index<i>::value>
+          (cmap2->mattribute_containers));
+   }
+};
 // ****************************************************************************
 // Functor which call Functor::operator() on the two given cell_attributes
  template<typename CMap, typename Cell_attribute, typename Functor>

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_internal_functors.h
@@ -75,6 +75,11 @@
  *
  * internal::Init_attribute_functor to initialize all attributes to NULL.
  *
+ * internal::Correct_invalid_attributes_functor to correct the i-attribute
+ *   associated with a given i-cell
+ *
+ * internal::Cleanup_useless_attributes to erase all attributes having
+ *   no more associated dart
  */
 
 namespace CGAL
@@ -292,7 +297,6 @@ struct Correct_invalid_attributes_functor
                   typename CMap::Dart_handle adart,
                   std::vector<size_type>* marks)
   {
-    // std::cout << "Correct_invalid_attributes_functor for " << i << "-cell" << std::endl;
     CGAL_static_assertion_msg(CMap::Helper::template
                               Dimension_index<i>::value>=0,
                               "Correct_invalid_attributes_functor<i> but "
@@ -340,6 +344,30 @@ struct Correct_invalid_attributes_functor
       typename CMap::template Attribute_handle<i>::type
         a2=amap->template create_attribute<i>(amap->template get_attribute<i>(a));
       amap->template set_attribute<i>(adart, a2);
+    }
+  }
+};
+// ****************************************************************************
+/// Functor used to erase all attributes having no more associated dart
+template<typename CMap>
+struct Cleanup_useless_attributes
+{
+  template <unsigned int i>
+  static void run(CMap* amap)
+  {
+    CGAL_static_assertion_msg(CMap::Helper::template
+                              Dimension_index<i>::value>=0,
+                              "Cleanup_useless_attributes<i> but "
+                              " i-attributes are disabled");
+
+    for ( typename CMap::template Attribute_range<i>::type::iterator
+            it=amap->template attributes<i>().begin(),
+            itend=amap->template attributes<i>().end(); it!=itend; ++it )
+    {
+      if ( amap->template get_attribute<i>(it).get_nb_refs()==0 )
+      {
+        amap->template erase_attribute<i>(it);
+      }
     }
   }
 };
@@ -407,7 +435,8 @@ struct Decrease_attribute_functor_run
     {
       amap->template get_attribute<i>(amap->template attribute<i>(adart)).
         dec_nb_refs();
-      if ( amap->template get_attribute<i>(amap->template attribute<i>(adart)).
+      if ( amap->are_attributes_automatically_managed() &&
+           amap->template get_attribute<i>(amap->template attribute<i>(adart)).
            get_nb_refs()==0 )
         amap->template erase_attribute<i>(amap->template attribute<i>(adart));
     }

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex.h
@@ -40,8 +40,6 @@ inherit from any model of the `CombinatorialMap` concept.
 \sa `LinearCellComplexTraits`
 \sa `CGAL::Linear_cell_complex_traits<d,K>`
 
-\deprecated Since \cgal 4.4, `vertex_attribute` and `point` methods are no more static. You can define the `CGAL_CMAP_DEPRECATED` macro to keep the old behavior.
-
 */
 template< typename d, typename d2, typename LCCTraits, typename Items, typename Alloc >
 class Linear_cell_complex  : public Combinatorial_map<d,Items,Alloc>

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
@@ -153,6 +153,20 @@ namespace CGAL {
     { Base::template copy<LCC2, Converters, Pointconverter>
           (alcc, converters, pointconverter);}
 
+    /** Affectation operation. Copies one map to the other.
+     * @param amap a lcc.
+     * @return A copy of that lcc.
+     */
+    Self & operator= (const Self & alcc)
+    {
+      if (this!=&alcc)
+      {
+        Self tmp(alcc);
+        this->swap(tmp);
+      }
+      return *this;
+    }
+
     /** Create a vertex attribute.
      * @return an handle on the new attribute.
      */
@@ -478,7 +492,7 @@ namespace CGAL {
                  are_facets_same_geometry(*it1,beta(*it2, 0)) )
             {
               ++res;
-              this->template sew<3>(*it1,beta(*it2, 0));
+              this->template sew<3>(*it1,this->beta(*it2, 0));
             }
           }
         }

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
@@ -136,20 +136,20 @@ namespace CGAL {
      *  @param alcc the linear cell complex to copy.
      *  @post *this is valid.
      */
-    Linear_cell_complex_base(const Self & alcc)
+    Linear_cell_complex_base(const Self & alcc) : Base()
     { Base::template copy<Self>(alcc); }
 
     template < class LCC2 >
-    Linear_cell_complex_base(const LCC2& alcc)
+    Linear_cell_complex_base(const LCC2& alcc) : Base()
     { Base::template copy<LCC2>(alcc);}
 
     template < class LCC2, typename Converters >
-    Linear_cell_complex_base(const LCC2& alcc, Converters& converters)
+    Linear_cell_complex_base(const LCC2& alcc, Converters& converters) : Base()
     { Base::template copy<LCC2, Converters>(alcc, converters);}
 
     template < class LCC2, typename Converters, typename Pointconverter >
     Linear_cell_complex_base(const LCC2& alcc, Converters& converters,
-                        const Pointconverter& pointconverter)
+                             const Pointconverter& pointconverter) : Base()
     { Base::template copy<LCC2, Converters, Pointconverter>
           (alcc, converters, pointconverter);}
 
@@ -908,16 +908,16 @@ namespace CGAL {
       { Base::template copy<Self>(alcc); }
 
       template < class LCC2 >
-      Linear_cell_complex(const LCC2& alcc)
+      Linear_cell_complex(const LCC2& alcc) : Base()
       { Base::template copy<LCC2>(alcc);}
 
       template < class LCC2, typename Converters >
-      Linear_cell_complex(const LCC2& alcc, Converters& converters)
+      Linear_cell_complex(const LCC2& alcc, Converters& converters) : Base()
       { Base::template copy<LCC2, Converters>(alcc, converters);}
 
       template < class LCC2, typename Converters, typename Pointconverter >
       Linear_cell_complex(const LCC2& alcc, Converters& converters,
-                                    const Pointconverter& pointconverter)
+                          const Pointconverter& pointconverter) : Base()
       { Base::template copy<LCC2, Converters, Pointconverter>
             (alcc, converters, pointconverter);}
 

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex.h
@@ -290,29 +290,6 @@ namespace CGAL {
     typename Base::size_type number_of_vertex_attributes() const
     { return Base::template number_of_attributes<0>(); }
 
-#ifdef CGAL_CMAP_DEPRECATED
-    static Vertex_attribute_handle vertex_attribute(Dart_handle adart)
-    {
-      CGAL_assertion(adart!=NULL);
-      return adart->template attribute<0>();
-    }
-   static Vertex_attribute_const_handle vertex_attribute(Dart_const_handle
-                                                          adart)
-    {
-      CGAL_assertion(adart!=NULL);
-      return adart->template attribute<0>();
-    }
-    static Point& point(Dart_handle adart)
-    {
-      CGAL_assertion(adart!=NULL && adart->template attribute<0>()!=NULL );
-      return adart->template attribute<0>()->point();
-    }
-    static const Point& point(Dart_const_handle adart)
-    {
-      CGAL_assertion(adart!=NULL && adart->template attribute<0>()!=NULL );
-      return adart->template attribute<0>()->point();
-    }
-#else
     /// Get the vertex_attribute associated with a dart.
     /// @param a dart
     /// @return the vertex_attribute.
@@ -343,17 +320,6 @@ namespace CGAL {
       CGAL_assertion(this->template attribute<0>(adart)!=null_handle );
       return point_of_vertex_attribute(this->template attribute<0>(adart));
     }
-#endif // CGAL_CMAP_DEPRECATED
-
-    // Temporary methods to allow to write lcc->temp_vertex_attribute
-    // even with the old method. Depending if CGAL_CMAP_DEPRECATED is defined or not
-    // call the static method or the new method. To remove when we remove the
-    // old code.
-    Vertex_attribute_handle temp_vertex_attribute(Dart_handle adart)
-    {return vertex_attribute(adart); }
-    Vertex_attribute_const_handle
-    temp_vertex_attribute(Dart_const_handle adart) const
-    {return vertex_attribute(adart); }
 
     /** Test if the lcc is valid.
      * A Linear_cell_complex is valid if it is a valid Combinatorial_map with
@@ -411,6 +377,10 @@ namespace CGAL {
           CGAL_assertion( this->is_whole_map_marked(marks[i]) );
           free_mark(marks[i]);
         }
+
+      Helper::template
+        Foreach_enabled_attributes<internal::Cleanup_useless_attributes<Self> >::
+          run(this);
     }
 
     /** test if the two given facets have the same geometry

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -165,7 +165,6 @@ namespace CGAL {
     return first;
   }
 
-
   template < class LCC >
   void load_off(LCC& alcc, std::istream& in)
   {

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
@@ -65,7 +65,7 @@ namespace CGAL {
       {
         lcc.template link_beta<1>(prev_dart, cur);
 
-        Dart_handle opposite=find_dart_between(i,lcc.temp_vertex_attribute(prev_dart));
+        Dart_handle opposite=find_dart_between(i,lcc.vertex_attribute(prev_dart));
         if ( opposite!=lcc.null_handle )
         {
           CGAL_assertion( lcc.template is_free<2>(opposite) );
@@ -91,7 +91,7 @@ namespace CGAL {
       lcc.template link_beta<1>(prev_dart, first_dart);
 
       Dart_handle opposite =
-        find_dart_between(first_vertex,lcc.temp_vertex_attribute(prev_dart));
+        find_dart_between(first_vertex,lcc.vertex_attribute(prev_dart));
       if ( opposite!=lcc.null_handle )
       {
         CGAL_assertion( lcc.template is_free<2>(opposite) );
@@ -131,7 +131,7 @@ namespace CGAL {
 
       for ( ; it!=itend; ++it )
       {
-        if ( lcc.temp_vertex_attribute(lcc.template beta<1>(*it))==vh ) return (*it);
+        if ( lcc.vertex_attribute(lcc.template beta<1>(*it))==vh ) return (*it);
       }
       return lcc.null_handle;
     }

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_storages.h
@@ -65,7 +65,7 @@ namespace CGAL {
     typedef typename Dart_container::size_type      size_type;
 
     typedef CGAL::Void* Null_handle_type;
-    static Null_handle_type null_handle;
+    static const Null_handle_type null_handle;
 
     typedef Items_ Items;
     typedef Alloc_ Alloc;
@@ -86,14 +86,14 @@ namespace CGAL {
     {};
     template<int i>
     struct Attribute_const_handle:
-        public Helper::template Attribute_const_handle<i>
+      public Helper::template Attribute_const_handle<i>
     {};
     template<int i>
     struct Attribute_range: public Helper::template Attribute_range<i>
     {};
     template<int i>
     struct Attribute_const_range:
-        public Helper::template Attribute_const_range<i>
+      public Helper::template Attribute_const_range<i>
     {};
 
     typedef typename Attribute_type<0>::type Vertex_attribute;
@@ -116,21 +116,15 @@ namespace CGAL {
     // Init
     void init_storage()
     {
-#ifdef CGAL_CMAP_DEPRECATED
-      // We must do this ony once, but problem because null_dart_handle
-      // is static !
-      if ( mnull_dart_container.empty() )
-#endif // CGAL_CMAP_DEPRECATED
-      { // emplace null_dart; initialized in Combinatorial_map class
-        null_dart_handle = mnull_dart_container.emplace();
-      }
+      // emplace null_dart; initialized in Combinatorial_map class
+      null_dart_handle = mnull_dart_container.emplace();
     }
 
-    /** Return if this dart is free for adimension.
-       * @param dh a dart handle
-       * @param i the dimension.
-       * @return true iff dh is linked with NULL for \em adimension.
-       */
+   /** Return if this dart is free for adimension.
+     * @param dh a dart handle
+     * @param i the dimension.
+     * @return true iff dh is linked with NULL for \em adimension.
+     */
     template<unsigned int i>
     bool is_free(Dart_const_handle dh) const
     {
@@ -208,24 +202,24 @@ namespace CGAL {
     typename Attribute_handle<i>::type attribute(Dart_handle ADart)
     {
       CGAL_static_assertion_msg(Helper::template Dimension_index<i>::value>=0,
-                       "attribute<i> called but i-attributes are disabled.");
+                     "attribute<i> called but i-attributes are disabled.");
       return CGAL::cpp11::get<Helper::template Dimension_index<i>::value>
-          (ADart->mattribute_handles);
+        (ADart->mattribute_handles);
     }
     template<unsigned int i>
     typename Attribute_const_handle<i>::type
     attribute(Dart_const_handle ADart) const
     {
       CGAL_static_assertion_msg(Helper::template Dimension_index<i>::value>=0,
-                       "attribute<i> called but i-attributes are disabled.");
+                     "attribute<i> called but i-attributes are disabled.");
       return CGAL::cpp11::get<Helper::template Dimension_index<i>::value>
-          (ADart->mattribute_handles);
+        (ADart->mattribute_handles);
     }
 
     // get the attribute given its handle
     template<unsigned int i>
-    typename Attribute_type<i>::type& get_attribute
-    (typename Attribute_handle<i>::type ah)
+    typename Attribute_type<i>::type&
+    get_attribute(typename Attribute_handle<i>::type ah)
     {
       CGAL_assertion( ah!=NULL );
       return *ah;
@@ -257,8 +251,8 @@ namespace CGAL {
       return ah->dart();
     }
     template<unsigned int i>
-    Dart_const_handle dart_of_attribute
-    (typename Attribute_const_handle<i>::type ah) const
+    Dart_const_handle
+    dart_of_attribute(typename Attribute_const_handle<i>::type ah) const
     {
       CGAL_assertion( ah!=NULL );
       return ah->dart();
@@ -289,7 +283,7 @@ namespace CGAL {
       return ah->info();
     }
 
-    // Get the info of the given dart
+    // Get the info of the i-cell attribute associated with the given dart
     template<unsigned int i>
     typename Attribute_type<i>::type::Info & info(Dart_handle adart)
     {
@@ -350,14 +344,14 @@ namespace CGAL {
                                   typename Attribute_handle<i>::type ah)
     {
       CGAL::cpp11::get<Helper::template Dimension_index<i>::value>
-          (dh->mattribute_handles) = ah;
+        (dh->mattribute_handles) = ah;
     }
 
     /** Link a dart with a given dart for a given dimension.
-       * @param adart the dart to link.
-       * @param adart2 the dart to link with.
-       * @param i the dimension.
-       */
+     * @param adart the dart to link.
+     * @param adart2 the dart to link with.
+     * @param i the dimension.
+     */
     template<unsigned int i>
     void dart_link_beta(Dart_handle adart, Dart_handle adart2)
     {
@@ -375,9 +369,9 @@ namespace CGAL {
     }
 
     /** Unlink a dart for a given dimension.
-       * @param adart a dart.
-       * @param i the dimension.
-       */
+     * @param adart a dart.
+     * @param i the dimension.
+     */
     template<unsigned int i>
     void dart_unlink_beta(Dart_handle adart)
     {
@@ -392,9 +386,6 @@ namespace CGAL {
 
   public:
     /// Void dart. A dart d is i-free if beta_i(d)=null_dart_handle.
-#ifdef CGAL_CMAP_DEPRECATED
-    static
-#endif // CGAL_CMAP_DEPRECATED
     Dart_handle null_dart_handle; // Todo Dart_const_handle ??
 
   protected:
@@ -402,9 +393,6 @@ namespace CGAL {
     Dart_container mdarts;
 
     /// Container for the null_dart_handle, static data member.
-#ifdef CGAL_CMAP_DEPRECATED
-    static
-#endif // CGAL_CMAP_DEPRECATED
     Dart_container mnull_dart_container;
 
     /// Tuple of attributes containers
@@ -414,32 +402,10 @@ namespace CGAL {
   /// null_handle
   template <unsigned int d_, unsigned int ambient_dim,
            class Traits_, class Items_, class Alloc_ >
-  typename Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
+  const typename Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
                                          Items_, Alloc_>::Null_handle_type
   Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
                                 Items_, Alloc_>::null_handle = NULL;
-
-#ifdef CGAL_CMAP_DEPRECATED
-  /// Allocation of static data members
-  /// mnull_dart_container
-  template <unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
-  typename Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::Dart_container
-  Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::mnull_dart_container;
-
-  /// null_dart_handle
-  template <unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
-  typename Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::Dart_handle
-  Linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::null_dart_handle;
-  // =  mnull_dart_container.emplace( std::bitset<NB_MARKS>() );
-  // Does not work on windows => segfault
-  // Thus we initialize null_dart_handle in the Combinatorial_map constructor
-#endif // CGAL_CMAP_DEPRECATED
 
 } // namespace CGAL
 

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
@@ -104,7 +104,7 @@ void display_lcc(LCC& lcc)
     for ( unsigned int i=0; i<=LCC::dimension; ++i)
     {
       std::cout << &(*it->beta(i)) << ",\t";
-      if (it->is_free(i)) std::cout << "\t";
+      if (lcc.is_free(it, i)) std::cout << "\t";
     }
     std::cout<<it->template attribute<0>()->point();
     std::cout << std::endl;
@@ -129,6 +129,29 @@ bool test_LCC_2()
   Dart_handle dh3=lcc.make_segment(Point(2,2),Point(3,1));
   if ( !check_number_of_cells_2(lcc, 6, 3, 6, 3) )
     return false;
+
+  { // Test swap operator
+    LCC lcc2;
+    lcc2.swap(lcc);
+    if ( !check_number_of_cells_2(lcc, 0, 0, 0, 0) )
+      return false;
+    if ( !check_number_of_cells_2(lcc2, 6, 3, 6, 3) )
+      return false;
+
+    lcc.swap(lcc2);
+    if ( !check_number_of_cells_2(lcc2, 0, 0, 0, 0) )
+      return false;
+    if ( !check_number_of_cells_2(lcc, 6, 3, 6, 3) )
+      return false;
+
+    // And test operator=
+    LCC lcc3;
+    lcc3=lcc;
+    if ( !check_number_of_cells_2(lcc3, 6, 3, 6, 3) )
+      return false;
+    if (!lcc.is_isomorphic_to(lcc3))
+      return false;
+  }
 
   typename LCC::Vertex_attribute_handle vh=lcc.template attribute<0>(dh1);
   if (!lcc.template is_attribute_used<0>(vh)) return false;

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
@@ -664,6 +664,10 @@ bool testCopy()
             map5b.number_of_attributes<2>()==map5.number_of_attributes<2>() &&
             map5b.number_of_attributes<3>()==map5.number_of_attributes<3>() );
     assert( map5b.is_isomorphic_to(map5)==map5.is_isomorphic_to(map5b) );
+
+    Map9 map5c;
+    map5c=map5b; // To test operator=
+    if ( !map5c.is_isomorphic_to(map5b) ) { assert(false); return false; }
   }
 
   /*map2.display_characteristics(std::cout)<<std::endl;

--- a/Polyhedron/include/CGAL/import_from_polyhedron_3.h
+++ b/Polyhedron/include/CGAL/import_from_polyhedron_3.h
@@ -33,7 +33,7 @@ namespace CGAL {
    * @return A dart created during the convertion.
    */
   template< class LCC, class Polyhedron >
-  typename LCC::Dart_handle import_from_polyhedron_3(LCC& alcc, 
+  typename LCC::Dart_handle import_from_polyhedron_3(LCC& alcc,
                                                      const Polyhedron &apoly)
   {
     CGAL_static_assertion( LCC::dimension>=2 && LCC::ambient_dimension==3 );
@@ -43,7 +43,7 @@ namespace CGAL {
     typedef typename Polyhedron::Halfedge_around_facet_const_circulator
       HF_circulator;
 
-    typedef std::map < Halfedge_handle, typename LCC::Dart_handle> 
+    typedef std::map < Halfedge_handle, typename LCC::Dart_handle>
       Halfedge_handle_map;
     typedef typename Halfedge_handle_map::iterator itmap_hds;
     Halfedge_handle_map TC;
@@ -61,7 +61,7 @@ namespace CGAL {
       {
         d = alcc.create_dart();
         TC[j] = d;
-      
+
         if (prev != LCC::null_handle) alcc.template link_beta<1>(prev, d);
         else firstFacet = d;
         it = TC.find(j->opposite());

--- a/Polyhedron/include/CGAL/import_from_polyhedron_3.h
+++ b/Polyhedron/include/CGAL/import_from_polyhedron_3.h
@@ -82,7 +82,7 @@ namespace CGAL {
       do
       {
         d = TC[j]; // Get the dart associated to the Halfedge
-        if (alcc.temp_vertex_attribute(d) == LCC::null_handle)
+        if (alcc.vertex_attribute(d) == LCC::null_handle)
         {
           alcc.set_vertex_attribute
             (d, alcc.create_vertex_attribute(j->opposite()->vertex()->point()));

--- a/Triangulation_3/include/CGAL/import_from_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/import_from_triangulation_3.h
@@ -123,8 +123,8 @@ namespace CGAL {
             case 2: neighbor = alcc.beta(maptcell_it->second, 2); break;
             case 3: neighbor = maptcell_it->second; break;
             }
-            while (alcc.temp_vertex_attribute(neighbor) !=
-                   alcc.temp_vertex_attribute(alcc.other_extremity(cur)) )
+            while (alcc.vertex_attribute(neighbor) !=
+                   alcc.vertex_attribute(alcc.other_extremity(cur)) )
               neighbor = alcc.beta(neighbor,1);
             alcc.template topo_sew<3>(cur, neighbor);
           }

--- a/Triangulation_3/include/CGAL/import_from_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/import_from_triangulation_3.h
@@ -40,7 +40,7 @@ namespace CGAL {
             typename LCC::Dart_handle >* avol_to_dart=NULL)
   {
     CGAL_static_assertion( LCC::dimension>=3 && LCC::ambient_dimension==3 );
-    
+
     // Case of empty triangulations.
     if (atr.number_of_vertices() == 0) return LCC::null_handle;
 
@@ -70,7 +70,7 @@ namespace CGAL {
     std::map<typename Triangulation::Cell_handle, typename LCC::Dart_handle> TC;
     std::map<typename Triangulation::Cell_handle, typename LCC::Dart_handle>*
       mytc = (avol_to_dart==NULL?&TC:avol_to_dart);
-    
+
     itmap_tcell maptcell_it;
 
     typename LCC::Dart_handle res=LCC::null_handle, dart=LCC::null_handle;
@@ -100,7 +100,7 @@ namespace CGAL {
           else if ( it->vertex(3) == atr.infinite_vertex() )
             dart = alcc.beta(res, 2, 0);
         }
-        
+
         for (unsigned int i = 0; i < 4; ++i)
         {
           switch (i)


### PR DESCRIPTION
* Bugfix in Combinatorial_map::copy and Combinatorial_map::swap
* Bugfix in erase dart if automatic attribute are disabled
* Add missing operator= in Linear_cell_complex
* Remove deprecated code in Linear_cell_complex storage (code which was already removed in Combinatorial_map_storage and not in LCC)
* add const for isomorphic function
* add more tests
* fix #1405 

No API modification; thus no feature/small feature associated with this PR.