### PR TITLE
Kernel_23: Add the function  FT  l_infinity_distance() for 2D and 3D points

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -243,6 +243,13 @@ and <code>src/</code> directories).
     easier and more intuitive to use.</li>
   </ul>
 <!-- Spatial Searching and Sorting -->
+<h3> Kernel_23 </h3>
+  <ul>
+    <li>
+      Add functions <code>l_infinity_distance()</code> for 2D and 3D.
+    </li>
+  </ul>
+
 <!-- Geometric Optimization -->
 <!-- Interpolation -->
 <!-- Kinetic Data Structures -->

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -165,6 +165,9 @@ and <code>src/</code> directories).
   <ul>
     <li>Added a 2D and 3D weighted point class and predicates and constructions.
     </li>
+    <li>
+      Add functions <code>l_infinity_distance()</code> for 2D and 3D.
+    </li>
   </ul>
 <!-- Convex Hull Algorithms -->
 <!-- Polygons -->
@@ -243,13 +246,6 @@ and <code>src/</code> directories).
     easier and more intuitive to use.</li>
   </ul>
 <!-- Spatial Searching and Sorting -->
-<h3> Kernel_23 </h3>
-  <ul>
-    <li>
-      Add functions <code>l_infinity_distance()</code> for 2D and 3D.
-    </li>
-  </ul>
-
 <!-- Geometric Optimization -->
 <!-- Interpolation -->
 <!-- Kinetic Data Structures -->

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -1988,6 +1988,13 @@ template <typename Kernel>
 Kernel::FT l_infinity_distance(const CGAL::Point_2<Kernel> &p,
                                const CGAL::Point_2<Kernel> &q);
 
+/*!
+returns the distance between `p` and `q` in the L-infinity metric.
+*/
+template <typename Kernel>
+Kernel::FT l_infinity_distance(const CGAL::Point_3<Kernel> &p,
+                               const CGAL::Point_3<Kernel> &q);
+
 /// @}
 
 /// \defgroup left_turn_grp CGAL::left_turn()

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -1975,14 +1975,29 @@ const CGAL::Point_3<Kernel>& t);
 /// \defgroup intersection_spherical_grp CGAL::intersection() (3D Spherical Kernel)
 /// \ingroup intersection_grp
 
+
+/// \defgroup l_infinity_distance_grp CGAL::l_infinity_distance()
+/// \ingroup kernel_global_function
+
+/// @{
+
+/*!
+returns the distance between `p` and `q` in the L-infinity metric.
+*/
+template <typename Kernel>
+Kernel::FT l_infinity_distance(const CGAL::Point_2<Kernel> &p,
+                               const CGAL::Point_2<Kernel> &q);
+
+/// @}
+
 /// \defgroup left_turn_grp CGAL::left_turn()
 /// \ingroup kernel_global_function
 /// \sa `collinear_grp`
 /// \sa `orientation_grp`
 /// \sa `right_turn_grp`
 
-/// @{
 
+/// @{
 /*!
 returns `true` iff `p`, `q`, and `r` form a left turn.
 */
@@ -1992,7 +2007,6 @@ const CGAL::Point_2<Kernel> &q,
 const CGAL::Point_2<Kernel> &r);
 
 /// @}
-
 
 
 /// \defgroup lexicographically_xy_larger_grp CGAL::lexicographically_xy_larger()

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -2323,6 +2323,7 @@ public:
 
 }; /* end Kernel::ComputeHw_2 */
 
+
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects
   \cgalConcept
@@ -2488,6 +2489,30 @@ public:
 
   /// @}
 };
+
+/*!
+  \ingroup PkgKernel23ConceptsFunctionObjects
+  \cgalConcept
+
+  \cgalRefines `AdaptableFunctor` (with 2 arguments)
+
+*/
+class ComputeLInfinityDistance_2 {
+public:
+  /// \name Operations
+  /// A model of this concept must provide:
+  /// @{
+
+  /*!
+    returns the distance between the two points in the L-infinity metric.
+  */
+  Kernel::FT operator()(const Kernel::Point_2& p,
+                        const Kernel::Point_2& q) const;
+
+
+  /// @}
+
+}; /* end Kernel::ComputeLInfinityDistance_2 */
 
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -2513,6 +2513,30 @@ public:
   /// @}
 
 }; /* end Kernel::ComputeLInfinityDistance_2 */
