### PR TITLE
Polyhedron_demo : Use floats in the Point_with_normals_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -1,3 +1,5 @@
+#define CGAL_data_type float
+#define CGAL_GL_data_type GL_FLOAT
 #include "Scene_points_with_normal_item.h"
 #include "Polyhedron_type.h"
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
@@ -112,13 +114,13 @@ struct Scene_points_with_normal_item_priv
   QSlider* normal_Slider;
   QSlider* point_Slider;
   mutable bool is_point_slider_moving;
-  mutable std::vector<double> positions_lines;
-  mutable std::vector<double> positions_points;
-  mutable std::vector<double> positions_selected_points;
-  mutable std::vector<double> normals;
-  mutable std::vector<double> positions_normals;
-  mutable std::vector<double> positions_selected_normals;
-  mutable std::vector<double> colors_points;
+  mutable std::vector<CGAL_data_type> positions_lines;
+  mutable std::vector<CGAL_data_type> positions_points;
+  mutable std::vector<CGAL_data_type> positions_selected_points;
+  mutable std::vector<CGAL_data_type> normals;
+  mutable std::vector<CGAL_data_type> positions_normals;
+  mutable std::vector<CGAL_data_type> positions_selected_normals;
+  mutable std::vector<CGAL_data_type> colors_points;
   mutable std::size_t nb_points;
   mutable std::size_t nb_selected_points;
   mutable std::size_t nb_lines;
@@ -186,25 +188,25 @@ void Scene_points_with_normal_item_priv::initializeBuffers(CGAL::Three::Viewer_i
         item->vaos[Edges]->bind();
         item->buffers[Edges_vertices].bind();
         item->buffers[Edges_vertices].allocate(positions_lines.data(),
-                            static_cast<int>(positions_lines.size()*sizeof(double)));
+                            static_cast<int>(positions_lines.size()*sizeof(CGAL_data_type)));
         program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
+        program->setAttributeBuffer("vertex",CGAL_GL_data_type,0,3);
         item->buffers[Edges_vertices].release();
 
         if (!(colors_points.empty()))
           {
             item->buffers[Points_colors].bind();
             item->buffers[Points_colors].allocate (colors_points.data(),
-                                                   static_cast<int>(colors_points.size()*sizeof(double)));
+                                                   static_cast<int>(colors_points.size()*sizeof(CGAL_data_type)));
             program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_DOUBLE,0,3);
+            program->setAttributeBuffer("colors",CGAL_GL_data_type,0,3);
             item->buffers[Points_colors].release();
           }
 
         item->vaos[Edges]->release();
         nb_lines = positions_lines.size();
         positions_lines.resize(0);
-        std::vector<double>(positions_lines).swap(positions_lines);
+        std::vector<CGAL_data_type>(positions_lines).swap(positions_lines);
         program->release();
     }
     //vao for the points
@@ -218,39 +220,38 @@ void Scene_points_with_normal_item_priv::initializeBuffers(CGAL::Three::Viewer_i
         item->vaos[ThePoints]->bind();
         item->buffers[Points_vertices].bind();
         item->buffers[Points_vertices].allocate(positions_points.data(),
-                            static_cast<int>(positions_points.size()*sizeof(double)));
+                            static_cast<int>(positions_points.size()*sizeof(CGAL_data_type)));
         program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
+        program->setAttributeBuffer("vertex",CGAL_GL_data_type,0,3);
         item->buffers[Points_vertices].release();
 
         if(item->has_normals() && !(m_points->has_colors()))
         {
           item->buffers[Points_normals].bind();
           item->buffers[Points_normals].allocate(positions_normals.data(),
-                                          static_cast<int>(positions_normals.size()*sizeof(double)));
+                                          static_cast<int>(positions_normals.size()*sizeof(CGAL_data_type)));
           program->enableAttributeArray("normals");
