### PR TITLE
Improve deprecation_warning.h and fix some missing / improper deprecated macros

### DIFF
--- a/Alpha_shapes_2/include/CGAL/Weighted_alpha_shape_euclidean_traits_2.h
+++ b/Alpha_shapes_2/include/CGAL/Weighted_alpha_shape_euclidean_traits_2.h
@@ -24,12 +24,15 @@
 
 #include <CGAL/license/Alpha_shapes_2.h>
 
+// temporarily silenced
+/*
 #define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_alpha_shape_euclidean_traits_2.h>"
 #define CGAL_REPLACEMENT_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
 #define CGAL_DEPRECATED_MESSAGE_DETAILS \
   "The class Weighted_alpha_shape_euclidean_traits_2<K> is deprecated in favor of "\
   "Regular_triangulation_euclidean_traits_2<K>."
 #include <CGAL/internal/deprecation_warning.h>
+*/
 
 #include <CGAL/Regular_triangulation_euclidean_traits_2.h>
 

--- a/Alpha_shapes_2/include/CGAL/Weighted_alpha_shape_euclidean_traits_2.h
+++ b/Alpha_shapes_2/include/CGAL/Weighted_alpha_shape_euclidean_traits_2.h
@@ -24,16 +24,16 @@
 
 #include <CGAL/license/Alpha_shapes_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_alpha_shape_euclidean_traits_2.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The class Weighted_alpha_shape_euclidean_traits_2<K> is deprecated in favor of "\