+/*!
+  \ingroup PkgKernel23ConceptsFunctionObjects
+  \cgalConcept
+
+  \cgalRefines `AdaptableFunctor`
+
+*/
+class ComputeLInfinityDistance_3 {
+public:
+
+  /// \name Operations
+  /// A model of this concept must provide:
+  /// @{
+
+  /*!
+    returns the distance between the two points in the L-infinity metric.
+  */
+  Kernel::FT operator()(const Kernel::Point_3& p,
+                        const Kernel::Point_3& q) const;
+
+
+  /// @}
+
+}; /* end Kernel::ComputeLInfinityDistance_3 */
 
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -478,6 +478,11 @@ public:
   typedef unspecified_type  Compute_hw_2;
 
   /*!
+    a model of `Kernel::ComputeLInfinityDistance_2`
+  */
+  typedef unspecified_type  Compute_L_infinity_distance_2;
+
+  /*!
     a model of `Kernel::ComputeXmax_2`
   */
   typedef unspecified_type  Compute_xmax_2;

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1194,6 +1194,11 @@ public:
   typedef unspecified_type  Compute_hw_3;
 
   /*!
+    a model of `Kernel::ComputeLInfinityDistance_3`
+  */
+  typedef unspecified_type  Compute_L_infinity_distance_3;
+
+  /*!
     a model of `Kernel::ComputeDx_3`
   */
   typedef unspecified_type  Compute_dx_3;

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -309,6 +309,7 @@
 - `Kernel::ComputeHx_2`
 - `Kernel::ComputeHy_2`
 - `Kernel::ComputeLInfinityDistance_2`
+- `Kernel::ComputeLInfinityDistance_3`
 - `Kernel::ComputePowerDistanceToPowerSphere_3`
 - `Kernel::ComputeScalarProduct_2`
 - `Kernel::ComputeScalarProduct_3`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -184,6 +184,7 @@
 - \link has_smaller_signed_distance_to_line_grp `CGAL::has_smaller_signed_distance_to_line()` \endlink
 - \link has_smaller_signed_distance_to_plane_grp `CGAL::has_smaller_signed_distance_to_plane()` \endlink
 - \link intersection_grp `CGAL::intersection()` \endlink
+- \link l_infinity_distance_grp `CGAL::l_infinity_distance()` \endlink
 - \link left_turn_grp `CGAL::left_turn()` \endlink
 - \link lexicographically_xyz_smaller_grp `CGAL::lexicographically_xyz_smaller()` \endlink
 - \link lexicographically_xyz_smaller_or_equal_grp `CGAL::lexicographically_xyz_smaller_or_equal()` \endlink
@@ -307,6 +308,7 @@
 - `Kernel::ComputeDy_2`
 - `Kernel::ComputeHx_2`
 - `Kernel::ComputeHy_2`
+- `Kernel::ComputeLInfinityDistance_2`
 - `Kernel::ComputePowerDistanceToPowerSphere_3`
 - `Kernel::ComputeScalarProduct_2`
 - `Kernel::ComputeScalarProduct_3`

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -1157,6 +1157,25 @@ public:
   };
 
   template <typename K>
+  class Compute_L_infinity_distance_3
+  {
+    typedef typename K::FT              FT;
+    typedef typename K::Point_3         Point_3;
+
+  public:
+    typedef FT               result_type;
+
+    result_type
+    operator()(const Point_3& p,
+               const Point_3& q) const
+    {
+      return (std::max)( CGAL::abs( K().compute_x_3_object()(p) -  K().compute_x_3_object()(q)),
+                         CGAL::abs( K().compute_y_3_object()(p) -  K().compute_y_3_object()(q)),
+                         CGAL::abs( K().compute_z_3_object()(p) -  K().compute_z_3_object()(q)));
+    }
+  };
+
+  template <typename K>
   class Construct_center_2
   {
     typedef typename K::Point_2   Point_2;

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -1139,6 +1139,24 @@ public:
   };
 
   template <typename K>
+  class Compute_L_infinity_distance_2
+  {
+    typedef typename K::FT              FT;
+    typedef typename K::Point_2         Point_2;
+
+  public:
+    typedef FT               result_type;
+
+    result_type
+    operator()(const Point_2& p,
+               const Point_2& q) const
+    {
+      return (std::max)( CGAL::abs( K().compute_x_2_object()(p) -  K().compute_x_2_object()(q)),
+                         CGAL::abs( K().compute_y_2_object()(p) -  K().compute_y_2_object()(q)) );
+    }
+  };
+
+  template <typename K>
   class Construct_center_2
   {
     typedef typename K::Point_2   Point_2;

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -1170,8 +1170,8 @@ public:
                const Point_3& q) const
     {
       return (std::max)( CGAL::abs( K().compute_x_3_object()(p) -  K().compute_x_3_object()(q)),
-                         CGAL::abs( K().compute_y_3_object()(p) -  K().compute_y_3_object()(q)),
-                         CGAL::abs( K().compute_z_3_object()(p) -  K().compute_z_3_object()(q)));
+                         (std::max)(CGAL::abs( K().compute_y_3_object()(p) -  K().compute_y_3_object()(q)),
+                                    CGAL::abs( K().compute_z_3_object()(p) -  K().compute_z_3_object()(q))));
     }
   };
 

