### PR TITLE
Fix Expr computation when a Node in the tree has a large MSB bound

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/ExprRep.h
+++ b/CGAL_Core/include/CGAL/CORE/ExprRep.h
@@ -1220,20 +1220,24 @@ void AddSubRep<Operator>::computeApproxValue(const extLong& relPrec,
     appValue() = first->getAppValue(relPrec, absPrec);
     return;
   }
-  if (lMSB() < EXTLONG_BIG && lMSB() > EXTLONG_SMALL) {
-    extLong rf = first->uMSB()-lMSB()+relPrec+EXTLONG_FOUR;  // 2 better
-    if (rf < EXTLONG_ZERO)
-      rf = EXTLONG_ZERO;  // from Koji's thesis P63: Proposition 26
-    extLong rs = second->uMSB()-lMSB()+relPrec+EXTLONG_FOUR; // 2 better
-    if (rs < EXTLONG_ZERO)
-      rs = EXTLONG_ZERO;  // from Koji's thesis P63: Proposition 26
-    extLong  a  = absPrec + EXTLONG_THREE;                      // 1 better
-    appValue() = Op(first->getAppValue(rf, a), second->getAppValue(rs, a));
-  } else {
+
+  // warn about large MSB bound but do the computation as extLong is
+  // handling overflow and underflow
+  if (lMSB() >= EXTLONG_BIG || lMSB() <= EXTLONG_SMALL)
+  {
     std::cerr << "lMSB = " << lMSB() << std::endl; // should be in core_error
     core_error("CORE WARNING: a huge lMSB in AddSubRep",
 	 	__FILE__, __LINE__, false);
   }
+
+  extLong rf = first->uMSB()-lMSB()+relPrec+EXTLONG_FOUR;  // 2 better
+  if (rf < EXTLONG_ZERO)
+    rf = EXTLONG_ZERO;  // from Koji's thesis P63: Proposition 26
+  extLong rs = second->uMSB()-lMSB()+relPrec+EXTLONG_FOUR; // 2 better
+  if (rs < EXTLONG_ZERO)
+    rs = EXTLONG_ZERO;  // from Koji's thesis P63: Proposition 26
+  extLong  a  = absPrec + EXTLONG_THREE;                      // 1 better
+  appValue() = Op(first->getAppValue(rf, a), second->getAppValue(rs, a));
 }
 
 /// \typedef AddRep

