### PR TITLE
Polyhedron_demo : Reverse alwaysUse

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -351,7 +351,7 @@ MainWindow::MainWindow(QWidget* parent)
   }
 
   QMenu* menuFile = findChild<QMenu*>("menuFile");
-  insertActionAfter(menuFile, QString("Load"), actionAddToGroup);
+  insertActionBefore(menuFile, actionAddToGroup);
   statistics_dlg = NULL;
   statistics_ui = new Ui::Statistics_on_item_dialog();
 
@@ -1010,7 +1010,7 @@ void MainWindow::open(QString filename)
     connect(actionResetDefaultLoaders, SIGNAL(triggered()),
             this, SLOT(reset_default_loaders()));
     default_plugin_selection[fileinfo.completeSuffix()]=load_pair.first;
-    insertActionAfter(ui->menuFile, QString("Load"), actionResetDefaultLoaders);
+    insertActionBefore(ui->menuFile, actionResetDefaultLoaders);
   }
   
   
@@ -1944,7 +1944,7 @@ void MainWindow::reset_default_loaders()
   menu->removeAction(actionResetDefaultLoaders);
 }
 
-void MainWindow::insertActionAfter(QMenu* menu, QString actionAfterName, QAction* actionToInsert)
+void MainWindow::insertActionBefore(QMenu* menu, QAction* actionToInsert)
 {
   const char* prop_name = "Menu modified by MainWindow.";
   if(menu)
@@ -1953,28 +1953,9 @@ void MainWindow::insertActionAfter(QMenu* menu, QString actionAfterName, QAction
     if(!menuChanged) {
       menu->setProperty(prop_name, true);
     }
-    QList<QAction*> menuActions = menu->actions();
-    if(menuActions.contains(actionToInsert))
-      return;
-    // Look for action just after "actionAfterName..." action
-    QAction* actionAfter = NULL;
-    for ( QList<QAction*>::iterator it_action = menuActions.begin(),
-          end = menuActions.end() ; it_action != end ; ++ it_action )
-    {
-      if ( NULL != *it_action && (*it_action)->text().contains(actionAfterName) )
-      {
-        ++it_action;
-        if ( it_action != end && NULL != *it_action )
-        {
-          actionAfter = *it_action;
-        }
-      }
-    }
 
-    // Insert "Load implicit function" action
-    if ( NULL != actionAfter )
-    {
-      menu->insertAction(actionAfter,actionToInsert);
-    }
+    QList<QAction*> menuActions = menu->actions();
+    if(!menuActions.contains(actionToInsert))
+      menu->insertAction(ui->actionLoadPlugin, actionToInsert);
   }
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -351,7 +351,7 @@ MainWindow::MainWindow(QWidget* parent)
   }
 
   QMenu* menuFile = findChild<QMenu*>("menuFile");
-  insertActionBefore(menuFile, actionAddToGroup);
+  insertActionBeforeLoadPlugin(menuFile, actionAddToGroup);
   statistics_dlg = NULL;
   statistics_ui = new Ui::Statistics_on_item_dialog();
 
@@ -1010,7 +1010,7 @@ void MainWindow::open(QString filename)
     connect(actionResetDefaultLoaders, SIGNAL(triggered()),
             this, SLOT(reset_default_loaders()));
     default_plugin_selection[fileinfo.completeSuffix()]=load_pair.first;
-    insertActionBefore(ui->menuFile, actionResetDefaultLoaders);
+    insertActionBeforeLoadPlugin(ui->menuFile, actionResetDefaultLoaders);
   }
   
   
@@ -1944,16 +1944,10 @@ void MainWindow::reset_default_loaders()
   menu->removeAction(actionResetDefaultLoaders);
 }
 
-void MainWindow::insertActionBefore(QMenu* menu, QAction* actionToInsert)
+void MainWindow::insertActionBeforeLoadPlugin(QMenu* menu, QAction* actionToInsert)
 {
-  const char* prop_name = "Menu modified by MainWindow.";
   if(menu)
   {
-    bool menuChanged = menu->property(prop_name).toBool();
-    if(!menuChanged) {
-      menu->setProperty(prop_name, true);
-    }
-
     QList<QAction*> menuActions = menu->actions();
     if(!menuActions.contains(actionToInsert))
       menu->insertAction(ui->actionLoadPlugin, actionToInsert);

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -88,6 +88,7 @@ public Q_SLOTS:
   void setExpanded(QModelIndex);
   void setCollapsed(QModelIndex);
   bool file_matches_filter(const QString& filters, const QString& filename);
+  void reset_default_loaders();
   //!Prints a dialog containing statistics on the selected polyhedrons.
   void statisticsOnItem();
   /*! Open a file with a given loader, and return true if it was successful.
@@ -372,11 +373,13 @@ private:
   QVector<PluginNamePair > plugins;
   //!Called when "Add new group" in the file menu is triggered.
   QAction* actionAddToGroup;
+  QAction* actionResetDefaultLoaders;
   void print_message(QString message) { messages->information(message); }
   Messages_interface* messages;
 
   QDialog *statistics_dlg;
   Ui::Statistics_on_item_dialog* statistics_ui;
+  void insertActionAfter(QMenu*, QString actionAfterName, QAction *actionToInsert);
 
 #ifdef QT_SCRIPT_LIB
   QScriptEngine* script_engine;

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -379,7 +379,7 @@ private:
 
   QDialog *statistics_dlg;
   Ui::Statistics_on_item_dialog* statistics_ui;
-  void insertActionAfter(QMenu*, QString actionAfterName, QAction *actionToInsert);
+  void insertActionBefore(QMenu*, QAction *actionToInsert);
 
 #ifdef QT_SCRIPT_LIB
   QScriptEngine* script_engine;

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -379,7 +379,7 @@ private:
 
   QDialog *statistics_dlg;
   Ui::Statistics_on_item_dialog* statistics_ui;
-  void insertActionBefore(QMenu*, QAction *actionToInsert);
+  void insertActionBeforeLoadPlugin(QMenu*, QAction *actionToInsert);
 
 #ifdef QT_SCRIPT_LIB
   QScriptEngine* script_engine;


### PR DESCRIPTION
## Summary of Changes

Add an action to the menuFile to reset the default_loaders_map, allowing the user to choose the loader for all items again, even if alwaysUse was checked.

This action appears if alwaysUse is checked, and disappears when it is clicked.

## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2008


