### PR TITLE
CTest support: now CTest will build targets before the tests

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -84,6 +84,12 @@ function(cgal_add_test exe_name)
   #      message(STATUS "  working dir: ${CGAL_CURRENT_SOURCE_DIR}")
   set_property(TEST "${exe_name}"
     PROPERTY WORKING_DIRECTORY ${CGAL_CURRENT_SOURCE_DIR})
+  add_test(NAME "build_target_${exe_name}"
+    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "${exe_name}")
+  set_property(TEST "build_target_${exe_name}"
+    APPEND PROPERTY LABELS "${PROJECT_NAME}")
+  set_property(TEST "${exe_name}"
+    APPEND PROPERTY DEPENDS "build_target_${exe_name}")
 
   return()
 


### PR DESCRIPTION
Improve the CTest support. For each target, there is a new test that builds the target. The real runtime test depends on it.
