### PR TITLE
Triangulation_2: Add implementation and test of Constrained_edges_iterator

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -78,6 +78,7 @@ public:
   typedef typename Ctr::Face_handle   Face_handle;
   typedef typename Ctr::Edge          Edge;
   typedef typename Ctr::Finite_faces_iterator Finite_faces_iterator;
+  typedef typename Ctr::Constrained_edges_iterator Constrained_edges_iterator;
   typedef typename Ctr::Face_circulator       Face_circulator;
   typedef typename Ctr::size_type             size_type;
   typedef typename Ctr::Locate_type           Locate_type;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -100,7 +100,9 @@ public:
     }
   };
 
-  typedef boost::filter_iterator<Is_constrained,All_edges_iterator> Constrained_edges_iterator;
+  typedef boost::filter_iterator<Is_constrained,
+                                 typename Triangulation::All_edges_iterator>
+                                                     Constrained_edges_iterator;
 
 
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
@@ -180,13 +182,17 @@ public:
   Constrained_edges_iterator constrained_edges_begin() const
   {
     Is_constrained pred(*this);
-    return Constrained_edges_iterator(pred, all_edges_begin(), all_edges_end());
+    return Constrained_edges_iterator(pred,
+                                      this->all_edges_begin(),
+                                      this->all_edges_end());
   }
 
   Constrained_edges_iterator constrained_edges_end() const
   {
     Is_constrained pred(*this);
-    return Constrained_edges_iterator(pred, all_edges_end(), all_edges_end());
+    return Constrained_edges_iterator(pred,
+                                      this->all_edges_end(),
+                                      this->all_edges_end());
   }
 
   // INSERTION

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -36,7 +36,7 @@
 #include <CGAL/squared_distance_2.h>
 
 #include <boost/mpl/if.hpp>
-
+#include <boost/iterator/filter_iterator.hpp>
 namespace CGAL {
 
 struct No_intersection_tag{};
@@ -85,6 +85,23 @@ public:
   typedef typename Triangulation::Edge_circulator Edge_circulator;
   typedef typename Triangulation::Vertex_circulator Vertex_circulator;
   typedef typename Triangulation::Line_face_circulator Line_face_circulator;
+
+  struct Is_constrained {
+    const Constrained_triangulation& ct;
+
+    Is_constrained(const Constrained_triangulation& ct)
+      : ct(ct)
+    {}
+
+    template <typename E>
+    bool operator()(const E& e) const
+    {
+      return ct.is_constrained(e);
+    }
+  };
+
+  typedef boost::filter_iterator<Is_constrained,All_edges_iterator> Constrained_edges_iterator;
+
 
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
   using Triangulation::number_of_vertices;
@@ -158,6 +175,19 @@ public:
 
   //TODO Is that destructor correct ?
   virtual ~Constrained_triangulation_2() {}
+
+
+  Constrained_edges_iterator constrained_edges_begin() const
+  {
+    Is_constrained pred(*this);
+    return Constrained_edges_iterator(pred, all_edges_begin(), all_edges_end());
+  }
+
+  Constrained_edges_iterator constrained_edges_end() const
+  {
+    Is_constrained pred(*this);
+    return Constrained_edges_iterator(pred, all_edges_end(), all_edges_end());
+  }
 
   // INSERTION
   Vertex_handle insert(const Point& p, 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -155,6 +155,7 @@ public:
   typedef typename Triangulation::List_faces       List_faces;
   typedef typename Triangulation::List_vertices    List_vertices;
   typedef typename Triangulation::List_constraints List_constraints;
+  typedef typename Triangulation::Constrained_edges_iterator Constrained_edges_iterator;
 
   typedef Pct2_vertex_handle_less_xy<Self>         Vh_less_xy;
   typedef Polyline_constraint_hierarchy_2<Vertex_handle, Vh_less_xy, Point>

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
@@ -43,6 +43,8 @@ _test_cls_constrained_triangulation(const Triang &)
   typedef typename Triang::Locate_type          Locate_type;
   typedef typename Triang::All_faces_iterator   All_faces_iterator;
 
+  typedef typename Triang::Constrained_edges_iterator Constrained_edges_iterator;
+
   typedef std::pair<Point,Point>                Constraint ;
   typedef std::list<Edge>                       List_edges;
   typedef std::list<Constraint>                 list_constraints;
@@ -276,5 +278,15 @@ _test_cls_constrained_triangulation(const Triang &)
   assert(ic_edges.size() == 2);
   T2_2.remove(vha);
   assert(T2_2.is_valid());
-  
+
+  // test Constained_edges_iterator
+  Triang T2_6;
+
+  T2_6.insert(Point(0,0));
+  T2_6.insert(Point(10,0));
+  T2_6.insert(Point(10,10));
+  assert(T2_6.constrained_edges_begin() == T2_6.constrained_edges_end());
+
+  T2_6.insert_constraint(Point(1,0.1), Point(2,0.2));
+  assert(std::distance(T2_6.constrained_edges_begin(),  T2_6.constrained_edges_end()) == 1);
 }

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
@@ -53,6 +53,7 @@ _test_cls_constrained_triangulation(const Triang &)
   CGAL_USE_TYPE(Gt);
   CGAL_USE_TYPE(Segment);
   CGAL_USE_TYPE(Triangle);
+  CGAL_USE_TYPE(Constrained_edges_iterator);
 
   /***********************/
   /***** SUBCLASSE ******/


### PR DESCRIPTION

## Summary of Changes

The  `Constrained_edges_iterator` was documented but not implemented.

## Release Management

* Affected package(s): Triangulation_2


