### PR TITLE
Make Algebraic_kernel_d independent from CGAL/Arr_enum.h

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
@@ -39,7 +39,6 @@
 #include <CGAL/Cache.h>
 #include <CGAL/function_objects.h>
 #include <CGAL/Handle_with_policy.h>
-#include <CGAL/Arr_enums.h>
 
 #include <CGAL/Algebraic_kernel_d/Bitstream_descartes.h>
 #include <CGAL/Algebraic_kernel_d/Interval_evaluate_1.h>
@@ -2099,21 +2098,21 @@ public:
     /*!
      * \brief Returns the limit an infinite arc converges to
      *
-     * \pre <tt>loc==CGAL::ARR_LEFT_BOUNDARY || 
-     *          loc==CGAL::ARR_RIGHT_BOUNDARY</tt>
+     * \pre <tt>loc==CGAL::LEFT_BOUNDARY || 
+     *          loc==CGAL::RIGHT_BOUNDARY</tt>
      *
      * This method returns for the <tt>arcno</tt>th arc that goes to -infinity
      * or +infinity (depending on \c loc) the y-coordinate it converges to.
      * Possible values are either a \c Algebraic_real_1 object, or one of the
-     * values \c CGAL::ARR_TOP_BOUNDARY, \c CGAL::ARR_BOTTOM_BOUNDARY
+     * values \c CGAL::TOP_BOUNDARY, \c CGAL::BOTTOM_BOUNDARY
      * that denote that the arc is unbounded in y-direction. 
      * The result is wrapped into a \c CGAL::Object object.
      */
