### PR TITLE
Polyhedron_demo: Surface reconstruction plugin outputs Scene_surface_mesh_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/CMakeLists.txt
@@ -2,7 +2,7 @@ include( polyhedron_demo_macros )
 if(EIGEN3_FOUND)
   qt5_wrap_ui( surface_reconstructionUI_FILES Surface_reconstruction_plugin.ui)
   polyhedron_demo_plugin(surface_reconstruction_plugin Surface_reconstruction_plugin Surface_reconstruction_plugin_impl ${surface_reconstructionUI_FILES})
-  target_link_libraries(surface_reconstruction_plugin scene_polygon_soup_item scene_polyhedron_item scene_points_with_normal_item)
+  target_link_libraries(surface_reconstruction_plugin scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item scene_points_with_normal_item)
 
   qt5_wrap_ui( point_set_normal_estimationUI_FILES Point_set_normal_estimation_plugin.ui)
   polyhedron_demo_plugin(point_set_normal_estimation_plugin Point_set_normal_estimation_plugin ${point_set_normal_estimationUI_FILES})

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -39,6 +39,7 @@
 #include <CGAL/structure_point_set.h>
 
 #include "ui_Surface_reconstruction_plugin.h"
+#include "CGAL/Kernel_traits.h"
 
 // Concurrency
 #ifdef CGAL_LINKED_WITH_TBB
@@ -62,7 +63,45 @@ typedef CGAL::Scale_space_reconstruction_3::Jet_smoother<Kernel> ScaleSpaceJS;
 typedef CGAL::Scale_space_reconstruction_3::Weighted_PCA_smoother<Kernel> ScaleSpaceWPS;
 
 typedef CGAL::cpp11::array<std::size_t,3> Facet;
+template<class Mesh, typename Traits>
+struct Construct{
+  typedef CGAL::cpp11::array<std::size_t,3> Facet;
+  typedef typename Traits::Point_3  Point_3;
+  typedef typename boost::property_map<Mesh, boost::vertex_point_t>::type VPmap;
+  Mesh& mesh;
+  VPmap vpmap;
+  std::vector<typename boost::graph_traits<Mesh>::vertex_descriptor> vertices;
+  template < typename PointIterator>
+  Construct(Mesh& mesh,PointIterator b, PointIterator e)
+    : mesh(mesh)
+  {
+    vpmap = get(boost::vertex_point, mesh);
+    for(; b!=e; ++b){
+      typename boost::graph_traits<Mesh>::vertex_descriptor v;
+      v = add_vertex(mesh);
+      vertices.push_back(v);
+      put(vpmap, v,  *b);
+    }
+  }
 
+  Construct& operator=(const Facet f)
+  {
+    typedef typename boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+    std::vector<vertex_descriptor> facet;
+    facet.resize(3);
+    facet[0]=vertices[f[0]];
+    facet[1]=vertices[f[1]];
+    facet[2]=vertices[f[2]];
+    CGAL::Euler::add_face(facet, mesh);
+    return *this;
+  }
+  Construct&
+  operator*() { return *this; }
+  Construct&
+  operator++() { return *this; }
+  Construct
+  operator++(int) { return *this; }
+};
 
 
 // Poisson reconstruction method:
@@ -74,7 +113,7 @@ Polyhedron* poisson_reconstruct_polyhedron(Point_set& points,
                                 const QString& solver_name, // solver name
                                 bool use_two_passes,
                                 bool do_not_fill_holes);
-
+// Reconstructs a surface mesh from a point set and returns it.
 SMesh* poisson_reconstruct_sm(Point_set& points,
                                 Kernel::FT sm_angle, // Min triangle angle (degrees).
                                 Kernel::FT sm_radius, // Max triangle size w.r.t. point set average spacing.
@@ -573,29 +612,62 @@ namespace SurfaceReconstruction
     }
   };
   
