### PR TITLE
Use faster Eigen implementation for diagonalization

### DIFF
--- a/Solver_interface/include/CGAL/Eigen_diagonalize_traits.h
+++ b/Solver_interface/include/CGAL/Eigen_diagonalize_traits.h
@@ -24,6 +24,17 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 
+
+// If the matrix to diagonalize is of dimension 2x2 or 3x3, Eigen
+// provides a faster implementation using a closed-form
+// algorithm. However, it offers less precision. See:
+// https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointEigenSolver.html
+// This is usually acceptable for CGAL algorithms but one might want
+// to use the slower but more accurate version. In that case, just
+// uncomment the following line:
+
+//#define DO_NOT_USE_EIGEN_COMPUTEDIRECT_FOR_DIAGONALIZATION
+
 #include <CGAL/array.h>
 
 namespace CGAL {
@@ -67,7 +78,14 @@ private:
   diagonalize_selfadjoint_matrix (EigenMatrix& m,
 				  EigenMatrix& eigenvectors,
                                   EigenVector& eigenvalues) {
-      Eigen::SelfAdjointEigenSolver<EigenMatrix> eigensolver(m);
+      Eigen::SelfAdjointEigenSolver<EigenMatrix> eigensolver;
+
+#ifndef DO_NOT_USE_EIGEN_COMPUTEDIRECT_FOR_DIAGONALIZATION
+      if (dim == 2 || dim == 3)
+        eigensolver.computeDirect(m);
+      else
+#endif
+        eigensolver.compute(m);
 
       if (eigensolver.info() != Eigen::Success) {
           return false;


### PR DESCRIPTION
Eigen provides [a faster implementation](https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointEigenSolver.html#afe520161701f5f585bcc4cedb8657bd1) for matrix diagonalization (if the dimension is 2x2 or 3x3 which is pretty much all that CGAL uses). This PR makes this implementation used by default.

There is indeed a noticeable gain of performance (from 4.5 to 3.0 seconds on my test computing covariance matrices on 6 nearest neighbors for each points on a sphere sampled by 10 million points).

I added a commentary and the possibility to fallback to the slower version for precision issues.