### PR TITLE
Mesh_3 : use PMP::Side_of_triangle_mesh

### DIFF
--- a/Generator/examples/Generator/random_points_in_tetrahedral_mesh_3.cpp
+++ b/Generator/examples/Generator/random_points_in_tetrahedral_mesh_3.cpp
@@ -3,6 +3,7 @@
 #include <CGAL/Mesh_criteria_3.h>
 
 
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/refine_mesh_3.h>

--- a/Generator/examples/Generator/random_points_on_tetrahedral_mesh_3.cpp
+++ b/Generator/examples/Generator/random_points_on_tetrahedral_mesh_3.cpp
@@ -2,7 +2,7 @@
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
 
-
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/refine_mesh_3.h>

--- a/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Polyhedral_mesh_domain_3.h
@@ -15,10 +15,8 @@ several other components (closed or not)
 that will be represented in the final mesh.   
 This class is a model of the concept `MeshDomain_3`.
 
-\tparam Polyhedron stands for the type of the input polyhedral surface(s). 
-The only requirements for this type is that the triangles of the surfaces 
-must be accessible through an object of the class 
-`TriangleAccessor`. 
+\tparam Polyhedron stands for the type of the input polyhedral surface(s),
+model of `FaceListGraph`.
 
 \tparam IGT stands for a geometric traits class 
 providing the types and functors required to implement 
@@ -26,18 +24,9 @@ the intersection tests and intersection computations
 for polyhedral boundary surfaces. This parameter has to be instantiated 
 with a model of the concept `IntersectionGeometricTraits_3`. 
 
-\tparam TriangleAccessor provides access to the triangles 
-of the input polyhedral 
-surface. It must be a model of the concept 
-`TriangleAccessor_3`. It defaults to 
-`Triangle_accessor_3<Polyhedron,IGT>`. The type `IGT::Triangle_3` must 
-be identical to the type `TriangleAccessor::Triangle_3`. 
-
 \cgalModels `MeshDomain_3` 
 
-\sa `TriangleAccessor_3` 
 \sa `IntersectionGeometricTraits_3` 
