### PR TITLE
Polyhedron_demo: Point set to mesh distance plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
@@ -294,6 +294,8 @@ private:
       double hausdorff = compute_distances(*poly_B,
                                            sorted_points,
                                            distances);
+      if(hausdorff == 0)
+        hausdorff++;
       //compute the colors
       colors.resize(sorted_points.size()*3);
       for(std::size_t i=0; i<sorted_points.size(); ++i)

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/CMakeLists.txt
@@ -65,3 +65,7 @@ endif()
   qt5_wrap_ui( alpha_shapeUI_FILES Alpha_shape_widget.ui )
   polyhedron_demo_plugin(alpha_shape_plugin Alpha_shape_plugin ${alpha_shapeUI_FILES})
   target_link_libraries(alpha_shape_plugin scene_points_with_normal_item scene_c3t3_item)
+
+  qt5_wrap_ui( distanceUI_FILES Point_set_to_mesh_distance_widget.ui )
+  polyhedron_demo_plugin(point_set_to_mesh_distance_plugin Point_set_to_mesh_distance_plugin ${distanceUI_FILES})
+  target_link_libraries(point_set_to_mesh_distance_plugin scene_points_with_normal_item scene_surface_mesh_item scene_polyhedron_item scene_color_ramp)

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -1,0 +1,290 @@
+#include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include <QApplication>
+#include <QDockWidget>
+#include <QObject>
+#include <QAction>
+#include <QMainWindow>
+#include <Scene_polyhedron_item.h>
+#include <Scene_surface_mesh_item.h>
+#include <Scene_points_with_normal_item.h>
+#include "Messages_interface.h"
+#include "Color_ramp.h"
+
+#include "ui_Point_set_to_mesh_distance_widget.h"
+
+
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/AABB_triangle_primitive.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/Kernel_traits.h>
+#ifdef CGAL_LINKED_WITH_TBB
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include <tbb/atomic.h>
+#endif // CGAL_LINKED_WITH_TBB
+
+#if defined(CGAL_LINKED_WITH_TBB)
+template <class AABB_tree, class Point_3>
+struct Distance_computation{
+  const AABB_tree& tree;
+  const Point_set & point_set;
+  Point_3 initial_hint;
+  tbb::atomic<double>* distance;
+  std::vector<double>& output;
+
+  Distance_computation(const AABB_tree& tree,
+                       const Point_3 p,
+                       const Point_set & point_set,
+                       tbb::atomic<double>* d,
+                       std::vector<double>& out )
+    : tree(tree)
+    , point_set(point_set)
+    , initial_hint(p)
+    , distance(d)
+    , output(out)
+  {
+  }
+  void
+  operator()(const tbb::blocked_range<Point_set::const_iterator>& range) const
+  {
+    Point_3 hint = initial_hint;
+    double hdist = 0;
+    for( Point_set::const_iterator it = range.begin(); it != range.end(); ++it)
+    {
+      hint = tree.closest_point(point_set.point(*it), hint);
+      Kernel::FT dist = squared_distance(hint,point_set.point(*it));
+      double d = CGAL::sqrt(dist);
+      output[std::size_t(*it)] = d;
+      if (d>hdist) hdist=d;
+    }
+
+    if (hdist > distance->load())
+      distance->store(hdist);
+  }
+};
+#endif
+
+
+template< class Mesh>
+double compute_distances(const Mesh& m, const Point_set & point_set,
+                         std::vector<double>& out)
+{
+  typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
+  typedef CGAL::AABB_traits<Kernel, Primitive> Traits;
+  typedef CGAL::AABB_tree< Traits > Tree;
+
+  Tree tree( faces(m).first, faces(m).second, m);
+  tree.accelerate_distance_queries();
+  tree.build();
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type VPMap;
+  VPMap vpmap = get(boost::vertex_point, m);
+  typename Traits::Point_3 hint = get(vpmap, *vertices(m).begin());
+
+#if !defined(CGAL_LINKED_WITH_TBB)
+  double hdist = 0;
+  for(Point_set::const_iterator it = point_set.begin();
+      it != point_set.end(); ++it )
+  {
+    hint = tree.closest_point(point_set.point(*it), hint);
+    Kernel::FT dist = squared_distance(hint,point_set.point(*it));
+    double d = CGAL::sqrt(dist);
+    out[std::size_t(*it)]= d;
+    if (d>hdist) hdist=d;
+  }
+    return hdist;
+#else
+  tbb::atomic<double> distance;
+  distance.store(0);
+  Distance_computation<Tree, typename Traits::Point_3> f(tree, hint, point_set, &distance, out);
+  tbb::parallel_for(tbb::blocked_range<Point_set::const_iterator>(point_set.begin(), point_set.end()), f);
+  return distance;
+#endif
+}
+
+
+using namespace CGAL::Three;
+
+class DistanceWidget:
+    public QDockWidget,
+    public Ui::DistanceWidget
+{
+public:
+  DistanceWidget(QString name, QWidget *parent)
+    :QDockWidget(name,parent)
+  {
+    setupUi(this);
+  }
+};
+
+class Point_set_to_mesh_distance_plugin :
+    public QObject,
+    public Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+public:
+
+  bool applicable(QAction*) const
+  {
+    if(!scene->numberOfEntries() == 2)
+      return false;
+    Scene_polyhedron_item* poly = NULL;
+    Scene_surface_mesh_item* sm = NULL;
+    Scene_points_with_normal_item* pn = NULL;
+    Q_FOREACH(Scene_interface::Item_id i,scene->selectionIndices())
+    {
+      if(!poly)
+        poly = qobject_cast<Scene_polyhedron_item*>(scene->item(i));
+      if(!sm)
+        sm = qobject_cast<Scene_surface_mesh_item*>(scene->item(i));
+      if(!pn)
+        pn = qobject_cast<Scene_points_with_normal_item*>(scene->item(i));
+    }
+    if((!poly && ! sm)|| !pn)
+      return false;
+    else
+      return true;
+  }
+
+  QList<QAction*> actions() const
+  {
+    return _actions;
+  }
+
+  void init(QMainWindow* mainWindow, Scene_interface* sc, Messages_interface* mi)
+  {
+
+    this->messageInterface = mi;
+
+    this->scene = sc;
+    this->mw = mainWindow;
+
+
+    QAction *actionDistance= new QAction(QString("Distance Mesh-Point Set"), mw);
+
+    actionDistance->setProperty("submenuName", "Point_set");
+    connect(actionDistance, SIGNAL(triggered()),
+            this, SLOT(distance()));
+    _actions << actionDistance;
+
+    dock_widget = new DistanceWidget("Compute distance", mw);
+    dock_widget->setVisible(false);
+    addDockWidget(dock_widget);
+    connect(dock_widget->pushButton, SIGNAL(clicked(bool)),
+            this, SLOT(perform()));
+  }
+private Q_SLOTS:
+  void perform()
+  {
+    Scene_polyhedron_item* poly = NULL;
+    Scene_surface_mesh_item* sm = NULL;
+    Scene_points_with_normal_item* pn = NULL;
+    Q_FOREACH(Scene_interface::Item_id i,scene->selectionIndices())
+    {
+      if(!poly)
+        poly = qobject_cast<Scene_polyhedron_item*>(scene->item(i));
+      if(!sm)
+        sm = qobject_cast<Scene_surface_mesh_item*>(scene->item(i));
+      if(!pn)
+        pn = qobject_cast<Scene_points_with_normal_item*>(scene->item(i));
+    }
+    if((!poly && ! sm)|| !pn)
+      return ;
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    Color_ramp thermal_ramp;
+    thermal_ramp.build_thermal();
+    Fcolor_map fred_map;
+    Fcolor_map fgreen_map;
+    Fcolor_map fblue_map;
+    Color_map red_map;
+    Color_map green_map;
+    Color_map blue_map;
+
+    bool r, g, b;
+     if(!pn->point_set()->check_colors())
+     {
+       //bind color pmaps
+       boost::tie(fred_map  , r) = pn->point_set()->add_property_map<double>("red",0);
+       boost::tie(fgreen_map, g)  = pn->point_set()->add_property_map<double>("green",0);
+       boost::tie(fblue_map , b)  = pn->point_set()->add_property_map<double>("blue",0);
+       //bind the new color maps to the right internal members so has_colors() return true in the item.
+       pn->point_set()->check_colors();
+     }
+     else
+     {
+       boost::tie(fred_map  , r) =  pn->point_set()->property_map<double>("red");
+       boost::tie(fgreen_map, g) =  pn->point_set()->property_map<double>("green");
+       boost::tie(fblue_map , b) =  pn->point_set()->property_map<double>("blue");
+       if(!r)
+         red_map = pn->point_set()->property_map<unsigned char>("red").first;
+       if(!g)
+         green_map = pn->point_set()->property_map<unsigned char>("green").first;
+       if(!b)
+         blue_map = pn->point_set()->property_map<unsigned char>("blue").first;
+     }
+    Point_set* points = pn->point_set();
+    points->collect_garbage();
+    std::vector<double> distances(points->size());
+    double hdist;
+    if(poly)
+      hdist = compute_distances(*poly->face_graph(), *points, distances);
+    else
+      hdist = compute_distances(*sm->face_graph(), *points, distances);
+    if(hdist == 0)
+      hdist++;
+
+    int id=0;
+    for (Point_set::const_iterator it = pn->point_set()->begin();
+         it != pn->point_set()->end(); ++ it)
+    {
+      double d = distances[id]/hdist;
+      //if r/g/b is false, it means the associated color map uses unsigned chars instead of doubles.
+      if(r)
+      fred_map[*it] = thermal_ramp.r(d) ;
+      else
+        red_map[*it]=static_cast<unsigned char>(thermal_ramp.r(d) * 255);
+      if(g)
+        fgreen_map[*it] =  thermal_ramp.g(d);
+      else
+        green_map[*it] = static_cast<unsigned char>(thermal_ramp.g(d) * 255);
+      if(b)
+        fblue_map[*it] = thermal_ramp.b(d);
+      else
+        blue_map[*it] = static_cast<unsigned char>(thermal_ramp.b(d) * 255);
+      ++id;
+    }
+
+    dock_widget->minLabel->setText(QString("Minimum Distance: %1").arg(0));
+    dock_widget->maxLabel->setText(QString("Maximum Distance: %1").arg(0));
+    dock_widget->fDecileLabel->setText(QString("First Decile: %1").arg(0));
+    dock_widget->lDecildeLabel->setText(QString("Last Decile: %1").arg(0));
+    dock_widget->medianLabel->setText(QString("Median Distance: %1").arg(0));
+    pn->invalidateOpenGLBuffers();
+    pn->itemChanged();
+    QApplication::restoreOverrideCursor();
+  }
+  void distance()
+  {
+    if(!dock_widget->isVisible())
+    {
+      dock_widget->show();
+    }
+    perform();
+  }
+  void closure()
+  {
+    dock_widget->hide();
+  }
+private:
+  QList<QAction*> _actions;
+  Messages_interface* messageInterface;
+  DistanceWidget* dock_widget;
+  typedef Point_set::Property_map<double> Fcolor_map;
+  typedef Point_set::Property_map<unsigned char> Color_map;
+
+};
+
+#include "Point_set_to_mesh_distance_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -201,32 +201,15 @@ private Q_SLOTS:
     Fcolor_map fred_map;
     Fcolor_map fgreen_map;
     Fcolor_map fblue_map;
