### PR TITLE
add missing include directive to use CGAL::to_double()

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -40,6 +40,7 @@
 #include <CGAL/Triangulation_face_base_2.h>
 #include <CGAL/Triangulation_line_face_circulator_2.h>
 #include <CGAL/spatial_sort.h>
+#include <CGAL/double.h>
 
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_smallint.hpp>


### PR DESCRIPTION
Minimal program producing the error:

```C++
#define protected public
#include <CGAL/Triangulation_2.h>
#include <CGAL/Simple_cartesian.h>

int main()
{
  CGAL::Triangulation_2<CGAL::Simple_cartesian<double> > T;
  CGAL::Simple_cartesian<double>::Point_2 p(0,0);
  T.has_inexact_negative_orientation(p,p,p);
}

```

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #2182 


