### PR TITLE
Polyhedron demo: fixes point set 3

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
@@ -204,7 +204,8 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
       }
         
       Scene_points_with_normal_item *point_item = new Scene_points_with_normal_item;
-            
+      point_item->point_set()->add_normal_map();
+      
       BOOST_FOREACH(std::size_t i, shape->indices_of_assigned_points())
         point_item->point_set()->insert(points->point(*(points->begin()+i)));
       

--- a/Polyhedron/demo/Polyhedron/include/CGAL/Point_set_3/IO.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/Point_set_3/IO.h
@@ -236,6 +236,7 @@ namespace internal
     virtual std::string get_string(const typename CGAL::Point_set_3<Point,Vector>::Index& index)
     {
       std::ostringstream oss;
+      oss.precision (std::numeric_limits<double>::digits10 + 2);
       oss << get(m_pmap, index);
       return oss.str();
     }


### PR DESCRIPTION
The shape detection plugin now segfaults when called. This is caused by a bad merge between PR #1324 and #1527 (`add_normal_map()` must be called before setting normal values).

This PR fixes that and also fixes a problem of precision when saving PLY input (also due to PR #1527).
