### PR TITLE
Polyhedron_demo: Use a recent OpenGL context if possible

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -19,7 +19,7 @@ function build_demo {
   cd build-travis
   if [ $NEED_3D = 1 ]; then
     #install libqglviewer
-    git clone --depth=4 -b v2.6.3 --single-branch https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
+    git clone --depth=1 https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
     pushd ./qglviewer/QGLViewer
     #use qt5 instead of qt4
 #    export QT_SELECT=5

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -19,7 +19,7 @@ function build_demo {
   cd build-travis
   if [ $NEED_3D = 1 ]; then
     #install libqglviewer
-    git clone --depth=1 https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
+    git clone --depth=4 -b v2.6.3 --single-branch https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
     pushd ./qglviewer/QGLViewer
     #use qt5 instead of qt4
 #    export QT_SELECT=5

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -59,6 +59,9 @@
         <file>resources/prism-open.png</file>
         <file>resources/pyramid.png</file>
         <file>resources/pyramid-open.png</file>
+        <file>resources/no_interpolation_shader.f</file>
+        <file>resources/no_interpolation_shader.g</file>
+        <file>resources/no_interpolation_shader.v</file>
     </qresource>
     <qresource prefix="/cgal/cursors">
         <file>resources/rotate_around_cursor.png</file>

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.qrc
@@ -62,6 +62,9 @@
         <file>resources/no_interpolation_shader.f</file>
         <file>resources/no_interpolation_shader.g</file>
         <file>resources/no_interpolation_shader.v</file>
+        <file>resources/shader_flat.g</file>
+        <file>resources/shader_flat.v</file>
+        <file>resources/shader_old_flat.f</file>
     </qresource>
     <qresource prefix="/cgal/cursors">
         <file>resources/rotate_around_cursor.png</file>

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -214,7 +214,7 @@ add_to_normal(unsigned char v,
 class Vertex_buffer_helper
 {
 public:
-  Vertex_buffer_helper(const Image_accessor& data);
+  Vertex_buffer_helper(const Image_accessor& data, bool is_recent);
   
   void fill_buffer_data();
 
@@ -252,13 +252,14 @@ private:
   Indices indices_;
   std::vector<GLfloat> colors_, normals_, vertices_;
   std::vector<GLuint> quads_;
+  bool is_recent;
 };
 
 int Vertex_buffer_helper::vertex_not_found_ = -1;
 
 Vertex_buffer_helper::
-Vertex_buffer_helper(const Image_accessor& data)
-  : data_(data)
+Vertex_buffer_helper(const Image_accessor& data, bool b)
+  : data_(data), is_recent(b)
 {}
 
 
@@ -296,7 +297,6 @@ Vertex_buffer_helper::push_color(std::size_t i, std::size_t j, std::size_t k)
 {
   const QColor& color = data_.vertex_color(i,j,k);
   if ( ! color.isValid() ) { return; }
-  
   colors_.push_back(color.red()/255.f);
   colors_.push_back(color.green()/255.f);
   colors_.push_back(color.blue()/255.f);
@@ -374,8 +374,11 @@ Vertex_buffer_helper::push_quad(int pos1, int pos2, int pos3, int pos4)
     quads_.push_back(pos1);
     quads_.push_back(pos2);
     quads_.push_back(pos3);
-    quads_.push_back(pos1);
-    quads_.push_back(pos3);
+    if(!is_recent)
+    {
+      quads_.push_back(pos1);
+      quads_.push_back(pos3);
+    }
     quads_.push_back(pos4);
   }
 }
@@ -421,6 +424,7 @@ struct Scene_image_item_priv
   {
     item = parent;
     v_box = new std::vector<float>();
+    is_recent = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->isRecent();
     is_hidden = hidden;
     compile_shaders();
     initializeBuffers();
@@ -461,6 +465,7 @@ struct Scene_image_item_priv
   mutable QOpenGLVertexArrayObject vao[vaoSize];
   mutable QOpenGLShaderProgram rendering_program;
   bool is_hidden;
+  bool is_recent;
   Scene_image_item* item;
 
 //#endif // SCENE_SEGMENTED_IMAGE_GL_BUFFERS_AVAILABLE
@@ -487,97 +492,118 @@ Scene_image_item::~Scene_image_item()
 
 void Scene_image_item_priv::compile_shaders()
 {
-
-    for(int i=0; i< vboSize; i++)
-        m_vbo[i].create();
-    for(int i=0; i< vaoSize; i++)
-        vao[i].create();
-    m_ibo = new QOpenGLBuffer(QOpenGLBuffer::IndexBuffer);
-    m_ibo->create();
+  for(int i=0; i< vboSize; i++)
+    m_vbo[i].create();
+  for(int i=0; i< vaoSize; i++)
+    vao[i].create();
+  m_ibo = new QOpenGLBuffer(QOpenGLBuffer::IndexBuffer);
+  m_ibo->create();
+  if(!is_recent)
+  {
     //Vertex source code
     const char vertex_source[] =
     {
-        "#version 120 \n"
-        "attribute highp vec4 vertex;\n"
-        "attribute highp vec3 normal;\n"
-        "attribute highp vec4 inColor;\n"
+      "#version 120 \n"
+      "attribute highp vec4 vertex;\n"
+      "attribute highp vec3 normal;\n"
+      "attribute highp vec4 inColor;\n"
 
-        "uniform highp mat4 mvp_matrix;\n"
-        "uniform highp mat4 mv_matrix; \n"
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
-        "varying highp vec4 color; \n"
-        "void main(void)\n"
-        "{\n"
-        "   color=inColor; \n"
-        "   fP = mv_matrix * vertex; \n"
-        "   fN = mat3(mv_matrix)* normal; \n"
-        "   gl_Position = mvp_matrix * vertex; \n"
-        "}"
+      "uniform highp mat4 mvp_matrix;\n"
+      "uniform highp mat4 mv_matrix; \n"
+      "varying highp vec4 fP; \n"
+      "varying highp vec3 fN; \n"
+      "varying highp vec4 color; \n"
+      "void main(void)\n"
+      "{\n"
+      "   color=inColor; \n"
+      "   fP = mv_matrix * vertex; \n"
+      "   fN = mat3(mv_matrix)* normal; \n"
+      "   gl_Position = mvp_matrix * vertex; \n"
+      "}"
     };
     //Fragment source code
     const char fragment_source[] =
     {
-        "#version 120 \n"
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
-        "varying highp vec4 color; \n"
-        "uniform bool is_two_side; \n"
-        "uniform highp vec4 light_pos;  \n"
-        "uniform highp vec4 light_diff; \n"
-        "uniform highp vec4 light_spec; \n"
-        "uniform highp vec4 light_amb;  \n"
-        "uniform float spec_power ; \n"
+      "#version 120 \n"
+      "varying highp vec4 fP; \n"
+      "varying highp vec3 fN; \n"
+      "varying highp vec4 color; \n"
+      "uniform bool is_two_side; \n"
+      "uniform highp vec4 light_pos;  \n"
+      "uniform highp vec4 light_diff; \n"
+      "uniform highp vec4 light_spec; \n"
+      "uniform highp vec4 light_amb;  \n"
+      "uniform float spec_power ; \n"
 
-        "void main(void) { \n"
+      "void main(void) { \n"
 
-        "   vec3 L = light_pos.xyz - fP.xyz; \n"
-        "   vec3 V = -fP.xyz; \n"
+      "   vec3 L = light_pos.xyz - fP.xyz; \n"
+      "   vec3 V = -fP.xyz; \n"
 
-        "   vec3 N; \n"
-        "   if(fN == vec3(0.0,0.0,0.0)) \n"
-        "       N = vec3(0.0,0.0,0.0); \n"
-        "   else \n"
-        "       N = normalize(fN); \n"
-        "   L = normalize(L); \n"
-        "   V = normalize(V); \n"
+      "   vec3 N; \n"
+      "   if(fN == vec3(0.0,0.0,0.0)) \n"
+      "       N = vec3(0.0,0.0,0.0); \n"
+      "   else \n"
+      "       N = normalize(fN); \n"
+      "   L = normalize(L); \n"
+      "   V = normalize(V); \n"
 
-        "   vec3 R = reflect(-L, N); \n"
-        "   vec4 diffuse; \n"
-        "   if(!is_two_side) \n"
-        "       diffuse = max(dot(N,L),0) * light_diff*color; \n"
-        "   else \n"
-        "       diffuse = max(abs(dot(N,L)),0) * light_diff*color; \n"
-        "   vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
+      "   vec3 R = reflect(-L, N); \n"
+      "   vec4 diffuse; \n"
+      "   if(!is_two_side) \n"
+      "       diffuse = max(dot(N,L),0) * light_diff*color; \n"
+      "   else \n"
+      "       diffuse = max(abs(dot(N,L)),0) * light_diff*color; \n"
+      "   vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-         "gl_FragColor = color*light_amb + diffuse + specular; \n"
-        "} \n"
-        "\n"
+      "gl_FragColor = color*light_amb + diffuse + specular; \n"
+      "} \n"
+      "\n"
     };
     QOpenGLShader *vertex_shader = new QOpenGLShader(QOpenGLShader::Vertex);
     if(!vertex_shader->compileSourceCode(vertex_source))
     {
-        std::cerr<<"Compiling vertex source FAILED"<<std::endl;
+      std::cerr<<"Compiling vertex source FAILED"<<std::endl;
     }
 
     QOpenGLShader *fragment_shader= new QOpenGLShader(QOpenGLShader::Fragment);
     if(!fragment_shader->compileSourceCode(fragment_source))
     {
-        std::cerr<<"Compiling fragmentsource FAILED"<<std::endl;
+      std::cerr<<"Compiling fragmentsource FAILED"<<std::endl;
     }
 
     if(!rendering_program.addShader(vertex_shader))
     {
-        std::cerr<<"adding vertex shader FAILED"<<std::endl;
+      std::cerr<<"adding vertex shader FAILED"<<std::endl;
     }
+
     if(!rendering_program.addShader(fragment_shader))
     {
-        std::cerr<<"adding fragment shader FAILED"<<std::endl;
+      std::cerr<<"adding fragment shader FAILED"<<std::endl;
     }
     if(!rendering_program.link())
     {
-        std::cerr<<"linking Program FAILED"<<std::endl;
+      std::cerr<<"linking Program FAILED"<<std::endl;
     }
+  }
+  else
+  {
+    if(!rendering_program.addShaderFromSourceFile(QOpenGLShader::Vertex,":/cgal/Polyhedron_3/resources/no_interpolation_shader.v"))
+    {
+      std::cerr<<"adding vertex shader FAILED"<<std::endl;
+    }
+
+    if(!rendering_program.addShaderFromSourceFile(QOpenGLShader::Fragment,":/cgal/Polyhedron_3/resources/no_interpolation_shader.f"))
+    {
+      std::cerr<<"adding fragment shader FAILED"<<std::endl;
+    }
+    if(!rendering_program.addShaderFromSourceFile(QOpenGLShader::Geometry,":/cgal/Polyhedron_3/resources/no_interpolation_shader.g"))
+    {
+      std::cerr<<"adding geometry shader FAILED"<<std::endl;
+    }
+    rendering_program.link();
+  }
+  rendering_program.bindAttributeLocation("colors", 1);
 }
 
 void Scene_image_item_priv::attribBuffers(Viewer_interface* viewer) const
@@ -623,7 +649,6 @@ void Scene_image_item_priv::attribBuffers(Viewer_interface* viewer) const
 
 
     rendering_program.bind();
-    colorLocation[0] = rendering_program.uniformLocation("color");
     twosideLocation = rendering_program.uniformLocation("is_two_side");
     mvpLocation[0] = rendering_program.uniformLocation("mvp_matrix");
     mvLocation[0] = rendering_program.uniformLocation("mv_matrix");
@@ -708,17 +733,13 @@ Scene_image_item::supportsRenderingMode(RenderingMode m) const
 { 
   switch ( m )
   {
-    case Gouraud:
-      return false;
-      
-    case Points:
-    case Wireframe:
-    case Flat:
-    case FlatPlusEdges:
-      return true;
-      
-    default:
-      return false;
+  case Wireframe:
+  case Flat:
+  case FlatPlusEdges:
+    return true;
+
+  default:
+    return false;
   }
   
   return false;
@@ -728,38 +749,31 @@ void
 Scene_image_item_priv::initializeBuffers()
 {
   draw_Bbox(item->bbox(), v_box);
-  std::vector<float> nul_vec(0);
-  for(std::size_t i=0; i<v_box->size(); i++)
-    nul_vec.push_back(0.0);
   if(!is_hidden)
   {
     internal::Image_accessor image_data_accessor (*item->m_image,
                                                   m_voxel_scale,
                                                   m_voxel_scale,
                                                   m_voxel_scale);
-    internal::Vertex_buffer_helper helper (image_data_accessor);
+    internal::Vertex_buffer_helper helper (image_data_accessor, is_recent);
     helper.fill_buffer_data();
     rendering_program.bind();
     vao[0].bind();
     m_vbo[0].bind();
     m_vbo[0].allocate(helper.vertices(), static_cast<int>(helper.vertex_size()));
-    poly_vertexLocation[0] = rendering_program.attributeLocation("vertex");
-    rendering_program.enableAttributeArray(poly_vertexLocation[0]);
-    rendering_program.setAttributeBuffer(poly_vertexLocation[0],GL_FLOAT,0,3);
+    rendering_program.enableAttributeArray("vertex");
+    rendering_program.setAttributeBuffer("vertex",GL_FLOAT,0,3);
     m_vbo[0].release();
-
     m_vbo[1].bind();
     m_vbo[1].allocate(helper.normals(), static_cast<int>(helper.normal_size()));
-    normalsLocation[0] = rendering_program.attributeLocation("normal");
-    rendering_program.enableAttributeArray(normalsLocation[0]);
-    rendering_program.setAttributeBuffer(normalsLocation[0],GL_FLOAT,0,3);
+    rendering_program.enableAttributeArray("normal");
+    rendering_program.setAttributeBuffer("normal",GL_FLOAT,0,3);
     m_vbo[1].release();
 
     m_vbo[2].bind();
     m_vbo[2].allocate(helper.colors(), static_cast<int>(helper.color_size()));
-    colorLocation[0] = rendering_program.attributeLocation("inColor");
-    rendering_program.enableAttributeArray(colorLocation[0]);
-    rendering_program.setAttributeBuffer(colorLocation[0],GL_FLOAT,0,3);
+    rendering_program.enableAttributeArray("inColor");
+    rendering_program.setAttributeBuffer("inColor",GL_FLOAT,0,3);
     m_vbo[2].release();
 
     m_ibo->bind();
@@ -771,34 +785,21 @@ Scene_image_item_priv::initializeBuffers()
       color.push_back(0.0);
     rendering_program.release();
   }
-  rendering_program.bind();
+  QOpenGLShaderProgram* line_program = item->getShaderProgram(Scene_item::PROGRAM_NO_SELECTION);
+  line_program->bind();
   vao[1].bind();
   m_vbo[3].bind();
   m_vbo[3].allocate(v_box->data(), static_cast<int>(v_box->size()*sizeof(float)));
-  poly_vertexLocation[0] = rendering_program.attributeLocation("vertex");
-  rendering_program.enableAttributeArray(poly_vertexLocation[0]);
-  rendering_program.setAttributeBuffer(poly_vertexLocation[0],GL_FLOAT,0,3);
+  line_program->enableAttributeArray("vertex");
+  line_program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
   m_vbo[3].release();
 
-  m_vbo[4].bind();
-  m_vbo[3].allocate(nul_vec.data(), static_cast<int>(nul_vec.size()*sizeof(float)));
-  normalsLocation[0] = rendering_program.attributeLocation("normal");
-  rendering_program.enableAttributeArray(normalsLocation[0]);
-  rendering_program.setAttributeBuffer(normalsLocation[0],GL_FLOAT,0,3);
-  m_vbo[4].release();
-
-  m_vbo[5].bind();
-  m_vbo[5].allocate(nul_vec.data(), static_cast<int>(nul_vec.size()*sizeof(float)));
-  colorLocation[0] = rendering_program.attributeLocation("inColor");
-  rendering_program.enableAttributeArray(colorLocation[0]);
-  rendering_program.setAttributeBuffer(colorLocation[0],GL_FLOAT,0,3);
-  m_vbo[5].release();
+  line_program->disableAttributeArray("colors");
 
   vao[1].release();
-  rendering_program.release();
+  line_program->release();
   m_initialized = true;
 }
-
 
 void
 Scene_image_item_priv::draw_gl(Viewer_interface* viewer) const
@@ -808,14 +809,22 @@ Scene_image_item_priv::draw_gl(Viewer_interface* viewer) const
   if(!is_hidden)
   {
     vao[0].bind();
-    viewer->glDrawElements(GL_TRIANGLES, m_ibo->size()/sizeof(GLuint), GL_UNSIGNED_INT, 0);
+    if(!is_recent)
+      viewer->glDrawElements(GL_TRIANGLES, m_ibo->size()/sizeof(GLuint), GL_UNSIGNED_INT, 0);
+    else
+      viewer->glDrawElements(GL_LINES_ADJACENCY, m_ibo->size()/sizeof(GLuint), GL_UNSIGNED_INT, 0);
     vao[0].release();
   }
+  rendering_program.release();
+  item->attribBuffers(viewer,Scene_item::PROGRAM_NO_SELECTION);
+  QOpenGLShaderProgram* line_program = item->getShaderProgram(Scene_item::PROGRAM_NO_SELECTION);
+  line_program->bind();
   vao[1].bind();
   viewer->glLineWidth(3);
+  line_program->setAttributeValue("colors", QColor(Qt::black));
   viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(v_box->size()/3));
   vao[1].release();
-  rendering_program.release();
+  line_program->release();
 }
 
 GLint

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -214,7 +214,7 @@ add_to_normal(unsigned char v,
 class Vertex_buffer_helper
 {
 public:
-  Vertex_buffer_helper(const Image_accessor& data, bool is_recent);
+  Vertex_buffer_helper(const Image_accessor& data, bool is_ogl_4_3);
   
   void fill_buffer_data();
 
@@ -252,14 +252,14 @@ private:
   Indices indices_;
   std::vector<GLfloat> colors_, normals_, vertices_;
   std::vector<GLuint> quads_;
-  bool is_recent;
+  bool is_ogl_4_3;
 };
 
 int Vertex_buffer_helper::vertex_not_found_ = -1;
 
 Vertex_buffer_helper::
 Vertex_buffer_helper(const Image_accessor& data, bool b)
-  : data_(data), is_recent(b)
+  : data_(data), is_ogl_4_3(b)
 {}
 
 
@@ -374,7 +374,7 @@ Vertex_buffer_helper::push_quad(int pos1, int pos2, int pos3, int pos4)
     quads_.push_back(pos1);
     quads_.push_back(pos2);
     quads_.push_back(pos3);
-    if(!is_recent)
+    if(!is_ogl_4_3)
     {
       quads_.push_back(pos1);
       quads_.push_back(pos3);
@@ -424,7 +424,7 @@ struct Scene_image_item_priv
   {
     item = parent;
     v_box = new std::vector<float>();
-    is_recent = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->isRecent();
+    is_ogl_4_3 = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->isOpenGL_4_3();
     is_hidden = hidden;
     compile_shaders();
     initializeBuffers();
@@ -465,7 +465,7 @@ struct Scene_image_item_priv
   mutable QOpenGLVertexArrayObject vao[vaoSize];
   mutable QOpenGLShaderProgram rendering_program;
   bool is_hidden;
-  bool is_recent;
+  bool is_ogl_4_3;
   Scene_image_item* item;
 
 //#endif // SCENE_SEGMENTED_IMAGE_GL_BUFFERS_AVAILABLE
@@ -498,7 +498,7 @@ void Scene_image_item_priv::compile_shaders()
     vao[i].create();
   m_ibo = new QOpenGLBuffer(QOpenGLBuffer::IndexBuffer);
   m_ibo->create();
-  if(!is_recent)
+  if(!is_ogl_4_3)
   {
     //Vertex source code
     const char vertex_source[] =
@@ -755,7 +755,7 @@ Scene_image_item_priv::initializeBuffers()
                                                   m_voxel_scale,
                                                   m_voxel_scale,
                                                   m_voxel_scale);
-    internal::Vertex_buffer_helper helper (image_data_accessor, is_recent);
+    internal::Vertex_buffer_helper helper (image_data_accessor, is_ogl_4_3);
     helper.fill_buffer_data();
     rendering_program.bind();
     vao[0].bind();
@@ -809,7 +809,7 @@ Scene_image_item_priv::draw_gl(Viewer_interface* viewer) const
   if(!is_hidden)
   {
     vao[0].bind();
-    if(!is_recent)
+    if(!is_ogl_4_3)
       viewer->glDrawElements(GL_TRIANGLES, m_ibo->size()/sizeof(GLuint), GL_UNSIGNED_INT, 0);
     else
       viewer->glDrawElements(GL_LINES_ADJACENCY, m_ibo->size()/sizeof(GLuint), GL_UNSIGNED_INT, 0);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -110,6 +110,7 @@ struct Scene_polyhedron_item_priv{
   }
 
   void init_default_values() {
+    program = NULL;
     show_only_feature_edges_m = false;
     show_feature_edges_m = false;
     facet_picking_m = false;
@@ -128,15 +129,20 @@ struct Scene_polyhedron_item_priv{
   }
 
 
-  void compute_normals_and_vertices(const bool colors_only = false, const bool draw_two_sides = false) const;
+  void compute_normals_and_vertices(const bool is_recent,
+                                    const bool colors_only = false,
+                                    const bool draw_two_sides = false) const;
+
   bool isFacetConvex(Facet_iterator, const Polyhedron::Traits::Vector_3&)const;
 
   void triangulate_convex_facet(Facet_iterator,
-                                const bool)const;
+                                const bool, const bool, const bool is_recent)const;
 
   void triangulate_facet(Scene_polyhedron_item::Facet_iterator,
                          const Traits::Vector_3& normal,
-                         const bool colors_only, const bool draw_two_sides) const;
+                         const bool colors_only,
+                         const bool draw_two_sides,
+                         const bool is_recent) const;
   void init();
   void invalidate_stats();
   void* get_aabb_tree();
@@ -402,7 +408,9 @@ bool Scene_polyhedron_item_priv::isFacetConvex(Facet_iterator f, const Polyhedro
 }
 
 void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
-                                                          const bool colors_only)const
+                                                          const bool colors_only,
+                                                          const bool draw_two_sides,
+                                                          const bool is_recent)const
 {
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
   Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
@@ -439,13 +447,18 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
     idx_faces.push_back(static_cast<unsigned int>(he->vertex()->id()));
     idx_faces.push_back(static_cast<unsigned int>(next(he, *poly)->vertex()->id()));
 
-    if(!no_flat)
+    if(!no_flat || !is_recent )
     {
       push_back_xyz(p0+offset, positions_facets);
       push_back_xyz(p1+offset, positions_facets);
       push_back_xyz(p2+offset, positions_facets);
     }
-
+    if(!draw_two_sides)
+    {
+      push_back_xyz(f->plane().orthogonal_vector(), normals_flat);
+      push_back_xyz(f->plane().orthogonal_vector(), normals_flat);
+      push_back_xyz(f->plane().orthogonal_vector(), normals_flat);
+    }
   }
 
 
@@ -455,7 +468,10 @@ void
 Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_iterator fit,
                                          const Traits::Vector_3& normal,
                                          const bool colors_only,
-                                         const bool draw_two_sides = false) const
+                                         const bool draw_two_sides,
+                                         const bool is_recent) const
+
+
 {
   typedef FacetTriangulator<Polyhedron, Polyhedron::Traits, boost::graph_traits<Polyhedron>::vertex_descriptor> FT;
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
@@ -498,7 +514,7 @@ Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_itera
     idx_faces.push_back(static_cast<unsigned int>(triangulation.v2v[ffit->vertex(1)]->id()));
     idx_faces.push_back(static_cast<unsigned int>(triangulation.v2v[ffit->vertex(2)]->id()));
 
-    if(!no_flat)
+    if(!no_flat || !is_recent)
     {
       push_back_xyz(ffit->vertex(0)->point()+offset, positions_facets);
       push_back_xyz(ffit->vertex(1)->point()+offset, positions_facets);
@@ -519,121 +535,144 @@ void
 Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* viewer) const
 {
     //vao containing the data for the facets
+    if(!viewer->isRecent() && !no_flat)
     {
-    if(viewer->property("draw_two_sides").toBool())
+      //flat
+      if(viewer->property("draw_two_sides").toBool())
+      {
+        program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_OLD_FLAT, viewer);
+      }
+      else
+      {
+        program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
+      }
+      item->vaos[Facets]->bind();
+      item->buffers[Facets_vertices].bind();
+      item->buffers[Facets_vertices].allocate(positions_facets.data(),
+                                              static_cast<int>(positions_facets.size()*sizeof(float)));
+      program->enableAttributeArray("vertex");
+      program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
+      item->buffers[Facets_vertices].release();
+      if(viewer->property("draw_two_sides").toBool())
+      {
+        //computed in the fragment shader
+        program->disableAttributeArray("normals");
+      }
+      else
+      {
+        //use computed flat normals
+        item->buffers[Facets_normals_flat].bind();
+        item->buffers[Facets_normals_flat].allocate(normals_flat.data(),
+                                                    static_cast<int>(normals_flat.size()*sizeof(float)));
+        program->enableAttributeArray("normals");
+        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+        item->buffers[Facets_normals_flat].release();
+      }
+      if(is_multicolor)
+      {
+        item->buffers[Facets_color].bind();
+        item->buffers[Facets_color].allocate(color_facets.data(),
+                                             static_cast<int>(color_facets.size()*sizeof(float)));
+        program->enableAttributeArray("colors");
+        program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+        item->buffers[Facets_color].release();
+      }
+      else
+      {
+        program->disableAttributeArray("colors");
+      }
+      item->vaos[Facets]->release();
+    }
+  program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
+  program->bind();
+  //gouraud
+  item->vaos[Gouraud_Facets]->bind();
+  item->buffers[Edges_vertices].bind();
+  program->enableAttributeArray("vertex");
+  program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
+  item->buffers[Edges_vertices].release();
+
+  item->buffers[Facets_normals_gouraud].bind();
+  item->buffers[Facets_normals_gouraud].allocate(normals_gouraud.data(),
+                                                 static_cast<int>(normals_gouraud.size()*sizeof(float)));
+  program->enableAttributeArray("normals");
+  program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+  item->buffers[Facets_normals_gouraud].release();
+  if(is_multicolor)
+  {
+    item->buffers[Facets_color].bind();
+    program->enableAttributeArray("colors");
+    program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+    item->buffers[Facets_color].release();
+  }
+  else
+  {
+    program->disableAttributeArray("colors");
+  }
+  item->vaos[Gouraud_Facets]->release();
+  program->release();
+  if(viewer->isRecent())
+  {
+    //modern flat
+    program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_FLAT, viewer);
+    program->bind();
+    item->vaos[Gouraud_Facets]->bind();
+    item->buffers[Edges_vertices].bind();
+    program->enableAttributeArray("vertex");
+    program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
+    item->buffers[Edges_vertices].release();
+
+    item->buffers[Facets_normals_gouraud].bind();
+    program->enableAttributeArray("normals");
+    program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+    item->buffers[Facets_normals_gouraud].release();
+    if(is_multicolor)
     {
-      program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_FLAT, viewer);
+      item->buffers[Facets_color].bind();
+      program->enableAttributeArray("colors");
+      program->setAttributeBuffer("colors",GL_FLOAT,0,3);
+      item->buffers[Facets_color].release();
     }
     else
     {
-      program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
+      program->disableAttributeArray("colors");
     }
+    item->vaos[Gouraud_Facets]->release();
+    program->release();
+  }
+  //vao containing the data for the lines
+  {
+    program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITHOUT_LIGHT, viewer);
     program->bind();
