### PR TITLE
Polyhedron_demo: Fix warning on windows

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -1029,7 +1029,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
     Seam_mesh::halfedge_descriptor hd(*it);
     FT u = uv_pm[target(hd, sMesh)].x();
     FT v = uv_pm[target(hd, sMesh)].y();
-    put(uv, *it, std::make_pair(u,v));
+    put(uv, *it, std::make_pair(static_cast<float>(u),static_cast<float>(v)));
     if(u<min.x())
       min.setX(u);
     if(u>max.x())


### PR DESCRIPTION
## Summary of Changes

This PR should fix the warning in Parameterization_plugin taht occurs on SOSNO about a conversion from const double to float.
## Release Management

* Affected package(s):Polyhedron_demo

