### PR TITLE
Algebraic_kernel_d: Remove dynamic exception specification. Fix of #1886

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
@@ -502,7 +502,6 @@ public:
                               const Polynomial_2& f,
                               CGAL::Degeneracy_strategy strategy
                                   = CGAL_ACK_DEFAULT_DEGENERACY_STRATEGY) 
-        throw(internal::Zero_resultant_exception<Polynomial_2>)
         : Base(Rep(kernel,f,strategy))
     {
 
@@ -812,7 +811,7 @@ private:
     
     // Creates a status line for the curve's <tt>index</tt>th critical point
     Status_line_1 create_status_line_at_event(size_type index) const 
-        throw(CGAL::internal::Non_generic_position_exception) {
+      {
 
         Event_coordinate_1& event = event_coordinates()[index];
         
@@ -1446,7 +1445,7 @@ private:
 
     //! Returns the Sturm-Habicht sequence of the primitive part of f
     std::vector<Polynomial_2>& sturm_habicht_of_primitive() const 
-    throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         if(! this->ptr()->sturm_habicht_of_primitive) {
             compute_sturm_habicht_of_primitive();
         }  
@@ -1460,7 +1459,7 @@ public:
      * of the primitive part of the defining polynomial
      */
     Polynomial_2 sturm_habicht_of_primitive(size_type i) const 
-      throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         CGAL_assertion(i>=0 && 
                     i < static_cast<size_type>
                        (sturm_habicht_of_primitive().size()));
@@ -1474,7 +1473,7 @@ public:
      * of the primitive part of the defining polynomial
      */
     Polynomial_1 principal_sturm_habicht_of_primitive(size_type i) const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         CGAL_assertion(i>=0 && 
                     i < static_cast<size_type>
                        (sturm_habicht_of_primitive().size()));
@@ -1496,7 +1495,7 @@ public:
      * of <tt>y^{i-1}</tt> of the <tt>i</tt>th Sturm-Habicht polynomial
      */
     Polynomial_1 coprincipal_sturm_habicht_of_primitive(size_type i) const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         CGAL_assertion(i>=1 && 
                     i < static_cast<size_type>
                        (sturm_habicht_of_primitive().size()));
@@ -1531,7 +1530,7 @@ private:
 
     // Internal method to compute the Sturm-Habicht sequence
     void compute_sturm_habicht_of_primitive() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         
 #if CGAL_ACK_DEBUG_FLAG
         CGAL_ACK_DEBUG_PRINT << "Compute Sturm-Habicht.." << std::flush;
@@ -1591,7 +1590,7 @@ private:
 
     //! Returns the resultant of the primitive part of f and its y-derivative
     Polynomial_1 resultant_of_primitive_and_derivative_y() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         if(! this->ptr()->resultant_of_primitive_and_derivative_y) {
             compute_resultant_of_primitive_and_derivative_y();
         }
@@ -1602,7 +1601,7 @@ private:
 
     //! Returns the resultant of the primitive part of f with its x-derivative
     Polynomial_1 resultant_of_primitive_and_derivative_x() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         if(! this->ptr()->resultant_of_primitive_and_derivative_x) {
             compute_resultant_of_primitive_and_derivative_x();
         }
@@ -1612,8 +1611,8 @@ private:
 private:
     // Computes <tt>res_y(f,f_y)</tt>, where \c f is the defining polynomial
     void compute_resultant_of_primitive_and_derivative_y() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
-        
+      {
+  
 #if CGAL_ACK_DEBUG_FLAG
         CGAL_ACK_DEBUG_PRINT << "Compute resultant.." << std::flush;
 #endif
@@ -1664,7 +1663,7 @@ private:
     
     // Computes <tt>res_y(f,f_x)</tt>, where \c f is the defining polynomial
     void compute_resultant_of_primitive_and_derivative_x() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         
 #if CGAL_ACK_DEBUG_FLAG
         CGAL_ACK_DEBUG_PRINT << "Compute x-resultant.." << std::flush;
@@ -1723,7 +1722,7 @@ private:
 
     // Returns the critical event coordinates
     std::vector<Event_coordinate_1>& event_coordinates() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
         if(! this->ptr()->event_coordinates) {
             compute_event_coordinates();
         }
@@ -1734,8 +1733,7 @@ private:
 
     // Returns the intermediate values for intervals between events
     std::vector<boost::optional<Bound> >& intermediate_values() const 
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
-        
+      {
         if(! this->ptr()->intermediate_values) {
             // This is created during event_coordiantes()
             event_coordinates();
@@ -1755,7 +1753,7 @@ private:
      * x-coordinates of the curve.
      */
     void compute_event_coordinates() const
-        throw(internal::Zero_resultant_exception<Polynomial_2>) {
+      {
          
 #if CGAL_ACK_DEBUG_FLAG
         CGAL_ACK_DEBUG_PRINT << "compute events..." << std::flush;
@@ -1953,7 +1951,6 @@ public:
      * of the Algebraic_curve_kernel_2 yet.
      */
     Self& shear_primitive_part(Integer s) const
-        throw(CGAL::internal::Non_generic_position_exception)
     {
         CGAL_assertion(s!=0);
 #if CGAL_ACK_USE_SPECIAL_TREATMENT_FOR_CONIX

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
@@ -1166,7 +1166,7 @@ private:
 
       
     Status_line_CPA_1 
-        create_event_slice_from_current_intersection_info (size_type i);
+        create_event_slice_from_current_intersection_info (size_type i) const;
 
     Bound x_sheared(Bound x, Bound y,Integer sh) const {
         return x-sh*y;
@@ -2407,7 +2407,7 @@ template<typename AlgebraicKernelWithAnalysis_2>
 typename Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>
     ::Status_line_CPA_1 
 Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>::
-create_event_slice_from_current_intersection_info (size_type i){
+create_event_slice_from_current_intersection_info (size_type i) const{
 #if CGAL_ACK_DEBUG_FLAG
     CGAL_ACK_DEBUG_PRINT << "Reduce the candidates.." << std::flush;
 #endif

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
@@ -480,8 +480,6 @@ public:
                           Curve_analysis_2 c2,
                           CGAL::Degeneracy_strategy strategy
                               = CGAL_ACK_DEFAULT_DEGENERACY_STRATEGY) 
-        throw(CGAL::internal::Zero_resultant_exception<Polynomial_2>,
-              CGAL::internal::Non_generic_position_exception)
         : Base(Rep(kernel,c1, c2, strategy)) 
     {
         
@@ -847,13 +845,11 @@ private:
 private:
 
     // Computes a slice_info object at Algebraic_real_1 \c alpha
-    Slice_info construct_slice_info(Algebraic_real_1 alpha) const
-        throw(CGAL::internal::Non_generic_position_exception);
+    Slice_info construct_slice_info(Algebraic_real_1 alpha) const;
       
 private:
       
-    Status_line_CPA_1 construct_generic_case(size_type i) const 
-        throw(CGAL::internal::Non_generic_position_exception);        
+    Status_line_CPA_1 construct_generic_case(size_type i) const;        
 
 private:
       
@@ -1170,8 +1166,7 @@ private:
 
       
     Status_line_CPA_1 
-        create_event_slice_from_current_intersection_info (size_type i) 
-        const throw(CGAL::internal::Non_generic_position_exception);
+        create_event_slice_from_current_intersection_info (size_type i);
 
     Bound x_sheared(Bound x, Bound y,Integer sh) const {
         return x-sh*y;
@@ -1992,8 +1987,7 @@ create_slice_from_slice_info(size_type id,
 template<typename AlgebraicKernelWithAnalysis_2>
 typename Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>::Slice_info 
 Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>::
-construct_slice_info(Algebraic_real_1 alpha) const
-    throw(CGAL::internal::Non_generic_position_exception) {
+construct_slice_info(Algebraic_real_1 alpha) const {
     
 /*
   #if CGAL_ACK_DEBUG_FLAG
@@ -2074,8 +2068,7 @@ template<typename AlgebraicKernelWithAnalysis_2>
 typename Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>
     ::Status_line_CPA_1 
 Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>::
-construct_generic_case(size_type i) const 
-    throw(CGAL::internal::Non_generic_position_exception) {
+construct_generic_case(size_type i) const {
     
     Algebraic_real_1 alpha = event_x(i);
     
@@ -2414,8 +2407,7 @@ template<typename AlgebraicKernelWithAnalysis_2>
 typename Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>
     ::Status_line_CPA_1 
 Curve_pair_analysis_2<AlgebraicKernelWithAnalysis_2>::
-create_event_slice_from_current_intersection_info (size_type i) 
-    const throw(CGAL::internal::Non_generic_position_exception){
+create_event_slice_from_current_intersection_info (size_type i){
 #if CGAL_ACK_DEBUG_FLAG
     CGAL_ACK_DEBUG_PRINT << "Reduce the candidates.." << std::flush;
 #endif

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Event_line_builder.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Event_line_builder.h
@@ -117,7 +117,6 @@ public:
     Event_line_builder(Algebraic_kernel_with_analysis_2* kernel,
                        Curve_analysis_2 curve,
                        Polynomial_2 polynomial)
-        throw(internal::Zero_resultant_exception<Polynomial_2>) 
         : _m_kernel(kernel), curve(curve), polynomial(polynomial)
     {}
 
@@ -151,7 +150,7 @@ public:
     Status_line_1
     create_event_line(int id,Algebraic_real_1 alpha,int arcs_left,int arcs_right,
                       bool root_of_resultant, bool root_of_content,int mult) 
-        throw(CGAL::internal::Non_generic_position_exception) {
+    {
 
         try {
 	
@@ -531,7 +530,7 @@ protected:
 						      int mult,
 						      int arcs_left,
 						      int arcs_right) 
-        throw(CGAL::internal::Non_generic_position_exception) {
+    {
         
         
         Bitstream_traits traits(Bitstream_coefficient_kernel(kernel(),alpha));
@@ -613,7 +612,7 @@ protected:
 			     int k,
 			     const Polynomial_2& der_1,
 			     const Polynomial_2& der_2) 
-        throw(CGAL::internal::Non_generic_position_exception) {
+    {
      
         //Guess the right expression for y
 /*


### PR DESCRIPTION
Fix #1886.
