### PR TITLE
Surface_mesh_segmentation: Add a Surface_mesh example at the end of the user manual 

### DIFF
--- a/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/Surface_Mesh_Segmentation.txt
+++ b/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/Surface_Mesh_Segmentation.txt
@@ -199,6 +199,12 @@ a polyhedron type with a facet type storing an extra ID field, together with a v
 The main advantage is to decrease from log to constant the complexity for accessing the data associated to facets.
 
 \cgalExample{Surface_mesh_segmentation/segmentation_with_facet_ids_example.cpp}
+
+\subsection Surface_mesh_segmentationUsingapolyhedron Using a Surface_mesh
+When using a `Surface_mesh`, you can use the built-in property mechanism. 
+
+\cgalExample{Surface_mesh_segmentation/segmentation_from_sdf_values_SM_example.cpp}
+
 <BR>
 \section Performances Performances
 <!-- \subsection SMSRuntime Runtime of the functions sdf_values() and segmentation_from_sdf_values() -->


### PR DESCRIPTION
## Summary of Changes

The example for `Surface_mesh`  was not in the User Manual.

## Release Management

* Affected package(s):  Surface_mesh_segmentation