-        //flat
-        if(!no_flat)
-        {
-          item->vaos[Facets]->bind();
-          item->buffers[Facets_vertices].bind();
-          item->buffers[Facets_vertices].allocate(positions_facets.data(),
-                                                  static_cast<int>(positions_facets.size()*sizeof(float)));
-          program->enableAttributeArray("vertex");
-          program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-          item->buffers[Facets_vertices].release();
-          if(viewer->property("draw_two_sides").toBool())
-          {
-            //computed in the fragment shader
-            program->disableAttributeArray("normals");
-          }
-          else
-          {
-           //use computed flat normals
-            item->buffers[Facets_normals_flat].bind();
-            item->buffers[Facets_normals_flat].allocate(normals_flat.data(),
-                                static_cast<int>(normals_flat.size()*sizeof(float)));
-            program->enableAttributeArray("normals");
-            program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-            item->buffers[Facets_normals_flat].release();
-          }
-          if(is_multicolor)
-          {
-            item->buffers[Facets_color].bind();
-            item->buffers[Facets_color].allocate(color_facets.data(),
-                                                 static_cast<int>(color_facets.size()*sizeof(float)));
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            item->buffers[Facets_color].release();
-          }
-          else
-          {
-            program->disableAttributeArray("colors");
-          }
-          item->vaos[Facets]->release();
-        }
-        program->release();
-        program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
-        program->bind();
-        //gouraud
-        item->vaos[Gouraud_Facets]->bind();
-        item->buffers[Edges_vertices].bind();
-        program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        item->buffers[Edges_vertices].release();
+    item->vaos[Edges]->bind();
 
