### PR TITLE
Polyhedron_demo: Fix the Save as option

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1498,6 +1498,10 @@ void MainWindow::on_actionSaveAs_triggered()
   }
 
   if(!item)
+  {
+    item = scene->item(scene->mainSelectionIndex());
+  }
+  if(!item)
     return;
 
   QVector<CGAL::Three::Polyhedron_demo_io_plugin_interface*> canSavePlugins;


### PR DESCRIPTION
 When Save as is called from menuFile, the sender is not an item. To fix it, use mainSelectionItem when no item is found as sender.