### PR TITLE
PMP and SMS : improve examples with a (pre)condition

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -3,7 +3,8 @@
 #include <CGAL/Mesh_triangulation_3.h>
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
-
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/boost/graph/helpers.h>
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/refine_mesh_3.h>
@@ -45,7 +46,12 @@ int main(int argc, char*argv[])
     return EXIT_FAILURE;
   }
   input.close();
-   
+  
+  if (!CGAL::is_triangle_mesh(polyhedron)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Create domain
   Mesh_domain domain(polyhedron);
   
@@ -71,5 +77,5 @@ int main(int argc, char*argv[])
   medit_file.open("out_2.mesh");
   c3t3.output_to_medit(medit_file);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -41,6 +41,12 @@ int main(int argc, char*argv[])
     std::cerr << "Error: Cannot read file " <<  fname << std::endl;
     return EXIT_FAILURE;
   }
+
+  if (!CGAL::is_triangle_mesh(polyhedron)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Create domain
   Mesh_domain domain(polyhedron);
   
@@ -58,4 +64,6 @@ int main(int argc, char*argv[])
   // Output
   std::ofstream medit_file("out.mesh");
   c3t3.output_to_medit(medit_file);
+
+  return EXIT_SUCCESS;
 }

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_lipschitz_sizing.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_lipschitz_sizing.cpp
@@ -47,6 +47,12 @@ int main(int argc, char*argv[])
     std::cerr << "Error: Cannot read file " << fname << std::endl;
     return EXIT_FAILURE;
   }
