### PR TITLE
Fix offset bug in polyhedron_demo

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -838,16 +838,15 @@ void MainWindow::updateViewerBBox()
   const double ymax = bbox.ymax();
   const double zmax = bbox.zmax();
 
-   //qDebug() << QString("Bounding box: (%1, %2, %3) - (%4, %5, %6)\n")
-   //.arg(xmin).arg(ymin).arg(zmin).arg(xmax).arg(ymax).arg(zmax);
+
   qglviewer::Vec 
     vec_min(xmin, ymin, zmin),
     vec_max(xmax, ymax, zmax),
     bbox_center((xmin+xmax)/2, (ymin+ymax)/2, (zmin+zmax)/2);
   qglviewer::Vec offset(0,0,0);
-  double l_dist = (std::max)((std::abs)(bbox_center.x + viewer->offset().x),
-                      (std::max)((std::abs)(bbox_center.y + viewer->offset().y),
-                          (std::abs)(bbox_center.z + viewer->offset().z)));
+  double l_dist = (std::max)((std::abs)(bbox_center.x - viewer->offset().x),
+                      (std::max)((std::abs)(bbox_center.y - viewer->offset().y),
+                          (std::abs)(bbox_center.z - viewer->offset().z)));
   if((std::log2)(l_dist) > 13.0 )
     for(int i=0; i<3; ++i)
     {


### PR DESCRIPTION
## Summary of Changes
Fixes the bug that happend when trying to recenter an offseted scene and the offset had not change.
## Release Management

* Affected package(s):Polyhedron_demo


