### PR TITLE
Fix a compilation error in Travis

### DIFF
--- a/Interpolation/include/CGAL/Voronoi_intersection_2_traits_3.h
+++ b/Interpolation/include/CGAL/Voronoi_intersection_2_traits_3.h
@@ -26,6 +26,8 @@
 
 #include <CGAL/Origin.h>
 #include <CGAL/tags.h>
+#include <CGAL/number_utils.h>
+#include <CGAL/double.h>
 #include <CGAL/number_utils_classes.h>
 #include <CGAL/representation_tags.h>
 #include <CGAL/predicates/predicates_for_voronoi_intersection_cartesian_2_3.h>


### PR DESCRIPTION
Fix an error introduced by the merge of #2198 in `master` and `releases/CGAL-4.10-branch`.

(fix the `check_pkg_Interpolation_headers` target)


* Affected package(s): all packages including `<CGAL/Triangulation_2.h>`
* Issue(s) solved (if any):
* Feature/Small Feature (if any):