### PR TITLE
Kernel_23: Initialize numbers in operator>>(istream&, Point/Vector/..)

### DIFF
--- a/CGAL_ipelets/demo/CGAL_ipelets/multi_delaunay.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/multi_delaunay.cpp
@@ -125,7 +125,7 @@ void MdelaunayIpelet::protected_run(int fn)
           Point_2 pt1_ori1=it->first->vertex(Delaunay::ccw(it->second))->info().back();
 
           if(CGAL::compare_xy(pt0_ori0,pt1_ori0)==CGAL::EQUAL || CGAL::compare_xy(pt0_ori1,pt1_ori0)==CGAL::EQUAL)
-`           rt.insert(Weighted_point_2(CGAL::centroid(pt0_ori0,pt0_ori1,pt1_ori1),-CGAL::to_double(CGAL::squared_distance(pt0_ori0,pt0_ori1)+
+            rt.insert(Weighted_point_2(CGAL::centroid(pt0_ori0,pt0_ori1,pt1_ori1),-CGAL::to_double(CGAL::squared_distance(pt0_ori0,pt0_ori1)+
               CGAL::squared_distance(pt0_ori0,pt1_ori1)+CGAL::squared_distance(pt1_ori1,pt0_ori1))/9.));
           else
             if(CGAL::compare_xy(pt0_ori0,pt1_ori1)==CGAL::EQUAL || CGAL::compare_xy(pt0_ori1,pt1_ori1)==CGAL::EQUAL)

--- a/CGAL_ipelets/demo/CGAL_ipelets/multi_delaunay.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/multi_delaunay.cpp
@@ -123,16 +123,15 @@ void MdelaunayIpelet::protected_run(int fn)
           Point_2 pt0_ori1=it->first->vertex(Delaunay::cw(it->second))->info().back();
           Point_2 pt1_ori0=it->first->vertex(Delaunay::ccw(it->second))->info().front();
           Point_2 pt1_ori1=it->first->vertex(Delaunay::ccw(it->second))->info().back();
-          Point_2 pt3 = Point_2();
+
           if(CGAL::compare_xy(pt0_ori0,pt1_ori0)==CGAL::EQUAL || CGAL::compare_xy(pt0_ori1,pt1_ori0)==CGAL::EQUAL)
-            pt3 = pt1_ori1;
+`           rt.insert(Weighted_point_2(CGAL::centroid(pt0_ori0,pt0_ori1,pt1_ori1),-CGAL::to_double(CGAL::squared_distance(pt0_ori0,pt0_ori1)+
+              CGAL::squared_distance(pt0_ori0,pt1_ori1)+CGAL::squared_distance(pt1_ori1,pt0_ori1))/9.));
           else
             if(CGAL::compare_xy(pt0_ori0,pt1_ori1)==CGAL::EQUAL || CGAL::compare_xy(pt0_ori1,pt1_ori1)==CGAL::EQUAL)
-              pt3 = pt1_ori0;
+              rt.insert(Weighted_point_2(CGAL::centroid(pt0_ori0,pt0_ori1,pt1_ori0),-CGAL::to_double(CGAL::squared_distance(pt0_ori0,pt0_ori1)+
+              CGAL::squared_distance(pt0_ori0,pt1_ori0)+CGAL::squared_distance(pt1_ori0,pt0_ori1))/9.));
 
