### PR TITLE
Spatial_searching: Fix strict equality / inconsistent early loop abort.

### DIFF
--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -98,7 +98,7 @@ namespace CGAL {
 				((*cit)-rectangle.max_coord(i))*((*cit)-rectangle.max_coord(i));
 		}
 		
-		return (distance <= squared_radius);
+		return (distance < squared_radius);
 	}
 
 


### PR DESCRIPTION
Compare https://github.com/CGAL/cgal/pull/1772 - I can't quickly find an answer in the documentation as to whether points on the sphere surface should be returned for an (exact) sphere query, so I fixed the inconsistency by relying on the function comment.

**Commit message:**

The method comment suggests the check should be a strict inequality
instead of less-or-equals to test whether the sphere _interior_ intersects.

Additionally, the early abort condition was inconsistent with the final
comparison.
The early abort part is the same kind of bug that was found and fixed in a
related method two weeks ago in this commit:

ed526b8f22ca0d075ca42c6337a39bf5f0421c68
    Spatial_searching: bug reported and fixed by Marc Glisse