### PR TITLE
Improve Lazy_alpha_nt_3

### DIFF
--- a/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
@@ -238,7 +238,7 @@ and it must be parameterized with vertex and cell classes, which are model of th
 The package provides models `Fixed_alpha_shape_vertex_base_3<Gt>` 
 and `Fixed_alpha_shape_cell_base_3<Gt>`, respectively.
 
-\section Alpha_shapes_3AlphaShape3OrFixedAlphaShape3 Alpha_shape_3 vs.\ Fixed_alpha_shape_3
+\section Alpha_shapes_3AlphaShape3OrFixedAlphaShape3 Alpha_shape_3 vs. Fixed_alpha_shape_3
 
 The class `Alpha_shape_3<Dt,ExactAlphaComparisonTag>` represents the whole family
 of alpha shapes for a given set of points while the class `Fixed_alpha_shape_3<Dt>`

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
@@ -72,7 +72,8 @@ resorting to exact arithmetic). Access to the interval containing the exact valu
 `FT::Approximate_nt approx() const` where `FT::Approximate_nt` is `Interval_nt<Protected>` 
 with `Protected=true`. Access to the exact value is provided through the function 
 `FT::Exact_nt exact() const` where `FT::Exact_nt` depends on the configuration of %CGAL 
-(it is `Gmpq` if `gmp` is available and `Quotient<CGAL::MP_Float>` otherwise). 
+(it is `Gmpq` if `gmp` is available and `Quotient<CGAL::MP_Float>` otherwise).
+An overload for the function `double to_double(FT)` is also available.
 It must be noted that an object of type `FT` is valid as long as the alpha shapes class that creates 
 it is valid and has not been modified. 
 For convenience, classical comparison operators are provided for the type `FT`. 

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -25,6 +25,7 @@
 #include <CGAL/Regular_triangulation_euclidean_traits_3.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/type_traits.hpp>
