### PR TITLE
Fix the patch from #1524

### DIFF
--- a/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
+++ b/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
@@ -62,10 +62,32 @@ public:
 
   typedef typename boost::graph_traits<G_copy>::vertex_descriptor
     g_copy_vertex_descriptor;
+  typedef typename boost::graph_traits<G_copy>::out_edge_iterator
+    g_copy_out_edge_iterator;
+  typedef typename boost::graph_traits<G_copy>::degree_size_type
+    g_copy_degree_size_type;
 
   bool operator()(g_copy_vertex_descriptor v1,
                   g_copy_vertex_descriptor v2) const {
-    return less(g_copy[v1], g_copy[v2]);
+    if(less(g_copy[v1], g_copy[v2]))
+      return true;
+    else if(less(g_copy[v2], g_copy[v1]))
+      return false;
+    // If g_copy[v1] and g_copy[v2] are equivalent, then compare the
+    // descriptors:
+    if(v1 == v2) return false;
+    //   - compare degrees:
+    const g_copy_degree_size_type dv1 = degree(v1, g_copy);
+    const g_copy_degree_size_type dv2 = degree(v2, g_copy);
+    if(dv1 != dv2)
+      return dv1 < dv2;
+    if(dv1 == 0) return v1 < v2;
+    ///  - then compare an adjacent vertex:
+    g_copy_vertex_descriptor other_v1 = target(*out_edges(v1, g_copy).first,
+                                               g_copy);
+    g_copy_vertex_descriptor other_v2 = target(*out_edges(v2, g_copy).first,
+                                               g_copy);
+    return less(g_copy[other_v1], g_copy[other_v2]);
   }
 }; // end class Less_on_G_copy_vertex_descriptors
 
