### PR TITLE
Point Set Structuring: Suppress warnings for VC 32bit

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -14,6 +14,10 @@ if ( CGAL_FOUND )
 
   include( CGAL_CreateSingleSourceCGALProgram )
 
+  if (MSVC AND ( CMAKE_SIZEOF_VOID_P EQUAL 4 ) )
+     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+  endif()
+
   include_directories (BEFORE "../../include")
 
   # create a target per cppfile

--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -17,10 +17,11 @@ if ( CGAL_FOUND )
 
   # VisualC++ optimization for applications dealing with large data
   if (MSVC)
-  
-    # Allow Windows 32bit applications to use up to 3GB of RAM
-    SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-
+    if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+      # Allow Windows 32bit applications to use up to 3GB of RAM
+      SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
+      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+    endif()
     # Prints new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )
     message( STATUS "USING DEBUG EXEFLAGS   = '${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_DEBUG}'" )

--- a/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
@@ -15,9 +15,11 @@ if ( CGAL_FOUND )
 
   # VisualC++ optimization for applications dealing with large data
   if (MSVC)
-    # Allow Windows 32bit applications to use up to 3GB of RAM
-    SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-
+    if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+      # Allow Windows 32bit applications to use up to 3GB of RAM
+      SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
+      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+    endif()
     # Prints new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )
     message( STATUS "USING DEBUG EXEFLAGS   = '${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_DEBUG}'" )


### PR DESCRIPTION
Suppress warnings for VC 32bit compilation in 2 CMakeLists.txt
This should fix a warning in the examples of Advancing Front and in Point Set Processing reported in Issue #1806.

(Fix #1806)