### PR TITLE
Polyhedron_demo: Fix segfault in distance_item 

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
@@ -245,7 +245,7 @@ private:
         if(triangulation.cdt->dimension() != 2 )
         {
           qDebug()<<"Error : cdt not right (dimension != 2). Facet not displayed";
-          return;
+          continue;
         }
 
         //iterates on the internal faces to add the vertices to the positions

--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -103,6 +103,11 @@ public:
      std::cerr<<"Facet not displayed"<<std::endl;
 
   }
+  ~FacetTriangulator()
+  {
+   if (cdt )
+     delete cdt;
+  }
 
 private:
   bool triangulate( std::vector<PointAndId > &idPoints,
@@ -128,11 +133,11 @@ private:
      typename CDT::Vertex_handle vh;
      //Always insert the first point, then only insert
      // if the distance with the previous is reasonable.
-     if(first == 0 || CGAL::squared_distance(idPoint.point, previous->point()) > min_sq_dist)
+     if(first == typename CDT::Vertex_handle() || CGAL::squared_distance(idPoint.point, previous->point()) > min_sq_dist)
      {
        vh = cdt->insert(idPoint.point);
        v2v[vh] = idPoint.id;
-       if(first == 0) {
+       if(first == typename CDT::Vertex_handle()) {
          first = vh;
        }
        if(previous != 0 && previous != vh) {
@@ -150,7 +155,7 @@ private:
      previous = vh;
      }
     }
-    if(last_inserted == 0)
+    if(last_inserted == typename CDT::Vertex_handle())
       return false;
     double sq_dist = CGAL::squared_distance(previous->point(), first->point());
 
@@ -207,11 +212,11 @@ private:
       typename CDT::Vertex_handle vh;
       //Always insert the first point, then only insert
       // if the distance with the previous is reasonable.
-      if(first == 0 || CGAL::squared_distance(idPoint.point, previous->point()) > min_sq_dist)
+      if(first == typename CDT::Vertex_handle() || CGAL::squared_distance(idPoint.point, previous->point()) > min_sq_dist)
       {
         vh = cdt->insert(idPoint.point);
         v2v[vh] = idPoint.id;
-        if(first == 0) {
+        if(first == typename CDT::Vertex_handle()) {
           first = vh;
         }
         if(previous != 0 && previous != vh) {
@@ -229,7 +234,7 @@ private:
       previous = vh;
       }
      }
-     if(last_inserted == 0)
+     if(last_inserted == typename CDT::Vertex_handle())
        return false;
      double sq_dist = CGAL::squared_distance(previous->point(), first->point());
 

--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -65,7 +65,8 @@ public:
       idPoints.push_back(idPoint);
 
     }
-    triangulate(idPoints, normal, item_diag);
+    if(!triangulate(idPoints, normal, item_diag))
+      std::cerr<<"Facet not displayed"<<std::endl;
   }
   FacetTriangulator(typename boost::graph_traits<Mesh>::face_descriptor fd,
                     const std::vector<typename Kernel::Point_3>& more_points,
@@ -82,25 +83,29 @@ public:
     idPoints.push_back(idPoint);
 
    }
-   triangulate_with_points(idPoints,more_points, normal, item_diag);
+   if(!triangulate_with_points(idPoints,more_points, normal, item_diag))
+     std::cerr<<"Facet not displayed"<<std::endl;
   }
 
   FacetTriangulator(std::vector<PointAndId > &idPoints,
                   const Vector& normal,
                   const double item_diag)
   {
-    triangulate(idPoints, normal, item_diag);
+    if(!triangulate(idPoints, normal, item_diag))
+      std::cerr<<"Facet not displayed"<<std::endl;
   }
   FacetTriangulator(std::vector<PointAndId > &idPoints,
                     const std::vector<typename Kernel::Point_3>& more_points,
                     const Vector& normal,
                     const double item_diag)
   {
-   triangulate_with_points(idPoints, more_points, normal, item_diag);
+   if(!triangulate_with_points(idPoints, more_points, normal, item_diag))
+     std::cerr<<"Facet not displayed"<<std::endl;
+
   }
 
 private:
-  void triangulate( std::vector<PointAndId > &idPoints,
+  bool triangulate( std::vector<PointAndId > &idPoints,
               const Vector& normal,
               const double item_diag )
   {
@@ -145,6 +150,8 @@ private:
      previous = vh;
      }
     }
+    if(last_inserted == 0)
+      return false;
     double sq_dist = CGAL::squared_distance(previous->point(), first->point());
 
     if(sq_dist > min_sq_dist)
@@ -178,9 +185,10 @@ private:
         }
       }
     }
+    return true;
   }
 
-  void triangulate_with_points( std::vector<PointAndId > &idPoints,
+  bool triangulate_with_points( std::vector<PointAndId > &idPoints,
                const std::vector<typename Kernel::Point_3>& more_points,
                const Vector& normal,
                const double item_diag )
@@ -221,6 +229,8 @@ private:
       previous = vh;
       }
      }
+     if(last_inserted == 0)
+       return false;
      double sq_dist = CGAL::squared_distance(previous->point(), first->point());
 
      if(sq_dist > min_sq_dist)
@@ -258,6 +268,7 @@ private:
          }
        }
      }
+     return true;
   }
 };
 


### PR DESCRIPTION
## Summary of Changes
If a facet is too small, a precision problem will cause it's triangulation to fail. This PR fixes the resulting segfault by stopping the triangulation process if there are too few points, and not display the facet. As it only happens for facets with a diagonal smaller than 0.0001 times the item's Bbox's diagonal, the user should not even notice it unless he(she) is looking for it. 
A message is displayed in the console in that case.
## Release Management

* Affected package(s):Polyhedron_demo


