### PR TITLE
Polyhedron_demo: Clipping box plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
@@ -9,6 +9,10 @@ target_link_libraries(affine_transform_plugin  scene_surface_mesh_item scene_pol
 polyhedron_demo_plugin(edit_box_plugin Edit_box_plugin)
 target_link_libraries(edit_box_plugin  scene_edit_box_item   scene_surface_mesh_item scene_polyhedron_item)
 
+qt5_wrap_ui( clipUI_FILES Clipping_box_widget.ui )
+polyhedron_demo_plugin(clipping_box_plugin Clipping_box_plugin ${clipUI_FILES})
+target_link_libraries(clipping_box_plugin  scene_edit_box_item )
+
 polyhedron_demo_plugin(create_bbox_mesh_plugin Create_bbox_mesh_plugin)
 target_link_libraries(create_bbox_mesh_plugin scene_surface_mesh_item scene_polyhedron_item)
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -1,0 +1,161 @@
+#include <QtCore/qglobal.h>
+
+#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_interface.h>
+#include "Scene_edit_box_item.h"
+#include <CGAL/Three/Viewer_interface.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include <QAction>
+#include <QMainWindow>
+#include <QApplication>
+#include "ui_Clipping_box_widget.h"
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+
+class ClipWidget :
+    public QDockWidget,
+    public Ui::DockWidget
+{
+public:
+  ClipWidget(QString name, QWidget *parent)
+    :QDockWidget(name,parent)
+  {
+   setupUi(this);
+  }
+};
+
+using namespace CGAL::Three;
+class Clipping_box_plugin :
+    public QObject,
+    public Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+
+public:
+  void init(QMainWindow* mainWindow, CGAL::Three::Scene_interface* scene_interface, Messages_interface*);
+  QList<QAction*> actions() const {
+    return QList<QAction*>() << actionClipbox;
+  }
+
+  bool applicable(QAction*) const {
+    return scene->numberOfEntries() > 0;
+    }
+  void closure()
+   {
+     dock_widget->hide();
+   }
+public Q_SLOTS:
+  void enableAction();
+  void clipbox();
+  void clip(bool);
+private:
+  QAction* actionClipbox;
+  ClipWidget* dock_widget;
+  Scene_edit_box_item* item;
+}; // end Clipping_box_plugin
+
+void Clipping_box_plugin::init(QMainWindow* mainWindow, CGAL::Three::Scene_interface* scene_interface, Messages_interface*)
+{
+  scene = scene_interface;
+  mw = mainWindow;
+  actionClipbox = new QAction(tr("Create Clipping Box"), mainWindow);
+  connect(actionClipbox, SIGNAL(triggered()),
+          this, SLOT(clipbox()));
+
+  dock_widget = new ClipWidget("Clip box", mw);
+  dock_widget->setVisible(false); // do not show at the beginning
+  addDockWidget(dock_widget);
+  connect(dock_widget->pushButton, SIGNAL(toggled(bool)),
+          this, SLOT(clip(bool)));
+  item = NULL;
+}
+
+void Clipping_box_plugin::clipbox()
+{
+  for(int i = 0, end = scene->numberOfEntries();
+      i < end; ++i)
+  {
+    if(qobject_cast<Scene_edit_box_item*>(scene->item(i)))
+      return;
+  }
+  QApplication::setOverrideCursor(Qt::WaitCursor);
+dock_widget->show();
+  if(!item)
+    item = new Scene_edit_box_item(scene);
+  connect(item, SIGNAL(destroyed()),
+          this, SLOT(enableAction()));
+  item->setName("Clipping box");
+  item->setRenderingMode(FlatPlusEdges);
+  QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+  viewer->installEventFilter(item);
+  scene->addItem(item);
+  actionClipbox->setEnabled(false);
+
+  QApplication::restoreOverrideCursor();
+}
+
+void Clipping_box_plugin::enableAction() {
+  item = NULL;
+  actionClipbox->setEnabled(true);
+}
+
+void Clipping_box_plugin::clip(bool b)
+{
+  typedef CGAL::Epick Kernel;
+  typedef CGAL::Polyhedron_3<Kernel> Mesh;
+  Viewer_interface* viewer = static_cast<Viewer_interface*>(*QGLViewer::QGLViewerPool().begin());
+  if(b)
+  {
+    if(!item)
+    {
+      dock_widget->hide();
+      return;
+    }
+    const qglviewer::Vec v_offset = viewer->offset();
+    Kernel::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
+    Mesh m;
+    Kernel::Point_3 points[8];
+    for(int i=0; i<8; ++i)
+    {
+      points[i] = Kernel::Point_3(item->point(i,0),item->point(i,1), item->point(i,2))-offset;
+    }
+    CGAL::make_hexahedron(
+          points[0],
+        points[3],
+        points[2],
+        points[1],
+        points[5],
+        points[4],
+        points[7],
+        points[6],
+        m);
+    QVector4D planes[6];
+    int fid=0;
+    BOOST_FOREACH(Mesh::Facet_iterator f, faces(m))
+    {
+      Kernel::Vector_3 normal = CGAL::Polygon_mesh_processing::compute_face_normal(f,m);
+      double norm = normal.squared_length()*normal.squared_length();
+      Kernel::Plane_3 plane(f->halfedge()->vertex()->point(), 1.1*normal/norm);
+      planes[fid++] = QVector4D(plane.a(),
+                                plane.b(),
+                                plane.c(),
+                                plane.d());
+    }
+    viewer->enableClippingBox(planes);
+  }
+  else
+  {
+    viewer->disableClippingBox();
+    if(!item)
+    {
+      dock_widget->hide();
+    }
+  }
+  viewer->update();
+}
+
+#include "Clipping_box_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -115,13 +115,11 @@ void Clipping_box_plugin::clip(bool b)
       dock_widget->hide();
       return;
     }
