### PR TITLE
Try without the PPA kalakris-cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,4 @@ addons:
       # - qttools5-dev 
       # - qttools5-dev-tools 
     sources: 
-      - kalakris-cmake 
       - boost-latest 


### PR DESCRIPTION
A lot of jobs randomly fail with:
```
The command "sudo -E apt-add-repository -y "ppa:kalakris/cmake"" failed and exited with 1 during .
```

Let's try to remove that PPA. If Travis can build our jobs without that PPA, that will remove one point of failure.
