### PR TITLE
Mesh_3: Do not construct from a string

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -166,6 +166,14 @@ and <code>src/</code> directories).
 
 <!-- Voronoi Diagrams -->
 <!-- Mesh Generation -->
+<h3> 3D Mesh Generation </h3>
+  <ul>
+    <li>
+      The constructor <code>CGAL::Polyhedral_mesh_domain_with_features_3(std::string)</code> is deprecated.
+    </li>
+  </ul>
+
+
 <!-- Surface Reconstruction -->
 <!-- Geometry Processing -->
 <!-- Spatial Searching and Sorting -->

--- a/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -57,11 +57,6 @@ Its interior of `bounding_polyhedron` will be meshed.
 template <typename Polyhedron> 
 Polyhedral_mesh_domain_with_features_3(Polyhedron bounding_polyhedron); 
 
-/*!
-\deprecated Constructs a `Polyhedral_mesh_domain_with_features_3` from an off file. No feature 
-detection is done at this level. 
-*/ 
-Polyhedral_mesh_domain_with_features_3(const std::string& filename); 
 
 /*!
 Constructs a `Polyhedral_mesh_domain_with_features_3` from a polyhedral surface, and a bounding polyhedral surface.
@@ -74,6 +69,13 @@ The inside of `bounding_polyhedron` will be meshed.
 template <typename Polyhedron> 
 Polyhedral_mesh_domain_with_features_3(Polyhedron polyhedron,
 							 Polyhedron bounding_polyhedron);
+
+/*!
+\deprecated Constructs a `Polyhedral_mesh_domain_with_features_3` from an off file. No feature 
+detection is done at this level. Users must read the file into a `Polyhedron_3` and call the
+constructor above.
+*/ 
+Polyhedral_mesh_domain_with_features_3(const std::string& filename); 
 
 /// @} 
 

--- a/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -58,7 +58,7 @@ template <typename Polyhedron>
 Polyhedral_mesh_domain_with_features_3(Polyhedron bounding_polyhedron); 
 
 /*!
-Constructs a `Polyhedral_mesh_domain_with_features_3` from an off file. No feature 
+\deprecated Constructs a `Polyhedral_mesh_domain_with_features_3` from an off file. No feature 
 detection is done at this level. 
 */ 
 Polyhedral_mesh_domain_with_features_3(const std::string& filename); 

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -40,7 +40,7 @@ int main(int argc, char*argv[])
   Polyhedron polyhedron;
   std::ifstream input(fname);
   input >> polyhedron;
