### PR TITLE
Polyhedron  demo: Fix displayed dimensions of a bbox

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -732,8 +732,8 @@ private:
     ui.objectNameSize->setText(
       tr("Object bbox size (w,h,d):  <b>%1</b>,  <b>%2</b>,  <b>%3</b>")
       .arg(bbox.xmax()-bbox.xmin(), 0, 'g', 3)
-      .arg(bbox.xmax()-bbox.xmin(), 0, 'g', 3)
-      .arg(bbox.xmax()-bbox.xmin(), 0, 'g', 3));
+      .arg(bbox.ymax()-bbox.ymin(), 0, 'g', 3)
+      .arg(bbox.zmax()-bbox.zmin(), 0, 'g', 3));
 
     double diago_length = CGAL::sqrt((bbox.xmax()-bbox.xmin())*(bbox.xmax()-bbox.xmin()) + (bbox.ymax()-bbox.ymin())*(bbox.ymax()-bbox.ymin()) + (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
     ui.edgeLength_dspinbox->setDecimals(3);


### PR DESCRIPTION
in the isotropic remeshing plugin.