### PR TITLE
Polyhedron_demo: Fix spheres in polylines

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -100,6 +100,7 @@ Scene_polylines_item_private::computeElements() const
 void
 Scene_polylines_item_private::computeSpheres()
 {
+      spheres->clear_spheres();
       QApplication::setOverrideCursor(Qt::WaitCursor);
       // FIRST, count the number of incident cycles and polylines
       // for all extremities.

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -194,6 +194,16 @@ Scene_polylines_item_private::computeSpheres()
           K::Sphere_3 *sphere = new K::Sphere_3(center, spheres_drawn_radius);
           spheres->add_sphere(sphere, c);
       }
+      spheres->setToolTip(
+            QString("<p>Legende of endpoints colors: <ul>"
+                    "<li>black: one incident polyline</li>"
+                    "<li>green: two incident polylines</li>"
+                    "<li>blue: three incident polylines</li>"
+                    "<li>red: four incident polylines</li>"
+                    "<li>fuchsia: five or more incident polylines</li>"
+                    "</ul></p>"
+                    "<p>Tip: To erase this item, set its radius to 0 or less. </p>")
+                            );
       QApplication::restoreOverrideCursor();
 }
 
@@ -280,15 +290,6 @@ Scene_polylines_item::toolTip() const {
             .arg(this->renderingModeName())
             .arg(this->color().name())
             .arg(polylines.size());
-    if(d->draw_extremities) {
-        s += tr("<p>Legende of endpoints colors: <ul>"
-                "<li>black: one incident polyline</li>"
-                "<li>green: two incident polylines</li>"
-                "<li>blue: three incident polylines</li>"
-                "<li>red: four incident polylines</li>"
-                "<li>fuchsia: five or more incident polylines</li>"
-                "</ul></p>");
-    }
     return s;
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -276,6 +276,8 @@ void Scene_spheres_item::remove_sphere(CGAL::Sphere_3<Kernel> *sphere)
 
 void Scene_spheres_item::clear_spheres()
 {
+  Q_FOREACH(Sphere_pair pair, d->spheres)
+    delete pair.first;
   d->spheres.clear();
 }
 void Scene_spheres_item::setPrecision(int prec) { d->precision = prec; }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -54,6 +54,7 @@ struct Scene_spheres_item_priv
   mutable QOpenGLShaderProgram *program;
   mutable int nb_centers;
   Scene_spheres_item* item;
+  QString tooltip;
 
 };
 Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, bool planed)
@@ -283,3 +284,13 @@ void Scene_spheres_item::clear_spheres()
 void Scene_spheres_item::setPrecision(int prec) { d->precision = prec; }
 void Scene_spheres_item::setPlane(Kernel::Plane_3 p_plane) { d->plane = p_plane; }
 void Scene_spheres_item::invalidateOpenGLBuffers(){are_buffers_filled = false;}
+
+QString
+Scene_spheres_item::toolTip() const {
+    return d->tooltip;
+}
+
+void Scene_spheres_item::setToolTip(QString s)
+{
+  d->tooltip = s;
+}

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -30,7 +30,7 @@ public:
   bool isFinite() const { return false; }
   bool isEmpty() const { return false; }
   Scene_item* clone() const {return 0;}
-  QString toolTip() const {return QString();}
+  QString toolTip() const;
   bool supportsRenderingMode(RenderingMode m) const {
     return (m == Gouraud || m == Wireframe);
   }
@@ -45,6 +45,7 @@ public:
   void invalidateOpenGLBuffers();
   void computeElements() const;
   void setPlane(Kernel::Plane_3 p_plane);
+  void setToolTip(QString s);
 
 protected:
   friend struct Scene_spheres_item_priv;


### PR DESCRIPTION
Fix #1531.

It also fixes a memory leak in the way the CGAL::Sphere_3 were cleared.
