### PR TITLE
Kernel_23:  Set the failbit in operator>> for Kernel objects

### DIFF
--- a/Kernel_23/include/CGAL/Circle_2.h
+++ b/Kernel_23/include/CGAL/Circle_2.h
@@ -283,6 +283,7 @@ extract(std::istream& is, Circle_2<R>& c)
         is >> o;
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Direction_2.h
+++ b/Kernel_23/include/CGAL/Direction_2.h
@@ -241,6 +241,7 @@ extract(std::istream& is, Direction_2<R>& d, const Cartesian_tag&)
         read(is, y);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << std::endl << "Stream must be in ascii or binary mode"
                   << std::endl;
         break;
@@ -265,6 +266,7 @@ extract(std::istream& is, Direction_2<R>& d, const Homogeneous_tag&)
         read(is, y);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Direction_3.h
+++ b/Kernel_23/include/CGAL/Direction_3.h
@@ -199,6 +199,7 @@ extract(std::istream& is, Direction_3<R>& d, const Cartesian_tag&)
       read(is, z);
       break;
     default:
+      is.setstate(std::ios::failbit);
       std::cerr << "" << std::endl;
       std::cerr << "Stream must be in ascii or binary mode" << std::endl;
       break;
@@ -224,6 +225,7 @@ extract(std::istream& is, Direction_3<R>& d, const Homogeneous_tag&)
         read(is, z);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Line_2.h
+++ b/Kernel_23/include/CGAL/Line_2.h
@@ -271,6 +271,7 @@ extract(std::istream& is, Line_2<R>& l)
         read(is, c);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Plane_3.h
+++ b/Kernel_23/include/CGAL/Plane_3.h
@@ -269,6 +269,7 @@ operator>>(std::istream &is, Plane_3<R> &p)
         read(is, d);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Point_2.h
+++ b/Kernel_23/include/CGAL/Point_2.h
@@ -239,6 +239,7 @@ extract(std::istream& is, Point_2<R>& p, const Cartesian_tag&)
         read(is, y);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;
@@ -265,6 +266,7 @@ extract(std::istream& is, Point_2<R>& p, const Homogeneous_tag&)
         read(is, hw);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Point_3.h
+++ b/Kernel_23/include/CGAL/Point_3.h
@@ -268,6 +268,7 @@ extract(std::istream& is, Point_3<R>& p, const Cartesian_tag&)
         read(is, z);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;
@@ -295,6 +296,7 @@ extract(std::istream& is, Point_3<R>& p, const Homogeneous_tag&)
         read(is, hw);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Sphere_3.h
+++ b/Kernel_23/include/CGAL/Sphere_3.h
@@ -301,6 +301,7 @@ extract(std::istream& is, Sphere_3<R>& c, const Cartesian_tag&)
         is >> o;
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;
@@ -328,6 +329,7 @@ extract(std::istream& is, Sphere_3<R>& c, const Homogeneous_tag&)
         is >> o;
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Vector_2.h
+++ b/Kernel_23/include/CGAL/Vector_2.h
@@ -345,6 +345,7 @@ extract(std::istream& is, Vector_2<R>& v, const Cartesian_tag&)
         read(is, y);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;
@@ -371,6 +372,7 @@ extract(std::istream& is, Vector_2<R>& v, const Homogeneous_tag&)
         read(is, hw);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;

--- a/Kernel_23/include/CGAL/Vector_3.h
+++ b/Kernel_23/include/CGAL/Vector_3.h
@@ -326,6 +326,7 @@ extract(std::istream& is, Vector_3<R>& v, const Cartesian_tag&)
       read(is, z);
       break;
     default:
+      is.setstate(std::ios::failbit);
       std::cerr << "" << std::endl;
       std::cerr << "Stream must be in ascii or binary mode" << std::endl;
       break;
@@ -352,6 +353,7 @@ extract(std::istream& is, Vector_3<R>& v, const Homogeneous_tag&)
         read(is, hw);
         break;
     default:
+        is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
         std::cerr << "Stream must be in ascii or binary mode" << std::endl;
         break;


### PR DESCRIPTION
It might fix this [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-25/Kernel_23/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz)