### PR TITLE
Kernel_23:  fix typesetting in the manual.

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -51,9 +51,9 @@ const CGAL::Point_3<Kernel>& r);
 
 /*!
 returns an approximation of the signed dihedral angle in the tetrahedron `pqrs` of edge `pq`.
-    The sign is negative if `orientation(p,q,r,s)` is `CGAL::NEGATIVE` and positive otherwise. 
-    The angle is given in degree.
-    \pre `p,q,r` and `p,q,s` are not collinear.
+The sign is negative if `orientation(p,q,r,s)` is `CGAL::NEGATIVE` and positive otherwise. 
+The angle is given in degree.
+\pre `p,q,r` and `p,q,s` are not collinear.
 */
 template <typename Kernel>
 Kernel::FT approximate_dihedral_angle(const CGAL::Point_3<Kernel>& p,


### PR DESCRIPTION

## Summary of Changes

Leading whitespace has semantics, so we remove it


## Release Management

* Affected package(s):  Kernel_23

