### PR TITLE
STL_Extension : fix conflict with min and max macros of windows

### DIFF
--- a/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
+++ b/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
@@ -598,7 +598,7 @@ private:
     static tbb::atomic<unsigned int> last_id;
     unsigned int id = ++last_id;
     // Ensure it is > 0
-    return (1 + id%(std::numeric_limits<unsigned int>::max()));
+    return (1 + id%((std::numeric_limits<unsigned int>::max)()));
   }
 
 protected:

--- a/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
+++ b/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
@@ -143,16 +143,16 @@ public:
       std::vector<int> locked_cells_tmp;
 
       // For each cell inside the square
-      for (int i = std::max(0, index_x-lock_radius) ;
-           i <= std::min(m_num_grid_cells_per_axis - 1, index_x+lock_radius) ;
+      for (int i = (std::max)(0, index_x-lock_radius) ;
+           i <= (std::min)(m_num_grid_cells_per_axis - 1, index_x+lock_radius) ;
            ++i)
       {
-        for (int j = std::max(0, index_y-lock_radius) ;
-             j <= std::min(m_num_grid_cells_per_axis - 1, index_y+lock_radius) ;
+        for (int j = (std::max)(0, index_y-lock_radius) ;
+             j <= (std::min)(m_num_grid_cells_per_axis - 1, index_y+lock_radius) ;
              ++j)
         {
-          for (int k = std::max(0, index_z-lock_radius) ;
-               k <= std::min(m_num_grid_cells_per_axis - 1, index_z+lock_radius) ;
+          for (int k = (std::max)(0, index_z-lock_radius) ;
+               k <= (std::min)(m_num_grid_cells_per_axis - 1, index_z+lock_radius) ;
                ++k)
           {
             int index_to_lock =


### PR DESCRIPTION
- replace `std::max` by `(std::max)` for windows
- same for min
