### PR TITLE
Polyhedron_demo: Fixes for the UI behavior

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1520,6 +1520,7 @@ bool MainWindow::on_actionErase_triggered()
 
 void MainWindow::on_actionEraseAll_triggered()
 {
+  scene->setSelectedItem(0);
   while(on_actionErase_triggered()) {
   }
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -107,6 +107,12 @@
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QDockWidget" name="sceneDockWidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <property name="locale">
     <locale language="English" country="UnitedStates"/>
    </property>
@@ -201,6 +207,12 @@
        </item>
        <item>
         <widget class="QTreeView" name="sceneView">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="editTriggers">
           <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
          </property>
@@ -282,7 +294,7 @@
             <x>0</x>
             <y>0</y>
             <width>541</width>
-            <height>175</height>
+            <height>176</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">

--- a/Polyhedron/demo/Polyhedron/Plugins/Camera_position/Camera_positions_list.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Camera_position/Camera_positions_list.ui
@@ -43,7 +43,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/plus</normaloff>:/cgal/icons/plus</iconset>
         </property>
        </widget>
@@ -54,7 +54,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/minus</normaloff>:/cgal/icons/minus</iconset>
         </property>
        </widget>
@@ -72,7 +72,7 @@
          <string>&amp;Up</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/up.png</normaloff>:/cgal/icons/resources/up.png</iconset>
         </property>
         <property name="shortcut">
@@ -86,7 +86,7 @@
          <string>&amp;Down</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/down.png</normaloff>:/cgal/icons/resources/down.png</iconset>
         </property>
         <property name="shortcut">
@@ -120,7 +120,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/front.png</normaloff>:/cgal/icons/resources/front.png</iconset>
         </property>
        </widget>
@@ -134,7 +134,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/back.png</normaloff>:/cgal/icons/resources/back.png</iconset>
         </property>
        </widget>
@@ -148,7 +148,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/top.png</normaloff>:/cgal/icons/resources/top.png</iconset>
         </property>
        </widget>
@@ -162,7 +162,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/bot.png</normaloff>:/cgal/icons/resources/bot.png</iconset>
         </property>
        </widget>
@@ -176,7 +176,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/left.png</normaloff>:/cgal/icons/resources/left.png</iconset>
         </property>
        </widget>
@@ -190,7 +190,7 @@
          <string>PushButton</string>
         </property>
         <property name="icon">
-         <iconset resource="Polyhedron_3.qrc">
+         <iconset resource="../../Polyhedron_3.qrc">
           <normaloff>:/cgal/icons/resources/right.png</normaloff>:/cgal/icons/resources/right.png</iconset>
         </property>
        </widget>
@@ -217,7 +217,7 @@
   </widget>
  </widget>
  <resources>
-  <include location="Polyhedron_3.qrc"/>
+  <include location="../../Polyhedron_3.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>312</width>
-    <height>307</height>
+    <width>313</width>
+    <height>313</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -124,6 +124,19 @@
        </widget>
       </item>
      </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>477</width>
-    <height>596</height>
+    <height>602</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -305,6 +305,19 @@
        </widget>
       </item>
      </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>461</width>
-    <height>242</height>
+    <height>248</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,6 +162,19 @@
        </widget>
       </item>
      </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -559,6 +559,19 @@
       </layout>
      </widget>
     </item>
+    <item>
+     <spacer name="verticalSpacer_4">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
    </layout>
   </widget>
  </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.ui
@@ -279,6 +279,19 @@
      </property>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>OutlierRemovalDialog</class>
- <widget class="QDialog" name="OutlierRemovalDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="OutlierRemovalDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,65 +10,78 @@
     <height>120</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Outlier Removal</string>
   </property>
-  <layout class="QGridLayout" >
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+  <layout class="QGridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>Removed Percentage:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" >
-    <widget class="QDoubleSpinBox" name="m_inputPercentage" >
-     <property name="suffix" >
-      <string> %</string>
-     </property>
-     <property name="minimum" >
-      <double>0.010000000000000</double>
-     </property>
-     <property name="maximum" >
-      <double>100.000000000000000</double>
-     </property>
-     <property name="singleStep" >
-      <double>0.100000000000000</double>
-     </property>
-     <property name="value" >
-      <double>5.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>Neighbors</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QSpinBox" name="m_inputNbNeighbors" >
-     <property name="minimum" >
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="m_inputNbNeighbors">
+     <property name="minimum">
       <number>6</number>
      </property>
-     <property name="maximum" >
+     <property name="maximum">
       <number>9999</number>
      </property>
-     <property name="value" >
+     <property name="value">
       <number>24</number>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" >
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="m_inputPercentage">
+     <property name="suffix">
+      <string> %</string>
      </property>
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
+     <property name="minimum">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>5.000000000000000</double>
      </property>
     </widget>
+   </item>
+   <item row="3" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -79,11 +93,11 @@
    <receiver>OutlierRemovalDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -95,11 +109,11 @@
    <receiver>OutlierRemovalDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_plugin_helper.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_plugin_helper.cpp
@@ -8,6 +8,7 @@
 void CGAL::Three::Polyhedron_demo_plugin_helper::addDockWidget(QDockWidget* dock_widget)
 {
   mw->addDockWidget(::Qt::LeftDockWidgetArea, dock_widget);
+  dock_widget->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed));
 
   QList<QDockWidget*> dockWidgets = mw->findChildren<QDockWidget*>();
   int counter = 0;


### PR DESCRIPTION
This PR fixes #1522 #1526 and #1546 

- Set all the plugins DockWidgets sizePolicy to `Fixed` so they won't expand when another one is killed
- Fix the Erase all action by selecting the first item before calling the while(erase()) loop.

- Fix #1522
- Fix #1526
- Fix #1546 