### PR TITLE
[WIP] GraphicsView: Add General_polygon_2 to QPainterPath converter. …

### DIFF
--- a/GraphicsView/include/CGAL/Qt/Converter.h
+++ b/GraphicsView/include/CGAL/Qt/Converter.h
@@ -24,9 +24,11 @@
 #include <CGAL/license/GraphicsView.h>
 
 
+#include <QtMath>
 #include <QPointF>
 #include <QLineF>
 #include <QRectF>
+#include <QPainterPath>
 #include <QPolygonF>
 #include <list>
 
@@ -181,6 +183,52 @@ public:
     for(int i = 0; i < qp.size(); i++){
       p.push_back(operator()(qp[i]));
     }
+  }
+
+  template < typename T >
+  QPainterPath operator()(const typename CGAL::General_polygon_2< T > &pgn) const
+  {
+    typedef typename CGAL::General_polygon_2< T > CGAL_Polygon_2;
+    typedef typename CGAL_Polygon_2::Curve_const_iterator        CGAL_Curve_const_iterator;
+    typedef typename CGAL_Polygon_2::X_monotone_curve_2          CGAL_X_monotone_curve_2;
+
+    QPainterPath result;
+
+    CGAL_Curve_const_iterator current = pgn.curves_begin();
+    CGAL_Curve_const_iterator end = pgn.curves_end();
+
+    result.moveTo(QPointF(CGAL::to_double(current->source().x()),
+                          CGAL::to_double(current->source().y())));
+
+    do {
+      const CGAL_X_monotone_curve_2 &curve = *current;
+      const QPointF target = QPointF(CGAL::to_double(curve.target().x()),
+                                     CGAL::to_double(curve.target().y()));
+
+      if (curve.is_linear()) {
+        result.lineTo(target);
+      }
+      else if (curve.is_circular()) {
+        const bool isClockwise = (curve.supporting_circle().orientation() == CGAL::CLOCKWISE);
+        const QRectF rect = operator()(curve.supporting_circle().bbox());
+        const QPointF center = QPointF(CGAL::to_double(curve.supporting_circle().center().x()),
+                                       CGAL::to_double(curve.supporting_circle().center().y()));
+        const QPointF source = QPointF(CGAL::to_double(curve.source().x()),
+                                       CGAL::to_double(curve.source().y()));
+        const QPointF p1 = source - center;
+        const QPointF p2 = target - center;
+        const double asource = qAtan2(p1.y(), p1.x());
+        const double atarget = qAtan2(p2.y(), p2.x());
+        double aspan = atarget - asource;
+        if (aspan < -CGAL_PI || (qFuzzyCompare(aspan, -CGAL_PI) && !isClockwise))
+            aspan += 2.0*CGAL_PI;
+        else if (aspan > CGAL_PI || (qFuzzyCompare(aspan, CGAL_PI) && isClockwise))
+            aspan -= 2.0*CGAL_PI;
+        result.arcTo(rect.normalized(), qRadiansToDegrees(-asource), qRadiansToDegrees(-aspan));
+      }
+    } while (++current != end);
+
+    return result;
   }
 
 };


### PR DESCRIPTION
## Summary of Changes

This adds a converter function to convert from General_polygon_2 to QPainterPath.

I couldn't get the template parameter right, eg, express the CGAL::General_polygon_2 concept that depends on the class template parameter K, without having to include `CGAL/General_polygon_2.h` directly.
I have tried to define it with:
```C++
template < template < typename K_> class  T> 
QPainterPath operator()(const typename T<K>::General_polygon_2 &pgn) const;
```
And using it this way:
```C++
typedef CGAL::Epeck                               Kernel;
typedef CGAL::Gps_circle_segment_traits_2<Kernel> Traits_2;
typedef Traits_2::General_polygon_2               Polygon_2;
typedef CGAL::Qt::Converter<Kernel>               QtConvert;

Polygon_2 pgn;
QtConverter convert;
QPainterPath path = convert(pgn);
```

I have tried other ways to define it, but in the best case, I always ended up with errors along 
"`template argument deduction/substitution failed`". The only other way around was to call the converter this way `convert.operator()<...>();` But I think this defeat the purpose of the functor approach of the converter...

I've marked this PR as 'WIP', as I am not sure how to solve this extra template parameter.
As well, do you want me to add an example code to the GraphicsView module? Eg, export to image (PNG), or maybe export to SVG?

## Release Management

* Affected package(s): GraphicsView
* Issue(s) solved (if any): fix #2021 

