### PR TITLE
Stream_support: No need for replacement of istream >> double for VC++

### DIFF
--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -121,7 +121,7 @@ public:
 };
 
 #if CGAL_FORCE_IFORMAT_DOUBLE || \
-  ( ( _MSC_VER > 1600 ) && (! defined( CGAL_NO_IFORMAT_DOUBLE )) )
+  ( ( _MSC_VER > 1600 ) && ( _MSC_VER < 1910 ) && (! defined( CGAL_NO_IFORMAT_DOUBLE )) )
 template <>
 class Input_rep<double> : public IO_rep_is_specialized {
     double& t;


### PR DESCRIPTION
VC 2017 is even a little bit faster than our code using scanf and parsing doubles.