### PR TITLE
Principal component analysis: Enhance matrix assembly

### DIFF
--- a/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_3.h
@@ -70,6 +70,9 @@ can be omitted: if Eigen 3 (or greater) is available and
 `Eigen_diagonalize_traits` is provided. Otherwise, the internal
 implementation `Diagonalize_traits` is used.
 
+\note This function is significantly faster when using
+`Eigen_diagonalize_traits` and it is strongly advised to use this
+model.
 
 \cgalHeading{Requirements}
 
@@ -113,6 +116,10 @@ can be omitted: if Eigen 3 (or greater) is available and
 `CGAL_EIGEN3_ENABLED` is defined then an overload using
 `Eigen_diagonalize_traits` is provided. Otherwise, the internal
 implementation `Diagonalize_traits` is used.
+
+\note This function is significantly faster when using
+`Eigen_diagonalize_traits` and it is strongly advised to use this
+model.
 
 \cgalHeading{Requirements}
 

--- a/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
@@ -16,6 +16,12 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})

--- a/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
@@ -15,96 +15,36 @@
 // $URL$
 // $Id$
 //
-// Author(s) : Pierre Alliez and Sylvain Pion and Ankit Gupta
+// Author(s) : Pierre Alliez and Sylvain Pion and Ankit Gupta and Simon Giraudot
 
-#ifndef CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_H
-#define CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_H
+#ifndef CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_EIGEN_H
+#define CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_EIGEN_H
 
 #include <CGAL/license/Principal_component_analysis.h>
 