-  if(input.bad()){
+  if(input.fail()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
     return EXIT_FAILURE;
   }

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -9,6 +9,7 @@
 
 // Domain 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 
 #ifdef CGAL_CONCURRENT_MESH_3
@@ -32,8 +33,15 @@ using namespace CGAL::parameters;
 int main(int argc, char*argv[])
 {
   const char* fname = (argc>1)?argv[1]:"data/fandisk.off";
+  std::ifstream input(fname);
+  Polyhedron polyhedron;
+  input >> polyhedron;
+  if(input.bad()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
   // Create domain
-  Mesh_domain domain(fname);
+  Mesh_domain domain(polyhedron);
   
   // Get sharp features
   domain.detect_features();

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -36,7 +36,7 @@ int main(int argc, char*argv[])
   std::ifstream input(fname);
   Polyhedron polyhedron;
   input >> polyhedron;
-  if(input.bad()){
+  if(input.fail()){
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
     return EXIT_FAILURE;
   }

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
@@ -56,5 +56,5 @@ int main()
   std::ofstream off_file("out.off");
   c3t3.output_boundary_to_off(off_file);
 
-  return off_file.bad() ? EXIT_FAILURE : EXIT_SUCCESS;
+  return off_file.fail() ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -74,9 +74,9 @@ class Polyhedral_mesh_domain_with_features_3
     Polyhedral_mesh_domain_3<
       Polyhedron_, IGT_, TriangleAccessor,
       Use_patch_id_tag, Use_exact_intersection_construction_tag > > Base;
-  
+
   typedef Polyhedron_ Polyhedron;
-  
+
 public:
   // Index types
   typedef typename Base::Index                Index;
@@ -99,13 +99,14 @@ public:
   /// Constructors
   Polyhedral_mesh_domain_with_features_3(const Polyhedron& p,
     CGAL::Random* p_rng = NULL);
-  Polyhedral_mesh_domain_with_features_3(const std::string& filename,
+
+  CGAL_DEPRECATED Polyhedral_mesh_domain_with_features_3(const std::string& filename,
     CGAL::Random* p_rng = NULL);
 
   // The following is needed, because otherwise, when a "const char*" is
   // passed, the constructors templates are a better match, than the
   // constructor with `std::string`.
-  Polyhedral_mesh_domain_with_features_3(const char* filename,
+  CGAL_DEPRECATED Polyhedral_mesh_domain_with_features_3(const char* filename,
     CGAL::Random* p_rng = NULL);
 
   // Inherited constructors
@@ -193,9 +194,10 @@ Polyhedral_mesh_domain_with_features_3(const Polyhedron& p,
   this->set_random_generator(p_rng);
 }
 
+
 template < typename GT_, typename P_, typename TA_,
            typename Tag_, typename E_tag_>
-Polyhedral_mesh_domain_with_features_3<GT_,P_,TA_,Tag_,E_tag_>::
+CGAL_DEPRECATED Polyhedral_mesh_domain_with_features_3<GT_,P_,TA_,Tag_,E_tag_>::
 Polyhedral_mesh_domain_with_features_3(const char* filename,
                                        CGAL::Random* p_rng)
   : Base()
@@ -209,9 +211,10 @@ Polyhedral_mesh_domain_with_features_3(const char* filename,
   this->set_random_generator(p_rng);
 }
 
+
 template < typename GT_, typename P_, typename TA_,
            typename Tag_, typename E_tag_>
-Polyhedral_mesh_domain_with_features_3<GT_,P_,TA_,Tag_,E_tag_>::
+CGAL_DEPRECATED Polyhedral_mesh_domain_with_features_3<GT_,P_,TA_,Tag_,E_tag_>::
 Polyhedral_mesh_domain_with_features_3(const std::string& filename,
                                        CGAL::Random* p_rng)
   : Base()

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -54,6 +54,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_meshing_determinism.cpp" )
   create_single_source_cgal_program( "test_c3t3_extract_subdomains_boundaries.cpp" )
   create_single_source_cgal_program( "test_mesh_3_issue_1554.cpp" )
+  create_single_source_cgal_program( "test_mesh_polyhedral_domain_with_features_deprecated.cpp" )
 
 else()
   

--- a/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
@@ -7,8 +7,11 @@
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
 
+#include <fstream>
+
 // Domain 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 
 #ifdef CGAL_CONCURRENT_MESH_3
@@ -43,7 +46,10 @@ int main(int argc, char*argv[])
 {
   const char* fname = (argc>1)?argv[1]:"data/fandisk.off";
   // Create domain
-  Mesh_domain domain(fname);
+  std::ifstream in(fname);
+  Polyhedron poly;
+  in >> poly;
+  Mesh_domain domain(poly);
   
   // Get sharp features
   domain.detect_features();

--- a/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
@@ -1,3 +1,5 @@
+#define  CGAL_NO_DEPRECATION_WARNINGS
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -31,26 +33,18 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main(int argc, char*argv[])
+int main()
 {
-  const char* fname = (argc>1)?argv[1]:"data/fandisk.off";
-  std::ifstream input(fname);
-  Polyhedron polyhedron;
-  input >> polyhedron;
-  if(input.fail()){
-    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
-    return EXIT_FAILURE;
-  }
   // Create domain
-  Mesh_domain domain(polyhedron);
+  Mesh_domain domain("data/cube.off");
   
   // Get sharp features
   domain.detect_features();
 
   // Mesh criteria
-  Mesh_criteria criteria(edge_size = 0.025,
-                         facet_angle = 25, facet_size = 0.05, facet_distance = 0.005,
-                         cell_radius_edge_ratio = 3, cell_size = 0.05);
+  Mesh_criteria criteria(edge_size = 0.3,
+                         facet_angle = 25, facet_size = 0.3, facet_distance = 0.1,
+                         cell_radius_edge_ratio = 3, cell_size = 0.3);
   
   // Mesh generation
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);

--- a/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
@@ -10,11 +10,13 @@
 #include <CGAL/perturb_mesh_3.h>
 #include <CGAL/exude_mesh_3.h>
 
+#include <fstream>
 #include <sstream>
 #include <cstring>
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 
 // Triangulation
@@ -39,7 +41,10 @@ int main(int, char*[])
 
   // Domain
   std::cout << "\tSeed is\t 0" << std::endl;
-  Mesh_domain domain("data/cube.off");
+  std::ifstream input("data/cube.off");
+  Polyhedron polyhedron;
+  input >> polyhedron;
+  Mesh_domain domain(polyhedron);
     //no random generator is given, so CGAL::Random(0) is used
 
   // Get sharp features

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -37,7 +37,7 @@ struct Polyhedron_with_features_tester : public Tester<K>
   void operator()() const
   {
     typedef CGAL::Mesh_3::Robust_intersection_traits_3<K> Gt;
-    typedef CGAL::Mesh_polyhedron_3<Gt>::type Polyhedron;
+    typedef typename CGAL::Mesh_polyhedron_3<Gt>::type Polyhedron;
     typedef CGAL::Polyhedral_mesh_domain_with_features_3<Gt> Mesh_domain;
     
     typedef typename CGAL::Mesh_triangulation_3<

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -29,12 +29,15 @@
 #include <CGAL/IO/File_tetgen.h>
 #include <CGAL/IO/File_binary_mesh_3.h>
 
+#include <fstream>
+
 template <typename K, typename Concurrency_tag = CGAL::Sequential_tag>
 struct Polyhedron_with_features_tester : public Tester<K>
 {
   void operator()() const
   {
     typedef CGAL::Mesh_3::Robust_intersection_traits_3<K> Gt;
+    typedef CGAL::Mesh_polyhedron_3<Gt>::type Polyhedron;
     typedef CGAL::Polyhedral_mesh_domain_with_features_3<Gt> Mesh_domain;
     
     typedef typename CGAL::Mesh_triangulation_3<
@@ -56,7 +59,10 @@ struct Polyhedron_with_features_tester : public Tester<K>
     //-------------------------------------------------------
     std::cout << "\tSeed is\t"
       << CGAL::get_default_random().get_seed() << std::endl;
-    Mesh_domain domain("data/cube.off", &CGAL::get_default_random());
+    std::ifstream input("data/cube.off");
+    Polyhedron polyhedron;
+    input >> polyhedron;
+    Mesh_domain domain(polyhedron, &CGAL::get_default_random());
     domain.detect_features();
 
     // Set mesh criteria


### PR DESCRIPTION
@lrineau and @janetournois: I am not at all lucky with the `typedef` for `Polyhedron` in the example. 
With `Polyhedron_3<K>` it does not compile. Isn't that a contradiction to the sentence  "The only requirement ...." in the [ref man page](http://doc.cgal.org/latest/Mesh_3/classCGAL_1_1Polyhedral__mesh__domain__with__features__3.html#ac4fcfea3273e4a83b580386a3ea29da3) 

With `Mesh_polyhedron_3<K>` it does not compile neither, as it needs the `"::type` suffix -- looks as it was a traits class.

I thought that `Mesh_domain::Polyhedron` could be a good choice but it is not public.