### PR TITLE
Polyhedron/Plugins/IO/VTK_plugin:  remove typename

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -81,7 +81,7 @@ typedef Scene_surface_mesh_item Scene_facegraph_item;
 typedef Scene_polyhedron_item Scene_facegraph_item;
 #endif
 typedef Scene_facegraph_item::Face_graph FaceGraph;
-typedef typename boost::property_traits<typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::type>::value_type Point;
+typedef boost::property_traits<boost::property_map<FaceGraph, CGAL::vertex_point_t>::type>::value_type Point;
 namespace CGAL{
 
   class ErrorObserverVtk : public vtkCommand


### PR DESCRIPTION

## Summary of Changes

Remove `typename` in non-template code.

Not spotted in the testsuite as for VC++ we do not have vtk installed.

## Release Management

* Affected package(s):  :Polyhedron demo
