### PR TITLE
Update code to match documented concepts

### DIFF
--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Filters.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Filters.h
@@ -84,7 +84,8 @@ public:
       std::map<face_descriptor, std::size_t> neighbors;
       NeighborSelector()(mesh,*facet_it, window_size,
                          neighbors); // gather neighbors in the window
-      double current_sdf_value = values[*facet_it];
+
+      double current_sdf_value = get(values, *facet_it);
 
       double range_parameter_actual;
       if(!range_parameter) {
@@ -92,7 +93,7 @@ public:
         double deviation = 0.0;
         for(typename std::map<face_descriptor, std::size_t>::iterator it =
               neighbors.begin(); it != neighbors.end(); ++it) {
-          deviation += std::pow(values[it->first] - current_sdf_value, 2);
+          deviation += std::pow(get(values, it->first) - current_sdf_value, 2);
         }
         deviation = std::sqrt(deviation / neighbors.size());
         if(deviation == 0.0) {
@@ -112,12 +113,12 @@ public:
             neighbors.begin(); it != neighbors.end(); ++it) {
         double spatial_weight = gaussian_function(static_cast<double>(it->second),
                                 spatial_parameter_actual);
-        double range_weight = gaussian_function(values[it->first] - current_sdf_value,
+        double range_weight = gaussian_function(get(values, it->first) - current_sdf_value,
                                                 range_parameter_actual);
         // we can use just spatial_weight for Gaussian filtering
         double weight = spatial_weight * range_weight;
 
-        total_sdf_value += values[it->first] * weight;
+        total_sdf_value += get(values, it->first) * weight;
         total_weight += weight;
       }
       smoothed_values.push_back(total_sdf_value / total_weight);
@@ -127,7 +128,7 @@ public:
     for(boost::tie(facet_it,fend) = faces(mesh);
         facet_it != fend;
         ++facet_it, ++smoothed_value_it) {
-      values[*facet_it] = *smoothed_value_it;
+      put(values, *facet_it, *smoothed_value_it);
     }
   }
 private:

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
@@ -204,9 +204,9 @@ public:
                                           cone_angle, true, disk_samples);
 
       if(sdf_value) {
-        sdf_values[*facet_begin] = *sdf_value;
+        put(sdf_values, *facet_begin, *sdf_value);
       } else          {
-        sdf_values[*facet_begin] = -1.0;
+        put(sdf_values, *facet_begin, -1.0);
       }
     }
   }

--- a/Surface_mesh_segmentation/include/CGAL/mesh_segmentation.h
+++ b/Surface_mesh_segmentation/include/CGAL/mesh_segmentation.h
@@ -21,6 +21,7 @@
  * @brief The API which contains free template functions for SDF computation and mesh segmentation.
  */
 #include <CGAL/internal/Surface_mesh_segmentation/Surface_mesh_segmentation.h>
+#include <CGAL/boost/graph/helpers.h>
 #include <boost/config.hpp>
 
 namespace CGAL
@@ -64,7 +65,7 @@ sdf_values( const TriangleMesh& triangle_mesh,
  * It is possible to compute raw SDF values (without post-processing). In such a case,
  * -1 is used to indicate when no SDF value could be computed for a facet.
  *
- * @pre @a triangle_mesh.is_pure_triangle()
+ * @pre `is_triangle_mesh(triangle_mesh)`
  *
  * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam SDFPropertyMap  a `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%face_descriptor` as key and `double` as value type
@@ -79,7 +80,7 @@ sdf_values( const TriangleMesh& triangle_mesh,
  * @param traits traits class
  * @param ppmap point property map. An overload is provided with `get(boost::vertex_point,triangle_mesh)` as default.
  *
- * @return minimum and maximum raw SDF values if @a postprocess is `true`, otherwise minimum and maximum SDF values (before linear normalization)
+ * @return minimum and maximum raw SDF values if  `postprocess` is `true`, otherwise minimum and maximum SDF values (before linear normalization)
  */
 template <class TriangleMesh, class SDFPropertyMap, class PointPropertyMap
 #ifdef DOXYGEN_RUNNING
@@ -117,7 +118,7 @@ sdf_values( const TriangleMesh& triangle_mesh,
  *
  * See the section \ref Surface_mesh_segmentationPostprocessing for more details.
  *
- * @pre @a triangle_mesh.is_pure_triangle()
+ * @pre `is_triangle_mesh(triangle_mesh)`
  * @pre Raw values should be greater or equal to 0. -1 indicates when no value could be computed
  *
  * @tparam TriangleMesh a model of `FaceListGraph`
@@ -133,7 +134,7 @@ std::pair<double, double>
 sdf_values_postprocessing(const TriangleMesh& triangle_mesh,
                           SDFPropertyMap sdf_values_map)
 {
-  CGAL_precondition(triangle_mesh.is_pure_triangle());
+  CGAL_precondition(is_triangle_mesh(triangle_mesh));
   return internal::Postprocess_sdf_values<TriangleMesh>().postprocess(triangle_mesh,
          sdf_values_map);
 }
@@ -155,8 +156,8 @@ sdf_values_postprocessing(const TriangleMesh& triangle_mesh,
  * \note There is no direct relation between the parameter `number_of_clusters`
  * and the final number of segments after segmentation. However, setting a large number of clusters will result in a detailed segmentation of the mesh with a large number of segments.
  *
- * @pre @a triangle_mesh.is_pure_triangle()
- * @pre @a number_of_clusters > 0
+ * @pre `is_triangle_mesh(triangle_mesh)`
+ * @pre `number_of_clusters > 0`
  *
  * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam SDFPropertyMap  a `ReadablePropertyMap` with `boost::graph_traits<TriangleMesh>::%face_descriptor` as key and `double` as value type
@@ -252,8 +253,8 @@ segmentation_via_sdf_values(const TriangleMesh& triangle_mesh,
  * it is more efficient to first compute the SDF values using `CGAL::sdf_values()` and use them in different calls to
  * `CGAL::segmentation_from_sdf_values()`.
  *
- * @pre @a triangle_mesh.is_pure_triangle()
- * @pre @a number_of_clusters > 0
+ * @pre `is_triangle_mesh(triangle_mesh)`
+ * @pre `number_of_clusters > 0`
  *
  * @tparam TriangleMesh a model of `FaceListGraph`
  * @tparam SegmentPropertyMap a `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%face_descriptor` as key and `std::size_t` as value type


### PR DESCRIPTION
The member function `is_pure_triangle()` was used and lvalue property map API was used instead of `rw`