### PR TITLE
Poisson reconstruction: Provide a simple function

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -147,6 +147,13 @@ and <code>src/</code> directories).
 <!-- Voronoi Diagrams -->
 <!-- Mesh Generation -->
 <!-- Surface Reconstruction -->
+<h3>Poisson Surface Reconstruction</h3>
+<ul>
+  <li>A new global
+    function <code>CGAL::poisson_surface_reconstruction_delaunay()</code>
+    is provided in addition to the current class-based API in order to
+    make it easier to use.</li>
+</ul>
 <!-- Geometry Processing -->
 <h3> 3D Surface Subdivision Methods </h3>
   <ul>
@@ -394,7 +401,8 @@ and <code>src/</code> directories).
     been renamed <code>CGAL::Polygon_mesh_processing::bbox()</code>.
     </li>
   </ul>
-
+<!-- Surface Reconstruction -->
+<!-- Geometry Processing -->
   <h3>Point Set Processing</h3>
   <ul>
     <li>Function <code>CGAL::remove_outliers()</code> has an

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/Poisson_surface_reconstruction_3.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/Poisson_surface_reconstruction_3.txt
@@ -74,20 +74,44 @@ the triangulation using a sparse linear solver. Eventually, the \cgal
 surface mesh generator extracts an isosurface with function value set
 by default to be the median value of \f$ f\f$ at all input points.
 
-\subsection Poisson_surface_reconstruction_3Interface Interface
+\section Poisson_surface_reconstruction_3Function Reconstruction Function
 
-The class template declaration is `template<class Gt> class Poisson_reconstruction_function` wher
+A global function `poisson_surface_reconstruction_delaunay()` is
+provided. It takes points with normals as input and handles the whole
+reconstruction pipeline :
+
+- it computes the implicit function
+- it reconstructs the surface with a given precision using the \cgal
+surface mesh generator based on Delaunay refinement
+\cgalCite{cgal:ry-gsddrm-06} \cgalCite{cgal:bo-pgsms-05}
+- it outputs the result in a polygon mesh.
+
+This function aims at providing a quick and user-friendly API for
+Poisson reconstruction. Advanced users may be interested in using the
+class (see \ref Poisson_surface_reconstruction_3Class) which allows
+them, for example, to use another surface mesher or a different output
+structure.
+
+\subsection Poisson_surface_reconstruction_3Example_function Example
+
+The following example reads a point set and reconstructs a surface using Poisson reconstruction.
+
+\cgalExample{Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp}
+
+\section Poisson_surface_reconstruction_3Class Reconstruction Class
+
+The class template declaration is `template<class Gt> class Poisson_reconstruction_function` where
 `Gt` is a geometric traits class.
 
 For details see: `Poisson_reconstruction_function<GeomTraits>`
 
-\subsection Poisson_surface_reconstruction_3Example Example
+\subsection Poisson_surface_reconstruction_3Example_class Example
 
 The following example reads a point set, creates a Poisson implicit function and reconstructs a surface.
 
 \cgalExample{Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp}
 
-\section Poisson_surface_reconstruction_3Contouring Contouring
+\subsection Poisson_surface_reconstruction_3Contouring Contouring
 
 
 The computed implicit functions can be iso-contoured to reconstruct a
@@ -101,7 +125,7 @@ The parameter `Tag` affects the behavior of `make_surface_mesh()`:
 - `Manifold_with_boundary_tag`: the output mesh is guaranteed to be manifold and may have boundaries.
 - `Non_manifold_tag`: the output mesh has no guarantee and hence is outputted as a polygon soup.
 
-\section Poisson_surface_reconstruction_3Output Output
+\subsection Poisson_surface_reconstruction_3Output Output
 
 The surface reconstructed by `make_surface_mesh()` is required to be a
 model of the concept `SurfaceMeshComplex_2InTriangulation_3`, a data

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/examples.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/examples.txt
@@ -1,1 +1,3 @@
+/// \example Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
 /// \example Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
+

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -35,6 +35,7 @@ if ( CGAL_FOUND )
     # Executables that require Eigen 3
     create_single_source_cgal_program( "poisson_reconstruction_example.cpp" )
     create_single_source_cgal_program( "poisson_reconstruction.cpp" )
