### PR TITLE
Poisson_surface_reconstruction: Reduce dependency on min enclosing sphere

### DIFF
--- a/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
@@ -29,10 +29,8 @@
 
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_cell_base_with_info_3.h>
-#include <CGAL/Min_sphere_of_spheres_d.h>
-#include <CGAL/Min_sphere_of_points_d_traits_3.h>
-#include <CGAL/centroid.h>
 
+#include <CGAL/bounding_box.h>
 #include <boost/random/random_number_generator.hpp>
 #include <boost/random/linear_congruential.hpp>
 
@@ -233,6 +231,7 @@ public:
   typedef typename Geom_traits::Point_3 Point;  ///< typedef to Point_with_normal_3<BaseGt>
   typedef typename Geom_traits::Point_3 Point_with_normal; ///< Point_with_normal_3<BaseGt>
   typedef typename Geom_traits::Sphere_3 Sphere;
+  typedef typename Geom_traits::Iso_cuboid_3 Iso_cuboid;
 
   /// Point type
   enum Point_type {
@@ -312,18 +311,9 @@ public:
 
   void initialize_bounding_sphere() const
   {
-    typedef Min_sphere_of_points_d_traits_3<Gt,FT> Traits;
-    typedef Min_sphere_of_spheres_d<Traits> Min_sphere;
-   
-    // Computes min sphere
-    Min_sphere ms(points.begin(),points.end());
-
-    typename Min_sphere::Cartesian_const_iterator coord = ms.center_cartesian_begin();
-    FT cx = *coord++;
-    FT cy = *coord++;
-    FT cz = *coord;
-
-    sphere = Sphere(Point(cx,cy,cz), ms.radius()*ms.radius());
+    Iso_cuboid ic = bounding_box(points.begin(), points.end());
+    Point center = midpoint(ic.min(), ic.max());
+    sphere = Sphere(center, squared_distance(center, ic.max()));
   }
 
   /// Insert point in the triangulation.

--- a/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
@@ -312,8 +312,8 @@ public:
   void initialize_bounding_sphere() const
   {
     Iso_cuboid ic = bounding_box(points.begin(), points.end());
-    Point center = midpoint(ic.min(), ic.max());
-    sphere = Sphere(center, squared_distance(center, ic.max()));
+    Point center = midpoint((ic.min)(), (ic.max)());
+    sphere = Sphere(center, squared_distance(center, (ic.max)()));
   }
 
   /// Insert point in the triangulation.


### PR DESCRIPTION
To use a sphere around the bbox of points instead of min_sphere_of_spheres of points should make  no difference in practice. 