### PR TITLE
WIP : fix PMP::compute_vertex_normal

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -261,7 +261,8 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
                            get(vpmap, target(next(he, pmesh), pmesh)));
       //v(i) and v(i+1) must me seen in ccw order, from v, so we reverse v1 and v2
       Vector ni = traits.construct_cross_product_vector_3_object()(v2, v1);
-      ni = traits.construct_scaled_vector_3_object()(ni, CGAL::sqrt(1./(sqlen(v1)*sqlen(v2))));
+      ni = traits.construct_scaled_vector_3_object()(ni,
+        CGAL::approximate_sqrt(FT(1)/(sqlen(v1)*sqlen(v2))));
 
       normal = traits.construct_sum_of_vectors_3_object()(normal, ni);
     }


### PR DESCRIPTION
This PR should be discussed in the issue before going further.

## Summary of Changes
This PR intends to improve the `PMP::compute_vertex_normal(v)` function, by changing the weights of face normals that are summed to compute a normal at vertex `v`.

The former implementation used `1` as weight, and the new weight is `sin(angle at v in f)`.
It is cheaper than computing `(angle at v in f)`, and should behave similarly.

## Release Management

* Affected package : PMP
* Issue solved : fixes #2047
