### PR TITLE
Polyhedron_demo: color and camera

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1469,7 +1469,7 @@ void MainWindow::on_actionLoad_triggered()
   std::vector<QColor> colors_;
   colors_.reserve(nb_files);
   compute_color_map(QColor(100, 100, 255),//Scene_item's default color
-                    nb_files,
+                    static_cast<unsigned>(nb_files),
                     std::back_inserter(colors_));
   std::size_t nb_item = -1;
   Q_FOREACH(const QString& filename, dialog.selectedFiles()) {
@@ -1973,7 +1973,7 @@ void MainWindow::colorItems()
   std::vector<QColor> colors_;
   colors_.reserve(nb_files);
   compute_color_map(scene->item(scene->selectionIndices().last())->color(),
-                    nb_files,
+                    static_cast<unsigned>(nb_files),
                     std::back_inserter(colors_));
   std::size_t nb_item = -1;
   Q_FOREACH(int id, scene->selectionIndices())

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1965,6 +1965,7 @@ void MainWindow::insertActionBeforeLoadPlugin(QMenu* menu, QAction* actionToInse
     if(!menuActions.contains(actionToInsert))
       menu->insertAction(ui->actionLoadPlugin, actionToInsert);
   }
+}
 
 void MainWindow::colorItems()
 {

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -137,6 +137,10 @@ public Q_SLOTS:
    */
   void selectAll();
   /*!
+   * Assigns a different color to each selected item.
+   */
+  void colorItems();
+  /*!
    * Adds the scene_item with the index i in the sceneView to the
    * current selection. Calls itemChanged(i) from the scene.
    */

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -37,7 +37,7 @@
      <x>0</x>
      <y>0</y>
      <width>978</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -66,6 +66,7 @@
     <addaction name="actionSetPolyhedronB"/>
     <addaction name="actionSelectAllItems"/>
     <addaction name="actionPreferences"/>
+    <addaction name="actionColorItems"/>
    </widget>
    <widget class="QMenu" name="menuOperations">
     <property name="title">
@@ -295,7 +296,7 @@
             <x>0</x>
             <y>0</y>
             <width>541</width>
-            <height>176</height>
+            <height>173</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">
@@ -683,6 +684,11 @@
    </property>
    <property name="text">
     <string>Orthographic Projection</string>
+   </property>
+  </action>
+  <action name="actionColorItems">
+   <property name="text">
+    <string>Set different colors to selected items</string>
    </property>
   </action>
  </widget>

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -4,8 +4,9 @@
 
 #include "config.h"
 #include "Scene.h"
-#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Scene_print_interface_item.h>
+#include <CGAL/Three/Scene_zoomable_item_interface.h>
 
 #include <QObject>
 #include <QMetaObject>
@@ -1287,3 +1288,17 @@ findItems(const CGAL::Three::Scene_interface* scene_interface,
 
 } // end namespace details
                 } // end namespace scene
+
+void Scene::zoomToPosition(QPoint point, Viewer_interface *viewer)
+{
+  for(int i=0; i<numberOfEntries(); ++i)
+  {
+    if(!item(i)->visible())
+      continue;
+    Scene_zoomable_item_interface* zoom_item = qobject_cast<Scene_zoomable_item_interface*>(item(i));
+    if(zoom_item)
+    {
+      zoom_item->zoomToPosition(point, viewer);
+    }
+  }
+}

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -166,6 +166,9 @@ public:
   //!Selects all the rows in the sceneView.
   QItemSelection createSelectionAll();
 
