### PR TITLE
Convex_hull_3: Make it work for OpenMesh

### DIFF
--- a/Convex_hull_3/doc/Convex_hull_3/examples.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/examples.txt
@@ -1,6 +1,8 @@
 /*!
 \example Convex_hull_3/dynamic_hull_3.cpp
+\example Convex_hull_3/dynamic_hull_OM_3.cpp
 \example Convex_hull_3/quickhull_3.cpp
+\example Convex_hull_3/quickhull_OM_3.cpp
 \example Convex_hull_3/halfspace_intersection_3.cpp
 \example Convex_hull_3/quickhull_any_dim_3.cpp
 */

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 find_package( OpenMesh QUIET )
 
 if ( OpenMesh_FOUND )
-include( UseOpenMesh )
+  include( UseOpenMesh )
 else()
   message(STATUS "Examples that use OpenMesh will not be compiled.")
 endif()
@@ -66,8 +66,8 @@ create_single_source_cgal_program( "quickhull_any_dim_3.cpp" )
 
 
 if(OpenMesh_FOUND)
-create_single_source_cgal_program( "quickhull_OM_3.cpp" )
-create_single_source_cgal_program( "dynamic_hull_OM_3.cpp" )
+  create_single_source_cgal_program( "quickhull_OM_3.cpp" )
+  create_single_source_cgal_program( "dynamic_hull_OM_3.cpp" )
 
   target_link_libraries( quickhull_OM_3 ${OPENMESH_LIBRARIES} )
   target_link_libraries( dynamic_hull_OM_3 ${OPENMESH_LIBRARIES} )

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -1,30 +1,74 @@
-# Created by the script cgal_create_cmake_script
-# This is the CMake script for compiling a CGAL application.
+# Created by the script cgal_create_CMakeLists
+# This is the CMake script for compiling a set of CGAL applications.
+
+project( Convex_hull_3 )
 
 
-project( Convex_hull_3_Examples )
+cmake_minimum_required(VERSION 2.8.11)
 
-cmake_minimum_required(VERSION 2.8.10)
+# CGAL and its components
+find_package( CGAL QUIET COMPONENTS  )
 
-find_package(CGAL QUIET)
+if ( NOT CGAL_FOUND )
 
-if ( CGAL_FOUND )
+  message(STATUS "This project requires the CGAL library, and will not be compiled.")
+  return()  
 
-  include( ${CGAL_USE_FILE} )
-
-  include( CGAL_CreateSingleSourceCGALProgram )
-
-  include_directories (BEFORE "../../include")
-
-  # create a target per cppfile
-  file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-  foreach(cppfile ${cppfiles})
-    create_single_source_cgal_program( "${cppfile}" )
-  endforeach()
-
-else()
-  
-    message(STATUS "This program requires the CGAL library, and will not be compiled.")
-  
 endif()
 
+# include helper file
+include( ${CGAL_USE_FILE} )
+
+
+# Boost and its components
+find_package( Boost REQUIRED )
+
+if ( NOT Boost_FOUND )
+
+  message(STATUS "This project requires the Boost library, and will not be compiled.")
+
+  return()  
+
+endif()
+
+find_package( OpenMesh QUIET )
+
+if ( OpenMesh_FOUND )
+include( UseOpenMesh )
+else()
+  message(STATUS "Examples that use OpenMesh will not be compiled.")
+endif()
+
+# include for local directory
+
+# include for local package
+include_directories( BEFORE ../../include )
+
+
+# Creating entries for all C++ files with "main" routine
+# ##########################################################
+
+include( CGAL_CreateSingleSourceCGALProgram )
+
+create_single_source_cgal_program( "dynamic_hull_3.cpp" )
+
+create_single_source_cgal_program( "dynamic_hull_LCC_3.cpp" )
+
+create_single_source_cgal_program( "dynamic_hull_SM_3.cpp" )
+
+create_single_source_cgal_program( "halfspace_intersection_3.cpp" )
+
+create_single_source_cgal_program( "lloyd_algorithm.cpp" )
+
+create_single_source_cgal_program( "quickhull_3.cpp" )
+
+create_single_source_cgal_program( "quickhull_any_dim_3.cpp" )
+
+
+if(OpenMesh_FOUND)
+create_single_source_cgal_program( "quickhull_OM_3.cpp" )
+create_single_source_cgal_program( "dynamic_hull_OM_3.cpp" )
+
+  target_link_libraries( quickhull_OM_3 ${OPENMESH_LIBRARIES} )
+  target_link_libraries( dynamic_hull_OM_3 ${OPENMESH_LIBRARIES} )
+endif()

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-project( Convex_hull_3 )
+project( Convex_hull_3_Examples )
 
 
 cmake_minimum_required(VERSION 2.8.11)

