### PR TITLE
Polyhedron_demo: Fixes for the override cursor.

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1459,6 +1459,7 @@ void MainWindow::on_actionLoad_triggered()
   dialog.setFileMode(QFileDialog::ExistingFiles);
 
   if(dialog.exec() != QDialog::Accepted) { return; }
+  viewer->update();
   FilterPluginMap::iterator it = 
     filterPluginMap.find(dialog.selectedNameFilter());
   
@@ -1541,6 +1542,8 @@ void MainWindow::on_actionSaveAs_triggered()
                                  filters.join(";;"));
   if(filename.isEmpty())
     return;
+
+  viewer->update();
   save(filename, item);
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -116,6 +116,7 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
   if(fileinfo.size() > 100000000)//100 MB
   {
     item->set_flat_disabled(true);
+    QApplication::restoreOverrideCursor();
     QMessageBox::warning((QWidget*)NULL,
                    tr("The file seems to be very big."),
                    tr("Flat shading has been disabled to gain memory. You can force it in the context menu of the item."));

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Self_intersection_plugin.cpp
@@ -183,10 +183,10 @@ void Polyhedron_demo_self_intersection_plugin::on_actionSelfIntersection_trigger
       found = true;
     }
   }
+  QApplication::restoreOverrideCursor();
   if(!found)
     QMessageBox::information(mw, tr("No self intersection"),
                              tr("None of the selected surfaces self-intersect."));
-  QApplication::restoreOverrideCursor();
 }
 
 #include "Self_intersection_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -959,8 +959,10 @@ Scene_polyhedron_item::load_obj(std::istream& in)
 bool
 Scene_polyhedron_item::save(std::ostream& out) const
 {
+  QApplication::setOverrideCursor(Qt::WaitCursor);
   out.precision(17);
     out << *(d->poly);
+    QApplication::restoreOverrideCursor();
     return (bool) out;
 }
 


### PR DESCRIPTION
## Summary of Changes
- Removes the save/load dialog displayed after validation of the path so it doesn't mess with the cursor.
- Restores the cursor before the `No self intersection` dialog appears
## Release Management

* Affected package(s):Polyhedron_demo

