### PR TITLE
Fix  warnings with MSVC 2017

### DIFF
--- a/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
@@ -384,8 +384,10 @@ public:
 
     initialize_bounding_sphere();
 
+    typedef std::iterator_traits<InputIterator> Iterator_traits;
+    typedef typename Iterator_traits::difference_type Diff_t;
     boost::rand48 random;
-    boost::random_number_generator<boost::rand48> rng(random);
+    boost::random_number_generator<boost::rand48, Diff_t> rng(random);
     std::random_shuffle (points.begin(), points.end(), rng);
     fraction = 0;
 

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_hierarchy_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_hierarchy_2.h
@@ -193,7 +193,10 @@ public:
       site_vec.push_back(Site_2(*it));
     }
 
-    boost::random_number_generator<boost::rand48> rng(random);
+    typedef std::iterator_traits<Input_iterator> Iterator_traits;
+    typedef typename Iterator_traits::difference_type Diff_t;
+
+    boost::random_number_generator<boost::rand48, Diff_t> rng(random);
     std::random_shuffle(site_vec.begin(), site_vec.end(),rng);
     return insert(site_vec.begin(), site_vec.end(), Tag_false());
   }

--- a/Spatial_sorting/include/CGAL/hilbert_sort.h
+++ b/Spatial_sorting/include/CGAL/hilbert_sort.h
@@ -46,8 +46,10 @@ namespace internal {
 		       Policy /*policy*/,
 		       typename Kernel::Point_2 *)
     {
+        typedef std::iterator_traits<RandomAccessIterator> ITraits;
+        typedef typename ITraits::difference_type Diff_t;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end, rng);
 #else
@@ -63,8 +65,10 @@ namespace internal {
 			 Policy /*policy*/,
 			 typename Kernel::Point_3 *)
     {
+        typedef std::iterator_traits<RandomAccessIterator> ITraits;
+        typedef typename ITraits::difference_type Diff_t;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end, rng);
 #else
@@ -80,8 +84,10 @@ namespace internal {
 			 Policy /*policy*/,
 			 typename Kernel::Point_d *)
     {
+        typedef std::iterator_traits<RandomAccessIterator> ITraits;
+        typedef typename ITraits::difference_type Diff_t;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end, rng);
 #else

--- a/Spatial_sorting/include/CGAL/hilbert_sort_on_sphere.h
+++ b/Spatial_sorting/include/CGAL/hilbert_sort_on_sphere.h
@@ -37,8 +37,10 @@ void hilbert_sort_on_sphere (RandomAccessIterator begin,
                    double sq_r,
                    const typename Kernel::Point_3 &p)
 {
+  typedef std::iterator_traits<RandomAccessIterator> ITraits;
+  typedef typename ITraits::difference_type Diff_t;
   boost::rand48 random;
-  boost::random_number_generator<boost::rand48> rng(random);
+  boost::random_number_generator<boost::rand48, Diff_t> rng(random);
   std::random_shuffle(begin,end, rng);
   (Hilbert_sort_on_sphere_3<Kernel, Policy> (k,sq_r,p))(begin, end);
 }

--- a/Spatial_sorting/include/CGAL/spatial_sort.h
+++ b/Spatial_sorting/include/CGAL/spatial_sort.h
@@ -47,9 +47,11 @@ namespace internal {
 		       std::ptrdiff_t threshold_multiscale,
 		       double ratio)
     {
+      typedef std::iterator_traits<RandomAccessIterator> Iterator_traits;
+      typedef typename Iterator_traits::difference_type Diff_t;
       typedef Hilbert_sort_2<Kernel, Policy> Sort;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end,rng);
 #else
@@ -74,9 +76,11 @@ namespace internal {
 		       std::ptrdiff_t threshold_multiscale,
 		       double ratio)
     {
+      typedef std::iterator_traits<RandomAccessIterator> Iterator_traits;
+      typedef typename Iterator_traits::difference_type Diff_t;
       typedef Hilbert_sort_3<Kernel, Policy> Sort;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end, rng);
 #else
