### PR TITLE
Point set 3: fix index type

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -120,12 +120,9 @@ public:
     friend class std::vector<Index>;
     std::size_t value;
     
-    // Only Point_set_3 and other friend classes are allowed to
-    // instantiate an Index with a specific value
-    Index (const std::size_t& value) : value (value) { }
-    /// \endcond
   public:
     Index (const Index& index) : value (index) { }
+    Index (const std::size_t& value) : value (value) { }
     Index () : value ((std::size_t)(-1)) { }
     Index operator= (const Index& index) { value = index.value; return *this; }
     /// \cond SKIP_IN_MANUAL

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -113,20 +113,27 @@ public:
   class Index
   {
     /// \cond SKIP_IN_MANUAL
+  public:
+#ifdef CGAL_POINT_SET_3_USE_STD_SIZE_T_AS_SIZE_TYPE
+    typedef std::size_t size_type;
+#else
+    typedef boost::uint32_t size_type;
+#endif
+  private:
     friend class Point_set_3;
     friend class Properties::Property_container<Point_set_3, Index>;
     template <class> friend class Properties::Property_array;
     template <class> friend struct Property_map;
     friend class std::vector<Index>;
-    std::size_t value;
+    size_type value;
     
   public:
     Index (const Index& index) : value (index) { }
-    Index (const std::size_t& value) : value (value) { }
-    Index () : value ((std::size_t)(-1)) { }
+    Index (const std::size_t& value) : value (static_cast<size_type>(value)) { }
+    Index () : value (static_cast<size_type>(-1)) { }
     Index operator= (const Index& index) { value = index.value; return *this; }
     /// \cond SKIP_IN_MANUAL
-    operator std::size_t() const { return value; }
+    operator std::size_t() const { return static_cast<std::size_t>(value); }
     bool operator== (const Index& index) const { return value == index.value; }
     bool operator!= (const Index& index) const { return value != index.value; }
     bool operator<  (const Index& index) const { return value < index.value; }
@@ -309,7 +316,7 @@ public:
   void clear()
   {
     m_base.clear();
-    boost::tie (m_indices, boost::tuples::ignore) = this->add_property_map<Index>("index", (std::size_t)(-1));
+    boost::tie (m_indices, boost::tuples::ignore) = this->add_property_map<Index>("index", typename Index::size_type(-1));
     boost::tie (m_points, boost::tuples::ignore) = this->add_property_map<Point>("point", Point (0., 0., 0.));
     m_nb_removed = 0;
   }
@@ -323,7 +330,7 @@ public:
   void clear_properties()
   {
     Base other;
-    other.template add<Index>("index", (std::size_t)(-1));
+    other.template add<Index>("index", typename Index::size_type(-1));
     other.template add<Point>("point", Point (0., 0., 0.));
     other.resize(m_base.size());
     other.transfer(m_base);

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -128,7 +128,7 @@ public:
     size_type value;
     
   public:
-    Index (const Index& index) : value (index) { }
+    Index (const Index& index) : value (static_cast<size_type>(index)) { }
     Index (const std::size_t& value) : value (static_cast<size_type>(value)) { }
     Index () : value (static_cast<size_type>(-1)) { }
     Index operator= (const Index& index) { value = index.value; return *this; }


### PR DESCRIPTION
## Summary of Changes

This PR fixes two problems:

1. The point set index violates the `Index` concept as the constructor using a `size_t` is private (this was done to avoid some mis-usage of the point set but should be removed)
2. The index map is using a `std::size_t` which can lead to an overly large memory usage when loading very big point sets. This PR makes it use `boost::uint32_t` which should be half the size and can still address more than 4 billion points. Anyway, loading more than 4 billion points requires at least 50GB of RAM with `CGAL::Simple_cartesian<float>`, which is not common at the moment. I added a `#ifdef` macro `CGAL_POINT_SET_3_USE_STD_SIZE_T_AS_SIZE_TYPE` which is undefined by default so that a user who actually needs to load more than 4 billion points can still do it.

## Release Management

* Affected package(s): Point_set_3

