### PR TITLE
Avoid namespace pollution

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -134,7 +134,7 @@ double approximate_Hausdorff_distance_impl(
   {
     tbb::atomic<double> distance;
     distance.store(0);
-    Distance_computation<Tree, Point_3> f(tree, hint, sample_points, &distance);
+    Distance_computation<AABBTree, typename Kernel::Point_3> f(tree, hint, sample_points, &distance);
     tbb::parallel_for(tbb::blocked_range<std::size_t>(0, sample_points.size()), f);
     return distance;
   }


### PR DESCRIPTION
## Summary of Changes

Move a class with a generic name outside CGAL namespace

## Release Management

* Affected package(s): PMP

