### PR TITLE
Aos 2 polycurve efif

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polycurve_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polycurve_traits_2.h
@@ -87,7 +87,7 @@ namespace CGAL {
    *   the template parameter `SubcurveTraits_2` models the concept as well)
    *
    * \sa `Arr_algebraic_segment_traits_2<Coefficient>`
-   * \sa `Arr_Bezier_curve_traits_2<RatKernel,AlgKernel,NtTraits>`
+   * \sa `Arr_Bezier_curve_traits_2<RatKernel, AlgKernel, NtTraits>`
    * \sa `Arr_circle_segment_traits_2<Kernel>`
    * \sa `Arr_conic_traits_2<RatKernel, AlgKernel, NtTraits>`
    * \sa `Arr_linear_traits_2<Kernel>`

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polycurve_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polycurve_traits_2.h
@@ -8,12 +8,11 @@
 /// @}
 
 namespace CGAL {
-  /*!
-   * \ingroup PkgArrangement2TraitsClasses
+  /*! \ingroup PkgArrangement2TraitsClasses
    *
-   * Note: The `GeometryTraits_2` can comprise of Line_segments, Conic_arcs,
-   *       Circular_arc, Bezier_curves or Linear_curves. A portion or a part
-   *       of any of the above mentioned geometric traits is called a segment.
+   * Note: The `SubcurveTraits_2` can comprise of Line_segments, Conic_arcs,
+   *       Circular_arc, Bezier_curves, or Linear_curves. A portion or a part
+   *       of any of the above mentioned geometric traits is called a subcurve.
    *
    * The traits class `Arr_polycurve_traits_2` handles piecewise curves that are
    * not necessarily linear, such as conic arcs, circular arcs, Bezier curves,
@@ -21,22 +20,22 @@ namespace CGAL {
    * is a chain of subcurves, where each two neighboring subcurves in the chain
    * share a common endpoint; that is, the polycurve is continuous. Furthermore,
    * the target of the \f$i\f$th segement of a polycurve has to coincide with
-   * the source of the \f$i+1\f$st segment; that is, the polycurve has to be \a
-   * well-oriented. Note that it is possible to construct general polycurves
+   * the source of the \f$i+1\f$st segment; that is, the polycurve has to be
+   * \a well-oriented. Note that it is possible to construct general polycurves
    * that are neither continuous nor well-oriented, as it is impossible to
    * enforce this precondition (using the set of predicates required by the
    * relevant concepts, see below). However, such polycurves cannot be used for
    * the actual computation of arrangements. The traits class template exploits
-   * the functionality of the `GeometryTraits_2` template-parameter to handle
+   * the functionality of the `SubcurveTraits_2` template-parameter to handle
    * the subcurves that compose the polycurve.
    *
-   * The type substituting the template parameter `GeometryTraits_2` when
+   * The type substituting the template parameter `SubcurveTraits_2` when
    * the template Arr_polycurve_traits_2 is instantiated must be a model
    * of the concepts
    *   - `ArrangementTraits_2` and
    *   - `ArrangementDirectionalXMonotoneTraits_2`.
    *
-   * If, in addition, the GeometryTraits_2 models the concept
+   * If, in addition, the SubcurveTraits_2 models the concept
    * `ArrangementApproximateTraits_2` then `Arr_polycurve_traits_2` models this
    * concept as well. The same holds for the concept
    * `ArrangementOpenBoundaryTraits_2`. If no type is provided, then
@@ -53,22 +52,22 @@ namespace CGAL {
    * `Arr_rational_function_traits_2<AlgebraicKernel_d_1>`,
    * or any other model of the concepts above can be used.
    *
-   * The number type used by the injected segment traits should support exact
+   * The number type used by the injected subcurve traits should support exact
    * rational arithmetic (that is, the number type should support the arithmetic
    * operations \f$ +\f$, \f$ -\f$, \f$ \times\f$ and \f$ \div\f$ carried out
    * without loss of precision), in order to avoid robustness problems, although
    * other inexact number types could be used at the user's own risk.
    *
-   * A polycurve that comprises \f$n > 0\f$ segments has \f$ n+1 \f$ segment
+   * A polycurve that comprises \f$n > 0\f$ subcurves has \f$ n+1 \f$ subcurve
    * end-points, and they are represented as objects of type
-   * `GeometryTraits_2::Point_2`. Since the notion of a \a vertex is reserved to
+   * `SubcurveTraits_2::Point_2`. Since the notion of a \a vertex is reserved to
    * 0-dimensional elements of an arrangement, we use, in this context, the
    * notion of \a points in order to refer to the vertices of a polycurve. For
    * example, an arrangement induced by a single non-self intersecting polycurve
-   * has exactly two vertices regardless of the number of segment
-   * end-points. Finally, the types `Segment_2` and `X_monotone_segment_2`
+   * has exactly two vertices regardless of the number of subcurve
+   * end-points. Finally, the types `Subcurve_2` and `X_monotone_subcurve_2`
    * nested in `Arr_polycurve_traits_2` are nothing but
-   * `GeometryTraits_2::Curve_2` and `GeometryTraits_2::X_monotone_curve_2`,
+   * `SubcurveTraits_2::Curve_2` and `SubcurveTraits_2::X_monotone_curve_2`,
    * respectively.
    *
    * \cgalHeading{A note on Backwards compatibility} In \cgal version 4.2 (and
@@ -85,7 +84,7 @@ namespace CGAL {
    * \cgalModels `ArrangementTraits_2`
    * \cgalModels `ArrangementDirectionalXMonotoneTraits_2`
    * \cgalModels `ArrangementApproximateTraits_2` (if the type that substitutes
-   *   the template parameter `GeometryTraits_2` models the concept as well)
+   *   the template parameter `SubcurveTraits_2` models the concept as well)
    *
    * \sa `Arr_algebraic_segment_traits_2<Coefficient>`
    * \sa `Arr_Bezier_curve_traits_2<RatKernel,AlgKernel,NtTraits>`
@@ -98,7 +97,7 @@ namespace CGAL {
    * \sa `CGAL_ALWAYS_LEFT_TO_RIGHT`
    */
 
-  template <typename GeometryTraits_2>
+  template <typename SubcurveTraits_2>
   class Arr_polycurve_traits_2 {
   public:
 
@@ -108,12 +107,12 @@ namespace CGAL {
      */
     // TODO: Have to turn these into links, so whenever I mention Point_2 it
     //       will point here and *not* to Kernel::Point_2 for instance.
-    typedef GeometryTraits_2::Point_2                   Point_2;
+    typedef SubcurveTraits_2::Point_2                   Point_2;
 
     /*!
      */
-    typedef GeometryTraits_2::Curve_2                   Segment_2;
-    typedef GeometryTraits_2::X_monotone_curve_2        X_monotone_segment_2;
+    typedef SubcurveTraits_2::Curve_2                   Subcurve_2;
+    typedef SubcurveTraits_2::X_monotone_curve_2        X_monotone_subcurve_2;
     /// @}
 
     /*! Construction functor of a general (not necessarily \f$x\f$-monotone)
@@ -122,7 +121,7 @@ namespace CGAL {
      * This functor constructs general polycurve. Its `operator()` is
      * oveloaded to support various input types.
      *
-     * Note that the composing segments, depending on the `GeometryTraits_2`,
+     * Note that the composing subcurves, depending on the `SubcurveTraits_2`,
      * might not be \f$x\f$-monotone.
      */
     class Construct_curve_2 {
@@ -130,15 +129,15 @@ namespace CGAL {
       /// \name Operations
       /// @{
 
-      /*! Obtain a polycurve that comprises of one given segment.
-       * \param seg input segment
-       * \pre `seg` is not degenerated (not tested)
-       * \return A polycurve with one segment, namely `seg`.
+      /*! Obtain a polycurve that comprises of one given subcurve.
+       * \param subcurve input subcurve.
+       * \pre `subcurve` is not degenerated (not tested).
+       * \return A polycurve with one subcurve, namely `subcurve`.
        */
-      Curve_2 operator()(const Segment_2& seg) const;
+      Curve_2 operator()(const Subcurve_2& subcurve) const;
 
       /*! Construct a well-oriented polycurve from a range of either
-       * `GeometryTraits_2::Point_2` or `GeometryTraits_2::Curve_2`.
+       * `SubcurveTraits_2::Point_2` or `SubcurveTraits_2::Curve_2`.
        *
        * \param begin iterator pointing to the first element in the
        *        range.
@@ -146,7 +145,7 @@ namespace CGAL {
        *        element in the range.
        * \pre The given range form a continuous and well-oriented polycurve
        *      (not tested).
-       * \pre Contains no degenerated segments (not tested)
+       * \pre Contains no degenerated subcurves (not tested)
        * \return A polycurve using the corresponding construction implementation.
        */
       template <typename ForwardIterator>
@@ -167,12 +166,12 @@ namespace CGAL {
      */
     class Construct_x_monotone_curve_2 {};
 
-    /*! Function object which returns the number of segment end-points of a
+    /*! Function object which returns the number of subcurve end-points of a
      * polycurve.
      */
     class Number_of_points_2 {};
 
-    /*! Functor to augment a polycurve by either adding a vertex or a segment
+    /*! Functor to augment a polycurve by either adding a vertex or a subcurve
      * at the back.
      */
     class Push_back_2 {
@@ -180,32 +179,31 @@ namespace CGAL {
       /// \name Operations
       /// @{
 
-      /*!
-       * Append a segment `seg` to an existing polycurve `cv` at the back.
-       * If `cv` is empty, `seg` will be its first segment.
+      /*! Append a subcurve `subcurve` to an existing polycurve `cv` at the back.
+       * If `cv` is empty, `subcurve` will be its first subcurve.
        * \param cv a polycurve. Note, `cv` is (not necessarily) \f$x\f$-monotone.
-       * \param seg a segment (not necessarily \f$x\f$-monotone) to be appended
-       *        to `cv`
+       * \param subcurve a subcurve (not necessarily \f$x\f$-monotone) to be
+       *        appended to `cv`
        */
-      void operator()(Curve_2& cv, const Segment_2& seg) const;
+      void operator()(Curve_2& cv, const Subcurve_2& subcurve) const;
 
-      /*! Append a segment `seg` to an existing \f$x\f$-monotone polycurve `xcv`
-       * at the back. If `xcv` is empty, `seg` will be its first segment.
+      /*! Append a subcurve `subcurve` to an existing \f$x\f$-monotone polycurve
+       * `xcv` at the back. If `xcv` is empty, `subcurve` will be its first
+       * subcurve.
        * \param xcv existing \f$x\f$-monotone polycurve
-       * \param seg the segment to be added
-       * \pre If `xcv` is not empty then `seg` extends `xcv` to the right if
-       *      `xcv` is oriented right-to-left. Otherwise, `seg` extends `xcv` to
-       *      the left.
-       * \pre `seg` is not degenerated.
-       * \pre `xcv` and `seg` should have the same orientation
+       * \param subcurve the subcurve to be added
+       * \pre If `xcv` is not empty then `subcurve` extends `xcv` to the right
+       *      if `xcv` is oriented right-to-left. Otherwise, `subcurve` extends
+       *      `xcv` to the left.
+       * \pre `subcurve` is not degenerated.
+       * \pre `xcv` and `subcurve` should have the same orientation
        */
-      void operator()(const X_monotone_curve_2& xcv, X_monotone_segment_2& seg)
-        const;
-
+      void operator()(X_monotone_curve_2& xcv,
+                      const X_monotone_subcurve_2& subcurve) const;
       /// @} /* end of operations */
     }; /* end of Arr_polycurve_traits_2::Push_back_2 */
 
-    /*! Functor to augment a polycurve by either adding a vertex or a segment
+    /*! Functor to augment a polycurve by either adding a vertex or a subcurve
      * at the front.
      */
     class Push_front_2 {
@@ -213,26 +211,27 @@ namespace CGAL {
       /// \name Operations
       /// @{
 
-      /*! Append a segment `seg` to an existing polycurve `cv` at the front.
-       * If `cv` is empty, `seg` will be its first segment.
+      /*! Append a subcurve `subcurve` to an existing polycurve `cv` at the
+       * front. If `cv` is empty, `subcurve` will be its first subcurve.
        * \param cv a polycurve. Note, `cv` is (not necessarily) \f$x\f$-monotone.
-       * \param seg a segment (not necessarily \f$x\f$-monotone) to be appended
-       * to `cv`
+       * \param subcurve a subcurve (not necessarily \f$x\f$-monotone) to be
+       *        appended to `cv`
        */
-      void operator()(Curve_2& cv, const Segment_2& seg) const;
+      void operator()(Curve_2& cv, const Subcurve_2& subcurve) const;
 
-      /*! Append a segment `seg` to an existing \f$x\f$-monotone polycurve `xcv`
-       * at the front. If `xcv` is empty, `seg` will be its first segment.
+      /*! Append a subcurve `subcurve` to an existing \f$x\f$-monotone polycurve
+       * `xcv` at the front. If `xcv` is empty, `subcurve` will be its first
+       * subcurve.
        * \param xcv existing \f$x\f$-monotone polycurve
-       * \param seg the segment to be added
-       * \pre If `xcv` is not empty then `seg` extends `xcv` to the left if
-       *      `xcv` is oriented right-to-left. Otherwise, `seg` extends `xcv` to
-       *      the right.
-       * \pre `seg` is not degenerated.
-       * \pre `xcv` and `seg` should have the same orientation
+       * \param subcurve the subcurve to be added
+       * \pre If `xcv` is not empty then `subcurve` extends `xcv` to the left if
+       *      `xcv` is oriented right-to-left. Otherwise, `subcurve` extends
+       *      `xcv` to the right.
+       * \pre `subcurve` is not degenerated.
+       * \pre `xcv` and `subcurve` should have the same orientation
        */
-      void operator()(const X_monotone_curve_2& xcv, X_monotone_segment_2& seg)
-        const;
+      void operator()(X_monotone_curve_2& xcv,
+                      const X_monotone_subcurve_2& subcurve) const;
 
       /// @} /* end of operations */
     }; /* end of Arr_polycurve_traits_2::Push_front_2 */
@@ -249,8 +248,8 @@ namespace CGAL {
                                     const Point_2& tgt) const;
     };
 
-    /*! Subdivide the given segment into x-monotone sub-segments and insert them
-     * into the given output iterator. Since the segments that
+    /*! Subdivide the given subcurve into x-monotone subcurves and insert them
+     * into the given output iterator. Since the subcurves that
      * constitute a general polycurve are not necessarily
      * \f$x\f$-monotone, this functor may break them.
      */
@@ -258,7 +257,7 @@ namespace CGAL {
     public:
       /*!
       * \pre if `cv` is not empty then it must be continuous and well-oriented.
-      * \param cv The segment.
+      * \param cv The subcurve.
       * \param oi The output iterator, whose value-type is Object. The output
       *           object is a wrapper of a X_monotone_curve_2 objects.
       * \return The past-the-end iterator.
@@ -268,25 +267,25 @@ namespace CGAL {
     };
 
     /*! The `Curve_2` type nested in the `Arr_polycurve_traits_2` represents
-     * general continuous piecewise-linear segments (a polycurve can be
+     * general continuous piecewise-linear subcurves (a polycurve can be
      * self-intersecting) and support their construction from range of
-     * segments. Construction of polycurves in various ways is supported using
+     * subcurves. Construction of polycurves in various ways is supported using
      * the construction functors. <em>It is strongly recommended to avoid
      * construction of `Curve_2` objects directly and prefer the usage of the
      * construction functors.</em> The type `Curve_2` has two template
-     * parameters, namely `Segment_type_T` and `Point_type_T`, which are
-     * `GeometryTraits_2::Curve_2` and `GeometryTraits_2::Point_2` types. Thus,
-     * in general, the segments that a `Curve_2` instance comprises could be
+     * parameters, namely `SubcurveType_2` and `PointType_2`, which are
+     * `SubcurveTraits_2::Curve_2` and `SubcurveTraits_2::Point_2` types. Thus,
+     * in general, the subcurves that a `Curve_2` instance comprises could be
      * either \f$x\f$-monotone or not!
      *
      * The copy and default constructor as well as the assignment operator are
-     * provided for polycurve segments. In addition, an \link
-     * PkgArrangement2op_left_shift `operator<<` \endlink for the segments is
+     * provided for polycurve subcurves. In addition, an \link
+     * PkgArrangement2op_left_shift `operator<<` \endlink for the subcurves is
      * defined for standard output streams, and an \link
-     * PkgArrangement2op_right_shift `operator>>` \endlink for the segments is
+     * PkgArrangement2op_right_shift `operator>>` \endlink for the subcurves is
      * defined for standard input streams.
      */
-    template <typename Segment_type_T, typename Point_type_T>
+    template <typename SubcurveType_2, typename PointType_2>
     class Curve_2 {
     public:
 
@@ -294,36 +293,37 @@ namespace CGAL {
       /// \name Types
       /// @{
 
-      /*! The container of the segments that comprises the polycurve.
+      /*! The container of the subcurves that comprises the polycurve.
        */
-      typedef typename std::vector<Segment_2>        Segments_container;
+      typedef typename std::vector<Subcurve_2>        Subcurves_container;
 
     public:
       /*! The size of the container that comprises the polycurve.
        */
-      typedef typename Segments_container::size_type Segments_size_type;
+      typedef typename Subcurves_container::size_type Size;
+      typedef typename Subcurves_container::size_type size_type;
 
       /*! \deprecated
        * A bidirectional iterator that allows traversing the points
-       * that comprise a polycurve's segments.
+       * that comprise a polycurve's subcurves.
        */
       typedef unspecified_type const_iterator;
 
       /*! \deprecated
        * A bidirectional iterator that allows traversing the points
-       * that comprise a polycurve's segments.
+       * that comprise a polycurve's subcurves.
        */
       typedef unspecified_type const_reverse_iterator;
 
       /*! A bidirectional constant iterator that allows traversing
-       * the segments that comprise the polycurve.
+       * the subcurves that comprise the polycurve.
        */
-      typedef unspecified_type Segment_const_iterator;
+      typedef unspecified_type Subcurve_const_iterator;
 
       /*! A bidirectional constant iterator that allows traversing
-       * the segments that comprise the polycurve.
+       * the subcurves that comprise the polycurve.
        */
-      typedef unspecified_type Segment_const_reverse_iterator;
+      typedef unspecified_type Subcurve_const_reverse_iterator;
 
       /// @} /* End of Types */
 
@@ -334,25 +334,25 @@ namespace CGAL {
        */
       Curve_2();
 
-      /*! Construct a polycurve from one segment.
+      /*! Construct a polycurve from one subcurve.
        */
-      Curve_2(const Segment_2 seg);
+      Curve_2(const Subcurve_2 subcurve);
 
-      /*! Construct a polycurve defined by the given range of segments
+      /*! Construct a polycurve defined by the given range of subcurves
        * `[first, last)` (the value-type of `InputIterator` must be
-       * `GeometryTraits_2::Curve_2`. In general, the segments might not
+       * `SubcurveTraits_2::Curve_2`. In general, the subcurves might not
        * be \f$x\f$-monotone, furthermore, they might not form a
        * continuous polycurve.
        *
-       * \pre The segments in the range should form a continuous and
+       * \pre The subcurves in the range should form a continuous and
        *       well-oriented polycurve.
        *
        * \deprecated For backwards compatibility, it is
        * possible to call this constructor with a range whose
-       * value-type is `GeometryTraits_2::Point_2`. In this case, the
+       * value-type is `SubcurveTraits_2::Point_2`. In this case, the
        * constructed polycurve will concatenate the \f$n\f$th point
        * with the \f$(n+1)\f$-st point in the range (using a
-       * `GeometryTraits_2::Segment_2`'s). This functionality is \a deprecated.
+       * `SubcurveTraits_2::Subcurve_2`'s). This functionality is \a deprecated.
        * Instead use the `Construct_curve_2` functors.
        */
       template <typename InputIterator>
@@ -364,9 +364,9 @@ namespace CGAL {
       /// @{
 
       /*! \deprecated
-       * Obtain the number of segment end-points that comprise the polycurve.
+       * Obtain the number of subcurve end-points that comprise the polycurve.
        * Note that for a bounded polycurve, if there are \f$ n\f$ points in the
-       * polycurve, it is comprised of \f$ (n - 1)\f$ segments.
+       * polycurve, it is comprised of \f$ (n - 1)\f$ subcurves.
        * Currently, only bounded polycurves are supported.
        */
       unsigned_int points() const;
@@ -376,53 +376,53 @@ namespace CGAL {
        */
       const_iterator begin() const;
 
-      /*! Obtain an iterator pointing at the first segment of the polycurve.
+      /*! Obtain an iterator pointing at the first subcurve of the polycurve.
        */
-      Segment_const_iterator begin_segments() const;
+      Subcurve_const_iterator begin_subcurves() const;
 
       /*! \deprecated
        * Obtain an iterator pointing after the end of the polycurve.
        */
       const_iterator end() const;
 
-      /*! Get an iterator pointing at the past-the-end segment of the polycurve.
+      /*! Get an iterator pointing at the past-the-end subcurve of the polycurve.
        */
-      Segment_const_iterator end_segments() const;
+      Subcurve_const_iterator end_subcurves() const;
 
       /*! \deprecated
        * Obtain an iterator pointing at the target point of the polycurve.
        */
       const_iterator rbegin() const;
 
-      /*! Obtain an iterator pointing at the last segment of the polycurve.
+      /*! Obtain an iterator pointing at the last subcurve of the polycurve.
        */
-      Segment_const_reverse_iterator rbegin_segments() const;
+      Subcurve_const_reverse_iterator rbegin_subcurves() const;
 
       /*! \deprecated
        * Obtain an iterator pointing before the beginning of the polycurve.
        */
       const_iterator rend() const;
 
-      /*! Obtain an iterator pointing at the past-the-end segment of
+      /*! Obtain an iterator pointing at the past-the-end subcurve of
        * the polycurve in reverse order.
        */
-      Segment_const_reverse_iterator rend_segments() const;
+      Subcurve_const_reverse_iterator rend_subcurves() const;
 
       /*! \deprecated
-       * Obtain the number of segments composing the polycurve
-       * (equivalent to `pi.points() - 1`). Was replaced by number_of_segments()
+       * Obtain the number of subcurves composing the polycurve
+       * (equivalent to `pi.points() - 1`). Was replaced by number_of_subcurves()
        */
-      Segments_size_type size() const;
+      size_type size() const;
 
-      /*! Obtain the number of segments that comprise the polycurve.
+      /*! Obtain the number of subcurves that comprise the polycurve.
        */
-      Segments_container_size number_of_segments() const;
+      size_type number_of_subcurves() const;
 
-      /*! Obtain the \f$ k\f$th segment of the polycurve.
+      /*! Obtain the \f$ k\f$th subcurve of the polycurve.
        * \pre \f$k\f$ is not greater then or equal to \f$n-1\f$, where
-       *      \f$n\f$ is the number of segments.
+       *      \f$n\f$ is the number of subcurves.
        */
-      typename GeometryTraits_2::X_monotone_curve_2
+      typename SubcurveTraits_2::X_monotone_curve_2
       operator[](size_t k) const;
 
       /*! Obtain the bounding box of the polycurve.
@@ -434,30 +434,32 @@ namespace CGAL {
       /// \name Operations
       /// @{
 
-      /*! Append a segment to the polycurve at the back.
+      /*! Append a subcurve to the polycurve at the back.
        * \a Warning: This function does not preform the precondition test
        *             that the `Push_back_2` functor does. Thus, it is
        *             recommended to use the latter.
-       * \param seg The new segment to be appended to the polycurve.
-       * \pre If the polycurve is not empty, the source of `seg` must coincide
-       *      with the target point of the last segment in the polycurve.
+       * \param subcurve The new subcurve to be appended to the polycurve.
+       * \pre If the polycurve is not empty, the source of `subcurve` must
+       *      coincide with the target point of the last subcurve in the
+       *      polycurve.
        */
-      inline void push_back(const Segment_2& seg);
+      inline void push_back(const Subcurve_2& subcurve);
 
-      /*! Append a segment to the polycurve at the front.
+      /*! Append a subcurve to the polycurve at the front.
        * \a Warning: This is a risky function! Don't use it! Prefer the
        *             corresponding functor which is provided in the traits
        *             class.
-       * \param seg The new segment to be appended to the polycurve.
-       * \pre If the polycurve is not empty, the target of `seg` must coincide
-       *      with the source point of the first segment in the polycurve.
+       * \param subcurve The new subcurve to be appended to the polycurve.
+       * \pre If the polycurve is not empty, the target of `subcurve` must
+       *      coincide with the source point of the first subcurve in the
+       *      polycurve.
        */
-      inline void push_front(const Segment_2& seg);
+      inline void push_front(const Subcurve_2& subcurve);
 
       /*! \deprecated
        * Add a new point to the polycurvs, which becomes the new target point
        * of `pi`.
-       * \pre GeometryTraits_2 is a model of
+       * \pre SubcurveTraits_2 is a model of
        * ArrangementConstructXMonotoneCurveTraits_2.
        */
       void push_back(const Point_2 & p);
@@ -472,15 +474,15 @@ namespace CGAL {
 
 
     /*! The `X_monotone_curve_2` class nested within the polycurve
-     * traits is used to represent \f$ x\f$-monotone piecewise linear segments.
+     * traits is used to represent \f$ x\f$-monotone piecewise linear subcurves.
      *
      * It inherits from the `Curve_2` type. `X_monotone_curve_2` can be
      * constructed just like `Curve_2`. However, there is precondition
      * (which is not tested) that the input defines an \f$
      * x\f$-monotone polycurve. Furthermore, in contrast to the general
-     * `Curve_2` type, in this case, the segments that an
+     * `Curve_2` type, in this case, the subcurves that an
      * `X_monotone_curve_2` comprises have to be instances of the type
-     * `GeometryTraits_2::X_monotone_curve_2`. Note that the \f$
+     * `SubcurveTraits_2::X_monotone_curve_2`. Note that the \f$
      * x\f$-monotonicity ensures that an \f$ x\f$-monotone polycurve
      * is not self-intersecting. (A self-intersecting polycurve is
      * subdivided into several interior-disjoint \f$x\f$-monotone subcurves).
@@ -490,7 +492,7 @@ namespace CGAL {
      * lexicographical \f$ xy\f$-order) or left-to-right (and in this case the
      * vertices are stored in a descending lexicographical \f$ xy\f$-order).
      */
-    template <typename Segment_type_2_T, typename Point_type_2_T>
+    template <typename SubcurveType_2, typename PointType_2>
     class X_monotone_curve_2 {
 
     }; /* end Arr_polycurve_traits_2::X_monotone_curve_2 */

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polyline_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_polyline_traits_2.h
@@ -84,7 +84,8 @@ namespace CGAL {
    * \cgalModels `ArrangementApproximateTraits_2` (if the type that substitutes
    *   the template parameter `SegmentTraits_2` models the concept as well)
    *
-   * \sa `Arr_Bezier_curve_traits_2<RatKernel,AlgKernel,NtTraits>`
+   * \sa `Arr_polycurve_traits_2<SubcurveTraits_2>`
+   * \sa `Arr_Bezier_curve_traits_2<RatKernel, AlgKernel, NtTraits>`
    * \sa `Arr_circle_segment_traits_2<Kernel>`
    * \sa `Arr_conic_traits_2<RatKernel, AlgKernel, NtTraits>`
    * \sa `Arr_linear_traits_2<Kernel>`
@@ -94,21 +95,22 @@ namespace CGAL {
    */
 
   template <typename SegmentTraits_2>
-  class Arr_polyline_traits_2 {
+  class Arr_polyline_traits_2 : public Arr_polycurve_traits_2<SegmentTraits_2>{
   public:
 
     /// \name Types
     /// @{
     /*!
      */
+    typedef SegmentTraits_2                             Segment_traits_2;
     // TODO: Have to turn these into links, so whenever I mention Point_2 it
     //       will point here and *not* to Kernel::Point_2 for instance.
-    typedef SegmentTraits_2::Point_2                      Point_2;
+    typedef SegmentTraits_2::Point_2                    Point_2;
 
     /*!
      */
-    typedef SegmentTraits_2::Curve_2                      Segment_2;
-    typedef SegmentTraits_2::X_monotone_curve_2           X_monotone_segment_2;
+    typedef SegmentTraits_2::Curve_2                    Segment_2;
+    typedef SegmentTraits_2::X_monotone_curve_2         X_monotone_segment_2;
     /// @}
 
     /*! Construction functor of a general (not necessarily \f$x\f$-monotone)
@@ -168,12 +170,7 @@ namespace CGAL {
      */
     class Construct_x_monotone_curve_2 {};
 
-    /*! Function object which returns the number of points of a polyline.
-     */
-    class Number_of_points_2 {};
-
-    /*!
-     * Functor to augment a polyline by either adding a vertex or a segment
+    /*! Functor to augment a polyline by either adding a vertex or a segment
      * at the back.
      */
     class Push_back_2 {
@@ -273,260 +270,6 @@ namespace CGAL {
       /// @} /* end of operations */
     }; /* end of Arr_polyline_traits_2::Push_front_2 */
 
-    class Trim_2 {
-    public:
-      /*! Obtain a trimmed version of the polycurve with src and tgt as end
-        * vertices.
-        * Src and tgt will be swaped if they do not conform to the direction of
-        * the polycurve.
-        */
-      X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv,
-                                    const Point_2& src,
-                                    const Point_2& tgt) const;
-    };
-
-    /*! Subdivide the given curve into x-monotone sub-curves and insert them
-     * into the given output iterator. Since the segments that
-     * constitute a general polyline are not necessarily
-     * \f$x\f$-monotone, this functor may break them.
-     */
-    class Make_x_monotone_2 {
-    public:
-      /*! \pre if `cv` is not empty then it must be continuous and well-oriented.
-      * \param cv The curve.
-      * \param oi The output iterator, whose value-type is Object. The output
-      *           object is a wrapper of a X_monotone_curve_2 objects.
-      * \return The past-the-end iterator.
-      */
-      template <typename OutputIterator>
-      OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const;
-    };
-
-    /*! The `Curve_2` type nested in the `Arr_polyline_traits_2` represents
-     * general continuous piecewise-linear curves (a polyline can be
-     * self-intersecting) and support their construction from range of
-     * segments. Construction of polylines in various ways is supported using the
-     * construction functors. <em>It is strongly recommended to avoid
-     * construction of `Curve_2` objects directly and prefer the usage of the
-     * construction functors.</em> The type `Curve_2` has two template
-     * parameters, namely `Segment_type_T` and `Point_type_T`, which are
-     * `SegmentTraits_2::Curve_2` and `SegmentTraits_2::Point_2` types. Thus, in
-     * general, the segments that a `Curve_2` instance comprises could be either
-     * \f$x\f$-monotone or not!
-     *
-     * The copy and default constructor as well as the assignment
-     * operator are provided for polyline curves. In addition, an \link
-     * PkgArrangement2op_left_shift `operator<<` \endlink for the
-     * curves is defined for standard output streams, and an \link
-     * PkgArrangement2op_right_shift `operator>>` \endlink for the
-     * curves is defined for standard input streams.
-     */
-    template <typename Segment_type_T, typename Point_type_T>
-    class Curve_2 {
-    public:
-
-    protected:
-      /// \name Types
-      /// @{
-
-      /*! The container of the segments that comprises the polyline.
-       */
-      typedef typename std::vector<Segment_2>        Segments_container;
-
-    public:
-      /*! The size of the container that comprises the polylines.
-       */
-      typedef typename Segments_container::size_type Segments_size_type;
-
-      /*! \deprecated
-       * A bidirectional iterator that allows traversing the points
-       * that comprise a polyline curve.
-       */
-      typedef unspecified_type const_iterator;
-
-      /*! \deprecated
-       * A bidirectional iterator that allows traversing the points
-       * that comprise a polyline curve.
-       */
-      typedef unspecified_type const_reverse_iterator;
-
-      /*! A bidirectional constant iterator that allows traversing
-       * the segments the comprise the polyline.
-       */
-      typedef unspecified_type Segment_const_iterator;
-
-      /*! A bidirectional constant iterator that allows traversing
-       * the segments the comprise the polyline.
-       */
-      typedef unspecified_type Segment_const_reverse_iterator;
-
-      /// @} /* End of Types */
-
-      /// \name Creation
-      /// @{
-
-      /*! Default constructor that constructs an empty polyline.
-       */
-      Curve_2();
-
-      /*! Construct a polyline from one segment.
-       */
-      Curve_2(const Segment_2 seg);
-
-      /*! Construct a polyline defined by the given range of segments
-       * `[first, last)` (the value-type of `InputIterator` must be
-       * `SegmentTraits_2::Curve_2`. In general, the segments might not be
-       * \f$x\f$-monotone, furthermore, they might not form a continuous
-       * polyline.
-       *
-       * \pre The segments in the range should form a continuous and
-       *      well-oriented polyline.
-       *
-       * \deprecated For backwards compatibility, it is
-       * possible to call this constructor with a range whose
-       * value-type is `SegmentTraits_2::Point_2`. In this case, the
-       * constructed polyline will concatenate the \f$n\f$th point
-       * with the \f$(n+1)\f$-st point in the range (using a
-       * `SegmentTraits_2::Segment_2`'s). This functionality is \a deprecated.
-       * Instead use the `Construct_curve_2` functors.
-       */
-      template <typename InputIterator>
-      Curve_2(Iterator first, Iterator last);
-
-      /// @} /* End of Creation */
-
-      /// \name Access Functions
-      /// @{
-
-      /*! \deprecated Obtain the number of points that comprise the polyline.
-       * Note that for a bounded polyline, if there are \f$ n\f$ points in the
-       * polyline, it is comprised of \f$ (n - 1)\f$ segments.
-       * Currently, only bounded polylines are supported.
-       */
-      unsigned_int points() const;
-
-      /*! \deprecated Obtain an iterator pointing at the source point of the
-       * polyline.
-       */
-      const_iterator begin() const;
-
-      /*! Obtain an iterator pointing at the first segment of the polyline.
-       */
-      Segment_const_iterator begin_segments() const;
-
-      /*! \deprecated Obtain an iterator pointing after the end of the polyline.
-       */
-      const_iterator end() const;
-
-      /*! Obtain an iterator pointing at the past-the-end segment of the
-       * polyline.
-       */
-      Segment_const_iterator end_segments() const;
-
-      /*! \deprecated Obtain an iterator pointing at the target point of the
-       * polyline.
-       */
-      const_iterator rbegin() const;
-
-      /*! Obtain an iterator pointing at the last segment of the polyline.
-       */
-      Segment_const_reverse_iterator rbegin_segments() const;
-
-      /*! \deprecated Obtain an iterator pointing before the beginning of the
-       * polyline.
-       */
-      const_iterator rend() const;
-
-      /*!
-       * Obtain an iterator pointing at the past-the-end segment of
-       * the polyline in reverse order.
-       */
-      Segment_const_reverse_iterator rend_segments() const;
-
-      /*! \deprecated Obtain the number of line segments composing the polyline
-       * (equivalent to `pi.points() - 1`). Was replaced by number_of_segments()
-       */
-      Segments_size_type size() const;
-
-      /*! Obtain the number of segments that comprise the polyline.
-       */
-      Segments_container_size number_of_segments() const;
-
-      /*! Obtain the \f$ k\f$th segment of the polyline.
-       * \pre \f$k\f$ is not greater then or equal to \f$n-1\f$, where
-       *      \f$n\f$ is the number of segments.
-       */
-      typename SegmentTraits_2::X_monotone_curve_2 operator[](size_t k) const;
-
-      /*!
-       * the bounding box of the polyline.
-       */
-      Bbox_2 bbox() const;
-
-      /// @} /* End of Access functions */
-
-      /// \name Operations
-      /// @{
-
-      /*! Append a segment to the polyline at the back.
-       * \a Warning: This function does not preform the precondition test
-                     that the `Push_back_2` functor does. Thus, it is
-                     recommended to use the latter.
-       * \param seg The new segment to be appended to the polyline.
-       * \pre If the polyline is not empty, the source of `seg` must coincide
-       *      with the target point of the last segment in the polyline.
-       */
-      inline void push_back(const Segment_2& seg);
-
-      /*! Append a segment to the polyline at the front.
-       * \a Warning: This is a risky function! Don't use it! Prefer the
-       *             corresponding functor which is provided in the traits
-       *             class.
-       * \param seg The new segment to be appended to the polyline.
-       * \pre If the polyline is not empty, the target of `seg` must coincide
-       *      with the source point of the first segment in the polyline.
-       */
-      inline void push_front(const Segment_2& seg);
-
-      /*! \deprecated adds a new point to the polyline, which becomes the new
-       * target point of `pi`.
-       */
-      void push_back(const Point_2& p);
-
-      /*! Reset the polyline.
-      */
-      void clear();
-
-      /// @} /* End of Operations */
-
-    }; /* end Arr_polyline_traits_2::Curve_2 */
-
-
-    /*! The `X_monotone_curve_2` class nested within the polyline
-     * traits is used to represent \f$ x\f$-monotone piecewise linear
-     * curves.
-     *
-     * It inherits from the `Curve_2` type. `X_monotone_curve_2` can be
-     * constructed just like `Curve_2`. However, there is precondition
-     * (which is not tested) that the input defines an \f$
-     * x\f$-monotone polyline. Furthermore, in contrast to the general
-     * `Curve_2` type, in this case, the segments that an
-     * `X_monotone_curve_2` comprises have to be instances of the type
-     * `SegmentTraits_2::X_monotone_curve_2`. Note that the \f$
-     * x\f$-monotonicity ensures that an \f$ x\f$-monotone polyline
-     * is not self-intersecting. (A self-intersecting polyline is
-     * subdivided into several interior-disjoint \f$x\f$-monotone subcurves).
-     *
-     * The defined \f$ x\f$-monotone polyline can be directed either from
-     * right-to-left (and in turn its vertices are stored in an ascending
-     * lexicographical \f$ xy\f$-order) or left-to-right (and in this case the
-     * vertices are stored in a descending lexicographical \f$ xy\f$-order).
-     */
-    template <typename Segment_type_2_T, typename Point_type_2_T>
-    class X_monotone_curve_2 {
-
-    }; /* end Arr_polyline_traits_2::X_monotone_curve_2 */
-
     /// \name Accessing Functor Objects
     /// @{
 
@@ -540,19 +283,11 @@ namespace CGAL {
 
     /*!
      */
-    Number_of_points_2 number_of_points_2_object() const;
-
-    /*!
-     */
     Push_back_2 push_back_2_object() const;
 
     /*!
      */
     Push_front_2 push_front_2_object() const;
-
-    /*!
-     */
-    Make_x_monotone_2 make_x_monotone_2_object() const;
 
     /// @} /* End Accessing Functor Objects */
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polyline_traits_2.h
@@ -50,6 +50,10 @@ class Arr_polyline_traits_2 : public Arr_polycurve_traits_2<SegmentTraits_2> {
 public:
   typedef SegmentTraits_2                             Segment_traits_2;
 
+  // For completeness
+  typedef typename Segment_traits_2::Curve_2            Segment_2;
+  typedef typename Segment_traits_2::X_monotone_curve_2 X_monotone_segment_2;
+
 private:
   typedef Arr_polyline_traits_2<Segment_traits_2>     Self;
   typedef Arr_polycurve_traits_2<Segment_traits_2>    Base;
@@ -72,7 +76,7 @@ public:
   typedef typename Base::Are_all_sides_oblivious_tag
     Are_all_sides_oblivious_tag;
 
-  typedef typename Base::X_monotone_subcurve_2         X_monotone_subcurve_2;
+  typedef typename Base::X_monotone_subcurve_2        X_monotone_subcurve_2;
   typedef typename Base::Subcurve_2                   Subcurve_2;
 
   typedef typename Base::Point_2                      Point_2;
@@ -133,7 +137,7 @@ public:
    */
   class Push_back_2 : public Base::Push_back_2 {
   protected:
-    typedef Arr_polyline_traits_2<SegmentTraits_2>     Polyline_traits_2;
+    typedef Arr_polyline_traits_2<Segment_traits_2>     Polyline_traits_2;
 
   public:
     /*! Constructor. */
@@ -246,7 +250,7 @@ public:
    */
   class Push_front_2 : public Base::Push_front_2 {
   protected:
-    typedef Arr_polyline_traits_2<SegmentTraits_2>     Polyline_traits_2;
+    typedef Arr_polyline_traits_2<Segment_traits_2>     Polyline_traits_2;
 
   public:
     /*! Constructor. */
@@ -300,7 +304,7 @@ public:
     /*! Append a point `p` to an existing polyline `xcv` at the front. */
     void operator()(const X_monotone_curve_2& xcv, Point_2& p) const
     {
-      const SegmentTraits_2* geom_traits =
+      const Segment_traits_2* geom_traits =
         this->m_poly_traits.subcurve_traits_2();
       CGAL_precondition_code
         (


### PR DESCRIPTION
## Summary of Changes

This is a pull request for a bug fix in the documentation of the Arr_polycurve_traits_2 class template, it's nested types Arr_polycurve_traits_2::Curve_2 and Arr_polycurve_traits_2::X_monotone_curve_2, the documentation of the Arr_polyline_traits_2 class template, and small fix to the Arr_polyline_traits_2 class template itself.

1. Documentation 

1.1. The documentation of Arr_polycurve_traits_2 did not reflect the code.
A polycurve is a sequence of curves, which do not need to be linear. In fact, they can even be algebraic. In the code we refer to them as subcurves, while in the documentation we used to refer to them as segments. The fix consist of replacing the string 'segment' with the string 'subcurve' in the name of the template parameters, nested types, nested functions, and variable types and names.
1.2. The Arr_polyline_traits_2 class template derives from the Arr_polycurve_traits_2 class template. However, in the documentation, all inherited types and member functions was duplicated. Moreover, they had the wrong name (see item 1.1. above). I removed all the duplications and wrong names and instead specified the derivation. The derivation is now shown in the documentation.

2. Code
I've added 2 nested types to Arr_polycurve_traits_2, namely Arr_polycurve_traits_2::Segment_2 and  Arr_polycurve_traits_2::X_monotone_segment_2 for backward compatibility.

## Release Management

* Affected package(s): 2D Arrangements

