### PR TITLE
Surface_mesh_shortest_path:  Use Surface_mesh

### DIFF
--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Surface_mesh_shortest_path.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/Surface_mesh_shortest_path.txt
@@ -38,7 +38,8 @@ of the input surface mesh.
 
 For efficiency reason, index property maps for vertices, halfedges and faces are internally used. For each simplex
 type the property map must provide an index between 0 and the number of simplices. We recommend to use
-the class `CGAL::Polyhedron_3` as model of `FaceListGraph` with the item class `CGAL::Polyhedron_items_with_id_3`,
+the class `CGAL::Surface_mesh` as model of `FaceListGraph`. 
+If you use the class `CGAL::Polyhedron_3`, you should use it with the item class `CGAL::Polyhedron_items_with_id_3`,
 for which default property maps are provided.
 This item class associates to each simplex an index that provides a \f$O(1)\f$ time access to the indices.
 Note that the initialization of the property maps requires a call to `set_halfedgeds_items_id()`.
@@ -99,6 +100,13 @@ but it will be extremely slow. Indeed, in order to compute the distance along th
 \section Surface_mesh_shortest_pathExamples Examples
 
 \subsection Surface_mesh_shortest_pathSimpleExample Simple Example
+
+The following example shows how to get the shortest path to every vertex from an arbitrary source point on a surface.  
+The shortest path class needs to have an index associated to each vertex, halfedge and face, which is naturally given for the class `Surface_mesh`. 
+
+\cgalExample{Surface_mesh_shortest_path/shortest_paths.cpp}
+
+\subsection Surface_mesh_shortest_pathExampleWithId Example Using Polyhedron_3
 
 The following example shows how to get the shortest path to every vertex from an arbitrary source point on the surface.  Note that this example uses the `Polyhedron_items_with_id_3` item class.  The shortest path class needs to have an index associated to each vertex, halfedge and face. Using this item class provide an efficient direct access to the required indices.
 

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/dependencies
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/dependencies
@@ -7,4 +7,5 @@ Stream_support
 BGL
 AABB_tree
 Polyhedron
