### PR TITLE
Polyhedron_demo: Change spheres colors in c3t3

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1497,7 +1497,18 @@ void Scene_c3t3_item_priv::computeSpheres()
     if(red)
       c = QColor(Qt::red);
     else
-      c = spheres->color().darker(250);
+      c = QColor::fromHsv(120, 200,200,255);
+    switch(vit->in_dimension())
+    {
+    case 0:
+      c = QColor::fromHsv((c.hue()+120)%360, c.saturation(),c.lightness(), c.alpha());
+      break;
+    case 1:
+      break;
+    default:
+      c.setRgb(50,50,50,255);
+    }
+
     const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
     Kernel::Point_3 center(vit->point().point().x()+offset.x,
     vit->point().point().y()+offset.y,

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1497,7 +1497,7 @@ void Scene_c3t3_item_priv::computeSpheres()
     if(red)
       c = QColor(Qt::red);
     else
-      c = QColor::fromHsv(120, 200,200,255);
+      c = spheres->color();
     switch(vit->in_dimension())
     {
     case 0:
@@ -1669,6 +1669,7 @@ void Scene_c3t3_item::show_spheres(bool b)
       d->spheres->setName("Protecting spheres");
       d->spheres->setRenderingMode(Gouraud);
       connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
+      connect(d->spheres, SIGNAL(on_color_changed()), this, SLOT(on_spheres_color_changed()));
       scene->addItem(d->spheres);
       scene->changeGroup(d->spheres, this);
       lockChild(d->spheres);
@@ -2041,6 +2042,13 @@ void Scene_c3t3_item::itemAboutToBeDestroyed(Scene_item *item)
     d=0;
   }
 
+}
+void Scene_c3t3_item::on_spheres_color_changed()
+{
+  if(!d->spheres)
+    return;
+  d->spheres->clear_spheres();
+  d->computeSpheres();
 }
 
 #include "Scene_c3t3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -125,6 +125,8 @@ public:
     float getShrinkFactor() const;
     bool keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
   public Q_SLOTS:
+
+  void on_spheres_color_changed();
   void export_facets_in_complex();
 
   void data_item_destroyed();

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -269,3 +269,9 @@ void Scene_spheres_item::setToolTip(QString s)
 {
   d->tooltip = s;
 }
+
+void Scene_spheres_item::setColor(QColor c)
+{
+  CGAL::Three::Scene_item::setColor(c);
+  this->on_color_changed();
+}

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -27,21 +27,21 @@ public:
 
   ~Scene_spheres_item();
 
-  bool isFinite() const { return false; }
-  bool isEmpty() const { return false; }
-  Scene_item* clone() const {return 0;}
-  QString toolTip() const;
-  bool supportsRenderingMode(RenderingMode m) const {
+  bool isFinite() const Q_DECL_OVERRIDE{ return false; }
+  bool isEmpty() const Q_DECL_OVERRIDE{ return false; }
+  Scene_item* clone() const Q_DECL_OVERRIDE{return 0;}
+  QString toolTip() const Q_DECL_OVERRIDE;
+  bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE{
     return (m == Gouraud || m == Wireframe);
   }
-  void compute_bbox() const { _bbox = Bbox(); }
+  void compute_bbox() const Q_DECL_OVERRIDE{ _bbox = Bbox(); }
   void add_sphere(const CGAL::Sphere_3<Kernel> &sphere, CGAL::Color = CGAL::Color(120,120,120));
   void clear_spheres();
   void setPrecision(int prec);
 
-  void draw(CGAL::Three::Viewer_interface* viewer) const;
-  void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
-  void invalidateOpenGLBuffers();
+  void draw(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+  void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
+  void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
   void computeElements() const;
   void setPlane(Kernel::Plane_3 p_plane);
   void setToolTip(QString s);

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -45,7 +45,9 @@ public:
   void computeElements() const;
   void setPlane(Kernel::Plane_3 p_plane);
   void setToolTip(QString s);
-
+  void setColor(QColor c) Q_DECL_OVERRIDE;
+Q_SIGNALS:
+  void on_color_changed();
 protected:
   friend struct Scene_spheres_item_priv;
   Scene_spheres_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.f
@@ -12,7 +12,7 @@ uniform bool is_selected;
 void main(void) {
  if(color.w<0)
  {
-    vec4 my_color = vec4(color.xzy, 1.);
+    vec4 my_color = vec4(color.xyz, 1.);
     highp vec3 L = light_pos.xyz - fP.xyz; 
     highp vec3 V = -fP.xyz; 
     highp vec3 N; 


### PR DESCRIPTION
## Summary of Changes

- Fix color in shader 
- Make spheres color depends on the in_dimension of their associated vertex.

## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2149 

