### PR TITLE
Cartesian kernel: improve plane bases computation

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -1764,10 +1764,10 @@ namespace CartesianKernelFunctors {
         // to avoid badly defined vectors with coordinates all close
         // to 0 when the plane is almost horizontal, we ignore the
         // smallest coordinate instead of always ignoring Z
-        if (a <= b && a <= c)
+        if (CGAL::possibly(a <= b && a <= c))
           return Vector_3(FT(0), -h.c(), h.b());
 
-        if (b <= a && b <= c)
+        if (CGAL::possibly(b <= a && b <= c))
           return Vector_3(-h.c(), FT(0), h.a());
 
         return Vector_3(-h.b(), h.a(), FT(0));

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -1723,7 +1723,6 @@ namespace CartesianKernelFunctors {
     
   };
 
-
   template <typename K>
   class Construct_base_vector_3
   {
@@ -1757,8 +1756,21 @@ namespace CartesianKernelFunctors {
 	
 	if ( CGAL_NTS is_zero(h.c()) )  // parallel to z-axis
 	  return Vector_3(FT(0), FT(0), FT(1));
-	
-	return Vector_3(-h.b(), h.a(), FT(0));
+
+        FT a = CGAL::abs(h.a()),
+          b = CGAL::abs(h.b()),
+          c = CGAL::abs(h.c());
+
+        // to avoid badly defined vectors with coordinates all close
+        // to 0 when the plane is almost horizontal, we ignore the
+        // smallest coordinate instead of always ignoring Z
+        if (a <= b && a <= c)
+          return Vector_3(FT(0), -h.c(), h.b());
+
+        if (b <= a && b <= c)
+          return Vector_3(-h.c(), FT(0), h.a());
+
+        return Vector_3(-h.b(), h.a(), FT(0));
       } else {
 	return cp(co(h), this->operator()(h,1));
       }


### PR DESCRIPTION
## Summary of Changes

Currently, the first base of a `Plane_3` object is computed by putting the Z coordinate to 0 (except if the normal vector of the plane is the vertical vector). This is usually fine except if the normal vector is almost vertical: in that case, the coordinates of the bases are all close to 0 and that leads to very unexpected behavior for the method `to_2d()` for example. Two 3D points on a line parallel to the plane become two 2D points on the plane domain that have huge coordinates and that can't be used (distances are all wrong).

Although it is true the distances are not guaranteed to stay the same (which makes sense as there is a projection) and that inexact kernel are documented to produce inexact constructions, this case is very disturbing and quite hard to justify. See what happens if I take two points on a line parallel to the plane and separated by 0.01:

```
Vector = 0 0 1
plane = [0 0 1 -0]
 * plane.base1() = [1 0 0]
 * plane.base2() = [0 1 0]
 * plane.to_2d(p1) = [-0 -0]
 * plane.to_2d(p2) = [-0 0.01]
 * distance 2D = 0.01

Vector = 1e-05 1e-05 1
plane = [1e-05 1e-05 1 -0]
 * plane.base1() = [-1e-05 1e-05 0]
 * plane.base2() = [-1e-05 -1e-05 2e-10]
 * plane.to_2d(p1) = [-0 -0]
 * plane.to_2d(p2) = [500 -500]
 * distance 2D = 707.107
```

This is not just inexact, this is all wrong. This kind of problem makes the `to_2d()` method simply not usable (in extreme cases, I had 3D points distributed on a plane, and their `to_2d()` versions had erratic coordinates with all 2D points aligned).

There is an easy way to correct this: instead of putting the Z coordinate to 0 by default, we simply check which of the 3 parameters `a` `b` or `c` of the plane is the smallest and don't use this one.

This solves the problem and experimentally does not have any effect (that I could measure) on performances:

```
Vector = 0 0 1
plane = [0 0 1 -0]
 * plane.base1() = [1 0 0]
 * plane.base2() = [0 1 0]
 * plane.to_2d(p1) = [-0 -0]
 * plane.to_2d(p2) = [-0 0.01]
 * distance 2D = 0.01

Vector = 1e-05 1e-05 1
plane = [1e-05 1e-05 1 -0]
 * plane.base1() = [0 -1 1e-05]
 * plane.base2() = [1 -1e-10 -1e-05]
 * plane.to_2d(p1) = [-0 0]
 * plane.to_2d(p2) = [-0.01 -1e-12]
 * distance 2D = 0.01
```

## Release Management

* Affected package(s): Cartesian kernel