### PR TITLE
Barycentric coordinate -> Barycentric coordinates

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -158,6 +158,14 @@ and <code>src/</code> directories).
       <b>Breaking change</b>: the requirements of the item class used to customize a combinatorial map and a linear cell complex changed. Instead of defining the type of darts used, you have to define the information you want to add in each dart. You can define the CGAL_CMAP_DART_DEPRECATED macro to keep the old behavior. 
     </li>
   </ul>
+
+<h3>Triangulated Surface Mesh Shortest Paths</h3>
+  <ul>
+    <li>
+      <b>Breaking change</b>: Rename all functions, types, and enums using <i>barycentric coordinate</i> to <i>barycentric coordinates</i>.
+    </li>
+  </ul>
+
 <!-- Arithmetic and Algebra -->
 <!-- Combinatorial Algorithms -->
 <!-- Geometry Kernels -->

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -27,8 +27,8 @@ struct Scene_polyhedron_shortest_path_item_priv
   typedef CGAL::AABB_traits<Kernel, AABB_face_graph_primitive> AABB_face_graph_traits;
   typedef CGAL::AABB_tree<AABB_face_graph_traits> AABB_face_graph_tree;
 
-  typedef Surface_mesh_shortest_path_traits::Barycentric_coordinate Barycentric_coordinate;
-  typedef Surface_mesh_shortest_path_traits::Construct_barycentric_coordinate Construct_barycentric_coordinate;
+  typedef Surface_mesh_shortest_path_traits::Barycentric_coordinates Barycentric_coordinates;
+  typedef Surface_mesh_shortest_path_traits::Construct_barycentric_coordinates Construct_barycentric_coordinates;
   typedef Surface_mesh_shortest_path_traits::Ray_3 Ray_3;
   typedef Surface_mesh_shortest_path_traits::Point_3 Point_3;
   typedef Surface_mesh_shortest_path_traits::FT FT;
@@ -344,12 +344,12 @@ void Scene_polyhedron_shortest_path_item_priv::get_as_edge_point(Scene_polyhedro
     }
   }
 
-  Construct_barycentric_coordinate construct_barycentric_coordinate;
+  Construct_barycentric_coordinates construct_barycentric_coordinates;
 
   Point_3 trianglePoints[3] = {
-    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinate(FT(1.0), FT(0.0), FT(0.0))),
-    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinate(FT(0.0), FT(1.0), FT(0.0))),
-    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinate(FT(0.0), FT(0.0), FT(1.0))),
+    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinates(FT(1.0), FT(0.0), FT(0.0))),
+    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinates(FT(0.0), FT(1.0), FT(0.0))),
+    m_shortestPaths->point(inOutLocation.first, construct_barycentric_coordinates(FT(0.0), FT(0.0), FT(1.0))),
   };
   
   CGAL::Surface_mesh_shortest_paths_3::Parametric_distance_along_segment_3<Surface_mesh_shortest_path_traits> parametricDistanceSegment3;
@@ -363,7 +363,7 @@ void Scene_polyhedron_shortest_path_item_priv::get_as_edge_point(Scene_polyhedro
   coords[nearestEdge[1]] = distanceAlongSegment;
   coords[nearestEdge[0]] = FT(1.0) - distanceAlongSegment;
 
-  inOutLocation.second = construct_barycentric_coordinate(coords[0], coords[1], coords[2]);
+  inOutLocation.second = construct_barycentric_coordinates(coords[0], coords[1], coords[2]);
 }
 
 void Scene_polyhedron_shortest_path_item_priv::get_as_vertex_point(Scene_polyhedron_shortest_path_item::Face_location& inOutLocation)
@@ -383,8 +383,8 @@ void Scene_polyhedron_shortest_path_item_priv::get_as_vertex_point(Scene_polyhed
   FT coords[3] = { FT(0.0), FT(0.0), FT(0.0), };
   coords[maxIndex] = FT(1.0);
   
-  Construct_barycentric_coordinate construct_barycentric_coordinate;
-  inOutLocation.second = construct_barycentric_coordinate(coords[0], coords[1], coords[2]);
+  Construct_barycentric_coordinates construct_barycentric_coordinates;
+  inOutLocation.second = construct_barycentric_coordinates(coords[0], coords[1], coords[2]);
 }
 
 bool Scene_polyhedron_shortest_path_item_priv::run_point_select(const Ray_3& ray)
