### PR TITLE
Optimal Transport Reconstruction: make a static variable of a member function class local

### DIFF
--- a/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
@@ -141,7 +141,7 @@ public:
   > MultiIndex;
 
   FT m_factor; // ghost vs solid
-
+  mutable Random rng;
 
 public:
   Reconstruction_triangulation_2(Traits_ traits = Traits_())
@@ -161,7 +161,6 @@ public:
   }
 
   Edge random_finite_edge() const {
-    static CGAL::Random rng;
     std::size_t nbf = Base::number_of_faces();
     int offset = rng.get_int(0, static_cast<int>(nbf - 1));
     Finite_faces_iterator fi = Base::finite_faces_begin();


### PR DESCRIPTION
@sgiraudot  can you please check that there is no need to make the variable thread local.

This PR fixes Issue #1408