--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1024,45 +1024,53 @@ void SqrtRep::computeApproxValue(const extLong& relPrec,
 CGAL_INLINE_FUNCTION
 void MultRep::computeApproxValue(const extLong& relPrec,
                                  const extLong& absPrec) {
-  if (lMSB() < EXTLONG_BIG && lMSB() > EXTLONG_SMALL) {
-    extLong r   = relPrec + EXTLONG_FOUR;
-    extLong  afr = - first->lMSB() + EXTLONG_ONE;
-    extLong  afa = second->uMSB() + absPrec + EXTLONG_FIVE;
-    extLong  af  = afr > afa ? afr : afa;
-    extLong  asr = - second->lMSB() + EXTLONG_ONE;
-    extLong  asa = first->uMSB() + absPrec + EXTLONG_FIVE;
-    extLong  as  = asr > asa ? asr : asa;
-    appValue() = first->getAppValue(r, af)*second->getAppValue(r, as);
-  } else {
-    std::cerr << "lMSB = " << lMSB() << std::endl;
-    core_error("a huge lMSB in MulRep", __FILE__, __LINE__, false);
+  // warn about large MSB bound but do the computation as extLong is
+  // handling overflow and underflow
+  if (lMSB() >= EXTLONG_BIG || lMSB() <= EXTLONG_SMALL)
+  {
+    std::cerr << "lMSB = " << lMSB() << std::endl; // should be in core_error
+    core_error("CORE WARNING: a huge lMSB in AddSubRep",
+	 	__FILE__, __LINE__, false);
   }
+
+  extLong r   = relPrec + EXTLONG_FOUR;
+  extLong  afr = - first->lMSB() + EXTLONG_ONE;
+  extLong  afa = second->uMSB() + absPrec + EXTLONG_FIVE;
+  extLong  af  = afr > afa ? afr : afa;
+  extLong  asr = - second->lMSB() + EXTLONG_ONE;
+  extLong  asa = first->uMSB() + absPrec + EXTLONG_FIVE;
+  extLong  as  = asr > asa ? asr : asa;
+  appValue() = first->getAppValue(r, af)*second->getAppValue(r, as);
 }
 
 CGAL_INLINE_FUNCTION
 void DivRep::computeApproxValue(const extLong& relPrec,
                                 const extLong& absPrec) {
-  if (lMSB() < EXTLONG_BIG && lMSB() > EXTLONG_SMALL) {
-    extLong rr  = relPrec + EXTLONG_SEVEN;		// These rules come from
-    extLong ra  = uMSB() + absPrec + EXTLONG_EIGHT;	// Koji's Master Thesis, page 65
-    extLong ra2 = core_max(ra, EXTLONG_TWO);
-    extLong r   = core_min(rr, ra2);
-    extLong  af  = - first->lMSB() + r;
-    extLong  as  = - second->lMSB() + r;
-
-    extLong pr = relPrec + EXTLONG_SIX;
-    extLong pa = uMSB() + absPrec + EXTLONG_SEVEN;
-    extLong p  = core_min(pr, pa);	// Seems to be an error:
-    // p can be negative here!
-    // Also, this does not conform to
-    // Koji's thesis which has a default
-    // relative precision (p.65).
-
-    appValue() = first->getAppValue(r, af).div(second->getAppValue(r, as), p);
-  } else {
-    std::cerr << "lMSB = " << lMSB() << std::endl;
-    core_error("a huge lMSB in DivRep", __FILE__, __LINE__, false);
+  // warn about large MSB bound but do the computation as extLong is
+  // handling overflow and underflow
+  if (lMSB() >= EXTLONG_BIG || lMSB() <= EXTLONG_SMALL)
+  {
+    std::cerr << "lMSB = " << lMSB() << std::endl; // should be in core_error
+    core_error("CORE WARNING: a huge lMSB in AddSubRep",
+	 	__FILE__, __LINE__, false);
   }
+
+  extLong rr  = relPrec + EXTLONG_SEVEN;		// These rules come from
+  extLong ra  = uMSB() + absPrec + EXTLONG_EIGHT;	// Koji's Master Thesis, page 65
+  extLong ra2 = core_max(ra, EXTLONG_TWO);
+  extLong r   = core_min(rr, ra2);
+  extLong  af  = - first->lMSB() + r;
+  extLong  as  = - second->lMSB() + r;
+
+  extLong pr = relPrec + EXTLONG_SIX;
+  extLong pa = uMSB() + absPrec + EXTLONG_SEVEN;
+  extLong p  = core_min(pr, pa);	// Seems to be an error:
+  // p can be negative here!
+  // Also, this does not conform to
+  // Koji's thesis which has a default
+  // relative precision (p.65).
+
+  appValue() = first->getAppValue(r, af).div(second->getAppValue(r, as), p);
 }
 
 //

--- a/Number_types/test/Number_types/CORE_Expr.cpp
+++ b/Number_types/test/Number_types/CORE_Expr.cpp
@@ -5,6 +5,7 @@
 #include <list>
 #include <cstdlib>
 #include <CGAL/CORE_Expr.h>
+#include <CGAL/Gmpq.h>
 #include <CGAL/Test/_test_algebraic_structure.h>
 #include <CGAL/Test/_test_real_embeddable.h>
 
@@ -36,9 +37,44 @@ void test_istream()
   std::cout << "test istream OK\n";
 }
 
+template <class FT>
+void test_MSB_bug()
+{
+  FT px1(4.7320508075688767), py1(4.0000000000000000), pz1(1.9999999999999969);
+  FT qx1(4.7320508075688767), qy1(4.0000000000000009), qz1(1.9999999999999880);
+  FT rx1(5.1624261825907327), ry1(4.0000000000000000), rz1(2.0000000000000009);
+
+  FT px2(4.7320508075688767), py2(4.0000000000000000), pz2(2.0000000000000044);
+  FT qx2(4.2679491924311224), qy2(4.2679491924311233), qz2(2.0000000000000013);
+  FT rx2(4.7320508075688767), ry2(4.0000000000000009), rz2(1.9999999999999880);
+
+  FT rqy1 = qy1-ry1; // this operation will trigger a -infinity lMSB()
+  FT rpx1 = px1-rx1;
+  FT rpy1 = py1-ry1;
+  FT rpz1 = pz1-rz1;
+  FT rqx1 = qx1-rx1;
+  FT rqz1 = qz1-rz1;
+
+  FT b1 = rpz1*rqx1 - rqz1*rpx1;
+  FT c1 = rpx1*rqy1 - rqx1*rpy1;
+
+  FT rpx2 = px2-rx2;
+  FT rpy2 = py2-ry2; // this operation will trigger a -infinity lMSB()
+  FT rpz2 = pz2-rz2;
+  FT rqx2 = qx2-rx2;
+  FT rqy2 = qy2-ry2;
+  FT rqz2 = qz2-rz2;
+  FT b2 = rpz2*rqx2 - rqz2*rpx2;
+  FT c2 = rpx2*rqy2 - rqx2*rpy2;
+  FT res = b1*c2-c1*b2;
+
+  assert(res != 0);
+}
 
 int main() {
     test_istream();
+    test_MSB_bug<CGAL::Gmpq>();
+    test_MSB_bug<CORE::Expr>();
   
     typedef CORE::Expr NT;
     typedef CGAL::Field_with_root_of_tag Tag;


### PR DESCRIPTION
## Summary of Changes
When the lower bound of the Most Significant Bit (MSB) is too large or too small, the evaluation of ExprRep was not done.
From what I understand, the code is able to handling it.

This was reveled by the test added. What happen is that the lower bound of MSB, computed with:
```
  /// lower bound on MSB
  /** defined to be cel(lg(real value));
      ilogb(x) is floor(log_2(|x|)). 
      Also, ilogb(0) = -INT_MAX.  ilogb(NaN) = ilogb(+/-Inf) = INT_MAX */
  extLong lMSB() const {
    return extLong(ilogb(core_abs(fpVal)-maxAbs*ind*CORE_EPS));
  }
```
is `INT_MAX` because of the operation _4.0000000000000000 - 4.0000000000000009_ that is close to 0.
Then, without the current patch the approximation was not refined and an erroneous decision was taken when computing a determinant (`Gmpq` is used as ground truth here but `BigFloat` could have also been used).

I'm not an expert so if for example @luis4a0, @akobel, @pougetma, or @mhsaar  can comment on this patch, it would be great.

## Release Management

* Affected package(s): CGAL_Core

