### PR TITLE
OT Reconstruction: fix warning unused variable

### DIFF
--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -984,7 +984,7 @@ public:
   }
 
   void copy_neighbors(
-    Face_handle f, Vertex_handle v, Vertex_handle_map& vmap,
+    Face_handle f, Vertex_handle v, Vertex_handle_map&,
     Face_handle_map& fmap) const
   {
     int i = f->index(v);

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -989,7 +989,6 @@ public:
   {
     int i = f->index(v);
     Face_handle cf = fmap[f];
-    Vertex_handle cv = vmap[v];
 
     if (fmap.find(f->neighbor(i)) != fmap.end()) {
       Face_handle fi = f->neighbor(i);

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -949,7 +949,7 @@ public:
     CGAL_For_all(fcirc, fend)
     {
       Face_handle f = fcirc;
-      copy_neighbors(f, s, cvmap, cfmap);
+      copy_neighbors(f, s, cfmap);
     }
 
     // make copy homeomorphic to S^2
@@ -984,7 +984,7 @@ public:
   }
 
   void copy_neighbors(
-    Face_handle f, Vertex_handle v, Vertex_handle_map&,
+    Face_handle f, Vertex_handle v,
     Face_handle_map& fmap) const
   {
     int i = f->index(v);


### PR DESCRIPTION
## Summary of Changes

Fix unused variable.

## Release Management

* Affected package(s): Optimal_transportation_reconstruction_2
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2111