-\sa `CGAL::Triangle_accessor_3<Polyhedron_3<K>,K>` 
 \sa `CGAL::make_mesh_3()`. 
 
 */

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
@@ -93,8 +93,6 @@ template <typename MeshDomain>
 struct Get_facet_patch_id_sm_property_traits<MeshDomain, true>
 {
   typedef typename MeshDomain::AABB_primitive::Id Id;
-  typedef typename std::iterator_traits<Id>::value_type Face;
-
   typedef typename MeshDomain::Patch_id value_type;
 
   typedef value_type& reference;
@@ -115,10 +113,15 @@ namespace CGAL { namespace Mesh_3 {
 
 template <typename MeshDomain>
 typename boost::property_traits< Get_facet_patch_id_sm<MeshDomain> >::value_type
-get(const Get_facet_patch_id_sm<MeshDomain>, const typename MeshDomain::AABB_primitive::Id& primitive_id) {
-  typedef typename boost::property_map<typename MeshDomain::Polyhedron::Graph, face_patch_id_t<typename MeshDomain::Patch_id> >::type Fpim;
-  Fpim fpim = get(face_patch_id_t<typename MeshDomain::Patch_id>(),*((*primitive_id).graph));
-  typename MeshDomain::Patch_id patch_index =  get(fpim, (*primitive_id).descriptor);
+get(const Get_facet_patch_id_sm<MeshDomain>,
+    const typename MeshDomain::AABB_primitive::Id& primitive_id)
+{
+  typedef typename boost::property_map<
+       typename MeshDomain::Polyhedron::Graph,
+       face_patch_id_t<typename MeshDomain::Patch_id> >::type Fpim;
+  Fpim fpim = get(face_patch_id_t<typename MeshDomain::Patch_id>(),
+                  *(primitive_id.graph));
+  typename MeshDomain::Patch_id patch_index = get(fpim, primitive_id.descriptor);
   return patch_index;
 }
 }} // end namespace CGAL::Mesh_3

--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -236,10 +236,8 @@ is union of the positive side of all of its facets, usually named the
 `Polyhedral_complex_mesh_domain_3` assumes that for each polyhedral
 surface, the sub-domain indices on both sides are known.
 
-\tparam Polyhedron stands for the type of the input polyhedral surface(s).
-The only requirements for this type is that the triangles of the surfaces
-must be accessible through an object of the class
-`TriangleAccessor`. @todo Document the requirements.
+\tparam Polyhedron stands for the type of the input polyhedral surface(s),
+model of `FaceListGraph`.
 
 \tparam IGT_ stands for a geometric traits class
 providing the types and functors required to implement
@@ -247,18 +245,9 @@ the intersection tests and intersection computations
 for polyhedral boundary surfaces. This parameter has to be instantiated
 with a model of the concept `IntersectionGeometricTraits_3`.
 
-\tparam TriangleAccessor provides access to the triangles
-of the input polyhedral
-surface. It must be a model of the concept
-`TriangleAccessor_3`. It defaults to
-`Triangle_accessor_3<Polyhedron,IGT_>`. The type `IGT_::Triangle_3` must
-be identical to the type `TriangleAccessor::Triangle_3`.
-
 \cgalModels `MeshDomainWithFeatures_3`
 
-\sa `TriangleAccessor_3`
 \sa `IntersectionGeometricTraits_3`
-\sa `CGAL::Triangle_accessor_3<Polyhedron_3<K>,K>`
 \sa `CGAL::make_mesh_3()`.
 \sa `CGAL::Mesh_domain_with_polyline_features_3<MeshDomain>`
 \sa `CGAL::Polyhedral_mesh_domain_3<Polyhedron,IGT_,TriangleAccessor>`
@@ -266,13 +255,13 @@ be identical to the type `TriangleAccessor::Triangle_3`.
 */
 template < class IGT_,
            class Polyhedron = typename Mesh_polyhedron_3<IGT_>::type,
-           class TriangleAccessor=Triangle_accessor_3<Polyhedron,IGT_>
+           class TriangleAccessor=CGAL::Default
            >
 class Polyhedral_complex_mesh_domain_3
   : public Mesh_domain_with_polyline_features_3<
       Polyhedral_mesh_domain_3< Polyhedron,
                                 IGT_,
-                                TriangleAccessor,
+                                CGAL::Default,
                                 Tag_true,   //Use_patch_id_tag
                                 Tag_true > >//Use_exact_intersection_tag
 {
@@ -287,17 +276,16 @@ protected:
 
 private:
   typedef IGT_ IGT;
-  typedef Polyhedral_mesh_domain_3<Polyhedron, IGT_, TriangleAccessor,
+  typedef Polyhedral_mesh_domain_3<Polyhedron, IGT_, CGAL::Default,
                                    Tag_true, Tag_true >       BaseBase;
-  typedef Polyhedral_complex_mesh_domain_3<IGT_, Polyhedron,
-                                           TriangleAccessor>  Self;
+  typedef Polyhedral_complex_mesh_domain_3<IGT_, Polyhedron>  Self;
   /// @endcond
 
 public:
   /// The base class
   typedef Mesh_domain_with_polyline_features_3<
     Polyhedral_mesh_domain_3<
-      Polyhedron, IGT_, TriangleAccessor,
+      Polyhedron, IGT_, CGAL::Default,
       Tag_true, Tag_true > > Base;
   /*!
   Numerical type.

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -29,17 +29,19 @@
 
 #include <CGAL/license/Mesh_3.h>
 
-
-#include <CGAL/Polygon_mesh_processing/internal/Side_of_triangle_mesh/Point_inside_vertical_ray_cast.h>
-
 #include <CGAL/Mesh_3/global_parameters.h>
 #include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
-#include <CGAL/Mesh_3/Triangle_accessor_primitive.h>
-#include <CGAL/Triangle_accessor_3.h>
+
+#include <CGAL/boost/graph/Graph_with_descriptor_with_graph.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Side_of_triangle_mesh.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <sstream>
 
+#include <CGAL/Default.h>
 #include <CGAL/Random.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/Mesh_3/Profile_counter.h>
@@ -217,9 +219,9 @@ struct IGT_generator<Gt,CGAL::Tag_false>
  *
  *
  */
-template<class Polyhedron,
+template<class Polyhedron,/*FaceGraph*/
          class IGT_,
-         class TriangleAccessor=Triangle_accessor_3<Polyhedron,IGT_>,
+         class TriangleAccessor = CGAL::Default,
          class Patch_id_ = void,
          class Use_exact_intersection_construction_tag = CGAL::Tag_true>
 class Polyhedral_mesh_domain_3
@@ -264,8 +266,7 @@ public:
   typedef IGT R;
 
 public:
-  typedef Mesh_3::Triangle_accessor_primitive<
-    TriangleAccessor, IGT>                              AABB_primitive;
+  typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron> AABB_primitive;
   typedef class AABB_traits<IGT,AABB_primitive>         AABB_traits;
   typedef class AABB_tree<AABB_traits>                  AABB_tree_;
 
@@ -673,8 +674,7 @@ public:
 protected:
   void add_primitives(const Polyhedron& p)
   {
-    tree_.insert(TriangleAccessor().triangles_begin(p),
-                 TriangleAccessor().triangles_end(p));
+    tree_.insert(faces(p).begin(), faces(p).end(), p);
   }
 
   void add_primitives_to_bounding_tree(const Polyhedron& p)
@@ -682,8 +682,7 @@ protected:
     if(bounding_tree_ == &tree_ || bounding_tree_ == 0) {
       bounding_tree_ = new AABB_tree_;
     }
-    bounding_tree_->insert(TriangleAccessor().triangles_begin(p),
-                           TriangleAccessor().triangles_end(p));
+    bounding_tree_->insert(faces(p).begin(), faces(p).end(), p);
   }
 
   void build() {
@@ -842,8 +841,9 @@ Is_in_domain::operator()(const Point_3& p) const
 {
   if(r_domain_.bounding_tree_ == 0) return Subdomain();
 
-  internal::Point_inside_vertical_ray_cast<IGT_, AABB_tree_> inside_functor;
-  Bounded_side side = inside_functor(p, *(r_domain_.bounding_tree_));
+  CGAL::Side_of_triangle_mesh<Polyhedron, IGT>
+    inside_functor(*(r_domain_.bounding_tree_));
+  Bounded_side side = inside_functor(p);
 
   if(side == CGAL::ON_UNBOUNDED_SIDE) { return Subdomain(); }
   else { return Subdomain(Subdomain_index(1)); } // case ON_BOUNDARY && ON_BOUNDED_SIDE

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -33,7 +33,7 @@
 #include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
 
 #include <CGAL/boost/graph/Graph_with_descriptor_with_graph.h>
-#include <CGAL/Surface_mesh.h>
+#include <CGAL/Surface_mesh/Surface_mesh_fwd.h>
 
 #include <CGAL/Side_of_triangle_mesh.h>
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -111,9 +111,10 @@ struct Surface_patch_index_generator<Subdomain_index, Graph_with_descriptor_with
   template < typename Primitive_id >
   Surface_patch_index operator()(const Primitive_id& primitive_id)
   {
-    typedef typename boost::property_map<Surface_mesh<P>, face_patch_id_t<Patch_id> >::type Fpim;
-    Fpim fpim = get(face_patch_id_t<Patch_id>(),*((*primitive_id).graph));
-    Surface_patch_index spi =  get(fpim, (*primitive_id).descriptor);
+    typedef typename boost::property_map<Surface_mesh<P>,
+                                         face_patch_id_t<Patch_id> >::type Fpim;
+    Fpim fpim = get(face_patch_id_t<Patch_id>(),*(primitive_id.graph));
+    Surface_patch_index spi =  get(fpim, primitive_id.descriptor);
     return spi;
   }
 };

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -265,7 +265,7 @@ public:
   typedef IGT R;
 
 public:
-  typedef typename Side_of_triangle_mesh<Polyhedron, IGT> Inside_functor;
+  typedef Side_of_triangle_mesh<Polyhedron, IGT>        Inside_functor;
   typedef typename Inside_functor::AABB_tree              AABB_tree_;
   typedef typename AABB_tree_::AABB_traits                AABB_traits;
   typedef typename AABB_tree_::Primitive                  AABB_primitive;

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -36,9 +36,7 @@
 #include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Side_of_triangle_mesh.h>
-#include <CGAL/AABB_face_graph_triangle_primitive.h>
-#include <CGAL/AABB_tree.h>
-#include <CGAL/AABB_traits.h>
+
 #include <sstream>
 
 #include <CGAL/Default.h>
@@ -267,10 +265,10 @@ public:
   typedef IGT R;
 
 public:
-  typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron> AABB_primitive;
-  typedef class AABB_traits<IGT,AABB_primitive>         AABB_traits;
-  typedef class AABB_tree<AABB_traits>                  AABB_tree_;
-
+  typedef typename Side_of_triangle_mesh<Polyhedron, IGT> Inside_functor;
+  typedef typename Inside_functor::AABB_tree              AABB_tree_;
+  typedef typename AABB_tree_::AABB_traits                AABB_traits;
+  typedef typename AABB_tree_::Primitive                  AABB_primitive;
   typedef typename AABB_tree_::Primitive_id             AABB_primitive_id;
   typedef typename AABB_tree_::Primitive                Primitive;
   typedef typename AABB_traits::Bounding_box            Bounding_box;
@@ -842,8 +840,7 @@ Is_in_domain::operator()(const Point_3& p) const
 {
   if(r_domain_.bounding_tree_ == 0) return Subdomain();
 
-  CGAL::Side_of_triangle_mesh<Polyhedron, IGT>
-    inside_functor(*(r_domain_.bounding_tree_));
+  Inside_functor inside_functor(*(r_domain_.bounding_tree_));
   Bounded_side side = inside_functor(p);
 
   if(side == CGAL::ON_UNBOUNDED_SIDE) { return Subdomain(); }

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -49,6 +49,7 @@
 #include <boost/graph/filtered_graph.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <CGAL/boost/graph/split_graph_into_polylines.h>
+#include <CGAL/Default.h>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/foreach.hpp>
@@ -193,7 +194,7 @@ struct Extract_polyline_with_context_visitor
  */
 template < class IGT_,
            class Polyhedron_ = typename Mesh_polyhedron_3<IGT_>::type,
-           class TriangleAccessor=Triangle_accessor_3<Polyhedron_,IGT_>,
+           class TriangleAccessor= CGAL::Default,
            class Patch_id=int,
            class Use_exact_intersection_construction_tag = Tag_true >
 class Polyhedral_mesh_domain_with_features_3

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -4,6 +4,7 @@
 // include this to get #define BOOST_PARAMETER_MAX_ARITY 12
 // as otherwise it gets set via inclusion of Polyhedron_3.h
 #include <CGAL/Mesh_3/global_parameters.h>
+#include <CGAL/Default.h>
 
 #include "Polyhedron_type.h"
 #include "SMesh_type.h"
@@ -48,13 +49,10 @@ private:
 };
 #endif
 
-typedef CGAL::Triangle_accessor_3<Polyhedron, Kernel> T_accessor;
-typedef CGAL::Triangle_accessor_3<SMwgd, Kernel> T_sm_accessor;
-
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<
-          Kernel, Polyhedron, T_accessor, CGAL::Tag_true> Polyhedral_mesh_domain;
+          Kernel, Polyhedron, CGAL::Default, CGAL::Tag_true> Polyhedral_mesh_domain;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<
-          Kernel, SMwgd, T_sm_accessor, int> Polyhedral_mesh_domain_sm;
+          Kernel, SMwgd, CGAL::Default, int> Polyhedral_mesh_domain_sm;
 // The last `Tag_true` says the Patch_id type will be int, and not pair<int, int>
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES


### PR DESCRIPTION
## Summary of Changes

This PR fixes issue #2084 by using `PMP::Side_of_triangle_mesh` and its public API from `Polyhedral_mesh_domain_3` in Mesh_3.

It also fixes some compilation issues for the use of Mesh_3 with `Surface_mesh` and `Graph_with_descriptor_with_graph`.

## Release Management

* Affected package : Mesh_3, Demo
* Issue solved : fix #2084

