### PR TITLE
Polyhedron demo: OFF_plugin optimizations

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -112,6 +112,14 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
                      .arg(item->getNbIsolatedvertices()));
     }
 
+  //if file > 100 MB, assume it is a very big file and disable flat shading to gain memory.
+  if(fileinfo.size() > 100000000)//100 MB
+  {
+    item->set_flat_disabled(true);
+    QMessageBox::warning((QWidget*)NULL,
+                   tr("The file seems to be very big."),
+                   tr("Flat shading has been disabled to gain memory. You can force it in the context menu of the item."));
+  }
   return item;
 }
 

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -48,6 +48,7 @@
         <file>resources/euler_vertex.png</file>
         <file>javascript/lib.js</file>
         <file>resources/shader_c3t3_tets.v</file>
+        <file>resources/shader_flat.f</file>
     </qresource>
     <qresource prefix="/cgal/cursors">
         <file>resources/rotate_around_cursor.png</file>

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -409,9 +409,9 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
     p1 = he->vertex()->point();
     p2 = next(he, *poly)->vertex()->point();
 
-    idx_faces.push_back(he_end->vertex()->id());
-    idx_faces.push_back(he->vertex()->id());
-    idx_faces.push_back(next(he, *poly)->vertex()->id());
+    idx_faces.push_back(static_cast<unsigned int>(he_end->vertex()->id()));
+    idx_faces.push_back(static_cast<unsigned int>(he->vertex()->id()));
+    idx_faces.push_back(static_cast<unsigned int>(next(he, *poly)->vertex()->id()));
 
     if(!no_flat)
     {
@@ -467,9 +467,9 @@ Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
     if (colors_only)
      continue;
 
-    idx_faces.push_back(triangulation.v2v[ffit->vertex(0)]->id());
-    idx_faces.push_back(triangulation.v2v[ffit->vertex(1)]->id());
-    idx_faces.push_back(triangulation.v2v[ffit->vertex(2)]->id());
+    idx_faces.push_back(static_cast<unsigned int>(triangulation.v2v[ffit->vertex(0)]->id()));
+    idx_faces.push_back(static_cast<unsigned int>(triangulation.v2v[ffit->vertex(1)]->id()));
+    idx_faces.push_back(static_cast<unsigned int>(triangulation.v2v[ffit->vertex(2)]->id()));
 
     if(!no_flat)
     {
@@ -672,7 +672,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
               push_back_xyz(p+offset, positions_facets);
             }
 
-            idx_faces.push_back(he->vertex()->id());
+            idx_faces.push_back(static_cast<unsigned int>(he->vertex()->id()));
          }
       }
       else if (is_quad(f->halfedge(), *poly))
@@ -692,9 +692,9 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
 
         //1st half-quad
 
-        idx_faces.push_back(f->halfedge()->vertex()->id());
-        idx_faces.push_back(f->halfedge()->next()->vertex()->id());
-        idx_faces.push_back(f->halfedge()->next()->next()->vertex()->id());
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->vertex()->id()));
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->vertex()->id()));
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->next()->vertex()->id()));
         if(!no_flat)
         {
           Point p0 = f->halfedge()->vertex()->point();
@@ -705,9 +705,9 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           push_back_xyz(p2+offset, positions_facets);
         }
         //2nd half-quad
