### PR TITLE
Bug fix in test_Prefix

### DIFF
--- a/BGL/test/BGL/test_Prefix.h
+++ b/BGL/test/BGL/test_Prefix.h
@@ -288,7 +288,7 @@ struct Surface_fixture_3 {
     assert(z != boost::graph_traits<Graph>::null_vertex());
 
     f1 = CGAL::is_border(halfedge(u, m),m) ? face(opposite(halfedge(u, m), m), m) : face(halfedge(u, m), m);
-    f2 = CGAL::is_border(halfedge(u, m),m) ? face(opposite(halfedge(z, m), m), m) : face(halfedge(z, m), m);
+    f2 = CGAL::is_border(halfedge(z, m),m) ? face(opposite(halfedge(z, m), m), m) : face(halfedge(z, m), m);
 
     assert(f1 != boost::graph_traits<Graph>::null_face());
     assert(f2 != boost::graph_traits<Graph>::null_face());


### PR DESCRIPTION
Strange that the assert(f2 !=null_face) was always true !!

## Summary of Changes

Bug fix in test_Prefix

## Release Management

* Affected package(s): BGL