-          if(pt3!=Point_2()) //if adjacent wpoints comed from a delaunay triangle
-            rt.insert(Weighted_point_2(CGAL::centroid(pt0_ori0,pt0_ori1,pt3),-CGAL::to_double(CGAL::squared_distance(pt0_ori0,pt0_ori1)+
-              CGAL::squared_distance(pt0_ori0,pt3)+CGAL::squared_distance(pt3,pt0_ori1))/9.));
         }
         if(fn==2){//Draw 3th Delauney
           draw_in_ipe(rt);

--- a/Filtered_kernel/include/CGAL/internal/Static_filters/Equal_2.h
+++ b/Filtered_kernel/include/CGAL/internal/Static_filters/Equal_2.h
@@ -39,6 +39,7 @@ template < typename K_base >
 class Equal_2
   : public K_base::Equal_2
 {
+  typedef typename K_base::FT        FT;
   typedef typename K_base::Point_2   Point_2;
   typedef typename K_base::Vector_2  Vector_2;
   typedef typename K_base::Equal_2   Base;
@@ -68,6 +69,7 @@ public:
     Get_approx<Point_2> get_approx; // Identity functor for all points
                                     // but lazy points
     double px, py, qx, qy;
+    init_double(px, py,qx, qy, (FT*)(0));
 
     if (fit_in_double(get_approx(p).x(), px) && fit_in_double(get_approx(p).y(), py) &&
         fit_in_double(get_approx(q).x(), qx) && fit_in_double(get_approx(q).y(), qy) )

--- a/GraphicsView/demo/Triangulation_2/Constrained_Delaunay_triangulation_2.cpp
+++ b/GraphicsView/demo/Triangulation_2/Constrained_Delaunay_triangulation_2.cpp
@@ -611,7 +611,7 @@ MainWindow::loadEdgConstraints(QString fileName)
   int n;
   ifs >> n;
   
-  K::Point_2 p,q, qold;
+  K::Point_2 p,q, qold(0,0); // initialize to avoid maybe-uninitialized warning from GCC6
 
   CDT::Vertex_handle vp, vq, vqold;
   while(ifs >> p) {

--- a/Kernel_23/include/CGAL/Circle_2.h
+++ b/Kernel_23/include/CGAL/Circle_2.h
@@ -271,7 +271,7 @@ std::istream&
 extract(std::istream& is, Circle_2<R>& c)
 {
     typename R::Point_2 center;
-    typename R::FT squared_radius;
+    typename R::FT squared_radius(0);
     int o;
     switch(get_mode(is)) {
     case IO::ASCII :

--- a/Kernel_23/include/CGAL/Direction_2.h
+++ b/Kernel_23/include/CGAL/Direction_2.h
@@ -231,7 +231,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Direction_2<R>& d, const Cartesian_tag&)
 {
-    typename R::FT x, y;
+  typename R::FT x(0), y(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(x) >> iformat(y);

--- a/Kernel_23/include/CGAL/Direction_3.h
+++ b/Kernel_23/include/CGAL/Direction_3.h
@@ -188,7 +188,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Direction_3<R>& d, const Cartesian_tag&) 
 {
-  typename R::FT x, y, z;
+  typename R::FT x(0), y(0), z(0);
   switch(get_mode(is)) {
     case IO::ASCII :
       is >> iformat(x) >> iformat(y) >> iformat(z);

--- a/Kernel_23/include/CGAL/Line_2.h
+++ b/Kernel_23/include/CGAL/Line_2.h
@@ -260,7 +260,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Line_2<R>& l)
 {
-    typename R::RT a, b, c;
+  typename R::RT a(0), b(0), c(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(a) >> iformat(b) >> iformat(c);

--- a/Kernel_23/include/CGAL/Plane_3.h
+++ b/Kernel_23/include/CGAL/Plane_3.h
@@ -257,7 +257,7 @@ template < class R >
 std::istream &
 operator>>(std::istream &is, Plane_3<R> &p)
 {
-    typename R::RT a, b, c, d;
+  typename R::RT a(0), b(0), c(0), d(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(a) >> iformat(b) >> iformat(c) >> iformat(d);

--- a/Kernel_23/include/CGAL/Point_2.h
+++ b/Kernel_23/include/CGAL/Point_2.h
@@ -214,7 +214,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Point_2<R>& p, const Cartesian_tag&)
 {
-    typename R::FT x, y;
+  typename R::FT x(0), y(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(x) >> iformat(y);

--- a/Kernel_23/include/CGAL/Point_3.h
+++ b/Kernel_23/include/CGAL/Point_3.h
@@ -242,7 +242,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Point_3<R>& p, const Cartesian_tag&)
 {
-    typename R::FT x, y, z;
+  typename R::FT x(0), y(0), z(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(x) >> iformat(y) >> iformat(z);

--- a/Kernel_23/include/CGAL/Sphere_3.h
+++ b/Kernel_23/include/CGAL/Sphere_3.h
@@ -289,7 +289,7 @@ std::istream&
 extract(std::istream& is, Sphere_3<R>& c, const Cartesian_tag&)
 {
     typename R::Point_3 center;
-    typename R::FT squared_radius;
+    typename R::FT squared_radius(0);
     int o=0;
     switch(get_mode(is)) {
     case IO::ASCII :

--- a/Kernel_23/include/CGAL/Vector_2.h
+++ b/Kernel_23/include/CGAL/Vector_2.h
@@ -299,7 +299,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Vector_2<R>& v, const Cartesian_tag&)
 {
-    typename R::FT x, y;
+  typename R::FT x(0), y(0);
     switch(get_mode(is)) {
     case IO::ASCII :
         is >> iformat(x) >> iformat(y);

--- a/Kernel_23/include/CGAL/Vector_3.h
+++ b/Kernel_23/include/CGAL/Vector_3.h
@@ -279,7 +279,7 @@ template <class R >
 std::istream&
 extract(std::istream& is, Vector_3<R>& v, const Cartesian_tag&) 
 {
-  typename R::FT x, y, z;
+  typename R::FT x(0), y(0), z(0);
   switch(get_mode(is)) {
     case IO::ASCII :
       is >> iformat(x) >> iformat(y) >> iformat(z);


### PR DESCRIPTION
When we do not do that, and after the reading access a coordinate
some versions of g++ warn on -Wmaybe-uninitialized  
See [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-21/Kernel_23/TestReport_lrineau_Debian-stable-Release.gz) in the testsuite

The initialization costs nothing compared to the IO operation itself.

I at the same time initialize doubles in a static filter. I have no idea  why the warning shows only up in one testsuite, namely [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-21/CGAL_ipelets_Demo/TestReport_lrineau_Debian-stable-Release.gz)