### PR TITLE
Make sure the approximation exceeds the separation bound

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/ExprRep.h
+++ b/CGAL_Core/include/CGAL/CORE/ExprRep.h
@@ -1129,7 +1129,11 @@ void AddSubRep<Operator>::computeExactFlags() {
 	std::cout << "Starting iteration at i = " << i << std::endl;
 #endif
 
-        for ( ; i<ua; i*=EXTLONG_TWO) {
+        bool current_precision_lower_than_bound = true;
+        for ( ; current_precision_lower_than_bound; i*=EXTLONG_TWO) {
+          // since at the previous loop i was lower than ua, we need
+          // another loop so that the precision bound is exceeded
+          if ( i>=ua ) current_precision_lower_than_bound = false;
           // relative bits = i
 	  //
 	  // PROBLEM WITH NEXT LINE: you must ensure that

--- a/CGAL_Core/include/CGAL/CORE/ExprRep.h
+++ b/CGAL_Core/include/CGAL/CORE/ExprRep.h
@@ -1133,7 +1133,10 @@ void AddSubRep<Operator>::computeExactFlags() {
         for ( ; current_precision_lower_than_bound; i*=EXTLONG_TWO) {
           // since at the previous loop i was lower than ua, we need
           // another loop so that the precision bound is exceeded
-          if ( i>=ua ) current_precision_lower_than_bound = false;
+          if ( i>=ua ){
+            current_precision_lower_than_bound = false;
+            i = ua; // do not compute more than needed
+          }
           // relative bits = i
 	  //
 	  // PROBLEM WITH NEXT LINE: you must ensure that

--- a/Number_types/test/Number_types/CORE_Expr.cpp
+++ b/Number_types/test/Number_types/CORE_Expr.cpp
@@ -8,6 +8,49 @@
 #include <CGAL/Test/_test_algebraic_structure.h>
 #include <CGAL/Test/_test_real_embeddable.h>
 
+void precision_bug()
+{
+  typedef CORE::Expr FT;
+  //computation with forced evaluation of sqrtD1D2
+  {
+    FT zero(0);
+    FT ipx(0.3080532378), iqx(0.3080629044), irx(0.3080725711);
+    FT a1(0.1282376364 - 0.1282279698);
+    FT a2(0.1282473031 - 0.1282376364);
+    FT b1 = ipx - iqx;
+    FT b2 = iqx - irx;
+    FT n1 = a1 * a1 + b1 * b1;
+    FT n2 = a2 * a2 + b2 * b2;
+    FT D1D2 = n1 * n2;
+    FT sqrtD1D2 = CGAL::sqrt(D1D2);
+    FT a1a2b1b2 = a1 * a2 + b1 * b2;
+    FT uz =  sqrtD1D2 -  a1a2b1b2 ;
+
+    sqrtD1D2.approx(53,1075); //force evaluation of sqrtD1D2
+    uz.approx(53,1075);
+
+    CGAL_assertion(!uz.isZero());
+  }
+  //computation without forced evaluation of sqrtD1D2
+  {
+    FT zero(0);
+    FT ipx(0.3080532378), iqx(0.3080629044), irx(0.3080725711);
+    FT a1(0.1282376364 - 0.1282279698);
+    FT a2(0.1282473031 - 0.1282376364);
+    FT b1 = ipx - iqx;
+    FT b2 = iqx - irx;
+    FT n1 = a1 * a1 + b1 * b1;
+    FT n2 = a2 * a2 + b2 * b2;
+    FT D1D2 = n1 * n2;
+    FT sqrtD1D2 = CGAL::sqrt(D1D2);
+    FT a1a2b1b2 = a1 * a2 + b1 * b2;
+    FT uz =  sqrtD1D2 -  a1a2b1b2 ;
+
+    CGAL_assertion(!uz.isZero());
+  }
+  std::cout << "precision bug OK\n";
+}
+
 void test_istream()
 {
   std::list<std::string> strings;
@@ -38,6 +81,7 @@ void test_istream()
 
 
 int main() {
+    precision_bug();
     test_istream();
   
     typedef CORE::Expr NT;


### PR DESCRIPTION
## Summary of Changes

The sign of a `CORE::Expr` is certified by computing approximations up to a given precision. The precision bound is computed thanks to a formula taking child nodes into account.
When evaluating the sign, the approximation with the full precision is not computed directly.
Instead, approximations with lower precision are computed while a certified answer is possible.
This patch makes sure that the approximation computed is larger than the theoretical bound.

In the test function added, the precision bound was 223 but the way the intermediate precision is increased was computing the approximation at 128, but the next one at 256 was ignored (since larger than 223). The patch the approximation precision is exceeded.

## Release Management

* Affected package(s): CORE
* Issue(s) solved (if any): fix #414


