### PR TITLE
Add various fix to demo/Polyhedron

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -794,14 +794,10 @@ Scene_edit_box_item::manipulatedFrame()
 
 double Scene_edit_box_item::point(short i, short j) const
 {
-  QVector3D pos(d->vertices[i].position().x()-d->center_.x,
-                d->vertices[i].position().y()-d->center_.y,
-                d->vertices[i].position().z()-d->center_.z);
-  QMatrix4x4 f_matrix;
-  for (int k=0; k<16; ++k){
-    f_matrix.data()[k] = (float)d->frame->matrix()[k];
-  }
-  return (f_matrix*pos)[j];
+  qglviewer::Vec pos(d->vertices[i].position().x()-d->center_.x,
+                     d->vertices[i].position().y()-d->center_.y,
+                     d->vertices[i].position().z()-d->center_.z);
+  return (d->frame->inverseCoordinatesOf(pos))[j];
 }
 
 void Scene_edit_box_item::highlight()

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
@@ -100,6 +100,7 @@ Polyhedron_demo::~Polyhedron_demo() {}
 
 void Polyhedron_demo::do_not_catch_exceptions() {
   d_ptr->catch_exceptions = false;
+  setProperty("no-try-catch", true);
 }
 
 bool Polyhedron_demo::notify(QObject* receiver, QEvent* event)

--- a/Three/include/CGAL/Three/exceptions.h
+++ b/Three/include/CGAL/Three/exceptions.h
@@ -23,6 +23,7 @@
 
 #include <exception>
 #include <QString>
+#include <QApplication>
 #include <QScriptable>
 #include <QScriptContext>
 #include <QScriptEngine>
@@ -81,7 +82,8 @@ wrap_a_call_to_cpp(Callable f,
   typedef Optional_or_bool<Callable_RT> O_r_b;
   typedef typename O_r_b::type Return_type;
 
-  if(qs == 0 || !qs->context()) return O_r_b::invoke(f);
+  const bool no_try_catch = qApp->property("no-try-catch").toBool();
+  if(no_try_catch || qs == 0 || !qs->context()) return O_r_b::invoke(f);
   else
     try {
       return O_r_b::invoke(f);


### PR DESCRIPTION
- Fix the `Scene_edit_box_item` to avoid a temporary computation using
  floats instead of doubles.

- Extend `--no-try-catch` to the try/catch used in handle C++ exceptions
  from C++ code called from a Qt Script.