### PR TITLE
Do not include graph_traits_{Polyhedron | Surface_mesh}.h

### DIFF
--- a/AABB_tree/examples/AABB_tree/AABB_face_graph_triangle_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_face_graph_triangle_example.cpp
@@ -6,7 +6,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/AABB_tree/examples/AABB_tree/AABB_halfedge_graph_edge_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_halfedge_graph_edge_example.cpp
@@ -6,7 +6,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_halfedge_graph_segment_primitive.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/AABB_tree/examples/AABB_tree/AABB_insertion_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_insertion_example.cpp
@@ -4,7 +4,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
 

--- a/AABB_tree/examples/AABB_tree/AABB_polyhedron_edge_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_polyhedron_edge_example.cpp
@@ -6,7 +6,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_halfedge_graph_segment_primitive.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_distance_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_distance_example.cpp
@@ -7,7 +7,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_intersection_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_intersection_example.cpp
@@ -7,7 +7,6 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
+++ b/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
@@ -2,11 +2,7 @@
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #if defined(CGAL_USE_OPENMESH)
 #include <OpenMesh/Core/IO/MeshIO.hh>

--- a/BGL/examples/BGL_polyhedron_3/distance.cpp
+++ b/BGL/examples/BGL_polyhedron_3/distance.cpp
@@ -1,8 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 #include <boost/graph/breadth_first_search.hpp>
 

--- a/BGL/examples/BGL_polyhedron_3/incident_vertices.cpp
+++ b/BGL/examples/BGL_polyhedron_3/incident_vertices.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <iostream>
 #include <fstream>

--- a/BGL/examples/BGL_polyhedron_3/kruskal.cpp
+++ b/BGL/examples/BGL_polyhedron_3/kruskal.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 #include <iostream>
 #include <list>

--- a/BGL/examples/BGL_polyhedron_3/kruskal_with_stored_id.cpp
+++ b/BGL/examples/BGL_polyhedron_3/kruskal_with_stored_id.cpp
@@ -1,8 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 #include <iostream>
 #include <list>

--- a/BGL/examples/BGL_polyhedron_3/normals.cpp
+++ b/BGL/examples/BGL_polyhedron_3/normals.cpp
@@ -9,11 +9,7 @@
 // Polyhedron
 #include <CGAL/Cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-
-// Graph traits adaptors
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 typedef CGAL::Cartesian<double>                                      Kernel;
 typedef Kernel::Point_3                                              Point;

--- a/BGL/examples/BGL_polyhedron_3/range.cpp
+++ b/BGL/examples/BGL_polyhedron_3/range.cpp
@@ -1,8 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Iterator_range.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <boost/foreach.hpp>
 
 

--- a/BGL/examples/BGL_polyhedron_3/transform_iterator.cpp
+++ b/BGL/examples/BGL_polyhedron_3/transform_iterator.cpp
@@ -1,11 +1,10 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/iterator.h>
-#include <fstream>
 
+#include <CGAL/boost/graph/iterator.h>
 #include <boost/iterator/transform_iterator.hpp>
+
+#include <fstream>
 #include <algorithm>
 
 typedef CGAL::Simple_cartesian<double> Kernel;

--- a/Generator/examples/Generator/random_points_on_triangle_mesh_3.cpp
+++ b/Generator/examples/Generator/random_points_on_triangle_mesh_3.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/point_generators_3.h>
 
 #include <iostream>

--- a/Nef_3/examples/Nef_3/surface_mesh_to_nef.cpp
+++ b/Nef_3/examples/Nef_3/surface_mesh_to_nef.cpp
@@ -1,10 +1,6 @@
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
-#include <CGAL/boost/graph/properties_Surface_mesh.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 #include <CGAL/Nef_polyhedron_3.h>
 #include <CGAL/IO/Nef_polyhedron_iostream_3.h>

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
@@ -15,8 +15,7 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Timer.h>
 #include <CGAL/trace.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh_default_triangulation_3.h>
 #include <CGAL/make_surface_mesh.h>
 #include <CGAL/Poisson_implicit_surface_3.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example_Polyhedron.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example_Polyhedron.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <boost/property_map/property_map.hpp>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_SM.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
@@ -1,7 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_difference_remeshed.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_difference_remeshed.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/boost/graph/selection.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_polyhedron_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_polyhedron_union.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 
 #include <CGAL/Polygon_mesh_processing/corefinement.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hausdorff_distance_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hausdorff_distance_remeshing_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/distance.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example.cpp
@@ -1,8 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 
 #include <iostream>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/border.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_slicer_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_slicer_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/AABB_halfedge_graph_segment_primitive.h>
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/point_generators_3.h>
 
 #include <CGAL/Side_of_triangle_mesh.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/polygon_soup_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/polygon_soup_example.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/IO/OFF_reader.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
@@ -1,8 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Polygon_mesh_processing/refine.h>
 #include <CGAL/Polygon_mesh_processing/fair.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/self_intersections_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/self_intersections_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
@@ -1,8 +1,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Polygon_mesh_processing/stitch_borders.h>
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/surface_mesh_intersection.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/surface_mesh_intersection.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/iterator.h>
 
 #include <CGAL/Polygon_mesh_processing/intersection.h>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 

