### PR TITLE
Work in progress: Kernel_23: Add Compare_slope_3 and Angle_3()(Point_3, Point_3, Point_3, Vector_3)

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -96,6 +96,13 @@ namespace CartesianKernelFunctors {
 		     r.x(), r.y(), r.z(),
 		     s.x(), s.y(), s.z());
     }
+
+    result_type
+    operator()(const Point_3& p, const Point_3& q,
+               const Point_3& r, const Vector_3& n) const
+    {
+      return enum_cast<Angle>(orientation(p,q,r,r+n));
+    }
   };
 
   template <typename K>

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -118,6 +118,7 @@ namespace HomogeneousKernelFunctors {
                const Point_3& r, const Vector_3& n) const
     {
       return enum_cast<Angle>(orientation(p,q,r,r+n));
+    }
   };
 
 

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -112,6 +112,12 @@ namespace HomogeneousKernelFunctors {
                const Point_3& r, const Point_3& s) const
     { return enum_cast<Angle>(CGAL_NTS sign(c(q,p) * c(s,r))); }
     // FIXME: scalar product
+
+    result_type
+    operator()(const Point_3& p, const Point_3& q,
+               const Point_3& r, const Vector_3& n) const
+    {
+      return enum_cast<Angle>(orientation(p,q,r,r+n));
   };
 
 

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -214,6 +214,9 @@ and <code>src/</code> directories).
         All models of the Kernel concept now provide the functor <code>Compare_slope_3</code>,
         and the free function <code>compare_slope()</code> is available.
     </li>
+    <li>Add an operator in CGAL Kernel concept <code>Angle_3</code> to qualify the angle 
+        between the normal of the triangle given by three points, and a vector.
+    </li>
   </ul>
 
   <h3>3D Convex Hull</h3>

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -210,6 +210,10 @@ and <code>src/</code> directories).
     <li>
       Add functions <code>l_infinity_distance()</code> for 2D and 3D.
     </li>
+    <li>Add a new functor in CGAL Kernel concept to compare the slope of two 3D segments.
+        All models of the Kernel concept now provide the functor <code>Compare_slope_3</code>,
+        and the free function <code>compare_slope()</code> is available.
+    </li>
   </ul>
 
   <h3>3D Convex Hull</h3>

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -805,25 +805,28 @@ const CGAL::Point_3<Kernel>& t);
 compares the slopes of the lines `l1` and `l2`
 */
 template <typename Kernel>
