### PR TITLE
Fix CMake warnings about unused variables set on command line

### DIFF
--- a/Scripts/developer_scripts/create_cgal_test
+++ b/Scripts/developer_scripts/create_cgal_test
@@ -82,6 +82,7 @@ configure()
 
   if eval 'cmake "\$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \\
                                      -DCGAL_DIR="\$CGAL_DIR" \\
+                                     --no-warn-unused-cli \\
                                      .' ; then
 
     echo "   successful configuration" >> \$ERRORFILE


### PR DESCRIPTION
`RUNNING_CGAL_AUTO_TEST` and `CGAL_DIR` are set on the command line by
our `cgal_test` scripts.

-> Add the option `--no-warn-unused-cli` to avoid warnings when the
   variables are actually not used (for example if a dependency is not
   satisfied).