### PR TITLE
Add missing const

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -1716,7 +1716,7 @@ struct result<F( BOOST_PP_ENUM_PARAMS(n, T) )> { \
 #define CGAL_CONSTRUCTION_OPERATOR(z, n, d)                                      \
   template<BOOST_PP_ENUM_PARAMS(n, class L)>                            \
   typename cpp11::result_of<Lazy_construction(BOOST_PP_ENUM_PARAMS(n, L))>::type \
-  operator()( BOOST_PP_ENUM(n, CGAL_LARGS, _) ) {                            \
+  operator()( BOOST_PP_ENUM(n, CGAL_LARGS, _) ) const {                            \
     BOOST_PP_REPEAT(n, CGAL_TYPEMAP_EC, L)                                     \
     BOOST_PP_REPEAT(n, CGAL_TYPEMAP_AC, L)                                     \
     typedef typename boost::remove_cv< typename boost::remove_reference < \


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Any const functor from Epeck defining the nested struct `result` could not call any `operator()`

## Release Management

* Affected package(s): Filtered kernel

