### PR TITLE
Polyhedron demo : improve .surf reader

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_io_plugin.cpp
@@ -15,6 +15,7 @@
 
 #include "Color_map.h"
 #include <fstream>
+#include <boost/container/flat_set.hpp>
 
 using namespace CGAL::Three;
 class Surf_io_plugin:
@@ -62,13 +63,19 @@ CGAL::Three::Scene_item* Surf_io_plugin::load(QFileInfo fileinfo)
   std::vector<MaterialData> material_data;
   CGAL::Bbox_3 grid_box;
   CGAL::cpp11::array<unsigned int, 3> grid_size = {{1, 1, 1}};
-  read_surf(in, patches, material_data, grid_box, grid_size);
+  boost::container::flat_set<Polyhedron::Point_3> duplicated_points;
+  read_surf(in, patches, material_data, grid_box, grid_size
+          , std::inserter(duplicated_points, duplicated_points.end()));
+
   for(std::size_t i=0; i<material_data.size(); ++i)
   {
    std::cout<<"The patch #"<<i<<":\n  -inner region : material's id = "<<material_data[i].innerRegion.first<<" material's name = "
            <<material_data[i].innerRegion.second<<"\n  -outer region: material's id = "<<material_data[i].outerRegion.first<<" material's name = "
              <<material_data[i].outerRegion.second<<std::endl;
   }
+  if (!duplicated_points.empty())
+    std::cout << duplicated_points.size() << " points have been duplicated." << std::endl;
+  
   std::vector<QColor> colors_;
   compute_color_map(QColor(100, 100, 255), static_cast<unsigned>(patches.size()),
                     std::back_inserter(colors_));

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -88,7 +88,6 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
   typedef typename CGAL::GetGeomTraits<Mesh,
       NamedParameters>::type Kernel;
   typedef typename Kernel::Point_3 Point_3;
-  typedef typename boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
   std::vector<Point_3> points;
   std::string line;
   std::istringstream iss;

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -233,7 +233,8 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
     }
 
     //connect triangles
-    std::vector<std::vector<std::size_t> > polygons;
+    typedef CGAL::cpp11::array<std::size_t, 3> Triangle_ind;
+    std::vector<Triangle_ind> polygons;
     polygons.reserve(nb_triangles);
     while(std::getline(input, line))
     {
@@ -249,7 +250,7 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
       iss.str(line);
       iss >> index[0] >> index[1] >> index[2];
 
-      std::vector<std::size_t> polygon(3);
+      Triangle_ind polygon;
       polygon[0] = index[0] - 1;
       polygon[1] = index[1] - 1;
       polygon[2] = index[2] - 1;

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -36,6 +36,7 @@ bool get_material_metadata(std::istream& input,
 
   iss >> _material.second;//name
 
+  static int material_id = 0;
   while (std::getline(input, line))
   {
     std::string prop; //property
@@ -45,7 +46,9 @@ bool get_material_metadata(std::istream& input,
 
     if (prop.compare("Id") == 0)
     {
-      iss >> _material.first;
+      int tmp_id;
+      iss >> tmp_id;
+      _material.first = material_id++;
 
       if ((0 == to_lower_case(_material.second).compare("exterior"))
           && _material.first != 0)


### PR DESCRIPTION
## Summary of Changes

This PR introduces improvement to the `.surf` reader, and the corresponding plugins.
- deal with non-manifold surfaces (there were holes in the generated surfaces, next to non-manifold configurations)
- number materials from `0` (Exterior) to `n-1` to make sure Mesh_3 will not get into trouble
- ignore isolated vertices
- reduce memory footprint

## Release Management

* Affected packages : Polyhedron demo, PMP (internal code only)