+#include <boost/optional.hpp>
 #include <iostream>
 
 namespace CGAL {
@@ -108,8 +109,7 @@ class Lazy_alpha_nt_3{
 //members  
   unsigned nb_pt;
   //the members can be updated when calling method exact()
-  mutable bool updated;
-  mutable NT_exact exact_;
+  mutable boost::optional<NT_exact> exact_;
   mutable NT_approx approx_;
   typedef std::vector<const Input_point*> Data_vector;
   boost::shared_ptr<Data_vector> inputs_ptr;
@@ -143,7 +143,6 @@ public:
       default:
         CGAL_assertion(false);
     }
-    updated=true;
   }
   
   void set_approx(){
@@ -166,22 +165,22 @@ public:
   }
 
   const NT_exact& exact() const {
-    if (!updated){
+    if (exact_ == boost::none){
       update_exact();
-      approx_=to_interval(exact_);
+      approx_=to_interval(*exact_);
     }
-    return exact_;
+    return *exact_;
   }
 
   const NT_approx& approx() const{
     return approx_;
   }
 //Constructors  
-  Lazy_alpha_nt_3():nb_pt(0),updated(true),exact_(0),approx_(0){}
+  Lazy_alpha_nt_3():nb_pt(0),exact_(Exact_nt(0)),approx_(0){}
   
-  Lazy_alpha_nt_3(double d):nb_pt(0),updated(true),exact_(d),approx_(d){}
+  Lazy_alpha_nt_3(double d):nb_pt(0),exact_(Exact_nt(d)),approx_(d){}
   
-  Lazy_alpha_nt_3(const Input_point& wp1):nb_pt(1),updated(false),inputs_ptr(new Data_vector())
+  Lazy_alpha_nt_3(const Input_point& wp1):nb_pt(1),inputs_ptr(new Data_vector())
   {
     data().reserve(nb_pt);
     data().push_back(&wp1);
@@ -189,7 +188,7 @@ public:
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
-           const Input_point& wp2):nb_pt(2),updated(false),inputs_ptr(new Data_vector())
+           const Input_point& wp2):nb_pt(2),inputs_ptr(new Data_vector())
   {
     data().reserve(nb_pt);
     data().push_back(&wp1);
@@ -199,7 +198,7 @@ public:
 
   Lazy_alpha_nt_3(const Input_point& wp1,
            const Input_point& wp2,
-           const Input_point& wp3):nb_pt(3),updated(false),inputs_ptr(new Data_vector())
+           const Input_point& wp3):nb_pt(3),inputs_ptr(new Data_vector())
   {
     data().reserve(nb_pt);
     data().push_back(&wp1);
@@ -211,7 +210,7 @@ public:
   Lazy_alpha_nt_3(const Input_point& wp1,
            const Input_point& wp2,
            const Input_point& wp3,
-           const Input_point& wp4):nb_pt(4),updated(false),inputs_ptr(new Data_vector())
+           const Input_point& wp4):nb_pt(4),inputs_ptr(new Data_vector())
   {
     data().reserve(nb_pt);
     data().push_back(&wp1);

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -225,12 +225,11 @@ public:
   bool \
   operator CMP (const Lazy_alpha_nt_3<Input_traits,Kernel_input,mode,Weighted_tag> &other) const \
   { \
-    try{ \
-      return this->approx() CMP other.approx(); \
-    } \
-    catch(CGAL::Uncertain_conversion_exception&){ \
+    Uncertain<bool> res = this->approx() CMP other.approx(); \
+    if (res.is_certain()) \
+      return res; \
+    else \
       return this->exact() CMP other.exact(); \
-    } \
   } \
 
   CGAL_LANT_COMPARE_FUNCTIONS(<)

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -28,13 +28,19 @@
 #include <boost/optional.hpp>
 #include <iostream>
 
-#if BOOST_VERSION >= 105400
-#include <boost/container/static_vector.hpp>
-#endif
-
 namespace CGAL {
 
 namespace internal{
+
+template <class Ptr>
+struct Input_points_for_lazy_alpha_nt_3
+{
+  int nbpts;
+  const Ptr* p0;
+  const Ptr* p1;
+  const Ptr* p2;
+  const Ptr* p3;
+};
 
 //non-weighted case  
 template <class Weighted_tag,class Input_traits,class Kernel_input,class Kernel_approx,class Kernel_exact>
@@ -116,58 +122,30 @@ class Lazy_alpha_nt_3{
   mutable NT_approx approx_;
 
 //private functions
-  #if BOOST_VERSION >= 105400
-  typedef boost::container::static_vector<const Input_point*, 4> Data_vector;
+  typedef Input_points_for_lazy_alpha_nt_3<Input_point> Data_vector;
   Data_vector input_points;
 
   const Data_vector& data() const{ return input_points;}
   Data_vector& data(){ return input_points;}
-  void init_input(int) {}
 
-public:
-  // why is the default one not fine?
-  Lazy_alpha_nt_3<Input_traits, Kernel_input, mode, Weighted_tag>&
-  operator=(const Lazy_alpha_nt_3<Input_traits, Kernel_input, mode, Weighted_tag>& other)
-  {
-    input_points=other.input_points;
-    approx_=other.approx_;
-    exact_=other.exact_;
-    return *this;
-  }
-private:
-
-  #else
-  typedef std::vector<const Input_point*> Data_vector;
-  boost::shared_ptr<Data_vector> input_points_ptr;
-
-  const Data_vector& data() const{ return *input_points_ptr;}
-  Data_vector& data(){ return *input_points_ptr;}
-
-  void init_input(int i) {
-    input_points_ptr = boost::shared_ptr<Data_vector>( new Data_vector() );
-    input_points_ptr->reserve(i);
-  }
-  #endif
-  
-  
 public:
 
   typedef NT_exact               Exact_nt;
   typedef NT_approx              Approximate_nt;
 
   void update_exact() const{
-    switch (data().size()){
+    switch (data().nbpts){
       case 1:
-        exact_ = Exact_squared_radius()( to_exact(*data()[0]) );
+        exact_ = Exact_squared_radius()( to_exact(*data().p0) );
       break;
       case 2:
-        exact_ = Exact_squared_radius()( to_exact(*data()[0]),to_exact(*data()[1]) );
+        exact_ = Exact_squared_radius()( to_exact(*data().p0),to_exact(*data().p1) );
       break;
       case 3:
-        exact_ = Exact_squared_radius()( to_exact(*data()[0]),to_exact(*data()[1]),to_exact(*data()[2]) );
+        exact_ = Exact_squared_radius()( to_exact(*data().p0),to_exact(*data().p1),to_exact(*data().p2) );
       break;
       case 4:
-        exact_ = Exact_squared_radius()( to_exact(*data()[0]),to_exact(*data()[1]),to_exact(*data()[2]),to_exact(*data()[3]) );
+        exact_ = Exact_squared_radius()( to_exact(*data().p0),to_exact(*data().p1),to_exact(*data().p2),to_exact(*data().p3) );
       break;
       default:
         CGAL_assertion(false);
@@ -175,18 +153,18 @@ public:
   }
   
   void set_approx(){
-    switch (data().size()){
+    switch (data().nbpts){
       case 1:
-        approx_ = Approx_squared_radius()( to_approx(*data()[0]) );
+        approx_ = Approx_squared_radius()( to_approx(*data().p0) );
       break;
       case 2:
-        approx_ = Approx_squared_radius()( to_approx(*data()[0]),to_approx(*data()[1]) );
+        approx_ = Approx_squared_radius()( to_approx(*data().p0),to_approx(*data().p1) );
       break;
       case 3:
-        approx_ = Approx_squared_radius()( to_approx(*data()[0]),to_approx(*data()[1]),to_approx(*data()[2]) );
+        approx_ = Approx_squared_radius()( to_approx(*data().p0),to_approx(*data().p1),to_approx(*data().p2) );
       break;
       case 4:
-        approx_ = Approx_squared_radius()( to_approx(*data()[0]),to_approx(*data()[1]),to_approx(*data()[2]),to_approx(*data()[3]) );
+        approx_ = Approx_squared_radius()( to_approx(*data().p0),to_approx(*data().p1),to_approx(*data().p2),to_approx(*data().p3) );
       break;
       default:
         CGAL_assertion(false);
@@ -211,17 +189,17 @@ public:
   
   Lazy_alpha_nt_3(const Input_point& wp1)
   {
-    init_input(1);
-    data().push_back(&wp1);
+    data().nbpts=1;
+    data().p0=&wp1;
     set_approx();
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
            const Input_point& wp2)
   {
-    init_input(2);
-    data().push_back(&wp1);
-    data().push_back(&wp2);
+    data().nbpts=2;
+    data().p0=&wp1;
+    data().p1=&wp2;
     set_approx();
   }
 
@@ -229,10 +207,10 @@ public:
            const Input_point& wp2,
            const Input_point& wp3)
   {
-    init_input(3);
-    data().push_back(&wp1);
-    data().push_back(&wp2);
-    data().push_back(&wp3);
+    data().nbpts=3;
+    data().p0=&wp1;
+    data().p1=&wp2;
+    data().p2=&wp3;
     set_approx();
   }
 
@@ -241,11 +219,11 @@ public:
            const Input_point& wp3,
            const Input_point& wp4)
   {
-    init_input(4);
-    data().push_back(&wp1);
-    data().push_back(&wp2);
-    data().push_back(&wp3);
-    data().push_back(&wp4);
+    data().nbpts=4;
+    data().p0=&wp1;
+    data().p1=&wp2;
+    data().p2=&wp3;
+    data().p3=&wp4;
     set_approx();
   }
     

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -32,14 +32,14 @@ namespace CGAL {
 
 namespace internal{
 
-template <class Ptr>
+template <class T>
 struct Input_points_for_lazy_alpha_nt_3
 {
   int nbpts;
-  const Ptr* p0;
-  const Ptr* p1;
-  const Ptr* p2;
-  const Ptr* p3;
+  const T* p0;
+  const T* p1;
+  const T* p2;
+  const T* p3;
 };
 
 //non-weighted case  

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -107,7 +107,6 @@ class Lazy_alpha_nt_3{
 
 
 //members  
-  unsigned nb_pt;
   //the members can be updated when calling method exact()
   mutable boost::optional<NT_exact> exact_;
   mutable NT_approx approx_;
@@ -127,7 +126,7 @@ public:
   typedef NT_approx              Approximate_nt;
 
   void update_exact() const{
-    switch (nb_pt){
+    switch (data().size()){
       case 1:
         exact_ = Exact_squared_radius()( to_exact(*data()[0]) );
       break;
@@ -146,7 +145,7 @@ public:
   }
   
   void set_approx(){
-    switch (nb_pt){
+    switch (data().size()){
       case 1:
         approx_ = Approx_squared_radius()( to_approx(*data()[0]) );
       break;
@@ -176,21 +175,21 @@ public:
     return approx_;
   }
 //Constructors  
-  Lazy_alpha_nt_3():nb_pt(0),exact_(Exact_nt(0)),approx_(0){}
+  Lazy_alpha_nt_3():exact_(Exact_nt(0)),approx_(0){}
   
-  Lazy_alpha_nt_3(double d):nb_pt(0),exact_(Exact_nt(d)),approx_(d){}
+  Lazy_alpha_nt_3(double d):exact_(Exact_nt(d)),approx_(d){}
   
-  Lazy_alpha_nt_3(const Input_point& wp1):nb_pt(1),inputs_ptr(new Data_vector())
+  Lazy_alpha_nt_3(const Input_point& wp1):inputs_ptr(new Data_vector())
   {
-    data().reserve(nb_pt);
+    data().reserve(1);
     data().push_back(&wp1);
     set_approx();
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
-           const Input_point& wp2):nb_pt(2),inputs_ptr(new Data_vector())
+           const Input_point& wp2):inputs_ptr(new Data_vector())
   {
-    data().reserve(nb_pt);
+    data().reserve(2);
     data().push_back(&wp1);
     data().push_back(&wp2);
     set_approx();
@@ -198,9 +197,9 @@ public:
 
   Lazy_alpha_nt_3(const Input_point& wp1,
            const Input_point& wp2,
-           const Input_point& wp3):nb_pt(3),inputs_ptr(new Data_vector())
+           const Input_point& wp3):inputs_ptr(new Data_vector())
   {
-    data().reserve(nb_pt);
+    data().reserve(3);
     data().push_back(&wp1);
     data().push_back(&wp2);
     data().push_back(&wp3);
@@ -210,9 +209,9 @@ public:
   Lazy_alpha_nt_3(const Input_point& wp1,
            const Input_point& wp2,
            const Input_point& wp3,
-           const Input_point& wp4):nb_pt(4),inputs_ptr(new Data_vector())
+           const Input_point& wp4):inputs_ptr(new Data_vector())
   {
-    data().reserve(nb_pt);
+    data().reserve(4);
     data().push_back(&wp1);
     data().push_back(&wp2);
     data().push_back(&wp3);

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -183,41 +183,63 @@ public:
     return approx_;
   }
 //Constructors  
-  Lazy_alpha_nt_3():exact_(Exact_nt(0)),approx_(0){}
+  Lazy_alpha_nt_3()
+   : exact_(Exact_nt(0)),approx_(0)
+  {
+    data().nbpts=0;
+    data().p0=NULL;
+    data().p1=NULL;
+    data().p2=NULL;
+    data().p3=NULL;
+  }
   
-  Lazy_alpha_nt_3(double d):exact_(Exact_nt(d)),approx_(d){}
+  Lazy_alpha_nt_3(double d)
+   : exact_(Exact_nt(d)),approx_(d)
+  {
+    data().nbpts=0;
+    data().p0=NULL;
+    data().p1=NULL;
+    data().p2=NULL;
+    data().p3=NULL;
+  }
   
   Lazy_alpha_nt_3(const Input_point& wp1)
   {
     data().nbpts=1;
     data().p0=&wp1;
+    data().p1=NULL;
+    data().p2=NULL;
+    data().p3=NULL;
     set_approx();
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
-           const Input_point& wp2)
+                  const Input_point& wp2)
   {
     data().nbpts=2;
     data().p0=&wp1;
     data().p1=&wp2;
+    data().p2=NULL;
+    data().p3=NULL;
     set_approx();
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
-           const Input_point& wp2,
-           const Input_point& wp3)
+                  const Input_point& wp2,
+                  const Input_point& wp3)
   {
     data().nbpts=3;
     data().p0=&wp1;
     data().p1=&wp2;
     data().p2=&wp3;
+    data().p3=NULL;
     set_approx();
   }
 
   Lazy_alpha_nt_3(const Input_point& wp1,
-           const Input_point& wp2,
-           const Input_point& wp3,
-           const Input_point& wp4)
+                  const Input_point& wp2,
+                  const Input_point& wp3,
+                  const Input_point& wp4)
   {
     data().nbpts=4;
     data().p0=&wp1;

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -337,6 +337,12 @@ struct Alpha_nt_selector_3:
 
 } //namespace internal
 
+template<class Input_traits, class Kernel_input, bool mode, class Weighted_tag>
+double to_double(const internal::Lazy_alpha_nt_3<Input_traits, Kernel_input, mode, Weighted_tag>& a)
+{
+  return to_double(a.approx());
+}
+
 } //namespace CGAL
 
 #endif //CGAL_INTERNAL_LAZY_ALPHA_NT_3_H

--- a/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_cls_alpha_shape_3.h
+++ b/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_cls_alpha_shape_3.h
@@ -111,6 +111,7 @@ _test_cls_alpha_shape_3()
     a1.set_alpha(*alpha_it);
     if (verbose) {
       std::cerr << std::endl;
+      CGAL::to_double(* alpha_it);
       std::cerr << "alpha value " << * alpha_it << std::endl;
     }
     count_faces(a1, verbose);


### PR DESCRIPTION
Fixes #1704 

@mglisse  for the version with `static_vector`, I have to define the `operator=` myself as the default one was not fine. Any idea why?