### PR TITLE
Surface_mesher IO.h: Add missing headers

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/IO.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO.h
@@ -24,6 +24,9 @@
 #include <string>
 #include <cstdio>
 #include <cstring>
+#include <algorithm>
+#include <vector>
+#include <stdexcept>
 
 
 #include <boost/array.hpp>


### PR DESCRIPTION
The new compiler g++-7 has change the C++ headers dependencies. `std::algorithm` is no longer found.

https://cgal.geometryfactory.com/CGAL/testsuite/results-4.11-Ic-35.shtml#Polyhedron_Demo