### PR TITLE
Added additional tests for CGAL::Unique_hash_map

### DIFF
--- a/Hash_map/test/Hash_map/Unique_hash_map_test.cpp
+++ b/Hash_map/test/Hash_map/Unique_hash_map_test.cpp
@@ -6,6 +6,11 @@
 using namespace std;
 typedef list<int>::iterator Iterator;
 
+struct Integer_hash_function
+{
+  int operator()(int i) const { return i; }
+};
+
 int main() {
     CGAL_TEST_START;
     list<int> L;
@@ -50,6 +55,26 @@ int main() {
         CGAL_TEST( H4[k] == *k);
     }
     hash = H4.hash_function();
+
+    // test the overload of boost::associative_property_map for CGAL::Unique_hash_map
+    typedef CGAL::Unique_hash_map<Iterator, int> Iterator_hmap;
+    typedef boost::associative_property_map<Iterator_hmap> Iterator_pmap;
+    Iterator_pmap H4_pmap = boost::make_assoc_property_map(H4);
+    for(Iterator k=L.begin(); k!=L.end(); ++k){
+      CGAL_TEST(get(H4_pmap, k) == *k);
+    }
+    L.push_front(0);
+    put(H4_pmap, L.begin(), 0);
+    CGAL_TEST(get(H4_pmap, L.begin()) == 0);
+
+    typedef CGAL::Unique_hash_map<int, int, Integer_hash_function>  Int_hmap;
+    typedef boost::associative_property_map<Int_hmap>               Int_pmap;
+    Int_hmap H5(-1);
+    Int_pmap H5_pmap(H5);
+    put(H5_pmap, -1, 1);
+    CGAL_TEST(get(H5_pmap, -1) == 1);
+    CGAL_TEST(H5_pmap[0] == -1);
+
     std::cerr << "done" << std::endl;
     CGAL_TEST_END;
 }


### PR DESCRIPTION
This PR adds new tests for the overload of `boost::associative_property_map` when the container is a `CGAL::Unique_hash_map`.

Specifically, two `CGAL::Unique_hash_map`s are used, one based on handles and the other on a type that cannot be dereferenced and thus for which the default hash function option (`Handle_hash_function`) cannot be used. Before PR https://github.com/CGAL/cgal/pull/1612, this would not have compiled due to an issue in the default parameters of the overload of `boost::associative_property_map`.

These tests are put in the file `Unique_hash_map_test.cpp` for consistency.