-
-#include <CGAL/Linear_algebraCd.h>
+#include <CGAL/Eigen_diagonalize_traits.h>
 #include <CGAL/Dimension.h>
 
 namespace CGAL {
 
 namespace internal {
 
-// Initialize a matrix in n dimension by an array or numbers
-template <typename K>
-typename CGAL::Linear_algebraCd<typename K::FT>::Matrix
-init_matrix(const int n,
-            typename K::FT entries[])
-{
-  CGAL_assertion(n > 1); // dimension > 1
-  typedef typename CGAL::Linear_algebraCd<typename K::FT>::Matrix Matrix;
-
-  Matrix m(n);
-  int i,j;
-  for(i = 0; i < n; i++) 
-    for(j = 0; j < n; j++)
-      m[i][j] = entries[i*n+j];
-
-  return m;
-} // end initialization of matrix
-
-// assemble covariance matrix from a point set 
-template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
-void
-assemble_covariance_matrix_3(InputIterator first,
-                             InputIterator beyond, 
-                             typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
-                             const typename K::Point_3& c, // centroid
-                             const K& k,                    // kernel
-                             const typename K::Point_3*,   // used for indirection
-                             const CGAL::Dimension_tag<0>&,
-			     const DiagonalizeTraits&)
-{
-  typedef typename K::FT       FT;
-  typedef typename K::Point_3  Point;
-  typedef typename K::Vector_3 Vector;
-
-  // Matrix numbering:
-  // 0 1 2
-  //   3 4
-  //     5          
-  covariance[0] = covariance[1] = covariance[2] = 
-  covariance[3] = covariance[4] = covariance[5] = (FT)0.0;
-  for(InputIterator it = first;
-      it != beyond;
-      it++)
-  {
-    const Point& p = *it;
-    Vector d = k.construct_vector_3_object()(c,p);
-    covariance[0] += d.x() * d.x();
-    covariance[1] += d.x() * d.y();
-    covariance[2] += d.x() * d.z();
-    covariance[3] += d.y() * d.y();
-    covariance[4] += d.y() * d.z();
-    covariance[5] += d.z() * d.z();
-  }
-}
-
 // assemble covariance matrix from a triangle set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond,
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K&,                    // kernel
                              const typename K::Triangle_3*,// used for indirection
                              const CGAL::Dimension_tag<2>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Triangle_3  Triangle;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -115,10 +55,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = 0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {1.0/12.0, 1.0/24.0, 1.0/24.0,
-                1.0/24.0, 1.0/12.0, 1.0/24.0,
-                1.0/24.0, 1.0/24.0, 1.0/12.0};
-  Matrix moment = init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << 1.0/12.0, 1.0/24.0, 1.0/24.0,
+            1.0/24.0, 1.0/12.0, 1.0/24.0,
+            1.0/24.0, 1.0/24.0, 1.0/12.0;
 
   for(InputIterator it = first;
       it != beyond;
@@ -129,10 +69,11 @@ assemble_covariance_matrix_3(InputIterator first,
     const Triangle& t = *it;
 
     // defined for convenience.
-    FT delta[9] = {t[0].x(), t[1].x(), t[2].x(), 
-                   t[0].y(), t[1].y(), t[2].y(),
-                   t[0].z(), t[1].z(), t[2].z()};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation;
+    transformation << t[0].x(), t[1].x(), t[2].x(), 
+                      t[0].y(), t[1].y(), t[2].y(),
+                      t[0].z(), t[1].z(), t[2].z();
+
     FT area = std::sqrt(t.squared_area());
 
 		// skip zero measure primitives
@@ -142,15 +83,15 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the triangle wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = 2 * area * transformation * moment * LA::transpose(transformation);
+    transformation = 2 * area * transformation * moment * transformation.transpose();
     
     // and add to covariance matrix
-    covariance[0] += transformation[0][0];
-    covariance[1] += transformation[1][0];
-    covariance[2] += transformation[2][0];
-    covariance[3] += transformation[1][1];
-    covariance[4] += transformation[2][1];
-    covariance[5] += transformation[2][2];
+    covariance[0] += transformation(0,0);
+    covariance[1] += transformation(1,0);
+    covariance[2] += transformation(2,0);
+    covariance[3] += transformation(1,1);
+    covariance[4] += transformation(2,1);
+    covariance[5] += transformation(2,2);
 
     mass += area;
   }
@@ -168,22 +109,20 @@ assemble_covariance_matrix_3(InputIterator first,
 
 // assemble covariance matrix from a cuboid set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond,
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K& ,                    // kernel
                              const typename K::Iso_cuboid_3*,// used for indirection
                              const CGAL::Dimension_tag<3>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Iso_cuboid_3    Iso_cuboid;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -194,10 +133,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = (FT)0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {(FT)(1.0/3.0), (FT)(1.0/4.0), (FT)(1.0/4.0),
-								(FT)(1.0/4.0), (FT)(1.0/3.0), (FT)(1.0/4.0),
-                (FT)(1.0/4.0), (FT)(1.0/4.0), (FT)(1.0/3.0)};
-  Matrix moment = init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << (FT)(1.0/3.0), (FT)(1.0/4.0), (FT)(1.0/4.0),
+            (FT)(1.0/4.0), (FT)(1.0/3.0), (FT)(1.0/4.0),
+            (FT)(1.0/4.0), (FT)(1.0/4.0), (FT)(1.0/3.0);
 
   for(InputIterator it = first;
       it != beyond;
@@ -212,10 +151,10 @@ assemble_covariance_matrix_3(InputIterator first,
     FT x0 = t[0].x();
     FT y0 = t[0].y();
     FT z0 = t[0].z();
-    FT delta[9] = {t[1].x()-x0, t[3].x()-x0, t[5].x()-x0, 
-                   t[1].y()-y0, t[3].y()-y0, t[5].y()-y0,
-                   t[1].z()-z0, t[3].z()-z0, t[5].z()-z0};
-    Matrix transformation = init_matrix<K>(3,delta);
+    FT delta[9] = {t[0].x(), t[1].x(), t[2].x(), 
+                   t[0].y(), t[1].y(), t[2].y(),
+                   t[0].z(), t[1].z(), t[2].z()};
+    Matrix transformation (delta);
     FT volume = t.volume();
 
 		// skip zero measure primitives
@@ -225,7 +164,7 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the cuboid wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = volume * transformation * moment * LA::transpose(transformation);
+    transformation = volume * transformation * moment * transformation.transpose();
     
     // Translate the 2nd order moment to the minimum corner (x0,y0,z0) of the cuboid.
     FT xav0 = (delta[0] + delta[1] + delta[2])/4.0;
@@ -233,12 +172,12 @@ assemble_covariance_matrix_3(InputIterator first,
     FT zav0 = (delta[6] + delta[7] + delta[8])/4.0;
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0] + volume * (2*x0*xav0 + x0*x0);
-    covariance[1] += transformation[1][0] + volume * (xav0*y0 + yav0*x0 + x0*y0);
-    covariance[2] += transformation[2][0] + volume * (x0*zav0 + xav0*z0 + x0*z0);
-    covariance[3] += transformation[1][1] + volume * (2*y0*yav0 + y0*y0);
-    covariance[4] += transformation[2][1] + volume * (yav0*z0 + y0*zav0 + z0*y0);
-    covariance[5] += transformation[2][2] + volume * (2*zav0*z0 + z0*z0);
+    covariance[0] += transformation(0,0) + volume * (2*x0*xav0 + x0*x0);
+    covariance[1] += transformation(1,0) + volume * (xav0*y0 + yav0*x0 + x0*y0);
+    covariance[2] += transformation(2,0) + volume * (x0*zav0 + xav0*z0 + x0*z0);
+    covariance[3] += transformation(1,1) + volume * (2*y0*yav0 + y0*y0);
+    covariance[4] += transformation(2,1) + volume * (yav0*z0 + y0*zav0 + z0*y0);
+    covariance[5] += transformation(2,2) + volume * (2*zav0*z0 + z0*z0);
 
     mass += volume;
   }
@@ -255,22 +194,20 @@ assemble_covariance_matrix_3(InputIterator first,
 
 // assemble covariance matrix from a cuboid set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond, 
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K& ,                    // kernel
                              const typename K::Iso_cuboid_3*,// used for indirection
                              const CGAL::Dimension_tag<2>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT FT;
   typedef typename K::Iso_cuboid_3 Iso_cuboid;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -281,10 +218,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = (FT)0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {(FT)(7.0/3.0), (FT)1.5,       (FT)1.5,
-                (FT)1.5,       (FT)(7.0/3.0), (FT)1.5,
-                (FT)1.5,       (FT)1.5,       (FT)(7.0/3.0)};
-  Matrix moment = init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << (FT)(7.0/3.0), (FT)1.5,       (FT)1.5,
+            (FT)1.5,       (FT)(7.0/3.0), (FT)1.5,
+            (FT)1.5,       (FT)1.5,       (FT)(7.0/3.0);
 
   for(InputIterator it = first;
       it != beyond;
@@ -301,7 +238,7 @@ assemble_covariance_matrix_3(InputIterator first,
     FT delta[9] = {t[1].x()-x0, t[3].x()-x0, t[5].x()-x0, 
                    t[1].y()-y0, t[3].y()-y0, t[5].y()-y0,
                    t[1].z()-z0, t[3].z()-z0, t[5].z()-z0};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation (delta);
     FT area = std::pow(delta[0]*delta[0] + delta[3]*delta[3] +
                   delta[6]*delta[6],1/3.0)*std::pow(delta[1]*delta[1] +
                   delta[4]*delta[4] + delta[7]*delta[7],1/3.0)*2 +
@@ -319,7 +256,7 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the cuboid wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = area * transformation * moment * LA::transpose(transformation);
+    transformation = area * transformation * moment * transformation.transpose();
     
     // Translate the 2nd order moment to the minimum corner (x0,y0,z0) of the cuboid.
     FT xav0 = (delta[0] + delta[1] + delta[2])/4.0;
@@ -327,12 +264,12 @@ assemble_covariance_matrix_3(InputIterator first,
     FT zav0 = (delta[6] + delta[7] + delta[8])/4.0;
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0] + area * (2*x0*xav0 + x0*x0);
-    covariance[1] += transformation[1][0] + area * (xav0*y0 + yav0*x0 + x0*y0);
-    covariance[2] += transformation[2][0] + area * (x0*zav0 + xav0*z0 + x0*z0);
-    covariance[3] += transformation[1][1] + area * (2*y0*yav0 + y0*y0);
-    covariance[4] += transformation[2][1] + area * (yav0*z0 + y0*zav0 + z0*y0);
-    covariance[5] += transformation[2][2] + area * (2*zav0*z0 + z0*z0);
+    covariance[0] += transformation(0,0) + area * (2*x0*xav0 + x0*x0);
+    covariance[1] += transformation(1,0) + area * (xav0*y0 + yav0*x0 + x0*y0);
+    covariance[2] += transformation(2,0) + area * (x0*zav0 + xav0*z0 + x0*z0);
+    covariance[3] += transformation(1,1) + area * (2*y0*yav0 + y0*y0);
+    covariance[4] += transformation(2,1) + area * (yav0*z0 + y0*zav0 + z0*y0);
+    covariance[5] += transformation(2,2) + area * (2*zav0*z0 + z0*z0);
 
     mass += area;
   }
@@ -350,22 +287,20 @@ assemble_covariance_matrix_3(InputIterator first,
 
 // assemble covariance matrix from a sphere set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond, 
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K&,                     // kernel
                              const typename K::Sphere_3*,  // used for indirection
                              const CGAL::Dimension_tag<3>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Sphere_3  Sphere;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -376,10 +311,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = 0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {4.0/15.0, 0.0,      0.0,
-                0.0,      4.0/15.0, 0.0,
-                0.0,      0.0,      4.0/15.0};
-  Matrix moment = init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << 4.0/15.0, 0.0,      0.0,
+            0.0,      4.0/15.0, 0.0,
+            0.0,      0.0,      4.0/15.0;
 
   for(InputIterator it = first;
       it != beyond;
@@ -391,10 +326,10 @@ assemble_covariance_matrix_3(InputIterator first,
 
     // defined for convenience.
     FT radius = std::sqrt(t.squared_radius());
-    FT delta[9] = {radius, 0.0, 0.0, 
-                   0.0, radius, 0.0,
-                   0.0, 0.0, radius};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation;
+    transformation << radius, 0.0, 0.0, 
+                      0.0, radius, 0.0,
+                      0.0, 0.0, radius;
     FT volume = (FT)(4.0/3.0) * radius * t.squared_radius();
 
 		// skip zero measure primitives
@@ -404,7 +339,7 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (3.0/4.0) * volume * transformation * moment * LA::transpose(transformation);
+    transformation = (3.0/4.0) * volume * transformation * moment * transformation.transpose();
     
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
@@ -412,12 +347,12 @@ assemble_covariance_matrix_3(InputIterator first,
     FT z0 = t.center().z();
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0] + volume * x0*x0;
-    covariance[1] += transformation[1][0] + volume * x0*y0;
-    covariance[2] += transformation[2][0] + volume * x0*z0;
-    covariance[3] += transformation[1][1] + volume * y0*y0;
-    covariance[4] += transformation[2][1] + volume * z0*y0;
-    covariance[5] += transformation[2][2] + volume * z0*z0;
+    covariance[0] += transformation(0,0) + volume * x0*x0;
+    covariance[1] += transformation(1,0) + volume * x0*y0;
+    covariance[2] += transformation(2,0) + volume * x0*z0;
+    covariance[3] += transformation(1,1) + volume * y0*y0;
+    covariance[4] += transformation(2,1) + volume * z0*y0;
+    covariance[5] += transformation(2,2) + volume * z0*z0;
 
     mass += volume;
   }
@@ -434,22 +369,20 @@ assemble_covariance_matrix_3(InputIterator first,
 }
 // assemble covariance matrix from a sphere set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond, 
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K&,                     // kernel
                              const typename K::Sphere_3*,  // used for indirection
                              const CGAL::Dimension_tag<2>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Sphere_3  Sphere;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -460,10 +393,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = 0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {4.0/3.0, 0.0,     0.0,
-                0.0,     4.0/3.0, 0.0,
-                0.0,     0.0,     4.0/3.0};
-  Matrix moment = init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << 4.0/3.0, 0.0,     0.0,
+            0.0,     4.0/3.0, 0.0,
+            0.0,     0.0,     4.0/3.0;
 
   for(InputIterator it = first;
       it != beyond;
@@ -476,10 +409,10 @@ assemble_covariance_matrix_3(InputIterator first,
     // defined for convenience.
     // FT example = CGAL::to_double(t[0].x());
     FT radius = std::sqrt(t.squared_radius());
-    FT delta[9] = {radius, 0.0,    0.0, 
-                   0.0,    radius, 0.0,
-                   0.0,    0.0,    radius};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation;
+    transformation << radius, 0.0,    0.0, 
+                      0.0,    radius, 0.0,
+                      0.0,    0.0,    radius;
     FT area = (FT)4.0 * t.squared_radius();
 
 		// skip zero measure primitives
@@ -489,7 +422,7 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (1.0/4.0) * area * transformation * moment * LA::transpose(transformation);
+    transformation = (1.0/4.0) * area * transformation * moment * transformation.transpose();
     
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
@@ -497,12 +430,12 @@ assemble_covariance_matrix_3(InputIterator first,
     FT z0 = t.center().z();
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0] + area * x0*x0;
-    covariance[1] += transformation[1][0] + area * x0*y0;
-    covariance[2] += transformation[2][0] + area * x0*z0;
-    covariance[3] += transformation[1][1] + area * y0*y0;
-    covariance[4] += transformation[2][1] + area * z0*y0;
-    covariance[5] += transformation[2][2] + area * z0*z0;
+    covariance[0] += transformation(0,0) + area * x0*x0;
+    covariance[1] += transformation(1,0) + area * x0*y0;
+    covariance[2] += transformation(2,0) + area * x0*z0;
+    covariance[3] += transformation(1,1) + area * y0*y0;
+    covariance[4] += transformation(2,1) + area * z0*y0;
+    covariance[5] += transformation(2,2) + area * z0*z0;
 
     mass += area;
   }
@@ -520,22 +453,20 @@ assemble_covariance_matrix_3(InputIterator first,
 
 // assemble covariance matrix from a tetrahedron set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond, 
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K& ,                    // kernel
                              const typename K::Tetrahedron_3*,// used for indirection
                              const CGAL::Dimension_tag<3>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Tetrahedron_3  Tetrahedron;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -546,11 +477,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = 0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {1.0/60.0,  1.0/120.0, 1.0/120.0,
-                1.0/120.0, 1.0/60.0,  1.0/120.0,
-                1.0/120.0, 1.0/120.0, 1.0/60.0};
-  Matrix moment = init_matrix<K>(3,temp);
-
+  Matrix moment;
+  moment << 1.0/60.0,  1.0/120.0, 1.0/120.0,
+            1.0/120.0, 1.0/60.0,  1.0/120.0,
+            1.0/120.0, 1.0/120.0, 1.0/60.0;
   for(InputIterator it = first;
       it != beyond;
       it++)
@@ -567,7 +497,7 @@ assemble_covariance_matrix_3(InputIterator first,
     FT delta[9] = {t[1].x()-x0, t[2].x()-x0, t[3].x()-x0, 
                    t[1].y()-y0, t[2].y()-y0, t[3].y()-y0,
                    t[1].z()-z0, t[2].z()-z0, t[3].z()-z0};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation (delta);
     FT volume = t.volume();
 
 		// skip zero measure primitives
@@ -577,7 +507,7 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the tetrahedron wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = 6 * volume * transformation * moment * LA::transpose(transformation);
+    transformation = 6 * volume * transformation * moment * transformation.transpose();
     
     // Translate the 2nd order moment to the center of the tetrahedron.
     FT xav0 = (delta[0]+delta[1]+delta[2])/4.0;
@@ -585,12 +515,12 @@ assemble_covariance_matrix_3(InputIterator first,
     FT zav0 = (delta[6]+delta[7]+delta[8])/4.0;
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0] + volume * (2*x0*xav0 + x0*x0);
-    covariance[1] += transformation[1][0] + volume * (xav0*y0 + yav0*x0 + x0*y0);
-    covariance[2] += transformation[2][0] + volume * (x0*zav0 + xav0*z0 + x0*z0);
-    covariance[3] += transformation[1][1] + volume * (2*y0*yav0 + y0*y0);
-    covariance[4] += transformation[2][1] + volume * (yav0*z0 + y0*zav0 + z0*y0);
-    covariance[5] += transformation[2][2] + volume * (2*zav0*z0 + z0*z0);
+    covariance[0] += transformation(0,0) + volume * (2*x0*xav0 + x0*x0);
+    covariance[1] += transformation(1,0) + volume * (xav0*y0 + yav0*x0 + x0*y0);
+    covariance[2] += transformation(2,0) + volume * (x0*zav0 + xav0*z0 + x0*z0);
+    covariance[3] += transformation(1,1) + volume * (2*y0*yav0 + y0*y0);
+    covariance[4] += transformation(2,1) + volume * (yav0*z0 + y0*zav0 + z0*y0);
+    covariance[5] += transformation(2,2) + volume * (2*zav0*z0 + z0*z0);
 
     mass += volume;
   }
@@ -607,22 +537,20 @@ assemble_covariance_matrix_3(InputIterator first,
 
 // assemble covariance matrix from a segment set 
 template < typename InputIterator,
-           typename K,
-	   typename DiagonalizeTraits >
+           typename K >
 void
 assemble_covariance_matrix_3(InputIterator first,
                              InputIterator beyond, 
-			     typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
+			     typename Eigen_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
                              const typename K::Point_3& c, // centroid
                              const K& ,                    // kernel
                              const typename K::Segment_3*,// used for indirection
                              const CGAL::Dimension_tag<1>&,
-			     const DiagonalizeTraits&)
+			     const Eigen_diagonalize_traits<typename K::FT, 3>&)
 {
   typedef typename K::FT          FT;
   typedef typename K::Segment_3  Segment;
-  typedef typename CGAL::Linear_algebraCd<FT> LA;
-  typedef typename LA::Matrix Matrix;
+  typedef typename Eigen::Matrix<FT, 3, 3> Matrix;
 
   // assemble covariance matrix as a semi-definite matrix. 
   // Matrix numbering:
@@ -633,10 +561,10 @@ assemble_covariance_matrix_3(InputIterator first,
   FT mass = 0.0;
 
   // assemble 2nd order moment about the origin.  
-  FT temp[9] = {1.0, 0.5, 0.0,
-                0.5, 1.0, 0.0,
-                0.0, 0.0, 0.0};
-  Matrix moment = (FT)(1.0/3.0) * init_matrix<K>(3,temp);
+  Matrix moment;
+  moment << 1.0, 0.5, 0.0,
+            0.5, 1.0, 0.0,
+            0.0, 0.0, 0.0;
 
   for(InputIterator it = first;
       it != beyond;
@@ -648,10 +576,10 @@ assemble_covariance_matrix_3(InputIterator first,
 
     // defined for convenience.
     // FT example = CGAL::to_double(t[0].x());
-    FT delta[9] = {t[0].x(), t[1].x(), 0.0, 
-       t[0].y(), t[1].y(), 0.0,
-                   t[0].z(), t[1].z(), 1.0};
-    Matrix transformation = init_matrix<K>(3,delta);
+    Matrix transformation;
+    transformation << t[0].x(), t[1].x(), 0.0, 
+                      t[0].y(), t[1].y(), 0.0,
+                      t[0].z(), t[1].z(), 1.0;
     FT length = std::sqrt(t.squared_length());
 
 		// skip zero measure primitives
@@ -661,15 +589,15 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the segment wrt to the origin by an affine transformation.
     
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = length * transformation * moment * LA::transpose(transformation);
+    transformation = length * transformation * moment * transformation.transpose();
 
     // and add to covariance matrix
-    covariance[0] += transformation[0][0];
-    covariance[1] += transformation[1][0];
-    covariance[2] += transformation[2][0];
-    covariance[3] += transformation[1][1];
-    covariance[4] += transformation[2][1];
-    covariance[5] += transformation[2][2];
+    covariance[0] += transformation(0,0);
+    covariance[1] += transformation(1,0);
+    covariance[2] += transformation(2,0);
+    covariance[3] += transformation(1,1);
+    covariance[4] += transformation(2,1);
+    covariance[5] += transformation(2,2);
 
     mass += length;
   }
@@ -686,101 +614,9 @@ assemble_covariance_matrix_3(InputIterator first,
 }
 
 
-// compute the eigen values and vectors of the covariance 
-// matrix and deduces the best linear fitting plane.
-// returns fitting quality
-template < typename K, typename DiagonalizeTraits >
-typename K::FT
-fitting_plane_3(typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
-                const typename K::Point_3& c,       // centroid
-                typename K::Plane_3& plane,         // best fit plane
-                const K&,                           // kernel
-		const DiagonalizeTraits& )                 // Diagonalize traits
-{
-  typedef typename K::FT       FT;
-  typedef typename K::Plane_3  Plane;
-  typedef typename K::Vector_3 Vector;
-
-  // solve for eigenvalues and eigenvectors.
-  // eigen values are sorted in ascending order, 
-  // eigen vectors are sorted in accordance.
-  typename DiagonalizeTraits::Vector eigen_values = {{ 0. , 0., 0. }};
-  typename DiagonalizeTraits::Matrix eigen_vectors = {{ 0., 0., 0.,
-							0., 0., 0.,
-							0., 0., 0. }};
-  DiagonalizeTraits::diagonalize_selfadjoint_covariance_matrix
-    (covariance, eigen_values, eigen_vectors);
-
-  // degenerate case 
-  if(eigen_values[0] == eigen_values[1] && 
-     eigen_values[1] == eigen_values[2])
-  {
-    // assemble a default horizontal plane that goes
-    // through the centroid.
-    plane = Plane(c,Vector(FT(0),FT(0),FT(1)));
-    return FT(0);
-  } 
-  else // regular and line case
-  {
-    Vector normal(eigen_vectors[0],
-                  eigen_vectors[1],
-                  eigen_vectors[2]);
-    plane = Plane(c,normal);
-    return FT(1) - eigen_values[0] / eigen_values[1];
-  } // end regular case
-}
-
-// compute the eigen values and vectors of the covariance 
-// matrix and deduces the best linear fitting line
-// (this is an internal function)
-// returns fitting quality
-template < typename K, typename DiagonalizeTraits >
-typename K::FT
-fitting_line_3(typename DiagonalizeTraits::Covariance_matrix& covariance, // covariance matrix
-               const typename K::Point_3& c,       // centroid
-               typename K::Line_3& line,           // best fit line
-	       const K&,                           // kernel
-	       const DiagonalizeTraits& )                 // Diagonalize traits
-{
-  typedef typename K::FT       FT;
-  typedef typename K::Line_3   Line;
-  typedef typename K::Vector_3 Vector;
-
-  // solve for eigenvalues and eigenvectors.
-  // eigen values are sorted in ascending order, 
-  // eigen vectors are sorted in accordance.
-  typename DiagonalizeTraits::Vector eigen_values = {{ 0. , 0., 0. }};
-  typename DiagonalizeTraits::Matrix eigen_vectors = {{ 0., 0., 0.,
-							0., 0., 0.,
-							0., 0., 0. }};
-  DiagonalizeTraits::diagonalize_selfadjoint_covariance_matrix
-    (covariance, eigen_values, eigen_vectors);
-
-    // isotropic case (infinite number of directions)
-  if(eigen_values[0] == eigen_values[1] && 
-     eigen_values[0] == eigen_values[2])
-  {
-    // assemble a default line along x axis which goes
-    // through the centroid.
-    line = Line(c,Vector(FT(1),FT(0),FT(0)));
-    return (FT)0.0;
-  }
-  else
-  {
-    // regular case
-    Vector direction(eigen_vectors[6],eigen_vectors[7],eigen_vectors[8]);
-    line = Line(c,direction);
-    return (FT)1.0 - eigen_values[1] / eigen_values[2];
-  } 
-}
 
 } // end namespace internal
 
 } //namespace CGAL
 
-#ifdef CGAL_EIGEN3_ENABLED
-#include <CGAL/PCA_util_Eigen.h>
-#endif
-
-
-#endif // CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_H
+#endif // CGAL_LINEAR_LEAST_SQUARES_FITTING_UTIL_EIGEN_H

--- a/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
@@ -23,6 +23,7 @@
 #include <CGAL/license/Principal_component_analysis.h>
 
 #include <CGAL/Eigen_diagonalize_traits.h>
+#include <CGAL/Default_diagonalize_traits.h>
 #include <CGAL/Dimension.h>
 
 namespace CGAL {
@@ -613,6 +614,121 @@ assemble_covariance_matrix_3(InputIterator first,
 
 }
 
+// Variants using default
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond,
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                    // kernel
+                             const typename K::Triangle_3* t,// used for indirection
+                             const CGAL::Dimension_tag<2>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, t, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond,
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                    // kernel
+                             const typename K::Iso_cuboid_3* ic,// used for indirection
+                             const CGAL::Dimension_tag<3>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, ic, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond, 
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                    // kernel
+                             const typename K::Iso_cuboid_3* ic,// used for indirection
+                             const CGAL::Dimension_tag<2>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, ic, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond, 
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                     // kernel
+                             const typename K::Sphere_3* s,  // used for indirection
+                             const CGAL::Dimension_tag<3>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, s, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+  
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond, 
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                     // kernel
+                             const typename K::Sphere_3* s,  // used for indirection
+                             const CGAL::Dimension_tag<2>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, s, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond, 
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                    // kernel
+                             const typename K::Tetrahedron_3* t,// used for indirection
+                             const CGAL::Dimension_tag<3>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, t, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+template < typename InputIterator,
+           typename K >
+void
+assemble_covariance_matrix_3(InputIterator first,
+                             InputIterator beyond, 
+			     typename Default_diagonalize_traits<typename K::FT, 3>::Covariance_matrix& covariance, // covariance matrix
+                             const typename K::Point_3& c, // centroid
+                             const K& k,                    // kernel
+                             const typename K::Segment_3* s,// used for indirection
+                             const CGAL::Dimension_tag<1>& tag,
+			     const Default_diagonalize_traits<typename K::FT, 3>&)
+{
+  assemble_covariance_matrix_3 (first, beyond, covariance, c, k, s, tag,
+                                Eigen_diagonalize_traits<typename K::FT, 3>());
+}
+
+  
 
 
 } // end namespace internal

--- a/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
@@ -32,7 +32,6 @@
 #include <CGAL/linear_least_squares_fitting_tetrahedra_3.h>
 #include <CGAL/linear_least_squares_fitting_spheres_3.h>
 
-#include <CGAL/Default_diagonalize_traits.h>
 #ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_diagonalize_traits.h>
 #else

--- a/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
@@ -32,7 +32,12 @@
 #include <CGAL/linear_least_squares_fitting_tetrahedra_3.h>
 #include <CGAL/linear_least_squares_fitting_spheres_3.h>
 
-#include <CGAL/Default_diagonalize_traits.h>
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Eigen_diagonalize_traits.h>
+#else
+#include <CGAL/Diagonalize_traits.h>
+#endif
+
 
 #include <CGAL/Dimension.h>
 
@@ -80,7 +85,11 @@ linear_least_squares_fitting_3(InputIterator first,
   typedef typename std::iterator_traits<InputIterator>::value_type Value_type;
   typedef typename Kernel_traits<Value_type>::Kernel Kernel;
   return CGAL::linear_least_squares_fitting_3(first,beyond,object,centroid,tag,Kernel(),
-					      Default_diagonalize_traits<typename Kernel::FT, 3>());
+#ifdef CGAL_EIGEN3_ENABLED
+					      Eigen_diagonalize_traits<typename Kernel::FT, 3>());
+#else
+  					      Diagonalize_traits<typename Kernel::FT, 3>());
+#endif
 
 }
 
@@ -100,7 +109,11 @@ linear_least_squares_fitting_3(InputIterator first,
   typedef typename Kernel_traits<Value_type>::Kernel Kernel;
   typename Kernel::Point_3 centroid; // not used by caller
   return CGAL::linear_least_squares_fitting_3(first,beyond,object,centroid,tag,Kernel(),
-					      Default_diagonalize_traits<typename Kernel::FT, 3>());
+#ifdef CGAL_EIGEN3_ENABLED
+					      Eigen_diagonalize_traits<typename Kernel::FT, 3>());
+#else
+  					      Diagonalize_traits<typename Kernel::FT, 3>());
+#endif
 
 }
 

--- a/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
@@ -32,6 +32,7 @@
 #include <CGAL/linear_least_squares_fitting_tetrahedra_3.h>
 #include <CGAL/linear_least_squares_fitting_spheres_3.h>
 
+#include <CGAL/Default_diagonalize_traits.h>
 #ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_diagonalize_traits.h>
 #else

--- a/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_3.h
@@ -32,12 +32,7 @@
 #include <CGAL/linear_least_squares_fitting_tetrahedra_3.h>
 #include <CGAL/linear_least_squares_fitting_spheres_3.h>
 
-#ifdef CGAL_EIGEN3_ENABLED
-#include <CGAL/Eigen_diagonalize_traits.h>
-#else
-#include <CGAL/Diagonalize_traits.h>
-#endif
-
+#include <CGAL/Default_diagonalize_traits.h>
 
 #include <CGAL/Dimension.h>
 
@@ -85,11 +80,7 @@ linear_least_squares_fitting_3(InputIterator first,
   typedef typename std::iterator_traits<InputIterator>::value_type Value_type;
   typedef typename Kernel_traits<Value_type>::Kernel Kernel;
   return CGAL::linear_least_squares_fitting_3(first,beyond,object,centroid,tag,Kernel(),
-#ifdef CGAL_EIGEN3_ENABLED
-					      Eigen_diagonalize_traits<typename Kernel::FT, 3>());
-#else
-  					      Diagonalize_traits<typename Kernel::FT, 3>());
-#endif
+					      Default_diagonalize_traits<typename Kernel::FT, 3>());
 
 }
 
@@ -109,11 +100,7 @@ linear_least_squares_fitting_3(InputIterator first,
   typedef typename Kernel_traits<Value_type>::Kernel Kernel;
   typename Kernel::Point_3 centroid; // not used by caller
   return CGAL::linear_least_squares_fitting_3(first,beyond,object,centroid,tag,Kernel(),
-#ifdef CGAL_EIGEN3_ENABLED
-					      Eigen_diagonalize_traits<typename Kernel::FT, 3>());
-#else
-  					      Diagonalize_traits<typename Kernel::FT, 3>());
-#endif
+					      Default_diagonalize_traits<typename Kernel::FT, 3>());
 
 }
 

--- a/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
@@ -16,6 +16,12 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
@@ -3,6 +3,10 @@
 #include <CGAL/linear_least_squares_fitting_3.h>
 #include <list>
 
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Diagonalize_traits.h>
+#endif
+
 typedef double               FT;
 typedef CGAL::Cartesian<FT>  Kernel;
 typedef Kernel::Line_3       Line;
@@ -43,6 +47,28 @@ int main()
   linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<1>());
   linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<0>());
+
+  // If Eigen is available, it's used by default everywhere.
+  // These additional lines test the fallback version
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),line,centroid,CGAL::Dimension_tag<3>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),line,centroid,CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),line,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),line,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<3>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(cuboids.begin(),cuboids.end(),plane,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+#endif
 
   return 0;
 }

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
@@ -5,7 +5,10 @@
 #include <CGAL/algorithm.h>
 #include <CGAL/linear_least_squares_fitting_3.h>
 #include <CGAL/point_generators_3.h>