-    Color_map red_map;
-    Color_map green_map;
-    Color_map blue_map;
 
     bool r, g, b;
-     if(!new_item->point_set()->check_colors())
-     {
-       //bind color pmaps
-       boost::tie(fred_map  , r) = new_item->point_set()->add_property_map<double>("red",0);
-       boost::tie(fgreen_map, g)  = new_item->point_set()->add_property_map<double>("green",0);
-       boost::tie(fblue_map , b)  = new_item->point_set()->add_property_map<double>("blue",0);
-       //bind the new color maps to the right internal members so has_colors() return true in the item.
-       new_item->point_set()->check_colors();
-     }
-     else
-     {
-       boost::tie(fred_map  , r) =  new_item->point_set()->property_map<double>("red");
-       boost::tie(fgreen_map, g) =  new_item->point_set()->property_map<double>("green");
-       boost::tie(fblue_map , b) =  new_item->point_set()->property_map<double>("blue");
-       if(!r)
-         red_map = new_item->point_set()->property_map<unsigned char>("red").first;
-       if(!g)
-         green_map = new_item->point_set()->property_map<unsigned char>("green").first;
-       if(!b)
-         blue_map = new_item->point_set()->property_map<unsigned char>("blue").first;
-     }
+    new_item->point_set()->remove_colors();
+    //bind color pmaps
+    boost::tie(fred_map  , r) = new_item->point_set()->add_property_map<double>("red",0);
+    boost::tie(fgreen_map, g)  = new_item->point_set()->add_property_map<double>("green",0);
+    boost::tie(fblue_map , b)  = new_item->point_set()->add_property_map<double>("blue",0);
+    new_item->point_set()->check_colors();
+
     Point_set* points = new_item->point_set();
     points->collect_garbage();
     std::vector<double> distances(points->size());
