### PR TITLE
Polyhedron_demo: Enhance id printing

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1169,29 +1169,57 @@ void Scene::printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface* viewer
       item->printPrimitiveId(point, viewer);
   }
 }
-void Scene::printPrimitiveIds(CGAL::Three::Viewer_interface* viewer)
+void Scene::printVertexIds(CGAL::Three::Viewer_interface* viewer)
 {
   Scene_item *it = item(mainSelectionIndex());
   if(it)
   {
-    //Only call printPrimitiveIds if the item is a Scene_print_item_interface
-    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
     if(item)
-      item->printPrimitiveIds(viewer);
+      item->printVertexIds(viewer);
+  }
+}
+
+void Scene::printEdgeIds(CGAL::Three::Viewer_interface* viewer)
+{
+  Scene_item *it = item(mainSelectionIndex());
+  if(it)
+  {
+    //Only call printEdgeIds if the item is a Scene_print_item_interface
+    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    if(item)
+      item->printEdgeIds(viewer);
+  }
+}
+
+void Scene::printFaceIds(CGAL::Three::Viewer_interface* viewer)
+{
+  Scene_item *it = item(mainSelectionIndex());
+  if(it)
+  {
+    //Only call printFaceIds if the item is a Scene_print_item_interface
+    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    if(item)
+      item->printFaceIds(viewer);
   }
 }
 void Scene::updatePrimitiveIds(CGAL::Three::Viewer_interface* viewer, CGAL::Three::Scene_item* it)
 {
   if(it)
   {
-    //Only call printPrimitiveIds if the item is a Scene_print_item_interface
-    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
     if(item)
     {
-      //As this function works as a toggle, the first call hides the ids and the second one  shows them again,
+      //As this function works as a toggle, the first call hides the ids and the second one shows them again,
       //thereby triggering their re-computation.
-      item->printPrimitiveIds(viewer);
-      item->printPrimitiveIds(viewer);
+      item->printVertexIds(viewer);
+      item->printVertexIds(viewer);
+
+      item->printEdgeIds(viewer);
+      item->printEdgeIds(viewer);
+
+      item->printFaceIds(viewer);
+      item->printFaceIds(viewer);
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1203,6 +1203,18 @@ void Scene::printFaceIds(CGAL::Three::Viewer_interface* viewer)
       item->printFaceIds(viewer);
   }
 }
+
+void Scene::printAllIds(CGAL::Three::Viewer_interface* viewer)
+{
+  Scene_item *it = item(mainSelectionIndex());
+  if(it)
+  {
+    //Only call printFaceIds if the item is a Scene_print_item_interface
+    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    if(item)
+      item->printAllIds(viewer);
+  }
+}
 void Scene::updatePrimitiveIds(CGAL::Three::Viewer_interface* viewer, CGAL::Three::Scene_item* it)
 {
   if(it)

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1174,7 +1174,7 @@ void Scene::printVertexIds(CGAL::Three::Viewer_interface* viewer)
   Scene_item *it = item(mainSelectionIndex());
   if(it)
   {
-    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
     if(item)
       item->printVertexIds(viewer);
   }
@@ -1186,7 +1186,7 @@ void Scene::printEdgeIds(CGAL::Three::Viewer_interface* viewer)
   if(it)
   {
     //Only call printEdgeIds if the item is a Scene_print_item_interface
-    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
     if(item)
       item->printEdgeIds(viewer);
   }
@@ -1198,7 +1198,7 @@ void Scene::printFaceIds(CGAL::Three::Viewer_interface* viewer)
   if(it)
   {
     //Only call printFaceIds if the item is a Scene_print_item_interface
-    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
     if(item)
       item->printFaceIds(viewer);
   }
@@ -1210,7 +1210,7 @@ void Scene::printAllIds(CGAL::Three::Viewer_interface* viewer)
   if(it)
   {
     //Only call printFaceIds if the item is a Scene_print_item_interface
-    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
     if(item)
       item->printAllIds(viewer);
   }
@@ -1219,7 +1219,7 @@ void Scene::updatePrimitiveIds(CGAL::Three::Viewer_interface* viewer, CGAL::Thre
 {
   if(it)
   {
-    Scene_print_item_interface* item= dynamic_cast<Scene_print_item_interface*>(it);
+    Scene_print_item_interface* item= qobject_cast<Scene_print_item_interface*>(it);
     if(item)
     {
       //As this function works as a toggle, the first call hides the ids and the second one shows them again,

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -85,7 +85,10 @@ public:
   bool keyPressEvent(QKeyEvent* e) Q_DECL_OVERRIDE;
   void printPrimitiveId(QPoint point,
                         CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
-  void printPrimitiveIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  void printVertexIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  void printEdgeIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  void printFaceIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  //!Re-computes the primitiveIds for `item`
   void updatePrimitiveIds(Viewer_interface *, Scene_item *item) Q_DECL_OVERRIDE;
   bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer) Q_DECL_OVERRIDE;
   Bbox bbox() const Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -88,6 +88,7 @@ public:
   void printVertexIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   void printEdgeIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   void printFaceIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  void printAllIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
   //!Re-computes the primitiveIds for `item`
   void updatePrimitiveIds(Viewer_interface *, Scene_item *item) Q_DECL_OVERRIDE;
   bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer) Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -2421,9 +2421,15 @@ void Scene_polyhedron_item::zoomToId()
             viewer->camera()->position().z - viewer->camera()->sceneCenter().z)
           .norm() * normal ;
 
-      viewer->camera()->setSceneCenter(qglviewer::Vec(p.x(),
-                                                      p.y(),
+#if QGLVIEWER_VERSION >= 0x020502
+      viewer->camera()->setPivotPoint(qglviewer::Vec(p.x(),
+                                                             p.y(),
                                                       p.z()));
+#else
+      viewer->camera()->setRevolveAroundPoint(qglviewer::Vec(p.x(),
+                                                             p.y(),
+                                                      p.z()));
+#endif
 
       viewer->moveCameraToCoordinates(QString("%1 %2 %3 %4 %5 %6 %7").arg(new_pos.x())
                                       .arg(new_pos.y())
@@ -2434,4 +2440,8 @@ void Scene_polyhedron_item::zoomToId()
                                       .arg(new_orientation[3]));
     }
   }
+}
+bool Scene_polyhedron_item::shouldDisplayIds(CGAL::Three::Scene_item *current_item) const
+{
+  return this == current_item;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1146,7 +1146,6 @@ QMenu* Scene_polyhedron_item::contextMenu()
     actionEraseNextFacet->setObjectName("actionEraseNextFacet");
     connect(actionEraseNextFacet, SIGNAL(toggled(bool)),
             this, SLOT(set_erase_next_picked_facet(bool)));
-    menu->setProperty(prop_name, true);
 
     QAction* actionDisableFlatShading=
         menu->addAction(tr("Disable Flat Shading"));
@@ -1155,6 +1154,7 @@ QMenu* Scene_polyhedron_item::contextMenu()
     connect(actionDisableFlatShading, SIGNAL(toggled(bool)),
             this, SLOT(set_flat_disabled(bool)));
 
+    menu->setProperty(prop_name, true);
   }
 
   QAction* action = menu->findChild<QAction*>("actionShowOnlyFeatureEdges");

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -70,9 +70,6 @@ public:
     bool has_stats()const Q_DECL_OVERRIDE{return true;}
     QString computeStats(int type)Q_DECL_OVERRIDE;
     CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
-    TextListItem* textVItems;
-    TextListItem* textEItems;
-    TextListItem* textFItems;
     Scene_polyhedron_item();
     //   Scene_polyhedron_item(const Scene_polyhedron_item&);
     Scene_polyhedron_item(const Polyhedron& p);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -137,6 +137,7 @@ public:
     bool printEdgeIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
     bool printFaceIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
     void printAllIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+    bool shouldDisplayIds(CGAL::Three::Scene_item *current_item) const Q_DECL_OVERRIDE;
     bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -173,6 +173,7 @@ public Q_SLOTS:
     void showVertices(bool);
     void showEdges(bool);
     void showFaces(bool);
+    void zoomToId();
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -70,7 +70,9 @@ public:
     bool has_stats()const Q_DECL_OVERRIDE{return true;}
     QString computeStats(int type)Q_DECL_OVERRIDE;
     CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
-    TextListItem* textItems;
+    TextListItem* textVItems;
+    TextListItem* textEItems;
+    TextListItem* textFItems;
     Scene_polyhedron_item();
     //   Scene_polyhedron_item(const Scene_polyhedron_item&);
     Scene_polyhedron_item(const Polyhedron& p);
@@ -131,7 +133,9 @@ public:
     bool isItemMulticolor();
 
     void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer)Q_DECL_OVERRIDE;
-    void printPrimitiveIds(CGAL::Three::Viewer_interface*viewer) const Q_DECL_OVERRIDE;
+    void printVertexIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    void printEdgeIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    void printFaceIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
     bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
 
 
@@ -166,6 +170,9 @@ public Q_SLOTS:
     void invalidate_aabb_tree();
     void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
     void resetColors();
+    void showVertices(bool);
+    void showEdges(bool);
+    void showFaces(bool);
 
 Q_SIGNALS:
     void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.h
@@ -133,9 +133,10 @@ public:
     bool isItemMulticolor();
 
     void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer)Q_DECL_OVERRIDE;
-    void printVertexIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
-    void printEdgeIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
-    void printFaceIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    bool printVertexIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    bool printEdgeIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    bool printFaceIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+    void printAllIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
     bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
 
 
@@ -173,6 +174,7 @@ public Q_SLOTS:
     void showVertices(bool);
     void showEdges(bool);
     void showFaces(bool);
+    void showPrimitives(bool);
     void zoomToId();
 
 Q_SIGNALS:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2210,49 +2210,35 @@ void Scene_polyhedron_selection_item::selection_changed(bool b)
 
 void Scene_polyhedron_selection_item::printPrimitiveId(QPoint p, CGAL::Three::Viewer_interface* viewer)
 {
-#ifndef USE_SURFACE_MESH
   d->item->polyhedron_item()->printPrimitiveId(p, viewer);
-#endif
 }
 bool Scene_polyhedron_selection_item::printVertexIds(CGAL::Three::Viewer_interface* viewer) const
 {
-#ifndef USE_SURFACE_MESH
   return d->item->polyhedron_item()->printVertexIds(viewer);
-#endif
   return false;
 }
 bool Scene_polyhedron_selection_item::printEdgeIds(CGAL::Three::Viewer_interface* viewer) const
 {
-#ifndef USE_SURFACE_MESH
   d->item->polyhedron_item()->printEdgeIds(viewer);
-#endif
   return false;
 }
 bool Scene_polyhedron_selection_item::printFaceIds(CGAL::Three::Viewer_interface* viewer) const
 {
-#ifndef USE_SURFACE_MESH
   return d->item->polyhedron_item()->printFaceIds(viewer);
-#endif
   return false;
 }
 void Scene_polyhedron_selection_item::printAllIds(CGAL::Three::Viewer_interface* viewer)
 {
-#ifndef USE_SURFACE_MESH
   d->item->polyhedron_item()->printAllIds(viewer);
-#endif
 }
 bool Scene_polyhedron_selection_item::testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer)const
 {
-#ifndef USE_SURFACE_MESH
   return d->item->polyhedron_item()->testDisplayId(x, y, z, viewer);
-#endif
   return false;
 }
 
 bool Scene_polyhedron_selection_item::shouldDisplayIds(CGAL::Three::Scene_item *current_item) const
 {
-#ifndef USE_SURFACE_MESH
   return d->item->polyhedron_item() == current_item;
-#endif
   return false;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2207,3 +2207,52 @@ void Scene_polyhedron_selection_item::selection_changed(bool b)
     viewer->setNoBinding();
   }
 }
