### PR TITLE
Polyhedron_demo: Scene_facegraph_interface

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -3,6 +3,7 @@
 
 #include "Scene_polyhedron_item_config.h"
 #include  <CGAL/Three/Scene_item.h>
+#include  <CGAL/Three/Scene_facegraph_interface.h>
 #include  <CGAL/Three/TextRenderer.h>
 #include "Polyhedron_type_fwd.h"
 #include "Polyhedron_type.h"
@@ -21,7 +22,9 @@ struct Scene_polyhedron_item_priv;
 
 // This class represents a polyhedron in the OpenGL scene
 class SCENE_POLYHEDRON_ITEM_EXPORT Scene_polyhedron_item
-        : public CGAL::Three::Scene_item{
+        : public CGAL::Three::Scene_item,
+          public CGAL::Three::Scene_facegraph_interface_item<Polyhedron>
+{
     Q_OBJECT
 public:
     enum STATS {
@@ -81,6 +84,9 @@ public:
     // Get wrapped polyhedron
     Polyhedron*       polyhedron();
     const Polyhedron* polyhedron() const;
+
+    Polyhedron* facegraph(){return polyhedron();}
+    const Polyhedron* facegraph() const{return polyhedron();}
 
     // Get dimensions
     bool isFinite() const { return true; }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -7,6 +7,7 @@
 
 #include "Scene_surface_mesh_item_config.h"
 #include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_facegraph_interface.h>
 #include <CGAL/Three/Viewer_interface.h>
 #include <vector>
 
@@ -22,7 +23,8 @@
 struct Scene_surface_mesh_item_priv;
 
 class SCENE_SURFACE_MESH_ITEM_EXPORT Scene_surface_mesh_item
-  : public CGAL::Three::Scene_item
+  : public CGAL::Three::Scene_item,
+    public CGAL::Three::Scene_facegraph_interface_item<CGAL::Surface_mesh<CGAL::Exact_predicates_inexact_constructions_kernel::Point_3> >
 {
   Q_OBJECT
 public:
@@ -51,6 +53,8 @@ public:
 
   SMesh* polyhedron();
   const SMesh* polyhedron() const;
+  SMesh* facegraph(){return polyhedron();}
+  const SMesh* facegraph() const{return polyhedron();}
   void compute_bbox()const;
 public Q_SLOTS:
   virtual void selection_changed(bool);

--- a/Three/include/CGAL/Three/Scene_facegraph_interface.h
+++ b/Three/include/CGAL/Three/Scene_facegraph_interface.h
@@ -1,0 +1,36 @@
+// Copyright (c) 20017  GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Maxime GIMENO
+#ifndef SCENE_FACEGRAPH_INTERFACE_H
+#define SCENE_FACEGRAPH_INTERFACE_H
+
+namespace CGAL
+{
+namespace Three {
+//! Base class for a Scene_item containing a FaceGraph
+template <typename Mesh>
+class Scene_facegraph_interface_item {
+public:
+  virtual ~Scene_facegraph_interface_item(){}
+ //!Returns the item's facegraph
+ virtual Mesh* facegraph() = 0;
+  virtual const Mesh* facegraph()const = 0;
+};
+}
+}
+#endif // SCENE_FACEGRAPH_INTERFACE_H


### PR DESCRIPTION
This PR is the first step to use Scene_surface_mesh_item in the Polyhedron_demo. ( #1931 )
## Summary of Changes
- Adds an interface that gives a function to return a facegraph
- Make Scene_polyhedron_item and Scene_surface_mesh_item inherit from this interface

## Release Management

* Affected package(s):Polyhedron_demo


