### PR TITLE
Polyhedron_demo: Enhancements for Io_image_plugin

### DIFF
--- a/AABB_tree/include/CGAL/internal/AABB_tree/AABB_drawing_traits.h
+++ b/AABB_tree/include/CGAL/internal/AABB_tree/AABB_drawing_traits.h
@@ -31,6 +31,7 @@ template<typename Primitive, typename Node>
 struct AABB_drawing_traits
 {
   std::vector<float> *v_edges;
+  double offset[3];
 
   typedef CGAL::Bbox_3 Bbox;
   bool go_further() { return true; }
@@ -83,13 +84,13 @@ struct AABB_drawing_traits
   void gl_draw_edge(double px, double py, double pz,
                            double qx, double qy, double qz)
   {
-      v_edges->push_back((float)px);
-      v_edges->push_back((float)py);
-      v_edges->push_back((float)pz);
+      v_edges->push_back((float)px+offset[0]);
+      v_edges->push_back((float)py+offset[1]);
+      v_edges->push_back((float)pz+offset[2]);
 
-      v_edges->push_back((float)qx);
-      v_edges->push_back((float)qy);
-      v_edges->push_back((float)qz);
+      v_edges->push_back((float)qx+offset[0]);
+      v_edges->push_back((float)qy+offset[1]);
+      v_edges->push_back((float)qz+offset[2]);
   }
 }; // AABB_drawing_traits
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -864,9 +864,9 @@ void MainWindow::updateViewerBBox()
   bool new_offset = false;
   for(int i=0; i<3; ++i)
   {
-    if(log2(bbox.min(i)) > 13.0 )
+    //if(log2(bbox.min(i)) > 13.0 )
     {
-      offset[i] = -bbox.min(i);
+      offset[i] = -200;//-bbox.min(i);
       new_offset = true;
     }
   }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -864,7 +864,7 @@ void MainWindow::updateViewerBBox()
   bool new_offset = false;
   for(int i=0; i<3; ++i)
   {
-    //if(log2(bbox.min(i)) > 13.0 )
+    if(log2(bbox.min(i)) > 13.0 )
     {
       offset[i] = -bbox.min(i);
       new_offset = true;

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -866,7 +866,7 @@ void MainWindow::updateViewerBBox()
   {
     //if(log2(bbox.min(i)) > 13.0 )
     {
-      offset[i] = -200;//-bbox.min(i);
+      offset[i] = -bbox.min(i);
       new_offset = true;
     }
   }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -860,6 +860,14 @@ void MainWindow::updateViewerBBox()
   qglviewer::Vec 
     vec_min(xmin, ymin, zmin),
     vec_max(xmax, ymax, zmax);
+  qglviewer::Vec offset(0,0,0);
+  for(int i=0; i<3; ++i)
+  {
+    if(log2(bbox.min(i)) > 13.0 )
+      offset[i] = -bbox.min(i);
+  }
+  viewer->setOffset(offset);
+  std::cerr<<offset.x<<", "<<offset.y<<", "<<offset.z<<std::endl;
   viewer->setSceneBoundingBox(vec_min,
                               vec_max);
   viewer->camera()->showEntireScene();

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1944,6 +1944,7 @@ void MainWindow::resetHeader()
   sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString("_AB_")));
   sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString("_View_")));
 
+}
 void MainWindow::recomputeItems()
 {
   for(int i=0; i<scene->numberOfEntries(); ++i)

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -861,20 +861,20 @@ void MainWindow::updateViewerBBox()
     vec_min(xmin, ymin, zmin),
     vec_max(xmax, ymax, zmax);
   qglviewer::Vec offset(0,0,0);
-  bool new_offset = false;
   for(int i=0; i<3; ++i)
   {
     if(log2(bbox.min(i)) > 13.0 )
     {
       offset[i] = -bbox.min(i);
-      new_offset = true;
     }
   }
-  if(new_offset)
+  if(offset != viewer->offset())
   {
     viewer->setOffset(offset);
     recomputeItems();
   }
+
+
   viewer->setSceneBoundingBox(vec_min,
                               vec_max);
   viewer->camera()->showEntireScene();

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1052,7 +1052,7 @@ void MainWindow::open(QString filename)
   }
   selectSceneItem(scene->addItem(scene_item));
   if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
-    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("_This is a very long name_")));
   else
     sceneView->resizeColumnToContents(Scene::NameColumn);
 }
@@ -1343,6 +1343,8 @@ void MainWindow::updateDisplayInfo() {
     ui->displayLabel->setPixmap(item->graphicalToolTip());
   else 
     ui->displayLabel->clear();
+
+  resetHeader();
 }
 
 void MainWindow::readSettings()
@@ -1456,7 +1458,7 @@ void MainWindow::on_actionLoad_triggered()
     Q_FOREACH(const QString& filter, split_filters) {
       FilterPluginMap::iterator it = filterPluginMap.find(filter);
       if(it != filterPluginMap.end()) {
-        qDebug() << "Duplicate Filter: " << it.value();
+        qDebug() << "Duplicate Filter: " << it.value()->name();
         qDebug() << "This filter will not be available.";
       } else {
         filterPluginMap[filter] = plugin;
@@ -1782,7 +1784,7 @@ void MainWindow::makeNewGroup()
     Scene_group_item * group = new Scene_group_item();
     scene->addItem(group);
     if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
-      sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+      sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("_This is a very long name_")));
     else
       sceneView->resizeColumnToContents(Scene::NameColumn);
 }
@@ -1938,7 +1940,7 @@ void MainWindow::resetHeader()
   sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width("_#_"));
   sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
   if(sceneView->columnWidth(Scene::NameColumn) > fontMetrics().width(QString("This is a very long name")))
-    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("This is a very long name")));
+    sceneView->header()->resizeSection(Scene::NameColumn, sceneView->header()->fontMetrics().width(QString("_This is a very long name_")));
   else
     sceneView->resizeColumnToContents(Scene::NameColumn);
   sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString("_AB_")));

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -863,7 +863,7 @@ void MainWindow::updateViewerBBox()
   qglviewer::Vec offset(0,0,0);
   for(int i=0; i<3; ++i)
   {
-    if(log2(bbox.min(i)) > 13.0 )
+   // if(log2(bbox.min(i)) > 13.0 )
       offset[i] = -bbox.min(i);
   }
   viewer->setOffset(offset);

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -354,6 +354,7 @@ private:
   void updateMenus();
   void load_plugin(QString names, bool blacklisted);
   void recurseExpand(QModelIndex index);
+  void recomputeItems();
   QMap<QString, QMenu*> menu_map;
   QString get_item_stats();
   QString strippedName(const QString &fullFileName);

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
@@ -196,11 +196,10 @@ Polyhedron_demo_nef_plugin::on_actionToPoly_triggered()
                            tr("The nef polyhedron \"%1\" is not simple, "
                               "and thus cannot be converted!")
                               .arg(item->name()));
+      QApplication::restoreOverrideCursor();
       return;
     }
 
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-    
     Scene_polyhedron_item* new_item = item->convert_to_polyhedron();
     new_item->setName(tr("%1 (from nef)").arg(item->name()));
     new_item->setRenderingMode(item->renderingMode());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -28,6 +28,7 @@
 #include <QInputDialog>
 #include <QSlider>
 #include <QLabel>
+#include <QLineEdit>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QDockWidget>
@@ -175,6 +176,7 @@ public Q_SLOTS:
     ready_to_move = true;
     QTimer::singleShot(0,this,SLOT(setFramePosition()));
   }
+  unsigned int getScale() const { return scale; }
 Q_SIGNALS:
   void realChange(int);
 
@@ -286,6 +288,40 @@ public:
 
 
 public Q_SLOTS:
+
+  void setXNum(int i)
+  {
+   x_cubeLabel->setText(QString("%1").arg(i));
+  }
+  void setYNum(int i)
+  {
+   y_cubeLabel->setText(QString("%1").arg(i));
+  }
+  void setZNum(int i)
+  {
+   z_cubeLabel->setText(QString("%1").arg(i));
+  }
+
+  void XTextEdited(QString s)
+  {
+    int i = s.toInt();
+    x_slider->setValue(i*qobject_cast<Plane_slider*>(x_slider)->getScale());
+    x_slider->sliderMoved(i);
+  }
+  void YTextEdited(QString s)
+  {
+    int i = s.toInt();
+    y_slider->setValue(i*qobject_cast<Plane_slider*>(y_slider)->getScale());
+    y_slider->sliderMoved(i);
+  }
+  void ZTextEdited(QString s)
+  {
+    int i = s.toInt();
+    z_slider->setValue(i*qobject_cast<Plane_slider*>(z_slider)->getScale());
+    z_slider->sliderMoved(i);
+
+  }
+
   void on_imageType_changed(int index)
   {
     if(index == 0)
@@ -349,10 +385,11 @@ public Q_SLOTS:
       x_slider = new Plane_slider(plane->translationVector(), id, scene, plane->manipulatedFrame(),
                                          Qt::Horizontal, x_control);
       x_slider->setRange(0, (plane->cDim() - 1) * 100);
-      connect(x_slider, SIGNAL(realChange(int)), x_cubeLabel, SLOT(setNum(int)));
+      connect(x_slider, SIGNAL(realChange(int)), this, SLOT(setXNum(int)));
+      connect(x_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(XTextEdited(QString)));
       connect(x_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
       connect(x_slider, SIGNAL(sliderMoved(int)), x_slider, SLOT(updateFramePosition()));
-      connect(plane, SIGNAL(manipulated(int)), x_cubeLabel, SLOT(setNum(int)));
+      connect(plane, SIGNAL(manipulated(int)), this, SLOT(setXNum(int)));
       connect(plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_x_item()));
       x_box->addWidget(x_slider);
       x_box->addWidget(x_cubeLabel);
@@ -363,10 +400,11 @@ public Q_SLOTS:
       y_slider = new Plane_slider(plane->translationVector(), id, scene, plane->manipulatedFrame(),
                                          Qt::Horizontal, y_control);
       y_slider->setRange(0, (plane->cDim() - 1) * 100);
-      connect(y_slider, SIGNAL(realChange(int)), y_cubeLabel, SLOT(setNum(int)));
+      connect(y_slider, SIGNAL(realChange(int)), this, SLOT(setYNum(int)));
+      connect(y_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(YTextEdited(QString)));
       connect(y_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
       connect(y_slider, SIGNAL(sliderMoved(int)), y_slider, SLOT(updateFramePosition()));
-      connect(plane, SIGNAL(manipulated(int)), y_cubeLabel, SLOT(setNum(int)));
+      connect(plane, SIGNAL(manipulated(int)), this, SLOT(setYNum(int)));
       connect(plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_y_item()));
       y_box->addWidget(y_slider);
       y_box->addWidget(y_cubeLabel);
@@ -377,10 +415,11 @@ public Q_SLOTS:
       z_slider = new Plane_slider(plane->translationVector(), id, scene, plane->manipulatedFrame(),
                                          Qt::Horizontal, z_control);
       z_slider->setRange(0, (plane->cDim() - 1) * 100);
-      connect(z_slider, SIGNAL(realChange(int)), z_cubeLabel, SLOT(setNum(int)));
+      connect(z_slider, SIGNAL(realChange(int)), this, SLOT(setZNum(int)));
+      connect(z_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(ZTextEdited(QString)));
       connect(z_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
       connect(z_slider, SIGNAL(sliderMoved(int)), z_slider, SLOT(updateFramePosition()));
-      connect(plane, SIGNAL(manipulated(int)), z_cubeLabel, SLOT(setNum(int)));
+      connect(plane, SIGNAL(manipulated(int)), this, SLOT(setZNum(int)));
       connect(plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_z_item()));
       z_box->addWidget(z_slider);
       z_box->addWidget(z_cubeLabel);
@@ -457,7 +496,7 @@ private:
   QAction* planeSwitch;
   QWidget *x_control, *y_control, *z_control;
   QSlider *x_slider, *y_slider, *z_slider;
-  QLabel *x_cubeLabel, *y_cubeLabel, *z_cubeLabel;
+  QLineEdit*x_cubeLabel, *y_cubeLabel, *z_cubeLabel;
   QHBoxLayout *x_box, *y_box, *z_box;
   PixelReader pxr_;
   Ui::ImagePrecisionDialog ui;
@@ -493,12 +532,13 @@ private:
 
       QWidget* vlabels = new QWidget(content);
       layout->addWidget(vlabels);
+      layout->setAlignment(Qt::AlignLeft);
       QHBoxLayout* vbox = new QHBoxLayout(vlabels);
-      vbox->setAlignment(Qt::AlignJustify);
-      QLabel* help = new QLabel(vlabels);
-      help->setText("Cut planes for the \nselected image:");
+      vbox->setAlignment(Qt::AlignLeft);
       QLabel* text = new QLabel(vlabels);
       text->setText("Isovalue at point:");
+      QLabel* help = new QLabel(vlabels);
+      help->setText("Cut planes for the selected image:");
       QLabel* x = new QLabel(vlabels);
 
       connect(&pxr_, SIGNAL(x(int)), x, SLOT(setNum(int)));
@@ -519,6 +559,7 @@ private:
     QApplication::setOverrideCursor(Qt::WaitCursor);
     //Control widgets creation
     QLayout* layout = createOrGetDockLayout();
+    QRegExpValidator* validator = new QRegExpValidator(QRegExp("\\d*"), this);
     if(x_control == NULL)
     {
       x_control = new QWidget;
@@ -529,12 +570,14 @@ private:
       label->setStyleSheet("QLabel { color : red; }");
       label->setText("X Slice");
 
-      x_cubeLabel = new QLabel(x_control);
+      x_cubeLabel = new QLineEdit(x_control);
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = x_cubeLabel->fontMetrics();
       x_cubeLabel->setFixedWidth(metric.width(QString("9999")));
-      x_cubeLabel->setNum(0);
+      x_cubeLabel->setText("0");
+      x_cubeLabel->setValidator(validator);
+
       x_slider = new QSlider(mw);
 
       x_box->addWidget(label);
@@ -552,13 +595,13 @@ private:
       label->setStyleSheet("QLabel { color : green; }");
       label->setText("Y Slice");
 
-      y_cubeLabel = new QLabel(y_control);
+      y_cubeLabel = new QLineEdit(y_control);
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = y_cubeLabel->fontMetrics();
       y_cubeLabel->setFixedWidth(metric.width(QString("9999")));
-      y_cubeLabel->setNum(0);
-
+      y_cubeLabel->setText("0");
+      y_cubeLabel->setValidator(validator);
       y_slider = new QSlider(mw);
 
       y_box->addWidget(label);
@@ -576,12 +619,13 @@ private:
       label->setStyleSheet("QLabel { color : blue; }");
       label->setText("Z Slice");
 
-      z_cubeLabel = new QLabel(z_control);
+      z_cubeLabel = new QLineEdit(z_control);
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = z_cubeLabel->fontMetrics();
       z_cubeLabel->setFixedWidth(metric.width(QString("9999")));
-      z_cubeLabel->setNum(0);
+      z_cubeLabel->setText("0");
+      z_cubeLabel->setValidator(validator);
       z_slider = new QSlider(mw);
 
       z_box->addWidget(label);
@@ -797,8 +841,9 @@ private Q_SLOTS:
       x_slider = new Plane_slider(x_plane->translationVector(), scene->item_id(x_plane), scene, x_plane->manipulatedFrame(),
                                   Qt::Horizontal, x_control);
       x_slider->setRange(0, (x_plane->cDim() - 1) * 100);
-      connect(x_slider, SIGNAL(realChange(int)), x_cubeLabel, SLOT(setNum(int)));
-      connect(x_plane, SIGNAL(manipulated(int)), x_cubeLabel, SLOT(setNum(int)));
+      connect(x_slider, SIGNAL(realChange(int)), this, SLOT(setXNum(int)));
+      connect(x_plane, SIGNAL(manipulated(int)), this, SLOT(setXNum(int)));
+      connect(x_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(XTextEdited(QString)));
       connect(x_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_x_item()));
       connect(x_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
       connect(x_slider, SIGNAL(sliderMoved(int)), x_slider, SLOT(updateFramePosition()));
@@ -816,8 +861,9 @@ private Q_SLOTS:
       y_slider = new Plane_slider(y_plane->translationVector(), scene->item_id(y_plane), scene, y_plane->manipulatedFrame(),
                                   Qt::Horizontal, z_control);
       y_slider->setRange(0, (y_plane->cDim() - 1) * 100);
-      connect(y_slider, SIGNAL(realChange(int)), y_cubeLabel, SLOT(setNum(int)));
-      connect(y_plane, SIGNAL(manipulated(int)), y_cubeLabel, SLOT(setNum(int)));
+      connect(y_slider, SIGNAL(realChange(int)), this, SLOT(setYNum(int)));
+      connect(y_plane, SIGNAL(manipulated(int)), this, SLOT(setYNum(int)));
+      connect(y_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(YTextEdited(QString)));
       connect(y_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_y_item()));
       connect(y_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));
       connect(y_slider, SIGNAL(sliderMoved(int)), y_slider, SLOT(updateFramePosition()));