-          program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
+          program->setAttributeBuffer("normals",CGAL_GL_data_type,0,3);
           item->buffers[Points_normals].release();
           positions_normals.resize(0);
-          std::vector<double>(positions_normals).swap(positions_normals);
+          std::vector<CGAL_data_type>(positions_normals).swap(positions_normals);
         }
-        
         if (!(colors_points.empty()))
           {
             item->buffers[Points_colors].bind();
             item->buffers[Points_colors].allocate (colors_points.data(),
-                                                   static_cast<int>(colors_points.size()*sizeof(double)));
+                                                   static_cast<int>(colors_points.size()*sizeof(CGAL_data_type)));
             program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_DOUBLE,0,3,6*sizeof(double));
+            program->setAttributeBuffer("colors",CGAL_GL_data_type,0,3,6*sizeof(CGAL_data_type));
             item->buffers[Points_colors].release();
             colors_points.resize(0);
-            std::vector<double>(colors_points).swap(colors_points);
+            std::vector<CGAL_data_type>(colors_points).swap(colors_points);
           }
 
         item->vaos[ThePoints]->release();
         nb_points = positions_points.size();
         positions_points.resize(0);
-        std::vector<double>(positions_points).swap(positions_points);
+        std::vector<CGAL_data_type>(positions_points).swap(positions_points);
         program->release();
     }
     //vao for the selected points
@@ -261,13 +262,12 @@ void Scene_points_with_normal_item_priv::initializeBuffers(CGAL::Three::Viewer_i
           program = item->getShaderProgram(Scene_points_with_normal_item::PROGRAM_NO_SELECTION, viewer);
 
         program->bind();
-
         item->vaos[Selected_points]->bind();
         item->buffers[Selected_points_vertices].bind();
         item->buffers[Selected_points_vertices].allocate(positions_selected_points.data(),
                             static_cast<int>(positions_selected_points.size()*sizeof(double)));
         program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_DOUBLE,0,3);
+        program->setAttributeBuffer("vertex",CGAL_GL_data_type,0,3);
         item->buffers[Selected_points_vertices].release();
 
         if(item->has_normals())
@@ -276,15 +276,15 @@ void Scene_points_with_normal_item_priv::initializeBuffers(CGAL::Three::Viewer_i
           item->buffers[Selected_points_normals].allocate(positions_selected_normals.data(),
                                           static_cast<int>(positions_selected_normals.size()*sizeof(double)));
           program->enableAttributeArray("normals");
-          program->setAttributeBuffer("normals",GL_DOUBLE,0,3);
+          program->setAttributeBuffer("normals",CGAL_GL_data_type,0,3);
           item->buffers[Selected_points_normals].release();
           positions_selected_normals.resize(0);
-          std::vector<double>(positions_selected_normals).swap(positions_selected_normals);
+          std::vector<CGAL_data_type>(positions_selected_normals).swap(positions_selected_normals);
         }
         item->vaos[Selected_points]->release();
         nb_selected_points = positions_selected_points.size();
         positions_selected_points.resize(0);
-        std::vector<double>(positions_selected_points).swap(positions_selected_points);
+        std::vector<CGAL_data_type>(positions_selected_points).swap(positions_selected_points);
         program->release();
     }
     item->are_buffers_filled = true;
@@ -310,6 +310,7 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
     if (m_points->nb_selected_points() != 0)
       std::random_shuffle (m_points->first_selected(), m_points->end());
     
+
     //The points
     {
         // The *non-selected* points
@@ -334,6 +335,7 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
     //The lines
     if (item->has_normals())
     {
+        positions_lines.reserve(m_points->size() * 6);
         positions_normals.reserve((m_points->size() - m_points->nb_selected_points()) * 3);
         positions_selected_normals.reserve(m_points->nb_selected_points() * 3);
         
@@ -352,7 +354,7 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
 
         double normal_length = (std::min)(average_spacing, std::sqrt(region_of_interest.squared_radius() / 1000.));
         double length_factor = 5.0/100*normal_Slider->value();
-        for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); it++)
+        for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->first_selected(); ++it)
 	  {
 	    const Kernel::Point_3& p = m_points->point(*it);
 	    const Kernel::Vector_3& n = m_points->normal(*it);
@@ -370,7 +372,7 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
             positions_normals.push_back(n.y());
             positions_normals.push_back(n.z());
 	  }