+  void zoomToPosition(QPoint point,
+                        CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+
 public Q_SLOTS:
   //!Specifies a group as Expanded for the view
   void setExpanded(QModelIndex);

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -2,6 +2,7 @@
 #define POINT_SET_ITEM_H
 #include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Scene_item_with_properties.h>
+#include <CGAL/Three/Scene_zoomable_item_interface.h>
 #include "Scene_points_with_normal_item_config.h"
 #include "Polyhedron_type_fwd.h"
 #include "Kernel_type.h"
@@ -17,9 +18,13 @@ class QAction;
 
 // This class represents a point set in the OpenGL scene
 class SCENE_POINTS_WITH_NORMAL_ITEM_EXPORT Scene_points_with_normal_item
-  : public CGAL::Three::Scene_item, public CGAL::Three::Scene_item_with_properties
+  : public CGAL::Three::Scene_item,
+    public CGAL::Three::Scene_item_with_properties,
+    public CGAL::Three::Scene_zoomable_item_interface
 {
   Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
 
 public:
   Scene_points_with_normal_item();
@@ -96,6 +101,8 @@ protected:
   friend struct Scene_points_with_normal_item_priv;
   Scene_points_with_normal_item_priv* d;
 
+public:
+ void zoomToPosition(const QPoint &, CGAL::Three::Viewer_interface *)const Q_DECL_OVERRIDE;
 }; // end class Scene_points_with_normal_item
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1597,6 +1597,7 @@ void Scene_polyhedron_item::printPrimitiveId(QPoint point, CGAL::Three::Viewer_i
   if(aabb_tree) {
     //find clicked facet
     bool found = false;
+
     const Kernel::Point_3 ray_origin(viewer->camera()->position().x, viewer->camera()->position().y, viewer->camera()->position().z);
     qglviewer::Vec point_under = viewer->camera()->pointUnderPixel(point,found);
     qglviewer::Vec dir = point_under - viewer->camera()->position();
@@ -1861,11 +1862,13 @@ void Scene_polyhedron_item::zoomToPosition(const QPoint &point, CGAL::Three::Vie
 
   Tree* aabb_tree = static_cast<Input_facets_AABB_tree*>(d->get_aabb_tree());
   if(aabb_tree) {
+
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     //find clicked facet
     bool found = false;
-    const Kernel::Point_3 ray_origin(viewer->camera()->position().x,
-                                     viewer->camera()->position().y,
-                                     viewer->camera()->position().z);
+    const Kernel::Point_3 ray_origin(viewer->camera()->position().x - offset.x,
+                                     viewer->camera()->position().y - offset.y,
+                                     viewer->camera()->position().z - offset.z);
     qglviewer::Vec point_under = viewer->camera()->pointUnderPixel(point,found);
     qglviewer::Vec dir = point_under - viewer->camera()->position();
     const Kernel::Vector_3 ray_dir(dir.x, dir.y, dir.z);
@@ -1932,7 +1935,9 @@ void Scene_polyhedron_item::zoomToPosition(const QPoint &point, CGAL::Three::Vie
 
           ++total;
         }
-        Kernel::Point_3 centroid(x/total, y/total, z/total);
+        Kernel::Point_3 centroid(x/total + offset.x,
+                                 y/total + offset.y,
+                                 z/total + offset.z);
 
         qglviewer::Quaternion new_orientation(qglviewer::Vec(0,0,-1),
                                               qglviewer::Vec(-face_normal.x(), -face_normal.y(), -face_normal.z()));
@@ -1943,8 +1948,10 @@ void Scene_polyhedron_item::zoomToPosition(const QPoint &point, CGAL::Three::Vie
         double factor = max_side/(tan(viewer->camera()->aspectRatio()/
                                         (viewer->camera()->fieldOfView()/2)));
 
-        Kernel::Point_3 new_pos = centroid + factor*face_normal;
-        viewer->camera()->setSceneCenter(qglviewer::Vec(centroid.x(), centroid.y(), centroid.z()));
+        Kernel::Point_3 new_pos = centroid + factor*face_normal ;
+        viewer->camera()->setSceneCenter(qglviewer::Vec(centroid.x(),
+                                                        centroid.y(),
+                                                        centroid.z()));
         viewer->moveCameraToCoordinates(QString("%1 %2 %3 %4 %5 %6 %7").arg(new_pos.x())
                                                                        .arg(new_pos.y())
                                                                        .arg(new_pos.z())

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -15,14 +15,18 @@
 #include <vector>
 
 #include <QColor>
+#include <CGAL/Three/Scene_zoomable_item_interface.h>
 
 class QMenu;
 struct Scene_polyhedron_item_priv;
 
 // This class represents a polyhedron in the OpenGL scene
 class SCENE_POLYHEDRON_ITEM_EXPORT Scene_polyhedron_item
-        : public CGAL::Three::Scene_item{
+        : public CGAL::Three::Scene_item,
+          public CGAL::Three::Scene_zoomable_item_interface{
     Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
 public:
     enum STATS {
       NB_VERTICES = 0,
@@ -157,6 +161,9 @@ public:
 protected:
     friend struct Scene_polyhedron_item_priv;
     Scene_polyhedron_item_priv* d;
+
+   public:
+    void zoomToPosition(const QPoint &point, CGAL::Three::Viewer_interface *)const Q_DECL_OVERRIDE;
 
 }; // end class Scene_polyhedron_item
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -25,8 +25,8 @@ class SCENE_POLYHEDRON_ITEM_EXPORT Scene_polyhedron_item
         : public CGAL::Three::Scene_item,
           public CGAL::Three::Scene_zoomable_item_interface{
     Q_OBJECT
-  Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
-  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
+    Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
+    Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
 public:
     enum STATS {
       NB_VERTICES = 0,

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -71,6 +71,7 @@ public:
   //! Decides if the distance between APoint and BPoint must be drawn;
   bool distance_is_displayed;
   bool i_is_pressed;
+  bool z_is_pressed;
   //!Draws the distance between two selected points.
   void showDistance(QPoint);
   qglviewer::Vec APoint;
@@ -155,6 +156,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->axis_are_displayed = true;
   d->has_text = false;
   d->i_is_pressed = false;
+  d->z_is_pressed = false;
   d->fpsTime.start();
   d->fpsCounter=0;
   d->f_p_s=0.0;
@@ -403,6 +405,12 @@ void Viewer::mousePressEvent(QMouseEvent* event)
   }
   else if(!event->modifiers()
           && event->button() == Qt::LeftButton
+          && d->z_is_pressed)
+  {
+      d->scene->zoomToPosition(event->pos(), this);
+  }
+  else if(!event->modifiers()
+          && event->button() == Qt::LeftButton
           && d->is_d_pressed)
   {
       d->showDistance(event->pos());
@@ -454,6 +462,9 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     else if(e->key() == Qt::Key_I) {
           d->i_is_pressed = true;
         }
+    else if(e->key() == Qt::Key_Z) {
+          d->z_is_pressed = true;
+        }
     else if(e->key() == Qt::Key_D) {
         if(e->isAutoRepeat())
         {
@@ -493,6 +504,9 @@ void Viewer::keyReleaseEvent(QKeyEvent *e)
 {
   if(e->key() == Qt::Key_I) {
     d->i_is_pressed = false;
+  }
+  else if(e->key() == Qt::Key_Z) {
+    d->z_is_pressed = false;
   }
   else if(!e->modifiers() && e->key() == Qt::Key_D)
   {

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -146,8 +146,8 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   setMouseBindingDescription(Qt::Key_D, Qt::NoModifier, Qt::LeftButton,
                              tr("Selects a point. When the second point is selected,  "
                                 "displays the two points and the distance between them."));
-  setMouseBindingDescription(Qt::Key_Z, Qt::NoModifier, Qt::LeftButton,
-                             tr("Zoom to the picked facet of a Scene_polyhedron_item or "
+  setMouseBindingDescription(Qt::Key_O, Qt::NoModifier, Qt::LeftButton,
+                             tr("Move the camera orthogonally to the picked facet of a Scene_polyhedron_item or "
                                 "to the current selection of a Scene_points_with_normal_item."));
 #else
   setMouseBinding(Qt::SHIFT + Qt::LeftButton, SELECT);
@@ -466,7 +466,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     else if(e->key() == Qt::Key_I) {
           d->i_is_pressed = true;
         }
-    else if(e->key() == Qt::Key_Z) {
+    else if(e->key() == Qt::Key_O) {
           d->z_is_pressed = true;
         }
     else if(e->key() == Qt::Key_D) {
@@ -509,7 +509,7 @@ void Viewer::keyReleaseEvent(QKeyEvent *e)
   if(e->key() == Qt::Key_I) {
     d->i_is_pressed = false;
   }
-  else if(e->key() == Qt::Key_Z) {
+  else if(e->key() == Qt::Key_O) {
     d->z_is_pressed = false;
   }
   else if(!e->modifiers() && e->key() == Qt::Key_D)

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -128,6 +128,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
                       tr("Toggle the primitive IDs visibility of the selected Item."));
   setKeyDescription(Qt::Key_D,
                       tr("Disable the distance between two points  visibility."));
+
 #if QGLVIEWER_VERSION >= 0x020501
   //modify mouse bindings that have been updated
   setMouseBinding(Qt::Key(0), Qt::NoModifier, Qt::LeftButton, RAP_FROM_PIXEL, true, Qt::RightButton);
@@ -145,6 +146,9 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   setMouseBindingDescription(Qt::Key_D, Qt::NoModifier, Qt::LeftButton,
                              tr("Selects a point. When the second point is selected,  "
                                 "displays the two points and the distance between them."));
+  setMouseBindingDescription(Qt::Key_Z, Qt::NoModifier, Qt::LeftButton,
+                             tr("Zoom to the picked facet of a Scene_polyhedron_item or "
+                                "to the current selection of a Scene_points_with_normal_item."));
 #else
   setMouseBinding(Qt::SHIFT + Qt::LeftButton, SELECT);
   setMouseBindingDescription(Qt::SHIFT + Qt::RightButton,

--- a/Three/include/CGAL/Three/Scene_draw_interface.h
+++ b/Three/include/CGAL/Three/Scene_draw_interface.h
@@ -59,6 +59,13 @@ public:
    * \brief printPrimitiveIds displays all the Ids if there are less than max_textItems.
    */
   virtual void printPrimitiveIds(CGAL::Three::Viewer_interface*) = 0;
+
+  //!\brief moves the camera orthogonally to the picked sface.
+  //!
+  //! \param point the picked point
+  //! \param viewer the active viewer
+  virtual void zoomToPosition(QPoint point,
+                        CGAL::Three::Viewer_interface* viewer) = 0;
 };
 }
 }

--- a/Three/include/CGAL/Three/Scene_zoomable_item_interface.h
+++ b/Three/include/CGAL/Three/Scene_zoomable_item_interface.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2009,2010,2012,2015  GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Maxime GIMENO
+
+#ifndef SCENE_ZOOMABLE_ITEM_INTERFACE_H
+#define SCENE_ZOOMABLE_ITEM_INTERFACE_H
+
+#include <CGAL/license/Three.h>
+#include <QtPlugin>
+#include <QPoint>
+namespace CGAL
+{
+namespace Three {
+  class Viewer_interface;
+
+
+//! This class provides a function to move the camera orthogonaly to the wanted region
+class Scene_zoomable_item_interface {
+public:
+  virtual ~Scene_zoomable_item_interface(){}
+ //! Move the camera orthogonaly to the region defined by `point`
+ virtual void zoomToPosition(const QPoint& point, CGAL::Three::Viewer_interface*)const = 0;
+};
+}
+}
+
+Q_DECLARE_INTERFACE(CGAL::Three::Scene_zoomable_item_interface, "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
+#endif // SCENE_ZOOMABLE_ITEM_INTERFACE_H


### PR DESCRIPTION

## Summary of Changes

This PR adds two features to the demo :
- The possibility to set a different color for each item of the current selection, so they are easier to distinguish, (automatically used when loading several items at the same time)
- The possibility to zoom on a picked facet from a polyhedron_item, or the current selection of points in a scene_points_with_normal_item, using a fitting plane. This can be performed using Z + left click.
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2037

