### PR TITLE
Fix a few typos in the documentation

### DIFF
--- a/AABB_tree/doc/AABB_tree/aabb_tree.txt
+++ b/AABB_tree/doc/AABB_tree/aabb_tree.txt
@@ -37,7 +37,7 @@ Each primitive gives access to both one input geometric object
 example primitive wraps a 3D triangle as datum and a face handle of a
 polyhedral surface as id. Each intersection query can return the
 intersection objects (e.g., 3D points or segments for ray queries) as
-well the as id (here the face handle) of the intersected
+well as the id (here the face handle) of the intersected
 primitives. Similarly, each distance query can return the closest
 point from the point query as well as the id of the closest primitive.
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
@@ -401,7 +401,7 @@ public:
     NT          y3 = p3.y();
 
 
-    // Make sure that the source and the taget are not the same.
+    // Make sure that the source and the target are not the same.
     CGAL_precondition (Kernel().compare_xy_2_object() (p1, p3) != EQUAL);
 
     // Compute the lines: A1*x + B1*y + C1 = 0,
@@ -532,7 +532,7 @@ public:
 
   /*!
    * Get the vertical tangency points the arc contains.
-   * \param vpts Output: The vertical tagnecy points.
+   * \param vpts Output: The vertical tangency points.
    * \pre The curve is circular.
    * \return The number of points (0, 1, or 2).
    */
@@ -593,8 +593,8 @@ private:
 
   /*!
    * Get the vertical tangency points the arc contains, assuming it is
-   * counterclockwise oreinted.
-   * \param vpts Output: The vertical tagnecy points.
+   * counterclockwise oriented.
+   * \param vpts Output: The vertical tangency points.
    * \return The number of points (0, 1, or 2).
    */
   unsigned int _ccw_vertical_tangency_points (const Point_2& src,

--- a/Boolean_set_operations_2/examples/Boolean_set_operations_2/circle_segment.cpp
+++ b/Boolean_set_operations_2/examples/Boolean_set_operations_2/circle_segment.cpp
@@ -43,7 +43,7 @@ Polygon_2 construct_polygon (const Circle_2& circle)
   return pgn;
 }
 
-// Construct a point from a rectangle.
+// Construct a polygon from a rectangle.
 Polygon_2 construct_polygon (const Point_2& p1, const Point_2& p2,
                              const Point_2& p3, const Point_2& p4)
 {

--- a/Kernel_23/doc/Kernel_23/CGAL/Filtered_kernel.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Filtered_kernel.h
@@ -54,7 +54,7 @@ namespace CGAL {
 \ingroup kernel_classes
 
 `Filtered_kernel` is a kernel that uses a filtering technique based
-on interval arithmetic from to achieve exact and efficient predicates.
+on interval arithmetic form to achieve exact and efficient predicates.
 It is based on \cgalCite{cgal:bbp-iayed-01}. In addition, a few selected important
 predicates are implemented using the formally proved, semi-static, filtering
 techniques from \cgalCite{cgal:mp-fcafg-05}.

--- a/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/Polygon_triangulation_decomposition_2.h
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/Polygon_triangulation_decomposition_2.h
@@ -4,7 +4,7 @@ namespace CGAL {
 \ingroup PkgMinkowskiSum2
 
 The `Polygon_triangulation_decomposition_2` class implements a convex
-decompostion of a polygon or a polygon with holes into triangles using
+decomposition of a polygon or a polygon with holes into triangles using
 the Delaunay constrained triangulation functionality of the
 \ref Chapter_2D_Triangulations "2D Triangulation" package.
 

--- a/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/Polygon_triangulation_decomposition_2.h
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/CGAL/Polygon_triangulation_decomposition_2.h
@@ -4,8 +4,8 @@ namespace CGAL {
 \ingroup PkgMinkowskiSum2
 
 The `Polygon_triangulation_decomposition_2` class implements a convex
-decompistion of a polygon or a polygon with holes into triangles using
-the Delaunay contrained triangulation functionality of the
+decompostion of a polygon or a polygon with holes into triangles using
+the Delaunay constrained triangulation functionality of the
 \ref Chapter_2D_Triangulations "2D Triangulation" package.
 
 \cgalModels `PolygonWithHolesConvexDecomposition_2`


### PR DESCRIPTION
## Summary of Changes

Just a few typo fixes that i have accumulated while reading the online documentation

## Release Management

* Affected package(s): AABB_tree, Arrangement_on_surface_2,  Boolean_set_operations_2,  Kernel_23 and  Minkowski_sum_2

