### PR TITLE
Polyhedron demo : extend selection

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -98,6 +98,8 @@ public:
     connect(ui_widget.Create_selection_item_button,  SIGNAL(clicked()), this, SLOT(on_Create_selection_item_button_clicked()));    
     connect(ui_widget.Selection_type_combo_box, SIGNAL(currentIndexChanged(int)), 
             this, SLOT(on_Selection_type_combo_box_changed(int)));
+    connect(ui_widget.lassoCheckBox, &QCheckBox::toggled,
+            this, &Polyhedron_demo_selection_plugin::on_LassoCheckBox_changed);
     connect(ui_widget.Insertion_radio_button, SIGNAL(toggled(bool)), this, SLOT(on_Insertion_radio_button_toggled(bool)));
     connect(ui_widget.Brush_size_spin_box, SIGNAL(valueChanged(int)), this, SLOT(on_Brush_size_spin_box_changed(int)));
     connect(ui_widget.validateButton, SIGNAL(clicked()), this, SLOT(on_validateButton_clicked()));
@@ -294,11 +296,31 @@ public Q_SLOTS:
     ui_widget.modeBox->setCurrentIndex(last_mode);
     connectItem(new_item);
   }
+  void on_LassoCheckBox_changed(bool b)
+  {
+    for(Selection_item_map::iterator it = selection_item_map.begin(); it != selection_item_map.end(); ++it)
+    {
+      it->second->set_lasso_mode(b);
+    }
+  }
   void on_Selection_type_combo_box_changed(int index) {
     typedef Scene_polyhedron_selection_item::Active_handle Active_handle;
     for(Selection_item_map::iterator it = selection_item_map.begin(); it != selection_item_map.end(); ++it) {
       it->second->set_active_handle_type(static_cast<Active_handle::Type>(index));
       Q_EMIT save_handleType();
+      switch(index)
+      {
+      case 0:
+      case 1:
+      case 2:
+        ui_widget.lassoCheckBox->show();
+        break;
+      default:
+        ui_widget.lassoCheckBox->hide();
+        ui_widget.lassoCheckBox->setChecked(false);
+        it->second->set_lasso_mode(false);
+        break;
+      }
       if(index == 1)
       {
         ui_widget.Select_all_NTButton->show();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -494,7 +494,7 @@ public Q_SLOTS:
         print_message("Error: there is no selected edge in this polyhedron selection item!");
         return;
       }
-      Polyhedron poly = *selection_item->polyhedron();
+      const Polyhedron& poly = *selection_item->polyhedron();
       BOOST_FOREACH(Scene_polyhedron_selection_item::edge_descriptor ed, selection_item->selected_edges)
       {
         selection_item->selected_facets.insert(face(halfedge(ed, poly), poly));
@@ -516,7 +516,7 @@ public Q_SLOTS:
         print_message("Error: there is no selected edge in this polyhedron selection item!");
         return;
       }
-      Polyhedron poly = *selection_item->polyhedron();
+      const Polyhedron& poly = *selection_item->polyhedron();
 
       BOOST_FOREACH(Scene_polyhedron_selection_item::edge_descriptor ed, selection_item->selected_edges)
       {
@@ -538,7 +538,7 @@ public Q_SLOTS:
         print_message("Error: there is no selected facet in this polyhedron selection item!");
         return;
       }
-      Polyhedron poly = *selection_item->polyhedron();
+      const Polyhedron& poly = *selection_item->polyhedron();
       std::vector<Scene_polyhedron_selection_item::Halfedge_handle> boundary_edges;
       CGAL::Polygon_mesh_processing::border_halfedges(selection_item->selected_facets, poly, std::back_inserter(boundary_edges));
       BOOST_FOREACH(Scene_polyhedron_selection_item::Halfedge_handle h, boundary_edges)
@@ -561,7 +561,7 @@ public Q_SLOTS:
         print_message("Error: there is no selected facet in this polyhedron selection item!");
         return;
       }
-      Polyhedron poly = *selection_item->polyhedron();
+      const Polyhedron& poly = *selection_item->polyhedron();
       BOOST_FOREACH(Scene_polyhedron_selection_item::Facet_handle fh, selection_item->selected_facets)
       {
         BOOST_FOREACH(Scene_polyhedron_selection_item::halfedge_descriptor h, CGAL::halfedges_around_face(fh->halfedge(), poly) )

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -527,6 +527,7 @@ public Q_SLOTS:
       selection_item->itemChanged();
       break;
     }
+      //Convert from Facet Selection to Bounding Edge Selection
     case 7:
     {
       Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
@@ -671,6 +672,7 @@ public Q_SLOTS:
       ui_widget.docImage_Label->clear();
       break;
     }
+    on_LassoCheckBox_changed(ui_widget.lassoCheckBox->isChecked());
   }
   void on_Select_sharp_edges_button_clicked() {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
@@ -741,6 +743,7 @@ public Q_SLOTS:
     if (scene_ptr)
       connect(selection_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
     connect(selection_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
+    on_LassoCheckBox_changed(ui_widget.lassoCheckBox->isChecked());
   }
   void item_about_to_be_destroyed(CGAL::Three::Scene_item* scene_item) {
     // if polyhedron item

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>479</width>
+    <width>508</width>
     <height>713</height>
    </rect>
   </property>
@@ -61,7 +61,7 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,0">
+             <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,0,0">
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
                 <item>
@@ -101,6 +101,13 @@
                  </widget>
                 </item>
                </layout>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="lassoCheckBox">
+                <property name="text">
+                 <string>Lasso</string>
+                </property>
+               </widget>
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,1,1">

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -416,6 +416,26 @@
                <string>Keep Connected Components of Selected Facets</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>Convert from Edge Selection to Facets Selection</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Convert from Edge Selection to Point Selection</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Convert from Facet Selection to Boundary Edge Selection</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Convert from Facet Selection to Point Selection</string>
+              </property>
+             </item>
             </widget>
            </item>
            <item>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -104,6 +104,15 @@ public:
     void printPrimitiveIds(CGAL::Three::Viewer_interface*viewer) const;
     bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*);
 
+    //! @returns `true` if `f` is the first facet intersected by a raytracing
+    bool intersect_face(double orig_x,
+                        double orig_y,
+                        double orig_z,
+                        double dir_x,
+                        double dir_y,
+                        double dir_z,
+                        Polyhedron::Facet_handle f);
+
 public Q_SLOTS:
     virtual void invalidateOpenGLBuffers();
     virtual void selection_changed(bool);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_k_ring_selection.h
@@ -67,6 +67,7 @@ public:
     is_highlighting = false;
     is_ready_to_highlight = true;
     is_ready_to_paint_select = true;
+    is_lasso_active = false;
     poly_item->enable_facets_picking(true);
     poly_item->set_color_vector_read_only(true);
 
@@ -86,6 +87,8 @@ public:
   {
     is_current_selection = b;
   }
+  void set_lasso_mode(bool b) { is_lasso_active = b; }
+
 public Q_SLOTS:
   // slots are called by signals of polyhedron_item
   void vertex_has_been_selected(void* void_ptr) 
@@ -343,6 +346,7 @@ protected:
   bool is_edit_mode;
   bool is_ready_to_highlight;
   bool is_ready_to_paint_select;
+  bool is_lasso_active;
   QPoint hl_pos;
   QPoint paint_pos;
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -198,7 +198,8 @@ protected:
   { return k_ring_selector.active_handle_type; }
   void set_active_handle_type(Active_handle::Type aht) 
   { k_ring_selector.active_handle_type = aht; }
-
+  void set_lasso_mode(bool b)
+  { k_ring_selector.set_lasso_mode(b); }
   int get_k_ring() { return k_ring_selector.k_ring; }
   void set_k_ring(int k) { k_ring_selector.k_ring = k; }
 


### PR DESCRIPTION
This PR fixes #1775 

 It adds conversion between edges selection and adjacent facet selection, and between facets selection and bounding edges selection.

It also adds a lasso selection.