### PR TITLE
Fix spelling of 'matches'

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
@@ -1154,7 +1154,7 @@ insert_at_vertices(const X_monotone_curve_2& cv,
                    Halfedge_handle prev1,
                    Vertex_handle v2)
 {
-  // Determine which one of the given vertices mathces the left end of the
+  // Determine which one of the given vertices matches the left end of the
   // given curve.
   const bool at_obnd1 = !m_geom_traits->is_closed_2_object()(cv, ARR_MIN_END);
   const bool at_obnd2 = !m_geom_traits->is_closed_2_object()(cv, ARR_MAX_END);
@@ -1319,7 +1319,7 @@ insert_at_vertices(const X_monotone_curve_2& cv,
 #endif
 
   // Determine which one of the given vertices (the target vertices of the
-  // given halfedges) mathces the left end of the given curve.
+  // given halfedges) matches the left end of the given curve.
   // Thus, we can determine the comparison result between prev1->target()
   // and prev2->target().
   const bool at_obnd1 = !m_geom_traits->is_closed_2_object()(cv, ARR_MIN_END);

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Overlay_test.h
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Overlay_test.h
@@ -209,7 +209,7 @@ protected:
 #endif
     }
 
-    /*! Create a vertex v that mathces v1, which lies of the edge e2. */
+    /*! Create a vertex v that matches v1, which lies of the edge e2. */
     virtual void create_vertex(Vertex_const_handle  v1,
                                Halfedge_const_handle e2,
                                Vertex_handle v) const
@@ -227,7 +227,7 @@ protected:
       }
     }
 
-    /*! Create a vertex v that mathces v1, contained in the face f2. */
+    /*! Create a vertex v that matches v1, contained in the face f2. */
     virtual void create_vertex(Vertex_const_handle v1, Face_const_handle f2,
                                Vertex_handle v) const
     {
@@ -244,7 +244,7 @@ protected:
       }
     }
 
-    /*! Create a vertex v that mathces v2, which lies of the edge e1. */
+    /*! Create a vertex v that matches v2, which lies of the edge e1. */
     virtual void create_vertex(Halfedge_const_handle e1, Vertex_const_handle v2,
                                Vertex_handle v) const
     {
@@ -261,7 +261,7 @@ protected:
       }
     }
 
-    /*! Create a vertex v that mathces v2, contained in the face f1. */
+    /*! Create a vertex v that matches v2, contained in the face f1. */
     virtual void create_vertex(Face_const_handle f1, Vertex_const_handle v2,
                                Vertex_handle v) const
     {
@@ -278,7 +278,7 @@ protected:
       }
     }
 
-    /*! Create a vertex v that mathces the intersection of the edges e1 and e2.
+    /*! Create a vertex v that matches the intersection of the edges e1 and e2.
      */
     virtual void create_vertex(Halfedge_const_handle e1,
                                Halfedge_const_handle e2,

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_overlay.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_spherical_overlay.cpp
@@ -86,27 +86,27 @@ public:
                              Vertex_handle v) const
   { v->set_data(v1->data() + v2->data()); }
 
-  /*! Create a vertex v that mathces v1, which lies of the edge e2. */
+  /*! Create a vertex v that matches v1, which lies of the edge e2. */
   virtual void create_vertex(Vertex_const_handle  v1, Halfedge_const_handle e2,
                              Vertex_handle v) const
   { v->set_data(v1->data() + e2->data()); }
 
-  /*! Create a vertex v that mathces v1, contained in the face f2. */
+  /*! Create a vertex v that matches v1, contained in the face f2. */
   virtual void create_vertex(Vertex_const_handle v1, Face_const_handle f2,
                              Vertex_handle v) const
   { v->set_data(v1->data() + f2->data());}
 
-  /*! Create a vertex v that mathces v2, which lies of the edge e1. */
+  /*! Create a vertex v that matches v2, which lies of the edge e1. */
   virtual void create_vertex(Halfedge_const_handle e1, Vertex_const_handle v2,
                              Vertex_handle v) const
   { v->set_data(e1->data() + v2->data()); }
 
-  /*! Create a vertex v that mathces v2, contained in the face f1. */
+  /*! Create a vertex v that matches v2, contained in the face f1. */
   virtual void create_vertex(Face_const_handle f1, Vertex_const_handle v2,
                              Vertex_handle v) const
   { v->set_data(f1->data() + v2->data()); }
 
-  /*! Create a vertex v that mathces the intersection of the edges e1 and e2. */
+  /*! Create a vertex v that matches the intersection of the edges e1 and e2. */
   virtual void create_vertex(Halfedge_const_handle e1, Halfedge_const_handle e2,
                              Vertex_handle v) const
   { v->set_data(e1->data() + e2->data()); }

--- a/Sweep_line_2/include/CGAL/Sweep_line_2/Arr_default_overlay_traits_base.h
+++ b/Sweep_line_2/include/CGAL/Sweep_line_2/Arr_default_overlay_traits_base.h
@@ -65,7 +65,7 @@ public:
   {}
 
   /*!
-   * Create a vertex v that mathces v1, which lies of the edge e2.
+   * Create a vertex v that matches v1, which lies of the edge e2.
    */
   virtual void create_vertex (Vertex_handle_A /* v1 */,
 			      Halfedge_handle_B /* e2 */,
@@ -73,7 +73,7 @@ public:
   {}
 
   /*!
-   * Create a vertex v that mathces v1, contained in the face f2.
+   * Create a vertex v that matches v1, contained in the face f2.
    */
   virtual void create_vertex (Vertex_handle_A /* v1 */,
 			      Face_handle_B /* f2 */,
@@ -81,7 +81,7 @@ public:
   {}
 
   /*!
-   * Create a vertex v that mathces v2, which lies of the edge e1.
+   * Create a vertex v that matches v2, which lies of the edge e1.
    */
   virtual void create_vertex (Halfedge_handle_A /* e1 */,
 			      Vertex_handle_B /* v2 */,
@@ -89,7 +89,7 @@ public:
   {}
 
   /*!
-   * Create a vertex v that mathces v2, contained in the face f1.
+   * Create a vertex v that matches v2, contained in the face f1.
    */
   virtual void create_vertex (Face_handle_A /* f1 */,
 			      Vertex_handle_B /* v2 */,
@@ -97,7 +97,7 @@ public:
   {}
 
   /*!
-   * Create a vertex v that mathces the intersection of the edges e1 and e2.
+   * Create a vertex v that matches the intersection of the edges e1 and e2.
    */
   virtual void create_vertex (Halfedge_handle_A /* e1 */,
 			      Halfedge_handle_B /* e2 */,


### PR DESCRIPTION
Looks like the misspelling got copy pasted a few other places.

#1756 has some other spelling corrections but it doesn't look like they noticed this.