### PR TITLE
Polyhedron_demo: Fix clipping bug

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -184,8 +184,8 @@ MainWindow::MainWindow(QWidget* parent)
   connect(scene, SIGNAL(itemAboutToBeDestroyed(CGAL::Three::Scene_item*)),
           this, SLOT(removeManipulatedFrame(CGAL::Three::Scene_item*)));
 
-  connect(scene, SIGNAL(updated_bbox()),
-          this, SLOT(updateViewerBBox()));
+  connect(scene, SIGNAL(updated_bbox(bool)),
+          this, SLOT(updateViewerBBox(bool)));
 
   connect(scene, SIGNAL(selectionChanged(int)),
           this, SLOT(selectSceneItem(int)));
@@ -813,9 +813,14 @@ void MainWindow::error(QString text) {
   this->message("ERROR: " + text, "red");
 }
 
-void MainWindow::updateViewerBBox()
+void MainWindow::updateViewerBBox(bool recenter = true)
 {
   const Scene::Bbox bbox = scene->bbox();
+#if QGLVIEWER_VERSION >= 0x020502
+    qglviewer::Vec center = viewer->camera()->pivotPoint();
+#else
+    qglviewer::Vec center = viewer->camera()->revolveAroundPoint();
+#endif
   const double xmin = bbox.xmin();
   const double ymin = bbox.ymin();
   const double zmin = bbox.zmin();
@@ -851,7 +856,18 @@ void MainWindow::updateViewerBBox()
 
   viewer->setSceneBoundingBox(vec_min,
                               vec_max);
-  viewer->camera()->showEntireScene();
+  if(recenter)
+  {
+    viewer->camera()->showEntireScene();
+  }
+  else
+  {
+#if QGLVIEWER_VERSION >= 0x020502
+    viewer->camera()->setPivotPoint(center);
+#else
+    viewer->camera()->setRevolveAroundPoint(center);
+#endif
+  }
 }
 
 void MainWindow::reloadItem() {

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -241,10 +241,8 @@ MainWindow::MainWindow(QWidget* parent)
   // can easily copy-paste its text.
   // connect(ui->infoLabel, SIGNAL(customContextMenuRequested(const QPoint & )),
   //         this, SLOT(showSceneContextMenu(const QPoint &)));
-
   connect(ui->actionRecenterScene, SIGNAL(triggered()),
           viewer, SLOT(update()));
-
   connect(ui->actionAntiAliasing, SIGNAL(toggled(bool)),
           viewer, SLOT(setAntiAliasing(bool)));
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -95,7 +95,8 @@ public Q_SLOTS:
   //!Creates a new group and adds it to the scene.
   void makeNewGroup();
   //! Re-computes the viewer's Bbox
-  void updateViewerBBox();
+  //! If `b` is true, recenters the scene.
+  void updateViewerBBox(bool b);
   //! Opens a script or a file with the default loader if there is.
   void open(QString);
   //! Is called when the up button is pressed.

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -347,7 +347,6 @@ protected Q_SLOTS:
   void filterOperations();
   //!Updates the bounding box and moves the camera to fits the scene.
   void on_actionRecenterScene_triggered();
-
   //!Resizes the header of the scene view
   void resetHeader();
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -346,60 +346,6 @@
     <string>Ctrl+Q</string>
    </property>
   </action>
-  <action name="actionSimplify">
-   <property name="text">
-    <string>&amp;Simplification</string>
-   </property>
-  </action>
-  <action name="actionCatmullClark">
-   <property name="text">
-    <string>&amp;Catmull-Clark</string>
-   </property>
-  </action>
-  <action name="actionKernel">
-   <property name="text">
-    <string>&amp;Kernel</string>
-   </property>
-  </action>
-  <action name="actionUnion">
-   <property name="text">
-    <string>&amp;Union (A/B)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O, U</string>
-   </property>
-  </action>
-  <action name="actionIntersection">
-   <property name="text">
-    <string>&amp;Intersection (A/B)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O, I</string>
-   </property>
-  </action>
-  <action name="actionDifference">
-   <property name="text">
-    <string>&amp;Difference (A/B)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O, D</string>
-   </property>
-  </action>
-  <action name="actionFitPlane">
-   <property name="text">
-    <string>Fit &amp;Plane</string>
-   </property>
-  </action>
-  <action name="actionFitLine">
-   <property name="text">
-    <string>Fit &amp;Line</string>
-   </property>
-  </action>
-  <action name="actionEstimateCurvature">
-   <property name="text">
-    <string>&amp;Curvature Estimation</string>
-   </property>
-  </action>
   <action name="actionLoad">
    <property name="icon">
     <iconset resource="Polyhedron_3.qrc">
@@ -436,11 +382,6 @@
     <string>Ctrl+D</string>
    </property>
   </action>
-  <action name="actionSqrt3">
-   <property name="text">
-    <string>&amp;Sqrt3</string>
-   </property>
-  </action>
   <action name="actionAntiAliasing">
    <property name="checkable">
     <bool>true</bool>
@@ -454,69 +395,14 @@
     <string>n/a</string>
    </property>
   </action>
-  <action name="actionConvexHull">
-   <property name="text">
-    <string>&amp;Convex Hull</string>
-   </property>
-  </action>
   <action name="actionEraseAll">
    <property name="text">
     <string>&amp;Erase All</string>
    </property>
   </action>
-  <action name="actionOptions">
-   <property name="text">
-    <string>&amp;Options...</string>
-   </property>
-  </action>
-  <action name="actionLoop">
-   <property name="text">
-    <string>&amp;Loop</string>
-   </property>
-  </action>
   <action name="actionSaveAs">
    <property name="text">
     <string>Save &amp;as...</string>
-   </property>
-  </action>
-  <action name="actionSave">
-   <property name="text">
-    <string>&amp;Save</string>
-   </property>
-  </action>
-  <action name="actionSaveAll">
-   <property name="text">
-    <string>Save A&amp;ll</string>
-   </property>
-  </action>
-  <action name="actionMergeAll">
-   <property name="text">
-    <string>Mer&amp;ge All</string>
-   </property>
-  </action>
-  <action name="actionMerge">
-   <property name="text">
-    <string>&amp;Merge</string>
-   </property>
-  </action>
-  <action name="actionSelfIntersection">
-   <property name="text">
-    <string>Self-&amp;intersection</string>
-   </property>
-  </action>
-  <action name="actionSelectAll">
-   <property name="text">
-    <string>Select &amp;All</string>
-   </property>
-  </action>
-  <action name="actionSelectNone">
-   <property name="text">
-    <string>Select &amp;None</string>
-   </property>
-  </action>
-  <action name="actionSelectInvert">
-   <property name="text">
-    <string>&amp;Invert Selection</string>
    </property>
   </action>
   <action name="actionShowHide">
@@ -535,46 +421,6 @@
   <action name="actionSetPolyhedronB">
    <property name="text">
     <string>Set Polyhedron B</string>
-   </property>
-  </action>
-  <action name="actionInsideOut">
-   <property name="text">
-    <string>&amp;Inside-Out</string>
-   </property>
-  </action>
-  <action name="actionRemeshing">
-   <property name="text">
-    <string>&amp;Remeshing</string>
-   </property>
-  </action>
-  <action name="actionConvexDecomposition">
-   <property name="text">
-    <string>Convex Decomposition</string>
-   </property>
-  </action>
-  <action name="actionMVC">
-   <property name="text">
-    <string>Mean &amp;Value Coordinates</string>
-   </property>
-  </action>
-  <action name="actionDCP">
-   <property name="text">
-    <string>Discrete &amp;Conformal Maps</string>
-   </property>
-  </action>
-  <action name="actionExplode">
-   <property name="text">
-    <string>Explode</string>
-   </property>
-  </action>
-  <action name="actionToNef">
-   <property name="text">
-    <string>Convert to Nef Polyhedron</string>
-   </property>
-  </action>
-  <action name="actionToPoly">
-   <property name="text">
-    <string>Convert to Normal Polyhedron</string>
    </property>
   </action>
   <action name="actionDrawTwoSides">
@@ -599,14 +445,6 @@
   <action name="actionSetBackgroundColor">
    <property name="text">
     <string>Change &amp;Background Color...</string>
-   </property>
-  </action>
-  <action name="actionMinkowskiSum">
-   <property name="text">
-    <string>&amp;Minkowski Sum (A/B)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O, M</string>
    </property>
   </action>
   <action name="actionLookAt">
@@ -650,11 +488,6 @@
   <action name="actionPreferences">
    <property name="text">
     <string>&amp;Preferences</string>
-   </property>
-  </action>
-  <action name="actionLSC">
-   <property name="text">
-    <string>Least Square Conformal Maps</string>
    </property>
   </action>
   <action name="actionLoadPlugin">
@@ -705,7 +538,6 @@
     <string>In Polyhedron Mode, the default type for facegraphs is Polyhedron, by opposition to Surface_mesh.</string>
    </property>
   </action>
-
  </widget>
  <customwidgets>
   <customwidget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -144,8 +144,8 @@ public:
             this, SLOT(on_actionSkeletonize()));
     connect(ui->pushButton_converge, SIGNAL(clicked()),
             this, SLOT(on_actionConverge()));
