### PR TITLE
Fix triangulation for nef facets with holes.

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -25,7 +25,7 @@ typedef CGAL::Triangulation_2_projection_traits_3<Traits>   P_traits;
 typedef Nef_polyhedron::Halfedge_const_handle Halfedge_handle;
 struct Face_info {
     Nef_polyhedron::Halfedge_const_handle e[3];
-    bool is_external;
+    int nesting_level;
 };
 typedef CGAL::Triangulation_vertex_base_with_info_2<Halfedge_handle,
 P_traits>        Vb;
@@ -88,6 +88,10 @@ struct Scene_nef_polyhedron_item_priv
   }
 
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer) const;
+  void mark_domains(CDT& ct,
+                    CDT::Face_handle start,
+                    int index,
+                    std::list<CDT::Edge>& border ) const;
   void compute_normals_and_vertices(void) const;
   Nef_polyhedron* nef_poly;
 
@@ -222,6 +226,35 @@ void Scene_nef_polyhedron_item_priv::initializeBuffers(CGAL::Three::Viewer_inter
     }
     item->are_buffers_filled = true;
 }
+void
+Scene_nef_polyhedron_item_priv::mark_domains(CDT& ct,
+                                             CDT::Face_handle start,
+                                             int index,
+                                             std::list<CDT::Edge>& border ) const
+{
+  if(start->info().nesting_level != -1){
+    return;
+  }
+  std::list<CDT::Face_handle> queue;
+  queue.push_back(start);
+  while(! queue.empty()){
+    CDT::Face_handle fh = queue.front();
+    queue.pop_front();
+    if(fh->info().nesting_level == -1){
+      fh->info().nesting_level = index;
+      for(int i = 0; i < 3; i++){
+        CDT::Edge e(fh,i);
+        CDT::Face_handle n = fh->neighbor(i);
+        if(n->info().nesting_level == -1){
+          if(ct.is_constrained(e)) border.push_back(e);
+          else queue.push_back(n);
+        }
+      }
+    }
+  }
+}
+
+
 void Scene_nef_polyhedron_item_priv::compute_normals_and_vertices(void) const
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -273,81 +306,79 @@ void Scene_nef_polyhedron_item_priv::compute_normals_and_vertices(void) const
                     } while( ++hc != he );
 
                     cdt.insert_constraint(previous, first);
-
-                    // sets mark is_external
-                    for(CDT::All_faces_iterator
-                        fit = cdt.all_faces_begin(),
-                        end = cdt.all_faces_end();
-                        fit != end; ++fit)
-                    {
-                        fit->info().is_external = false;
-
-                    }
-                    //check if the facet is external or internal
-                    std::queue<CDT::Face_handle> face_queue;
-                    face_queue.push(cdt.infinite_vertex()->face());
-
-                    while(! face_queue.empty() ) {
-                        CDT::Face_handle fh = face_queue.front();
-                        face_queue.pop();
-                        if(fh->info().is_external) continue;
-                        fh->info().is_external = true;
-                        for(int i = 0; i <3; ++i) {
-                            if(!cdt.is_constrained(std::make_pair(fh, i)))
-                            {
-                                face_queue.push(fh->neighbor(i));
-                            }
-                        }
-
-                    }
-                    //iterates on the internal faces to add the vertices to the positions
-                    //and the normals to the appropriate vectors
-
-                    for(CDT::Finite_faces_iterator
-                        ffit = cdt.finite_faces_begin(),
-                        end = cdt.finite_faces_end();
-                        ffit != end; ++ffit)
-                    {
-
-
-                        if(ffit->info().is_external){ continue;}
-                        for(int i = 0; i<3; i++)
-                        {
-                            positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().x())+offset.x);
-                            positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().y())+offset.y);
-                            positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().z())+offset.z);
-
-                        }
-
-
-
-                        Nef_polyhedron::Vector_3 v = f->plane().orthogonal_vector();
-                        GLdouble normal[3];
-                        normal[0] = CGAL::to_double(v.x());
-                        normal[1] = CGAL::to_double(v.y());
-                        normal[2] = CGAL::to_double(v.z());
-                        GLdouble norm = normal[0]*normal[0]
-                                + normal[1]*normal[1]
-                                + normal[2]*normal[2];
-                        norm = CGAL::sqrt(norm);
-                        normal[0] /= norm;
-                        normal[1] /= norm;
-                        normal[2] /= norm;
-
-                        normals.push_back(normal[0]);
-                        normals.push_back(normal[1]);
-                        normals.push_back(normal[2]);
-
-                        normals.push_back(normal[0]);
-                        normals.push_back(normal[1]);
-                        normals.push_back(normal[2]);
-
-                        normals.push_back(normal[0]);
-                        normals.push_back(normal[1]);
-                        normals.push_back(normal[2]);
-
-                    }
                 }
+            }
+            // sets mark is_external
+            for(CDT::All_faces_iterator
+                fit = cdt.all_faces_begin(),
+                end = cdt.all_faces_end();
+                fit != end; ++fit)
+            {
+                fit->info().nesting_level = -1;
+
+            }
+
+            //check if the facet is external or internal
+            std::queue<CDT::Face_handle> face_queue;
+            face_queue.push(cdt.infinite_vertex()->face());
+
+            std::list<CDT::Edge> border;
+            mark_domains(cdt, cdt.infinite_face(), 0, border);
+            while(! border.empty()){
+              CDT::Edge e = border.front();
+              border.pop_front();
+              CDT::Face_handle n = e.first->neighbor(e.second);
+              if(n->info().nesting_level == -1){
+                mark_domains(cdt, n, e.first->info().nesting_level+1, border);
+              }
+            }
+
+            //iterates on the internal faces to add the vertices to the positions
+            //and the normals to the appropriate vectors
+
+            for(CDT::Finite_faces_iterator
+                ffit = cdt.finite_faces_begin(),
+                end = cdt.finite_faces_end();
+                ffit != end; ++ffit)
+            {
+
+
+                if(ffit->info().nesting_level%2 != 1){ continue;}
+                for(int i = 0; i<3; i++)
+                {
+                    positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().x())+offset.x);
+                    positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().y())+offset.y);
+                    positions_facets.push_back(CGAL::to_double(ffit->vertex(i)->point().z())+offset.z);
+
+                }
+
+
+
+                Nef_polyhedron::Vector_3 v = f->plane().orthogonal_vector();
+                GLdouble normal[3];
+                normal[0] = CGAL::to_double(v.x());
+                normal[1] = CGAL::to_double(v.y());
+                normal[2] = CGAL::to_double(v.z());
+                GLdouble norm = normal[0]*normal[0]
+                        + normal[1]*normal[1]
+                        + normal[2]*normal[2];
+                norm = CGAL::sqrt(norm);
+                normal[0] /= norm;
+                normal[1] /= norm;
+                normal[2] /= norm;
+
+                normals.push_back(normal[0]);
+                normals.push_back(normal[1]);
+                normals.push_back(normal[2]);
+
+                normals.push_back(normal[0]);
+                normals.push_back(normal[1]);
+                normals.push_back(normal[2]);
+
+                normals.push_back(normal[0]);
+                normals.push_back(normal[1]);
+                normals.push_back(normal[2]);
+
             }
         }
 


### PR DESCRIPTION
## Summary of Changes

When a facet of a nef_polyhedron have a hole, the triangulation for the visualization fills it. This PR changes the external targeting of the CDT facets.
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #1977 
* Feature/Small Feature (if any):

