### PR TITLE
Polyhedron_demo: Surf_to_sm_io_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -33,6 +33,8 @@ target_link_libraries(surface_mesh_io_plugin scene_surface_mesh_item scene_polyg
 polyhedron_demo_plugin(surf_io_plugin Surf_io_plugin)
 target_link_libraries(surf_io_plugin scene_polyhedron_item)
 
+polyhedron_demo_plugin(surf_to_sm_io_plugin Surf_to_sm_io_plugin)
+target_link_libraries(surf_to_sm_io_plugin scene_surface_mesh_item)
 
 
 find_package(VTK QUIET COMPONENTS

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_to_sm_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_to_sm_io_plugin.cpp
@@ -1,0 +1,87 @@
+#include "Scene_surface_mesh_item.h"
+
+#include <QMainWindow>
+#include <QObject>
+#include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include <CGAL/Three/Scene_group_item.h>
+
+#include <CGAL/IO/read_surf_trianglemesh.h>
+
+#include <CGAL/Bbox_3.h>
+#include <CGAL/array.h>
+
+#include "Color_map.h"
+#include <fstream>
+
+using namespace CGAL::Three;
+class Surf_io_plugin:
+    public QObject,
+    public Polyhedron_demo_io_plugin_interface,
+    public Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface CGAL::Three::Polyhedron_demo_io_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.IOPluginInterface/1.0")
+
+public:
+  void init(QMainWindow* mainWindow,
+            CGAL::Three::Scene_interface* scene_interface,
+            Messages_interface*) {
+    //get the references
+    this->scene = scene_interface;
+    this->mw = mainWindow;
+  }
+  QList<QAction*> actions() const {
+    return QList<QAction*>();
+  }
+  bool applicable(QAction*) const { return false;}
+  QString name() const { return "surf_to_sm_io_plugin"; }
+  QString nameFilters() const { return "Amira files (*.surf)"; }
+  bool canLoad() const{ return true; }
+  CGAL::Three::Scene_item* load(QFileInfo fileinfo);
+
+  bool canSave(const CGAL::Three::Scene_item*) { return false; }
+  bool save(const CGAL::Three::Scene_item*, QFileInfo) { return false; }
+};
+
+
+CGAL::Three::Scene_item* Surf_io_plugin::load(QFileInfo fileinfo)
+{
+  typedef Scene_surface_mesh_item::SMesh SMesh;
+  // Open file
+  std::ifstream in(fileinfo.filePath().toUtf8());
+  if(!in) {
+    std::cerr << "Error! Cannot open file " << (const char*)fileinfo.filePath().toUtf8() << std::endl;
+    return NULL;
+  }
+
+  std::vector<SMesh> patches;
+  std::vector<MaterialData> material_data;
+  CGAL::Bbox_3 grid_box;
+  CGAL::cpp11::array<unsigned int, 3> grid_size = {{1, 1, 1}};
+  read_surf(in, patches, material_data, grid_box, grid_size);
+  for(std::size_t i=0; i<material_data.size(); ++i)
+  {
+   std::cout<<"The patch #"<<i<<":\n  -inner region : material's id = "<<material_data[i].innerRegion.first<<" material's name = "
+           <<material_data[i].innerRegion.second<<"\n  -outer region: material's id = "<<material_data[i].outerRegion.first<<" material's name = "
+             <<material_data[i].outerRegion.second<<std::endl;
+  }
+  std::vector<QColor> colors_;
+  compute_color_map(QColor(100, 100, 255), static_cast<unsigned>(patches.size()),
+                    std::back_inserter(colors_));
+  Scene_group_item* group = new Scene_group_item(fileinfo.completeBaseName());
+  for(std::size_t i=0; i<patches.size(); ++i)
+  {
+    Scene_surface_mesh_item *patch = new Scene_surface_mesh_item(patches[i]);
+    patch->setName(QString("Patch #%1").arg(i));
+    patch->setColor(colors_[i]);
+    scene->addItem(patch);
+    scene->changeGroup(patch, group);
+  }
+  return group;
+}
+
+#include "Surf_to_sm_io_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -106,8 +106,7 @@ Scene_surface_mesh_item::Scene_surface_mesh_item(const Scene_surface_mesh_item& 
   are_buffers_filled = false;
 }
 
-Scene_surface_mesh_item::Scene_surface_mesh_item(SMesh* sm)
-  : CGAL::Three::Scene_item(Scene_surface_mesh_item_priv::NbOfVbos,Scene_surface_mesh_item_priv::NbOfVaos)
+void Scene_surface_mesh_item::standard_constructor(SMesh* sm)
 {
   d = new Scene_surface_mesh_item_priv(sm, this);
   d->floated = false;
@@ -174,6 +173,17 @@ Scene_surface_mesh_item::Scene_surface_mesh_item(SMesh* sm)
 
   d->compute_elements();
   are_buffers_filled = false;
+}
+Scene_surface_mesh_item::Scene_surface_mesh_item(SMesh* sm)
+  : CGAL::Three::Scene_item(Scene_surface_mesh_item_priv::NbOfVbos,Scene_surface_mesh_item_priv::NbOfVaos)
+{
+  standard_constructor(sm);
+}
+
+Scene_surface_mesh_item::Scene_surface_mesh_item(SMesh sm)
+  : CGAL::Three::Scene_item(Scene_surface_mesh_item_priv::NbOfVbos,Scene_surface_mesh_item_priv::NbOfVaos)
+{
+  standard_constructor(new SMesh(sm));
 }
 
 Scene_surface_mesh_item*

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -33,7 +33,7 @@ public:
 
   // Takes ownership of the argument.
   Scene_surface_mesh_item(SMesh*);
-
+  Scene_surface_mesh_item(SMesh);
   Scene_surface_mesh_item(const Scene_surface_mesh_item& other);
 
   ~Scene_surface_mesh_item();
@@ -52,6 +52,7 @@ public:
   SMesh* polyhedron();
   const SMesh* polyhedron() const;
   void compute_bbox()const;
+  void standard_constructor(SMesh *sm);
 public Q_SLOTS:
   virtual void selection_changed(bool);
 protected:

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -84,7 +84,6 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
   typedef typename CGAL::GetGeomTraits<Mesh,
       NamedParameters>::type Kernel;
   typedef typename Kernel::Point_3 Point_3;
-  typedef typename boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
   std::vector<Point_3> points;
   std::string line;
   std::istringstream iss;


### PR DESCRIPTION
## Summary of Changes
- Add a plugin to read a surf in surface_meshes
- Add a constructor to the Scene_surface_mesh_item that takes a SMesh.
## Release Management

* Affected package(s):
* Issue(s) solved (if any): Polyhedron_demo, fix CGAL/GeometryFactory#4