-  void advancing_front (const Point_set& points, Scene_polyhedron_item* new_item, double size,
+
+  struct Radius {
+
+    double bound;
+
+    Radius(double bound)
+      : bound(bound)
+    {}
+
+    template <typename AdvancingFront, typename Cell_handle>
+    double operator() (const AdvancingFront& adv, Cell_handle& c,
+                       const int& index) const
+    {
+      // bound == 0 is better than bound < infinity
+      // as it avoids the distance computations
+      if(bound == 0){
+        return adv.smallest_radius_delaunay_sphere (c, index);
+      }
+
+      // If radius > bound, return infinity so that facet is not used
+      double d  = 0;
+      d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                                c->vertex((index+2)%4)->point()));
+      if(d>bound) return adv.infinity();
+      d = sqrt(squared_distance(c->vertex((index+2)%4)->point(),
+                                 c->vertex((index+3)%4)->point()));
+      if(d>bound) return adv.infinity();
+      d = sqrt(squared_distance(c->vertex((index+1)%4)->point(),
+                                 c->vertex((index+3)%4)->point()));
+      if(d>bound) return adv.infinity();
+
+      // Otherwise, return usual priority value: smallest radius of
+      // delaunay sphere
+      return adv.smallest_radius_delaunay_sphere (c, index);
+    }
+  };
+
+  template<class FaceGraphItem>
+  void advancing_front (const Point_set& points, FaceGraphItem* new_item, double size,
                         double radius_ratio_bound = 5., double beta = 0.52)
   {
 
     // TODO: build DT with indices
-    
-    Polyhedron& P = * const_cast<Polyhedron*>(new_item->polyhedron());
-    Radius filter (size);
+    typedef typename FaceGraphItem::Face_graph FaceGraph;
+    typedef typename CGAL::Kernel_traits<typename boost::property_traits<typename boost::property_map<FaceGraph,
+        typename boost::vertex_point_t>::type>::value_type>::Kernel Traits;
 
-    typedef CGAL::Advancing_front_surface_reconstruction_vertex_base_3<Kernel> LVb;
-    typedef CGAL::Advancing_front_surface_reconstruction_cell_base_3<Kernel> LCb;
-
-    typedef CGAL::Triangulation_data_structure_3<LVb,LCb> Tds;
-    typedef CGAL::Delaunay_triangulation_3<Kernel,Tds> Triangulation_3;
-
-    typedef CGAL::Advancing_front_surface_reconstruction<Triangulation_3, Radius> Reconstruction;
-
-    Triangulation_3 dt( boost::make_transform_iterator(points.begin_or_selection_begin(), Point_set_make_pair_point_index(points)),
-                        boost::make_transform_iterator(points.end(), Point_set_make_pair_point_index(points)) );
-
-    Reconstruction R(dt, filter);
-    R.run(radius_ratio_bound, beta);
-    CGAL::AFSR::construct_polyhedron(P, R);
+    FaceGraph& P = * const_cast<FaceGraph*>(new_item->face_graph());
+    Radius filter(size);
+    Construct<FaceGraph, Traits> construct(P,points.points().begin(),points.points().end());
+    CGAL::advancing_front_surface_reconstruction(points.points().begin(),
+                                                 points.points().end(),
+                                                 construct,
+                                                 filter,
+                                                 radius_ratio_bound,
+                                                 beta);
 						  
   }
 
@@ -706,6 +778,7 @@ class Polyhedron_demo_surface_reconstruction_plugin :
 public:
   void init(QMainWindow* mainWindow, CGAL::Three::Scene_interface* scene_interface, Messages_interface*) {
     scene = scene_interface;
+    mw = mainWindow;
     actionSurfaceReconstruction = new QAction(tr("Surface Reconstruction"), mainWindow);
     actionSurfaceReconstruction->setObjectName("actionSurfaceReconstruction");
     autoConnectActions();
@@ -880,14 +953,26 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	      std::cerr << "Advancing front reconstruction... ";
 	      time.restart();
 
-	      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-	      SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
-	      
-	      reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
-	      reco_item->setColor(Qt::lightGray);
-	      reco_item->setRenderingMode(FlatPlusEdges);
-	      scene->addItem(reco_item);
+              if(mw->property("is_polyhedron_mode").toBool())
+              {
+                Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
+                SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
 
+                reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+                reco_item->setColor(Qt::lightGray);
+                reco_item->setRenderingMode(FlatPlusEdges);
+                scene->addItem(reco_item);
+              }
+              else
+              {
+                Scene_surface_mesh_item* reco_item = new Scene_surface_mesh_item(SMesh());
+                SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
+
+                reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+                reco_item->setColor(Qt::lightGray);
+                reco_item->setRenderingMode(FlatPlusEdges);
+                scene->addItem(reco_item);
+              }
 	      std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
 	    }
 
