### PR TITLE
Polyhedron demo: open PLY with floating colors

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -483,11 +483,22 @@ public Q_SLOTS:
     new_item->setName(QString("%1 (selected points)").arg(point_set_item->name()));
     if (point_set_item->has_normals())
       new_item->point_set()->add_normal_map();
+    Point_set::Byte_map red, green, blue;
+    Point_set::Double_map fred, fgreen, fblue;
     if (point_set_item->point_set()->has_colors())
       {
-        new_item->point_set()->add_property_map<unsigned char>("red", 0);
-        new_item->point_set()->add_property_map<unsigned char>("green", 0);
-        new_item->point_set()->add_property_map<unsigned char>("blue", 0);
+        if (point_set_item->point_set()->has_byte_colors())
+          {
+            red = new_item->point_set()->add_property_map<unsigned char>("red", 0).first;
+            green = new_item->point_set()->add_property_map<unsigned char>("green", 0).first;
+            blue = new_item->point_set()->add_property_map<unsigned char>("blue", 0).first;
+          }
+        else
+          {
+            fred = new_item->point_set()->add_property_map<double>("red", 0).first;
+            fgreen = new_item->point_set()->add_property_map<double>("green", 0).first;
+            fblue = new_item->point_set()->add_property_map<double>("blue", 0).first;
+          }
         new_item->point_set()->check_colors(); 
       }
     
@@ -506,9 +517,18 @@ public Q_SLOTS:
             new_item->point_set()->normal(*new_point) = point_set_item->point_set()->normal(*it);
           if (point_set_item->point_set()->has_colors())
             {
-              new_item->point_set()->red(*new_point) = point_set_item->point_set()->red(*it);
-              new_item->point_set()->green(*new_point) = point_set_item->point_set()->green(*it);
-              new_item->point_set()->blue(*new_point) = point_set_item->point_set()->blue(*it);
+              if (point_set_item->point_set()->has_byte_colors())
+                {
+                  red[*new_point] = (unsigned char)(255. * point_set_item->point_set()->red(*it));
+                  green[*new_point] = (unsigned char)(255. * point_set_item->point_set()->green(*it));
+                  blue[*new_point] = (unsigned char)(255. * point_set_item->point_set()->blue(*it));
+                }
+              else
+                {
+                  fred[*new_point] = point_set_item->point_set()->red(*it);
+                  fgreen[*new_point] = point_set_item->point_set()->green(*it);
+                  fblue[*new_point] = point_set_item->point_set()->blue(*it);
+                }
             }
         }
     }

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -395,12 +395,12 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
 
         for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
 	  {
-            colors_points.push_back ((double)(m_points->red(*it) / 255.));
-            colors_points.push_back ((double)(m_points->green(*it) / 255.));
-            colors_points.push_back ((double)(m_points->blue(*it) / 255.));
-            colors_points.push_back ((double)(m_points->red(*it) / 255.));
-            colors_points.push_back ((double)(m_points->green(*it) / 255.));
-            colors_points.push_back ((double)(m_points->blue(*it) / 255.));
+            colors_points.push_back (m_points->red(*it));
+            colors_points.push_back (m_points->green(*it));
+            colors_points.push_back (m_points->blue(*it));
+            colors_points.push_back (m_points->red(*it));
+            colors_points.push_back (m_points->green(*it));
+            colors_points.push_back (m_points->blue(*it));
 	  }
     }
         
