### PR TITLE
Polyhedron_demo: Mesh_3_plugins for surface_mesh

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/properties_Surface_mesh.h
+++ b/Mesh_3/include/CGAL/Mesh_3/properties_Surface_mesh.h
@@ -130,7 +130,7 @@ typename boost::lazy_disable_if<
 inline get(CGAL::face_patch_id_t<I>, Surface_mesh<P> & smesh)
 {
  typedef typename boost::graph_traits<Surface_mesh<P> >::face_descriptor face_descriptor;
-  return smesh. template add_property_map<face_descriptor,I>("f:patch_id").first;
+  return smesh. template add_property_map<face_descriptor,I>("f:patch_id", 1).first;
 }
 
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/CMakeLists.txt
@@ -41,7 +41,7 @@ if ( Boost_VERSION GREATER 103400 )
   polyhedron_demo_plugin(mesh_3_optimization_plugin Optimization_plugin
     Optimization_plugin_cgal_code.cpp Optimizer_thread.cpp
     ${meshingUI_FILES})
-  target_link_libraries(mesh_3_optimization_plugin scene_c3t3_item scene_polyhedron_item scene_image_item scene_implicit_function_item )
+  target_link_libraries(mesh_3_optimization_plugin scene_c3t3_item scene_polyhedron_item scene_surface_mesh_item scene_image_item scene_implicit_function_item )
 
 
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
@@ -2,7 +2,9 @@
 #include "config_mesh_3.h"
 #include "C3t3_type.h"
 #include "Scene_c3t3_item.h"
+#include "Scene_surface_mesh_item.h"
 #include "Scene_polyhedron_item.h"
+#include <CGAL/Mesh_3/properties_Surface_mesh.h>
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES
 #include "Scene_image_item.h"
@@ -142,6 +144,27 @@ Optimizer_thread* cgal_code_optimization(Scene_c3t3_item& c3t3_item,
     return new Optimizer_thread(p_opt_function, p_result_item);
   }
   
+  // Surface mesh
+  const Scene_surface_mesh_item* sm_item =
+    qobject_cast<const Scene_surface_mesh_item*>(c3t3_item.data_item());
+
+  if ( NULL != sm_item )
+  {
+    // Build domain
+    const SMesh* smesh = sm_item->face_graph();
+    if ( NULL == smesh )
+    {
+      return NULL;
+    }
+    SMwgd smesh_wg(const_cast< SMesh& >(*smesh));
+    Polyhedral_mesh_domain_sm* sm_domain = new Polyhedral_mesh_domain_sm(smesh_wg);
+
+    // Create thread
+    typedef Optimization_function<Polyhedral_mesh_domain_sm,Parameters> Opt_function;
+    Opt_function* p_opt_function = new Opt_function(p_result_item->c3t3(), sm_domain, param);
+    return new Optimizer_thread(p_opt_function, p_result_item);
+  }
+
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
   // Function
   const Scene_implicit_function_item* function_item = 

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1115,7 +1115,7 @@ bool Scene_surface_mesh_item::intersect_face(double orig_x,
 void Scene_surface_mesh_item::setItemIsMulticolor(bool b)
 {
   if(b)
-    d->fpatch_id_map = d->smesh_->add_property_map<face_descriptor,int>("f:patch_id").first;
+    d->fpatch_id_map = d->smesh_->add_property_map<face_descriptor,int>("f:patch_id", 1).first;
   else if(d->smesh_->property_map<face_descriptor,int>("f:patch_id").second)
   {
     d->fpatch_id_map = d->smesh_->property_map<face_descriptor,int>("f:patch_id").first;


### PR DESCRIPTION
## Summary of Changes
- Fix mesh_3_plugin with Surface_mesh 
- Make the optimization_plugin work with a c3t3 made from a surface_mesh
## Release Management

* Affected package(s):Polyhedron_demo, Mesh_3(the properties_Surface_mesh file)
* Issue(s) solved (if any): fix #1932 