@@ -101,9 +105,11 @@ namespace internal {
 		       std::ptrdiff_t threshold_multiscale,
 		       double ratio)
     {
+      typedef std::iterator_traits<RandomAccessIterator> Iterator_traits;
+      typedef typename Iterator_traits::difference_type Diff_t;
       typedef Hilbert_sort_d<Kernel, Policy> Sort;
         boost::rand48 random;
-        boost::random_number_generator<boost::rand48> rng(random);
+        boost::random_number_generator<boost::rand48, Diff_t> rng(random);
 #if defined(CGAL_HILBERT_SORT_WITH_MEDIAN_POLICY_CROSS_PLATFORM_BEHAVIOR)
         CGAL::random_shuffle(begin,end, rng);
 #else

--- a/Spatial_sorting/include/CGAL/spatial_sort_on_sphere.h
+++ b/Spatial_sorting/include/CGAL/spatial_sort_on_sphere.h
@@ -42,8 +42,11 @@ void spatial_sort_on_sphere (
                    double ratio)
 {
   typedef Hilbert_sort_on_sphere_3<Kernel, Policy> Sort;
+    typedef std::iterator_traits<RandomAccessIterator> ITraits;
+    typedef typename ITraits::difference_type Diff_t;
+
     boost::rand48 random;
-    boost::random_number_generator<boost::rand48> rng(random);
+    boost::random_number_generator<boost::rand48, Diff_t> rng(random);
     std::random_shuffle(begin,end, rng);
 
             if (threshold_hilbert==0) threshold_hilbert=4;


### PR DESCRIPTION
Should fix that warning:
```
c:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.10.24930\include\algorithm(1782): warning C4244: 'argument': conversion from '_Diff' to 'long', possible loss of data
c:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.10.24930\include\algorithm(1796): note: see reference to function template instantiation 'void std::_Random_shuffle_unchecked<CGAL::Point_3<Kernel_>*,_RngFn>(_RanIt,_RanIt,_RngFn &)' being compiled
        with
        [
            Kernel_=CGAL::Simple_cartesian<float>,
            _RngFn=boost::random::random_number_generator<boost::random::rand48,long>,
            _RanIt=CGAL::Point_3<CGAL::Simple_cartesian<float>> *
        ]
c:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.10.24930\include\algorithm(1815): note: see reference to function template instantiation 'void std::_Random_shuffle1<_RanIt,boost::random::random_number_generator<boost::random::rand48,long>>(_RanIt,_RanIt,_RngFn &)' being compiled
        with
        [
            _RanIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<CGAL::Point_3<CGAL::Simple_cartesian<float>>>>>,
            _RngFn=boost::random::random_number_generator<boost::random::rand48,long>
        ]
C:\CGAL\test\CGAL-4.10-Ic-125\include\CGAL/spatial_sort.h(83): note: see reference to function template instantiation 'void std::random_shuffle<RandomAccessIterator,boost::random::random_number_generator<boost::random::rand48,long>&>(_RanIt,_RanIt,_RngFn)' being compiled
        with
        [
            RandomAccessIterator=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<CGAL::Point_3<CGAL::Simple_cartesian<float>>>>>,
            _RanIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<CGAL::Point_3<CGAL::Simple_cartesian<float>>>>>,
            _RngFn=boost::random::random_number_generator<boost::random::rand48,long> &
        ]
C:\CGAL\test\CGAL-4.10-Ic-125\include\CGAL/spatial_sort.h(136): note: see reference to function template instantiation 'void CGAL::internal::spatial_sort<RandomAccessIterator,Policy,Kernel>(RandomAccessIterator,RandomAccessIterator,const Kernel &,Policy,CGAL::Point_3<Kernel_> *,ptrdiff_t,ptrdiff_t,double)' being compiled
        with
        [
            RandomAccessIterator=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<CGAL::Point_3<CGAL::Simple_cartesian<float>>>>>,
            Policy=CGAL::Hilbert_sort_median_policy,
            Kernel=Kernel,
            Kernel_=CGAL::Simple_cartesian<float>
        ]
C:\CGAL\test\CGAL-4.10-Ic-125\include\CGAL/spatial_sort.h(152): note: see reference to function template instantiation 'void CGAL::spatial_sort<RandomAccessIterator,CGAL::Hilbert_sort_median_policy,Kernel>(RandomAccessIterator,RandomAccessIterator,const Kernel &,Policy,ptrdiff_t,ptrdiff_t,double)' being compiled
        with
        [
            RandomAccessIterator=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<CGAL::Point_3<CGAL::Simple_cartesian<float>>>>>,
            Kernel=Kernel,
            Policy=CGAL::Hilbert_sort_median_policy
        ]
```
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-Ic-125/AABB_tree/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz