### PR TITLE
make Nth_of_tuple_property_map compatible with std::tuple

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/property_map.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/property_map.cpp
@@ -22,11 +22,6 @@ typedef K::Vector_3 Vector_3;
 // Point with normal vector stored in a std::pair.
 typedef std::pair<Point_3, Vector_3> PointVectorPair; 
 
-// Data type = index, followed by the point, followed by a boolean
-// that tells us whether the normal is oriented or not, followed by the normal vector.
-typedef boost::tuple<int, Point_3, bool, Vector_3> IndexedPointWithOrientableNormalTuple;
-
-
 
 // This is an implementation detail of the process_point_set function.
 // We need this function because in process_point_set() we use std::sort.
@@ -128,6 +123,9 @@ int main()
   // As the point is the second element of the tuple (that is with index 1)
   // we use a property map that accesses the 1st element of the tuple.
   {
+    // Data type = index, followed by the point, followed by a boolean
+    // that tells us whether the normal is oriented or not, followed by the normal vector.
+    typedef boost::tuple<int, Point_3, bool, Vector_3> IndexedPointWithOrientableNormalTuple;
     std::vector<IndexedPointWithOrientableNormalTuple> points;
 
     for(int i = 0; i < 10; i++){
@@ -156,5 +154,27 @@ int main()
       std::cout << points[i]  << std::endl;
     }     
   }
+
+  #ifndef CGAL_CFG_NO_CPP0X_TUPLE
+  // same test with std::tuple
+  {
+    typedef std::tuple<int, Point_3, bool, Vector_3> IndexedPointWithOrientableNormalTuple;
+    std::vector<IndexedPointWithOrientableNormalTuple> points;
+
+    for(int i = 0; i < 10; i++){
+      double x = (i%2)?i:-i;
+      points.push_back(std::make_tuple(i,Point_3(9-i,0,0), false, Vector_3(x,0,0)));
+    }
+
+    process_point_set(points.begin(),
+                      points.end(),
+                      CGAL::Nth_of_tuple_property_map<1,IndexedPointWithOrientableNormalTuple>());
+
+    orient_normals(points.begin(),
+                   points.end(),
+                   CGAL::make_nth_of_tuple_property_map<2>(IndexedPointWithOrientableNormalTuple()),
+                   CGAL::make_nth_of_tuple_property_map<3>(IndexedPointWithOrientableNormalTuple()));
+  }
+  #endif
   return 0;
 }

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -276,8 +276,8 @@ struct Nth_of_tuple_property_map<N,std::tuple<T...> >
   value_type& operator[](key_type& tuple) const { return get<N>(tuple); }
 
   typedef Nth_of_tuple_property_map<N,Tuple> Self;
-  friend reference get(const Self&,const key_type& k) {return get<N>(k);}
-  friend void put(const Self&,key_type& k, const value_type& v) {get<N>(k)=v;}
+  friend reference get(const Self&,const key_type& k) {return std::get<N>(k);}
+  friend void put(const Self&,key_type& k, const value_type& v) {std::get<N>(k)=v;}
 };
 #endif
 

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -31,6 +31,7 @@
 
 #endif
 #include <boost/tuple/tuple.hpp>
+#include <CGAL/tuple.h>
 
 #include <utility> // defines std::pair
 
@@ -233,17 +234,21 @@ Second_of_pair_property_map<Pair>
 
 /// \ingroup PkgProperty_map
 /// 
-/// Property map that accesses the Nth item of a `boost::tuple`. 
+/// Property map that accesses the Nth item of a `boost::tuple` or a `std::tuple`.
 /// 
 /// \tparam N %Index of the item to access.
-/// \tparam Tuple Instance of `boost::tuple`.
+/// \tparam Tuple Instance of `boost::tuple` or `std::tuple`.
 /// 
 /// \cgalModels `LvaluePropertyMap`
 template <int N, typename Tuple>
 struct Nth_of_tuple_property_map
 {
   typedef Tuple key_type; ///< typedef to `Tuple`
-  typedef typename boost::tuples::element<N,Tuple>::type value_type; ///< typedef to `boost::tuples::element<N,Tuple>::%type`
+  #ifdef DOXYGEN_RUNNING
+  typedef unspecified_type value_type;  ///< typedef to the N-th type of the tuple
+  #else
+  typedef typename boost::tuples::element<N,Tuple>::type value_type;
+  #endif
   typedef const value_type& reference; ///< typedef to `value_type&`
   typedef boost::lvalue_property_map_tag category; ///< `boost::lvalue_property_map_tag`
   /// Access a property map element.
@@ -257,6 +262,25 @@ struct Nth_of_tuple_property_map
   friend void put(const Self&,key_type& k, const value_type& v) {k.template get<N>()=v;}
   /// @}
 };
+
+#ifndef CGAL_CFG_NO_CPP0X_TUPLE
+template <int N, typename ... T>
+struct Nth_of_tuple_property_map<N,std::tuple<T...> >
+{
+  typedef std::tuple<T...> Tuple;
+  typedef Tuple key_type;
+  typedef typename cpp11::tuple_element<N,Tuple>::type value_type;
+  typedef const value_type& reference;
+  typedef boost::lvalue_property_map_tag category;
+
+  value_type& operator[](key_type& tuple) const { return get<N>(tuple); }
+
+  typedef Nth_of_tuple_property_map<N,Tuple> Self;
+  friend reference get(const Self&,const key_type& k) {return get<N>(k);}
+  friend void put(const Self&,key_type& k, const value_type& v) {get<N>(k)=v;}
+};
+#endif
+
 
 /// Free function to create a Nth_of_tuple_property_map property map.
 ///


### PR DESCRIPTION
Fixes  #1809 

I consider this as a bug and should target 4.10