### PR TITLE
Shape detection: bugfix on connected components

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -19,7 +19,7 @@ function build_demo {
   cd build-travis
   if [ $NEED_3D = 1 ]; then
     #install libqglviewer
-    git clone --depth=1 https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
+    git clone --depth=4 -b v2.6.3 --single-branch https://github.com/GillesDebunne/libQGLViewer.git ./qglviewer
     pushd ./qglviewer/QGLViewer
     #use qt5 instead of qt4
     export QT_SELECT=5

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Shape_base.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Shape_base.h
@@ -94,8 +94,7 @@ namespace CGAL {
       m_upper_bound((std::numeric_limits<FT>::min)()),
       m_score(0),
       m_sum_expected_value(0),
-      m_nb_subset_used(0),
-      m_has_connected_component(false) {
+      m_nb_subset_used(0) {
     }
 
     virtual ~Shape_base() {}
@@ -137,10 +136,6 @@ namespace CGAL {
       if (indices.size() == 0)
         return 0;
 
-      if (m_has_connected_component)
-        return m_score;
-
-      m_has_connected_component = true;
       if (!this->supports_connected_component())
         return connected_component_kdTree(indices, cluster_epsilon);
       
@@ -298,8 +293,6 @@ namespace CGAL {
       typedef CGAL::Kd_tree<Search_traits_adapter> Kd_Tree;
       typedef CGAL::Fuzzy_sphere<Search_traits_adapter> Fuzzy_sphere;
 
-      m_has_connected_component = true;
-      
       std::vector<Point_and_size_t> pts;
       std::vector<std::size_t> label_map;
       pts.resize(indices.size());
@@ -693,7 +686,6 @@ namespace CGAL {
     //count the number of subset used so far for the score,
     //and thus indicate the next one to use
     std::size_t m_nb_subset_used;
-    bool m_has_connected_component;
 
     Input_iterator m_first;
 


### PR DESCRIPTION
## Summary of Changes

When a shape is detected, the largest connected component is sought after. In the implementation, it seems that a cache mechanism was partially implemented: there is a boolean that tells if the largest connected component was already computed. But this component is not saved (only its cardinality is saved), which produces the following bug: if a shape is discarded once but then tried again (it can happen that a shape is not discarded at the second trial because of a variation of probability), the largest connected component is not computed. Therefore, _all the points_ are considered part of the largest connected component (which is usually wrong).

I removed this boolean and the associated test: the bug is gone and there's no noticeable impact on the performances.

## Release Management

* Affected package(s): _Point Set Shape Detection 3_