-        idx_faces.push_back(f->halfedge()->next()->next()->vertex()->id());
-        idx_faces.push_back(f->halfedge()->prev()->vertex()->id());
-        idx_faces.push_back(f->halfedge()->vertex()->id());
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->next()->vertex()->id()));
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->prev()->vertex()->id()));
+        idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->vertex()->id()));
 
         if(!no_flat)
         {
@@ -759,16 +759,16 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           if (colors_only)
             continue;
 
-          idx_feature_lines.push_back(he->vertex()->id());
-          idx_feature_lines.push_back(he->opposite()->vertex()->id());
+          idx_feature_lines.push_back(static_cast<unsigned int>(he->vertex()->id()));
+          idx_feature_lines.push_back(static_cast<unsigned int>(he->opposite()->vertex()->id()));
         }
         else
         {
           if (colors_only)
             continue;
 
-          idx_lines.push_back(he->vertex()->id());
-          idx_lines.push_back(he->opposite()->vertex()->id());
+          idx_lines.push_back(static_cast<unsigned int>(he->vertex()->id()));
+          idx_lines.push_back(static_cast<unsigned int>(he->opposite()->vertex()->id()));
         }
     }
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -116,7 +116,6 @@ struct Scene_polyhedron_item_priv{
   bool isFacetConvex(Facet_iterator, const Polyhedron::Traits::Vector_3&)const;
 
   void triangulate_convex_facet(Facet_iterator,
-                                const Polyhedron::Traits::Vector_3&,
                                 const bool)const;
 
   void triangulate_facet(Scene_polyhedron_item::Facet_iterator,
@@ -377,8 +376,7 @@ bool Scene_polyhedron_item_priv::isFacetConvex(Facet_iterator f, const Polyhedro
 }
 
 void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
-                                                     const Traits::Vector_3& normal,
-                                                     const bool colors_only)const
+                                                          const bool colors_only)const
 {
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
@@ -726,7 +724,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
       {
         if(isFacetConvex(f, nf))
         {
-          triangulate_convex_facet(f, nf, colors_only);
+          triangulate_convex_facet(f, colors_only);
         }
         else
         {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -414,18 +414,14 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
     push_back_xyz(p1+offset, positions_facets);
     push_back_xyz(p2+offset, positions_facets);
 
+    idx_faces.push_back(he_end->vertex()->id());
+    idx_faces.push_back(he->vertex()->id());
+    idx_faces.push_back(next(he, *poly)->vertex()->id());
+
     push_back_xyz(normal, normals_flat);
     push_back_xyz(normal, normals_flat);
     push_back_xyz(normal, normals_flat);
 
-//    Traits::Vector_3 ng = get(vnmap, he_end->vertex());
-//    push_back_xyz(ng, normals_gouraud);
-
-//    ng = get(vnmap, he->vertex());
-//    push_back_xyz(ng, normals_gouraud);
-
-//    ng = get(vnmap, next(he, *poly)->vertex());
-//    push_back_xyz(ng, normals_gouraud);
   }
 
 
@@ -455,7 +451,6 @@ Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
   //iterates on the internal faces to add the vertices to the positions
   //and the normals to the appropriate vectors
   const int this_patch_id = fit->patch_id();
-
   for(FT::CDT::Finite_faces_iterator
       ffit = triangulation.cdt->finite_faces_begin(),
       end = triangulation.cdt->finite_faces_end();
@@ -475,23 +470,17 @@ Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
      continue;
 
     push_back_xyz(ffit->vertex(0)->point()+offset, positions_facets);
-
     push_back_xyz(ffit->vertex(1)->point()+offset, positions_facets);
-
     push_back_xyz(ffit->vertex(2)->point()+offset, positions_facets);
 
+    idx_faces.push_back(triangulation.v2v[ffit->vertex(0)]->id());
+    idx_faces.push_back(triangulation.v2v[ffit->vertex(1)]->id());
+    idx_faces.push_back(triangulation.v2v[ffit->vertex(2)]->id());
+
     push_back_xyz(normal, normals_flat);
     push_back_xyz(normal, normals_flat);
     push_back_xyz(normal, normals_flat);
 
-//    Traits::Vector_3 ng = get(vnmap, triangulation.v2v[ffit->vertex(0)]);
-//    push_back_xyz(ng, normals_gouraud);
-
-//    ng = get(vnmap, triangulation.v2v[ffit->vertex(1)]);
-//    push_back_xyz(ng, normals_gouraud);
-
-//    ng = get(vnmap, triangulation.v2v[ffit->vertex(2)]);
-//    push_back_xyz(ng, normals_gouraud);
   }
 }
 
@@ -687,10 +676,6 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
             // If Flat shading:1 normal per polygon added once per vertex
             push_back_xyz(nf, normals_flat);
 
-            //// If Gouraud shading: 1 normal per vertex
-//            Vector nv = get(nv_pmap, he->vertex());
-//            push_back_xyz(nv, normals_gouraud);
-
             //position
             const Point& p = he->vertex()->point();
             push_back_xyz(p+offset, positions_facets);
@@ -718,23 +703,17 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
         Point p2 = f->halfedge()->next()->next()->vertex()->point();
 
         push_back_xyz(p0+offset, positions_facets);
-
         push_back_xyz(p1+offset, positions_facets);
-
         push_back_xyz(p2+offset, positions_facets);
 
+        idx_faces.push_back(f->halfedge()->vertex()->id());
+        idx_faces.push_back(f->halfedge()->next()->vertex()->id());
+        idx_faces.push_back(f->halfedge()->next()->next()->vertex()->id());
+
+
         push_back_xyz(nf, normals_flat);
         push_back_xyz(nf, normals_flat);
         push_back_xyz(nf, normals_flat);
-
-//        Vector nv = get(nv_pmap, f->halfedge()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
-
-//        nv = get(nv_pmap, f->halfedge()->next()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
-
-//        nv = get(nv_pmap, f->halfedge()->next()->next()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
 
         //2nd half-quad
         p0 = f->halfedge()->next()->next()->vertex()->point();
@@ -742,23 +721,17 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
         p2 = f->halfedge()->vertex()->point();
 
         push_back_xyz(p0+offset, positions_facets);
-
         push_back_xyz(p1+offset, positions_facets);
-
         push_back_xyz(p2+offset, positions_facets);
 
+        idx_faces.push_back(f->halfedge()->next()->next()->vertex()->id());
+        idx_faces.push_back(f->halfedge()->prev()->vertex()->id());
+        idx_faces.push_back(f->halfedge()->vertex()->id());
+
         push_back_xyz(nf, normals_flat);
         push_back_xyz(nf, normals_flat);
         push_back_xyz(nf, normals_flat);
 
-//        nv = get(nv_pmap, f->halfedge()->next()->next()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
-
-//        nv = get(nv_pmap, f->halfedge()->prev()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
-
-//        nv = get(nv_pmap, f->halfedge()->vertex());
-//        push_back_xyz(nv, normals_gouraud);
       }
       else
       {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -70,7 +70,7 @@ public:
     QMenu* contextMenu();
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const { return (m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); }
+    virtual bool supportsRenderingMode(RenderingMode m) const;
     // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
     void draw() const {}
     virtual void draw(CGAL::Three::Viewer_interface*) const;
@@ -121,6 +121,7 @@ public Q_SLOTS:
     void show_only_feature_edges(bool);
     void enable_facets_picking(bool);
     void set_erase_next_picked_facet(bool);
+    void set_flat_disabled(bool b);
 
     void select(double orig_x,
                 double orig_y,

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -94,6 +94,7 @@ struct Scene_surface_mesh_item_priv{
   mutable std::vector<cgal_gl_data> flat_normals;
   mutable std::vector<cgal_gl_data> f_colors;
   mutable std::vector<cgal_gl_data> v_colors;
+  mutable std::size_t nb_flat;
   mutable QOpenGLShaderProgram *program;
   Scene_surface_mesh_item *item;
 
@@ -418,6 +419,21 @@ void Scene_surface_mesh_item_priv::initializeBuffers(CGAL::Three::Viewer_interfa
   program->setAttributeBuffer("vertex",CGAL_GL_DATA,0,3);
   item->buffers[Scene_surface_mesh_item_priv::Smooth_vertices].release();
   program->release();
+
+  nb_flat = flat_vertices.size();
+  smooth_vertices.resize(0);
+  smooth_normals .resize(0);
+  flat_vertices  .resize(0);
+  flat_normals   .resize(0);
+  f_colors       .resize(0);
+  v_colors       .resize(0);
+  smooth_vertices.shrink_to_fit();
+  smooth_normals .shrink_to_fit();
+  flat_vertices  .shrink_to_fit();
+  flat_normals   .shrink_to_fit();
+  f_colors       .shrink_to_fit();
+  v_colors       .shrink_to_fit();
+
   item->are_buffers_filled = true;
 }
 
@@ -456,7 +472,7 @@ void Scene_surface_mesh_item::draw(CGAL::Three::Viewer_interface *viewer) const
       d->program->setAttributeValue("is_selected", false);
     if(!d->has_fcolors)
       d->program->setAttributeValue("colors", this->color());
-    glDrawArrays(GL_TRIANGLES,0,static_cast<GLsizei>(d->flat_vertices.size()/3));
+    glDrawArrays(GL_TRIANGLES,0,static_cast<GLsizei>(d->nb_flat/3));
     vaos[Scene_surface_mesh_item_priv::Flat_facets]->release();
   }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -684,6 +684,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
     case PROGRAM_C3T3_TETS:
+    case PROGRAM_FLAT:
         program->setUniformValue("light_pos", position);
         program->setUniformValue("light_diff",diffuse);
         program->setUniformValue("light_spec", specular);
@@ -701,6 +702,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
     case PROGRAM_C3T3_TETS:
+    case PROGRAM_FLAT:
       program->setUniformValue("mv_matrix", mv_mat);
       break;
     case PROGRAM_WITHOUT_LIGHT:
@@ -1090,317 +1092,87 @@ void Viewer::resizeGL(int w, int h)
     d->rendering_program.release();
 
 }
+QOpenGLShaderProgram* Viewer::declare_program(int name,
+                                      const char* v_shader,
+                                      const char* f_shader) const
+{
+  // workaround constness issues in Qt
+  Viewer* viewer = const_cast<Viewer*>(this);
 
+  if(d->shader_programs[name])
+  {
+    return d->shader_programs[name];
+  }
+
+  else
+  {
+
+    QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
+    if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,v_shader))
+    {
+      std::cerr<<"adding vertex shader FAILED"<<std::endl;
+    }
+    if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,f_shader))
+    {
+      std::cerr<<"adding fragment shader FAILED"<<std::endl;
+    }
+    program->bindAttributeLocation("colors", 1);
+    program->link();
+    d->shader_programs[name] = program;
+    return program;
+  }
+}
 QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
 {
-    // workaround constness issues in Qt
-    Viewer* viewer = const_cast<Viewer*>(this);
-
     switch(name)
     {
-    /// @TODO: factorize this code   
     case PROGRAM_C3T3:
-        if(d->shader_programs[PROGRAM_C3T3])
-        {
-            return d->shader_programs[PROGRAM_C3T3];
-        }
-
-        else
-        {
-
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_c3t3.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_C3T3] = program;
-            return program;
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_c3t3.v" , ":/cgal/Polyhedron_3/resources/shader_c3t3.f");
         break;
     case PROGRAM_C3T3_EDGES:
-        if(d->shader_programs[PROGRAM_C3T3_EDGES])
-        {
-            return d->shader_programs[PROGRAM_C3T3_EDGES];
-        }
-
-        else
-        {
-
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_edges.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_c3t3_edges.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_C3T3_EDGES] = program;
-            return program;
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_c3t3_edges.v" , ":/cgal/Polyhedron_3/resources/shader_c3t3_edges.f");
         break;
     case PROGRAM_WITH_LIGHT:
-        if(d->shader_programs[PROGRAM_WITH_LIGHT])
-        {
-            return d->shader_programs[PROGRAM_WITH_LIGHT];
-        }
-
-        else
-        {
-
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_with_light.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_WITH_LIGHT] = program;
-            return program;
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_light.v" , ":/cgal/Polyhedron_3/resources/shader_with_light.f");
         break;
     case PROGRAM_WITHOUT_LIGHT:
-        if( d->shader_programs[PROGRAM_WITHOUT_LIGHT])
-        {
-            return d->shader_programs[PROGRAM_WITHOUT_LIGHT];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_without_light.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_without_light.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_WITHOUT_LIGHT] = program;
-            return program;
-        }
-        break;
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_without_light.v" , ":/cgal/Polyhedron_3/resources/shader_without_light.f");
+       break;
     case PROGRAM_NO_SELECTION:
-        if( d->shader_programs[PROGRAM_NO_SELECTION])
-        {
-            return d->shader_programs[PROGRAM_NO_SELECTION];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_without_light.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_no_light_no_selection.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_NO_SELECTION] = program;
-            return program;
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_without_light.v" , ":/cgal/Polyhedron_3/resources/shader_no_light_no_selection.f");
         break;
     case PROGRAM_WITH_TEXTURE:
-        if( d->shader_programs[PROGRAM_WITH_TEXTURE])
-        {
-            return d->shader_programs[PROGRAM_WITH_TEXTURE];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_with_texture.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_texture.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("color_facets", 1);
-            program->link();
-            d->shader_programs[PROGRAM_WITH_TEXTURE] = program;
-            return program;
-        }
-        break;
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_texture.v" , ":/cgal/Polyhedron_3/resources/shader_with_texture.f");
+      break;
     case PROGRAM_PLANE_TWO_FACES:
-        if(d->shader_programs[PROGRAM_PLANE_TWO_FACES])
-        {
-            return d->shader_programs[PROGRAM_PLANE_TWO_FACES];
-        }
-
-        else
-        {
-
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_without_light.v"))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_plane_two_faces.f"))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->link();
-            d->shader_programs[PROGRAM_PLANE_TWO_FACES] = program;
-            return program;
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_without_light.v" , ":/cgal/Polyhedron_3/resources/shader_plane_two_faces.f");
         break;