+
+void Scene_polyhedron_selection_item::printPrimitiveId(QPoint p, CGAL::Three::Viewer_interface* viewer)
+{
+#ifndef USE_SURFACE_MESH
+  d->item->polyhedron_item()->printPrimitiveId(p, viewer);
+#endif
+}
+bool Scene_polyhedron_selection_item::printVertexIds(CGAL::Three::Viewer_interface* viewer) const
+{
+#ifndef USE_SURFACE_MESH
+  return d->item->polyhedron_item()->printVertexIds(viewer);
+#endif
+  return false;
+}
+bool Scene_polyhedron_selection_item::printEdgeIds(CGAL::Three::Viewer_interface* viewer) const
+{
+#ifndef USE_SURFACE_MESH
+  d->item->polyhedron_item()->printEdgeIds(viewer);
+#endif
+  return false;
+}
+bool Scene_polyhedron_selection_item::printFaceIds(CGAL::Three::Viewer_interface* viewer) const
+{
+#ifndef USE_SURFACE_MESH
+  return d->item->polyhedron_item()->printFaceIds(viewer);
+#endif
+  return false;
+}
+void Scene_polyhedron_selection_item::printAllIds(CGAL::Three::Viewer_interface* viewer)
+{
+#ifndef USE_SURFACE_MESH
+  d->item->polyhedron_item()->printAllIds(viewer);
+#endif
+}
+bool Scene_polyhedron_selection_item::testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer)const
+{
+#ifndef USE_SURFACE_MESH
+  return d->item->polyhedron_item()->testDisplayId(x, y, z, viewer);
+#endif
+  return false;
+}
+
+bool Scene_polyhedron_selection_item::shouldDisplayIds(CGAL::Three::Scene_item *current_item) const
+{
+#ifndef USE_SURFACE_MESH
+  return d->item->polyhedron_item() == current_item;
+#endif
+  return false;
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -17,6 +17,8 @@
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
+#include <CGAL/Three/Scene_print_item_interface.h>
+
 #include "Polyhedron_demo_detect_sharp_edges.h"
 
 // Laurent Rineau, 2016/04/07: that header should not be included here, but
@@ -201,9 +203,12 @@ struct Selection_traits<typename SelectionItem::fg_edge_descriptor, SelectionIte
 //////////////////////////////////////////////////////////////////////////
 struct Scene_polyhedron_selection_item_priv;
 class SCENE_POLYHEDRON_SELECTION_ITEM_EXPORT Scene_polyhedron_selection_item 
-  : public Scene_polyhedron_item_decorator
+  : public Scene_polyhedron_item_decorator,
+    public CGAL::Three::Scene_print_item_interface
 {
   Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Scene_print_item_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PrintInterface/1.0")
 
 friend class Polyhedron_demo_selection_plugin;
 
@@ -220,6 +225,14 @@ public:
   ~Scene_polyhedron_selection_item();
   void inverse_selection();
   void setPathSelection(bool b);
+  //For ID printing
+  void printPrimitiveId(QPoint, CGAL::Three::Viewer_interface*);
+  bool printVertexIds(CGAL::Three::Viewer_interface*) const;
+  bool printEdgeIds(CGAL::Three::Viewer_interface*) const;
+  bool printFaceIds(CGAL::Three::Viewer_interface*) const;
+  void printAllIds(CGAL::Three::Viewer_interface*);
+  bool testDisplayId(double, double, double, CGAL::Three::Viewer_interface*)const;
+  bool shouldDisplayIds(CGAL::Three::Scene_item *current_item) const;
 
 protected: 
   void init(Scene_face_graph_item* poly_item, QMainWindow* mw);

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1622,6 +1622,55 @@ QMenu* Scene_surface_mesh_item::contextMenu()
     menu->removeAction(actionResetColor);
     actionResetColor->deleteLater();
   }
+  const char* prop_name = "Menu modified by Scene_surface_mesh_item.";
+  bool menuChanged = menu->property(prop_name).toBool();
+
+  if(!menuChanged) {
+    menu->addSeparator();
+    QAction* actionPrintVertices=
+        menu->addAction(tr("Display Vertices Ids"));
+    actionPrintVertices->setCheckable(true);
+    actionPrintVertices->setObjectName("actionPrintVertices");
+    connect(actionPrintVertices, SIGNAL(triggered(bool)),
+            this, SLOT(showVertices(bool)));
+
+    QAction* actionPrintEdges=
+        menu->addAction(tr("Display Edges Ids"));
+    actionPrintEdges->setCheckable(true);
+    actionPrintEdges->setObjectName("actionPrintEdges");
+    connect(actionPrintEdges, SIGNAL(triggered(bool)),
+            this, SLOT(showEdges(bool)));
+
+    QAction* actionPrintFaces=
+        menu->addAction(tr("Display Faces Ids"));
+    actionPrintFaces->setCheckable(true);
+    actionPrintFaces->setObjectName("actionPrintFaces");
+    connect(actionPrintFaces, SIGNAL(triggered(bool)),
+            this, SLOT(showFaces(bool)));
+
+    QAction* actionPrintAll=
+        menu->addAction(tr("Display All Ids"));
+    actionPrintAll->setCheckable(true);
+    actionPrintAll->setObjectName("actionPrintAll");
+    connect(actionPrintAll, SIGNAL(triggered(bool)),
+            this, SLOT(showPrimitives(bool)));
+
+    QAction* actionZoomToId=
+        menu->addAction(tr("Zoom to Index"));
+    actionZoomToId->setObjectName("actionZoomToId");
+    connect(actionZoomToId, &QAction::triggered,
+            this, &Scene_surface_mesh_item::zoomToId);
+    menu->setProperty(prop_name, true);
+  }
+
+  QAction* action = menu->findChild<QAction*>("actionPrintVertices");
+  if(action) action->setChecked(d->vertices_displayed);
+  action = menu->findChild<QAction*>("actionPrintEdges");
+  if(action) action->setChecked(d->edges_displayed);
+  action = menu->findChild<QAction*>("actionPrintFaces");
+  if(action) action->setChecked(d->faces_displayed);
+  action = menu->findChild<QAction*>("actionPrintAll");
+  if(action) action->setChecked(d->all_primitives_displayed);
   return menu;
 }
 void Scene_surface_mesh_item::printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface *viewer)
