### PR TITLE
Circular_kernel_2: Fix testsuite

### DIFF
--- a/Circular_kernel_2/test/Circular_kernel_2/test_Line_arc.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Line_arc.cpp
@@ -832,7 +832,7 @@ void _test_intersection_Line_arc_Circular_arc(CK ck)
      do{
        p_random4 = Point_2(theRandom.get_int(random_min, random_max),
 			   theRandom.get_int(random_min, random_max));
-     }while(p_random4 == center_circle_random1);
+     } while (p_random4 == center_circle_random1 || (p_random3 == p_random4));
    
      std::vector< CGAL::Object > 
        vector_for_intersection_random3;


### PR DESCRIPTION

## Summary of Changes

With the value of the variable random_seed == 105214 the testsuite constructed a Line_2 from two identical points, which led to an assertion in CGAL-4.11-Ic5

## Release Management

* Affected package(s): Circular_kernel_2