--- a/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
+++ b/Ridges_3/examples/Ridges_3/Ridges_Umbilics_SM.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include "PolyhedralSurf_rings.h"
 #include "compute_normals.h"
 #include <CGAL/Ridges.h>

--- a/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices.cpp
@@ -3,8 +3,6 @@
 #include <CGAL/Search_traits_adapter.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <fstream>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;

--- a/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
@@ -1,8 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Search_traits_adapter.h>

--- a/Surface_mesh/examples/Surface_mesh/sm_aabbtree.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_aabbtree.cpp
@@ -5,8 +5,6 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
-#include <CGAL/boost/graph/properties_Surface_mesh.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 
 typedef CGAL::Simple_cartesian<double> K;

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example.cpp
@@ -1,10 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-// HalfedgeGraph adapters for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 
 #include <CGAL/Surface_mesh_deformation.h>
 

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example_Surface_mesh.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example_Surface_mesh.cpp
@@ -1,6 +1,5 @@
 #include <fstream>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh_deformation.h>
 

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example_custom_polyhedron.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/all_roi_assign_example_custom_polyhedron.cpp
@@ -37,13 +37,7 @@ struct Custom_point_3{
   }
 };
 
-#include <CGAL/basic.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-// Halfedge adapters for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
-
 #include <CGAL/Surface_mesh_deformation.h>
 
 struct Custom_traits{

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/custom_weight_for_edges_example.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/custom_weight_for_edges_example.cpp
@@ -1,10 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-// HalfedgeGraph adapters for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
-
 #include <CGAL/Surface_mesh_deformation.h>
 
 #include <fstream>

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/deform_mesh_for_botsch08_format_sre_arap.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/deform_mesh_for_botsch08_format_sre_arap.cpp
@@ -1,10 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-// HalfedgeGraph adapters for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <boost/foreach.hpp>
 #include <CGAL/Surface_mesh_deformation.h>
 

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/deform_polyhedron_with_custom_pmap_example.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/deform_polyhedron_with_custom_pmap_example.cpp
@@ -1,9 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-// Halfedge adaptors for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Surface_mesh_deformation.h>
 

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/k_ring_roi_translate_rotate_Surface_mesh.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/k_ring_roi_translate_rotate_Surface_mesh.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/Surface_mesh_deformation.h>
 
 #include <fstream>

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/k_ring_roi_translate_rotate_example.cpp
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/k_ring_roi_translate_rotate_example.cpp
@@ -1,10 +1,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-// HalfedgeGraph adaptors for Polyhedron_3
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 
 #include <CGAL/Surface_mesh_deformation.h>
 

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/sdf_values_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/mesh_segmentation.h>
 
 #include <CGAL/property_map.h>

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp
@@ -1,10 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
 #include <CGAL/Surface_mesh.h>
-
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/mesh_segmentation.h>
-
 #include <CGAL/property_map.h>
 
 #include <iostream>

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_from_sdf_values_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/mesh_segmentation.h>
 
 #include <CGAL/property_map.h>

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_via_sdf_values_example.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/mesh_segmentation.h>
 
 #include <CGAL/property_map.h>

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp
@@ -1,7 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/mesh_segmentation.h>
 
 #include <CGAL/property_map.h>

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
@@ -9,10 +9,8 @@
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Surface_mesh_shortest_path.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/boost/graph/iterator.h>
 
 #include <boost/variant.hpp>

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -9,10 +9,8 @@
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Surface_mesh_shortest_path.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/boost/graph/iterator.h>
 
 

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -4,17 +4,10 @@
 #include <iterator>
 
 #include <CGAL/Random.h>
-#include <CGAL/Default.h>
-
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-
 #include <CGAL/Surface_mesh_shortest_path.h>
 
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/iterator.h>
 
 #include <boost/lexical_cast.hpp>
 

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
@@ -9,11 +9,8 @@
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 
 #include <CGAL/Surface_mesh_shortest_path.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/iterator.h>
 
 #include <boost/lexical_cast.hpp>
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
@@ -3,7 +3,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrain_sharp_edges.cpp
@@ -3,8 +3,6 @@
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Constrained_placement.h>

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
@@ -4,8 +4,6 @@
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
@@ -5,9 +5,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
-
-
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
@@ -3,9 +3,6 @@
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -3,8 +3,6 @@
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
@@ -4,8 +4,6 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
-
 // Simplification function
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
@@ -1,6 +1,4 @@
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Mean_curvature_flow_skeletonization.h>
 

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
-#include <CGAL/boost/graph/properties_Surface_mesh.h>
 #include <CGAL/Mean_curvature_flow_skeletonization.h>
 
 #include <fstream>

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/segmentation_example.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/extract_mean_curvature_flow_skeleton.h>
 #include <CGAL/mesh_segmentation.h>

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
@@ -1,8 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/extract_mean_curvature_flow_skeleton.h>
 #include <CGAL/boost/graph/split_graph_into_polylines.h>
 #include <fstream>

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
@@ -1,7 +1,5 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
-#include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/extract_mean_curvature_flow_skeleton.h>
 
 #include <fstream>


### PR DESCRIPTION

## Summary of Changes

In the examples we no longer include the files that define the graph_traits and properties for Polyhedron_3 and Surface_mesh, as their header files already include those files. 


