### PR TITLE
BGL:  doxygen doc for concepts

### DIFF
--- a/BGL/doc/BGL/Concepts/EdgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/EdgeListGraph.h
@@ -30,15 +30,15 @@ boost::graph_traits<EdgeListGraph>::ver_size_type
 num_edges(const EdgeListGraph& g);
 
 
-/*! \relates EdgeGraph
+/*! \relates EdgeListGraph
 returns the source vertex of `h`.
  */
-boost::graph_traits<EdgeGraph>::vertex_descriptor
-source(boost::graph_traits<EdgeGraph>::halfedge_descriptor h, EdgeGraph& g);
+boost::graph_traits<EdgeListGraph>::vertex_descriptor
+source(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, EdgeListGraph& g);
 
 
-/*! \relates EdgeGraph
+/*! \relates EdgeListGraph
 returns the target vertex of `h`.
  */
-boost::graph_traits<EdgeGraph>::vertex_descriptor
-target(boost::graph_traits<EdgeGraph>::halfedge_descriptor h, EdgeGraph& g);
+boost::graph_traits<EdgeListGraph>::vertex_descriptor
+target(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, EdgeListGraph& g);

--- a/BGL/doc/BGL/Concepts/EdgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/EdgeListGraph.h
@@ -1,0 +1,44 @@
+/*!
+\ingroup PkgBGLConcepts
+\cgalConcept
+
+The concept `EdgeListGraph` refines the concept `Graph` and adds
+the requirement for traversal of all edges in a graph.
+
+\cgalRefines `Graph`
+\cgalHasModel `CGAL::Polyhedron_3`
+\cgalHasModel `CGAL::Surface_mesh`
+
+*/
+class EdgeListGraph{};
+
+
+/*! \relates EdgeListGraph
+ * returns an iterator range over all edges.
+ */
+std::pair<boost::graph_traits<EdgeListGraph>::edge_iterator,
+          boost::graph_traits<EdgeListGraph>::edge_iterator>
+edges(const EdgeListGraph& g);
+
+
+/*! \relates EdgeListGraph
+  returns an upper bound of the number of edges of the graph.
+  \attention `num_edges()` may return a number larger than `std::distance(edges(g).first, edges(g).second)`.
+  This is the case for implementations only marking edges deleted in the edge container.
+ */
+boost::graph_traits<EdgeListGraph>::ver_size_type
+num_edges(const EdgeListGraph& g);
+
+
+/*! \relates EdgeGraph
+returns the source vertex of `h`.
+ */
+boost::graph_traits<EdgeGraph>::vertex_descriptor
+source(boost::graph_traits<EdgeGraph>::halfedge_descriptor h, EdgeGraph& g);
+
+
+/*! \relates EdgeGraph
+returns the target vertex of `h`.
+ */
+boost::graph_traits<EdgeGraph>::vertex_descriptor
+target(boost::graph_traits<EdgeGraph>::halfedge_descriptor h, EdgeGraph& g);

--- a/BGL/doc/BGL/Concepts/EdgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/EdgeListGraph.h
@@ -16,6 +16,7 @@ class EdgeListGraph{};
 /*! \relates EdgeListGraph
  * returns an iterator range over all edges.
  */
+template <typename EdgeListGraph>
 std::pair<boost::graph_traits<EdgeListGraph>::edge_iterator,
           boost::graph_traits<EdgeListGraph>::edge_iterator>
 edges(const EdgeListGraph& g);
@@ -26,6 +27,7 @@ edges(const EdgeListGraph& g);
   \attention `num_edges()` may return a number larger than `std::distance(edges(g).first, edges(g).second)`.
   This is the case for implementations only marking edges deleted in the edge container.
  */
+template <typename EdgeListGraph>
 boost::graph_traits<EdgeListGraph>::ver_size_type
 num_edges(const EdgeListGraph& g);
 
@@ -33,12 +35,14 @@ num_edges(const EdgeListGraph& g);
 /*! \relates EdgeListGraph
 returns the source vertex of `h`.
  */
+template <typename EdgeListGraph>
 boost::graph_traits<EdgeListGraph>::vertex_descriptor
-source(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, EdgeListGraph& g);
+source(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, const EdgeListGraph& g);
 
 
 /*! \relates EdgeListGraph
 returns the target vertex of `h`.
  */
+template <typename EdgeListGraph>
 boost::graph_traits<EdgeListGraph>::vertex_descriptor
-target(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, EdgeListGraph& g);
+target(boost::graph_traits<EdgeListGraph>::halfedge_descriptor h, const EdgeListGraph& g);

--- a/BGL/doc/BGL/Concepts/FaceGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceGraph.h
@@ -34,7 +34,7 @@ boost::graph_traits<FaceGraph>::degree_size_type
 degree(boost::graph_traits<FaceGraph>::face_descriptor f, FaceGraph& g);
 
 /*! \relates FaceGraph
-returns a special face that is not equal to any other face
+returns a special face that is not equal to any other face.
  */
 boost::graph_traits<FaceGraph>::face_descriptor
 null_face(FaceGraph& g);

--- a/BGL/doc/BGL/Concepts/FaceGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceGraph.h
@@ -18,23 +18,27 @@ class FaceGraph {};
 /*! \relates FaceGraph
 returns the face incident to halfedge `h`.
  */
+template <typename FaceGraph>
 boost::graph_traits<FaceGraph>::face_descriptor
-face(boost::graph_traits<FaceGraph>::halfedge_descriptor h, FaceGraph& g);
+face(boost::graph_traits<FaceGraph>::halfedge_descriptor h, const FaceGraph& g);
 
 /*! \relates FaceGraph
 returns the halfedge incident to face `f`.
  */
+template <typename FaceGraph>
 boost::graph_traits<FaceGraph>::halfedge_descriptor
-halfedge(boost::graph_traits<FaceGraph>::face_descriptor f, FaceGraph& g);
+halfedge(boost::graph_traits<FaceGraph>::face_descriptor f, const FaceGraph& g);
 
 /*! \relates FaceGraph
 returns the number of halfedges incident to face `f`.
  */
+template <typename FaceGraph>
 boost::graph_traits<FaceGraph>::degree_size_type
-degree(boost::graph_traits<FaceGraph>::face_descriptor f, FaceGraph& g);
+degree(boost::graph_traits<FaceGraph>::face_descriptor f, const FaceGraph& g);
 
 /*! \relates FaceGraph
 returns a special face that is not equal to any other face.
  */
+template <typename FaceGraph>
 boost::graph_traits<FaceGraph>::face_descriptor
-null_face(FaceGraph& g);
+null_face(const FaceGraph& g);

