### PR TITLE
Polyhedron_demo: Enhance memory management in the demo

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -2014,8 +2014,10 @@ void Scene_c3t3_item::resetCutPlane()
  d->reset_cut_plane();
 }
 
-void Scene_c3t3_item::destroyData()
+void Scene_c3t3_item::itemAboutToBeDestroyed(Scene_item *item)
 {
+  Scene_item::itemAboutToBeDestroyed(item);
+
   if(d)
   {
     d->destroy();

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -281,9 +281,6 @@ struct Scene_c3t3_item_priv {
   }
   ~Scene_c3t3_item_priv()
   {
-  }
-  void destroy()
-  {
     c3t3.clear();
     tree.clear();
     if(frame)
@@ -294,6 +291,7 @@ struct Scene_c3t3_item_priv {
       delete tet_Slider;
     }
   }
+
   void init_default_values() {
     positions_lines.resize(0);
     positions_poly.resize(0);
@@ -531,7 +529,6 @@ Scene_c3t3_item::~Scene_c3t3_item()
 {
   if(d)
   {
-    d->destroy();
     delete d;
     d = NULL;
   }
@@ -2018,9 +2015,17 @@ void Scene_c3t3_item::itemAboutToBeDestroyed(Scene_item *item)
 {
   Scene_item::itemAboutToBeDestroyed(item);
 
-  if(d)
+  if(d && item == this)
   {
-    d->destroy();
+    d->c3t3.clear();
+    d->tree.clear();
+    if(d->frame)
+    {
+      static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->setManipulatedFrame(0);
+      delete d->frame;
+      d->frame = NULL;
+      delete d->tet_Slider;
+    }
     delete d;
     d=0;
   }

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -149,6 +149,8 @@ public:
 
   QColor get_histogram_color(const double v) const;
 
+  void destroyData();
+
   protected:
     friend struct Scene_c3t3_item_priv;
     Scene_c3t3_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -149,7 +149,7 @@ public:
 
   QColor get_histogram_color(const double v) const;
 
-  void itemAboutToBeDestroyed(Scene_item *);
+  void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
 
   protected:
     friend struct Scene_c3t3_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -149,7 +149,7 @@ public:
 
   QColor get_histogram_color(const double v) const;
 
-  void destroyData();
+  void itemAboutToBeDestroyed(Scene_item *);
 
   protected:
     friend struct Scene_c3t3_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -37,8 +37,6 @@ CGAL::Three::Scene_item::Scene_item(int buffers_size, int vaos_size)
   has_group = 0;
   parent_group = 0;
   is_selected = false;
-  connect(this, &Scene_item::aboutToBeDestroyed,
-          this, &Scene_item::destroyData);
 }
 
 CGAL::Three::Scene_item::~Scene_item() {
@@ -59,10 +57,6 @@ void CGAL::Three::Scene_item::itemAboutToBeDestroyed(CGAL::Three::Scene_item* it
     {
       Q_EMIT aboutToBeDestroyed();
     }
-}
-
-void CGAL::Three::Scene_item::destroyData()
-{
 }
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -37,6 +37,8 @@ CGAL::Three::Scene_item::Scene_item(int buffers_size, int vaos_size)
   has_group = 0;
   parent_group = 0;
   is_selected = false;
+  connect(this, &Scene_item::aboutToBeDestroyed,
+          this, &Scene_item::destroyData);
 }
 
 CGAL::Three::Scene_item::~Scene_item() {
@@ -57,6 +59,10 @@ void CGAL::Three::Scene_item::itemAboutToBeDestroyed(CGAL::Three::Scene_item* it
     {
       Q_EMIT aboutToBeDestroyed();
     }
+}
+
+void CGAL::Three::Scene_item::destroyData()
+{
 }
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -84,8 +84,11 @@ struct Scene_points_with_normal_item_priv
   }
   ~Scene_points_with_normal_item_priv()
   {
-    Q_ASSERT(m_points != NULL);
-    delete m_points; m_points = NULL;
+    if(m_points)
+    {
+      delete m_points;
+      m_points = NULL;
+    }
     delete normal_Slider;
     delete point_Slider;
   }
@@ -869,4 +872,13 @@ int Scene_points_with_normal_item::getNormalSliderValue()
 int Scene_points_with_normal_item::getPointSliderValue()
 {
   return d->point_Slider->value();
+}
+
+void Scene_points_with_normal_item::destroyData()
+{
+  if(d && d->m_points)
+  {
+    delete d->m_points;
+    d->m_points = NULL;
+  }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -874,8 +874,9 @@ int Scene_points_with_normal_item::getPointSliderValue()
   return d->point_Slider->value();
 }
 
-void Scene_points_with_normal_item::destroyData()
+void Scene_points_with_normal_item::itemAboutToBeDestroyed(Scene_item *item)
 {
+  Scene_item::itemAboutToBeDestroyed(item);
   if(d && d->m_points)
   {
     delete d->m_points;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -877,7 +877,7 @@ int Scene_points_with_normal_item::getPointSliderValue()
 void Scene_points_with_normal_item::itemAboutToBeDestroyed(Scene_item *item)
 {
   Scene_item::itemAboutToBeDestroyed(item);
-  if(d && d->m_points)
+  if(d && d->m_points && item == this)
   {
     delete d->m_points;
     d->m_points = NULL;

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -89,7 +89,7 @@ public Q_SLOTS:
   void pointSliderPressed();
   //Set the status of the slider as `released`
   void pointSliderReleased();
-  void itemAboutToBeDestroyed(Scene_item *);
+  void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
 
 // Data
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -89,6 +89,7 @@ public Q_SLOTS:
   void pointSliderPressed();
   //Set the status of the slider as `released`
   void pointSliderReleased();
+  void destroyData();
 
 // Data
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -89,7 +89,7 @@ public Q_SLOTS:
   void pointSliderPressed();
   //Set the status of the slider as `released`
   void pointSliderReleased();
-  void destroyData();
+  void itemAboutToBeDestroyed(Scene_item *);
 
 // Data
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -854,13 +854,12 @@ std::vector<CGAL::Color> Scene_polygon_soup_item::getFColors() const{return d->s
 void Scene_polygon_soup_item::itemAboutToBeDestroyed(Scene_item *item)
 {
   Scene_item::itemAboutToBeDestroyed(item);
- if(d)
- {
-   if(d->soup)
-   {
-     delete d->soup;
-     d->soup=NULL;
-   }
- }
-
+  if(d && item == this)
+  {
+    if(d->soup)
+    {
+      delete d->soup;
+      d->soup=NULL;
+    }
+  }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -851,8 +851,9 @@ bool Scene_polygon_soup_item::isDataColored() { return d->soup->fcolors.size()>0
 std::vector<CGAL::Color> Scene_polygon_soup_item::getVColors() const{return d->soup->vcolors;}
 std::vector<CGAL::Color> Scene_polygon_soup_item::getFColors() const{return d->soup->fcolors;}
 
-void Scene_polygon_soup_item::destroyData()
+void Scene_polygon_soup_item::itemAboutToBeDestroyed(Scene_item *item)
 {
+  Scene_item::itemAboutToBeDestroyed(item);
  if(d)
  {
    if(d->soup)

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -44,7 +44,11 @@ struct Scene_polygon_soup_item_priv{
   }
   ~Scene_polygon_soup_item_priv()
   {
-    delete soup;
+    if(soup)
+    {
+      delete soup;
+      soup = NULL;
+    }
   }
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer) const;
   void compute_normals_and_vertices(void) const;
@@ -846,3 +850,16 @@ const Scene_polygon_soup_item::Points& Scene_polygon_soup_item::points() const {
 bool Scene_polygon_soup_item::isDataColored() { return d->soup->fcolors.size()>0 || d->soup->vcolors.size()>0;}
 std::vector<CGAL::Color> Scene_polygon_soup_item::getVColors() const{return d->soup->vcolors;}
 std::vector<CGAL::Color> Scene_polygon_soup_item::getFColors() const{return d->soup->fcolors;}
+
+void Scene_polygon_soup_item::destroyData()
+{
+ if(d)
+ {
+   if(d->soup)
+   {
+     delete d->soup;
+     d->soup=NULL;
+   }
+ }
+
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -151,7 +151,7 @@ public Q_SLOTS:
 
     void setDisplayNonManifoldEdges(const bool);
     bool displayNonManifoldEdges() const;
-    void destroyData();
+    void itemAboutToBeDestroyed(Scene_item *item);
 
 protected:
     friend struct Scene_polygon_soup_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -151,6 +151,7 @@ public Q_SLOTS:
 
     void setDisplayNonManifoldEdges(const bool);
     bool displayNonManifoldEdges() const;
+    void destroyData();
 
 protected:
     friend struct Scene_polygon_soup_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -151,7 +151,7 @@ public Q_SLOTS:
 
     void setDisplayNonManifoldEdges(const bool);
     bool displayNonManifoldEdges() const;
-    void itemAboutToBeDestroyed(Scene_item *item);
+    void itemAboutToBeDestroyed(Scene_item *item) Q_DECL_OVERRIDE;
 
 protected:
     friend struct Scene_polygon_soup_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1845,8 +1845,9 @@ void Scene_polyhedron_item::set_flat_disabled(bool b)
   itemChanged();
 }
 
-void Scene_polyhedron_item::itemAboutToBeDestroyed(Scene_item *)
+void Scene_polyhedron_item::itemAboutToBeDestroyed(Scene_item *item)
 {
+  Scene_item::itemAboutToBeDestroyed(item);
   if(d)
   {
     d->destroy();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -811,14 +811,22 @@ Scene_polyhedron_item::~Scene_polyhedron_item()
       CGAL::Three::Viewer_interface* v = qobject_cast<CGAL::Three::Viewer_interface*>(viewer);
 
       //Clears the targeted Id
-      v->textRenderer->removeText(d->targeted_id);
+      if(d)
+        v->textRenderer->removeText(d->targeted_id);
       //Remove textitems
-      v->textRenderer->removeTextList(textItems);
-      delete textItems;
+      if(textItems)
+      {
+        v->textRenderer->removeTextList(textItems);
+        delete textItems;
+        textItems=NULL;
+      }
     }
-
-    d->destroy();
-    delete d;
+    if(d)
+    {
+      d->destroy();
+      delete d;
+      d=NULL;
+    }
 }
 
 #include "Color_map.h"
@@ -1819,6 +1827,7 @@ bool Scene_polyhedron_item::intersect_face(double orig_x,
   return false;
 
 }
+
 bool Scene_polyhedron_item::supportsRenderingMode(RenderingMode m) const
 {
   return (
@@ -1834,4 +1843,14 @@ void Scene_polyhedron_item::set_flat_disabled(bool b)
   d->no_flat = b;
   invalidateOpenGLBuffers();
   itemChanged();
+}
+
+void Scene_polyhedron_item::itemAboutToBeDestroyed(Scene_item *)
+{
+  if(d)
+  {
+    d->destroy();
+    delete d;
+    d=NULL;
+  }
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -94,6 +94,11 @@ struct Scene_polyhedron_item_priv{
   {
     init_default_values();
   }
+  ~Scene_polyhedron_item_priv()
+  {
+    delete poly;
+    delete targeted_id;
+  }
 
   void init_default_values() {
     show_only_feature_edges_m = false;
@@ -123,11 +128,6 @@ struct Scene_polyhedron_item_priv{
                          const bool colors_only) const;
   void init();
   void invalidate_stats();
-  void destroy()
-  {
-    delete poly;
-    delete targeted_id;
-  }
   void* get_aabb_tree();
   QList<Kernel::Triangle_3> triangulate_primitive(Polyhedron::Facet_iterator fit,
                                                   Traits::Vector_3 normal);
@@ -823,7 +823,6 @@ Scene_polyhedron_item::~Scene_polyhedron_item()
     }
     if(d)
     {
-      d->destroy();
       delete d;
       d=NULL;
     }
@@ -1848,9 +1847,8 @@ void Scene_polyhedron_item::set_flat_disabled(bool b)
 void Scene_polyhedron_item::itemAboutToBeDestroyed(Scene_item *item)
 {
   Scene_item::itemAboutToBeDestroyed(item);
-  if(d)
+  if(d && item == this)
   {
-    d->destroy();
     delete d;
     d=NULL;
   }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -142,7 +142,7 @@ public Q_SLOTS:
     void update_facet_indices();
     void update_halfedge_indices();
     void invalidate_aabb_tree();
-    void itemAboutToBeDestroyed(Scene_item *);
+    void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -142,7 +142,7 @@ public Q_SLOTS:
     void update_facet_indices();
     void update_halfedge_indices();
     void invalidate_aabb_tree();
-    void destroyData();
+    void itemAboutToBeDestroyed(Scene_item *);
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -142,7 +142,7 @@ public Q_SLOTS:
     void update_facet_indices();
     void update_halfedge_indices();
     void invalidate_aabb_tree();
-    void itemAboutToBeDestroyed(Scene_item *);
+    void destroyData();
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -142,6 +142,7 @@ public Q_SLOTS:
     void update_facet_indices();
     void update_halfedge_indices();
     void invalidate_aabb_tree();
+    void itemAboutToBeDestroyed(Scene_item *);
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -54,9 +54,9 @@ public:
       MEAN_ANGLE
     };
 
-    bool has_stats()const {return true;}
-    QString computeStats(int type);
-    CGAL::Three::Scene_item::Header_data header() const;
+    bool has_stats()const Q_DECL_OVERRIDE{return true;}
+    QString computeStats(int type)Q_DECL_OVERRIDE;
+    CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
     TextListItem* textItems;
     Scene_polyhedron_item();
     //   Scene_polyhedron_item(const Scene_polyhedron_item&);
@@ -64,7 +64,7 @@ public:
     Scene_polyhedron_item(Polyhedron* const p);
     ~Scene_polyhedron_item();
 
-    Scene_polyhedron_item* clone() const;
+    Scene_polyhedron_item* clone() const Q_DECL_OVERRIDE;
 
     // IO
     bool load(std::istream& in);
@@ -73,28 +73,28 @@ public:
     bool save_obj(std::ostream& out) const;
 
     // Function for displaying meta-data of the item
-    virtual QString toolTip() const;
+    virtual QString toolTip() const Q_DECL_OVERRIDE;
 
     // Function to override the context menu
-    QMenu* contextMenu();
+    QMenu* contextMenu() Q_DECL_OVERRIDE;
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const;
+    virtual bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE;
     // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
     void draw() const {}
-    virtual void draw(CGAL::Three::Viewer_interface*) const;
-    virtual void drawEdges() const {}
-    virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
-    virtual void drawPoints(CGAL::Three::Viewer_interface*) const;
+    virtual void draw(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
+    virtual void drawEdges() const Q_DECL_OVERRIDE{}
+    virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+    virtual void drawPoints(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
 
     // Get wrapped polyhedron
     Polyhedron*       polyhedron();
     const Polyhedron* polyhedron() const;
 
     // Get dimensions
-    bool isFinite() const { return true; }
-    bool isEmpty() const;
-    void compute_bbox() const;
+    bool isFinite() const Q_DECL_OVERRIDE { return true; }
+    bool isEmpty() const Q_DECL_OVERRIDE;
+    void compute_bbox() const Q_DECL_OVERRIDE;
     std::vector<QColor>& color_vector();
     void set_color_vector_read_only(bool on_off);
     bool is_color_vector_read_only();
@@ -109,9 +109,9 @@ public:
     //! @returns `true` if the item has multiple colors at the same time.
     bool isItemMulticolor();
 
-    void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer);
-    void printPrimitiveIds(CGAL::Three::Viewer_interface*viewer) const;
-    bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*);
+    void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer) Q_DECL_OVERRIDE;
+    void printPrimitiveIds(CGAL::Three::Viewer_interface*viewer) const Q_DECL_OVERRIDE;
+    bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
 
     //! @returns `true` if `f` is the first facet intersected by a raytracing
     bool intersect_face(double orig_x,
@@ -123,9 +123,9 @@ public:
                         Polyhedron::Facet_handle f);
 
 public Q_SLOTS:
-    virtual void invalidateOpenGLBuffers();
-    virtual void selection_changed(bool);
-    virtual void setColor(QColor c);
+    virtual void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
+    virtual void selection_changed(bool) Q_DECL_OVERRIDE;
+    virtual void setColor(QColor c) Q_DECL_OVERRIDE;
     virtual void show_feature_edges(bool);
     void show_only_feature_edges(bool);
     void enable_facets_picking(bool);
@@ -137,7 +137,7 @@ public Q_SLOTS:
                 double orig_z,
                 double dir_x,
                 double dir_y,
-                double dir_z);
+                double dir_z) Q_DECL_OVERRIDE;
     void update_vertex_indices();
     void update_facet_indices();
     void update_halfedge_indices();

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -643,8 +643,9 @@ void Scene_surface_mesh_item::compute_bbox()const
 
 }
 
-void Scene_surface_mesh_item::destroyData()
+void Scene_surface_mesh_item::itemAboutToBeDestroyed(Scene_item *item)
 {
+  Scene_item::itemAboutToBeDestroyed(item);
   if(d && d->smesh_)
   {
     delete d->smesh_;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -42,7 +42,11 @@ struct Scene_surface_mesh_item_priv{
 
   ~Scene_surface_mesh_item_priv()
   {
-    delete smesh_;
+    if(smesh_)
+    {
+      delete smesh_;
+      smesh_ = NULL;
+    }
   }
 
   void initializeBuffers(CGAL::Three::Viewer_interface *) const;
@@ -639,3 +643,11 @@ void Scene_surface_mesh_item::compute_bbox()const
 
 }
 
+void Scene_surface_mesh_item::destroyData()
+{
+  if(d && d->smesh_)
+  {
+    delete d->smesh_;
+    d->smesh_ = NULL;
+  }
+}

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -646,7 +646,7 @@ void Scene_surface_mesh_item::compute_bbox()const
 void Scene_surface_mesh_item::itemAboutToBeDestroyed(Scene_item *item)
 {
   Scene_item::itemAboutToBeDestroyed(item);
-  if(d && d->smesh_)
+  if(d && d->smesh_ && item == this)
   {
     delete d->smesh_;
     d->smesh_ = NULL;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -53,7 +53,7 @@ public:
   const SMesh* polyhedron() const;
   void compute_bbox()const;
 public Q_SLOTS:
-  void destroyData();
+  void itemAboutToBeDestroyed(Scene_item *);
   virtual void selection_changed(bool);
 protected:
   friend struct Scene_surface_mesh_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -53,7 +53,7 @@ public:
   const SMesh* polyhedron() const;
   void compute_bbox()const;
 public Q_SLOTS:
-  void itemAboutToBeDestroyed(Scene_item *);
+  void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
   virtual void selection_changed(bool);
 protected:
   friend struct Scene_surface_mesh_item_priv;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -53,6 +53,7 @@ public:
   const SMesh* polyhedron() const;
   void compute_bbox()const;
 public Q_SLOTS:
+  void destroyData();
   virtual void selection_changed(bool);
 protected:
   friend struct Scene_surface_mesh_item_priv;

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -323,6 +323,11 @@ public Q_SLOTS:
   //!Emits an aboutToBeDestroyed() signal.
   virtual void itemAboutToBeDestroyed(Scene_item*);
 
+  //!Override this function to delete what needs to be deleted when aboutToBeDestroyed() is emitted.
+  //!This might be needed as items are not always deleted right away by Qt and this behaviour may cause a simily
+  //!memory leak, for example when multiple items are created at the same time.
+  virtual void destroyData();
+
   //!Selects a point through raycasting.
   virtual void select(double orig_x,
                       double orig_y,
@@ -330,6 +335,8 @@ public Q_SLOTS:
                       double dir_x,
                       double dir_y,
                       double dir_z);
+
+
 
 Q_SIGNALS:
   //! Is emitted to notify a change in the item's data.

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -321,12 +321,10 @@ public Q_SLOTS:
   }
   
   //!Emits an aboutToBeDestroyed() signal.
-  virtual void itemAboutToBeDestroyed(Scene_item*);
-
-  //!Override this function to delete what needs to be deleted when aboutToBeDestroyed() is emitted.
+  //!Override this function to delete what needs to be deleted on destruction.
   //!This might be needed as items are not always deleted right away by Qt and this behaviour may cause a simily
   //!memory leak, for example when multiple items are created at the same time.
-  virtual void destroyData();
+  virtual void itemAboutToBeDestroyed(Scene_item*);
 
   //!Selects a point through raycasting.
   virtual void select(double orig_x,


### PR DESCRIPTION
## Summary of Changes

Add a function to Scene_item that allows to delete things when the signal aboutToBeDestroyed is called, and use it on the big-data items so the memory is freed when it must be.

## Release Management

* Affected package(s): Polyhedron_demo
* Issue(s) solved (if any): fix #1957 