-        item->buffers[Facets_normals_gouraud].bind();
-        item->buffers[Facets_normals_gouraud].allocate(normals_gouraud.data(),
-                            static_cast<int>(normals_gouraud.size()*sizeof(float)));
-        program->enableAttributeArray("normals");
-        program->setAttributeBuffer("normals",GL_FLOAT,0,3);
-        item->buffers[Facets_normals_gouraud].release();
-        if(is_multicolor)
-        {
-            item->buffers[Facets_color].bind();
-            program->enableAttributeArray("colors");
-            program->setAttributeBuffer("colors",GL_FLOAT,0,3);
-            item->buffers[Facets_color].release();
-        }
-        else
-        {
-            program->disableAttributeArray("colors");
-        }
-        item->vaos[Gouraud_Facets]->release();
+    item->buffers[Edges_vertices].bind();
+    item->buffers[Edges_vertices].allocate(positions_lines.data(),
+                                           static_cast<int>(positions_lines.size()*sizeof(float)));
+    program->enableAttributeArray("vertex");
+    program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
+    item->buffers[Edges_vertices].release();
 
-        program->release();
+    program->disableAttributeArray("colors");
+    program->release();
 
-    }
-    //vao containing the data for the lines
-    {
-        program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITHOUT_LIGHT, viewer);
-        program->bind();
-        item->vaos[Edges]->bind();
+    item->vaos[Edges]->release();
 
