### PR TITLE
Polyhedron_demo: Keep the point's size when reloading

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -851,3 +851,22 @@ void Scene_points_with_normal_item::pointSliderReleased()
   d->is_point_slider_moving = false;
 }
 
+void Scene_points_with_normal_item::copyProperties(Scene_item *item)
+{
+  Scene_points_with_normal_item* point_item = qobject_cast<Scene_points_with_normal_item*>(item);
+  if(!point_item)
+    return;
+  d->point_Slider->setValue(point_item->getPointSliderValue());
+  if(has_normals())
+    d->normal_Slider->setValue(point_item->getNormalSliderValue());
+}
+
+int Scene_points_with_normal_item::getNormalSliderValue()
+{
+  return d->normal_Slider->value();
+}
+
+int Scene_points_with_normal_item::getPointSliderValue()
+{
+  return d->point_Slider->value();
+}

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -1,11 +1,11 @@
 #ifndef POINT_SET_ITEM_H
 #define POINT_SET_ITEM_H
-#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_item_with_properties.h>
 #include "Scene_points_with_normal_item_config.h"
 #include "Polyhedron_type_fwd.h"
 #include "Kernel_type.h"
 #include "Point_set_3.h"
-
 #include <iostream>
 
 struct Scene_points_with_normal_item_priv;
@@ -17,7 +17,7 @@ class QAction;
 
 // This class represents a point set in the OpenGL scene
 class SCENE_POINTS_WITH_NORMAL_ITEM_EXPORT Scene_points_with_normal_item
-  : public CGAL::Three::Scene_item
+  : public CGAL::Three::Scene_item, public CGAL::Three::Scene_item_with_properties
 {
   Q_OBJECT
 
@@ -70,6 +70,9 @@ public:
   void computes_local_spacing(int k);
 
   bool has_normals() const;
+  void copyProperties(Scene_item *);
+  int getNormalSliderValue();
+  int getPointSliderValue();
 
 public Q_SLOTS:
   // Delete selection


### PR DESCRIPTION
## Summary of Changes

This PR allows the Scene_points_with_normal_item to keep its point_size and normal_size if any when it is reloaded.
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #1889 
* Feature/Small Feature (if any):

