### PR TITLE
More bbox 3 overloads for face graph models

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -130,6 +130,9 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_slicer`
 - `CGAL::Side_of_triangle_mesh`
 - `CGAL::Polygon_mesh_processing::bbox_3()`
+- `CGAL::Polygon_mesh_processing::vertex_bbox_3()`
+- `CGAL::Polygon_mesh_processing::edge_bbox_3()`
+- `CGAL::Polygon_mesh_processing::face_bbox_3()`
 - `CGAL::Polygon_mesh_processing::border_halfedges()`
 
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -130,9 +130,6 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_slicer`
 - `CGAL::Side_of_triangle_mesh`
 - `CGAL::Polygon_mesh_processing::bbox_3()`
-- `CGAL::Polygon_mesh_processing::vertex_bbox_3()`
-- `CGAL::Polygon_mesh_processing::edge_bbox_3()`
-- `CGAL::Polygon_mesh_processing::face_bbox_3()`
 - `CGAL::Polygon_mesh_processing::border_halfedges()`
 
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -129,6 +129,9 @@ and provides a list of the parameters that are used in this package.
 ## Miscellaneous ##
 - `CGAL::Polygon_mesh_slicer`
 - `CGAL::Side_of_triangle_mesh`
+- `CGAL::Polygon_mesh_processing::vertex_bbox_3()`
+- `CGAL::Polygon_mesh_processing::edge_bbox_3()`
+- `CGAL::Polygon_mesh_processing::face_bbox_3()`
 - `CGAL::Polygon_mesh_processing::bbox_3()`
 - `CGAL::Polygon_mesh_processing::border_halfedges()`
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -129,10 +129,10 @@ and provides a list of the parameters that are used in this package.
 ## Miscellaneous ##
 - `CGAL::Polygon_mesh_slicer`
 - `CGAL::Side_of_triangle_mesh`
+- `CGAL::Polygon_mesh_processing::bbox_3()`
 - `CGAL::Polygon_mesh_processing::vertex_bbox_3()`
 - `CGAL::Polygon_mesh_processing::edge_bbox_3()`
 - `CGAL::Polygon_mesh_processing::face_bbox_3()`
