### PR TITLE
Polyhedron_demo: Fix draw two sides for Polyhedron

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -117,7 +117,7 @@ struct Scene_polyhedron_item_priv{
   }
 
 
-  void compute_normals_and_vertices(const bool colors_only = false) const;
+  void compute_normals_and_vertices(const bool colors_only = false, const bool is_two_side = false) const;
   bool isFacetConvex(Facet_iterator, const Polyhedron::Traits::Vector_3&)const;
 
   void triangulate_convex_facet(Facet_iterator,
@@ -125,7 +125,7 @@ struct Scene_polyhedron_item_priv{
 
   void triangulate_facet(Scene_polyhedron_item::Facet_iterator,
                          const Traits::Vector_3& normal,
-                         const bool colors_only) const;
+                         const bool colors_only, const bool is_two_side) const;
   void init();
   void invalidate_stats();
   void* get_aabb_tree();
@@ -153,6 +153,7 @@ struct Scene_polyhedron_item_priv{
   mutable std::vector<unsigned int> idx_faces;
   mutable std::vector<float> positions_facets;
   mutable std::vector<float> normals_gouraud;
+  mutable std::vector<float> normals_flat;
   mutable std::vector<float> color_facets;
   mutable std::size_t nb_facets;
   mutable std::size_t nb_lines;
@@ -180,6 +181,7 @@ struct Scene_polyhedron_item_priv{
     Feature_edges_vertices,
     Edges_color,
     Facets_normals_gouraud,
+    Facets_normals_flat,
     NbOfVbos
   };
   // Initialization
@@ -428,11 +430,12 @@ void Scene_polyhedron_item_priv::triangulate_convex_facet(Facet_iterator f,
 void
 Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_iterator fit,
                                          const Traits::Vector_3& normal,
-                                         const bool colors_only) const
+                                         const bool colors_only,
+                                         const bool is_two_side = false) const
 {
   typedef FacetTriangulator<Polyhedron, Polyhedron::Traits, boost::graph_traits<Polyhedron>::vertex_descriptor> FT;
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
-Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
+  Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
   double diagonal;
   if(item->diagonalBbox() != std::numeric_limits<double>::infinity())
     diagonal = item->diagonalBbox();
@@ -476,6 +479,12 @@ Vector offset = Vector(v_offset.x, v_offset.y, v_offset.z);
       push_back_xyz(ffit->vertex(0)->point()+offset, positions_facets);
       push_back_xyz(ffit->vertex(1)->point()+offset, positions_facets);
       push_back_xyz(ffit->vertex(2)->point()+offset, positions_facets);
+      if(!is_two_side)
+      {
+        push_back_xyz(normal, normals_flat);
+        push_back_xyz(normal, normals_flat);
+        push_back_xyz(normal, normals_flat);
+      }
     }
   }
 }
@@ -491,7 +500,14 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
 {
     //vao containing the data for the facets
     {
-    program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_FLAT, viewer);
+    if(viewer->property("is_two_sides").toBool())
+    {
+      program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_FLAT, viewer);
+    }
+    else
+    {
+      program = item->getShaderProgram(Scene_polyhedron_item::PROGRAM_WITH_LIGHT, viewer);
+    }
     program->bind();
         //flat
         if(!no_flat)
@@ -503,8 +519,21 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
           program->enableAttributeArray("vertex");
           program->setAttributeBuffer("vertex",GL_FLOAT,0,3);
           item->buffers[Facets_vertices].release();
-          //computed in the fragment shader
-          program->disableAttributeArray("normals");
+          if(viewer->property("is_two_sides").toBool())
+          {
+            //computed in the fragment shader
+            program->disableAttributeArray("normals");
+          }
+          else
+          {
+           //use computed flat normals
+            item->buffers[Facets_normals_flat].bind();
+            item->buffers[Facets_normals_flat].allocate(normals_flat.data(),
+                                static_cast<int>(normals_flat.size()*sizeof(float)));
+            program->enableAttributeArray("normals");
+            program->setAttributeBuffer("normals",GL_FLOAT,0,3);
+            item->buffers[Facets_normals_flat].release();
+          }
           if(is_multicolor)
           {
             item->buffers[Facets_color].bind();
@@ -598,6 +627,8 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
   color_facets.shrink_to_fit();
   normals_gouraud.resize(0);
   normals_gouraud.shrink_to_fit();
+  normals_flat.resize(0);
+  normals_flat.shrink_to_fit();
 
   if (viewer->hasText())
     item->printPrimitiveIds(viewer);
@@ -606,7 +637,7 @@ Scene_polyhedron_item_priv::initialize_buffers(CGAL::Three::Viewer_interface* vi
 }
 
 void
-Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only) const
+Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only, const bool is_two_side) const
 {
   const qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
 
@@ -614,6 +645,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
     positions_facets.resize(0);
     positions_lines.resize(0);
     normals_gouraud.resize(0);
+    normals_flat.resize(0);
     color_facets.resize(0);
     idx_faces.resize(0);
     idx_lines.resize(0);
@@ -670,6 +702,8 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
             if(!no_flat)
             {
               push_back_xyz(p+offset, positions_facets);
+              if(!is_two_side)
+                push_back_xyz(nf, normals_flat);
             }
 
             idx_faces.push_back(static_cast<unsigned int>(he->vertex()->id()));
@@ -703,6 +737,12 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           push_back_xyz(p0+offset, positions_facets);
           push_back_xyz(p1+offset, positions_facets);
           push_back_xyz(p2+offset, positions_facets);
+          if(!is_two_side)
+          {
+            push_back_xyz(nf, normals_flat);
+            push_back_xyz(nf, normals_flat);
+            push_back_xyz(nf, normals_flat);
+          }
         }
         //2nd half-quad
         idx_faces.push_back(static_cast<unsigned int>(f->halfedge()->next()->next()->vertex()->id()));