@@ -1866,61 +1915,4 @@ bool Scene_surface_mesh_item::shouldDisplayIds(CGAL::Three::Scene_item *current_
   return this == current_item;
 }
 
-QMenu* Scene_surface_mesh_item::contextMenu()
-{
-  const char* prop_name = "Menu modified by Scene_surface_mesh_item.";
 
-  QMenu* menu = CGAL::Three::Scene_item::contextMenu();
-
-  // Use dynamic properties:
-  // http://doc.qt.io/qt-5/qobject.html#property
-  bool menuChanged = menu->property(prop_name).toBool();
-
-  if(!menuChanged) {
-    menu->addSeparator();
-    QAction* actionPrintVertices=
-        menu->addAction(tr("Display Vertices Ids"));
-    actionPrintVertices->setCheckable(true);
-    actionPrintVertices->setObjectName("actionPrintVertices");
-    connect(actionPrintVertices, SIGNAL(triggered(bool)),
-            this, SLOT(showVertices(bool)));
-
-    QAction* actionPrintEdges=
-        menu->addAction(tr("Display Edges Ids"));
-    actionPrintEdges->setCheckable(true);
-    actionPrintEdges->setObjectName("actionPrintEdges");
-    connect(actionPrintEdges, SIGNAL(triggered(bool)),
-            this, SLOT(showEdges(bool)));
-
-    QAction* actionPrintFaces=
-        menu->addAction(tr("Display Faces Ids"));
-    actionPrintFaces->setCheckable(true);
-    actionPrintFaces->setObjectName("actionPrintFaces");
-    connect(actionPrintFaces, SIGNAL(triggered(bool)),
-            this, SLOT(showFaces(bool)));
-
-    QAction* actionPrintAll=
-        menu->addAction(tr("Display All Ids"));
-    actionPrintAll->setCheckable(true);
-    actionPrintAll->setObjectName("actionPrintAll");
-    connect(actionPrintAll, SIGNAL(triggered(bool)),
-            this, SLOT(showPrimitives(bool)));
-
-    QAction* actionZoomToId=
-        menu->addAction(tr("Zoom to Index"));
-    actionZoomToId->setObjectName("actionZoomToId");
-    connect(actionZoomToId, &QAction::triggered,
-            this, &Scene_surface_mesh_item::zoomToId);
-  }
-
-  QAction* action = menu->findChild<QAction*>("actionPrintVertices");
-  if(action) action->setChecked(d->vertices_displayed);
-  action = menu->findChild<QAction*>("actionPrintEdges");
-  if(action) action->setChecked(d->edges_displayed);
-  action = menu->findChild<QAction*>("actionPrintFaces");
-  if(action) action->setChecked(d->faces_displayed);
-  action = menu->findChild<QAction*>("actionPrintAll");
-  if(action) action->setChecked(d->all_primitives_displayed);
-
-  return menu;
-}

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -5,9 +5,12 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <QOpenGLShaderProgram>
+#include <QInputDialog>
 #include <QOpenGLBuffer>
 #include <QApplication>
 #include <QVariant>
+#include <QMessageBox>
+#include <QMenu>
 
 //#include <CGAL/boost/graph/properties_Surface_mesh.h>
 #include <CGAL/Surface_mesh.h>
@@ -31,6 +34,7 @@
 #include <CGAL/statistics_helpers.h>
 
 #include <QMenu>
+#include "id_printing.h"
 
 //Used to triangulate the AABB_Tree
 class Primitive
@@ -83,6 +87,10 @@ struct Scene_surface_mesh_item_priv{
     item = parent;
     has_feature_edges = false;
     invalidate_stats();
+    vertices_displayed = true;
+    edges_displayed = true;
+    faces_displayed = true;
+    all_primitives_displayed = false;
   }
 
   Scene_surface_mesh_item_priv(SMesh* sm, Scene_surface_mesh_item *parent):
@@ -91,6 +99,10 @@ struct Scene_surface_mesh_item_priv{
     item = parent;
     has_feature_edges = false;
     invalidate_stats();
+    vertices_displayed = true;
+    edges_displayed = true;
+    faces_displayed = true;
+    all_primitives_displayed = false;
   }
 
   ~Scene_surface_mesh_item_priv()
@@ -101,6 +113,11 @@ struct Scene_surface_mesh_item_priv{
       smesh_ = NULL;
     }
   }
+  void killIds();
+  void fillTargetedIds(const face_descriptor& selected_fh,
+                       const EPICK::Point_3 &point_under,
+                       CGAL::Three::Viewer_interface *viewer,
+                       const qglviewer::Vec &offset);
 
   void initialize_colors();
   void invalidate_stats();
@@ -141,6 +158,15 @@ struct Scene_surface_mesh_item_priv{
     FColors,
     NbOfVbos
   };
+  TextListItem* textVItems;
+  TextListItem* textEItems;
+  TextListItem* textFItems;
+  mutable bool vertices_displayed;
+  mutable bool edges_displayed;
+  mutable bool faces_displayed;
+  mutable bool all_primitives_displayed;
+  mutable QList<double> text_ids;
+  mutable std::vector<TextItem*> targeted_id;
 
   mutable bool has_fpatch_id;
   mutable bool has_feature_edges;
@@ -187,6 +213,9 @@ Scene_surface_mesh_item::Scene_surface_mesh_item()
   d->has_vcolors = false;
   d->has_fcolors = false;
   d->checkFloat();
+  d->textVItems = new TextListItem(this);
+  d->textEItems = new TextListItem(this);
+  d->textFItems = new TextListItem(this);
 
   are_buffers_filled = false;
 }
@@ -196,6 +225,9 @@ Scene_surface_mesh_item::Scene_surface_mesh_item(const Scene_surface_mesh_item& 
 {
   d = new Scene_surface_mesh_item_priv(other, this);
   are_buffers_filled = false;
+  d->textVItems = new TextListItem(this);
+  d->textEItems = new TextListItem(this);
+  d->textFItems = new TextListItem(this);
 }
 
 void Scene_surface_mesh_item::standard_constructor(SMesh* sm)
@@ -206,6 +238,9 @@ void Scene_surface_mesh_item::standard_constructor(SMesh* sm)
   d->has_vcolors = false;
   d->has_fcolors = false;
   d->checkFloat();
+  d->textVItems = new TextListItem(this);
+  d->textEItems = new TextListItem(this);
+  d->textFItems = new TextListItem(this);
 
   are_buffers_filled = false;
 }
@@ -1587,5 +1622,305 @@ QMenu* Scene_surface_mesh_item::contextMenu()
     menu->removeAction(actionResetColor);
     actionResetColor->deleteLater();
   }