-Comparison_result compare_slopes(const CGAL::Line_2<Kernel> &l1,
+Comparison_result compare_slope(const CGAL::Line_2<Kernel> &l1,
 const CGAL::Line_2<Kernel> &l2);
 
 /*!
-compares the slopes of the segments `s1` and `s2`
+compares the slopes of the segments `s1` and `s2`,
+where the slope is the variation of the `y`-coordinate
+from the left to the right endpoint of the segments.
 */
 template <typename Kernel>
-Comparison_result compare_slopes(const CGAL::Segment_2<Kernel> &s1,
+Comparison_result compare_slope(const CGAL::Segment_2<Kernel> &s1,
 const CGAL::Segment_2<Kernel> &s2);
 
 /*!
 compares the slopes of the segments `(p,q)` and `(r,s)`,
-with `p.z() >= q.z()` and  `r.z() >= s.z()`.
+where the slope is the variation of the `z`-coordinate from the first
+to the second point of the segment.
 */
 template <typename Kernel>
-Comparison_result compare_slopes(const CGAL::Point_3<Kernel> &p,
-                                 const CGAL::Point_3<Kernel> &q,
-                                 const CGAL::Point_3<Kernel> &r,
-                                 const CGAL::Point_3<Kernel> &s);
+Comparison_result compare_slope(const CGAL::Point_3<Kernel> &p,
+                                const CGAL::Point_3<Kernel> &q,
+                                const CGAL::Point_3<Kernel> &r,
+                                const CGAL::Point_3<Kernel> &s);
 /// @}
 
 /// \defgroup compare_squared_distance_grp CGAL::compare_squared_distance()

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -37,6 +37,7 @@ const CGAL::Point_2<Kernel>& q,
 const CGAL::Point_2<Kernel>& r,
 const CGAL::Point_2<Kernel>& s);
 
+
 /*!
 
 returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
@@ -60,6 +61,17 @@ Kernel::FT approximate_dihedral_angle(const CGAL::Point_3<Kernel>& p,
                                       const CGAL::Point_3<Kernel>& q,
                                       const CGAL::Point_3<Kernel>& r,
                                       const CGAL::Point_3<Kernel>& s);
+
+/*!
+
+returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
+on the angle formed by the normal vector of the plane `pqr` and `v`. 
+*/
+template <typename Kernel>
+Angle angle(const CGAL::Point_3<Kernel>& p,
+const CGAL::Point_3<Kernel>& q,
+const CGAL::Point_3<Kernel>& r,
+const CGAL::Vector_3<Kernel>& v);
 
 /// @}
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -803,6 +803,15 @@ template <typename Kernel>
 Comparison_result compare_slopes(const CGAL::Segment_2<Kernel> &s1,
 const CGAL::Segment_2<Kernel> &s2);
 
+/*!
+compares the slopes of the segments `(p,q)` and `(r,s)`,
+with `p.z() >= q.z()` and  `r.z() >= s.z()`.
+*/
+template <typename Kernel>
+Comparison_result compare_slopes(const CGAL::Point_3<Kernel> &p,
+                                 const CGAL::Point_3<Kernel> &q,
+                                 const CGAL::Point_3<Kernel> &r,
+                                 const CGAL::Point_3<Kernel> &s);
 /// @}
 
 /// \defgroup compare_squared_distance_grp CGAL::compare_squared_distance()

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -820,7 +820,7 @@ const CGAL::Segment_2<Kernel> &s2);
 /*!
 compares the slopes of the segments `(p,q)` and `(r,s)`,
 where the slope is the variation of the `z`-coordinate from the first
-to the second point of the segment.
+to the second point  of the segment divided by the length of the segment.
 */
 template <typename Kernel>
 Comparison_result compare_slope(const CGAL::Point_3<Kernel> &p,

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -37,9 +37,16 @@ const CGAL::Point_2<Kernel>& q,
 const CGAL::Point_2<Kernel>& r,
 const CGAL::Point_2<Kernel>& s);
 
+/*!
+returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+on the angle formed by the two vectors `u` and `v`.
+*/
+template <typename Kernel>
+Angle angle(const CGAL::Vector_3<Kernel>& u,
+            const CGAL::Vector_3<Kernel>& v);
+
 
 /*!
-
 returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
 on the angle formed by the three points `p`, `q`, `r` (`q` being the vertex of
 the angle).
@@ -48,6 +55,29 @@ template <typename Kernel>
 Angle angle(const CGAL::Point_3<Kernel>& p,
 const CGAL::Point_3<Kernel>& q,
 const CGAL::Point_3<Kernel>& r);
+
+/*!
+returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+on the angle formed by the two vectors `pq`, `rs`. The returned value is
+the same as `angle(q - p, s - r)`.
+*/
+template<typename Kernel >
+Angle angle(const CGAL::Point_3<Kernel>&p,
+            const CGAL::Point_3<Kernel>&q,
+            const CGAL::Point_3<Kernel>&r,
+            const CGAL::Point_3<Kernel>&s);
+
+/*!
+returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+on the angle formed by the normal of the triangle `pqr` and the vector `v`.
+*/
+
+template<typename Kernel >
+Angle angle(const CGAL::Point_3<Kernel>&p,
+            const CGAL::Point_3<Kernel>&q,
+            const CGAL::Point_3<Kernel>&r,
+            const CGAL::Vector_3<Kernel>&v);
+
 
 
 /*!
@@ -62,16 +92,6 @@ Kernel::FT approximate_dihedral_angle(const CGAL::Point_3<Kernel>& p,
                                       const CGAL::Point_3<Kernel>& r,
                                       const CGAL::Point_3<Kernel>& s);
 
-/*!
-
-returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
-on the angle formed by the normal vector of the plane `pqr` and `v`. 
-*/
-template <typename Kernel>
-Angle angle(const CGAL::Point_3<Kernel>& p,
-const CGAL::Point_3<Kernel>& q,
-const CGAL::Point_3<Kernel>& r,
-const CGAL::Vector_3<Kernel>& v);
 
 /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -85,7 +85,16 @@ public:
   Angle operator()(const Kernel::Point_3&p, 
                    const Kernel::Point_3&q, 
                    const Kernel::Point_3&r, 
-                   const Kernel::Point_3&s); 
+                   const Kernel::Point_3&s);   
+
+  /*!
+    returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending 
+    on the angle formed by the twonormal vector of the plane `pqr` and `v`. 
+  */ 
+  Angle operator()(const Kernel::Point_3&p, 
+                   const Kernel::Point_3&q, 
+                   const Kernel::Point_3&r, 
+                   const Kernel::Vector_3&s); 
   /// @}
 
 }; /* end Kernel::Angle_3 */

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1013,7 +1013,9 @@ public:
                                const Kernel::Line_2& l2); 
 
   /*!
-    compares the slopes of the segments `s1` and `s2` 
+    compares the slopes of the segments `s1` and `s2`,
+    where the slope is the variation of the `y`-coordinate
+    from the left to the right endpoint of the segments. 
   */ 
   Comparison_result operator()(const Kernel::Segment_2& s1, 
                                const Kernel::Segment_2& s2); 
