### PR TITLE
Fix the Unique_hash_map specialization of boost's associative property map

### DIFF
--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -129,10 +129,13 @@ namespace boost {
 
   struct lvalue_property_map_tag;
 
-  template <typename KeyType, typename ValueType>
-  class associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >
+  template <typename KeyType, typename ValueType,
+            typename HashFunction, typename Allocator>
+  class associative_property_map<CGAL::Unique_hash_map<KeyType, ValueType,
+                                                       HashFunction, Allocator> >
   {
-    typedef CGAL::Unique_hash_map<KeyType,ValueType> C;
+    typedef CGAL::Unique_hash_map<KeyType, ValueType, HashFunction, Allocator> C;
+
   public:
     typedef KeyType key_type;
     typedef ValueType value_type;
@@ -146,16 +149,14 @@ namespace boost {
 
   friend
   const value_type&
-  get(const associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm,
-      const key_type& key)
+  get(const associative_property_map<C>& uhm, const key_type& key)
   {
     return uhm[key];
   }
 
   friend
   void
-  put(associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm,
-      const key_type& key, const value_type& val)
+  put(associative_property_map<C>& uhm, const key_type& key, const value_type& val)
   {
     uhm[key] = val;
   }
@@ -164,18 +165,18 @@ namespace boost {
     C* m_c;
   };
 
-
-  template <typename KeyType, typename ValueType>
-  associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >
-  make_assoc_property_map(CGAL::Unique_hash_map<KeyType,ValueType> & c)
+  template <typename KeyType, typename ValueType,
+            typename HashFunction, typename Allocator>
+  associative_property_map<CGAL::Unique_hash_map<KeyType, ValueType,
+                                                 HashFunction, Allocator> >
+  make_assoc_property_map(CGAL::Unique_hash_map<KeyType, ValueType,
+                                                HashFunction, Allocator>& c)
   {
-    return associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >(c);
+    return associative_property_map<CGAL::Unique_hash_map<KeyType, ValueType,
+                                                          HashFunction, Allocator> >(c);
   }
 
-
 }
-
-
 
 #endif // CGAL_UNIQUE_HASH_MAP_H
 // EOF

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -136,13 +136,25 @@ namespace boost {
   public:
     typedef KeyType key_type;
     typedef ValueType value_type;
-    typedef value_type& reference;
+    typedef const value_type& reference;
     typedef lvalue_property_map_tag category;
     associative_property_map() : m_c(0) { }
     associative_property_map(C& c) : m_c(&c) { }
-    reference operator[](const key_type& k) const {
+    value_type& operator[](const key_type& k) const {
       return (*m_c)[k];
     }
+
+  friend const ValueType&  get(const associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key)
+  {
+    return uhm[key];
+  }
+
+  friend
+  void put(associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key, const ValueType& val)
+  {
+    uhm[key] = val;
+  }
+
   private:
     C* m_c;
   };
@@ -153,19 +165,6 @@ namespace boost {
   make_assoc_property_map(CGAL::Unique_hash_map<KeyType,ValueType> & c)
   {
     return associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >(c);
-  }
-  
-  
-  template <typename KeyType, typename ValueType>
-  ValueType&  get(const associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key)
-  {
-    return uhm[key];
-  }
-  
-  template <typename KeyType, typename ValueType>
-  void put(associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key, const ValueType& val)
-  {
-    uhm[key] = val;
   }
 
 

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -144,13 +144,18 @@ namespace boost {
       return (*m_c)[k];
     }
 
-  friend const ValueType&  get(const associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key)
+  friend
+  const value_type&
+  get(const associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm,
+      const key_type& key)
   {
     return uhm[key];
   }
 
   friend
-  void put(associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm, const KeyType& key, const ValueType& val)
+  void
+  put(associative_property_map<CGAL::Unique_hash_map<KeyType,ValueType> >& uhm,
+      const key_type& key, const value_type& val)
   {
     uhm[key] = val;
   }


### PR DESCRIPTION
This PR is a bugfix to the specialization of `boost::associative_property_map` using `CGAL::Unique_hash_map`. The latter uses four template parameters (last two having default values), but only the first two were used in the specialization, which created issues if one wished to use a `Unique_hash_map` that does not rely on the default parameters for `HashFunction` and `Allocator`.

I also included the improvements of commit f32b291, which seemed natural.