-    connect(dynamic_cast<Scene*>(scene), SIGNAL(updated_bbox()),
-            this, SLOT(on_actionUpdateBBox()));
+    connect(dynamic_cast<Scene*>(scene), SIGNAL(updated_bbox(bool)),
+            this, SLOT(on_actionUpdateBBox(bool)));
     connect(ui->pushButton_segment, SIGNAL(clicked()),
             this, SLOT(on_actionSegment()));
 
@@ -361,7 +361,7 @@ public Q_SLOTS:
   void on_actionRun();
   void on_actionSkeletonize();
   void on_actionConverge();
-  void on_actionUpdateBBox();
+  void on_actionUpdateBBox(bool);
   void on_actionSegment();
   void on_actionItemAboutToBeDestroyed(CGAL::Three::Scene_item*);
 
@@ -408,7 +408,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionMCFSkeleton_t
   }
 }
 
-void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionUpdateBBox()
+void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionUpdateBBox(bool)
 {
   double diag = scene->len_diagonal();
   ui->min_edge_length->setValue(0.002 * diag);

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -61,6 +61,8 @@ Scene::addItem(CGAL::Three::Scene_item* item)
     m_entries.push_back(item);
     connect(item, SIGNAL(itemChanged()),
             this, SLOT(itemChanged()));
+    connect(item, SIGNAL(itemVisibilityChanged()),
+            this, SLOT(itemVisibilityChanged()));
     connect(item, SIGNAL(redraw()),
             this, SLOT(callDraw()));
     if(item->isFinite()
@@ -68,7 +70,7 @@ Scene::addItem(CGAL::Three::Scene_item* item)
             && bbox_before + item->bbox() != bbox_before
             )
     {
-        Q_EMIT updated_bbox();
+        Q_EMIT updated_bbox(true);
     }
     QList<QStandardItem*> list;
     for(int i=0; i<5; i++)
@@ -98,6 +100,8 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
 
     connect(item, SIGNAL(itemChanged()),
             this, SLOT(itemChanged()));
+    connect(item, SIGNAL(itemVisibilityChanged()),
+            this, SLOT(itemVisibilityChanged()));
     CGAL::Three::Scene_group_item* group =
             qobject_cast<CGAL::Three::Scene_group_item*>(m_entries[index]);
     if(group)
@@ -116,7 +120,7 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
          m_entries[index]->isFinite() && !m_entries[index]->isEmpty() &&
          item->bbox()!=m_entries[index]->bbox() )
     {
-    Q_EMIT updated_bbox();
+    Q_EMIT updated_bbox(true);
     }
 
     if(emit_item_about_to_be_destroyed) {
@@ -909,6 +913,26 @@ void Scene::itemChanged(CGAL::Three::Scene_item*)
   Q_EMIT dataChanged(this->createIndex(0, 0),
                      this->createIndex(m_entries.size() - 1, LastColumn));
 }
