### PR TITLE
Fix #2206

### DIFF
--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
@@ -455,7 +455,7 @@ weighted_circumcenterC2( const RT &px, const RT &py, const We &pw,
   RT dqw = RT(qw-pw);
   RT drw = RT(rw-pw);
 
-  weighted_circumcenter_translateC2(qx-px, qy-py, dqw,rx-px, ry-py,drw,x, y);
+  weighted_circumcenter_translateC2<RT>(qx-px, qy-py, dqw,rx-px, ry-py,drw,x, y);
   x += px;
   y += py;
 }


### PR DESCRIPTION
Fix #2206

@mglisse:
> For number types using expression templates, we need to specify the
  template parameter


* Affected package(s): Kernel
* Issue(s) solved (if any): fix #2206