### PR TITLE
Polyhedron_demo: Use surface mesh item in AABB_tree package

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -19,7 +19,7 @@ function build_demo {
   cd build-travis
   if [ $NEED_3D = 1 ]; then
     #install libqglviewer
-    git clone --depth=1 https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
+    git clone --depth=4 -b v2.6.3 --single-branch https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
     pushd ./qglviewer/QGLViewer
     #use qt5 instead of qt4
     export QT_SELECT=5

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/CMakeLists.txt
@@ -1,4 +1,4 @@
 include( polyhedron_demo_macros )
 
 polyhedron_demo_plugin(cut_plugin Cut_plugin )
-target_link_libraries(cut_plugin scene_polyhedron_item scene_basic_objects scene_color_ramp)
+target_link_libraries(cut_plugin scene_polyhedron_item scene_surface_mesh_item scene_basic_objects scene_color_ramp)

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -239,7 +239,6 @@ typedef CGAL::AABB_tree<Edge_traits>                                Edge_tree;
 typedef QMap<QObject*, Facet_tree*>                   Facet_trees;
 typedef QMap<QObject*, Edge_tree*>                    Edge_trees;
 
-typedef Scene_surface_mesh_item::SMesh SMesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<SMesh, PPMAP<SMesh> > Facet_sm_primitive;
 typedef CGAL::AABB_traits<Simple_kernel, Facet_sm_primitive>           Facet_sm_traits;
 typedef CGAL::AABB_tree<Facet_sm_traits>                               Facet_sm_tree;

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -1138,29 +1138,58 @@ public Q_SLOTS:
   void deleteTrees(CGAL::Three::Scene_item* sender)
   {
     Scene_polyhedron_item* item = qobject_cast<Scene_polyhedron_item*>(sender);
-    if(!item)
-      return;
-    if(facet_trees.keys().contains(item))
+    if(item)
     {
-      delete facet_trees[item];
-      facet_trees.remove(item);
-    }
-    if(edge_trees.keys().contains(item))
-    {
-      delete edge_trees[item];
-      edge_trees.remove(item);
-    }
-    if(facet_trees.empty())
-    {
-      if(plane_item)
-        scene->erase(scene->item_id(plane_item));
-      if(edges_item)
-        scene->erase(scene->item_id(edges_item));
+      if(facet_trees.keys().contains(item))
+      {
+        delete facet_trees[item];
+        facet_trees.remove(item);
+      }
+      if(edge_trees.keys().contains(item))
+      {
+        delete edge_trees[item];
+        edge_trees.remove(item);
+      }
+      if(facet_trees.empty())
+      {
+        if(plane_item)
+          scene->erase(scene->item_id(plane_item));
+        if(edges_item)
+          scene->erase(scene->item_id(edges_item));
+      }
+      else
+      {
+        ready_to_cut = true;
+        cut();
+      }
     }
     else
     {
-      ready_to_cut = true;
-      cut();
+      Scene_surface_mesh_item* sm_item = qobject_cast<Scene_surface_mesh_item*>(sender);
+      if(!sm_item)
+        return;
+      if(facet_sm_trees.keys().contains(sm_item))
+      {
+        delete facet_sm_trees[sm_item];
+        facet_sm_trees.remove(sm_item);
+      }
+      if(edge_sm_trees.keys().contains(sm_item))
+      {
+        delete edge_sm_trees[sm_item];
+        edge_sm_trees.remove(sm_item);
+      }
+      if(facet_sm_trees.empty())
+      {
+        if(plane_item)
+          scene->erase(scene->item_id(plane_item));
+        if(edges_item)
+          scene->erase(scene->item_id(edges_item));
+      }
+      else
+      {
+        ready_to_cut = true;
+        cut();
+      }
     }
   }
   void updateTrees(int id);

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -69,12 +69,12 @@ class FillGridSize {
   Point_distance (&distance_function)[100][100];
   FT diag;
   FT& max_distance_function;
-  QMap<QObject*, Tree*> *trees;
+  std::vector<Tree*>&trees;
   bool is_signed;
   qglviewer::ManipulatedFrame* frame;
 public:
   FillGridSize(std::size_t grid_size, FT diag, Point_distance (&distance_function)[100][100],
-  FT& max_distance_function,QMap<QObject*, Tree*>* trees,
+  FT& max_distance_function, std::vector<Tree*>& trees,
   bool is_signed, qglviewer::ManipulatedFrame* frame)
   : grid_size(grid_size), distance_function (distance_function), diag(diag),
     max_distance_function(max_distance_function),
@@ -103,10 +103,8 @@ public:
         Point query = transfo( Point(x,y,z))-offset;
         FT min = DBL_MAX;
 
-        Q_FOREACH(Tree *tree, trees->values())
+        Q_FOREACH(Tree *tree, trees)
         {
-          if(is_signed && !qobject_cast<Scene_polyhedron_item*>(trees->key(tree))->polyhedron()->is_closed())
-            continue;
           FT dist = CGAL::sqrt( tree->squared_distance(query) );
           if(dist < min)
           {
@@ -685,6 +683,10 @@ private:
     const FT z (0);
     const FT fd =  FT(1);
     Tree *min_tree = NULL;
+    std::vector<Tree*> closed_trees;
+    Q_FOREACH(Tree *tree, trees->values())
+    if(!(is_signed && !qobject_cast<Scene_polyhedron_item*>(trees->key(tree))->polyhedron()->is_closed()))
+      closed_trees.push_back(tree);
     for(int i=0 ; i<m_grid_size ; ++i)
     {
       FT x = -diag/fd + FT(i)/FT(m_grid_size) * dx;
@@ -695,10 +697,8 @@ private:
         Simple_kernel::Point_3 query = t( Simple_kernel::Point_3(x,y,z) );
         FT min = DBL_MAX;
 
-        Q_FOREACH(Tree *tree, trees->values())
+        Q_FOREACH(Tree *tree, closed_trees)
         {
-          if(is_signed && !qobject_cast<Scene_polyhedron_item*>(trees->key(tree))->polyhedron()->is_closed())
-            continue;
           FT dist = CGAL::sqrt( tree->squared_distance(query) );
           if(dist < min)
           {
@@ -733,7 +733,11 @@ private:
         }
     }
 #else
-    FillGridSize<Tree> f(m_grid_size, diag, m_distance_function, m_max_distance_function, trees, is_signed, frame);
+    std::vector<Tree*> closed_trees;
+    Q_FOREACH(Tree *tree, trees->values())
+    if(!(is_signed && !qobject_cast<Scene_polyhedron_item*>(trees->key(tree))->polyhedron()->is_closed()))
+      closed_trees.push_back(tree);
+    FillGridSize<Tree> f(m_grid_size, diag, m_distance_function, m_max_distance_function, closed_trees, is_signed, frame);
     tbb::parallel_for(tbb::blocked_range<size_t>(0, m_grid_size*m_grid_size), f);
 #endif
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -748,8 +748,6 @@ private:
       texture->setData(i,j,255*pos_ramp.r(i00),255*pos_ramp.g(i00),255*pos_ramp.b(i00));
     else
       texture->setData(i,j,255*neg_ramp.r(i00),255*neg_ramp.g(i00),255*neg_ramp.b(i00));
-
-
   }
 
 #ifdef CGAL_LINKED_WITH_TBB

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -148,9 +148,9 @@ Scene::erase(Scene::Item_id index)
     item->parentGroup()->removeChild(item);
 
   //removes the item from all groups that contain it
+  m_entries.removeAll(item);
   Q_EMIT itemAboutToBeDestroyed(item);
     item->deleteLater();
-    m_entries.removeAll(item);
     selected_item = -1;
     //re-creates the Scene_view
     Q_FOREACH(Scene_item* item, m_entries)
@@ -193,9 +193,9 @@ Scene::erase(QList<int> indices)
   Q_FOREACH(Scene_item* item, to_be_removed) {
       if(item->parentGroup())
         item->parentGroup()->removeChild(item);
+      m_entries.removeAll(item);
     Q_EMIT itemAboutToBeDestroyed(item);
     item->deleteLater();
-    m_entries.removeAll(item);
   }
   clear();
   index_map.clear();

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -28,7 +28,23 @@ public:
   ~Scene_plane_item();
 
   double scene_diag() const {
-    const Scene_item::Bbox& bbox = scene->bbox();
+    /*If no item is visible, scene->bbox is 0,0,0,0,0,0 and the texture is empty.
+    To avoid that, we need to compute the scene's bbox if the items were visible.
+    {
+*/
+    Scene_item::Bbox bbox;
+    if(scene->bbox() == Scene_item::Bbox(0,0,0,0,0,0))
+    {
+      for(int id = 0; id< scene->numberOfEntries(); ++id)
+      {
+        bbox = bbox + scene->item(id)->bbox();
+      }
+    }
+    else
+    {
+      bbox = scene->bbox();
+    }
+    //}
     const double& xdelta = bbox.xmax()-bbox.xmin();
     const double& ydelta = bbox.ymax()-bbox.ymin();
     const double& zdelta = bbox.zmax()-bbox.zmin();

--- a/Polyhedron/demo/Polyhedron/Scene_plane_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_plane_item.h
@@ -32,12 +32,20 @@ public:
     To avoid that, we need to compute the scene's bbox if the items were visible.
     {
 */
-    Scene_item::Bbox bbox;
-    if(scene->bbox() == Scene_item::Bbox(0,0,0,0,0,0))
+    Scene_item::Bbox bbox = scene->bbox();
+    if(bbox == Scene_item::Bbox(std::numeric_limits<double>::infinity(),
+                                std::numeric_limits<double>::infinity(),
+                                std::numeric_limits<double>::infinity(),
+                                -std::numeric_limits<double>::infinity(),
+                                -std::numeric_limits<double>::infinity(),
+                                -std::numeric_limits<double>::infinity()))
+      bbox = Scene_item::Bbox(0,0,0,0,0,0);
+    if(bbox == Scene_item::Bbox(0,0,0,0,0,0))
     {
       for(int id = 0; id< scene->numberOfEntries(); ++id)
       {
-        bbox = bbox + scene->item(id)->bbox();
+        if(scene->item(id)->isFinite() && !scene->item(id)->isEmpty())
+          bbox = bbox + scene->item(id)->bbox();
       }
     }
     else


### PR DESCRIPTION
## Summary of Changes

The Cut_plugin is now able to work on a Scene_surface_mesh_item as well as on a Scene_polyhedron_item.
This PR is based on #1954 
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #1932