-    const qglviewer::Vec v_offset = viewer->offset();
-    Kernel::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
     Mesh m;
     Kernel::Point_3 points[8];
     for(int i=0; i<8; ++i)
     {
-      points[i] = Kernel::Point_3(item->point(i,0),item->point(i,1), item->point(i,2))-offset;
+      points[i] = Kernel::Point_3(item->point(i,0),item->point(i,1), item->point(i,2));
     }
     CGAL::make_hexahedron(
           points[0],

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DockWidget</class>
+ <widget class="QDockWidget" name="DockWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>219</width>
+    <height>62</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Clipping Box</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0">
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton">
+      <property name="text">
+       <string>Clip</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -377,6 +377,7 @@ void Scene_edit_box_item::drawSpheres(Viewer_interface *viewer, const QMatrix4x4
   d->program->setUniformValue("mvp_matrix", mvp_mat);
   d->program->setUniformValue("mv_matrix", mv_mat);
   d->program->setUniformValue("light_pos", light_pos);
+  d->program->setUniformValue("is_clipbox_on", false);
   d->program->setAttributeValue("radius",radius);
   d->program->setAttributeValue("colors", QColor(Qt::red));
   viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
@@ -428,6 +429,7 @@ void Scene_edit_box_item::draw(Viewer_interface *viewer) const
   d->program->setUniformValue("light_spec", specular);
   d->program->setUniformValue("light_amb", ambient);
   d->program->setUniformValue("spec_power", 51.8f);
+  d->program->setUniformValue("is_clipbox_on", false);
   d->program->setAttributeValue("colors", QColor(128,128,128,128));
   viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(d->vertex_faces.size()/3));
   vaos[Scene_edit_box_item_priv::Faces]->release();
@@ -453,6 +455,7 @@ void Scene_edit_box_item::drawEdges(Viewer_interface* viewer) const
   attribBuffers(viewer, PROGRAM_WITHOUT_LIGHT);
   d->program->bind();
   d->program->setUniformValue("f_matrix", f_matrix);
+  d->program->setUniformValue("is_clipbox_on", false);
   d->program->setAttributeValue("colors", QColor(Qt::black));
   viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(d->vertex_edges.size()/3));
   viewer->glLineWidth(1.0f);
@@ -1179,6 +1182,7 @@ void Scene_edit_box_item_priv::draw_picking(Viewer_interface* viewer)
     item->attribBuffers(viewer, Scene_item::PROGRAM_WITHOUT_LIGHT);
     program->bind();
     program->setUniformValue("mvp_matrix", mvp_mat);
+    program->setUniformValue("is_clipbox_on", false);
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(vertex_faces.size()/3));
     item->vaos[P_Faces]->release();
     program->release();
