### PR TITLE
Unify the links to the Polyhedron demo in the package descriptions.

### DIFF
--- a/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
+++ b/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
@@ -33,7 +33,7 @@
 \cgalPkgSince{3.1}
 \cgalPkgBib{cgal:kmz-isiobd}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
+++ b/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgSince{3.5}
 \cgalPkgBib{cgal:h-emspe}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
@@ -35,7 +35,7 @@ degenerate hull may also be possible.
 \cgalPkgDependsOn{The dynamic algorithms depend on \ref PkgTriangulation3Summary "3D Triangulations".}
 \cgalPkgBib{cgal:hs-ch3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{See Polyhedral Surface,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
@@ -16,7 +16,7 @@
 \cgalPkgDependsOn{\ref PkgSolverSummary} 
 \cgalPkgBib{cgal:pc-eldp}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -45,7 +45,7 @@
 \cgalPkgDependsOn{\ref PkgTriangulation3Summary}
 \cgalPkgBib{cgal:rty-m3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
+++ b/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
@@ -15,7 +15,7 @@
 \cgalPkgDependsOn{\ref PkgNef3Summary\, \ref PkgConvexDecomposition3Summary}
 \cgalPkgBib{cgal:h-msp3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -19,7 +19,7 @@
 \cgalPkgDependsOn{\ref PkgNef2Summary\, \ref PkgNefS2Summary}
 \cgalPkgBib{cgal:hk-bonp3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -12,7 +12,7 @@
 \cgalPkgSince{4.10}
 \cgalPkgBib{cgal:g-ps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -16,7 +16,7 @@
 \cgalPkgDependsOn{\ref PkgSolverSummary} 
 \cgalPkgBib{cgal:ass-psp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{See Polyhedral Surface,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/PackageDescription.txt
+++ b/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/PackageDescription.txt
@@ -24,7 +24,7 @@
 \cgalPkgSince{4.7}
 \cgalPkgBib{cgal:ovja-pssd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgDependsOn{\ref PkgSolverSummary} 
 \cgalPkgBib{cgal:asg-srps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{See Polyhedral Surface,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -59,7 +59,7 @@ ranging from basic operations on simplices, to complex geometry processing algor
 \cgalPkgDependsOn{documented for each function; \ref PkgSolverSummary}
 \cgalPkgBib{cgal:lty-pmp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
  
 \cgalPkgDescriptionEnd

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -19,7 +19,7 @@
 \cgalPkgDependsOn{\ref PkgHDSSummary}
 \cgalPkgBib{cgal:k-ps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
+++ b/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
@@ -30,7 +30,7 @@
 \cgalPkgDependsOn{\ref PkgSolverSummary} 
 \cgalPkgBib{cgal:ap-pcad}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Principal Component Analysis,pca.zip,Operations on Polygons,polygon.zip,Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Principal Component Analysis,pca.zip,Operations on Polygons,polygon.zip,Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
@@ -20,7 +20,7 @@
 \cgalPkgSince{3.2}
 \cgalPkgBib{cgal:s-ssm2}
 \cgalPkgLicense{\ref licensesLGPL "LGPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
@@ -17,7 +17,7 @@ under positional constraints of some of its vertices, without requiring any addi
 \cgalPkgDependsOn{\ref PkgSolverSummary and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:lsxy-tsmd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Edit plugin of the Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
@@ -15,7 +15,7 @@
 \cgalPkgDependsOn{\ref PkgSolverSummary} 
 \cgalPkgBib{cgal:sal-pptsm2}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
+++ b/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
@@ -25,7 +25,7 @@
 \cgalPkgDependsOn{\ref PkgAABB_treeSummary}
 \cgalPkgBib{cgal:y-smsimpl}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
@@ -26,7 +26,7 @@
 \cgalPkgSince{4.7}
 \cgalPkgBib{cgal:klcdv-tsmsp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
@@ -15,7 +15,7 @@
 \cgalPkgSince{3.3}
 \cgalPkgBib{cgal:c-tsms-12}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Operations on Polyhedra,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
+++ b/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
@@ -21,7 +21,7 @@
 \cgalPkgDependsOn{ \ref PkgSolverSummary}
 \cgalPkgBib{cgal:glt-tsms}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{See Polyhedral Surface,polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 


### PR DESCRIPTION
This PR fixes #1515.
It replaces all the link texts by "Polyhedron demo"