### PR TITLE
Workaround a bug in boost 1.58 with c++14

### DIFF
--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -1320,14 +1320,22 @@ public:
   template<BOOST_VARIANT_ENUM_PARAMS(typename T)>
   Self& operator=(const boost::variant<BOOST_VARIANT_ENUM_PARAMS(T) >& t) {
     internal::Output_visitor<Self> visitor(this);
+    #if BOOST_VERSION==105800
+    t.apply_visitor(visitor);
+    #else
     boost::apply_visitor(visitor, t);
+    #endif
     return *this;
   }
 
   template<BOOST_VARIANT_ENUM_PARAMS(typename T)>
   Self& operator=(const boost::optional< boost::variant<BOOST_VARIANT_ENUM_PARAMS(T) > >& t) {
     internal::Output_visitor<Self> visitor(this);
-    if(t) boost::apply_visitor(visitor, *t);
+    #if BOOST_VERSION==105800
+    if(t) t->apply_visitor(visitor);
+    #else
+    if(t)  boost::apply_visitor(visitor, *t);
+    #endif
     return *this;
   }
 


### PR DESCRIPTION
Fixes [this test](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-25/STL_Extension/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz) and [that example](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-25/Kernel_23_Examples/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz).

See also https://svn.boost.org/trac/boost/ticket/11285