### PR TITLE
Polyhedron_demo: Fix empty group_item RenderingMode

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -36,10 +36,11 @@ Scene_group_item::Bbox Scene_group_item::bbox() const
 
 
 bool Scene_group_item::supportsRenderingMode(RenderingMode m) const {
+
     Q_FOREACH(Scene_item* item, children)
         if(!item->supportsRenderingMode(m))
             return false;
-    return !children.isEmpty();
+    return true;
 
 }
 


### PR DESCRIPTION
## Summary of Changes

If a group_item is empty, supportsRenderingMode() must return true, not false, or else the scene will enter an infinite loop as it does not expect any item returning false to every renderingMode.

## Release Management

* Affected package(s):Polyhedron_demo


