### PR TITLE
Polyhedron_demo: Make it possible to switch between projection modes

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -257,6 +257,8 @@ MainWindow::MainWindow(QWidget* parent)
           viewer, SLOT(setTwoSides(bool)));
   connect(ui->actionQuickCameraMode, SIGNAL(toggled(bool)),
           viewer, SLOT(setFastDrawing(bool)));
+  connect(ui->actionSwitchProjection, SIGNAL(toggled(bool)),
+          viewer, SLOT(SetOrthoProjection(bool)));
 
   // add the "About CGAL..." and "About demo..." entries
   this->addAboutCGAL();

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -95,6 +95,7 @@
     <addaction name="actionAntiAliasing"/>
     <addaction name="actionDrawTwoSides"/>
     <addaction name="actionQuickCameraMode"/>
+    <addaction name="actionSwitchProjection"/>
     <addaction name="actionMaxTextItemsDisplayed"/>
     <addaction name="actionSetBackgroundColor"/>
     <addaction name="menuDockWindows"/>
@@ -674,6 +675,14 @@
   <action name="actionMaxTextItemsDisplayed">
    <property name="text">
     <string>Set Maximum  Text Items Displayed :</string>
+   </property>
+  </action>
+  <action name="actionSwitchProjection">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Orthographic/Perspective Projection</string>
    </property>
   </action>
  </widget>

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -682,7 +682,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Orthographic/Perspective Projection</string>
+    <string>Orthographic Projection</string>
    </property>
   </action>
  </widget>

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1762,6 +1762,15 @@ void Viewer_impl::sendSnapshotToClipboard(Viewer *viewer)
 #endif
     delete snap;
   }
+}
+void Viewer::SetOrthoProjection(bool b)
+{
+  if(b)
+    camera()->setType(qglviewer::Camera::ORTHOGRAPHIC);
+  else
+    camera()->setType(qglviewer::Camera::PERSPECTIVE);
+
+
 
 }
  #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -79,6 +79,7 @@ public Q_SLOTS:
   //! If b is true, facets will be ligted from both internal and external sides.
   //! If b is false, only the side that is exposed to the light source will be lighted.
   void setTwoSides(bool b);
+  void SetOrthoProjection( bool b);
   //! If b is true, some items are displayed in a simplified version when moving the camera.
   //! If b is false, items display is never altered, even when moving.
   void setFastDrawing(bool b);


### PR DESCRIPTION
This PR adds a switch in the MainWindow's View menu to make the projection matrix orthographic.