### PR TITLE
Mesh_3 plugin made able to mesh surfaces with border inside a closed polyhedral domain

### DIFF
--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -777,6 +777,22 @@ void clear(FaceGraph& g)
   CGAL_postcondition(num_faces(g) == 0);
 }
 
+/**
+* \ingroup PkgBGLHelperFct
+*
+* checks whether the graph is empty, by checking that it does not contain any vertex.
+*
+* @tparam FaceGraph model of `FaceGraph`
+*
+* @param g the graph to test
+*
+**/
+template<typename FaceGraph>
+bool empty(const FaceGraph& g)
+{
+  return vertices(g).begin() == vertices(g).end();
+}
+
 
 } // namespace CGAL
 

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -22,6 +22,7 @@
 
 
 #include <boost/foreach.hpp>
+#include <boost/range/empty.hpp>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/boost/graph/internal/Has_member_clear.h>
@@ -790,7 +791,7 @@ void clear(FaceGraph& g)
 template<typename FaceGraph>
 bool is_empty(const FaceGraph& g)
 {
-  return boost::begin(vertices(g)) == boost::end(vertices(g));
+  return boost::empty(vertices(g));
 }
 
 

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -788,9 +788,9 @@ void clear(FaceGraph& g)
 *
 **/
 template<typename FaceGraph>
-bool empty(const FaceGraph& g)
+bool is_empty(const FaceGraph& g)
 {
-  return vertices(g).begin() == vertices(g).end();
+  return boost::begin(vertices(g)) == boost::end(vertices(g));
 }
 
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -284,7 +284,7 @@ public:
     stored_polyhedra[1] = bounding_p;
     this->add_primitives(stored_polyhedra[0]);
     this->add_primitives(stored_polyhedra[1]);
-    if(bounding_p.empty()) {
+    if(empty(bounding_p)) {
       this->set_surface_only();
     } else {
       this->add_primitives_to_bounding_tree(stored_polyhedra[1]);

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -284,7 +284,7 @@ public:
     stored_polyhedra[1] = bounding_p;
     this->add_primitives(stored_polyhedra[0]);
     this->add_primitives(stored_polyhedra[1]);
-    if(empty(bounding_p)) {
+    if(is_empty(bounding_p)) {
       this->set_surface_only();
     } else {
       this->add_primitives_to_bounding_tree(stored_polyhedra[1]);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -732,8 +732,9 @@ treat_result(Scene_item& source_item,
   result_item.setRenderingMode(source_item.renderingMode());
   result_item.set_data_item(&source_item);
 
-  source_item.setVisible(false);
-
+  Q_FOREACH(int ind, scene->selectionIndices()) {
+    scene->item(ind)->setVisible(false);
+  }
   const Scene_interface::Item_id index = scene->mainSelectionIndex();
   scene->itemChanged(index);
   scene->setSelectedItem(-1);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -42,6 +42,7 @@ struct Polyhedral_mesh_domain_selector<SMwgd>
 template<class Mesh>
 Meshing_thread* cgal_code_mesh_3_templated(const Mesh* pMesh,
                                  const Polylines_container& polylines,
+                                 const Mesh* pBoundingMesh,
                                  QString filename,
                                  const double facet_angle,
                                  const double facet_sizing,
@@ -75,6 +76,8 @@ Meshing_thread* cgal_code_mesh_3_templated(const Mesh* pMesh,
   Polyhedral_mesh_domain* p_domain = NULL;
   if (!surface_only && is_closed(*pMesh))
     p_domain = new Polyhedral_mesh_domain(*pMesh);
+  else if (!surface_only && pBoundingMesh != NULL && is_closed(*pBoundingMesh))
+    p_domain = new Polyhedral_mesh_domain(*pMesh, *pBoundingMesh);
   else
   {
     std::vector<const Mesh*> poly_ptrs_vector(1, pMesh);
@@ -138,6 +141,7 @@ Meshing_thread* cgal_code_mesh_3_templated(const Mesh* pMesh,
 
 Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
                                  const Polylines_container& polylines,
+                                 const Polyhedron* pBoundingMesh,
                                  QString filename,
                                  const double facet_angle,
                                  const double facet_sizing,
@@ -154,6 +158,7 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
 {
   return cgal_code_mesh_3_templated(pMesh,
                           polylines,
+                          pBoundingMesh,
                           filename,
                           facet_angle,
                           facet_sizing,
@@ -171,6 +176,7 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
 
 Meshing_thread* cgal_code_mesh_3(const SMwgd* pMesh,
                                  const Polylines_container& polylines,
+                                 const SMwgd* pBoundingMesh,
                                  QString filename,
                                  const double facet_angle,
                                  const double facet_sizing,
@@ -187,6 +193,7 @@ Meshing_thread* cgal_code_mesh_3(const SMwgd* pMesh,
 {
   return cgal_code_mesh_3_templated(pMesh,
                           polylines,
+                          pBoundingMesh,
                           filename,
                           facet_angle,
                           facet_sizing,

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
@@ -28,6 +28,7 @@ typedef std::list<std::vector<CGAL::Exact_predicates_inexact_constructions_kerne
 
 Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
                                  const Polylines_container& polylines,
+                                 const Polyhedron* pBoundingMesh,
                                  QString filename,
                                  const double facet_angle,
                                  const double facet_sizing,
@@ -44,6 +45,7 @@ Meshing_thread* cgal_code_mesh_3(const Polyhedron* pMesh,
 
 Meshing_thread* cgal_code_mesh_3(const SMwgd* pMesh,
                                  const Polylines_container& polylines,
+                                 const SMwgd* pBoundingMesh,
                                  QString filename,
                                  const double facet_angle,
                                  const double facet_sizing,


### PR DESCRIPTION
## Summary of Changes

fixes issue #1157 

<strike>I would like both input polyhedra to be hidden once the c3t3 is displayed, but I did not figure out how to do that until now... Any clue?</strike>
