### PR TITLE
Polyhedron_demo : Fix the picking

### DIFF
--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -728,7 +728,7 @@ void Viewer::endSelection(const QPoint&)
 {
     glDisable(GL_SCISSOR_TEST);
     //redraw thetrue scene for the glReadPixel in postSelection();
-    update();
+    d->draw_aux(false, this);
 }
 
 void Viewer_impl::makeArrow(double R, int prec, qglviewer::Vec from, qglviewer::Vec to, qglviewer::Vec color, Viewer_impl::AxisData &data)


### PR DESCRIPTION
This PR fixes the picking in the demo. 
 After the" selection picking" used to find which item to select, the scene must be re-drawn before the point/facet picking is performed.
 This is because pointUnderPixel() is called to do so, and the first pass erases an item before drawing the next one, so only the last item of the scene remains after it is done.