### PR TITLE
Polyhedron_demo: Fix the header of the sceneView.

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1012,7 +1012,10 @@ void MainWindow::open(QString filename)
     this->addToRecentFiles(fileinfo.absoluteFilePath());
   }
   selectSceneItem(scene->addItem(scene_item));
-  sceneView->resizeColumnToContents(Scene::NameColumn);
+  if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
+    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+  else
+    sceneView->resizeColumnToContents(Scene::NameColumn);
 }
 
 bool MainWindow::open(QString filename, QString loader_name) {
@@ -1723,7 +1726,10 @@ void MainWindow::makeNewGroup()
 {
     Scene_group_item * group = new Scene_group_item();
     scene->addItem(group);
-    sceneView->resizeColumnToContents(Scene::NameColumn);
+    if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
+      sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+    else
+      sceneView->resizeColumnToContents(Scene::NameColumn);
 }
 
 void MainWindow::on_upButton_pressed()
@@ -1874,9 +1880,12 @@ void MainWindow::resetHeader()
   sceneView->header()->setSectionResizeMode(Scene::RenderingModeColumn, QHeaderView::ResizeToContents);
   sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
   sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
-  sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width(" Color "));
+  sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width("_#_"));
   sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
-  sceneView->resizeColumnToContents(Scene::NameColumn);
-  sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString(" AB ")));
-  sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString(" View ")));
+  if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
+    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+  else
+    sceneView->resizeColumnToContents(Scene::NameColumn);
+  sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString("_AB_")));
+  sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString("_View_")));
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -157,19 +157,8 @@ MainWindow::MainWindow(QWidget* parent)
 
   // setup the sceneview: delegation and columns sizing...
   sceneView->setItemDelegate(delegate);
+  resetHeader();
 
- //sceneView->header()->setStretchLastSection(false);
-  /* sceneView->header()->setSectionResizeMode(Scene::NameColumn, QHeaderView::Stretch);
-   sceneView->header()->setSectionResizeMode(Scene::NameColumn, QHeaderView::Stretch);
-  sceneView->header()->setSectionResizeMode(Scene::ColorColumn, QHeaderView::ResizeToContents);
-  sceneView->header()->setSectionResizeMode(Scene::RenderingModeColumn, QHeaderView::Fixed);
-  sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
-  sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
-  sceneView->resizeColumnToContents(Scene::ColorColumn);
-  sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
-  sceneView->resizeColumnToContents(Scene::ABColumn);
-  sceneView->resizeColumnToContents(Scene::VisibleColumn);
-*/
   // setup connections
   connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
           this, SLOT(updateInfo()));
@@ -1023,6 +1012,7 @@ void MainWindow::open(QString filename)
     this->addToRecentFiles(fileinfo.absoluteFilePath());
   }
   selectSceneItem(scene->addItem(scene_item));
+  sceneView->resizeColumnToContents(Scene::NameColumn);
 }
 
 bool MainWindow::open(QString filename, QString loader_name) {
@@ -1180,6 +1170,7 @@ void MainWindow::selectionChanged()
             this, SLOT(updateInfo()));
   }
   viewer->update();
+  resetHeader();
 }
 
 void MainWindow::contextMenuRequested(const QPoint& global_pos) {
@@ -1726,11 +1717,13 @@ void MainWindow::restoreCollapseState()
     QModelIndex modelIndex = scene->index(0,0,scene->invisibleRootItem()->index());
     if(modelIndex.isValid())
         recurseExpand(modelIndex);
+    resetHeader();
 }
 void MainWindow::makeNewGroup()
 {
-    Scene_group_item * group = new Scene_group_item("New group");
+    Scene_group_item * group = new Scene_group_item();
     scene->addItem(group);
+    sceneView->resizeColumnToContents(Scene::NameColumn);
 }
 
 void MainWindow::on_upButton_pressed()
@@ -1871,4 +1864,19 @@ void MainWindow::on_actionMaxTextItemsDisplayed_triggered()
     viewer->textRenderer->setMax(text.toInt());
     ui->actionMaxTextItemsDisplayed->setText(QString("Set Maximum Text Items Displayed : %1").arg(text.toInt()));
   }
+}
+
+void MainWindow::resetHeader()
+{
+  scene->invisibleRootItem()->setColumnCount(5);
+  sceneView->header()->setSectionResizeMode(Scene::NameColumn, QHeaderView::Interactive);
+  sceneView->header()->setSectionResizeMode(Scene::ColorColumn, QHeaderView::Fixed);
+  sceneView->header()->setSectionResizeMode(Scene::RenderingModeColumn, QHeaderView::ResizeToContents);
+  sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
+  sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
+  sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width(" Color "));
+  sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
+  sceneView->resizeColumnToContents(Scene::NameColumn);
+  sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString(" AB ")));
+  sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString(" View ")));
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -315,6 +315,9 @@ protected Q_SLOTS:
   void filterOperations();
   //!Updates the bounding box and moves the camera to fits the scene.
   void on_actionRecenterScene_triggered();
+
+  //!Resizes the header of the scene view
+  void resetHeader();
 protected:
   QList<QAction*> createSubMenus(QList<QAction*>);
   /*! For each objects in the sceneView, loads the associated plugins.

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -591,9 +591,7 @@ Scene::data(const QModelIndex &index, int role) const
     switch(index.column())
     {
     case ColorColumn:
-        if(role == ::Qt::DisplayRole || role == ::Qt::EditRole)
-            return m_entries.value(id)->color();
-        else if(role == ::Qt::DecorationRole)
+        if(role == ::Qt::DecorationRole)
             return m_entries.value(id)->color();
         break;
     case NameColumn:
@@ -937,8 +935,8 @@ bool SceneDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
                 QColor color =
                         QColorDialog::getColor(model->data(index).value<QColor>(),
                                                0/*,
-                                                                                                                                 tr("Select color"),
-                                                                                                                                 QColorDialog::ShowAlphaChannel*/);
+                                               tr("Select color"),
+                                               QColorDialog::ShowAlphaChannel*/);
                 if (color.isValid()) {
                     model->setData(index, color );
                 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -619,7 +619,7 @@ Scene::data(const QModelIndex &index, int role) const
                 return "B";
         }
         else if(role == ::Qt::TextAlignmentRole) {
-            return ::Qt::AlignCenter;
+            return ::Qt::AlignLeft;
         }
         break;
     case VisibleColumn:
@@ -644,7 +644,7 @@ Scene::headerData ( int section, ::Qt::Orientation orientation, int role ) const
                 return tr("Name");
                 break;
             case ColorColumn:
-                return tr("Color");
+                return tr("#");
                 break;
             case RenderingModeColumn:
                 return tr("Mode");


### PR DESCRIPTION
This PR fixes #1319

With this PR, the header is always displayed, and the space for each column is fixed to its minimum, except for the Name column that is resizable and the RenderingMode column that fits its content.