### PR TITLE
Polyhedron_demo: Fix discarding during deformation 

### DIFF
--- a/Surface_mesh_deformation/include/CGAL/Surface_mesh_deformation.h
+++ b/Surface_mesh_deformation/include/CGAL/Surface_mesh_deformation.h
@@ -823,8 +823,6 @@ public:
    */
   void reset()
   {
-    if(roi.empty()) { return; } // no ROI to reset
-
     region_of_solution(); // since we are using original vector
 
     //restore the current positions to be the original positions


### PR DESCRIPTION
## Summary of Changes
It is now possible to discard changes when deforming a mesh even without ROIs.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #2228
* Feature/Small Feature (if any):