-- `CGAL::Polygon_mesh_processing::bbox_3()`
 - `CGAL::Polygon_mesh_processing::border_halfedges()`
 
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -52,13 +52,13 @@ namespace CGAL {
     *
     * @return a bounding box of `pmesh`
     */
-    template<typename PolygonMesh, typename NamedParameters>
+    template<typename PolygonMesh, typename CGAL_PMP_NP_TEMPLATE_PARAMETERS>
     CGAL::Bbox_3 bbox_3(const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+                        const CGAL_PMP_NP_CLASS& np)
     {
       using boost::choose_param;
       using boost::get_param;
-      typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
+      typename GetVertexPointMap<PolygonMesh, CGAL_PMP_NP_CLASS>::const_type
         vpm = choose_param(get_param(np, vertex_point),
                            get_const_property_map(CGAL::vertex_point, pmesh));
 
@@ -73,13 +73,144 @@ namespace CGAL {
       return bb;
     }
 
+    /*!
+    * \ingroup PkgPolygonMeshProcessing
+    *  computes a bounding box of a vertex of a polygon mesh.
+    *
+    * @tparam PolygonMesh a model of `HalfedgeGraph`
+    * @tparam NamedParameters a sequence of \ref namedparameters
+    *
+    * @param vd a descriptor of a vertex in `pmesh`
+    * @param pmesh a polygon mesh
+    * @param np optional sequence of \ref namedparameters among the ones listed below
+    *
+    * \cgalNamedParamsBegin
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+    *   If this parameter is omitted, an internal property map for
+    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    * \cgalNamedParamsEnd
+    *
+    * @return a bounding box of `pmesh`
+    */
+    template<typename PolygonMesh, typename NamedParameters>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
+    {
+      using boost::choose_param;
+      using boost::get_param;
+      typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
+        vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(CGAL::vertex_point, pmesh));
+
+      return get(vpm, vd).bbox();
+    }
+
+    /*!
+    * \ingroup PkgPolygonMeshProcessing
+    *  computes a bounding box of an edge of a polygon mesh.
+    *
+    * @tparam PolygonMesh a model of `HalfedgeGraph`
+    * @tparam NamedParameters a sequence of \ref namedparameters
+    *
+    * @param ed a descriptor of an edge in `pmesh`
+    * @param pmesh a polygon mesh
+    * @param np optional sequence of \ref namedparameters among the ones listed below
+    *
+    * \cgalNamedParamsBegin
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+    *   If this parameter is omitted, an internal property map for
+    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    * \cgalNamedParamsEnd
+    *
+    * @return a bounding box of `pmesh`
+    */
+    template<typename PolygonMesh, typename NamedParameters>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
+    {
+      using boost::choose_param;
+      using boost::get_param;
+      typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
+        vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(CGAL::vertex_point, pmesh));
+
+      typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
+
+      return get(vpm, source(ed, pmesh)).bbox() +
+             get(vpm, target(ed, pmesh)).bbox();
+    }
+
+    /*!
+    * \ingroup PkgPolygonMeshProcessing
+    *  computes a bounding box of a face of a polygon mesh.
+    *
+    * @tparam PolygonMesh a model of `HalfedgeGraph`
+    * @tparam NamedParameters a sequence of \ref namedparameters
+    *
+    * @param fd a descriptor of a face in `pmesh`
+    * @param pmesh a polygon mesh
+    * @param np optional sequence of \ref namedparameters among the ones listed below
+    *
+    * \cgalNamedParamsBegin
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
+    *   If this parameter is omitted, an internal property map for
+    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    * \cgalNamedParamsEnd
+    *
+    * @return a bounding box of `pmesh`
+    */
+    template<typename PolygonMesh, typename NamedParameters>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
+    {
+      using boost::choose_param;
+      using boost::get_param;
+      typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
+        vpm = choose_param(get_param(np, vertex_point),
+                           get_const_property_map(CGAL::vertex_point, pmesh));
+
+      typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
+
+      CGAL::Bbox_3 bb;
+      BOOST_FOREACH(halfedge_descriptor h,
+                    halfedges_around_face(halfedge(fd, pmesh), pmesh))
+      {
+        bb += get(vpm, target(h, pmesh)).bbox();
+      }
+      return bb;
+    }
+
+    template<typename PolygonMesh>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                        const PolygonMesh& pmesh)
+    {
+      return bbox_3(vd, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
+    }
+    template<typename PolygonMesh>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                        const PolygonMesh& pmesh)
+    {
+      return bbox_3(ed, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
+    }
+    template<typename PolygonMesh>
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                        const PolygonMesh& pmesh)
+    {
+      return bbox_3(fd, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
+    }
+
     template<typename PolygonMesh>
     CGAL::Bbox_3 bbox_3(const PolygonMesh& pmesh)
     {
       return bbox_3(pmesh,
         CGAL::Polygon_mesh_processing::parameters::all_default());
     }
-
 
   }
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -14,7 +14,7 @@
 //
 // $URL$
 // $Id$
-// 
+//
 //
 // Author(s)     : Jane Tournois
 
