### PR TITLE
Polyhedron demo: add point set support in PCA plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
@@ -1,6 +1,6 @@
 include( polyhedron_demo_macros )
 polyhedron_demo_plugin(pca_plugin Pca_plugin)
-target_link_libraries(pca_plugin scene_polyhedron_item scene_basic_objects)
+target_link_libraries(pca_plugin scene_polyhedron_item scene_points_with_normal_item scene_basic_objects)
 
 qt5_wrap_ui( transformUI_FILES Transformation_widget.ui )
 polyhedron_demo_plugin(affine_transform_plugin Affine_transform_plugin ${transformUI_FILES})


### PR DESCRIPTION
## Summary of Changes

PCA plugin in the demo only works for meshes. This adds support for point sets.

## Release Management

* Affected package(s): Polyhedron (demo)
* Issue(s) solved (if any):
* Feature/Small Feature (if any):