+
+  if (!CGAL::is_triangle_mesh(polyhedron)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Create domain
   Mesh_domain domain(polyhedron);
 

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
@@ -31,6 +31,12 @@ int main()
   Polyhedron poly;
   std::ifstream input("data/lion-head.off");
   input >> poly;
+
+  if (!CGAL::is_triangle_mesh(poly)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Create a vector with only one element: the pointer to the polyhedron.
   std::vector<Polyhedron*> poly_ptrs_vector(1, &poly);
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -36,8 +36,8 @@ int main(int argc, char* argv[])
   std::ifstream input(filename);
 
   Mesh mesh;
-  if (!input || !(input >> mesh)) {
-    std::cerr << "Not a valid off file." << std::endl;
+  if (!input || !(input >> mesh) || !CGAL::is_triangle_mesh(mesh)) {
+    std::cerr << "Not a valid input file." << std::endl;
     return 1;
   }
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_slicer_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_slicer_example.cpp
@@ -25,8 +25,9 @@ int main(int argc, char* argv[])
   std::ifstream input(filename);
 
   Mesh mesh;
-  if (!input || !(input >> mesh) || mesh.is_empty()) {
-    std::cerr << "Not a valid off file." << std::endl;
+  if (!input || !(input >> mesh) || mesh.is_empty()
+             || !CGAL::is_triangle_mesh(mesh)) {
+    std::cerr << "Not a valid input file." << std::endl;
     return 1;
   }
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
@@ -34,9 +34,10 @@ int main(int argc, char* argv[])
   std::ifstream input(filename);
 
   Polyhedron poly;
-  if (!input || !(input >> poly) || poly.empty())
+  if (!input || !(input >> poly) || poly.empty()
+             || !CGAL::is_triangle_mesh(poly))
   {
-    std::cerr << "Not a valid off file." << std::endl;
+    std::cerr << "Not a valid input file." << std::endl;
     return 1;
   }
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
   OpenMesh::IO::read_mesh(mesh, filename);
   if (!CGAL::is_triangle_mesh(mesh))
   {
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
  
@@ -73,10 +73,10 @@ int main(int argc, char* argv[])
     if (res == CGAL::ON_BOUNDARY) { ++nb_boundary; }
   }
 
-  std::cerr << "Total query size: " << points.size() << std::endl;
-  std::cerr << "  " << nb_inside << " points inside " << std::endl;
-  std::cerr << "  " << nb_boundary << " points on boundary " << std::endl;
-  std::cerr << "  " << points.size() - nb_inside - nb_boundary << " points outside " << std::endl;
+  std::cout << "Total query size: " << points.size() << std::endl;
+  std::cout << "  " << nb_inside << " points inside " << std::endl;
+  std::cout << "  " << nb_boundary << " points on boundary " << std::endl;
+  std::cout << "  " << points.size() - nb_inside - nb_boundary << " points outside " << std::endl;
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
@@ -43,6 +43,11 @@ int main(int argc, char* argv[])
 
   Mesh mesh;
   OpenMesh::IO::read_mesh(mesh, filename);
+  if (!CGAL::is_triangle_mesh(mesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
  
   CGAL::Side_of_triangle_mesh<Mesh, K> inside(mesh);
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
@@ -48,8 +48,9 @@ int main(int argc, char* argv[])
   std::ifstream input(filename);
 
   Polyhedron poly;
-  if ( !input || !(input >> poly) || poly.empty() ) {
-    std::cerr << "Not a valid off file." << std::endl;
+  if ( !input || !(input >> poly) || poly.empty()
+              || !CGAL::is_triangle_mesh(poly)) {
+    std::cerr << "Not a valid input file." << std::endl;
     return 1;
   }
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/self_intersections_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/self_intersections_example.cpp
@@ -18,9 +18,9 @@ int main(int argc, char* argv[])
   std::ifstream input(filename);
 
   Mesh mesh;
-  if (!input || !(input >> mesh))
+  if (!input || !(input >> mesh) || !CGAL::is_triangle_mesh(mesh))
   {
-    std::cerr << "Not a valid off file." << std::endl;
+    std::cerr << "Not a valid input file." << std::endl;
     return 1;
   }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
   Polyhedron mesh;
   std::ifstream input("data/cactus.off");
   if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-    std::cout << "Input is not a triangle mesh" << std::endl;
+    std::cerr << "Input is not a triangle mesh" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
@@ -16,8 +16,8 @@ int main()
   // create and read Polyhedron
   Polyhedron mesh;
   std::ifstream input("data/cactus.off");
-  if ( !input || !(input >> mesh) || mesh.empty() ) {
-    std::cerr << "Not a valid off file." << std::endl;
+  if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
+    std::cerr << "Input is not a triangle mesh" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -48,4 +48,5 @@ int main()
       std::cout << sdf_property_map[facet_it] << " ";
   }
   std::cout << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
   Polyhedron mesh;
   std::ifstream input("data/cactus.off");
   if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-    std::cerr << "Input is not a triangle mesh" << std::endl;
+    std::cout << "Input is not a triangle mesh" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
@@ -27,7 +27,11 @@ int main(int argc, char** argv )
     OpenMesh::IO::read_mesh(mesh, argv[1]);
   else
     OpenMesh::IO::read_mesh(mesh, "data/cactus.off");
-
+ 
+  if (!CGAL::is_triangle_mesh(mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
   std::cout << "#F : " << num_faces(mesh) << std::endl;
   std::cout << "#H : " << num_halfedges(mesh) << std::endl;
   std::cout << "#V : " << num_vertices(mesh) << std::endl;
@@ -65,4 +69,5 @@ int main(int argc, char** argv )
   // Note that we can use the same SDF values (sdf_property_map) over and over again for segmentation.
   // This feature is relevant for segmenting the mesh several times with different parameters.
   CGAL::segmentation_from_sdf_values(mesh, sdf_property_map, segment_property_map, number_of_clusters, smoothing_lambda);
+  return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv )
     OpenMesh::IO::read_mesh(mesh, "data/cactus.off");
  
   if (!CGAL::is_triangle_mesh(mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << "#F : " << num_faces(mesh) << std::endl;

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_OpenMesh_example.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv )
     OpenMesh::IO::read_mesh(mesh, "data/cactus.off");
  
   if (!CGAL::is_triangle_mesh(mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << "#F : " << num_faces(mesh) << std::endl;

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
@@ -29,6 +29,10 @@ int main(int argc, char** argv )
     std::ifstream cactus("data/cactus.off");
     cactus >> mesh;
   }
+  if (!CGAL::is_triangle_mesh(mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
   typedef Mesh::Property_map<face_descriptor,double> Facet_double_map;
   Facet_double_map sdf_property_map;
 
@@ -62,4 +66,5 @@ int main(int argc, char** argv )
   // Note that we can use the same SDF values (sdf_property_map) over and over again for segmentation.
   // This feature is relevant for segmenting the mesh several times with different parameters.
   CGAL::segmentation_from_sdf_values(mesh, sdf_property_map, segment_property_map, number_of_clusters, smoothing_lambda);
+  return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv )
     cactus >> mesh;
   }
   if (!CGAL::is_triangle_mesh(mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input is not a triangle mesh" << std::endl;
     return EXIT_FAILURE;
   }
   typedef Mesh::Property_map<face_descriptor,double> Facet_double_map;

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv )
     cactus >> mesh;
   }
   if (!CGAL::is_triangle_mesh(mesh)){
-    std::cout << "Input is not a triangle mesh" << std::endl;
+    std::cerr << "Input is not a triangle mesh" << std::endl;
     return EXIT_FAILURE;
   }
   typedef Mesh::Property_map<face_descriptor,double> Facet_double_map;

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
@@ -16,8 +16,8 @@ int main()
     // create and read Polyhedron
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
-    if ( !input || !(input >> mesh) || mesh.empty() ) {
-      std::cerr << "Not a valid off file." << std::endl;
+    if ( !input || !(input >> mesh) || mesh.empty()  || ( !CGAL::is_triangle_mesh(mesh))) {
+      std::cerr << "Input is not a triangle mesh." << std::endl;
       return EXIT_FAILURE;
     }
 
@@ -54,4 +54,6 @@ int main()
     // This feature is relevant for segmenting the mesh several times with different parameters.
     CGAL::segmentation_from_sdf_values(
       mesh, sdf_property_map, segment_property_map, number_of_clusters, smoothing_lambda);
+
+    return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty()  || ( !CGAL::is_triangle_mesh(mesh))) {
-      std::cerr << "Input is not a triangle mesh." << std::endl;
+      std::cout << "Input is not a triangle mesh." << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty()  || ( !CGAL::is_triangle_mesh(mesh))) {
-      std::cout << "Input is not a triangle mesh." << std::endl;
+      std::cerr << "Input is not a triangle mesh." << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
@@ -16,7 +16,7 @@ int main()
     // create and read Polyhedron
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
-    if ( !input || !(input >> mesh) || mesh.empty() ) {
+    if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
         std::cerr << "Not a valid off file." << std::endl;
         return EXIT_FAILURE;
     }
@@ -37,4 +37,5 @@ int main()
         std::cout << segment_property_map[facet_it] << " ";
     }
     std::cout << std::endl;
+    return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-        std::cerr << "Not a valid off file." << std::endl;
+        std::cout << "Input is not a triangle mesh" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
@@ -17,7 +17,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-        std::cout << "Input is not a triangle mesh" << std::endl;
+        std::cerr << "Input is not a triangle mesh" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
@@ -39,7 +39,7 @@ int main()
     // create and read Polyhedron
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
-    if ( !input || !(input >> mesh) || mesh.empty() ) {
+    if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
       std::cerr << "Not a valid off file." << std::endl;
       return EXIT_FAILURE;
     }
@@ -76,4 +76,5 @@ int main()
         std::cout << segment_property_map[facet_it] << " ";
     }
     std::cout << std::endl;
+    return EXIT_SUCCESS;
 }

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
@@ -40,7 +40,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-      std::cout << "Input is not a triangle mesh" << std::endl;
+      std::cerr << "Input is not a triangle mesh" << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
@@ -40,7 +40,7 @@ int main()
     Polyhedron mesh;
     std::ifstream input("data/cactus.off");
     if ( !input || !(input >> mesh) || mesh.empty() || ( !CGAL::is_triangle_mesh(mesh)) ) {
-      std::cerr << "Not a valid off file." << std::endl;
+      std::cout << "Input is not a triangle mesh" << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
@@ -65,7 +65,7 @@ int main( int argc, char** argv )
     OpenMesh::IO::read_mesh(surface_mesh, "cube.off");
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -92,7 +92,7 @@ int main( int argc, char** argv )
              );
   
   surface_mesh.garbage_collection();
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << num_edges(surface_mesh) << " final edges.\n" ;
         
    OpenMesh::IO::write_mesh(surface_mesh, "out.off");

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
@@ -65,7 +65,7 @@ int main( int argc, char** argv )
     OpenMesh::IO::read_mesh(surface_mesh, "cube.off");
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_OpenMesh.cpp
@@ -63,6 +63,12 @@ int main( int argc, char** argv )
     OpenMesh::IO::read_mesh(surface_mesh, argv[1]);
   else
     OpenMesh::IO::read_mesh(surface_mesh, "cube.off");
+
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // For the pupose of the example we mark 10 edges as constrained edges
   edge_iterator b,e;
   int count=0;
@@ -86,12 +92,10 @@ int main( int argc, char** argv )
              );
   
   surface_mesh.garbage_collection();
-  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
             << num_edges(surface_mesh) << " final edges.\n" ;
         
    OpenMesh::IO::write_mesh(surface_mesh, "out.off");
   
-  return 0 ;      
+  return EXIT_SUCCESS;
 }
-
-// EOF //

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
@@ -23,7 +23,7 @@ int main( int argc, char** argv )
 {
   if (argc<3)
   {
-    std::cout << "Usage: " << argv[0] << " input.off minimal_edge_length [out.off]\n";
+    std::cerr << "Usage: " << argv[0] << " input.off minimal_edge_length [out.off]\n";
     return EXIT_FAILURE;
   }
 
@@ -33,7 +33,7 @@ int main( int argc, char** argv )
   double threshold = atof(argv[2]);
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
@@ -24,13 +24,18 @@ int main( int argc, char** argv )
   if (argc<3)
   {
     std::cerr << "Usage: " << argv[0] << " input.off minimal_edge_length [out.off]\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 
   Surface_mesh surface_mesh;
 
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   double threshold = atof(argv[2]);
+
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   int r = SMS::edge_collapse
             (surface_mesh
@@ -41,10 +46,10 @@ int main( int argc, char** argv )
                                .get_placement(SMS::Midpoint_placement<Surface_mesh>())
             );
 
-  std::cout << "\nFinished...\n" << r << " edges removed.\n"
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
   std::ofstream os( argc > 3 ? argv[3] : "out.off" ) ; os << surface_mesh ;
 
-  return 0 ;
+  return EXIT_SUCCESS ;
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
@@ -23,7 +23,7 @@ int main( int argc, char** argv )
 {
   if (argc<3)
   {
-    std::cerr << "Usage: " << argv[0] << " input.off minimal_edge_length [out.off]\n";
+    std::cout << "Usage: " << argv[0] << " input.off minimal_edge_length [out.off]\n";
     return EXIT_FAILURE;
   }
 
@@ -33,7 +33,7 @@ int main( int argc, char** argv )
   double threshold = atof(argv[2]);
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -46,7 +46,7 @@ int main( int argc, char** argv )
                                .get_placement(SMS::Midpoint_placement<Surface_mesh>())
             );
 
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
+  std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
   std::ofstream os( argc > 3 ? argv[3] : "out.off" ) ; os << surface_mesh ;

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
@@ -65,20 +65,20 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc < 2){
-    std::cerr << "Usage: " << argv[0] << " input.off [out.off]\n";
+    std::cout << "Usage: " << argv[0] << " input.off [out.off]\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr << "Filename provided is invalid\n";
+    std::cout << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -101,7 +101,7 @@ int main( int argc, char** argv )
   {
     halfedge_descriptor hd = halfedge(*eb,surface_mesh);
     if ( is_border(*eb,surface_mesh) ){
-      std::cerr << "border" << std::endl;
+      std::cout << "border" << std::endl;
       ++nb_sharp_edges;
       constraint_hmap[*eb]=true;
       constrained_edges[*eb]=std::make_pair(point(source(hd,surface_mesh),surface_mesh),
@@ -124,7 +124,7 @@ int main( int argc, char** argv )
   }
   cst_output.close();
 
-  std::cerr << "# sharp edges = " << nb_sharp_edges << std::endl;
+  std::cout << "# sharp edges = " << nb_sharp_edges << std::endl;
 
   // Contract the surface mesh as much as possible
   SMS::Count_stop_predicate<Surface_mesh> stop(0);
@@ -138,11 +138,11 @@ int main( int argc, char** argv )
                                          .get_placement(placement)
    );
 
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
+  std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << num_edges(surface_mesh) << " final edges.\n" ;
   std::ofstream os(argc > 2 ? argv[2] : "out.off") ; os << surface_mesh ;
 
-  std::cerr  << "Checking sharped edges were preserved...\n";
+  std::cout  << "Checking sharped edges were preserved...\n";
   // check sharp edges were preserved
   for(boost::tie(eb,ee) = edges(surface_mesh); eb != ee ; ++eb )
   {
@@ -166,10 +166,10 @@ int main( int argc, char** argv )
       }
     }
   }
-  std::cerr  << "OK\n";
-  std::cerr << "# sharp edges = " << nb_sharp_edges << std::endl;
+  std::cout  << "OK\n";
+  std::cout << "# sharp edges = " << nb_sharp_edges << std::endl;
 
-  std::cerr << "Check that no removable edge has been forgotten..." << std::endl;
+  std::cout << "Check that no removable edge has been forgotten..." << std::endl;
   r = SMS::edge_collapse(surface_mesh
                          ,stop
                          ,CGAL::parameters::vertex_index_map(get(CGAL::vertex_external_index, surface_mesh))
@@ -181,9 +181,9 @@ int main( int argc, char** argv )
   assert(r==0);
 
   if ( r==0 )
-    std::cerr  << "OK\n";
+    std::cout << "OK\n";
   else{
-    std::cerr  << "ERROR! " << r << " edges removed!\n";
+    std::cout << "ERROR! " << r << " edges removed!\n";
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
@@ -65,17 +65,22 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc < 2){
-    std::cerr<< "Usage: " << argv[0] << " input.off [out.off]\n";
-    return 1;
+    std::cerr << "Usage: " << argv[0] << " input.off [out.off]\n";
+    return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr<< "Filename provided is invalid\n";
-    return 1;
+    std::cerr << "Filename provided is invalid\n";
+    return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
+
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   Constrained_edge_map constraints_map(constraint_hmap);
   SMS::Constrained_placement<SMS::Midpoint_placement<Surface_mesh>,
@@ -133,11 +138,11 @@ int main( int argc, char** argv )
                                          .get_placement(placement)
    );
 
-  std::cout << "\nFinished...\n" << r << " edges removed.\n"
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
             << num_edges(surface_mesh) << " final edges.\n" ;
   std::ofstream os(argc > 2 ? argv[2] : "out.off") ; os << surface_mesh ;
 
-  std::cout  << "Checking sharped edges were preserved...\n";
+  std::cerr  << "Checking sharped edges were preserved...\n";
   // check sharp edges were preserved
   for(boost::tie(eb,ee) = edges(surface_mesh); eb != ee ; ++eb )
   {
@@ -161,10 +166,10 @@ int main( int argc, char** argv )
       }
     }
   }
-  std::cout  << "OK\n";
+  std::cerr  << "OK\n";
   std::cerr << "# sharp edges = " << nb_sharp_edges << std::endl;
 
-  std::cout << "Check that no removable edge has been forgotten..." << std::endl;
+  std::cerr << "Check that no removable edge has been forgotten..." << std::endl;
   r = SMS::edge_collapse(surface_mesh
                          ,stop
                          ,CGAL::parameters::vertex_index_map(get(CGAL::vertex_external_index, surface_mesh))
@@ -176,11 +181,11 @@ int main( int argc, char** argv )
   assert(r==0);
 
   if ( r==0 )
-    std::cout  << "OK\n";
+    std::cerr  << "OK\n";
   else{
-    std::cout  << "ERROR! " << r << " edges removed!\n";
-    return 1;
+    std::cerr  << "ERROR! " << r << " edges removed!\n";
+    return EXIT_FAILURE;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
@@ -65,20 +65,20 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc < 2){
-    std::cout << "Usage: " << argv[0] << " input.off [out.off]\n";
+    std::cerr << "Usage: " << argv[0] << " input.off [out.off]\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cout << "Filename provided is invalid\n";
+    std::cerr << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
 
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -101,7 +101,7 @@ int main( int argc, char** argv )
   {
     halfedge_descriptor hd = halfedge(*eb,surface_mesh);
     if ( is_border(*eb,surface_mesh) ){
-      std::cout << "border" << std::endl;
+      std::cerr << "border" << std::endl;
       ++nb_sharp_edges;
       constraint_hmap[*eb]=true;
       constrained_edges[*eb]=std::make_pair(point(source(hd,surface_mesh),surface_mesh),
@@ -124,7 +124,7 @@ int main( int argc, char** argv )
   }
   cst_output.close();
 
-  std::cout << "# sharp edges = " << nb_sharp_edges << std::endl;
+  std::cerr << "# sharp edges = " << nb_sharp_edges << std::endl;
 
   // Contract the surface mesh as much as possible
   SMS::Count_stop_predicate<Surface_mesh> stop(0);
@@ -167,7 +167,7 @@ int main( int argc, char** argv )
     }
   }
   std::cout  << "OK\n";
-  std::cout << "# sharp edges = " << nb_sharp_edges << std::endl;
+  std::cerr << "# sharp edges = " << nb_sharp_edges << std::endl;
 
   std::cout << "Check that no removable edge has been forgotten..." << std::endl;
   r = SMS::edge_collapse(surface_mesh

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
@@ -55,19 +55,19 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cout << "Usage: " << argv[0] << " input.off\n";
+    std::cerr << "Usage: " << argv[0] << " input.off\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cout << "Filename provided is invalid\n";
+    std::cerr << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
@@ -55,19 +55,19 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cerr << "Usage: " << argv[0] << " input.off\n";
+    std::cout << "Usage: " << argv[0] << " input.off\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr << "Filename provided is invalid\n";
+    std::cout << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -106,7 +106,7 @@ int main( int argc, char** argv )
                                .get_placement(Placement(bem))
             );
 
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
+  std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
@@ -55,17 +55,21 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cerr<< "Usage: " << argv[0] << " input.off\n";
-    return 1;
+    std::cerr << "Usage: " << argv[0] << " input.off\n";
+    return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr<< "Filename provided is invalid\n";
-    return 1;
+    std::cerr << "Filename provided is invalid\n";
+    return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // map used to check that constrained_edges and the points of its vertices
   // are preserved at the end of the simplification
@@ -102,7 +106,7 @@ int main( int argc, char** argv )
                                .get_placement(Placement(bem))
             );
 
-  std::cout << "\nFinished...\n" << r << " edges removed.\n"
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
@@ -121,5 +125,5 @@ int main( int argc, char** argv )
   }
   assert( nb_border_edges==0 );
 
-  return 0 ;
+  return EXIT_SUCCESS ;
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
@@ -59,19 +59,19 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cout << "Usage: " << argv[0] << " input.off\n";
+    std::cerr << "Usage: " << argv[0] << " input.off\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cout << "Filename provided is invalid\n";
+    std::cerr << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -113,7 +113,7 @@ int main( int argc, char** argv )
       --nb_border_edges;
       if(constrained_halfedges[hd] != std::make_pair(surface_mesh.point(source(hd,surface_mesh)),
                                                      surface_mesh.point(target(hd,surface_mesh)))){
-        std::cout << "oops. send us a bug report\n";
+        std::cerr << "oops. send us a bug report\n";
       }
 
     }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
@@ -59,19 +59,19 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cerr << "Usage: " << argv[0] << " input.off\n";
+    std::cout << "Usage: " << argv[0] << " input.off\n";
     return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr << "Filename provided is invalid\n";
+    std::cout << "Filename provided is invalid\n";
     return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -102,7 +102,7 @@ int main( int argc, char** argv )
                                .get_placement(Placement(bem))
             );
 
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
+  std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << surface_mesh.number_of_edges() << " final edges.\n" ;
 
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
@@ -113,7 +113,7 @@ int main( int argc, char** argv )
       --nb_border_edges;
       if(constrained_halfedges[hd] != std::make_pair(surface_mesh.point(source(hd,surface_mesh)),
                                                      surface_mesh.point(target(hd,surface_mesh)))){
-        std::cerr << "oops. send us a bug report\n";
+        std::cout << "oops. send us a bug report\n";
       }
 
     }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
@@ -59,18 +59,22 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
 
   if (argc!=2){
-    std::cerr<< "Usage: " << argv[0] << " input.off\n";
-    return 1;
+    std::cerr << "Usage: " << argv[0] << " input.off\n";
+    return EXIT_FAILURE;
   }
 
   std::ifstream is(argv[1]);
   if(!is){
-    std::cerr<< "Filename provided is invalid\n";
-    return 1;
+    std::cerr << "Filename provided is invalid\n";
+    return EXIT_FAILURE;
   }
 
   is >> surface_mesh  ;
-  
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
   Surface_mesh::Property_map<halfedge_descriptor,std::pair<Point_3, Point_3> > constrained_halfedges;
 
   constrained_halfedges = surface_mesh.add_property_map<halfedge_descriptor,std::pair<Point_3, Point_3> >("h:vertices").first;
@@ -98,7 +102,7 @@ int main( int argc, char** argv )
                                .get_placement(Placement(bem))
             );
 
-  std::cout << "\nFinished...\n" << r << " edges removed.\n"
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n"
             << surface_mesh.number_of_edges() << " final edges.\n" ;
 
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
@@ -116,5 +120,5 @@ int main( int argc, char** argv )
   }
   assert( nb_border_edges==0 );
 