-#include <CGAL/Default_diagonalize_traits.h>
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Eigen_diagonalize_traits.h>
+#endif
+#include <CGAL/Diagonalize_traits.h>
 
 #include <vector>
 #include <cassert>
@@ -36,12 +39,20 @@ FT fit_set(std::list<Segment>& segments,
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),line,CGAL::Dimension_tag<1>());
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<1>());
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<1>(),kernel,
-					   CGAL::Default_diagonalize_traits<FT,3>());
+					   CGAL::Diagonalize_traits<FT,3>());
+#ifdef CGAL_EIGEN3_ENABLED
+  quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<1>(),kernel,
+					   CGAL::Eigen_diagonalize_traits<FT,3>());
+#endif
 
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,CGAL::Dimension_tag<1>());
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,centroid,CGAL::Dimension_tag<1>());
   quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,centroid,CGAL::Dimension_tag<1>(),kernel,
-					   CGAL::Default_diagonalize_traits<FT,3>());
+					   CGAL::Diagonalize_traits<FT,3>());
+#ifdef CGAL_EIGEN3_ENABLED
+  quality = linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,centroid,CGAL::Dimension_tag<1>(),kernel,
+					   CGAL::Eigen_diagonalize_traits<FT,3>());
+#endif
 
   return quality;
 }
