### PR TITLE
Bug fix in doc of Linear cell complex

### DIFF
--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -7,9 +7,6 @@
 /// \ingroup PkgLinearCellComplex
 
 /*! Basic constructions.
-  \code
-  #include <CGAL/Linear_cell_complex_constructors.h>
-  \endcode
 */
 /// \defgroup PkgLinearCellComplexConstructions Constructions for Linear Cell Complex
 /// \ingroup PkgLinearCellComplex


### PR DESCRIPTION

## Summary of Changes

Bug fix in the doc of Linear cell complex. Following a previous refactoring, constructions are not all in "CGAL/Linear_cell_complex_constructors.h" but are in different files (given in the doc of each function).

Thus this global include is now wrong.

## Release Management

* Affected package(s): Linear cell complex