@@ -899,13 +984,26 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	      std::cerr << "Advancing front reconstruction... ";
 	      time.restart();
 
-	      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-	      SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
-	      
-	      reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
-	      reco_item->setColor(Qt::lightGray);
-	      reco_item->setRenderingMode(FlatPlusEdges);
-	      scene->addItem(reco_item);
+              if(mw->property("is_polyhedron_mode").toBool())
+              {
+                Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
+                SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
+
+                reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+                reco_item->setColor(Qt::lightGray);
+                reco_item->setRenderingMode(FlatPlusEdges);
+                scene->addItem(reco_item);
+              }
+              else
+              {
+                Scene_surface_mesh_item* reco_item = new Scene_surface_mesh_item(SMesh());
+                SurfaceReconstruction::advancing_front (*points, reco_item, 10. * (std::max)(noise_size, aniso_size));
+
+                reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+                reco_item->setColor(Qt::lightGray);
+                reco_item->setRenderingMode(FlatPlusEdges);
+                scene->addItem(reco_item);
+              }
 
 	      std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
 	    }
@@ -994,16 +1092,32 @@ void Polyhedron_demo_surface_reconstruction_plugin::advancing_front_reconstructi
 
       std::cerr << "Advancing front reconstruction... ";
 
-      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-      SurfaceReconstruction::advancing_front (*points, reco_item,
-                                              dialog.longest_edge (),
-                                              dialog.radius_ratio_bound (),
-                                              CGAL_PI * dialog.beta_angle () / 180.);
-	      
-      reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
-      reco_item->setColor(Qt::lightGray);
-      reco_item->setRenderingMode(FlatPlusEdges);
-      scene->addItem(reco_item);
+      if(mw->property("is_polyhedron_mode").toBool())
+      {
+        Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
+        SurfaceReconstruction::advancing_front (*points, reco_item,
+                                                dialog.longest_edge (),
+                                                dialog.radius_ratio_bound (),
+                                                CGAL_PI * dialog.beta_angle () / 180.);
+
+        reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+        reco_item->setColor(Qt::lightGray);
+        reco_item->setRenderingMode(FlatPlusEdges);
+        scene->addItem(reco_item);
+      }
+      else
+      {
+        Scene_surface_mesh_item* reco_item = new Scene_surface_mesh_item(SMesh());
+        SurfaceReconstruction::advancing_front (*points, reco_item,
+                                                dialog.longest_edge (),
+                                                dialog.radius_ratio_bound (),
+                                                CGAL_PI * dialog.beta_angle () / 180.);
+
+        reco_item->setName(tr("%1 (advancing front)").arg(scene->item(index)->name()));
+        reco_item->setColor(Qt::lightGray);
+        reco_item->setRenderingMode(FlatPlusEdges);
+        scene->addItem(reco_item);
+      }
 
       QApplication::restoreOverrideCursor();
     }
@@ -1120,25 +1234,48 @@ void Polyhedron_demo_surface_reconstruction_plugin::poisson_reconstruction
 
 
       // Reconstruct point set as a polyhedron
-      Polyhedron* pRemesh = poisson_reconstruct_polyhedron(*points, sm_angle, sm_radius, sm_distance, sm_solver, use_two_passes,
-                                                do_not_fill_holes);
+      Polyhedron* pRemesh = NULL;
+      SMesh* smRemesh= NULL;
+      if(mw->property("is_polyhedron_mode").toBool())
+        pRemesh = poisson_reconstruct_polyhedron(*points, sm_angle, sm_radius, sm_distance, sm_solver, use_two_passes,
+                                                 do_not_fill_holes);
+      else
+        smRemesh = poisson_reconstruct_sm(*points, sm_angle, sm_radius, sm_distance, sm_solver, use_two_passes,
+                                          do_not_fill_holes);
       if(pRemesh)