-        item->buffers[Edges_vertices].bind();
-        item->buffers[Edges_vertices].allocate(positions_lines.data(),
-                            static_cast<int>(positions_lines.size()*sizeof(float)));
-        program->enableAttributeArray("vertex");
-        program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-        item->buffers[Edges_vertices].release();
-
-        program->disableAttributeArray("colors");
-        program->release();
-
-        item->vaos[Edges]->release();
-
-    }
+  }
   //vao containing the data for the feature_edges
   {
-      program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_NO_SELECTION, viewer);
-      program->bind();
-      item->vaos[Feature_edges]->bind();
+    program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_NO_SELECTION, viewer);
+    program->bind();
+    item->vaos[Feature_edges]->bind();
 
-      item->buffers[Edges_vertices].bind();
-      program->enableAttributeArray("vertex");
-      program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
-      item->buffers[Edges_vertices].release();
-      program->disableAttributeArray("colors");
-      program->release();
+    item->buffers[Edges_vertices].bind();
+    program->enableAttributeArray("vertex");
+    program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
+    item->buffers[Edges_vertices].release();
+    program->disableAttributeArray("colors");
+    program->release();
 
-      item->vaos[Feature_edges]->release();
+    item->vaos[Feature_edges]->release();
 
   }
   nb_lines = positions_lines.size();
@@ -656,8 +695,11 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
 }
 
 void
-Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only, const bool draw_two_sides) const
+Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool is_recent,
+                                                         const bool colors_only,
+                                                         const bool draw_two_sides) const
 {
+  bool add_flat_data = !is_recent || !no_flat;
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -706,7 +748,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only,
           HF_circulator end = he;
           CGAL_For_all(he,end)
           {
-            if (!no_flat && item->isItemMulticolor())
+            if (add_flat_data && item->isItemMulticolor())
             {
               color_facets.push_back(colors_[this_patch_id-m_min_patch_id].redF());
               color_facets.push_back(colors_[this_patch_id-m_min_patch_id].greenF());
@@ -718,7 +760,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only,
             const Point& p = he->vertex()->point();
 
             // If Flat shading:1 normal per polygon added once per vertex
-            if(!no_flat)
+            if(add_flat_data)
             {
               push_back_xyz(p+offset, positions_facets);
               if(!draw_two_sides)
@@ -748,7 +790,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only,
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->vertex()->id()));
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->vertex()->id()));
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->next()->vertex()->id()));
-        if(!no_flat)
+        if(add_flat_data)
         {
           Point p0 = f->halfedge()->vertex()->point();
           Point p1 = f->halfedge()->next()->vertex()->point();
@@ -768,7 +810,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only,
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->prev()->vertex()->id()));
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->vertex()->id()));
 
