### PR TITLE
Polyhedron_demo : Fix spheres item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -409,8 +409,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(void)
             if(spheres)
             {
               CGAL::Color c(0,255,0);
-              Kernel::Sphere_3 *sphere = new Kernel::Sphere_3(vd->point(), length_of_axis/15.0);
-              spheres->add_sphere(sphere, c);
+              spheres->add_sphere(Kernel::Sphere_3(vd->point(), length_of_axis/15.0*length_of_axis/15.0), c);
             }
         }
 
@@ -446,8 +445,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(void)
             if(spheres_ctrl)
             {
               CGAL::Color c(255*r,0,255*b);
-              Kernel::Sphere_3 *sphere = new Kernel::Sphere_3((*hb)->point(), length_of_axis/15.0);
-              spheres_ctrl->add_sphere(sphere, c);
+              spheres_ctrl->add_sphere(Kernel::Sphere_3((*hb)->point(), length_of_axis/15.0*length_of_axis/15.0), c);
             }
         }
     }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1338,7 +1338,7 @@ void Scene_c3t3_item_priv::computeSpheres()
     Kernel::Point_3 center(vit->point().point().x(),
     vit->point().point().y(),
     vit->point().point().z());
-    float radius = CGAL::sqrt(vit->point().weight());
+    float radius = vit->point().weight();
     Kernel::Sphere_3* sphere = new Kernel::Sphere_3(center, radius);
     spheres->add_sphere(sphere, CGAL::Color(c.red(), c.green(), c.blue()));
   }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1338,9 +1338,8 @@ void Scene_c3t3_item_priv::computeSpheres()
     Kernel::Point_3 center(vit->point().point().x(),
     vit->point().point().y(),
     vit->point().point().z());
