### PR TITLE
Fix PMP::isotropic_remeshing doc bug

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -41,8 +41,7 @@ namespace Polygon_mesh_processing {
 * edge flips, tangential relaxation and projection to the initial surface
 * to generate a smooth mesh with a prescribed edge length.
 *
-* @tparam PolygonMesh model of `MutableFaceGraph` that 
-*         has an internal property map for `CGAL::vertex_point_t`.
+* @tparam PolygonMesh model of `MutableFaceGraph`.
 *         The descriptor types `boost::graph_traits<PolygonMesh>::%face_descriptor`
 *         and `boost::graph_traits<PolygonMesh>::%halfedge_descriptor` must be
 *         models of `Hashable`.


### PR DESCRIPTION
this internal property map is not needed anymore