### PR TITLE
Polygon_mesh_processing: Fix documentation

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -76,7 +76,7 @@ namespace Polygon_mesh_processing {
 *    sequence of atomic operations performed (listed in the above description)
 *  \cgalParamEnd
 *  \cgalParamBegin{edge_is_constrained_map} a property map containing the
-*    constrained-or-not status of each edge of `pmesh`. A constrained edge can be splitted
+*    constrained-or-not status of each edge of `pmesh`. A constrained edge can be split
 *    or collapsed, but not flipped, nor its endpoints moved by smoothing.
 *    Note that patch boundary edges (i.e. incident to only one face in the range)
 *    are always considered as constrained edges.
@@ -87,7 +87,7 @@ namespace Polygon_mesh_processing {
 *  \cgalParamEnd
 *  \cgalParamBegin{protect_constraints} If `true`, the edges set as constrained
 *     in `edge_is_constrained_map` (or by default the boundary edges)
-*     are not splitted nor collapsed during remeshing.
+*     are not split nor collapsed during remeshing.
 *     Note that around constrained edges that have their length higher than
 *     twice `target_edge_length`, remeshing will fail to provide
 *     good quality results. It can even fail to terminate because of cascading vertex


### PR DESCRIPTION
splitted -> split  (see [wiktionary](https://en.wiktionary.org/wiki/splitted))