### PR TITLE
Boolean_set_operations_2: Fix insert to Gps

### DIFF
--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_on_surface_base_2_impl.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_on_surface_base_2_impl.h
@@ -447,9 +447,9 @@ template <class Traits_, class TopTraits_, class ValidationPolicy>
 {
   typename std::iterator_traits<PolygonIter>::value_type pgn;
   //check validity of all polygons
-  for( ; p_begin != p_end; ++p_begin)
+  for(PolygonIter pitr = p_begin; pitr != p_end; ++pitr)
   {
-    ValidationPolicy::is_valid(*p_begin, *m_traits);
+    ValidationPolicy::is_valid(*pitr, *m_traits);
   }
 
   _insert(p_begin, p_end, pgn);


### PR DESCRIPTION
## Summary of Changes

`insert` method is broken. After validation `p_begin` point to the end of the iterator and actual insertion is not performed.

## Release Management

* Affected package(s): Boolean_set_operations_2

