### PR TITLE
Polyhedron demo : fix surf reader

### DIFF
--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -261,9 +261,13 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
     {
       std::cout << "Orientation of patch #" << (i + 1) << "...";
       std::cout.flush();
+      bool no_duplicates =
       PMP::orient_polygon_soup(points, polygons);//returns false if some points
                                                  //were duplicated
-      std::cout << "\rOrientation of patch #" << (i + 1) << " done." << std::endl;
+      std::cout << "\rOrientation of patch #" << (i + 1) << " done";
+      if (!no_duplicates)
+        std::cout << " (non manifold -> duplicated vertices)";
+      std::cout << "." << std::endl;
     }
     Mesh& mesh = output[i];
 

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -5,6 +5,7 @@
 #include <CGAL/Bbox_3.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
@@ -243,9 +244,12 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
       std::cout << "\rOrientation of patch #" << (i + 1) << " done." << std::endl;
     }
     Mesh& mesh = output[i];
+
     CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(
       points, polygons, mesh);
+    CGAL::Polygon_mesh_processing::remove_isolated_vertices(mesh);
 
+    CGAL_assertion(is_valid(mesh));
   } // end loop on patches
 
   return true;

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -4,6 +4,7 @@
 #include <CGAL/array.h>
 #include <CGAL/Bbox_3.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
+#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -247,7 +247,10 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
       iss.str(line);
       iss >> index[0] >> index[1] >> index[2];
 
-      std::vector<std::size_t> polygon = {index[0] - 1, index[1] - 1, index[2] - 1};
+      std::vector<std::size_t> polygon(3);
+      polygon[0] = index[0] - 1;
+      polygon[1] = index[1] - 1;
+      polygon[2] = index[2] - 1;
       polygons.push_back(polygon);
     }
     CGAL_assertion(nb_triangles == polygons.size());

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <algorithm>
 
 #include <CGAL/array.h>
 #include <CGAL/Bbox_3.h>
@@ -19,6 +20,13 @@ struct MaterialData
   material outerRegion;
 };
 
+std::string to_lower_case(const std::string& str)
+{
+  std::string r = str;
+  std::transform(r.begin(), r.end(), r.begin(), ::tolower);
+  return r;
+}
+
 bool get_material_metadata(std::istream& input,
                            std::string& line,
                            material& _material)
@@ -36,7 +44,18 @@ bool get_material_metadata(std::istream& input,
     iss >> prop;
 
     if (prop.compare("Id") == 0)
+    {
       iss >> _material.first;
+
+      if ((0 == to_lower_case(_material.second).compare("exterior"))
+          && _material.first != 0)
+      {
+        std::cerr << "Exterior should have index 0. ";
+        std::cerr << "In this file it has index " << _material.first << "." << std::endl;
+        std::cerr << "Reader failed, because Meshing will fail to terminate." << std::endl;
+        return false;
+      }
+    }
     else if (prop.compare("}") == 0)
       return true; //end of this material
   }

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -212,6 +212,7 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
 
     //connect triangles
     std::vector<std::vector<std::size_t> > polygons;
+    polygons.reserve(nb_triangles);
     while(std::getline(input, line))
     {
       std::size_t fnws=line.find_first_not_of(" \t");

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -38,8 +38,6 @@ bool get_material_metadata(std::istream& input,
       iss >> _material.first;
     else if (prop.compare("}") == 0)
       return true; //end of this material
-    else
-      CGAL_assertion(prop.compare("Color") == 0);
   }
   return false;
 }


### PR DESCRIPTION
## Summary of Changes
This PR intends to fix the behavior of the `.surf` reader when the input surface is non-manifold.
Because `CGAL::Polyhedron_3` cannot handle a non-manifold surface, the built polyhedron has holes wherever the builder tries to make a non-manifold configuration.

We use `PMP::orient_polygon_soup` and `PMP::polygon_soup_to_polygon_mesh` to build a valid polygon mesh, which can be a `CGAL::Polyhedron_3` with duplicated vertices on geometrically non-manifold edges/vertices.

## Release Management
* Affected package(s): Polyhedron demo
