### PR TITLE
Auto-enable Eigen3 if detected

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -590,4 +590,8 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 #define CGAL_ADDITIONAL_VARIANT_FOR_ICL
 #endif
 
+#if __has_include(<Eigen/Jacobi>) && !defined CGAL_EIGEN3_ENABLED
+#  define CGAL_EIGEN3_ENABLED 1
+#endif
+
 #endif // CGAL_CONFIG_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -590,7 +590,9 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 #define CGAL_ADDITIONAL_VARIANT_FOR_ICL
 #endif
 
-#if __has_include(<Eigen/Jacobi>) && !defined CGAL_EIGEN3_ENABLED
+#if !defined CGAL_EIGEN3_ENABLED && \
+    !defined CGAL_EIGEN3_DISABLED && \
+    __has_include(<Eigen/Jacobi>)
 #  define CGAL_EIGEN3_ENABLED 1
 #endif
 


### PR DESCRIPTION
I am a bit tired of typing -DCGAL_EIGEN3_ENABLED (and still allergic to cmake), and my compiler understands `__has_include`. For a header-only dependency, that seems safe enough. The header I am testing was absent in 2.0.17 and present in 3.0.0.