-
     case PROGRAM_WITH_TEXTURED_EDGES:
-        if( d->shader_programs[PROGRAM_WITH_TEXTURED_EDGES])
-        {
-            return d->shader_programs[PROGRAM_WITH_TEXTURED_EDGES];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_with_textured_edges.v" ))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_textured_edges.f" ))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("color_lines", 1);
-            program->link();
-            d->shader_programs[PROGRAM_WITH_TEXTURED_EDGES] = program;
-            return program;
-
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_textured_edges.v" , ":/cgal/Polyhedron_3/resources/shader_with_textured_edges.f");
         break;
     case PROGRAM_INSTANCED:
-        if( d->shader_programs[PROGRAM_INSTANCED])
-        {
-            return d->shader_programs[PROGRAM_INSTANCED];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_instanced.v" ))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f" ))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_INSTANCED] = program;
-            return program;
-
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_instanced.v" , ":/cgal/Polyhedron_3/resources/shader_with_light.f");
         break;
     case PROGRAM_INSTANCED_WIRE:
-        if( d->shader_programs[PROGRAM_INSTANCED_WIRE])
-        {
-            return d->shader_programs[PROGRAM_INSTANCED_WIRE];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_instanced.v" ))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_without_light.f" ))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_INSTANCED_WIRE] = program;
-            return program;
-
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_instanced.v" , ":/cgal/Polyhedron_3/resources/shader_without_light.f");
         break;
     case PROGRAM_CUTPLANE_SPHERES:
