### PR TITLE
Workaround for gmp-4.2 with gcc 4.9 and C++11

### DIFF
--- a/Installation/config/support/print_GMP_version.cpp
+++ b/Installation/config/support/print_GMP_version.cpp
@@ -25,6 +25,8 @@
 // Tests if GMP is available.
 
 #include <iostream>
+#include <cstdio>
+#include <cstddef>
 #include "gmp.h"
 
 int main()

--- a/Installation/config/support/print_MPFR_version.cpp
+++ b/Installation/config/support/print_MPFR_version.cpp
@@ -25,6 +25,8 @@
 // Tests if MPFR is available.
 
 #include <iostream>
+#include <cstdio>
+#include <cstddef>
 #include "mpfr.h"
 
 int main()


### PR DESCRIPTION
Include `<cstdio>` and `<cstddef>` to avoid a compilation error.

```
include/c++/4.9.3/cstddef:51:11: error: '::max_align_t' has not been declared
    using ::max_align_t;
            ^
```

See https://gcc.gnu.org/gcc-4.9/porting_to.html


* Affected package(s): Installation
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):