### PR TITLE
PMP : fix isotropic remeshing of a selection

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -48,6 +48,7 @@
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/container/flat_set.hpp>
 
 #include <map>
 #include <list>
@@ -1377,7 +1378,7 @@ private:
     template <typename FaceRange>
     void constrain_patch_corners(const FaceRange& face_range)
     {
-      std::set<vertex_descriptor> visited;
+      boost::container::flat_set<vertex_descriptor> visited;
 
       BOOST_FOREACH(face_descriptor f, face_range)
       {


### PR DESCRIPTION
## Summary of Changes

Fix a bug when the face range to remesh is incident to the boundary of the mesh.

Vertices that are at the "corner" of the face range to be remeshed,
i.e. on the border of the face range, and also on the border of the mesh,
incident to both the selected and unselected faces, should be constrained,
to avoid making a "axe blow" in the border

## Release Management
* Affected package(s): PMP