+    create_single_source_cgal_program( "poisson_reconstruction_function.cpp" )
   else()
     message(STATUS "NOTICE: The examples need Eigen 3.1 (or greater) will not be compiled.")
   endif()

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
@@ -30,12 +30,15 @@ int main(void)
     }
 
   Polyhedron output_mesh;
+  
+  double average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>
+    (points.begin(), points.end(), CGAL::First_of_pair_property_map<Pwn>(), 6);
 
-  if (CGAL::poisson_surface_reconstruction<CGAL::Sequential_tag>
+  if (CGAL::poisson_surface_reconstruction
       (points.begin(), points.end(),
        CGAL::First_of_pair_property_map<Pwn>(),
        CGAL::Second_of_pair_property_map<Pwn>(),
-       output_mesh))
+       output_mesh, average_spacing))
     {
         std::ofstream out("kitten_poisson-20-30-0.375.off");
         out << output_mesh;

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
@@ -1,0 +1,47 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/poisson_surface_reconstruction.h>
+#include <CGAL/IO/read_xyz_points.h>
+
+#include <vector>
+#include <fstream>
+
+// Types
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef Kernel::Point_3 Point;
+typedef Kernel::Vector_3 Vector;
+typedef std::pair<Point, Vector> Pwn;
+typedef CGAL::Polyhedron_3<Kernel> Polyhedron;
+
+int main(void)
+{
+  std::vector<Pwn> points;
+  std::ifstream stream("data/kitten.xyz");
+  if (!stream ||
+      !CGAL::read_xyz_points_and_normals(
+           stream,
+           std::back_inserter(points),
+           CGAL::First_of_pair_property_map<Pwn>(),
+           CGAL::Second_of_pair_property_map<Pwn>()))
+    {
+      std::cerr << "Error: cannot read file data/kitten.xyz" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  Polyhedron output_mesh;
+
+  if (CGAL::poisson_surface_reconstruction<CGAL::Sequential_tag>
+      (points.begin(), points.end(),
+       CGAL::First_of_pair_property_map<Pwn>(),
+       CGAL::Second_of_pair_property_map<Pwn>(),
+       output_mesh))
+    {
+        std::ofstream out("kitten_poisson-20-30-0.375.off");
+        out << output_mesh;
+    }
+  else
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_function.cpp
@@ -34,7 +34,7 @@ int main(void)
   double average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>
     (points.begin(), points.end(), CGAL::First_of_pair_property_map<Pwn>(), 6);
 
-  if (CGAL::poisson_surface_reconstruction
+  if (CGAL::poisson_surface_reconstruction_delaunay
       (points.begin(), points.end(),
        CGAL::First_of_pair_property_map<Pwn>(),
        CGAL::Second_of_pair_property_map<Pwn>(),

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -82,6 +82,7 @@ namespace CGAL {
     \param tag surface mesher tag.
     \return `true` if reconstruction succeeded, `false` otherwise.
   */
+#if defined(DOXYGEN_RUNNING) || !defined(CGAL_CFG_NO_CPP0X_DEFAULT_TEMPLATE_ARGUMENTS_FOR_FUNCTION_TEMPLATES)
   template <typename PointInputIterator,
             typename PointMap,
             typename NormalMap,
@@ -98,6 +99,65 @@ namespace CGAL {
                                            double sm_radius = 30.0,
                                            double sm_distance = 0.375,
                                            Tag tag = Tag())
+#else
+  template <typename PointInputIterator,
+            typename PointMap,
+            typename NormalMap,
+            typename PolygonMesh>
+  bool
+  poisson_surface_reconstruction_delaunay (PointInputIterator begin,
+                                           PointInputIterator end,
+                                           PointMap point_map,
+                                           NormalMap normal_map,
+                                           PolygonMesh& output_mesh,
+                                           double spacing,
+                                           double sm_angle = 20.0,
+                                           double sm_radius = 30.0,
+                                           double sm_distance = 0.375)
+  {
+    return poisson_surface_reconstruction_delaunay (begin, end, point_map, normal_map, output_mesh,
+                                                    spacing, sm_angle, sm_radius, sm_distance,
+                                                    CGAL::Manifold_with_boundary_tag());
+  }
+
+  template <typename PointInputIterator,
+            typename PointMap,
+            typename NormalMap,
+            typename PolygonMesh,
+            typename Tag>
+  bool
+  poisson_surface_reconstruction_delaunay (PointInputIterator begin,
+                                           PointInputIterator end,
+                                           PointMap point_map,
+                                           NormalMap normal_map,
+                                           PolygonMesh& output_mesh,
+                                           double spacing,
+                                           double sm_angle = 20.0,
+                                           double sm_radius = 30.0,
+                                           double sm_distance = 0.375)
+  {
+    return poisson_surface_reconstruction_delaunay (begin, end, point_map, normal_map, output_mesh,
+                                                    spacing, sm_angle, sm_radius, sm_distance,
+                                                    Tag());
+  }
+
+  template <typename PointInputIterator,
+            typename PointMap,
+            typename NormalMap,
+            typename PolygonMesh,
+            typename Tag>
+  bool
+  poisson_surface_reconstruction_delaunay (PointInputIterator begin,
+                                           PointInputIterator end,
+                                           PointMap point_map,
+                                           NormalMap normal_map,
+                                           PolygonMesh& output_mesh,
+                                           double spacing,
+                                           double sm_angle,
+                                           double sm_radius,
+                                           double sm_distance,
+                                           Tag tag)
+#endif
   {
     typedef typename boost::property_traits<PointMap>::value_type Point;
     typedef typename Kernel_traits<Point>::Kernel Kernel;

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -35,9 +35,14 @@ namespace CGAL {
 
     Performs surface reconstruction as follows:
 
-    - compute the Poisson implicit function
-    - meshes the function with a user-defined precision
-    - outputs the result in a polygon mesh
+    - compute the Poisson implicit function, through a conjugate
+      gradient solver, represented as a piecewise linear function
+      stored on a 3D Delaunay mesh generated via Delaunay refinement
+    - meshes the function with a user-defined precision using another
+      round of Delaunay refinement: it contours the isosurface
+      corresponding to the isovalue of the median of the function
+      values at the input points
+    - outputs the result in a polygon mesh 
 
     This function relies mainly on the size parameter `spacing`. A
     reasonable solution is to use the average spacing of the input

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -67,10 +67,12 @@ namespace CGAL {
     \param end past the end iterator of the point sequence.
     \param point_map property map: value_type of `InputIterator` -> Point_3.
     \param normal_map property map: value_type of `InputIterator` -> Vector_3.
+    \param output_mesh where the reconstruction is stored.
     \param spacing size parameter.
     \param sm_angle bound for the minimum facet angle in degrees.
     \param sm_radius bound for the radius of the surface Delaunay balls (relatively to the `average_spacing`).
     \param sm_distance bound for the center-center distances (relatively to the `average_spacing`).
+    \param tag surface mesher tag.
   */
   template <typename PointInputIterator,
             typename PointMap,

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -20,6 +20,8 @@
 #ifndef CGAL_POISSON_SURFACE_RECONSTRUCTION_H
 #define CGAL_POISSON_SURFACE_RECONSTRUCTION_H
 
+#include <CGAL/license/Poisson_surface_reconstruction_3.h>
+
 #include <CGAL/Surface_mesh_default_triangulation_3.h>
 #include <CGAL/make_surface_mesh.h>
 #include <CGAL/Implicit_surface_3.h>

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -73,6 +73,7 @@ namespace CGAL {
     \param sm_radius bound for the radius of the surface Delaunay balls (relatively to the `average_spacing`).
     \param sm_distance bound for the center-center distances (relatively to the `average_spacing`).
     \param tag surface mesher tag.
+    \return `true` if reconstruction succeeded, `false` otherwise.
   */
   template <typename PointInputIterator,
             typename PointMap,

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -20,8 +20,6 @@
 #ifndef CGAL_POISSON_SURFACE_RECONSTRUCTION_H
 #define CGAL_POISSON_SURFACE_RECONSTRUCTION_H
 
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/Surface_mesh_default_triangulation_3.h>
 #include <CGAL/make_surface_mesh.h>
 #include <CGAL/Implicit_surface_3.h>
@@ -34,26 +32,25 @@ namespace CGAL {
 
   
   template <typename ConcurrencyTag,
-            typename Kernel,
             typename PointInputIterator,
             typename PointMap,
             typename NormalMap,
-            typename Items,
-            template < class T, class I, class A> class HDS,
-            typename Alloc>
+            typename PolygonMesh>
   bool
   poisson_surface_reconstruction(PointInputIterator begin,
                                  PointInputIterator end,
                                  PointMap point_map,
                                  NormalMap normal_map,
-                                 Polyhedron_3<Kernel,Items,HDS,Alloc>& output_mesh,
-                                 typename Kernel::FT sm_angle = 20.0,
-                                 typename Kernel::FT sm_radius = 30.0,
-                                 typename Kernel::FT sm_distance = 0.375)
+                                 PolygonMesh& output_mesh,
+                                 double sm_angle = 20.0,
+                                 double sm_radius = 30.0,
+                                 double sm_distance = 0.375)
   {
+    typedef typename boost::property_traits<PointMap>::value_type Point;
+    typedef typename Kernel_traits<Point>::Kernel Kernel;
     typedef typename Kernel::FT FT;
-    typedef typename Kernel::Point_3 Point;
     typedef typename Kernel::Sphere_3 Sphere;
+    
     typedef CGAL::Poisson_reconstruction_function<Kernel> Poisson_reconstruction_function;
     typedef CGAL::Surface_mesh_default_triangulation_3 STr;
     typedef CGAL::Surface_mesh_complex_2_in_triangulation_3<STr> C2t3;

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2017  GeometryFactory (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Simon Giraudot
+
+#ifndef CGAL_POISSON_SURFACE_RECONSTRUCTION_H
+#define CGAL_POISSON_SURFACE_RECONSTRUCTION_H
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Surface_mesh_default_triangulation_3.h>
+#include <CGAL/make_surface_mesh.h>
+#include <CGAL/Implicit_surface_3.h>
+#include <CGAL/IO/output_surface_facets_to_polyhedron.h>
+#include <CGAL/Poisson_reconstruction_function.h>
+#include <CGAL/property_map.h>
+#include <CGAL/compute_average_spacing.h>
+
+namespace CGAL {
+
+  
+  template <typename ConcurrencyTag,
+            typename Kernel,
+            typename PointInputIterator,
+            typename PointMap,
+            typename NormalMap,
+            typename Items,
+            template < class T, class I, class A> class HDS,
+            typename Alloc>
+  bool
+  poisson_surface_reconstruction(PointInputIterator begin,
+                                 PointInputIterator end,
+                                 PointMap point_map,
+                                 NormalMap normal_map,
+                                 Polyhedron_3<Kernel,Items,HDS,Alloc>& output_mesh,
+                                 typename Kernel::FT sm_angle = 20.0,
+                                 typename Kernel::FT sm_radius = 30.0,
+                                 typename Kernel::FT sm_distance = 0.375)
+  {
+    typedef typename Kernel::FT FT;
+    typedef typename Kernel::Point_3 Point;
+    typedef typename Kernel::Sphere_3 Sphere;
+    typedef CGAL::Poisson_reconstruction_function<Kernel> Poisson_reconstruction_function;
+    typedef CGAL::Surface_mesh_default_triangulation_3 STr;
+    typedef CGAL::Surface_mesh_complex_2_in_triangulation_3<STr> C2t3;
+    typedef CGAL::Implicit_surface_3<Kernel, Poisson_reconstruction_function> Surface_3;
+    
+    Poisson_reconstruction_function function(begin, end, point_map, normal_map);
+    if ( ! function.compute_implicit_function() ) 
+      return false;
+
+    FT average_spacing = CGAL::compute_average_spacing<ConcurrencyTag>
+      (begin, end, point_map, 6);
+
+    Point inner_point = function.get_inner_point();
+    Sphere bsphere = function.bounding_sphere();
+    FT radius = std::sqrt(bsphere.squared_radius());
+
+    FT sm_sphere_radius = 5.0 * radius;
+    FT sm_dichotomy_error = sm_distance * average_spacing / 1000.0;
+    
+    Surface_3 surface(function,
+                      Sphere (inner_point, sm_sphere_radius * sm_sphere_radius),
+                      sm_dichotomy_error / sm_sphere_radius);
+
+    CGAL::Surface_mesh_default_criteria_3<STr> criteria (sm_angle,
+                                                         sm_radius * average_spacing,
+                                                         sm_distance * average_spacing);
+
+    STr tr;
+    C2t3 c2t3(tr);
+    
+    CGAL::make_surface_mesh(c2t3,
+                            surface,
+                            criteria,
+                            CGAL::Manifold_with_boundary_tag());
+
+    if(tr.number_of_vertices() == 0)
+      return false;
+
+    CGAL::output_surface_facets_to_polyhedron(c2t3, output_mesh);
+
+    return true;
+  }
+
+
+}
+
+
+#endif // CGAL_POISSON_SURFACE_RECONSTRUCTION_H

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -60,6 +60,9 @@ namespace CGAL {
     \tparam PolygonMesh a model of `MutableFaceGraph` with an internal
     point property map.
 
+    \tparam Tag is a tag whose type affects the behavior of the 
+    meshing algorithm (see `make_surface_mesh()`).
+
     \param begin iterator on the first point of the sequence.
     \param end past the end iterator of the point sequence.
     \param point_map property map: value_type of `InputIterator` -> Point_3.
@@ -72,7 +75,8 @@ namespace CGAL {
   template <typename PointInputIterator,
             typename PointMap,
             typename NormalMap,
-            typename PolygonMesh>
+            typename PolygonMesh,
+            typename Tag = CGAL::Manifold_with_boundary_tag>
   bool
   poisson_surface_reconstruction(PointInputIterator begin,
                                  PointInputIterator end,
@@ -82,7 +86,8 @@ namespace CGAL {
                                  double spacing,
                                  double sm_angle = 20.0,
                                  double sm_radius = 30.0,
-                                 double sm_distance = 0.375)
+                                 double sm_distance = 0.375,
+                                 Tag tag = Tag())
   {
     typedef typename boost::property_traits<PointMap>::value_type Point;
     typedef typename Kernel_traits<Point>::Kernel Kernel;
@@ -118,7 +123,7 @@ namespace CGAL {
     CGAL::make_surface_mesh(c2t3,
                             surface,
                             criteria,
-                            CGAL::Manifold_with_boundary_tag());
+                            tag);
 
     if(tr.number_of_vertices() == 0)
       return false;

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -78,16 +78,16 @@ namespace CGAL {
             typename PolygonMesh,
             typename Tag = CGAL::Manifold_with_boundary_tag>
   bool
-  poisson_surface_reconstruction(PointInputIterator begin,
-                                 PointInputIterator end,
-                                 PointMap point_map,
-                                 NormalMap normal_map,
-                                 PolygonMesh& output_mesh,
-                                 double spacing,
-                                 double sm_angle = 20.0,
-                                 double sm_radius = 30.0,
-                                 double sm_distance = 0.375,
-                                 Tag tag = Tag())
+  poisson_surface_reconstruction_delaunay (PointInputIterator begin,
+                                           PointInputIterator end,
+                                           PointMap point_map,
+                                           NormalMap normal_map,
+                                           PolygonMesh& output_mesh,
+                                           double spacing,
+                                           double sm_angle = 20.0,
+                                           double sm_radius = 30.0,
+                                           double sm_distance = 0.375,
+                                           Tag tag = Tag())
   {
     typedef typename boost::property_traits<PointMap>::value_type Point;
     typedef typename Kernel_traits<Point>::Kernel Kernel;


### PR DESCRIPTION
## Summary of Changes

This adds a syntaxic sugar simple function for the Poisson reconstruction algorithm (which, at the moment, is pretty complicated to use as it lets the user do everything after computing the implicit function). This is a small feature.

## Release Management

* Affected package(s): Poisson Surface Reconstruction
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/1659
* [Small Features/Provide_simple_function_for_Poisson_Reconstruction](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Provide_simple_function_for_Poisson_Reconstruction) (pre-approved by Pierre Alliez, 2017/06/12)