-      if( d->shader_programs[PROGRAM_CUTPLANE_SPHERES])
-      {
-          return d->shader_programs[PROGRAM_CUTPLANE_SPHERES];
-      }
-      else
-      {
-        QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-        if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.v"))
-        {
-            std::cerr<<"adding vertex shader FAILED"<<std::endl;
-        }
-        if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_c3t3.f" ))
-        {
-            std::cerr<<"adding fragment shader FAILED"<<std::endl;
-        }
-        program->bindAttributeLocation("colors", 1);
-        program->link();
-        d->shader_programs[PROGRAM_CUTPLANE_SPHERES] = program;
-        return program;
-      }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.v" , ":/cgal/Polyhedron_3/resources/shader_c3t3.f");
+     break;
     case PROGRAM_C3T3_TETS:
-      if( d->shader_programs[PROGRAM_C3T3_TETS])
-      {
-          return d->shader_programs[PROGRAM_C3T3_TETS];
-      }
-      else
-      {
-        QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-        if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_c3t3_tets.v"))
-        {
-            std::cerr<<"adding vertex shader FAILED"<<std::endl;
-        }
-        if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f" ))
-        {
-            std::cerr<<"adding fragment shader FAILED"<<std::endl;
-        }
-        program->bindAttributeLocation("colors", 1);
-        program->link();
-        d->shader_programs[PROGRAM_C3T3_TETS] = program;
-        return program;
-      }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_c3t3_tets.v" , ":/cgal/Polyhedron_3/resources/shader_with_light.f");
+     break;
     case PROGRAM_SPHERES:
