### PR TITLE
Polyhedron_demo: Fix group_item draw().

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -147,7 +147,7 @@ void Scene_group_item::draw(CGAL::Three::Viewer_interface* viewer) const  {
     default: break;
     }
     if(child->renderingMode() == Splatting)
-      child->drawSplats(viewer); break;
+      child->drawSplats(viewer);
   }
   already_drawn = true;
 }


### PR DESCRIPTION
## Summary of Changes

Fix the display of the Scene_group_item, that only displays the first of its children since #2147 .
## Release Management

* Affected package(s):Polyhedron_demo

