### PR TITLE
Remove a non needed requirement from concepts

### DIFF
--- a/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_2.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_2.h
@@ -15,8 +15,7 @@ public:
 /// @{
 
 /*!
-Point type. `CGAL::Kernel_traits` has to be 
-specialized for this type. 
+Point type.
 */ 
 typedef unspecified_type Point_2; 
 

--- a/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_3.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_3.h
@@ -17,8 +17,7 @@ public:
 /// @{
 
 /*!
-Point type. `CGAL::Kernel_traits` has to be 
-specialized for this type. 
+Point type.
 */ 
 typedef unspecified_type Point_3; 
 

--- a/Spatial_searching/doc/Spatial_searching/Concepts/SearchTraits.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/SearchTraits.h
@@ -30,8 +30,7 @@ or `CGAL::Dynamic_dimension_tag`.
 typedef unspecified_type Dimension;
 
 /*!
-Point type. `CGAL::Kernel_traits` has to be 
-specialized for this type. 
+Point type.
 */ 
 typedef unspecified_type Point_d; 
 

--- a/Spatial_searching/examples/Spatial_searching/Point.h
+++ b/Spatial_searching/examples/Spatial_searching/Point.h
@@ -21,20 +21,6 @@ struct Point {
   bool  operator!=(const Point& p) const { return ! (*this == p); }
 }; //end of class
 
-
-
-namespace CGAL {
-
-  template <>
-  struct Kernel_traits<Point> {
-    struct Kernel {
-      typedef double FT;
-      typedef double RT;
-    };
-  };
-}
-
-
 struct Construct_coord_iterator {
   typedef  const double* result_type;
   const double* operator()(const Point& p) const

--- a/Spatial_searching/examples/Spatial_searching/user_defined_point_and_distance.cpp
+++ b/Spatial_searching/examples/Spatial_searching/user_defined_point_and_distance.cpp
@@ -4,7 +4,8 @@
 #include "Point.h"  // defines types Point, Construct_coord_iterator
 #include "Distance.h"
 
-typedef CGAL::Random_points_in_cube_3<Point> Random_points_iterator;
+typedef CGAL::Creator_uniform_3<double,Point> Point_creator;
+typedef CGAL::Random_points_in_cube_3<Point, Point_creator> Random_points_iterator;
 typedef CGAL::Counting_iterator<Random_points_iterator> N_Random_points_iterator;
 typedef CGAL::Dimension_tag<3> D;
 typedef CGAL::Search_traits<double, Point, const double*, Construct_coord_iterator, D> Traits;

--- a/Spatial_searching/test/Spatial_searching/Building_kd_tree_with_own_pointtype.cpp
+++ b/Spatial_searching/test/Spatial_searching/Building_kd_tree_with_own_pointtype.cpp
@@ -10,7 +10,7 @@
 #include "Distance.h"
 #include "Point_with_info.h"
 
-typedef CGAL::Random_points_in_cube_3<Point>                                            Random_points_iterator;
+typedef CGAL::Random_points_in_cube_3<Point, CGAL::Creator_uniform_3<double,Point> >    Random_points_iterator;
 typedef CGAL::Counting_iterator<Random_points_iterator>                                 N_Random_points_iterator;
 typedef CGAL::Search_traits<double, Point, const double*, Construct_coord_iterator>     Traits;
 typedef CGAL::Orthogonal_k_neighbor_search<Traits, Distance>                            K_neighbor_search;

--- a/Spatial_searching/test/Spatial_searching/Point.h
+++ b/Spatial_searching/test/Spatial_searching/Point.h
@@ -21,20 +21,6 @@ struct Point {
   bool  operator!=(const Point& p) const { return ! (*this == p); }
 }; //end of class
 
-
-
-namespace CGAL {
-
-  template <>
-  struct Kernel_traits<Point> {
-    struct Kernel {
-      typedef double FT;
-      typedef double RT;
-    };
-  };
-}
-
-
 struct Construct_coord_iterator {
   typedef const double* result_type;
   const double* operator()(const Point& p) const 


### PR DESCRIPTION
Kernel_traits was needed for the random generator in the examples/tests