@@ -46,8 +46,14 @@ namespace CGAL {
     *
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
-    *   If this parameter is omitted, an internal property map for
-    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
+    *       providing the functor `Construct_bbox_3` and the function
+    *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
+    *       must provide `BBox_3 operator()(Point_3)` where `Point_3` is the value type
+    *       of the vertex point map.
+    *     \cgalParamEnd
     * \cgalNamedParamsEnd
     *
     * @return a bounding box of `pmesh`
@@ -62,13 +68,17 @@ namespace CGAL {
         vpm = choose_param(get_param(np, vertex_point),
                            get_const_property_map(CGAL::vertex_point, pmesh));
 
+      typedef typename GetGeomTraits<PolygonMesh, CGAL_PMP_NP_CLASS>::type GT;
+      GT gt = choose_param(get_param(np, geom_traits), GT());
+      typename GT::Construct_bbox_3 get_bbox = gt.construct_bbox_3_object();
+
       typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 
       halfedge_descriptor h0 = *(halfedges(pmesh).first);
       CGAL::Bbox_3 bb = get(vpm, target(h0, pmesh)).bbox();
       BOOST_FOREACH(halfedge_descriptor h, halfedges(pmesh))
       {
-        bb += get(vpm, target(h, pmesh)).bbox();
+        bb += get_bbox( get(vpm, target(h, pmesh)) );
       }
       return bb;
     }
@@ -86,8 +96,14 @@ namespace CGAL {
     *
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
-    *   If this parameter is omitted, an internal property map for
-    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
+    *       providing the functor `Construct_bbox_3` and the function
+    *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
+    *       must provide `BBox_3 operator()(Point_3)` where `Point_3` is the value type
+    *       of the vertex point map.
+    *     \cgalParamEnd
     * \cgalNamedParamsEnd
     *
     * @return a bounding box of `pmesh`
@@ -103,7 +119,11 @@ namespace CGAL {
         vpm = choose_param(get_param(np, vertex_point),
                            get_const_property_map(CGAL::vertex_point, pmesh));
 
-      return get(vpm, vd).bbox();
+      typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
+      GT gt = choose_param(get_param(np, geom_traits), GT());
+      typename GT::Construct_bbox_3 get_bbox = gt.construct_bbox_3_object();
+
+      return get_bbox( get(vpm, vd) );
     }
 
     /*!
@@ -119,8 +139,14 @@ namespace CGAL {
     *
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
-    *   If this parameter is omitted, an internal property map for
-    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
+    *       providing the functor `Construct_bbox_3` and the function
+    *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
+    *       must provide `BBox_3 operator()(Point_3)` where `Point_3` is the value type
+    *       of the vertex point map.
+    *     \cgalParamEnd
     * \cgalNamedParamsEnd
     *
     * @return a bounding box of `pmesh`
@@ -136,10 +162,14 @@ namespace CGAL {
         vpm = choose_param(get_param(np, vertex_point),
                            get_const_property_map(CGAL::vertex_point, pmesh));
 
+      typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
+      GT gt = choose_param(get_param(np, geom_traits), GT());
+      typename GT::Construct_bbox_3 get_bbox = gt.construct_bbox_3_object();
+
       typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 
-      return get(vpm, source(ed, pmesh)).bbox() +
-             get(vpm, target(ed, pmesh)).bbox();
+      return get_bbox( get(vpm, source(ed, pmesh)) ) +
+             get_bbox( get(vpm, target(ed, pmesh)) );
     }
 
     /*!
@@ -155,8 +185,14 @@ namespace CGAL {
     *
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
-    *   If this parameter is omitted, an internal property map for
-    *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
+    *       providing the functor `Construct_bbox_3` and the function
+    *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
+    *       must provide `BBox_3 operator()(Point_3)` where `Point_3` is the value type
+    *       of the vertex point map.
+    *     \cgalParamEnd
     * \cgalNamedParamsEnd
     *
     * @return a bounding box of `pmesh`
@@ -172,13 +208,17 @@ namespace CGAL {
         vpm = choose_param(get_param(np, vertex_point),
                            get_const_property_map(CGAL::vertex_point, pmesh));
 
+      typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
+      GT gt = choose_param(get_param(np, geom_traits), GT());
+      typename GT::Construct_bbox_3 get_bbox = gt.construct_bbox_3_object();
+
       typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 
       CGAL::Bbox_3 bb;
       BOOST_FOREACH(halfedge_descriptor h,
                     halfedges_around_face(halfedge(fd, pmesh), pmesh))
       {
-        bb += get(vpm, target(h, pmesh)).bbox();
+        bb += get_bbox( get(vpm, target(h, pmesh)) );
       }
       return bb;
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -166,8 +166,6 @@ namespace CGAL {
       GT gt = choose_param(get_param(np, geom_traits), GT());
       typename GT::Construct_bbox_3 get_bbox = gt.construct_bbox_3_object();
 
-      typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
-
       return get_bbox( get(vpm, source(ed, pmesh)) ) +
              get_bbox( get(vpm, target(ed, pmesh)) );
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -109,9 +109,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                               const PolygonMesh& pmesh,
+                               const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -152,9 +152,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                             const PolygonMesh& pmesh,
+                             const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -198,9 +198,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                             const PolygonMesh& pmesh,
+                             const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -224,22 +224,25 @@ namespace CGAL {
     }
 
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                               const PolygonMesh& pmesh)
     {
-      return bbox_3(vd, pmesh, parameters::all_default());
+      return vertex_bbox_3(vd, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                             const PolygonMesh& pmesh)
     {
-      return bbox_3(ed, pmesh, parameters::all_default());
+      return edge_bbox_3(ed, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                             const PolygonMesh& pmesh)
     {
-      return bbox_3(fd, pmesh, parameters::all_default());
+      return face_bbox_3(fd, pmesh,
+        CGAL::Polygon_mesh_processing::parameters::all_default());
     }
 
     template<typename PolygonMesh>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -109,9 +109,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                               const PolygonMesh& pmesh,
-                               const NamedParameters& np)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -152,9 +152,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                             const PolygonMesh& pmesh,
-                             const NamedParameters& np)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -198,9 +198,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                             const PolygonMesh& pmesh,
-                             const NamedParameters& np)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                        const PolygonMesh& pmesh,
+                        const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -224,25 +224,22 @@ namespace CGAL {
     }
 
     template<typename PolygonMesh>
-    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                               const PolygonMesh& pmesh)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                        const PolygonMesh& pmesh)
     {
-      return vertex_bbox_3(vd, pmesh,
-        CGAL::Polygon_mesh_processing::parameters::all_default());
+      return bbox_3(vd, pmesh, parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                             const PolygonMesh& pmesh)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                        const PolygonMesh& pmesh)
     {
-      return edge_bbox_3(ed, pmesh,
-        CGAL::Polygon_mesh_processing::parameters::all_default());
+      return bbox_3(ed, pmesh, parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                             const PolygonMesh& pmesh)
+    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                        const PolygonMesh& pmesh)
     {
-      return face_bbox_3(fd, pmesh,
-        CGAL::Polygon_mesh_processing::parameters::all_default());
+      return bbox_3(fd, pmesh, parameters::all_default());
     }
 
     template<typename PolygonMesh>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -93,9 +93,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                               const PolygonMesh& pmesh,
+                               const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -126,9 +126,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                             const PolygonMesh& pmesh,
+                             const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -162,9 +162,9 @@ namespace CGAL {
     * @return a bounding box of `pmesh`
     */
     template<typename PolygonMesh, typename NamedParameters>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                        const PolygonMesh& pmesh,
-                        const NamedParameters& np)
+    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                             const PolygonMesh& pmesh,
+                             const NamedParameters& np)
     {
       using boost::choose_param;
       using boost::get_param;
@@ -184,24 +184,24 @@ namespace CGAL {
     }
 
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 vertex_bbox_3(typename boost::graph_traits<PolygonMesh>::vertex_descriptor vd,
+                               const PolygonMesh& pmesh)
     {
-      return bbox_3(vd, pmesh,
+      return vertex_bbox_3(vd, pmesh,
         CGAL::Polygon_mesh_processing::parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 edge_bbox_3(typename boost::graph_traits<PolygonMesh>::edge_descriptor ed,
+                             const PolygonMesh& pmesh)
     {
-      return bbox_3(ed, pmesh,
+      return edge_bbox_3(ed, pmesh,
         CGAL::Polygon_mesh_processing::parameters::all_default());
     }
     template<typename PolygonMesh>
-    CGAL::Bbox_3 bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
-                        const PolygonMesh& pmesh)
+    CGAL::Bbox_3 face_bbox_3(typename boost::graph_traits<PolygonMesh>::face_descriptor fd,
+                             const PolygonMesh& pmesh)
     {
-      return bbox_3(fd, pmesh,
+      return face_bbox_3(fd, pmesh,
         CGAL::Polygon_mesh_processing::parameters::all_default());
     }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
@@ -399,8 +399,6 @@ namespace parameters{
 
 } //namespace CGAL
 
-#include <boost/graph/graph_traits.hpp>
-
 // partial specializations hate inheritance and we need to repeat
 // those here. this is rather fragile.
 namespace boost {
@@ -419,13 +417,6 @@ namespace boost {
       return lookup_named_param_def<Tag1, Base, Def>::get(p.m_base, def);
     }
   };
-
-  // add this specialization to disambiguate function overloads in the PMP package
-  // (like bbox_3 for exemple)
-  template <typename T, typename Tag, typename Base>
-  struct graph_traits< CGAL::pmp_bgl_named_params<T, Tag, Base> >
-  {};
-
 } // boost
 
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/named_function_params.h
@@ -399,6 +399,8 @@ namespace parameters{
 
 } //namespace CGAL
 
+#include <boost/graph/graph_traits.hpp>
+
 // partial specializations hate inheritance and we need to repeat
 // those here. this is rather fragile.
 namespace boost {
@@ -417,6 +419,13 @@ namespace boost {
       return lookup_named_param_def<Tag1, Base, Def>::get(p.m_base, def);
     }
   };
+
+  // add this specialization to disambiguate function overloads in the PMP package
+  // (like bbox_3 for exemple)
+  template <typename T, typename Tag, typename Base>
+  struct graph_traits< CGAL::pmp_bgl_named_params<T, Tag, Base> >
+  {};
+
 } // boost
 
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -440,7 +440,7 @@ std::size_t remove_null_edges(
                            parameters::all_default());
 }
 
-/// \ingroup PkgPolygonMeshProcessing
+/// \ingroup PMP_repairing_grp
 /// removes the degenerate faces from a triangulated surface mesh.
 /// A face is considered degenerate if two of its vertices share the same location,
 /// or more generally if all its vertices are collinear.
@@ -471,7 +471,6 @@ std::size_t remove_null_edges(
 /// \cgalNamedParamsEnd
 ///
 /// \return number of removed degenerate faces
-/// \endcond
 template <class TriangleMesh, class NamedParameters>
 std::size_t remove_degenerate_faces(TriangleMesh& tmesh,
                                     const NamedParameters& np)
@@ -802,7 +801,7 @@ std::size_t remove_degenerate_faces(TriangleMesh& tmesh,
   return nb_deg_faces;
 }
 
-/// \cond SKIP_IN_MANUAL
+
 template<class TriangleMesh>
 std::size_t remove_degenerate_faces(TriangleMesh& tmesh)
 {
@@ -812,7 +811,7 @@ std::size_t remove_degenerate_faces(TriangleMesh& tmesh)
 /// \endcond
 
 
-/// \ingroup PkgPolygonMeshProcessing
+/// \ingroup PMP_repairing_grp
 /// removes the isolated vertices from any polygon mesh.
 /// A vertex is considered isolated if it is not incident to any simplex
 /// of higher dimension.
@@ -1147,7 +1146,7 @@ bool remove_self_intersections(TriangleMesh& tm, const int max_steps = 7, bool v
 
   return step<max_steps;
 }
-///
+/// \endcond
 
 } } // end of CGAL::Polygon_mesh_processing
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -102,15 +102,15 @@ void test_pmesh(const Mesh& pmesh)
 
   CGAL::Bbox_3 bb_v;
   BOOST_FOREACH(vertex_descriptor vd, vertices(pmesh))
-    bb_v+=PMP::bbox_3(vd, pmesh);
+    bb_v+=PMP::vertex_bbox_3(vd, pmesh);
 
   CGAL::Bbox_3 bb_f;
   BOOST_FOREACH(face_descriptor fd, faces(pmesh))
-    bb_f+=PMP::bbox_3(fd, pmesh);
+    bb_f+=PMP::face_bbox_3(fd, pmesh);
 
   CGAL::Bbox_3 bb_e;
   BOOST_FOREACH(edge_descriptor ed, edges(pmesh))
-    bb_e+=PMP::bbox_3(ed, pmesh);
+    bb_e+=PMP::edge_bbox_3(ed, pmesh);
 
   assert(bb==bb_v);
   assert(bb==bb_f);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -102,15 +102,15 @@ void test_pmesh(const Mesh& pmesh)
 
   CGAL::Bbox_3 bb_v;
   BOOST_FOREACH(vertex_descriptor vd, vertices(pmesh))
-    bb_v+=PMP::vertex_bbox_3(vd, pmesh);
+    bb_v+=PMP::bbox_3(vd, pmesh);
 
   CGAL::Bbox_3 bb_f;
   BOOST_FOREACH(face_descriptor fd, faces(pmesh))
-    bb_f+=PMP::face_bbox_3(fd, pmesh);
+    bb_f+=PMP::bbox_3(fd, pmesh);
 
   CGAL::Bbox_3 bb_e;
   BOOST_FOREACH(edge_descriptor ed, edges(pmesh))
-    bb_e+=PMP::edge_bbox_3(ed, pmesh);
+    bb_e+=PMP::bbox_3(ed, pmesh);
 
   assert(bb==bb_v);
   assert(bb==bb_f);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -34,6 +34,8 @@ void test_pmesh(const Mesh& pmesh)
 
   typedef typename boost::graph_traits<Mesh>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<Mesh>::face_descriptor     face_descriptor;
+  typedef typename boost::graph_traits<Mesh>::vertex_descriptor   vertex_descriptor;
+  typedef typename boost::graph_traits<Mesh>::edge_descriptor     edge_descriptor;
 
   halfedge_descriptor border_he;
   BOOST_FOREACH(halfedge_descriptor h, halfedges(pmesh))
@@ -98,6 +100,21 @@ void test_pmesh(const Mesh& pmesh)
   std::cout << "     y[" << bb.ymin() << "; " << bb.ymax() << "]" << std::endl;
   std::cout << "     z[" << bb.zmin() << "; " << bb.zmax() << "]" << std::endl;
 
+  CGAL::Bbox_3 bb_v;
+  BOOST_FOREACH(vertex_descriptor vd, vertices(pmesh))
+    bb_v+=PMP::bbox_3(vd, pmesh);
+
+  CGAL::Bbox_3 bb_f;
+  BOOST_FOREACH(face_descriptor fd, faces(pmesh))
+    bb_f+=PMP::bbox_3(fd, pmesh);
+
+  CGAL::Bbox_3 bb_e;
+  BOOST_FOREACH(edge_descriptor ed, edges(pmesh))
+    bb_e+=PMP::bbox_3(ed, pmesh);
+
+  assert(bb==bb_v);
+  assert(bb==bb_f);
+  assert(bb==bb_e);
 }
 
 template <typename Polyhedron, typename K>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_helpers.h
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_helpers.h
@@ -6,6 +6,7 @@
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Side_of_triangle_mesh.h>
+#include <CGAL/Polygon_mesh_processing/bbox.h>
 
 #include <CGAL/Timer.h>
 #include <boost/foreach.hpp>
@@ -71,15 +72,12 @@ void generate_near_boundary(const PolygonMesh& mesh,
   }
 }
 