@@ -237,30 +220,17 @@ private Q_SLOTS:
       hdist = compute_distances(*sm->face_graph(), *points, distances);
     if(hdist == 0)
       hdist++;
-
-    int id=0;
-
+    int id = 0;
     for (Point_set::const_iterator it = new_item->point_set()->begin();
          it != new_item->point_set()->end(); ++ it)
     {
       double d = distances[id]/hdist;
-      //if r/g/b is false, it means the associated color map uses unsigned chars instead of doubles.
-      if(r)
       fred_map[*it] = thermal_ramp.r(d) ;
-      else
-        red_map[*it]=static_cast<unsigned char>(thermal_ramp.r(d) * 255);
-      if(g)
-        fgreen_map[*it] =  thermal_ramp.g(d);
-      else
-        green_map[*it] = static_cast<unsigned char>(thermal_ramp.g(d) * 255);
-      if(b)
-        fblue_map[*it] = thermal_ramp.b(d);
-      else
-        blue_map[*it] = static_cast<unsigned char>(thermal_ramp.b(d) * 255);
+      fgreen_map[*it] =  thermal_ramp.g(d);
+      fblue_map[*it] = thermal_ramp.b(d);
       ++id;
     }
     std::sort(distances.begin(), distances.end());
-
     dock_widget->minLabel->setText(QString("%1").arg(distances.front()));
     dock_widget->maxLabel->setText(QString("%1").arg(distances.back()));
     dock_widget->fDecileLabel->setText(QString("%1").arg(distances[distances.size()/10]));
