### PR TITLE
Polyhedron_demo::Cut_plugin: static cast to avoid warning

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -94,7 +94,7 @@ public:
     Tree *min_tree = NULL ;
     for( std::size_t t = r.begin(); t != r.end(); ++t)
     {
-      int i(t%grid_size), j(t/grid_size);
+      int i = static_cast<int>(t%grid_size), j = static_cast<int>(t/grid_size);
       FT x = -diag/fd + FT(i)/FT(grid_size) * dx;
       {
         FT y = -diag/fd + FT(j)/FT(grid_size) * dy;
@@ -765,7 +765,7 @@ private:
     {
       for(std::size_t t = r.begin(); t!= r.end(); ++t)
       {
-        int i(t%grid_size), j(t/grid_size);
+        int i = static_cast<int>(t%grid_size), j = static_cast<int>(t/grid_size);
         item->compute_texture(i,j, pos_ramp, neg_ramp);
       }
     }


### PR DESCRIPTION
Fix a [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-I-12/Polyhedron_Demo/TestReport_jtournois_x64_Cygwin-Windows10_MSVC2015-Debug-64bits.gz)  in the Cut_plugin of the Polyhedron demo