+  return menu;
+}
+void Scene_surface_mesh_item::printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface *viewer)
+{
+  if(d->all_primitives_displayed)
+    return;
+  typedef Input_facets_AABB_tree Tree;
+  Tree* aabb_tree = static_cast<Input_facets_AABB_tree*>(d->get_aabb_tree());
+  if(!aabb_tree)
+    return;
+  face_descriptor selected_fh;
+  EPICK::Point_3 pt_under;
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  if(find_primitive_id(point, aabb_tree, viewer, selected_fh, pt_under))
+    d->fillTargetedIds(selected_fh, pt_under, viewer, offset);
+
+}
+void Scene_surface_mesh_item_priv::fillTargetedIds(const face_descriptor &selected_fh,
+                                                 const EPICK::Point_3& pt_under,
+                                                 CGAL::Three::Viewer_interface *viewer,
+                                                 const qglviewer::Vec& offset)
+{
+  compute_displayed_ids(*smesh_,
+                        viewer,
+                        selected_fh,
+                        pt_under,
+                        offset,
+                        textVItems,
+                        textEItems,
+                        textFItems,
+                        &targeted_id,
+                        &all_primitives_displayed);
+
+
+  if(vertices_displayed
+     && !textVItems->isEmpty())
+    item->showVertices(true);
+  if(edges_displayed
+    && !textEItems->isEmpty())
+    item->showEdges(true);
+  if(faces_displayed
+     && !textFItems->isEmpty())
+    item->showFaces(true);
+
+}
+
+bool Scene_surface_mesh_item::printVertexIds(CGAL::Three::Viewer_interface *viewer) const
+{
+  if(d->vertices_displayed)
+  {
+    return ::printVertexIds(*d->smesh_,
+                            d->textVItems,
+                            viewer);
+  }
+  return true;
+}
+
+bool Scene_surface_mesh_item::printEdgeIds(CGAL::Three::Viewer_interface *viewer) const
+{
+  if(d->edges_displayed)
+  {
+    return ::printEdgeIds(*d->smesh_,
+                            d->textEItems,
+                            viewer);
+  }
+  return true;
+}
+
+bool Scene_surface_mesh_item::printFaceIds(CGAL::Three::Viewer_interface *viewer) const
+{
+  if(d->faces_displayed)
+  {
+    return ::printFaceIds(*d->smesh_,
+                            d->textFItems,
+                            viewer);
+  }
+  return true;
+}
+
+void Scene_surface_mesh_item_priv::killIds()
+{
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  deleteIds(viewer,
+            textVItems,
+            textEItems,
+            textFItems,
+            &targeted_id,
+            &all_primitives_displayed);
+}
+
+void Scene_surface_mesh_item::printAllIds(CGAL::Three::Viewer_interface *viewer)
+{
+  static bool all_ids_displayed = false;
+
+  all_ids_displayed = !all_ids_displayed;
+  if(all_ids_displayed )
+  {
+    bool s1(printVertexIds(viewer)),
+        s2(printEdgeIds(viewer)),
+        s3(printFaceIds(viewer));
+    if((s1 && s2 && s3))
+    {
+      d->all_primitives_displayed = true;
+      viewer->update();
+    }
+    return;
+  }
+  d->killIds();
+}
+
+bool Scene_surface_mesh_item::testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer)const
+{
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  EPICK::Point_3 src(x - offset.x,
+                      y - offset.y,
+                      z - offset.z);
+  EPICK::Point_3 dest(viewer->camera()->position().x - offset.x,
+                       viewer->camera()->position().y - offset.y,
+                       viewer->camera()->position().z - offset.z);
+  EPICK::Vector_3 v(src,dest);
+  v = 0.01*v;
+  EPICK::Point_3 point = src;
+  point = point + v;
+  EPICK::Segment_3 query(point, dest);
+  return !static_cast<Input_facets_AABB_tree*>(d->get_aabb_tree())->do_intersect(query);
+}
+
+
+void Scene_surface_mesh_item::showVertices(bool b)
+{
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  TextRenderer *renderer = viewer->textRenderer();
+  if(b)
+    if(d->textVItems->isEmpty())
+    {
+      d->vertices_displayed = b;
+      printVertexIds(viewer);
+    }
+    else
+      renderer->addTextList(d->textVItems);
+  else
+    renderer->removeTextList(d->textVItems);
+  viewer->update();
+  d->vertices_displayed = b;
+}
+
+void Scene_surface_mesh_item::showEdges(bool b)
+{
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  TextRenderer *renderer = viewer->textRenderer();
+  if(b)
+  {
+    if(d->textEItems->isEmpty())
+    {
+      d->edges_displayed = b;
+      printFaceIds(viewer);
+    }
+    else
+      renderer->addTextList(d->textEItems);
+  }
+  else
+    renderer->removeTextList(d->textEItems);
+  viewer->update();
+  d->edges_displayed = b;
+}
+
+void Scene_surface_mesh_item::showFaces(bool b)
+{
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  TextRenderer *renderer = viewer->textRenderer();
+  if(b)
+  {
+    if(d->textFItems->isEmpty())
+    {
+      d->faces_displayed = b;
+      printFaceIds(viewer);
+    }
+    else
+      renderer->addTextList(d->textFItems);
+  }
+  else
+    renderer->removeTextList(d->textFItems);
+  viewer->update();
+  d->faces_displayed = b;
+}
+
+void Scene_surface_mesh_item::showPrimitives(bool)
+{
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  printAllIds(viewer);
+}
+void Scene_surface_mesh_item::zoomToId()
+{
+  face_descriptor selected_fh;
+  bool ok;
+  QString text = QInputDialog::getText(QApplication::activeWindow(), tr("Zoom to Index"),
+                                       tr("Simplex"), QLineEdit::Normal,
+                                       tr("v0"), &ok);
+  CGAL::Three::Viewer_interface* viewer =
+      qobject_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first());
+  Point_3 p;
+  QString id = text.right(text.length()-1);
+  int return_value = ::zoomToId(*d->smesh_, text, viewer, selected_fh, p);
+  switch(return_value)
+  {
+  case 1:
+    QMessageBox::warning(QApplication::activeWindow(),
+                       "ERROR",
+                       tr("Input must be of the form [v/e/f][int]")
+                       );
+    return;
+  case 2:
+    QMessageBox::warning(QApplication::activeWindow(),
+                       "ERROR",
+                       tr("No vertex with id %1").arg(id)
+                       );
+    return;
+  case 3:
+    QMessageBox::warning(QApplication::activeWindow(),
+                       "ERROR",
+                       tr("No edge with id %1").arg(id)
+                       );
+    return;
+  case 4:
+    QMessageBox::warning(QApplication::activeWindow(),
+                       "ERROR",
+                       tr("No face with id %1").arg(id)
+                       );
+    return;
+  default: //case 0
+    d->fillTargetedIds(selected_fh, p, viewer, viewer->offset());
+    break;
+  }
+}
+bool Scene_surface_mesh_item::shouldDisplayIds(CGAL::Three::Scene_item *current_item) const
+{
+  return this == current_item;
+}
+
+QMenu* Scene_surface_mesh_item::contextMenu()
+{
+  const char* prop_name = "Menu modified by Scene_surface_mesh_item.";
+
+  QMenu* menu = CGAL::Three::Scene_item::contextMenu();
+
+  // Use dynamic properties:
+  // http://doc.qt.io/qt-5/qobject.html#property
+  bool menuChanged = menu->property(prop_name).toBool();
+
+  if(!menuChanged) {
+    menu->addSeparator();
+    QAction* actionPrintVertices=
+        menu->addAction(tr("Display Vertices Ids"));
+    actionPrintVertices->setCheckable(true);
+    actionPrintVertices->setObjectName("actionPrintVertices");
+    connect(actionPrintVertices, SIGNAL(triggered(bool)),
+            this, SLOT(showVertices(bool)));
+
+    QAction* actionPrintEdges=
+        menu->addAction(tr("Display Edges Ids"));
+    actionPrintEdges->setCheckable(true);
+    actionPrintEdges->setObjectName("actionPrintEdges");
+    connect(actionPrintEdges, SIGNAL(triggered(bool)),
+            this, SLOT(showEdges(bool)));
+
+    QAction* actionPrintFaces=
+        menu->addAction(tr("Display Faces Ids"));
+    actionPrintFaces->setCheckable(true);
+    actionPrintFaces->setObjectName("actionPrintFaces");
+    connect(actionPrintFaces, SIGNAL(triggered(bool)),
+            this, SLOT(showFaces(bool)));
+
+    QAction* actionPrintAll=
+        menu->addAction(tr("Display All Ids"));
+    actionPrintAll->setCheckable(true);
+    actionPrintAll->setObjectName("actionPrintAll");
+    connect(actionPrintAll, SIGNAL(triggered(bool)),
+            this, SLOT(showPrimitives(bool)));
+
+    QAction* actionZoomToId=
+        menu->addAction(tr("Zoom to Index"));
+    actionZoomToId->setObjectName("actionZoomToId");
+    connect(actionZoomToId, &QAction::triggered,
+            this, &Scene_surface_mesh_item::zoomToId);
+  }
+
+  QAction* action = menu->findChild<QAction*>("actionPrintVertices");
+  if(action) action->setChecked(d->vertices_displayed);
+  action = menu->findChild<QAction*>("actionPrintEdges");
+  if(action) action->setChecked(d->edges_displayed);
+  action = menu->findChild<QAction*>("actionPrintFaces");
+  if(action) action->setChecked(d->faces_displayed);
+  action = menu->findChild<QAction*>("actionPrintAll");
+  if(action) action->setChecked(d->all_primitives_displayed);
+
   return menu;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -7,6 +7,7 @@
 
 #include "Scene_surface_mesh_item_config.h"
 #include <CGAL/Three/Scene_zoomable_item_interface.h>
+#include <CGAL/Three/Scene_print_item_interface.h>
 #include "SMesh_type.h"
 #include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Viewer_interface.h>
@@ -23,8 +24,10 @@ struct Scene_surface_mesh_item_priv;
 
 class SCENE_SURFACE_MESH_ITEM_EXPORT Scene_surface_mesh_item
   : public CGAL::Three::Scene_item,
-    public CGAL::Three::Scene_zoomable_item_interface
-{
+    public CGAL::Three::Scene_zoomable_item_interface,
+    public CGAL::Three::Scene_print_item_interface{
+  Q_INTERFACES(CGAL::Three::Scene_print_item_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PrintInterface/1.0")
   Q_OBJECT
   Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
   Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
@@ -52,6 +55,8 @@ public:
   Bbox bbox() const Q_DECL_OVERRIDE;
   QString toolTip() const Q_DECL_OVERRIDE;
 
+  QMenu* contextMenu() Q_DECL_OVERRIDE;
+
   // Only needed for Scene_polyhedron_item
   void setItemIsMulticolor(bool);
   void update_vertex_indices(){}
@@ -78,6 +83,7 @@ public:
   bool save(std::ostream& out) const;
   bool save_obj(std::ostream& out) const;
   bool load_obj(std::istream& in);
+  //statistics
   enum STATS {
     NB_VERTICES = 0,
     NB_CONNECTED_COMPOS,
@@ -112,8 +118,18 @@ public:
   bool has_stats()const Q_DECL_OVERRIDE{return true;}
   QString computeStats(int type)Q_DECL_OVERRIDE;
   CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
+  //zoomable interface
   void zoomToPosition(const QPoint &point, CGAL::Three::Viewer_interface *)const Q_DECL_OVERRIDE;
   QMenu* contextMenu() Q_DECL_OVERRIDE;
+ //print_interface
+  void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer)Q_DECL_OVERRIDE;
+  bool printVertexIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+  bool printEdgeIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+  bool printFaceIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+  void printAllIds(CGAL::Three::Viewer_interface*) Q_DECL_OVERRIDE;
+  bool shouldDisplayIds(CGAL::Three::Scene_item *current_item) const Q_DECL_OVERRIDE;
+  bool testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;
+
 Q_SIGNALS:
   void item_is_about_to_be_changed();
   void selection_done();
@@ -140,6 +156,11 @@ public Q_SLOTS:
                       double dir_z,
                       const face_descriptor &f);
   void resetColors();
+  void showVertices(bool);
+  void showEdges(bool);
+  void showFaces(bool);
+  void showPrimitives(bool);
+  void zoomToId();
 protected:
   friend struct Scene_surface_mesh_item_priv;
   Scene_surface_mesh_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -120,7 +120,6 @@ public:
   CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
   //zoomable interface
   void zoomToPosition(const QPoint &point, CGAL::Three::Viewer_interface *)const Q_DECL_OVERRIDE;
-  QMenu* contextMenu() Q_DECL_OVERRIDE;
  //print_interface
   void printPrimitiveId(QPoint point, CGAL::Three::Viewer_interface*viewer)Q_DECL_OVERRIDE;
   bool printVertexIds(CGAL::Three::Viewer_interface*)const Q_DECL_OVERRIDE;

--- a/Polyhedron/demo/Polyhedron/TextRenderer.cpp
+++ b/Polyhedron/demo/Polyhedron/TextRenderer.cpp
@@ -1,5 +1,7 @@
 #include <CGAL/Three/TextRenderer.h>
 #include <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_print_item_interface.h>
+#include "Scene_polyhedron_selection_item.h"
 void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
 {
     QPainter *painter = viewer->getPainter();
@@ -9,7 +11,12 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
     qglviewer::Camera* camera = viewer->camera();
     //Display the items textItems
     Q_FOREACH(TextListItem* list, textItems)
-      if(list->item() == scene->item(scene->mainSelectionIndex()))
+    {
+      CGAL::Three::Scene_print_item_interface* item =
+      qobject_cast<CGAL::Three::Scene_print_item_interface*>(scene->item(scene->mainSelectionIndex()));
+      if( item &&
+          item->shouldDisplayIds(list->item())
+         )
         Q_FOREACH(TextItem* item, list->textList())
         {
           qglviewer::Vec src(item->position().x(), item->position().y(),item->position().z());
@@ -31,6 +38,7 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
             painter->drawText(rect, item->text());
           }
         }
+    }
 
     //Display the local TextItems
     Q_FOREACH(TextItem* item, local_textItems)

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -519,9 +519,7 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     }
   }
   else if(e->key() == Qt::Key_I && e->modifiers() & Qt::ControlModifier){
-    d->scene->printVertexIds(this);
-    d->scene->printEdgeIds(this);
-    d->scene->printFaceIds(this);
+    d->scene->printAllIds(this);
     update();
     return;
   }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -519,7 +519,9 @@ void Viewer::keyPressEvent(QKeyEvent* e)
     }
   }
   else if(e->key() == Qt::Key_I && e->modifiers() & Qt::ControlModifier){
-    d->scene->printPrimitiveIds(this);
+    d->scene->printVertexIds(this);
+    d->scene->printEdgeIds(this);
+    d->scene->printFaceIds(this);
     update();
     return;
   }

