### PR TITLE
Spatial_searching: Fix early loop abort.

### DIFF
--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -89,7 +89,7 @@ namespace CGAL {
                   traits.construct_cartesian_const_iterator_d_object();
                 typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
                                                                   end = construct_it(c, 0);
-		for (int i = 0; cit != end && (distance < squared_radius); ++cit, ++i) {
+		for (int i = 0; cit != end && (distance <= squared_radius); ++cit, ++i) {
 			if ((*cit) < rectangle.min_coord(i))
 				distance += 
 				(rectangle.min_coord(i)-(*cit))*(rectangle.min_coord(i)-(*cit));


### PR DESCRIPTION
If distance==squared_radius, we don't yet know if we can abort or not.
This is the same kind of bug that was found and fixed in a related
method two weeks ago in this commit:

ed526b8f22ca0d075ca42c6337a39bf5f0421c68
    Spatial_searching: bug reported and fixed by Marc Glisse