--- a/BGL/doc/BGL/Concepts/FaceGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceGraph.h
@@ -12,32 +12,29 @@ face.
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-\cgalHeading{Notations}
-
-<dl>
-<dt>`G`</dt> 	<dd>A type that is a model of `FaceGraph`.</dd>
-<dt>`g`</dt> 	<dd>An object of type `G`.</dd>
-<dt>`e`</dt> 	<dd>An edge descriptor.</dd>
-<dt>`f`</dt> 	<dd>A face descriptor.</dd>
-<dt>`h`</dt> 	<dd>A halfedge descriptor.</dd>
-</dl>
-
-\cgalHeading{Associated Types}
-
-Type                 | Description
--------------------- | ------------
-`boost::graph_traits<G>::%face_descriptor`              | A `face_descriptor` corresponds to a unique face in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable` and `LessThanComparable`.
-
-
-\cgalHeading{Valid Expressions}
-
-Expression                             | Returns                                                                  | Description  
--------------------------------------- | ------------------------------------------------------------------------ | ------------------------
-`face(h, g)`                           | `face_descriptor`                                                        | The face incident to halfedge `h`.
-`halfedge(f, g)`                       | `halfedge_descriptor`                                                    | A halfedge incident to face `f`.
-`degree(f,g)`                          | `degree_size_type`                                                       | The number of halfedges, incident to face `f`.
-`boost::graph_traits<G>::%null_face()` | `face_descriptor`                                                        | Returns a special face that is not equal to any other face.
-
-
 */
 class FaceGraph {};
+
+/*! \relates FaceGraph
+returns the face incident to halfedge `h`.
+ */
+boost::graph_traits<FaceGraph>::face_descriptor
+face(boost::graph_traits<FaceGraph>::halfedge_descriptor h, FaceGraph& g);
+
+/*! \relates FaceGraph
+returns the halfedge incident to face `f`.
+ */
+boost::graph_traits<FaceGraph>::halfedge_descriptor
+halfedge(boost::graph_traits<FaceGraph>::face_descriptor f, FaceGraph& g);
+
+/*! \relates FaceGraph
+returns the number of halfedges incident to face `f`.
+ */
+boost::graph_traits<FaceGraph>::degree_size_type
+degree(boost::graph_traits<FaceGraph>::face_descriptor f, FaceGraph& g);
+
+/*! \relates FaceGraph
+returns a special face that is not equal to any other face
+ */
+boost::graph_traits<FaceGraph>::face_descriptor
+null_face(FaceGraph& g);

--- a/BGL/doc/BGL/Concepts/FaceListGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceListGraph.h
@@ -9,34 +9,6 @@ the requirement for traversal of all faces in a graph.
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-\cgalHeading{Notations}
-
-<dl>
-<dt>`G`</dt> 	<dd>A type that is a model of `FaceListGraph`.</dd>
-<dt>`g`</dt> 	<dd>An object of type `G`.</dd>
-</dl>
-
-\cgalHeading{Associated Types}
-
-Type              | Description
------------------ | -----------
-`boost::graph_traits<G>::%face_iterator`   | %Iterator over all faces.
-`boost::graph_traits<G>::%faces_size_type` | Unsigned integer type for number of faces.
-
-
-\cgalHeading{Valid Expressions}
-
-Expression        |  returns                               | Description
------------------ | ---------------                        | -----------------------
-`faces(g)`        |  `std::pair<face_iterator, face_iterator>` | An iterator range over all faces. 
-`num_faces(g)`    |  `faces_size_type`                     | An upper bound of the number of faces of the graph.
-
-\attention `num_faces()` may return a number larger than `std::distance(faces(g).first, faces(g).second)`.
-This is the case for implementations only marking faces deleted in the face container.
-<!--
-This is for example the case for `CGAL::Surface_mesh` or `OpenMesh::PolyMesh_ArrayKernelT`. 
--->
-
 */
 class FaceListGraph{};
 
@@ -48,3 +20,14 @@ class FaceListGraph{};
 std::pair<boost::graph_traits<FaceListGraph>::face_iterator,
           boost::graph_traits<FaceListGraph>::face_iterator>
 faces(const FaceListGraph& g);
+
+
+/*! \relates FaceListGraph
+  returns an upper bound of the number of faces of the graph.
+  \attention `num_faces()` may return a number larger than `std::distance(faces(g).first, faces(g).second)`.
+  This is the case for implementations only marking faces deleted in the face container.
+ */
+
+boost::graph_traits<FaceListGraph>::face_size_type
+num_faces(const FaceListGraph& g);
+

--- a/BGL/doc/BGL/Concepts/FaceListGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceListGraph.h
@@ -16,7 +16,7 @@ class FaceListGraph{};
 /*! \relates FaceListGraph
  * returns an iterator range over all faces.
  */
-
+template <typename FaceListGraph>
 std::pair<boost::graph_traits<FaceListGraph>::face_iterator,
           boost::graph_traits<FaceListGraph>::face_iterator>
 faces(const FaceListGraph& g);
@@ -27,7 +27,7 @@ faces(const FaceListGraph& g);
   \attention `num_faces()` may return a number larger than `std::distance(faces(g).first, faces(g).second)`.
   This is the case for implementations only marking faces deleted in the face container.
  */
-
+template <typename FaceListGraph>
 boost::graph_traits<FaceListGraph>::face_size_type
 num_faces(const FaceListGraph& g);
 

--- a/BGL/doc/BGL/Concepts/FaceListGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceListGraph.h
@@ -39,3 +39,12 @@ This is for example the case for `CGAL::Surface_mesh` or `OpenMesh::PolyMesh_Arr
 
 */
 class FaceListGraph{};
+
+
+/*! \relates FaceListGraph
+ * An iterator range over all faces.
+ */
+
+std::pair<boost::graph_traits<FaceListGraph>::face_iterator,
+          boost::graph_traits<FaceListGraph>::face_iterator>
+faces(const FaceListGraph& g);

--- a/BGL/doc/BGL/Concepts/FaceListGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceListGraph.h
@@ -14,7 +14,7 @@ class FaceListGraph{};
 
 
 /*! \relates FaceListGraph
- * An iterator range over all faces.
+ * returns an iterator range over all faces.
  */
 
 std::pair<boost::graph_traits<FaceListGraph>::face_iterator,

--- a/BGL/doc/BGL/Concepts/HalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeGraph.h
@@ -27,64 +27,74 @@ A model of `HalfedgeGraph` must have the interior property `vertex_point` attach
 class HalfedgeGraph {};
 
 /*! \relates HalfedgeGraph
-returns the edge corresponding to halfedges `h` and `opposite(h)` .
+returns the edge corresponding to halfedges `h` and `opposite(h)`.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::edge_descriptor
-edge(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+edge(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns one of the halfedges corresponding to `e`.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-halfedge(boost::graph_traits<HalfedgeGraph>::edge_descriptor f, HalfedgeGraph& g);
+halfedge(boost::graph_traits<HalfedgeGraph>::edge_descriptor f, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns a halfedge with target `v`.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-halfedge(boost::graph_traits<HalfedgeGraph>::vertex_descriptor v, HalfedgeGraph& g);
+halfedge(boost::graph_traits<HalfedgeGraph>::vertex_descriptor v, const HalfedgeGraph& g);
 
 
 /*! \relates HalfedgeGraph
 returns the halfedge with source `u` and target `v`. The Boolean is `true`, iff this halfedge exists.
  */