@@ -589,9 +589,9 @@ void Scene_points_with_normal_item::drawSplats(CGAL::Three::Viewer_interface* vi
        {
          const Point_set::Point& p = d->m_points->point (*it);
          const Point_set::Vector& n = d->m_points->normal (*it);
-         viewer->glColor4d((double)(d->m_points->red(*it)) / 255.,
-                           (double)(d->m_points->green(*it)) / 255.,
-                           (double)(d->m_points->blue(*it)) / 255.,
+         viewer->glColor4d(d->m_points->red(*it),
+                           d->m_points->green(*it),
+                           d->m_points->blue(*it),
                            1.0);
          viewer->glNormal3dv(&n.x());
          viewer->glMultiTexCoord1d(GL_TEXTURE2, d->m_points->radius(*it));
@@ -738,7 +738,6 @@ void Scene_points_with_normal_item::computes_local_spacing(int k)
 
   // Compute the radius of each point = (distance max to k nearest neighbors)/2.
   {
-    d->m_points->test();
     int i=0;
     for (Point_set::iterator it=d->m_points->begin(); it!=d->m_points->end(); ++it, ++i)
     {

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -16,7 +16,7 @@
 // $Id$
 //
 //
-// Author(s)     : Laurent Saboret, Nader Salman, Gael Guennebaud
+// Author(s)     : Laurent Saboret, Nader Salman, Gael Guennebaud, Simon Giraudot
 
 #ifndef POINT_SET_3_H
 #define POINT_SET_3_H
@@ -91,6 +91,9 @@ private:
   Byte_map m_red;
   Byte_map m_green;
   Byte_map m_blue;
+  Double_map m_fred;
+  Double_map m_fgreen;
+  Double_map m_fblue;
 
   // Assignment operator not implemented and declared private to make
   // sure nobody uses the default one without knowing it
@@ -132,8 +135,6 @@ public:
   double& radius (const Index& index) { return m_radius[index]; }
   const double& radius (const Index& index) const { return m_radius[index]; }
 
-  void test () { }
-  
   bool check_colors()
   {
     bool found = false;
@@ -143,7 +144,7 @@ public:
       {
         boost::tie (m_red, found) = this->template property_map<unsigned char>("r");
         if (!found)
-          return false;
+          return get_float_colors();
       }
 
     boost::tie (m_green, found) = this->template property_map<unsigned char>("green");
@@ -165,17 +166,53 @@ public:
     return true;
   }
 
+  bool get_float_colors()
+  {
+    bool found = false;
+
+    boost::tie (m_fred, found) = this->template property_map<double>("red");
+    if (!found)
+      {
+        boost::tie (m_fred, found) = this->template property_map<double>("r");
+        if (!found)
+          return false;
+      }
+
+    boost::tie (m_fgreen, found) = this->template property_map<double>("green");
+    if (!found)
+      {
+        boost::tie (m_fgreen, found) = this->template property_map<double>("g");
+        if (!found)
+          return false;
+      }
+
+    boost::tie (m_fblue, found) = this->template property_map<double>("blue");
+    if (!found)
+      {
+        boost::tie (m_fblue, found) = this->template property_map<double>("b");
+        if (!found)
+          return false;
+      }
+    return true;
+  }
+
   bool has_colors() const
   {
-    return m_blue != Byte_map();
+    return (m_blue != Byte_map() || m_fblue != Double_map());
+  }
+
+  bool has_byte_colors() const
+  {
+    return (m_blue != Byte_map());
   }
     
-  unsigned char& red (const Index& index) { return m_red[index]; }
-  unsigned char& green (const Index& index) { return m_green[index]; }
-  unsigned char& blue (const Index& index) { return m_blue[index]; }
-  const unsigned char& red (const Index& index) const { return m_red[index]; }
-  const unsigned char& green (const Index& index) const { return m_green[index]; }
-  const unsigned char& blue (const Index& index) const { return m_blue[index]; }
+  double red (const Index& index) const
+  { return (m_red == Byte_map()) ? m_fred[index]  : double(m_red[index]) / 255.; }
+  double green (const Index& index) const
+  { return (m_green == Byte_map()) ? m_fgreen[index]  : double(m_green[index]) / 255.; }
+  double blue (const Index& index) const
+  { return (m_blue == Byte_map()) ? m_fblue[index]  : double(m_blue[index]) / 255.; }
+
   
   iterator first_selected() { return this->m_indices.end() - this->m_nb_removed; }
   const_iterator first_selected() const { return this->m_indices.end() - this->m_nb_removed; }


### PR DESCRIPTION
Currently, the demo only displays colors if they were found in the input as 3 `unsigned char` numbers (that's the usual way to store colors).

As colors can sometimes be stored on 3 `double` numbers, the demo might not display them: this PR adds the handling of colors as `double` numbers.