-  return 0 ;
+  return EXIT_SUCCESS ;
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
@@ -123,6 +123,10 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh; 
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // The items in this polyhedron have an "id()" field 
   // which the default index maps used in the algorithm
@@ -167,7 +171,7 @@ int main( int argc, char** argv )
                               .visitor      (vis)
            );
   
-  std::cout << "\nEdges collected: "  << stats.collected
+  std::cerr << "\nEdges collected: "  << stats.collected
             << "\nEdges proccessed: " << stats.processed
             << "\nEdges collapsed: "  << stats.collapsed
             << std::endl
@@ -176,12 +180,11 @@ int main( int argc, char** argv )
             << "\nEdge not collapsed due to placement computation constraints: " << stats.placement_uncomputable 
             << std::endl ; 
             
-  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
   
-  return 0 ;      
+  return EXIT_SUCCESS ;      
 }
 
-// EOF //

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
@@ -70,7 +70,7 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
   void OnCollected( Profile const&, boost::optional<double> const& )
   {
     ++ stats->collected ;
-    std::cout << "\rEdges collected: " << stats->collected << std::flush ;
+    std::cerr << "\rEdges collected: " << stats->collected << std::flush ;
   }                
   
   // Called during the processing phase for each edge selected.
@@ -86,8 +86,8 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
       ++ stats->cost_uncomputable ;
       
     if ( current == initial )