@@ -1041,8 +1043,9 @@ public:
 
 
   /*!
-    compares the slopes of the segments `(p,q)` and `(r,s)`
-    with `p.z() >= q.z()` and  `r.z() >= s.z()`.
+    compares the slopes of the segments `(p,q)` and `(r,s)`,
+    where the slope is the variation of the `z`-coordinate 
+    from the first to the second point of the segment.
   */ 
   Comparison_result operator()(const Kernel::Point_3& p, 
                                const Kernel::Point_3& q,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1013,6 +1013,40 @@ public:
 
 }; /* end Kernel::CompareSlope_2 */
 
+
+/*!
+  \ingroup PkgKernel23ConceptsFunctionObjects
+  \cgalConcept
+
+  \cgalRefines `AdaptableFunctor` (with two arguments) 
+
+  \sa `compare_slopes_grp`
+
+*/
+class CompareSlope_3 {
+public:
+
+  /// \name Operations
+  /// A model of this concept must provide:
+  /// @{
+
+
+  /*!
+    compares the slopes of the segments `(p,q)` and `(r,s)`
+    with `p.z() >= q.z()` and  `r.z() >= s.z()`.
+  */ 
+  Comparison_result operator()(const Kernel::Point_3& p, 
+                               const Kernel::Point_3& q,
+                               const Kernel::Point_3& r, 
+                               const Kernel::Point_3& s); 
+
+
+  /// @}
+
+}; /* end Kernel::CompareSlope_2 */
+
+
+
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects
   \cgalConcept

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1045,7 +1045,8 @@ public:
   /*!
     compares the slopes of the segments `(p,q)` and `(r,s)`,
     where the slope is the variation of the `z`-coordinate 
-    from the first to the second point of the segment.
+    from the first to the second point of the segment divided
+    by the length of the segment.
   */ 
   Comparison_result operator()(const Kernel::Point_3& p, 
                                const Kernel::Point_3& q,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -62,20 +62,20 @@ public:
   /// @{
 
   /*!
-    returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending 
-  on the angle formed by the two vectors `u` and `v`. 
-  */ 
-  Angle operator()(const Kernel::Vector_3&u, 
-                   const Kernel::Vector_3&v); 
+    returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+  on the angle formed by the two vectors `u` and `v`.
+  */
+  Angle operator()(const Kernel::Vector_3&u,
+                   const Kernel::Vector_3&v);
 
   /*!
-    returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending 
-    on the angle formed by the three points `p`, `q`, `r` (`q` being the vertex of 
+    returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+    on the angle formed by the three points `p`, `q`, `r` (`q` being the vertex of
     the angle). The returned value is the same as `operator()(p - q, r - q)`.
-  */ 
-  Angle operator()(const Kernel::Point_3&p, 
-                   const Kernel::Point_3&q, 
-                   const Kernel::Point_3&r); 
+  */
+  Angle operator()(const Kernel::Point_3&p,
+                   const Kernel::Point_3&q,
+                   const Kernel::Point_3&r);
 
   /*!
     returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending 
@@ -89,12 +89,12 @@ public:
 
   /*!
     returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending 
-    on the angle formed by the twonormal vector of the plane `pqr` and `v`. 
+    on the angle formed by the normal of the triangle `pqr` and the vector `v`. 
   */ 
   Angle operator()(const Kernel::Point_3&p, 
                    const Kernel::Point_3&q, 
                    const Kernel::Point_3&r, 
-                   const Kernel::Vector_3&s); 
+                   const Kernel::Vector_3&v); 
   /// @}
 
 }; /* end Kernel::Angle_3 */

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1055,7 +1055,7 @@ public:
 
   /// @}
 