@@ -718,6 +758,12 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
           push_back_xyz(p0+offset, positions_facets);
           push_back_xyz(p1+offset, positions_facets);
           push_back_xyz(p2+offset, positions_facets);
+          if(!is_two_side)
+          {
+            push_back_xyz(nf, normals_flat);
+            push_back_xyz(nf, normals_flat);
+            push_back_xyz(nf, normals_flat);
+          }
         }
       }
       else
@@ -728,7 +774,7 @@ Scene_polyhedron_item_priv::compute_normals_and_vertices(const bool colors_only)
         }
         else
         {
-          this->triangulate_facet(f, nf, colors_only);
+          this->triangulate_facet(f, nf, colors_only, is_two_side);
         }
       }
 
@@ -1036,7 +1082,7 @@ void Scene_polyhedron_item::set_erase_next_picked_facet(bool b)
 void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices();
+        d->compute_normals_and_vertices(false, viewer->property("is_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }
@@ -1044,8 +1090,16 @@ void Scene_polyhedron_item::draw(CGAL::Three::Viewer_interface* viewer) const {
     if(renderingMode() == Flat || (!d->no_flat && renderingMode() == FlatPlusEdges))
     {
         vaos[Scene_polyhedron_item_priv::Facets]->bind();
-        attribBuffers(viewer, PROGRAM_FLAT);
-        d->program = getShaderProgram(PROGRAM_FLAT);
+        if(viewer->property("is_two_sides").toBool())
+        {
+          attribBuffers(viewer, PROGRAM_FLAT);
+          d->program = getShaderProgram(PROGRAM_FLAT);
+        }
+        else
+        {
+          attribBuffers(viewer, PROGRAM_WITH_LIGHT);
+          d->program = getShaderProgram(PROGRAM_WITH_LIGHT);
+        }
         d->program->bind();
         if(!d->is_multicolor)
         {
@@ -1089,7 +1143,7 @@ void Scene_polyhedron_item::drawEdges(CGAL::Three::Viewer_interface* viewer) con
 {
     if (!are_buffers_filled)
     {
-        d->compute_normals_and_vertices();
+        d->compute_normals_and_vertices(false, viewer->property("is_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }
@@ -1137,7 +1191,7 @@ void
 Scene_polyhedron_item::drawPoints(CGAL::Three::Viewer_interface* viewer) const {
     if(!are_buffers_filled)
     {
-        d->compute_normals_and_vertices();
+        d->compute_normals_and_vertices(false, viewer->property("is_two_sides").toBool());
         d->initialize_buffers(viewer);
         compute_bbox();
     }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -105,7 +105,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->scene = 0;
   d->antialiasing = antialiasing;
   d->twosides = false;
-  this->setProperty("is_two_sides", false);
+  this->setProperty("draw_two_sides", false);
   d->macro_mode = false;
   d->inFastDrawing = true;
   d->inDrawWithNames = false;
@@ -188,7 +188,7 @@ void Viewer::setAntiAliasing(bool b)
 
 void Viewer::setTwoSides(bool b)
 {
-  this->setProperty("is_two_sides", b);
+  this->setProperty("draw_two_sides", b);
   d->twosides = b;
   update();
 }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -105,6 +105,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->scene = 0;
   d->antialiasing = antialiasing;
   d->twosides = false;
+  this->setProperty("is_two_sides", false);
   d->macro_mode = false;
   d->inFastDrawing = true;
   d->inDrawWithNames = false;
@@ -187,6 +188,7 @@ void Viewer::setAntiAliasing(bool b)
 
 void Viewer::setTwoSides(bool b)
 {
+  this->setProperty("is_two_sides", b);
   d->twosides = b;
   update();
 }


### PR DESCRIPTION
## Summary of Changes
The PROGRAM_FLAT allows to save memory by not keeping the flat normals and computing them in real time in the fragment shader, but it loses the orientation of the faces. To fix it, we decided to drop this enhancement in the case the draw_two_sides option is set, and keep computing the flat normals.

## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2103 
* Feature/Small Feature (if any):