-        if( d->shader_programs[PROGRAM_SPHERES])
-        {
-            return d->shader_programs[PROGRAM_SPHERES];
-        }
-        else
-        {
-            QOpenGLShaderProgram *program = new QOpenGLShaderProgram(viewer);
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/shader_spheres.v" ))
-            {
-                std::cerr<<"adding vertex shader FAILED"<<std::endl;
-            }
-            if(!program->addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/shader_with_light.f" ))
-            {
-                std::cerr<<"adding fragment shader FAILED"<<std::endl;
-            }
-            program->bindAttributeLocation("colors", 1);
-            program->link();
-            d->shader_programs[PROGRAM_SPHERES] = program;
-            return program;
-
-        }
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_spheres.v" , ":/cgal/Polyhedron_3/resources/shader_with_light.f");
+      break;
+    case PROGRAM_FLAT:
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_light.v", ":/cgal/Polyhedron_3/resources/shader_flat.f");
       break;
 
     default:
         std::cerr<<"ERROR : Program not found."<<std::endl;
         return 0;
     }
-}
 void Viewer::wheelEvent(QWheelEvent* e)
 {
     if(e->modifiers().testFlag(Qt::ShiftModifier))

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1173,6 +1173,7 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
         std::cerr<<"ERROR : Program not found."<<std::endl;
         return 0;
     }