@@ -164,6 +175,12 @@ void test_4()
   FT quality1;
   quality1 = linear_least_squares_fitting_3(points.begin(),points.end(),line1,CGAL::Dimension_tag<0>());
   quality1 = linear_least_squares_fitting_3(points.begin(),points.end(),line1,centroid1,CGAL::Dimension_tag<0>());
+  // If Eigen is available, it's used by default everywhere.
+  // These additional lines test the fallback version
+#ifdef CGAL_EIGEN3_ENABLED
+  quality1 = linear_least_squares_fitting_3(points.begin(),points.end(),line1,centroid1,CGAL::Dimension_tag<0>(),
+                                            Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+#endif
   std::cout << "done, quality: " << quality1 << std::endl;
 
   if(!(line.has_on(line1.point(0)) && (double)line.to_vector().y()/line.to_vector().x() -
@@ -225,6 +242,19 @@ void test_6()
   linear_least_squares_fitting_3(segments.begin(),segments.end(),line,CGAL::Dimension_tag<0>());
   linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<1>());
   linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<0>());
+
+    // If Eigen is available, it's used by default everywhere.
+  // These additional lines test the fallback version
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(segments.begin(),segments.end(),plane,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(segments.begin(),segments.end(),line,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+#endif
 }
 
 int main()

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
@@ -2,7 +2,10 @@
 
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>
-#include <CGAL/Default_diagonalize_traits.h>
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Eigen_diagonalize_traits.h>
+#endif
+#include <CGAL/Diagonalize_traits.h>
 
 #include <list>
 
@@ -41,17 +44,29 @@ int main(void)
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<3>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<3>(),kernel,
-				 CGAL::Default_diagonalize_traits<FT,3>());
+				 CGAL::Diagonalize_traits<FT,3>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<2>(),kernel,
-				 CGAL::Default_diagonalize_traits<FT,3>());
+				 CGAL::Diagonalize_traits<FT,3>());
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<3>(),kernel,
+				 CGAL::Eigen_diagonalize_traits<FT,3>());
+  linear_least_squares_fitting_3(spheres.begin(),spheres.end(),line,centroid,CGAL::Dimension_tag<2>(),kernel,
+				 CGAL::Eigen_diagonalize_traits<FT,3>());
+#endif
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,CGAL::Dimension_tag<3>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<3>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<3>(),kernel,
-				 CGAL::Default_diagonalize_traits<FT,3>());
+				 CGAL::Diagonalize_traits<FT,3>());
   linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<2>(),kernel,
