### PR TITLE
Circular_kernel_2: Add a dummy field to the variant to work around an ICL bug

### DIFF
--- a/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
+++ b/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
@@ -38,6 +38,12 @@ struct CK2_Intersection_traits
 {};
 
 // Intersection_traits for the circular kernel
+
+// The additional int in the variant has the only purpose to work around
+// a bug of the Intel compiler, which without it produces the error
+// /usr/include/boost/type_traits/has_nothrow_copy.hpp(36): internal error: bad pointer
+// template struct has_nothrow_copy_constructor : public integral_constant{};
+// See also https://github.com/CGAL/cgal/issues/1581
 template<typename CK>
 struct CK2_Intersection_traits<CK, typename CK::Circle_2, typename CK::Circle_2>
 {

--- a/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
+++ b/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
@@ -44,7 +44,8 @@ struct CK2_Intersection_traits<CK, typename CK::Circle_2, typename CK::Circle_2>
   typedef typename
   boost::variant< typename CK::Circle_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >,
+                  int >
   type;
 };
 
@@ -54,7 +55,8 @@ struct CK2_Intersection_traits<CK, typename CK::Circular_arc_2, typename CK::Cir
   typedef typename
   boost::variant< typename CK::Circular_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >,
+                  int  >
   type;
 };
 
@@ -64,7 +66,8 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Line_ar
   typedef typename
   boost::variant< typename CK::Line_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >,
+                  int  >
   type;
 };
 
@@ -102,7 +105,8 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Line_2>
   typedef typename
   boost::variant< typename CK::Line_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >,
+                  int  >
   type;
 };
 

--- a/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
+++ b/Circular_kernel_2/include/CGAL/Circular_kernel_2/Intersection_traits.h
@@ -39,19 +39,22 @@ struct CK2_Intersection_traits
 
 // Intersection_traits for the circular kernel
 
-// The additional int in the variant has the only purpose to work around
-// a bug of the Intel compiler, which without it produces the error
+// The additional CGAL_ADDITIONAL_VARIANT_FOR_ICL ( = int) in the variant 
+// has the only purpose to work around a bug of the Intel compiler,
+// which without it produces the error
 // /usr/include/boost/type_traits/has_nothrow_copy.hpp(36): internal error: bad pointer
 // template struct has_nothrow_copy_constructor : public integral_constant{};
 // See also https://github.com/CGAL/cgal/issues/1581