-        {
-          // Add polyhedron to scene
-          Scene_polyhedron_item* new_item = new Scene_polyhedron_item(pRemesh);
-          new_item->setName(tr("%1 Poisson (%2 %3 %4)")
-                            .arg(point_set_item->name())
-                            .arg(sm_angle)
-                            .arg(sm_radius)
-                            .arg(sm_distance));
-          new_item->setColor(Qt::lightGray);
-          scene->addItem(new_item);
+      {
+        // Add polyhedron to scene
+        Scene_polyhedron_item* new_item = new Scene_polyhedron_item(pRemesh);
+        new_item->setName(tr("%1 Poisson (%2 %3 %4)")
+                          .arg(point_set_item->name())
+                          .arg(sm_angle)
+                          .arg(sm_radius)
+                          .arg(sm_distance));
+        new_item->setColor(Qt::lightGray);
+        scene->addItem(new_item);
 
 
-          // Hide point set
-          point_set_item->setVisible(false);
-          scene->itemChanged(index);
-        }
+        // Hide point set
+        point_set_item->setVisible(false);
+        scene->itemChanged(index);
+      }
+      else if(smRemesh)
+      {
+        // Add polyhedron to scene
+        Scene_surface_mesh_item* new_item = new Scene_surface_mesh_item(smRemesh);
+        new_item->setName(tr("%1 Poisson (%2 %3 %4)")
+                          .arg(point_set_item->name())
+                          .arg(sm_angle)
+                          .arg(sm_radius)
+                          .arg(sm_distance));
+        new_item->setColor(Qt::lightGray);
+        scene->addItem(new_item);
+
+
+        // Hide point set
+        point_set_item->setVisible(false);
+        scene->itemChanged(index);
+      }
 
       QApplication::restoreOverrideCursor();
     }
@@ -1225,47 +1362,58 @@ void Polyhedron_demo_surface_reconstruction_plugin::ransac_reconstruction
       std::cerr << structured->point_set()->size() << " point(s) generated in "
                 << local_timer.time() << std::endl;
       local_timer.reset();
-      typedef CGAL::Advancing_front_surface_reconstruction_vertex_base_3<Kernel> LVb;
-      typedef CGAL::Advancing_front_surface_reconstruction_cell_base_3<Kernel> LCb;
-
-      typedef CGAL::Triangulation_data_structure_3<LVb,LCb> Tds;
-      typedef CGAL::Delaunay_triangulation_3<Kernel,Tds> Triangulation_3;
-
-      typedef CGAL::Advancing_front_surface_reconstruction<Triangulation_3,
-                                                           Priority_with_structure_coherence<Structuring> > Reconstruction;
 
       std::cerr << "Reconstructing... ";
       local_timer.start();
 
-      Triangulation_3 dt (boost::make_transform_iterator(structured->point_set()->begin(), On_the_fly_pair(*(structured->point_set()))),
-                          boost::make_transform_iterator(structured->point_set()->end(), On_the_fly_pair(*(structured->point_set()))));
-
-
       Priority_with_structure_coherence<Structuring> priority (structuring, 10. * op.cluster_epsilon);
-      Reconstruction R(dt, priority);
 
-      R.run (5., 0.52);
+      if(mw->property("is_polyhedron_mode").toBool())
+      {
+        Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
+        Polyhedron& P = * const_cast<Polyhedron*>(reco_item->polyhedron());
+        Construct<Polyhedron, Traits> construct(P,structured->point_set()->points().begin(),structured->point_set()->points().end());
+        CGAL::advancing_front_surface_reconstruction(structured->point_set()->points().begin(),
+                                                     structured->point_set()->points().end(),
+                                                     construct,
+                                                     priority,
+                                                     5.,
+                                                     0.52);
+        local_timer.stop();
+        std::cerr << "done in " << local_timer.time() << " second(s)" << std::endl;
 
-      Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(Polyhedron());
-      Polyhedron& P = * const_cast<Polyhedron*>(reco_item->polyhedron());
-      CGAL::AFSR::construct_polyhedron(P, R);
-      local_timer.stop();
-      std::cerr << "done in " << local_timer.time() << " second(s)" << std::endl;
-      
+        reco_item->setName(tr("%1 (RANSAC-based reconstruction)").arg(scene->item(index)->name()));
+        reco_item->setColor(Qt::magenta);
+        reco_item->setRenderingMode(FlatPlusEdges);
+        scene->addItem(reco_item);
+      }
+      else
+      {
+        Scene_surface_mesh_item* reco_item = new Scene_surface_mesh_item(SMesh());
+        SMesh& P = * const_cast<SMesh*>(reco_item->polyhedron());
+        Construct<SMesh, Traits> construct(P,structured->point_set()->points().begin(),structured->point_set()->points().end());
+        CGAL::advancing_front_surface_reconstruction(structured->point_set()->points().begin(),
+                                                     structured->point_set()->points().end(),
+                                                     construct,
+                                                     priority,
+                                                     5.,
+                                                     0.52);
+        local_timer.stop();
+        std::cerr << "done in " << local_timer.time() << " second(s)" << std::endl;
+        reco_item->setName(tr("%1 (RANSAC-based reconstruction)").arg(scene->item(index)->name()));
+        reco_item->setColor(Qt::magenta);
+        reco_item->setRenderingMode(FlatPlusEdges);
+        scene->addItem(reco_item);
+      }
       if (dialog.generate_structured ())