-				 CGAL::Default_diagonalize_traits<FT,3>());
+				 CGAL::Diagonalize_traits<FT,3>());
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<3>(),kernel,
+				 CGAL::Eigen_diagonalize_traits<FT,3>());
+  linear_least_squares_fitting_3(spheres.begin(),spheres.end(),plane,centroid,CGAL::Dimension_tag<2>(),kernel,
+				 CGAL::Eigen_diagonalize_traits<FT,3>());
+#endif
 
   return 0;
 }

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
@@ -5,6 +5,10 @@
 #include <CGAL/linear_least_squares_fitting_3.h>
 #include <list>
 
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Diagonalize_traits.h>
+#endif
+
 typedef double                FT;
 typedef CGAL::Cartesian<FT>   Kernel;
 typedef Kernel::Line_3        Line;
@@ -53,6 +57,28 @@ int main()
   linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<1>());
   linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<0>());
+
+  // If Eigen is available, it's used by default everywhere.
+  // These additional lines test the fallback version
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),line,centroid,CGAL::Dimension_tag<3>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),line,centroid,CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),line,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),line,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<3>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(tetrahedra.begin(),tetrahedra.end(),plane,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+#endif
 
   return 0;
 }

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
@@ -1,6 +1,10 @@
 // Example program for the linear_least_square_fitting function on set of triangles in 3D
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>
+#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/Diagonalize_traits.h>
+#endif
+
 #include <list>
 
 typedef double               FT;
@@ -41,6 +45,23 @@ int main()
   linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<2>());
   linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<1>());
   linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<0>());
+  
+  // If Eigen is available, it's used by default everywhere.
+  // These additional lines test the fallback version
+#ifdef CGAL_EIGEN3_ENABLED
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),line,centroid, CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),line,centroid, CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),line,centroid, CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<2>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<1>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+  linear_least_squares_fitting_3(triangles.begin(),triangles.end(),plane,centroid,CGAL::Dimension_tag<0>(),
+                                 Kernel(), CGAL::Diagonalize_traits<FT, 3>());
+#endif
   
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

- Specialization of `assemble_covariance_matrix_3()` when `CGAL::Eigen_diagonalize_traits` is used, so that we stop relying on `Linear_algebraCd` internally (which is very slow) and use the Eigen library instead (which is by definition available if `CGAL::Eigen_diagonalize_traits` is used)
- Addition of lines in the test files so that both the Eigen and internal CGAL versions are tested
- Addition of notes in the doc to advise the user to use Eigen (which is much faster)

## Release Management

* Affected package(s): Principal Component Analysis
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2069

