### PR TITLE
Polyhedron_demo: Add statistics and orthogonal zoom to SM item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -2070,8 +2070,8 @@ void Scene_polyhedron_item::zoomToPosition(const QPoint &point, CGAL::Three::Vie
                                      zmax-zmin);
         //put the camera in way we are sure the longest side is entirely visible on the screen
         //See openGL's frustum definition
-        double factor = max_side/(tan(viewer->camera()->aspectRatio()/
-                                        (viewer->camera()->fieldOfView()/2)));
+        double factor = CGAL::abs(max_side/(tan(viewer->camera()->aspectRatio()/
+                                        (viewer->camera()->fieldOfView()/2))));
 
         Kernel::Point_3 new_pos = centroid + factor*face_normal ;
         viewer->camera()->setSceneCenter(qglviewer::Vec(centroid.x(),

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -16,16 +16,19 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 
+#include <CGAL/Polygon_mesh_processing/connected_components.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <CGAL/Polygon_mesh_processing/repair.h>
+
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include "triangulate_primitive.h"
 
-//#include <CGAL/IO/Polyhedron_iostream.h>
 #include <CGAL/IO/File_writer_wavefront.h>
 #include <CGAL/IO/generic_copy_OFF.h>
 #include <CGAL/IO/OBJ_reader.h>
+#include <CGAL/Polygon_mesh_processing/measure.h>
+#include <CGAL/statistics_helpers.h>
 
 //Used to triangulate the AABB_Tree
 class Primitive
@@ -77,6 +80,7 @@ struct Scene_surface_mesh_item_priv{
   {
     item = parent;
     has_feature_edges = false;
+    invalidate_stats();
   }
 
   Scene_surface_mesh_item_priv(SMesh* sm, Scene_surface_mesh_item *parent):
@@ -84,6 +88,7 @@ struct Scene_surface_mesh_item_priv{
   {
     item = parent;
     has_feature_edges = false;
+    invalidate_stats();
   }
 
   ~Scene_surface_mesh_item_priv()
@@ -96,6 +101,7 @@ struct Scene_surface_mesh_item_priv{
   }
 
   void initialize_colors();
+  void invalidate_stats();
   void initializeBuffers(CGAL::Three::Viewer_interface *) const;
   void addFlatData(Point, EPICK::Vector_3, CGAL::Color *) const;
   void* get_aabb_tree();
@@ -162,6 +168,11 @@ struct Scene_surface_mesh_item_priv{
   mutable SMesh::Property_map<halfedge_descriptor, bool> h_is_feature_map;
 
   Color_vector colors_;
+  double volume, area;
+  unsigned int number_of_null_length_edges;
+  unsigned int number_of_degenerated_faces;
+  int genus;
+  bool self_intersect;
 };
 
 const char* aabb_property_name = "Scene_surface_mesh_item aabb tree";
@@ -1021,6 +1032,7 @@ void Scene_surface_mesh_item::invalidateOpenGLBuffers()
   delete_aabb_tree(this);
   d->smesh_->collect_garbage();
   are_buffers_filled = false;
+  d->invalidate_stats();
 }
 
 
@@ -1185,4 +1197,249 @@ Scene_surface_mesh_item::save_obj(std::ostream& out) const
   CGAL::File_writer_wavefront  writer;
   CGAL::generic_print_surface_mesh(out, *(d->smesh_), writer);
   return out.good();
+}
+
+void
+Scene_surface_mesh_item_priv::
+invalidate_stats()
+{
+  number_of_degenerated_faces = (unsigned int)(-1);
+  number_of_null_length_edges = (unsigned int)(-1);
+  volume = -std::numeric_limits<double>::infinity();
+  area = -std::numeric_limits<double>::infinity();
+  self_intersect = false;
+  genus = -1;
+}
+
+QString Scene_surface_mesh_item::computeStats(int type)
+{
+  double minl, maxl, meanl, midl;
+  switch (type)
+  {
+  case MIN_LENGTH:
+  case MAX_LENGTH:
+  case MID_LENGTH:
+  case MEAN_LENGTH:
+  case NB_NULL_LENGTH:
+    edges_length(d->smesh_, minl, maxl, meanl, midl, d->number_of_null_length_edges);
+  }
+
+  double mini, maxi, ave;
+  switch (type)
+  {
+  case MIN_ANGLE:
+  case MAX_ANGLE:
+  case MEAN_ANGLE:
+    angles(d->smesh_, mini, maxi, ave);
+  }
+  double min_area, max_area, med_area, mean_area;
+  switch (type)
+  {
+  case MIN_AREA:
+  case MAX_AREA:
+  case MEAN_AREA:
+  case MED_AREA:
+    if(!is_triangle_mesh(*d->smesh_))
+    {
+      return QString("n/a");
+    }
+    faces_area(d->smesh_, min_area, max_area, mean_area, med_area);
+  }
+  double min_altitude, min_ar, max_ar, mean_ar;
+  switch (type)
+  {
+  case MIN_ALTITUDE:
+  case MIN_ASPECT_RATIO:
+  case MAX_ASPECT_RATIO:
+  case MEAN_ASPECT_RATIO:
+    if(!is_triangle_mesh(*d->smesh_))
+    {
+      return QString("n/a");
+    }
+    faces_aspect_ratio(d->smesh_, min_altitude, min_ar, max_ar, mean_ar);
+  }
+
+  switch(type)
+  {
+  case NB_VERTICES:
+    return QString::number(num_vertices(*d->smesh_));
+
+  case NB_FACETS:
+    return QString::number(num_faces(*d->smesh_));
+
+  case NB_CONNECTED_COMPOS:
+  {
+    boost::vector_property_map<int,
+      boost::property_map<SMesh, boost::face_index_t>::type>
+      fccmap(get(boost::face_index, *(d->smesh_)));
+    return QString::number(CGAL::Polygon_mesh_processing::connected_components(*(d->smesh_), fccmap));
+  }
+  case NB_BORDER_EDGES:
+  {
+    int i=0;
+    BOOST_FOREACH(halfedge_descriptor hd, halfedges(*d->smesh_))
+    {
+      if(is_border(hd, *d->smesh_))
+        ++i;
+    }
+    return QString::number(i);
+  }
+
+  case NB_EDGES:
+    return QString::number(num_halfedges(*d->smesh_) / 2);
+
+  case NB_DEGENERATED_FACES:
+  {
+    if(is_triangle_mesh(*d->smesh_))
+    {
+      if (d->number_of_degenerated_faces == (unsigned int)(-1))
+        d->number_of_degenerated_faces = nb_degenerate_faces(d->smesh_, get(CGAL::vertex_point, *(d->smesh_)));
+      return QString::number(d->number_of_degenerated_faces);
+    }
+    else
+      return QString("n/a");
+  }
+  case AREA:
+  {
+    if(is_triangle_mesh(*d->smesh_))
+    {
+      if(d->area == -std::numeric_limits<double>::infinity())
+        d->area = CGAL::Polygon_mesh_processing::area(*(d->smesh_));
+      return QString::number(d->area);
+    }
+    else
+      return QString("n/a");
+  }
+  case VOLUME:
+  {
+    if(is_triangle_mesh(*d->smesh_) && is_closed(*d->smesh_))
+    {
+      if (d->volume == -std::numeric_limits<double>::infinity())
+        d->volume = CGAL::Polygon_mesh_processing::volume(*(d->smesh_));
+      return QString::number(d->volume);
+    }
+    else
+      return QString("n/a");
+  }
+  case SELFINTER:
+  {
+    //todo : add a test about cache validity
+    if(is_triangle_mesh(*d->smesh_))
+      d->self_intersect = CGAL::Polygon_mesh_processing::does_self_intersect(*(d->smesh_));
+    if (d->self_intersect)
+      return QString("Yes");
+    else if(is_triangle_mesh(*d->smesh_))
+      return QString("No");
+    else
+      return QString("n/a");
+  }
+  case GENUS:
+  {
+    if(!is_closed(*d->smesh_))
+    {
+      return QString("n/a");
+    }
+    else if(d->genus == -1)
+    {
+      std::ptrdiff_t s(num_vertices(*d->smesh_)),
+          a(num_halfedges(*d->smesh_)/2),
+          f(num_faces(*d->smesh_));
+      d->genus = 1.0 - double(s-a+f)/2.0;
+    }
+    if(d->genus < 0)
+    {
+      return QString("n/a");
+    }
+    else
+    {
+      return QString::number(d->genus);
+    }
+
+  }
+  case MIN_LENGTH:
+    return QString::number(minl);
+  case MAX_LENGTH:
+    return QString::number(maxl);
+  case MID_LENGTH:
+    return QString::number(midl);
+  case MEAN_LENGTH:
+    return QString::number(meanl);
+  case NB_NULL_LENGTH:
+    return QString::number(d->number_of_null_length_edges);
+
+  case MIN_ANGLE:
+    return QString::number(mini);
+  case MAX_ANGLE:
+    return QString::number(maxi);
+  case MEAN_ANGLE:
+    return QString::number(ave);
+  case HOLES:
+    return QString::number(nb_holes(d->smesh_));
+
+  case MIN_AREA:
+    return QString::number(min_area);
+  case MAX_AREA:
+    return QString::number(max_area);
+  case MED_AREA:
+    return QString::number(med_area);
+  case MEAN_AREA:
+    return QString::number(mean_area);
+  case MIN_ALTITUDE:
+    return QString::number(min_altitude);
+  case MIN_ASPECT_RATIO:
+    return QString::number(min_ar);
+  case MAX_ASPECT_RATIO:
+    return QString::number(max_ar);
+  case MEAN_ASPECT_RATIO:
+    return QString::number(mean_ar);
+  case IS_PURE_TRIANGLE:
+    if(is_triangle_mesh(*d->smesh_))
+      return QString("yes");
+    else
+      return QString("no");
+  }
+  return QString();
+}
+
+CGAL::Three::Scene_item::Header_data Scene_surface_mesh_item::header() const
+{
+  CGAL::Three::Scene_item::Header_data data;
+  //categories
+
+  data.categories.append(std::pair<QString,int>(QString("Properties"),9));
+  data.categories.append(std::pair<QString,int>(QString("Faces"),10));
+  data.categories.append(std::pair<QString,int>(QString("Edges"),6));
+  data.categories.append(std::pair<QString,int>(QString("Angles"),3));
+
+
+  //titles
+  data.titles.append(QString("#Vertices"));
+  data.titles.append(QString("#Connected Components"));
+  data.titles.append(QString("#Border Edges"));
+  data.titles.append(QString("Pure Triangle"));
+  data.titles.append(QString("#Degenerated Faces"));
+  data.titles.append(QString("Connected Components of the Boundary"));
+  data.titles.append(QString("Area"));
+  data.titles.append(QString("Volume"));
+  data.titles.append(QString("Self-Intersecting"));
+  data.titles.append(QString("#Faces"));
+  data.titles.append(QString("Min Area"));
+  data.titles.append(QString("Max Area"));
+  data.titles.append(QString("Median Area"));
+  data.titles.append(QString("Mean Area"));
+  data.titles.append(QString("Min Altitude"));
+  data.titles.append(QString("Min Aspect-Ratio"));
+  data.titles.append(QString("Max Aspect-Ratio"));
+  data.titles.append(QString("Mean Aspect-Ratio"));
+  data.titles.append(QString("Genus"));
+  data.titles.append(QString("#Edges"));
+  data.titles.append(QString("Minimum Length"));
+  data.titles.append(QString("Maximum Length"));
+  data.titles.append(QString("Median Length"));
+  data.titles.append(QString("Mean Length"));
+  data.titles.append(QString("#Null Length"));
+  data.titles.append(QString("Minimum"));
+  data.titles.append(QString("Maximum"));
+  data.titles.append(QString("Average"));
+  return data;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1443,3 +1443,116 @@ CGAL::Three::Scene_item::Header_data Scene_surface_mesh_item::header() const
   data.titles.append(QString("Average"));
   return data;
 }
+
+void Scene_surface_mesh_item::zoomToPosition(const QPoint &point, CGAL::Three::Viewer_interface *viewer) const
+{
+  typedef Input_facets_AABB_tree Tree;
+  typedef Tree::Intersection_and_primitive_id<EPICK::Ray_3>::Type Intersection_and_primitive_id;
+
+  Tree* aabb_tree = static_cast<Input_facets_AABB_tree*>(d->get_aabb_tree());
+  if(aabb_tree) {
+
+    const qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+    //find clicked facet
+    bool found = false;
+    const EPICK::Point_3 ray_origin(viewer->camera()->position().x - offset.x,
+                                     viewer->camera()->position().y - offset.y,
+                                     viewer->camera()->position().z - offset.z);
+    qglviewer::Vec point_under = viewer->camera()->pointUnderPixel(point,found);
+    qglviewer::Vec dir = point_under - viewer->camera()->position();
+    const EPICK::Vector_3 ray_dir(dir.x, dir.y, dir.z);
+    const EPICK::Ray_3 ray(ray_origin, ray_dir);
+    typedef std::list<Intersection_and_primitive_id> Intersections;
+    Intersections intersections;
+    aabb_tree->all_intersections(ray, std::back_inserter(intersections));
+
+    if(!intersections.empty()) {
+      Intersections::iterator closest = intersections.begin();
+      const EPICK::Point_3* closest_point =
+          boost::get<EPICK::Point_3>(&closest->first);
+      for(Intersections::iterator
+          it = boost::next(intersections.begin()),
+          end = intersections.end();
+          it != end; ++it)
+      {
+        if(! closest_point) {
+          closest = it;
+        }
+        else {
+          const EPICK::Point_3* it_point =
+              boost::get<EPICK::Point_3>(&it->first);
+          if(it_point &&
+             (ray_dir * (*it_point - *closest_point)) < 0)
+          {
+            closest = it;
+            closest_point = it_point;
+          }
+        }
+      }
+      if(closest_point) {
+        SMesh::Property_map<vertex_descriptor, SMesh::Point> positions =
+          d->smesh_->points();
+        face_descriptor selected_fh = closest->second;
+        //compute new position and orientation
+        EPICK::Vector_3 face_normal = CGAL::Polygon_mesh_processing::
+            compute_face_normal(selected_fh,
+                                *d->smesh_,
+                                CGAL::Polygon_mesh_processing::parameters::all_default());
+
+
+        double x(0), y(0), z(0),
+            xmin(std::numeric_limits<double>::infinity()), ymin(std::numeric_limits<double>::infinity()), zmin(std::numeric_limits<double>::infinity()),
+            xmax(-std::numeric_limits<double>::infinity()), ymax(-std::numeric_limits<double>::infinity()), zmax(-std::numeric_limits<double>::infinity());
+        int total(0);
+        BOOST_FOREACH(vertex_descriptor vh, vertices_around_face(halfedge(selected_fh, *d->smesh_), *d->smesh_))
+        {
+          x+=positions[vh].x();
+          y+=positions[vh].y();
+          z+=positions[vh].z();
+
+          if(positions[vh].x() < xmin)
+            xmin = positions[vh].x();
+          if(positions[vh].y() < ymin)
+            ymin = positions[vh].y();
+          if(positions[vh].z() < zmin)
+            zmin = positions[vh].z();
+
+          if(positions[vh].x() > xmax)
+            xmax = positions[vh].x();
+          if(positions[vh].y() > ymax)
+            ymax = positions[vh].y();
+          if(positions[vh].z() > zmax)
+            zmax = positions[vh].z();
+
+          ++total;
+        }
+        EPICK::Point_3 centroid(x/total + offset.x,
+                                 y/total + offset.y,
+                                 z/total + offset.z);
+
+        qglviewer::Quaternion new_orientation(qglviewer::Vec(0,0,-1),
+                                              qglviewer::Vec(-face_normal.x(), -face_normal.y(), -face_normal.z()));
+        double max_side = (std::max)((std::max)(xmax-xmin, ymax-ymin),
+                                     zmax-zmin);
+        //put the camera in way we are sure the longest side is entirely visible on the screen
+        //See openGL's frustum definition
+        double factor = CGAL::abs(max_side/(tan(viewer->camera()->aspectRatio()/
+                                        (viewer->camera()->fieldOfView()/2))));
+
+        EPICK::Point_3 new_pos = centroid + factor*face_normal ;
+        viewer->camera()->setSceneCenter(qglviewer::Vec(centroid.x(),
+                                                        centroid.y(),
+                                                        centroid.z()));
+        viewer->moveCameraToCoordinates(QString("%1 %2 %3 %4 %5 %6 %7").arg(new_pos.x())
+                                                                       .arg(new_pos.y())
+                                                                       .arg(new_pos.z())
+                                                                       .arg(new_orientation[0])
+                                                                       .arg(new_orientation[1])
+                                                                       .arg(new_orientation[2])
+                                                                       .arg(new_orientation[3]));
+
+      }
+    }
+  }
+
+}

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -74,6 +74,41 @@ public:
   bool save(std::ostream& out) const;
   bool save_obj(std::ostream& out) const;
   bool load_obj(std::istream& in);
+
+  enum STATS {
+    NB_VERTICES = 0,
+    NB_CONNECTED_COMPOS,
+    NB_BORDER_EDGES,
+    IS_PURE_TRIANGLE,
+    NB_DEGENERATED_FACES,
+    HOLES,
+    AREA,
+    VOLUME,
+    SELFINTER,
+    NB_FACETS,
+    MIN_AREA,
+    MAX_AREA,
+    MED_AREA,
+    MEAN_AREA,
+    MIN_ALTITUDE,
+    MIN_ASPECT_RATIO,
+    MAX_ASPECT_RATIO,
+    MEAN_ASPECT_RATIO,
+    GENUS,
+    NB_EDGES,
+    MIN_LENGTH,
+    MAX_LENGTH,
+    MID_LENGTH,
+    MEAN_LENGTH,
+    NB_NULL_LENGTH,
+    MIN_ANGLE,
+    MAX_ANGLE,
+    MEAN_ANGLE
+  };
+
+  bool has_stats()const Q_DECL_OVERRIDE{return true;}
+  QString computeStats(int type)Q_DECL_OVERRIDE;
+  CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
 Q_SIGNALS:
   void item_is_about_to_be_changed();
   void selection_done();

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.h
@@ -6,6 +6,7 @@
 #define CGAL_IS_FLOAT 1
 
 #include "Scene_surface_mesh_item_config.h"
+#include <CGAL/Three/Scene_zoomable_item_interface.h>
 #include "SMesh_type.h"
 #include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Viewer_interface.h>
@@ -21,9 +22,12 @@
 struct Scene_surface_mesh_item_priv;
 
 class SCENE_SURFACE_MESH_ITEM_EXPORT Scene_surface_mesh_item
-  : public CGAL::Three::Scene_item
+  : public CGAL::Three::Scene_item,
+    public CGAL::Three::Scene_zoomable_item_interface
 {
   Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Scene_zoomable_item_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.ZoomInterface/1.0")
 public:
   typedef SMesh Face_graph;
   typedef SMesh::Property_map<vertex_descriptor,int> Vertex_selection_map;
@@ -109,6 +113,8 @@ public:
   bool has_stats()const Q_DECL_OVERRIDE{return true;}
   QString computeStats(int type)Q_DECL_OVERRIDE;
   CGAL::Three::Scene_item::Header_data header() const Q_DECL_OVERRIDE;
+  void zoomToPosition(const QPoint &point, CGAL::Three::Viewer_interface *)const Q_DECL_OVERRIDE;
+
 Q_SIGNALS:
   void item_is_about_to_be_changed();
   void selection_done();


### PR DESCRIPTION
## Summary of Changes

- SM items have statistics.
- Orthogonal zoom (O + Left Click) is fixed and works for SM items.

I wanted to add ID printing to the SM item too but I'd rather wait for #2204 to be integrated, it will make it better and much easier.
## Release Management

* Affected package(s):Polyhedron_demo
