### PR TITLE
Polyhedron_demo: 'Save as' for Surface_mesh items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Surface_mesh_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Surface_mesh_io_plugin.cpp
@@ -35,11 +35,11 @@ public:
      return QList<QAction*>();
    }
    QString name() const { return "surface_mesh_io_plugin"; }
-   QString nameFilters() const { return "OFF files to Surface_mesh (*.off)"; }
+   QString nameFilters() const { return "OFF files to Surface_mesh (*.off);;Wavefront Surface_mesh OBJ (*.obj)"; }
    bool canLoad() const { return true; }
    CGAL::Three::Scene_item* load(QFileInfo fileinfo) {
-     if(fileinfo.suffix().toLower() != "off") return 0;
-
+     if(fileinfo.suffix().toLower() == "off")
+     {
      // Open file
      std::ifstream in(fileinfo.filePath().toUtf8());
      if(!in) {
@@ -69,17 +69,46 @@ public:
      Scene_surface_mesh_item* item = new Scene_surface_mesh_item(surface_mesh);
      item->setName(fileinfo.completeBaseName());
      return item;
+     }
+     else if(fileinfo.suffix().toLower() == "obj")
+     {
+       // Open file
+       std::ifstream in(fileinfo.filePath().toUtf8());
+       if(!in) {
+         std::cerr << "Error! Cannot open file " << (const char*)fileinfo.filePath().toUtf8() << std::endl;
+         return NULL;
+       }
+       Scene_surface_mesh_item* item = new Scene_surface_mesh_item();
+       if(item->load_obj(in))
+         return item;
+     }
+
+     return 0;
 
    }
    bool canSave(const CGAL::Three::Scene_item* ) {
-     return false;
+     return true;
    }
 
-   bool save(const CGAL::Three::Scene_item* , QFileInfo ) {
+   bool save(const CGAL::Three::Scene_item* item, QFileInfo fileinfo) {
+
+     const Scene_surface_mesh_item* sm_item =
+       qobject_cast<const Scene_surface_mesh_item*>(item);
+
+     if(!sm_item)
+       return false;
+
+     std::ofstream out(fileinfo.filePath().toUtf8());
+     out.precision (std::numeric_limits<double>::digits10 + 2);
+
+     if(fileinfo.suffix().toLower() == "off"){
+       return (sm_item && sm_item->save(out));
+     }
+     if(fileinfo.suffix().toLower() == "obj"){
+       return (sm_item && sm_item->save_obj(out));
+     }
      return false;
    }
-
-
 
 private:
    QList<QAction*> _actions;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -11,6 +11,7 @@
 
 //#include <CGAL/boost/graph/properties_Surface_mesh.h>
 #include <CGAL/Surface_mesh.h>
+#include <CGAL/Surface_mesh/IO.h>
 #include <CGAL/intersections.h>
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -556,13 +556,15 @@ void Scene_surface_mesh_item_priv::initializeBuffers(CGAL::Three::Viewer_interfa
   item->buffers[Scene_surface_mesh_item_priv::Smooth_normals].release();
   if(has_vcolors)
   {
-    item->buffers[VColors].bind();
-    item->buffers[VColors].allocate(v_colors.data(),
+    item->buffers[Scene_surface_mesh_item_priv::VColors].bind();
+    item->buffers[Scene_surface_mesh_item_priv::VColors].allocate(v_colors.data(),
                              static_cast<int>(v_colors.size()*sizeof(cgal_gl_data)));
-    //program->enableAttributeArray("colors");
+    program->enableAttributeArray("colors");
     program->setAttributeBuffer("colors",CGAL_GL_DATA,0,3);
-    item->buffers[VColors].release();
+    item->buffers[Scene_surface_mesh_item_priv::VColors].release();
   }
+  else
+    program->disableAttributeArray("colors");
   item->vaos[Scene_surface_mesh_item_priv::Smooth_facets]->release();
   program->release();
 

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -70,7 +70,9 @@ public:
 
   void compute_bbox()const Q_DECL_OVERRIDE;
   void standard_constructor(SMesh *sm);
-
+  bool save(std::ostream& out) const;
+  bool save_obj(std::ostream& out) const;
+  bool load_obj(std::istream& in);
 Q_SIGNALS:
   void item_is_about_to_be_changed();
   void selection_done();

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO.h
@@ -401,7 +401,7 @@ bool read_mesh(Surface_mesh<K>& mesh, const std::string& filename) {
     std::string::size_type dot(filename.rfind("."));
     if (dot == std::string::npos) return false;
     std::string ext = filename.substr(dot+1, filename.length()-dot-1);
-    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
     // extension determines reader
     if (ext == "off")

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO.h
@@ -39,6 +39,7 @@
 #include <CGAL/Surface_mesh/Surface_mesh.h>
 #include <CGAL/Surface_mesh/Properties.h>
 #include <CGAL/Kernel_traits.h>
+#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
 //=============================================================================
 
@@ -446,7 +447,50 @@ bool write_mesh(const Surface_mesh<K>& mesh, const std::string& filename)
 
 /// group io
 /// @}
+template <class P, class Writer>
+void
+generic_print_surface_mesh( std::ostream&   out,
+                          const Surface_mesh<P>&       M,
+                          Writer&           writer) {
+  // writes M to `out' in the format provided by `writer'.
+  typedef typename boost::graph_traits<Surface_mesh<P> >::vertex_iterator VCI;
+  typedef typename boost::graph_traits<Surface_mesh<P> >::face_iterator   FCI;
+  typedef typename Surface_mesh<P>::Halfedge_around_face_circulator            HFCC;
+  typedef typename boost::property_map<Surface_mesh<P>,CGAL::vertex_point_t>::type VPmap;
+  VPmap map = get(CGAL::vertex_point, M);
+  // Print header.
+  writer.write_header( out,
+                       num_vertices(M),
+                       num_halfedges(M),
+                       num_faces(M));
 
+  std::map<typename Surface_mesh<P>::vertex_index, std::size_t> index_map;
+  typename std::map<typename Surface_mesh<P>::vertex_index, std::size_t>::iterator hint = index_map.begin();
+  std::size_t id = 0;
+
+  for( VCI vi = vertices(M).begin(); vi != vertices(M).end(); ++vi) {
+    writer.write_vertex( ::CGAL::to_double( get(map, *vi).x()),
+                         ::CGAL::to_double( get(map, *vi).y()),
+                         ::CGAL::to_double( get(map, *vi).z()));
+
+    hint = index_map.insert(hint, std::make_pair(*vi, id++));
+  }
+
+  writer.write_facet_header();
+  for( FCI fi = faces(M).begin(); fi != faces(M).end(); ++fi) {
+    HFCC hc(halfedge(*fi, M), M);
+    HFCC hc_end = hc;
+    std::size_t n = circulator_size( hc);
+    CGAL_assertion( n >= 3);
+    writer.write_facet_begin( n);
+    do {
+      writer.write_facet_vertex_index(index_map[target(*hc, M)]);
+      ++hc;
+    } while( hc != hc_end);
+    writer.write_facet_end();
+  }
+  writer.write_footer();
+}
 } // CGAL
 
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1969,12 +1969,28 @@ private: //------------------------------------------------------- private data
     typedef typename Mesh::Vertex_index Vertex_index;
     typedef typename Mesh::Face_index Face_index;
 
-    os << "OFF\n" << sm.number_of_vertices() << " " << sm.number_of_faces() << " 0\n";
+    typename Mesh::template Property_map<typename Mesh::Vertex_index, CGAL::Color> vcolors;
+    bool has_vcolors;
+    boost::tie(vcolors, has_vcolors) = sm.template property_map<typename Mesh::Vertex_index, CGAL::Color >("v:color");
+    typename Mesh::template Property_map<typename Mesh::Face_index, CGAL::Color> fcolors;
+    bool has_fcolors;
+    boost::tie(fcolors, has_fcolors) = sm.template property_map<typename Mesh::Face_index, CGAL::Color >("f:color");
+
+    if(!has_fcolors && !has_vcolors)
+      os << "OFF\n" << sm.number_of_vertices() << " " << sm.number_of_faces() << " 0\n";
+    else
+      os << "COFF\n" << sm.number_of_vertices() << " " << sm.number_of_faces() << " 0\n";
     std::vector<int> reindex;
     reindex.resize(sm.num_vertices());
     int n = 0;
     BOOST_FOREACH(Vertex_index v, sm.vertices()){
-      os << sm.point(v) << '\n';
+      os << sm.point(v);
+      if(has_vcolors)
+      {
+        CGAL::Color color = vcolors[v];
+        os <<" "<< static_cast<int>(color.r())<<" "<< static_cast<int>(color.g())<<" "<< static_cast<int>(color.b());
+      }
+      os << '\n';
       reindex[v]=n++;
     }
 
@@ -1982,6 +1998,11 @@ private: //------------------------------------------------------- private data
       os << sm.degree(f);
       BOOST_FOREACH(Vertex_index v, CGAL::vertices_around_face(sm.halfedge(f),sm)){
         os << " " << reindex[v];
+      }
+      if(has_fcolors)
+      {
+        CGAL::Color color = fcolors[f];
+        os <<" "<< static_cast<int>(color.r())<<" "<< static_cast<int>(color.g())<<" "<< static_cast<int>(color.b());
       }
       os << '\n';
     }


### PR DESCRIPTION
## Summary of Changes
- Adds a Save_as in OFF and OBJ format for the Surface_mesh items
- Adds a color writing for the OFF format. As it does not seem to be officially supported by Wavefront OBJ format, I didn't think it was a good idea to add it, I don't want to break any compatibility.

## Release Management

* Affected package(s):Surface_mesh, Polyhedron_demo
* Issue(s) solved (if any): fix #2169

