### PR TITLE
WLOP Bugfix: use radius2 in parallel version too

### DIFF
--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -580,7 +580,7 @@ wlop_simplify_and_regularize_point_set(
                            sample_points,          
                            original_kd_tree,
                            sample_kd_tree,
-                           radius, 
+                           radius2,
                            original_density_weights,
                            sample_density_weights);
 


### PR DESCRIPTION
## Summary of Changes

WLOP gives different results in parallel and sequential versions. This is because the parallel version wrongly uses the radius instead of the squared radius. This PR fixes this.

## Release Management

* Affected package(s): Point Set processing
