### PR TITLE
Followup to #1736

### DIFF
--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
@@ -129,13 +129,13 @@ configure()
 {
   echo "Configuring... "
   rm -rf CMakeCache.txt CMakeFiles/
-  echo "cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  echo "cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
  -DCGAL_DIR=\"$CGAL_DIR\" \
  -DCGAL_CXX_FLAGS:STRING=\"$TESTSUITE_CXXFLAGS -I../../include\" \
  -DCGAL_EXE_LINKER_FLAGS=\"$TESTSUITE_LDFLAGS\" \
  -DCMAKE_BUILD_TYPE=NOTFOUND \
  ."
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                     -DCGAL_DIR="$CGAL_DIR" \
                                     -DCGAL_CXX_FLAGS:STRING="$TESTSUITE_CXXFLAGS -I../../include" \
                                     -DCGAL_EXE_LINKER_FLAGS="$TESTSUITE_LDFLAGS" \

--- a/CGAL_ipelets/demo/CGAL_ipelets/cgal_test_with_cmake
+++ b/CGAL_ipelets/demo/CGAL_ipelets/cgal_test_with_cmake
@@ -26,7 +26,7 @@ configure()
 {
   echo "Configuring... "
   
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
                                      

--- a/Minkowski_sum_2/test/Minkowski_sum_2/cgal_test_with_cmake
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/cgal_test_with_cmake
@@ -26,7 +26,7 @@ configure()
 {
   echo "Configuring... "
 
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
 

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/cgal_test_with_cmake
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/cgal_test_with_cmake
@@ -49,7 +49,7 @@ configure()
 {
   echo "Configuring... "
 
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
 

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/cgal_test_with_cmake
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/cgal_test_with_cmake
@@ -49,7 +49,7 @@ configure()
 {
   echo "Configuring... "
 
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
 

--- a/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
+++ b/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
@@ -26,7 +26,7 @@ configure()
 {
   echo "Configuring... "
   
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
                                      

--- a/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
+++ b/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
@@ -25,7 +25,7 @@ configure()
 {
   echo "Configuring... "
     
-  if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
         

--- a/Sweep_line_2/test/Sweep_line_2/cgal_test_base
+++ b/Sweep_line_2/test/Sweep_line_2/cgal_test_base
@@ -32,7 +32,7 @@ configure()
 
     rm CMakeCache.txt
 
-    if eval 'cmake "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+    if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      -DCGAL_CXX_FLAGS:STRING="$TESTSUITE_CXXFLAGS" \
                                      -DCGAL_EXE_LINKER_FLAGS="$TESTSUITE_LDFLAGS" \


### PR DESCRIPTION
Add `--no-warn-unused-cli` to avoid warnings.

In #1736, I covered only `cgal_test_with_cmake` files that were auto-generated. I forgot to deal with the versions that are committed. That is the purpose of this second PR.