-}; /* end Kernel::CompareSlope_2 */
+}; /* end Kernel::CompareSlope_3 */
 
 
 

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1409,6 +1409,11 @@ public:
   typedef unspecified_type Compare_xyz_3; 
 
   /*!
+    a model of `Kernel::CompareSlope_3`
+  */
+  typedef unspecified_type Compare_slope_3;
+
+  /*!
     a model of `Kernel::CompareSquaredDistance_3`
   */
   typedef unspecified_type Compare_squared_distance_3;

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -276,6 +276,7 @@
 - `Kernel::CompareDistance_2`
 - `Kernel::CompareDistance_3`
 - `Kernel::CompareSlope_2`
+- `Kernel::CompareSlope_3`
 - `Kernel::ComparePowerDistance_2`
 - `Kernel::ComparePowerDistance_3`
 - `Kernel::CompareSquaredDistance_2`

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -636,15 +636,24 @@ public:
 
     result_type operator()(const Point_3& p, const Point_3& q, const Point_3& r, const Point_3& s) const
     { 
-      CGAL_assertion((p.z() >= q.z()) && (r.z() >= s.z()));
-
-      if(p.z() == q.z() || r.z() == s.z()){
-        return CGAL::compare(p.z() - q.z(), r.z() - s.z());
+      Comparison_result sign_pq = compare(q.z(),p.z());
+      Comparison_result sign_rs = compare(s.z(),r.z());
+      
+      if(sign_pq != sign_rs){
+        return compare(static_cast<int>(sign_pq), static_cast<int>(sign_rs));
       }
-     
-      return CGAL::compare(squared_distance(p,q) / (p.z() - q.z()) ,
-                           squared_distance(r,s) / (r.z() - s.z())); 
+
+      if((sign_pq == EQUAL) && (sign_rs == EQUAL)){
+        return EQUAL;
+      }
+
+      CGAL_assertion( (sign_pq == sign_rs) && (sign_pq != EQUAL)  );
+      
+      Comparison_result res = CGAL::compare(square(p.z() - q.z()) * squared_distance(r,s),
+                                            square(r.z() - s.z()) * squared_distance(p,q));
+      return (sign_pq == SMALLER) ? opposite(res) : res;
     } 
+  
   };
 
 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -626,9 +626,26 @@ public:
 };
 
 
+  template <typename K>
+  class Compare_slope_3
+  {
+    typedef typename K::FT                 FT;
+    typedef typename K::Point_3 Point_3;
+  public:
+    typedef typename K::Comparison_result  result_type;
 
+    result_type operator()(const Point_3& p, const Point_3& q, const Point_3& r, const Point_3& s) const
+    { 
+      CGAL_assertion((p.z() >= q.z()) && (r.z() >= s.z()));
 
-  //////////////////////
+      if(p.z() == q.z() || r.z() == s.z()){
+        return CGAL::compare(p.z() - q.z(), r.z() - s.z());
+      }
+     
+      return CGAL::compare(squared_distance(p,q) / (p.z() - q.z()) ,
+                           squared_distance(r,s) / (r.z() - s.z())); 
+    } 
+  };
 
 
 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -649,8 +649,8 @@ public:
 
       CGAL_assertion( (sign_pq == sign_rs) && (sign_pq != EQUAL)  );
       