-        for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); it++)
+        for (Point_set_3<Kernel>::const_iterator it = m_points->first_selected(); it != m_points->end(); ++it)
           {
 	    const Kernel::Point_3& p = m_points->point(*it);
 	    const Kernel::Vector_3& n = m_points->normal(*it);
@@ -392,9 +394,9 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
     //The colors
     if (m_points->has_colors())
     {
-        colors_points.reserve((m_points->size() - m_points->nb_selected_points()) * 3);
+        colors_points.reserve((m_points->size() - m_points->nb_selected_points()) * 6);
 
-        for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); it++)
+        for (Point_set_3<Kernel>::const_iterator it = m_points->begin(); it != m_points->end(); ++it)
 	  {
             colors_points.push_back (m_points->red(*it));
             colors_points.push_back (m_points->green(*it));
@@ -638,7 +640,6 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
 {
     if(!are_buffers_filled)
         d->initializeBuffers(viewer);
-
     GLfloat point_size;
     viewer->glGetFloatv(GL_POINT_SIZE, &point_size);
     viewer->glPointSize(d->point_Slider->value());
@@ -646,7 +647,6 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
     if ((viewer->inFastDrawing () || d->isPointSliderMoving())
         &&((d->nb_points + d->nb_selected_points)/3 > limit_fast_drawing)) // arbitrary large value
       ratio_displayed = 3 * limit_fast_drawing / (double)(d->nb_points + d->nb_selected_points);
-
     vaos[Scene_points_with_normal_item_priv::ThePoints]->bind();
     if(has_normals() && renderingMode() == ShadedPoints)
     {
@@ -663,12 +663,10 @@ void Scene_points_with_normal_item::drawPoints(CGAL::Three::Viewer_interface* vi
       d->program->setAttributeValue("colors", this->color());
     if(renderingMode() != ShadedPoints)
       d->program->setAttributeValue("normals", QVector3D(0,0,0));
-
     viewer->glDrawArrays(GL_POINTS, 0,
                          static_cast<GLsizei>(((std::size_t)(ratio_displayed * d->nb_points)/3)));
     vaos[Scene_points_with_normal_item_priv::ThePoints]->release();
     d->program->release();
-
     vaos[Scene_points_with_normal_item_priv::Selected_points]->bind();
     if(has_normals() && renderingMode() == ShadedPoints)
     {
@@ -735,7 +733,7 @@ void Scene_points_with_normal_item::computes_local_spacing(int k)
             );
   Distance tr_dist(d->m_points->point_map());
 
-  if (!(d->m_points->has_property_map<double> ("radius")))
+  if (!(d->m_points->has_property_map<CGAL_data_type> ("radius")))
     d->m_points->add_radius();
 
   // Compute the radius of each point = (distance max to k nearest neighbors)/2.

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -733,7 +733,7 @@ void Scene_points_with_normal_item::computes_local_spacing(int k)
             );
   Distance tr_dist(d->m_points->point_map());
 
-  if (!(d->m_points->has_property_map<CGAL_data_type> ("radius")))
+  if (!(d->m_points->has_property_map<double> ("radius")))
     d->m_points->add_radius();
 
   // Compute the radius of each point = (distance max to k nearest neighbors)/2.


### PR DESCRIPTION
This PR fixes #1754 . We use floats instead of doubles in the Scene_point_with_normals_item to reduce the needed memory.

 This is a temporary fix, as we only gain a factor 2 in the acceptable memory size. A better fix could be to split the data into several VBOs.