### PR TITLE
Polyhedron_demo : Keep the c3t3_item's state when reloading

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -40,7 +40,7 @@
 
 #include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
-
+#include <CGAL/Three/Scene_item_with_properties.h>
 #include "ui_MainWindow.h"
 #include "ui_Preferences.h"
 #include "ui_Statistics_on_item_dialog.h"
@@ -884,6 +884,9 @@ void MainWindow::reloadItem() {
   new_item->setColor(item->color());
   new_item->setRenderingMode(item->renderingMode());
   new_item->setVisible(item->visible());
+  Scene_item_with_properties *property_item = dynamic_cast<Scene_item_with_properties*>(new_item);
+  if(property_item)
+    property_item->copyProperties(item);
   new_item->invalidateOpenGLBuffers();
   scene->replaceItem(item_index, new_item, true);
   item->deleteLater();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -390,6 +390,7 @@ struct Set_show_tetrahedra {
   Scene_c3t3_item_priv* priv;
   Set_show_tetrahedra(Scene_c3t3_item_priv* priv) : priv(priv) {}
   void operator()(bool b) {
+    qDebug()<<"coucou";
     priv->show_tetrahedra = b;
     priv->item->show_intersection(b);
   }
@@ -1483,11 +1484,23 @@ Scene_c3t3_item::setColor(QColor c)
 void Scene_c3t3_item::show_grid(bool b)
 {
   d->is_grid_shown = b;
+  Q_FOREACH(QAction* action, contextMenu()->actions())
+    if(action->objectName() == "actionShowGrid")
+    {
+      action->setChecked(b);
+      break;
+    }
   itemChanged();
 }
 void Scene_c3t3_item::show_spheres(bool b)
 {
   d->spheres_are_shown = b;
+  Q_FOREACH(QAction* action, contextMenu()->actions())
+    if(action->objectName() == "actionShowSpheres")
+    {
+      action->setChecked(b);
+      break;
+    }
   if(b && !d->spheres)
   {
     d->spheres = new Scene_spheres_item(this, true);
@@ -1509,6 +1522,12 @@ void Scene_c3t3_item::show_spheres(bool b)
 }
 void Scene_c3t3_item::show_intersection(bool b)
 {
+  Q_FOREACH(QAction* action, contextMenu()->actions())
+    if(action->objectName() == "actionShowTets")
+    {
+      action->setChecked(b);
+      break;
+    }
   if(b && !d->intersection)
   {
     d->intersection = new Scene_intersection_item(this);
@@ -1535,6 +1554,12 @@ void Scene_c3t3_item::show_intersection(bool b)
 void Scene_c3t3_item::show_cnc(bool b)
 {
   d->cnc_are_shown = b;
+  Q_FOREACH(QAction* action, contextMenu()->actions())
+    if(action->objectName() == "actionShowCNC")
+    {
+      action->setChecked(b);
+      break;
+    }
   Q_EMIT redraw();
 
 }
@@ -1556,7 +1581,38 @@ void Scene_c3t3_item::setPosition(float x, float y, float z) {
   d->frame->setPosition(x, y, z);
 }
 
+bool Scene_c3t3_item::has_spheres()const { return d->spheres_are_shown;}
+
+bool Scene_c3t3_item::has_grid()const { return d->is_grid_shown;}
+
+bool Scene_c3t3_item::has_cnc()const { return d->cnc_are_shown;}
+
+bool Scene_c3t3_item::has_tets()const { if(d->intersection) return true; else return false; }
+
 void Scene_c3t3_item::setNormal(float x, float y, float z) {
   d->frame->setOrientation(x, y, z, 0.f);
+}
+
+void Scene_c3t3_item::copyProperties(Scene_item *item)
+{
+  Scene_c3t3_item* c3t3_item = qobject_cast<Scene_c3t3_item*>(item);
+  if(!c3t3_item)
+    return;
+  d->frame->setPositionAndOrientation(c3t3_item->manipulatedFrame()->position(),
+                                      c3t3_item->manipulatedFrame()->orientation());
+
+  if(c3t3_item->has_tets())
+    show_intersection(true);
+
+  if(c3t3_item->has_spheres())
+    show_spheres(true);
+
+
+  if(c3t3_item->has_cnc())
+    show_cnc(true);
+
+  show_grid(c3t3_item->has_grid());
+
+
 }
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -390,7 +390,6 @@ struct Set_show_tetrahedra {
   Scene_c3t3_item_priv* priv;
   Set_show_tetrahedra(Scene_c3t3_item_priv* priv) : priv(priv) {}
   void operator()(bool b) {
-    qDebug()<<"coucou";
     priv->show_tetrahedra = b;
     priv->item->show_intersection(b);
   }
@@ -1484,23 +1483,13 @@ Scene_c3t3_item::setColor(QColor c)
 void Scene_c3t3_item::show_grid(bool b)
 {
   d->is_grid_shown = b;
-  Q_FOREACH(QAction* action, contextMenu()->actions())
-    if(action->objectName() == "actionShowGrid")
-    {
-      action->setChecked(b);
-      break;
-    }
+  contextMenu()->findChild<QAction*>("actionShowGrid")->setChecked(b);
   itemChanged();
 }
 void Scene_c3t3_item::show_spheres(bool b)
 {
   d->spheres_are_shown = b;
-  Q_FOREACH(QAction* action, contextMenu()->actions())
-    if(action->objectName() == "actionShowSpheres")
-    {
-      action->setChecked(b);
-      break;
-    }
+  contextMenu()->findChild<QAction*>("actionShowSpheres")->setChecked(b);
   if(b && !d->spheres)
   {
     d->spheres = new Scene_spheres_item(this, true);
@@ -1522,12 +1511,7 @@ void Scene_c3t3_item::show_spheres(bool b)
 }
 void Scene_c3t3_item::show_intersection(bool b)
 {
-  Q_FOREACH(QAction* action, contextMenu()->actions())
-    if(action->objectName() == "actionShowTets")
-    {
-      action->setChecked(b);
-      break;
-    }
+      contextMenu()->findChild<QAction*>("actionShowTets")->setChecked(b);
   if(b && !d->intersection)
   {
     d->intersection = new Scene_intersection_item(this);
@@ -1554,12 +1538,7 @@ void Scene_c3t3_item::show_intersection(bool b)
 void Scene_c3t3_item::show_cnc(bool b)
 {
   d->cnc_are_shown = b;
-  Q_FOREACH(QAction* action, contextMenu()->actions())
-    if(action->objectName() == "actionShowCNC")
-    {
-      action->setChecked(b);
-      break;
-    }
+  contextMenu()->findChild<QAction*>("actionShowCNC")->setChecked(b);
   Q_EMIT redraw();
 
 }
@@ -1587,7 +1566,7 @@ bool Scene_c3t3_item::has_grid()const { return d->is_grid_shown;}
 
 bool Scene_c3t3_item::has_cnc()const { return d->cnc_are_shown;}
 
-bool Scene_c3t3_item::has_tets()const { if(d->intersection) return true; else return false; }
+bool Scene_c3t3_item::has_tets()const { return d->intersection; }
 
 void Scene_c3t3_item::setNormal(float x, float y, float z) {
   d->frame->setOrientation(x, y, z, 0.f);
@@ -1601,18 +1580,12 @@ void Scene_c3t3_item::copyProperties(Scene_item *item)
   d->frame->setPositionAndOrientation(c3t3_item->manipulatedFrame()->position(),
                                       c3t3_item->manipulatedFrame()->orientation());
 
-  if(c3t3_item->has_tets())
-    show_intersection(true);
+  show_intersection(c3t3_item->has_tets());
 
-  if(c3t3_item->has_spheres())
-    show_spheres(true);
+  show_spheres(c3t3_item->has_spheres());
 
-
-  if(c3t3_item->has_cnc())
-    show_cnc(true);
+  show_cnc(c3t3_item->has_cnc());
 
   show_grid(c3t3_item->has_grid());
-
-
 }
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -23,13 +23,14 @@
 #include <Scene_polyhedron_item.h>
 #include <Scene_polygon_soup_item.h>
 #include <CGAL/IO/File_binary_mesh_3.h>
+#include <CGAL/Three/Scene_item_with_properties.h>
 
 struct Scene_c3t3_item_priv;
 class Scene_spheres_item;
 class Scene_intersection_item;
 using namespace CGAL::Three;
   class SCENE_C3T3_ITEM_EXPORT Scene_c3t3_item
-  : public Scene_group_item
+  : public Scene_group_item, public Scene_item_with_properties
 {
   Q_OBJECT
 public:
@@ -64,6 +65,11 @@ public:
   bool manipulatable() const {
     return true;
   }
+
+  bool has_spheres() const;
+  bool has_grid() const;
+  bool has_cnc() const;
+  bool has_tets() const;
   ManipulatedFrame* manipulatedFrame();
 
   void setPosition(float x, float y, float z) ;
@@ -108,6 +114,7 @@ public:
   void drawPoints(CGAL::Three::Viewer_interface * viewer) const;
   public:
     QMenu* contextMenu();
+    void copyProperties(Scene_item *);
   public Q_SLOTS:
   void export_facets_in_complex();
 

--- a/Three/include/CGAL/Three/Scene_item_with_properties.h
+++ b/Three/include/CGAL/Three/Scene_item_with_properties.h
@@ -29,7 +29,7 @@ class Scene_item_with_properties {
 public:
   virtual ~Scene_item_with_properties(){}
  //!Copies properties from another Scene_item
- virtual void copyProperties(Scene_item*){}
+ virtual void copyProperties(Scene_item*)=0; //pure virtual method
 };
 }
 }

--- a/Three/include/CGAL/Three/Scene_item_with_properties.h
+++ b/Three/include/CGAL/Three/Scene_item_with_properties.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2016  GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Maxime GIMENO
+
+#ifndef SCENE_ITEM_WITH_PROPERTIES_H
+#define SCENE_ITEM_WITH_PROPERTIES_H
+namespace CGAL
+{
+namespace Three {
+  class Scene_item;
+
+//! Base class to allow an item to copy properties from another.
+class Scene_item_with_properties {
+public:
+  virtual ~Scene_item_with_properties(){}
+ //!Copies properties from another Scene_item
+ virtual void copyProperties(Scene_item*){}
+};
+}
+}
+#endif // SCENE_ITEM_WITH_PROPERTIES_H
+


### PR DESCRIPTION
This PR introduces  a new interface for items that adds a virtual function, which is used to retrieve special properties from a scene_item. In this case, it is used in a c3t3_item to retrieve the spheres, grid, intersections and CNC from another c3t3_item. This allows to keep all of it in the same state when we reload a c3t3_item from file.