@@ -1186,6 +1190,7 @@ void Scene_edit_box_item_priv::draw_picking(Viewer_interface* viewer)
   item->vaos[P_Spheres]->bind();
   pick_sphere_program.bind();
   pick_sphere_program.setUniformValue("mvp_matrix", mvp_mat);
+  program->setUniformValue("is_clipbox_on", false);
   viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                 static_cast<GLsizei>(vertex_spheres.size()/3),
                                 static_cast<GLsizei>(8));
@@ -1198,6 +1203,7 @@ void Scene_edit_box_item_priv::draw_picking(Viewer_interface* viewer)
   item->attribBuffers(viewer, Scene_item::PROGRAM_WITHOUT_LIGHT);
   program->bind();
   program->setUniformValue("f_matrix", f_matrix);
+  program->setUniformValue("is_clipbox_on", false);
   viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(vertex_edges.size()/3));
   viewer->glLineWidth(1.0f);
   item->vaos[P_Edges]->release();
@@ -1397,6 +1403,7 @@ void Scene_edit_box_item::drawHl(Viewer_interface* viewer)const
         (point(6,1) - point(0,1)) * (point(6,1) - point(0,1)) +
         (point(6,2) - point(0,2)) * (point(6,2) - point(0,2))) *0.02 ;
     d->program->setAttributeValue("radius", radius);
+    d->program->setUniformValue("is_clipbox_on", false);
     viewer->glDrawArraysInstanced(GL_TRIANGLES, 0,
                                   static_cast<GLsizei>(d->vertex_spheres.size()/3),
                                   static_cast<GLsizei>(d->hl_vertex.size()/3));
@@ -1413,6 +1420,7 @@ void Scene_edit_box_item::drawHl(Viewer_interface* viewer)const
     d->program->bind();
     d->program->setUniformValue("f_matrix", f_matrix);
     d->program->setAttributeValue("colors", QColor(Qt::yellow));
+    d->program->setUniformValue("is_clipbox_on", false);
     viewer->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(d->hl_vertex.size()/3));
     viewer->glLineWidth(1.0f);
     vaos[Scene_edit_box_item_priv::S_Edges]->release();
@@ -1434,6 +1442,7 @@ void Scene_edit_box_item::drawHl(Viewer_interface* viewer)const
     d->program->setUniformValue("light_spec", specular);
     d->program->setUniformValue("light_amb", ambient);
     d->program->setUniformValue("spec_power", 51.8f);
+    d->program->setUniformValue("is_clipbox_on", false);
     d->program->setAttributeValue("colors", QColor(128,128,0,128));
     viewer->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(d->hl_vertex.size()/3));
     vaos[Scene_edit_box_item_priv::S_Faces]->release();

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
@@ -40,8 +40,15 @@ class SCENE_EDIT_BOX_ITEM_EXPORT Scene_edit_box_item: public CGAL::Three::Scene_
       compute_bbox();
       are_buffers_filled = false;
     }
-    double point(short i, short j) const;
+    //      5-----6
+    //  .   |  .  |
+    // 4------7   |
+    // |    | |   |
+    // |    1-|---2
+    // | .    |.
+    // 0------3
 
+    double point(short i, short j) const;
 public Q_SLOTS:
     void highlight();
     void clearHL();

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
@@ -2,18 +2,24 @@
 #define SCENE_EDIT_BOX_ITEM_H
 
 #include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_transparent_interface.h>
 #include <CGAL/Simple_cartesian.h>
 #include "create_sphere.h"
 #include "Scene_edit_box_item_config.h"
 struct Scene_edit_box_item_priv;