+}
 void Viewer::wheelEvent(QWheelEvent* e)
 {
     if(e->modifiers().testFlag(Qt::ShiftModifier))

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -69,6 +69,10 @@ public:
   void attribBuffers(int program_name) const;
   //! Implementation of `Viewer_interface::getShaderProgram()`
   QOpenGLShaderProgram* getShaderProgram(int name) const;
+  //!Declares a program names `name`, using `v_shader` as vertex shader and `f_shader` as fragment shader.
+  QOpenGLShaderProgram* declare_program(int name,
+                                        const char* v_shader,
+                                        const char* f_shader)const;
   QPainter* getPainter();
   void saveSnapshot(bool , bool overwrite = false);
   void setOffset(qglviewer::Vec offset);

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.f
@@ -1,22 +1,25 @@
 #version 120
 varying highp vec4 color;
-varying highp vec4 fP; 
-varying highp vec3 fN;
-uniform highp vec4 light_pos;  
-uniform highp vec4 light_diff; 
-uniform highp vec4 light_spec; 
+varying highp vec4 fP;
+uniform highp vec4 light_pos;
+uniform highp vec4 light_diff;
+uniform highp vec4 light_spec;
 uniform highp vec4 light_amb;
-uniform highp float spec_power ; 
-uniform int is_two_side; 
+uniform highp float spec_power ;
+uniform int is_two_side;
 uniform bool is_selected;
 void main(void) {
    highp vec3 L = light_pos.xyz - fP.xyz;
    highp vec3 V = -fP.xyz;
    highp vec3 N;
-   if(fN == highp vec3(0.0,0.0,0.0))
+   vec3 X = dFdx(fP.xyz);
+   vec3 Y = dFdy(fP.xyz);
+   vec3 normal=normalize(cross(X,Y));
+
+   if(normal == highp vec3(0.0,0.0,0.0))
        N = highp vec3(0.0,0.0,0.0);
    else
-       N = normalize(fN);
+       N = normalize(normal);
    L = normalize(L);
    V = normalize(V);
    highp vec3 R = reflect(-L, N);

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
@@ -6,11 +6,11 @@ uniform highp mat4 mvp_matrix;
 uniform highp mat4 mv_matrix; 
 varying highp vec4 fP; 
 varying highp vec3 fN; 
-varying highp vec4 color; 
+varying highp vec4 color;
 void main(void)
 {
    color = vec4(colors, 1.0);
    fP = mv_matrix * vertex; 
    fN = mat3(mv_matrix)* normals; 
-   gl_Position = mvp_matrix * vertex; 
+   gl_Position = mvp_matrix * vertex;
 }

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -81,6 +81,7 @@ public:
   PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
   PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
   PROGRAM_C3T3_TETS,           /** Used to render the tetrahedra of the intersection of a c3t3_item.*/
+  PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
   NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
  };
   typedef CGAL::Bbox_3 Bbox;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -70,6 +70,7 @@ public:
    PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
    PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
    PROGRAM_C3T3_TETS,           /** Used to render the tetrahedra of the intersection of a c3t3_item.*/
+   PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
    NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
   };
 


### PR DESCRIPTION
## Summary of Changes
- Use indexed drawing for Edges and gouraud.
- Remove Edge_colors as it is never used
- Use only 3 coordinates for vertices (stop filling 1.0 everywhere)
- Add a toggle for the Flat shading and automatic detection for disabling it at item's creation
- Use special shader for flat rendering in which normals are computed inside the fragment shader.
- Factorize program creation in Viewer.cpp
- use shrink_to_fit() in Scene_surface_mesh_item
## Release Management

* Affected package(s):Polyhedron_demo

