### PR TITLE
Polyhedron demo: mesh simplification on selection

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(mesh_segmentation_plugin scene_polyhedron_item)
 
 qt5_wrap_ui( mesh_simplificationUI_FILES  Mesh_simplification_dialog.ui)
 polyhedron_demo_plugin(mesh_simplification_plugin Mesh_simplification_plugin ${mesh_simplificationUI_FILES})
-target_link_libraries(mesh_simplification_plugin scene_polyhedron_item)
+target_link_libraries(mesh_simplification_plugin scene_polyhedron_item scene_polyhedron_selection_item)
 
 
 qt5_wrap_ui( remeshingUI_FILES  Remeshing_dialog.ui)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -12,7 +12,8 @@ qt5_wrap_ui( segmentationUI_FILES Mesh_segmentation_widget.ui)
 polyhedron_demo_plugin(mesh_segmentation_plugin Mesh_segmentation_plugin ${segmentationUI_FILES})
 target_link_libraries(mesh_segmentation_plugin scene_polyhedron_item)
 
-polyhedron_demo_plugin(mesh_simplification_plugin Mesh_simplification_plugin)
+qt5_wrap_ui( mesh_simplificationUI_FILES  Mesh_simplification_dialog.ui)
+polyhedron_demo_plugin(mesh_simplification_plugin Mesh_simplification_plugin ${mesh_simplificationUI_FILES})
 target_link_libraries(mesh_simplification_plugin scene_polyhedron_item)
 
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Mesh_simplification_dialog</class>
+ <widget class="QDialog" name="Mesh_simplification_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>311</width>
+    <height>171</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Stop Predicate</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Stop simplification as soon as:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="m_use_nb_edges">
+       <property name="text">
+        <string>Number of edges =</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="m_nb_edges">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>400000000</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="m_combinatorial">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <item>
+        <property name="text">
+         <string>AND</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OR</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="m_use_edge_length">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Minimum edge length =</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="m_edge_length">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>10000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Mesh_simplification_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>384</x>
+     <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Mesh_simplification_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>384</x>
+     <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -12,6 +12,43 @@
 #include <CGAL/Surface_mesh_simplification/HalfedgeGraph_Polyhedron_3.h>
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Count_stop_predicate.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_length_stop_predicate.h>
+
+#include "ui_Mesh_simplification_dialog.h"
+
+class Custom_stop_predicate
+{
+  bool m_and;
+    CGAL::Surface_mesh_simplification::Count_stop_predicate<Polyhedron> m_count_stop;
+  CGAL::Surface_mesh_simplification::Edge_length_stop_predicate<double> m_length_stop;
+  
+public:
+
+  Custom_stop_predicate (bool use_and, std::size_t nb_edges, double edge_length)
+    : m_and (use_and), m_count_stop (nb_edges), m_length_stop (edge_length)
+  {
+    std::cerr << "Simplifying until:" << std::endl
+              << " * Number of edges = " << nb_edges << std::endl
+              << (use_and ? " AND " : " OR ") << std::endl
+              << " * Minimum edge length = " << edge_length << std::endl;
+
+  }
+
+  template <typename Profile>
+  bool operator() (const double& current_cost, const Profile& edge_profile,
+                   std::size_t initial_count, std::size_t current_count) const 
+  {
+    if (m_and)
+      return (m_count_stop(current_count, edge_profile, initial_count, current_count)
+              && m_length_stop(current_count, edge_profile, initial_count, current_count));
+    else
+      return (m_count_stop(current_count, edge_profile, initial_count, current_count)
+              || m_length_stop(current_count, edge_profile, initial_count, current_count));
+  }
+
+};
+
+
 using namespace CGAL::Three;
 class Polyhedron_demo_mesh_simplification_plugin : 
   public QObject,
@@ -63,20 +100,26 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
   {
     Polyhedron* pMesh = item->polyhedron();
 
-    // get option (#edges)
-    bool ok;
-  
-    const int nb_edges = 
-    QInputDialog::getInt(mw, tr("Stop condition"),
-      tr("Number of edges:"),
-      (int)(pMesh->size_of_halfedges () / 4), // default value: current #edges / 2 
-      3, // min = one triangle
-      (int)pMesh->size_of_halfedges(), // max #edges
-      1, // step for the spinbox
-      &ok);
+    // get option
+    QDialog dialog(mw);
+    Ui::Mesh_simplification_dialog ui;
+    ui.setupUi(&dialog);
+    connect(ui.buttonBox, SIGNAL(accepted()),
+            &dialog, SLOT(accept()));
+    connect(ui.buttonBox, SIGNAL(rejected()),
+            &dialog, SLOT(reject()));
+
+    Scene_interface::Bbox bbox = item->bbox();
+    double diago_length = CGAL::sqrt((bbox.xmax()-bbox.xmin())*(bbox.xmax()-bbox.xmin())
+                                     + (bbox.ymax()-bbox.ymin())*(bbox.ymax()-bbox.ymin()) +
+                                     (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
+    
+    ui.m_nb_edges->setValue ((int)(pMesh->size_of_halfedges () / 4));
+    ui.m_nb_edges->setMaximum ((int)(pMesh->size_of_halfedges ()));
+    ui.m_edge_length->setValue (diago_length * 0.05);
 
     // check user cancellation
-    if(!ok)
+    if(dialog.exec() == QDialog::Rejected)
       return;
 
     // simplify
@@ -85,9 +128,17 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
     std::cout << "Simplify...";
     QApplication::setOverrideCursor(Qt::WaitCursor);
     QApplication::processEvents();
-    namespace SMS = CGAL::Surface_mesh_simplification;
-    SMS::Count_stop_predicate< Polyhedron > stop(nb_edges); // target #edges
-    SMS::edge_collapse( *pMesh, stop,
+    Custom_stop_predicate stop ((ui.m_combinatorial->currentIndex() == 0)
+                                && !(ui.m_use_nb_edges->isChecked())
+                                && !(ui.m_use_edge_length->isChecked()),
+                                (ui.m_use_nb_edges->isChecked()
+                                 ? ui.m_nb_edges->value()
+                                 : 0),
+                                (ui.m_use_edge_length->isChecked()
+                                 ? ui.m_edge_length->value()
+                                 : std::numeric_limits<double>::max()));
+    
+    CGAL::Surface_mesh_simplification::edge_collapse( *pMesh, stop,
                         CGAL::parameters::vertex_index_map(get(CGAL::vertex_external_index,*pMesh))
                                          .halfedge_index_map(get(CGAL::halfedge_external_index,*pMesh)));
     std::cout << "ok (" << time.elapsed() << " ms, " 

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_length_stop_predicate.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_length_stop_predicate.h
@@ -32,7 +32,7 @@ Edge_length_stop_predicate<ECM>( FT threshold );
 /// @{
 
 /*!
-Returns `(CGAL::squared_distance(edge_profile.p0(),edge_profile.p1()) < threshold*threshold)`.
+Returns `(CGAL::squared_distance(edge_profile.p0(),edge_profile.p1()) > threshold*threshold)`.
 All other parameters are ignored (but exist since this is a generic policy).
 */
 bool operator()( FT const&


### PR DESCRIPTION
This PR adds the following functionalities for the mesh simplification plugin:
- using a stop predicate on edge length in addition (or instead of) the current stop predicate on the number of edges
- applying simplification to a Polyhedron with selected edges as constraints