-      Comparison_result res = CGAL::compare(square(p.z() - q.z()) * squared_distance(r,s),
-                                            square(r.z() - s.z()) * squared_distance(p,q));
+      Comparison_result res = CGAL::compare(square(p.z() - q.z()) * (square(r.x()-s.x())+square(r.y()-s.y())),
+                                            square(r.z() - s.z()) *  (square(p.x()-q.x())+square(p.y()-q.y())));
       return (sign_pq == SMALLER) ? opposite(res) : res;
     } 
   

--- a/Kernel_23/include/CGAL/Kernel/global_functions_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_2.h
@@ -332,17 +332,35 @@ compare_lexicographically_xy(const Point_2<K> &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_slopes(const Line_2<K> &l1, const Line_2<K> &l2)
+compare_slope(const Line_2<K> &l1, const Line_2<K> &l2)
 {
-  return internal::compare_slopes(l1, l2, K());
+  return internal::compare_slope(l1, l2, K());
 }
 
 template < class K >
 inline
 typename K::Comparison_result
+compare_slope(const Segment_2<K> &s1, const Segment_2<K> &s2)
+{
+  return internal::compare_slope(s1, s2, K());
+}
+
+// kept for backward compatibility
+template < class K >
+inline
+typename K::Comparison_result
+compare_slopes(const Line_2<K> &l1, const Line_2<K> &l2)
+{
+  return internal::compare_slope(l1, l2, K());
+}
+
+// kept for backward compatibility
+template < class K >
+inline
+typename K::Comparison_result
 compare_slopes(const Segment_2<K> &s1, const Segment_2<K> &s2)
 {
-  return internal::compare_slopes(s1, s2, K());
+  return internal::compare_slope(s1, s2, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -347,6 +347,17 @@ compare_distance_to_point(const Point_3<K> &p,
 template < class K >
 inline
 typename K::Comparison_result
+compare_slopes(const Point_3<K> &p,
+               const Point_3<K> &q,
+               const Point_3<K> &r,
+               const Point_3<K> &s)
+{
+  return internal::compare_slopes(p, q, r, s, K());
+}
+
+template < class K >
+inline
+typename K::Comparison_result
 compare_squared_distance(const Point_3<K> &p,
                          const Point_3<K> &q,
                          const typename K::FT &d2)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -356,12 +356,12 @@ compare_distance_to_point(const Point_3<K> &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_slopes(const Point_3<K> &p,
+compare_slope(const Point_3<K> &p,
                const Point_3<K> &q,
                const Point_3<K> &r,
                const Point_3<K> &s)
 {
-  return internal::compare_slopes(p, q, r, s, K());
+  return internal::compare_slope(p, q, r, s, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -59,6 +59,15 @@ angle(const Point_3<K> &p, const Point_3<K> &q,
   return internal::angle(p, q, r, s, K());
 }
 
+template <typename K>
+inline
+Angle
+angle(const Point_3<K> &p, const Point_3<K> &q,
+      const Point_3<K> &r, const Vector_3<K> &v)
+{
+  return internal::angle(p, q, r, v, K());
+}
+
 template < class K >
 inline
 typename K::FT

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
@@ -360,8 +360,8 @@ compare_signed_distance_to_line(const typename K::Line_2& l,
 template < class K >
 inline
 typename K::Comparison_result
-compare_slopes(const typename K::Line_2 &l1,
-               const typename K::Line_2 &l2, const K& k)
+compare_slope(const typename K::Line_2 &l1,
+              const typename K::Line_2 &l2, const K& k)
 {
   return k.compare_slope_2_object()(l1, l2);
 }
@@ -369,8 +369,8 @@ compare_slopes(const typename K::Line_2 &l1,
 template < class K >
 inline
 typename K::Comparison_result
-compare_slopes(const typename K::Segment_2 &s1,
-               const typename K::Segment_2 &s2, const K& k)
+compare_slope(const typename K::Segment_2 &s1,
+              const typename K::Segment_2 &s2, const K& k)
 {
   return k.compare_slope_2_object()(s1, s2);
 }

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -417,11 +417,11 @@ compare_distance_to_point(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_slopes(const typename K::Point_3 &p,
-               const typename K::Point_3 &q,
-               const typename K::Point_3 &r,
-               const typename K::Point_3 &s,
-               const K& k)
+compare_slope(const typename K::Point_3 &p,
+              const typename K::Point_3 &q,
+              const typename K::Point_3 &r,
+              const typename K::Point_3 &s,
+              const K& k)
 {
   return k.compare_slope_3_object()(p, q, r, s);
 }

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -70,6 +70,18 @@ angle(const typename K::Point_3 &p,
   return k.angle_3_object()(p, q, r, s);
 }
 
+template <typename K>
+inline
+typename K::Angle
+angle(const typename K::Point_3 &p,
+      const typename K::Point_3 &q,
+      const typename K::Point_3 &r,
+      const typename K::Vector_3 &v,
+      const K &k)
+{
+  return k.angle_3_object()(p, q, r, v);
+}
+
 template < class K >
 inline
 typename K::FT

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -405,6 +405,18 @@ compare_distance_to_point(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::Comparison_result
+compare_slopes(const typename K::Point_3 &p,
+               const typename K::Point_3 &q,
+               const typename K::Point_3 &r,
+               const typename K::Point_3 &s,
+               const K& k)
+{
+  return k.compare_slope_3_object()(p, q, r, s);
+}
+
+template < class K >
+inline
+typename K::Comparison_result
 compare_squared_distance(const typename K::Point_3 &p,
                          const typename K::Point_3 &q,
                          const typename K::FT &d2,

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -122,6 +122,8 @@ CGAL_Kernel_pred_RT(Compare_distance_3,
 		    compare_distance_3_object)
 CGAL_Kernel_pred(Compare_slope_2,
 		 compare_slope_2_object)
+CGAL_Kernel_pred(Compare_slope_3,
+		 compare_slope_3_object)
 CGAL_Kernel_pred(Compare_squared_distance_2,
 		 compare_squared_distance_2_object)
 CGAL_Kernel_pred(Compare_squared_distance_3,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
@@ -33,6 +33,7 @@ _test_angle(const R&)
   typedef CGAL::Point_3<R>  Point_3;
 
   typedef CGAL::Vector_2<R> Vector_2;
+  typedef CGAL::Vector_3<R> Vector_3;
 
   Point_2 p(RT(2),RT(1));
   Point_2 q(RT(5),RT(4));
@@ -67,6 +68,12 @@ _test_angle(const R&)
   assert( CGAL::angle( org3 - sz, sz - sy) == CGAL::OBTUSE );
   assert( CGAL::angle( org3 - sx, sy - sx) == CGAL::ACUTE );
 
+  Vector_3 vz(RT0, RT0, RT1);
+  Vector_3 vcoplanar(RT1, RT1, RT0);
+  Vector_3 vmz(RT0, RT0, -RT1);
+  assert( CGAL::angle( org3, sx, sy, vz) ==  CGAL::ACUTE );
+  assert( CGAL::angle( org3, sx, sy, vcoplanar) ==  CGAL::RIGHT );
+  assert( CGAL::angle( org3, sx, sy, vmz) ==  CGAL::OBTUSE );
   return true;
 }
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
@@ -93,36 +93,36 @@ _test_fct_line_2(const R& )
  Line_2 l2(p3, p2);
  Line_2 l3(p4, p6);
 
- assert( CGAL::compare_slopes(l1,l2) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l1,l3) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l3,l1) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l1,l2) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l1,l3) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l3,l1) == CGAL::EQUAL );
 
  std::cout <<'.';
 
  // horizontal lines
  Line_2 l4(p3, p8);
  Line_2 l5(p4, p9);
- assert( CGAL::compare_slopes(l4, l5) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l3, l4) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l4, l3) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l4, l5) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l3, l4) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l4, l3) == CGAL::SMALLER );
 
  std::cout <<'.';
 
  // parallel lines
  Line_2 l5a(p6, p7);
  Line_2 l5b(p11, p1);
- assert( CGAL::compare_slopes(l5a, l5b) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l5a, l5b) == CGAL::EQUAL );
  assert( CGAL::parallel(l5a, l5b) );
 
  // two positive slopes
  Line_2 l6(p2, p4);
  Line_2 l7(p2, p6);
  Line_2 l8(p7, p10);
- assert( CGAL::compare_slopes(l6, l6) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l6, l7) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l7, l6) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l6, l8) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l8, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l6) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l6, l7) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l7, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l8) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l8, l6) == CGAL::SMALLER );
  assert(   CGAL::parallel(l6, l6) );
  assert( ! CGAL::parallel(l6, l7) );
  assert( ! CGAL::parallel(l7, l6) );