@@ -834,8 +880,9 @@ private Q_SLOTS:
       z_slider = new Plane_slider(z_plane->translationVector(), scene->item_id(z_plane), scene, z_plane->manipulatedFrame(),
                                   Qt::Horizontal, z_control);
       z_slider->setRange(0, (z_plane->cDim() - 1) * 100);
-      connect(z_slider, SIGNAL(realChange(int)), z_cubeLabel, SLOT(setNum(int)));
-      connect(z_plane, SIGNAL(manipulated(int)), z_cubeLabel, SLOT(setNum(int)));
+      connect(z_slider, SIGNAL(realChange(int)), this, SLOT(setZNum(int)));
+      connect(z_plane, SIGNAL(manipulated(int)), this, SLOT(setZNum(int)));
+      connect(z_cubeLabel, SIGNAL(textEdited(QString)), this, SLOT(ZTextEdited(QString)));
       connect(z_plane, SIGNAL(aboutToBeDestroyed()), this, SLOT(destroy_z_item()));
       connect(z_slider, SIGNAL(sliderMoved(int)), z_slider, SLOT(updateFramePosition()));
       connect(z_slider, SIGNAL(realChange(int)), this, SLOT(set_value()));

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -532,6 +532,7 @@ private:
       layout->addWidget(x_control);
 
       QLabel* label = new QLabel(x_control);
+      label->setStyleSheet("QLabel { color : red; }");
       label->setText("X Slice");
 
       x_cubeLabel = new QLabel(x_control);
@@ -554,6 +555,7 @@ private:
       layout->addWidget(y_control);
 
       QLabel* label = new QLabel(y_control);
+      label->setStyleSheet("QLabel { color : green; }");
       label->setText("Y Slice");
 
       y_cubeLabel = new QLabel(y_control);
@@ -577,6 +579,7 @@ private:
       layout->addWidget(z_control);
 
       QLabel* label = new QLabel(z_control);
+      label->setStyleSheet("QLabel { color : blue; }");
       label->setText("Z Slice");
 
       z_cubeLabel = new QLabel(z_control);
@@ -624,6 +627,9 @@ private:
     Volume_plane<x_tag> *x_item = new Volume_plane<x_tag>();
     Volume_plane<y_tag> *y_item = new Volume_plane<y_tag>();
     Volume_plane<z_tag> *z_item = new Volume_plane<z_tag>();
