### PR TITLE
Do not early exit if IPE_FULL_VERSION is not there

### DIFF
--- a/Installation/cmake/modules/FindIPE.cmake
+++ b/Installation/cmake/modules/FindIPE.cmake
@@ -8,7 +8,7 @@
 
 
 # Is it already configured?
-if (IPE_INCLUDE_DIR AND IPE_LIBRARIES )
+if (IPE_INCLUDE_DIR AND IPE_LIBRARIES AND IPE_FULL_VERSION)
   set(IPE_FOUND TRUE)
 else()  
   find_path(IPE_INCLUDE_DIR 


### PR DESCRIPTION
If `IPE_FULL_VERSION` is missing, that leads to a CMake error in
`CMakeLists.txt` files using it.