-        {
-          structured->setName(tr("%1 (structured)").arg(point_set_item->name()));
-          structured->setRenderingMode(PointsPlusNormals);
-          structured->setColor(Qt::blue);
-          scene->addItem (structured);
-        }
+      {
+        structured->setName(tr("%1 (structured)").arg(point_set_item->name()));
+        structured->setRenderingMode(PointsPlusNormals);
+        structured->setColor(Qt::blue);
+        scene->addItem (structured);
+      }
       else
         delete structured;
-
-      reco_item->setName(tr("%1 (RANSAC-based reconstruction)").arg(scene->item(index)->name()));
-      reco_item->setColor(Qt::magenta);
-      reco_item->setRenderingMode(FlatPlusEdges);
-      scene->addItem(reco_item);
 
       std::cerr << "All done in " << global_timer.time() << " seconds." << std::endl;
       

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -9,8 +9,10 @@
 
 #include "Scene_polygon_soup_item.h"
 #include "Scene_polyhedron_item.h"
+#include "Scene_surface_mesh_item.h"
 #include "Scene_points_with_normal_item.h"
 #include "Polyhedron_type.h"
+#include "SMesh_type.h"
 #include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
 #include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
 
@@ -65,13 +67,21 @@ typedef CGAL::cpp11::array<std::size_t,3> Facet;
 
 // Poisson reconstruction method:
 // Reconstructs a surface mesh from a point set and returns it as a polyhedron.
-Polyhedron* poisson_reconstruct(Point_set& points,
-                                Kernel::FT sm_angle, // Min triangle angle (degrees). 
-                                Kernel::FT sm_radius, // Max triangle size w.r.t. point set average spacing. 
+Polyhedron* poisson_reconstruct_polyhedron(Point_set& points,
+                                Kernel::FT sm_angle, // Min triangle angle (degrees).
+                                Kernel::FT sm_radius, // Max triangle size w.r.t. point set average spacing.
                                 Kernel::FT sm_distance, // Approximation error w.r.t. point set average spacing.
-                                const QString& solver, // solver name
+                                const QString& solver_name, // solver name
                                 bool use_two_passes,
-				bool do_not_fill_holes);
+                                bool do_not_fill_holes);
+
+SMesh* poisson_reconstruct_sm(Point_set& points,
+                                Kernel::FT sm_angle, // Min triangle angle (degrees).
+                                Kernel::FT sm_radius, // Max triangle size w.r.t. point set average spacing.
+                                Kernel::FT sm_distance, // Approximation error w.r.t. point set average spacing.
+                                const QString& solver_name, // solver name
+                                bool use_two_passes,
+                                bool do_not_fill_holes);
 
 
 struct Radius {
@@ -917,19 +927,18 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 	      std::cerr << "Poisson reconstruction... ";
 	      time.restart();
 
-	      Polyhedron* pRemesh = poisson_reconstruct(*points, 20,
-							100 * (std::max)(noise_size, aniso_size),
-							(std::max)(noise_size, aniso_size),
-							QString ("Eigen - built-in CG"), false, false);
-	      if(pRemesh)
-
-		{
-		  // Add polyhedron to scene
-		  Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(pRemesh);
-		  reco_item->setName(tr("%1 (poisson)").arg(pts_item->name()));
-		  reco_item->setColor(Qt::lightGray);
-		  scene->addItem(reco_item);
-		}
+              Polyhedron* pRemesh = poisson_reconstruct_polyhedron(*points, 20,
+                                                                   100 * (std::max)(noise_size, aniso_size),
+                                                                   (std::max)(noise_size, aniso_size),
+                                                                   QString ("Eigen - built-in CG"), false, false);
+              if(pRemesh)
+              {
+                // Add polyhedron to scene
+                Scene_polyhedron_item* reco_item = new Scene_polyhedron_item(pRemesh);
+                reco_item->setName(tr("%1 (poisson)").arg(pts_item->name()));
+                reco_item->setColor(Qt::lightGray);
+                scene->addItem(reco_item);
+              }
 
 	      std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
 	    }