-      std::cout << "\n" << std::flush ;
-    std::cout << "\r" << current << std::flush ;
+      std::cerr << "\n" << std::flush ;
+    std::cerr << "\r" << current << std::flush ;
   }                
   
   // Called during the processing phase for each edge being collapsed.
@@ -124,7 +124,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
@@ -70,7 +70,7 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
   void OnCollected( Profile const&, boost::optional<double> const& )
   {
     ++ stats->collected ;
-    std::cerr << "\rEdges collected: " << stats->collected << std::flush ;
+    std::cout << "\rEdges collected: " << stats->collected << std::flush ;
   }                
   
   // Called during the processing phase for each edge selected.
@@ -86,8 +86,8 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
       ++ stats->cost_uncomputable ;
       
     if ( current == initial )
-      std::cerr << "\n" << std::flush ;
-    std::cerr << "\r" << current << std::flush ;
+      std::cout << "\n" << std::flush ;
+    std::cout << "\r" << current << std::flush ;
   }                
   
   // Called during the processing phase for each edge being collapsed.
@@ -124,7 +124,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -171,7 +171,7 @@ int main( int argc, char** argv )
                               .visitor      (vis)
            );
   
-  std::cerr << "\nEdges collected: "  << stats.collected
+  std::cout << "\nEdges collected: "  << stats.collected
             << "\nEdges proccessed: " << stats.processed
             << "\nEdges collapsed: "  << stats.collapsed
             << std::endl
