### PR TITLE
Documentation bugfixes for arrays

### DIFF
--- a/STL_Extension/doc/STL_Extension/CGAL/array.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/array.h
@@ -23,7 +23,7 @@ dimension of the array.
 \cgal provides a `make_array` function for this purpose, up to a
 certain number of arguments.
 */
-template< typename T, int >
+template< typename T, std::size_t >
 class array {
 }; /* end cpp11::array */
 

--- a/STL_Extension/doc/STL_Extension/CGAL/array.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/array.h
@@ -32,7 +32,7 @@ class array {
 /*!
 \relates cpp11::array 
 
-\returns `array<T, N>` where `N` is the number of arguments given to
+\returns `cpp11::array<T, N>` where `N` is the number of arguments given to
 the function. The position of each argument in the array is the same
 as its position in the argument list.
 

--- a/STL_Extension/doc/STL_Extension/CGAL/array.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/array.h
@@ -27,6 +27,8 @@ template< typename T, int >
 class array {
 }; /* end cpp11::array */
 
+} /* end namespace cpp11 */
+
 /*!
 \relates cpp11::array 
 
@@ -36,7 +38,6 @@ as its position in the argument list.
 
 The maximal number of arguments is `6`.
 */ 
-template <class T> array<T, N> make_array(const T&...); 
+template <class T> cpp11::array<T, N> make_array(const T&...);
 
-} /* end namespace cpp11 */
 } /* end namespace CGAL */


### PR DESCRIPTION
## Summary of Changes

This fixes 2 documentation bugs:
- `make_array()` is currently documented as `CGAL::cpp11::make_array()` whereas it isn't actully in the `cpp11` namespace (it's just `CGAL::make_array()`)
- the template arguments for `CGAL::cpp11::array` are a type `T` and an `int`. This second argument should be a `std::size_t` (this is the case both in the [STL version](http://fr.cppreference.com/w/cpp/container/array) and in the [Boost version](http://www.boost.org/doc/libs/1_62_0/doc/html/boost/array.html)).

## Release Management

* Affected package(s): STL_Extensions (doc only)
