### PR TITLE
Polyhedron_demo : Add Q_DECL_OVERRIDE

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -40,12 +40,12 @@ public:
   Scene_c3t3_item(const C3t3& c3t3);
   ~Scene_c3t3_item();
 
-  bool has_stats()const {return true;}
-  QString computeStats(int type);
-  CGAL::Three::Scene_item::Header_data header() const;
+  bool has_stats()const  Q_DECL_OVERRIDE {return true;}
+  QString computeStats(int type)  Q_DECL_OVERRIDE;
+  CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
 
 
-  void setColor(QColor c);
+  void setColor(QColor c) Q_DECL_OVERRIDE;
   bool save_binary(std::ostream& os) const
   {
     return CGAL::Mesh_3::save_binary_file(os, c3t3());
@@ -57,7 +57,7 @@ public:
       return !!(os << c3t3());
   }
 
-  void invalidateOpenGLBuffers();
+  void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
 
   void c3t3_changed();
 
@@ -68,7 +68,7 @@ public:
   const C3t3& c3t3() const;
   C3t3& c3t3();
 
-  bool manipulatable() const {
+  bool manipulatable() const  Q_DECL_OVERRIDE{
     return true;
   }
 
@@ -77,7 +77,7 @@ public:
   bool has_cnc() const;
   bool has_tets() const;
   bool is_valid() const;//true if the c3t3 is correct, false if it was made from a .mesh, for example
-  ManipulatedFrame* manipulatedFrame();
+  ManipulatedFrame* manipulatedFrame() Q_DECL_OVERRIDE;
 
   void setPosition(float x, float y, float z) ;
 
@@ -85,8 +85,8 @@ public:
 
   Kernel::Plane_3 plane(qglviewer::Vec offset = qglviewer::Vec(0,0,0)) const;
 
-  bool isFinite() const { return true; }
-  bool isEmpty() const {
+  bool isFinite() const Q_DECL_OVERRIDE { return true; }
+  bool isEmpty() const Q_DECL_OVERRIDE {
     return c3t3().triangulation().number_of_vertices() == 0
       || (    c3t3().number_of_vertices_in_complex() == 0
            && c3t3().number_of_facets_in_complex()   == 0
@@ -94,12 +94,12 @@ public:
   }
 
 
-  void compute_bbox() const;
-  Scene_item::Bbox bbox() const
+  void compute_bbox() const Q_DECL_OVERRIDE;
+  Scene_item::Bbox bbox() const Q_DECL_OVERRIDE
   {
       return Scene_item::bbox();
   }
-  Scene_c3t3_item* clone() const {
+  Scene_c3t3_item* clone() const  Q_DECL_OVERRIDE{
     return 0;
   }
 
@@ -109,21 +109,21 @@ public:
   const Scene_item* data_item() const;
   void set_data_item(const Scene_item* data_item);
 
-  QString toolTip() const;
+  QString toolTip() const Q_DECL_OVERRIDE;
 
   // Indicate if rendering mode is supported
-  bool supportsRenderingMode(RenderingMode m) const {
+  bool supportsRenderingMode(RenderingMode m) const  Q_DECL_OVERRIDE{
     return (m != Gouraud && m != PointsPlusNormals && m != Splatting && m != Points && m != ShadedPoints);
   }
 
-  void draw(CGAL::Three::Viewer_interface* viewer) const;
-  void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
-  void drawPoints(CGAL::Three::Viewer_interface * viewer) const;
+  void draw(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+  void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+  void drawPoints(CGAL::Three::Viewer_interface * viewer) const Q_DECL_OVERRIDE;
   public:
-    QMenu* contextMenu();
-    void copyProperties(Scene_item *);
+    QMenu* contextMenu() Q_DECL_OVERRIDE;
+    void copyProperties(Scene_item *) Q_DECL_OVERRIDE;
     float getShrinkFactor() const;
-    bool keyPressEvent(QKeyEvent *);
+    bool keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
   public Q_SLOTS:
   void export_facets_in_complex();
 
@@ -137,7 +137,7 @@ public:
   void show_grid(bool b);
   void show_cnc(bool b);
 
-  virtual QPixmap graphicalToolTip() const;
+  virtual QPixmap graphicalToolTip() const Q_DECL_OVERRIDE;
 
   void update_histogram();
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -26,13 +26,13 @@ public:
   Scene_points_with_normal_item(const Scene_points_with_normal_item& toCopy);
   Scene_points_with_normal_item(const Polyhedron& p);
   ~Scene_points_with_normal_item();
-  Scene_points_with_normal_item* clone() const;
+  Scene_points_with_normal_item* clone() const Q_DECL_OVERRIDE;
 
   // Is selection empty?
   virtual bool isSelectionEmpty() const;
 
   // Function to override the context menu
-  QMenu* contextMenu();
+  QMenu* contextMenu() Q_DECL_OVERRIDE;
 
   // IO
   bool read_ply_point_set(std::istream& in);
@@ -43,34 +43,34 @@ public:
   bool write_xyz_point_set(std::ostream& out) const;
 
   // Function for displaying meta-data of the item
-  virtual QString toolTip() const;
+  virtual QString toolTip() const Q_DECL_OVERRIDE;
 
-  virtual void invalidateOpenGLBuffers();
+  virtual void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
 
   // Indicate if rendering mode is supported
-  virtual bool supportsRenderingMode(RenderingMode m) const;
+  virtual bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE;
 
-  virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
-  virtual void drawPoints(CGAL::Three::Viewer_interface*) const;
+  virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+  virtual void drawPoints(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
 
-  virtual void drawSplats(CGAL::Three::Viewer_interface*) const;
+  virtual void drawSplats(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
   
   // Gets wrapped point set
   Point_set*       point_set();
   const Point_set* point_set() const;
 
   // Gets dimensions
-  virtual bool isFinite() const { return true; }
-  virtual bool isEmpty() const;
-  virtual void compute_bbox() const;
+  virtual bool isFinite() const Q_DECL_OVERRIDE { return true; }
+  virtual bool isEmpty() const Q_DECL_OVERRIDE;
+  virtual void compute_bbox() const Q_DECL_OVERRIDE;
 
-  virtual void setRenderingMode(RenderingMode m);
+  virtual void setRenderingMode(RenderingMode m) Q_DECL_OVERRIDE;
 
   // computes the local point spacing (aka radius) of each point
   void computes_local_spacing(int k);
 
   bool has_normals() const;
-  void copyProperties(Scene_item *);
+  void copyProperties(Scene_item *) Q_DECL_OVERRIDE;
   int getNormalSliderValue();
   int getPointSliderValue();
 

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -110,7 +110,7 @@ public:
     Scene_polygon_soup_item();
     ~Scene_polygon_soup_item();
 
-    Scene_polygon_soup_item* clone() const;
+    Scene_polygon_soup_item* clone() const Q_DECL_OVERRIDE;
 
     template <class Point, class Polygon>
     void load(const std::vector<Point>& points, const std::vector<Polygon>& polygons);
@@ -122,19 +122,19 @@ public:
     bool save(std::ostream& out) const;
     std::vector<CGAL::Color> getVColors() const;
     std::vector<CGAL::Color> getFColors() const;
-    QString toolTip() const;
+    QString toolTip() const Q_DECL_OVERRIDE;
 
     // Indicate if rendering mode is supported
-    virtual bool supportsRenderingMode(RenderingMode m) const { return ( m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); }
+    virtual bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE{ return ( m!=PointsPlusNormals && m!=Splatting && m!=ShadedPoints); }
     // OpenGL drawing in a display list
-    virtual void draw() const {}
-    virtual void draw(CGAL::Three::Viewer_interface*) const;
-    virtual void drawPoints(CGAL::Three::Viewer_interface*) const;
-    virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
-    void invalidateOpenGLBuffers();
-    bool isFinite() const { return true; }
-    bool isEmpty() const;
-    void compute_bbox() const;
+    virtual void draw() const Q_DECL_OVERRIDE{}
+    virtual void draw(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
+    virtual void drawPoints(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
+    virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+    void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
+    bool isFinite() const Q_DECL_OVERRIDE{ return true; }
+    bool isEmpty() const Q_DECL_OVERRIDE;
+    void compute_bbox() const Q_DECL_OVERRIDE;
 
     void new_vertex(const double&, const double&, const double&);
     void new_triangle(const std::size_t, const std::size_t, const std::size_t);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -81,7 +81,7 @@ public:
     // Indicate if rendering mode is supported
     virtual bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE;
     // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
-    void draw() const {}
+    void draw() const Q_DECL_OVERRIDE{}
     virtual void draw(CGAL::Three::Viewer_interface*) const Q_DECL_OVERRIDE;
     virtual void drawEdges() const Q_DECL_OVERRIDE{}
     virtual void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -38,24 +38,24 @@ public:
 
   ~Scene_surface_mesh_item();
 
-  Scene_surface_mesh_item* clone() const;
-  void draw(CGAL::Three::Viewer_interface *) const;
-  void drawEdges(CGAL::Three::Viewer_interface *) const;
-  void drawPoints(CGAL::Three::Viewer_interface *) const;
+  Scene_surface_mesh_item* clone() const Q_DECL_OVERRIDE;
+  void draw(CGAL::Three::Viewer_interface *) const Q_DECL_OVERRIDE;
+  void drawEdges(CGAL::Three::Viewer_interface *) const Q_DECL_OVERRIDE;
+  void drawPoints(CGAL::Three::Viewer_interface *) const Q_DECL_OVERRIDE;
 
-  bool supportsRenderingMode(RenderingMode m) const;
-  bool isFinite() const { return true; }
-  bool isEmpty() const;
-  Bbox bbox() const;
-  QString toolTip() const;
+  bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE;
+  bool isFinite() const Q_DECL_OVERRIDE { return true; }
+  bool isEmpty() const Q_DECL_OVERRIDE;
+  Bbox bbox() const Q_DECL_OVERRIDE;
+  QString toolTip() const Q_DECL_OVERRIDE;
 
   SMesh* polyhedron();
   const SMesh* polyhedron() const;
-  void compute_bbox()const;
+  void compute_bbox()const Q_DECL_OVERRIDE;
   void standard_constructor(SMesh *sm);
 public Q_SLOTS:
   void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
-  virtual void selection_changed(bool);
+  virtual void selection_changed(bool) Q_DECL_OVERRIDE;
 protected:
   friend struct Scene_surface_mesh_item_priv;
   Scene_surface_mesh_item_priv* d;


### PR DESCRIPTION
## Summary of Changes
Adds `Q_DECL_OVERRIDE` where it was missing to fix the clang warnings
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2026
* Feature/Small Feature (if any):

