### PR TITLE
Allow to load OBJ files containing polygon soups

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -965,18 +965,14 @@ Scene_polyhedron_item::load_obj(std::istream& in)
   std::vector<std::vector<std::size_t> > faces;
   bool failed = !CGAL::read_OBJ(in,points,faces);
 
-  if(CGAL::Polygon_mesh_processing::orient_polygon_soup(points,faces)){
-    CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh( points,faces,*(d->poly));
-  }else{
-    std::cerr << "not orientable"<< std::endl;
-    return false;
+  CGAL::Polygon_mesh_processing::orient_polygon_soup(points,faces);
+  CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh( points,faces,*(d->poly));
+  if ( (! failed) && !isEmpty() )
+  {
+    invalidateOpenGLBuffers();
+    return true;
   }
-    if ( (! failed) && !isEmpty() )
-    {
-        invalidateOpenGLBuffers();
-        return true;
-    }
-    return false;
+  return false;
 }
 
 // Write polyhedron to .OFF file


### PR DESCRIPTION
If the content of an OBJ file is not a correct polyhedron, but a polygon soups, then the current code cannot load the file.

This PR allows to load the file anyway, producing a polyhedron with self-intersections.
