### PR TITLE
Polyhedron_demo : Update the ids when the item's geometry is changed

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1158,6 +1158,19 @@ void Scene::printPrimitiveIds(CGAL::Three::Viewer_interface* viewer)
       item->printPrimitiveIds(viewer);
   }
 }
+void Scene::updatePrimitiveIds(CGAL::Three::Viewer_interface* viewer, CGAL::Three::Scene_item* it)
+{
+  if(it)
+  {
+    //Only call printPrimitiveIds if the item is a Scene_print_interface_item
+    Scene_print_interface_item* item= dynamic_cast<Scene_print_interface_item*>(it);
+    if(item)
+    {
+      item->printPrimitiveIds(viewer);
+       item->printPrimitiveIds(viewer);
+    }
+  }
+}
 bool Scene::testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer)
 {
     CGAL::Three::Scene_item *i = item(mainSelectionIndex());

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1166,8 +1166,10 @@ void Scene::updatePrimitiveIds(CGAL::Three::Viewer_interface* viewer, CGAL::Thre
     Scene_print_interface_item* item= dynamic_cast<Scene_print_interface_item*>(it);
     if(item)
     {
+      //As this function works as a toggle, the first call hides the ids and the second one  shows them again,
+      //thereby triggering their re-computation.
       item->printPrimitiveIds(viewer);
-       item->printPrimitiveIds(viewer);
+      item->printPrimitiveIds(viewer);
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -126,6 +126,8 @@ public:
   void printPrimitiveId(QPoint point,
                         CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   void printPrimitiveIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  //!Re-computes the primitiveIds for `item`
+  void updatePrimitiveIds(Viewer_interface *, Scene_item *item);
   bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer) Q_DECL_OVERRIDE;
   //!@returns the scene bounding box
   Bbox bbox() const Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -127,7 +127,7 @@ public:
                         CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   void printPrimitiveIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   //!Re-computes the primitiveIds for `item`
-  void updatePrimitiveIds(Viewer_interface *, Scene_item *item);
+  void updatePrimitiveIds(Viewer_interface *, Scene_item *item) Q_DECL_OVERRIDE;
   bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer) Q_DECL_OVERRIDE;
   //!@returns the scene bounding box
   Bbox bbox() const Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1239,6 +1239,7 @@ invalidateOpenGLBuffers()
     are_buffers_filled = false;
 
     d->invalidate_stats();
+    static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->updateIds(this);
 }
 
 void

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1781,6 +1781,7 @@ qglviewer::Vec Viewer::offset()const { return d->offset; }
 void Viewer::setSceneBoundingBox(const qglviewer::Vec &min, const qglviewer::Vec &max)
 {
   QGLViewer::setSceneBoundingBox(min+d->offset, max+d->offset);
+}
 
 void Viewer::updateIds(CGAL::Three::Scene_item * item)
 {

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1781,5 +1781,13 @@ qglviewer::Vec Viewer::offset()const { return d->offset; }
 void Viewer::setSceneBoundingBox(const qglviewer::Vec &min, const qglviewer::Vec &max)
 {
   QGLViewer::setSceneBoundingBox(min+d->offset, max+d->offset);
+
+void Viewer::updateIds(CGAL::Three::Scene_item * item)
+{
+  //all ids are computed when they are displayed the first time.
+  //Calling printPrimitiveIds twice hides and show the ids again, so they are re-computed.
+
+  d->scene->updatePrimitiveIds(this, item);
+  d->scene->updatePrimitiveIds(this, item);
 }
  #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -36,6 +36,7 @@ public:
   Viewer(QWidget * parent, bool antialiasing = false);
   ~Viewer();
   bool testDisplayId(double, double, double);
+  void updateIds(CGAL::Three::Scene_item *);
   // overload several QGLViewer virtual functions
   //! Draws the scene.
   void draw();

--- a/Three/include/CGAL/Three/Scene_draw_interface.h
+++ b/Three/include/CGAL/Three/Scene_draw_interface.h
@@ -27,6 +27,7 @@ namespace CGAL
 {
 namespace Three {
   class Viewer_interface;
+  class Scene_item;
 
 
 // Base class to interact with the scene from the viewer.
@@ -41,6 +42,7 @@ public:
   virtual bool keyPressEvent(QKeyEvent* e) = 0;
   virtual float get_bbox_length() const = 0;
   virtual void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*) = 0;
+  virtual void updatePrimitiveIds(CGAL::Three::Viewer_interface* , CGAL::Three::Scene_item*) = 0;
 
   /*!
    * \brief testDisplayId checks if the id at position (x,y,z) is visible or not.

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -39,6 +39,7 @@ class TextListItem;
 namespace CGAL{
 namespace Three{
 class Scene_draw_interface;
+class Scene_item;
 //! Base class to interact with the viewer from the plugins, the items and the scene.
 class VIEWER_EXPORT Viewer_interface : public QGLViewer, public QOpenGLFunctions_2_1 {
 
@@ -83,6 +84,8 @@ public:
   * \param z the Z coordinate of the id's position.
   * \return true if the ID is visible. */
   virtual bool testDisplayId(double x, double y, double z) = 0;
+  //!Recomputes the ids of the selected item.
+  virtual void updateIds(CGAL::Three::Scene_item *) = 0;
   //!Returns true if the primitive ids are displayed
   virtual bool hasText() const { return false; }
 


### PR DESCRIPTION
This PR fixes #1706 :

 Recomputes the ids in Scene_polyhedron_item::invalidateOpenGLBuffers()