### PR TITLE
Constrained_triangulation_2: Deal with an empty range as input

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
@@ -38,13 +38,16 @@ namespace CGAL {
                                     IndicesIterator indices_first,
                                     IndicesIterator indices_beyond )
   {
+    if(indices_first == indices_beyond){
+      return 0;
+    }
     typedef typename T::Vertex_handle Vertex_handle;
     typedef typename T::Face_handle Face_handle;
     typedef typename T::Geom_traits Geom_traits;
     typedef typename T::Point Point;
     typedef std::vector<std::size_t> Vertex_indices;
     typedef std::vector<Vertex_handle> Vertices;
-    
+
     Vertex_indices vertex_indices;
     vertex_indices.resize(points.size());
 


### PR DESCRIPTION
The bug was revealed in the [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-22/Visibility_2/TestReport_afabri_x64_Cygwin-Windows8_MSVC2012-Debug-64bits.gz) for Visibility_2.