+template <typename HalfedgeGraph>
 std::pair<boost::graph_traits<HalfedgeGraph>::halfedge_descriptor,bool>
 halfedge(boost::graph_traits<HalfedgeGraph>::vertex_descriptor u,
          boost::graph_traits<HalfedgeGraph>::vertex_descriptor v,
-         HalfedgeGraph& g);
+         const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns the halfedge with source and target swapped.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-opposite(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+opposite(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns the source vertex of `h`.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::vertex_descriptor
-source(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+source(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns the target vertex of `h`.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::vertex_descriptor
-target(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+target(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns the next halfedge around its face.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-next(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+next(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns the previous halfedge around its face.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-prev(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+prev(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, const HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
 returns a special halfedge that is not equal to any other halfedge.
  */
+template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-null_halfedge(HalfedgeGraph& g);
+null_halfedge(const HalfedgeGraph& g);

--- a/BGL/doc/BGL/Concepts/HalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeGraph.h
@@ -27,7 +27,7 @@ A model of `HalfedgeGraph` must have the interior property `vertex_point` attach
 class HalfedgeGraph {};
 
 /*! \relates HalfedgeGraph
-returns the edge corresponding to halfedges `h` and `opposite(h)`.
+returns the edge corresponding to halfedges `h` and `opposite(h,g)`.
  */
 template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::edge_descriptor

--- a/BGL/doc/BGL/Concepts/HalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeGraph.h
@@ -23,43 +23,68 @@ A model of `HalfedgeGraph` must have the interior property `vertex_point` attach
 
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
-
-\cgalHeading{Notations}
-
-<dl>
-<dt>`G`</dt> 	  <dd>A type that is a model of `HalfedgeGraph`.</dd>
-<dt>`g`</dt> 	  <dd>An object of type `G`.</dd>
-<dt>`u`, `v`</dt> <dd>Vertex descriptors.</dd>
-<dt>`e`</dt> 	  <dd>An edge descriptor.</dd>
-<dt>`h`</dt> 	  <dd>A halfedge descriptor.</dd>
-</dl>
-
-\cgalHeading{Associated Types}
-
-Type                                                      | Description
---------------------------------------------------------- | ------------
-`boost::graph_traits<G>::%halfedge_descriptor`             | A `halfedge_descriptor` corresponds to a halfedge in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable` and `LessThanComparable`.
-
-
-\cgalHeading{Valid Expressions}
-
-Expression                              | Returns                                                                      | Description  
---------------------------------------- | ---------------------------------------------------------------------------- | -----------
-`edge(h, g)`                            | `edge_descriptor`                                                            | The edge corresponding to `h` and `opposite(h)`.
-`halfedge(e, g)`                        | `halfedge_descriptor`                                                        | One of the halfedges corresponding to `e`.
-`halfedge(v, g)`                        | `halfedge_descriptor`                                                        | A halfedge with target `v`. 
-`halfedge(u, v, g)`                     | `std::pair<halfedge_descriptor,bool>`                                        | The halfedge with source `u` and target `v`. The Boolean is `true`, iff this halfedge exists.
-`opposite(h, g)`                        | `halfedge_descriptor`                                                        | The halfedge with source and target swapped.
-`source(h,g)`                           | `vertex_descriptor`                                                          | The source vertex of `h`.
-`target(h,g)`                           | `vertex_descriptor`                                                          | The target vertex of `h`.
-`next(h, g)`                            | `halfedge_descriptor`                                                        | The next halfedge around its face.
-`prev(h, g)`                            | `halfedge_descriptor`                                                        | The previous halfedge around its face.
-`boost::graph_traits<G>::%null_halfedge()` | `halfedge_descriptor`                                                     | Returns a special halfedge that is not equal to any other halfedge.
-
-\cgalHeading{Invariants}
-
-`halfedge(edge(h,g))==h`
-
-
 */
 class HalfedgeGraph {};
+
+/*! \relates HalfedgeGraph
+returns the edge corresponding to halfedges `h` and `opposite(h)` .
+ */
+boost::graph_traits<HalfedgeGraph>::edge_descriptor
+edge(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns one of the halfedges corresponding to `e`.
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+halfedge(boost::graph_traits<HalfedgeGraph>::edge_descriptor f, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns a halfedge with target `v`.
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+halfedge(boost::graph_traits<HalfedgeGraph>::vertex_descriptor v, HalfedgeGraph& g);
+
+
+/*! \relates HalfedgeGraph
+returns the halfedge with source `u` and target `v`. The Boolean is `true`, iff this halfedge exists.
+ */
+std::pair<boost::graph_traits<HalfedgeGraph>::halfedge_descriptor,bool>
+halfedge(boost::graph_traits<HalfedgeGraph>::vertex_descriptor u,
+         boost::graph_traits<HalfedgeGraph>::vertex_descriptor v,
+         HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns the halfedge with source and target swapped.
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+opposite(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns the source vertex of `h`.
+ */
+boost::graph_traits<HalfedgeGraph>::vertex_descriptor
+source(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns the target vertex of `h`.
+ */
+boost::graph_traits<HalfedgeGraph>::vertex_descriptor
+target(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns the next halfedge around its face.
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+next(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns the previous halfedge around its face.
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+prev(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
+
+/*! \relates HalfedgeGraph
+returns a special halfedge that is not equal to any other halfedge
+ */
+boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
+null_halfedge(HalfedgeGraph& g);

--- a/BGL/doc/BGL/Concepts/HalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeGraph.h
@@ -84,7 +84,7 @@ boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
 prev(boost::graph_traits<HalfedgeGraph>::halfedge_descriptor h, HalfedgeGraph& g);
 
 /*! \relates HalfedgeGraph
-returns a special halfedge that is not equal to any other halfedge
+returns a special halfedge that is not equal to any other halfedge.
  */
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
 null_halfedge(HalfedgeGraph& g);

--- a/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
@@ -14,7 +14,7 @@ and adds the requirements for traversal of all halfedges in the graph.
 class HalfedgeListGraph {};
 
 /*! \relates HalfedgeListGraph
- * An iterator range over all halfedges.
+ * returns an iterator range over all halfedges.
  */
 
 std::pair<boost::graph_traits<HalfedgeListGraph>::halfedge_iterator,

--- a/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
@@ -9,35 +9,25 @@ and adds the requirements for traversal of all halfedges in the graph.
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-\cgalHeading{Notations}
-
-<dl>
-<dt>`G`</dt> 	<dd>A type that is a model of `HalfedgeListGraph`.</dd>
-<dt>`g`</dt> 	<dd>An object of type `G`.</dd>
-</dl>
-
-\cgalHeading{Associated Types}
-
-Type                 | Description
--------------------- | ------------
-`boost::graph_traits<G>::%halfedge_iterator`      | A `BidirectionalIterator` over all halfedges in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable`.
-`boost::graph_traits<G>::%halfedges_size_type`    | A size type.
-
-
-\cgalHeading{Valid Expressions}
-
-Expression                            | Returns                                   | Description  
-------------------------------------- | ------------------------------------------| -----------
-`num_halfedges(g)`                    | `halfedges_size_type`                     | An upper bound of the number of halfedges of the graph.
-`halfedges(g)`                        | `std::pair<halfedge_iterator,halfedge_iterator>` | An iterator range over the halfedges of the graph.
-
-\attention `num_halfedges()` may return a number larger than `std::distance(halfedges(g).first,halfedges(g).second)`.
-This is the case for implementations only marking halfedges deleted in the halfedge container.
-
-<!--
-This is for example the case for `CGAL::Surface_mesh` or `OpenMesh::PolyMesh_ArrayKernelT`. 
--->
-
 */
 
 class HalfedgeListGraph {};
+
+/*! \relates HalfedgeListGraph
+ * An iterator range over all halfedges.
+ */
+
+std::pair<boost::graph_traits<HalfedgeListGraph>::halfedge_iterator,
+          boost::graph_traits<HalfedgeListGraph>::halfedge_iterator>
+halfedges(const HalfedgeListGraph& g);
+
+
+/*! \relates HalfedgeListGraph
+  returns an upper bound of the number of halfedges of the graph.
+  \attention `num_halfedges()` may return a number larger than `std::distance(halfedges(g).first, halfedges(g).second)`.
+  This is the case for implementations only marking halfedges deleted in the halfedge container.
+ */
+
+boost::graph_traits<HalfedgeListGraph>::halfedge_size_type
+num_halfedges(const FaceListGraph& g);
+

--- a/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeListGraph.h
@@ -16,7 +16,7 @@ class HalfedgeListGraph {};
 /*! \relates HalfedgeListGraph
  * returns an iterator range over all halfedges.
  */
-
+template <typename HalfedgeListGraph>
 std::pair<boost::graph_traits<HalfedgeListGraph>::halfedge_iterator,
           boost::graph_traits<HalfedgeListGraph>::halfedge_iterator>
 halfedges(const HalfedgeListGraph& g);
@@ -27,7 +27,7 @@ halfedges(const HalfedgeListGraph& g);
   \attention `num_halfedges()` may return a number larger than `std::distance(halfedges(g).first, halfedges(g).second)`.
   This is the case for implementations only marking halfedges deleted in the halfedge container.
  */
-
+template <typename HalfedgeListGraph>
 boost::graph_traits<HalfedgeListGraph>::halfedge_size_type
-num_halfedges(const FaceListGraph& g);
+num_halfedges(const HalfedgeListGraph& g);
 

--- a/BGL/doc/BGL/Concepts/MutableFaceGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableFaceGraph.h
@@ -10,7 +10,7 @@ the requirement for operations to add faces and to modify face-halfedge relation
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-
+*/
 class MutableFaceGraph{};
 
 /*! \relates MutableFaceGraph

--- a/BGL/doc/BGL/Concepts/MutableFaceGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableFaceGraph.h
@@ -10,23 +10,34 @@ the requirement for operations to add faces and to modify face-halfedge relation
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-\cgalHeading{Notations}
 
-<dl>
-<dt>`G`</dt> 	<dd>A type that is a model of `MutableFaceGraph`.</dd>
-<dt>`g`</dt> 	<dd>An object of type `G`.</dd>
-<dt>`h`</dt> 	<dd>A halfedge descriptor.</dd>
-<dt>`f`</dt> 	<dd>A face descriptor.</dd>
-</dl>
-
-\cgalHeading{Valid Expressions}
-
-Expression              | returns           | Description                           
------------------------ | ------------      | -----------
-`add_face(g)`           | `face_descriptor` | Adds a new face to the graph without initializing the connectivity.
-`remove_face(f, g)`     | `void`            | Removes `f` from the graph.
-`set_face(h, f, g)`     | `void`            | Sets the corresponding face of `h` to `f`.
-`set_halfedge(f, h, g)` | `void`            | Sets the corresponding halfedge of `f` to `h`.
-`reserve(g, nv, ne, nf)`| `void`            | Called to indicate the expected size of vertices (`nv`), edges (`ed`) and faces (`nf`)
-*/
 class MutableFaceGraph{};
+
+/*! \relates MutableFaceGraph
+Adds a new face to the graph without initializing the connectivity.
+ */
+boost::graph_traits<MutableFaceGraph>::face_descriptor
+add_face(MutableFaceGraph& g);
+
+/*! \relates MutableFaceGraph
+Removes `f` from the graph.
+ */
+boost::graph_traits<MutableFaceGraph>::face_descriptor
+remove_face(boost::graph_traits<MutableFaceGraph>::face_descriptor f, MutableFaceGraph& g);
+
+/*! \relates MutableFaceGraph
+Sets the corresponding face of `h` to `f`.
+ */
+void
+set_face(boost::graph_traits<MutableFaceGraph>::halfedge_descriptor h, boost::graph_traits<MutableFaceGraph>::face_descriptor f, MutableFaceGraph& g);
+
+/*! \relates MutableFaceGraph
+Sets the corresponding halfedge of `f` to `h`.
+ */
+void
+set_halfedge(boost::graph_traits<MutableFaceGraph>::face_descriptor f, boost::graph_traits<MutableFaceGraph>::halfedge_descriptor h, MutableFaceGraph& g);
+/*! \relates MutableFaceGraph
+Indicates the expected size of vertices (`nv`), edges (`ed`) and faces (`nf`).
+ */
+void
+reserve(MutableFaceGraph& g, boost::graph_traits<MutableFaceGraph>::vertices_size_type nv, boost::graph_traits<MutableFaceGraph>::vertices_size_type ne, boost::graph_traits<MutableFaceGraph>::vertices_size_type nf);

--- a/BGL/doc/BGL/Concepts/MutableFaceGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableFaceGraph.h
@@ -16,28 +16,34 @@ class MutableFaceGraph{};
 /*! \relates MutableFaceGraph
 Adds a new face to the graph without initializing the connectivity.
  */
+template <typename MutableFaceGraph>
 boost::graph_traits<MutableFaceGraph>::face_descriptor
 add_face(MutableFaceGraph& g);
 
 /*! \relates MutableFaceGraph
 Removes `f` from the graph.
  */
+template <typename MutableFaceGraph>
 boost::graph_traits<MutableFaceGraph>::face_descriptor
 remove_face(boost::graph_traits<MutableFaceGraph>::face_descriptor f, MutableFaceGraph& g);
 
 /*! \relates MutableFaceGraph
 Sets the corresponding face of `h` to `f`.
  */
+template <typename MutableFaceGraph>
 void
 set_face(boost::graph_traits<MutableFaceGraph>::halfedge_descriptor h, boost::graph_traits<MutableFaceGraph>::face_descriptor f, MutableFaceGraph& g);
 
 /*! \relates MutableFaceGraph
 Sets the corresponding halfedge of `f` to `h`.
  */
+template <typename MutableFaceGraph>
 void
 set_halfedge(boost::graph_traits<MutableFaceGraph>::face_descriptor f, boost::graph_traits<MutableFaceGraph>::halfedge_descriptor h, MutableFaceGraph& g);
+
 /*! \relates MutableFaceGraph
 Indicates the expected size of vertices (`nv`), edges (`ed`) and faces (`nf`).
  */
+template <typename MutableFaceGraph>
 void
 reserve(MutableFaceGraph& g, boost::graph_traits<MutableFaceGraph>::vertices_size_type nv, boost::graph_traits<MutableFaceGraph>::vertices_size_type ne, boost::graph_traits<MutableFaceGraph>::vertices_size_type nf);

--- a/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
@@ -18,24 +18,28 @@ class MutableHalfedgeGraph{};
 /*! \relates MutableFaceGraph
 Adds a new vertex to the graph without initializing the connectivity.
  */
+template <typename MutableHalfedgeGraph>
 boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
 add_vertex(MutableHalfedgeGraph& g);
 
 /*! \relates MutableHalfedgeGraph
 Removes `v` from the graph.
  */
+template <typename MutableHalfedgeGraph>
 boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
 remove_vertex(boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, MutableHalfedgeGraph& g);
 
 /*! \relates MutableFaceGraph
 Adds two opposite halfedges to the graph without initializing the connectivity.
  */
+template <typename MutableHalfedgeGraph>
 boost::graph_traits<MutableHalfedgeGraph>::edge_descriptor
 add_edge(MutableHalfedgeGraph& g);
 
 /*! \relates MutableHalfedgeGraph
 Removes the two halfedges corresponding to `e` from the graph.
  */
+template <typename MutableHalfedgeGraph>
 boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
 remove_edge(boost::graph_traits<MutableHalfedgeGraph>::edge_descriptor e, MutableHalfedgeGraph& g);
 
@@ -43,12 +47,14 @@ remove_edge(boost::graph_traits<MutableHalfedgeGraph>::edge_descriptor e, Mutabl
 /*! \relates MutableHalfedgeGraph
 Sets the target vertex of `h` and the source of `opposite(h)` to `v`.
  */
+template <typename MutableHalfedgeGraph>
 void
 set_target(boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h, boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, MutableHalfedgeGraph& g);
 
 /*! \relates MutableHalfedgeGraph
 Sets the halfedge of `v` to `h`. The target vertex of `h` must be `v`. 
  */
+template <typename MutableHalfedgeGraph>
 void
 set_halfedge(boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h, MutableHalfedgeGraph& g);
 
@@ -56,5 +62,6 @@ set_halfedge(boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, boo
 /*! \relates MutableHalfedgeGraph
 Sets the successor of `h1` around a face to `h2`, and the prededecessor of `h2` to `h1`.
  */
+template <typename MutableHalfedgeGraph>
 void
 set_next(boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h1, boost::graph_traits<MutableHalfedgeGraph>::halfede_descriptor h2, MutableHalfedgeGraph& g);

--- a/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
@@ -11,20 +11,9 @@ update the incidence information between vertices and halfedges.
 \cgalHasModel `CGAL::Polyhedron_3`
 \cgalHasModel `CGAL::Surface_mesh`
 
-\cgalHeading{Notations}
-
-<dl>
-<dt>`G`</dt>        <dd>A type that is a model of `MutableHalfedgeGraph`.</dd>
-<dt>`g`</dt>        <dd>An object of type `G`.</dd>
-<dt>`v`</dt>        <dd>A vertex descriptor.</dd>
-<dt>`h`, `h1`, `h2`</dt> <dd>Halfedge descriptors.</dd>
-<dt>`e`</dt>        <dd>An edge descriptor.</dd>
-</dl>
-
-\cgalHeading{Valid Expressions}
-
-Expression                | returns             | Description                           
-------------------------- | ------------        | -----------
+*/
+class MutableHalfedgeGraph{};
+/*
 `add_vertex(g)`           | `vertex_descriptor` | Adds a new vertex to the graph without initializing the connectivity.
 `remove_vertex(v, g)`     | `void`              | Removes `v` from the graph.
 `add_edge(g)`             | `edge_descriptor`   | Adds two opposite halfedges to the graph without initializing the connectivity.
@@ -32,7 +21,4 @@ Expression                | returns             | Description
 `set_target(h, v, g)`     | `void`              | Sets the target vertex of `h` and the source of `opposite(h)` to `v`.
 `set_halfedge(v, h, g)`   | `void`              | Sets the halfedge of `v` to `h`. The target vertex of `h` must be `v`. 
 `set_next(h1, h2, g)`     | `void`              | Sets the successor of `h1` around a face to `h2`, and the prededecessor of `h2` to `h1`.
-
-
 */
-class MutableHalfedgeGraph{};

--- a/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableHalfedgeGraph.h
@@ -13,12 +13,48 @@ update the incidence information between vertices and halfedges.
 
 */
 class MutableHalfedgeGraph{};
-/*
-`add_vertex(g)`           | `vertex_descriptor` | Adds a new vertex to the graph without initializing the connectivity.
-`remove_vertex(v, g)`     | `void`              | Removes `v` from the graph.
-`add_edge(g)`             | `edge_descriptor`   | Adds two opposite halfedges to the graph without initializing the connectivity.
-`remove_edge(e, g)`       | `void`              | Removes the two halfedges corresponding to `e` from the graph.
-`set_target(h, v, g)`     | `void`              | Sets the target vertex of `h` and the source of `opposite(h)` to `v`.
-`set_halfedge(v, h, g)`   | `void`              | Sets the halfedge of `v` to `h`. The target vertex of `h` must be `v`. 
-`set_next(h1, h2, g)`     | `void`              | Sets the successor of `h1` around a face to `h2`, and the prededecessor of `h2` to `h1`.
-*/
+
+
+/*! \relates MutableFaceGraph
+Adds a new vertex to the graph without initializing the connectivity.
+ */
+boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
+add_vertex(MutableHalfedgeGraph& g);
+
+/*! \relates MutableHalfedgeGraph
+Removes `v` from the graph.
+ */
+boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
+remove_vertex(boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, MutableHalfedgeGraph& g);
+
+/*! \relates MutableFaceGraph
+Adds two opposite halfedges to the graph without initializing the connectivity.
+ */
+boost::graph_traits<MutableHalfedgeGraph>::edge_descriptor
+add_edge(MutableHalfedgeGraph& g);
+
+/*! \relates MutableHalfedgeGraph
+Removes the two halfedges corresponding to `e` from the graph.
+ */
+boost::graph_traits<MutableHalfedgeGraph>::face_descriptor
+remove_edge(boost::graph_traits<MutableHalfedgeGraph>::edge_descriptor e, MutableHalfedgeGraph& g);
+
+
+/*! \relates MutableHalfedgeGraph
+Sets the target vertex of `h` and the source of `opposite(h)` to `v`.
+ */
+void
+set_target(boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h, boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, MutableHalfedgeGraph& g);
+
+/*! \relates MutableHalfedgeGraph
+Sets the halfedge of `v` to `h`. The target vertex of `h` must be `v`. 
+ */
+void
+set_halfedge(boost::graph_traits<MutableHalfedgeGraph>::vertex_descriptor v, boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h, MutableHalfedgeGraph& g);
+
+
+/*! \relates MutableHalfedgeGraph
+Sets the successor of `h1` around a face to `h2`, and the prededecessor of `h2` to `h1`.
+ */
+void
+set_next(boost::graph_traits<MutableHalfedgeGraph>::halfedge_descriptor h1, boost::graph_traits<MutableHalfedgeGraph>::halfede_descriptor h2, MutableHalfedgeGraph& g);

--- a/BGL/doc/BGL/Concepts/VertexListGraph.h
+++ b/BGL/doc/BGL/Concepts/VertexListGraph.h
@@ -16,7 +16,7 @@ class VertexListGraph{};
 /*! \relates VertexListGraph
  * returns an iterator range over all vertices.
  */
-
+template <typename VertexListGraph>
 std::pair<boost::graph_traits<VertexListGraph>::vertex_iterator,
           boost::graph_traits<VertexListGraph>::vertex_iterator>
 vertices(const VertexListGraph& g);
@@ -27,7 +27,7 @@ vertices(const VertexListGraph& g);
   \attention `num_vertices()` may return a number larger than `std::distance(vertices(g).first, vertices(g).second)`.
   This is the case for implementations only marking vertices deleted in the vertex container.
  */
-
+template <typename VertexListGraph>
 boost::graph_traits<VertexListGraph>::ver_size_type
 num_vertices(const VertexListGraph& g);
 

--- a/BGL/doc/BGL/Concepts/VertexListGraph.h
+++ b/BGL/doc/BGL/Concepts/VertexListGraph.h
@@ -1,0 +1,33 @@
+/*!
+\ingroup PkgBGLConcepts
+\cgalConcept
+
+The concept `VertexListGraph` refines the concept `Graph` and adds
+the requirement for traversal of all vertices in a graph.
+
+\cgalRefines `Graph`
+\cgalHasModel `CGAL::Polyhedron_3`
+\cgalHasModel `CGAL::Surface_mesh`
+
+*/
+class VertexListGraph{};
+
+
+/*! \relates VertexListGraph
+ * returns an iterator range over all vertices.
+ */
+
+std::pair<boost::graph_traits<VertexListGraph>::vertex_iterator,
+          boost::graph_traits<VertexListGraph>::vertex_iterator>
+vertices(const VertexListGraph& g);
+
+
+/*! \relates VertexListGraph
+  returns an upper bound of the number of vertices of the graph.
+  \attention `num_vertices()` may return a number larger than `std::distance(vertices(g).first, vertices(g).second)`.
+  This is the case for implementations only marking vertices deleted in the vertex container.
+ */
+
+boost::graph_traits<VertexListGraph>::ver_size_type
+num_vertices(const VertexListGraph& g);
+

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -3,7 +3,7 @@
 /*! \defgroup PkgBGLConcepts Concepts
  \ingroup PkgBGL
 
- We extend the Boost Graph Library(\sc{Bgl} for short) with a set of new concepts. 
+ We extend the Boost Graph Library (\sc{Bgl} for short) with a set of new concepts. 
  The documentation of the concepts lists at the same time the functions
  related to it. Models of the concept and their related functions
  must be in the same namespace (they will be found by Koenig lookup).

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -232,7 +232,6 @@ incident to a given face, and all the halfedges having a given vertex as target.
 \cgalClassifedRefPages
 
 ## Concepts ##
-- `Graph`
 - `VertexListGraph`
 - `HalfedgeGraph`
 - `HalfedgeListGraph`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -34,11 +34,12 @@ digraph example {
  \cgalHeading{Notations}
 
  <dl>
- <dt>`G`</dt> 	<dd>A type that is a model of `FaceGraph`.</dd>
+ <dt>`G`</dt> 	<dd>A type that is a model of a graph concept.</dd>
  <dt>`g`</dt> 	<dd>An object of type `G`.</dd>
- <dt>`e`</dt> 	<dd>An edge descriptor.</dd>
- <dt>`f`</dt> 	<dd>A face descriptor.</dd>
- <dt>`h`</dt> 	<dd>A halfedge descriptor.</dd>
+ <dt>`u`, `v`</dt> 	<dd>An object of type `boost::graph_traits<G>::vertex descriptor`.</dd>
+ <dt>`h`</dt> 	<dd>An object of type `boost::graph_traits<G>::halfedge descriptor`.</dd>
+ <dt>`e`</dt> 	<dd>An object of type `boost::graph_traits<G>::edge descriptor`.</dd>
+ <dt>`f`</dt> 	<dd>An object of type `boost::graph_traits<G>::face descriptor`.</dd>
  </dl>
 
 \cgalHeading{%VertexListGraph}
@@ -135,6 +136,18 @@ Valid Expression                       | Returns                                
 `boost::graph_traits<G>::%null_face()` | `face_descriptor`                                                        | A special face that is not equal to any other face.
 
 
+\cgalHeading{%MutableFaceGraph}
+
+The concept `MutableFaceGraph` refines the concepts `FaceGraph` and `MutableHalfedgeGraph` and adds
+the requirement for operations to add faces and to modify face-halfedge relations.
+
+Valid Expression              | returns           | Description                           
+----------------------- | ------------      | -----------
+`add_face(g)`           | `face_descriptor` | Adds a new face to the graph without initializing the connectivity.
+`remove_face(f, g)`     | `void`            | Removes `f` from the graph.
+`set_face(h, f, g)`     | `void`            | Sets the corresponding face of `h` to `f`.
+`set_halfedge(f, h, g)` | `void`            | Sets the corresponding halfedge of `f` to `h`.
+`reserve(g, nv, ne, nf)`| `void`            | Called to indicate the expected size of vertices (`nv`), edges (`ed`) and faces (`nf`)
 
 \cgalHeading{%FaceListGraph}
 
@@ -219,6 +232,8 @@ incident to a given face, and all the halfedges having a given vertex as target.
 \cgalClassifedRefPages
 
 ## Concepts ##
+- `Graph`
+- `VertexListGraph`
 - `HalfedgeGraph`
 - `HalfedgeListGraph`
 - `MutableHalfedgeGraph`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -3,7 +3,9 @@
 /*! \defgroup PkgBGLConcepts Concepts
  \ingroup PkgBGL
 
- We extend the Boost Graph Library (\sc{Bgl} for short) with a set of new concepts. 
+ We extend the Boost Graph Library (\sc{Bgl} for short) with a set of new concepts.
+ In order to make this documentation self-contained we here also document
+ concepts that are defined in the original version of the \sc{Bgl}.
  The documentation of the concepts lists at the same time the functions
  related to it. Models of the concept and their related functions
  must be in the same namespace (they will be found by Koenig lookup).

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -1,33 +1,161 @@
 /// \defgroup PkgBGL CGAL and the Boost Graph Library Reference
 
-/// \defgroup PkgBGLConcepts Concepts
-/// \ingroup PkgBGL
-///
-/// We extend the Boost Graph Library(\sc{Bgl} for short) with a set of new concepts. 
-/// The documentation of the concepts lists at the same time the functions
-/// related to it. Models of the concept and their related functions
-/// must be in the same namespace (they will be found by Koenig lookup).
-///
-///\dot
-///digraph example {
-///  node [shape=record, fontname=Helvetica, fontsize=10];
-///  rankdir=BT
-///
-///  "boost Graph" [ URL="http://www.boost.org/libs/graph/doc/Graph.html" ];
-///  HalfedgeGraph [ URL="\ref HalfedgeGraph"];
-///  HalfedgeListGraph [ URL="\ref HalfedgeListGraph"];
-///  MutableHalfedgeGraph [ URL="\ref MutableHalfedgeGraph"];
-///  FaceGraph [ URL="\ref FaceGraph"];
-///  FaceListGraph [ URL="\ref FaceListGraph"];
-///  MutableFaceGraph [ URL="\ref MutableFaceGraph"];
-///  
-///  MutableHalfedgeGraph -> HalfedgeGraph -> "boost Graph" [ arrowhead="open", label="refines" ];
-///  FaceListGraph -> FaceGraph -> HalfedgeGraph [ arrowhead="open", label="refines" ];
-///  MutableFaceGraph -> MutableHalfedgeGraph [ arrowhead="open", label="refines" ];
-///  MutableFaceGraph -> FaceGraph [ arrowhead="open", label="refines" ];
-///  HalfedgeListGraph -> HalfedgeGraph [ arrowhead="open", label="refines" ];
-///}
-///\enddot
+/*! \defgroup PkgBGLConcepts Concepts
+ \ingroup PkgBGL
+
+ We extend the Boost Graph Library(\sc{Bgl} for short) with a set of new concepts. 
+ The documentation of the concepts lists at the same time the functions
+ related to it. Models of the concept and their related functions
+ must be in the same namespace (they will be found by Koenig lookup).
+
+  
+
+\dot
+digraph example {
+  node [shape=record, fontname=Helvetica, fontsize=10];
+  rankdir=BT
+
+  "boost Graph" [ URL="http://www.boost.org/libs/graph/doc/Graph.html" ];
+  HalfedgeGraph [ URL="\ref HalfedgeGraph"];
+  HalfedgeListGraph [ URL="\ref HalfedgeListGraph"];
+  MutableHalfedgeGraph [ URL="\ref MutableHalfedgeGraph"];
+  FaceGraph [ URL="\ref FaceGraph"];
+  FaceListGraph [ URL="\ref FaceListGraph"];
+  MutableFaceGraph [ URL="\ref MutableFaceGraph"];
+  
+  MutableHalfedgeGraph -> HalfedgeGraph -> "boost Graph" [ arrowhead="open", label="refines" ];
+  FaceListGraph -> FaceGraph -> HalfedgeGraph [ arrowhead="open", label="refines" ];
+  MutableFaceGraph -> MutableHalfedgeGraph [ arrowhead="open", label="refines" ];
+  MutableFaceGraph -> FaceGraph [ arrowhead="open", label="refines" ];
+  HalfedgeListGraph -> HalfedgeGraph [ arrowhead="open", label="refines" ];
+}
+\enddot
+
+ \cgalHeading{Notations}
+
+ <dl>
+ <dt>`G`</dt> 	<dd>A type that is a model of `FaceGraph`.</dd>
+ <dt>`g`</dt> 	<dd>An object of type `G`.</dd>
+ <dt>`e`</dt> 	<dd>An edge descriptor.</dd>
+ <dt>`f`</dt> 	<dd>A face descriptor.</dd>
+ <dt>`h`</dt> 	<dd>A halfedge descriptor.</dd>
+ </dl>
+
+\cgalHeading{%VertexListGraph}
+
+The concept `VertexListGraph` refines the concept `Graph` and adds
+the requirement for traversal of all vertices in a graph.
+
+Associated Type                               | Description
+-----------------                             | -----------
+`boost::graph_traits<G>::%vertex_iterator`    | %Iterator over all vertices.
+`boost::graph_traits<G>::%vertices_size_type` | Unsigned integer type for number of vertices.
+
+
+
+Valid Expression     |  returns                                       | Description
+-----------------    | ---------------                                | -----------------------
+`vertices(g)`        |  `std::pair<vertex_iterator, vertex_iterator>` | An iterator range over all vertices. 
+`num_vertices(g)`    |  `vertices_size_type`                          | An upper bound of the number of vertices of the graph.
+
+
+\cgalHeading{%HalfedgeGraph}
+
+The concept `HalfedgeGraph` refines the concept `Graph` and adds
+the notion of halfedges, where each edge corresponds to two opposite halfedges.
+
+Associated Type                                           | Description
+--------------------------------------------------------- | ------------
+`boost::graph_traits<G>::%halfedge_descriptor`            | A `halfedge_descriptor` corresponds to a halfedge in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable` and `LessThanComparable`.
+
+Valid Expression                        | Returns                                     | Description  
+--------------------------------------- | --------------------------------------------| -----------
+`edge(h, g)`                            | `edge_descriptor`                           | The edge corresponding to halfedges `h` and `opposite(h)`.
+`halfedge(e, g)`                        | `halfedge_descriptor`                       | One of the halfedges corresponding to `e`.
+`halfedge(v, g)`                        | `halfedge_descriptor`                       | A halfedge with target `v`. 
+`halfedge(u, v, g)`                     | `std::pair<halfedge_descriptor,bool>`       | The halfedge with source `u` and target `v`. The Boolean is `true`, iff this halfedge exists.
+`opposite(h, g)`                        | `halfedge_descriptor`                       | The halfedge with source and target swapped.
+`source(h,g)`                           | `vertex_descriptor`                         | The source vertex of `h`.
+`target(h,g)`                           | `vertex_descriptor`                         | The target vertex of `h`.
+`next(h, g)`                            | `halfedge_descriptor`                       | The next halfedge around its face.
+`prev(h, g)`                            | `halfedge_descriptor`                       | The previous halfedge around its face.
+`boost::graph_traits<G>::%null_halfedge()` | `halfedge_descriptor`                    | Returns a special halfedge that is not equal to any other halfedge.
+
+\cgalHeading{%MutableHalfedgeGraph}
+
+The concept `MutableHalfedgeGraph` refines the concept `HalfedgeGraph`
+and adds the requirements for operations to add vertices and edges, and to
+update the incidence information between vertices and halfedges.
+
+Valid Expression          | returns             | Description                           
+------------------------- | ------------        | -----------
+`add_vertex(g)`           | `vertex_descriptor` | Adds a new vertex to the graph without initializing the connectivity.
+`remove_vertex(v, g)`     | `void`              | Removes `v` from the graph.
+`add_edge(g)`             | `edge_descriptor`   | Adds two opposite halfedges to the graph without initializing the connectivity.
+`remove_edge(e, g)`       | `void`              | Removes the two halfedges corresponding to `e` from the graph.
+`set_target(h, v, g)`     | `void`              | Sets the target vertex of `h` and the source of `opposite(h)` to `v`.
+`set_halfedge(v, h, g)`   | `void`              | Sets the halfedge of `v` to `h`. The target vertex of `h` must be `v`. 
+`set_next(h1, h2, g)`     | `void`              | Sets the successor of `h1` around a face to `h2`, and the prededecessor of `h2` to `h1`.
+
+
+\cgalHeading{%HalfedgeListGraph}
+
+The concept `HalfedgeListGraph` refines the concept `HalfedgeGraph`
+and adds the requirements for traversal of all halfedges in the graph.
+
+Associated Type                                   | Description
+--------------------                              | ------------
+`boost::graph_traits<G>::%halfedge_iterator`      | A `BidirectionalIterator` over all halfedges in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable`.
+`boost::graph_traits<G>::%halfedges_size_type`    | A size type.
+
+
+Valid Expression                      | Returns                                   | Description  
+------------------------------------- | ------------------------------------------| -----------
+`num_halfedges(g)`                    | `halfedges_size_type`                     | An upper bound of the number of halfedges of the graph.
+`halfedges(g)`                        | `std::pair<halfedge_iterator,halfedge_iterator>` | An iterator range over the halfedges of the graph.
+
+\cgalHeading{%FaceGraph}
+
+The concept `FaceGraph` refines the concept `HalfedgeGraph`. 
+It adds the requirements for a graph to explicitly
+maintain faces described by halfedges, to provide access from a face to
+an incident halfedge, and to provide access from a halfedge to its incident
+face. 
+
+Associated Type                              | Description
+-------------------------------------------- | ------------
+`boost::graph_traits<G>::%face_descriptor`   | A `face_descriptor` corresponds to a unique face in a graph. Must be `DefaultConstructible`, `Assignable`, `EqualityComparable` and `LessThanComparable`.
+
+
+Valid Expression                       | Returns                                                                  | Description  
+-------------------------------------- | ------------------------------------------------------------------------ | ------------------------
+`face(h, g)`                           | `face_descriptor`                                                        | The face incident to halfedge `h`.
+`halfedge(f, g)`                       | `halfedge_descriptor`                                                    | A halfedge incident to face `f`.
+`degree(f,g)`                          | `degree_size_type`                                                       | The number of halfedges incident to face `f`.
+`boost::graph_traits<G>::%null_face()` | `face_descriptor`                                                        | A special face that is not equal to any other face.
+
+
+
+\cgalHeading{%FaceListGraph}
+
+The concept `FaceListGraph` refines the concept `FaceGraph` and adds
+the requirement for traversal of all faces in a graph.
+
+Associated Type                             | Description
+------------------------------------------ | -----------
+`boost::graph_traits<G>::%face_iterator`   | %Iterator over all faces.
+`boost::graph_traits<G>::%faces_size_type` | Unsigned integer type for number of faces.
+
+
+
+
+Valid Expression  |  returns                                   | Description
+----------------- | ---------------                            | -----------------------
+`faces(g)`        |  `std::pair<face_iterator, face_iterator>` | An iterator range over all faces. 
+`num_faces(g)`    |  `faces_size_type`                         | An upper bound of the number of faces of the graph.
+
+
+*/
 
 /// The property tags model of the boost concept <a href="http://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>.
 /// These tags are used to retrieve default property maps using the traits class <a href="http://www.boost.org/libs/graph/doc/property_map.html">boost::property_map</a>.

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -99,7 +99,7 @@ Valid Expression                        | Returns                               
 `prev(h, g)`                            | `halfedge_descriptor`                       | The previous halfedge around its face.
 `boost::graph_traits<G>::%null_halfedge()` | `halfedge_descriptor`                    | Returns a special halfedge that is not equal to any other halfedge.
 
-The `HalfedgeGraph`has the invariant  `halfedge(edge(h,g))==h`.
+The `HalfedgeGraph` has the invariant  `halfedge(edge(h,g))==h`.
 
 \cgalHeading{%MutableHalfedgeGraph}
 

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -59,6 +59,23 @@ Valid Expression     |  returns                                       | Descript
 `vertices(g)`        |  `std::pair<vertex_iterator, vertex_iterator>` | An iterator range over all vertices. 
 `num_vertices(g)`    |  `vertices_size_type`                          | An upper bound of the number of vertices of the graph.
 
+\cgalHeading{%EdgeListGraph}
+
+The concept `EdgeListGraph` refines the concept `Graph` and adds
+the requirement for traversal of all edges in a graph.
+
+Associated Type                               | Description
+-----------------                             | -----------
+`boost::graph_traits<G>::%edge_iterator`      | %Iterator over all edges.
+`boost::graph_traits<G>::%edges_size_type`    | Unsigned integer type for number of edges.
+
+
+Valid Expression  |  returns                                    | Description
+----------------- | ---------------                             | -----------------------
+`edges(g)`        |  `std::pair<edge_iterator, edge_iterator>`  | An iterator range over all edges. 
+`num_edges(g)`    |  `edges_size_type`                          | An upper bound of the number of edges of the graph.
+`source(e,g)`     | `vertex_descriptor`                         | The source vertex of `e`.
+`target(e,g)`     | `vertex_descriptor`                         | The target vertex of `e`.
 
 \cgalHeading{%HalfedgeGraph}
 
@@ -233,6 +250,7 @@ incident to a given face, and all the halfedges having a given vertex as target.
 
 ## Concepts ##
 - `VertexListGraph`
+- `EdgeListGraph`
 - `HalfedgeGraph`
 - `HalfedgeListGraph`
 - `MutableHalfedgeGraph`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -99,6 +99,8 @@ Valid Expression                        | Returns                               
 `prev(h, g)`                            | `halfedge_descriptor`                       | The previous halfedge around its face.
 `boost::graph_traits<G>::%null_halfedge()` | `halfedge_descriptor`                    | Returns a special halfedge that is not equal to any other halfedge.
 
+The `HalfedgeGraph`has the invariant  `halfedge(edge(h,g))==h`.
+
 \cgalHeading{%MutableHalfedgeGraph}
 
 The concept `MutableHalfedgeGraph` refines the concept `HalfedgeGraph`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -36,10 +36,10 @@ digraph example {
  <dl>
  <dt>`G`</dt> 	<dd>A type that is a model of a graph concept.</dd>
  <dt>`g`</dt> 	<dd>An object of type `G`.</dd>
- <dt>`u`, `v`</dt> 	<dd>An object of type `boost::graph_traits<G>::vertex descriptor`.</dd>
- <dt>`h`</dt> 	<dd>An object of type `boost::graph_traits<G>::halfedge descriptor`.</dd>
- <dt>`e`</dt> 	<dd>An object of type `boost::graph_traits<G>::edge descriptor`.</dd>
- <dt>`f`</dt> 	<dd>An object of type `boost::graph_traits<G>::face descriptor`.</dd>
+ <dt>`u`, `v`</dt> 	<dd>An object of type `boost::graph_traits<G>::%vertex_descriptor`.</dd>
+ <dt>`h`</dt> 	<dd>An object of type `boost::graph_traits<G>::%halfedge_descriptor`.</dd>
+ <dt>`e`</dt> 	<dd>An object of type `boost::graph_traits<G>::%edge_descriptor`.</dd>
+ <dt>`f`</dt> 	<dd>An object of type `boost::graph_traits<G>::%face_descriptor`.</dd>
  </dl>
 
 \cgalHeading{%VertexListGraph}

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -273,6 +273,8 @@ namespace CGAL {
   ///         besides being default constructible and assignable. 
   ///         In typical use cases it will be a 2D or 3D point type.
   /// \cgalModels `MutableFaceGraph` and `FaceListGraph`
+  ///
+  /// \sa \ref PkgBGLConcepts "Graph Concepts"
 
 template <typename P>
 class Surface_mesh


### PR DESCRIPTION
## Summary of Changes

Regroup the tables for valid expressions of the various graph concepts on one page, as it is done  on [boost.org](http://www.boost.org/doc/libs/1_64_0/libs/graph/doc/graph_concepts.html), and document the free function with `\relates` to the pages of the individual concepts. 

This is WIP in order to get feedback. 

## Release Management

* Affected package(s): BGL
* Issue(s) solved (if any): fix #1246