@@ -180,7 +180,7 @@ int main( int argc, char** argv )
             << "\nEdge not collapsed due to placement computation constraints: " << stats.placement_uncomputable 
             << std::endl ; 
             
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -25,6 +25,10 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh;
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // This is a stop predicate (defines when the algorithm terminates).
   // In this example, the simplification stops when the number of undirected edges
@@ -44,12 +48,10 @@ int main( int argc, char** argv )
                                .get_placement(SMS::Midpoint_placement<Surface_mesh>())
             );
   
-  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
   
-  return 0 ;      
+  return EXIT_SUCCESS ;      
 }
-
-// EOF //

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -26,7 +26,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -26,7 +26,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -48,7 +48,7 @@ int main( int argc, char** argv )
                                .get_placement(SMS::Midpoint_placement<Surface_mesh>())
             );
   
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
@@ -119,6 +119,10 @@ int main( int argc, char** argv )
   Surface_mesh surface_mesh; 
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
+  if (!CGAL::is_triangle_mesh(surface_mesh)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // In this example, the simplification stops when the number of undirected edges
   // drops below 10% of the initial count
@@ -141,7 +145,7 @@ int main( int argc, char** argv )
                               .visitor      (vis)
            );
   
-  std::cout << "\nEdges collected: "  << stats.collected
+  std::cerr << "\nEdges collected: "  << stats.collected
             << "\nEdges proccessed: " << stats.processed
             << "\nEdges collapsed: "  << stats.collapsed
             << std::endl
@@ -150,12 +154,10 @@ int main( int argc, char** argv )
             << "\nEdge not collapsed due to placement computation constraints: " << stats.placement_uncomputable 
             << std::endl ; 
             
-  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
             << num_edges(surface_mesh) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
   
-  return 0 ;      
+  return EXIT_SUCCESS ;      
 }
-
-// EOF //

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
@@ -66,7 +66,7 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
   void OnCollected( Profile const&, boost::optional<double> const& )
   {
     ++ stats->collected ;
-    std::cout << "\rEdges collected: " << stats->collected << std::flush ;
+    std::cerr << "\rEdges collected: " << stats->collected << std::flush ;
   }                
   
   // Called during the processing phase for each edge selected.
@@ -82,8 +82,8 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
       ++ stats->cost_uncomputable ;
       
     if ( current == initial )
-      std::cout << "\n" << std::flush ;
-    std::cout << "\r" << current << std::flush ;
+      std::cerr << "\n" << std::flush ;
+    std::cerr << "\r" << current << std::flush ;
   }                
   
   // Called during the processing phase for each edge being collapsed.
@@ -120,7 +120,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cout << "Input geometry is not triangulated." << std::endl;
+    std::cerr << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
@@ -66,7 +66,7 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
   void OnCollected( Profile const&, boost::optional<double> const& )
   {
     ++ stats->collected ;
-    std::cerr << "\rEdges collected: " << stats->collected << std::flush ;
+    std::cout << "\rEdges collected: " << stats->collected << std::flush ;
   }                
   
   // Called during the processing phase for each edge selected.
@@ -82,8 +82,8 @@ struct My_visitor : SMS::Edge_collapse_visitor_base<Surface_mesh>
       ++ stats->cost_uncomputable ;
       
     if ( current == initial )
-      std::cerr << "\n" << std::flush ;
-    std::cerr << "\r" << current << std::flush ;
+      std::cout << "\n" << std::flush ;
+    std::cout << "\r" << current << std::flush ;
   }                
   
   // Called during the processing phase for each edge being collapsed.
@@ -120,7 +120,7 @@ int main( int argc, char** argv )
   
   std::ifstream is(argv[1]) ; is >> surface_mesh ;
   if (!CGAL::is_triangle_mesh(surface_mesh)){
-    std::cerr << "Input geometry is not triangulated." << std::endl;
+    std::cout << "Input geometry is not triangulated." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -145,7 +145,7 @@ int main( int argc, char** argv )
                               .visitor      (vis)
            );
   
-  std::cerr << "\nEdges collected: "  << stats.collected
+  std::cout << "\nEdges collected: "  << stats.collected
             << "\nEdges proccessed: " << stats.processed
             << "\nEdges collapsed: "  << stats.collapsed
             << std::endl
@@ -154,7 +154,7 @@ int main( int argc, char** argv )
             << "\nEdge not collapsed due to placement computation constraints: " << stats.placement_uncomputable 
             << std::endl ; 
             
