### PR TITLE
Point set shape detection: Fix incomplete clear

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -397,6 +397,7 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
       m_num_available_points = m_num_total_points;
 
       clear_octrees();
+      clear_shape_factories();
     }
     /// @}
 

--- a/Point_set_shape_detection_3/test/Point_set_shape_detection_3/test_regularization.cpp
+++ b/Point_set_shape_detection_3/test/Point_set_shape_detection_3/test_regularization.cpp
@@ -132,7 +132,6 @@ int main()
 
 
   Efficient_ransac ransac;
-  ransac.add_shape_factory<CGAL::Shape_detection_3::Plane<Traits> >();
   
   const std::size_t nb_pts = 5000;
   
@@ -156,6 +155,7 @@ int main()
                             5000, std::back_inserter (points));
 
     ransac.set_input(points);
+    ransac.add_shape_factory<CGAL::Shape_detection_3::Plane<Traits> >();
     ransac.detect(op);
     check_ransac_size (ransac, 2);
 
@@ -187,6 +187,7 @@ int main()
 
     
     ransac.set_input(points);
+    ransac.add_shape_factory<CGAL::Shape_detection_3::Plane<Traits> >();
     ransac.detect(op);
     check_ransac_size (ransac, 2);
 
@@ -217,6 +218,7 @@ int main()
                             5000, std::back_inserter (points));
 
     ransac.set_input(points);
+    ransac.add_shape_factory<CGAL::Shape_detection_3::Plane<Traits> >();
     ransac.detect(op);
     check_ransac_size (ransac, 2);
 
@@ -252,6 +254,7 @@ int main()
                             5000, std::back_inserter (points));
 
     ransac.set_input(points);
+    ransac.add_shape_factory<CGAL::Shape_detection_3::Plane<Traits> >();
     ransac.detect(op);
     check_ransac_size (ransac, 2);
 


### PR DESCRIPTION
## Summary of Changes

The `clear()` method of `CGAL::Efficient_RANSAC` states that _all internal structures are cleaned, including formerly detected shapes_, but in practice it does not clear the shape factories. It seems rather counter-intuitive: a user reported a bug on the `cgal-discuss` list (he was looping on a RANSAC object, clearing and adding a shape factory everytime, so the number of shape factories became higher and higher). This PR makes the `clear()` function also call `clear_shape_factories()`.

## Release Management

* Affected package(s): Point set shape detection
* Issue(s) solved (if any): (see `cgal-discuss`)