@@ -130,14 +130,14 @@ _test_fct_line_2(const R& )
  assert( ! CGAL::parallel(l8, l6) );
 
  // vertical and positive slope
- assert( CGAL::compare_slopes(l1, l6) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l6, l1) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l1, l6) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l6, l1) == CGAL::SMALLER );
  assert( ! CGAL::parallel(l1, l6) );
  assert( ! CGAL::parallel(l6, l1) );
 
  // horizontal and positive slope
- assert( CGAL::compare_slopes(l5, l6) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l6, l5) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l5, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l5) == CGAL::LARGER );
  assert( ! CGAL::parallel(l5, l6) );
  assert( ! CGAL::parallel(l6, l5) );
 
@@ -148,28 +148,28 @@ _test_fct_line_2(const R& )
  Line_2 l10(p9, p8);
  Line_2 l11(p5, p3);
 
- assert( CGAL::compare_slopes(l9, l10) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l10, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l11, l10) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l10) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l10, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l11, l10) == CGAL::LARGER );
  assert( ! CGAL::parallel(l9, l10) );
  assert( ! CGAL::parallel(l10, l9) );
  assert( ! CGAL::parallel(l11, l10) );
 
  // vertical and negative slope
- assert( CGAL::compare_slopes(l2, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l2) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l2, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l2) == CGAL::SMALLER );
  assert( ! CGAL::parallel(l2, l9) );
  assert( ! CGAL::parallel(l9, l2) );
 
  // horizontal and negative slope