@@ -1093,7 +1102,7 @@ void Polyhedron_demo_surface_reconstruction_plugin::poisson_reconstruction
 
 
       // Reconstruct point set as a polyhedron
-      Polyhedron* pRemesh = poisson_reconstruct(*points, sm_angle, sm_radius, sm_distance, sm_solver, use_two_passes,
+      Polyhedron* pRemesh = poisson_reconstruct_polyhedron(*points, sm_angle, sm_radius, sm_distance, sm_solver, use_two_passes,
                                                 do_not_fill_holes);
       if(pRemesh)
         {

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -925,12 +925,21 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
 		}
 	      
 	      std::cerr << "Poisson reconstruction... ";
-	      time.restart();
-
-              Polyhedron* pRemesh = poisson_reconstruct_polyhedron(*points, 20,
-                                                                   100 * (std::max)(noise_size, aniso_size),
-                                                                   (std::max)(noise_size, aniso_size),
-                                                                   QString ("Eigen - built-in CG"), false, false);
+              time.restart();
+              Polyhedron* pRemesh = NULL;
+              SMesh* smRemesh = NULL;
+              if(mw->property("is_polyhedron_mode").toBool())
+                pRemesh = poisson_reconstruct_polyhedron(*points,
+                                                         20,
+                                                         100 * (std::max)(noise_size, aniso_size),
+                                                         (std::max)(noise_size, aniso_size),
+                                                         QString ("Eigen - built-in CG"), false, false);
+              else
+                smRemesh = poisson_reconstruct_sm(*points,
+                                                  20,
+                                                  100 * (std::max)(noise_size, aniso_size),
+                                                  (std::max)(noise_size, aniso_size),
+                                                  QString ("Eigen - built-in CG"), false, false);
               if(pRemesh)
               {
                 // Add polyhedron to scene
@@ -939,6 +948,15 @@ void Polyhedron_demo_surface_reconstruction_plugin::automatic_reconstruction
                 reco_item->setColor(Qt::lightGray);
                 scene->addItem(reco_item);
               }
+              else if(smRemesh)
+              {
+                // Add polyhedron to scene
+                Scene_surface_mesh_item* reco_item = new Scene_surface_mesh_item(smRemesh);
+                reco_item->setName(tr("%1 (poisson)").arg(pts_item->name()));
+                reco_item->setColor(Qt::lightGray);
+                scene->addItem(reco_item);
+              }
+
 
 	      std::cerr << "ok (" << time.elapsed() << " ms)" << std::endl;
 	    }

