### PR TITLE
Polyhedron demo: Reorganize selection plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -105,7 +105,7 @@ public:
     connect(ui_widget.validateButton, SIGNAL(clicked()), this, SLOT(on_validateButton_clicked()));
     connect(ui_widget.Expand_reduce_button, SIGNAL(clicked()), this, SLOT(on_Expand_reduce_button_clicked()));
     connect(ui_widget.Select_sharp_edges_button, SIGNAL(clicked()), this, SLOT(on_Select_sharp_edges_button_clicked()));
-    connect(ui_widget.modeBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_ModeBox_changed(int)));
+    connect(ui_widget.selectionOrEuler, SIGNAL(currentChanged(int)), this, SLOT(on_SelectionOrEuler_changed(int)));
     connect(ui_widget.editionBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_editionBox_changed(int)));
 
     ui_widget.Add_to_selection_button->hide();
@@ -149,7 +149,7 @@ public Q_SLOTS:
       connect(new_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
     connect(new_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
     scene->setSelectedItem(item_id);
-    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
+    on_SelectionOrEuler_changed(ui_widget.selectionOrEuler->currentIndex());
     if(last_mode == 0)
       on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
   }
@@ -293,7 +293,7 @@ public Q_SLOTS:
     // all other arrangements (putting inside selection_item_map), setting names etc,
     // other params (e.g. k_ring) will be set inside new_item_created
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
-    ui_widget.modeBox->setCurrentIndex(last_mode);
+    ui_widget.selectionOrEuler->setCurrentIndex(last_mode);
     connectItem(new_item);
   }
   void on_LassoCheckBox_changed(bool b)
@@ -580,7 +580,7 @@ public Q_SLOTS:
     return;
   }
 
