### PR TITLE
Point_set_processing: define CGAL_VORONOI_COVARIANCE_USE_CONSTRUCTIONS

### DIFF
--- a/Point_set_processing_3/include/CGAL/internal/Voronoi_covariance_3/voronoi_covariance_3.h
+++ b/Point_set_processing_3/include/CGAL/internal/Voronoi_covariance_3/voronoi_covariance_3.h
@@ -21,6 +21,9 @@
 #ifndef CGAL_INTERNAL_VCM_VORONOI_COVARIANCE_3_HPP
 #define CGAL_INTERNAL_VCM_VORONOI_COVARIANCE_3_HPP
 
+// See mail on cgal-develop from 1.Dec 2016
+#define CGAL_VORONOI_COVARIANCE_USE_CONSTRUCTIONS
+
 #include <list>
 #include <CGAL/array.h>
 #include <CGAL/internal/Voronoi_covariance_3/voronoi_covariance_sphere_3.h>


### PR DESCRIPTION
Use halfspace intersection that produces better vertex coordinates (even if the topology of the CH3 might not be fully correct).

halfspace_intersections()  for a range of planes has a robustness problem when `intersection()` is called with three planes.  To `#define CGAL_VORONOI_COVARIANCE_USE_CONSTRUCTIONS` is a quick solution, and the problem wih the intersection must be investigated later. 