--- a/Polyhedron/demo/Polyhedron/include/id_printing.h
+++ b/Polyhedron/demo/Polyhedron/include/id_printing.h
@@ -1,0 +1,615 @@
+#ifndef ID_PRINTING_H
+#define ID_PRINTING_H
+#include <CGAL/Three/Viewer_interface.h>
+#include <CGAL/Three/TextRenderer.h>
+#include <CGAL/Kernel_traits.h>
+#include <boost/foreach.hpp>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <vector>
+
+template<class Mesh>
+struct VKRingPMAP{
+  typedef typename boost::graph_traits<Mesh>::vertex_descriptor key_type;
+  typedef bool                                                  value_type;
+  typedef value_type                                            reference;
+  typedef boost::read_write_property_map_tag                    category;
+  typedef typename boost::property_map<Mesh, boost::vertex_index_t>::type IDmap;
+  std::vector<bool>* vec;
+  Mesh* poly;
+  IDmap idmap;
+
+
+  VKRingPMAP(std::vector<bool>* vec, Mesh* poly)
+    :vec(vec), poly(poly)
+  {
+    idmap = get(boost::vertex_index, *poly);
+  }
+
+  friend value_type get(const VKRingPMAP<Mesh>& map, const key_type& f){
+    return (*map.vec)[get(map.idmap, f)];
+  }
+  friend void put(VKRingPMAP<Mesh>& map, const key_type& f, const value_type i){
+    (*map.vec)[get(map.idmap, f)] = i;
+  }
+};
+template<class Mesh>
+struct EdgeKRingPMAP{
+  typedef typename boost::graph_traits<Mesh>::edge_descriptor  key_type;
+  typedef bool                                                 value_type;
+  typedef value_type                                           reference;
+  typedef boost::read_write_property_map_tag                   category;
+  typedef typename boost::property_map<Mesh, boost::halfedge_index_t>::type IDmap;
+  std::vector<bool>* vec;
+  Mesh* poly;
+  IDmap idmap;
+
+  EdgeKRingPMAP(std::vector<bool>* vec, Mesh* poly)
+    :vec(vec), poly(poly)
+  {
+    idmap = get(boost::halfedge_index, *poly);
+  }
+
+  friend value_type get(const EdgeKRingPMAP<Mesh>& map, const key_type& f){
+    return (*map.vec)[get(map.idmap, halfedge(f, *map.poly))/2];
+  }
+  friend void put(EdgeKRingPMAP<Mesh>& map, const key_type& f, const value_type i){
+    (*map.vec)[get(map.idmap, halfedge(f, *map.poly))/2] = i;
+  }
+};
+template<class Mesh>
+struct FKRingPMAP{
+  typedef typename boost::graph_traits<Mesh>::face_descriptor key_type;
+  typedef bool                                                value_type;
+  typedef value_type                                          reference;
+  typedef boost::read_write_property_map_tag                  category;
+  typedef typename boost::property_map<Mesh, boost::face_index_t>::type IDmap;
+  std::vector<bool>* vec;
+  Mesh* poly;
+  IDmap idmap;
+
+  FKRingPMAP(std::vector<bool>* vec, Mesh* poly)
+    :vec(vec), poly(poly)
+  {
+    idmap = get(boost::face_index, *poly);
+  }
+
+  friend value_type get(const FKRingPMAP<Mesh>& map, const key_type& f){
+    return (*map.vec)[get(map.idmap, f)];
+  }
+  friend void put(FKRingPMAP<Mesh>& map, const key_type& f, const value_type i){
+    (*map.vec)[get(map.idmap, f)] = i;
+  }
+};
+void deleteIds(CGAL::Three::Viewer_interface* viewer,
+               TextListItem* vitems,
+               TextListItem* eitems,
+               TextListItem* fitems,
+               std::vector<TextItem*>* targeted_ids,
+               bool *all_primitives_displayed)
+{
+  TextRenderer *renderer = viewer->textRenderer();
+  BOOST_FOREACH(TextItem* it, vitems->textList())
+      delete it;
+  BOOST_FOREACH(TextItem* it, eitems->textList())
+      delete it;
+  BOOST_FOREACH(TextItem* it, fitems->textList())
+      delete it;
+  vitems->clear();
+  renderer->removeTextList(vitems);
+  eitems->clear();
+  renderer->removeTextList(eitems);
+  fitems->clear();
+  renderer->removeTextList(fitems);
+  targeted_ids->clear();
+  *all_primitives_displayed = false;
+  viewer->update();
+}
+
+
+
+
+template<typename Handle, typename Point, typename Tree>
+void find_primitive_id(const QPoint& point,
+                       Tree* aabb_tree,
+                       CGAL::Three::Viewer_interface *viewer,
+                       Handle& selected_fh,
+                       Point& pt_under)
+{
+  typedef typename CGAL::Kernel_traits<Point>::Kernel Traits;
+  bool found = false;
+  qglviewer::Vec point_under = viewer->camera()->pointUnderPixel(point,found);
+  const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+
+  //find clicked facet
+  qglviewer::Vec dir = point_under - viewer->camera()->position();
+  const Point ray_origin(viewer->camera()->position().x - offset.x,
+                         viewer->camera()->position().y - offset.y,
+                         viewer->camera()->position().z - offset.z);
+
+  const typename Traits::Vector_3 ray_dir(dir.x, dir.y, dir.z);
+  const typename Traits::Ray_3 ray(ray_origin, ray_dir);
+
+  typedef typename Tree::template Intersection_and_primitive_id<typename Traits::Ray_3>::Type Intersection_and_primitive_id;
+  typedef std::list<Intersection_and_primitive_id> Intersections;
+  Intersections intersections;
+  aabb_tree->all_intersections(ray, std::back_inserter(intersections));
+
+  if(intersections.empty())
+    return;
+  typename Intersections::iterator closest = intersections.begin();
+  const Point* closest_point =
+      boost::get<Point>(&closest->first);
+  for(typename Intersections::iterator
+      it = boost::next(intersections.begin()),
+      end = intersections.end();
+      it != end; ++it)
+  {
+    if(! closest_point) {
+      closest = it;
+    }
+    else {
+      const Point* it_point =
+          boost::get<Point>(&it->first);
+      if(it_point &&
+         (ray_dir * (*it_point - *closest_point)) < 0)
+      {
+        closest = it;
+        closest_point = it_point;
+      }
+    }
+  }
+  if(!closest_point)
+    return;
+  pt_under = Point(point_under.x, point_under.y, point_under.z);
+  selected_fh = closest->second;
+}
+
+template<typename Mesh, typename Point >
+void compute_displayed_ids(Mesh& mesh,
+                           CGAL::Three::Viewer_interface *viewer,
+                           const typename boost::graph_traits<Mesh>::face_descriptor& selected_fh,
+                           const Point& pt_under,
+                           const qglviewer::Vec& offset,
+                           TextListItem* vitems,
+                           TextListItem* eitems,
+                           TextListItem* fitems,
+                           std::vector<TextItem*>* targeted_ids,
+                           bool *all_primitives_displayed)
+{
+  typedef typename boost::graph_traits<Mesh>::face_descriptor face_descriptor;
+  typedef typename boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<Mesh>::edge_descriptor edge_descriptor;
+  typedef typename boost::graph_traits<Mesh>::halfedge_descriptor halfedge_descriptor;
+
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::type Ppmap;
+  Ppmap ppmap = get(boost::vertex_point, mesh);
+  QFont font;
+  font.setBold(true);
+  std::vector<vertex_descriptor> displayed_vertices;
+  std::vector<edge_descriptor> displayed_edges;
+  std::vector<face_descriptor> displayed_faces;
+  //Test spots around facet to find the closest to point
+
+  double min_dist = (std::numeric_limits<double>::max)();
+
+  // test the vertices of the closest face
+  BOOST_FOREACH(vertex_descriptor vh, vertices_around_face(halfedge(selected_fh, mesh), mesh))
+  {
+    Point test=Point(get(ppmap, vh).x()+offset.x,
+                     get(ppmap, vh).y()+offset.y,
+                     get(ppmap, vh).z()+offset.z);
+    double dist = CGAL::squared_distance(test, pt_under);
+    if( dist < min_dist){
+      min_dist = dist;
+      displayed_vertices.clear();
+      displayed_vertices.push_back(vh);
+    }
+  }
+  QVector3D point(get(ppmap, displayed_vertices[0]).x(),
+      get(ppmap, displayed_vertices[0]).y(),
+      get(ppmap, displayed_vertices[0]).z());
+
+  //test if we want to erase or not
+  BOOST_FOREACH(TextItem* text_item, *targeted_ids)
+  {
+    if(text_item->position() == point)
+    {
+      //hide and stop
+      deleteIds(viewer, vitems, eitems, fitems, targeted_ids, all_primitives_displayed);
+      return;
+    }
+  }
+  deleteIds(viewer, vitems, eitems, fitems, targeted_ids, all_primitives_displayed);
+  // test the midpoint of edges of the closest face
+  BOOST_FOREACH(halfedge_descriptor e, halfedges_around_face(selected_fh->halfedge(), mesh))
+  {
+    Point test=CGAL::midpoint(source(e, mesh)->point(),target(e, mesh)->point());
+    test = Point(test.x()+offset.x,
+                 test.y()+offset.y,
+                 test.z()+offset.z);
+    double dist = CGAL::squared_distance(test, pt_under);
+    if(dist < min_dist){
+      min_dist = dist;
+      displayed_vertices.clear();
+      displayed_edges.clear();
+      displayed_edges.push_back(edge(e, mesh));
+    }
+  }
+  // test the centroid of the closest face
+  double x(0), y(0), z(0);
+  int total(0);
+  BOOST_FOREACH(vertex_descriptor vh, vertices_around_face(selected_fh->halfedge(), mesh))
+  {
+    x+=get(ppmap, vh).x();
+    y+=get(ppmap, vh).y();
+    z+=get(ppmap, vh).z();
+    ++total;
+  }
+
+  Point test(x/total+offset.x,
+             y/total+offset.y,
+             z/total+offset.z);
+  double dist = CGAL::squared_distance(test, pt_under);
+  if(dist < min_dist){
+    min_dist = dist;
+    displayed_vertices.clear();
+    displayed_edges.clear();
+    displayed_faces.clear();
+    displayed_faces.push_back(selected_fh);
+  }
+
+  if(!displayed_vertices.empty())
+  {
+    BOOST_FOREACH(face_descriptor f, CGAL::faces_around_target(halfedge(displayed_vertices[0],mesh), mesh))
+    {
+      displayed_faces.push_back(f);
+    }
+    BOOST_FOREACH(halfedge_descriptor h, CGAL::halfedges_around_target(halfedge(displayed_vertices[0], mesh), mesh))
+    {
+      displayed_edges.push_back(edge(h, mesh));
+    }
+  }
+  else if(!displayed_edges.empty())
+  {
+    displayed_vertices.push_back(target(halfedge(displayed_edges[0], mesh), mesh));
+    displayed_vertices.push_back(target(halfedge(displayed_edges[0], mesh)->opposite(),mesh));
+
+    displayed_faces.push_back(face(halfedge(displayed_edges[0], mesh),mesh));
+    displayed_faces.push_back(face(halfedge(displayed_edges[0], mesh)->opposite(),mesh));
+  }
+
+  else if(!displayed_faces.empty())
+  {
+    BOOST_FOREACH(halfedge_descriptor h, CGAL::halfedges_around_face(halfedge(displayed_faces[0], mesh), mesh))
+    {
+      displayed_edges.push_back(edge(h, mesh));
+      displayed_vertices.push_back(target(h, mesh));
+    }
+  }
+  //fill TextItems
+  std::vector<bool> vertex_selection(false);
+  vertex_selection.resize(num_vertices(mesh));
+  VKRingPMAP<Mesh> vpmap(&vertex_selection, &mesh);
+  BOOST_FOREACH(vertex_descriptor v_h, displayed_vertices)
+      put(vpmap, v_h, true);
+  CGAL::expand_vertex_selection(displayed_vertices,
+                                mesh,
+                                1,
+                                vpmap,
+                                std::back_inserter(displayed_vertices));
+
+  std::vector<bool> edge_selection(false);
+  edge_selection.resize(num_edges(mesh));
+  EdgeKRingPMAP<Mesh> epmap(&edge_selection, &mesh);
+  BOOST_FOREACH(edge_descriptor e_d, displayed_edges)
+      put(epmap, e_d, true);
+  CGAL::expand_edge_selection(displayed_edges,
+                              mesh,
+                              1,
+                              epmap,
+                              std::back_inserter(displayed_edges));
+
+  std::vector<bool> face_selection(false);
+  face_selection.resize(num_faces(mesh));
+  FKRingPMAP<Mesh> fpmap(&face_selection, &mesh);
+  BOOST_FOREACH(face_descriptor f_h, displayed_faces)
+      put(fpmap, f_h, true);
+  CGAL::expand_face_selection(displayed_faces,
+                              mesh,
+                              1,
+                              fpmap,
+                              std::back_inserter(displayed_faces));
+
+  BOOST_FOREACH(vertex_descriptor vh, displayed_vertices)
+  {
+    Point pos=Point(get(ppmap, vh).x()+offset.x,
+                    get(ppmap, vh).y()+offset.y,
+                    get(ppmap, vh).z()+offset.z);
+    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(vh->id()), true, font, Qt::red);
+    vitems->append(text_item);
+    targeted_ids->push_back(text_item);
+  }
+  BOOST_FOREACH(edge_descriptor e, displayed_edges)
+  {
+    halfedge_descriptor  h(halfedge(e, mesh));
+    Point pos=CGAL::midpoint(source(h, mesh)->point(),target(h, mesh)->point());
+    pos = Point(pos.x()+offset.x,
+                pos.y()+offset.y,
+                pos.z()+offset.z);
+
+    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(h->id()/2), true, font, Qt::green);
+    eitems->append(text_item);
+  }
+
+  BOOST_FOREACH(face_descriptor  f, displayed_faces)
+  {
+    double x(0), y(0), z(0);
+    int total(0);
+    BOOST_FOREACH(vertex_descriptor  vh, vertices_around_face(halfedge(f, mesh), mesh))
+    {
+      x+=get(ppmap, vh).x();
+      y+=get(ppmap, vh).y();
+      z+=get(ppmap, vh).z();
+      ++total;
+    }
+
+    Point pos(x/total+offset.x,
+              y/total+offset.y,
+              z/total+offset.z);
+    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(f->id()), true, font, Qt::blue);
+    fitems->append(text_item);
+  }
+}
+
+template<class Mesh>
+bool printVertexIds(const Mesh& mesh,
+                    TextListItem* vitems,
+                    CGAL::Three::Viewer_interface *viewer)
+{
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type Ppmap;
+  typedef typename boost::property_traits<Ppmap>::value_type Point;
+  typedef typename boost::property_map<Mesh, boost::vertex_index_t>::type IDmap;
+
+  Ppmap ppmap = get(boost::vertex_point, mesh);
+  IDmap idmap = get(boost::vertex_index, mesh);
+  TextRenderer *renderer = viewer->textRenderer();
+  const qglviewer::Vec offset = viewer->offset();
+  QFont font;
+  font.setBold(true);
+
+  //fills textItems
+  BOOST_FOREACH(typename boost::graph_traits<Mesh>::vertex_descriptor vh, vertices(mesh))
+  {
+    const Point& p = get(ppmap, vh);
+    vitems->append(new TextItem((float)p.x() + offset.x,
+                                (float)p.y() + offset.y,
+                                (float)p.z() + offset.z,
+                                QString("%1").arg(get(idmap, vh)), true, font, Qt::red));
+
+  }
+  //add the QList to the render's pool
+  renderer->addTextList(vitems);
+  if(vitems->size() > static_cast<std::size_t>(renderer->getMax_textItems()))
+  {
+    return false;
+  }
+  return true;
+}
+
+template<class Mesh>
+bool printEdgeIds(const Mesh& mesh,
+                  TextListItem* eitems,
+                  CGAL::Three::Viewer_interface *viewer)
+{
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type Ppmap;
+  typedef typename boost::property_traits<Ppmap>::value_type Point;
+  typedef typename boost::property_map<Mesh, boost::halfedge_index_t>::type IDmap;
+
+  Ppmap ppmap = get(boost::vertex_point, mesh);
+  IDmap idmap = get(boost::halfedge_index, mesh);
+  TextRenderer *renderer = viewer->textRenderer();
+  const qglviewer::Vec offset = viewer->offset();
+  QFont font;
+  font.setBold(true);
+
+  BOOST_FOREACH(typename boost::graph_traits<Mesh>::edge_descriptor e, edges(mesh))
+  {
+    const Point& p1 = get(ppmap, source(e, mesh));
+    const Point& p2 = get(ppmap, target(e, mesh));
+    eitems->append(new TextItem((float)(p1.x() + p2.x()) / 2 + offset.x,
+                                (float)(p1.y() + p2.y()) / 2 + offset.y,
+                                (float)(p1.z() + p2.z()) / 2 + offset.z,
+                                QString("%1").arg(get(idmap, halfedge(e, mesh)) / 2), true, font, Qt::green));
+  }
+  //add the QList to the render's pool
+  renderer->addTextList(eitems);
+  if(eitems->size() > static_cast<std::size_t>(renderer->getMax_textItems()))
+  {
+    return false;
+  }
+  return true;
+}
+
+template<class Mesh>
+bool printFaceIds(const Mesh& mesh,
+                  TextListItem* fitems,
+                  CGAL::Three::Viewer_interface *viewer)
+{
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type Ppmap;
+  typedef typename boost::property_map<Mesh, boost::face_index_t>::type IDmap;
+
+  Ppmap ppmap = get(boost::vertex_point, mesh);
+  IDmap idmap = get(boost::face_index, mesh);
+  TextRenderer *renderer = viewer->textRenderer();
+  const qglviewer::Vec offset = viewer->offset();
+  QFont font;
+  font.setBold(true);
+  BOOST_FOREACH(typename boost::graph_traits<Mesh>::face_descriptor fh, faces(mesh))
+  {
+    double x(0), y(0), z(0);
+    int total(0);
+    BOOST_FOREACH(typename boost::graph_traits<Mesh>::vertex_descriptor vh, vertices_around_face(fh->halfedge(), mesh))
+    {
+      x += get(ppmap, vh).x();
+      y += get(ppmap, vh).y();
+      z += get(ppmap, vh).z();
+      ++total;
+    }
+
+    fitems->append(new TextItem((float)x / total + offset.x,
+                                (float)y / total + offset.y,
+                                (float)z / total + offset.z,
+                                QString("%1").arg(get(idmap, fh)), true, font, Qt::blue));
+  }
+  //add the QList to the render's pool
+  renderer->addTextList(fitems);
+  if(fitems->size() > static_cast<std::size_t>(renderer->getMax_textItems()))
+  {
+    return false;
+  }
+  return true;
+}
+
+template<class Mesh, typename Point>
+int zoomToId(const Mesh& mesh,
+             const QString& text,
+             CGAL::Three::Viewer_interface* viewer,
+             typename boost::graph_traits<Mesh>::face_descriptor& selected_fh,
+             Point& p)
+{
+  typedef typename boost::graph_traits<Mesh>::face_descriptor face_descriptor;
+  typedef typename boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type Ppmap;
+  typedef typename boost::property_map<Mesh, boost::vertex_index_t>::type VIDmap;
+  typedef typename boost::property_map<Mesh, boost::halfedge_index_t>::type EIDmap;
+  typedef typename boost::property_map<Mesh, boost::face_index_t>::type FIDmap;
+  typedef typename CGAL::Kernel_traits<Point>::Kernel Traits;
+
+
+  Ppmap ppmap = get(boost::vertex_point, mesh);
+  VIDmap vidmap = get(boost::vertex_index, mesh);
+  EIDmap eidmap = get(boost::halfedge_index, mesh);
+  FIDmap fidmap = get(boost::face_index, mesh);
+
+  bool is_int;
+  typename boost::property_traits<VIDmap>::value_type id = text.right(text.length()-1).toUInt(&is_int);
+  QString first = text.left(1);
+  if((first != QString("v") &&
+      first != QString("e") &&
+      first != QString("f")) ||
+     !is_int)
+  {
+    return 1; //("Input must be of the form [v/e/f][int]"
+  }
+  const qglviewer::Vec offset = viewer->offset();
+  typename Traits::Vector_3 normal;
+  if(first == QString("v"))
+  {
+    bool found = false;
+    BOOST_FOREACH(vertex_descriptor vh, vertices(mesh))
+    {
+      if(get(vidmap, vh) == id)
+      {
+        p = Point(get(ppmap, vh).x() + offset.x,
+                  get(ppmap, vh).y() + offset.y,
+                  get(ppmap, vh).z() + offset.z);
+        selected_fh = face(halfedge(vh, mesh), mesh);
+        normal = CGAL::Polygon_mesh_processing::compute_vertex_normal(vh, mesh);
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      return 2;//"No vertex with id %1").arg(id)
+    }
+  }
+  else if(first == QString("e"))
+  {
+    bool found = false;
+    BOOST_FOREACH(typename boost::graph_traits<Mesh>::edge_descriptor e, edges(mesh))
+    {
+      if(get(eidmap, halfedge(e, mesh))/2 == id)
+      {
+        const Point& p1 = get(ppmap, source(e, mesh));
+        const Point& p2 = get(ppmap, target(e, mesh));
+        p = Point((float)(p1.x() + p2.x()) / 2 + offset.x,
+                  (float)(p1.y() + p2.y()) / 2 + offset.y,
+                  (float)(p1.z() + p2.z()) / 2 + offset.z );
+        typename Traits::Vector_3 normal1 = CGAL::Polygon_mesh_processing::compute_face_normal(face(halfedge(e, mesh),mesh),
+                                                                                               mesh);
+        typename Traits::Vector_3 normal2 = CGAL::Polygon_mesh_processing::compute_face_normal(face(opposite(halfedge(e, mesh), mesh), mesh),
+                                                                                               mesh);
+        normal = 0.5*normal1+0.5*normal2;
+        selected_fh = face(halfedge(e, mesh), mesh);
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      return 3;//"No edge with id %1").arg(id)
+    }
+  }
+  else if(first == QString("f"))
+  {
+    bool found = false;
+    double x(0), y(0), z(0);
+    int total(0);
+    BOOST_FOREACH(face_descriptor fh, faces(mesh))
+    {
+      if(get(fidmap, fh) != id)
+        continue;
+      BOOST_FOREACH(vertex_descriptor vh, vertices_around_face(halfedge(fh, mesh), mesh))
+      {
+        x+=get(ppmap, vh).x();
+        y+=get(ppmap, vh).y();
+        z+=get(ppmap, vh).z();
+        ++total;
+      }
+      p = Point(x/total + offset.x,
+                          y/total + offset.y,
+                          z/total + offset.z);
+      normal = CGAL::Polygon_mesh_processing::compute_face_normal(
+            fh,
+            mesh);
+      selected_fh = fh;
+      found = true;
+      break;
+    }
+    if(!found)
+    {
+      return 4; //"No face with id %1").arg(id)
+    }
+  }
+  qglviewer::Quaternion new_orientation(qglviewer::Vec(0,0,-1),
+                                        qglviewer::Vec(-normal.x(), -normal.y(), -normal.z()));
+  Point new_pos = p +
+      qglviewer::Vec(
+        viewer->camera()->position().x - viewer->camera()->sceneCenter().x,
+        viewer->camera()->position().y - viewer->camera()->sceneCenter().y,
+        viewer->camera()->position().z - viewer->camera()->sceneCenter().z)
+      .norm() * normal ;
+
+#if QGLVIEWER_VERSION >= 0x020502
+  viewer->camera()->setPivotPoint(qglviewer::Vec(p.x(),
+                                                 p.y(),
+                                                 p.z()));
+#else
+  viewer->camera()->setRevolveAroundPoint(qglviewer::Vec(p.x(),
+                                                         p.y(),
+                                                         p.z()));
+#endif
+
+  viewer->moveCameraToCoordinates(QString("%1 %2 %3 %4 %5 %6 %7").arg(new_pos.x())
+                                  .arg(new_pos.y())
+                                  .arg(new_pos.z())
+                                  .arg(new_orientation[0])
+      .arg(new_orientation[1])
+      .arg(new_orientation[2])
+      .arg(new_orientation[3]));
+  viewer->update();
+  return 0; //all clear;
+}
+#endif // ID_PRINTING_H
+

--- a/Three/include/CGAL/Three/Scene_draw_interface.h
+++ b/Three/include/CGAL/Three/Scene_draw_interface.h
@@ -69,10 +69,13 @@ public:
    * \param viewer the viewer used to display the Scene.
    * \return true if the TextItem is visible. */
   virtual bool  testDisplayId(double x, double y, double z, CGAL::Three::Viewer_interface* viewer) = 0;
- /*!
-   * \brief printPrimitiveIds displays all the TextItems if there are less than Viewer::max_textItems.
-   */
-  virtual void printPrimitiveIds(CGAL::Three::Viewer_interface*) = 0;
+
+  ///\brief displays all the vertices ids if there are less than max_textItems.
+  virtual void printVertexIds(CGAL::Three::Viewer_interface*) = 0;
+  ///\brief displays all the edges ids if there are less than max_textItems.
+  virtual void printEdgeIds(CGAL::Three::Viewer_interface*) = 0;
+  ///\brief displays all the faces ids if there are less than max_textItems.
+  virtual void printFaceIds(CGAL::Three::Viewer_interface*) = 0;
 
   //!\brief moves the camera orthogonally to the picked sface.
   //!

--- a/Three/include/CGAL/Three/Scene_draw_interface.h
+++ b/Three/include/CGAL/Three/Scene_draw_interface.h
@@ -76,6 +76,8 @@ public:
   virtual void printEdgeIds(CGAL::Three::Viewer_interface*) = 0;
   ///\brief displays all the faces ids if there are less than max_textItems.
   virtual void printFaceIds(CGAL::Three::Viewer_interface*) = 0;
+  ///\brief displays all the primitive ids if there are less than max_textItems.
+  virtual void printAllIds(CGAL::Three::Viewer_interface*) = 0;
 
   //!\brief moves the camera orthogonally to the picked sface.
   //!

--- a/Three/include/CGAL/Three/Scene_print_item_interface.h
+++ b/Three/include/CGAL/Three/Scene_print_item_interface.h
@@ -35,9 +35,16 @@ public:
   virtual ~Scene_print_item_interface(){}
  //! Finds the spot the closest to `point` and prints the id of the corresponding Primitive (vertex, edge or face).
  virtual void printPrimitiveId(QPoint, CGAL::Three::Viewer_interface*) = 0;
-  //! Prints all the primitive ids if their number is not too high. The limit is
+
+  //! Prints all the vertices ids if their number is not too high. The limit is
   //! editable in the View menu of the application.
- virtual void printPrimitiveIds(CGAL::Three::Viewer_interface*)const = 0;
+  virtual void printVertexIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! Prints all the edges ids if their number is not too high. The limit is
+  //! editable in the View menu of the application.
+  virtual void printEdgeIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! Prints all the faces ids if their number is not too high. The limit is
+  //! editable in the View menu of the application.
+  virtual void printFaceIds(CGAL::Three::Viewer_interface*) const= 0;
   //! \brief Tests if an id should be displayed or not.
   //!
   //! \returns true if the Id should be displayed

--- a/Three/include/CGAL/Three/Scene_print_item_interface.h
+++ b/Three/include/CGAL/Three/Scene_print_item_interface.h
@@ -38,13 +38,19 @@ public:
 
   //! Prints all the vertices ids if their number is not too high. The limit is
   //! editable in the View menu of the application.
-  virtual void printVertexIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! \returns `false` if the number of ids is too high to be displayed.
+  virtual bool printVertexIds(CGAL::Three::Viewer_interface*) const= 0;
   //! Prints all the edges ids if their number is not too high. The limit is
   //! editable in the View menu of the application.
-  virtual void printEdgeIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! \returns `false` if the number of ids is too high to be displayed.
+  virtual bool printEdgeIds(CGAL::Three::Viewer_interface*) const= 0;
   //! Prints all the faces ids if their number is not too high. The limit is
   //! editable in the View menu of the application.
-  virtual void printFaceIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! \returns `false` if the number of ids is too high to be displayed.
+  virtual bool printFaceIds(CGAL::Three::Viewer_interface*) const= 0;
+  //! Prints all the primitive ids if their number is not too high. The limit is
+  //! editable in the View menu of the application.
+  virtual void printAllIds(CGAL::Three::Viewer_interface*) = 0;
   //! \brief Tests if an id should be displayed or not.
   //!
   //! \returns true if the Id should be displayed

--- a/Three/include/CGAL/Three/Scene_print_item_interface.h
+++ b/Three/include/CGAL/Three/Scene_print_item_interface.h
@@ -27,6 +27,7 @@ namespace CGAL
 {
 namespace Three {
   class Viewer_interface;
+  class Scene_item;
 
 
 //! An item that wants to print its primitive IDs must derive from this interface.
@@ -56,6 +57,14 @@ public:
   //! \returns true if the Id should be displayed
   //! \returns false if the Id should not be displayed (if it is hidden for example)
   virtual bool testDisplayId(double, double, double, CGAL::Three::Viewer_interface*)const = 0;
+
+  //! \brief Tests if this item should display its ids.
+  //!
+  //! The default behavior is to only display ids of the currently selected item (\see mainSelectionIndex()).
+  //! This function allows to override this behavior.
+  //! @param tets_item the currently tested TextListItem.
+  //! \return true if this item should display its ids when `test_item` is tested.
+  virtual bool shouldDisplayIds(CGAL::Three::Scene_item* test_item)const = 0;
 };
 }
 }

--- a/Three/include/CGAL/Three/TextRenderer.h
+++ b/Three/include/CGAL/Three/TextRenderer.h
@@ -137,7 +137,7 @@ private:
 class VIEWER_EXPORT TextRenderer : public QObject{
   Q_OBJECT
 public:
-    TextRenderer() : max_textItems(30000)
+    TextRenderer() : max_textItems(10000)
     {
     }
     //!Draws all the `TextItem`s
@@ -155,9 +155,11 @@ public:
     //!
     void addTextList(TextListItem*);
     //!Removes a `textItem` from TextRenderer::local_textItems
+    //! @attention the memory of the TextItem is not de-allocated.
     //! @see addText(TextItem*)
     void removeText(TextItem* textItem);
     //!Removes a TextItemList from TextRenderer::textItems
+    //! //! @attention the memory of the TextItems is not de-allocated.
     void removeTextList(TextListItem*);
     //!The local TextListItem.
     QList<TextItem*> getLocalTextItems(){return local_textItems;}


### PR DESCRIPTION
## Summary of Changes

With this PR, the polyhedron_item has new options in its context menu allowing to display all the vertex IDs and/or all the edge IDs and/or all the face IDs. It also adds an action to zoom to the wanted primitive by giving its Id (v0 for the vertex with Id 0, e0 for an edge and f0 for a face).
## Release Management

* Affected package(s):Polyhedron_demo

