### PR TITLE
try_run to detect the C++ version

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupBoost.cmake
+++ b/Installation/cmake/modules/CGAL_SetupBoost.cmake
@@ -5,23 +5,16 @@ if ( NOT CGAL_Boost_Setup )
   set ( CGAL_requires_Boost_libs TRUE )
   if ( DEFINED  MSVC_VERSION AND "${MSVC_VERSION}" GREATER 1800)
     set ( CGAL_requires_Boost_libs FALSE )
-  endif()
-
-  if ( CMAKE_COMPILER_IS_GNUCXX
-      AND(
-        #CMAKE_CXX_STANDARD_DEFAULT is available starting cmake 3.4
-        ( DEFINED CMAKE_CXX_STANDARD_DEFAULT
-          AND ${CMAKE_CXX_STANDARD_DEFAULT} GREATER 03
-          AND ${CMAKE_CXX_STANDARD_DEFAULT} LESS 98 )
-        #GCC 4.8+ with c++11 on
-        OR ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8
-          AND CMAKE_CXX_FLAGS MATCHES "\\-std=(c|gnu)\\+\\+[01][14yxz]")
-        #GCC 6.0+ without c++03 on
-        OR ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0
-             AND NOT CMAKE_CXX_FLAGS MATCHES "\\-std=(c|gnu)\\+\\+[90][83]"
-             AND NOT CMAKE_CXX_FLAGS MATCHES "\\-ansi")
-      ) )
-    set ( CGAL_requires_Boost_libs FALSE )
+  else()
+    try_run( CGAL_test_cpp_version_RUN_RES CGAL_test_cpp_version_COMPILE_RES
+      "${CMAKE_BINARY_DIR}"
+      "${CGAL_INSTALLATION_PACKAGE_DIR}/config/support/CGAL_test_cpp_version.cpp"
+      RUN_OUTPUT_VARIABLE CGAL_cplusplus)
+    message(STATUS "__cplusplus is ${CGAL_cplusplus}")
+    if(NOT CGAL_test_cpp_version_RUN_RES)
+      set ( CGAL_requires_Boost_libs FALSE )
+      message(STATUS "  --> Do not link with Boost.Thread")
+    endif()
   endif()
 
   if (CGAL_requires_Boost_libs)

--- a/Installation/config/support/CGAL_test_cpp_version.cpp
+++ b/Installation/config/support/CGAL_test_cpp_version.cpp
@@ -1,5 +1,10 @@
 #include <iostream>
 
+// This file displays the value of `__cplusplus` on `stderr`, and then
+// return 0 if and only if C++ `thread_local` feature can be used.
+// The tests are the same as for the definition of
+// `CGAL_CAN_USE_CXX11_THREAD_LOCAL` in `<CGAL/config.h>`.
+
 #ifndef __has_feature
   #define __has_feature(x) 0  // Compatibility with non-clang compilers.
 #endif
@@ -10,10 +15,12 @@ int main() {
   return 1;
 #else
   std::cout << __cplusplus;
-#  if __has_feature(cxx_thread_local) || __cplusplus >= 201103L
+#endif
+
+#if __has_feature(cxx_thread_local) || \
+    ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L )
   return 0;
-#  else
+#else
   return 1;
-#  endif
 #endif
 }

--- a/Installation/config/support/CGAL_test_cpp_version.cpp
+++ b/Installation/config/support/CGAL_test_cpp_version.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+
+#ifndef __has_feature
+  #define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#endif
+
+int main() {
+#if ! defined(__cplusplus)
+  std::cout << "Undefined";
+  return 1;
+#else
+  std::cout << __cplusplus;
+#  if __has_feature(cxx_thread_local) || __cplusplus >= 201103L
+  return 0;
+#  else
+  return 1;
+#  endif
+#endif
+}

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -473,6 +473,7 @@ using std::max;
 #if __has_feature(cxx_thread_local) || \
     ( (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L ) || \
     ( _MSC_VER >= 1900 )
+// see also Installation/config/support/CGAL_test_cpp_version.cpp
 #define CGAL_CAN_USE_CXX11_THREAD_LOCAL
 #endif
 


### PR DESCRIPTION
Before this PR, there was a complicated `if()` trying to detect the C++
version. That is simpler to use `try_run()` and read the version in
the value of `__cplusplus`.