### PR TITLE
Mesh_3: Address TBB performance warning on hashing

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -41,6 +41,8 @@
 #include <CGAL/Mesh_3/io_signature.h>
 #include <CGAL/Union_find.h>
 
+#include <boost/functional/hash.hpp>
+
 #ifdef CGAL_LINKED_WITH_TBB
   #include <tbb/atomic.h>
   #include <tbb/concurrent_hash_map.h>
@@ -51,11 +53,36 @@ namespace CGAL {
   {
     return CGAL::internal::hash_value(it);
   }
+
+
   template < class DSC, bool Const >
   std::size_t tbb_hasher(const CGAL::CCC_internal::CCC_iterator<DSC, Const>& it)
   {
     return CGAL::CCC_internal::hash_value(it);
   }
+
+  // As Marc Glisse pointed out the TBB hash of a std::pair is
+  // simplistic and leads to the
+  // TBB Warning: Performance is not optimal because the hash function
+  //              produces bad randomness in lower bits in class
+  //              tbb::interface5::concurrent_hash_map
+  template < class DSC, bool Const >
+  std::size_t tbb_hasher(const std::pair<CGAL::internal::CC_iterator<DSC, Const>,
+                                         CGAL::internal::CC_iterator<DSC, Const> >& p)
+  {
+    return boost::hash<std::pair<CGAL::internal::CC_iterator<DSC, Const>,
+                                 CGAL::internal::CC_iterator<DSC, Const> > >()(p);
+  }
+
+
+  template < class DSC, bool Const >
+  std::size_t tbb_hasher(const std::pair<CGAL::CCC_internal::CCC_iterator<DSC, Const>,
+                                         CGAL::CCC_internal::CCC_iterator<DSC, Const> >& p)
+  {
+    return boost::hash<std::pair<CGAL::CCC_internal::CCC_iterator<DSC, Const>,
+                                 CGAL::CCC_internal::CCC_iterator<DSC, Const> > >()(p);
+  }
+
 }
 #endif
 


### PR DESCRIPTION
## Summary of Changes

Provide an overload of tbb_hasher for a pair of CCC_iterators in the Concurrent_compact_container.

After a mail exchange on cgal-discuss, where @mglisse wrote:

> My first reaction was that hashing a std::pair should already do some mixing, but apparently TBB uses a simplistic implementation with just a XOR. This means for instance that the pairs (first, second) and (third, fourth) are likely to both have hash 1, and all pairs (x,x) have the same hash 0. Boost seems to combine hashes in a pair more cleverly, does that help?

It did help. thanks.

I did not do any benchmarking.  @cjamin do you know how important this concurrent_hash_map is?

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #2049

