### PR TITLE
Surface_mesh: Set the failbit instead of writing a warning message to std::cout

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2043,8 +2043,10 @@ private: //------------------------------------------------------- private data
   /// Extracts the surface mesh from an input stream in Ascii OFF, COFF, NOFF, CNOFF 
   /// format and appends it to the surface mesh `sm`.
   /// The operator reads the point property as well as "v:normal", "v:color", and "f:color".
-  /// Vertex texture coordinates are ignored.
+  /// Vertex texture coordinates are ignored. The surface mesh `sm` is initially cleared.
   /// \pre `operator>>(std::istream&,const P&)` must be defined.
+  /// \pre The data in the stream must represent a two-manifold. If this is not the case
+  ///      the `failbit` of `is` is set and the mesh cleared.
 
   template <typename P>
   bool read_off(std::istream& is, Surface_mesh<P>& sm)
@@ -2123,9 +2125,9 @@ private: //------------------------------------------------------- private data
       Face_index fi = sm.add_face(vr);
       if(fi == sm.null_face())
       {
-       std::cout<< "Warning: Facets don't seem to be oriented. Loading a Soup of polygons instead."<<std::endl;
-       sm.clear();
-       return false;
+        is.setstate(std::ios::failbit);
+        sm.clear();
+        return false;
       }
 
       // the first face will tell us if faces have a color map

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2043,7 +2043,7 @@ private: //------------------------------------------------------- private data
   /// Extracts the surface mesh from an input stream in Ascii OFF, COFF, NOFF, CNOFF 
   /// format and appends it to the surface mesh `sm`.
   /// The operator reads the point property as well as "v:normal", "v:color", and "f:color".
-  /// Vertex texture coordinates are ignored. The surface mesh `sm` is initially cleared.
+  /// Vertex texture coordinates are ignored.
   /// \pre `operator>>(std::istream&,const P&)` must be defined.
   /// \pre The data in the stream must represent a two-manifold. If this is not the case
   ///      the `failbit` of `is` is set and the mesh cleared.


### PR DESCRIPTION

## Summary of Changes

Instead of issuing a warning to `std::cout` we set the failbit in the  `operator>>(istream&, Surface_mesh&)`

## Release Management

* Affected package(s):  Surface_mesh
* Issue(s) solved (if any): fix #2195 


