### PR TITLE
Bugfix in copy face graph example

### DIFF
--- a/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
+++ b/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
     
     CGAL::copy_face_graph(T1, S, std::inserter(v2v, v2v.end()), std::inserter(h2h, h2h.end()));
     std::ofstream out("reverse.off");
-    out << T1;
+    out << S;
   }
   return 0;
 }


### PR DESCRIPTION
Here we need to write S (and not T1 as in the current example).
