### PR TITLE
Add a .mesh reader

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -1,0 +1,674 @@
+#ifndef CGAL_MESH_3_TET_SOUP_TO_C3T3_H
+#define CGAL_MESH_3_TET_SOUP_TO_C3T3_H
+
+#include <CGAL/IO/File_medit.h>
+
+#include <CGAL/assertions.h>
+
+#include <boost/array.hpp>
+#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/foreach.hpp>
+
+// The purpose of this file is to rebuild manually a triangulation from a c3t3
+// output file (because generating a new triangulation every time is expensive)
+
+namespace CGAL
+{
+// the output gives all the cells :
+// - the cells in complex are under 'Tetrahedra', with a reference field that is
+//   their subdomain's index
+// - the finite cells not in complex are also given under 'Tetrahedra', but their
+//   reference field is '-1'
+// - the infinite cells are given under 'InfiniteCells', which is not a medit
+//   keyword and will get ignored by medit, but it is useful information (to me)
+//   to build a triangulation from the output file
+
+template <class C3T3,
+          class Vertex_index_property_map,
+          class Facet_index_property_map,
+          class Facet_index_property_map_twice,
+          class Cell_index_property_map>
+void
+output_to_medit_all_cells(std::ostream& os,
+                          const C3T3& c3t3,
+                          const Vertex_index_property_map& vertex_pmap,
+                          const Facet_index_property_map& facet_pmap,
+                          const Cell_index_property_map& cell_pmap,
+                          const Facet_index_property_map_twice& facet_twice_pmap = Facet_index_property_map_twice(),
+                          const bool print_each_facet_twice = false)
+{
+  typedef typename C3T3::Triangulation                  Tr;
+  typedef typename C3T3::Facets_in_complex_iterator     Facet_iterator;
+
+  typedef typename Tr::Finite_vertices_iterator         Finite_vertices_iterator;
+  typedef typename Tr::All_cells_iterator               All_cells_iterator;
+  typedef typename Tr::Finite_cells_iterator            Finite_cells_iterator;
+  typedef typename Tr::Vertex_handle                    Vertex_handle;
+  typedef typename Tr::Point                            Point_3;
+
+  const Tr& tr = c3t3.triangulation();
+
+  //-------------------------------------------------------
+  // Header
+  //-------------------------------------------------------
+  os << std::setprecision(17);
+
+  os << "MeshVersionFormatted 1" << std::endl
+     << "Dimension 3" << std::endl;
+
+  //-------------------------------------------------------
+  // Vertices
+  //-------------------------------------------------------
+  os << "Vertices" << std::endl
+     << tr.number_of_vertices() << std::endl;
+
+  std::map<Vertex_handle, int> V;
+  int inum = 1;
+
+  Finite_vertices_iterator fvend = tr.finite_vertices_end();
+  for(Finite_vertices_iterator vit = tr.finite_vertices_begin();
+                               vit != fvend; ++vit)
+  {
+    V[vit] = inum++;
+    Point_3 p = vit->point();
+    os << CGAL::to_double(p.x()) << " "
+       << CGAL::to_double(p.y()) << " "
+       << CGAL::to_double(p.z()) << " "
+       << get(vertex_pmap, vit)
+       << std::endl;
+  }
+
+  //-------------------------------------------------------
+  // Facets
+  //-------------------------------------------------------
+  typename C3T3::size_type number_of_triangles = c3t3.number_of_facets_in_complex();
+
+  if(print_each_facet_twice)
+    number_of_triangles += number_of_triangles;
+
+  os << "Triangles" << std::endl
+     << number_of_triangles << std::endl;
+
+  Facet_iterator ficend = c3t3.facets_in_complex_end();
+  for(Facet_iterator fit = c3t3.facets_in_complex_begin();
+                     fit != ficend; ++fit)
+  {
+    for(int i=0; i<4; i++)
+    {
+      if(i != fit->second)
+      {
+        const Vertex_handle vh = (*fit).first->vertex(i);
+        os << V[vh] << " ";
+      }
+    }
+    os << get(facet_pmap, *fit) << std::endl;
+
+    // Print triangle again if needed
+    if(print_each_facet_twice)
+    {
+      for(int i=0; i<4; i++)
+      {
+        if(i != fit->second)
+        {
+          const Vertex_handle vh = (*fit).first->vertex(i);
+          os << V[vh] << " ";
+        }
+      }
+      os << get(facet_twice_pmap, *fit) << std::endl;
+    }
+  }
+
+  std::cout << "output: " << std::endl;
+  std::cout << tr.number_of_vertices() << " vertices" << std::endl;
+  std::cout << c3t3.number_of_cells_in_complex() << " finite cells in complex" << std::endl;
+  std::cout << tr.number_of_finite_cells() << " finite cells" << std::endl;
+  std::cout << tr.number_of_cells() << " total cells" << std::endl;
+
+  //-------------------------------------------------------
+  // Tetrahedra
+  //-------------------------------------------------------
+
+  os << "Tetrahedra" << std::endl
+     << tr.number_of_finite_cells() << std::endl;
+
+  Finite_cells_iterator fcend = tr.finite_cells_end();
+  for(Finite_cells_iterator cit = tr.finite_cells_begin();
+                            cit != fcend; ++cit )
+  {
+    for(int i=0; i<4; i++)
+      os << V[cit->vertex(i)] << " ";
+    os << get(cell_pmap, cit) << std::endl;
+  }
+
+  //-------------------------------------------------------
+  // Infinite cells
+  //-------------------------------------------------------
+
+  os << "InfiniteCells" << std::endl
+     << tr.number_of_cells() - tr.number_of_finite_cells() << std::endl;
+
+  All_cells_iterator acend = tr.all_cells_end();
+  for(All_cells_iterator cit=tr.all_cells_begin();
+                         cit!=acend; ++cit )
+  {
+    if(!tr.is_infinite(cit))
+      continue;
+
+    for (int i=0; i<4; i++)
+    {
+      Vertex_handle vh = cit->vertex(i);
+      if(tr.is_infinite(vh))
+        os << "0 ";
+      else
+        os << V[vh] << " ";
+    }
+    os << "-1" << std::endl;
+  }
+
+  //-------------------------------------------------------
+  // End
+  //-------------------------------------------------------
+  os << "End" << std::endl;
+}
+
+
+template <class C3T3, bool rebind, bool no_patch>
+void
+output_to_medit_all_cells(std::ostream& os,
+                          const C3T3& c3t3)
+{
+  typedef CGAL::Mesh_3::Medit_pmap_generator<C3T3,rebind,no_patch> Generator;
+  typedef typename Generator::Cell_pmap Cell_pmap;
+  typedef typename Generator::Facet_pmap Facet_pmap;
+  typedef typename Generator::Facet_pmap_twice Facet_pmap_twice;
+  typedef typename Generator::Vertex_pmap Vertex_pmap;
+
+  Cell_pmap cell_pmap(c3t3);
+  Facet_pmap facet_pmap(c3t3,cell_pmap);
+  Facet_pmap_twice facet_pmap_twice(c3t3,cell_pmap);
+  Vertex_pmap vertex_pmap(c3t3,cell_pmap,facet_pmap);
+
+  output_to_medit_all_cells(os,
+                            c3t3,
+                            vertex_pmap,
+                            facet_pmap,
+                            cell_pmap,
+                            facet_pmap_twice,
+                            Generator().print_twice());
+
+#ifdef CGAL_MESH_3_IO_VERBOSE
+  std::cerr << "done.\n";
+#endif
+}
+
+// The function below reads a medit file and builds a triangulation from it.
+
+// -- If we're given every cell (finite & infinite), we can easily build
+//    the full triangulation with the same connectivity than the input !
+// -- If we're only given every finite cell, we can deduce the infinite cells and
+//    build the full triangulation
+// -- If we're only given the cells in complex, well... Since the cells in complex
+//    are usually not the convex hull of the points it's problematic and the input
+//    is remeshed (or rejected)
+
+// Side note on the numbering: since the vertex n° 0 is the infinite vertex,
+// we have to shift everything by one (but in the other direction than medit...)
+
+template<class Tr>
+void build_vertices(Tr& tr,
+                    const std::vector<typename Tr::Point>& points,
+                    std::vector<typename Tr::Vertex_handle>& vertex_handle_vector)
+{
+  typedef typename Tr::Vertex_handle            Vertex_handle;
+
+  vertex_handle_vector[0] = tr.tds().create_vertex(); // creates the infinite vertex
+  tr.infinite_vertex() = vertex_handle_vector[0];
+
+  // build vertices
+  for(std::size_t i=0; i<points.size(); ++i)
+  {
+    Vertex_handle vh = tr.tds().create_vertex();
+    vertex_handle_vector[i+1] = vh;
+    vh->set_point(points[i]);
+  }
+}
+
+template<class Tr>
+void add_facet_to_incident_cells_map(const typename Tr::Cell_handle c, int i,
+                                     std::map<std::set<typename Tr::Vertex_handle>,
+                                              std::vector<std::pair<typename Tr::Cell_handle,
+                                                                    int> > >& incident_cells_map)
+{
+  typedef typename Tr::Vertex_handle                            Vertex_handle;
+  typedef typename Tr::Cell_handle                              Cell_handle;
+  typedef std::set<Vertex_handle>                               Facet;
+  typedef std::pair<Cell_handle, int>                           Incident_cell;
+  typedef std::map<Facet, std::vector<Incident_cell> >          Incident_cells_map;
+
+  // the opposite vertex of f in c is i
+  Facet f;
+  f.insert(c->vertex((i + 1) % 4));
+  f.insert(c->vertex((i + 2) % 4));
+  f.insert(c->vertex((i + 3) % 4));
+  CGAL_precondition(f.size() == 3);
+
+  Incident_cell e = std::make_pair(c, i);
+  std::vector<Incident_cell> vec;
+  vec.push_back(e);
+  std::pair<typename Incident_cells_map::iterator, bool> is_insert_successful =
+                              incident_cells_map.insert(std::make_pair(f, vec));
+  if(!is_insert_successful.second) // the entry already exists in the map
+  {
+    // a facet must have exactly two incident cells
+    CGAL_assertion(is_insert_successful.first->second.size() == 1);
+    is_insert_successful.first->second.push_back(e);
+  }
+}
+
+template<class Tr>
+void build_finite_cells(Tr& tr,
+                        const std::vector<boost::array<int,5> >& finite_cells,
+                        const std::vector<typename Tr::Vertex_handle>& vertex_handle_vector,
+                        std::map<std::set<typename Tr::Vertex_handle>,
+                                 std::vector<std::pair<typename Tr::Cell_handle,
+                                                       int> > >& incident_cells_map,
+                                                 const std::map<boost::array<int,3>, int>& border_facets)
+{
+  typedef boost::array<int, 5>              Tet_with_ref; // 4 ids + 1 reference
+
+  typedef typename Tr::Vertex_handle                            Vertex_handle;
+  typedef typename Tr::Cell_handle                              Cell_handle;
+
+  // build the finite cells
+  for(std::size_t i=0; i<finite_cells.size(); ++i)
+  {
+    const Tet_with_ref& tet = finite_cells[i];
+    boost::array<Vertex_handle, 4> vs;
+
+    for(int j=0; j<4; ++j)
+    {
+      CGAL_precondition(static_cast<std::size_t>(tet[j]) < tr.number_of_vertices() &&
+                        tet[j] >= 0);
+      vs[j] = vertex_handle_vector[tet[j] + 1];
+      CGAL_postcondition(vs[j] != Vertex_handle());
+    }
+
+    // this assertion also tests for degeneracy
+    CGAL_assertion(CGAL::orientation(vs[0]->point().point(), vs[1]->point().point(),
+                                     vs[2]->point().point(), vs[3]->point().point()) == POSITIVE);
+
+    Cell_handle c = tr.tds().create_cell(vs[0], vs[1], vs[2], vs[3]);
+    c->info() = tet[4]; // the reference encodes the interior/exterior info
+
+    // the reference must either be -1 for finite interior or > 0 for subdomains
+    CGAL_precondition(tet[4] != 0);
+    // assign cells to vertices
+    for(int j=0; j<4; ++j)
+    {
+      if(vs[j]->cell() == Cell_handle())
+        vs[j]->set_cell(c);
+    }
+
+    // build the map used for adjacency later
+    for(int j=0; j<4; ++j)
+    {
+      add_facet_to_incident_cells_map<Tr>(c, j, incident_cells_map);
+      if(border_facets.size() !=0)
+      {
+        boost::array<int,3> facet;
+        facet[0]=tet[(j+ 1) % 4];
+        facet[1]=tet[(j+ 2) % 4];
+        facet[2]=tet[(j+ 3) % 4];
+        //find the circular permutation that puts the smallest index in the first place.
+        int n0 = (std::min)((std::min)(facet[0],facet[1]), facet[2]);
+        int k=0;
+        boost::array<int,3> f;
+        do
+        {
+          f[0]=facet[(0+k)%3];
+          f[1]=facet[(1+k)%3];
+          f[2]=facet[(2+k)%3];
+          ++k;
+        }while(f[0] != n0);
+        if(border_facets.find(f) != border_facets.end())
+            c->set_surface_patch_index(j, border_facets.at(f));
+        else
+        {
+          int temp = f[2];
+          f[2]=f[1];
+          f[1]=temp;
+          if(border_facets.find(f) != border_facets.end())
+            c->set_surface_patch_index(j, border_facets.at(f));
+          else
+            c->set_surface_patch_index(j, 0);
+        }
+      }
+    }
+  }
+}
+
+template<class Tr>
+void add_infinite_facets_to_incident_cells_map(typename Tr::Cell_handle c,
+                                               int inf_vert_pos,
+                                               std::map<std::set<typename Tr::Vertex_handle>,
+                                                        std::vector<std::pair<typename Tr::Cell_handle,
+                                                                              int> > >& incident_cells_map)
+{
+  int l = (inf_vert_pos + 1) % 4;
+  add_facet_to_incident_cells_map<Tr>(c, l, incident_cells_map);
+  l = (inf_vert_pos + 2) % 4;
+  add_facet_to_incident_cells_map<Tr>(c, l, incident_cells_map);
+  l = (inf_vert_pos + 3) % 4;
+  add_facet_to_incident_cells_map<Tr>(c, l, incident_cells_map);
+}
+
+template<class Tr>
+void build_infinite_cells(Tr& tr,
+                          const std::vector<boost::array<int,4> >& infinite_cells,
+                          const std::vector<typename Tr::Vertex_handle>& vertex_handle_vector,
+                          std::map<std::set<typename Tr::Vertex_handle>,
+                                   std::vector<std::pair<typename Tr::Cell_handle,
+                                                         int> > >& incident_cells_map)
+{
+  typedef boost::array<int, 4>                            Tet; // 4 ids
+
+  typedef typename Tr::Vertex_handle                      Vertex_handle;
+  typedef typename Tr::Cell_handle                        Cell_handle;
+  typedef std::set<Vertex_handle>                         Facet;
+  typedef std::pair<Cell_handle, int>                     Incident_cell;
+  typedef std::map<Facet, std::vector<Incident_cell> >    Incident_cells_map;
+
+  // build the infinite cells if provided
+  for(std::size_t i=0; i<infinite_cells.size(); ++i)
+  {
+    const Tet& tet = infinite_cells[i];
+
+    int inf_pos = -1; // position of the infinite vertex
+    boost::array<Vertex_handle, 4> vs;
+    for(int j=0; j<4; ++j)
+    {
+      if(tet[j] == -1)
+      {
+        vs[j] = tr.infinite_vertex();
+        inf_pos = j;
+      }
+      else
+        vs[j] = vertex_handle_vector[tet[j] + 1];
+    }
+    CGAL_precondition(inf_pos != -1);
+
+    Cell_handle c = tr.tds().create_cell(vs[0], vs[1], vs[2], vs[3]);
+
+    // could simply be 'if(!i)', but this is clearer
+    if(tr.infinite_vertex()->cell() == Cell_handle())
+      tr.infinite_vertex()->set_cell(c);
+
+    // add the cell to the incident cells map
+    Facet f;
+    for(int j=1; j<=3; ++j)
+      f.insert(vertex_handle_vector[tet[(inf_pos + j) % 4] + 1]);
+
+    // we're adding infinite cells, and have already inserted the finite cells
+    // in the map, so there has to be an entry in the map for this face already
+    typename Incident_cells_map::iterator it = incident_cells_map.find(f);
+    CGAL_assertion(it != incident_cells_map.end());
+    (it->second).push_back(std::make_pair(c, inf_pos));
+
+    // the three infinite facets
+    add_infinite_facets_to_incident_cells_map<Tr>(c, inf_pos, incident_cells_map);
+  }
+
+  // manually build the infinite cells if they were not provided
+  if(infinite_cells.empty())
+  {
+    // check the incident cells map for facets who only have one incident cell
+    // and build the infinite cell on the opposite side
+    typename Incident_cells_map::iterator it = incident_cells_map.begin();
+    for(; it!=incident_cells_map.end(); ++it)
+    {
+      if(it->second.size() == 2) // facet already has both its incident cells
+        continue;
+      CGAL_assertion(it->second.size() == 1);
+
+      Cell_handle c = it->second[0].first;
+      int i = it->second[0].second;
+
+      Cell_handle opp_c;
+      // the infinite cell that we are creating needs to be well oriented...
+      int inf_vert_position_in_opp_c = -1;
+      if(i == 0 || i == 2)
+      {
+        inf_vert_position_in_opp_c = 1;
+        opp_c = tr.tds().create_cell(c->vertex((i+3)%4),
+                                     tr.infinite_vertex(),
+                                     c->vertex((i+1)%4),
+                                     c->vertex((i+2)%4));
+      }
+      else
+      {
+        inf_vert_position_in_opp_c = 0;
+        opp_c = tr.tds().create_cell(tr.infinite_vertex(),
+                                     c->vertex((i+1)%4),
+                                     c->vertex((i+2)%4),
+                                     c->vertex((i+3)%4));
+      }
+      // set the infinite_vertex's incident cell
+      if(tr.infinite_vertex()->cell() == Cell_handle())
+        tr.infinite_vertex()->set_cell(opp_c);
+
+      // add the facets to the incident cells map
+
+
+      // the only finite facet
+      it->second.push_back(std::make_pair(opp_c, inf_vert_position_in_opp_c));
+
+      add_infinite_facets_to_incident_cells_map<Tr>(opp_c, inf_vert_position_in_opp_c,
+                                                    incident_cells_map);
+    }
+  }
+}
+
+template<class Tr>
+bool assign_neighbors(Tr& tr,
+                      const std::map<std::set<typename Tr::Vertex_handle>,
+                                     std::vector<std::pair<typename Tr::Cell_handle,
+                                                           int> > >& incident_cells_map)
+{
+  typedef typename Tr::Vertex_handle                              Vertex_handle;
+  typedef typename Tr::Cell_handle                                Cell_handle;
+  typedef std::set<Vertex_handle>                                 Facet;
+  typedef std::pair<Cell_handle, int>                             Incident_cell;
+  typedef std::map<Facet, std::vector<Incident_cell> >            Incident_cells_map;
+
+  // 4 facets per cell, each facet shared by 2 cells
+  if(incident_cells_map.size() != tr.number_of_cells() * 2)
+      return false;
+
+  typename Incident_cells_map::const_iterator icit = incident_cells_map.begin();
+  for(; icit!=incident_cells_map.end(); ++icit)
+  {
+    const std::vector<Incident_cell>& adjacent_cells = icit->second;
+    if(adjacent_cells.size() != 2)
+        return false;
+
+    Cell_handle c0 = adjacent_cells[0].first;
+    int i0 = adjacent_cells[0].second;
+    Cell_handle c1 = adjacent_cells[1].first;
+    int i1 = adjacent_cells[1].second;
+
+    tr.tds().set_adjacency(c0, i0, c1, i1);
+  }
+  return true;
+}
+
+template<class Tr, bool c3t3_loader_failed>
+bool build_triangulation(Tr& tr,
+                         const std::vector<typename Tr::Point>& points,
+                         const std::vector<boost::array<int,5> >& finite_cells,
+                         const std::vector<boost::array<int,4> >& infinite_cells,
+                         const std::map<boost::array<int,3>, int>& border_facets)
+{
+  typedef typename Tr::Vertex_handle            Vertex_handle;
+  typedef typename Tr::Cell_handle              Cell_handle;
+  typedef std::set<Vertex_handle>               Facet;
+
+  // associate to a face the two (at most) incident tets and the id of the face in the cell
+  typedef std::pair<Cell_handle, int>                   Incident_cell;
+  typedef std::map<Facet, std::vector<Incident_cell> >  Incident_cells_map;
+
+  Incident_cells_map incident_cells_map;
+  std::vector<Vertex_handle> vertex_handle_vector(points.size() + 1); // id to vertex_handle
+
+  CGAL_precondition(!points.empty() && !finite_cells.empty());
+
+  tr.tds().clear(); // not tr.clear() since it calls tr.init() which we don't want
+
+  build_vertices<Tr>(tr, points, vertex_handle_vector);
+  build_finite_cells<Tr>(tr, finite_cells, vertex_handle_vector, incident_cells_map, border_facets);
+  build_infinite_cells<Tr>(tr, infinite_cells, vertex_handle_vector, incident_cells_map);
+  tr.tds().set_dimension(3);
+  if(!assign_neighbors<Tr>(tr, incident_cells_map))
+      return false;
+
+  std::cout << "built triangulation : " << std::endl;
+  std::cout << tr.number_of_vertices() << " vertices" << std::endl;
+  std::cout << tr.number_of_cells() << " cells" << std::endl;
+
+  BOOST_FOREACH(Vertex_handle vh, vertex_handle_vector)
+  {
+      vh->set_dimension(3);
+  }
+  if(c3t3_loader_failed)
+  {
+      return true;
+  }
+  else
+      return tr.is_valid(true);
+}
+
+template<class Tr, bool c3t3_loader_failed>
+bool build_triangulation_from_file(std::istream& is,
+                                   Tr& tr,
+                                   std::vector<bool>& border_info_vec)
+{
+  typedef typename Tr::Point                                  Point_3;
+
+  typedef boost::array<int, 3> Facet; // 3 = id
+  typedef boost::array<int, 4> Tet; // 4 = id
+  typedef boost::array<int, 5> Tet_with_ref; // first 4 = id, fifth = reference
+
+  std::size_t finite_exterior_cells_counter = 0;
+  std::vector<Tet_with_ref> finite_cells;
+  std::vector<Tet> infinite_cells;
+  std::vector<Point_3> points;
+  std::map<Facet, int> border_facets;
+
+  // grab the vertices
+  int dim;
+  int nv, nf, ntet, nic, border_info;
+  std::string word;
+
+  is >> word >> dim; // MeshVersionFormatted 1
+  is >> word >> dim; // Dimension 3
+
+  CGAL_assertion(dim == 3);
+
+  while(is >> word && word != "End")
+  {
+    if(word == "Vertices")
+    {
+      is >> nv;
+      for(int i=0; i<nv; ++i)
+      {
+        double x,y,z;
+        is >> x >> y >> z >> border_info;
+        border_info_vec.push_back(border_info);
+        points.push_back(Point_3(x,y,z));
+      }
+    }
+
+    if(word == "Triangles")
+    {
+      is >> nf;
+      for(int i=0; i<nf; ++i)
+      {
+        int n1, n2, n3, surface_patch_id;
+        is >> n1 >> n2 >> n3 >> surface_patch_id;
+        // no use for boundary facets for now...
+        Facet facet;
+        facet[0] =n1 -1;
+        facet[1] =n2 -1;
+        facet[2] =n3 -1;
+        //find the circular permutation that puts the smallest index in the first place.
+        int n0 = (std::min)((std::min)(facet[0],facet[1]), facet[2]);
+        int k=0;
+        Facet f;
+        do
+        {
+          f[0]=facet[(0+k)%3];
+          f[1]=facet[(1+k)%3];
+          f[2]=facet[(2+k)%3];
+          ++k;
+        }while(f[0] != n0);
+        border_facets.insert(std::make_pair(f, surface_patch_id));
+      }
+    }
+
+    if(word == "Tetrahedra")
+    {
+      is >> ntet;
+      for(int i=0; i<ntet; ++i)
+      {
+        int n0, n1, n2, n3, reference;
+        is >> n0 >> n1 >> n2 >> n3 >> reference;
+        CGAL_assertion(reference >= 0);
+        Tet_with_ref t;
+        t[0] = n0 - 1;
+        t[1] = n1 - 1;
+        t[2] = n2 - 1;
+        t[3] = n3 - 1;
+        t[4] = reference;
+        finite_cells.push_back(t);
+      }
+    }
+
+    if(word == "InfiniteCells")
+    {
+      is >> nic;
+      for(int i=0; i<nic; ++i)
+      {
+        int n0, n1, n2, n3, reference;
+        is >> n0 >> n1 >> n2 >> n3 >> reference;
+        Tet t;
+        t[0] = n0 - 1;
+        t[1] = n1 - 1;
+        t[2] = n2 - 1;
+        t[3] = n3 - 1;
+        t[4] = reference;
+        infinite_cells.push_back(t);
+      }
+    }
+  }
+
+
+
+  if(infinite_cells.empty())
+    std::cerr << "WARNING: no infinite cell information provided" << std::endl;
+
+  if(!finite_exterior_cells_counter)
+  {
+    // The finite interior cells MUST be the convex hulls of the point
+    std::cerr << "WARNING: no finite exterior cell provided..." << std::endl;
+    // todo, remesh the provided triangulation with Mesh_3
+  }
+
+  CGAL_precondition(!finite_cells.empty());
+
+  bool is_well_built = build_triangulation<Tr, c3t3_loader_failed>(tr, points, finite_cells, infinite_cells, border_facets);
+  return is_well_built;
+}
+
+}  // namespace CGAL
+
+#endif // CGAL_MESH_3_TET_SOUP_TO_C3T3_H

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -362,7 +362,7 @@ bool build_triangulation_from_file(std::istream& is,
 
   // grab the vertices
   int dim;
-  int nv, nf, ntet;
+  int nv, nf, ntet, ref;
   std::string word;
 
   is >> word >> dim; // MeshVersionFormatted 1
@@ -378,7 +378,7 @@ bool build_triangulation_from_file(std::istream& is,
       for(int i=0; i<nv; ++i)
       {
         double x,y,z;
-        is >> x >> y >> z;
+        is >> x >> y >> z>>ref;
         points.push_back(Point_3(x,y,z));
       }
     }

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -104,6 +104,8 @@ void build_finite_cells(Tr& tr,
     Cell_handle c = tr.tds().create_cell(vs[0], vs[1], vs[2], vs[3]);
     c->info() = tet[4]; // the reference encodes the interior/exterior info
 
+    // the reference must either be -1 for finite interior or > 0 for subdomains
+    CGAL_precondition(tet[4] != 0);
     // assign cells to vertices
     for(int j=0; j<4; ++j)
     {

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -228,7 +228,8 @@ void build_infinite_cells(Tr& tr,
     // check the incident cells map for facets who only have one incident cell
     // and build the infinite cell on the opposite side
     typename Incident_cells_map::iterator it = incident_cells_map.begin();
-    for(; it!=incident_cells_map.end(); ++it)
+    typename Incident_cells_map::iterator end = incident_cells_map.end();
+    for(; it != end; ++it)
     {
       if(it->second.size() == 2) // facet already has both its incident cells
         continue;
@@ -259,9 +260,7 @@ void build_infinite_cells(Tr& tr,
 
       // the only finite facet
       it->second.push_back(std::make_pair(opp_c, inf_vert_position_in_opp_c));
-
-      add_infinite_facets_to_incident_cells_map<Tr>(opp_c, inf_vert_position_in_opp_c,
-                                                    incident_cells_map);
+      CGAL_assertion(it->second.size() == 2);
     }
   }
 }
@@ -277,10 +276,6 @@ bool assign_neighbors(Tr& tr,
   typedef std::set<Vertex_handle>                                 Facet;
   typedef std::pair<Cell_handle, int>                             Incident_cell;
   typedef std::map<Facet, std::vector<Incident_cell> >            Incident_cells_map;
-
-  // 4 facets per cell, each facet shared by 2 cells
-  if(incident_cells_map.size() != tr.number_of_cells() * 2)
-    return false;
 
   typename Incident_cells_map::const_iterator icit = incident_cells_map.begin();
   for(; icit!=incident_cells_map.end(); ++icit)

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -1,6 +1,9 @@
 #ifndef CGAL_MESH_3_TET_SOUP_TO_C3T3_H
 #define CGAL_MESH_3_TET_SOUP_TO_C3T3_H
 
+#include <CGAL/license/Mesh_3.h>
+
+
 #include <CGAL/IO/File_medit.h>
 
 #include <CGAL/assertions.h>

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -437,29 +437,23 @@ void build_infinite_cells(Tr& tr,
 
       Cell_handle opp_c;
       // the infinite cell that we are creating needs to be well oriented...
-      int inf_vert_position_in_opp_c = -1;
+      int inf_vert_position_in_opp_c = 0;
       if(i == 0 || i == 2)
-      {
-        inf_vert_position_in_opp_c = 1;
-        opp_c = tr.tds().create_cell(c->vertex((i+3)%4),
-                                     tr.infinite_vertex(),
-                                     c->vertex((i+1)%4),
-                                     c->vertex((i+2)%4));
-      }
-      else
-      {
-        inf_vert_position_in_opp_c = 0;
         opp_c = tr.tds().create_cell(tr.infinite_vertex(),
                                      c->vertex((i+1)%4),
                                      c->vertex((i+2)%4),
                                      c->vertex((i+3)%4));
-      }
+      else
+        opp_c = tr.tds().create_cell(tr.infinite_vertex(),
+                                     c->vertex((i+1)%4),
+                                     c->vertex((i+3)%4),
+                                     c->vertex((i+2)%4));
+
       // set the infinite_vertex's incident cell
       if(tr.infinite_vertex()->cell() == Cell_handle())
         tr.infinite_vertex()->set_cell(opp_c);
 
       // add the facets to the incident cells map
-
 
       // the only finite facet
       it->second.push_back(std::make_pair(opp_c, inf_vert_position_in_opp_c));

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -71,7 +71,7 @@ output_to_medit_all_cells(std::ostream& os,
 
   Finite_vertices_iterator fvend = tr.finite_vertices_end();
   for(Finite_vertices_iterator vit = tr.finite_vertices_begin();
-                               vit != fvend; ++vit)
+      vit != fvend; ++vit)
   {
     V[vit] = inum++;
     Point_3 p = vit->point();
@@ -95,7 +95,7 @@ output_to_medit_all_cells(std::ostream& os,
 
   Facet_iterator ficend = c3t3.facets_in_complex_end();
   for(Facet_iterator fit = c3t3.facets_in_complex_begin();
-                     fit != ficend; ++fit)
+      fit != ficend; ++fit)
   {
     for(int i=0; i<4; i++)
     {
@@ -137,7 +137,7 @@ output_to_medit_all_cells(std::ostream& os,
 
   Finite_cells_iterator fcend = tr.finite_cells_end();
   for(Finite_cells_iterator cit = tr.finite_cells_begin();
-                            cit != fcend; ++cit )
+      cit != fcend; ++cit )
   {
     for(int i=0; i<4; i++)
       os << V[cit->vertex(i)] << " ";
@@ -153,7 +153,7 @@ output_to_medit_all_cells(std::ostream& os,
 
   All_cells_iterator acend = tr.all_cells_end();
   for(All_cells_iterator cit=tr.all_cells_begin();
-                         cit!=acend; ++cit )
+      cit!=acend; ++cit )
   {
     if(!tr.is_infinite(cit))
       continue;
@@ -240,8 +240,8 @@ void build_vertices(Tr& tr,
 template<class Tr>
 void add_facet_to_incident_cells_map(const typename Tr::Cell_handle c, int i,
                                      std::map<std::set<typename Tr::Vertex_handle>,
-                                              std::vector<std::pair<typename Tr::Cell_handle,
-                                                                    int> > >& incident_cells_map)
+                                     std::vector<std::pair<typename Tr::Cell_handle,
+                                     int> > >& incident_cells_map)
 {
   typedef typename Tr::Vertex_handle                            Vertex_handle;
   typedef typename Tr::Cell_handle                              Cell_handle;
@@ -260,7 +260,7 @@ void add_facet_to_incident_cells_map(const typename Tr::Cell_handle c, int i,
   std::vector<Incident_cell> vec;
   vec.push_back(e);
   std::pair<typename Incident_cells_map::iterator, bool> is_insert_successful =
-                              incident_cells_map.insert(std::make_pair(f, vec));
+      incident_cells_map.insert(std::make_pair(f, vec));
   if(!is_insert_successful.second) // the entry already exists in the map
   {
     // a facet must have exactly two incident cells
@@ -274,9 +274,9 @@ void build_finite_cells(Tr& tr,
                         const std::vector<boost::array<int,5> >& finite_cells,
                         const std::vector<typename Tr::Vertex_handle>& vertex_handle_vector,
                         std::map<std::set<typename Tr::Vertex_handle>,
-                                 std::vector<std::pair<typename Tr::Cell_handle,
-                                                       int> > >& incident_cells_map,
-                                                 const std::map<boost::array<int,3>, int>& border_facets)
+                        std::vector<std::pair<typename Tr::Cell_handle,
+                        int> > >& incident_cells_map,
+                        const std::map<boost::array<int,3>, int>& border_facets)
 {
   typedef boost::array<int, 5>              Tet_with_ref; // 4 ids + 1 reference
 
@@ -299,7 +299,7 @@ void build_finite_cells(Tr& tr,
 
     // this assertion also tests for degeneracy
     CGAL_assertion(CGAL::orientation(vs[0]->point().point(), vs[1]->point().point(),
-                                     vs[2]->point().point(), vs[3]->point().point()) == POSITIVE);
+        vs[2]->point().point(), vs[3]->point().point()) == POSITIVE);
 
     Cell_handle c = tr.tds().create_cell(vs[0], vs[1], vs[2], vs[3]);
     c->info() = tet[4]; // the reference encodes the interior/exterior info
@@ -335,7 +335,7 @@ void build_finite_cells(Tr& tr,
           ++k;
         }while(f[0] != n0);
         if(border_facets.find(f) != border_facets.end())
-            c->set_surface_patch_index(j, border_facets.at(f));
+          c->set_surface_patch_index(j, border_facets.at(f));
         else
         {
           int temp = f[2];
@@ -355,8 +355,8 @@ template<class Tr>
 void add_infinite_facets_to_incident_cells_map(typename Tr::Cell_handle c,
                                                int inf_vert_pos,
                                                std::map<std::set<typename Tr::Vertex_handle>,
-                                                        std::vector<std::pair<typename Tr::Cell_handle,
-                                                                              int> > >& incident_cells_map)
+                                               std::vector<std::pair<typename Tr::Cell_handle,
+                                               int> > >& incident_cells_map)
 {
   int l = (inf_vert_pos + 1) % 4;
   add_facet_to_incident_cells_map<Tr>(c, l, incident_cells_map);
@@ -371,8 +371,8 @@ void build_infinite_cells(Tr& tr,
                           const std::vector<boost::array<int,4> >& infinite_cells,
                           const std::vector<typename Tr::Vertex_handle>& vertex_handle_vector,
                           std::map<std::set<typename Tr::Vertex_handle>,
-                                   std::vector<std::pair<typename Tr::Cell_handle,
-                                                         int> > >& incident_cells_map)
+                          std::vector<std::pair<typename Tr::Cell_handle,
+                          int> > >& incident_cells_map)
 {
   typedef boost::array<int, 4>                            Tet; // 4 ids
 
@@ -475,8 +475,8 @@ void build_infinite_cells(Tr& tr,
 template<class Tr>
 bool assign_neighbors(Tr& tr,
                       const std::map<std::set<typename Tr::Vertex_handle>,
-                                     std::vector<std::pair<typename Tr::Cell_handle,
-                                                           int> > >& incident_cells_map)
+                      std::vector<std::pair<typename Tr::Cell_handle,
+                      int> > >& incident_cells_map)
 {
   typedef typename Tr::Vertex_handle                              Vertex_handle;
   typedef typename Tr::Cell_handle                                Cell_handle;
@@ -486,14 +486,14 @@ bool assign_neighbors(Tr& tr,
 
   // 4 facets per cell, each facet shared by 2 cells
   if(incident_cells_map.size() != tr.number_of_cells() * 2)
-      return false;
+    return false;
 
   typename Incident_cells_map::const_iterator icit = incident_cells_map.begin();
   for(; icit!=incident_cells_map.end(); ++icit)
   {
     const std::vector<Incident_cell>& adjacent_cells = icit->second;
     if(adjacent_cells.size() != 2)
-        return false;
+      return false;
 
     Cell_handle c0 = adjacent_cells[0].first;
     int i0 = adjacent_cells[0].second;
@@ -532,7 +532,7 @@ bool build_triangulation(Tr& tr,
   build_infinite_cells<Tr>(tr, infinite_cells, vertex_handle_vector, incident_cells_map);
   tr.tds().set_dimension(3);
   if(!assign_neighbors<Tr>(tr, incident_cells_map))
-      return false;
+    return false;
 
   std::cout << "built triangulation : " << std::endl;
   std::cout << tr.number_of_vertices() << " vertices" << std::endl;
@@ -540,14 +540,14 @@ bool build_triangulation(Tr& tr,
 
   BOOST_FOREACH(Vertex_handle vh, vertex_handle_vector)
   {
-      vh->set_dimension(3);
+    vh->set_dimension(3);
   }
   if(c3t3_loader_failed)
   {
-      return true;
+    return true;
   }
   else
-      return tr.is_valid(true);
+    return tr.is_valid(true);
 }
 
 template<class Tr, bool c3t3_loader_failed>

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -115,6 +115,7 @@ void build_finite_cells(Tr& tr,
     {
       CGAL_precondition(static_cast<std::size_t>(tet[j]) < tr.number_of_vertices() &&
                         tet[j] >= 0);
+      vertex_handle_vector[tet[j] + 1]->set_dimension(3);
       vs[j] = vertex_handle_vector[tet[j] + 1];
       CGAL_postcondition(vs[j] != Vertex_handle());
     }
@@ -294,6 +295,10 @@ bool build_triangulation(Tr& tr,
   tr.tds().clear(); // not tr.clear() since it calls tr.init() which we don't want
 
   build_vertices<Tr>(tr, points, vertex_handle_vector);
+  BOOST_FOREACH(Vertex_handle vh, vertex_handle_vector)
+  {
+    vh->set_dimension(-1);
+  }
   if(!finite_cells.empty())
   {
     build_finite_cells<Tr>(tr, finite_cells, vertex_handle_vector, incident_cells_map, border_facets);
@@ -305,11 +310,6 @@ bool build_triangulation(Tr& tr,
     std::cout << tr.number_of_cells() << " cells" << std::endl;
   }
   std::cout << tr.number_of_vertices() << " vertices" << std::endl;
-
-  BOOST_FOREACH(Vertex_handle vh, vertex_handle_vector)
-  {
-    vh->set_dimension(3);
-  }
   if(c3t3_loader_failed)
   {
     return true;

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -284,20 +284,27 @@ bool build_triangulation(Tr& tr,
   Incident_cells_map incident_cells_map;
   std::vector<Vertex_handle> vertex_handle_vector(points.size() + 1); // id to vertex_handle
 
-  CGAL_precondition(!points.empty() && !finite_cells.empty());
+  CGAL_precondition(!points.empty());
+
+  if(finite_cells.empty())
+  {
+    std::cout << "WARNING: No finite cells were provided. Only the points will be loaded."<<std::endl;
+  }
 
   tr.tds().clear(); // not tr.clear() since it calls tr.init() which we don't want
 
   build_vertices<Tr>(tr, points, vertex_handle_vector);
-  build_finite_cells<Tr>(tr, finite_cells, vertex_handle_vector, incident_cells_map, border_facets);
-  build_infinite_cells<Tr>(tr, incident_cells_map);
-  tr.tds().set_dimension(3);
-  if(!assign_neighbors<Tr>(tr, incident_cells_map))
-    return false;
-
-  std::cout << "built triangulation : " << std::endl;
+  if(!finite_cells.empty())
+  {
+    build_finite_cells<Tr>(tr, finite_cells, vertex_handle_vector, incident_cells_map, border_facets);
+    build_infinite_cells<Tr>(tr, incident_cells_map);
+    tr.tds().set_dimension(3);
+    if(!assign_neighbors<Tr>(tr, incident_cells_map))
+      return false;
+    std::cout << "built triangulation : " << std::endl;
+    std::cout << tr.number_of_cells() << " cells" << std::endl;
+  }
   std::cout << tr.number_of_vertices() << " vertices" << std::endl;
-  std::cout << tr.number_of_cells() << " cells" << std::endl;
 
   BOOST_FOREACH(Vertex_handle vh, vertex_handle_vector)
   {
@@ -318,7 +325,6 @@ bool build_triangulation_from_file(std::istream& is,
   typedef typename Tr::Point                                  Point_3;
 
   typedef boost::array<int, 3> Facet; // 3 = id
-  typedef boost::array<int, 4> Tet; // 4 = id
   typedef boost::array<int, 5> Tet_with_ref; // first 4 = id, fifth = reference
 
   std::vector<Tet_with_ref> finite_cells;
@@ -391,7 +397,10 @@ bool build_triangulation_from_file(std::istream& is,
       }
     }
   }
-  CGAL_precondition(!finite_cells.empty());
+  if(finite_cells.empty())
+  {
+    return false;
+  }
 
   bool is_well_built = build_triangulation<Tr, c3t3_loader_failed>(tr, points, finite_cells, border_facets);
   return is_well_built;

--- a/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/tet_soup_to_c3t3.h
@@ -304,8 +304,6 @@ void build_finite_cells(Tr& tr,
     Cell_handle c = tr.tds().create_cell(vs[0], vs[1], vs[2], vs[3]);
     c->info() = tet[4]; // the reference encodes the interior/exterior info
 
-    // the reference must either be -1 for finite interior or > 0 for subdomains
-    CGAL_precondition(tet[4] != 0);
     // assign cells to vertices
     for(int j=0; j<4; ++j)
     {

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -68,7 +68,12 @@ typedef CGAL::Polyhedron_demo_labeled_mesh_domain_3<Function_domain> Function_me
                                      CGAL::Kernel_traits<Polyhedral_mesh_domain>::Kernel,
                                      CGAL::Parallel_tag>::type Tr;
 #else
-  typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain>::type Tr;
+typedef CGAL::Kernel_traits<Polyhedral_mesh_domain> Gt;
+
+  typedef CGAL::Compact_mesh_cell_base_3<Kernel, Polyhedral_mesh_domain>  Cell_base;
+  typedef CGAL::Triangulation_cell_base_with_info_3< int, Kernel, Cell_base> Cell_base_with_info;
+
+  typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain, CGAL::Default, CGAL::Sequential_tag, CGAL::Default, Cell_base_with_info>::type Tr;
 #endif
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -63,18 +63,23 @@ typedef CGAL::Polyhedron_demo_labeled_mesh_domain_3<Function_domain> Function_me
 #endif
 
 // Triangulation
+typedef CGAL::Compact_mesh_cell_base_3<Kernel, Polyhedral_mesh_domain>     Cell_base;
+typedef CGAL::Triangulation_cell_base_with_info_3< int, Kernel, Cell_base> Cell_base_with_info;
+
 #ifdef CGAL_CONCURRENT_MESH_3
   typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain, 
                                      CGAL::Kernel_traits<Polyhedral_mesh_domain>::Kernel,
-                                     CGAL::Parallel_tag>::type Tr;
+                                     CGAL::Parallel_tag,
+                                     CGAL::Default,
+                                     Cell_base_with_info>::type Tr;
 #else
-typedef CGAL::Kernel_traits<Polyhedral_mesh_domain> Gt;
-
-  typedef CGAL::Compact_mesh_cell_base_3<Kernel, Polyhedral_mesh_domain>  Cell_base;
-  typedef CGAL::Triangulation_cell_base_with_info_3< int, Kernel, Cell_base> Cell_base_with_info;
-
-  typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain, CGAL::Default, CGAL::Sequential_tag, CGAL::Default, Cell_base_with_info>::type Tr;
+  typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain,
+                                     CGAL::Kernel_traits<Polyhedral_mesh_domain>::Kernel,
+                                     CGAL::Sequential_tag,
+                                     CGAL::Default,
+                                     Cell_base_with_info>::type Tr;
 #endif
+
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
 
 typedef Tr::Geom_traits Geom_traits;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -97,6 +97,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
       Scene_c3t3_item* item = new Scene_c3t3_item();
       item->setName(fileinfo.baseName());
       item->setScene(scene);
+      item->set_valid(false);
       std::vector<bool> border_infos;
       bool facets_in_complex = false;
       if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, item->c3t3().triangulation(), border_infos))

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <fstream>
 
+#include <QMessageBox>
 
 class Polyhedron_demo_c3t3_binary_io_plugin :
   public QObject,
@@ -143,6 +144,13 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
         }
         item->c3t3_changed();
         return item;
+      }
+      else if(item->c3t3().triangulation().number_of_finite_cells() == 0)
+      {
+        QMessageBox::warning((QWidget*)NULL, tr("C3t3_io_plugin"),
+                                       tr("No finite cell provided.\n"
+                                          "Nothing to display."),
+                                        QMessageBox::Ok);
       }
     }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -101,9 +101,8 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
       item->setName(fileinfo.baseName());
       item->setScene(scene);
       item->set_valid(false);
-      std::vector<bool> border_infos;
       bool facets_in_complex = false;
-      if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, item->c3t3().triangulation(), border_infos))
+      if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, item->c3t3().triangulation()))
       {
         for( C3t3::Triangulation::All_cells_iterator cit = item->c3t3().triangulation().all_cells_begin();
              cit != item->c3t3().triangulation().all_cells_end();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -27,7 +27,7 @@ public:
   QString name() const { return "C3t3_io_plugin"; }
   QString nameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma)"; }
   QString saveNameFilters() const { return "binary files (*.cgal);;ascii (*.mesh);;maya (*.ma);;avizo (*.am);;OFF files (*.off)"; }
-  QString loadNameFilters() const { return "binary files (*.cgal)" ; }
+  QString loadNameFilters() const { return "binary files (*.cgal);;ascii (*.mesh)"; }
   QList<QAction*> actions() const
   {
     return QList<QAction*>();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -67,7 +67,6 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
     Scene_c3t3_item* item = new Scene_c3t3_item();
     if(fileinfo.suffix().toLower() == "cgal")
     {
-
         item->setName(fileinfo.baseName());
         item->setScene(scene);
 
@@ -94,6 +93,10 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
     }
     else if (fileinfo.suffix().toLower() == "mesh")
     {
+      in.close();
+      in.open(fileinfo.filePath().toUtf8(), std::ios_base::in);//not binary
+      CGAL_assertion(!(!in));
+
       Scene_c3t3_item* item = new Scene_c3t3_item();
       item->setName(fileinfo.baseName());
       item->setScene(scene);
@@ -110,7 +113,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
           {
             CGAL_assertion(cit->info() >= 0);
             item->c3t3().add_to_complex(cit, cit->info());
-            for(std::size_t i=0; i<4; ++i)
+            for(int i=0; i < 4; ++i)
             {
               if(cit->surface_patch_index(i)>0)
               {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -81,6 +81,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
         if(try_load_other_binary_format(in, item->c3t3())) {
           item->c3t3_changed();
           item->changed();
+          item->resetCutPlane();
           return item;
         }
 
@@ -89,6 +90,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
         if(try_load_a_cdt_3(in, item->c3t3())) {
           item->c3t3_changed();
           item->changed();
+          item->resetCutPlane();
           return item;
         }
     }
@@ -143,6 +145,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
           }
         }
         item->c3t3_changed();
+        item->resetCutPlane();
         return item;
       }
       else if(item->c3t3().triangulation().number_of_finite_cells() == 0)

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -104,31 +104,29 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
       item->setName(fileinfo.baseName());
       item->setScene(scene);
       item->set_valid(false);
-      bool facets_in_complex = false;
+
       if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, item->c3t3().triangulation()))
       {
-        for( C3t3::Triangulation::All_cells_iterator cit = item->c3t3().triangulation().all_cells_begin();
-             cit != item->c3t3().triangulation().all_cells_end();
+        for( C3t3::Triangulation::Finite_cells_iterator
+             cit = item->c3t3().triangulation().finite_cells_begin();
+             cit != item->c3t3().triangulation().finite_cells_end();
              ++cit)
         {
-          if(!item->c3t3().triangulation().is_infinite(cit))
-          {
             CGAL_assertion(cit->info() >= 0);
             item->c3t3().add_to_complex(cit, cit->info());
             for(int i=0; i < 4; ++i)
             {
               if(cit->surface_patch_index(i)>0)
               {
-                item->c3t3().add_to_complex(cit, i, cit->info());
-                facets_in_complex = true;
+                item->c3t3().add_to_complex(cit, i, cit->surface_patch_index(i));
               }
             }
-          }
         }
         //if there is no facet in the complex, we add the border facets.
-        if(!facets_in_complex)
+        if(item->c3t3().number_of_facets_in_complex() == 0)
         {
-          for( C3t3::Triangulation::All_cells_iterator cit = item->c3t3().triangulation().all_cells_begin();
+          for( C3t3::Triangulation::All_cells_iterator
+               cit = item->c3t3().triangulation().all_cells_begin();
                cit != item->c3t3().triangulation().all_cells_end();
                ++cit)
           {
@@ -139,9 +137,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(QFileInfo fileinfo) {
                if(!item->c3t3().triangulation().is_infinite(cit, i))
                  item->c3t3().add_to_complex(cit, i, 1);
               }
-
             }
-
           }
         }
         item->c3t3_changed();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_rib_exporter_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_rib_exporter_plugin.cpp
@@ -47,7 +47,9 @@ public:
   {
     return QList<QAction*>() << actionCreateRib;
   }
-  bool applicable(QAction*)const{return qobject_cast<Scene_c3t3_item*>(scene->item(scene->mainSelectionIndex()));}
+  bool applicable(QAction*)const{
+    Scene_c3t3_item* item = qobject_cast<Scene_c3t3_item*>(scene->item(scene->mainSelectionIndex()));
+    return item && item->is_valid();}
   
 public Q_SLOTS:
   void create_rib();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
@@ -90,7 +90,7 @@ public:
   bool applicable(QAction* a) const {
     Scene_c3t3_item* item
       = qobject_cast<Scene_c3t3_item*>(scene->item(scene->mainSelectionIndex()));
-    if (NULL == item)
+    if (NULL == item || !item->is_valid())
       return false;
 
     if (a == actionOdt || a == actionLloyd)

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -47,6 +47,7 @@
         <file>resources/euler_facet.png</file>
         <file>resources/euler_vertex.png</file>
         <file>javascript/lib.js</file>
+        <file>resources/shader_c3t3_tets.v</file>
     </qresource>
     <qresource prefix="/cgal/cursors">
         <file>resources/rotate_around_cursor.png</file>

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -234,6 +234,7 @@ private:
       Lines,
       NumberOfVaos
   };
+
   //contains the data
   mutable std::vector<float> *vertices;
   mutable std::vector<float> *normals;
@@ -394,6 +395,23 @@ struct Scene_c3t3_item_priv {
       iEdges,
       iFacets,
       NumberOfVaos
+  };
+
+  enum STATS {
+    MIN_EDGES_LENGTH = 0,
+    MAX_EDGES_LENGTH,
+    MEAN_EDGES_LENGTH,
+    MIN_DIHEDRAL_ANGLE,
+    MAX_DIHEDRAL_ANGLE,
+    MEAN_DIHEDRAL_ANGLE,
+    NB_SPHERES,
+    NB_CNC,
+    NB_VERTICES,
+    NB_TETS,
+    SMALLEST_RAD_RAD,
+    SMALLEST_EDGE_RAD,
+    BIGGEST_VL3_CUBE,
+    NB_SUBDOMAINS
   };
   Scene_c3t3_item* item;
   C3t3 c3t3;
@@ -1903,33 +1921,33 @@ QString Scene_c3t3_item::computeStats(int type)
 
   switch (type)
   {
-  case MIN_EDGES_LENGTH:
+  case Scene_c3t3_item_priv::MIN_EDGES_LENGTH:
     return QString::number(d->min_edges_length);
-  case MAX_EDGES_LENGTH:
+  case Scene_c3t3_item_priv::MAX_EDGES_LENGTH:
     return QString::number(d->max_edges_length);
-  case MEAN_EDGES_LENGTH:
+  case Scene_c3t3_item_priv::MEAN_EDGES_LENGTH:
     return QString::number(d->mean_edges_length);
-  case MIN_DIHEDRAL_ANGLE:
+  case Scene_c3t3_item_priv::MIN_DIHEDRAL_ANGLE:
     return QString::number(d->min_dihedral_angle);
-  case MAX_DIHEDRAL_ANGLE:
+  case Scene_c3t3_item_priv::MAX_DIHEDRAL_ANGLE:
     return QString::number(d->max_dihedral_angle);
-  case MEAN_DIHEDRAL_ANGLE:
+  case Scene_c3t3_item_priv::MEAN_DIHEDRAL_ANGLE:
     return QString::number(d->mean_dihedral_angle);
-  case NB_SPHERES:
+  case Scene_c3t3_item_priv::NB_SPHERES:
     return QString::number(d->nb_spheres);
-  case NB_CNC:
+  case Scene_c3t3_item_priv::NB_CNC:
     return QString::number(d->nb_cnc);
-  case NB_VERTICES:
+  case Scene_c3t3_item_priv::NB_VERTICES:
     return QString::number(d->nb_vertices);
-  case NB_TETS:
+  case Scene_c3t3_item_priv::NB_TETS:
     return QString::number(d->nb_tets);
-  case SMALLEST_RAD_RAD:
+  case Scene_c3t3_item_priv::SMALLEST_RAD_RAD:
     return QString::number(d->smallest_radius_radius);
-  case SMALLEST_EDGE_RAD:
+  case Scene_c3t3_item_priv::SMALLEST_EDGE_RAD:
     return QString::number(d->smallest_edge_radius);
-  case BIGGEST_VL3_CUBE:
+  case Scene_c3t3_item_priv::BIGGEST_VL3_CUBE:
     return QString::number(d->biggest_v_sma_cube);
-  case NB_SUBDOMAINS:
+  case Scene_c3t3_item_priv::NB_SUBDOMAINS:
     return QString::number(d->nb_subdomains);
 
   default:

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -48,12 +48,15 @@ public :
       std::vector<float> *p_vertices,
       std::vector<float> *p_normals,
       std::vector<float> *p_edges,
-      std::vector<float> *p_colors)
+      std::vector<float> *p_colors,
+      std::vector<float> *p_bary)
   {
     vertices = p_vertices;
     normals = p_normals;
     edges = p_edges;
     colors = p_colors;
+    barycenters = p_bary;
+
   }
   void setColor(QColor c)
   {
@@ -188,11 +191,17 @@ public :
     edges->push_back(pa.y()+offset.y);
     edges->push_back(pa.z()+offset.z);
 
+
+    Kernel::Point_3 bary = (pa+pb+pc)/3.0;
     for(int i=0; i<3; i++)
     {
       colors->push_back((float)color.red()/255);
       colors->push_back((float)color.green()/255);
       colors->push_back((float)color.blue()/255);
+      barycenters->push_back(bary.x());
+      barycenters->push_back(bary.y());
+      barycenters->push_back(bary.z());
+
     }
   }
 
@@ -218,6 +227,7 @@ private:
   mutable std::vector<float> *normals;
   mutable std::vector<float> *edges;
   mutable std::vector<float> *colors;
+  mutable std::vector<float> *barycenters;
   mutable QOpenGLShaderProgram *program;
 }; //end of class Scene_triangle_item
 
@@ -373,6 +383,7 @@ struct Scene_c3t3_item_priv {
   mutable std::vector<float> positions_lines_not_in_complex;
   mutable std::vector<float> positions_grid;
   mutable std::vector<float> positions_poly;
+  mutable std::vector<float> positions_barycenter;
 
   mutable std::vector<float> normals;
   mutable std::vector<float> f_colors;
@@ -977,6 +988,13 @@ void Scene_c3t3_item_priv::draw_triangle(const Kernel::Point_3& pa,
   positions_poly.push_back(pc.y()+offset.y);
   positions_poly.push_back(pc.z()+offset.z);
 
+  Kernel::Point_3 bary = (pa+pb+pc)/3.0;
+  for(int i=0; i<3; ++i)
+  {
+   positions_barycenter.push_back(bary.x());
+   positions_barycenter.push_back(bary.y());
+   positions_barycenter.push_back(bary.z());
+  }
 
 
 }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1644,25 +1644,28 @@ void Scene_c3t3_item::show_grid(bool b)
 }
 void Scene_c3t3_item::show_spheres(bool b)
 {
-  d->spheres_are_shown = b;
-  contextMenu()->findChild<QAction*>("actionShowSpheres")->setChecked(b);
-  if(b && !d->spheres)
+  if(is_valid())
   {
-    d->spheres = new Scene_spheres_item(this, true);
-    d->spheres->setName("Protecting spheres");
-    d->spheres->setRenderingMode(Gouraud);
-    connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
-    scene->addItem(d->spheres);
-    scene->changeGroup(d->spheres, this);
-    lockChild(d->spheres);
-    d->computeSpheres();
+    d->spheres_are_shown = b;
+    contextMenu()->findChild<QAction*>("actionShowSpheres")->setChecked(b);
+    if(b && !d->spheres)
+    {
+      d->spheres = new Scene_spheres_item(this, true);
+      d->spheres->setName("Protecting spheres");
+      d->spheres->setRenderingMode(Gouraud);
+      connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
+      scene->addItem(d->spheres);
+      scene->changeGroup(d->spheres, this);
+      lockChild(d->spheres);
+      d->computeSpheres();
+    }
+    else if (!b && d->spheres!=NULL)
+    {
+      unlockChild(d->spheres);
+      scene->erase(scene->item_id(d->spheres));
+    }
+    Q_EMIT redraw();
   }
-  else if (!b && d->spheres!=NULL)
-  {
-    unlockChild(d->spheres);
-    scene->erase(scene->item_id(d->spheres));
-  }
-  Q_EMIT redraw();
 
 }
 void Scene_c3t3_item::show_intersection(bool b)
@@ -1694,10 +1697,12 @@ void Scene_c3t3_item::show_intersection(bool b)
 }
 void Scene_c3t3_item::show_cnc(bool b)
 {
-  d->cnc_are_shown = b;
-  contextMenu()->findChild<QAction*>("actionShowCNC")->setChecked(b);
-  Q_EMIT redraw();
-
+  if(is_valid())
+  {
+    d->cnc_are_shown = b;
+    contextMenu()->findChild<QAction*>("actionShowCNC")->setChecked(b);
+    Q_EMIT redraw();
+  }
 }
 
 void Scene_c3t3_item::reset_intersection_item()

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -492,18 +492,6 @@ struct Set_show_tetrahedra {
   }
 };
 
-
-double complex_diag(const Scene_item* item) {
-  const Scene_item::Bbox& bbox = item->bbox();
-  const double& xdelta = bbox.xmax()-bbox.xmin();
-  const double& ydelta = bbox.ymax()-bbox.ymin();
-  const double& zdelta = bbox.zmax()-bbox.zmin();
-  const double diag = std::sqrt(xdelta*xdelta +
-                                ydelta*ydelta +
-                                zdelta*zdelta);
-  return diag * 0.7;
-}
-
 Scene_c3t3_item::Scene_c3t3_item()
   : Scene_group_item("unnamed", Scene_c3t3_item_priv::NumberOfBuffers, Scene_c3t3_item_priv::NumberOfVaos)
   , d(new Scene_c3t3_item_priv(this))
@@ -1519,6 +1507,7 @@ void Scene_c3t3_item_priv::computeElements()
 
   //The grid
   {
+
     float x = (2 * (float)complex_diag()) / 10.0;
     float y = (2 * (float)complex_diag()) / 10.0;
     for (int u = 0; u < 11; u++)
@@ -1996,5 +1985,9 @@ void Scene_c3t3_item::invalidateOpenGLBuffers()
   are_buffers_filled = false;
   compute_bbox();
   d->invalidate_stats();
+}
+void Scene_c3t3_item::resetCutPlane()
+{
+ d->reset_cut_plane();
 }
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -231,6 +231,7 @@ struct Scene_c3t3_item_priv {
     , histogram_()
     , surface_patch_indices_()
     , subdomain_indices_()
+    , is_valid(true)
   {
     init_default_values();
   }
@@ -241,6 +242,7 @@ struct Scene_c3t3_item_priv {
     , histogram_()
     , surface_patch_indices_()
     , subdomain_indices_()
+    , is_valid(true)
   {
     init_default_values();
   }
@@ -389,6 +391,7 @@ struct Scene_c3t3_item_priv {
   bool show_tetrahedra;
   bool is_aabb_tree_built;
   bool cnc_are_shown;
+  bool is_valid;
 };
 
 struct Set_show_tetrahedra {
@@ -1129,20 +1132,22 @@ QMenu* Scene_c3t3_item::contextMenu()
       SIGNAL(triggered()), this,
       SLOT(export_facets_in_complex()));
 
-    QAction* actionShowSpheres =
-      menu->addAction(tr("Show protecting &spheres"));
-    actionShowSpheres->setCheckable(true);
-    actionShowSpheres->setObjectName("actionShowSpheres");
-    connect(actionShowSpheres, SIGNAL(toggled(bool)),
-            this, SLOT(show_spheres(bool)));
+    if(is_valid())
+    {
+      QAction* actionShowSpheres =
+          menu->addAction(tr("Show protecting &spheres"));
+      actionShowSpheres->setCheckable(true);
+      actionShowSpheres->setObjectName("actionShowSpheres");
+      connect(actionShowSpheres, SIGNAL(toggled(bool)),
+              this, SLOT(show_spheres(bool)));
 
-    QAction* actionShowCNC =
-      menu->addAction(tr("Show cells not in complex"));
-    actionShowCNC->setCheckable(true);
-    actionShowCNC->setObjectName("actionShowCNC");
-    connect(actionShowCNC, SIGNAL(toggled(bool)),
-            this, SLOT(show_cnc(bool)));
-
+      QAction* actionShowCNC =
+          menu->addAction(tr("Show cells not in complex"));
+      actionShowCNC->setCheckable(true);
+      actionShowCNC->setObjectName("actionShowCNC");
+      connect(actionShowCNC, SIGNAL(toggled(bool)),
+              this, SLOT(show_cnc(bool)));
+    }
     QAction* actionShowTets =
       menu->addAction(tr("Show &tetrahedra"));
     actionShowTets->setCheckable(true);
@@ -1623,5 +1628,14 @@ void Scene_c3t3_item::copyProperties(Scene_item *item)
   show_cnc(c3t3_item->has_cnc());
 
   show_grid(c3t3_item->has_grid());
+}
+
+bool Scene_c3t3_item::is_valid() const
+{
+  return d->is_valid;
+}
+void Scene_c3t3_item::set_valid(bool b)
+{
+  d->is_valid = b;
 }
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -842,14 +842,21 @@ void Scene_c3t3_item::compute_bbox() const {
   if (isEmpty())
     _bbox = Bbox();
   else {
+    bool bbox_init = false;
     CGAL::Bbox_3 result;
     for (Tr::Finite_vertices_iterator
-           vit = ++c3t3().triangulation().finite_vertices_begin(),
+           vit = c3t3().triangulation().finite_vertices_begin(),
            end = c3t3().triangulation().finite_vertices_end();
          vit != end; ++vit)
     {
       if(vit->in_dimension() == -1) continue;
-      result = result + vit->point().bbox();
+      if (bbox_init)
+        result = result + vit->point().bbox();
+      else
+      {
+        result = vit->point().bbox();
+        bbox_init = true;
+      }
     }
     _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
                  result.xmax(), result.ymax(), result.zmax());

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1810,12 +1810,12 @@ QString Scene_c3t3_item::computeStats(int type)
       }
     }
 
-    typedef typename C3t3::Triangulation::Point Point_3;
-    typename Kernel::Compute_approximate_dihedral_angle_3 approx_dihedral_angle
+    typedef C3t3::Triangulation::Point Point_3;
+    Kernel::Compute_approximate_dihedral_angle_3 approx_dihedral_angle
       = Kernel().compute_approximate_dihedral_angle_3_object();
 
     QVector<int> sub_ids;
-    for (typename C3t3::Cells_in_complex_iterator cit = d->c3t3.cells_in_complex_begin();
+    for (C3t3::Cells_in_complex_iterator cit = d->c3t3.cells_in_complex_begin();
       cit != d->c3t3.cells_in_complex_end();
       ++cit)
     {

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -59,6 +59,8 @@ public:
 
   void c3t3_changed();
 
+  void set_valid(bool);
+
   const C3t3& c3t3() const;
   C3t3& c3t3();
 
@@ -70,6 +72,7 @@ public:
   bool has_grid() const;
   bool has_cnc() const;
   bool has_tets() const;
+  bool is_valid() const;//true if the c3t3 is correct, false if it was made from a .mesh, for example
   ManipulatedFrame* manipulatedFrame();
 
   void setPosition(float x, float y, float z) ;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -118,6 +118,8 @@ public:
   public:
     QMenu* contextMenu();
     void copyProperties(Scene_item *);
+    float getShrinkFactor() const;
+    bool keyPressEvent(QKeyEvent *);
   public Q_SLOTS:
   void export_facets_in_complex();
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -39,6 +39,28 @@ public:
   Scene_c3t3_item();
   Scene_c3t3_item(const C3t3& c3t3);
   ~Scene_c3t3_item();
+
+  enum STATS {
+    MIN_EDGES_LENGTH = 0,
+    MAX_EDGES_LENGTH,
+    MEAN_EDGES_LENGTH,
+    MIN_DIHEDRAL_ANGLE,
+    MAX_DIHEDRAL_ANGLE,
+    MEAN_DIHEDRAL_ANGLE,
+    NB_SPHERES,
+    NB_CNC,
+    NB_VERTICES,
+    NB_TETS,
+    SMALLEST_RAD_RAD,
+    SMALLEST_EDGE_RAD,
+    BIGGEST_VL3_CUBE,
+    NB_SUBDOMAINS
+  };
+  bool has_stats()const {return true;}
+  QString computeStats(int type);
+  CGAL::Three::Scene_item::Header_data header() const;
+
+
   void setColor(QColor c);
   bool save_binary(std::ostream& os) const
   {
@@ -51,11 +73,7 @@ public:
       return !!(os << c3t3());
   }
 
-  void invalidateOpenGLBuffers()
-  {
-    are_buffers_filled = false;
-    compute_bbox();
-  }
+  void invalidateOpenGLBuffers();
 
   void c3t3_changed();
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -61,6 +61,8 @@ public:
 
   void c3t3_changed();
 
+  void resetCutPlane();
+
   void set_valid(bool);
 
   const C3t3& c3t3() const;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -40,22 +40,6 @@ public:
   Scene_c3t3_item(const C3t3& c3t3);
   ~Scene_c3t3_item();
 
-  enum STATS {
-    MIN_EDGES_LENGTH = 0,
-    MAX_EDGES_LENGTH,
-    MEAN_EDGES_LENGTH,
-    MIN_DIHEDRAL_ANGLE,
-    MAX_DIHEDRAL_ANGLE,
-    MEAN_DIHEDRAL_ANGLE,
-    NB_SPHERES,
-    NB_CNC,
-    NB_VERTICES,
-    NB_TETS,
-    SMALLEST_RAD_RAD,
-    SMALLEST_EDGE_RAD,
-    BIGGEST_VL3_CUBE,
-    NB_SUBDOMAINS
-  };
   bool has_stats()const {return true;}
   QString computeStats(int type);
   CGAL::Three::Scene_item::Header_data header() const;

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -683,6 +683,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_WITH_TEXTURE:
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
+    case PROGRAM_C3T3_TETS:
         program->setUniformValue("light_pos", position);
         program->setUniformValue("light_diff",diffuse);
         program->setUniformValue("light_spec", specular);
@@ -699,6 +700,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_INSTANCED:
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
+      case PROGRAM_C3T3_TETS:
       program->setUniformValue("mv_matrix", mv_mat);
       break;
     case PROGRAM_WITHOUT_LIGHT:
@@ -1347,6 +1349,27 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
         program->bindAttributeLocation("colors", 1);
         program->link();
         d->shader_programs[PROGRAM_CUTPLANE_SPHERES] = program;
+        return program;
+      }
+    case PROGRAM_C3T3_TETS:
+      if( d->shader_programs[PROGRAM_C3T3_TETS])
+      {
+          return d->shader_programs[PROGRAM_C3T3_TETS];
+      }
+      else
+      {
+        QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+        if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_tets.v"))
+        {
+            std::cerr<<"adding vertex shader FAILED"<<std::endl;
+        }
+        if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f" ))
+        {
+            std::cerr<<"adding fragment shader FAILED"<<std::endl;
+        }
+        program->bindAttributeLocation("colors", 1);
+        program->link();
+        d->shader_programs[PROGRAM_C3T3_TETS] = program;
         return program;
       }
     case PROGRAM_SPHERES:

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -700,7 +700,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_INSTANCED:
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
-      case PROGRAM_C3T3_TETS:
+    case PROGRAM_C3T3_TETS:
       program->setUniformValue("mv_matrix", mv_mat);
       break;
     case PROGRAM_WITHOUT_LIGHT:

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
@@ -6,7 +6,7 @@ uniform highp vec4 light_pos;
 uniform highp vec4 light_diff; 
 uniform highp vec4 light_spec; 
 uniform highp vec4 light_amb;  
-uniform highp float spec_power ; 
+uniform highp float spec_power ;
 uniform int is_two_side; 
 uniform bool is_selected;
 void main(void) {

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.v
@@ -2,9 +2,11 @@
 attribute highp vec4 vertex;
 attribute highp vec3 normals;
 attribute highp vec3 colors;
+attribute highp vec3 barycenter;
 uniform highp mat4 mvp_matrix;
-uniform highp mat4 mv_matrix; 
+uniform highp mat4 mv_matrix;
 uniform highp vec4 cutplane;
+uniform highp float shrink_factor;
 varying highp vec4 fP; 
 varying highp vec3 fN; 
 varying highp vec4 color; 
@@ -13,5 +15,17 @@ void main(void)
   color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
   fP = mv_matrix * vertex; 
   fN = mat3(mv_matrix)* normals; 
-  gl_Position = mvp_matrix * vertex; 
+  mat4 transOB = mat4(1, 0, 0, 0, // first column
+   0, 1, 0, 0, // second column
+   0, 0, 1, 0, // third column
+   barycenter.x, barycenter.y, barycenter.z, 1); // fourth column
+   mat4 transBO = mat4(1, 0, 0, 0, // first column
+    0, 1, 0, 0, // second column
+    0, 0, 1, 0, // third column
+    -barycenter.x, -barycenter.y, -barycenter.z, 1); // fourth column
+    mat4 scaling = mat4(shrink_factor, 0, 0, 0,
+    0, shrink_factor, 0, 0,
+    0, 0, shrink_factor, 0,
+    0, 0, 0, shrink_factor);
+  gl_Position = mvp_matrix *transOB * scaling * transBO * vertex;
 }

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_tets.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_tets.v
@@ -5,16 +5,15 @@ attribute highp vec3 colors;
 attribute highp vec3 barycenter;
 uniform highp mat4 mvp_matrix;
 uniform highp mat4 mv_matrix;
-uniform highp vec4 cutplane;
 uniform highp float shrink_factor;
-varying highp vec4 fP; 
-varying highp vec3 fN; 
-varying highp vec4 color; 
+varying highp vec4 fP;
+varying highp vec3 fN;
+varying highp vec4 color;
 void main(void)
 {
-  color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
-  fP = mv_matrix * vertex; 
-  fN = mat3(mv_matrix)* normals; 
+  color = vec4(colors, 1.0);
+  fP = mv_matrix * vertex;
+  fN = mat3(mv_matrix)* normals;
   highp mat4 transOB = mat4(1, 0, 0, 0, // first column
    0, 1, 0, 0, // second column
    0, 0, 1, 0, // third column

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -80,6 +80,7 @@ public:
   PROGRAM_C3T3_EDGES,          /** Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.*/
   PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
   PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
+  PROGRAM_C3T3_TETS,           /** Used to render the tetrahedra of the intersection of a c3t3_item.*/
   NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
  };
   typedef CGAL::Bbox_3 Bbox;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -69,6 +69,7 @@ public:
    PROGRAM_C3T3_EDGES,          /** Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.*/
    PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
    PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
+   PROGRAM_C3T3_TETS,           /** Used to render the tetrahedra of the intersection of a c3t3_item.*/
    NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
   };
 


### PR DESCRIPTION
## Summary of Changes
This PR:
- provides a reader for the .mesh files
-  allows the c3t3_io_plugin of the Polyhedron_demo to load tetrahedron soups from .mesh files into "invalid" Scene_c3t3_items. 
- Adds statistics to the scene_c3t3_item
- Adds a slider to _shrink_ the facets of a scene_c3t3_item (by using the slider in the item's context menu or using + and - ).

## Release Management

* Affected package(s): Polyhedron_demo, Mesh_3
* Issue(s) solved (if any): fix #1851 