-    Asymptote_y asymptotic_value_of_arc(CGAL::Arr_parameter_space loc,
+    Asymptote_y asymptotic_value_of_arc(CGAL::Box_parameter_space_2 loc,
                                         size_type arcno) const {
         
-        CGAL_precondition(loc == CGAL::ARR_LEFT_BOUNDARY ||
-                          loc == CGAL::ARR_RIGHT_BOUNDARY);
+        CGAL_precondition(loc == CGAL::LEFT_BOUNDARY ||
+                          loc == CGAL::RIGHT_BOUNDARY);
 
 #if CGAL_ACK_USE_SPECIAL_TREATMENT_FOR_CONIX
         if(CGAL::degree(polynomial_2(),1)==2) {
@@ -2121,7 +2120,7 @@ public:
         }
 #endif
         
-        if(loc == CGAL::ARR_LEFT_BOUNDARY) {
+        if(loc == CGAL::LEFT_BOUNDARY) {
             
             if(! this->ptr()->horizontal_asymptotes_left) {
                 compute_horizontal_asymptotes();
@@ -2131,7 +2130,7 @@ public:
             CGAL_precondition(arcno>=0 && 
                               arcno<static_cast<size_type>(asym_info.size()));
             return asym_info[arcno];
-        } // else loc == CGAL::ARR_RIGHT_BOUNDARY
+        } // else loc == CGAL::RIGHT_BOUNDARY
 
         if(! this->ptr()->horizontal_asymptotes_right) {
             compute_horizontal_asymptotes();
@@ -2210,7 +2209,7 @@ private:
         while(i<number_of_roots_at_left_end) {
             if(current_stripe==static_cast<size_type>(stripe_bounds.size())) {
                 asym_left_info.push_back( CGAL::make_object
-                                              (CGAL::ARR_TOP_BOUNDARY) );
+                                              (CGAL::TOP_BOUNDARY) );
                 i++;
                 continue;
             }
@@ -2221,7 +2220,7 @@ private:
             if(roots_at_left_end[i].high() < stripe_bounds[current_stripe]) {
                 if(current_stripe==0) {
                     asym_left_info.push_back(CGAL::make_object
-                                                 (CGAL::ARR_BOTTOM_BOUNDARY));
+                                                 (CGAL::BOTTOM_BOUNDARY));
                     i++;
                     continue;
                 } else {
@@ -2249,7 +2248,7 @@ private:
         while(i<number_of_roots_at_right_end) {
             if(current_stripe==static_cast<size_type>(stripe_bounds.size())) {
                 asym_right_info.push_back(CGAL::make_object
-                                              (CGAL::ARR_TOP_BOUNDARY) );
+                                              (CGAL::TOP_BOUNDARY) );
                 i++;
                 continue;
             }
@@ -2260,7 +2259,7 @@ private:
             if(roots_at_right_end[i].high() < stripe_bounds[current_stripe]) {
                 if(current_stripe==0) {
                     asym_right_info.push_back(CGAL::make_object
-                                                  (CGAL::ARR_BOTTOM_BOUNDARY));
+                                                  (CGAL::BOTTOM_BOUNDARY));
                     i++;
                     continue;
                 } else {
@@ -2387,7 +2386,7 @@ private:
         CGAL_error_msg("Implement me");
     }
 
-    Asymptote_y conic_asymptotic_value_of_arc(CGAL::Arr_parameter_space loc,
+    Asymptote_y conic_asymptotic_value_of_arc(CGAL::Box_parameter_space_2 loc,
                                               size_type arcno) const {
         CGAL_error_msg("Implement me");
         return Asymptote_y();
@@ -2443,19 +2442,19 @@ std::ostream& operator<< (
       for (size_type i = 0; i < curve.arcs_over_interval(0); i++) {
         
         const Asymptote_y& curr_asym_info_obj 
-          = curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,i);
+          = curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,i);
         typename Curve::Algebraic_real_1 curr_asym_info;
         bool is_finite = CGAL::assign(curr_asym_info,curr_asym_info_obj);
         if (!is_finite) {
           // Assignment to prevent compiler warning
-          CGAL::Arr_parameter_space loc = CGAL::ARR_LEFT_BOUNDARY;
+          CGAL::Box_parameter_space_2 loc = CGAL::LEFT_BOUNDARY;
           CGAL_assertion_code(bool is_valid = )
             CGAL::assign(loc, curr_asym_info_obj);
           CGAL_assertion(is_valid);
-          if (loc == CGAL::ARR_TOP_BOUNDARY) {
+          if (loc == CGAL::TOP_BOUNDARY) {
             out << "+infty " << std::flush;
           } else {
-            CGAL_assertion(loc == CGAL::ARR_BOTTOM_BOUNDARY);
+            CGAL_assertion(loc == CGAL::BOTTOM_BOUNDARY);
             out << "-infty " << std::flush;
           }
         } else { // is_finite
@@ -2485,19 +2484,19 @@ std::ostream& operator<< (
       for (size_type i = 0; i < curve.arcs_over_interval(no_events); i++) {
         
         const Asymptote_y& curr_asym_info_obj 
-          = curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,i);
+          = curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,i);
         typename Curve::Algebraic_real_1 curr_asym_info;
         bool is_finite = CGAL::assign(curr_asym_info,curr_asym_info_obj);
         if(! is_finite) {
           // Assignment to prevent compiler warning
-          CGAL::Arr_parameter_space loc = CGAL::ARR_LEFT_BOUNDARY;
+          CGAL::Box_parameter_space_2 loc = CGAL::LEFT_BOUNDARY;
           CGAL_assertion_code(bool is_valid = )
             CGAL::assign(loc, curr_asym_info_obj);
           CGAL_assertion(is_valid);
-          if(loc == CGAL::ARR_TOP_BOUNDARY) {
+          if(loc == CGAL::TOP_BOUNDARY) {
             out << "+infty " << std::flush;
           } else {
-            CGAL_assertion(loc == CGAL::ARR_BOTTOM_BOUNDARY);
+            CGAL_assertion(loc == CGAL::BOTTOM_BOUNDARY);
             out << "-infty " << std::flush;
           }
         } else { // is_finite

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/Curve_analysis_2.cpp
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/Curve_analysis_2.cpp
@@ -145,16 +145,16 @@ template<typename Arithmetic_kernel> void test_routine() {
         assert(number_of_objects<Algebraic_kernel_d_2>(curve)==1);
         //assert(!curve.may_be_singular());
 
-        CGAL::Arr_parameter_space loc;
+        CGAL::Box_parameter_space_2 loc;
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (loc,
-                curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+                curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,0)));
+        assert( loc == CGAL::TOP_BOUNDARY);
         
     }
     {
@@ -174,16 +174,16 @@ template<typename Arithmetic_kernel> void test_routine() {
                ==1);
         assert(event.number_of_branches_approaching_plus_infinity().first==1);
         assert(event.number_of_branches_approaching_plus_infinity().second==0);
-        CGAL::Arr_parameter_space loc;
+        CGAL::Box_parameter_space_2 loc;
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (loc,
-                curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+                curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,0)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
     }
     {
@@ -235,62 +235,62 @@ template<typename Arithmetic_kernel> void test_routine() {
         assert(event.upper_bound(3) < Rational(201,100));
         assert(! event.is_event(0));
 
-        CGAL::Arr_parameter_space loc;
+        CGAL::Box_parameter_space_2 loc;
         Algebraic_real y_coor;
 
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,1)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,1)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (y_coor,
-                curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,2)));
+                curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,2)));
         assert( y_coor == Rational(0));
 
         assert(CGAL::assign
                (y_coor,
-                curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,3)));
+                curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,3)));
         assert( y_coor == Rational(2));
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,4)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,4)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,5)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,5)));
+        assert( loc == CGAL::TOP_BOUNDARY);
         
         
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,1)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,1)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (y_coor,
-                curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,2)));
+                curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,2)));
         assert( y_coor == Rational(0));
 
         assert(CGAL::assign
                (y_coor,
-                curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,3)));
+                curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,3)));
         assert( y_coor == Rational(2));
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,4)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,4)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,5)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,5)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
 
     }
