### PR TITLE
Remove a warning (unused variable)

### DIFF
--- a/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_test.cpp
+++ b/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_test.cpp
@@ -179,6 +179,7 @@ bool test_get_new_mark()
   if ( !res )
   {
       std::cerr<<"PB we can reserve NB_MARK+1 !! mark, exit."<<std::endl;
+      map.free_mark(mark); // This is never supposed to occur.
       return false;
   }
   


### PR DESCRIPTION

## Summary of Changes

Remove a warning in combinatorial map test.

## Release Management

* Affected package(s): Combinatorial map
* Issue(s) solved (if any): fix #2112 

