### PR TITLE
Epick_d: check gcc version and return() if < 4.4

### DIFF
--- a/NewKernel_d/test/NewKernel_d/CMakeLists.txt
+++ b/NewKernel_d/test/NewKernel_d/CMakeLists.txt
@@ -5,8 +5,12 @@
 
 project( NewKernel_d_Tests )
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 
+if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+  message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")
+  return()
+endif()
 
 find_package(CGAL QUIET)
 

--- a/Triangulation/examples/Triangulation/CMakeLists.txt
+++ b/Triangulation/examples/Triangulation/CMakeLists.txt
@@ -4,7 +4,12 @@
 
 project( Triangulation_Examples )
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
+
+if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+  message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")
+  return()
+endif()
 
 
 find_package(CGAL QUIET)

--- a/Triangulation/test/Triangulation/CMakeLists.txt
+++ b/Triangulation/test/Triangulation/CMakeLists.txt
@@ -3,8 +3,12 @@
 
 project( Triangulation_Tests )
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 
+if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+  message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")
+  return()
+endif()
 
 find_package(CGAL QUIET)
 


### PR DESCRIPTION
This PR will disable the CMake configuration of tests and examples for Epick_d and Triangulation (dD).

That will avoid compilation errors in the CentOS5 testsuite results.

Cc @mglisse 
