### PR TITLE
Polyhedron_demo : Fix waitcursor for windows in some plugins

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Detect_sharp_edges_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Detect_sharp_edges_plugin.cpp
@@ -104,7 +104,7 @@ void Polyhedron_demo_detect_sharp_edges_plugin::detectSharpEdges(bool input_dial
   }
   // Detect edges
   QApplication::setOverrideCursor(Qt::WaitCursor);
-
+  QApplication::processEvents();
   Q_FOREACH(Poly_tuple tuple, polyhedrons)
   {
     Polyhedron* pMesh = tuple.second;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -434,6 +434,7 @@ public Q_SLOTS:
         settings.setValue("Open directory",
           fileinfo.absoluteDir().absolutePath());
         QApplication::setOverrideCursor(Qt::WaitCursor);
+        QApplication::processEvents();
         loadDCM(dir);
         QApplication::restoreOverrideCursor();
       }
@@ -847,6 +848,7 @@ Io_image_plugin::load(QFileInfo fileinfo) {
         if( raw_dialog.exec() ){
 
           QApplication::setOverrideCursor(Qt::WaitCursor);
+          QApplication::processEvents();
 
           if(image->read_raw(fileinfo.filePath().toUtf8(),
                              raw_dialog.dim_x->value(),
@@ -958,7 +960,7 @@ Io_image_plugin::load(QFileInfo fileinfo) {
   else
     type = "Gray-level image";
   QApplication::setOverrideCursor(Qt::WaitCursor);
-
+  QApplication::processEvents();
   Scene_image_item* image_item;
   if(type == "Gray-level image")
   {
@@ -1028,6 +1030,7 @@ bool Io_image_plugin::loadDCM(QString dirname)
       return false;
     }
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
 
     // Get selected precision
     int voxel_scale = ui.precisionList->currentIndex() + 1;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_polyline_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_polyline_plugin.cpp
@@ -114,6 +114,7 @@ public Q_SLOTS:
       NULL, "Use Delaunay Triangulation", "Use Delaunay Triangulation ?", QMessageBox::Yes|QMessageBox::No);
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
     std::size_t counter = 0;
     for(Scene_polylines_item::Polylines_container::iterator it = polylines_item->polylines.begin();
       it != polylines_item->polylines.end(); ++it, ++counter) 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Point_inside_polyhedron_plugin.cpp
@@ -237,6 +237,7 @@ public Q_SLOTS:
 
     if(!ok) { return; }
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
     // sample random points and constuct item
     Scene_points_with_normal_item* point_item = new Scene_points_with_normal_item();
     point_item->setName(QString("sample-%1").arg(nb_points));

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
@@ -87,7 +87,7 @@ void Polyhedron_demo_point_set_average_spacing_plugin::on_actionAverageSpacing_t
       return;
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
-
+    QApplication::processEvents();
     CGAL::Timer task_timer; task_timer.start();
     std::cerr << "Average spacing (k=" << nb_neighbors <<")...\n";
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_interference_plugin.cpp
@@ -88,7 +88,7 @@ private Q_SLOTS:
                                 flags);
     if(!ok) return;
     QApplication::setOverrideCursor(Qt::WaitCursor);
-
+    QApplication::processEvents();
     CGAL::Random_points_in_sphere_3<Kernel::Point_3> generator(max_dist);
 
     for(Point_set::iterator psit = points->begin_or_selection_begin(); psit != points->end(); ++psit)

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -163,6 +163,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
       return;
       
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
 
     // First point to delete
     Point_set::iterator first_unoriented_point = points->end();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_smoothing_plugin.cpp
@@ -80,7 +80,7 @@ void Polyhedron_demo_point_set_smoothing_plugin::on_actionJetSmoothing_triggered
     if(!ok) return;
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
-
+    QApplication::processEvents();
     CGAL::jet_smooth_point_set<Concurrency_tag>(points->begin_or_selection_begin(), points->end(),
                                                 points->point_map(),
                                                 nb_neighbors, Kernel());

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -84,6 +84,7 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
     time.start();
     std::cout << "Simplify...";
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
     namespace SMS = CGAL::Surface_mesh_simplification;
     SMS::Count_stop_predicate< Polyhedron > stop(nb_edges); // target #edges
     SMS::edge_collapse( *pMesh, stop,


### PR DESCRIPTION
This fixes #1645 .
 On windows, the modal dialogs mess with the application of the Waitcursor when they are called too soon after the closure of the said dialogs. This commit adds a call to processEvents() after the waitcursor where it is needed to fix that.