### PR TITLE
Mesh_3: Allow AbstractCriterion to be visited by Cell_criteria_visitor_with_f…

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/mesh_standard_cell_criteria.h
+++ b/Mesh_3/include/CGAL/Mesh_3/mesh_standard_cell_criteria.h
@@ -505,8 +505,7 @@ public:
     Base::do_visit(criterion);
   }
 
-  template <typename C3t3>
-  void visit(const No_bridge_cell_criterion<C3t3, Self>& criterion)
+  void visit(const Criterion& criterion)
   {
     Base::do_visit(criterion);
   }


### PR DESCRIPTION
Changes one of the overloaded visit functions in Cell_criteria_visitor_with_features to
allow an AbstractCriterion to be visited as well, thus allowing to use the visitor in
combination with custom cell criteria.

## Release Management

* Affected package(s): Mesh_3

