### PR TITLE
Travis: restore -Werror=inconsistent-missing-override

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -35,9 +35,11 @@ function build_demo {
     popd
   fi
   EXTRA_CXX_FLAGS=
-  if [ "$CC" = "clang" ]; then
-    EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
-  fi
+  case "$CC" in
+    clang*)
+      EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
+      ;;
+  esac
   if [ $NEED_3D = 1 ]; then
     QGLVIEWERROOT=$PWD/qglviewer
     export QGLVIEWERROOT


### PR DESCRIPTION
With the switch to clang-3.6, the `$CC` no longer matches "clang". This patch should re-add that the flag `-Werror=inconsistent-missing-override` to clang builds.