-        if(!no_flat)
+        if(add_flat_data)
         {
           Point p0 = f->halfedge()->next()->next()->vertex()->point();
           Point p1 = f->halfedge()->prev()->vertex()->point();
@@ -789,11 +831,11 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only,
       {
         if(isFacetConvex(f, nf))
         {
-          triangulate_convex_facet(f, colors_only);
+          triangulate_convex_facet(f, colors_only, draw_two_sides, is_recent);
         }
         else
         {
-          this->triangulate_facet(f, nf, colors_only, draw_two_sides);
+          this->triangulate_facet(f, nf, colors_only, draw_two_sides, is_recent);
         }
       }
 
@@ -1146,7 +1188,6 @@ QMenu* Scene_polyhedron_item::contextMenu()
     actionEraseNextFacet->setObjectName("actionEraseNextFacet");
     connect(actionEraseNextFacet, SIGNAL(toggled(bool)),
             this, SLOT(set_erase_next_picked_facet(bool)));
-
     QAction* actionDisableFlatShading=
         menu->addAction(tr("Disable Flat Shading"));
     actionDisableFlatShading->setCheckable(true);
@@ -1204,24 +1245,19 @@ void Scene_polyhedron_item::set_erase_next_picked_facet(bool b)
 void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(false, viewer->property("draw_two_sides").toBool());
+        d->compute_normals_and_vertices(viewer->isRecent(),
+                                        false,
+                                        viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }
 
-    if(renderingMode() == Flat || (!d->no_flat && renderingMode() == FlatPlusEdges))
+    if(viewer->isRecent() &&
+       (renderingMode() == Flat || renderingMode() == FlatPlusEdges))
     {
-        vaos[Scene_polyhedron_item_priv::Facets]->bind();
-        if(viewer->property("draw_two_sides").toBool())
-        {
-          attribBuffers(viewer, PROGRAM_FLAT);
-          d->program = getShaderProgram(PROGRAM_FLAT);
-        }
-        else
-        {
-          attribBuffers(viewer, PROGRAM_WITH_LIGHT);
-          d->program = getShaderProgram(PROGRAM_WITH_LIGHT);
-        }
+        vaos[Scene_polyhedron_item_priv::Gouraud_Facets]->bind();
+        attribBuffers(viewer, PROGRAM_FLAT);
+        d->program = getShaderProgram(PROGRAM_FLAT);
         d->program->bind();
         if(!d->is_multicolor)
         {
@@ -1231,9 +1267,37 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
                 d->program->setUniformValue("is_selected", true);
         else
                 d->program->setUniformValue("is_selected", false);
-        viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(d->nb_facets/3));
+        glDrawElements(GL_TRIANGLES, static_cast<GLuint>(d->idx_faces.size()),
+                       GL_UNSIGNED_INT, d->idx_faces.data());
         d->program->release();
-        vaos[Scene_polyhedron_item_priv::Facets]->release();
+        vaos[Scene_polyhedron_item_priv::Gouraud_Facets]->release();
+    }
+    else if(!viewer->isRecent()&&
+            (renderingMode() == Flat || renderingMode() == FlatPlusEdges))
+    {
+      vaos[Scene_polyhedron_item_priv::Facets]->bind();
+      if(viewer->property("draw_two_sides").toBool())
+      {
+        attribBuffers(viewer, PROGRAM_OLD_FLAT);
+        d->program = getShaderProgram(PROGRAM_OLD_FLAT);
+      }
+      else
+      {
+        attribBuffers(viewer, PROGRAM_WITH_LIGHT);
+        d->program = getShaderProgram(PROGRAM_WITH_LIGHT);
+      }
+      d->program->bind();
+      if(!d->is_multicolor)
+      {
+        d->program->setAttributeValue("colors", this->color());
+      }
+      if(is_selected)
+        d->program->setUniformValue("is_selected", true);
+      else
+        d->program->setUniformValue("is_selected", false);
+      viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(d->nb_facets/3));
+      d->program->release();
+      vaos[Scene_polyhedron_item_priv::Facets]->release();
     }
     else
     {
@@ -1255,9 +1319,6 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
         d->program->release();
         vaos[Scene_polyhedron_item_priv::Gouraud_Facets]->release();
     }
-
-
-
 }
 
 // Points/Wireframe/Flat/Gouraud OpenGL drawing in a display list
