### PR TITLE
Triangulation_2: initialize data members to avoid warning

### DIFF
--- a/Triangulation_2/include/CGAL/boost/graph/graph_traits_Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/boost/graph/graph_traits_Triangulation_2.h
@@ -270,6 +270,7 @@ public:
       operator std::pair<face_descriptor, int>() { return std::make_pair(first,second); }
       
       T2_halfedge_descriptor()
+        : first(), second(0)
       {}
       
       T2_halfedge_descriptor(const typename Tr::Edge& e)


### PR DESCRIPTION
This should fix this [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-25/Hash_map/TestReport_lrineau_CentOS7-Release.gz)