### PR TITLE
Eigen: Static cast to avoid warning

### DIFF
--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -118,9 +118,9 @@ public:
   }
 
   /// Return the matrix number of rows
-  int row_dimension() const    { return m_matrix.rows(); }
+  int row_dimension() const    { return static_cast<int>(m_matrix.rows()); }
   /// Return the matrix number of columns
-  int column_dimension() const { return m_matrix.cols(); }
+  int column_dimension() const { return static_cast<int>(m_matrix.cols()); }
 
 
   /// Write access to a matrix coefficient: a_ij <- val.


### PR DESCRIPTION
Should fix [this](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-76/Solver_interface_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz) and other warnings in packages using Eigen.