--- a/Surface_mesher/include/CGAL/IO/output_surface_facets_to_facegraph.h
+++ b/Surface_mesher/include/CGAL/IO/output_surface_facets_to_facegraph.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2007-09  INRIA Sophia-Antipolis (France).
+// Copyright (c) 2017 GeometryFactory (France).
+
+
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+// Author(s) : Maxime Gimeno, Pierre Alliez
+#ifndef CGAL_OUTPUT_SURFACE_FACETS_TO_FACEGRAPH_H
+#define CGAL_OUTPUT_SURFACE_FACETS_TO_FACEGRAPH_H
+
+#include <CGAL/license/Surface_mesher.h>
+
+//! Gets reconstructed surface out of a SurfaceMeshComplex_2InTriangulation_3 object.
+//!
+//! This variant exports the surface as a FaceGraph and appends it to `graph`.
+//! It requires the surface to be manifold. For this purpose,
+//! you may call make_surface_mesh() with Manifold_tag or Manifold_with_boundary_tag parameter.
+//!
+//! @tparam C2T3 model of the SurfaceMeshComplex_2InTriangulation_3 concept.
+//! @tparam FaceGraph a model of FaceGraph.
+//!
+//! @param c2t3 an instance of a manifold C2T3.
+//! @param graph an instance of FaceGraph.
+template<class C2T3, class FaceGraph>
+void c2t3_to_facegraph(const C2T3& c2t3, FaceGraph& graph)
+{
+  typedef typename boost::property_map<FaceGraph, boost::vertex_point_t>::type VertexPointMap;
+  typedef typename C2T3::Triangulation Tr;
+  typedef typename Tr::Vertex_handle Vertex_handle;
+  typedef typename Tr::Vertex_iterator Vertex_iterator;
+  typedef typename Tr::Geom_traits::Vector_3 Vector;
+  typedef typename Tr::Edge Edge;
+  typedef typename Tr::Facet Facet;
+  typedef typename Tr::Finite_facets_iterator Finite_facets_iterator;
+
+  const Tr& tr = c2t3.triangulation();
+  VertexPointMap vpmap = get(boost::vertex_point, graph);
+  const typename Tr::size_type number_of_facets = c2t3.number_of_facets();
+  {
+    // Finite vertices coordinates.
+    Finite_facets_iterator fit = tr.finite_facets_begin();
+    std::set<Facet> oriented_set;
+    std::stack<Facet> stack;
+
+    CGAL_assertion_code(typename Tr::size_type nb_facets = 0; )
+
+        while (oriented_set.size() != number_of_facets) {
+      while ( fit->first->is_facet_on_surface(fit->second) == false ||
+              oriented_set.find(*fit) != oriented_set.end() ||
+
+              oriented_set.find(c2t3.opposite_facet(*fit)) !=
+              oriented_set.end() ) {
+        ++fit;
+      }
+      oriented_set.insert(*fit);
+      stack.push(*fit);
+      while(! stack.empty() ) {
+        Facet f = stack.top();
+        stack.pop();
+        for(int ih = 0 ; ih < 3 ; ++ih) {
+          const int i1  = tr.vertex_triple_index(f.second, tr. cw(ih));
+          const int i2  = tr.vertex_triple_index(f.second, tr.ccw(ih));
+          if( c2t3.face_status(Edge(f.first, i1, i2)) == C2T3::REGULAR ) {
+            Facet fn = c2t3.neighbor(f, ih);
+            if (oriented_set.find(fn) == oriented_set.end() &&
+                oriented_set.find(c2t3.opposite_facet(fn)) == oriented_set.end())
+            {
+              oriented_set.insert(fn);
+              stack.push(fn);
+            }
+          } // end "if the edge is regular"
+        } // end "for each neighbor of f"
+      } // end "stack non empty"
+    } // end "oriented_set not full"
+
+    // Orients the whole mesh towards outside:
+    // - find the facet with max z
+    typename std::set<Facet>::const_iterator top_facet = oriented_set.begin();
+    for(typename std::set<Facet>::const_iterator fit = oriented_set.begin();
+        fit != oriented_set.end();
+        ++fit)
+    {
+      double top_z =
+          (top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 0))->point().z()
+           + top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 1))->point().z()
+           + top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 2))->point().z())/3.;
+      double z =
+          (fit->first->vertex(tr.vertex_triple_index(fit->second, 0))->point().z()
+           + fit->first->vertex(tr.vertex_triple_index(fit->second, 1))->point().z()
+           + fit->first->vertex(tr.vertex_triple_index(fit->second, 2))->point().z())/3.;
+      if (top_z < z)
+        top_facet = fit;
+    }
+    // - orient the facet with max z towards +Z axis
+    Vertex_handle v0 = top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 0));
+    Vertex_handle v1 = top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 1));
+    Vertex_handle v2 = top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 2));
+    Vector normal = cross_product(v1->point()-v0->point(), v2->point()-v1->point());
+    const Vector Z(0, 0, 1);
+    bool regular_orientation = (Z * normal >= 0);
+
+    //used to set indices of vertices
+    std::map<Vertex_handle, int> V;
+    //int inum = 0;
+
+    //add vertices
+    std::vector<typename boost::graph_traits<FaceGraph>::vertex_descriptor> vertices;
+    for(Vertex_iterator vit = tr.vertices_begin();
+        vit != tr.vertices_end();
+        ++vit)
+    {
+
+      typename boost::graph_traits<FaceGraph>::vertex_descriptor v = add_vertex(graph);
+      vertices.push_back(v);
+      put(vpmap,
+          v,
+          typename Tr::Point_3(
+            vit->point().x(),
+            vit->point().y(),
+            vit->point().z())
+          );
+    }
+    //add faces
+    for(typename std::set<Facet>::const_iterator fit =
+        oriented_set.begin();
+        fit != oriented_set.end();
+        ++fit)
+    {
+      int id0(V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))]),
+          id1(regular_orientation ? V[fit->first->vertex(tr.vertex_triple_index(fit->second, 1))]
+              : V[fit->first->vertex(tr.vertex_triple_index(fit->second, 2))]),
+          id2(regular_orientation ? V[fit->first->vertex(tr.vertex_triple_index(fit->second, 2))]
+              : V[fit->first->vertex(tr.vertex_triple_index(fit->second, 1))]);
+      std::vector<typename boost::graph_traits<FaceGraph>::vertex_descriptor> face;
+      face.resize(3);
+      face[0] = vertices[id0];
+      face[1] = vertices[id1];
+      face[2] = vertices[id2];
+      CGAL::Euler::add_face(face, graph);
+      CGAL_assertion_code(++nb_facets);
+    }
+    CGAL_assertion(nb_facets == number_of_facets);
+  }
+}
+#endif // CGAL_OUTPUT_SURFACE_FACETS_TO_FACEGRAPH_H

