### PR TITLE
Fix <CGAL/Surface_mesh/Properties.h> introduced by #1791

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -86,15 +86,22 @@ public:
 
   class Index;
 
-  typedef typename Properties::Property_container<Index> Base;
+  typedef typename Properties::Property_container<Point_set, Index> Base;
 
   template <class Type>
   struct Property_map
-    : public Properties::Property_map<Index, Type>
+    : public Properties::Property_map_base<Index, Type, Property_map<Type> >
   {
+    typedef Properties::Property_map_base<Index, Type, Property_map<Type> > Base;
+    Property_map() : Base() {}
+    Property_map(const Base& pm): Base(pm) {}
   };
   typedef Property_map<Index> Index_map;
 
+  template <typename Key, typename T>
+  struct Get_property_map {
+    typedef Property_map<T> type;
+  };
   /// \endcond
   
   /*!
@@ -107,7 +114,7 @@ public:
   {
     /// \cond SKIP_IN_MANUAL
     friend class Point_set_3;
-    friend class Properties::Property_container<Index>;
+    friend class Properties::Property_container<Point_set_3, Index>;
     template <class> friend class Properties::Property_array;
     template <class> friend struct Property_map;
     friend class std::vector<Index>;
@@ -672,7 +679,7 @@ public:
   template <typename T>
   bool has_property_map (const std::string& name) const
   {
-    std::pair<typename Properties::template Property_map<Index, T>, bool>
+    std::pair<Property_map<T>, bool>
       pm = m_base.template get<T> (name);
     return pm.second;
   }
@@ -694,10 +701,10 @@ public:
   std::pair<Property_map<T>, bool>
   add_property_map (const std::string& name, const T t=T())
   {
-    Properties::Property_map<Index,T> pm;
+    Property_map<T> pm;
     bool added = false;
     boost::tie (pm, added) = m_base.template add<T> (name, t);
-    return std::make_pair (reinterpret_cast<Property_map<T>&>(pm), added);
+    return std::make_pair (pm, added);
   }
   
   /*!
@@ -715,10 +722,10 @@ public:
   std::pair<Property_map<T>,bool>
   property_map (const std::string& name) const
   {
-    Properties::Property_map<Index,T> pm;
+    Property_map<T> pm;
     bool okay = false;
     boost::tie (pm, okay) = m_base.template get<T>(name);
-    return std::make_pair (reinterpret_cast<Property_map<T>&>(pm), okay);
+    return std::make_pair (pm, okay);
   }
 
   /*!
@@ -734,7 +741,7 @@ public:
   template <class T> 
   bool remove_property_map (Property_map<T>& prop)
   {
-    return m_base.remove (reinterpret_cast<Properties::Property_map<Index,T>&>(prop));
+    return m_base.template remove<T> (prop);
   }
 
   /*!
@@ -791,7 +798,7 @@ public:
   */
   bool remove_normal_map()
   {
-    return m_base.remove (m_normals);
+    return m_base.template remove<Vector> (m_normals);
   }
   /*!
     \brief Returns the property map of the point property.

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -97,7 +97,7 @@ void set_vcolors(Scene_surface_mesh_item::SMesh* smesh, std::vector<CGAL::Color>
 {
   typedef Scene_surface_mesh_item::SMesh SMesh;
   typedef boost::graph_traits<SMesh>::vertex_descriptor vertex_descriptor;
-  CGAL::Properties::Property_map<vertex_descriptor, CGAL::Color> vcolors =
+  SMesh::Property_map<vertex_descriptor, CGAL::Color> vcolors =
     smesh->property_map<vertex_descriptor, CGAL::Color >("v:color").first;
   bool created;
   boost::tie(vcolors, created) = smesh->add_property_map<SMesh::Vertex_index,CGAL::Color>("v:color",CGAL::Color(0,0,0));
@@ -111,7 +111,7 @@ void set_fcolors(Scene_surface_mesh_item::SMesh* smesh, std::vector<CGAL::Color>
 {
   typedef Scene_surface_mesh_item::SMesh SMesh;
   typedef boost::graph_traits<SMesh>::face_descriptor face_descriptor;
-  CGAL::Properties::Property_map<face_descriptor, CGAL::Color> fcolors =
+  SMesh::Property_map<face_descriptor, CGAL::Color> fcolors =
     smesh->property_map<face_descriptor, CGAL::Color >("f:color").first;
   bool created;
    boost::tie(fcolors, created) = smesh->add_property_map<SMesh::Face_index,CGAL::Color>("f:color",CGAL::Color(0,0,0));

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -57,8 +57,8 @@ struct Scene_surface_mesh_item_priv{
   //! fill the flat data vectors.
   void
   triangulate_facet(face_descriptor fd,
-                    CGAL::Properties::Property_map<face_descriptor, Kernel::Vector_3 > *fnormals,
-                    CGAL::Properties::Property_map<face_descriptor, CGAL::Color> *fcolors,
+                    SMesh::Property_map<face_descriptor, Kernel::Vector_3 > *fnormals,
+                    SMesh::Property_map<face_descriptor, CGAL::Color> *fcolors,
                     boost::property_map< SMesh, boost::vertex_index_t >::type* im,
                     bool index) const;
   void compute_elements();
@@ -114,10 +114,10 @@ Scene_surface_mesh_item::Scene_surface_mesh_item(SMesh* sm)
   d->has_vcolors = false;
   d->has_fcolors = false;
   d->checkFloat();
-  CGAL::Properties::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
+  SMesh::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
     d->smesh_->add_property_map<vertex_descriptor, Kernel::Vector_3 >("v:normal").first;
 
-  CGAL::Properties::Property_map<face_descriptor, Kernel::Vector_3 > fnormals =
+  SMesh::Property_map<face_descriptor, Kernel::Vector_3 > fnormals =
       d->smesh_->add_property_map<face_descriptor, Kernel::Vector_3 >("v:normal").first;
   CGAL::Polygon_mesh_processing::compute_face_normals(*d->smesh_,fnormals);
 
@@ -210,18 +210,18 @@ void Scene_surface_mesh_item_priv::compute_elements()
   f_colors.clear();
   v_colors.clear();
   const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
-  CGAL::Properties::Property_map<vertex_descriptor, SMesh::Point> positions =
+  SMesh::Property_map<vertex_descriptor, SMesh::Point> positions =
     smesh_->points();
-  CGAL::Properties::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
+  SMesh::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
     smesh_->property_map<vertex_descriptor, Kernel::Vector_3 >("v:normal").first;
 
-  CGAL::Properties::Property_map<face_descriptor, Kernel::Vector_3 > fnormals =
+  SMesh::Property_map<face_descriptor, Kernel::Vector_3 > fnormals =
       smesh_->add_property_map<face_descriptor, Kernel::Vector_3 >("v:normal").first;
 
-  CGAL::Properties::Property_map<vertex_descriptor, CGAL::Color> vcolors =
+  SMesh::Property_map<vertex_descriptor, CGAL::Color> vcolors =
     smesh_->property_map<vertex_descriptor, CGAL::Color >("v:color").first;
 
-  CGAL::Properties::Property_map<face_descriptor, CGAL::Color> fcolors =
+  SMesh::Property_map<face_descriptor, CGAL::Color> fcolors =
       smesh_->property_map<face_descriptor, CGAL::Color >("f:color").first;
 
   assert(positions.data() != NULL);
@@ -336,9 +336,9 @@ void Scene_surface_mesh_item_priv::compute_elements()
 }
 void Scene_surface_mesh_item_priv::initializeBuffers(CGAL::Three::Viewer_interface* viewer)const
 {
-  CGAL::Properties::Property_map<vertex_descriptor, SMesh::Point> positions =
+  SMesh::Property_map<vertex_descriptor, SMesh::Point> positions =
     smesh_->points();
-  CGAL::Properties::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
+  SMesh::Property_map<vertex_descriptor, Kernel::Vector_3 > vnormals =
     smesh_->property_map<vertex_descriptor, Kernel::Vector_3 >("v:normal").first;
   //vao containing the data for the flat facets
 
@@ -540,8 +540,8 @@ void Scene_surface_mesh_item_priv::checkFloat()const
 
 void
 Scene_surface_mesh_item_priv::triangulate_facet(face_descriptor fd,
-                                           CGAL::Properties::Property_map<face_descriptor, Kernel::Vector_3> *fnormals,
-                                           CGAL::Properties::Property_map<face_descriptor, CGAL::Color> *fcolors,
+                                           SMesh::Property_map<face_descriptor, Kernel::Vector_3> *fnormals,
+                                           SMesh::Property_map<face_descriptor, CGAL::Color> *fcolors,
                                            boost::property_map< SMesh, boost::vertex_index_t >::type *im,
                                            bool index) const
 {
@@ -611,7 +611,7 @@ const Scene_surface_mesh_item::SMesh* Scene_surface_mesh_item::polyhedron() cons
 
 void Scene_surface_mesh_item::compute_bbox()const
 {
-  CGAL::Properties::Property_map<vertex_descriptor, Point> pprop = d->smesh_->points();
+  SMesh::Property_map<vertex_descriptor, Point> pprop = d->smesh_->points();
   CGAL::Bbox_3 bbox;
 
   BOOST_FOREACH(vertex_descriptor vd,vertices(*d->smesh_))

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO.h
@@ -72,8 +72,8 @@ bool read_off_binary(Surface_mesh<Point_3>& mesh,
     typename Mesh::Vertex_index  v;
 
     // properties
-    typename Properties:: template Property_map<typename Mesh::Vertex_index, Normal>              normals;
-    typename Properties:: template Property_map<typename Mesh::Vertex_index, Texture_coordinate>  texcoords;
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, Normal>              normals;
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, Texture_coordinate>  texcoords;
     if (has_normals)   normals   = mesh.template add_property_map<typename Mesh::Vertex_index, Normal>("v:normal").first;
     if (has_texcoords) texcoords = mesh.template add_property_map<typename Mesh::Vertex_index, Texture_coordinate>("v:texcoord").first;
 
@@ -149,8 +149,8 @@ bool read_off_ascii(Surface_mesh<Point_3>& mesh,
     typename Mesh::Vertex_index   v;
 
     // properties
-    typename Properties::template Property_map<typename Mesh::Vertex_index, Normal>                 normals;
-    typename Properties::template Property_map<typename Mesh::Vertex_index, Texture_coordinate>     texcoords;
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, Normal>                 normals;
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, Texture_coordinate>     texcoords;
     
     if (has_normals)   normals   = mesh.template add_property_map<typename Mesh::Vertex_index, Normal>("v:normal").first;
     if (has_texcoords) texcoords = mesh.template add_property_map<typename Mesh::Vertex_index, Texture_coordinate>("v:texcoord").first;
@@ -347,7 +347,7 @@ bool write_off(const Surface_mesh<K>& mesh, const std::string& filename)
 
 
     // vertices
-    typename Properties::template Property_map<typename Mesh::Vertex_index, Point_3> points 
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, Point_3> points
       = mesh.template property_map<typename Mesh::Vertex_index, Point_3>("v:point").first;
     for (typename Mesh::Vertex_iterator vit=mesh.vertices_begin(); vit!=mesh.vertices_end(); ++vit)
     {

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -62,8 +62,8 @@ public:
   }
 
 private:
-   typename CGAL::Properties::template Property_map< typename SM::Vertex_index, 
-                                               typename SM::Point > pm_;
+   typename SM::template Property_map< typename SM::Vertex_index,
+                                       typename SM::Point > pm_;
   const SM& sm_;
 };
 
@@ -92,7 +92,7 @@ template <typename Point, typename T>
 struct property_map<CGAL::Surface_mesh<Point>, boost::vertex_property_t<T> >
 {
   typedef CGAL::Surface_mesh<Point> SM;
-  typedef typename CGAL::Properties:: template Property_map<typename SM::vertex_index,T> type;
+  typedef typename SM:: template Property_map<typename SM::vertex_index,T> type;
   typedef type const_type;
 };
 
@@ -223,9 +223,9 @@ struct property_map<CGAL::Surface_mesh<P>, CGAL::vertex_point_t >
   typedef CGAL::Surface_mesh<P> SM;
 
   typedef typename
-    CGAL::Properties::template Property_map< typename SM::Vertex_index, 
-                                       P
-                                       > type;
+    SM::template Property_map< typename SM::Vertex_index,
+                               P
+                               > type;
   
   typedef type const_type;
 
@@ -291,7 +291,7 @@ put(CGAL::vertex_point_t p, const CGAL::Surface_mesh<Point>& g,
     const Point& point) {
   typedef CGAL::Surface_mesh<Point> SM;
   CGAL_assertion(g.is_valid(x));
-  typename CGAL::Properties::template Property_map< typename boost::graph_traits<SM>::vertex_descriptor, 
+  typename SM::template Property_map< typename boost::graph_traits<SM>::vertex_descriptor,
                     Point> prop = get(p, g);
   prop[x] = point;
 }

--- a/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
+++ b/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
@@ -221,7 +221,7 @@ void properties () {
   Surface_fixture f;
   
 
-  CGAL::Properties::Property_map<Sm::Vertex_index, int> prop;
+  Sm::Property_map<Sm::Vertex_index, int> prop;
   bool created = false;
 
   boost::tie(prop,created) = f.m.add_property_map<Sm::Vertex_index, int>("illuminatiproperty", 23);


### PR DESCRIPTION
The PR #1791 introduced `CGAL::Point_set_3`, and factorized the
`Property_map` implementation of `Surface_mesh` into a new class
template `CGAL::Properties::Property_map<Key, T>`.

The backward compatibility was supposed to be ensured by the fact that
`Surface_mesh<Point>::Property_map<Key,T>` had
`Properties::Property_map<Key, T>` as base class. But that compatibility
was only partial, and there could be ambiguities in the calls to `get`
and `put` with those property maps.

This commit/PR renamed `Properties::Property_map` to
`Properties::Property_map_base`, and added a third parameter, used as
the `Derived` class in the CRTP used by `boost::put_get_helper`. That
way, the `get` and `put` functions are defined directory on the real
class `Surface_mesh::Property_map<Key, T>` and not on its base class.

The same has been modified in `CGAL::Point_set_3`.

That makes the use of `Property_base_base` and `Property_container` a
little trickier, but that removes several ugly non-portable hacks, like
the `reinterpret_cast` that were used to convert a pointer to base class
of the pmap to the pointer the real pmap. Now that is a lot cleaner.

I have verified that the documentation is not modified. Actually, the
PR #1791 did modify the documentation of `Surface_mesh` (see the member
method `add_property_map` for example), and this PR fixes the situation:
the documentation of `Surface_mesh` is put back to the version in
CGAL-4.9.