### PR TITLE
Shape detection: fix segfault

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -597,12 +597,13 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
         if (best_candidate->indices_of_assigned_points().size() <
           m_options.min_points) 
         {
-          for (std::size_t i = 0;i < candidates.size() - 1;i++) {
-            if (best_candidate->is_same(candidates[i])) {
-              delete candidates[i];
-              candidates[i] = NULL;
+          if (!(best_candidate->indices_of_assigned_points().empty()))
+            for (std::size_t i = 0;i < candidates.size() - 1;i++) {
+              if (best_candidate->is_same(candidates[i])) {
+                delete candidates[i];
+                candidates[i] = NULL;
+              }
             }
-          }
 
           candidates.back() = NULL;
           delete best_candidate;


### PR DESCRIPTION
Fix for https://github.com/CGAL/cgal/issues/1818.

The problem comes from calling `get_default_random()(m_indices.size())` with `m_indices.size()==0`. The random number is picked in `(0,size-1)`, and `0-1` is not something we want to do with unsigned numbers...