--- a/Surface_mesher/include/CGAL/IO/output_surface_facets_to_facegraph.h
+++ b/Surface_mesher/include/CGAL/IO/output_surface_facets_to_facegraph.h
@@ -23,6 +23,8 @@
 #define CGAL_OUTPUT_SURFACE_FACETS_TO_FACEGRAPH_H
 
 #include <CGAL/license/Surface_mesher.h>
+#include <CGAL/boost/graph/Euler_operations.h>
+#include <map>
 
 //! Gets reconstructed surface out of a SurfaceMeshComplex_2InTriangulation_3 object.
 //!
@@ -39,6 +41,7 @@ template<class C2T3, class FaceGraph>
 void c2t3_to_facegraph(const C2T3& c2t3, FaceGraph& graph)
 {
   typedef typename boost::property_map<FaceGraph, boost::vertex_point_t>::type VertexPointMap;
+  typedef typename boost::property_traits<VertexPointMap>::value_type Point_3;
   typedef typename C2T3::Triangulation Tr;
   typedef typename Tr::Vertex_handle Vertex_handle;
   typedef typename Tr::Vertex_iterator Vertex_iterator;
@@ -115,7 +118,8 @@ void c2t3_to_facegraph(const C2T3& c2t3, FaceGraph& graph)
 
     //used to set indices of vertices
     std::map<Vertex_handle, int> V;
-    //int inum = 0;
+    int inum = 0;
+
 
     //add vertices
     std::vector<typename boost::graph_traits<FaceGraph>::vertex_descriptor> vertices;
@@ -128,11 +132,12 @@ void c2t3_to_facegraph(const C2T3& c2t3, FaceGraph& graph)
       vertices.push_back(v);
       put(vpmap,
           v,
-          typename Tr::Point_3(
+           Point_3(
             vit->point().x(),
             vit->point().y(),
             vit->point().z())
           );
+      V.insert(std::make_pair(vit, inum++));
     }
     //add faces
     for(typename std::set<Facet>::const_iterator fit =


### PR DESCRIPTION
## Summary of Changes

The surface_reconstruction_plugin outputs Polyhedron or Surface_mesh items according to the Preferences.
## Release Management
Remark : The file used for BGLizing the poisson reconstruction is introduced in #2254 
* Affected package(s):Polyhedron_demo
* Issue(s) solved (if any): fix #1932
* Feature/Small Feature (if any):