- assert( CGAL::compare_slopes(l5, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l5) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l5, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l5) == CGAL::SMALLER );
 
  std::cout <<'.';
 
  // positive and negative slope
- assert( CGAL::compare_slopes(l6, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l7) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l7) == CGAL::SMALLER );
  assert( ! CGAL::parallel(l6, l9) );
  assert( ! CGAL::parallel(l9, l7) );
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
@@ -233,6 +233,13 @@ _test_fct_point_3(const R& )
    assert( CGAL::compare_squared_radius(p0, p1, p2, p3, four) == CGAL::EQUAL );
  }
 
+ {
+   CGAL::Point_3<R> p0(0,0,1), p1(0,0,2), p2(1,0,0), p3(1,0,1);
+   assert( CGAL::compare_slopes(p0,p2, p1, p2) == CGAL::SMALLER );
+   assert( CGAL::compare_slopes(p0,p2, p1, p3) == CGAL::EQUAL );
+ }
+
+
  assert(CGAL::l_infinity_distance(p1,p2) == FT(11));
  assert(CGAL::l_infinity_distance(p1,p5) == FT(6));
  // More tests, that require sqrt().

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_point_3.h
@@ -234,9 +234,17 @@ _test_fct_point_3(const R& )
  }
 
  {
-   CGAL::Point_3<R> p0(0,0,1), p1(0,0,2), p2(1,0,0), p3(1,0,1);
-   assert( CGAL::compare_slopes(p0,p2, p1, p2) == CGAL::SMALLER );
-   assert( CGAL::compare_slopes(p0,p2, p1, p3) == CGAL::EQUAL );
+   CGAL::Point_3<R> p0(0,0,1), p1(0,0,2), p2(1,0,1), p3(1,0,2), p4(1,0,3);
+   assert( CGAL::compare_slope(p0, p2, p1, p3) == CGAL::EQUAL );
+   assert( CGAL::compare_slope(p0, p2, p0, p3) == CGAL::SMALLER );
+   assert( CGAL::compare_slope(p0, p2, p1, p2) == CGAL::LARGER );
+   assert( CGAL::compare_slope(p0, p3, p0, p2) == CGAL::LARGER );
+   assert( CGAL::compare_slope(p0, p3, p0, p4) == CGAL::SMALLER );
+   assert( CGAL::compare_slope(p0, p3, p1, p2) == CGAL::LARGER );
+   assert( CGAL::compare_slope(p1, p2, p0, p2) == CGAL::SMALLER );
+   assert( CGAL::compare_slope(p1, p2, p0, p3) == CGAL::SMALLER );
+   assert( CGAL::compare_slope(p1, p2, p4, p0) == CGAL::LARGER );
+   
  }
 
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_segment_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_segment_2.h
@@ -51,43 +51,43 @@ _test_fct_segment_2(const R& )
  Segment_2 l2(p3, p2);
  Segment_2 l3(p4, p6);
 