@@ -469,62 +469,62 @@ template<typename Arithmetic_kernel> void test_routine() {
         assert(! event.is_event(0));
 
 
-        CGAL::Arr_parameter_space loc;
+        CGAL::Box_parameter_space_2 loc;
         Sqrt_algebraic_real y_coor;
 
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,1)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,1)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (y_coor,
-                sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,2)));
+                sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,2)));
         assert( y_coor == Rational(0));
 
         assert(CGAL::assign
                (y_coor,
-                sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,3)));
+                sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,3)));
         assert( y_coor == Rational(2));
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,4)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,4)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_LEFT_BOUNDARY,5)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::LEFT_BOUNDARY,5)));
+        assert( loc == CGAL::TOP_BOUNDARY);
         
         
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,0)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,0)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,1)));
-        assert( loc == CGAL::ARR_BOTTOM_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,1)));
+        assert( loc == CGAL::BOTTOM_BOUNDARY);
 
         assert(CGAL::assign
                (y_coor,
-                sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,2)));
+                sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,2)));
         assert( y_coor == Rational(0));
 
         assert(CGAL::assign
                (y_coor,
-                sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,3)));
+                sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,3)));
         assert( y_coor == Rational(2));
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,4)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,4)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
         assert(CGAL::assign
-               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::ARR_RIGHT_BOUNDARY,5)));
-        assert( loc == CGAL::ARR_TOP_BOUNDARY);
+               (loc,sqrt_curve.asymptotic_value_of_arc(CGAL::RIGHT_BOUNDARY,5)));
+        assert( loc == CGAL::TOP_BOUNDARY);
 
     }
 #endif

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_enums.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_enums.h
@@ -24,9 +24,32 @@ enum Arr_halfedge_direction { ARR_LEFT_TO_RIGHT, ARR_RIGHT_TO_LEFT };
 /*!
   \ingroup PkgArrangement2Enums
 */
