### PR TITLE
Point set 3: bug fix remove index

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -581,8 +581,7 @@ public:
   */
   void remove (const Index& index)
   {
-    std::swap (index, *(end() - 1));
-    ++ m_nb_removed;
+    remove (m_indices.begin() + index);
   }
 
 

--- a/Point_set_3/test/Point_set_3/point_set_test.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test.cpp
@@ -74,6 +74,12 @@ int main (int, char**)
   point_set.collect_garbage();
   test (!(point_set.has_garbage()), "point set shouldn't have garbage.");
 
+  point_set.remove (*(point_set.begin()));
+  
+  test (point_set.has_garbage(), "point set should have garbage.");
+  point_set.collect_garbage();
+  test (!(point_set.has_garbage()), "point set shouldn't have garbage.");
+  
   test (!(point_set.has_property_map<Color> ("color")), "point set shouldn't have colors.");
   Point_set::Property_map<Color> color_prop;
   bool garbage;


### PR DESCRIPTION
## Summary of Changes

The removal method that takes an indexed was not usable (and not tested) because the index was modified internally while being const. This fixes it.

## Release Management

* Affected package(s): Point_set_3
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2221

