### PR TITLE
PMP : fixes for isotropic remeshing

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1718,9 +1718,9 @@ private:
           continue;
         Patch_id pid = get_patch_id(face(hd, mesh_));
 
-        if (patch1 == -1)
+        if (patch1 == Patch_id(-1))
           patch1 = pid; //not met yet
-        else if (patch2 == -1 && patch1 != pid)
+        else if (patch2 == Patch_id(-1) && patch1 != pid)
           patch2 = pid; //not met yet
         CGAL_assertion(pid == patch1 || pid == patch2);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -835,7 +835,6 @@ namespace internal {
     void tangential_relaxation(const bool relax_constraints/*1d smoothing*/
                              , const unsigned int nb_iterations)
     {
-      //todo : move border vertices along 1-dimensional features
 #ifdef CGAL_PMP_REMESHING_VERBOSE
       std::cout << "Tangential relaxation (" << nb_iterations << " iter.)...";
       std::cout << std::endl;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1129,7 +1129,8 @@ private:
         if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
           return false;//collapse would induce pinching the selection
         else
-          return is_collapse_allowed(he) && is_collapse_allowed(hopp);
+          return (is_collapse_allowed_on_patch(he)
+               && is_collapse_allowed_on_patch(hopp));
       }
       else if (is_on_patch_border(he))
         return is_collapse_allowed_on_patch_border(he);
@@ -1138,7 +1139,7 @@ private:
       return false;
     }
 
