### PR TITLE
SDG_2: Set the failbit if the operator>> for Site fails.

### DIFF
--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_site_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_site_2.h
@@ -330,6 +330,8 @@ operator>>(std::istream &is,
       Point_2 p1, p2;
       is >> p1 >> p2;
       t = Site_2::construct_site_2(p1, p2);
+    } else {
+      is.setstate(std::ios::failbit);
     }
   }
   return is;


### PR DESCRIPTION
This should fix this [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-25/Segment_Delaunay_graph_2/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz)