### PR TITLE
Arrangment: Spherical Gaussian Map bug fix

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
@@ -2936,7 +2936,7 @@ public:
     CGAL_precondition(!kernel.equal_3_object()(source, target));
     CGAL_precondition(!kernel.equal_3_object()
                       (kernel.construct_opposite_direction_3_object()(source),
-                       target));
+                       static_cast<const Direction_3&>(target)));
     this->m_normal = this->construct_normal_3(source, target);
 
     // Check whether one of the endpoints coincides with a pole: */

--- a/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm.h
@@ -335,7 +335,6 @@ private:
   virtual void handle_new_edge(typename Base::Halfedge_handle edge)
   {
     typedef typename Base::Face_handle          Arr_face_handle;
-    typedef typename Base::Vertex_handle        Arr_vertex_handle;
 
     Arr_face_handle src_face = edge->twin()->face();
     Arr_face_handle trg_face = edge->face();

--- a/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_polyhedron_3.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_polyhedron_3.h
@@ -14,7 +14,7 @@
 //
 // $URL$
 // $Id$
-// 
+//
 //
 // Author(s)     : Efi Fogel          <efif@post.tau.ac.il>
 
@@ -160,7 +160,7 @@ public:
 
   /*! Set the vertex */
   void set_vertex(Arr_vertex_handle vertex) { m_vertex = vertex; }
-  
+
   /*! Set the "marked" flag */
   void set_marked(bool marked) { m_marked = marked; }
 
@@ -215,6 +215,24 @@ struct Arr_polyhedral_sgm_polyhedron_3 :
   /*! Constructor */
   Arr_polyhedral_sgm_polyhedron_3() {}
 };
+
+//! Make the polyhedron a model of FaceGraph
+namespace boost {
+
+template <typename Sgm, typename Traits>
+struct graph_traits<CGAL::Arr_polyhedral_sgm_polyhedron_3<Sgm, Traits> > :
+  public graph_traits<CGAL::Polyhedron_3
+                      <Traits, CGAL::Arr_polyhedral_sgm_polyhedron_items<Sgm> > >
+{};
+
+template <typename Sgm, typename Traits, typename Tag>
+struct property_map<CGAL::Arr_polyhedral_sgm_polyhedron_3<Sgm, Traits>, Tag> :
+  public property_map<CGAL::Polyhedron_3
+                      <Traits, CGAL::Arr_polyhedral_sgm_polyhedron_items<Sgm> >,
+                      Tag>
+{};
+
+}
 
 } //namespace CGAL
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_polyhedron_3.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_polyhedron_3.h
@@ -216,6 +216,8 @@ struct Arr_polyhedral_sgm_polyhedron_3 :
   Arr_polyhedral_sgm_polyhedron_3() {}
 };
 
+} //namespace CGAL
+
 //! Make the polyhedron a model of FaceGraph
 namespace boost {
 
@@ -233,7 +235,5 @@ struct property_map<CGAL::Arr_polyhedral_sgm_polyhedron_3<Sgm, Traits>, Tag> :
 {};
 
 }
-
-} //namespace CGAL
 
 #endif

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
@@ -581,8 +581,8 @@ function(test_segment_traits_adaptor)
 
   compile_test_with_flags(test_traits_adaptor segments "${flags}")
 #  if [ -n "${SUCCESS}" ] ; then
-  execute_commands_traits_adaptor( segments segments_traits_adaptor 
-    COMPARE_Y_POSITION COMPARE_CW_AROUND_POINT COMPARE_Y_AT_X_LEFT 
+  execute_commands_traits_adaptor( segments segments_traits_adaptor
+    COMPARE_Y_POSITION COMPARE_CW_AROUND_POINT COMPARE_Y_AT_X_LEFT
     ARE_MERGEABLE MERGE IS_IN_X_RANGE IS_BETWEEN_CW)
 endfunction()
 
@@ -597,8 +597,8 @@ function(test_linear_traits_adaptor)
 
   compile_test_with_flags( test_traits_adaptor linear "${flags}")
 
-  execute_commands_traits_adaptor( linear linear_traits_adaptor 
-    COMPARE_Y_AT_X_LEFT ARE_MERGEABLE MERGE IS_IN_X_RANGE 
+  execute_commands_traits_adaptor( linear linear_traits_adaptor
+    COMPARE_Y_AT_X_LEFT ARE_MERGEABLE MERGE IS_IN_X_RANGE
     COMPARE_Y_POSITION IS_BETWEEN_CW COMPARE_CW_AROUND_POINT)
 endfunction()
 
@@ -614,8 +614,8 @@ function(test_spherical_arcs_traits_adaptor)
 
   compile_test_with_flags( test_traits_adaptor geodesic_arcs_on_sphere "${flags}")
 
-  execute_commands_traits_adaptor( spherical_arcs spherical_arcs_traits_adaptor 
-    COMPARE_Y_AT_X_LEFT ARE_MERGEABLE MERGE IS_IN_X_RANGE 
+  execute_commands_traits_adaptor( spherical_arcs spherical_arcs_traits_adaptor
+    COMPARE_Y_AT_X_LEFT ARE_MERGEABLE MERGE IS_IN_X_RANGE
     COMPARE_Y_POSITION IS_BETWEEN_CW COMPARE_CW_AROUND_POINT)
 endfunction()
 
@@ -1365,3 +1365,5 @@ compile_and_run(test_unbounded_removal)
 compile_and_run(test_spherical_removal)
 
 compile_and_run(test_io)
+
+compile_and_run(test_sgm)

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
@@ -1711,6 +1711,8 @@ compile_and_run test_spherical_removal
 
 compile_and_run test_io
 
+compile_and_run test_sgm
+
 # if any error occured then append the full error description file to error file
 
 if [ -f $FULL_ERROR_DESCRIPTION_FILE ] ; then

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_sgm.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_sgm.cpp
@@ -1,0 +1,69 @@
+#define CGAL_IDENTIFICATION_XY 2
+
+// Testing the spherical gaussian map
+#include <iostream>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/convex_hull_3.h>
+#include <CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_traits.h>
+#include <CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm.h>
+#include <CGAL/Arr_spherical_gaussian_map_3/Arr_polyhedral_sgm_polyhedron_3.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel       Kernel;
+typedef Kernel::Point_3                                         Point_3;
+typedef CGAL::Arr_polyhedral_sgm_traits<Kernel>                 Gm_traits;
+typedef CGAL::Arr_polyhedral_sgm<Gm_traits>                     Gm;
+typedef CGAL::Arr_polyhedral_sgm_polyhedron_3<Gm, Kernel>       Gm_polyhedron;
+typedef CGAL::Arr_polyhedral_sgm_initializer<Gm, Gm_polyhedron> Gm_initializer;
+
+int main()
+{
+  // Construct the Gaussian map of a tetrahedron
+  Point_3 points[] = {
+    Point_3(1.0, 0.0, 0.0),
+    Point_3(0.0, 1.0, 0.0),
+    Point_3(0.0, 0.0, 1.0),
+    Point_3(0.0, 0.0, 0.0)
+  };
+  Gm_polyhedron P1;
+  CGAL::convex_hull_3(points, &points[4], P1);
+  Gm gm1;
+  Gm_initializer gm_initializer1(gm1);
+  gm_initializer1(P1);
+  if (! gm1.is_valid()) return -1;
+
+  // Construct the Gaussian map of the reflection of a tetrahedron
+  Gm_polyhedron P2;
+  for (Point_3* p = points; p != &points[4]; ++p) {
+    Kernel::Vector_3 v = CGAL::ORIGIN - *p;
+    *p = CGAL::ORIGIN + v;
+  }
+  CGAL::convex_hull_3(points, &points[4], P2);
+  Gm gm2;
+  Gm_initializer gm_initializer2(gm2);
+  gm_initializer2(P2);
+  if (! gm2.is_valid()) return -1;
+
+  // Compute the Minowski sum of the Gaussian maps
+  Gm gm;
+  gm.minkowski_sum(gm1, gm2);
+  if (! gm.is_valid()) return -1;
+
+  Kernel::FT sw(16);
+  Gm::Vertex_const_handle it;
+  for (it = gm.vertices_begin(); it != gm.vertices_end(); ++it) {
+    if (it->degree() < 3) continue;
+    Gm::Halfedge_around_vertex_const_circulator hec3(it->incident_halfedges());
+    Gm::Halfedge_around_vertex_const_circulator hec1 = hec3++;
+    Gm::Halfedge_around_vertex_const_circulator hec2 = hec3++;
+    Kernel::Plane_3 plane((*hec1).face()->point(), (*hec2).face()->point(),
+                          (*hec3).face()->point());
+    Kernel::Vector_3 v(CGAL::ORIGIN, plane.projection(CGAL::ORIGIN));
+    Kernel::FT tmp = v.squared_length();
+    if (tmp < sw) sw = tmp;
+  }
+  // std::cout << sw << std::endl;
+  CGAL::Gmpq res(1,3);
+  if (sw.exact() != res) return -1;
+  return 0;
+}


### PR DESCRIPTION
Fixed the Spherical Gaussian Map (undocumented) feature.
Added a test that tests the feature.

Apparently, every data structure that derives from an instance of CGAL::Polyhedron_3 must be explicitly made a model of FaceGraph by adding the appropriate boost::graph_traits and boost::property_map templates. This bug-fix simply introduces the above two templates for CGAL::Arr_polyhedral_sgm_polyhedron_3.

