### PR TITLE
add a precondition

### DIFF
--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -423,7 +423,10 @@ class Polygon_2 {
 
     /// Returns a (const) reference to the `i`-th vertex.
     const Point_2& vertex(std::size_t i) const
-      { return *(d_container.begin() + i); }
+      {
+        CGAL_precondition( i < d_container.size() );
+        return *(d_container.begin() + i);
+      }
 
 
     /// Returns a (const) reference to the `i`-th vertex.


### PR DESCRIPTION
## Summary of Changes

Add a precondition that checks the index of the vertex is not out of bounds

## Release Management

* Affected package(s): Polygon
* Issue(s) solved (if any): fix #2073