+Surface_mesh
 Number_types

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/examples.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/examples.txt
@@ -1,4 +1,5 @@
 /*!
+\example Surface_mesh_shortest_path/shortest_paths.cpp
 \example Surface_mesh_shortest_path/shortest_paths_with_id.cpp
 \example Surface_mesh_shortest_path/shortest_paths_no_id.cpp
 \example Surface_mesh_shortest_path/shortest_paths_OpenMesh.cpp

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
@@ -21,6 +21,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "shortest_paths_multiple_sources.cpp" )
   create_single_source_cgal_program( "shortest_paths_no_id.cpp" )
   create_single_source_cgal_program( "shortest_paths_with_id.cpp" )
+  create_single_source_cgal_program( "shortest_paths.cpp" )
   
   find_package( OpenMesh QUIET )
   if ( OpenMesh_FOUND )

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
@@ -1,27 +1,24 @@
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
-#include <iterator>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Random.h>
 
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polyhedron_items_with_id_3.h>
+#include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Surface_mesh_shortest_path.h>
-#include <CGAL/boost/graph/iterator.h>
 
 #include <boost/variant.hpp>
 #include <boost/lexical_cast.hpp>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 typedef Traits::Barycentric_coordinates Barycentric_coordinates;
-typedef boost::graph_traits<Polyhedron_3> Graph_traits;
+typedef boost::graph_traits<Mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 typedef Graph_traits::vertex_descriptor vertex_descriptor;
@@ -57,9 +54,9 @@ struct Sequence_collector
 // A visitor to print what a variant contains using boost::apply_visitor
 struct Print_visitor : public boost::static_visitor<> {
   int i;
-  Polyhedron_3& g;
+  Mesh& g;
 
-  Print_visitor(Polyhedron_3& g) :i(-1), g(g) {}
+  Print_visitor(Mesh& g) :i(-1), g(g) {}
 
   void operator()(vertex_descriptor v)
   {
@@ -85,13 +82,10 @@ struct Print_visitor : public boost::static_visitor<> {
 int main(int argc, char** argv)
 {
   // read input polyhedron
-  Polyhedron_3 polyhedron;
+  Mesh polyhedron;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   input >> polyhedron;
   input.close();
-
-  // initialize indices of vertices, halfedges and faces
-  CGAL::set_halfedgeds_items_id(polyhedron);
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_sequence.cpp
@@ -14,18 +14,18 @@
 #include <boost/lexical_cast.hpp>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 typedef Traits::Barycentric_coordinates Barycentric_coordinates;
-typedef boost::graph_traits<Mesh> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 typedef Graph_traits::vertex_descriptor vertex_descriptor;
 typedef Graph_traits::face_descriptor face_descriptor;
 typedef Graph_traits::halfedge_descriptor halfedge_descriptor;
 
-// A model of SurfaceMeshShortestPathVisitor storing simplicies
+// A model of SurfacemeshShortestPathVisitor storing simplicies
 // using boost::variant
 struct Sequence_collector
 {
@@ -54,9 +54,9 @@ struct Sequence_collector
 // A visitor to print what a variant contains using boost::apply_visitor
 struct Print_visitor : public boost::static_visitor<> {
   int i;
-  Mesh& g;
+  Triangle_mesh& g;
 
-  Print_visitor(Mesh& g) :i(-1), g(g) {}
+  Print_visitor(Triangle_mesh& g) :i(-1), g(g) {}
 
   void operator()(vertex_descriptor v)
   {
@@ -81,35 +81,34 @@ struct Print_visitor : public boost::static_visitor<> {
 
 int main(int argc, char** argv)
 {
-  // read input polyhedron
-  Mesh polyhedron;
+  Triangle_mesh tmesh;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
-  input >> polyhedron;
+  input >> tmesh;
   input.close();
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
-  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
-  face_iterator face_it = faces(polyhedron).first;
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(tmesh)));
+  face_iterator face_it = faces(tmesh).first;
   std::advance(face_it,target_face_index);
   // ... and define a barycentric coordinates inside the face
   Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
-  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  Surface_mesh_shortest_path shortest_paths(tmesh);
   shortest_paths.add_source_point(*face_it, face_location);
 
   // pick a random target point inside a face
-  face_it = faces(polyhedron).first;
-  std::advance(face_it, rand.get_int(0, static_cast<int>(num_faces(polyhedron))));
+  face_it = faces(tmesh).first;
+  std::advance(face_it, rand.get_int(0, static_cast<int>(num_faces(tmesh))));
 
   // collect the sequence of simplicies crossed by the shortest path
   Sequence_collector sequence_collector;
   shortest_paths.shortest_path_sequence_to_source_points(*face_it, face_location, sequence_collector);
 
   // print the sequence using the visitor pattern
-  Print_visitor print_visitor(polyhedron);
+  Print_visitor print_visitor(tmesh);
   for (size_t i = 0; i < sequence_collector.sequence.size(); ++i)
     boost::apply_visitor(print_visitor, sequence_collector.sequence[i]);
 

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
@@ -1,0 +1,61 @@
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Random.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Surface_mesh_shortest_path.h>
+
+#include <boost/lexical_cast.hpp>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
+typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
+typedef boost::graph_traits<Mesh> Graph_traits;
+typedef Graph_traits::vertex_iterator vertex_iterator;
+typedef Graph_traits::face_iterator face_iterator;
+
+int main(int argc, char** argv)
+{
+  // read input polyhedron
+  Mesh polyhedron;
+  std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
+  input >> polyhedron;
+  input.close();
+
+  // pick up a random face
+  const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
+  CGAL::Random rand(randSeed);
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
+  face_iterator face_it = faces(polyhedron).first;
+  std::advance(face_it,target_face_index);
+  // ... and define a barycentric coordinates inside the face
+  Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
+
+  // construct a shortest path query object and add a source point
+  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  shortest_paths.add_source_point(*face_it, face_location);
+
+  // For all vertices in the polyhedron, compute the points of
+  // the shortest path to the source point and write them
+  // into a file readable using the CGAL Polyhedron demo
+  std::ofstream output("shortest_paths_with_id.cgal");
+  vertex_iterator vit, vit_end;
+  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+        vit != vit_end; ++vit)
+  {
+    std::vector<Traits::Point_3> points;
+    shortest_paths.shortest_path_points_to_source_points(*vit, std::back_inserter(points));
+
+    // print the points
+    output << points.size() << " ";
+    for (std::size_t i = 0; i < points.size(); ++i)
+      output << " " << points[i];
+    output << std::endl;
+  }
+  return 0;
+}

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
@@ -12,40 +12,39 @@
 #include <boost/lexical_cast.hpp>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-typedef boost::graph_traits<Mesh> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 
 int main(int argc, char** argv)
 {
-  // read input polyhedron
-  Mesh polyhedron;
+  Triangle_mesh tmesh;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
-  input >> polyhedron;
+  input >> tmesh;
   input.close();
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
-  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
-  face_iterator face_it = faces(polyhedron).first;
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(tmesh)));
+  face_iterator face_it = faces(tmesh).first;
   std::advance(face_it,target_face_index);
   // ... and define a barycentric coordinates inside the face
   Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
-  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  Surface_mesh_shortest_path shortest_paths(tmesh);
   shortest_paths.add_source_point(*face_it, face_location);
 
-  // For all vertices in the polyhedron, compute the points of
+  // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
   // into a file readable using the CGAL Polyhedron demo
   std::ofstream output("shortest_paths_with_id.cgal");
   vertex_iterator vit, vit_end;
-  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+  for ( boost::tie(vit, vit_end) = vertices(tmesh);
         vit != vit_end; ++vit)
   {
     std::vector<Traits::Point_3> points;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_OpenMesh.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_OpenMesh.cpp
@@ -22,42 +22,42 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 
-typedef OpenMesh::PolyMesh_ArrayKernelT<> Mesh;
+typedef OpenMesh::PolyMesh_ArrayKernelT<> Triangle_mesh;
 
-typedef boost::graph_traits<Mesh> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_descriptor vertex_descriptor;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_descriptor face_descriptor;
 typedef Graph_traits::face_iterator face_iterator;
 
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 
 int main(int argc, char** argv)
 {
   // read the input surface mesh
-  Mesh polyhedron;
-  OpenMesh::IO::read_mesh(polyhedron, (argc>1)?argv[1]:"data/elephant.off");
+  Triangle_mesh tmesh;
+  OpenMesh::IO::read_mesh(tmesh, (argc>1)?argv[1]:"data/elephant.off");
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
-  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
-  face_iterator face_it = faces(polyhedron).first;
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(tmesh)));
+  face_iterator face_it = faces(tmesh).first;
   std::advance(face_it,target_face_index);
   // ... and define a barycentric coordinates inside the face
   Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
-  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  Surface_mesh_shortest_path shortest_paths(tmesh);
   shortest_paths.add_source_point(*face_it, face_location);
 
-  // For all vertices in the polyhedron, compute the points of
+  // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
-  // into a file readable using the CGAL Polyhedron demo
+  // into a file readable using the CGAL Tmesh demo
   std::ofstream output("shortest_paths_OpenMesh.cgal");
   vertex_iterator vit, vit_end;
-  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+  for ( boost::tie(vit, vit_end) = vertices(tmesh);
         vit != vit_end; ++vit)
   {
     std::vector<Traits::Point_3> points;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -6,20 +6,18 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Random.h>
-
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polyhedron_items_with_id_3.h>
+#include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Surface_mesh_shortest_path.h>
-#include <CGAL/boost/graph/iterator.h>
+
 
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 typedef Surface_mesh_shortest_path::Face_location Face_location;
-typedef boost::graph_traits<Polyhedron_3> Graph_traits;
+typedef boost::graph_traits<Mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 typedef Graph_traits::face_descriptor face_descriptor;
@@ -27,13 +25,10 @@ typedef Graph_traits::face_descriptor face_descriptor;
 int main(int argc, char** argv)
 {
   // read input polyhedron
-  Polyhedron_3 polyhedron;
+  Mesh polyhedron;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   input >> polyhedron;
   input.close();
-
-  // initialize indices of vertices, halfedges and faces
-  CGAL::set_halfedgeds_items_id(polyhedron);
 
   // pick up some source points inside faces,
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -13,30 +13,30 @@
 
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Mesh> Traits;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 typedef Surface_mesh_shortest_path::Face_location Face_location;
-typedef boost::graph_traits<Mesh> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 typedef Graph_traits::face_descriptor face_descriptor;
 
 int main(int argc, char** argv)
 {
-  // read input polyhedron
-  Mesh polyhedron;
+  // read input tmesh
+  Triangle_mesh tmesh;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
-  input >> polyhedron;
+  input >> tmesh;
   input.close();
 
   // pick up some source points inside faces,
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
   // by copying the faces in a vector to get a direct access to faces
-  std::size_t nb_faces=num_faces(polyhedron);
+  std::size_t nb_faces=num_faces(tmesh);
   face_iterator fit, fit_end;
-  boost::tie(fit, fit_end) = faces(polyhedron);
+  boost::tie(fit, fit_end) = faces(tmesh);
   std::vector<face_descriptor> face_vector(fit, fit_end);
   // and creating a vector of Face_location objects
   const std::size_t nb_source_points = 30;
@@ -48,15 +48,15 @@ int main(int argc, char** argv)
   }
 
   // construct a shortest path query object and add a range of source points
-  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  Surface_mesh_shortest_path shortest_paths(tmesh);
   shortest_paths.add_source_points(faceLocations.begin(), faceLocations.end());
 
-  // For all vertices in the polyhedron, compute the points of
+  // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
-  // into a file readable using the CGAL Polyhedron demo
+  // into a file readable using the CGAL Tmesh demo
   std::ofstream output("shortest_paths_multiple_sources.cgal");
   vertex_iterator vit, vit_end;
-  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+  for ( boost::tie(vit, vit_end) = vertices(tmesh);
         vit != vit_end; ++vit)
   {
     std::vector<Traits::Point_3> points;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -12,20 +12,20 @@
 #include <boost/lexical_cast.hpp>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Polyhedron_3<Kernel> Polyhedron_3;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
+typedef CGAL::Polyhedron_3<Kernel> Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 // default property maps
-typedef boost::property_map<Polyhedron_3,
+typedef boost::property_map<Triangle_mesh,
                             boost::vertex_external_index_t>::type  Vertex_index_map;
-typedef boost::property_map<Polyhedron_3,
+typedef boost::property_map<Triangle_mesh,
                             CGAL::halfedge_external_index_t>::type Halfedge_index_map;
-typedef boost::property_map<Polyhedron_3,
+typedef boost::property_map<Triangle_mesh,
                             CGAL::face_external_index_t>::type     Face_index_map;
 typedef CGAL::Surface_mesh_shortest_path<Traits,
                                          Vertex_index_map,
                                          Halfedge_index_map,
                                          Face_index_map>  Surface_mesh_shortest_path;
-typedef boost::graph_traits<Polyhedron_3> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::halfedge_iterator halfedge_iterator;
 typedef Graph_traits::face_iterator face_iterator;
@@ -33,36 +33,35 @@ typedef Graph_traits::face_iterator face_iterator;
 
 int main(int argc, char** argv)
 {
-  // read input polyhedron
-  Polyhedron_3 polyhedron;
+  Triangle_mesh tmesh;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
-  input >> polyhedron;
+  input >> tmesh;
   input.close();
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
-  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
-  face_iterator face_it = faces(polyhedron).first;
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(tmesh)));
+  face_iterator face_it = faces(tmesh).first;
   std::advance(face_it,target_face_index);
   // ... and define a barycentric coordinates inside the face
   Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
   // Note that the external index property map are automatically initialized
-  Surface_mesh_shortest_path shortest_paths(polyhedron,
-                                            get(boost::vertex_external_index, polyhedron),
-                                            get(CGAL::halfedge_external_index, polyhedron),
-                                            get(CGAL::face_external_index, polyhedron),
-                                            get(CGAL::vertex_point, polyhedron));
+  Surface_mesh_shortest_path shortest_paths(tmesh,
+                                            get(boost::vertex_external_index, tmesh),
+                                            get(CGAL::halfedge_external_index, tmesh),
+                                            get(CGAL::face_external_index, tmesh),
+                                            get(CGAL::vertex_point, tmesh));
   shortest_paths.add_source_point(*face_it, face_location);
 
-  // For all vertices in the polyhedron, compute the points of
+  // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
   // into a file readable using the CGAL Polyhedron demo
   std::ofstream output("shortest_paths_no_id.cgal");
   vertex_iterator vit, vit_end;
-  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+  for ( boost::tie(vit, vit_end) = vertices(tmesh);
         vit != vit_end; ++vit)
   {
     std::vector<Traits::Point_3> points;

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
@@ -15,43 +15,43 @@
 #include <boost/lexical_cast.hpp>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Polyhedron_3;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Polyhedron_3> Traits;
+typedef CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3> Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-typedef boost::graph_traits<Polyhedron_3> Graph_traits;
+typedef boost::graph_traits<Triangle_mesh> Graph_traits;
 typedef Graph_traits::vertex_iterator vertex_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 
 int main(int argc, char** argv)
 {
   // read input polyhedron
-  Polyhedron_3 polyhedron;
+  Triangle_mesh tmesh;
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
-  input >> polyhedron;
+  input >> tmesh;
   input.close();
 
   // initialize indices of vertices, halfedges and faces
-  CGAL::set_halfedgeds_items_id(polyhedron);
+  CGAL::set_halfedgeds_items_id(tmesh);
 
   // pick up a random face
   const unsigned int randSeed = argc > 2 ? boost::lexical_cast<unsigned int>(argv[2]) : 7915421;
   CGAL::Random rand(randSeed);
-  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(polyhedron)));
-  face_iterator face_it = faces(polyhedron).first;
+  const int target_face_index = rand.get_int(0, static_cast<int>(num_faces(tmesh)));
+  face_iterator face_it = faces(tmesh).first;
   std::advance(face_it,target_face_index);
   // ... and define a barycentric coordinates inside the face
   Traits::Barycentric_coordinates face_location = {{0.25, 0.5, 0.25}};
 
   // construct a shortest path query object and add a source point
-  Surface_mesh_shortest_path shortest_paths(polyhedron);
+  Surface_mesh_shortest_path shortest_paths(tmesh);
   shortest_paths.add_source_point(*face_it, face_location);
 
-  // For all vertices in the polyhedron, compute the points of
+  // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
   // into a file readable using the CGAL Polyhedron demo
   std::ofstream output("shortest_paths_with_id.cgal");
   vertex_iterator vit, vit_end;
-  for ( boost::tie(vit, vit_end) = vertices(polyhedron);
+  for ( boost::tie(vit, vit_end) = vertices(tmesh);
         vit != vit_end; ++vit)
   {
     std::vector<Traits::Point_3> points;


### PR DESCRIPTION
## Summary of Changes

In the examples change from `Polyhedron` to `Surface_mesh`, but keep two examples that shows how to use `Polyhedron_3` either with items with id, or with an external  map for the indices. 

@sloriot I am wondering what the best choice for  the `typedef` of `Surface_mesh` or `Polyhedron_3` is.

## Release Management

* Affected package(s): Surface_mesh_shortest_path

