### PR TITLE
Demo Distance_plugin : fix compilation error

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
@@ -166,7 +166,7 @@ private:
     tree.accelerate_distance_queries();
     tree.build();
 
-    typename Traits::Point_3 hint = m.vertices_begin()->point();
+    Traits::Point_3 hint = m.vertices_begin()->point();
 
 #ifndef CGAL_LINKED_WITH_TBB
     double hdist = 0;

--- a/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
+++ b/Polyhedron/demo/Polyhedron/cgal_test_with_cmake
@@ -131,6 +131,7 @@ corefinement_plugin \
 create_bbox_mesh_plugin \
 cut_plugin \
 detect_sharp_edges_plugin \
+distance_plugin \
 edit_polyhedron_plugin \
 fairing_plugin \
 features_detection_plugin \


### PR DESCRIPTION
This PR removes a `typename` that causes a compilation error on msvc :
"C2899: typename cannot be used outside a template declaration"

The compilation error was introduced by PR #1578