### PR TITLE
Point set 3: Bugfix with carriage return

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3/IO.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO.h
@@ -201,10 +201,11 @@ std::istream& operator>>(std::istream& is,
   std::string line;
   if (!getline(is, line))
     return is;
+
   is.seekg(0);
-  if (line == "OFF" || line == "NOFF")
+  if (line.find("OFF") == 0 || line.find("NOFF") == 0)
     CGAL::read_off_point_set (is, ps);
-  else if (line == "ply")
+  else if (line.find("ply") == 0)
     CGAL::read_ply_point_set (is, ps);
   else
     CGAL::read_xyz_point_set (is, ps);


### PR DESCRIPTION
## Summary of Changes

The `operator>>` of the class `Point_set_3` uses the first line read (tag) to estimate the format. I just realized that using a simple string comparison could lead to bugs if the file read was not generated from the same platform (the usual differences of carriage return between `\n`, `\r\n`, etc.).

Using `std::string::find()` and checking if the line starts with the tag is enough and solves the bug.

## Release Management

* Affected package(s): Point_set_3