-  void on_ModeBox_changed(int index)
+  void on_SelectionOrEuler_changed(int index)
   {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
     if(selection_item)
@@ -590,15 +590,11 @@ public Q_SLOTS:
     {
     //Selection mode
     case 0:
-      ui_widget.selection_groupBox->setVisible(true);
-      ui_widget.edition_groupBox->setVisible(false);
       Q_EMIT set_operation_mode(-1);
       on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
       break;
       //Edition mode
     case 1:
-      ui_widget.selection_groupBox->setVisible(false);
-      ui_widget.edition_groupBox->setVisible(true);
       Q_EMIT save_handleType();
       on_editionBox_changed(ui_widget.editionBox->currentIndex());
       break;
@@ -610,7 +606,7 @@ public Q_SLOTS:
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
     if(selection_item)
       selection_item->on_Ctrlz_pressed();
-    if(ui_widget.modeBox->currentIndex() == 0)
+    if(ui_widget.selectionOrEuler->currentIndex() == 0)
     {
       Q_EMIT set_operation_mode(-1);
     }
@@ -744,7 +740,7 @@ public Q_SLOTS:
       connect(selection_item,SIGNAL(simplicesSelected(CGAL::Three::Scene_item*)), scene_ptr, SLOT(setSelectedItem(CGAL::Three::Scene_item*)));
     connect(selection_item,SIGNAL(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)), this, SLOT(isCurrentlySelected(Scene_polyhedron_item_k_ring_selection*)));
     on_LassoCheckBox_changed(ui_widget.lassoCheckBox->isChecked());
-    on_ModeBox_changed(ui_widget.modeBox->currentIndex());
+    on_SelectionOrEuler_changed(ui_widget.selectionOrEuler->currentIndex());
     if(last_mode == 0)
       on_Selection_type_combo_box_changed(ui_widget.Selection_type_combo_box->currentIndex());
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -6,62 +6,77 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>508</width>
-    <height>713</height>
+    <width>597</width>
+    <height>334</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Selection</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QVBoxLayout" name="verticalLayout_6">
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,1">
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
-       <widget class="QComboBox" name="modeBox">
-        <item>
-         <property name="text">
-          <string>Selection Mode</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Edition Mode</string>
-         </property>
-        </item>
+       <widget class="QPushButton" name="Create_selection_item_button">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Create Selection Item</string>
+        </property>
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="QPushButton" name="Clear_all_button">
+        <property name="toolTip">
+         <string extracomment="Clear selection for All Types"/>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
+        <property name="text">
+         <string>Clear Selection Item</string>
         </property>
-       </spacer>
+       </widget>
       </item>
      </layout>
     </item>
     <item>
-     <widget class="QGroupBox" name="selection_groupBox">
-      <property name="title">
-       <string>Selection Operations</string>
+     <spacer name="verticalSpacer_3">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QGroupBox" name="groupBox">
-           <property name="title">
-            <string>Selection by Type</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_5">
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,0,0">
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QTabWidget" name="selectionOrEuler">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="tab_3">
+       <attribute name="title">
+        <string>Selection</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QTabWidget" name="tabWidget">
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <widget class="QWidget" name="tab">
+             <attribute name="title">
+              <string>Simplices</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
                 <item>
@@ -103,14 +118,27 @@
                </layout>
               </item>
               <item>
-               <widget class="QCheckBox" name="lassoCheckBox">
-                <property name="text">
-                 <string>Lasso</string>
+               <spacer name="verticalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
                 </property>
-               </widget>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,1,1">
+               <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1,0,1">
+                <item>
+                 <widget class="QCheckBox" name="lassoCheckBox">
+                  <property name="text">
+                   <string>Lasso</string>
+                  </property>
+                 </widget>
+                </item>
                 <item>
                  <spacer name="horizontalSpacer_3">
                   <property name="orientation">
@@ -146,448 +174,464 @@
                 </item>
                </layout>
               </item>
+              <item>
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <item>
+                 <widget class="QRadioButton" name="Insertion_radio_button">
+                  <property name="text">
+                   <string>Insertion</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="Removal_radio_button">
+                  <property name="text">
+                   <string>Removal</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>Brush &amp;size:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>Brush_size_spin_box</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="Brush_size_spin_box"/>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_2">
+             <attribute name="title">
+              <string>Components</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_3">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Threshold:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>Threshold_size_spin_box</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="Threshold_size_spin_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximum">
+                   <number>999999999</number>
+                  </property>
+                  <property name="value">
+                   <number>8</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="Get_minimum_button">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>&amp;Get Minimum</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="Select_isolated_components_button">
+                <property name="text">
+                 <string>Select &amp;Isolated Components Below Threshold</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <widget class="QLabel" name="label_6">
+                  <property name="text">
+                   <string>Sharp edges angle:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="Sharp_angle_spinbox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximum">
+                   <number>180</number>
+                  </property>
+                  <property name="value">
+                   <number>60</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="Select_sharp_edges_button">
+                  <property name="text">
+                   <string>Select</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <spacer name="verticalSpacer_10">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <item>
+               <widget class="QPushButton" name="Expand_reduce_button">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Expand/Reduce</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="Expand_reduce_spin_box">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimum">
+                 <number>-50</number>
+                </property>
+                <property name="maximum">
+                 <number>50</number>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_2">
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_2">
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout">
-                  <item>
-                   <widget class="QRadioButton" name="Insertion_radio_button">
-                    <property name="text">
-                     <string>Insertion</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QRadioButton" name="Removal_radio_button">
-                    <property name="text">
-                     <string>Removal</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_6">
-                    <item>
-                     <widget class="QLabel" name="label">
-                      <property name="text">
-                       <string>Brush &amp;size:</string>
-                      </property>
-                      <property name="buddy">
-                       <cstring>Brush_size_spin_box</cstring>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSpinBox" name="Brush_size_spin_box"/>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_3">
-                <item>
-                 <widget class="QPushButton" name="Select_all_button">
-                  <property name="toolTip">
-                   <string extracomment="Select all simplices of Selection Type"/>
-                  </property>
-                  <property name="text">
-                   <string>Select &amp;All</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="Inverse_selection_button">
-                  <property name="toolTip">
-                   <string extracomment="Invert selection for Selection Type"/>
-                  </property>
-                  <property name="text">
-                   <string>Invert Selection</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="Clear_button">
-                  <property name="toolTip">
-                   <string extracomment="Clear selection for Selection Type"/>
-                  </property>
-                  <property name="text">
-                   <string>&amp;Clear</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
+             <widget class="QPushButton" name="Clear_button">
+              <property name="toolTip">
+               <string extracomment="Clear selection for Selection Type"/>
+              </property>
+              <property name="text">
+               <string>&amp;Clear</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="Inverse_selection_button">
+              <property name="toolTip">
+               <string extracomment="Invert selection for Selection Type"/>
+              </property>
+              <property name="text">
+               <string>Invert Selection</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="Select_all_button">
+              <property name="toolTip">
+               <string extracomment="Select all simplices of Selection Type"/>
+              </property>
+              <property name="text">
+               <string>Select &amp;All</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,0">
+          <item>
+           <widget class="QComboBox" name="operationsBox">
+            <item>
+             <property name="text">
+              <string>Create Point Set Item from Selected Vertices</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Create Polyline Item from Selected Edges</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Create Polyhedron Item from Selected Facets</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Erase Selected Facets from Polyhedron Item</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Keep Connected Components of Selected Facets</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Convert from Edge Selection to Facets Selection</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Convert from Edge Selection to Point Selection</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Convert from Facet Selection to Boundary Edge Selection</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Convert from Facet Selection to Point Selection</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="validateButton">
+            <property name="text">
+             <string>Validate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_5">
+       <attribute name="title">
+        <string>Edition</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="edition_groupBox">
+          <property name="title">
+           <string>Euler Operations</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_8">
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <spacer name="verticalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0,1,0,0">
              <item>
-              <widget class="QLabel" name="label_3">
+              <widget class="QComboBox" name="editionBox">
+               <item>
+                <property name="text">
+                 <string>Join vertex</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Split vertex</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Split edges</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Join face</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Split face</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Collapse edge</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Flip edge</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Add center vertex</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Remove center vertex</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Add vertex and face to border (Advanced)</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Add face to border (Advanced)</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Move point</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="instructionsLabel">
                <property name="text">
-                <string>Isolated &amp;Component Size:</string>
-               </property>
-               <property name="buddy">
-                <cstring>Threshold_size_spin_box</cstring>
+                <string>Instructions 
+
+</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QSpinBox" name="Threshold_size_spin_box">
-               <property name="maximum">
-                <number>999999999</number>
-               </property>
-               <property name="value">
-                <number>8</number>
+              <widget class="QLabel" name="docImage_Label">
+               <property name="text">
+                <string/>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="Get_minimum_button">
+              <widget class="QLabel" name="label_4">
                <property name="text">
-                <string>&amp;Get Minimum</string>
+                <string>Ctrl+Z to cancel the temporary selection.</string>
                </property>
               </widget>
              </item>
             </layout>
            </item>
-           <item>
-            <widget class="QPushButton" name="Select_isolated_components_button">
-             <property name="text">
-              <string>Select &amp;Isolated Components Below Threshold</string>
-             </property>
-            </widget>
-           </item>
           </layout>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_1">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
-           <item>
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Sharp edges angle:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="Sharp_angle_spinbox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximum">
-              <number>180</number>
-             </property>
-             <property name="value">
-              <number>60</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="Select_sharp_edges_button">
-             <property name="text">
-              <string>Select</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Expand or reduce selection:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="Expand_reduce_spin_box">
-             <property name="minimum">
-              <number>-50</number>
-             </property>
-             <property name="maximum">
-              <number>50</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="Expand_reduce_button">
-             <property name="text">
-              <string>Apply</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,0">
-           <item>
-            <widget class="QComboBox" name="operationsBox">
-             <item>
-              <property name="text">
-               <string>Create Point Set Item from Selected Vertices</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Create Polyline Item from Selected Edges</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Create Polyhedron Item from Selected Facets</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Erase Selected Facets from Polyhedron Item</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Keep Connected Components of Selected Facets</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Convert from Edge Selection to Facets Selection</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Convert from Edge Selection to Point Selection</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Convert from Facet Selection to Boundary Edge Selection</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Convert from Facet Selection to Point Selection</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="validateButton">
-             <property name="text">
-              <string>Validate</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-      </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-       <widget class="QPushButton" name="Create_selection_item_button">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Create Selection Item</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="Clear_all_button">
-        <property name="toolTip">
-         <string extracomment="Clear selection for All Types"/>
-        </property>
-        <property name="text">
-         <string>Clear Selection Item</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="edition_groupBox">
-      <property name="title">
-       <string>Editions Operations</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_8">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0,1,0,0">
-         <item>
-          <widget class="QComboBox" name="editionBox">
-           <item>
-            <property name="text">
-             <string>Join vertex</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Split vertex</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Split edges</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Join face</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Split face</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Collapse edge</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Flip edge</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Add center vertex</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Remove center vertex</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Add vertex and face to border (Advanced)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Add face to border (Advanced)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Move point</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="instructionsLabel">
-           <property name="text">
-            <string>Instructions 
-
-</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="docImage_Label">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Ctrl+Z to cancel the temporary selection.</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <spacer name="verticalSpacer_4">
+     <spacer name="verticalSpacer">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>


### PR DESCRIPTION
The selection plugin is overly long and usually makes the left column way to high.

## Summary of Changes

__Note: this PR is not ready to merge, I'm creating it so we can discuss it.__

Using tab widgets and moving stuff around, I managed to reduce the height by about 50%. It's a bit wider than before, but as screens are mainly 16/9 now, I think it's less of an issue.

The main problem remaining is the Euler operations: because of the images, the height becomes really important when clicking on the tab. Note that before, there was a bug when switching back to selection mode (the widget was dropping to the bottom) that is fixed, but now there's a bug when switching to edition mode (the widget goes over the bottom bar).

Is there a reason why this Euler operation is not in a different widget? It seems to me that there should even be two separated actions (one for Selection, one for Edition) that each raises its own widget. I understand that both share a code about selection, but that seems counter-intuitive to go to Selection to actually use the Euler operations.

## Release Management

* Affected package(s): Polyhedron demo