+
+void Scene::itemVisibilityChanged()
+{
+    CGAL::Three::Scene_item* item = qobject_cast<CGAL::Three::Scene_item*>(sender());
+    if(item)
+        itemVisibilityChanged(item);
+}
+
+void Scene::itemVisibilityChanged(CGAL::Three::Scene_item* item)
+{
+  Bbox bbox_before = bbox();
+
+  if(item->isFinite()
+     && !item->isEmpty())
+  {
+    //does not recenter
+    Q_EMIT updated_bbox(false);
+  }
+}
+
 
 bool SceneDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
                                 const QStyleOptionViewItem &option,

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -923,8 +923,6 @@ void Scene::itemVisibilityChanged()
 
 void Scene::itemVisibilityChanged(CGAL::Three::Scene_item* item)
 {
-  Bbox bbox_before = bbox();
-
   if(item->isFinite()
      && !item->isEmpty())
   {

--- a/Polyhedron/demo/Polyhedron/Scene.h
+++ b/Polyhedron/demo/Polyhedron/Scene.h
@@ -142,6 +142,9 @@ public Q_SLOTS:
   void itemChanged();
   void itemChanged(int i) Q_DECL_OVERRIDE;
   void itemChanged(CGAL::Three::Scene_item*) Q_DECL_OVERRIDE;
+  //!Transmits a CGAL::Three::Scene_item::itemVisibilityChanged() signal to the scene.
+  void itemVisibilityChanged();
+  void itemVisibilityChanged(CGAL::Three::Scene_item*) Q_DECL_OVERRIDE;
   //!Removes `item` from all the groups of the scene.
   void remove_item_from_groups(CGAL::Three::Scene_item* item);
   //!Re-organizes the sceneView.
@@ -209,7 +212,8 @@ Q_SIGNALS:
   //! Is emitted when a new item is added to the scene.
   void newItem(int);
   //! Emit this to re-compute the viewer's Bbox;
-  void updated_bbox();
+  //! If `b` is true, the scene will be recentered
+  void updated_bbox(bool b);
   //! Emit this to redraw the scene.
   void updated();
   //! Is emitted when `item` is erased.

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -160,6 +160,8 @@ void CGAL::Three::Scene_item::selection_changed(bool) {}
 void CGAL::Three::Scene_item::setVisible(bool b)
 {
   visible_ = b;
+  if(b)
+    itemVisibilityChanged();
 }
 
 

--- a/Three/include/CGAL/Three/Scene_interface.h
+++ b/Three/include/CGAL/Three/Scene_interface.h
@@ -138,13 +138,14 @@ public:
   virtual double len_diagonal() const = 0;
 
 public:
-  //! Updates the information about the item `i`th in the
+  //! Updates the information about the `i`th item in the
   //! Geometric Objects list and redraws the scene.
   virtual void itemChanged(Item_id i) = 0;
   //! Updates the information about `item` in the
   //! Geometric Objects list and redraws the scene.
-  virtual void itemChanged(CGAL::Three::Scene_item* itme) = 0;
-
+  virtual void itemChanged(CGAL::Three::Scene_item* item) = 0;
+  //! Re computes the scnee's Bbox without recentering it.
+  virtual void itemVisibilityChanged(CGAL::Three::Scene_item*) = 0;
   //! Clears the current selection then sets the selected item to the target index.
   //! Used to update the selection in the Geometric Objects view.
   virtual void setSelectedItem(Item_id) = 0;  

--- a/Three/include/CGAL/Three/Scene_interface.h
+++ b/Three/include/CGAL/Three/Scene_interface.h
@@ -144,7 +144,7 @@ public:
   //! Updates the information about `item` in the
   //! Geometric Objects list and redraws the scene.
   virtual void itemChanged(CGAL::Three::Scene_item* item) = 0;
-  //! Re computes the scnee's Bbox without recentering it.
+  //! Re computes the scene Bbox without recentering it.
   virtual void itemVisibilityChanged(CGAL::Three::Scene_item*) = 0;
   //! Clears the current selection then sets the selected item to the target index.
   //! Used to update the selection in the Geometric Objects view.

--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -374,6 +374,9 @@ public Q_SLOTS:
 Q_SIGNALS:
   //! Is emitted to notify a change in the item's data.
   void itemChanged();
+  //! Is emitted when the item is shown to notify a change in the item's visibility.
+  //! Typically used to update the scene's bbox;
+  void itemVisibilityChanged();
   //! Is emitted to notify that the item is about to be deleted.
   void aboutToBeDestroyed();
   //! Is emitted to require a new display.


### PR DESCRIPTION
Fixes the clipping bug that occurs when the user recenters the scene and then changes its Bbox (by un-hiding an item for example)

## Release Management

* Affected package(s):Polyhedron_demo