@@ -89,20 +111,23 @@ void duplicate_terminal_vertices(Graph& graph,
   std::vector<vertex_descriptor> V(b,e);
   BOOST_FOREACH(vertex_descriptor v, V)
   {
-    if (degree(v, graph) > 2 || is_terminal(graph[v], orig))
+    typename boost::graph_traits<OrigGraph>::vertex_descriptor orig_v = graph[v];
+    CGAL_assertion(degree(v, graph) == degree(orig_v, orig));
+    if (is_terminal(orig_v, orig) || degree(v, graph) > 2)
       {
         out_edge_iterator b, e;
         boost::tie(b, e) = out_edges(v, graph);
-        std::vector<edge_descriptor> E(b, e);
-        for (unsigned int i = 1; i < E.size(); ++i)
+        std::vector<edge_descriptor> out_edges_of_v(b, e);
+        for (unsigned int i = 1; i < out_edges_of_v.size(); ++i)
           {
-            edge_descriptor e = E[i];
+            edge_descriptor e = out_edges_of_v[i];
             vertex_descriptor w = target(e, graph);
             remove_edge(e, graph);
             vertex_descriptor vc = add_vertex(graph);
-            graph[vc] = graph[v];
+            graph[vc] = orig_v;
             add_edge(vc, w, graph);
           }
+        CGAL_assertion(degree(v, graph) == 1);
       }
   }
 

--- a/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
+++ b/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
@@ -113,7 +113,6 @@ void duplicate_terminal_vertices(Graph& graph,
   {
     typename boost::graph_traits<OrigGraph>::vertex_descriptor orig_v = graph[v];
     typename boost::graph_traits<Graph>::degree_size_type deg = degree(v, graph);
-    CGAL_assertion(deg == degree(orig_v, orig));
     if ((deg != 0 && is_terminal(orig_v, orig)) || deg > 2)
       {
         out_edge_iterator b, e;

--- a/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
+++ b/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
@@ -112,8 +112,9 @@ void duplicate_terminal_vertices(Graph& graph,
   BOOST_FOREACH(vertex_descriptor v, V)
   {
     typename boost::graph_traits<OrigGraph>::vertex_descriptor orig_v = graph[v];
-    CGAL_assertion(degree(v, graph) == degree(orig_v, orig));
-    if (is_terminal(orig_v, orig) || degree(v, graph) > 2)
+    typename boost::graph_traits<Graph>::degree_size_type deg = degree(v, graph);
+    CGAL_assertion(deg == degree(orig_v, orig));
+    if ((deg != 0 && is_terminal(orig_v, orig)) || deg > 2)
       {
         out_edge_iterator b, e;
         boost::tie(b, e) = out_edges(v, graph);

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -509,7 +509,7 @@ insert_point(const Bare_point& p, const Weight& w, int dim, const Index& index,
   default:
     std::cerr << " ERROR dim=" << dim << " index=";
   }
-  std::cerr  << index << std::endl;
+  std::cerr  << CGAL::oformat(index) << std::endl;
   if(v == Vertex_handle()) std::cerr << "  HIDDEN!\n";
   std::cerr << "The weight was " << w << std::endl;
 #endif // CGAL_MESH_3_PROTECTION_DEBUG
@@ -537,7 +537,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
   std::cerr << "smart_insert_point( (" << p 
             << "), w=" << w
             << ", dim=" << dim
-            << ", index=" << index << ")\n";
+            << ", index=" << CGAL::oformat(index) << ")\n";
 #endif
   const Tr& tr = c3t3_.triangulation();
   typename Gt::Compute_squared_distance_3 sq_distance =
@@ -1211,7 +1211,7 @@ change_ball_size(const Vertex_handle& v, const FT size, const bool special_ball)
   std::cerr << "change_ball_size(v=" << (void*)(&*v) 
             << " (" << v->point()
             << ") dim=" << c3t3_.in_dimension(v) 
-            << " index=" << c3t3_.index(v)
+            << " index=" << CGAL::oformat(c3t3_.index(v))
             << " ,\n"
             << "                 size=" << size 
             << ", special_ball=" << std::boolalpha << special_ball << std::endl;
@@ -1345,7 +1345,7 @@ check_and_fix_vertex_along_edge(const Vertex_handle& v, ErasedVeOutIt out)
   std::cerr << "check_and_fix_vertex_along_edge(" 
             << (void*)(&*v) << "= (" << v->point() 
             << ") dim=" << get_dimension(v)
-            << " index=" << c3t3_.index(v)
+            << " index=" << CGAL::oformat(c3t3_.index(v))
             << " special=" << std::boolalpha << is_special(v)
             << ")\n";
 #endif
@@ -1511,7 +1511,7 @@ repopulate(InputIterator begin, InputIterator last,
             << " (" << (*last)->point() << ")\n"
             << "                  distance(begin, last)=" 
             << std::distance(begin, last) << ",\n"
-            << "           index=" << index << ")\n";
+            << "           index=" << CGAL::oformat(index) << ")\n";
 #endif
   CGAL_assertion( std::distance(begin,last) >= 0 );
   
@@ -1551,7 +1551,7 @@ repopulate(InputIterator begin, InputIterator last,
     default:
       std::cerr << " ERROR dim=" << get_dimension(*current)  << " index=";
     }
-    std::cerr  << c3t3_.index(*current) << std::endl;
+    std::cerr  << CGAL::oformat(c3t3_.index(*current)) << std::endl;
 #endif // CGAL_MESH_3_PROTECTION_DEBUG
     *out++ = *current;
     c3t3_.triangulation().remove(*current);
@@ -1587,7 +1587,7 @@ analyze_and_repopulate(InputIterator begin, InputIterator last,
             << " (" << (*last)->point() << ")\n"
             << "                              distance(begin, last)=" 
             << std::distance(begin, last) << ",\n"
-            << "                       index=" << index << ")\n";
+            << "                       index=" << CGAL::oformat(index) << ")\n";
 #endif
   CGAL_assertion( std::distance(begin,last) >= 0 );
   

--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -91,13 +91,16 @@ struct Angle_tester
       const typename Kernel::Point_3& p1 = g[v1];
       const typename Kernel::Point_3& p2 = g[v2];
 
-      const typename Kernel::Vector_3 e1 = p1 - p;
-      const typename Kernel::Vector_3 e2 = p2 - p;
-      const typename Kernel::FT sc_prod = e1 * e2;
-      if (sc_prod >= 0 ||   // angle < 135 degrees (3*pi/4)
-        (sc_prod < 0 &&
-          CGAL::square(sc_prod) < (e1 * e1) * (e2 * e2) / 2))
+      if(CGAL::angle(p1, p, p2) == CGAL::ACUTE) {
+        // const typename Kernel::Vector_3 e1 = p1 - p;
+        // const typename Kernel::Vector_3 e2 = p2 - p;
+        // std::cerr << "At point " << p << ": the angle is "
+        //           << ( std::acos(e1 * e2
+        //                          / CGAL::sqrt(e1*e1)
+        //                          / CGAL::sqrt(e2*e2))
+        //                * 180 / CGAL_PI ) << std::endl;
         return true;
+      }
     }
     return false;
   }

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -380,30 +380,30 @@ struct Mesh_domain_segment_of_curve_primitive{
 
 template <typename MDwPF, bool patch_id_is_streamable>
 struct Display_incidences_to_patches_aux {
-  template <typename Container>
-  void operator()(std::ostream& os, typename MDwPF::Curve_segment_index id,
+  template <typename Container, typename Point>
+  void operator()(std::ostream& os, Point p, typename MDwPF::Curve_segment_index id,
                   const Container&) const;
 };
 
 template <typename MDwPF> //specialization when patch_id_is_streamable == false
 struct Display_incidences_to_patches_aux<MDwPF, false> {
-  template <typename Container>
-  void operator()(std::ostream& os,
+  template <typename Container, typename Point>
+  void operator()(std::ostream& os, Point p,
                   typename MDwPF::Curve_segment_index id,
                   const Container&) const;
 };
 
 template <typename MDwPF, bool curve_id_is_streamable>
 struct Display_incidences_to_curves_aux {
-  template <typename Container>
-  void operator()(std::ostream& os, typename MDwPF::Curve_segment_index id,
+  template <typename Container, typename Point>
+  void operator()(std::ostream& os, Point p, typename MDwPF::Curve_segment_index id,
                   const Container&) const;
 };
 
 template <typename MDwPF> //specialization when curve_id_is_streamable == false
 struct Display_incidences_to_curves_aux<MDwPF, false> {
-  template <typename Container>
-  void operator()(std::ostream& os, typename MDwPF::Curve_segment_index id,
+  template <typename Container, typename Point>
+  void operator()(std::ostream& os, Point p,  typename MDwPF::Curve_segment_index id,
                   const Container&) const;
 };
 
@@ -569,7 +569,7 @@ public:
   const Surface_patch_index_set&
   get_incidences(Curve_segment_index id) const;
 
-  void display_corner_incidences(std::ostream& os, Corner_index id);
+  void display_corner_incidences(std::ostream& os, Point_3, Corner_index id);
 
   template <typename InputIterator>
   void
@@ -829,13 +829,14 @@ namespace internal { namespace Mesh_3 {
 
 template <typename MDwPF_, bool curve_id_is_streamable>
 // here 'curve_id_is_streamable' is true
-template <typename Container2>
+template <typename Container2, typename Point>
 void
 Display_incidences_to_curves_aux<MDwPF_,curve_id_is_streamable>::
-operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
+operator()(std::ostream& os, Point p, typename MDwPF_::Curve_segment_index id,
            const Container2& corners_tmp_incidences_of_id) const
 {
-  os << "Corner #" << id << " is incident to the following curves: {";
+  os << "Corner #" << id << " (" << p
+     << ") is incident to the following curves: {";
   BOOST_FOREACH(typename MDwPF_::Curve_segment_index curve_index,
                 corners_tmp_incidences_of_id)
   {
@@ -846,26 +847,28 @@ operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
 
 template <class MDwPF_>
 // here 'curve_id_is_streamable' is false
-template <typename Container2>
+template <typename Container2, typename Point>
 void
 Display_incidences_to_curves_aux<MDwPF_,false>::
-operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
+operator()(std::ostream& os, Point p, typename MDwPF_::Curve_segment_index id,
            const Container2& corners_tmp_incidences_of_id) const
 {
-  os << "Corner #" << id << " is incident to "
+  os << "Corner #" << id << " (" << p
+     << ") is incident to "
      << corners_tmp_incidences_of_id .size()
      << " curve(s).\n";
 }
 
 template <typename MDwPF_, bool patch_id_is_streamable>
 // here 'patch_id_is_streamable' is true
-template <typename Container>
+template <typename Container, typename Point>
 void
 Display_incidences_to_patches_aux<MDwPF_,patch_id_is_streamable>::
-operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
+operator()(std::ostream& os, Point p, typename MDwPF_::Curve_segment_index id,
            const Container& corners_incidences_of_id) const
 {
-  os << "Corner #" << id << " is incident to the following patches: {";
+  os << "Corner #" << id << " (" << p
+     << ") is incident to the following patches: {";
   BOOST_FOREACH(typename MDwPF_::Surface_patch_index i,
                 corners_incidences_of_id)
   {
@@ -876,13 +879,13 @@ operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
 
 template <class MDwPF_>
 // here 'patch_id_is_streamable' is false
-template <typename Container>
+template <typename Container, typename Point>
 void
 Display_incidences_to_patches_aux<MDwPF_,false>::
-operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
+operator()(std::ostream& os, Point p, typename MDwPF_::Curve_segment_index id,
            const Container& corners_incidences_id) const
 {
-  os << "Corner #" << id << " is incident to "
+  os << "Corner #" << id << " (" << p << ") is incident to "
      << corners_incidences_id.size()
      << " surface patch(es).\n";
 }
@@ -892,7 +895,7 @@ operator()(std::ostream& os, typename MDwPF_::Curve_segment_index id,
 template <class MD_>
 void
 Mesh_domain_with_polyline_features_3<MD_>::
-display_corner_incidences(std::ostream& os, Corner_index id)
+display_corner_incidences(std::ostream& os, Point_3 p, Corner_index id)
 {
   typedef Mesh_domain_with_polyline_features_3<MD_> Mdwpf;
   typedef is_streamable<Surface_patch_index> i_s_spi;
@@ -901,8 +904,8 @@ display_corner_incidences(std::ostream& os, Corner_index id)
   using namespace internal::Mesh_3;
   typedef Display_incidences_to_curves_aux<Mdwpf,i_s_csi::value> D_i_t_c;
   typedef Display_incidences_to_patches_aux<Mdwpf,i_s_spi::value> D_i_t_p;
-  D_i_t_c()(os, id, corners_tmp_incidences_[id]);
-  D_i_t_p()(os, id, corners_incidences_[id]);
+  D_i_t_c()(os, p, id, corners_tmp_incidences_[id]);
+  D_i_t_p()(os, p, id, corners_incidences_[id]);
 }
 
 template <class MD_>
@@ -940,7 +943,7 @@ compute_corners_incidences()
                                    incidences.begin()));
     }
 #ifdef CGAL_MESH_3_PROTECTION_DEBUG
-    display_corner_incidences(std::cerr, id);
+    display_corner_incidences(std::cerr, cit->first, id);
 #endif // CGAL_MESH_3_PROTECTION_DEBUG
 
     // increment the loop variable

--- a/Mesh_3/include/CGAL/internal/Mesh_3/Handle_IO_for_pair_of_int.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/Handle_IO_for_pair_of_int.h
@@ -25,6 +25,7 @@
 #include <CGAL/Mesh_3/io_signature.h>
 #include <ostream>
 #include <istream>
+#include <boost/variant.hpp>
 
 namespace CGAL {
 template <>
@@ -56,6 +57,25 @@ public:
     } else {
       CGAL::write(out, t.first);
       CGAL::write(out, t.second);
+    }
+    return out;
+  }
+};
+
+template <>
+class Output_rep<boost::variant<int,
+                                std::pair<int, int> > >
+  : public IO_rep_is_specialized
+{
+  typedef boost::variant<int, std::pair<int, int> > Variant;
+  const Variant& v;
+public:
+  Output_rep(const Variant& v) : v(v) {}
+  std::ostream& operator()( std::ostream& out) const {
+    if(v.which() == 1) {
+      out << oformat(boost::get<std::pair<int, int> >(v));
+    } else {
+      out << boost::get<int>(v);
     }
     return out;
   }


### PR DESCRIPTION
The main goal of this PR is to fix a bug introduced by #1524 (for CGAL-4.9.1). This PR also improves or adds minor fixes:

  - in `polylines_to_protect`, change the split angle from 135° to 90°,

  - improve debug messages,

  - fix `CGAL_MESH_3_PROTECTION_DEBUG` with a mesh domain where the
    `Surface_patch_index` is `pair<int, int>`.