@@ -1265,7 +1326,8 @@ void Scene_polyhedron_item::drawEdges(CGAL::Three::Viewer_interface* viewer) con
 {
     if (!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(false, viewer->property("draw_two_sides").toBool());
+        d->compute_normals_and_vertices(viewer->isRecent(), false,
+                                        viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }
@@ -1313,7 +1375,7 @@ void
 Scene_polyhedron_item::drawPoints(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(false, viewer->property("draw_two_sides").toBool());
+        d->compute_normals_and_vertices(viewer->isRecent(), false, viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -535,7 +535,7 @@ void
 Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* viewer) const
 {
     //vao containing the data for the facets
-    if(!viewer->isRecent() && !no_flat)
+    if(!viewer->isOpenGL_4_3() && !no_flat)
     {
       //flat
       if(viewer->property("draw_two_sides").toBool())
@@ -611,7 +611,7 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
   }
   item->vaos[Gouraud_Facets]->release();
   program->release();
-  if(viewer->isRecent())
+  if(viewer->isOpenGL_4_3())
   {
     //modern flat
     program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_FLAT, viewer);
@@ -1188,13 +1188,15 @@ QMenu* Scene_polyhedron_item::contextMenu()
     actionEraseNextFacet->setObjectName("actionEraseNextFacet");
     connect(actionEraseNextFacet, SIGNAL(toggled(bool)),
             this, SLOT(set_erase_next_picked_facet(bool)));
-    QAction* actionDisableFlatShading=
-        menu->addAction(tr("Disable Flat Shading"));
-    actionDisableFlatShading->setCheckable(true);
-    actionDisableFlatShading->setObjectName("actionDisableFlatShading");
-    connect(actionDisableFlatShading, SIGNAL(toggled(bool)),
-            this, SLOT(set_flat_disabled(bool)));
-
+    if(! static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->isOpenGL_4_3())
+    {
+      QAction* actionDisableFlatShading=
+          menu->addAction(tr("Disable Flat Shading"));
+      actionDisableFlatShading->setCheckable(true);
+      actionDisableFlatShading->setObjectName("actionDisableFlatShading");
+      connect(actionDisableFlatShading, SIGNAL(toggled(bool)),
+              this, SLOT(set_flat_disabled(bool)));
+    }
     menu->setProperty(prop_name, true);
   }
 
@@ -1245,14 +1247,14 @@ void Scene_polyhedron_item::set_erase_next_picked_facet(bool b)
 void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(viewer->isRecent(),
+        d->compute_normals_and_vertices(viewer->isOpenGL_4_3(),
                                         false,
                                         viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }
 
-    if(viewer->isRecent() &&
+    if(viewer->isOpenGL_4_3() &&
        (renderingMode() == Flat || renderingMode() == FlatPlusEdges))
     {
         vaos[Scene_polyhedron_item_priv::Gouraud_Facets]->bind();
@@ -1272,7 +1274,7 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
         d->program->release();
         vaos[Scene_polyhedron_item_priv::Gouraud_Facets]->release();
     }
-    else if(!viewer->isRecent()&&
+    else if(!viewer->isOpenGL_4_3()&&
             (renderingMode() == Flat || renderingMode() == FlatPlusEdges))
     {
       vaos[Scene_polyhedron_item_priv::Facets]->bind();
@@ -1326,7 +1328,7 @@ void Scene_polyhedron_item::drawEdges(CGAL::Three::Viewer_interface* viewer) con
 {
     if (!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(viewer->isRecent(), false,
+        d->compute_normals_and_vertices(viewer->isOpenGL_4_3(), false,
                                         viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
@@ -1375,7 +1377,7 @@ void
 Scene_polyhedron_item::drawPoints(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices(viewer->isRecent(), false, viewer->property("draw_two_sides").toBool());
+        d->compute_normals_and_vertices(viewer->isOpenGL_4_3(), false, viewer->property("draw_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1678,6 +1678,5 @@ bool Viewer::isRecent() const { return d->is_recent; }
 
 bool Viewer::isOpenGL_4_3() const { return d->is_ogl_4_3; }
 
-QOpenGLFunctions_4_3_Compatibility* Viewer::recentFunctions() { return d->_recentFunctions; }
-
+QOpenGLFunctions_4_3_Compatibility* Viewer::openGL_4_3_functions() { return d->_recentFunctions; }
  #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -787,6 +787,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
     case PROGRAM_C3T3_TETS:
+    case PROGRAM_OLD_FLAT:
     case PROGRAM_FLAT:
         program->setUniformValue("light_pos", position);
         program->setUniformValue("light_diff",diffuse);
@@ -805,6 +806,7 @@ void Viewer::attribBuffers(int program_name) const {
     case PROGRAM_CUTPLANE_SPHERES:
     case PROGRAM_SPHERES:
     case PROGRAM_C3T3_TETS:
+    case PROGRAM_OLD_FLAT:
     case PROGRAM_FLAT:
       program->setUniformValue("mv_matrix", mv_mat);
       break;
@@ -1168,6 +1170,13 @@ QOpenGLShaderProgram* Viewer::declare_program(int name,
     {
       std::cerr<<"adding fragment shader FAILED"<<std::endl;
     }
+    if(strcmp(f_shader,":/cgal/Polyhedron_3/resources/shader_flat.f" ) == 0)
+    {
+      if(!program->addShaderFromSourceFile(QOpenGLShader::Geometry,":/cgal/Polyhedron_3/resources/shader_flat.g" ))
+      {
+        std::cerr<<"adding geometry shader FAILED"<<std::endl;
+      }
+    }
     program->bindAttributeLocation("colors", 1);
     program->link();
     d->shader_programs[name] = program;
@@ -1218,7 +1227,9 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
       return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_spheres.v" , ":/cgal/Polyhedron_3/resources/shader_with_light.f");
       break;
     case PROGRAM_FLAT:
-      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_light.v", ":/cgal/Polyhedron_3/resources/shader_flat.f");
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_flat.v", ":/cgal/Polyhedron_3/resources/shader_flat.f");
+    case PROGRAM_OLD_FLAT:
+      return declare_program(name, ":/cgal/Polyhedron_3/resources/shader_with_light.v", ":/cgal/Polyhedron_3/resources/shader_old_flat.f");
       break;
 
     default:

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -43,7 +43,7 @@ public:
   bool _displayMessage;
   QTimer messageTimer;
   QOpenGLFunctions_4_3_Compatibility* _recentFunctions;
-  bool is_recent;
+  bool is_ogl_4_3;
 
   //! Holds useful data to draw the axis system
   struct AxisData
@@ -246,11 +246,11 @@ void Viewer::initializeGL()
     format.setVersion(2,1);
     new_context->setFormat(format);
     created = new_context->create();
-    d->is_recent = false;
+    d->is_ogl_4_3 = false;
   }
   else
   {
-    d->is_recent = true;
+    d->is_ogl_4_3 = true;
     d->_recentFunctions = new QOpenGLFunctions_4_3_Compatibility();
   }
   CGAL_warning_msg(created && new_context->isValid(), "The openGL context initialization failed "
@@ -259,7 +259,7 @@ void Viewer::initializeGL()
   context()->makeCurrent();
   QGLViewer::initializeGL();
   initializeOpenGLFunctions();
-  if(isRecent())
+  if(isOpenGL_4_3())
   {
    d->_recentFunctions->initializeOpenGLFunctions();
   }
@@ -1674,6 +1674,9 @@ void Viewer::enableClippingBox(QVector4D box[6])
 }
 
 bool Viewer::isRecent() const { return d->is_recent; }
+
+
+bool Viewer::isOpenGL_4_3() const { return d->is_ogl_4_3; }
 
 QOpenGLFunctions_4_3_Compatibility* Viewer::recentFunctions() { return d->_recentFunctions; }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1673,8 +1673,6 @@ void Viewer::enableClippingBox(QVector4D box[6])
     d->clipbox[i] = box[i];
 }
 
-bool Viewer::isRecent() const { return d->is_recent; }
-
 
 bool Viewer::isOpenGL_4_3() const { return d->is_ogl_4_3; }
 

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -151,8 +151,8 @@ protected:
   double prev_radius;
 
 public:
-  bool isOpenGL_4_3() const;
-  QOpenGLFunctions_4_3_Compatibility* recentFunctions();
+  bool isOpenGL_4_3() const Q_DECL_OVERRIDE;
+  QOpenGLFunctions_4_3_Compatibility* openGL_4_3_functions() Q_DECL_OVERRIDE;
 
 }; // end class Viewer
 

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -151,7 +151,7 @@ protected:
   double prev_radius;
 
 public:
-  bool isRecent() const;
+  bool isOpenGL_4_3() const;
   QOpenGLFunctions_4_3_Compatibility* recentFunctions();
 
 }; // end class Viewer

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -150,6 +150,10 @@ protected:
   Viewer_impl* d;
   double prev_radius;
 
+public:
+  bool isRecent() const;
+  QOpenGLFunctions_4_3_Compatibility* recentFunctions();
+
 }; // end class Viewer
 
 

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.f
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.f
@@ -1,0 +1,61 @@
+#version 430 core
+
+in GS_OUT
+{
+  vec4 fP;
+  vec3 fN;
+  flat vec4 color[4];
+  vec2 uv;
+  flat vec4 prob[4];
+} fs_in;
+
+uniform bool is_two_side;
+uniform vec4 light_pos;
+uniform vec4 light_diff;
+uniform vec4 light_spec;
+uniform vec4 light_amb;
+uniform float spec_power ;
+
+out vec4 out_color;
+
+void main(void)
+{
+  vec4 color;
+  //find base color of pixel
+  vec4 m1 = mix(fs_in.prob[0], fs_in.prob[1], fs_in.uv.y);
+  vec4 m2 = mix(fs_in.prob[3], fs_in.prob[2], fs_in.uv.y);
+  vec4 m3 = mix(m1,m2, fs_in.uv.x);
+  float maximum =
+    max(m3[0],
+          max(m3[1],
+            max(m3[2],m3[3])));
+  if(maximum == m3[0])
+    color = fs_in.color[0];
+  else if(maximum == m3[1])
+    color = fs_in.color[1];
+  else if(maximum == m3[2])
+    color = fs_in.color[2];
+  else //(maximum == m3[3])
+    color = fs_in.color[3];
+
+  //compute and apply light effects
+  vec3 L = light_pos.xyz - fs_in.fP.xyz;
+  vec3 V = -fs_in.fP.xyz;
+
+  vec3 N;
+  if(fs_in.fN == vec3(0.0,0.0,0.0))
+      N = vec3(0.0,0.0,0.0);
+  else
+      N = normalize(fs_in.fN);
+  L = normalize(L);
+  V = normalize(V);
+
+  vec3 R = reflect(-L, N);
+  vec4 diffuse;
+  if(!is_two_side)
+      diffuse = max(dot(N,L),0) * light_diff*color;
+  else
+      diffuse = max(abs(dot(N,L)),0) * light_diff*color;
+  vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
+  out_color = color*light_amb + diffuse + specular;
+}

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.f
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.f
@@ -57,5 +57,5 @@ void main(void)
   else
       diffuse = max(abs(dot(N,L)),0) * light_diff*color;
   vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
-  out_color = color*light_amb + diffuse + specular;
+  out_color = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1.0);
 }

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.g
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.g
@@ -1,0 +1,103 @@
+#version 430 core
+
+layout (lines_adjacency) in;
+layout (triangle_strip, max_vertices = 6) out;
+
+in VS_OUT
+{
+  vec4 fP;
+  vec3 fN;
+  vec4 out_color;
+} gs_in[4];
+
+out GS_OUT
+{
+  vec4 fP;
+  vec3 fN;
+  flat vec4 color[4];
+  vec2 uv;
+  flat vec4 prob[4];
+} gs_out;
+
+void main(void)
+{
+  gl_Position = gl_in[0].gl_Position;
+  gs_out.fN = gs_in[0].fN;
+  gs_out.fP = gs_in[0].fP;
+  gs_out.uv = vec2(0.0, 0.0);
+
+  EmitVertex();
+
+  gl_Position = gl_in[1].gl_Position;
+  gs_out.fN = gs_in[1].fN;
+  gs_out.fP = gs_in[1].fP;
+  gs_out.uv = vec2(0.0, 1.0);
+  EmitVertex();
+
+  gl_Position = gl_in[3].gl_Position;
+  gs_out.fN = gs_in[3].fN;
+  gs_out.fP = gs_in[3].fP;
+  gs_out.uv = vec2(1.0, 0.0);
+
+  // We're only writing the output color for the last
+  // vertex here because they're flat attributes,
+  // and the last vertex is the provoking vertex by default
+  gs_out.color[0] = gs_in[0].out_color;
+  gs_out.color[1] = gs_in[1].out_color;
+  gs_out.color[2] = gs_in[2].out_color;
+  gs_out.color[3] = gs_in[3].out_color;
+  for(int i=0; i<4; ++i)
+   for(int j=0;j<4;++j)
+     gs_out.prob[i][j]=0;
+  for(int i=0; i<4; ++i)
+  {
+    for(int j=0; j<4; ++j)
+    {
+      if(gs_out.color[i] == gs_out.color[j])
+      {
+        gs_out.prob[i][j] = 1.0;
+      }
+    }
+  }
+  EmitVertex();
+
+  EndPrimitive();
+
+  gl_Position = gl_in[1].gl_Position;
+  gs_out.fN = gs_in[1].fN;
+  gs_out.fP = gs_in[1].fP;
+  gs_out.uv = vec2(0.0, 1.0);
+  EmitVertex();
+
+  gl_Position = gl_in[2].gl_Position;
+  gs_out.fN = gs_in[2].fN;
+  gs_out.fP = gs_in[2].fP;
+  gs_out.uv = vec2(1.0, 1.0);
+  EmitVertex();
+
+  gl_Position = gl_in[3].gl_Position;
+  gs_out.fN = gs_in[3].fN;
+  gs_out.fP = gs_in[3].fP;
+  gs_out.uv = vec2(1.0, 0.0);
+  // Again, only write the output color for the last vertex
+  gs_out.color[0] = gs_in[0].out_color;
+  gs_out.color[1] = gs_in[1].out_color;
+  gs_out.color[2] = gs_in[2].out_color;
+  gs_out.color[3] = gs_in[3].out_color;
+  for(int i=0; i<4; ++i)
+    for(int j=0;j<4;++j)
+      gs_out.prob[i][j]=0;
+  for(int i=0; i<4; ++i)
+  {
+    for(int j=0; j<4; ++j)
+    {
+      if(gs_out.color[i] == gs_out.color[j])
+      {
+        gs_out.prob[i][j] = 1.0;
+      }
+    }
+  }
+  EmitVertex();
+
+  EndPrimitive();
+}

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.v
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.v
@@ -1,0 +1,23 @@
+#version 430 core
+
+in vec4 vertex;
+in vec3 normal;
+in vec4 inColor;
+
+out VS_OUT
+{
+  vec4 fP;
+  vec3 fN;
+  vec4 out_color;
+}vs_out;
+
+uniform mat4 mvp_matrix;
+uniform mat4 mv_matrix;
+
+void main(void)
+{
+   vs_out.out_color=inColor;
+   vs_out.fP = mv_matrix * vertex;
+   vs_out.fN = mat3(mv_matrix)* normal;
+   gl_Position = mvp_matrix * vertex;
+}

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.f
@@ -1,51 +1,46 @@
-#version 120
-varying highp vec4 color;
-varying highp vec4 fP;
-varying highp float dist[6];
-uniform highp vec4 light_pos;
-uniform highp vec4 light_diff;
-uniform highp vec4 light_spec;
-uniform highp vec4 light_amb;
-uniform highp float spec_power ;
-uniform int is_two_side;
-uniform bool is_selected;
-uniform bool is_clipbox_on;
-void main(void) {
+#version 430 core
 
-if(is_clipbox_on)
-  if(dist[0]>0 ||
-     dist[1]>0 ||
-     dist[2]>0 ||
-     dist[3]>0 ||
-     dist[4]>0 ||
-     dist[5]>0)
-    discard;
+in GS_OUT
+{
+  vec4 fP;
+  flat vec3 normal;
+  flat vec4 color;
+} fs_in;
 
-   highp vec3 L = light_pos.xyz - fP.xyz;
-   highp vec3 V = -fP.xyz;
-   highp vec3 N;
-   vec3 X = dFdx(fP.xyz);
-   vec3 Y = dFdy(fP.xyz);
-   vec3 normal=normalize(cross(X,Y));
+uniform bool is_two_side;
+uniform vec4 light_pos;
+uniform vec4 light_diff;
+uniform vec4 light_spec;
+uniform vec4 light_amb;
+uniform float spec_power ;
 
-   if(normal == highp vec3(0.0,0.0,0.0))
+out vec4 out_color;
+
+void main(void)
+{
+  vec3 L = light_pos.xyz - fs_in.fP.xyz;
+  vec3 V = -fs_in.fP.xyz;
+
+  vec3 N;
+  vec3 X = dFdx(fs_in.fP.xyz);
+  vec3 Y = dFdy(fs_in.fP.xyz);
+  vec3 normal=normalize(cross(X,Y));
+  if(dot(normal, fs_in.normal) <0)
+    normal = - normal;
+
+  if(normal == highp vec3(0.0,0.0,0.0))
        N = highp vec3(0.0,0.0,0.0);
    else
        N = normalize(normal);
-   L = normalize(L);
-   V = normalize(V);
-   highp vec3 R = reflect(-L, N);
+  L = normalize(L);
+  V = normalize(V);
+
+  vec3 R = reflect(-L, N);
   vec4 diffuse;
-   if(is_two_side == 1)
-       diffuse = abs(dot(N,L)) * light_diff * color;
-   else
-       diffuse = max(dot(N,L), 0.0) * light_diff * color;
-   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
-   vec4 ret_color = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1);
-   if(is_selected)
-       gl_FragColor = vec4(ret_color.r+70.0/255.0, ret_color.g+70.0/255.0, ret_color.b+70.0/255.0, 1.0);
-   else
-       gl_FragColor = ret_color;
+  if(!is_two_side)
+      diffuse = max(dot(N,L),0) * light_diff*fs_in.color;
+  else
+      diffuse = max(abs(dot(N,L)),0) * light_diff*fs_in.color;
+  vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
+  out_color = vec4((fs_in.color*light_amb).xyz + diffuse.xyz + specular.xyz,1.0);
 }
-
-

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.g
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.g
@@ -1,0 +1,51 @@
+#version 430 core
+
+layout (triangles) in;
+layout (triangle_strip, max_vertices = 3) out;
+
+in VS_OUT
+{
+  vec4 fP;
+  vec3 normal;
+  vec4 out_color;
+} gs_in[3];
+
+out GS_OUT
+{
+  vec4 fP;
+  flat vec3 normal;
+  flat vec4 color;
+} gs_out;
+
+uniform mat4 mv_matrix;
+
+void main(void)
+{
+  gl_Position = gl_in[0].gl_Position;
+  gs_out.fP = gs_in[0].fP;
+
+  EmitVertex();
+
+  gl_Position = gl_in[1].gl_Position;
+  gs_out.fP = gs_in[1].fP;
+
+EmitVertex();
+
+  gl_Position = gl_in[2].gl_Position;
+  gs_out.fP = gs_in[2].fP;
+
+  // We're only writing the output color for the last
+  // vertex here because they're flat attributes,
+  // and the last vertex is the provoking vertex by default
+  vec3 normal = vec3(0.0,0.0,0.0);
+  for(int i=0; i<3; ++i)
+  {
+    normal+=gs_in[i].normal/3;
+  }
+  gs_out.normal = mat3(mv_matrix)* normal;
+  gs_out.color = gs_in[2].out_color;
+
+  EmitVertex();
+
+  EndPrimitive();
+}

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.v
@@ -1,0 +1,23 @@
+#version 430 core
+
+in vec4 vertex;
+in vec3 normals;
+in vec4 colors;
+
+out VS_OUT
+{
+  vec4 fP;
+  vec3 normal;
+  vec4 out_color;
+}vs_out;
+
+uniform mat4 mvp_matrix;
+uniform mat4 mv_matrix;
+
+void main(void)
+{
+   vs_out.out_color=colors;
+   vs_out.fP = mv_matrix * vertex;
+   vs_out.normal = normals;
+   gl_Position = mvp_matrix * vertex;
+}

--- a/Polyhedron/demo/Polyhedron/resources/shader_old_flat.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_old_flat.f
@@ -1,0 +1,37 @@
+#version 120
+varying highp vec4 color;
+varying highp vec4 fP;
+uniform highp vec4 light_pos;
+uniform highp vec4 light_diff;
+uniform highp vec4 light_spec;
+uniform highp vec4 light_amb;
+uniform highp float spec_power ;
+uniform int is_two_side;
+uniform bool is_selected;
+void main(void) {
+   highp vec3 L = light_pos.xyz - fP.xyz;
+   highp vec3 V = -fP.xyz;
+   highp vec3 N;
+   vec3 X = dFdx(fP.xyz);
+   vec3 Y = dFdy(fP.xyz);
+   vec3 normal=normalize(cross(X,Y));
+
+   if(normal == highp vec3(0.0,0.0,0.0))
+       N = highp vec3(0.0,0.0,0.0);
+   else
+       N = normalize(normal);
+   L = normalize(L);
+   V = normalize(V);
+   highp vec3 R = reflect(-L, N);
+  vec4 diffuse;
+   if(is_two_side == 1)
+       diffuse = abs(dot(N,L)) * light_diff * color;
+   else
+       diffuse = max(dot(N,L), 0.0) * light_diff * color;
+   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
+   vec4 ret_color = vec4((color*light_amb).xyz + diffuse.xyz + specular.xyz,1);
+   if(is_selected)
+       gl_FragColor = vec4(ret_color.r+70.0/255.0, ret_color.g+70.0/255.0, ret_color.b+70.0/255.0, 1.0);
+   else
+       gl_FragColor = ret_color;
+}

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -70,21 +70,22 @@ public:
    */
  enum OpenGL_program_IDs
  {
-  PROGRAM_WITH_LIGHT = 0,      //! Used to render a surface or an edge affected by the light. It uses a per fragment lighting model, and renders the selected item brighter.
-  PROGRAM_WITHOUT_LIGHT,       //! Used to render a polyhedron edge or points. It renders in a uniform color and is not affected by light. \attention It renders the selected item in black.
-  PROGRAM_NO_SELECTION,        //! Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.
-  PROGRAM_WITH_TEXTURE,        //! Used to render a textured polyhedron. Affected by light.
-  PROGRAM_PLANE_TWO_FACES,     //! Used to render a two-faced plane. The two faces have a different color. Not affected by light.
-  PROGRAM_WITH_TEXTURED_EDGES, //! Used to render the edges of a textured polyhedron. Not affected by light.
-  PROGRAM_INSTANCED,           //! Used to display instanced rendered spheres.Affected by light.
-  PROGRAM_INSTANCED_WIRE,      //! Used to display instanced rendered wired spheres. Not affected by light.
-  PROGRAM_C3T3,                //! Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.
-  PROGRAM_C3T3_EDGES,          //! Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.
-  PROGRAM_CUTPLANE_SPHERES,    //! Used to render the spheres of an item with a cut plane.
-  PROGRAM_SPHERES,             //! Used to render one or several spheres.
-  PROGRAM_C3T3_TETS,           //! Used to render the tetrahedra of the intersection of a c3t3_item.
-  PROGRAM_FLAT,                //! Used to render flat shading without pre computing normals
-  NB_OF_PROGRAMS               //! Holds the number of different programs in this enum.
+  PROGRAM_WITH_LIGHT = 0,      /** Used to render a surface or edge affected by the light. It uses a per fragment lighting model, and renders brighter the selected item.*/
+  PROGRAM_WITHOUT_LIGHT,       /** Used to render a polygon edge or points. It renders in a uniform color and is not affected by light. It renders the selected item in black.*/
+  PROGRAM_NO_SELECTION,        /** Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.*/
+  PROGRAM_WITH_TEXTURE,        /** Used to render a textured polyhedron. Affected by light.*/
+  PROGRAM_PLANE_TWO_FACES,     /** Used to render a two-faced plane. The two faces have a different color. Not affected by light.*/
+  PROGRAM_WITH_TEXTURED_EDGES, /** Used to render the edges of a textured polyhedorn. Not affected by light.*/
+  PROGRAM_INSTANCED,           /** Used to display instanced rendered spheres.Affected by light.*/
+  PROGRAM_INSTANCED_WIRE,      /** Used to display instanced rendered wired spheres. Not affected by light.*/
+  PROGRAM_C3T3,                /** Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.*/
+  PROGRAM_C3T3_EDGES,          /** Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.*/
+  PROGRAM_CUTPLANE_SPHERES,    /** Used to render the spheres of an item with a cut plane.*/
+  PROGRAM_SPHERES,             /** Used to render one or several spheres.*/
+  PROGRAM_C3T3_TETS,           /** Used to render the tetrahedra of the intersection of a c3t3_item.*/
+  PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
+  PROGRAM_OLD_FLAT,            /** Used to render flat shading without pre computing normals without geometry shader*/
+  NB_OF_PROGRAMS               /** Holds the number of different programs in this enum.*/
  };
   typedef CGAL::Bbox_3 Bbox;
   typedef qglviewer::ManipulatedFrame ManipulatedFrame;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -243,7 +243,7 @@ public:
   //! Geometry Shaders or Depth Textures.
   //! @returns a pointer to an initialized  QOpenGLFunctions_4_3_Compatibility if `isOpenGL_4_3()` is `true`
   //! @returns NULL if `isOpenGL_4_3()` is `false`
-  virtual QOpenGLFunctions_4_3_Compatibility* recentFunctions() = 0;
+  virtual QOpenGLFunctions_4_3_Compatibility* openGL_4_3_functions() = 0;
 }; // end class Viewer_interface
 }
 }

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -28,6 +28,7 @@
 #include <QWidget>
 #include <QPoint>
 #include <QOpenGLFunctions_2_1>
+#include <QOpenGLFunctions_4_3_Compatibility>
 #include <CGAL/Qt/CreateOpenGLContext.h>
 // forward declarations
 class QWidget;
@@ -232,7 +233,16 @@ public Q_SLOTS:
 //! \param animation_duration is the duration of the animation of the movement.
   virtual bool moveCameraToCoordinates(QString target,
                                        float animation_duration = 0.5f) = 0;
-
+public:
+  //! Is used to know if the openGL context is 4.3 or 2.1.
+  //! @returns `true` if the context is 4.3.
+  //! @returns `false` if the context is 2.1.
+  virtual bool isRecent() const = 0;
+  //! Gives acces to recent openGL(4.3) features, allowing use of things like
+  //! Geometry Shaders or Depth Textures.
+  //! @returns a pointer to an initialized  QOpenGLFunctions_4_3_Compatibility if `isRecent()` is `true`
+  //! @returns NULL if `isRecent()` is `false`
+  virtual QOpenGLFunctions_4_3_Compatibility* recentFunctions() = 0;
 }; // end class Viewer_interface
 }
 }

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -238,11 +238,11 @@ public:
   //! Is used to know if the openGL context is 4.3 or 2.1.
   //! @returns `true` if the context is 4.3.
   //! @returns `false` if the context is 2.1.
-  virtual bool isRecent() const = 0;
+  virtual bool isOpenGL_4_3() const = 0;
   //! Gives acces to recent openGL(4.3) features, allowing use of things like
   //! Geometry Shaders or Depth Textures.
-  //! @returns a pointer to an initialized  QOpenGLFunctions_4_3_Compatibility if `isRecent()` is `true`
-  //! @returns NULL if `isRecent()` is `false`
+  //! @returns a pointer to an initialized  QOpenGLFunctions_4_3_Compatibility if `isOpenGL_4_3()` is `true`
+  //! @returns NULL if `isOpenGL_4_3()` is `false`
   virtual QOpenGLFunctions_4_3_Compatibility* recentFunctions() = 0;
 }; // end class Viewer_interface
 }

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -72,7 +72,8 @@ public:
    PROGRAM_CUTPLANE_SPHERES,    //! Used to render the spheres of an item with a cut plane.
    PROGRAM_SPHERES,             //! Used to render one or several spheres.
    PROGRAM_C3T3_TETS,           //! Used to render the tetrahedra of the intersection of a c3t3_item.
-   PROGRAM_FLAT,                //! Used to render flat shading without pre computing normals
+   PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
+   PROGRAM_OLD_FLAT,            /** Used to render flat shading without pre computing normals without geometry shader*/
    NB_OF_PROGRAMS               //! Holds the number of different programs in this enum.
   };
 


### PR DESCRIPTION
## Summary of Changes
Set an OpenGL 4.3 format if possible and create a QOpenGLFunctions_4_3_Compatibility in that case.
Use this recent context to link geometry shaders in order to use an efficient flat shading in polyhedron_item and to fix the visual problems remaining in #950.
## Release Management

* Affected package(s): Polyhedron_demo
* Issue(s) solved (if any): fix #2055 

