### PR TITLE
doc.cgal.org/master: Try to be more robust on errors

### DIFF
--- a/Documentation/doc/scripts/compare_testsuites.sh
+++ b/Documentation/doc/scripts/compare_testsuites.sh
@@ -40,8 +40,8 @@ cd ..
 echo "Output generated"
 if ! [ -d "$DOC_REF" ]; then
   echo "No reference given. Script is finished."
-  exit 2
+  exit 0
 fi
 
 #diff the output and the reference output, ignoring the differences in whitespaces
-diff -u -N -w ./doc_data $DOC_REF > ./diff.txt
+diff -u -N -w ./doc_data $DOC_REF > ./diff.txt || true

--- a/Documentation/doc/scripts/test_doxygen_versions.sh
+++ b/Documentation/doc/scripts/test_doxygen_versions.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [ "$1" == '--help' ]; then
   echo "Usage: $0 <doxygen_1> [doxygen_2] [publish_dir]"
   echo "Compares the output of doxygen_1 and doxygen_2 of this CGAL version, "

--- a/Documentation/doc/scripts/test_doxygen_versions.sh
+++ b/Documentation/doc/scripts/test_doxygen_versions.sh
@@ -47,7 +47,7 @@ make -j$NB_CORES doc  &> /dev/null
 echo "done."
 cd ../ #scripts
 echo "Creating text files for diff...."
-bash compare_testsuites.sh $PWD/build_doc/doc_output 1> /dev/null
+bash -$- compare_testsuites.sh $PWD/build_doc/doc_output 1> /dev/null
 mv ./doc_data ./doc_ref
 echo "done."
 
@@ -82,7 +82,7 @@ cd ../ #scripts
 DOXYGEN_1=$($PATH_TO_1 --version)
 DOXYGEN_2=$($PATH_TO_2 --version)
 echo "Comparing results..."
-bash ./compare_testsuites.sh $PWD/build_doc/doc_output $PWD/doc_ref 1> /dev/null
+bash -$- ./compare_testsuites.sh $PWD/build_doc/doc_output $PWD/doc_ref 1> /dev/null
 echo "done."
 #add post-processing
 cd ./build_doc

--- a/Scripts/developer_scripts/run_doxygen_testsuite
+++ b/Scripts/developer_scripts/run_doxygen_testsuite
@@ -65,7 +65,7 @@ export PATH
 cd "$PWD/doc/scripts"
 bash ./test_doxygen_versions.sh /home/cgal-testsuite/local/bin/doxygen '' /srv/CGAL/www/Members/Manual_doxygen_test
 case "$CGAL_RELEASE_ID" in
-    *-I-*) ln -snf "../Manual_doxygen_test/$CGAL_RELEASE_ID/output" /srv/CGAL/www/doc/master
+    *-I-*) rsync -a --delete "../Manual_doxygen_test/$CGAL_RELEASE_ID/output/" /srv/CGAL/www/doc/master/
            ;;
 esac
 rm -rf "${CGAL_DOC_BUILD}"


### PR DESCRIPTION
- Use rsync instead of a symbolic link,
- and exit earlier on errors.

If there is an error, then the rsync will not overwrite the current documentation.