--- a/Kernel_23/include/CGAL/Kernel/global_functions_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_2.h
@@ -715,6 +715,13 @@ lexicographically_yx_larger_or_equal(const Point_2<K> &p, const Point_2<K> &q)
 }
 
 template < class K >
+typename K::FT
+l_infinity_distance(const Point_2<K> &p, const Point_2<K> &q)
+{
+  return internal::l_infinity_distance(p,q, K());
+}
+
+template < class K >
 inline
 typename K::Point_2
 midpoint(const Point_2<K> &p, const Point_2<K> &q)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -641,6 +641,13 @@ lexicographically_xyz_smaller_or_equal(const Point_3<K> &p,
 }
 
 template < class K >
+typename K::FT
+l_infinity_distance(const Point_3<K> &p, const Point_3<K> &q)
+{
+  return internal::l_infinity_distance(p,q, K());
+}
+
+template < class K >
 inline
 typename K::Point_3
 midpoint(const Point_3<K> &p, const Point_3<K> &q)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
@@ -772,6 +772,17 @@ lexicographically_yx_larger_or_equal(const typename K::Point_2 &p,
 
 template < class K >
 inline
+typename K::FT
+l_infinity_distance(const typename K::Point_2 &p,
+                    const typename K::Point_2 &q,
+                    const K& k)
+{
+  return k.compute_L_infinity_distance_2_object()(p, q);
+}
+
+
+template < class K >
+inline
 typename K::Point_2
 midpoint(const typename K::Point_2 &p,
          const typename K::Point_2 &q, const K &k)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -724,6 +724,16 @@ lexicographically_xyz_smaller(const typename K::Point_3 &p,
 
 template < class K >
 inline
+typename K::FT
+l_infinity_distance(const typename K::Point_3 &p,
+                    const typename K::Point_3 &q,
+                    const K& k)
+{
+  return k.compute_L_infinity_distance_3_object()(p, q);
+}
+
+template < class K >
+inline
 typename K::Point_3
 midpoint(const typename K::Point_3 &p,
          const typename K::Point_3 &q, const K &k)

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -182,6 +182,8 @@ CGAL_Kernel_cons(Compute_determinant_3,
 		 compute_determinant_3_object)
 CGAL_Kernel_cons(Compute_L_infinity_distance_2,
 		 compute_L_infinity_distance_2_object)
+CGAL_Kernel_cons(Compute_L_infinity_distance_3,
+                 compute_L_infinity_distance_3_object)
 CGAL_Kernel_cons(Compute_scalar_product_2,
 		 compute_scalar_product_2_object)
 CGAL_Kernel_cons(Compute_scalar_product_3,

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -180,6 +180,8 @@ CGAL_Kernel_cons(Compute_determinant_2,
 		 compute_determinant_2_object)
 CGAL_Kernel_cons(Compute_determinant_3,
 		 compute_determinant_3_object)
+CGAL_Kernel_cons(Compute_L_infinity_distance_2,
+		 compute_L_infinity_distance_2_object)
 CGAL_Kernel_cons(Compute_scalar_product_2,
 		 compute_scalar_product_2_object)
 CGAL_Kernel_cons(Compute_scalar_product_3,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_2.h
@@ -277,6 +277,8 @@ _test_fct_point_2(const R& )
  
  std::cout << '.';
 
+ assert(CGAL::l_infinity_distance(p1,p2) == FT(1));
+ assert(CGAL::l_infinity_distance(p1,p8) == FT(2));
  std::cout << "done" << std::endl;
  return true;
 }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
@@ -234,7 +234,7 @@ _test_fct_point_3(const R& )
  }
 
  assert(CGAL::l_infinity_distance(p1,p2) == FT(11));
- assert(CGAL::l_infinity_distance(p1,p5) == FT(12));
+ assert(CGAL::l_infinity_distance(p1,p5) == FT(6));
  // More tests, that require sqrt().
  {
      typedef ::CGAL::Algebraic_structure_traits<FT> AST; 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
@@ -233,6 +233,8 @@ _test_fct_point_3(const R& )
    assert( CGAL::compare_squared_radius(p0, p1, p2, p3, four) == CGAL::EQUAL );
  }
 
+ assert(CGAL::l_infinity_distance(p1,p2) == FT(11));
+ assert(CGAL::l_infinity_distance(p1,p5) == FT(12));
  // More tests, that require sqrt().
  {
      typedef ::CGAL::Algebraic_structure_traits<FT> AST; 


### PR DESCRIPTION
Add the function  `FT  l_infinity_distance(Point_2, Point_2)` as well as the corresponding functor

This is a function where the implementation is in the file
`Kernel_23/include/CGAL/Kernel/function_objects.h`

When the implementation is different for Cartesian and Homogeneous coordinates
the code should go into the `function_objects.h` files
in the packages Cartesian_kernel and Homogeneous_kernel

This fixes the 2D version of the Issue #1624 

Small feature: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_L_Infinity_Distance()

Pre-approved: 18 November 2016