+  "Regular_triangulation_euclidean_traits_2<K>."
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Regular_triangulation_euclidean_traits_2.h>
 
 namespace CGAL {
-
-//------------------ Traits class -------------------------------------
-
-#ifdef CGAL_NO_DEPRECATED_CODE
-#error The class Weighted_alpha_shape_euclidean_traits_2<K> is deprecated in favor of Regular_triangulation_euclidean_traits_2<K>.
-#endif
 
 template< class R >
 class Weighted_alpha_shape_euclidean_traits_2 : public

--- a/Alpha_shapes_3/include/CGAL/Weighted_alpha_shape_euclidean_traits_3.h
+++ b/Alpha_shapes_3/include/CGAL/Weighted_alpha_shape_euclidean_traits_3.h
@@ -23,12 +23,15 @@
 
 #include <CGAL/license/Alpha_shapes_3.h>
 
+// temporarily silenced
+/*
 #define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_alpha_shape_euclidean_traits_3.h>"
 #define CGAL_REPLACEMENT_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
 #define CGAL_DEPRECATED_MESSAGE_DETAILS \
   "The class Weighted_alpha_shape_euclidean_traits_3<K> is deprecated in favor of "\
   "Regular_triangulation_euclidean_traits_3<K>."
 #include <CGAL/internal/deprecation_warning.h>
+*/
 
 #include <CGAL/Regular_triangulation_euclidean_traits_3.h>
 

--- a/Alpha_shapes_3/include/CGAL/Weighted_alpha_shape_euclidean_traits_3.h
+++ b/Alpha_shapes_3/include/CGAL/Weighted_alpha_shape_euclidean_traits_3.h
@@ -23,18 +23,16 @@
 
 #include <CGAL/license/Alpha_shapes_3.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_alpha_shape_euclidean_traits_3.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The class Weighted_alpha_shape_euclidean_traits_3<K> is deprecated in favor of "\
+  "Regular_triangulation_euclidean_traits_3<K>."
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Regular_triangulation_euclidean_traits_3.h>
 
 namespace CGAL {
-
-
-   
-//------------------ Traits class -------------------------------------
-
-#ifdef CGAL_NO_DEPRECATED_CODE
-#error The class Weighted_alpha_shape_euclidean_traits_3<K> is deprecated in favor of Regular_triangulation_euclidean_traits_3<K>.
-#endif
 
 template <class K>
 class Weighted_alpha_shape_euclidean_traits_3 : public 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_face_map.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_face_map.h
@@ -23,17 +23,15 @@
 
 #include <CGAL/license/Arrangement_on_surface_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Arr_face_map.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Arr_face_index_map.h>"
+#include <CGAL/internal/deprecation_warning.h>
+
+#include <CGAL/Arr_face_index_map.h>
 
 /*! \file
  * Definition of the Arr_face_index_map<Arrangement> class.
+
  */
-
-#if (defined __GNUC__)
-  #warning Arr_face_map.h is DEPRECATED, please include Arr_face_index_map.h instead
-#elif (defined _MSC_VER)
-  #pragma message("Arr_face_map.h is DEPRECATED, please include Arr_face_index_map.h instead")
-#endif
-
-#include <CGAL/Arr_face_index_map.h>
 
 #endif

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polyline_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Polyline_2.h
@@ -19,18 +19,17 @@
 
 #include <CGAL/license/Arrangement_on_surface_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Arr_geometry_traits/Polyline_2.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Arr_geometry_traits/Polycurve_2.h>"
+#include <CGAL/internal/deprecation_warning.h>
+
+#include <CGAL/Arr_geometry_traits/Polycurve_2.h>
 
 /*! \file
  * Header file for the polyline classes used by the
  * Arr_polycurve_basic_traits_2, Arr_polycurve_traits_2, and
  * Arr_polyline_traits_2 classes.
  */
-
-#if (defined __GNUC__)
-  #warning Polyline_2.h is DEPRECATED, please include Polycurve_2.h instead
-#elif (defined _MSC_VER)
-  #pragma message("Polyline_2.h is DEPRECATED, please include Polycurve_2.h instead")
-#endif
 
 #include <CGAL/Arr_geometry_traits/Polycurve_2.h>
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay.h
@@ -23,16 +23,15 @@
 
 #include <CGAL/license/Arrangement_on_surface_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Arr_overlay.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Arr_overlay_2.h>"
+#include <CGAL/internal/deprecation_warning.h>
+
+#include <CGAL/Arr_overlay_2.h>
 
 /*! \file
  * Helping file to include Arr_overlay_2 for backward compatibility.
  */
-
-#if (defined __GNUC__)
-  #warning Arr_overlay.h is DEPRECATED, please include Arr_overlay_2.h instead
-#elif (defined _MSC_VER)
-  #pragma message("Arr_overlay.h is DEPRECATED, please include Arr_overlay_2.h instead")
-#endif
 
 #include <CGAL/Arr_overlay_2.h>
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_vertex_map.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_vertex_map.h
@@ -24,16 +24,15 @@
 
 #include <CGAL/license/Arrangement_on_surface_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Arr_vertex_map.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Arr_vertex_index_map.h>"
+#include <CGAL/internal/deprecation_warning.h>
+
+#include <CGAL/Arr_vertex_index_map.h>
 
 /*! \file
  * Definition of the Arr_vertex_index_map<Arrangement> class.
  */
-
-#if (defined __GNUC__)
-  #warning Arr_vertex_map.h is DEPRECATED, please include Arr_vertex_index_map.h instead
-#elif (defined _MSC_VER)
-  #pragma message("Arr_vertex_map.h is DEPRECATED, please include Arr_vertex_index_map.h instead")
-#endif
 
 #include <CGAL/Arr_vertex_index_map.h>
 

--- a/Bounding_volumes/include/CGAL/Minimum_enclosing_quadrilateral_traits_2.h
+++ b/Bounding_volumes/include/CGAL/Minimum_enclosing_quadrilateral_traits_2.h
@@ -24,10 +24,11 @@
 
 #include <CGAL/license/Bounding_volumes.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Minimum_enclosing_quadrilateral_traits_2.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Min_quadrilateral_traits_2.h>"
+#include <CGAL/internal/deprecation_warning.h>
 
-#ifndef CGAL_NO_DEPRECATED_CODE
 #include <CGAL/Min_quadrilateral_traits_2.h>
-#endif // CGAL_NO_DEPRECATED_CODE
 
 #endif // ! (CGAL_MINIMUM_ENCLOSING_QUADRILATERAL_TRAITS_2_H)
 

--- a/Bounding_volumes/include/CGAL/minimum_enclosing_quadrilateral_2.h
+++ b/Bounding_volumes/include/CGAL/minimum_enclosing_quadrilateral_2.h
@@ -24,10 +24,11 @@
 
 #include <CGAL/license/Bounding_volumes.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/minimum_enclosing_quadrilateral_2.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/min_quadrilateral_2.h>"
+#include <CGAL/internal/deprecation_warning.h>
 
-#ifndef CGAL_NO_DEPRECATED_CODE
 #include <CGAL/min_quadrilateral_2.h>
-#endif // CGAL_NO_DEPRECATED_CODE
 
 #endif // ! (CGAL_MINIMUM_ENCLOSING_QUADRILATERAL_2_H)
 

--- a/CGAL_ipelets/examples/CGAL_ipelets/test_grabbers.cpp
+++ b/CGAL_ipelets/examples/CGAL_ipelets/test_grabbers.cpp
@@ -3,9 +3,6 @@
 #include <cassert>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polygon_2.h>
-#include <CGAL/Weighted_point.h>
-
-
 #include <CGAL/grabbers.h>
 
 typedef CGAL::Simple_cartesian<double> Kernel;

--- a/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v6.h
+++ b/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base_v6.h
@@ -29,7 +29,6 @@ typedef unsigned int uint;
 
 #include <ipelib.h>
 #include <CGAL/Polygon_2.h>
-#include <CGAL/Weighted_point.h>
 #include <CGAL/iterator.h>
 #include <CGAL/Triangulation_2.h>
 #include <CGAL/grabbers.h>

--- a/Convex_hull_d/include/CGAL/Convex_hull_d.h
+++ b/Convex_hull_d/include/CGAL/Convex_hull_d.h
@@ -32,7 +32,8 @@
 #include <CGAL/license/Convex_hull_d.h>
 
 #define CGAL_DEPRECATED_HEADER "<CGAL/Convex_hull_d.h>"
-#define CGAL_REPLACEMENT_HEADER "the Triangulation package (see http://doc.cgal.org/latest/Triangulation)"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The Triangulation package (see http://doc.cgal.org/latest/Triangulation) should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 /*{\Manpage {Convex_hull_d}{R}{Convex Hulls}{C}}*/

--- a/Convex_hull_d/include/CGAL/Convex_hull_d_to_polyhedron_3.h
+++ b/Convex_hull_d/include/CGAL/Convex_hull_d_to_polyhedron_3.h
@@ -24,7 +24,8 @@
 #include <CGAL/license/Convex_hull_d.h>
 
 #define CGAL_DEPRECATED_HEADER "<CGAL/Convex_hull_d_to_polyhedron_3.h>"
-#define CGAL_REPLACEMENT_HEADER "the Triangulation package (see http://doc.cgal.org/latest/Triangulation)"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The Triangulation package (see http://doc.cgal.org/latest/Triangulation) should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Convex_hull_d.h>

--- a/Convex_hull_d/include/CGAL/Convex_hull_d_traits_3.h
+++ b/Convex_hull_d/include/CGAL/Convex_hull_d_traits_3.h
@@ -24,7 +24,8 @@
 #include <CGAL/license/Convex_hull_d.h>
 
 #define CGAL_DEPRECATED_HEADER "<CGAL/Convex_hull_d_traits_3.h>"
-#define CGAL_REPLACEMENT_HEADER "the Triangulation package (see http://doc.cgal.org/latest/Triangulation)"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The Triangulation package (see http://doc.cgal.org/latest/Triangulation) should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Point_3.h>

--- a/Convex_hull_d/include/CGAL/Delaunay_d.h
+++ b/Convex_hull_d/include/CGAL/Delaunay_d.h
@@ -32,7 +32,8 @@
 #include <CGAL/license/Convex_hull_d.h>
 
 #define CGAL_DEPRECATED_HEADER "<CGAL/Delaunay_d.h>"
-#define CGAL_REPLACEMENT_HEADER "the Triangulation package (see http://doc.cgal.org/latest/Triangulation)"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The Triangulation package (see http://doc.cgal.org/latest/Triangulation) should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 /*{\Manpage {Delaunay_d}{R,Lifted_R}{Delaunay Triangulations}{DT}}*/

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -32,7 +32,8 @@
 #include <CGAL/license/Convex_hull_d.h>
 
 #define CGAL_DEPRECATED_HEADER "<CGAL/Regular_complex_d.h>"
-#define CGAL_REPLACEMENT_HEADER "the Triangulation package (see http://doc.cgal.org/latest/Triangulation)"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The Triangulation package (see http://doc.cgal.org/latest/Triangulation) should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/basic.h>

--- a/Envelope_2/include/CGAL/Env_default_diagram_1.h
+++ b/Envelope_2/include/CGAL/Env_default_diagram_1.h
@@ -24,6 +24,9 @@
 
 #include <CGAL/license/Envelope_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Env_default_diagram_1.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Envelope_diagram_1>"
+#include <CGAL/internal/deprecation_warning.h>
 
 #if (defined __GNUC__)
   #if !(defined __STRICT_ANSI__)

--- a/Installation/include/CGAL/internal/deprecation_warning.h
+++ b/Installation/include/CGAL/internal/deprecation_warning.h
@@ -12,44 +12,69 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
-// Author(s)     : Philipp Möller
+// Author(s)     : Philipp Möller, Mael Rouxel-Labbé
 
-// Including this header will issue a warning during compilation or
-// cause compilation to fail if CGAL_NO_DEPRECATED_CODE is defined.
-// CGAL_DEPRECATED_HEADER and CGAL_REPLACEMENT_HEADER can be defined
+// Including this header will cause compilation to fail
+// if CGAL_NO_DEPRECATED_CODE is defined. If this is not the case, it will issue
+// a warning during compilation unless CGAL_NO_DEPRECATION_WARNINGS.
+
+// CGAL_DEPRECATED_HEADER, CGAL_REPLACEMENT_HEADER, and
+// CGAL_DEPRECATED_MESSAGE_DETAILS can be defined
 // to a string literal to customize the warning.
-// CGAL_DEPRECATED_HEADER and CGAL_REPLACEMENT_HEADER are undefined,
-// after the file is included.  
+
+// CGAL_DEPRECATED_HEADER, CGAL_REPLACEMENT_HEADER, and
+// CGAL_DEPRECATED_MESSAGE_DETAILS are undefined after the file is included.
 
 // The lack of an include guard is intentional and necessary.
 
 #include <CGAL/assertions.h>
 
-#ifndef CGAL_NO_DEPRECATION_WARNINGS
-
+// whether to print Warning or Error
 #if defined(CGAL_NO_DEPRECATED_CODE)
-// No deprecated code.
-CGAL_static_assertion_msg(false, "A deprecated header has been included and CGAL_NO_DEPRECATED_CODE is defined.");
-#endif // CGAL_NO_DEPRECATED_CODE
-
-// Build the message
-#define CGAL_INTERNAL_DEPRECATED_MESSAGE "Warning: A deprecated header has been included."
-
-#if defined(CGAL_DEPRECATED_HEADER) && defined(CGAL_REPLACEMENT_HEADER)
-#  undef CGAL_INTERNAL_DEPRECATED_MESSAGE
-#  define CGAL_INTERNAL_DEPRECATED_MESSAGE "Warning: The header " CGAL_DEPRECATED_HEADER " is deprecated. " \
-                                           "Please use " CGAL_REPLACEMENT_HEADER " instead."
-#elif defined(CGAL_DEPRECATED_HEADER)
-#  undef CGAL_INTERNAL_DEPRECATED_MESSAGE
-#  define CGAL_INTERNAL_DEPRECATED_MESSAGE "Warning: The header " CGAL_DEPRECATED_HEADER " is deprecated."
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_STATUS "Error: "
+#  define CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE " and CGAL_NO_DEPRECATED_CODE is defined."
+#else
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_STATUS "Warning: "
+#  define CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE "."
 #endif
 
-// don't trigger on NO_DEPRECATIOON_WARNINGS and don't trigger twice on NO_DEPRECATED_CODE
-#if !defined(CGAL_NO_DEPRECATION_WARNINGS) && !defined(CGAL_NO_DEPRECATED_CODE)
+// if the name of the deprecated header is given, print it
+#if defined(CGAL_DEPRECATED_HEADER)
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
+     "The header `" CGAL_DEPRECATED_HEADER "` is deprecated"
+#else
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
+     "A deprecated header has been included"
+#endif
+
+// if a replacement header is given, print it
+#if defined(CGAL_REPLACEMENT_HEADER)
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS \
+            CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
+            CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE \
+            " Please use `" CGAL_REPLACEMENT_HEADER "` instead.\n"
+#else
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS \
+            CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
+            CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE "\n"
+#endif
+
+// if more details are given, print them
+#if defined(CGAL_DEPRECATED_MESSAGE_DETAILS)
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE \
+     CGAL_INTERNAL_DEPRECATED_MESSAGE_STATUS \
+     CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS \
+     "Additional information: "\
+     CGAL_DEPRECATED_MESSAGE_DETAILS
+#else
+#  define CGAL_INTERNAL_DEPRECATED_MESSAGE \
+     CGAL_INTERNAL_DEPRECATED_MESSAGE_STATUS \
+     CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS
+#endif
+
+#if defined(CGAL_NO_DEPRECATED_CODE) // No deprecated code.
+CGAL_static_assertion_msg(false, CGAL_INTERNAL_DEPRECATED_MESSAGE);
+#elif !defined(CGAL_NO_DEPRECATION_WARNINGS) // don't trigger on NO_DEPRECATION_WARNINGS
 #  if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__DMC__)
 #    pragma message (CGAL_INTERNAL_DEPRECATED_MESSAGE)
 #  elif defined(__GNUC__) || defined(__HP_aCC) || defined(__SUNPRO_CC) || defined(__IBMCPP__)
@@ -59,7 +84,15 @@ CGAL_static_assertion_msg(false, "A deprecated header has been included and CGAL
 #  endif //defined
 #endif
 
-#endif // CGAL_NO_DEPRECATION_WARNINGS
+// those macros have been defined in all cases
+#undef CGAL_INTERNAL_DEPRECATED_MESSAGE_STATUS
+#undef CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER
+#undef CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS
+#undef CGAL_INTERNAL_DEPRECATED_MESSAGE
+
+#if defined(CGAL_DEPRECATED_MESSAGE_DETAILS)
+#  undef CGAL_DEPRECATED_MESSAGE_DETAILS
+#endif
 
 #if defined(CGAL_DEPRECATED_HEADER)
 #  undef CGAL_DEPRECATED_HEADER
@@ -67,8 +100,4 @@ CGAL_static_assertion_msg(false, "A deprecated header has been included and CGAL
 
 #if defined(CGAL_REPLACEMENT_HEADER)
 #  undef CGAL_REPLACEMENT_HEADER
-#endif
-
-#if defined(CGAL_INTERNAL_DEPRECATED_MESSAGE)
-#  undef CGAL_INTERNAL_DEPRECATED_MESSAGE
 #endif

--- a/Mesh_3/benchmark/Mesh_3/StdAfx.h
+++ b/Mesh_3/benchmark/Mesh_3/StdAfx.h
@@ -274,7 +274,7 @@
 #include <CGAL/tuple.h>
 #include <CGAL/Unique_hash_map.h>
 #include <CGAL/utility.h>
-#include <CGAL/Weighted_point.h>
+//#include <CGAL/Weighted_point.h>
 
 // Mesh_3
 /*#include <CGAL_demo/Viewer.h>

--- a/Mesh_3/include/CGAL/Mesh_3/io_signature.h
+++ b/Mesh_3/include/CGAL/Mesh_3/io_signature.h
@@ -27,7 +27,6 @@
 #define CGAL_MESH_3_IO_H // the old include macro, tested by other files
 
 #include <CGAL/Point_3.h>
-#include <CGAL/Weighted_point.h>
 #include <CGAL/Weighted_point_3.h>
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_vertex_base_3.h>
@@ -169,14 +168,6 @@ struct Get_io_signature<Point_3<Kernel> >
 {
   std::string operator()() {
     return "Point_3";
-  }
-};
-
-template <class Point, typename FT>
-struct Get_io_signature<Weighted_point<Point, FT> >
-{
-  std::string operator()() {
-    return std::string("Weighted_point<") + Get_io_signature<Point>()() + ">";
   }
 };
 

--- a/Mesh_3/include/CGAL/Mesh_3/io_signature.h
+++ b/Mesh_3/include/CGAL/Mesh_3/io_signature.h
@@ -27,6 +27,7 @@
 #define CGAL_MESH_3_IO_H // the old include macro, tested by other files
 
 #include <CGAL/Point_3.h>
+#include <CGAL/Weighted_point.h>
 #include <CGAL/Weighted_point_3.h>
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_vertex_base_3.h>
@@ -168,6 +169,14 @@ struct Get_io_signature<Point_3<Kernel> >
 {
   std::string operator()() {
     return "Point_3";
+  }
+};
+
+template <class Point, typename FT>
+struct Get_io_signature<Weighted_point<Point, FT> >
+{
+  std::string operator()() {
+    return std::string("Weighted_point<") + Get_io_signature<Point>()() + ">";
   }
 };
 

--- a/Nef_2/include/CGAL/Nef_2/geninfo.h
+++ b/Nef_2/include/CGAL/Nef_2/geninfo.h
@@ -23,10 +23,9 @@
 
 #include <CGAL/license/Nef_2.h>
 
-
-
-//This file is deprecated and something like boost::any or boost::variant should 
-//be used instead
+#define CGAL_DEPRECATED_HEADER "<CGAL/Nef_2/geninfo.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "Something like boost::any or boost::variant should be used instead."
 #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/config.h>

--- a/Number_types/include/CGAL/known_bit_size_integers.h
+++ b/Number_types/include/CGAL/known_bit_size_integers.h
@@ -31,11 +31,9 @@
 #ifndef CGAL_KNOWN_BIT_SIZE_INTEGERS_H
 #define CGAL_KNOWN_BIT_SIZE_INTEGERS_H
 
-#if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__DMC__)
-#  pragma message ("Warning: This header is deprecated. Please use boost/cstdint.hpp instead")
-#elif defined(__GNUC__) || defined(__HP_aCC) || defined(__SUNPRO_CC) || defined(__IBMCPP__)
-#  warning "This header is deprecated. Please use boost/cstdint.hpp instead"
-#endif
+#define CGAL_DEPRECATED_HEADER "<CGAL/known_bit_size_integers.h>"
+#define CGAL_REPLACEMENT_HEADER "<boost/cstdint.hpp>"
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/number_type_basic.h>
 #include <boost/cstdint.hpp>

--- a/STL_Extension/include/CGAL/Fourtuple.h
+++ b/STL_Extension/include/CGAL/Fourtuple.h
@@ -27,6 +27,10 @@
 
 #include <CGAL/config.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Fourtuple.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS "Please use `CGAL::cpp11::array` instead."
+#include <CGAL/internal/deprecation_warning.h>
+
 #ifndef CGAL_NO_DEPRECATED_CODE
 
 namespace CGAL {

--- a/STL_Extension/include/CGAL/Sixtuple.h
+++ b/STL_Extension/include/CGAL/Sixtuple.h
@@ -27,6 +27,10 @@
 
 #include <CGAL/config.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Sixtuple.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS "Please use `CGAL::cpp11::array` instead."
+#include <CGAL/internal/deprecation_warning.h>
+
 #ifndef CGAL_NO_DEPRECATED_CODE
 
 namespace CGAL {

--- a/STL_Extension/include/CGAL/Threetuple.h
+++ b/STL_Extension/include/CGAL/Threetuple.h
@@ -27,6 +27,10 @@
 
 #include <CGAL/config.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Threetuple.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS "Please use `CGAL::cpp11::array` instead."
+#include <CGAL/internal/deprecation_warning.h>
+
 #ifndef CGAL_NO_DEPRECATED_CODE
 
 namespace CGAL {

--- a/STL_Extension/include/CGAL/Twotuple.h
+++ b/STL_Extension/include/CGAL/Twotuple.h
@@ -27,6 +27,10 @@
 
 #include <CGAL/config.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Twotuple.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS "Please use `CGAL::cpp11::array` instead."
+#include <CGAL/internal/deprecation_warning.h>
+
 #ifndef CGAL_NO_DEPRECATED_CODE
 
 namespace CGAL {

--- a/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
@@ -24,11 +24,11 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
-#ifdef CGAL_NO_DEPRECATED_CODE
-#error The class Regular_triangulation_euclidean_traits_2<K> is deprecated;
-       the kernel K can be used directly as traits since the weighted point and
-       the function objects for weighted points are part of the concept Kernel.
-#endif
+#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The kernel K can be used directly as traits since weighted points and "\
+  "the associated function objects are now part of the concept Kernel."
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/config.h>
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
@@ -27,14 +27,13 @@
 // Below will be decommented in a short bit, when implicit conversions are removed
 // and `Regular_triangulation_euclidean_traits_2` becomes empty
 
-// #define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
-// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
-//   "The kernel K can be used directly as traits since weighted points and "\
-//   "the associated function objects are now part of the concept Kernel."
-// #include <CGAL/internal/deprecation_warning.h>
-
-#include <CGAL/config.h>
-
+/*
+#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The kernel K can be used directly as traits since weighted points and "\
+  "the associated function objects are now part of the concept Kernel."
+#include <CGAL/internal/deprecation_warning.h>
+*/
 
 namespace CGAL { 
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
@@ -24,11 +24,14 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
-#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
-#define CGAL_DEPRECATED_MESSAGE_DETAILS \
-  "The kernel K can be used directly as traits since weighted points and "\
-  "the associated function objects are now part of the concept Kernel."
-#include <CGAL/internal/deprecation_warning.h>
+// Below will be decommented in a short bit, when implicit conversions are removed
+// and `Regular_triangulation_euclidean_traits_2` becomes empty
+
+// #define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_2.h>"
+// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
+//   "The kernel K can be used directly as traits since weighted points and "\
+//   "the associated function objects are now part of the concept Kernel."
+// #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/config.h>
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
@@ -24,6 +24,11 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
+#ifdef CGAL_NO_DEPRECATED_CODE
+#error The class Regular_triangulation_euclidean_traits_2<K> is deprecated;
+       the kernel K can be used directly as traits since the weighted point and
+       the function objects for weighted points are part of the concept Kernel.
+#endif
 
 #include <CGAL/config.h>
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_euclidean_traits_2.h
@@ -35,6 +35,8 @@
 #include <CGAL/internal/deprecation_warning.h>
 */
 
+#include <CGAL/config.h>
+
 namespace CGAL { 
 
 template < class R, class W = typename R::RT>

--- a/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2_filtered_projection_traits_3.h
@@ -24,11 +24,10 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
-
 #define CGAL_DEPRECATED_HEADER "<CGAL/Triangulation_2_filtered_projection_traits_3.h>"
 #define CGAL_REPLACEMENT_HEADER "<CGAL/Triangulation_2_projection_traits_3.h>"
 #include <CGAL/internal/deprecation_warning.h>
 
-#include <CGAL/internal/Triangulation_2_filtered_projection_traits_3.h>
+#include <CGAL/Triangulation_2_projection_traits_3.h>
 
 #endif // CGAL_TRIANGULATION_2_FILTERED_PROJECTION_TRAITS_3_H

--- a/Triangulation_2/include/CGAL/Weighted_point.h
+++ b/Triangulation_2/include/CGAL/Weighted_point.h
@@ -24,6 +24,11 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_point.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "Weighted points are now part of the concept Kernel. One should therefore "\
+  "use `CGAL::Weighted_point_2<K>` and `CGAL::Weighted_point_3<K>`."
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Dimension.h>

--- a/Triangulation_2/include/CGAL/Weighted_point.h
+++ b/Triangulation_2/include/CGAL/Weighted_point.h
@@ -24,11 +24,12 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
-#define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_point.h>"
-#define CGAL_DEPRECATED_MESSAGE_DETAILS \
-  "Weighted points are now part of the concept Kernel. One should therefore "\
-  "use `CGAL::Weighted_point_2<K>` and `CGAL::Weighted_point_3<K>`."
-#include <CGAL/internal/deprecation_warning.h>
+// Below is silenced until Surface_mesher is cleaned from Weighted_point.h
+// #define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_point.h>"
+// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
+//   "Weighted points are now part of the concept Kernel. One should therefore "\
+//   "use `CGAL::Weighted_point_2<K>` and `CGAL::Weighted_point_3<K>`."
+// #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Dimension.h>

--- a/Triangulation_2/include/CGAL/Weighted_point.h
+++ b/Triangulation_2/include/CGAL/Weighted_point.h
@@ -25,11 +25,13 @@
 #include <CGAL/license/Triangulation_2.h>
 
 // Below is silenced until Surface_mesher is cleaned from Weighted_point.h
-// #define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_point.h>"
-// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
-//   "Weighted points are now part of the concept Kernel. One should therefore "\
-//   "use `CGAL::Weighted_point_2<K>` and `CGAL::Weighted_point_3<K>`."
-// #include <CGAL/internal/deprecation_warning.h>
+/*
+#define CGAL_DEPRECATED_HEADER "<CGAL/Weighted_point.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+   "Weighted points are now part of the concept Kernel. One should therefore "\
+   "use `CGAL::Weighted_point_2<K>` and `CGAL::Weighted_point_3<K>`."
+#include <CGAL/internal/deprecation_warning.h>
+*/
 
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Dimension.h>

--- a/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
@@ -24,15 +24,13 @@
 
 #include <CGAL/license/Triangulation_3.h>
 
-#ifdef CGAL_NO_DEPRECATED_CODE
-#error The class Regular_triangulation_euclidean_traits_3<K> is deprecated;
-       the kernel K can be used directly as traits since the weighted point and
-       the function objects for weighted points are part of the concept Kernel.
-#endif
+#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The kernel K can be used directly as traits since weighted points and "\
+  "the associated function objects are now part of the concept Kernel."
+#include <CGAL/internal/deprecation_warning.h>
 
 namespace CGAL {
-
-
 
 template < class K_, class Weight = typename K_::RT >
 class Regular_triangulation_euclidean_traits_3

--- a/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
@@ -24,11 +24,14 @@
 
 #include <CGAL/license/Triangulation_3.h>
 
-#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
-#define CGAL_DEPRECATED_MESSAGE_DETAILS \
-  "The kernel K can be used directly as traits since weighted points and "\
-  "the associated function objects are now part of the concept Kernel."
-#include <CGAL/internal/deprecation_warning.h>
+// Below will be decommented in a short bit, when implicit conversions are removed
+// and `Regular_triangulation_euclidean_traits_3` becomes empty
+
+// #define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
+// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
+//   "The kernel K can be used directly as traits since weighted points and "\
+//   "the associated function objects are now part of the concept Kernel."
+// #include <CGAL/internal/deprecation_warning.h>
 
 namespace CGAL {
 

--- a/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
@@ -27,11 +27,13 @@
 // Below will be decommented in a short bit, when implicit conversions are removed
 // and `Regular_triangulation_euclidean_traits_3` becomes empty
 
-// #define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
-// #define CGAL_DEPRECATED_MESSAGE_DETAILS \
-//   "The kernel K can be used directly as traits since weighted points and "\
-//   "the associated function objects are now part of the concept Kernel."
-// #include <CGAL/internal/deprecation_warning.h>
+/*
+#define CGAL_DEPRECATED_HEADER "<CGAL/Regular_triangulation_euclidean_traits_3.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "The kernel K can be used directly as traits since weighted points and "\
+  "the associated function objects are now part of the concept Kernel."
+#include <CGAL/internal/deprecation_warning.h>
+*/
 
 namespace CGAL {
 

--- a/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_euclidean_traits_3.h
@@ -24,6 +24,11 @@
 
 #include <CGAL/license/Triangulation_3.h>
 
+#ifdef CGAL_NO_DEPRECATED_CODE
+#error The class Regular_triangulation_euclidean_traits_3<K> is deprecated;
+       the kernel K can be used directly as traits since the weighted point and
+       the function objects for weighted points are part of the concept Kernel.
+#endif
 
 namespace CGAL {
 

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -23,6 +23,8 @@
 
 #include <CGAL/license/Triangulation_3.h>
 
+// #define CGAL_DEPRECATED_HEADER "<CGAL/Triangulation_hierarchy_3.h>"
+// #include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/basic.h>
 #include <CGAL/triangulation_assertions.h>


### PR DESCRIPTION
## Summary of Changes

[This commit](https://github.com/CGAL/cgal/commit/6d13fa2c3178dfecd30b04bcefc5861304466ce8) and other commits deprecated Regular_triangulation_euclidean_traits, but the macros `CGAL_NO_DEPRECATED_CODE` are missing in the files.

## Release Management

* Affected package(s): Triangulation_2/3
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