-class SCENE_EDIT_BOX_ITEM_EXPORT Scene_edit_box_item: public CGAL::Three::Scene_item
+class SCENE_EDIT_BOX_ITEM_EXPORT Scene_edit_box_item:
+    public CGAL::Three::Scene_item,
+    public CGAL::Three::Scene_transparent_interface
 {
     Q_OBJECT
+    Q_INTERFACES(CGAL::Three::Scene_transparent_interface)
+    Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.TransparentInterface/1.0")
   public:
     typedef CGAL::Simple_cartesian<double>  Kernel;
     struct vertex;
     struct edge;
     struct face;
+    Scene_edit_box_item();
     Scene_edit_box_item(const CGAL::Three::Scene_interface* scene_interface);
     ~Scene_edit_box_item();
     bool isFinite() const { return true; }
@@ -32,6 +38,7 @@ class SCENE_EDIT_BOX_ITEM_EXPORT Scene_edit_box_item: public CGAL::Three::Scene_
     // Indicate if rendering mode is supported
     bool supportsRenderingMode(RenderingMode m) const;
     void draw(CGAL::Three::Viewer_interface *) const;
+    void drawTransparent(CGAL::Three::Viewer_interface*)const;
     void drawHl(CGAL::Three::Viewer_interface *) const;
     void drawEdges(CGAL::Three::Viewer_interface* viewer) const;
     void drawSpheres(CGAL::Three::Viewer_interface* viewer, const QMatrix4x4 f_matrix) const;

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -6,7 +6,7 @@
 #include "Scene.h"
 
 #include <CGAL/Three/Scene_item.h>
-#include <CGAL/Three/Scene_print_interface_item.h>
+#include <CGAL/Three/Scene_print_item_interface.h>
 #include <CGAL/Three/Scene_transparent_interface.h>
 #include <CGAL/Three/Scene_zoomable_item_interface.h>
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -30,6 +30,8 @@ public:
   bool macro_mode;
   bool inFastDrawing;
   bool inDrawWithNames;
+  bool clipping;
+  QVector4D clipbox[6];
   QPainter *painter;
   // F P S    d i s p l a y
   QTime fpsTime;
@@ -113,6 +115,7 @@ Viewer::Viewer(QWidget* parent, bool antialiasing)
   d->macro_mode = false;
   d->inFastDrawing = true;
   d->inDrawWithNames = false;
+  d->clipping = false;
   d->shader_programs.resize(NB_OF_PROGRAMS);
   d->offset = qglviewer::Vec(0,0,0);
   d->textRenderer = new TextRenderer();
@@ -517,6 +520,12 @@ void Viewer::keyPressEvent(QKeyEvent* e)
         update();
         return;
     }
