### PR TITLE
Polyhedron_demo : Load empty OFF files

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -64,6 +64,7 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
     {
       in.seekg(0);
       Scene_points_with_normal_item* item = new Scene_points_with_normal_item();
+      if (scanner.size_of_vertices()==0) return item;
       if(!item->read_off_point_set(in))
         {
           delete item;


### PR DESCRIPTION
This PR makes the demo create an empty scene_polyhedron_item if the OFF is empty, instead of crashing (in command line) or popping an error message.