### PR TITLE
Kernel_23: Division free functors may use Mpzf

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -478,10 +478,10 @@ CGAL_Kernel_cons(Construct_cartesian_const_iterator_2,
 		 construct_cartesian_const_iterator_2_object)
 CGAL_Kernel_cons(Construct_cartesian_const_iterator_3,
 		 construct_cartesian_const_iterator_3_object)
-CGAL_Kernel_pred(Coplanar_orientation_3,
-		 coplanar_orientation_3_object)
-CGAL_Kernel_pred(Coplanar_side_of_bounded_circle_3,
-		 coplanar_side_of_bounded_circle_3_object)
+CGAL_Kernel_pred_RT(Coplanar_orientation_3,
+                    coplanar_orientation_3_object)
+CGAL_Kernel_pred_RT(Coplanar_side_of_bounded_circle_3,
+                    coplanar_side_of_bounded_circle_3_object)
 CGAL_Kernel_pred(Coplanar_3,
 		 coplanar_3_object)
 CGAL_Kernel_pred(Counterclockwise_in_between_2,


### PR DESCRIPTION
## Summary of Changes

Change interface_macro for two functors used by Delaunay_3

## Release Management

* Affected package(s): Kernel_23