+
 template<typename CK>
 struct CK2_Intersection_traits<CK, typename CK::Circle_2, typename CK::Circle_2>
 {
   typedef typename
   boost::variant< typename CK::Circle_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int >,
-                  int >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -61,8 +64,9 @@ struct CK2_Intersection_traits<CK, typename CK::Circular_arc_2, typename CK::Cir
   typedef typename
   boost::variant< typename CK::Circular_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int >,
-                  int  >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -72,8 +76,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Line_ar
   typedef typename
   boost::variant< typename CK::Line_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int >,
-                  int  >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -82,7 +87,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Circle_
 {
   typedef typename
   boost::variant< typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -96,7 +103,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Circula
 {
   typedef typename
   boost::variant< typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -111,8 +120,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_arc_2, typename CK::Line_2>
   typedef typename
   boost::variant< typename CK::Line_arc_2,
                   typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int >,
-                  int  >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -126,7 +136,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_2, typename CK::Circular_ar
 {
   typedef typename
   boost::variant< typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 
@@ -154,7 +166,9 @@ struct CK2_Intersection_traits<CK, typename CK::Line_2, typename CK::Circle_2>
 {
   typedef typename
   boost::variant< typename std::pair< typename CK::Circular_arc_point_2,
-                                      unsigned int > >
+                                      unsigned int >
+                  CGAL_ADDITIONAL_VARIANT_FOR_ICL
+                  >
   type;
 };
 

--- a/Circular_kernel_2/include/CGAL/Circular_kernel_2/internal_functions_on_line_arc_2.h
+++ b/Circular_kernel_2/include/CGAL/Circular_kernel_2/internal_functions_on_line_arc_2.h
@@ -508,6 +508,13 @@ namespace CircularFunctors {
     bool operator()(const std::pair<typename CK::Circular_arc_point_2, unsigned>& pair) const {
       return has_on<CK>(*l,pair.first,true);
     }
+
+#ifdef CGAL_ADDITIONAL_VARIANT_FOR_ICL
+    bool operator()(const int) const
+    {
+      return true;
+    }
+#endif
   };
 
   template< class CK, class OutputIterator>

--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
@@ -35,11 +35,21 @@ template <typename SK, typename T1, typename T2, typename T3=void*>
 struct SK3_Intersection_traits
 {};
 
+// Intersection_traits for the circular kernel
+
+// The additional CGAL_ADDITIONAL_VARIANT_FOR_ICL ( = int) in the variant 
+// has the only purpose to work around a bug of the Intel compiler,
+// which without it produces the error
+// /usr/include/boost/type_traits/has_nothrow_copy.hpp(36): internal error: bad pointer
+// template struct has_nothrow_copy_constructor : public integral_constant{};
+// See also https://github.com/CGAL/cgal/issues/1581
+
 template <typename SK>
 struct SK3_Intersection_traits<SK, typename SK::Sphere_3, typename SK::Line_3>
 { 
   typedef boost::variant< 
-            std::pair< typename SK::Circular_arc_point_3, unsigned int > 
+            std::pair< typename SK::Circular_arc_point_3, unsigned int >
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type; 
 };
 
@@ -52,8 +62,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Plane_3>
 {
   typedef boost::variant< 
             std::pair< typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circle_3,
-            int
+            typename SK::Circle_3
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type; };
 
 template <typename SK>
@@ -61,19 +71,13 @@ struct SK3_Intersection_traits<SK, typename SK::Plane_3, typename SK::Circle_3>
   : SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Plane_3> {};
 
 
-// The additional int in the variant has the only purpose to work around
-// a bug of the Intel compiler, which without it produces the error
-// /usr/include/boost/type_traits/has_nothrow_copy.hpp(36): internal error: bad pointer
-// template struct has_nothrow_copy_constructor : public integral_constant{};
-// See also https://github.com/CGAL/cgal/issues/1581
-
 template <typename SK>
 struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Sphere_3>
 { 
   typedef boost::variant< 
             std::pair< typename SK::Circular_arc_point_3, unsigned int >, 
-            typename SK::Circle_3 ,
-            int
+            typename SK::Circle_3 
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type;
 };
 
@@ -86,8 +90,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Circle_3>
 {
   typedef boost::variant< 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circle_3,
-            int 
+            typename SK::Circle_3
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL 
           > type; 
 };
 
@@ -95,7 +99,8 @@ template <typename SK>
 struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Line_3>
 {
   typedef boost::variant<
-            std::pair <typename SK::Circular_arc_point_3, unsigned int > 
+            std::pair <typename SK::Circular_arc_point_3, unsigned int >
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type; 
 };
 
@@ -109,8 +114,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circular_arc_3, typename SK::Cir
   typedef boost::variant< 
             typename SK::Circle_3, 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circular_arc_3 ,
-            int
+            typename SK::Circular_arc_3
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type;
 };
 
@@ -119,8 +124,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circular_arc_3, typename SK::Pla
 {
   typedef boost::variant<
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circular_arc_3,
-            int 
+            typename SK::Circular_arc_3
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type;
 };
 
@@ -133,8 +138,8 @@ struct SK3_Intersection_traits<SK, typename SK::Line_arc_3, typename SK::Line_ar
 { 
   typedef boost::variant< 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Line_arc_3,
-            int 
+            typename SK::Line_arc_3
+            CGAL_ADDITIONAL_VARIANT_FOR_ICL
           > type; 
 };
   

--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
@@ -52,7 +52,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Plane_3>
 {
   typedef boost::variant< 
             std::pair< typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circle_3 
+            typename SK::Circle_3,
+            int
           > type; };
 
 template <typename SK>
@@ -64,7 +65,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Sphere_3>
 { 
   typedef boost::variant< 
             std::pair< typename SK::Circular_arc_point_3, unsigned int >, 
-            typename SK::Circle_3 
+            typename SK::Circle_3 ,
+            int
           > type;
 };
 
@@ -77,7 +79,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Circle_3>
 {
   typedef boost::variant< 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circle_3 
+            typename SK::Circle_3,
+            int 
           > type; 
 };
 
@@ -99,7 +102,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circular_arc_3, typename SK::Cir
   typedef boost::variant< 
             typename SK::Circle_3, 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circular_arc_3 
+            typename SK::Circular_arc_3 ,
+            int
           > type;
 };
 
@@ -108,7 +112,8 @@ struct SK3_Intersection_traits<SK, typename SK::Circular_arc_3, typename SK::Pla
 {
   typedef boost::variant<
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Circular_arc_3 
+            typename SK::Circular_arc_3,
+            int 
           > type;
 };
 
@@ -121,7 +126,8 @@ struct SK3_Intersection_traits<SK, typename SK::Line_arc_3, typename SK::Line_ar
 { 
   typedef boost::variant< 
             std::pair <typename SK::Circular_arc_point_3, unsigned int >,
-            typename SK::Line_arc_3 
+            typename SK::Line_arc_3,
+            int 
           > type; 
 };
   
@@ -133,7 +139,8 @@ struct SK3_intersect_ternary
             typename SK::Circle_3,
             typename SK::Plane_3,
             typename SK::Sphere_3,
-            std::pair< typename SK::Circular_arc_point_3, unsigned >
+            std::pair< typename SK::Circular_arc_point_3, unsigned >,
+            int
           > type;
 };
 

--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/Intersection_traits.h
@@ -60,6 +60,13 @@ template <typename SK>
 struct SK3_Intersection_traits<SK, typename SK::Plane_3, typename SK::Circle_3>
   : SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Plane_3> {};
 
+
+// The additional int in the variant has the only purpose to work around
+// a bug of the Intel compiler, which without it produces the error
+// /usr/include/boost/type_traits/has_nothrow_copy.hpp(36): internal error: bad pointer
+// template struct has_nothrow_copy_constructor : public integral_constant{};
+// See also https://github.com/CGAL/cgal/issues/1581
+
 template <typename SK>
 struct SK3_Intersection_traits<SK, typename SK::Circle_3, typename SK::Sphere_3>
 { 

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -547,4 +547,10 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 #  define CGAL_NO_ASSERTIONS_BOOL true
 #endif
 
+#if defined( __INTEL_COMPILER)
+#define CGAL_ADDITIONAL_VARIANT_FOR_ICL ,int
+#else
+#define CGAL_ADDITIONAL_VARIANT_FOR_ICL
+#endif
+
 #endif // CGAL_CONFIG_H


### PR DESCRIPTION
This should fix Issue #1581  which shows up as error in the [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-22/Circular_kernel_2/TestReport_lrineau_x86-64_Linux-Fedora_IntelCompiler-17.gz)