### PR TITLE
PMP : fixes for isotropic remeshing

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1139,7 +1139,8 @@ private:
         if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
           return false;//collapse would induce pinching the selection
         else
-          return is_collapse_allowed(he) && is_collapse_allowed(hopp);
+          return (is_collapse_allowed_on_patch(he)
+               && is_collapse_allowed_on_patch(hopp));
       }
       else if (is_on_patch_border(he))
         return is_collapse_allowed_on_patch_border(he);
@@ -1148,7 +1149,7 @@ private:
       return false;
     }
 
-    bool is_collapse_allowed(const halfedge_descriptor& he) const
+    bool is_collapse_allowed_on_patch(const halfedge_descriptor& he) const
     {
       halfedge_descriptor hopp = opposite(he, mesh_);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -930,7 +930,21 @@ namespace internal {
       // perform moves
       BOOST_FOREACH(const VP_pair& vp, new_locations)
       {
+        const Point initial_pos = get(vpmap_, vp.first);
+        const Vector_3 move(initial_pos, vp.second);
+
         put(vpmap_, vp.first, vp.second);
+
+        //check that no inversion happened
+        double frac = 1.;
+        while (frac > 0.03 //5 attempts maximum
+           && !check_normals(vp.first)) //if a face has been inverted
+        {
+          frac = 0.5 * frac;
+          put(vpmap_, vp.first, initial_pos + frac * move);//shorten the move by 2
+        }
+        if (frac <= 0.02)
+          put(vpmap_, vp.first, initial_pos);//cancel move
       }
 
       CGAL_assertion(is_valid(mesh_));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1185,6 +1185,8 @@ private:
       {
         if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
           return false;
+        else if (next_on_patch_border(h) == hopp)
+          return false; //isolated patch border
         else
           return true;
       }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -620,6 +620,9 @@ namespace internal {
             he = opposite(he, mesh_);
             va = source(he, mesh_);
             vb = target(he, mesh_);
+
+            if (is_on_patch_border(va) && !is_on_patch_border(vb))
+              continue;//we cannot swap again. It would lead to a face inversion
           }
           else
             continue;//both directions invert a face

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -846,7 +846,6 @@ namespace internal {
     void tangential_relaxation(const bool relax_constraints/*1d smoothing*/
                              , const unsigned int nb_iterations)
     {
-      //todo : move border vertices along 1-dimensional features
 #ifdef CGAL_PMP_REMESHING_VERBOSE
       std::cout << "Tangential relaxation (" << nb_iterations << " iter.)...";
       std::cout << std::endl;


### PR DESCRIPTION
This PR introduces 2 fixes for `PMP::isotropic_remeshing`
- do not collapse an isolated constrained edge
- avoid all face inversions during collapse and relaxation steps

~~Note this PR requires a little more local testing, I will edit it as soon as it is ready for testing~~
Note 2 : this PR is for 4.9. I will rebase it and repush it asap