--- a/Convex_hull_3/examples/Convex_hull_3/dynamic_hull_OM_3.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/dynamic_hull_OM_3.cpp
@@ -1,0 +1,55 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/point_generators_3.h>
+#include <CGAL/Delaunay_triangulation_3.h>
+
+#include <CGAL/algorithm.h>
+#include <CGAL/convex_hull_3_to_face_graph.h>
+
+#include <OpenMesh/Core/IO/MeshIO.hh>
+#include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
+
+#include <CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h>
+#include <list>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel     K;
+typedef K::Point_3                                              Point_3;
+typedef CGAL::Delaunay_triangulation_3<K>                       Delaunay;
+typedef Delaunay::Vertex_handle                                 Vertex_handle;
+
+
+typedef OpenMesh::TriMesh_ArrayKernelT</* MyTraits*/> Surface_mesh;
+
+int main()
+{
+  CGAL::Random_points_in_sphere_3<Point_3> gen(100.0);
+  std::list<Point_3>   points;
+
+  // generate 250 points randomly in a sphere of radius 100.0
+  // and insert them into the triangulation
+  CGAL::cpp11::copy_n(gen, 250, std::back_inserter(points) );
+  Delaunay T;
+  T.insert(points.begin(), points.end());
+
+  std::list<Vertex_handle>  vertices;
+  T.incident_vertices(T.infinite_vertex(), std::back_inserter(vertices));
+  std::cout << "This convex hull of the 250 points has "
+            << vertices.size() << " points on it." << std::endl;
+
+  // remove 25 of the input points
+  std::list<Vertex_handle>::iterator v_set_it = vertices.begin();
+  for (int i = 0; i < 25; i++)
+  {
+     T.remove(*v_set_it);
+     v_set_it++;
+  }
+
+  //copy the convex hull of points into a polyhedron and use it
+  //to get the number of points on the convex hull
+  Surface_mesh chull;
+  CGAL::convex_hull_3_to_face_graph(T, chull);
+  
+  std::cout << "After removal of 25 points, there are "
+            << num_vertices(chull) << " points on the convex hull." << std::endl;
+
+  return 0;
+}

--- a/Convex_hull_3/examples/Convex_hull_3/quickhull_OM_3.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/quickhull_OM_3.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
   
   CGAL::convex_hull_3(points.begin(), points.end(), sm);
 
-        CGAL::write_off((argc>2)?argv[2]:"out.off", sm);
+  CGAL::write_off((argc>2)?argv[2]:"out.off", sm);
 
   return 0;
 }

--- a/Convex_hull_3/examples/Convex_hull_3/quickhull_OM_3.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/quickhull_OM_3.cpp
@@ -1,0 +1,39 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/convex_hull_3.h>
+#include <vector>
+#include <fstream>
+
+#include <OpenMesh/Core/IO/MeshIO.hh>
+#include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
+
+#include <CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
+typedef K::Point_3  
+                              Point_3;
+typedef OpenMesh::TriMesh_ArrayKernelT</* MyTraits*/> Mesh;
+
+int main(int argc, char* argv[])
+{
+  std::ifstream in( (argc>1)? argv[1] : "data/cube.xyz");
+  std::vector<Point_3> points;
+  Point_3 p, n;
+  while(in >> p >> n){
+    points.push_back(p);
+  }
+
+  // define polyhedron to hold convex hull
+  Mesh poly;
+  
+  // compute convex hull of non-collinear points
+  CGAL::convex_hull_3(points.begin(), points.end(), poly);
+
+
+  Mesh sm;
+  
+  CGAL::convex_hull_3(points.begin(), points.end(), sm);
+
+        CGAL::write_off((argc>2)?argv[2]:"out.off", sm);
+
+  return 0;
+}

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -313,10 +313,13 @@ void coplanar_3_hull(InputIterator first, InputIterator beyond,
     }
   }
 
+  typename boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type vpm
+    = get(CGAL::vertex_point, P);
   std::vector<typename boost::graph_traits<Polyhedron_3>::vertex_descriptor> vertices;
   vertices.reserve(CH_2.size());
   BOOST_FOREACH(const Point_3& p, CH_2){
-    vertices.push_back(add_vertex(p,P));
+    vertices.push_back(add_vertex(P));
+    put(vpm, vertices.back(),p);
   }
   Euler::add_face(vertices, P);
 }

--- a/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
@@ -14,6 +14,14 @@ if ( CGAL_FOUND )
 
   include( CGAL_CreateSingleSourceCGALProgram )
 
+  find_package( OpenMesh QUIET )
+
+  if ( OpenMesh_FOUND )
+    include( UseOpenMesh )
+  else()
+    message(STATUS "Examples that use OpenMesh will not be compiled.")
+  endif()
+
   include_directories (BEFORE "../../include")
 
     include_directories (BEFORE "include")

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -3690,7 +3690,7 @@ is_valid(Cell_handle c, bool verbose, int level) const
             return false;
           }
         
-          int j1n,j2n,j3n;
+          int j1n=4,j2n=4,j3n=4;
           if ( ! n->has_vertex(c->vertex((i+1)&3),j1n) ) {
             if (verbose) { std::cerr << "vertex " << ((i+1)&3)
                                      << " not vertex of neighbor "

--- a/Triangulation_3/include/CGAL/link_to_face_graph.h
+++ b/Triangulation_3/include/CGAL/link_to_face_graph.h
@@ -56,6 +56,9 @@ link_to_face_graph(const Triangulation_3& t,
   t.incident_cells(t.infinite_vertex(),std::back_inserter(cells));
   CGAL::cpp11::array<vertex_descriptor,3> face;
 
+  typename boost::property_map<FG, CGAL::vertex_point_t>::type vpm
+    = get(CGAL::vertex_point, fg);
+
   BOOST_FOREACH(Cell_handle ch, cells){
     bool infinite_face = false;
     int vhi = ch->index(vh);
@@ -68,7 +71,8 @@ link_to_face_graph(const Triangulation_3& t,
         std::pair<typename Vertex_map::iterator,bool> res 
           = vertex_map.insert(std::make_pair(vhj,nullvertex));
         if(res.second){
-          res.first->second = add_vertex(vhj->point(), fg);
+          res.first->second = add_vertex(fg);
+          put(vpm, res.first->second, vhj->point());
           if(t.is_infinite(vhj)){
             inf = res.first->second;
           }


### PR DESCRIPTION


## Summary of Changes

Add examples for using 3D convex hull functions with open mesh.  And fix a bug in convex hull code as it does use more than in the concept `MutableFaceGraph`.

## Release Management

* Affected package(s): Convex_hull_3


