### PR TITLE
SearchStructures: No need to make an allocator a static data member

### DIFF
--- a/SearchStructures/include/CGAL/Segment_tree_d.h
+++ b/SearchStructures/include/CGAL/Segment_tree_d.h
@@ -704,9 +704,6 @@ public:
   }
 };
 
-template <class C_Data, class C_Window, class C_Interface>
-std::allocator<Segment_tree_node<C_Data,C_Window,C_Interface> > 
-    Segment_tree_d<C_Data,C_Window,C_Interface>::alloc;
 
 } //namespace CGAL
 

--- a/SearchStructures/include/CGAL/Segment_tree_d.h
+++ b/SearchStructures/include/CGAL/Segment_tree_d.h
@@ -103,7 +103,7 @@ protected:
   typedef Segment_tree_node<C_Data,C_Window,C_Interface> Segment_tree_node_t;
   typedef Segment_tree_node<C_Data,C_Window,C_Interface> *link_type;
   
-  static std::allocator<Segment_tree_node_t> alloc;
+  std::allocator<Segment_tree_node_t> alloc;
   
   C_Interface m_interface;
   bool is_built;


### PR DESCRIPTION
This should fix #1401