### PR TITLE
Mesh_3: fix conversion warnings

### DIFF
--- a/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
+++ b/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
@@ -51,7 +51,7 @@ struct Dummy_visitor_for_split_graph_into_polylines
 
 namespace internal {
 
-/// Splits a graph at vertices with degree higher than two and at vertices where `is_terminal  returns `true`
+/// Splits a graph at vertices with degree higher than two and at vertices where `is_terminal` returns `true`
 /// The vertices are duplicated, and new incident edges created.
 /// OrigGraph must be undirected
 template <typename Graph,

--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -1622,7 +1622,7 @@ float triLinInterp(const _image* image,
   posz = static_cast<float>(posz /(image->vz));
 
   //patch suggested by J.Cugnoni to prevent integer overflow
-  if(posz >= dimz-1 || posy >= dimy-1 || posx >= dimx-1)
+  if(posz >= float(dimz-1) || posy >= float(dimy-1) || posx >= float(dimx-1))
     return value_outside;
   
   const int i1 = (int)(posz);

--- a/CGAL_ImageIO/include/CGAL/Image_3.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3.h
@@ -257,9 +257,9 @@ Image_3::trilinear_interpolation(const Coord_type& x,
   if(lx < 0 ||
      ly < 0 ||
      lz < 0 ||
-     lz >= dimz-1 ||
-     ly >= dimy-1 ||
-     lx >= dimx-1)
+     lz >= Coord_type(dimz-1) ||
+     ly >= Coord_type(dimy-1) ||
+     lx >= Coord_type(dimx-1))
   {
     return value_outside;
   }  
@@ -448,9 +448,9 @@ Image_3::labellized_trilinear_interpolation
   if( lx < 0 ||
       ly < 0 ||
       lz < 0 ||
-     lz >= dimz-1 ||
-     ly >= dimy-1 ||
-     lx >= dimx-1)
+     lz >= Coord_type(dimz-1) ||
+     ly >= Coord_type(dimy-1) ||
+     lx >= Coord_type(dimx-1))
   {
     return value_outside;
   }  

--- a/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
@@ -46,49 +46,49 @@ struct VTK_type_generator {
 
 template <>
 struct VTK_type_generator<double> {
-  static const vtkIdType type = VTK_DOUBLE;
+  static const int type = VTK_DOUBLE;
   typedef vtkDoubleArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<float> {
-  static const vtkIdType type = VTK_FLOAT;
+  static const int type = VTK_FLOAT;
   typedef vtkFloatArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<char> {
-  static const vtkIdType type = VTK_CHAR;
+  static const int type = VTK_CHAR;
   typedef vtkCharArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<boost::uint8_t> {
-  static const vtkIdType type = VTK_UNSIGNED_CHAR;
+  static const int type = VTK_UNSIGNED_CHAR;
   typedef vtkUnsignedCharArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<boost::int16_t> {
-  static const vtkIdType type = VTK_SHORT;
+  static const int type = VTK_SHORT;
   typedef vtkShortArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<boost::uint16_t> {
-  static const vtkIdType type = VTK_UNSIGNED_SHORT;
+  static const int type = VTK_UNSIGNED_SHORT;
   typedef vtkUnsignedShortArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<boost::int32_t> {
-  static const vtkIdType type = VTK_INT;
+  static const int type = VTK_INT;
   typedef vtkIntArray ArrayType;
 };
 
 template <>
 struct VTK_type_generator<boost::uint32_t> {
-  static const vtkIdType type = VTK_UNSIGNED_INT;
+  static const int type = VTK_UNSIGNED_INT;
   typedef vtkUnsignedIntArray ArrayType;
 };
 
@@ -96,7 +96,7 @@ struct VTK_type_generator<boost::uint32_t> {
 {
   vtkImageData* vtk_image = vtkImageData::New();
   vtkDataArray* data_array = 0;
-  vtkIdType type = 0;
+  int type = 0;
 
   _image* image_ptr = image.image();
 

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -733,7 +733,7 @@ operator()(int nb_iterations, Visitor visitor)
     //Pb with Freeze : sometimes a few vertices continue moving indefinitely
     //if the nb of moving vertices is < 1% of total nb AND does not decrease
     if(do_freeze_
-      && nb_vertices_moved < 0.005 * double(initial_vertices_nb)
+      && double(nb_vertices_moved) < 0.005 * double(initial_vertices_nb)
       && nb_vertices_moved == moving_vertices.size())
     {
       // we should stop because we are

--- a/Mesh_3/include/CGAL/Mesh_3/vertex_perturbation.h
+++ b/Mesh_3/include/CGAL/Mesh_3/vertex_perturbation.h
@@ -342,7 +342,7 @@ public:
   double time() const { return timer().time(); }
   int total_counter() const { return total_counter_ + counter(); }
   std::size_t total_time() const 
-  { return static_cast<std::size_t>(total_time_ + 1000*time()); }
+  { return static_cast<std::size_t>(double(total_time_) + 1000*time()); }
   virtual std::string perturbation_name() const = 0;
 private:
   CGAL::Timer &timer() const

--- a/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
+++ b/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
@@ -393,7 +393,7 @@ std::istream& operator>>( std::istream& in, File_header_OFF& h) {
         // facets and we do not know the genus of the surface.
         // So we add 12 and a factor of 5 percent.
         if (    h.size_of_halfedges() == 0
-             || h.size_of_halfedges() > double(h.size_of_vertices()
+             || double(h.size_of_halfedges()) > double(h.size_of_vertices()
                 + h.size_of_facets() - 2 + 12) * 2.1
              || h.size_of_halfedges() < (h.size_of_vertices()
                 + h.size_of_facets() - 2) * 2

--- a/Stream_support/include/CGAL/IO/File_header_extended_OFF_impl.h
+++ b/Stream_support/include/CGAL/IO/File_header_extended_OFF_impl.h
@@ -63,7 +63,7 @@ int  File_header_extended_OFF::
 is_CBPn() const {
     if ( is_POL() && triangulated() && non_empty_facets() &&
          normalized_to_sphere() && rounded() &&
-         (radius() <= ( 1l << rounded_bits())))
+         (radius() <= double( 1l << rounded_bits())))
         return rounded_bits();
     else
         return 0;


### PR DESCRIPTION
There are conversion warnings that were not quieted. As usual, the
"solution" is to use an explicit cast.

Note that I avoid the C-style cast, because the later prevent the
compiler from any warning.