@@ -535,8 +535,8 @@ bool Scene_polyhedron_shortest_path_item::deferred_load(Scene_polyhedron_item* p
 
   std::string line;
   std::size_t faceId;
-  Barycentric_coordinate location;
-  Construct_barycentric_coordinate construct_barycentric_coordinate;
+  Barycentric_coordinates location;
+  Construct_barycentric_coordinates construct_barycentric_coordinates;
 
   while (std::getline(inFile, line))
   {
@@ -544,7 +544,7 @@ bool Scene_polyhedron_shortest_path_item::deferred_load(Scene_polyhedron_item* p
     FT coords[3];
     lineStream >> faceId >> coords[0] >> coords[1] >> coords[2];
     
-    location = construct_barycentric_coordinate(coords[0], coords[1], coords[2]);
+    location = construct_barycentric_coordinates(coords[0], coords[1], coords[2]);
     
     // std::cout << "Read in face: " << faceId << " , " << location << std::endl;
     

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.h
@@ -54,8 +54,8 @@ public:
   typedef CGAL::AABB_traits<Kernel, AABB_face_graph_primitive> AABB_face_graph_traits;
   typedef CGAL::AABB_tree<AABB_face_graph_traits> AABB_face_graph_tree;
   
-  typedef Surface_mesh_shortest_path_traits::Barycentric_coordinate Barycentric_coordinate;
-  typedef Surface_mesh_shortest_path_traits::Construct_barycentric_coordinate Construct_barycentric_coordinate;
+  typedef Surface_mesh_shortest_path_traits::Barycentric_coordinates Barycentric_coordinates;
+  typedef Surface_mesh_shortest_path_traits::Construct_barycentric_coordinates Construct_barycentric_coordinates;
   typedef Surface_mesh_shortest_path_traits::Ray_3 Ray_3;
   typedef Surface_mesh_shortest_path_traits::Point_3 Point_3;
   typedef Surface_mesh_shortest_path_traits::FT FT;

--- a/Surface_mesh_shortest_path/benchmark/Surface_mesh_shortest_path/benchmark_shortest_paths.cpp
+++ b/Surface_mesh_shortest_path/benchmark/Surface_mesh_shortest_path/benchmark_shortest_paths.cpp
@@ -148,13 +148,13 @@ void print_results(std::ostream& stream, const std::string& filename, const Benc
 }
 
 template <class Traits>
-typename Traits::Barycentric_coordinate random_coordinate(CGAL::Random& rand)
+typename Traits::Barycentric_coordinates random_coordinates(CGAL::Random& rand)
 {
   typedef typename Traits::FT FT;
-  typename Traits::Construct_barycentric_coordinate construct_barycentric_coordinate;
+  typename Traits::Construct_barycentric_coordinates construct_barycentric_coordinates;
   FT u = rand.uniform_real(FT(0.0), FT(1.0));
   FT v = rand.uniform_real(FT(0.0), FT(1.0) - u);
-  return construct_barycentric_coordinate(u, v, FT(1.0) - u - v);
+  return construct_barycentric_coordinates(u, v, FT(1.0) - u - v);
 }
 
 template <class Kernel>
@@ -162,7 +162,7 @@ void run_benchmarks(CGAL::Random& rand, size_t numTrials, size_t numSources, siz
 {
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef typename Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef typename Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
   typedef typename Surface_mesh_shortest_path::Face_location Face_location;
   typedef typename Surface_mesh_shortest_path::FT FT;
@@ -211,7 +211,7 @@ void run_benchmarks(CGAL::Random& rand, size_t numTrials, size_t numSources, siz
     while (sourcePoints.size() < numSources)
     {
       face_descriptor sourceFace = allFaces[rand.get_int(0, allFaces.size())];
-      Barycentric_coordinate sourceLocation = random_coordinate<Traits>(rand);
+      Barycentric_coordinates sourceLocation = random_coordinate<Traits>(rand);
       sourcePoints.push_back(Face_location(sourceFace, sourceLocation));
     }
 
@@ -233,7 +233,7 @@ void run_benchmarks(CGAL::Random& rand, size_t numTrials, size_t numSources, siz
     for (size_t j = 0; j < numQueries; ++j)
     {
       face_descriptor sourceFace = allFaces[rand.get_int(0, allFaces.size())];
-      Barycentric_coordinate sourceLocation = random_coordinate<Traits>(rand);
+      Barycentric_coordinates sourceLocation = random_coordinate<Traits>(rand);
       
       timer.start();
       FT distance = shortestPaths.shortest_distance_to_source_points(sourceFace, sourceLocation).first;

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathTraits.h
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathTraits.h
@@ -43,7 +43,7 @@ public:
   typedef unspecified_type Triangle_2;
 
   /// An ordered triple to specify barycentric coordinates in triangles.
-  typedef unspecified_type Barycentric_coordinate;
+  typedef unspecified_type Barycentric_coordinates;
 
   /// The 3-dimensional point type
   typedef unspecified_type Point_3;
@@ -247,31 +247,31 @@ public:
 
   /*!
   Function object type that provides
-  `Barycentric_coordinate operator()(FT a, FT b, FT c)`
-  to introduce a new triangular barycentric coordinate.
+  `Barycentric_coordinates operator()(FT a, FT b, FT c)`
+  to introduce some new triangular barycentric coordinates.
   */
-  typedef unspecified_type Construct_barycentric_coordinate;
+  typedef unspecified_type Construct_barycentric_coordinates;
 
   /*!
   Function object type that provides
-  `FT operator(Barycentric_coordinate b, std::size_t i)`
-  to get the `i`th weight of barycentric coordinate `b`.
+  `FT operator(Barycentric_coordinates b, std::size_t i)`
+  to get the `i`th weight of barycentric coordinates `b`.
   */
-  typedef unspecified_type Construct_barycentric_coordinate_weight;
+  typedef unspecified_type Construct_barycentric_coordinates_weight;
 
   /*!
   Function object type that provides
-  `Barycentric_coordinate operator()(Triangle_2 t, Point_2 p)`
+  `Barycentric_coordinates operator()(Triangle_2 t, Point_2 p)`
   which computes the Barycentric location of `p` in `t`.
   */
-  typedef unspecified_type Construct_barycentric_coordinate_in_triangle_2;
+  typedef unspecified_type Construct_barycentric_coordinates_in_triangle_2;
 
   /*!
   Function object type that provides
-  `Barycentric_coordinate operator()(Triangle_3 t, Point_3 p)`
+  `Barycentric_coordinates operator()(Triangle_3 t, Point_3 p)`
   which computes the Barycentric location of `p` in `t`.
   */
-  typedef unspecified_type Construct_barycentric_coordinate_in_triangle_3;
+  typedef unspecified_type Construct_barycentric_coordinates_in_triangle_3;
 
 /// @}
 
@@ -280,17 +280,17 @@ public:
 
   /*!
   Function object type that provides
-  `std::pair<CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type,std::size_t> operator()(Barycentric_coordinate b)`,
-  which computes the classification and the associated edge (if applicable) of the coordinate `b`
-  \details Returns the pair (`type`, `i`), such that `type` is one of the values of `CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type`
-  - If `type` is `CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX`, `i` is the index of that vertex
-  - If `type` is `CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDARY`, `i` is the index of the non-zero edge
+  `std::pair<CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type,std::size_t> operator()(Barycentric_coordinates b)`,
+  which computes the classification and the associated edge (if applicable) of the coordinates `b`
+  \details Returns the pair (`type`, `i`), such that `type` is one of the values of `CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type`
+  - If `type` is `CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX`, `i` is the index of that vertex
+  - If `type` is `CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDARY`, `i` is the index of the non-zero edge
     - 0 if (0,1) are the non-zero coordinates
     - 1 if (1,2) are the non-zero coordinates
     - 2 if (2,0) are the non-zero coordinates
   - Otherwise, the value of `i` is undefined.
   */
-  typedef unspecified_type Classify_barycentric_coordinate;
+  typedef unspecified_type Classify_barycentric_coordinates;
 
   /*!
   Function object type that provides

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathTraits.h
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathTraits.h
@@ -248,7 +248,7 @@ public:
   /*!
   Function object type that provides
   `Barycentric_coordinates operator()(FT a, FT b, FT c)`
-  to introduce some new triangular barycentric coordinates.
+  to introduce new triangular barycentric coordinates.
   */
   typedef unspecified_type Construct_barycentric_coordinates;
 

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathVisitor.h
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Concepts/SurfaceMeshShortestPathVisitor.h
@@ -45,7 +45,7 @@ public:
   sequence, and only if the target/source point is an internal face location
   (i.e. not on an edge or at a vertex).
   \param face a face of the surface mesh encountered at the start or the end of the shortest path.
-  \param location the barycentric coordinate inside `face` of this point on the path.
+  \param location the barycentric coordinates inside `face` of this point on the path.
   */
-  void operator()(face_descriptor face, Barycentric_coordinate location);
+  void operator()(face_descriptor face, Barycentric_coordinates location);
 };

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
@@ -43,7 +43,7 @@
 
 ## Enums ##
 
-- `CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type`
+- `CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type`
 
 */
 

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Surface_mesh_shortest_path.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Surface_mesh_shortest_path.txt
@@ -53,8 +53,8 @@ If the traits class used holds some local state, it must also be passed to the c
 
 The set of source points for shortest path queries can be populated one by one or using a range.
 A source point can be specified using either a vertex of the input surface mesh or a face of the input surface mesh
-with some barycentric coordinate.
-Given a point \f$p\f$ that lies inside a triangle face \f$(A,B,C)\f$, its barycentric coordinate is a weight triple \f$(b_0,b_1,b_2)\f$ such that \f$p = b_0\cdot~A + b_1\cdot~B + b_2\cdot~C\f$, and \f$b_0 + b_1 + b_2 = 1\f$.
+with some barycentric coordinates.
+Given a point \f$p\f$ that lies inside a triangle face \f$(A,B,C)\f$, its barycentric coordinates are a weight triple \f$(b_0,b_1,b_2)\f$ such that \f$p = b_0\cdot~A + b_1\cdot~B + b_2\cdot~C\f$, and \f$b_0 + b_1 + b_2 = 1\f$.
 
 \subsubsection Surface_mesh_shortest_pathClassBuild Building the Internal Sequence Tree
 
@@ -69,7 +69,7 @@ Note that it can also be built manually by a call to `Surface_mesh_shortest_path
 
 As for specifying the source points, the target point for a shortest path query
 can be specified using either a vertex of the input surface mesh or a face of the input surface mesh
-and a barycentric coordinate.
+and some barycentric coordinates.
 
 There are three different kinds of query functions that can be called using the class `Surface_mesh_shortest_path`.
 Given a target point, all these functions compute the shortest path between that target point and the set of
@@ -82,8 +82,8 @@ source points:
 \subsubsection Surface_mesh_shortest_pathClassMore Additional Convenience Functionalities
 
 Some convenience functions are provided to compute:
-- the point on the input surface mesh specified as a face of the input surface mesh and a barycentric coordinate.
-- the closest point on the input surface mesh (specified as a face of the input surface mesh and a barycentric coordinate) to a given 3D point. Those function are using the class `CGAL::AABB_tree`.
+- the point on the input surface mesh specified as a face of the input surface mesh and some barycentric coordinates.
+- the closest point on the input surface mesh (specified as a face of the input surface mesh and some barycentric coordinates) to a given 3D point. Those function are using the class `CGAL::AABB_tree`.
 
 \subsection Surface_mesh_shortest_pathKernelRecommendataions Kernel Recommendations
 In short, we recommend to use a \cgal kernel with exact predicates such as `CGAL::Exact_predicates_inexact_constructions_kernel`.

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
@@ -21,7 +21,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
 typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+typedef Traits::Barycentric_coordinates Barycentric_coordinates;
 typedef boost::graph_traits<Polyhedron_3> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
@@ -35,7 +35,7 @@ struct Sequence_collector
 {
   typedef boost::variant< vertex_descriptor,
                          std::pair<halfedge_descriptor,double>,
-                         std::pair<face_descriptor, Barycentric_coordinate> > Simplex;
+                         std::pair<face_descriptor, Barycentric_coordinates> > Simplex;
   std::vector< Simplex > sequence;
 
   void operator()(halfedge_descriptor he, double alpha)
@@ -49,7 +49,7 @@ struct Sequence_collector
     sequence.push_back( v );
   }
 
-  void operator()(face_descriptor f, Barycentric_coordinate alpha)
+  void operator()(face_descriptor f, Barycentric_coordinates alpha)
   {
     sequence.push_back( std::make_pair(f, alpha) );
   }
@@ -74,7 +74,7 @@ struct Print_visitor : public boost::static_visitor<> {
                                             << h_a.second << ")\n";
   }
 
-  void operator()(const std::pair<face_descriptor, Barycentric_coordinate>& f_bc)
+  void operator()(const std::pair<face_descriptor, Barycentric_coordinates>& f_bc)
   {
     std::cout << "#" << ++i << " : Face : " << get(CGAL::face_index, g)[f_bc.first] << " , ("
                                             << f_bc.second[0] << " , "
@@ -100,8 +100,8 @@ int main(int argc, char** argv)
   const int target_face_index = rand.get_int(0, num_faces(polyhedron));
   face_iterator face_it = faces(polyhedron).first;
   std::advance(face_it,target_face_index);
-  // ... and define a barycentric coordinate inside the face
-  Barycentric_coordinate face_location = {{0.25, 0.5, 0.25}};
+  // ... and define a barycentric coordinates inside the face
+  Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
   Surface_mesh_shortest_path shortest_paths(polyhedron);

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
   input >> polyhedron;
   input.close();
 
-  // initialize indices of vertices, halfedges and facets
+  // initialize indices of vertices, halfedges and faces
   CGAL::set_halfedgeds_items_id(polyhedron);
 
   // pick up a random face

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_OpenMesh.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_OpenMesh.cpp
@@ -42,8 +42,8 @@ int main(int argc, char** argv)
   const int target_face_index = rand.get_int(0, num_faces(polyhedron));
   face_iterator face_it = faces(polyhedron).first;
   std::advance(face_it,target_face_index);
-  // ... and define a barycentric coordinate inside the face
-  Traits::Barycentric_coordinate face_location = {{0.25, 0.5, 0.25}};
+  // ... and define a barycentric coordinates inside the face
+  Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
   Surface_mesh_shortest_path shortest_paths(polyhedron);

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
   input >> polyhedron;
   input.close();
 
-  // initialize indices of vertices, halfedges and facets
+  // initialize indices of vertices, halfedges and faces
   CGAL::set_halfedgeds_items_id(polyhedron);
 
   // pick up some source points inside faces,

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
   std::vector<face_descriptor> face_vector(fit, fit_end);
   // and creating a vector of Face_location objects
   const std::size_t nb_source_points = 30;
-  Traits::Barycentric_coordinate face_location = {{0.25, 0.5, 0.25}};
+  Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
   std::vector<Face_location> faceLocations(nb_source_points, Face_location(face_descriptor(), face_location));
   for (std::size_t i = 0; i < nb_source_points; ++i)
   {

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -50,8 +50,8 @@ int main(int argc, char** argv)
   const int target_face_index = rand.get_int(0, num_faces(polyhedron));
   face_iterator face_it = faces(polyhedron).first;
   std::advance(face_it,target_face_index);
-  // ... and define a barycentric coordinate inside the face
-  Traits::Barycentric_coordinate face_location = {{0.25, 0.5, 0.25}};
+  // ... and define a barycentric coordinates inside the face
+  Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
   // Note that the external index property map are automatically initialized

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
@@ -41,8 +41,8 @@ int main(int argc, char** argv)
   const int target_face_index = rand.get_int(0, num_faces(polyhedron));
   face_iterator face_it = faces(polyhedron).first;
   std::advance(face_it,target_face_index);
-  // ... and define a barycentric coordinate inside the face
-  Traits::Barycentric_coordinate face_location = {{0.25, 0.5, 0.25}};
+  // ... and define a barycentric coordinates inside the face
+  Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
   Surface_mesh_shortest_path shortest_paths(polyhedron);

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
   input >> polyhedron;
   input.close();
 
-  // initialize indices of vertices, halfedges and facets
+  // initialize indices of vertices, halfedges and faces
   CGAL::set_halfedgeds_items_id(polyhedron);
 
   // pick up a random face

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -136,7 +136,12 @@ public:
 
   /// An ordered triple which specifies a location inside a triangle as
   /// a convex combination of its three vertices.
-  typedef typename Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef typename Traits::Barycentric_coordinates Barycentric_coordinates;
+
+#ifndef CGAL_NO_DEPRECATED_CODE
+  // deprecated in CGAL 4.10
+  typedef Barycentric_coordinates Barycentric_coordinate;
+#endif
 
   /// \brief An ordered pair specifying a location on the surface of the `Triangle_mesh`.
   /// \details If `tm` is the input graph and given the pair (`f`, `bc`) such that `bc` is `(w0, w1, w2)`,
@@ -144,7 +149,7 @@ public:
   /// - `w0 = source(halfedge(f,tm),tm)`
   /// - `w1 = target(halfedge(f,tm),tm)`
   /// - `w2 = target(next(halfedge(f,tm),tm),tm)`
-  typedef std::pair<face_descriptor, Barycentric_coordinate> Face_location;
+  typedef std::pair<face_descriptor, Barycentric_coordinates> Face_location;
 
 private:
 
@@ -310,7 +315,7 @@ private:
       ++m_output;
     }
 
-    void operator()(face_descriptor f, Barycentric_coordinate location)
+    void operator()(face_descriptor f, Barycentric_coordinates location)
     {
       *m_output = m_owner.point(f, location);
       ++m_output;
@@ -440,29 +445,29 @@ private:
 #endif
   }
 
-  Point_2 construct_barycenter_in_triangle_2(const Triangle_2& t, const Barycentric_coordinate& b) const
+  Point_2 construct_barycenter_in_triangle_2(const Triangle_2& t, const Barycentric_coordinates& b) const
   {
     return construct_barycenter_in_triangle_2(t, b, m_traits);
   }
 
-  static Point_2 construct_barycenter_in_triangle_2(const Triangle_2& t, const Barycentric_coordinate& b, const Traits& traits)
+  static Point_2 construct_barycenter_in_triangle_2(const Triangle_2& t, const Barycentric_coordinates& b, const Traits& traits)
   {
     typename Traits::Construct_vertex_2 cv2(traits.construct_vertex_2_object());
-    typename Traits::Construct_barycentric_coordinate_weight cbcw(traits.construct_barycentric_coordinate_weight_object());
+    typename Traits::Construct_barycentric_coordinates_weight cbcw(traits.construct_barycentric_coordinates_weight_object());
     typename Traits::Construct_barycenter_2 cb2(traits.construct_barycenter_2_object());
 
     return cb2(cv2(t, 0), cbcw(b, 0), cv2(t, 1), cbcw(b, 1), cv2(t, 2), cbcw(b, 2));
   }
 
-  Point_3 construct_barycenter_in_triangle_3(const Triangle_3& t, const Barycentric_coordinate& b) const
+  Point_3 construct_barycenter_in_triangle_3(const Triangle_3& t, const Barycentric_coordinates& b) const
   {
     return construct_barycenter_in_triangle_3(t, b, m_traits);
   }
 
-  static Point_3 construct_barycenter_in_triangle_3(const Triangle_3& t, const Barycentric_coordinate& b, const Traits& traits)
+  static Point_3 construct_barycenter_in_triangle_3(const Triangle_3& t, const Barycentric_coordinates& b, const Traits& traits)
   {
     typename Traits::Construct_vertex_3 cv3(traits.construct_vertex_3_object());
-    typename Traits::Construct_barycentric_coordinate_weight cbcw(traits.construct_barycentric_coordinate_weight_object());
+    typename Traits::Construct_barycentric_coordinates_weight cbcw(traits.construct_barycentric_coordinates_weight_object());
     typename Traits::Construct_barycenter_3 cb3(traits.construct_barycenter_3_object());
 
     return cb3(cv3(t, 0), cbcw(b, 0), cv3(t, 1), cbcw(b, 1), cv3(t, 2), cbcw(b, 2));
@@ -659,21 +664,21 @@ private:
     Determines whether to expand `location` as a face, edge, or vertex root, depending on
     whether it is near to a given edge or vertex, or is an internal face location
   */
-  void expand_root(face_descriptor f, Barycentric_coordinate location, Source_point_iterator sourcePointIt)
+  void expand_root(face_descriptor f, Barycentric_coordinates location, Source_point_iterator sourcePointIt)
   {
-    typename Traits::Construct_barycentric_coordinate_weight cbcw(m_traits.construct_barycentric_coordinate_weight_object());
-    typename Traits::Classify_barycentric_coordinate classify_barycentric_coordinate(m_traits.classify_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates_weight cbcw(m_traits.construct_barycentric_coordinates_weight_object());
+    typename Traits::Classify_barycentric_coordinates classify_barycentric_coordinates(m_traits.classify_barycentric_coordinates_object());
 
     std::size_t associatedEdge;
-    CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type type;
-    boost::tie(type, associatedEdge) = classify_barycentric_coordinate(location);
+    CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type type;
+    boost::tie(type, associatedEdge) = classify_barycentric_coordinates(location);
 
     switch (type)
     {
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDED_SIDE:
         expand_face_root(f, location, sourcePointIt);
         break;
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDARY:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDARY:
         {
           halfedge_descriptor he = halfedge(f, m_graph);
           for (std::size_t i = 0; i < associatedEdge; ++i)
@@ -683,7 +688,7 @@ private:
           expand_edge_root(he, cbcw(location, associatedEdge), cbcw(location, (associatedEdge + 1) % 3), sourcePointIt);
         }
         break;
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX:
         {
           halfedge_descriptor he = halfedge(f, m_graph);
           for (std::size_t i = 0; i < associatedEdge; ++i)
@@ -702,7 +707,7 @@ private:
   /*
     Create source nodes facing each edge of `f`, rooted at the given `faceLocation`
   */
-  void expand_face_root(face_descriptor f, Barycentric_coordinate faceLocation, Source_point_iterator sourcePointIt)
+  void expand_face_root(face_descriptor f, Barycentric_coordinates faceLocation, Source_point_iterator sourcePointIt)
   {
     typename Traits::Construct_triangle_3_to_triangle_2_projection pt3t2(m_traits.construct_triangle_3_to_triangle_2_projection_object());
     typename Traits::Construct_vertex_2 cv2(m_traits.construct_vertex_2_object());
@@ -716,7 +721,7 @@ private:
 
     if (m_debugOutput)
     {
-      typename Traits::Construct_barycentric_coordinate_weight cbcw(m_traits.construct_barycentric_coordinate_weight_object());
+      typename Traits::Construct_barycentric_coordinates_weight cbcw(m_traits.construct_barycentric_coordinates_weight_object());
       std::cout << "\tFace Root Expansion: id = " << get(m_faceIndexMap, f) << " , Location = " << cbcw(faceLocation, 0) << " " << cbcw(faceLocation, 1) << " " << cbcw(faceLocation, 2) << " " << std::endl;
     }
 
@@ -724,7 +729,7 @@ private:
     {
       Triangle_3 face3d(triangle_from_halfedge(current));
       Triangle_2 layoutFace(pt3t2(face3d));
-      Barycentric_coordinate rotatedFaceLocation(shifted_coordiate(faceLocation, currentVertex));
+      Barycentric_coordinates rotatedFaceLocation(shifted_coordinates(faceLocation, currentVertex));
       Point_2 sourcePoint(construct_barycenter_in_triangle_2(layoutFace, rotatedFaceLocation));
 
       Cone_tree_node* child = new Cone_tree_node(m_traits, m_graph, current, layoutFace, sourcePoint, FT(0.0), cv2(layoutFace, 0), cv2(layoutFace, 2), Cone_tree_node::FACE_SOURCE);
@@ -1647,26 +1652,26 @@ private:
     }
   }
 
-  Point_2 face_location_with_normalized_coordinate(Cone_tree_node* node, Barycentric_coordinate location)
+  Point_2 face_location_with_normalized_coordinates(Cone_tree_node* node, Barycentric_coordinates location)
   {
     return construct_barycenter_in_triangle_2(node->layout_face(), localized_coordiate(node, location));
   }
 
-  Barycentric_coordinate localized_coordiate(Cone_tree_node* node, Barycentric_coordinate location)
+  Barycentric_coordinates localized_coordiate(Cone_tree_node* node, Barycentric_coordinates location)
   {
-    return shifted_coordiate(location, node->edge_face_index());
+    return shifted_coordinates(location, node->edge_face_index());
   }
 
-  Barycentric_coordinate shifted_coordiate(Barycentric_coordinate location, std::size_t shift)
+  Barycentric_coordinates shifted_coordinates(Barycentric_coordinates location, std::size_t shift)
   {
-    typename Traits::Construct_barycentric_coordinate_weight cbcw(m_traits.construct_barycentric_coordinate_weight_object());
-    typename Traits::Construct_barycentric_coordinate cbc(m_traits.construct_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates_weight cbcw(m_traits.construct_barycentric_coordinates_weight_object());
+    typename Traits::Construct_barycentric_coordinates cbc(m_traits.construct_barycentric_coordinates_object());
     return cbc(cbcw(location, shift), cbcw(location, (shift + 1) % 3), cbcw(location, (shift + 2) % 3));
   }
 
-  std::pair<Node_distance_pair, Barycentric_coordinate> nearest_on_face(face_descriptor f, Barycentric_coordinate location)
+  std::pair<Node_distance_pair, Barycentric_coordinates> nearest_on_face(face_descriptor f, Barycentric_coordinates location)
   {
-    typename Traits::Construct_barycentric_coordinate cbc(m_traits.construct_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates cbc(m_traits.construct_barycentric_coordinates_object());
 
     std::size_t faceIndex = get(m_faceIndexMap, f);
 
@@ -1684,7 +1689,7 @@ private:
         continue;
       }
 
-      Point_2 locationInContext = face_location_with_normalized_coordinate(current, location);
+      Point_2 locationInContext = face_location_with_normalized_coordinates(current, location);
 
       if (current->inside_window(locationInContext))
       {
@@ -1708,21 +1713,21 @@ private:
     }
   }
 
-  std::pair<Node_distance_pair, Barycentric_coordinate> nearest_to_location(face_descriptor f, Barycentric_coordinate location)
+  std::pair<Node_distance_pair, Barycentric_coordinates> nearest_to_location(face_descriptor f, Barycentric_coordinates location)
   {
-    typename Traits::Construct_barycentric_coordinate_weight cbcw(m_traits.construct_barycentric_coordinate_weight_object());
-    typename Traits::Construct_barycentric_coordinate cbc(m_traits.construct_barycentric_coordinate_object());
-    typename Traits::Classify_barycentric_coordinate classify_barycentric_coordinate(m_traits.classify_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates_weight cbcw(m_traits.construct_barycentric_coordinates_weight_object());
+    typename Traits::Construct_barycentric_coordinates cbc(m_traits.construct_barycentric_coordinates_object());
+    typename Traits::Classify_barycentric_coordinates classify_barycentric_coordinates(m_traits.classify_barycentric_coordinates_object());
 
     std::size_t associatedEdge;
-    CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type type;
-    boost::tie(type, associatedEdge) = classify_barycentric_coordinate(location);
+    CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type type;
+    boost::tie(type, associatedEdge) = classify_barycentric_coordinates(location);
 
     switch (type)
     {
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDED_SIDE:
         return nearest_on_face(f, location);
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDARY:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDARY:
         {
           halfedge_descriptor he = halfedge(f, m_graph);
           for (std::size_t i = 0; i < associatedEdge; ++i)
@@ -1737,9 +1742,9 @@ private:
           FT oppositeLocationCoords[3] = { FT(0.0), FT(0.0), FT(0.0) };
           oppositeLocationCoords[oppositeIndex] = cbcw(location, (associatedEdge + 1) % 3);
           oppositeLocationCoords[(oppositeIndex + 1) % 3] = cbcw(location, associatedEdge);
-          std::pair<Node_distance_pair,Barycentric_coordinate> mainFace = nearest_on_face(f, location);
-          Barycentric_coordinate oppositeLocation(cbc(oppositeLocationCoords[0], oppositeLocationCoords[1], oppositeLocationCoords[2]));
-          std::pair<Node_distance_pair,Barycentric_coordinate> otherFace = nearest_on_face(face(oppositeHalfedge, m_graph), oppositeLocation);
+          std::pair<Node_distance_pair,Barycentric_coordinates> mainFace = nearest_on_face(f, location);
+          Barycentric_coordinates oppositeLocation(cbc(oppositeLocationCoords[0], oppositeLocationCoords[1], oppositeLocationCoords[2]));
+          std::pair<Node_distance_pair,Barycentric_coordinates> otherFace = nearest_on_face(face(oppositeHalfedge, m_graph), oppositeLocation);
 
           if (mainFace.first.first == NULL)
           {
@@ -1755,7 +1760,7 @@ private:
           }
         }
         break;
-      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX:
+      case CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX:
         {
           halfedge_descriptor he = halfedge(f, m_graph);
 
@@ -1772,7 +1777,7 @@ private:
 
       default:
         CGAL_assertion(false && "Invalid face location");
-        return std::pair<Node_distance_pair, Barycentric_coordinate>();
+        return std::pair<Node_distance_pair, Barycentric_coordinates>();
     }
   }
 
@@ -2076,10 +2081,10 @@ public:
   the first shortest path query is done.
 
   \param f A face of the input face graph
-  \param location Barycentric coordinate in face `f` specifying the source point.
+  \param location Barycentric coordinates in face `f` specifying the source point.
   \return An iterator to the source point added
   */
-  Source_point_iterator add_source_point(face_descriptor f, Barycentric_coordinate location)
+  Source_point_iterator add_source_point(face_descriptor f, Barycentric_coordinates location)
   {
     return add_source_point(std::make_pair(f, location));
   }
@@ -2271,17 +2276,17 @@ public:
   \brief Computes the shortest surface distance from any surface location to any source point
 
   \param f A face of the input face graph
-  \param location Barycentric coordinate of the query point on face `f`
+  \param location Barycentric coordinates of the query point on face `f`
   \return A pair, containing the distance to the source point, and an
     iterator to the source point.  If no source point was reachable (can
     occur when the graph is disconnected), the distance will be a negative
     value and the source point iterator will be equal to `source_points_end()`.
   */
-  Shortest_path_result shortest_distance_to_source_points(face_descriptor f, Barycentric_coordinate location)
+  Shortest_path_result shortest_distance_to_source_points(face_descriptor f, Barycentric_coordinates location)
   {
     build_sequence_tree();
 
-    std::pair<Node_distance_pair, Barycentric_coordinate> result = nearest_to_location(f, location);
+    std::pair<Node_distance_pair, Barycentric_coordinates> result = nearest_to_location(f, location);
 
     Cone_tree_node* current = result.first.first;
 
@@ -2347,7 +2352,7 @@ public:
   (not even for the query point).
 
   \param f A face of the input face graph
-  \param location Barycentric coordinate of the query point on face `f`
+  \param location Barycentric coordinates of the query point on face `f`
   \param visitor A model of `SurfaceMeshShortestPathVisitor` to receive the shortest path
   \return A pair, containing the distance to the source point, and an
     iterator to the source point.  If no source point was reachable (can
@@ -2356,11 +2361,11 @@ public:
   */
   template <class Visitor>
   Shortest_path_result
-  shortest_path_sequence_to_source_points(face_descriptor f, Barycentric_coordinate location, Visitor& visitor)
+  shortest_path_sequence_to_source_points(face_descriptor f, Barycentric_coordinates location, Visitor& visitor)
   {
     build_sequence_tree();
 
-    std::pair<Node_distance_pair, Barycentric_coordinate> result = nearest_to_location(f, location);
+    std::pair<Node_distance_pair, Barycentric_coordinates> result = nearest_to_location(f, location);
     Cone_tree_node* current = result.first.first;
 
     if (current)
@@ -2409,7 +2414,7 @@ public:
     source point.
 
   \param f A face of on the input face graph
-  \param location The barycentric coordinate of the query point on face `f`
+  \param location The barycentric coordinates of the query point on face `f`
   \param output An OutputIterator to receive the shortest path points as `Point_3` objects
   \return A pair, containing the distance to the source point, and an
     iterator to the source point.  If no source point was reachable (can
@@ -2418,7 +2423,7 @@ public:
   */
   template <class OutputIterator>
   Shortest_path_result
-  shortest_path_points_to_source_points(face_descriptor f, Barycentric_coordinate location, OutputIterator output)
+  shortest_path_points_to_source_points(face_descriptor f, Barycentric_coordinates location, OutputIterator output)
   {
     build_sequence_tree();
 
@@ -2432,30 +2437,30 @@ public:
   /// @{
 
   /*!
-  \brief Returns the 3-dimensional coordinate at the barycentric coordinate
+  \brief Returns the 3-dimensional coordinates at the barycentric coordinates
     of the given face.
 
   \details The following static overloads are also available:
-    - `static Point_3 point(face_descriptor f, Barycentric_coordinate location, const Triangle_mesh& tm, const Traits& traits = Traits())`
-    - `static Point_3 point(face_descriptor f, Barycentric_coordinate location, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())`
+    - `static Point_3 point(face_descriptor f, Barycentric_coordinates location, const Triangle_mesh& tm, const Traits& traits = Traits())`
+    - `static Point_3 point(face_descriptor f, Barycentric_coordinates location, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())`
 
   \param f A face of on the input face graph
-  \param location The barycentric coordinate of the query point on face `f`
+  \param location The barycentric coordinates of the query point on face `f`
   */
-  Point_3 point(face_descriptor f, Barycentric_coordinate location) const
+  Point_3 point(face_descriptor f, Barycentric_coordinates location) const
   {
     return point(f, location, m_graph, m_vertexPointMap, m_traits);
   }
 
   /// \cond
 
-  static Point_3 point(face_descriptor f, Barycentric_coordinate location, const Triangle_mesh& tm, const Traits& traits = Traits())
+  static Point_3 point(face_descriptor f, Barycentric_coordinates location, const Triangle_mesh& tm, const Traits& traits = Traits())
   {
     using boost::get;
     return point(f, location, tm, get(CGAL::vertex_point, tm), traits);
   }
 
-  static Point_3 point(face_descriptor f, Barycentric_coordinate location, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
+  static Point_3 point(face_descriptor f, Barycentric_coordinates location, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
   {
     return construct_barycenter_in_triangle_3(triangle_from_face(f, tm, vertexPointMap), location, traits);
   }
@@ -2463,7 +2468,7 @@ public:
   /// \endcond
 
   /*!
-  \brief Returns the 3-dimensional coordinate at the parametric location
+  \brief Returns the 3-dimensional coordinates at the parametric location
     along the given edge.
 
   \details The following static overloads are also available:
@@ -2490,14 +2495,14 @@ public:
   {
     typename Traits::Construct_barycenter_3 construct_barycenter_3(traits.construct_barycenter_3_object());
 
-    // Note: the parameter t is meant to be the weighted coordinate on the _endpoint_ (i.e. target) of the segment
+    // Note: the parameter t is meant to be the weighted coordinates on the _endpoint_ (i.e. target) of the segment
     return construct_barycenter_3(get(vertexPointMap, target(edge, tm)), t, get(vertexPointMap, source(edge, tm)));
   }
 
   /// \endcond
 
   /*!
-  \brief Returns the 3-dimensional coordinate of the given vertex.
+  \brief Returns the 3-dimensional coordinates of the given vertex.
 
   \param vertex A vertex of the input face graph
   */
@@ -2528,7 +2533,7 @@ public:
 
   static Face_location face_location(vertex_descriptor vertex, const Triangle_mesh& tm, const Traits& traits = Traits())
   {
-    typename Traits::Construct_barycentric_coordinate construct_barycentric_coordinate(traits.construct_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates construct_barycentric_coordinates(traits.construct_barycentric_coordinates_object());
     halfedge_descriptor he = next(halfedge(vertex, tm), tm);
     face_descriptor locationFace = face(he, tm);
     std::size_t edgeIndex = CGAL::internal::edge_index(he, tm);
@@ -2537,7 +2542,7 @@ public:
 
     coords[edgeIndex] = FT(1.0);
 
-    return Face_location(locationFace, construct_barycentric_coordinate(coords[0], coords[1], coords[2]));
+    return Face_location(locationFace, construct_barycentric_coordinates(coords[0], coords[1], coords[2]));
   }
 
   /// \endcond
@@ -2560,7 +2565,7 @@ public:
 
   static Face_location face_location(halfedge_descriptor he, FT t, const Triangle_mesh& tm, const Traits& traits = Traits())
   {
-    typename Traits::Construct_barycentric_coordinate cbc(traits.construct_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates cbc(traits.construct_barycentric_coordinates_object());
     face_descriptor locationFace = face(he, tm);
     std::size_t edgeIndex = CGAL::internal::edge_index(he, tm);
 
@@ -2635,11 +2640,11 @@ public:
   template <class AABBTraits>
   static Face_location locate(const Point_3& location, const AABB_tree<AABBTraits>& tree, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
   {
-    typename Traits::Construct_barycentric_coordinate_in_triangle_3 cbcit3(traits.construct_barycentric_coordinate_in_triangle_3_object());
+    typename Traits::Construct_barycentric_coordinates_in_triangle_3 cbcit3(traits.construct_barycentric_coordinates_in_triangle_3_object());
     typename AABB_tree<AABBTraits>::Point_and_primitive_id result = tree.closest_point_and_primitive(location);
 
     face_descriptor f = result.second;
-    Barycentric_coordinate b = cbcit3(triangle_from_face(f, tm, vertexPointMap), result.first);
+    Barycentric_coordinates b = cbcit3(triangle_from_face(f, tm, vertexPointMap), result.first);
     return Face_location(f, b);
   }
 
@@ -2701,8 +2706,8 @@ public:
   static Face_location locate(const Ray_3& ray, const AABB_tree<AABBTraits>& tree, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
   {
     typedef AABB_tree<AABBTraits> AABB_face_graph_tree;
-    typename Traits::Construct_barycentric_coordinate_in_triangle_3 cbcit3(traits.construct_barycentric_coordinate_in_triangle_3_object());
-    typename Traits::Construct_barycentric_coordinate cbc(traits.construct_barycentric_coordinate_object());
+    typename Traits::Construct_barycentric_coordinates_in_triangle_3 cbcit3(traits.construct_barycentric_coordinates_in_triangle_3_object());
+    typename Traits::Construct_barycentric_coordinates cbc(traits.construct_barycentric_coordinates_object());
     typename Traits::Compute_squared_distance_3 csd3(traits.compute_squared_distance_3_object());
     typedef typename AABB_face_graph_tree::template Intersection_and_primitive_id<Ray_3>::Type Intersection_type;
     typedef boost::optional<Intersection_type> Ray_intersection;
@@ -2739,7 +2744,7 @@ public:
 
     if (foundOne)
     {
-      Barycentric_coordinate b = cbcit3(triangle_from_face(nearestFace, tm, vertexPointMap), nearestPoint);
+      Barycentric_coordinates b = cbcit3(triangle_from_face(nearestFace, tm, vertexPointMap), nearestPoint);
       return Face_location(nearestFace, b);
     }
     else

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits.h
@@ -57,24 +57,23 @@ public:
 
   typedef typename Kernel::FT FT;
 
-  /// Barycentric coordinate type
-  typedef typename CGAL::cpp11::array<FT,3> Barycentric_coordinate;
+  /// Barycentric coordinates type
+  typedef typename CGAL::cpp11::array<FT,3> Barycentric_coordinates;
 
   // Predicates
-public:
   typedef typename Surface_mesh_shortest_paths_3::Compare_relative_intersection_along_segment_2<Kernel> Compare_relative_intersection_along_segment_2;
   typedef typename Surface_mesh_shortest_paths_3::Is_saddle_vertex<Kernel, Triangle_mesh> Is_saddle_vertex;
 
   // Constructions
 public:
-  class Construct_barycentric_coordinate
+  class Construct_barycentric_coordinates
   {
   public:
-    typedef Barycentric_coordinate result_type;
+    typedef Barycentric_coordinates result_type;
 
     result_type operator() (const FT& a, const FT& b, const FT& c) const
     {
-      Barycentric_coordinate output;
+      Barycentric_coordinates output;
       output[0] = a;
       output[1] = b;
       output[2] = c;
@@ -82,12 +81,12 @@ public:
     }
   };
 
-  class Construct_barycentric_coordinate_weight
+  class Construct_barycentric_coordinates_weight
   {
   public:
     typedef FT result_type;
 
-    result_type operator() (const Barycentric_coordinate b, std::size_t i) const
+    result_type operator() (const Barycentric_coordinates b, std::size_t i) const
     {
       return b[i % 3];
     }
@@ -96,19 +95,19 @@ public:
   typedef typename Surface_mesh_shortest_paths_3::Construct_triangle_3_to_triangle_2_projection<K> Construct_triangle_3_to_triangle_2_projection;
   typedef typename Surface_mesh_shortest_paths_3::Construct_triangle_3_along_segment_2_flattening<K> Construct_triangle_3_along_segment_2_flattening;
   typedef typename Surface_mesh_shortest_paths_3::Compute_parametric_distance_along_segment_2<K> Compute_parametric_distance_along_segment_2;
-  typedef typename Surface_mesh_shortest_paths_3::Construct_barycentric_coordinate_in_triangle_2<K, Barycentric_coordinate, Construct_barycentric_coordinate> Construct_barycentric_coordinate_in_triangle_2;
-  typedef typename Surface_mesh_shortest_paths_3::Construct_barycentric_coordinate_in_triangle_3<K, Barycentric_coordinate, Construct_barycentric_coordinate> Construct_barycentric_coordinate_in_triangle_3;
-  typedef typename Surface_mesh_shortest_paths_3::Classify_barycentric_coordinate<Barycentric_coordinate, Construct_barycentric_coordinate_weight> Classify_barycentric_coordinate;
+  typedef typename Surface_mesh_shortest_paths_3::Construct_barycentric_coordinates_in_triangle_2<K, Barycentric_coordinates, Construct_barycentric_coordinates> Construct_barycentric_coordinates_in_triangle_2;
+  typedef typename Surface_mesh_shortest_paths_3::Construct_barycentric_coordinates_in_triangle_3<K, Barycentric_coordinates, Construct_barycentric_coordinates> Construct_barycentric_coordinates_in_triangle_3;
+  typedef typename Surface_mesh_shortest_paths_3::Classify_barycentric_coordinates<Barycentric_coordinates, Construct_barycentric_coordinates_weight> Classify_barycentric_coordinates;
 
 private:
   Kernel m_kernel;
-  Construct_barycentric_coordinate m_construct_barycentric_coordinate_object;
-  Construct_barycentric_coordinate_weight m_construct_barycentric_coordinate_weight_object;
-  Classify_barycentric_coordinate m_classify_barycentric_coordinate_object;
+  Construct_barycentric_coordinates m_construct_barycentric_coordinates_object;
+  Construct_barycentric_coordinates_weight m_construct_barycentric_coordinates_weight_object;
+  Classify_barycentric_coordinates m_classify_barycentric_coordinates_object;
   Construct_triangle_3_to_triangle_2_projection m_construct_triangle_3_to_triangle_2_projection_object;
   Construct_triangle_3_along_segment_2_flattening m_construct_triangle_3_along_segment_2_flattening_object;
-  Construct_barycentric_coordinate_in_triangle_2 m_construct_barycentric_coordinate_in_triangle_2_object;
-  Construct_barycentric_coordinate_in_triangle_3 m_construct_barycentric_coordinate_in_triangle_3_object;
+  Construct_barycentric_coordinates_in_triangle_2 m_construct_barycentric_coordinates_in_triangle_2_object;
+  Construct_barycentric_coordinates_in_triangle_3 m_construct_barycentric_coordinates_in_triangle_3_object;
   Compare_relative_intersection_along_segment_2 m_compare_relative_intersection_along_segment_2_object;
   Is_saddle_vertex m_is_saddle_vertex_object;
   Compute_parametric_distance_along_segment_2 m_compute_parametric_distance_along_segment_2_object;
@@ -121,32 +120,49 @@ public:
 
   Surface_mesh_shortest_path_traits(const Kernel& kernel)
     : m_kernel(kernel)
-    , m_classify_barycentric_coordinate_object(m_construct_barycentric_coordinate_weight_object)
+    , m_classify_barycentric_coordinates_object(m_construct_barycentric_coordinates_weight_object)
     , m_construct_triangle_3_to_triangle_2_projection_object(m_kernel)
     , m_construct_triangle_3_along_segment_2_flattening_object(m_kernel)
     , m_is_saddle_vertex_object(m_kernel, m_construct_triangle_3_to_triangle_2_projection_object, m_construct_triangle_3_along_segment_2_flattening_object)
     , m_compare_relative_intersection_along_segment_2_object(m_kernel)
-    , m_construct_barycentric_coordinate_in_triangle_2_object(m_construct_barycentric_coordinate_object, m_kernel.construct_vector_2_object(), m_kernel.compute_scalar_product_2_object())
-    , m_construct_barycentric_coordinate_in_triangle_3_object(m_construct_barycentric_coordinate_object, m_kernel.construct_vector_3_object(), m_kernel.compute_scalar_product_3_object())
+    , m_construct_barycentric_coordinates_in_triangle_2_object(m_construct_barycentric_coordinates_object, m_kernel.construct_vector_2_object(), m_kernel.compute_scalar_product_2_object())
+    , m_construct_barycentric_coordinates_in_triangle_3_object(m_construct_barycentric_coordinates_object, m_kernel.construct_vector_3_object(), m_kernel.compute_scalar_product_3_object())
   {
   }
 
-  Construct_barycentric_coordinate construct_barycentric_coordinate_object() const { return m_construct_barycentric_coordinate_object; }
-  Construct_barycentric_coordinate_weight construct_barycentric_coordinate_weight_object() const { return m_construct_barycentric_coordinate_weight_object; }
-  Classify_barycentric_coordinate classify_barycentric_coordinate_object() const { return m_classify_barycentric_coordinate_object; }
+  Construct_barycentric_coordinates construct_barycentric_coordinates_object() const { return m_construct_barycentric_coordinates_object; }
+  Construct_barycentric_coordinates_weight construct_barycentric_coordinates_weight_object() const { return m_construct_barycentric_coordinates_weight_object; }
+  Classify_barycentric_coordinates classify_barycentric_coordinates_object() const { return m_classify_barycentric_coordinates_object; }
 
   Is_saddle_vertex is_saddle_vertex_object() const { return m_is_saddle_vertex_object; }
 
   Compare_relative_intersection_along_segment_2 compare_relative_intersection_along_segment_2_object() const { return m_compare_relative_intersection_along_segment_2_object; }
   Construct_triangle_3_to_triangle_2_projection construct_triangle_3_to_triangle_2_projection_object() const { return m_construct_triangle_3_to_triangle_2_projection_object; }
   Construct_triangle_3_along_segment_2_flattening construct_triangle_3_along_segment_2_flattening_object() const { return m_construct_triangle_3_along_segment_2_flattening_object; }
-  Construct_barycentric_coordinate_in_triangle_2 construct_barycentric_coordinate_in_triangle_2_object() const { return m_construct_barycentric_coordinate_in_triangle_2_object; }
-  Construct_barycentric_coordinate_in_triangle_3 construct_barycentric_coordinate_in_triangle_3_object() const { return m_construct_barycentric_coordinate_in_triangle_3_object; }
+  Construct_barycentric_coordinates_in_triangle_2 construct_barycentric_coordinates_in_triangle_2_object() const { return m_construct_barycentric_coordinates_in_triangle_2_object; }
+  Construct_barycentric_coordinates_in_triangle_3 construct_barycentric_coordinates_in_triangle_3_object() const { return m_construct_barycentric_coordinates_in_triangle_3_object; }
   Compute_parametric_distance_along_segment_2 compute_parametric_distance_along_segment_2_object() const { return m_compute_parametric_distance_along_segment_2_object; }
+
+  #ifndef CGAL_NO_DEPRECATED_CODE
+  //deprecated in CGAL 4.10
+  typedef Barycentric_coordinates Barycentric_coordinate;
+  typedef Construct_barycentric_coordinates_weight Construct_barycentric_coordinate_weight;
+  typedef Construct_barycentric_coordinates Construct_barycentric_coordinate;
+  typedef Construct_barycentric_coordinates_in_triangle_2 Construct_barycentric_coordinate_in_triangle_2;
+  typedef Construct_barycentric_coordinates_in_triangle_3 Construct_barycentric_coordinate_in_triangle_3;
+  typedef Classify_barycentric_coordinates Classify_barycentric_coordinate;
+
+  Construct_barycentric_coordinates construct_barycentric_coordinate_object() const { return m_construct_barycentric_coordinates_object; }
+  Construct_barycentric_coordinates_weight construct_barycentric_coordinate_weight_object() const { return m_construct_barycentric_coordinates_weight_object; }
+  Classify_barycentric_coordinates classify_barycentric_coordinate_object() const { return m_classify_barycentric_coordinates_object; }
+  Construct_barycentric_coordinates_in_triangle_2 construct_barycentric_coordinate_in_triangle_2_object() const { return m_construct_barycentric_coordinates_in_triangle_2_object; }
+  Construct_barycentric_coordinates_in_triangle_3 construct_barycentric_coordinate_in_triangle_3_object() const { return m_construct_barycentric_coordinates_in_triangle_3_object; }
+  #endif
+
 };
 
 template <class Kernel, class Triangle_mesh>
-std::ostream& operator<<(std::ostream& os, typename Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh>::Barycentric_coordinate b)
+std::ostream& operator<<(std::ostream& os, typename Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh>::Barycentric_coordinates b)
 {
   return os << b[0] << " " << b[1] << " " << b[2];
 }

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/barycentric.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/barycentric.h
@@ -29,8 +29,8 @@ namespace CGAL {
 
 namespace Surface_mesh_shortest_paths_3 {
 
-template <class K, class B, class Construct_barycentric_coordinate>
-class Construct_barycentric_coordinate_in_triangle_2
+template <class K, class B, class Construct_barycentric_coordinates>
+class Construct_barycentric_coordinates_in_triangle_2
 {
 public:
   typedef typename K::FT FT;
@@ -44,17 +44,17 @@ public:
   typedef B result_type;
 
 private:
-  Construct_barycentric_coordinate m_construct_barycentric_coordinate;
+  Construct_barycentric_coordinates m_construct_barycentric_coordinates;
   Construct_vector_2 m_construct_vector_2;
   Compute_scalar_product_2 m_compute_scalar_product_2;
 
 public:
-  Construct_barycentric_coordinate_in_triangle_2()
+  Construct_barycentric_coordinates_in_triangle_2()
   {
   }
 
-  Construct_barycentric_coordinate_in_triangle_2(const Construct_barycentric_coordinate& cbc, const Construct_vector_2& cv2, const Compute_scalar_product_2& csp2)
-    : m_construct_barycentric_coordinate(cbc)
+  Construct_barycentric_coordinates_in_triangle_2(const Construct_barycentric_coordinates& cbc, const Construct_vector_2& cv2, const Compute_scalar_product_2& csp2)
+    : m_construct_barycentric_coordinates(cbc)
     , m_construct_vector_2(cv2)
     , m_compute_scalar_product_2(csp2)
   {
@@ -76,12 +76,12 @@ public:
 
     FT v = (d11 * d20 - d01 * d21) / denom;
     FT w = (d00 * d21 - d01 * d20) / denom;
-    return m_construct_barycentric_coordinate(FT(1.0) - v - w, v, w);
+    return m_construct_barycentric_coordinates(FT(1.0) - v - w, v, w);
   }
 };
 
-template <class K, class B, class Construct_barycentric_coordinate>
-class Construct_barycentric_coordinate_in_triangle_3
+template <class K, class B, class Construct_barycentric_coordinates>
+class Construct_barycentric_coordinates_in_triangle_3
 {
 public:
   typedef typename K::FT FT;
@@ -95,17 +95,17 @@ public:
   typedef B result_type;
 
 private:
-  Construct_barycentric_coordinate m_construct_barycentric_coordinate;
+  Construct_barycentric_coordinates m_construct_barycentric_coordinates;
   Construct_vector_3 m_construct_vector_3;
   Compute_scalar_product_3 m_compute_scalar_product_3;
 
 public:
-  Construct_barycentric_coordinate_in_triangle_3()
+  Construct_barycentric_coordinates_in_triangle_3()
   {
   }
 
-  Construct_barycentric_coordinate_in_triangle_3(const Construct_barycentric_coordinate& cbc, const Construct_vector_3& cv3, const Compute_scalar_product_3& csp3)
-    : m_construct_barycentric_coordinate(cbc)
+  Construct_barycentric_coordinates_in_triangle_3(const Construct_barycentric_coordinates& cbc, const Construct_vector_3& cv3, const Compute_scalar_product_3& csp3)
+    : m_construct_barycentric_coordinates(cbc)
     , m_construct_vector_3(cv3)
     , m_compute_scalar_product_3(csp3)
   {
@@ -127,58 +127,71 @@ public:
 
     FT v = (d11 * d20 - d01 * d21) / denom;
     FT w = (d00 * d21 - d01 * d20) / denom;
-    return m_construct_barycentric_coordinate(FT(1.0) - v - w, v, w);
+    return m_construct_barycentric_coordinates(FT(1.0) - v - w, v, w);
   }
 };
 
 /*!
-  \brief Classification of the location of a 3-tuple barycentric coordinate in a triangle
+  \brief Classification of the location of a 3-tuple barycentric coordinates in a triangle
 */
-enum Barycentric_coordinate_type
+enum Barycentric_coordinates_type
 {
-  /// If the coordinate is invalid
-  BARYCENTRIC_COORDINATE_INVALID = 0,
-  /// if the coordinate has exactly one non-zero weight equal to 1, and the rest are zero
-  BARYCENTRIC_COORDINATE_ON_VERTEX,
-  ///if the coordinate has exactly one zero weight, and the rest sum to 1
-  BARYCENTRIC_COORDINATE_ON_BOUNDARY,
-  /// if the coordinate has no non-zero weight, and they all sum to 1
-  BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE,
-  /// if the weights of the coordinate do not sum to 1
-  BARYCENTRIC_COORDINATE_ON_UNBOUNDED_SIDE
+  /// If the coordinates is invalid
+  BARYCENTRIC_COORDINATES_INVALID = 0,
+  /// if the coordinates has exactly one non-zero weight equal to 1, and the rest are zero
+  BARYCENTRIC_COORDINATES_ON_VERTEX,
+  ///if the coordinates has exactly one zero weight, and the rest sum to 1
+  BARYCENTRIC_COORDINATES_ON_BOUNDARY,
+  /// if the coordinates has no non-zero weight, and they all sum to 1
+  BARYCENTRIC_COORDINATES_ON_BOUNDED_SIDE,
+  /// if the weights of the coordinates do not sum to 1
+  BARYCENTRIC_COORDINATES_ON_UNBOUNDED_SIDE
+  #ifndef CGAL_NO_DEPRECATED_CODE
+  // deprecated in CGAL 4.10
+  , BARYCENTRIC_COORDINATE_INVALID = 0
+  , BARYCENTRIC_COORDINATE_ON_VERTEX
+  , BARYCENTRIC_COORDINATE_ON_BOUNDARY
+  , BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE
+  , BARYCENTRIC_COORDINATE_ON_UNBOUNDED_SIDE
+  #endif
 };
 
-template <class B, class Construct_barycentric_coordinate_weight>
-class Classify_barycentric_coordinate
+#ifndef CGAL_NO_DEPRECATED_CODE
+// deprecated in CGAL 4.10
+typedef Barycentric_coordinates_type Barycentric_coordinate_type;
+#endif
+
+template <class B, class Construct_barycentric_coordinates_weight>
+class Classify_barycentric_coordinates
 {
 public:
-  typedef B Barycentric_coordinate;
-  typedef std::pair<Barycentric_coordinate_type, std::size_t> result_type;
+  typedef B Barycentric_coordinates;
+  typedef std::pair<Barycentric_coordinates_type, std::size_t> result_type;
 
 private:
-  Construct_barycentric_coordinate_weight m_construct_barycentric_coordinate_weight;
+  Construct_barycentric_coordinates_weight m_construct_barycentric_coordinates_weight;
 
 public:
 
-  Classify_barycentric_coordinate()
+  Classify_barycentric_coordinates()
   {
   }
 
-  Classify_barycentric_coordinate(const Construct_barycentric_coordinate_weight& construct_barycentric_coordinate_weight)
-    : m_construct_barycentric_coordinate_weight(construct_barycentric_coordinate_weight)
+  Classify_barycentric_coordinates(const Construct_barycentric_coordinates_weight& construct_barycentric_coordinates_weight)
+    : m_construct_barycentric_coordinates_weight(construct_barycentric_coordinates_weight)
   {
   }
 
-  result_type operator()(const Barycentric_coordinate& baryCoords)
+  result_type operator()(const Barycentric_coordinates& baryCoords)
   {
-    Construct_barycentric_coordinate_weight cbcw;
+    Construct_barycentric_coordinates_weight cbcw;
 
     bool nonZero[3];
     std::size_t numNonZero = 0;
 
     if (cbcw(baryCoords, 0) + cbcw(baryCoords, 1) + cbcw(baryCoords, 2) > 1.00001 || cbcw(baryCoords, 0) + cbcw(baryCoords, 1) + cbcw(baryCoords, 2) < 0.99999)
     {
-      return std::make_pair(BARYCENTRIC_COORDINATE_ON_UNBOUNDED_SIDE, 0);
+      return std::make_pair(BARYCENTRIC_COORDINATES_ON_UNBOUNDED_SIDE, 0);
     }
 
     for (std::size_t i = 0; i < 3; ++i)
@@ -193,7 +206,7 @@ public:
 
     if (numNonZero == 3)
     {
-      return std::make_pair(BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE, 0);
+      return std::make_pair(BARYCENTRIC_COORDINATES_ON_BOUNDED_SIDE, 0);
     }
     else if (numNonZero == 2)
     {
@@ -212,7 +225,7 @@ public:
         associatedEdge = 0;
       }
 
-      return std::make_pair(BARYCENTRIC_COORDINATE_ON_BOUNDARY, associatedEdge);
+      return std::make_pair(BARYCENTRIC_COORDINATES_ON_BOUNDARY, associatedEdge);
     }
     else if (numNonZero == 1)
     {
@@ -231,11 +244,11 @@ public:
         associatedEdge = 2;
       }
 
-      return std::make_pair(BARYCENTRIC_COORDINATE_ON_VERTEX, associatedEdge);
+      return std::make_pair(BARYCENTRIC_COORDINATES_ON_VERTEX, associatedEdge);
     }
     else
     {
-      return std::make_pair(BARYCENTRIC_COORDINATE_INVALID, 0);
+      return std::make_pair(BARYCENTRIC_COORDINATES_INVALID, 0);
     }
   }
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
@@ -30,7 +30,7 @@ void shortest_path_regular_tetrahedron()
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef boost::graph_traits<Polyhedron_3> Graph_traits;
   typedef Graph_traits::vertex_iterator vertex_iterator;
@@ -40,7 +40,7 @@ void shortest_path_regular_tetrahedron()
 
   Traits traits;
 
-  Traits::Construct_barycentric_coordinate construct_barycentric_coordinate(traits.construct_barycentric_coordinate_object());
+  Traits::Construct_barycentric_coordinates construct_barycentric_coordinates(traits.construct_barycentric_coordinates_object());
 
   Polyhedron_3 P;
 
@@ -48,7 +48,7 @@ void shortest_path_regular_tetrahedron()
 
   CGAL::set_halfedgeds_items_id(P);
 
-  Barycentric_coordinate b = construct_barycentric_coordinate(FT(1.0) / FT(3.0), FT(1.0) / FT(3.0), FT(1.0) / FT(3.0));
+  Barycentric_coordinates b = construct_barycentric_coordinates(FT(1.0) / FT(3.0), FT(1.0) / FT(3.0), FT(1.0) / FT(3.0));
 
   face_iterator startFace;
   face_iterator endFace;
@@ -87,7 +87,7 @@ void test_simple_saddle_vertex_mesh()
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef Traits::Point_3 Point_3;
   typedef Traits::Point_2 Point_2;
@@ -107,7 +107,7 @@ void test_simple_saddle_vertex_mesh()
   Traits::Compute_squared_distance_3 compute_squared_distance_3(traits.compute_squared_distance_3_object());
   Traits::Compute_squared_distance_2 compute_squared_distance_2(traits.compute_squared_distance_2_object());
   Traits::Construct_triangle_3_along_segment_2_flattening flatten_triangle_3_along_segment_2(traits.construct_triangle_3_along_segment_2_flattening_object());
-  Traits::Construct_barycentric_coordinate construct_barycentric_coordinate(traits.construct_barycentric_coordinate_object());
+  Traits::Construct_barycentric_coordinates construct_barycentric_coordinates(traits.construct_barycentric_coordinates_object());
 
   std::ifstream inFile("data/saddle_vertex_mesh.off");
 
@@ -130,7 +130,7 @@ void test_simple_saddle_vertex_mesh()
 
   face_descriptor currentFace = CGAL::face(CGAL::halfedge(rootSearchVertex, P), P);
   size_t vertexIndex = CGAL::test::face_vertex_index(currentFace, rootSearchVertex, P);
-  Barycentric_coordinate baryCoord = construct_barycentric_coordinate(vertexIndex == 0 ? FT(1.0) : FT(0.0), vertexIndex == 1 ? FT(1.0) : FT(0.0), vertexIndex == 2 ? FT(1.0) : FT(0.0));
+  Barycentric_coordinates baryCoord = construct_barycentric_coordinates(vertexIndex == 0 ? FT(1.0) : FT(0.0), vertexIndex == 1 ? FT(1.0) : FT(0.0), vertexIndex == 2 ? FT(1.0) : FT(0.0));
 
   Surface_mesh_shortest_path shortestPaths(P, traits);
   //shortestPaths.m_debugOutput = true;
@@ -217,10 +217,10 @@ void test_simple_saddle_vertex_mesh()
 
   size_t edgeIndex = CGAL::internal::edge_index(firstCrossing, P);
 
-  Barycentric_coordinate location = construct_barycentric_coordinate(0.25, 0.5, 0.25);
+  Barycentric_coordinates location = construct_barycentric_coordinates(0.25, 0.5, 0.25);
 
   collector.m_sequence.clear();
-  shortestPaths.shortest_path_sequence_to_source_points(CGAL::face(firstCrossing, P), construct_barycentric_coordinate(location[edgeIndex], location[(edgeIndex + 1) % 3], location[(edgeIndex + 2) % 3]), collector);
+  shortestPaths.shortest_path_sequence_to_source_points(CGAL::face(firstCrossing, P), construct_barycentric_coordinates(location[edgeIndex], location[(edgeIndex + 1) % 3], location[(edgeIndex + 2) % 3]), collector);
 
   CHECK_EQUAL(collector.m_sequence.size(), 4u);
   CHECK_EQUAL(collector.m_sequence[1].type, CGAL::test::SEQUENCE_ITEM_EDGE);
@@ -242,7 +242,7 @@ void test_simple_saddle_vertex_mesh()
 
   face_descriptor currentFace2 = CGAL::face(CGAL::halfedge(rootSearchVertex2, P), P);
   size_t vertexIndex2 = CGAL::test::face_vertex_index(currentFace2, rootSearchVertex2, P);
-  Barycentric_coordinate baryCoord2 = construct_barycentric_coordinate(vertexIndex2 == 0 ? FT(1.0) : FT(0.0), vertexIndex2 == 1 ? FT(1.0) : FT(0.0), vertexIndex2 == 2 ? FT(1.0) : FT(0.0));
+  Barycentric_coordinates baryCoord2 = construct_barycentric_coordinates(vertexIndex2 == 0 ? FT(1.0) : FT(0.0), vertexIndex2 == 1 ? FT(1.0) : FT(0.0), vertexIndex2 == 2 ? FT(1.0) : FT(0.0));
 
   Surface_mesh_shortest_path::Source_point_iterator secondSourcePoint = shortestPaths.add_source_point(currentFace2, baryCoord2);
   shortestPaths.build_sequence_tree();
@@ -320,7 +320,7 @@ void test_boundary_mesh()
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef Traits::Point_3 Point_3;
   typedef Traits::Triangle_3 Triangle_3;
@@ -340,7 +340,7 @@ void test_boundary_mesh()
   Traits::Construct_barycenter_3 construct_barycenter_3(traits.construct_barycenter_3_object());
   Traits::Construct_triangle_3_along_segment_2_flattening flatten_triangle_3_along_segment_2(traits.construct_triangle_3_along_segment_2_flattening_object());
   CGAL_USE(flatten_triangle_3_along_segment_2);
-  Traits::Construct_barycentric_coordinate construct_barycentric_coordinate(traits.construct_barycentric_coordinate_object());
+  Traits::Construct_barycentric_coordinates construct_barycentric_coordinates(traits.construct_barycentric_coordinates_object());
 
   struct Construct_barycenter_in_triangle_3
   {
@@ -351,7 +351,7 @@ void test_boundary_mesh()
     {
     }
 
-    Point_3 operator() (const Triangle_3& t, const Barycentric_coordinate& b)
+    Point_3 operator() (const Triangle_3& t, const Barycentric_coordinates& b)
     {
       return m_cb3(t[0], b[0], t[1], b[1], t[2], b[2]);
     }
@@ -397,7 +397,7 @@ void test_boundary_mesh()
     ++currentFaceIndex;
   }
 
-  Barycentric_coordinate startLocation = construct_barycentric_coordinate(FT(0.1), FT(0.8), FT(0.1));
+  Barycentric_coordinates startLocation = construct_barycentric_coordinates(FT(0.1), FT(0.8), FT(0.1));
 
   typedef boost::property_map<Polyhedron_3, CGAL::face_external_index_t>::type FaceIndexMap;
 
@@ -430,13 +430,13 @@ void test_boundary_mesh()
   FT dist5 = shortestPaths.shortest_distance_to_source_points(vertexHandles[5]).first;
   CHECK_CLOSE(dist5, CGAL::sqrt(compute_squared_distance_3(locationInTriangle, vertexLocations[3])) + CGAL::sqrt(compute_squared_distance_3(vertexLocations[3], vertexLocations[5])), FT(0.000001));
 
-  Barycentric_coordinate somewhereElseInFirstTriangle = construct_barycentric_coordinate(0.8, 0.05, 0.15);
+  Barycentric_coordinates somewhereElseInFirstTriangle = construct_barycentric_coordinates(0.8, 0.05, 0.15);
 
   FT distT0 = shortestPaths.shortest_distance_to_source_points(faceHandles[0], somewhereElseInFirstTriangle).first;
   CHECK_CLOSE(distT0, CGAL::sqrt(compute_squared_distance_3(locationInTriangle, construct_barycenter_in_triangle_3(firstTriangle, somewhereElseInFirstTriangle))), FT(0.000001));
 
   Triangle_3 oneStepTriangle(vertexLocations[4], vertexLocations[1], vertexLocations[3]);
-  Barycentric_coordinate locationInOneStepTriangle = construct_barycentric_coordinate(0.1, 0.8, 0.1);
+  Barycentric_coordinates locationInOneStepTriangle = construct_barycentric_coordinates(0.1, 0.8, 0.1);
 
   CGAL::test::Edge_sequence_collector<Traits> collector(P);
   shortestPaths.shortest_path_sequence_to_source_points(faceHandles[2], locationInOneStepTriangle, collector);
@@ -445,13 +445,13 @@ void test_boundary_mesh()
   CHECK_CLOSE(distT2, dist1 + CGAL::sqrt(compute_squared_distance_3(vertexLocations[1], construct_barycenter_in_triangle_3(oneStepTriangle, locationInOneStepTriangle))), FT(0.00001));
 
   Triangle_3 twoStepTriangle(vertexLocations[6], vertexLocations[5], vertexLocations[7]);
-  Barycentric_coordinate locationInTwoStepTriangle = construct_barycentric_coordinate(0.8, 0.1, 0.1);
+  Barycentric_coordinates locationInTwoStepTriangle = construct_barycentric_coordinates(0.8, 0.1, 0.1);
 
   FT distT5 = shortestPaths.shortest_distance_to_source_points(faceHandles[5], locationInTwoStepTriangle).first;
   CHECK_CLOSE(distT5, dist3 + CGAL::sqrt(compute_squared_distance_3(vertexLocations[3], construct_barycenter_in_triangle_3(twoStepTriangle, locationInTwoStepTriangle))), FT(0.00001));
 
   Triangle_3 threeStepTriangle(vertexLocations[7], vertexLocations[5], vertexLocations[8]);
-  Barycentric_coordinate locationInThreeStepTriangle = construct_barycentric_coordinate(0.2, 0.6, 0.2);
+  Barycentric_coordinates locationInThreeStepTriangle = construct_barycentric_coordinates(0.2, 0.6, 0.2);
 
   FT distT6 = shortestPaths.shortest_distance_to_source_points(faceHandles[6], locationInThreeStepTriangle).first;
   CHECK_CLOSE(distT6, dist5 + CGAL::sqrt(compute_squared_distance_3(vertexLocations[5], construct_barycenter_in_triangle_3(threeStepTriangle, locationInThreeStepTriangle))), FT(0.00001));

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
 
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef boost::graph_traits<Polyhedron_3> Graph_traits;
   typedef Graph_traits::vertex_descriptor vertex_descriptor;
@@ -198,8 +198,8 @@ int main(int argc, char* argv[])
     face_descriptor startFace = faces[startFaceIndex];
     face_descriptor endFace = faces[endFaceIndex];
 
-    Barycentric_coordinate startLocation = CGAL::test::random_coordinate<Traits>(rand);
-    Barycentric_coordinate endLocation = CGAL::test::random_coordinate<Traits>(rand);
+    Barycentric_coordinates startLocation = CGAL::test::random_coordinates<Traits>(rand);
+    Barycentric_coordinates endLocation = CGAL::test::random_coordinates<Traits>(rand);
 
     //shortestPaths.m_debugOutput = true;
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef Traits::Point_3 Point_3;
   typedef Traits::Triangle_3 Triangle_3;
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
 
     Triangle_3 faceTriangle = CGAL::internal::triangle_from_halfedge<Triangle_3, Polyhedron_3, VPM>(halfedge(face, polyhedron), polyhedron, vertexPointMap);
 
-    Barycentric_coordinate location = CGAL::test::random_coordinate<Traits>(random);
+    Barycentric_coordinates location = CGAL::test::random_coordinates<Traits>(random);
 
     Point_3 location3d = construct_barycenter_3(faceTriangle[0], location[0], faceTriangle[1], location[1], faceTriangle[2], location[2]);
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef Traits::Point_3 Point_3;
   typedef Traits::Vector_3 Vector_3;
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 
     Triangle_3 faceTriangle = CGAL::internal::triangle_from_halfedge<Triangle_3, Polyhedron_3, VPM>(halfedge(face, polyhedron), polyhedron, vertexPointMap);
 
-    Barycentric_coordinate location = CGAL::test::random_coordinate<Traits>(random);
+    Barycentric_coordinates location = CGAL::test::random_coordinates<Traits>(random);
 
     Point_3 location3d = construct_barycenter_3(faceTriangle[0], location[0], faceTriangle[1], location[1], faceTriangle[2], location[2]);
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef Traits::FT FT;
   typedef boost::graph_traits<Polyhedron_3> Graph_traits;
   typedef Graph_traits::vertex_descriptor vertex_descriptor;
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
   for (size_t i = 0; i < numInitialLocations; ++i)
   {
     size_t faceId = rand.get_int(0, faces.size());
-    sourcePoints.push_back(Face_location(faces[faceId], CGAL::test::random_coordinate<Traits>(rand)));
+    sourcePoints.push_back(Face_location(faces[faceId], CGAL::test::random_coordinates<Traits>(rand)));
     shortestPaths.add_source_point(sourcePoints.back().first, sourcePoints.back().second);
   }
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits_test.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits_test.cpp
@@ -42,7 +42,7 @@ void project_triangle3D_to_triangle2D()
 
 }
 
-void test_simple_2D_barycentric_coordinates()
+void test_simple_2D_barycentric_coordinatess()
 {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel> Polyhedron_3;
@@ -50,9 +50,9 @@ void test_simple_2D_barycentric_coordinates()
 
   Traits traits;
 
-  Traits::Construct_barycentric_coordinate_in_triangle_2 construct_barycentric_coordinate_in_triangle_2(traits.construct_barycentric_coordinate_in_triangle_2_object());
+  Traits::Construct_barycentric_coordinates_in_triangle_2 construct_barycentric_coordinates_in_triangle_2(traits.construct_barycentric_coordinates_in_triangle_2_object());
   Traits::Construct_barycenter_2 construct_barycenter_2(traits.construct_barycenter_2_object());
-  Traits::Classify_barycentric_coordinate classify_barycentric_coordinate(traits.classify_barycentric_coordinate_object());
+  Traits::Classify_barycentric_coordinates classify_barycentric_coordinates(traits.classify_barycentric_coordinates_object());
 
   // effectively a 1-1 mapping triangle for barycentric coords
   Traits::Triangle_2 simpleTriangle(
@@ -60,53 +60,53 @@ void test_simple_2D_barycentric_coordinates()
     Traits::Point_2(Kernel::FT(1), Kernel::FT(0)),
     Traits::Point_2(Kernel::FT(0), Kernel::FT(1)));
 
-  Traits::Barycentric_coordinate b0 = construct_barycentric_coordinate_in_triangle_2(simpleTriangle, simpleTriangle[0]);
+  Traits::Barycentric_coordinates b0 = construct_barycentric_coordinates_in_triangle_2(simpleTriangle, simpleTriangle[0]);
 
   CHECK_CLOSE(Kernel::FT(1.0), b0[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b0[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b0[2], Kernel::FT(0.000001));
 
   size_t outVertex0;
-  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type b0Type;
-  boost::tie(b0Type, outVertex0) = classify_barycentric_coordinate(b0);
+  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type b0Type;
+  boost::tie(b0Type, outVertex0) = classify_barycentric_coordinates(b0);
 
-  CHECK_EQUAL(b0Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX);
+  CHECK_EQUAL(b0Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX);
   CHECK_EQUAL(outVertex0, 0u);
 
-  Traits::Barycentric_coordinate b1 = construct_barycentric_coordinate_in_triangle_2(simpleTriangle, simpleTriangle[1]);
+  Traits::Barycentric_coordinates b1 = construct_barycentric_coordinates_in_triangle_2(simpleTriangle, simpleTriangle[1]);
 
   CHECK_CLOSE(Kernel::FT(0.0), b1[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(1.0), b1[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b1[2], Kernel::FT(0.000001));
 
   size_t outVertex1;
-  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type b1Type;
-  boost::tie(b1Type, outVertex1) = classify_barycentric_coordinate(b1);
+  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type b1Type;
+  boost::tie(b1Type, outVertex1) = classify_barycentric_coordinates(b1);
 
-  CHECK_EQUAL(b1Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX);
+  CHECK_EQUAL(b1Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX);
   CHECK_EQUAL(outVertex1, 1u);
 
-  Traits::Barycentric_coordinate b2 = construct_barycentric_coordinate_in_triangle_2(simpleTriangle, simpleTriangle[2]);
+  Traits::Barycentric_coordinates b2 = construct_barycentric_coordinates_in_triangle_2(simpleTriangle, simpleTriangle[2]);
 
   CHECK_CLOSE(Kernel::FT(0.0), b2[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b2[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(1.0), b2[2], Kernel::FT(0.000001));
 
   size_t outVertex2;
-  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type b2Type;
-  boost::tie(b2Type, outVertex2) = classify_barycentric_coordinate(b2);
+  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type b2Type;
+  boost::tie(b2Type, outVertex2) = classify_barycentric_coordinates(b2);
 
-  CHECK_EQUAL(b2Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_VERTEX);
+  CHECK_EQUAL(b2Type, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_VERTEX);
   CHECK_EQUAL(outVertex2, 2u);
 
   Traits::Point_2 location(Kernel::FT(0.3), Kernel::FT(0.2));
-  Traits::Barycentric_coordinate bLocation = construct_barycentric_coordinate_in_triangle_2(simpleTriangle, location);
+  Traits::Barycentric_coordinates bLocation = construct_barycentric_coordinates_in_triangle_2(simpleTriangle, location);
 
   size_t dummyOut;
-  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinate_type bLocationType;
-  boost::tie(bLocationType, dummyOut) = classify_barycentric_coordinate(bLocation);
+  CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type bLocationType;
+  boost::tie(bLocationType, dummyOut) = classify_barycentric_coordinates(bLocation);
 
-  CHECK_EQUAL(bLocationType, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATE_ON_BOUNDED_SIDE);
+  CHECK_EQUAL(bLocationType, CGAL::Surface_mesh_shortest_paths_3::BARYCENTRIC_COORDINATES_ON_BOUNDED_SIDE);
 
   CHECK_CLOSE(Kernel::FT(1.0) - location[0] - location[1], bLocation[0], Kernel::FT(0.000001));
   CHECK_CLOSE(location[0], bLocation[1], Kernel::FT(0.000001));
@@ -125,7 +125,7 @@ void barycentric_coords_3D()
 
   Traits traits;
 
-  Traits::Construct_barycentric_coordinate_in_triangle_3 construct_barycentric_coordinate_in_triangle_3(traits.construct_barycentric_coordinate_in_triangle_3_object());
+  Traits::Construct_barycentric_coordinates_in_triangle_3 construct_barycentric_coordinates_in_triangle_3(traits.construct_barycentric_coordinates_in_triangle_3_object());
   Traits::Construct_barycenter_3 construct_barycenter_3(traits.construct_barycenter_3_object());
 
   Traits::Triangle_3 quadrantTriangle(
@@ -133,25 +133,25 @@ void barycentric_coords_3D()
     Traits::Point_3(Kernel::FT(-1.0), Kernel::FT(-1.0), Kernel::FT(-1.0)),
     Traits::Point_3(Kernel::FT(-1.0), Kernel::FT(1.0), Kernel::FT(-1.0)));
 
-  Traits::Barycentric_coordinate b0 = construct_barycentric_coordinate_in_triangle_3(quadrantTriangle, quadrantTriangle[0]);
+  Traits::Barycentric_coordinates b0 = construct_barycentric_coordinates_in_triangle_3(quadrantTriangle, quadrantTriangle[0]);
 
   CHECK_CLOSE(Kernel::FT(1.0), b0[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b0[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b0[2], Kernel::FT(0.000001));
 
-  Traits::Barycentric_coordinate b1 = construct_barycentric_coordinate_in_triangle_3(quadrantTriangle, quadrantTriangle[1]);
+  Traits::Barycentric_coordinates b1 = construct_barycentric_coordinates_in_triangle_3(quadrantTriangle, quadrantTriangle[1]);
 
   CHECK_CLOSE(Kernel::FT(0.0), b1[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(1.0), b1[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b1[2], Kernel::FT(0.000001));
 
-  Traits::Barycentric_coordinate b2 = construct_barycentric_coordinate_in_triangle_3(quadrantTriangle, quadrantTriangle[2]);
+  Traits::Barycentric_coordinates b2 = construct_barycentric_coordinates_in_triangle_3(quadrantTriangle, quadrantTriangle[2]);
 
   CHECK_CLOSE(Kernel::FT(0.0), b2[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.0), b2[1], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(1.0), b2[2], Kernel::FT(0.000001));
 
-  Traits::Barycentric_coordinate bOrigin = construct_barycentric_coordinate_in_triangle_3(quadrantTriangle, Traits::Point_3(CGAL::ORIGIN));
+  Traits::Barycentric_coordinates bOrigin = construct_barycentric_coordinates_in_triangle_3(quadrantTriangle, Traits::Point_3(CGAL::ORIGIN));
 
   CHECK_CLOSE(Kernel::FT(0.5), bOrigin[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.25), bOrigin[1], Kernel::FT(0.000001));
@@ -164,7 +164,7 @@ void barycentric_coords_3D()
   CHECK_CLOSE(Kernel::FT(0.0), originOutAgain[2], Kernel::FT(0.000001));
 
   Traits::Point_3 pNegative(Kernel::FT(-0.5), Kernel::FT(-0.5), Kernel::FT(-0.5));
-  Traits::Barycentric_coordinate bNegative = construct_barycentric_coordinate_in_triangle_3(quadrantTriangle, pNegative);
+  Traits::Barycentric_coordinates bNegative = construct_barycentric_coordinates_in_triangle_3(quadrantTriangle, pNegative);
 
   CHECK_CLOSE(Kernel::FT(0.25), bNegative[0], Kernel::FT(0.000001));
   CHECK_CLOSE(Kernel::FT(0.625), bNegative[1], Kernel::FT(0.000001));
@@ -303,7 +303,7 @@ void detect_is_saddle_vertex()
 int main()
 {
   project_triangle3D_to_triangle2D();
-  test_simple_2D_barycentric_coordinates();
+  test_simple_2D_barycentric_coordinatess();
   barycentric_coords_3D();
   simple_flattening_triangle_along_edge();
   nonsimple_flattening_triangle_along_edge();

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -47,7 +47,7 @@ struct TestMeshProgramInstance
   //typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
   typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
-  typedef typename Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef typename Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef typename Traits::FT FT;
   typedef typename Traits::Point_3 Point_3;
   typedef typename Traits::Point_2 Point_2;
@@ -86,7 +86,7 @@ struct TestMeshProgramInstance
 
   Face_location next_location(Surface_mesh_shortest_path& shortestPath, Polyhedron_3& polyhedron, const std::vector<vertex_descriptor>& vertices)
   {
-    typename Traits::Construct_barycentric_coordinate construct_barycentric_coordinate;
+    typename Traits::Construct_barycentric_coordinates construct_barycentric_coordinates;
 
     if (randomizer)
     {
@@ -122,10 +122,10 @@ struct TestMeshProgramInstance
         double alpha0, alpha1, alpha2;
         std::cin >> x >> y >> alpha0 >> alpha1 >> alpha2;
         std::pair<halfedge_descriptor, bool> he = halfedge(vertices[x], vertices[y], polyhedron);
-        return Face_location(face(he.first, polyhedron), construct_barycentric_coordinate(FT(alpha0), FT(alpha1), FT(alpha2)));
+        return Face_location(face(he.first, polyhedron), construct_barycentric_coordinates(FT(alpha0), FT(alpha1), FT(alpha2)));
       }
 
-      return Face_location(Graph_traits::null_face(), construct_barycentric_coordinate(FT(0.0), FT(0.0), FT(0.0)));
+      return Face_location(Graph_traits::null_face(), construct_barycentric_coordinates(FT(0.0), FT(0.0), FT(0.0)));
     }
   }
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/include/CGAL/test_util.h
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/include/CGAL/test_util.h
@@ -24,7 +24,7 @@ struct Sequence_item
 {
   typedef typename Traits::Triangle_mesh Triangle_mesh;
   typedef typename Traits::FT FT;
-  typedef typename Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef typename Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef typename boost::graph_traits<Triangle_mesh> Graph_traits;
   typedef typename Graph_traits::vertex_descriptor vertex_descriptor;
   typedef typename Graph_traits::halfedge_descriptor halfedge_descriptor;
@@ -32,7 +32,7 @@ struct Sequence_item
   
   Sequence_item_type type;
   size_t index;
-  Barycentric_coordinate faceAlpha;
+  Barycentric_coordinates faceAlpha;
   FT edgeAlpha;
   
   halfedge_descriptor halfedge;
@@ -48,7 +48,7 @@ struct Edge_sequence_collector
 {
   typedef typename Traits::Triangle_mesh Triangle_mesh;
   typedef typename Traits::FT FT;
-  typedef typename Traits::Barycentric_coordinate Barycentric_coordinate;
+  typedef typename Traits::Barycentric_coordinates Barycentric_coordinates;
   typedef VIM VertexIndexMap;
   typedef HIM HalfedgeIndexMap;
   typedef FIM FaceIndexMap;
@@ -96,7 +96,7 @@ struct Edge_sequence_collector
     m_sequence.push_back(item);
   }
   
-  void operator()(face_descriptor f, Barycentric_coordinate alpha)
+  void operator()(face_descriptor f, Barycentric_coordinates alpha)
   {
     Sequence_item<Traits> item;
     item.type = SEQUENCE_ITEM_FACE;
@@ -108,13 +108,13 @@ struct Edge_sequence_collector
 };
 
 template <class Traits>
-typename Traits::Barycentric_coordinate random_coordinate(CGAL::Random& rand)
+typename Traits::Barycentric_coordinates random_coordinates(CGAL::Random& rand)
 {
   typedef typename Traits::FT FT;
-  typename Traits::Construct_barycentric_coordinate construct_barycentric_coordinate;
+  typename Traits::Construct_barycentric_coordinates construct_barycentric_coordinates;
   FT u = rand.uniform_real(FT(0.0), FT(1.0));
   FT v = rand.uniform_real(FT(0.0), FT(FT(1.0) - u));
-  return construct_barycentric_coordinate(u, v, FT(FT(1.0) - u - v));
+  return construct_barycentric_coordinates(u, v, FT(FT(1.0) - u - v));
 }
 
 template <class FT>


### PR DESCRIPTION
As reported privately by @efifogel , coordinate should be plurial.

The rename comes with a fallback for deprecated code (I locally tested that example of 4.9 and previous compiles with updated headers).

CC @Hippocrates do you agree?