@@ -271,6 +241,7 @@ private Q_SLOTS:
     pn->setVisible(false);
     new_item->setName(tr("%1 (distance)").arg(pn->name()));
     scene->addItem(new_item);
+
     QApplication::restoreOverrideCursor();
   }
   void distance()
@@ -290,7 +261,6 @@ private:
   Messages_interface* messageInterface;
   DistanceWidget* dock_widget;
   typedef Point_set::Property_map<double> Fcolor_map;
-  typedef Point_set::Property_map<unsigned char> Color_map;
 
 };
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -68,7 +68,8 @@ struct Distance_computation{
 
 
 template< class Mesh>
-double compute_distances(const Mesh& m, const Point_set & point_set,
+double compute_distances(const Mesh& m,
+                         const Point_set & point_set,
                          std::vector<double>& out)
 {
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
@@ -237,6 +238,7 @@ private Q_SLOTS:
       hdist++;
 
     int id=0;
+
     for (Point_set::const_iterator it = pn->point_set()->begin();
          it != pn->point_set()->end(); ++ it)
     {
@@ -256,12 +258,13 @@ private Q_SLOTS:
         blue_map[*it] = static_cast<unsigned char>(thermal_ramp.b(d) * 255);
       ++id;
     }
+    std::sort(distances.begin(), distances.end());
 
-    dock_widget->minLabel->setText(QString("Minimum Distance: %1").arg(0));
-    dock_widget->maxLabel->setText(QString("Maximum Distance: %1").arg(0));
-    dock_widget->fDecileLabel->setText(QString("First Decile: %1").arg(0));
-    dock_widget->lDecildeLabel->setText(QString("Last Decile: %1").arg(0));
-    dock_widget->medianLabel->setText(QString("Median Distance: %1").arg(0));
+    dock_widget->minLabel->setText(QString("%1").arg(distances.front()));
+    dock_widget->maxLabel->setText(QString("%1").arg(distances.back()));
+    dock_widget->fDecileLabel->setText(QString("%1").arg(distances[distances.size()/10]));
+    dock_widget->lDecildeLabel->setText(QString("%1").arg(distances[9*distances.size()/10]));
+    dock_widget->medianLabel->setText(QString("%1").arg(distances[distances.size()/2]));
     pn->invalidateOpenGLBuffers();
     pn->itemChanged();
     QApplication::restoreOverrideCursor();

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -130,7 +130,7 @@ public:
 
   bool applicable(QAction*) const
   {
-    if(scene->numberOfEntries() != 2)
+    if(scene->selectionIndices().size() != 2)
       return false;
     Scene_polyhedron_item* poly = NULL;
     Scene_surface_mesh_item* sm = NULL;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -18,38 +18,112 @@
     <item>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QLabel" name="minLabel">
-        <property name="text">
-         <string>min</string>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>Statistics</string>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="maxLabel">
-        <property name="text">
-         <string>max</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="fDecileLabel">
-        <property name="text">
-         <string>first decile</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="lDecildeLabel">
-        <property name="text">
-         <string>last decile</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="medianLabel">
-        <property name="text">
-         <string>median</string>
-        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="4" column="1">
+          <widget class="QLabel" name="medianLabel">
+           <property name="text">
+            <string>median</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="lDecildeLabel">
+           <property name="text">
+            <string>last decile</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="minLabel">
+           <property name="text">
+            <string>min</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="fDecileLabel">
+           <property name="text">
+            <string>first decile</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="maxLabel">
+           <property name="text">
+            <string>max</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Minimum Distance:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Maximum Distance:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>First Decile:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Last Decile:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Median Distance:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+        <zorder>medianLabel</zorder>
+        <zorder>minLabel</zorder>
+        <zorder>fDecileLabel</zorder>
+        <zorder>maxLabel</zorder>
+        <zorder>lDecildeLabel</zorder>
+        <zorder>medianLabel</zorder>
+        <zorder>minLabel</zorder>
+        <zorder>fDecileLabel</zorder>
+        <zorder>maxLabel</zorder>
+        <zorder>lDecildeLabel</zorder>
+        <zorder>label</zorder>
+        <zorder>label_2</zorder>
+        <zorder>label_3</zorder>
+        <zorder>label_4</zorder>
+        <zorder>label_5</zorder>
        </widget>
       </item>
       <item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -23,38 +23,17 @@
          <string>Statistics</string>
         </property>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="4" column="1">
-          <widget class="QLabel" name="medianLabel">
-           <property name="text">
-            <string>median</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLabel" name="lDecildeLabel">
-           <property name="text">
-            <string>last decile</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="minLabel">
-           <property name="text">
-            <string>min</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLabel" name="fDecileLabel">
-           <property name="text">
-            <string>first decile</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
+         <item row="6" column="1">
           <widget class="QLabel" name="maxLabel">
            <property name="text">
             <string>max</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="lDecildeLabel">
+           <property name="text">
+            <string>last decile</string>
            </property>
           </widget>
          </item>
@@ -68,7 +47,31 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Last Decile:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="fDecileLabel">
+           <property name="text">
+            <string>first decile</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="minLabel">
+           <property name="text">
+            <string>min</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
           <widget class="QLabel" name="label_2">
            <property name="text">
             <string>Maximum Distance:</string>
@@ -89,16 +92,6 @@
           </widget>
          </item>
          <item row="3" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Last Decile:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>Median Distance:</string>
@@ -108,22 +101,24 @@
            </property>
           </widget>
          </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="medianLabel">
+           <property name="text">
+            <string>median</string>
+           </property>
+          </widget>
+         </item>
         </layout>
-        <zorder>medianLabel</zorder>
         <zorder>minLabel</zorder>
         <zorder>fDecileLabel</zorder>
-        <zorder>maxLabel</zorder>
-        <zorder>lDecildeLabel</zorder>
-        <zorder>medianLabel</zorder>
-        <zorder>minLabel</zorder>
-        <zorder>fDecileLabel</zorder>
-        <zorder>maxLabel</zorder>
         <zorder>lDecildeLabel</zorder>
         <zorder>label</zorder>
-        <zorder>label_2</zorder>
         <zorder>label_3</zorder>
         <zorder>label_4</zorder>
+        <zorder>label_2</zorder>
+        <zorder>maxLabel</zorder>
         <zorder>label_5</zorder>
+        <zorder>medianLabel</zorder>
        </widget>
       </item>
       <item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DistanceWidget</class>
+ <widget class="QDockWidget" name="DistanceWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Distance Between Point Set and Mesh</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout_2">
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="minLabel">
+        <property name="text">
+         <string>min</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="maxLabel">
+        <property name="text">
+         <string>max</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="fDecileLabel">
+        <property name="text">
+         <string>first decile</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lDecildeLabel">
+        <property name="text">
+         <string>last decile</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="medianLabel">
+        <property name="text">
+         <string>median</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton">
+          <property name="text">
+           <string>Compute Distance</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>316</width>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,21 +23,21 @@
          <string>Statistics</string>
         </property>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="6" column="1">
+         <item row="7" column="1">
           <widget class="QLabel" name="maxLabel">
            <property name="text">
             <string>max</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QLabel" name="lDecildeLabel">
            <property name="text">
             <string>last decile</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
             <string>Minimum Distance:</string>
@@ -47,7 +47,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>Last Decile:</string>
@@ -57,21 +57,21 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QLabel" name="fDecileLabel">
            <property name="text">
             <string>first decile</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="1" column="1">
           <widget class="QLabel" name="minLabel">
            <property name="text">
             <string>min</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="label_2">
            <property name="text">
             <string>Maximum Distance:</string>
@@ -81,7 +81,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="label_3">
            <property name="text">
             <string>First Decile:</string>
@@ -91,7 +91,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>Median Distance:</string>
@@ -101,10 +101,20 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QLabel" name="medianLabel">
            <property name="text">
             <string>median</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QPushButton" name="pushButton">
+           <property name="toolTip">
+            <string>Creates a new colored point set. The further a point is from the mesh, the darker it is displayed.</string>
+           </property>
+           <property name="text">
+            <string>Compute Distance</string>
            </property>
           </widget>
          </item>
@@ -119,6 +129,47 @@
         <zorder>maxLabel</zorder>
         <zorder>label_5</zorder>
         <zorder>medianLabel</zorder>
+        <zorder>pushButton</zorder>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>Selection</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
+           <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="distance_spinbox">
+             <property name="toolTip">
+              <string>Points further than this distance will be selected.</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QPushButton" name="select_button">
+             <property name="toolTip">
+              <string>Selects the points that are further than the threshold.</string>
+             </property>
+             <property name="text">
+              <string>Select </string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Threshold:</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -133,30 +184,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton">
-          <property name="text">
-           <string>Compute Distance</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </item>

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -955,3 +955,13 @@ zoomToPosition(const QPoint &, CGAL::Three::Viewer_interface *viewer) const
                                                                  .arg(new_orientation[3]));
 
 }
+
+void Scene_points_with_normal_item::setPointSize(int size)
+{
+  d->point_Slider->setValue(size);
+}
+
+void Scene_points_with_normal_item::setNormalSize(int size)
+{
+  d->normal_Slider->setValue(size);
+}

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -95,6 +95,8 @@ public Q_SLOTS:
   //Set the status of the slider as `released`
   void pointSliderReleased();
   void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
+  void setPointSize(int size);
+  void setNormalSize(int size);
 
 // Data
 protected:

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -207,6 +207,22 @@ public:
     return (m_blue != Byte_map());
   }
     
+  void remove_colors()
+  {
+    if (m_blue != Byte_map())
+      {
+        this->template remove_property_map<unsigned char>(m_red);
+        this->template remove_property_map<unsigned char>(m_green);
+        this->template remove_property_map<unsigned char>(m_blue);
+      }
+    if (m_fblue != Double_map())
+      {
+        this->template remove_property_map<double>(m_fred);
+        this->template remove_property_map<double>(m_fgreen);
+        this->template remove_property_map<double>(m_fblue);
+      }
+  }
+  
   double red (const Index& index) const
   { return (m_red == Byte_map()) ? m_fred[index]  : double(m_red[index]) / 255.; }
   double green (const Index& index) const


### PR DESCRIPTION
## Summary of Changes

This is a plugin that allows to colorize a point set according to the distance of each point to a selected mesh (polyhedron or surface_mesh.
## Release Management

* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #2163

