### PR TITLE
Fix iterator range size type

### DIFF
--- a/Point_set_shape_detection_3/test/Point_set_shape_detection_3/test_regularization.cpp
+++ b/Point_set_shape_detection_3/test/Point_set_shape_detection_3/test_regularization.cpp
@@ -96,7 +96,7 @@ bool planes_differ (const Plane& a, const Plane& b)
           (std::fabs (a.d() - b.d()) > 1e-6));
 }
 
-void check_ransac_size (const Efficient_ransac& ransac, std::ptrdiff_t nb)
+void check_ransac_size (const Efficient_ransac& ransac, std::size_t nb)
 {
   if (ransac.shapes().size() != nb)
     {

--- a/STL_Extension/doc/STL_Extension/CGAL/Iterator_range.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Iterator_range.h
@@ -62,10 +62,10 @@ namespace CGAL {
   }
 
   /// returns `std::distance(begin(), end())`
-  typename std::iterator_traits<I>::difference_type
+  std::size_t
   size() const
   {
-    return std::distance(begin(), end());
+    return static_cast<std::size_t>(std::distance(begin(), end()));
   }
 };
 

--- a/STL_Extension/include/CGAL/Iterator_range.h
+++ b/STL_Extension/include/CGAL/Iterator_range.h
@@ -65,10 +65,10 @@ namespace CGAL {
   }
 
   /// returns `std::distance(begin(), end())`
-  typename std::iterator_traits<I>::difference_type
+  std::size_t
   size() const
   {
-    return std::distance(begin(), end());
+    return static_cast<std::size_t>(std::distance(begin(), end()));
   }
 
   /// returns `std::distance(begin(), end())==0`


### PR DESCRIPTION
## Summary of Changes

Currently, our `CGAL::Iterator_range` has a method `size()` which returns a signed integer (`difference_type`). This is probably due to the fact that we use `std::distance()` to compute it, which does return a signed number.

However, it seems very counter-intuitive to have a signed size (a range where `begin()` is after `end()` souldn't be valid anyway) and it leads to warnings if a user does a comparison of `size()` with an unsigned integer (this is how I discovered this problem). In addition, the [boost::iterator_range](http://www.boost.org/doc/libs/1_55_0/libs/range/doc/html/range/reference/utilities/iterator_range.html) that we cloned (as the documentation says) uses an unsigned type.

This PR makes `CGAL::Iterator_range::size()` return a `std::size_t` number (with a static cast internally – I'm not sure if this should be indicated in the doc, as we indicate we are using `std::distance`).

## Release Management

* Affected package(s): STL_Extensions

