### PR TITLE
BGL Add a description to doxygen groups

### DIFF
--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -51,7 +51,7 @@
 
 /*!
 \addtogroup PkgBGLHelper
-Several classes that enable to store ids in vertices/halfedges/faces of a `Polyhedron_3`, as well as adapters such as `Dual`.
+Several classes that enable to store ids in vertices/halfedges/faces of a `CGAL::Polyhedron_3`, as well as adapters such as `CGAL::Dual`.
 */
 
 /*!

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -59,7 +59,7 @@ Several classes that enable to store ids in vertices/halfedges/faces of a `Polyh
 Generic convenience functions for testing if an edge is a border edge, if a mesh is triangular,
 for conversion between models of different `FaceGraph` concepts, etc.
 
-Most functions are in the header file `<CGAL/boost/graph/helpers.h>
+Most functions are in the header file `<CGAL/boost/graph/helpers.h>`
 */
 
 /*!

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -46,10 +46,27 @@
 /// \defgroup PkgBGLSelectionFct Selection Functions
 /// \ingroup PkgBGL
 
+/// \defgroup PkgBGLEulerOperations Euler Operations
+/// \ingroup PkgBGL
+
+/*!
+\addtogroup PkgBGLHelper
+Several classes that enable to store ids in vertices/halfedges/faces of a `Polyhedron_3`, as well as adapters such as `Dual`.
+*/
+
+/*!
+\addtogroup PkgBGLHelperFct
+Generic convenience functions for testing if an edge is a border edge, if a mesh is triangular,
+for conversion between models of different `FaceGraph` concepts, etc.
+
+Most functions are in the header file `<CGAL/boost/graph/helpers.h>
+*/
+
 /*!
 \addtogroup PkgBGLIterators
 
-Several iterators and circulators are provided that enable to iterate through the  halfedges incident to a given face or vertex.
+Several iterators and circulators are provided that enable, for example,
+to iterate through the  halfedges incident to a given face or vertex.
 
 Starting at a halfedge `h`, applying several times `next(h,g)` brings us back 
 to the halfedge where we started. All halfedges traversed on the way are 
@@ -59,10 +76,14 @@ in another cycle, namely the cycle of halfedges which are incident to
 the same vertex.
 For convenience, two iterator and circulator types enable iterating through all the halfedges
 incident to a given face, and all the halfedges having a given vertex as target.
+
+All functions are in the header file `<CGAL/boost/graph/iterator.h>
 */
 
-/// \defgroup PkgBGLEulerOperations Euler Operations
-/// \ingroup PkgBGL
+/*!
+\addtogroup PkgBGLSelectionFct
+Several functions to enlarge or reduce a k-ring selection of vertices, edges, or faces.
+*/
 
 /*!
 \addtogroup PkgBGLTraits

--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -213,7 +213,7 @@ reduce_face_selection(
 
 /*!
 \ingroup PkgBGLSelectionFct
-discovers and puts in `out` all faces incident to the target vertex
+Discovers and puts in `out` all faces incident to the target vertex
 of a halfedge in `hedges`. Faces are put exactly once in `out`.
 \tparam HalfedgeRange a range of halfedge descriptors, model of `Range`.
           Its iterator type is `InputIterator`.
@@ -252,7 +252,6 @@ select_incident_faces(
   return out;
 }
 
-// Operations on edges
 /*!
 \ingroup PkgBGLSelectionFct
 Augments a selection with edges of `fg` that are adjacent
@@ -406,7 +405,6 @@ reduce_edge_selection(
   return out;
 }
 
-// Operations on vertices
 /*!
 \ingroup PkgBGLSelectionFct
 Augments a selection with vertices of `fg` that are adjacent


### PR DESCRIPTION

## Summary of Changes

For each group there is a line in a generated table of the entry page of the reference manual.
* Adding a sentence improves this table
* On the page of the group with functions I added the name of the header file, as when the functions only have a short dfescription, the line with the `#include` is not added automatically. 

## Release Management

* Affected package(s): BGL

