### PR TITLE
Make the reference to the TriangleMesh const. 

### DIFF
--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -31,9 +31,11 @@ typedef Graph_traits::halfedge_iterator halfedge_iterator;
 typedef Graph_traits::face_iterator face_iterator;
 
 
+
 int main(int argc, char** argv)
 {
   Triangle_mesh tmesh;
+
   std::ifstream input((argc>1)?argv[1]:"data/elephant.off");
   input >> tmesh;
   input.close();
@@ -73,6 +75,5 @@ int main(int argc, char** argv)
       output << " " << points[i];
     output << std::endl;
   }
-
   return 0;
 }

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -1997,13 +1997,13 @@ public:
 
   Equivalent to `Surface_mesh_shortest_path(tm, get(boost::vertex_index, tm), get(boost::halfedge_index, tm), get(boost::face_index, tm), get(CGAL::vertex_point, tm), traits)`.
   */
-  Surface_mesh_shortest_path(Triangle_mesh& tm, const Traits& traits = Traits())
+  Surface_mesh_shortest_path(const Triangle_mesh& tm, const Traits& traits = Traits())
     : m_traits(traits)
-    , m_graph(tm)
+    , m_graph(const_cast<Triangle_mesh&>(tm))
     , m_vertexIndexMap(get(boost::vertex_index, tm))
     , m_halfedgeIndexMap(get(boost::halfedge_index, tm))
     , m_faceIndexMap(get(boost::face_index, tm))
-    , m_vertexPointMap(get(CGAL::vertex_point, tm))
+    , m_vertexPointMap(get(CGAL::vertex_point, m_graph))
     , m_debugOutput(false)
   {
     reset_algorithm();
@@ -2026,9 +2026,9 @@ public:
 
   \param traits Optional instance of the traits class to use.
   */
-  Surface_mesh_shortest_path(Triangle_mesh& tm, Vertex_index_map vertexIndexMap, Halfedge_index_map halfedgeIndexMap, Face_index_map faceIndexMap, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
+  Surface_mesh_shortest_path(const Triangle_mesh& tm, Vertex_index_map vertexIndexMap, Halfedge_index_map halfedgeIndexMap, Face_index_map faceIndexMap, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
     : m_traits(traits)
-    , m_graph(tm)
+    , m_graph(const_cast<Triangle_mesh&>(tm))
     , m_vertexIndexMap(vertexIndexMap)
     , m_halfedgeIndexMap(halfedgeIndexMap)
     , m_faceIndexMap(faceIndexMap)


### PR DESCRIPTION

## Summary of Changes

The constructor of `Surface_mesh_shortest_path` took a reference to a `TriangleMesh`. I changed that to `const&`.
 
In the implementation we cast the constness away due to a problem with the vertex point pmap



## Release Management

* Affected package(s): Surface_mesh_shortest_path
* Issue(s) solved (if any): a mail on cgal-discuss