-  std::cerr << "\nFinished...\n" << r << " edges removed.\n" 
+  std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << num_edges(surface_mesh) << " final edges.\n" ;
         
   std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
@@ -24,6 +24,11 @@ int main(int argc, char* argv[])
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   Polyhedron tmesh;
   input >> tmesh;
+  if (!CGAL::is_triangle_mesh(tmesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   Skeleton skeleton;
   Skeletonization mcs(tmesh);

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
@@ -72,6 +72,6 @@ int main(int argc, char* argv[])
     BOOST_FOREACH(vertex_descriptor vd, skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
@@ -71,5 +71,5 @@ int main(int argc, char* argv[])
     BOOST_FOREACH(vertex_descriptor vd, skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
@@ -23,6 +23,11 @@ int main(int argc, char* argv[])
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   Triangle_mesh tmesh;
   input >> tmesh;
+  if (!CGAL::is_triangle_mesh(tmesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   Skeleton skeleton;
   Skeletonization mcs(tmesh);

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
@@ -98,6 +98,6 @@ int main(int argc, char* argv[])
   std::cout << "Number of segments: "
             << CGAL::segmentation_from_sdf_values(tmesh, sdf_property_map, segment_property_map) <<"\n";
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
@@ -49,6 +49,11 @@ int main(int argc, char* argv[])
   std::ifstream input((argc>1)?argv[1]:"data/161.off");
   Polyhedron tmesh;
   input >> tmesh;
+  if (!CGAL::is_triangle_mesh(tmesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // extract the skeleton
   Skeleton skeleton;

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
@@ -79,6 +79,6 @@ int main(int argc, char* argv[])
       output << "2 " << skeleton[v].point << " "
                      << get(CGAL::vertex_point, tmesh, vd)  << "\n";
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[])
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   Polyhedron tmesh;
   input >> tmesh;
+  if (!CGAL::is_triangle_mesh(tmesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   Skeleton skeleton;
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
@@ -57,6 +57,6 @@ int main(int argc, char* argv[])
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";
 
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
@@ -27,6 +27,11 @@ int main(int argc, char* argv[])
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   Triangle_mesh tmesh;
   input >> tmesh;
+  if (!CGAL::is_triangle_mesh(tmesh))
+  {
+    std::cout << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
 
   Skeleton skeleton;
 


### PR DESCRIPTION
## Summary of Changes

This PR improves the examples given in the packages `Polygon_mesh_processing` and `Surface_mesh_simplification` by adding a condition to run them : the input mesh needs to be a triangle mesh.

## Release Management

* Affected packages :  `Polygon_mesh_processing` and `Surface_mesh_simplification`
* Issue solved : fix #2050