-    bool is_collapse_allowed(const halfedge_descriptor& he) const
+    bool is_collapse_allowed_on_patch(const halfedge_descriptor& he) const
     {
       halfedge_descriptor hopp = opposite(he, mesh_);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1175,6 +1175,8 @@ private:
       {
         if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
           return false;
+        else if (next_on_patch_border(h) == hopp)
+          return false; //isolated patch border
         else
           return true;
       }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1002,7 +1002,7 @@ private:
   Patch_id get_patch_id(const face_descriptor& f) const
   {
     if (f == boost::graph_traits<PM>::null_face())
-      return Patch_id();
+      return Patch_id(-1);
     return get(patch_ids_map_, f);
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -609,6 +609,9 @@ namespace internal {
             he = opposite(he, mesh_);
             va = source(he, mesh_);
             vb = target(he, mesh_);
+
+            if (is_on_patch_border(va) && !is_on_patch_border(vb))
+              continue;//we cannot swap again. It would lead to a face inversion
           }
           else
             continue;//both directions invert a face

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1334,7 +1334,7 @@ private:
         if (nb_incident_features > 2)
           return true;
       }
-      return false;
+      return (nb_incident_features == 1);
     }
 
     Vector_3 compute_normal(const face_descriptor& f) const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -919,7 +919,21 @@ namespace internal {
       // perform moves
       BOOST_FOREACH(const VP_pair& vp, new_locations)
       {
+        const Point initial_pos = get(vpmap_, vp.first);
+        const Vector_3 move(initial_pos, vp.second);
+
         put(vpmap_, vp.first, vp.second);
+
+        //check that no inversion happened
+        double frac = 1.;
+        while (frac > 0.03 //5 attempts maximum
+           && !check_normals(vp.first)) //if a face has been inverted
+        {
+          frac = 0.5 * frac;
+          put(vpmap_, vp.first, initial_pos + frac * move);//shorten the move by 2
+        }
+        if (frac <= 0.02)
+          put(vpmap_, vp.first, initial_pos);//cancel move
       }
 
       CGAL_assertion(is_valid(mesh_));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -591,29 +591,29 @@ namespace internal {
         vertex_descriptor va = source(he, mesh_);
         vertex_descriptor vb = target(he, mesh_);
 
+        bool swap_done = false;
         if (is_on_patch_border(va) && !is_on_patch_border(vb))
         {
           he = opposite(he, mesh_);
           va = source(he, mesh_);
           vb = target(he, mesh_);
+          swap_done = true;
           CGAL_assertion(is_on_patch_border(vb) && !is_on_patch_border(va));
         }
-        else if (is_on_patch(va) && is_on_patch(vb))
-        {
-          if(!collapse_does_not_invert_face(he))
-          {
-            if (collapse_does_not_invert_face(opposite(he, mesh_)))
-            {
-              he = opposite(he, mesh_);
-              va = source(he, mesh_);
-              vb = target(he, mesh_);
-            }
-            else
-              continue;//both directions invert a face
-          }
-          CGAL_assertion(collapse_does_not_invert_face(he));
-        }
 
+        if(!collapse_does_not_invert_face(he))
+        {
+          if (!swap_done//if swap has already been done, don't re-swap
+           && collapse_does_not_invert_face(opposite(he, mesh_)))
+          {
+            he = opposite(he, mesh_);
+            va = source(he, mesh_);
+            vb = target(he, mesh_);
+          }
+          else
+            continue;//both directions invert a face
+        }
+        CGAL_assertion(collapse_does_not_invert_face(he));
         CGAL_assertion(is_collapse_allowed(e));
 
         if (degree(va, mesh_) < 3
@@ -651,7 +651,8 @@ namespace internal {
           }
 
           //before collapse
-          bool mesh_border_case     = is_on_border(opposite(he, mesh_));
+          bool mesh_border_case     = is_on_border(he);
+          bool mesh_border_case_opp = is_on_border(opposite(he, mesh_));
           halfedge_descriptor ep_p  = prev(opposite(he, mesh_), mesh_);
           halfedge_descriptor epo_p = opposite(ep_p, mesh_);
           halfedge_descriptor en    = next(he, mesh_);
@@ -663,14 +664,16 @@ namespace internal {
 
           // merge halfedge_status to keep the more important on both sides
           //do it before collapse is performed to be sure everything is valid
-          merge_status(en, s_epo, s_ep);
           if (!mesh_border_case)
+            merge_status(en, s_epo, s_ep);
+          if (!mesh_border_case_opp)
             merge_status(en_p, s_epo_p, s_ep_p);
 
-          if (!mesh_border_case)
-            halfedge_and_opp_removed(prev(opposite(he, mesh_), mesh_));
           halfedge_and_opp_removed(he);
-          halfedge_and_opp_removed(prev(he, mesh_));
+          if (!mesh_border_case)
+            halfedge_and_opp_removed(prev(he, mesh_));
+          if (!mesh_border_case_opp)
+            halfedge_and_opp_removed(prev(opposite(he, mesh_), mesh_));
 
           //constrained case
           bool constrained_case = is_constrained(va) || is_constrained(vb);
@@ -1126,6 +1129,7 @@ private:
         return false;
       if (is_on_patch(he)) //hopp is also on patch
       {
+        CGAL_assertion(is_on_patch(hopp));
         if (is_on_patch_border(target(he, mesh_)) && is_on_patch_border(source(he, mesh_)))
           return false;//collapse would induce pinching the selection
         else
@@ -1319,6 +1323,9 @@ private:
 
     Vector_3 compute_normal(const face_descriptor& f) const
     {
+      if (f == boost::graph_traits<PM>::null_face())
+        return CGAL::NULL_VECTOR;
+
       halfedge_descriptor hd = halfedge(f, mesh_);
       typename GeomTraits::Triangle_3
         tr(get(vpmap_, target(hd, mesh_)),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1714,6 +1714,8 @@ private:
                     halfedges_around_target(halfedge(v, mesh_), mesh_))
       {
         Vector_3 n = compute_normal(face(hd, mesh_));
+        if (n == CGAL::NULL_VECTOR)
+          continue;
         Patch_id pid = get_patch_id(face(hd, mesh_));
 
         if (patch1 == -1)      patch1 = pid; //not met yet

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1718,8 +1718,10 @@ private:
           continue;
         Patch_id pid = get_patch_id(face(hd, mesh_));
 
-        if (patch1 == -1)      patch1 = pid; //not met yet
-        else if (patch2 == -1) patch2 = pid; //not met yet
+        if (patch1 == -1)
+          patch1 = pid; //not met yet
+        else if (patch2 == -1 && patch1 != pid)
+          patch2 = pid; //not met yet
         CGAL_assertion(pid == patch1 || pid == patch2);
 
         if (pid == patch1)     normals_patch1.push_back(n);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -496,18 +496,20 @@ void Scene_edit_polyhedron_item::deform()
 struct ROI_faces_pmap
 {
   typedef face_descriptor                    key_type;
-  typedef bool                               value_type;
-  typedef bool                               reference;
+  typedef std::size_t                        value_type;
+  typedef std::size_t&                       reference;
   typedef boost::read_write_property_map_tag category;
 
-  friend bool get(const ROI_faces_pmap&, const key_type& f)
-  {
-    return f->patch_id() == 12345;/*magic number*/
+  friend value_type get(const ROI_faces_pmap&, const key_type& f)
+  { 
+    /*magic number 12345*/
+    if (f->patch_id() == 12345) return 1;
+    else                        return 0;
   }
   friend void put(ROI_faces_pmap&, const key_type& f, const value_type b)
   {
-    if (b)  f->set_patch_id(12345);
-    else    f->set_patch_id(patch_id_default_value(1));
+    if(b != 0)  f->set_patch_id(12345);
+    else        f->set_patch_id(0);
   }
 };
 
@@ -621,7 +623,7 @@ void Scene_edit_polyhedron_item_priv::remesh()
       if(add_face)
       {
         roi_facets.insert(fv);
-        put(roi_faces_pmap, fv, true);
+        put(roi_faces_pmap, fv, 1/*true*/);
       }
     }
   }
@@ -712,14 +714,14 @@ void Scene_edit_polyhedron_item_priv::remesh()
 
   BOOST_FOREACH(face_descriptor f, faces(g))
   {
-    if (!get(roi_faces_pmap, f))
+    if (get(roi_faces_pmap, f) == 0/*false*/)
       continue;
     BOOST_FOREACH(halfedge_descriptor h, halfedges_around_face(halfedge(f, g), g))
     {
       vertex_descriptor v = target(h, g);
       item->insert_roi_vertex(v);
     }
-    put(roi_faces_pmap, f, false); //reset ids
+    put(roi_faces_pmap, f, 0/*false*/); //reset ids
   }
 
   reset_drawing_data();


### PR DESCRIPTION
This PR introduces 2 fixes for `PMP::isotropic_remeshing`
- do not collapse an isolated constrained edge
- avoid all face inversions during collapse and relaxation steps

This PR replaces #1692 and is based on CGAL-4.9 instead of master

~~Note : this PR is not completely ready for testing. The no-inversion test should still be done surface patch per surface patch~~