### PR TITLE
STL_extension: error/warning behavior/handler is not thread safe

### DIFF
--- a/STL_Extension/doc/STL_Extension/CGAL/assertions_behaviour.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/assertions_behaviour.h
@@ -29,24 +29,28 @@ typedef
 
 
 /*!
+This function is not thread safe.
  */
 Failure_function
 set_error_handler( Failure_function handler);
 
 
 /*!
+This function is not thread safe.
  */
 Failure_function
 set_warning_handler( Failure_function handler);
 
 
 /*!
+This function is not thread safe.
  */
 Failure_behaviour
 set_error_behaviour(Failure_behaviour eb);
 
 
 /*!
+This function is not thread safe.
  */
 Failure_behaviour
 set_warning_behaviour(Failure_behaviour eb);

--- a/STL_Extension/doc/STL_Extension/STL_Extension.txt
+++ b/STL_Extension/doc/STL_Extension/STL_Extension.txt
@@ -333,6 +333,8 @@ For warnings we provide `set_warning_behaviour()` which works in the same way.
 The only difference is that for warnings the default value is
 `CONTINUE`.
 
+Setting the error and warning behavior is not thead safe.
+
 
 \subsection stl_control Control at a Finer Granularity
 

--- a/STL_Extension/include/CGAL/vector.h
+++ b/STL_Extension/include/CGAL/vector.h
@@ -174,11 +174,7 @@ public:
     typedef std::reverse_iterator<const_iterator>    const_reverse_iterator;
 
 protected:
-#ifndef _MSC_VER
-    // Somehow the static initialization does not work correctly for MSVC
-    // ---> strange linker errors
-    static
-#endif // _MSC_VER
+
     Allocator alloc;
 
     iterator start_;
@@ -520,11 +516,6 @@ protected:
     }
 }; // class vector
 
-#ifndef _MSC_VER
-// init static member allocator object
-template <class T, class Alloc>
-Alloc vector< T, Alloc>::alloc = Alloc();
-#endif // _MSC_VER
 
 
 template <class T, class Alloc>


### PR DESCRIPTION
We document it, and don't try to make it thread safe.

@sloriot This should solve some, but not all items of  #1396