### PR TITLE
Add missing namespace

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/edge_collapse.h
@@ -151,7 +151,7 @@ int edge_collapse ( ECM& aSurface
 template<class ECM, class ShouldStop>
 int edge_collapse ( ECM& aSurface, ShouldStop const& aShould_stop ) 
 {
-  return edge_collapse(aSurface,aShould_stop, halfedge_index_map(get(boost::halfedge_index,aSurface))); // AF why the halfedge_index_map?
+  return edge_collapse(aSurface,aShould_stop, CGAL::parameters::halfedge_index_map(get(boost::halfedge_index,aSurface)));
 }
 
   template<class ECM, class ShouldStop, class GT>


### PR DESCRIPTION
@afabri in  a comment you ask why `halfedge_index_map`. It is just to create a default named parameter and give it to the function. In PMP we have all_defaults() for that purpose. 