### PR TITLE
Surface_mesh: Fix #1949

### DIFF
--- a/BGL/test/BGL/test_graph_traits.cpp
+++ b/BGL/test/BGL/test_graph_traits.cpp
@@ -11,7 +11,6 @@ typedef boost::unordered_set<std::size_t> id_map;
 template <typename Graph>
 void test_isolated_vertex(const Graph& g)
 {
-  std::cerr << typeid(g).name() << std::endl;
   Graph G;
   typedef boost::graph_traits< Graph > Traits;
   typedef typename Traits::vertex_descriptor vertex_descriptor;

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1697,7 +1697,7 @@ public:
     /// With the default value for
     /// `check_all_incident_halfedges` the function iteratates over the incident halfedges.
     /// With `check_all_incident_halfedges == false` the function returns `true`, if the incident
-    /// halfedge associated to vertex `v` is a border halfedge.
+    /// halfedge associated to vertex `v` is a border halfedge, or if the vertex is isolated.
     /// \cgalAdvancedEnd
   bool is_border(Vertex_index v, bool check_all_incident_halfedges = true) const
     {
@@ -1714,7 +1714,7 @@ public:
           }while(++hatc != done);
           return false;
         }
-        return (!(is_valid(h) && is_border(h)));
+        return is_valid(h) && is_border(h);
     }
 
     /// returns whether `h` is a border halfege, that is if its incident face is `sm.null_face()`.

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1683,7 +1683,7 @@ public:
     ///
     ///  A halfedge, or edge is on the border of a surface mesh
     /// if it is incident to a `null_face()`.  A vertex is on a border
-    /// if it is incident to a border halfedge. While for a halfedge and
+    /// if it is isolated or incident to a border halfedge. While for a halfedge and
     /// edge this is a constant time operation, for a vertex it means
     /// to look at all incident halfedges.  If algorithms operating on a 
     /// surface mesh maintain that the halfedge associated to a border vertex is
@@ -1703,7 +1703,7 @@ public:
     {
         Halfedge_index h(halfedge(v));
         if (h == null_halfedge()){
-          return false;
+          return true;
         }
         if(check_all_incident_halfedges){
           Halfedge_around_target_circulator hatc(h,*this), done(hatc);
@@ -1714,7 +1714,7 @@ public:
           }while(++hatc != done);
           return false;
         }
-        return is_valid(h) && is_border(h);
+        return is_border(h);
     }
 
     /// returns whether `h` is a border halfege, that is if its incident face is `sm.null_face()`.

--- a/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
+++ b/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
@@ -182,8 +182,8 @@ void isolated_vertex_check()
   Sm::Vertex_index isolated = f.m.add_vertex(Point_3(10, 10, 10));
   assert(f.m.is_isolated(isolated));
   assert(!f.m.halfedge(isolated).is_valid());
-  assert(! f.m.is_border(isolated));
-  assert(! f.m.is_border(isolated, false));
+  assert(f.m.is_border(isolated));
+  assert(f.m.is_border(isolated, false));
   assert(f.m.degree(isolated) == 0);
 }
 

--- a/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
+++ b/Surface_mesh/test/Surface_mesh/surface_mesh_test.cpp
@@ -183,6 +183,7 @@ void isolated_vertex_check()
   assert(f.m.is_isolated(isolated));
   assert(!f.m.halfedge(isolated).is_valid());
   assert(! f.m.is_border(isolated));
+  assert(! f.m.is_border(isolated, false));
   assert(f.m.degree(isolated) == 0);
 }
 
@@ -202,6 +203,9 @@ void border_vertex_check()
   assert(f.m.is_border(f.y));
   assert(f.m.degree(f.y) == 2);
   assert(f.m.halfedge(f.y).is_valid());
+  set_halfedge(f.y, opposite(next(f.m.halfedge(f.y),f.m), f.m), f.m);
+  assert(f.m.is_border(f.y));
+  assert(! f.m.is_border(f.y, false));
 }
 
 


### PR DESCRIPTION

## Summary of Changes

I added an assertion in the testsuite, that confirmed the bug report, fixed the bug and completed the documentation, as an isolated vertex is also considered as a border vertex.

## Release Management

* Affected package(s): Surface_mesh
* Issue(s) solved (if any): fix #1949