+    x_item->setColor(QColor("red"));
+    y_item->setColor(QColor("green"));
+    z_item->setColor(QColor("blue"));
     scene->setSelectedItem(-1);
     group = new Scene_group_item(QString("Planes for %1").arg(seg_img->name()));
     connect(group, SIGNAL(aboutToBeDestroyed()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -630,6 +630,10 @@ private:
     x_item->setColor(QColor("red"));
     y_item->setColor(QColor("green"));
     z_item->setColor(QColor("blue"));
+    CGAL::Three::Viewer_interface* viewer = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+    viewer->installEventFilter(x_item);
+    viewer->installEventFilter(y_item);
+    viewer->installEventFilter(z_item);
     scene->setSelectedItem(-1);
     group = new Scene_group_item(QString("Planes for %1").arg(seg_img->name()));
     connect(group, SIGNAL(aboutToBeDestroyed()),
@@ -660,7 +664,7 @@ private:
     connect(threads.back(), SIGNAL(finished(Volume_plane_thread*)), this, SLOT(addVP(Volume_plane_thread*)));
     threads.back()->start();
 
-    first_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    first_offset = viewer->offset();
 
   }
   template<typename T>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
@@ -174,7 +174,7 @@ private:
   unsigned int adim_, bdim_, cdim_;
   double xscale_, yscale_, zscale_;
   mutable int currentCube;
-
+  mutable double max_dim;
   mutable QOpenGLBuffer vVBO;
   mutable QOpenGLBuffer cbuffer;
   mutable QOpenGLBuffer rectBuffer;
@@ -193,6 +193,18 @@ private:
   QString name(y_tag) const { return tr("Y Slice for %2").arg(name_); }
   QString name(z_tag) const { return tr("Z Slice for %2").arg(name_); }
 
+  void update_maxDim() const
+  {
+    double ax((adim_ - 1) * xscale_), ay((adim_ - 1) * yscale_), az((adim_ - 1) * zscale_),
+           bx((bdim_ - 1) * xscale_), by((bdim_ - 1) * yscale_), bz((bdim_ - 1) * zscale_),
+           cx((cdim_ - 1) * xscale_), cy((cdim_ - 1) * yscale_), cz((cdim_ - 1) * zscale_);
+
+    double max_a = (std::max)((std::max)(ax, ay), az);
+    double max_b = (std::max)((std::max)(bx, by), bz);
+    double max_c = (std::max)((std::max)(cx, cy), cz);
+    max_dim = (std::max)((std::max)(max_a, max_b), max_c);
+
+  }
   void drawRectangle(x_tag) const {
 
 
@@ -200,6 +212,7 @@ private:
       v_rec.push_back(0.0f); v_rec.push_back((adim_ - 1) * yscale_); v_rec.push_back(0.0f);
       v_rec.push_back(0.0f); v_rec.push_back((adim_ - 1) * yscale_); v_rec.push_back((bdim_ - 1) * zscale_);
       v_rec.push_back(0.0f); v_rec.push_back(0.0f); v_rec.push_back((bdim_ - 1) * zscale_);
+
 
   }
 
@@ -219,7 +232,7 @@ private:
 
   void drawSpheres(x_tag) const
   {
-      int max_dim = (std::max)((std::max)(adim_, bdim_ ), cdim_);
+      update_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres, 18);
 
@@ -232,7 +245,7 @@ private:
 
   void drawSpheres(y_tag) const
   {
-      int max_dim = (std::max)((std::max)(adim_, bdim_ ), cdim_);
+      update_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres,18);
 
@@ -244,7 +257,7 @@ private:
 
   void drawSpheres(z_tag) const
   {
-      int max_dim = (std::max)((std::max)(adim_, bdim_ ), cdim_);
+      update_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres,18);
 
@@ -486,7 +499,7 @@ void Volume_plane<T>::draw(Viewer_interface *viewer) const {
   spheres_program = getShaderProgram(PROGRAM_SPHERES, viewer);
   attribBuffers(viewer, PROGRAM_SPHERES);
   spheres_program->bind();
-  int max_dim = (std::max)((std::max)(adim_, bdim_ ), cdim_);
+  update_maxDim();
   sphere_radius = max_dim/20.0f * sphere_Slider->value()/100.0f;
   spheres_program->setAttributeValue("radius", sphere_radius);
   spheres_program->setAttributeValue("colors", this->color());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
@@ -174,7 +174,6 @@ private:
   unsigned int adim_, bdim_, cdim_;
   double xscale_, yscale_, zscale_;
   mutable int currentCube;
-  mutable double max_dim;
   mutable QOpenGLBuffer vVBO;
   mutable QOpenGLBuffer cbuffer;
   mutable QOpenGLBuffer rectBuffer;
@@ -193,7 +192,7 @@ private:
   QString name(y_tag) const { return tr("Y Slice for %2").arg(name_); }
   QString name(z_tag) const { return tr("Z Slice for %2").arg(name_); }
 
-  void update_maxDim() const
+  double compute_maxDim() const
   {
     double ax((adim_ - 1) * xscale_), ay((adim_ - 1) * yscale_), az((adim_ - 1) * zscale_),
            bx((bdim_ - 1) * xscale_), by((bdim_ - 1) * yscale_), bz((bdim_ - 1) * zscale_),
@@ -202,7 +201,7 @@ private:
     double max_a = (std::max)((std::max)(ax, ay), az);
     double max_b = (std::max)((std::max)(bx, by), bz);
     double max_c = (std::max)((std::max)(cx, cy), cz);
-    max_dim = (std::max)((std::max)(max_a, max_b), max_c);
+    return (std::max)((std::max)(max_a, max_b), max_c);
 
   }
   void drawRectangle(x_tag) const {
@@ -232,7 +231,7 @@ private:
 
   void drawSpheres(x_tag) const
   {
-      update_maxDim();
+      double max_dim = compute_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres, 18);
 
@@ -245,7 +244,7 @@ private:
 
   void drawSpheres(y_tag) const
   {
-      update_maxDim();
+      double max_dim = compute_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres,18);
 
@@ -257,7 +256,7 @@ private:
 
   void drawSpheres(z_tag) const
   {
-      update_maxDim();
+      double max_dim = compute_maxDim();
       sphere_radius = max_dim / 40.0f;
       create_flat_sphere(1.0f, v_spheres, n_spheres,18);
 
@@ -499,7 +498,7 @@ void Volume_plane<T>::draw(Viewer_interface *viewer) const {
   spheres_program = getShaderProgram(PROGRAM_SPHERES, viewer);
   attribBuffers(viewer, PROGRAM_SPHERES);
   spheres_program->bind();
-  update_maxDim();
+  double max_dim = compute_maxDim();
   sphere_radius = max_dim/20.0f * sphere_Slider->value()/100.0f;
   spheres_program->setAttributeValue("radius", sphere_radius);
   spheres_program->setAttributeValue("colors", this->color());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane.h
@@ -627,6 +627,7 @@ bool Volume_plane<T>::eventFilter(QObject *, QEvent *event)
             if(!found)
                 return false;
             is_grabbing = true;
+            emitSelection();
             viewer->setManipulatedFrame(manipulatedFrame());
             viewer->setMouseBinding(
                         Qt::NoModifier,

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_interface.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_interface.h
@@ -2,6 +2,10 @@
 #define CGAL_VOLUME_PLANE_INTERFACE_H_
 
 #include <QObject>
+#include <QAction>
+#include <QMenu>
+#include <QSlider>
+#include <QWidgetAction>
 #include <QGLViewer/qglviewer.h>
 #include <CGAL/Three/Scene_item.h>
 #include <iostream>
@@ -37,6 +41,29 @@ public:
 
   virtual qglviewer::ManipulatedFrame* manipulatedFrame() { return mFrame_; }
 
+  QMenu* contextMenu()
+  {
+      const char* prop_name = "Menu modified by Scene_c3t3_item.";
+
+      QMenu* menu = Scene_item::contextMenu();
+
+      // Use dynamic properties:
+      // http://doc.qt.io/qt-5/qobject.html#property
+      bool menuChanged = menu->property(prop_name).toBool();
+
+      if (!menuChanged) {
+          QMenu *container = new QMenu(tr("Spheres Size"));
+          QWidgetAction *sliderAction = new QWidgetAction(0);
+          connect(sphere_Slider, &QSlider::valueChanged, this, &Volume_plane_interface::itemChanged);
+
+          sliderAction->setDefaultWidget(sphere_Slider);
+
+          container->addAction(sliderAction);
+          menu->addMenu(container);
+          menu->setProperty(prop_name, true);
+      }
+      return menu;
+  }
 Q_SIGNALS:
   void planeDestructionIncoming(Volume_plane_interface*);
   void manipulated(int);
@@ -47,6 +74,8 @@ private Q_SLOTS:
   }
 protected:
   qglviewer::ManipulatedFrame* mFrame_;
+  bool hide_spheres;
+  QSlider* sphere_Slider;
 };
 
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_interface.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_interface.h
@@ -33,12 +33,14 @@ public:
   }
 
   virtual unsigned int getCurrentCube() const = 0;
+  void emitSelection()  { Q_EMIT selected(this); }
 
   virtual qglviewer::ManipulatedFrame* manipulatedFrame() { return mFrame_; }
 
 Q_SIGNALS:
   void planeDestructionIncoming(Volume_plane_interface*);
   void manipulated(int);
+  void selected(CGAL::Three::Scene_item*);
 private Q_SLOTS:
   void propagateManipulation() {
     Q_EMIT manipulated(getCurrentCube());

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.cpp
@@ -193,7 +193,7 @@ Volume_plane_intersection::Volume_plane_intersection(float x, float y, float z)
   :Scene_item(Volume_plane_intersection_priv::NumberOfVbos, Volume_plane_intersection_priv::NumberOfVaos),
     d(new Volume_plane_intersection_priv(x,y,z,this))
 {
-  setColor(QColor(255, 0, 0));
+  setColor(QColor(255, 128, 0));
   setName("Volume plane intersection");
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.cpp
@@ -49,15 +49,28 @@ void Volume_plane_intersection_priv::computeElements()
    a_vertex.resize(0);
    b_vertex.resize(0);
    c_vertex.resize(0);
+   const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
-   a_vertex.push_back(0.0); a_vertex.push_back(0.0); a_vertex.push_back(0.0);
-   a_vertex.push_back(x);   a_vertex.push_back(0.0); a_vertex.push_back(0.0);
+   a_vertex.push_back(0.0-offset.x);
+   a_vertex.push_back(0.0-offset.y);
+   a_vertex.push_back(0.0-offset.z);
+   a_vertex.push_back(x  -offset.x);
+   a_vertex.push_back(0.0-offset.y);
+   a_vertex.push_back(0.0-offset.z);
 
-   b_vertex.push_back(0.0); b_vertex.push_back(0.0); b_vertex.push_back(0.0);
-   b_vertex.push_back(0.0); b_vertex.push_back(y);   b_vertex.push_back(0.0);
+   b_vertex.push_back(0.0-offset.x);
+   b_vertex.push_back(0.0-offset.y);
+   b_vertex.push_back(0.0-offset.z);
+   b_vertex.push_back(0.0-offset.x);
+   b_vertex.push_back(y  -offset.y);
+   b_vertex.push_back(0.0-offset.z);
 
-   c_vertex.push_back(0.0); c_vertex.push_back(0.0); c_vertex.push_back(0.0);
-   c_vertex.push_back(0.0); c_vertex.push_back(0.0); c_vertex.push_back(z);
+   c_vertex.push_back(0.0-offset.x);
+   c_vertex.push_back(0.0-offset.y);
+   c_vertex.push_back(0.0-offset.z);
+   c_vertex.push_back(0.0-offset.x);
+   c_vertex.push_back(0.0-offset.y);
+   c_vertex.push_back(z  -offset.z);
 
    item->_bbox =  Scene_item::Bbox( 0, 0, 0,
                   x, y, z);
@@ -195,4 +208,9 @@ void Volume_plane_intersection::planeRemoved(Volume_plane_interface* i) {
   } else if(d->c == i) {
     d->c = NULL;
   }
+}
+
+void Volume_plane_intersection::invalidateOpenGLBuffers()
+{
+ are_buffers_filled = false;
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Volume_plane_intersection.h
@@ -33,7 +33,7 @@ public:
   void setX(Volume_plane_interface* x);
   void setY(Volume_plane_interface* x);
   void setZ(Volume_plane_interface* x);
-
+  void invalidateOpenGLBuffers();
 public Q_SLOTS:
   void planeRemoved(Volume_plane_interface* i);
 protected:

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -187,18 +187,18 @@ public Q_SLOTS:
       //apply the clipping function
       Q_FOREACH(Scene_polyhedron_item* poly, polyhedra)
       {
-
+        const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
         if(ui_widget.close_checkBox->isChecked() && poly->polyhedron()->is_closed())
         {
           std::pair<Polyhedron*, Polyhedron*>polyhedron;
           if(ui_widget.clip_radioButton->isChecked())
           {
-            polyhedron.first = CGAL::corefinement::clip_polyhedron(*(poly->polyhedron()),plane->plane());
+            polyhedron.first = CGAL::corefinement::clip_polyhedron(*(poly->polyhedron()),plane->plane(offset));
             polyhedron.second = NULL;
           }
           else
           {
-            polyhedron = CGAL::corefinement::split_polyhedron(*(poly->polyhedron()),plane->plane());
+            polyhedron = CGAL::corefinement::split_polyhedron(*(poly->polyhedron()),plane->plane(offset));
           }
           if(polyhedron.first != NULL)
           {
@@ -212,6 +212,7 @@ public Q_SLOTS:
             new_item->setVisible(poly->visible());
             new_item->invalidateOpenGLBuffers();
             new_item->setProperty("source filename", poly->property("source filename"));
+            new_item->setProperty("loader_name", poly->property("loader_name"));
             scene->replaceItem(scene->item_id(poly),new_item);
             new_item->invalidateOpenGLBuffers();
             viewer->updateGL();
@@ -232,6 +233,7 @@ public Q_SLOTS:
             new_item->setVisible(poly->visible());
             new_item->invalidateOpenGLBuffers();
             new_item->setProperty("source filename", poly->property("source filename"));
+            new_item->setProperty("loader_name", poly->property("loader_name"));
             scene->addItem(new_item);
             new_item->invalidateOpenGLBuffers();
             viewer->updateGL();
@@ -246,15 +248,17 @@ public Q_SLOTS:
         {
           Scene_polyhedron_item* poly1 = new Scene_polyhedron_item(*(poly->polyhedron()));
           poly1->setProperty("source filename", poly->property("source filename"));
+          poly1->setProperty("loader_name", poly->property("loader_name"));
           Scene_polyhedron_item* poly2 = NULL;
           if(!ui_widget.clip_radioButton->isChecked())
           {
             poly2 = new Scene_polyhedron_item(*(poly->polyhedron()));
             poly2->setProperty("source filename", poly->property("source filename"));
+            poly2->setProperty("loader_name", poly->property("loader_name"));
           }
 
 
-            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly1->polyhedron()),plane->plane());
+            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly1->polyhedron()),plane->plane(offset));
             if(poly2 != NULL)
               poly1->setName(QString("%1 %2").arg(poly->name()).arg("1"));
             else
@@ -270,7 +274,7 @@ public Q_SLOTS:
 
           if(poly2 != NULL)
           {
-            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly2->polyhedron()),plane->plane().opposite());
+            CGAL::corefinement::inplace_clip_open_polyhedron(*(poly2->polyhedron()),plane->plane(offset).opposite());
             poly2->setName(QString("%1 %2").arg(poly->name()).arg("2"));
             poly2->setColor(poly->color());
             poly2->setRenderingMode(poly->renderingMode());

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Scene_combinatorial_map_item.cpp
@@ -282,6 +282,7 @@ void Scene_combinatorial_map_item_priv::compute_elements(void) const{
     normals.resize(0);
     positions_lines.resize(0);
     positions_points.resize(0);
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
     //Facets
     {
@@ -331,9 +332,9 @@ void Scene_combinatorial_map_item_priv::compute_elements(void) const{
                               face_it!=face_end; ++face_it)
                         {
                             const Kernel::Point_3& p= face_it->attribute<0>()->point();
-                            positions_facets.push_back(p.x());
-                            positions_facets.push_back(p.y());
-                            positions_facets.push_back(p.z());
+                            positions_facets.push_back(p.x()+offset.x);
+                            positions_facets.push_back(p.y()+offset.y);
+                            positions_facets.push_back(p.z()+offset.z);
                             item->combinatorial_map().mark(face_it,facetreated);
                             item->combinatorial_map().mark(face_it, voltreated);
                         }
@@ -363,13 +364,13 @@ void Scene_combinatorial_map_item_priv::compute_elements(void) const{
             CGAL_assertion(!item->combinatorial_map().is_free(dit,1));
             const Kernel::Point_3& a = dit->attribute<0>()->point();
             const Kernel::Point_3& b = dit->beta(1)->attribute<0>()->point();
-            positions_lines.push_back(a.x());
-            positions_lines.push_back(a.y());
-            positions_lines.push_back(a.z());
+            positions_lines.push_back(a.x()+offset.x);
+            positions_lines.push_back(a.y()+offset.y);
+            positions_lines.push_back(a.z()+offset.z);
 
-            positions_lines.push_back(b.x());
-            positions_lines.push_back(b.y());
-            positions_lines.push_back(b.z());
+            positions_lines.push_back(b.x()+offset.x);
+            positions_lines.push_back(b.y()+offset.y);
+            positions_lines.push_back(b.z()+offset.z);
 
         }
     }
@@ -380,9 +381,9 @@ void Scene_combinatorial_map_item_priv::compute_elements(void) const{
         const Point_range& points=item->combinatorial_map().attributes<0>();
         for(Point_range::const_iterator pit=boost::next(points.begin());pit!=points.end();++pit){
             const Kernel::Point_3& p=pit->point();
-            positions_points.push_back(p.x());
-            positions_points.push_back(p.y());
-            positions_points.push_back(p.z());
+            positions_points.push_back(p.x()+offset.x);
+            positions_points.push_back(p.y()+offset.y);
+            positions_points.push_back(p.z()+offset.z);
         }
 
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
@@ -29,7 +29,8 @@ public:
       center_(pos),
       frame(new CGAL::Three::Scene_item::ManipulatedFrame())
   {
-    frame->setPosition(pos);
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    frame->setPosition(pos+offset);
     Point_set ps= *item->point_set();
     const Kernel::Point_3& p = ps.point(*(ps.begin()));
     CGAL::Bbox_3 bbox(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
@@ -128,8 +129,6 @@ public:
     qglviewer::Vec min(bbox.xmin(),bbox.ymin(),bbox.zmin());
     qglviewer::Vec max(bbox.xmax(),bbox.ymax(),bbox.zmax());
 
-    min +=frame->translation()-center();
-    max += frame->translation()-center();
     _bbox = Bbox(min.x,min.y,min.z,
                  max.x,max.y,max.z);
   }
@@ -298,12 +297,16 @@ public Q_SLOTS:
 
     if(!is_point_set)
     {
+      const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
       transform_item->manipulatedFrame()->setFromMatrix(matrix);
+      transform_item->manipulatedFrame()->translate(offset);
       transform_item->itemChanged();
     }
     else
     {
+      const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
       transform_points_item->manipulatedFrame()->setFromMatrix(matrix);
+      transform_points_item->manipulatedFrame()->translate(offset);
       transform_points_item->itemChanged();
     }
   }
@@ -467,6 +470,10 @@ void Polyhedron_demo_affine_transform_plugin::end(){
   QApplication::restoreOverrideCursor();
   double matrix[16];
   transformMatrix(&matrix[0]);
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  matrix[12]-=offset.x;
+  matrix[13]-=offset.y;
+  matrix[14]-=offset.z;
   resetTransformMatrix();
   if(transform_item)
   {
@@ -543,6 +550,10 @@ void Polyhedron_demo_affine_transform_plugin::updateUiMatrix()
     matrix(1,3) -= transform_points_item->center().y;
     matrix(2,3) -= transform_points_item->center().z;
   }
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  matrix.data()[12]-=offset.x;
+  matrix.data()[13]-=offset.y;
+  matrix.data()[14]-=offset.z;
   ui.matrix_00->setText(QString("%1").arg(matrix(0,0))); ui.matrix_01->setText(QString("%1").arg(matrix(0,1))); ui.matrix_02->setText(QString("%1").arg(matrix(0,2))); ui.matrix_03->setText(QString("%1").arg(matrix(0,3)));
   ui.matrix_10->setText(QString("%1").arg(matrix(1,0))); ui.matrix_11->setText(QString("%1").arg(matrix(1,1))); ui.matrix_12->setText(QString("%1").arg(matrix(1,2))); ui.matrix_13->setText(QString("%1").arg(matrix(1,3)));
   ui.matrix_20->setText(QString("%1").arg(matrix(2,0))); ui.matrix_21->setText(QString("%1").arg(matrix(2,1))); ui.matrix_22->setText(QString("%1").arg(matrix(2,2))); ui.matrix_23->setText(QString("%1").arg(matrix(2,3)));

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Edit_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Edit_box_plugin.cpp
@@ -98,6 +98,8 @@ void Edit_box_plugin::enableAction() {
 void Edit_box_plugin::exportToPoly()
 {
   int id =0;
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  Kernel::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
   Scene_edit_box_item* item = NULL;
   for(int i = 0, end = scene->numberOfEntries();
       i < end; ++i)
@@ -112,7 +114,7 @@ void Edit_box_plugin::exportToPoly()
   Polyhedron::Point_3 points[8];
   for(int i=0; i<8; ++i)
   {
-    points[i] = Polyhedron::Point_3(item->point(i,0),item->point(i,1), item->point(i,2));
+    points[i] = Polyhedron::Point_3(item->point(i,0),item->point(i,1), item->point(i,2))-offset;
   }
   Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
   CGAL::make_hexahedron(

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -77,6 +77,7 @@ struct Scene_edit_box_item_priv{
   };
   Scene_edit_box_item_priv(const Scene_interface *scene_interface, Scene_edit_box_item* ebi)
   {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     ready_to_hl = true;
     scene = scene_interface;
     item = ebi;
@@ -90,7 +91,7 @@ struct Scene_edit_box_item_priv{
     remodel_frame = new Scene_item::ManipulatedFrame();
     remodel_frame->setTranslationSensitivity(1.0);
     frame = new Scene_item::ManipulatedFrame();
-    frame->setPosition(center_);
+    frame->setPosition(center_+offset);
     frame->setSpinningSensitivity(100.0); //forbid spinning
     constraint.setRotationConstraintType(qglviewer::AxisPlaneConstraint::AXIS);
     constraint.setTranslationConstraintType(qglviewer::AxisPlaneConstraint::FREE);
@@ -468,18 +469,16 @@ void Scene_edit_box_item::drawEdges(Viewer_interface* viewer) const
 
 void Scene_edit_box_item::compute_bbox() const
 {
-  QMatrix4x4 f_matrix;
-  for (int i=0; i<16; ++i){
-    f_matrix.data()[i] = (float)d->frame->matrix()[i];
-  }
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
 
   QVector3D min(d->pool[0], d->pool[1], d->pool[2]);
   QVector3D max(d->pool[3], d->pool[4], d->pool[5]);
 
   for(int i=0; i< 3; ++i)
   {
-    min[i] += d->frame->translation()[i]-d->center_[i];
-    max[i] += d->frame->translation()[i]-d->center_[i];
+    min[i] += d->frame->translation()[i]-d->center_[i]-offset[i];
+    max[i] += d->frame->translation()[i]-d->center_[i]-offset[i];
   }
 
   _bbox = Scene_item::Bbox(min.x(),min.y(),min.z(),max.x(),max.y(),max.z());

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_polyhedron_transform_item.cpp
@@ -14,7 +14,8 @@ struct Scene_polyhedron_transform_item_priv
       center_(pos)
   {
     item = parent;
-    frame->setPosition(pos);
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    frame->setPosition(pos+offset);
     nb_lines = 0;
   }
   ~Scene_polyhedron_transform_item_priv()
@@ -148,9 +149,6 @@ Scene_polyhedron_transform_item::compute_bbox() const {
     }
     qglviewer::Vec min(bbox.xmin(),bbox.ymin(),bbox.zmin());
     qglviewer::Vec max(bbox.xmax(),bbox.ymax(),bbox.zmax());
-
-    min +=d->frame->translation()-center();
-    max += d->frame->translation()-center();
     _bbox = Bbox(min.x,min.y,min.z,
                  max.x,max.y,max.z);
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
@@ -219,10 +219,11 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
   }
 
   if(!on_Update_plane_button_clicked()) { return; }
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   QApplication::setOverrideCursor(Qt::WaitCursor);
   // get plane position and normal
   qglviewer::ManipulatedFrame* mf = plane_item->manipulatedFrame();
-  const qglviewer::Vec& pos = mf->position();
+  const qglviewer::Vec& pos = mf->position()-offset;
   // WARNING: due to fp arithmetic (setting quaternion based orientation from base vectors then getting plane normal back from this orientation)
   // for base vectors like: 1,0,0 - 0,1,0 we might not have exact corresponding normal vector.
   // So not using below normal but construct plane directly from bases from text boxes

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -339,6 +339,8 @@ protected:
       points->unselect_all();
     
     QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(viewer)->offset();
+
     qglviewer::Camera* camera = viewer->camera();
 
     std::vector<Point_set::Index> unselected, selected;
@@ -349,8 +351,8 @@ protected:
 	bool already_selected = points->is_selected (it);
 
         const Kernel::Point_3 p = points->point (*it);
-	qglviewer::Vec vp (p.x (), p.y (), p.z ());
-	qglviewer::Vec vsp = camera->projectedCoordinatesOf (vp);
+        qglviewer::Vec vp (p.x (), p.y (), p.z ());
+        qglviewer::Vec vsp = camera->projectedCoordinatesOf (vp + offset);
 	    
 	bool now_selected = visualizer->is_selected (vsp);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -121,12 +121,14 @@ void Scene_polyhedron_shortest_path_item_priv::compute_elements() const
     QApplication::setOverrideCursor(Qt::WaitCursor);
     vertices.resize(0);
 
+     const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
     for(Scene_polyhedron_shortest_path_item::Surface_mesh_shortest_path::Source_point_iterator it = m_shortestPaths->source_points_begin(); it != m_shortestPaths->source_points_end(); ++it)
     {
       const Kernel::Point_3& p = m_shortestPaths->point(it->first, it->second);
-      vertices.push_back(p.x());
-      vertices.push_back(p.y());
-      vertices.push_back(p.z());
+      vertices.push_back(p.x() + offset.x);
+      vertices.push_back(p.y() + offset.y);
+      vertices.push_back(p.z() + offset.z);
     }
     QApplication::restoreOverrideCursor();
 }
@@ -275,14 +277,14 @@ void Scene_polyhedron_shortest_path_item::invalidateOpenGLBuffers()
 bool Scene_polyhedron_shortest_path_item_priv::get_mouse_ray(QMouseEvent* mouseEvent, Kernel::Ray_3& outRay)
 {
   bool found = false;
-  
   QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(viewer)->offset();
   qglviewer::Camera* camera = viewer->camera();
-  const qglviewer::Vec point = camera->pointUnderPixel(mouseEvent->pos(), found);
+  const qglviewer::Vec point = camera->pointUnderPixel(mouseEvent->pos(), found) - offset;
   
   if(found)
   {
-    const qglviewer::Vec orig = camera->position();
+    const qglviewer::Vec orig = camera->position() - offset;
     outRay = Ray_3(Point_3(orig.x, orig.y, orig.z), Point_3(point.x, point.y, point.z));
   }
   

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -30,6 +30,7 @@ struct Scene_edit_polyhedron_item_priv
     spheres = NULL;
     spheres_ctrl = NULL;
     need_change = false;
+
   }
   ~Scene_edit_polyhedron_item_priv()
   {
@@ -209,13 +210,28 @@ void Scene_edit_polyhedron_item_priv::initializeBuffers(CGAL::Three::Viewer_inte
 {
     //vao for the facets
     {
+        std::vector<GLdouble> *vertices;
+        const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+        if(offset.norm() !=0)
+        {
+          vertices = new std::vector<GLdouble>();
+          vertices->resize(positions.size());
+          for(std::size_t i=0; i<positions.size(); ++i)
+          {
+            (*vertices)[i] = positions[i]+offset[i%3];
+          }
+        }
+        else
+        {
+          vertices = &positions;
+        }
         program = item->getShaderProgram(Scene_edit_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
         program->bind();
 
         item->vaos[Facets]->bind();
         item->buffers[Facet_vertices].bind();
-        item->buffers[Facet_vertices].allocate(positions.data(),
-                            static_cast<int>(positions.size()*sizeof(double)));
+        item->buffers[Facet_vertices].allocate(vertices->data(),
+                            static_cast<int>(vertices->size()*sizeof(double)));
         program->enableAttributeArray("vertex");
         program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
         item->buffers[Facet_vertices].release();
@@ -228,6 +244,7 @@ void Scene_edit_polyhedron_item_priv::initializeBuffers(CGAL::Three::Viewer_inte
         item->buffers[Facet_normals].release();
         item->vaos[Facets]->release();
         program->release();
+        delete vertices;
     }
     //vao for the ROI points
     {   program = item->getShaderProgram(Scene_edit_polyhedron_item::PROGRAM_NO_SELECTION, viewer);
@@ -398,18 +415,21 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(void)
     control_points.resize(0);
     control_color.resize(0);
     pos_frame_plane.resize(0);
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
     BOOST_FOREACH(vertex_descriptor vd, deform_mesh->roi_vertices())
     {
         if(!deform_mesh->is_control_vertex(vd))
         {
-            ROI_points.push_back(vd->point().x());
-            ROI_points.push_back(vd->point().y());
-            ROI_points.push_back(vd->point().z());
+            ROI_points.push_back(vd->point().x()+offset.x);
+            ROI_points.push_back(vd->point().y()+offset.y);
+            ROI_points.push_back(vd->point().z()+offset.z);
 
             if(spheres)
             {
               CGAL::Color c(0,255,0);
-              spheres->add_sphere(Kernel::Sphere_3(vd->point(), length_of_axis/15.0*length_of_axis/15.0), c);
+              Kernel::Point_3 point(vd->point().x()+offset.x, vd->point().y()+offset.y, vd->point().z()+offset.z);
+              spheres->add_sphere(Kernel::Sphere_3(point, length_of_axis/15.0*length_of_axis/15.0), c);
             }
         }
 
@@ -435,9 +455,9 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(void)
 
         for(std::vector<vertex_descriptor>::const_iterator hb = hgb_data->ctrl_vertices_group.begin(); hb != hgb_data->ctrl_vertices_group.end(); ++hb)
         {
-            control_points.push_back((*hb)->point().x());
-            control_points.push_back((*hb)->point().y());
-            control_points.push_back((*hb)->point().z());
+            control_points.push_back((*hb)->point().x()+offset.x);
+            control_points.push_back((*hb)->point().y()+offset.y);
+            control_points.push_back((*hb)->point().z()+offset.z);
             control_color.push_back(r);
             control_color.push_back(0);
             control_color.push_back(b);
@@ -445,7 +465,11 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(void)
             if(spheres_ctrl)
             {
               CGAL::Color c(255*r,0,255*b);
-              spheres_ctrl->add_sphere(Kernel::Sphere_3((*hb)->point(), length_of_axis/15.0*length_of_axis/15.0), c);
+
+              Kernel::Point_3 center((*hb)->point().x()+offset.x,
+                                     (*hb)->point().y()+offset.y,
+                                     (*hb)->point().z()+offset.z);
+              spheres_ctrl->add_sphere(Kernel::Sphere_3(center, length_of_axis/15.0*length_of_axis/15.0), c);
             }
         }
     }
@@ -1395,7 +1419,9 @@ void Scene_edit_polyhedron_item::create_ctrl_vertices_group()
   }
 
   // No empty group of control vertices
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   qglviewer::ManipulatedFrame* new_frame = new qglviewer::ManipulatedFrame();
+  new_frame->setPosition(offset);
   new_frame->setRotationSensitivity(2.0f);
   connect(new_frame, SIGNAL(manipulated()), this, SLOT(change()));
 
@@ -1475,9 +1501,10 @@ void Scene_edit_polyhedron_item::pivoting_end()
     //update constraint rotation vector, set only for the last group
     it->rot_direction = it->frame->rotation().rotate( qglviewer::Vec(0.,0.,1.) );
     //translate center of the frame
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     qglviewer::Vec vec= it->frame->position();
     it->refresh();
-    it->frame_initial_center = vec;
+    it->frame_initial_center = vec-offset;
     it->frame->setPosition(vec);
   }
   for(Ctrl_vertices_group_data_list::iterator it = d->ctrl_vertex_frame_map.begin(); it != d->ctrl_vertex_frame_map.end(); ++it)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -124,11 +124,13 @@ public:
     bool oldState = frame->blockSignals(true); // do not let it Q_EMIT modified, which will cause a deformation
                                   // but we are just adjusting the center so it does not require a deformation
     // frame->setOrientation(qglviewer::Quaternion());
-    frame->setPosition(frame_initial_center);
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    frame->setPosition(frame_initial_center+offset);
     frame->blockSignals(oldState);
   }
   void set_target_positions()
   {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     std::vector<vertex_descriptor>::iterator hb = ctrl_vertices_group.begin();
     for(std::vector<qglviewer::Vec>::iterator it = initial_positions.begin(); it != initial_positions.end(); ++it, ++hb)
     {
@@ -136,7 +138,7 @@ public:
       qglviewer::Vec rotated = frame->orientation() * dif_from_initial_center;
       qglviewer::Vec rotated_and_translated = rotated + frame->position();
 
-      deform_mesh->set_target_position(*hb, Point(rotated_and_translated.x, rotated_and_translated.y, rotated_and_translated.z) );
+      deform_mesh->set_target_position(*hb, Point(rotated_and_translated.x-offset.x, rotated_and_translated.y-offset.y, rotated_and_translated.z-offset.z) );
     }
   }
   qglviewer::Vec calculate_initial_center() const

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1082,7 +1082,7 @@ Scene::Bbox Scene::bbox() const
     Bbox bbox = Bbox(0,0,0,0,0,0);
     Q_FOREACH(CGAL::Three::Scene_item* item, m_entries)
     {
-        if(item->isFinite() && !item->isEmpty()) {
+        if(item->isFinite() && !item->isEmpty() && item->visible()) {
             if(bbox_initialized) {
 
                 bbox = bbox + item->bbox();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -141,6 +141,7 @@ public :
   }
   void addTriangle(Kernel::Point_3 pa, Kernel::Point_3 pb, Kernel::Point_3 pc, CGAL::Color color)
   {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     Kernel::Vector_3 n = cross_product(pb - pa, pc - pa);
     n = n / CGAL::sqrt(n*n);
 
@@ -151,41 +152,41 @@ public :
       normals->push_back(n.y());
       normals->push_back(n.z());
     }
-    vertices->push_back(pa.x());
-    vertices->push_back(pa.y());
-    vertices->push_back(pa.z());
+    vertices->push_back(pa.x()+offset.x);
+    vertices->push_back(pa.y()+offset.y);
+    vertices->push_back(pa.z()+offset.z);
 
-    vertices->push_back(pb.x());
-    vertices->push_back(pb.y());
-    vertices->push_back(pb.z());
+    vertices->push_back(pb.x()+offset.x);
+    vertices->push_back(pb.y()+offset.y);
+    vertices->push_back(pb.z()+offset.z);
 
-    vertices->push_back(pc.x());
-    vertices->push_back(pc.y());
-    vertices->push_back(pc.z());
+    vertices->push_back(pc.x()+offset.x);
+    vertices->push_back(pc.y()+offset.y);
+    vertices->push_back(pc.z()+offset.z);
 
-    edges->push_back(pa.x());
-    edges->push_back(pa.y());
-    edges->push_back(pa.z());
+    edges->push_back(pa.x()+offset.x);
+    edges->push_back(pa.y()+offset.y);
+    edges->push_back(pa.z()+offset.z);
 
-    edges->push_back(pb.x());
-    edges->push_back(pb.y());
-    edges->push_back(pb.z());
+    edges->push_back(pb.x()+offset.x);
+    edges->push_back(pb.y()+offset.y);
+    edges->push_back(pb.z()+offset.z);
 
-    edges->push_back(pb.x());
-    edges->push_back(pb.y());
-    edges->push_back(pb.z());
+    edges->push_back(pb.x()+offset.x);
+    edges->push_back(pb.y()+offset.y);
+    edges->push_back(pb.z()+offset.z);
 
-    edges->push_back(pc.x());
-    edges->push_back(pc.y());
-    edges->push_back(pc.z());
+    edges->push_back(pc.x()+offset.x);
+    edges->push_back(pc.y()+offset.y);
+    edges->push_back(pc.z()+offset.z);
 
-    edges->push_back(pc.x());
-    edges->push_back(pc.y());
-    edges->push_back(pc.z());
+    edges->push_back(pc.x()+offset.x);
+    edges->push_back(pc.y()+offset.y);
+    edges->push_back(pc.z()+offset.z);
 
-    edges->push_back(pa.x());
-    edges->push_back(pa.y());
-    edges->push_back(pa.z());
+    edges->push_back(pa.x()+offset.x);
+    edges->push_back(pa.y()+offset.y);
+    edges->push_back(pa.z()+offset.z);
 
     for(int i=0; i<3; i++)
     {
@@ -719,8 +720,8 @@ Scene_c3t3_item_priv::compute_color_map(const QColor& c)
   }
 }
 
-Kernel::Plane_3 Scene_c3t3_item::plane() const {
-  const qglviewer::Vec& pos = d->frame->position();
+Kernel::Plane_3 Scene_c3t3_item::plane(qglviewer::Vec offset) const {
+  const qglviewer::Vec& pos = d->frame->position() - offset;
   const qglviewer::Vec& n =
     d->frame->inverseTransformOf(qglviewer::Vec(0.f, 0.f, 1.f));
   return Kernel::Plane_3(n[0], n[1], n[2], -n * pos);
@@ -933,7 +934,7 @@ void Scene_c3t3_item_priv::draw_triangle(const Kernel::Point_3& pa,
   #undef darker
   Kernel::Vector_3 n = cross_product(pb - pa, pc - pa);
   n = n / CGAL::sqrt(n*n);
-
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
   for (int i = 0; i<3; i++)
   {
@@ -941,17 +942,17 @@ void Scene_c3t3_item_priv::draw_triangle(const Kernel::Point_3& pa,
     normals.push_back(n.y());
     normals.push_back(n.z());
   }
-  positions_poly.push_back(pa.x());
-  positions_poly.push_back(pa.y());
-  positions_poly.push_back(pa.z());
+  positions_poly.push_back(pa.x()+offset.x);
+  positions_poly.push_back(pa.y()+offset.y);
+  positions_poly.push_back(pa.z()+offset.z);
 
-  positions_poly.push_back(pb.x());
-  positions_poly.push_back(pb.y());
-  positions_poly.push_back(pb.z());
+  positions_poly.push_back(pb.x()+offset.x);
+  positions_poly.push_back(pb.y()+offset.y);
+  positions_poly.push_back(pb.z()+offset.z);
 
-  positions_poly.push_back(pc.x());
-  positions_poly.push_back(pc.y());
-  positions_poly.push_back(pc.z());
+  positions_poly.push_back(pc.x()+offset.x);
+  positions_poly.push_back(pc.y()+offset.y);
+  positions_poly.push_back(pc.z()+offset.z);
 
 
 
@@ -962,29 +963,30 @@ void Scene_c3t3_item_priv::draw_triangle_edges(const Kernel::Point_3& pa,
   const Kernel::Point_3& pc)const {
 
 #undef darker
-  positions_lines.push_back(pa.x());
-  positions_lines.push_back(pa.y());
-  positions_lines.push_back(pa.z());
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  positions_lines.push_back(pa.x()+offset.x);
+  positions_lines.push_back(pa.y()+offset.y);
+  positions_lines.push_back(pa.z()+offset.z);
 
-  positions_lines.push_back(pb.x());
-  positions_lines.push_back(pb.y());
-  positions_lines.push_back(pb.z());
+  positions_lines.push_back(pb.x()+offset.x);
+  positions_lines.push_back(pb.y()+offset.y);
+  positions_lines.push_back(pb.z()+offset.z);
 
-  positions_lines.push_back(pb.x());
-  positions_lines.push_back(pb.y());
-  positions_lines.push_back(pb.z());
+  positions_lines.push_back(pb.x()+offset.x);
+  positions_lines.push_back(pb.y()+offset.y);
+  positions_lines.push_back(pb.z()+offset.z);
 
-  positions_lines.push_back(pc.x());
-  positions_lines.push_back(pc.y());
-  positions_lines.push_back(pc.z());
+  positions_lines.push_back(pc.x()+offset.x);
+  positions_lines.push_back(pc.y()+offset.y);
+  positions_lines.push_back(pc.z()+offset.z);
 
-  positions_lines.push_back(pc.x());
-  positions_lines.push_back(pc.y());
-  positions_lines.push_back(pc.z());
+  positions_lines.push_back(pc.x()+offset.x);
+  positions_lines.push_back(pc.y()+offset.y);
+  positions_lines.push_back(pc.z()+offset.z);
 
-  positions_lines.push_back(pa.x());
-  positions_lines.push_back(pa.y());
-  positions_lines.push_back(pa.z());
+  positions_lines.push_back(pa.x()+offset.x);
+  positions_lines.push_back(pa.y()+offset.y);
+  positions_lines.push_back(pa.z()+offset.z);
 
 }
 void Scene_c3t3_item_priv::draw_triangle_edges_cnc(const Kernel::Point_3& pa,
@@ -992,29 +994,30 @@ void Scene_c3t3_item_priv::draw_triangle_edges_cnc(const Kernel::Point_3& pa,
                                           const Kernel::Point_3& pc)const {
 
 #undef darker
-  positions_lines_not_in_complex.push_back(pa.x());
-  positions_lines_not_in_complex.push_back(pa.y());
-  positions_lines_not_in_complex.push_back(pa.z());
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  positions_lines_not_in_complex.push_back(pa.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pa.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pa.z()+offset.z);
 
-  positions_lines_not_in_complex.push_back(pb.x());
-  positions_lines_not_in_complex.push_back(pb.y());
-  positions_lines_not_in_complex.push_back(pb.z());
+  positions_lines_not_in_complex.push_back(pb.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pb.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pb.z()+offset.z);
 
-  positions_lines_not_in_complex.push_back(pb.x());
-  positions_lines_not_in_complex.push_back(pb.y());
-  positions_lines_not_in_complex.push_back(pb.z());
+  positions_lines_not_in_complex.push_back(pb.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pb.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pb.z()+offset.z);
 
-  positions_lines_not_in_complex.push_back(pc.x());
-  positions_lines_not_in_complex.push_back(pc.y());
-  positions_lines_not_in_complex.push_back(pc.z());
+  positions_lines_not_in_complex.push_back(pc.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pc.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pc.z()+offset.z);
 
-  positions_lines_not_in_complex.push_back(pc.x());
-  positions_lines_not_in_complex.push_back(pc.y());
-  positions_lines_not_in_complex.push_back(pc.z());
+  positions_lines_not_in_complex.push_back(pc.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pc.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pc.z()+offset.z);
 
-  positions_lines_not_in_complex.push_back(pa.x());
-  positions_lines_not_in_complex.push_back(pa.y());
-  positions_lines_not_in_complex.push_back(pa.z());
+  positions_lines_not_in_complex.push_back(pa.x()+offset.x);
+  positions_lines_not_in_complex.push_back(pa.y()+offset.y);
+  positions_lines_not_in_complex.push_back(pa.z()+offset.z);
 
 }
 
@@ -1295,13 +1298,14 @@ struct ComputeIntersection {
 
 void Scene_c3t3_item_priv::computeIntersections()
 {
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   if(!is_aabb_tree_built) fill_aabb_tree();
 
   positions_poly.clear();
   normals.clear();
   f_colors.clear();
   positions_lines.clear();
-  const Kernel::Plane_3& plane = item->plane();
+  const Kernel::Plane_3& plane = item->plane(offset);
   tree.all_intersected_primitives(plane,
         boost::make_function_output_iterator(ComputeIntersection(*this)));
 }
@@ -1335,9 +1339,10 @@ void Scene_c3t3_item_priv::computeSpheres()
       c = QColor(Qt::red);
     else
       c = spheres->color().darker(250);
-    Kernel::Point_3 center(vit->point().point().x(),
-    vit->point().point().y(),
-    vit->point().point().z());
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    Kernel::Point_3 center(vit->point().point().x()+offset.x,
+    vit->point().point().y()+offset.y,
+    vit->point().point().z()+offset.z);
     float radius = vit->point().weight() ;
     spheres->add_sphere(Kernel::Sphere_3(center, radius), CGAL::Color(c.red(), c.green(), c.blue()));
   }
@@ -1465,8 +1470,8 @@ Scene_c3t3_item_priv::reset_cut_plane() {
   const float xcenter = static_cast<float>((bbox.xmax()+bbox.xmin())/2.);
   const float ycenter = static_cast<float>((bbox.ymax()+bbox.ymin())/2.);
   const float zcenter = static_cast<float>((bbox.zmax()+bbox.zmin())/2.);
-
-  frame->setPosition(qglviewer::Vec(xcenter, ycenter, zcenter));
+ const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  frame->setPosition(qglviewer::Vec(xcenter+offset.x, ycenter+offset.y, zcenter+offset.z));
 }
 
 void
@@ -1555,7 +1560,8 @@ CGAL::Three::Scene_item::ManipulatedFrame* Scene_c3t3_item::manipulatedFrame() {
 }
 
 void Scene_c3t3_item::setPosition(float x, float y, float z) {
-  d->frame->setPosition(x, y, z);
+   const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  d->frame->setPosition(x+offset.x, y+offset.y, z+offset.z);
 }
 
 bool Scene_c3t3_item::has_spheres()const { return d->spheres_are_shown;}
@@ -1575,7 +1581,8 @@ void Scene_c3t3_item::copyProperties(Scene_item *item)
   Scene_c3t3_item* c3t3_item = qobject_cast<Scene_c3t3_item*>(item);
   if(!c3t3_item)
     return;
-  d->frame->setPositionAndOrientation(c3t3_item->manipulatedFrame()->position(),
+   const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  d->frame->setPositionAndOrientation(c3t3_item->manipulatedFrame()->position() - offset,
                                       c3t3_item->manipulatedFrame()->orientation());
 
   show_intersection(c3t3_item->has_tets());

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -76,7 +76,7 @@ public:
 
   void setNormal(float x, float y, float z) ;
 
-  Kernel::Plane_3 plane() const;
+  Kernel::Plane_3 plane(qglviewer::Vec offset = qglviewer::Vec(0,0,0)) const;
 
   bool isFinite() const { return true; }
   bool isEmpty() const {

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -449,7 +449,6 @@ struct Scene_image_item_priv
   std::vector<float> color;
   static const int vaoSize = 2;
   static const int vboSize = 6;
-
   mutable int poly_vertexLocation[1];
   mutable int normalsLocation[1];
   mutable int mvpLocation[1];

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -321,6 +321,7 @@ Vertex_buffer_helper::push_normal(std::size_t i, std::size_t j, std::size_t k)
 void
 Vertex_buffer_helper::push_vertex(std::size_t i, std::size_t j, std::size_t k)
 {
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   indices_.insert(std::make_pair(compute_position(i,j,k),
                                  vertices_.size()/3)); 
   //resize the "border vertices"
@@ -338,9 +339,9 @@ Vertex_buffer_helper::push_vertex(std::size_t i, std::size_t j, std::size_t k)
   if (dk == data_.zdim())
     dk = data_.zdim()-0.5;
 
-  vertices_.push_back( (di - 0.5) * data_.vx());
-  vertices_.push_back( (dj - 0.5) * data_.vy());
-  vertices_.push_back( (dk - 0.5) * data_.vz());
+  vertices_.push_back( (di - 0.5) * data_.vx()+offset.x);
+  vertices_.push_back( (dj - 0.5) * data_.vy()+offset.y);
+  vertices_.push_back( (dk - 0.5) * data_.vz()+offset.z);
 }
 
 void
@@ -837,101 +838,102 @@ void Scene_image_item::changed()
 
 void Scene_image_item_priv::draw_Bbox(Scene_item::Bbox bbox, std::vector<float> *vertices)
 {
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmin());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmin()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmin());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmin()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymax());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymax()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
-    vertices->push_back(bbox.xmax());
-    vertices->push_back(bbox.ymin());
-    vertices->push_back(bbox.zmax());
+    vertices->push_back(bbox.xmax()+offset.x);
+    vertices->push_back(bbox.ymin()+offset.y);
+    vertices->push_back(bbox.zmax()+offset.z);
 
 }
 
@@ -939,3 +941,9 @@ void Scene_image_item::drawEdges(CGAL::Three::Viewer_interface* viewer) const
 { d->draw_gl(viewer); }
 
 bool Scene_image_item::isGray() { return d->is_hidden;}
+
+void Scene_image_item::invalidateOpenGLBuffers()
+{
+  d->v_box->clear();
+  changed();
+}

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.h
@@ -45,6 +45,7 @@ public:
   const Image* image() const { return m_image; }
   bool isGray();
   Image* m_image;
+  void invalidateOpenGLBuffers();
 protected :
   friend struct Scene_image_item_priv;
   Scene_image_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_implicit_function_item.cpp
@@ -30,6 +30,7 @@ struct Scene_implicit_function_item_priv
     , red_color_ramp_()
     , textureId(-1)
   {
+    init=false;
     item = parent;
     texture = new Texture(grid_size_-1,grid_size_-1);
     blue_color_ramp_.build_blue();
@@ -65,6 +66,7 @@ struct Scene_implicit_function_item_priv
   int grid_size_;
   double max_value_;
   double min_value_;
+  bool init;
   mutable Point_value implicit_grid_[SCENE_IMPLICIT_GRID_SIZE][SCENE_IMPLICIT_GRID_SIZE];
   Color_ramp blue_color_ramp_;
   Color_ramp red_color_ramp_;
@@ -271,124 +273,125 @@ void Scene_implicit_function_item_priv::compute_vertices_and_texmap(void)
     }
     //the Box
     {
+      const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
-
-
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmin());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmin()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmin());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymax());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmin()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
 
-        positions_cube.push_back(b.xmax());
-        positions_cube.push_back(b.ymin());
-        positions_cube.push_back(b.zmax());
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymax()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
+
+
+        positions_cube.push_back(b.xmax()+offset.x);
+        positions_cube.push_back(b.ymin()+offset.y);
+        positions_cube.push_back(b.zmax()+offset.z);
 
     }
 
@@ -410,12 +413,6 @@ Scene_implicit_function_item(Implicit_function_interface* f)
   d = new Scene_implicit_function_item_priv(f, this);
   //Generates an integer which will be used as ID for each buffer
   d->compute_min_max();
-  compute_function_grid();
-  double offset_x = (bbox().xmin() + bbox().xmax()) / 2;
-  double offset_y = (bbox().ymin() + bbox().ymax()) / 2;
-  double offset_z = (bbox().zmin() + bbox().zmax()) / 2;
-  d->frame_->setPosition(offset_x, offset_y, offset_z);
-  d->frame_->setOrientation(1., 0, 0, 0);
   connect(d->frame_, SIGNAL(modified()), this, SLOT(plane_was_moved()));
   plane_was_moved();
   invalidateOpenGLBuffers();
@@ -437,6 +434,17 @@ Scene_implicit_function_item::compute_bbox() const
 void
 Scene_implicit_function_item::draw(CGAL::Three::Viewer_interface* viewer) const
 {
+  if(!d->init)
+  {
+    compute_function_grid();
+    double offset_x = (bbox().xmin() + bbox().xmax()) / 2;
+    double offset_y = (bbox().ymin() + bbox().ymax()) / 2;
+    double offset_z = (bbox().zmin() + bbox().zmax()) / 2;
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    d->frame_->setPosition(offset_x+offset.x, offset_y+offset.y, offset_z+offset.z);
+    d->frame_->setOrientation(1., 0, 0, 0);
+    d->init = true;
+  }
     if(!are_buffers_filled)
         d->initialize_buffers(viewer);
     if(d->frame_->isManipulated()) {
@@ -550,6 +558,7 @@ void
 Scene_implicit_function_item::
 compute_function_grid() const
 {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     typedef CGAL::Simple_cartesian<double>  K;
     typedef K::Aff_transformation_3         Aff_transformation;
     typedef K::Point_3                      Point_3;
@@ -558,9 +567,9 @@ compute_function_grid() const
     const GLdouble* m = d->frame_->matrix();
 
     // OpenGL matrices are row-major matrices
-    Aff_transformation t (m[0], m[4], m[8], m[12],
-            m[1], m[5], m[9], m[13],
-            m[2], m[6], m[10], m[14]);
+    Aff_transformation t (m[0], m[4], m[8], m[12]-offset.x,
+            m[1], m[5], m[9], m[13]-offset.y,
+            m[2], m[6], m[10], m[14]-offset.z);
 
     double diag = (CGAL::sqrt((bbox().xmax()-bbox().xmin())*(bbox().xmax()-bbox().xmin()) + (bbox().ymax()-bbox().ymin())*(bbox().ymax()-bbox().ymin())  + (bbox().zmax()-bbox().zmin())*(bbox().zmax()-bbox().zmin()) )) * .6;
 

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -12,6 +12,7 @@ Scene_plane_item::Scene_plane_item(const CGAL::Three::Scene_interface* scene_int
       frame(new ManipulatedFrame())
   {
     setNormal(0., 0., 1.);
+
     //Generates an integer which will be used as ID for each buffer
     invalidateOpenGLBuffers();
   }
@@ -50,6 +51,7 @@ void Scene_plane_item::initializeBuffers(Viewer_interface *viewer) const
 
 void Scene_plane_item::compute_normals_and_vertices(void) const
 {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     QApplication::setOverrideCursor(Qt::WaitCursor);
     positions_quad.resize(0);
     positions_lines.resize(0);
@@ -60,23 +62,23 @@ void Scene_plane_item::compute_normals_and_vertices(void) const
 
     positions_quad.push_back(-diag);
     positions_quad.push_back(-diag);
-    positions_quad.push_back(0.0);
+    positions_quad.push_back(0.0  );
     positions_quad.push_back(-diag);
-    positions_quad.push_back(diag);
-    positions_quad.push_back(0.0);
-    positions_quad.push_back(diag);
+    positions_quad.push_back(diag );
+    positions_quad.push_back(0.0  );
+    positions_quad.push_back(diag );
     positions_quad.push_back(-diag);
-    positions_quad.push_back(0.0);
+    positions_quad.push_back(0.0  );
 
-    positions_quad.push_back(diag);
+    positions_quad.push_back(diag );
     positions_quad.push_back(-diag);
-    positions_quad.push_back(0.0);
+    positions_quad.push_back(0.0  );
     positions_quad.push_back(-diag);
-    positions_quad.push_back(diag);
-    positions_quad.push_back(0.0);
-    positions_quad.push_back(diag);
-    positions_quad.push_back(diag);
-    positions_quad.push_back(0.0);
+    positions_quad.push_back(diag );
+    positions_quad.push_back(0.0  );
+    positions_quad.push_back(diag );
+    positions_quad.push_back(diag );
+    positions_quad.push_back(0.0  );
 
 }
     //The grid
@@ -87,23 +89,23 @@ void Scene_plane_item::compute_normals_and_vertices(void) const
         {
 
             positions_lines.push_back(-diag + x* u);
-            positions_lines.push_back(-diag);
-            positions_lines.push_back(0.0);
+            positions_lines.push_back(-diag       );
+            positions_lines.push_back(0.0         );
 
             positions_lines.push_back(-diag + x* u);
-            positions_lines.push_back(diag);
-            positions_lines.push_back(0.0);
+            positions_lines.push_back(diag        );
+            positions_lines.push_back(0.0         );
         }
         for(int v=0; v<11; v++)
         {
 
-            positions_lines.push_back(-diag);
+            positions_lines.push_back(-diag        );
             positions_lines.push_back(-diag + v * y);
-            positions_lines.push_back(0.0);
+            positions_lines.push_back(0.0          );
 
-            positions_lines.push_back(diag);
+            positions_lines.push_back(diag         );
             positions_lines.push_back(-diag + v * y);
-            positions_lines.push_back(0.0);
+            positions_lines.push_back(0.0          );
         }
 
     }
@@ -227,7 +229,8 @@ void Scene_plane_item::setPosition(float x, float y, float z) {
 }
 
 void Scene_plane_item::setPosition(double x, double y, double z) {
-  frame->setPosition((float)x, (float)y, (float)z);
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  frame->setPosition((float)x+offset.x, (float)y+offset.y, (float)z+offset.z);
 }
 
 void Scene_plane_item::setNormal(float x, float y, float z) {

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -209,8 +209,8 @@ QString Scene_plane_item::toolTip() const {
     .arg(manipulable?tr("true"):tr("false"));
 }
 
-Plane_3 Scene_plane_item::plane() const {
-  const qglviewer::Vec& pos = frame->position();
+Plane_3 Scene_plane_item::plane(qglviewer::Vec offset) const {
+  const qglviewer::Vec& pos = frame->position() - offset;
   const qglviewer::Vec& n =
     frame->inverseTransformOf(qglviewer::Vec(0.f, 0.f, 1.f));
   return Plane_3(n[0], n[1],  n[2], - n * pos);

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.cpp
@@ -51,7 +51,6 @@ void Scene_plane_item::initializeBuffers(Viewer_interface *viewer) const
 
 void Scene_plane_item::compute_normals_and_vertices(void) const
 {
-    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     QApplication::setOverrideCursor(Qt::WaitCursor);
     positions_quad.resize(0);
     positions_lines.resize(0);

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -53,7 +53,7 @@ public:
   }
   virtual void draw(CGAL::Three::Viewer_interface*) const;
  virtual void drawEdges(CGAL::Three::Viewer_interface* viewer)const;
-  Plane_3 plane() const;
+  Plane_3 plane(qglviewer::Vec offset = qglviewer::Vec(0,0,0)) const;
 
 public Q_SLOTS:
   virtual void invalidateOpenGLBuffers();

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -292,6 +292,7 @@ void Scene_points_with_normal_item_priv::initializeBuffers(CGAL::Three::Viewer_i
 
 void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
 {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     QApplication::setOverrideCursor(Qt::WaitCursor);
     positions_points.resize(0);
     positions_lines.resize(0);
@@ -316,18 +317,18 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
       for (Point_set::const_iterator it = m_points->begin();
            it != m_points->first_selected(); ++ it)
 	{
-	  positions_points.push_back(m_points->point(*it).x());
-	  positions_points.push_back(m_points->point(*it).y());
-	  positions_points.push_back(m_points->point(*it).z());
+          positions_points.push_back(m_points->point(*it).x()+offset.x);
+          positions_points.push_back(m_points->point(*it).y()+offset.y);
+          positions_points.push_back(m_points->point(*it).z()+offset.z);
 	}
 
         // Draw *selected* points
       for (Point_set::const_iterator it = m_points->first_selected();
            it != m_points->end(); ++ it)
 	{
-	  positions_selected_points.push_back(m_points->point(*it).x());
-	  positions_selected_points.push_back(m_points->point(*it).y());
-	  positions_selected_points.push_back(m_points->point(*it).z());
+          positions_selected_points.push_back(m_points->point(*it).x()+offset.x);
+          positions_selected_points.push_back(m_points->point(*it).y()+offset.y);
+          positions_selected_points.push_back(m_points->point(*it).z()+offset.z);
 	}
     }
 
@@ -357,13 +358,13 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
 	    const Kernel::Point_3& p = m_points->point(*it);
 	    const Kernel::Vector_3& n = m_points->normal(*it);
             Point_set_3<Kernel>::Point q = p + normal_length * length_factor* n;
-	    positions_lines.push_back(p.x());
-	    positions_lines.push_back(p.y());
-	    positions_lines.push_back(p.z());
+            positions_lines.push_back(p.x()+offset.x);
+            positions_lines.push_back(p.y()+offset.y);
+            positions_lines.push_back(p.z()+offset.z);
 
-	    positions_lines.push_back(q.x());
-	    positions_lines.push_back(q.y());
-	    positions_lines.push_back(q.z());
+            positions_lines.push_back(q.x()+offset.x);
+            positions_lines.push_back(q.y()+offset.y);
+            positions_lines.push_back(q.z()+offset.z);
 
 
             positions_normals.push_back(n.x());
@@ -375,13 +376,13 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
 	    const Kernel::Point_3& p = m_points->point(*it);
 	    const Kernel::Vector_3& n = m_points->normal(*it);
             Point_set_3<Kernel>::Point q = p + normal_length * length_factor* n;
-            positions_lines.push_back(p.x());
-            positions_lines.push_back(p.y());
-            positions_lines.push_back(p.z());
+            positions_lines.push_back(p.x()+offset.x);
+            positions_lines.push_back(p.y()+offset.y);
+            positions_lines.push_back(p.z()+offset.z);
 
-            positions_lines.push_back(q.x());
-            positions_lines.push_back(q.y());
-            positions_lines.push_back(q.z());
+            positions_lines.push_back(q.x()+offset.x);
+            positions_lines.push_back(q.y()+offset.y);
+            positions_lines.push_back(q.z()+offset.z);
 
 
             positions_selected_normals.push_back(n.x());

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <boost/array.hpp>
 
-const std::size_t limit_fast_drawing = 300000; //arbitraty large valu
+const std::size_t limit_fast_drawing = 300000; //arbitraty large value
 
 struct Scene_points_with_normal_item_priv
 {
@@ -585,12 +585,15 @@ bool Scene_points_with_normal_item::supportsRenderingMode(RenderingMode m) const
 
 void Scene_points_with_normal_item::drawSplats(CGAL::Three::Viewer_interface* viewer) const
 {
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+ Kernel::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
+
    // TODO add support for selection
    viewer->glBegin(GL_POINTS);
    if (d->m_points->has_colors())
      for ( Point_set_3<Kernel>::const_iterator it = d->m_points->begin(); it != d->m_points->end(); it++)
        {
-         const Point_set::Point& p = d->m_points->point (*it);
+         Point_set::Point p = d->m_points->point (*it) + offset;
          const Point_set::Vector& n = d->m_points->normal (*it);
          viewer->glColor4d(d->m_points->red(*it),
                            d->m_points->green(*it),
@@ -604,7 +607,7 @@ void Scene_points_with_normal_item::drawSplats(CGAL::Three::Viewer_interface* vi
    else
      for ( Point_set_3<Kernel>::const_iterator it = d->m_points->begin(); it != d->m_points->end(); it++)
        {
-         const Point_set::Point& p = d->m_points->point (*it);
+         const Point_set::Point p = d->m_points->point (*it) + offset;
          const Point_set::Vector& n = d->m_points->normal (*it);
          viewer->glNormal3dv(&n.x());
          viewer->glMultiTexCoord1d(GL_TEXTURE2, d->m_points->radius(*it));

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -380,6 +380,8 @@ Scene_polygon_soup_item_priv::compute_normals_and_vertices() const{
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
     //get the vertices and normals
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
     typedef Polygon_soup::Polygons::size_type size_type;
     positions_poly.resize(0);
     positions_lines.resize(0);
@@ -421,9 +423,9 @@ Scene_polygon_soup_item_priv::compute_normals_and_vertices() const{
             for(size_type i = 0; i < it->size(); ++i)
             {
                 const Point_3& p = soup->points[it->at(i)];
-                positions_poly.push_back(p.x());
-                positions_poly.push_back(p.y());
-                positions_poly.push_back(p.z());
+                positions_poly.push_back(p.x()+offset.x);
+                positions_poly.push_back(p.y()+offset.y);
+                positions_poly.push_back(p.z()+offset.z);
                 positions_poly.push_back(1.0);
                 if(!soup->fcolors.empty())
                 {
@@ -450,14 +452,14 @@ Scene_polygon_soup_item_priv::compute_normals_and_vertices() const{
 
             const Point_3& pa = soup->points[it->at(i)];
             const Point_3& pb = soup->points[it->at((i+1)%it->size())];
-            positions_lines.push_back(pa.x());
-            positions_lines.push_back(pa.y());
-            positions_lines.push_back(pa.z());
+            positions_lines.push_back(pa.x()+offset.x);
+            positions_lines.push_back(pa.y()+offset.y);
+            positions_lines.push_back(pa.z()+offset.z);
             positions_lines.push_back(1.0);
 
-            positions_lines.push_back(pb.x());
-            positions_lines.push_back(pb.y());
-            positions_lines.push_back(pb.z());
+            positions_lines.push_back(pb.x()+offset.x);
+            positions_lines.push_back(pb.y()+offset.y);
+            positions_lines.push_back(pb.z()+offset.z);
             positions_lines.push_back(1.0);
         }
     }
@@ -469,14 +471,14 @@ Scene_polygon_soup_item_priv::compute_normals_and_vertices() const{
 
         const Point_3& a = soup->points[edge[0]];
         const Point_3& b = soup->points[edge[1]];
-        positions_nm_lines.push_back(a.x());
-        positions_nm_lines.push_back(a.y());
-        positions_nm_lines.push_back(a.z());
+        positions_nm_lines.push_back(a.x()+offset.x);
+        positions_nm_lines.push_back(a.y()+offset.y);
+        positions_nm_lines.push_back(a.z()+offset.z);
         positions_nm_lines.push_back(1.0);
 
-        positions_nm_lines.push_back(b.x());
-        positions_nm_lines.push_back(b.y());
-        positions_nm_lines.push_back(b.z());
+        positions_nm_lines.push_back(b.x()+offset.x);
+        positions_nm_lines.push_back(b.y()+offset.y);
+        positions_nm_lines.push_back(b.z()+offset.z);
         positions_nm_lines.push_back(1.0);
     }
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -715,7 +715,10 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
             push_back_xyz(nv, normals_gouraud);
 
             //position
-            const Point& p = he->vertex()->point();
+            const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+            const Point& p = Point(he->vertex()->point().x()+offset.x,
+                                   he->vertex()->point().y()+offset.y,
+                                   he->vertex()->point().z()+offset.z);
             push_back_xyz(p, positions_facets);
             positions_facets.push_back(1.0);
          }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -383,6 +383,8 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
                                                      const VertexNormalPmap& vnmap,
                                                      const bool colors_only)const
 {
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
   Polyhedron::Traits::Point_3 p0,p1,p2;
   Facet::Halfedge_around_facet_circulator
       he = f->facet_begin(),
@@ -411,11 +413,11 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
     p0 = he_end->vertex()->point();
     p1 = he->vertex()->point();
     p2 = next(he, *poly)->vertex()->point();
-    push_back_xyz(p0, positions_facets);
+    push_back_xyz(p0+offset, positions_facets);
     positions_facets.push_back(1.0);
-    push_back_xyz(p1, positions_facets);
+    push_back_xyz(p1+offset, positions_facets);
     positions_facets.push_back(1.0);
-    push_back_xyz(p2, positions_facets);
+    push_back_xyz(p2+offset, positions_facets);
     positions_facets.push_back(1.0);
 
     push_back_xyz(normal, normals_flat);
@@ -443,6 +445,8 @@ Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_itera
                                          const bool colors_only) const
 {
   typedef FacetTriangulator<Polyhedron, Polyhedron::Traits, boost::graph_traits<Polyhedron>::vertex_descriptor> FT;
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
   double diagonal;
   if(item->diagonalBbox() != std::numeric_limits<double>::infinity())
     diagonal = item->diagonalBbox();
@@ -478,13 +482,13 @@ Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_itera
     if (colors_only)
      continue;
 
-    push_back_xyz(ffit->vertex(0)->point(), positions_facets);
+    push_back_xyz(ffit->vertex(0)->point()+offset, positions_facets);
     positions_facets.push_back(1.0);
 
-    push_back_xyz(ffit->vertex(1)->point(), positions_facets);
+    push_back_xyz(ffit->vertex(1)->point()+offset, positions_facets);
     positions_facets.push_back(1.0);
 
-    push_back_xyz(ffit->vertex(2)->point(), positions_facets);
+    push_back_xyz(ffit->vertex(2)->point()+offset, positions_facets);
     positions_facets.push_back(1.0);
 
     push_back_xyz(normal, normals_flat);
@@ -655,6 +659,8 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
 void
 Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only) const
 {
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
     QApplication::setOverrideCursor(Qt::WaitCursor);
     positions_facets.resize(0);
     positions_lines.resize(0);
@@ -672,6 +678,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
     typedef Polyhedron::Halfedge_around_facet_circulator HF_circulator;
     typedef boost::graph_traits<Polyhedron>::face_descriptor   face_descriptor;
     typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
+    Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
 
     CGAL::Unique_hash_map<face_descriptor, Vector> face_normals_map;
     boost::associative_property_map<CGAL::Unique_hash_map<face_descriptor, Vector> >
@@ -715,11 +722,8 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
             push_back_xyz(nv, normals_gouraud);
 
             //position
-            const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
-            const Point& p = Point(he->vertex()->point().x()+offset.x,
-                                   he->vertex()->point().y()+offset.y,
-                                   he->vertex()->point().z()+offset.z);
-            push_back_xyz(p, positions_facets);
+            const Point& p = he->vertex()->point();
+            push_back_xyz(p+offset, positions_facets);
             positions_facets.push_back(1.0);
          }
       }
@@ -743,13 +747,13 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
         Point p1 = f->halfedge()->next()->vertex()->point();
         Point p2 = f->halfedge()->next()->next()->vertex()->point();
 
-        push_back_xyz(p0, positions_facets);
+        push_back_xyz(p0+offset, positions_facets);
         positions_facets.push_back(1.0);
 
-        push_back_xyz(p1, positions_facets);
+        push_back_xyz(p1+offset, positions_facets);
         positions_facets.push_back(1.0);
 
-        push_back_xyz(p2, positions_facets);
+        push_back_xyz(p2+offset, positions_facets);
         positions_facets.push_back(1.0);
 
         push_back_xyz(nf, normals_flat);
@@ -770,13 +774,13 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
         p1 = f->halfedge()->prev()->vertex()->point();
         p2 = f->halfedge()->vertex()->point();
 
-        push_back_xyz(p0, positions_facets);
+        push_back_xyz(p0+offset, positions_facets);
         positions_facets.push_back(1.0);
 
-        push_back_xyz(p1, positions_facets);
+        push_back_xyz(p1+offset, positions_facets);
         positions_facets.push_back(1.0);
 
-        push_back_xyz(p2, positions_facets);
+        push_back_xyz(p2+offset, positions_facets);
         positions_facets.push_back(1.0);
 
         push_back_xyz(nf, normals_flat);
@@ -820,10 +824,10 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           if (colors_only)
             continue;
 
-          push_back_xyz(a, positions_feature_lines);
+          push_back_xyz(a+offset, positions_feature_lines);
           positions_feature_lines.push_back(1.0);
 
-          push_back_xyz(b, positions_feature_lines);
+          push_back_xyz(b+offset, positions_feature_lines);
           positions_feature_lines.push_back(1.0);
         }
         else
@@ -841,10 +845,10 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           if (colors_only)
             continue;
 
-          push_back_xyz(a, positions_lines);
+          push_back_xyz(a+offset, positions_lines);
           positions_lines.push_back(1.0);
 
-          push_back_xyz(b, positions_lines);
+          push_back_xyz(b+offset, positions_lines);
           positions_lines.push_back(1.0);
         }
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
@@ -115,15 +115,16 @@ public Q_SLOTS:
   {
     if(is_ready_to_paint_select)
     {
+      const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
       // paint with mouse move event
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
       qglviewer::Camera* camera = viewer->camera();
 
       bool found = false;
-      const qglviewer::Vec& point = camera->pointUnderPixel(paint_pos, found);
+      const qglviewer::Vec& point = camera->pointUnderPixel(paint_pos, found) - offset;
       if(found)
       {
-        const qglviewer::Vec& orig = camera->position();
+        const qglviewer::Vec& orig = camera->position() - offset;
         const qglviewer::Vec& dir = point - orig;
         poly_item->select(orig.x, orig.y, orig.z, dir.x, dir.y, dir.z);
       }
@@ -133,17 +134,17 @@ public Q_SLOTS:
 
   void highlight()
   {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     if(is_ready_to_highlight)
     {
       // highlight with mouse move event
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
       qglviewer::Camera* camera = viewer->camera();
-
       bool found = false;
-      const qglviewer::Vec& point = camera->pointUnderPixel(hl_pos, found);
+      const qglviewer::Vec& point = camera->pointUnderPixel(hl_pos, found) - offset;
       if(found)
       {
-        const qglviewer::Vec& orig = camera->position();
+        const qglviewer::Vec& orig = camera->position() - offset;
         const qglviewer::Vec& dir = point - orig;
         is_highlighting = true;
         poly_item->select(orig.x, orig.y, orig.z, dir.x, dir.y, dir.z);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -425,6 +425,7 @@ Scene_polyhedron_selection_item_priv::triangulate_facet(Facet_handle fit,const V
 void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<float>& p_facets, std::vector<float>& p_lines, std::vector<float>& p_points, std::vector<float>& p_normals,
                                                            const Selection_set_vertex& p_sel_vertices, const Selection_set_facet& p_sel_facets, const Selection_set_edge& p_sel_edges)const
 {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     p_facets.clear();
     p_lines.clear();
     p_points.clear();
@@ -463,22 +464,23 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
         CGAL_For_all(he,cend)
         {
           const Point& p = he->vertex()->point();
-          p_facets.push_back(p.x());
-          p_facets.push_back(p.y());
-          p_facets.push_back(p.z());
+          p_facets.push_back(p.x()+offset.x);
+          p_facets.push_back(p.y()+offset.y);
+          p_facets.push_back(p.z()+offset.z);
         }
       }
       else if (is_quad(f->halfedge(), *poly))
       {
+        Kernel::Vector_3 v_offset(offset.x, offset.y, offset.z);
         Vector nf = get(nf_pmap, f);
         //1st half-quad
         Point p0 = f->halfedge()->vertex()->point();
         Point p1 = f->halfedge()->next()->vertex()->point();
         Point p2 = f->halfedge()->next()->next()->vertex()->point();
 
-        push_back_xyz(p0, p_facets);
-        push_back_xyz(p1, p_facets);
-        push_back_xyz(p2, p_facets);
+        push_back_xyz(p0+v_offset, p_facets);
+        push_back_xyz(p1+v_offset, p_facets);
+        push_back_xyz(p2+v_offset, p_facets);
 
         push_back_xyz(nf, p_normals);
         push_back_xyz(nf, p_normals);
@@ -489,9 +491,9 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
         p1 = f->halfedge()->prev()->vertex()->point();
         p2 = f->halfedge()->vertex()->point();
 
-        push_back_xyz(p0, p_facets);
-        push_back_xyz(p1, p_facets);
-        push_back_xyz(p2, p_facets);
+        push_back_xyz(p0+v_offset, p_facets);
+        push_back_xyz(p1+v_offset, p_facets);
+        push_back_xyz(p2+v_offset, p_facets);
 
         push_back_xyz(nf, p_normals);
         push_back_xyz(nf, p_normals);
@@ -509,13 +511,13 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
         for(Selection_set_edge::iterator it = p_sel_edges.begin(); it != p_sel_edges.end(); ++it) {
             const Point& a = (it->halfedge())->vertex()->point();
             const Point& b = (it->halfedge())->opposite()->vertex()->point();
-            p_lines.push_back(a.x());
-            p_lines.push_back(a.y());
-            p_lines.push_back(a.z());
+            p_lines.push_back(a.x()+offset.x);
+            p_lines.push_back(a.y()+offset.y);
+            p_lines.push_back(a.z()+offset.z);
 
-            p_lines.push_back(b.x());
-            p_lines.push_back(b.y());
-            p_lines.push_back(b.z());
+            p_lines.push_back(b.x()+offset.x);
+            p_lines.push_back(b.y()+offset.y);
+            p_lines.push_back(b.z()+offset.z);
         }
 
     }
@@ -527,9 +529,9 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
             it != end; ++it)
         {
             const Point& p = (*it)->point();
-            p_points.push_back(p.x());
-            p_points.push_back(p.y());
-            p_points.push_back(p.z());
+            p_points.push_back(p.x()+offset.x);
+            p_points.push_back(p.y()+offset.y);
+            p_points.push_back(p.z()+offset.z);
         }
     }
 }
@@ -547,6 +549,7 @@ void Scene_polyhedron_selection_item_priv::compute_temp_elements()const
                        item->temp_selected_vertices, item->temp_selected_facets, item->temp_selected_edges);
   //The fixed points
   {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     color_fixed_points.clear();
     positions_fixed_points.clear();
     int i=0;
@@ -556,9 +559,9 @@ void Scene_polyhedron_selection_item_priv::compute_temp_elements()const
         it != end; ++it)
     {
       const Point& p = (*it)->point();
-      positions_fixed_points.push_back(p.x());
-      positions_fixed_points.push_back(p.y());
-      positions_fixed_points.push_back(p.z());
+      positions_fixed_points.push_back(p.x()+offset.x);
+      positions_fixed_points.push_back(p.y()+offset.y);
+      positions_fixed_points.push_back(p.z()+offset.z);
 
       if(*it == constrained_vertices.first()|| *it == constrained_vertices.last())
       {
@@ -1084,11 +1087,12 @@ bool Scene_polyhedron_selection_item::treat_selection(const std::set<Polyhedron:
     }
     case 11:
       QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+      const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(viewer)->offset();
       if(viewer->manipulatedFrame() != d->manipulated_frame)
       {
         temp_selected_vertices.insert(vh);
         k_ring_selector.setEditMode(false);
-        d->manipulated_frame->setPosition(vh->point().x(), vh->point().y(), vh->point().z());
+        d->manipulated_frame->setPosition(vh->point().x()+offset.x, vh->point().y()+offset.y, vh->point().z()+offset.z);
         viewer->setManipulatedFrame(d->manipulated_frame);
         connect(d->manipulated_frame, SIGNAL(modified()), this, SLOT(updateTick()));
         invalidateOpenGLBuffers();
@@ -1098,7 +1102,7 @@ bool Scene_polyhedron_selection_item::treat_selection(const std::set<Polyhedron:
       {
         temp_selected_vertices.clear();
         temp_selected_vertices.insert(vh);
-        d->manipulated_frame->setPosition(vh->point().x(), vh->point().y(), vh->point().z());
+        d->manipulated_frame->setPosition(vh->point().x()+offset.x, vh->point().y()+offset.y, vh->point().z()+offset.z);
         invalidateOpenGLBuffers();
       }
       break;
@@ -1911,10 +1915,11 @@ void Scene_polyhedron_selection_item::moveVertex()
 {
   if(d->ready_to_move)
   {
+     const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     Vertex_handle vh = *temp_selected_vertices.begin();
-    vh->point() = Kernel::Point_3(d->manipulated_frame->position().x,
-                                  d->manipulated_frame->position().y,
-                                  d->manipulated_frame->position().z);
+    vh->point() = Kernel::Point_3(d->manipulated_frame->position().x-offset.x,
+                                  d->manipulated_frame->position().y-offset.y,
+                                  d->manipulated_frame->position().z-offset.z);
     invalidateOpenGLBuffers();
     poly_item->invalidateOpenGLBuffers();
     d->ready_to_move = false;

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -137,6 +137,9 @@ Scene_polylines_item_private::computeElements() const
 void
 Scene_polylines_item_private::computeSpheres()
 {
+  const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  K::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
+
       spheres->clear_spheres();
       QApplication::setOverrideCursor(Qt::WaitCursor);
       // FIRST, count the number of incident cycles and polylines
@@ -227,8 +230,7 @@ Scene_polylines_item_private::computeSpheres()
           }
 
           CGAL::Color c(colors[0], colors[1], colors[2]);
-
-          spheres->add_sphere(K::Sphere_3(center, spheres_drawn_square_radius), c);
+          spheres->add_sphere(K::Sphere_3(center+offset, spheres_drawn_square_radius), c);
       }
       spheres->setToolTip(
             QString("<p>Legende of endpoints colors: <ul>"

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -86,6 +86,7 @@ Scene_polylines_item_private::initializeBuffers(CGAL::Three::Viewer_interface *v
 void
 Scene_polylines_item_private::computeElements() const
 {
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     QApplication::setOverrideCursor(Qt::WaitCursor);
     positions_lines.resize(0);
     double mean = 0;
@@ -115,14 +116,14 @@ Scene_polylines_item_private::computeElements() const
                 mean += length;
             }
 
-            positions_lines.push_back(a.x());
-            positions_lines.push_back(a.y());
-            positions_lines.push_back(a.z());
+            positions_lines.push_back(a.x()+offset.x);
+            positions_lines.push_back(a.y()+offset.y);
+            positions_lines.push_back(a.z()+offset.z);
             positions_lines.push_back(1.0);
 
-            positions_lines.push_back(b.x());
-            positions_lines.push_back(b.y());
-            positions_lines.push_back(b.z());
+            positions_lines.push_back(b.x()+offset.x);
+            positions_lines.push_back(b.y()+offset.y);
+            positions_lines.push_back(b.z()+offset.z);
             positions_lines.push_back(1.0);
         }
 

--- a/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_textured_polyhedron_item.cpp
@@ -188,6 +188,8 @@ Scene_textured_polyhedron_item_priv::compute_normals_and_vertices(void) const
     typedef Base::Facet Facet;
     typedef Base::Facet_iterator Facet_iterator;
 
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
     //Facets
     Facet_iterator f = poly->facets_begin();
 
@@ -224,9 +226,9 @@ Scene_textured_polyhedron_item_priv::compute_normals_and_vertices(void) const
 
             //position
             const Point& p = he->vertex()->point();
-            positions_facets.push_back(p.x());
-            positions_facets.push_back(p.y());
-            positions_facets.push_back(p.z());
+            positions_facets.push_back(p.x() + offset.x);
+            positions_facets.push_back(p.y() + offset.y);
+            positions_facets.push_back(p.z() + offset.z);
             positions_facets.push_back(1.0);
 
             const double u = he->vertex()->u();
@@ -250,9 +252,9 @@ Scene_textured_polyhedron_item_priv::compute_normals_and_vertices(void) const
 
         const Point& a = he->vertex()->point();
         const Point& b = he->opposite()->vertex()->point();
-        positions_lines.push_back(a.x());
-        positions_lines.push_back(a.y());
-        positions_lines.push_back(a.z());
+        positions_lines.push_back(a.x() + offset.x);
+        positions_lines.push_back(a.y() + offset.y);
+        positions_lines.push_back(a.z() + offset.z);
         positions_lines.push_back(1.0);
 
         const double u = he->vertex()->u();
@@ -260,9 +262,9 @@ Scene_textured_polyhedron_item_priv::compute_normals_and_vertices(void) const
         textures_map_lines.push_back(u);
         textures_map_lines.push_back(v);
 
-        positions_lines.push_back(b.x());
-        positions_lines.push_back(b.y());
-        positions_lines.push_back(b.z());
+        positions_lines.push_back(b.x()+ offset.x);
+        positions_lines.push_back(b.y()+ offset.y);
+        positions_lines.push_back(b.z()+ offset.z);
         positions_lines.push_back(1.0);
 
         const double ou = he->opposite()->vertex()->u();

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -571,7 +571,7 @@ void Viewer::postSelection(const QPoint& pixel)
 {
   Q_EMIT selected(this->selectedName());
   bool found = false;
-  qglviewer::Vec point = camera()->pointUnderPixel(pixel, found);
+  qglviewer::Vec point = camera()->pointUnderPixel(pixel, found) - d->offset;
   if(found) {
     Q_EMIT selectedPoint(point.x,
                        point.y,
@@ -1511,9 +1511,9 @@ void Viewer_impl::showDistance(QPoint pixel)
         double dist = std::sqrt((BPoint.x-APoint.x)*(BPoint.x-APoint.x) + (BPoint.y-APoint.y)*(BPoint.y-APoint.y) + (BPoint.z-APoint.z)*(BPoint.z-APoint.z));
         QFont font;
         font.setBold(true);
-        TextItem *ACoord = new TextItem(APoint.x, APoint.y, APoint.z,QString("A(%1,%2,%3)").arg(APoint.x).arg(APoint.y).arg(APoint.z), true, font, Qt::red, true);
+        TextItem *ACoord = new TextItem(APoint.x, APoint.y, APoint.z,QString("A(%1,%2,%3)").arg(APoint.x-offset.x).arg(APoint.y-offset.y).arg(APoint.z-offset.z), true, font, Qt::red, true);
         distance_text.append(ACoord);
-        TextItem *BCoord = new TextItem(BPoint.x, BPoint.y, BPoint.z,QString("B(%1,%2,%3)").arg(BPoint.x).arg(BPoint.y).arg(BPoint.z), true, font, Qt::red, true);
+        TextItem *BCoord = new TextItem(BPoint.x, BPoint.y, BPoint.z,QString("B(%1,%2,%3)").arg(BPoint.x-offset.x).arg(BPoint.y-offset.y).arg(BPoint.z-offset.z), true, font, Qt::red, true);
         distance_text.append(BCoord);
         qglviewer::Vec centerPoint = 0.5*(BPoint+APoint);
         TextItem *centerCoord = new TextItem(centerPoint.x, centerPoint.y, centerPoint.z,QString(" distance: %1").arg(dist), true, font, Qt::red, true);
@@ -1522,12 +1522,12 @@ void Viewer_impl::showDistance(QPoint pixel)
         Q_FOREACH(TextItem* ti, distance_text)
           viewer->textRenderer->addText(ti);
         Q_EMIT(viewer->sendMessage(QString("First point : A(%1,%2,%3), second point : B(%4,%5,%6), distance between them : %7")
-                  .arg(APoint.x)
-                  .arg(APoint.y)
-                  .arg(APoint.z)
-                  .arg(BPoint.x)
-                  .arg(BPoint.y)
-                  .arg(BPoint.z)
+                  .arg(APoint.x-offset.x)
+                  .arg(APoint.y-offset.y)
+                  .arg(APoint.z-offset.z)
+                  .arg(BPoint.x-offset.x)
+                  .arg(BPoint.y-offset.y)
+                  .arg(BPoint.z-offset.z)
                   .arg(dist)));
     }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -75,6 +75,7 @@ public:
   void showDistance(QPoint);
   qglviewer::Vec APoint;
   qglviewer::Vec BPoint;
+  qglviewer::Vec offset;
   bool is_d_pressed;
   /*!
    * \brief makeArrow creates an arrow and stores it in a struct of vectors.
@@ -108,6 +109,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->inFastDrawing = true;
   d->inDrawWithNames = false;
   d->shader_programs.resize(NB_OF_PROGRAMS);
+  d->offset = qglviewer::Vec(0,0,0);
   textRenderer = new TextRenderer();
   connect( textRenderer, SIGNAL(sendMessage(QString,int)),
            this, SLOT(printMessage(QString,int)) );
@@ -727,7 +729,7 @@ void Viewer::beginSelection(const QPoint &point)
 void Viewer::endSelection(const QPoint&)
 {
     glDisable(GL_SCISSOR_TEST);
-    //redraw thetrue scene for the glReadPixel in postSelection();
+    //redraw the true scene for the glReadPixel in postSelection();
     d->draw_aux(false, this);
 }
 
@@ -1772,5 +1774,12 @@ void Viewer::SetOrthoProjection(bool b)
 
 
 
+}
+
+void Viewer::setOffset(qglviewer::Vec offset){ d->offset = offset; }
+qglviewer::Vec Viewer::offset()const { return d->offset; }
+void Viewer::setSceneBoundingBox(const qglviewer::Vec &min, const qglviewer::Vec &max)
+{
+  QGLViewer::setSceneBoundingBox(min+d->offset, max+d->offset);
 }
  #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -576,7 +576,7 @@ void Viewer::postSelection(const QPoint& pixel)
     Q_EMIT selectedPoint(point.x,
                        point.y,
                        point.z);
-    const qglviewer::Vec orig = camera()->position();
+    const qglviewer::Vec orig = camera()->position() - d->offset;
     const qglviewer::Vec dir = point - orig;
     Q_EMIT selectionRay(orig.x, orig.y, orig.z,
                       dir.x, dir.y, dir.z);

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -70,6 +70,9 @@ public:
   QOpenGLShaderProgram* getShaderProgram(int name) const;
   QPainter* getPainter();
   void saveSnapshot(bool , bool overwrite = false);
+  void setOffset(qglviewer::Vec offset);
+  qglviewer::Vec offset()const;
+  void setSceneBoundingBox(const qglviewer::Vec &min, const qglviewer::Vec &max);
 
 Q_SIGNALS:
   void sendMessage(QString);

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -134,6 +134,8 @@ public:
   bool extension_is_found;
   //!The matrix used for the picking.
   mutable GLfloat pickMatrix_[16];
+  //!Returns the scene's offset
+  virtual qglviewer::Vec offset()const = 0;
   //!Sets the binding for SHIFT+LEFT CLICK to SELECT (initially used in Scene_polyhedron_selection_item.h)
   void setBindingSelect()
   {


### PR DESCRIPTION
This PR fixes #1721 by adding colors and handles for the Volume planes. 
It also fixes the fluidity problems when handling the planes from the ManipulatedFrame interface and destroys the planes of an image when the said image is destroyed, to avoid an unstable state of the sliders when there is several images open at once.

@afabri and @sloriot, can you test it and say if you are satisfied with the modifications before it is integrated ? 
@lrineau This PR needs #1737 about the offseted items.