-template<typename PolygonMesh>
-CGAL::Bbox_3 bbox(const PolygonMesh& mesh);
-
 template<class Point, class OutputIterator, typename PolygonMesh>
 void random_points(const PolygonMesh& mesh,
                    int n,
                    OutputIterator out)
 {
-  CGAL::Bbox_3 bb = bbox(mesh);
+  CGAL::Bbox_3 bb = CGAL::Polygon_mesh_processing::bbox_3(mesh);
   CGAL::Random rg(1340818006); // seed some value for make it easy to debug
 
   double grid_dx = bb.xmax() - bb.xmin();
@@ -126,21 +124,6 @@ void inside_test(
   std::cerr << "  " << nb_boundary << " points boundary " << std::endl;
   std::cerr << "  " << points.size() - nb_inside - nb_boundary << " points outside " << std::endl;
   std::cerr << " Queries took " << timer.time() << " sec." << std::endl;
-}
-
-template<typename PolygonMesh>
-CGAL::Bbox_3 bbox(const PolygonMesh& mesh)
-{
-  typedef typename boost::graph_traits<PolygonMesh>::vertex_descriptor vertex_descriptor;
-  typename boost::property_map<PolygonMesh, boost::vertex_point_t>::const_type
-      ppmap = get(boost::vertex_point, mesh);
-
-  CGAL::Bbox_3 bbox(ppmap[*vertices(mesh).first].bbox());
-  BOOST_FOREACH(vertex_descriptor vb, vertices(mesh))
-  {
-    bbox = bbox + ppmap[vb].bbox();
-  }
-  return bbox;
 }
 
 template<typename Point>


### PR DESCRIPTION
It add `vertex_bbox_3()`, `edge_bbox_3()`, and `face_bbox_3()`.

I would prefer having 3 more `bbox_3()` overloads for  but since these functions have 2 arguments this would cause an ambiguity with the 2 argument version of `bbox_3()` for a halfedge list graph model.