- assert( CGAL::compare_slopes(l1,l2) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l1,l3) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l3,l1) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l1,l2) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l1,l3) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l3,l1) == CGAL::EQUAL );
 
  std::cout <<'.';
 
  // horizontal segments
  Segment_2 l4(p3, p8);
  Segment_2 l5(p4, p9);
- assert( CGAL::compare_slopes(l4, l5) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l3, l4) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l4, l3) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l4, l5) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l3, l4) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l4, l3) == CGAL::SMALLER );
 
  std::cout <<'.';
 
  // parallel segments
  Segment_2 l5a(p6, p7);
  Segment_2 l5b(p11, p1);
- assert( CGAL::compare_slopes(l5a, l5b) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l5a, l5b) == CGAL::EQUAL );
 
- // two positive slopes
+ // two positive slope
  Segment_2 l6(p2, p4);
  Segment_2 l7(p2, p6);
  Segment_2 l8(p7, p10);
- assert( CGAL::compare_slopes(l6, l6) == CGAL::EQUAL );
- assert( CGAL::compare_slopes(l6, l7) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l7, l6) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l6, l8) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l8, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l6) == CGAL::EQUAL );
+ assert( CGAL::compare_slope(l6, l7) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l7, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l8) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l8, l6) == CGAL::SMALLER );
 
  // vertical and positive slope
- assert( CGAL::compare_slopes(l1, l6) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l6, l1) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l1, l6) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l6, l1) == CGAL::SMALLER );
 
  // horizontal and positive slope
- assert( CGAL::compare_slopes(l5, l6) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l6, l5) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l5, l6) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l5) == CGAL::LARGER );
 
 
 
@@ -98,23 +98,23 @@ _test_fct_segment_2(const R& )
  Segment_2 l10(p9, p8);
  Segment_2 l11(p5, p3);
 
- assert( CGAL::compare_slopes(l9, l10) == CGAL::SMALLER );
- assert( CGAL::compare_slopes(l10, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l11, l10) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l10) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l10, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l11, l10) == CGAL::LARGER );
  
  // vertical and negative slope
- assert( CGAL::compare_slopes(l2, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l2) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l2, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l2) == CGAL::SMALLER );
 
  // horizontal and negative slope
- assert( CGAL::compare_slopes(l5, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l5) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l5, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l5) == CGAL::SMALLER );
 
  std::cout <<'.';
 
  // positive and negative slope
- assert( CGAL::compare_slopes(l6, l9) == CGAL::LARGER );
- assert( CGAL::compare_slopes(l9, l7) == CGAL::SMALLER );
+ assert( CGAL::compare_slope(l6, l9) == CGAL::LARGER );
+ assert( CGAL::compare_slope(l9, l7) == CGAL::SMALLER );
 
  std::cout << "done" << std::endl;
  return true;


### PR DESCRIPTION
(**update** by @lrineau: I took over this PR, and in particular the text of this first message.)

This PR adds two things in the CGAL Kernel concepts (and its models), plus the global functions:

- A functor `Compare_slope_3`,

- and an overload of `Angle_3::operator()(Point_3, Point_3, Point_3, Vector_3)`.

There are two a small features:
- [`Kernel::Compare_slope_3`][slope]
- [`Kernel::Angle_3`][angle]

  [slope]: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Kernel::Compare_slope_3
  [angle]: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Kernel::Angle_3

The PR also adds the free functions, and tests.