-    float radius = vit->point().weight();
-    Kernel::Sphere_3* sphere = new Kernel::Sphere_3(center, radius);
-    spheres->add_sphere(sphere, CGAL::Color(c.red(), c.green(), c.blue()));
+    float radius = vit->point().weight() ;
+    spheres->add_sphere(Kernel::Sphere_3(center, radius), CGAL::Color(c.red(), c.green(), c.blue()));
   }
   spheres->invalidateOpenGLBuffers();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -14,7 +14,7 @@ struct Scene_polylines_item_private {
 
     Scene_polylines_item_private(Scene_polylines_item *parent) :
         draw_extremities(false),
-        spheres_drawn_radius(0)
+        spheres_drawn_square_radius(0)
     {
       item = parent;
       invalidate_stats();
@@ -47,7 +47,7 @@ struct Scene_polylines_item_private {
     void initializeBuffers(CGAL::Three::Viewer_interface *viewer) const;
     void computeElements() const;
     bool draw_extremities;
-    double spheres_drawn_radius;
+    double spheres_drawn_square_radius;
     Scene_polylines_item *item;
     mutable std::size_t nb_vertices;
     mutable std::size_t nb_edges;
@@ -227,8 +227,7 @@ Scene_polylines_item_private::computeSpheres()
 
           CGAL::Color c(colors[0], colors[1], colors[2]);
 
-          K::Sphere_3 *sphere = new K::Sphere_3(center, spheres_drawn_radius);
-          spheres->add_sphere(sphere, c);
+          spheres->add_sphere(K::Sphere_3(center, spheres_drawn_square_radius), c);
       }
       spheres->setToolTip(
             QString("<p>Legende of endpoints colors: <ul>"
@@ -436,7 +435,7 @@ void Scene_polylines_item::invalidateOpenGLBuffers()
 
 void Scene_polylines_item::change_corner_radii() {
     bool ok = true;
-    double proposed_radius = d->spheres_drawn_radius;
+    double proposed_radius = d->spheres_drawn_square_radius;
     if(proposed_radius == 0) {
         CGAL::Three::Scene_interface::Bbox b = bbox();
         proposed_radius = (std::max)(b.xmax() - b.xmin(),
@@ -462,7 +461,7 @@ void Scene_polylines_item::change_corner_radii() {
 
 void Scene_polylines_item::change_corner_radii(double r) {
     if(r >= 0) {
-        d->spheres_drawn_radius = r;
+        d->spheres_drawn_square_radius = r*r;
         d->draw_extremities = (r > 0);
         if(r>0 && !d->spheres)
         {

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -90,7 +90,7 @@ void Scene_spheres_item::computeElements() const
     d->centers.push_back(sp.first->center().y());
     d->centers.push_back(sp.first->center().z());
 
-    d->radius.push_back(sp.first->squared_radius());
+    d->radius.push_back(CGAL::sqrt(sp.first->squared_radius()));
 
   }
   QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -4,7 +4,6 @@
 struct Scene_spheres_item_priv
 {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-  typedef std::pair<CGAL::Sphere_3<Kernel>*, CGAL::Color> Sphere_pair ;
 
   Scene_spheres_item_priv(bool planed, Scene_spheres_item* parent)
     :precision(36)
@@ -13,11 +12,14 @@ struct Scene_spheres_item_priv
   {
     item = parent;
     create_flat_and_wire_sphere(1.0f,vertices,normals, edges);
+    colors.clear();
+    edges_colors.clear();
+    centers.clear();
+    radius.clear();
   }
 
-  ~Scene_spheres_item_priv() {
-    Q_FOREACH(Sphere_pair sphere, spheres)
-      delete sphere.first;
+  ~Scene_spheres_item_priv()
+  {
   }
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer)const;
   enum Vbos
@@ -43,7 +45,6 @@ struct Scene_spheres_item_priv
   mutable CGAL::Plane_3<Kernel> plane;
   bool has_plane;
 
-  QList<Sphere_pair> spheres;
   mutable std::vector<float> vertices;
   mutable std::vector<float> normals;
   mutable std::vector<float> edges;
@@ -68,32 +69,6 @@ Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, bool planed)
 Scene_spheres_item::~Scene_spheres_item()
 {
   delete d;
-}
-void Scene_spheres_item::computeElements() const
-{
-  QApplication::setOverrideCursor(Qt::WaitCursor);
-  d->colors.clear();
-  d->edges_colors.clear();
-  d->centers.clear();
-  d->radius.clear();
-  Q_FOREACH(Sphere_pair sp, d->spheres)
-  {
-    d->colors.push_back((float)sp.second.red()/255);
-    d->colors.push_back((float)sp.second.green()/255);
-    d->colors.push_back((float)sp.second.blue()/255);
-
-    d->edges_colors.push_back((float)sp.second.red()/255);
-    d->edges_colors.push_back((float)sp.second.green()/255);
-    d->edges_colors.push_back((float)sp.second.blue()/255);
-
-    d->centers.push_back(sp.first->center().x());
-    d->centers.push_back(sp.first->center().y());
-    d->centers.push_back(sp.first->center().z());
-
-    d->radius.push_back(CGAL::sqrt(sp.first->squared_radius()));
-
-  }
-  QApplication::restoreOverrideCursor();
 }
 
 void Scene_spheres_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *viewer) const
@@ -206,7 +181,6 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
 {
   if (!are_buffers_filled)
   {
-    computeElements();
     d->initializeBuffers(viewer);
   }
   vaos[Scene_spheres_item_priv::Facets]->bind();
@@ -235,7 +209,6 @@ void Scene_spheres_item::drawEdges(Viewer_interface *viewer) const
 {
   if (!are_buffers_filled)
   {
-    computeElements();
     d->initializeBuffers(viewer);
   }
   vaos[Scene_spheres_item_priv::Edges]->bind();
@@ -259,27 +232,29 @@ void Scene_spheres_item::drawEdges(Viewer_interface *viewer) const
   d->program->release();
   vaos[Scene_spheres_item_priv::Edges]->release();
 }
-void Scene_spheres_item::add_sphere(CGAL::Sphere_3<Kernel> *sphere, CGAL::Color color)
+void Scene_spheres_item::add_sphere(const CGAL::Sphere_3<Kernel>& sphere, CGAL::Color color)
 {
-  Scene_spheres_item::Sphere_pair pair_(sphere, color);
-  d->spheres.append(pair_);
-}
+    d->colors.push_back((float)color.red()/255);
+    d->colors.push_back((float)color.green()/255);
+    d->colors.push_back((float)color.blue()/255);
 
-void Scene_spheres_item::remove_sphere(CGAL::Sphere_3<Kernel> *sphere)
-{
-  Q_FOREACH(Sphere_pair pair_, d->spheres)
-    if(pair_.first == sphere)
-    {
-      d->spheres.removeAll(pair_);
-      break;
-    }
+    d->edges_colors.push_back((float)color.red()/255);
+    d->edges_colors.push_back((float)color.green()/255);
+    d->edges_colors.push_back((float)color.blue()/255);
+
+    d->centers.push_back(sphere.center().x());
+    d->centers.push_back(sphere.center().y());
+    d->centers.push_back(sphere.center().z());
+
+    d->radius.push_back(CGAL::sqrt(sphere.squared_radius()));
 }
 
 void Scene_spheres_item::clear_spheres()
 {
-  Q_FOREACH(Sphere_pair pair, d->spheres)
-    delete pair.first;
-  d->spheres.clear();
+  d->colors.clear();
+  d->edges_colors.clear();
+  d->centers.clear();
+  d->radius.clear();
 }
 void Scene_spheres_item::setPrecision(int prec) { d->precision = prec; }
 void Scene_spheres_item::setPlane(Kernel::Plane_3 p_plane) { d->plane = p_plane; }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -35,8 +35,7 @@ public:
     return (m == Gouraud || m == Wireframe);
   }
   void compute_bbox() const { _bbox = Bbox(); }
-  void add_sphere(CGAL::Sphere_3<Kernel>* sphere, CGAL::Color = CGAL::Color(120,120,120));
-  void remove_sphere(CGAL::Sphere_3<Kernel>* sphere);
+  void add_sphere(const CGAL::Sphere_3<Kernel> &sphere, CGAL::Color = CGAL::Color(120,120,120));
   void clear_spheres();
   void setPrecision(int prec);
 


### PR DESCRIPTION
This fixes #1667.

The sphere_item now directly adds the values to its buffers when a sphere is added instead of storing the sphere/color pair into a list
The items now give a squared radius to the CGAL::Spheres, and the square root of this value is stored in the buffers. 