### PR TITLE
AABB_tree: Accelerate construction

### DIFF
--- a/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <fstream>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/Timer.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef K::FT FT;
+typedef K::Point_3 Point_3;
+typedef CGAL::Bbox_3 Bbox_3;
+typedef CGAL::Surface_mesh<Point_3> Surface_mesh; 
+typedef CGAL::Polyhedron_3<K> Polyhedron_3;
+typedef CGAL::Timer Timer;
+
+
+template <typename TriangleMesh>
+void triangle_mesh(char* fname)
+{
+  typedef CGAL::AABB_face_graph_triangle_primitive<TriangleMesh> Primitive;
+  typedef CGAL::AABB_traits<K, Primitive> Traits;
+  typedef CGAL::AABB_tree<Traits> Tree;
+
+  TriangleMesh tmesh;
+  std::ifstream in(fname);
+  in >> tmesh; 
+  Timer t;
+  t.start();
+  Tree tree(faces(tmesh).first, faces(tmesh).second, tmesh);
+  tree.build();
+  std::cout << t.time() << " sec." << std::endl;
+  std::cout << "Closest point to ORIGIN:" << tree.closest_point(CGAL::ORIGIN) << std::endl;
+}
+
+
+Bbox_3 bbox(boost::graph_traits<Surface_mesh>::face_descriptor fd, 
+            const Surface_mesh& p)
+{
+  boost::graph_traits<Surface_mesh>::halfedge_descriptor hd = halfedge(fd,p);
+  Bbox_3 res = p.point(source(hd,p)).bbox();
+  res += p.point(target(hd,p)).bbox();
+  res += p.point(target(next(hd,p),p)).bbox();
+  return res;
+}
+
+
+void surface_mesh_cache_bbox(char* fname)
+{
+  typedef boost::graph_traits<Surface_mesh>::face_descriptor face_descriptor;
+  typedef Surface_mesh::Property_map<face_descriptor,Bbox_3> Bbox_pmap;
+  typedef CGAL::AABB_face_graph_triangle_primitive<Surface_mesh> Primitive;
+  typedef CGAL::AABB_traits<K, Primitive,Bbox_pmap> Traits;
+  typedef CGAL::AABB_tree<Traits> Tree;
+
+  Surface_mesh tmesh;
+  std::ifstream in(fname);
+  in >> tmesh;
+  
+  Timer t;
+  t.start();
+  Bbox_pmap bb = tmesh.add_property_map<face_descriptor,Bbox_3>("f:bbox",Bbox_3()).first;
+ 
+  BOOST_FOREACH(face_descriptor fd, faces(tmesh)){
+    put(bb, fd, bbox(fd,tmesh));
+  }
+  Traits traits(bb);
+  Tree tree(traits);
+  tree.insert(faces(tmesh).first, faces(tmesh).second, tmesh);
+  tree.build();
+  tmesh.remove_property_map(bb);
+
+  std::cout << t.time() << " sec."<< std::endl;
+   std::cout << "Closest point to ORIGIN:" << tree.closest_point(CGAL::ORIGIN) << std::endl;
+}
+
+
+int main(int argc, char* argv[])
+{
+  std::cout << "Polyhedron_3" << std::endl;
+  triangle_mesh<Polyhedron_3>(argv[1]);
+
+  std::cout << "Surface_mesh" << std::endl;
+  triangle_mesh<Surface_mesh>(argv[1]);
+
+  std::cout << "Surface_mesh with cached Bbox_3" << std::endl;
+  surface_mesh_cache_bbox(argv[1]);
+
+  return EXIT_SUCCESS;
+}

--- a/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
@@ -19,7 +19,7 @@ typedef CGAL::Timer Timer;
 
 
 template <typename TriangleMesh>