-enum Arr_parameter_space { ARR_LEFT_BOUNDARY,
-                           ARR_RIGHT_BOUNDARY,
-                           ARR_BOTTOM_BOUNDARY,
-                           ARR_TOP_BOUNDARY,
-                           ARR_INTERIOR};
+typedef Box_parameter_space_2 Arr_parameter_space;
+
+/*!
+  \ingroup PkgArrangement2Enums
+*/
+const Arr_parameter_space ARR_LEFT_BOUNDARY = LEFT_BOUNDARY;
+
+/*!
+  \ingroup PkgArrangement2Enums
+*/
+const Arr_parameter_space ARR_RIGHT_BOUNDARY = RIGHT_BOUNDARY;
+
+/*!
+  \ingroup PkgArrangement2Enums
+*/
+const Arr_parameter_space ARR_BOTTOM_BOUNDARY = BOTTOM_BOUNDARY;
+
+/*!
+  \ingroup PkgArrangement2Enums
+*/
+const Arr_parameter_space ARR_TOP_BOUNDARY = TOP_BOUNDARY;
+
+/*!
+  \ingroup PkgArrangement2Enums
+*/
+  const Arr_parameter_space ARR_INTERIOR = INTERIOR;
+
+
 } /* end namespace CGAL */

--- a/Arrangement_on_surface_2/include/CGAL/Arr_enums.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_enums.h
@@ -138,13 +138,18 @@ OutputStream& operator<<(
 /*! \enum The various surface parameter space options categorizing the
  * surface range according to the parameter domain.
  */
-enum Arr_parameter_space {
-  ARR_LEFT_BOUNDARY = 0,
-  ARR_RIGHT_BOUNDARY,
-  ARR_BOTTOM_BOUNDARY,
-  ARR_TOP_BOUNDARY,
-  ARR_INTERIOR
-};
+
+typedef Box_parameter_space_2 Arr_parameter_space;
+
+const Arr_parameter_space ARR_LEFT_BOUNDARY = LEFT_BOUNDARY;
+
+const Arr_parameter_space ARR_RIGHT_BOUNDARY = RIGHT_BOUNDARY;
+
+const Arr_parameter_space ARR_BOTTOM_BOUNDARY = BOTTOM_BOUNDARY;
+
+const Arr_parameter_space ARR_TOP_BOUNDARY = TOP_BOUNDARY;
+
+const Arr_parameter_space ARR_INTERIOR = INTERIOR;
 
 
 //! \brief prints parameter space (for debugging)

--- a/Kernel_23/doc/Kernel_23/CGAL/enum.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/enum.h
@@ -124,6 +124,19 @@ const CGAL::Orientation DEGENERATE = ZERO;
 
 /*!
 \ingroup kernel_enums
+*/
+enum Box_parameter_space_2
+     {
+        LEFT_BOUNDARY = 0,
+        RIGHT_BOUNDARY,
+        BOTTOM_BOUNDARY,
+        TOP_BOUNDARY,
+        INTERIOR,
+        EXTERIOR
+     };
+
+/*!
+\ingroup kernel_enums
 
 A symbolic constant used to construct zero length vectors.
 

--- a/Kernel_23/include/CGAL/enum.h
+++ b/Kernel_23/include/CGAL/enum.h
@@ -96,6 +96,19 @@ inline Sign operator* (Sign s1, Sign s2)
     return static_cast<Sign> (static_cast<int> (s1) * static_cast<int> (s2));
 }
 
+
+enum Box_parameter_space_2
+     {
+        LEFT_BOUNDARY = 0,
+        RIGHT_BOUNDARY,
+        BOTTOM_BOUNDARY,
+        TOP_BOUNDARY,
+        INTERIOR,
+        EXTERIOR
+     };
+    
+
+
 #ifdef CGAL_CFG_MATCHING_BUG_5
 
 template < typename T, typename U >


### PR DESCRIPTION
Introduce the `enum Box_parameterization_2` in `CGAL/enum.h`
Add a `typedef `and constants in the Arrangement package to stay backward compatible

This solves Issue #1495