### PR TITLE
Hole_filling_plugin works with Surface_mesh_items

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -19,7 +19,7 @@ function build_demo {
   cd build-travis
   if [ $NEED_3D = 1 ]; then
     #install libqglviewer
-    git clone --depth=1 https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
+    git clone --depth=4 -b v2.6.3 --single-branch https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
     pushd ./qglviewer/QGLViewer
     #use qt5 instead of qt4
     export QT_SELECT=5

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -15,6 +15,11 @@ if(EIGEN3_FOUND)
     polyhedron_demo_plugin(hole_filling_plugin Hole_filling_plugin ${hole_fillingUI_FILES})
     target_link_libraries(hole_filling_plugin scene_polyhedron_item scene_polylines_item scene_polyhedron_selection_item)
 
+
+    polyhedron_demo_plugin(hole_filling_sm_plugin Hole_filling_plugin ${hole_fillingUI_FILES})
+    target_link_libraries(hole_filling_sm_plugin scene_surface_mesh_item scene_polylines_item scene_surface_mesh_selection_item)
+    target_compile_definitions(hole_filling_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
+
     qt5_wrap_ui( fairingUI_FILES Fairing_widget.ui)
     polyhedron_demo_plugin(fairing_plugin Fairing_plugin ${fairingUI_FILES})
     target_link_libraries(fairing_plugin scene_polyhedron_selection_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -51,7 +51,7 @@ typedef Scene_surface_mesh_item Scene_facegraph_item;
 #else
 typedef Scene_facegraph_item Scene_facegraph_item;
 #endif
-typedef Scene_facegraph_item::FaceGraph FaceGraph;
+typedef Scene_facegraph_item::Face_graph FaceGraph;
 
 typedef boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
 typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
@@ -736,7 +736,7 @@ void Polyhedron_demo_hole_filling_plugin::on_Fill_from_selection_button() {
   QVector<vertex_descriptor> vertices;
   std::vector<Polyhedron::Point_3> points;
   bool use_DT = ui_widget.Use_delaunay_triangulation_check_box->isChecked();
-  //! \todo Is this needed for Surface-Mesh ? If yes how to do it ?
+
 #ifndef USE_SURFACE_MESH
   poly->normalize_border();
 #endif


### PR DESCRIPTION
## Summary of Changes

The Hole_filling_plugin now works with a Surface_mesh. 
There is still an interrogation about normalize_border() : is it needed ? how to do it with a surface_mesh ?

This PR is based on #1983 
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #1931