-void triangle_mesh(char* fname)
+void triangle_mesh(const char* fname)
 {
   typedef CGAL::AABB_face_graph_triangle_primitive<TriangleMesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;

--- a/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
@@ -48,7 +48,7 @@ Bbox_3 bbox(boost::graph_traits<Surface_mesh>::face_descriptor fd,
 }
 
 
-void surface_mesh_cache_bbox(char* fname)
+void surface_mesh_cache_bbox(const char* fname)
 {
   typedef boost::graph_traits<Surface_mesh>::face_descriptor face_descriptor;
   typedef Surface_mesh::Property_map<face_descriptor,Bbox_3> Bbox_pmap;

--- a/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
@@ -81,13 +81,13 @@ void surface_mesh_cache_bbox(char* fname)
 int main(int argc, char* argv[])
 {
   std::cout << "Polyhedron_3" << std::endl;
-  triangle_mesh<Polyhedron_3>(argv[1]);
+  triangle_mesh<Polyhedron_3>((argc>1)?argv[1]:"data/tetrahedron.off");
 
   std::cout << "Surface_mesh" << std::endl;
-  triangle_mesh<Surface_mesh>(argv[1]);
+  triangle_mesh<Surface_mesh>((argc>1)?argv[1]:"data/tetrahedron.off");
 
   std::cout << "Surface_mesh with cached Bbox_3" << std::endl;
-  surface_mesh_cache_bbox(argv[1]);
+  surface_mesh_cache_bbox((argc>1)?argv[1]:"data/tetrahedron.off");
 
   return EXIT_SUCCESS;
 }

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -188,7 +188,7 @@ struct AABB_traits_base_2<GeomTraits,true>{
 /// \tparam Primitive provide the type of primitives stored in the AABB_tree.
 ///   It is a model of the concept `AABBPrimitive` or `AABBPrimitiveWithSharedData`.
 ///
-/// \tparam BboxMap must be a property map that has as key type a primitive id,
+/// \tparam BboxMap must be a model of `ReadablePropertyMap` that has as key type a primitive id,
 ///                 and as value type a `Bounding_box`.
 ///                 If the type is `Default` the `Datum` must have the
 ///                 member function `bbox()` that returns the bounding box  of the primitive.

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -25,6 +25,7 @@
 #include <CGAL/license/AABB_tree.h>
 
 #include <CGAL/Bbox_3.h>
+#include <CGAL/Default.h>
 #include <CGAL/intersections.h>
 #include <CGAL/internal/AABB_tree/Has_nested_type_Shared_data.h>
 #include <CGAL/internal/AABB_tree/Is_ray_intersection_geomtraits.h>

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -466,7 +466,7 @@ private:
   template <typename PM>
   Bounding_box compute_bbox(const Primitive& pr, const PM&)const
   {
-  return get(bbm, pr.id());
+    return get(bbm, pr.id());
   }
 
   Bounding_box compute_bbox(const Primitive& pr, const Default&)const

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -188,7 +188,10 @@ struct AABB_traits_base_2<GeomTraits,true>{
 /// \tparam Primitive provide the type of primitives stored in the AABB_tree.
 ///   It is a model of the concept `AABBPrimitive` or `AABBPrimitiveWithSharedData`.
 ///
-/// \tparam BboxMap must be a property map....................
+/// \tparam BboxMap must be a property map that has as key type a primitive id,
+///                 and as value type a `Bounding_box`.
+///                 If the type is `Default` the `Datum` must have the
+///                 member function `bbox()` that returns the bounding box  of the primitive.
 ///
 /// If the argument `GeomTraits` is a model of the concept \ref
 /// `AABBRayIntersectionGeomTraits`, this class is also a model of \ref

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -24,7 +24,6 @@
 
 #include <CGAL/license/AABB_tree.h>
 
-
 #include <CGAL/Bbox_3.h>
 #include <CGAL/intersections.h>
 #include <CGAL/internal/AABB_tree/Has_nested_type_Shared_data.h>
@@ -188,15 +187,18 @@ struct AABB_traits_base_2<GeomTraits,true>{
 /// \tparam Primitive provide the type of primitives stored in the AABB_tree.
 ///   It is a model of the concept `AABBPrimitive` or `AABBPrimitiveWithSharedData`.
 ///
-/// If the argument GeomTraits is a model of the concept \ref
-/// AABBRayIntersectionGeomTraits, this class is also a model of \ref
-/// AABBRayIntersectionTraits.
+/// \tparam BboxMap must be a property map....................
+///
+/// If the argument `GeomTraits` is a model of the concept \ref
+/// `AABBRayIntersectionGeomTraits`, this class is also a model of \ref
+/// `AABBRayIntersectionTraits`.
 ///
 /// \sa `AABBTraits`
 /// \sa `AABB_tree`
 /// \sa `AABBPrimitive`
 /// \sa `AABBPrimitiveWithSharedData`
-template<typename GeomTraits, typename AABBPrimitive>
+
+  template<typename GeomTraits, typename AABBPrimitive, typename BboxMap = Default>
 class AABB_traits:
   public internal::AABB_tree::AABB_traits_base<AABBPrimitive>,
   public internal::AABB_tree::AABB_traits_base_2<GeomTraits>
@@ -205,7 +207,7 @@ class AABB_traits:
 public:
   typedef GeomTraits Geom_traits;
 
-  typedef AABB_traits<GeomTraits, AABBPrimitive> AT;
+  typedef AABB_traits<GeomTraits, AABBPrimitive, BboxMap> AT;
   // AABBTraits concept types
   typedef typename GeomTraits::FT FT;
   typedef AABBPrimitive Primitive;
@@ -254,8 +256,14 @@ public:
   typedef typename GeomTraits::Construct_max_vertex_3 Construct_max_vertex_3;
   typedef typename GeomTraits::Construct_iso_cuboid_3 Construct_iso_cuboid_3;
 
+  BboxMap bbm;
+
   /// Default constructor.
-  AABB_traits() { };
+  AABB_traits() { }
+
+  AABB_traits(BboxMap bbm)
+    : bbm(bbm)
+  {}
 
 
   typedef typename GeomTraits::Compute_squared_distance_3 Squared_distance;
@@ -276,9 +284,9 @@ public:
    */
   class Sort_primitives
   {
-    const AABB_traits<GeomTraits,AABBPrimitive>& m_traits;
+  const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& m_traits;
   public:
-    Sort_primitives(const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+    Sort_primitives(const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& traits)
       : m_traits(traits) {}
 
     template<typename PrimitiveIterator>
@@ -314,31 +322,32 @@ public:
    * @return the bounding box of the primitives of the iterator range
    */
   class Compute_bbox {
-    const AABB_traits<GeomTraits,AABBPrimitive>& m_traits;
+    const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& m_traits;
   public:
-    Compute_bbox(const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+    Compute_bbox(const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
       :m_traits (traits) {}
-
+    
     template<typename ConstPrimitiveIterator>
     typename AT::Bounding_box operator()(ConstPrimitiveIterator first,
                                          ConstPrimitiveIterator beyond) const
-      {
-        typename AT::Bounding_box bbox = compute_bbox(*first,m_traits);
-        for(++first; first != beyond; ++first)
+    {
+      typename AT::Bounding_box bbox = m_traits.compute_bbox(*first,m_traits.bbm);
+      for(++first; first != beyond; ++first)
         {
-          bbox = bbox + compute_bbox(*first,m_traits);
+          bbox = bbox + m_traits.compute_bbox(*first,m_traits.bbm);
         }
-        return bbox;
-      }
+      return bbox;
+    }
+    
   };
 
   Compute_bbox compute_bbox_object() const {return Compute_bbox(*this);}
 
 
   class Do_intersect {
-    const AABB_traits<GeomTraits,AABBPrimitive>& m_traits;
+    const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& m_traits;
   public:
-    Do_intersect(const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+    Do_intersect(const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
       :m_traits(traits) {}
 
     template<typename Query>
@@ -357,9 +366,9 @@ public:
   Do_intersect do_intersect_object() const {return Do_intersect(*this);}
 
   class Intersection {
-    const AABB_traits<GeomTraits,AABBPrimitive>& m_traits;
+    const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& m_traits;
   public:
-    Intersection(const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+    Intersection(const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& traits)
       :m_traits(traits) {}
     #if CGAL_INTERSECTION_VERSION < 2
     template<typename Query>
@@ -394,9 +403,9 @@ public:
   class Closest_point {
       typedef typename AT::Point_3 Point;
       typedef typename AT::Primitive Primitive;
-    const AABB_traits<GeomTraits,AABBPrimitive>& m_traits;
+    const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& m_traits;
   public:
-    Closest_point(const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+    Closest_point(const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
       : m_traits(traits) {}
 
 
@@ -450,11 +459,17 @@ private:
    * @param pr the primitive
    * @return the bounding box of the primitive \c pr
    */
-  static Bounding_box compute_bbox (const Primitive& pr,
-                                    const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+  template <typename PM>
+  Bounding_box compute_bbox(const Primitive& pr, const PM&)const
   {
-    return internal::Primitive_helper<AT>::get_datum(pr,traits).bbox();
+  return get(bbm, pr.id());
   }
+
+  Bounding_box compute_bbox(const Primitive& pr, const Default&)const
+  {
+    return internal::Primitive_helper<AT>::get_datum(pr,*this).bbox();
+  }
+  
 
   typedef enum { CGAL_AXIS_X = 0,
                  CGAL_AXIS_Y = 1,
@@ -463,17 +478,17 @@ private:
   static Axis longest_axis(const Bounding_box& bbox);
 
   /// Comparison functions
-  static bool less_x(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+  static bool less_x(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
   {
     return GeomTraits().less_x_3_object()( internal::Primitive_helper<AT>::get_reference_point(pr1,traits),
                                            internal::Primitive_helper<AT>::get_reference_point(pr2,traits) );
   }
-  static bool less_y(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+  static bool less_y(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
   {
     return GeomTraits().less_y_3_object()( internal::Primitive_helper<AT>::get_reference_point(pr1,traits),
                                            internal::Primitive_helper<AT>::get_reference_point(pr2,traits) );
   }
-  static bool less_z(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive>& traits)
+  static bool less_z(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)
   {
     return GeomTraits().less_z_3_object()( internal::Primitive_helper<AT>::get_reference_point(pr1,traits),
                                            internal::Primitive_helper<AT>::get_reference_point(pr2,traits) );
@@ -485,9 +500,9 @@ private:
 //-------------------------------------------------------
 // Private methods
 //-------------------------------------------------------
-template<typename GT, typename P>
-typename AABB_traits<GT,P>::Axis
-AABB_traits<GT,P>::longest_axis(const Bounding_box& bbox)
+  template<typename GT, typename P, typename B>
+  typename AABB_traits<GT,P,B>::Axis
+  AABB_traits<GT,P,B>::longest_axis(const Bounding_box& bbox)
 {
   const double dx = bbox.xmax() - bbox.xmin();
   const double dy = bbox.ymax() - bbox.ymin();

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -194,8 +194,8 @@ struct AABB_traits_base_2<GeomTraits,true>{
 ///                 member function `bbox()` that returns the bounding box  of the primitive.
 ///
 /// If the argument `GeomTraits` is a model of the concept \ref
-/// `AABBRayIntersectionGeomTraits`, this class is also a model of \ref
-/// `AABBRayIntersectionTraits`.
+/// AABBRayIntersectionGeomTraits, this class is also a model of \ref
+/// AABBRayIntersectionTraits.
 ///
 /// \sa `AABBTraits`
 /// \sa `AABB_tree`

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -217,6 +217,7 @@ and <code>src/</code> directories).
       Sqrt3 subdivision can now handle input surfaces with a border.
     </li>
   </ul>
+<<<<<<< HEAD
   <h3>Scale-Space Surface Reconstruction (breaking change)</h3>
   <ul>
     <li><b>Breaking change</b>: the API was rewritten to separate the
@@ -388,12 +389,16 @@ and <code>src/</code> directories).
     function to write PLY with properties is provided
       (<code>CGAL::write_ply_points_with_properties()</code>).</li>
   </ul>
-  <h3>Spatial Searching</h3>
+
+<!-- Spatial Searching and Sorting -->
+
+<h3>Spatial Searching</h3>
   <ul>
     <li>
       Add function <code>Kd_tree::remove(Point)</code>.
     </li>
   </ul>
+<<<<<<< HEAD
   <h3>CGAL and the Boost Graph Library</h3>
   <ul>
     <li>
@@ -423,6 +428,21 @@ and <code>src/</code> directories).
      and <code>write_off()</code>.
     </li>
   </ul>
+=======
+
+ <h3>3D Fast Intersection and Distance Computation</h3>
+  <ul>
+    <li>Add a template parameter to <code>AABB_traits</code> 
+        for a property map that associates a bounding box to a primitive</li>
+  </ul>
+<!-- Geometric Optimization -->
+<!-- Interpolation -->
+<!-- Kinetic Data Structures -->
+<!-- Support Library -->
+<!-- Visualization -->
+
+<!-- end of the div for 4.10 -->
+
 </div>
 
 <h2 id="release4.10">Release 4.10 </h2>

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -217,7 +217,6 @@ and <code>src/</code> directories).
       Sqrt3 subdivision can now handle input surfaces with a border.
     </li>
   </ul>
-<<<<<<< HEAD
   <h3>Scale-Space Surface Reconstruction (breaking change)</h3>
   <ul>
     <li><b>Breaking change</b>: the API was rewritten to separate the
@@ -389,16 +388,17 @@ and <code>src/</code> directories).
     function to write PLY with properties is provided
       (<code>CGAL::write_ply_points_with_properties()</code>).</li>
   </ul>
-
-<!-- Spatial Searching and Sorting -->
-
-<h3>Spatial Searching</h3>
+  <h3>Spatial Searching</h3>
   <ul>
     <li>
       Add function <code>Kd_tree::remove(Point)</code>.
     </li>
   </ul>
-<<<<<<< HEAD
+  <h3>3D Fast Intersection and Distance Computation</h3>
+  <ul>
+    <li>Add a template parameter to <code>AABB_traits</code>
+        for a property map that associates a bounding box to a primitive</li>
+  </ul>
   <h3>CGAL and the Boost Graph Library</h3>
   <ul>
     <li>
@@ -428,21 +428,6 @@ and <code>src/</code> directories).
      and <code>write_off()</code>.
     </li>
   </ul>
-=======
-
- <h3>3D Fast Intersection and Distance Computation</h3>
-  <ul>
-    <li>Add a template parameter to <code>AABB_traits</code> 
-        for a property map that associates a bounding box to a primitive</li>
-  </ul>
-<!-- Geometric Optimization -->
-<!-- Interpolation -->
-<!-- Kinetic Data Structures -->
-<!-- Support Library -->
-<!-- Visualization -->
-
-<!-- end of the div for 4.10 -->
-
 </div>
 
 <h2 id="release4.10">Release 4.10 </h2>


### PR DESCRIPTION
## Summary of Changes
Add a template argument to `AABB_traits` for a property map from the primitive id to a `Bbox_3`.
The construction with a mesh with 1.637.579 triangles takes
* 4.574 sec. for a Polyhedron
* 2.591 sec. for a `Surface_mesh`
* 1.872 sec. for a `Surface_mesh` with a `Bbox_3` as property per `face_descriptor`.

We stay backward compatible. This is documented. The computation of the Bbox_3 could be done in a `tbb::parallel_for` loop.  Well, I gave it a try but there is no gain. 

## Release Management

* Affected package(s): AABB_tree
* Feature/Small Feature (if any): [Small_Features/AABB_traits: Add Bboxmap](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/AABB_traits:_Add_Bboxmap)