+    else if(e->key() == Qt::Key_C) {
+      QVector4D box[6];
+      for(int i=0; i<6; ++i)
+        box[i] = QVector4D(1,0,0,0);
+          enableClippingBox(box);
+        }
   }
   else if(e->key() == Qt::Key_I && e->modifiers() & Qt::ControlModifier){
     d->scene->printAllIds(this);
@@ -727,6 +736,19 @@ void Viewer::attribBuffers(int program_name) const {
     QOpenGLShaderProgram* program = getShaderProgram(program_name);
     program->bind();
     program->setUniformValue("mvp_matrix", mvp_mat);
+    program->setUniformValue("is_clipbox_on", d->clipping);
+    if(d->clipping)
+    {
+      QMatrix4x4 clipbox1;
+      QMatrix4x4 clipbox2;
+      for(int i=0;i<12;++i)
+      {
+        clipbox1.data()[i]=d->clipbox[i/4][i%4];
+        clipbox2.data()[i]=d->clipbox[(i+12)/4][(i+12)%4];
+      }
+      program->setUniformValue("clipbox1", clipbox1);
+      program->setUniformValue("clipbox2", clipbox2);
+    }
     switch(program_name)
     {
     case PROGRAM_WITH_LIGHT:
@@ -1596,5 +1618,19 @@ TextRenderer* Viewer::textRenderer()
 bool Viewer::isExtensionFound()
 {
   return d->extension_is_found;
+
 }
+
+void Viewer::disableClippingBox()
+{
+  d->clipping = false;
+}
+
+void Viewer::enableClippingBox(QVector4D box[6])
+{
+  d->clipping = true;
+  for(int i=0; i<6; ++i)
+    d->clipbox[i] = box[i];
+}
+
  #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -82,6 +82,8 @@ public:
   void setSceneBoundingBox(const qglviewer::Vec &min, const qglviewer::Vec &max);
 
   TextRenderer* textRenderer() Q_DECL_OVERRIDE;
+  void enableClippingBox(QVector4D box[]) Q_DECL_OVERRIDE;
+  void disableClippingBox() Q_DECL_OVERRIDE;
 
 Q_SIGNALS:
   void sendMessage(QString);

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.f
@@ -1,6 +1,7 @@
 #version 120
 varying highp vec4 color;
 varying highp vec4 fP;
+varying highp float dist[6];
 uniform highp vec4 light_pos;
 uniform highp vec4 light_diff;
 uniform highp vec4 light_spec;
@@ -8,7 +9,18 @@ uniform highp vec4 light_amb;
 uniform highp float spec_power ;
 uniform int is_two_side;
 uniform bool is_selected;
+uniform bool is_clipbox_on;
 void main(void) {
+
+if(is_clipbox_on)
+  if(dist[0]>0 ||
+     dist[1]>0 ||
+     dist[2]>0 ||
+     dist[3]>0 ||
+     dist[4]>0 ||
+     dist[5]>0)
+    discard;
+
    highp vec3 L = light_pos.xyz - fP.xyz;
    highp vec3 V = -fP.xyz;
    highp vec3 N;

--- a/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_no_light_no_selection.f
@@ -1,6 +1,16 @@
 #version 120
 varying highp vec4 color;
+varying highp float dist[6];
+uniform bool is_clipbox_on;
 void main(void) 
 {
+if(is_clipbox_on)
+  if(dist[0]>0 ||
+     dist[1]>0 ||
+     dist[2]>0 ||
+     dist[3]>0 ||
+     dist[4]>0 ||
+     dist[5]>0)
+    discard;
   gl_FragColor = color; 
 }  

--- a/Polyhedron/demo/Polyhedron/resources/shader_spheres.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_spheres.v
@@ -9,10 +9,13 @@ uniform highp mat4 mv_matrix;
 varying highp vec4 fP;
 varying highp vec3 fN;
 varying highp vec4 color;
+varying highp float dist[6];
 
 
 void main(void)
 {
+ for(int i=0; i<6; ++i)
+  dist[i] = 1;
   color = vec4(colors, 1.0);
   fP = mv_matrix * vertex;
   fN = mat3(mv_matrix)* normals;

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.f
@@ -2,6 +2,7 @@
 varying highp vec4 color;
 varying highp vec4 fP; 
 varying highp vec3 fN;
+varying highp float dist[6];
 uniform highp vec4 light_pos;  
 uniform highp vec4 light_diff; 
 uniform highp vec4 light_spec; 
@@ -9,7 +10,18 @@ uniform highp vec4 light_amb;
 uniform highp float spec_power ; 
 uniform int is_two_side; 
 uniform bool is_selected;
+uniform bool is_clipbox_on;
 void main(void) {
+
+if(is_clipbox_on)
+  if(dist[0]>0 ||
+     dist[1]>0 ||
+     dist[2]>0 ||
+     dist[3]>0 ||
+     dist[4]>0 ||
+     dist[5]>0)
+    discard;
+
    highp vec3 L = light_pos.xyz - fP.xyz;
    highp vec3 V = -fP.xyz;
    highp vec3 N;

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.v
@@ -7,10 +7,36 @@ uniform highp mat4 mv_matrix;
 varying highp vec4 fP; 
 varying highp vec3 fN; 
 varying highp vec4 color;
+varying highp float dist[6];
+uniform bool is_clipbox_on;
+uniform highp mat4x4 clipbox1;
+uniform highp mat4x4 clipbox2;
+
+void compute_distances(void)
+{
+  for(int i=0; i<3; ++i)
+  {
+    dist[i]=
+    clipbox1[i][0]*vertex.x+
+    clipbox1[i][1]*vertex.y+
+    clipbox1[i][2]*vertex.z +
+    clipbox1[i][3];
+    dist[i+3]=
+    clipbox2[i][0]*vertex.x+
+    clipbox2[i][1]*vertex.y+
+    clipbox2[i][2]*vertex.z +
+    clipbox2[i][3];
+  }
+}
+
+
 void main(void)
 {
    color = vec4(colors, 1.0);
-   fP = mv_matrix * vertex; 
+   //
+   if(is_clipbox_on)
+    compute_distances();
+   fP = mv_matrix * vertex;
    fN = mat3(mv_matrix)* normals; 
    gl_Position = mvp_matrix * vertex;
 }

--- a/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_without_light.f
@@ -1,8 +1,19 @@
 #version 120
 varying highp vec4 color;
+varying highp float dist[6];
 uniform bool is_selected;
+uniform bool is_clipbox_on;
 void main(void) 
 { 
+if(is_clipbox_on)
+  if(dist[0]>0 ||
+     dist[1]>0 ||
+     dist[2]>0 ||
+     dist[3]>0 ||
+     dist[4]>0 ||
+     dist[5]>0)
+    discard;
+
 if(is_selected)
   gl_FragColor = vec4(0,0,0,1.0);
 else

--- a/Polyhedron/demo/Polyhedron/resources/shader_without_light.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_without_light.v
@@ -4,9 +4,33 @@ attribute highp vec3 colors;
 uniform highp mat4 mvp_matrix;
 uniform highp mat4 f_matrix;
 varying highp vec4 color; 
+varying highp float dist[6];
+uniform bool is_clipbox_on;
+uniform highp mat4x4 clipbox1;
+uniform highp mat4x4 clipbox2;
+
+void compute_distances(void)
+{
+  for(int i=0; i<3; ++i)
+  {
+    dist[i]=
+    clipbox1[i][0]*vertex.x+
+    clipbox1[i][1]*vertex.y+
+    clipbox1[i][2]*vertex.z +
+    clipbox1[i][3];
+    dist[i+3]=
+    clipbox2[i][0]*vertex.x+
+    clipbox2[i][1]*vertex.y+
+    clipbox2[i][2]*vertex.z +
+    clipbox2[i][3];
+  }
+}
+
 void main(void)
 {
-   color = vec4(colors, 1.0); 
+   color = vec4(colors, 1.0);
+   if(is_clipbox_on)
+    compute_distances();
    gl_Position = mvp_matrix * f_matrix * vertex;
 }
  

--- a/Three/include/CGAL/Three/Scene_transparent_interface.h
+++ b/Three/include/CGAL/Three/Scene_transparent_interface.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2009,2010,2012,2015  GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s)     : Maxime GIMENO
+#ifndef SCENE_TRANSPARENT_INTERFACE_H
+#define SCENE_TRANSPARENT_INTERFACE_H
+#include <CGAL/license/Three.h>
+#include <QtPlugin>
+namespace CGAL
+{
+namespace Three {
+  class Viewer_interface;
+
+
+//! Base class to allow an item to print its primitive IDs.
+class Scene_transparent_interface {
+public:
+  virtual ~Scene_transparent_interface(){}
+ //!Print the ID of the selected primitive.
+ virtual void drawTransparent(CGAL::Three::Viewer_interface*)const = 0;
+};
+}
+}
+Q_DECLARE_INTERFACE(CGAL::Three::Scene_transparent_interface, "com.geometryfactory.PolyhedronDemo.TransparentInterface/1.0")
+#endif // SCENE_TRANSPARENT_INTERFACE_H

--- a/Three/include/CGAL/Three/Scene_transparent_interface.h
+++ b/Three/include/CGAL/Three/Scene_transparent_interface.h
@@ -26,11 +26,15 @@ namespace Three {
   class Viewer_interface;
 
 
-//! Base class to allow an item to print its primitive IDs.
+//! Base class to allow an item to draw transparent faces.
 class Scene_transparent_interface {
 public:
   virtual ~Scene_transparent_interface(){}
- //!Print the ID of the selected primitive.
+ //! Draw transparent faces. It is the last drawing call in the Scene, so all
+ //! the items are already in place and the blending
+ //! takes them all, their points and their edges into account, whatever the
+ //! position of the transparent item is in the scene's entries.
+ //!
  virtual void drawTransparent(CGAL::Three::Viewer_interface*)const = 0;
 };
 }

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -146,6 +146,17 @@ public:
   //! @see OpenGL_program_IDs
   //!
   virtual void attribBuffers(int program_name) const = 0;
+  /*! Enables the clipping box. Each Vector4 of `box` contains the equation of a plane of the clipping box.
+   * Everything that is located on the positive side of one of those planes will not be displayed.
+   * @see disableCLippingBox()
+   */
+  virtual void enableClippingBox(QVector4D box[6])=0;
+
+  /*!
+   * Disables the clipping box. The six clipping planes will be ignored.
+   * @see enableClippingBox()
+   */
+  virtual void disableClippingBox()= 0;
 
   //! \brief Returns a program according to name.
   //!


### PR DESCRIPTION
## Summary of Changes

Adds a plugin that use a Scene_edit_box to define a zone of clipping. Only the content of the box is displayed. (Only work for items displayed with the most common shaders).
It also fixes some transparency problems, by defining and using a new interface for transparent items.

## Release Management

* Affected package(s):Polyhedron_demo

