### PR TITLE
force the usage of CGAL compare function

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -762,11 +762,11 @@ namespace CommonKernelFunctors {
 
     result_type operator()(const Point_3& p, const Point_3& q, const Point_3& r, const Point_3& s) const
     { 
-      Comparison_result sign_pq = compare(q.z(),p.z());
-      Comparison_result sign_rs = compare(s.z(),r.z());
+      Comparison_result sign_pq = CGAL::compare(q.z(),p.z());
+      Comparison_result sign_rs = CGAL::compare(s.z(),r.z());
       
       if(sign_pq != sign_rs){
-        return compare(static_cast<int>(sign_pq), static_cast<int>(sign_rs));
+        return CGAL::compare(static_cast<int>(sign_pq), static_cast<int>(sign_rs));
       }
 
       if((sign_pq == EQUAL) && (sign_rs == EQUAL)){


### PR DESCRIPTION
Fixes [these errors](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.10-I-194/Polygon_mesh_processing/TestReport_cgaltester_x86-64_Darwin-13.0_Apple-clang-5.1_Release-LEDA-without-GMP.gz).


