### PR TITLE
Qualify call of is_empty() as CentOS6-CXX11 sees an ambiguity with struct std::is_empty

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -284,7 +284,7 @@ public:
     stored_polyhedra[1] = bounding_p;
     this->add_primitives(stored_polyhedra[0]);
     this->add_primitives(stored_polyhedra[1]);
-    if(is_empty(bounding_p)) {
+    if(CGAL::is_empty(bounding_p)) {
       this->set_surface_only();
     } else {
       this->add_primitives_to_bounding_tree(stored_polyhedra[1]);


### PR DESCRIPTION
Should fix [this compilation error][1]:
```
[100%] Building CXX object CMakeFiles/mesh_polyhedral_domain_with_surface_inside.dir/mesh_polyhedral_domain_with_surface_inside.cpp.o
/usr/bin/c++   -DCGAL_MESH_3_NO_DEPRECATED_C3T3_ITERATORS -DCGAL_MESH_3_NO_DEPRECATED_SURFACE_INDEX -DCGAL_TEST_SUITE -DCGAL_USE_GMP -DCGAL_USE_MPFR -DCGAL_USE_ZLIB -Wall -std=c++0x -frounding-math -I/home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/test/Mesh_3_Examples/../../include -I/home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/test/Mesh_3_Examples -I/home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/include -I/mnt/testsuite/include -isystem /usr/local/include    -o CMakeFiles/mesh_polyhedral_domain_with_surface_inside.dir/mesh_polyhedral_domain_with_surface_inside.cpp.o -c /home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/test/Mesh_3_Examples/mesh_polyhedral_domain_with_surface_inside.cpp
In file included from /home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/test/Mesh_3_Examples/mesh_polyhedral_domain_with_surface_inside.cpp:8:
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/tr1_impl/type_traits: In constructor ‘CGAL::Polyhedral_mesh_domain_with_features_3<IGT_, Polyhedron_, TriangleAccessor, Patch_id, Use_exact_intersection_construction_tag>::Polyhedral_mesh_domain_with_features_3(const Polyhedron_&, const Polyhedron_&, CGAL::Random*) [with IGT_ = CGAL::Epick, Polyhedron_ = CGAL::Polyhedron_3<CGAL::Epick, CGAL::Mesh_3::Mesh_polyhedron_items<int>, CGAL::HalfedgeDS_default, std::allocator<int> >, TriangleAccessor = CGAL::Triangle_accessor_3<CGAL::Polyhedron_3<CGAL::Epick, CGAL::Mesh_3::Mesh_polyhedron_items<int>, CGAL::HalfedgeDS_default, std::allocator<int> >, CGAL::Epick>, Patch_id = int, Use_exact_intersection_construction_tag = CGAL::Boolean_tag<true>]’:
/home/cgal_tester/build/src/cmake/platforms/CentOS6-CXX11-Boost157/test/Mesh_3_Examples/mesh_polyhedral_domain_with_surface_inside.cpp:50:   instantiated from here
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/tr1_impl/type_traits:326: error: ‘template<class _Tp> struct std::is_empty’ is not a function,
/mnt/testsuite/include/CGAL/boost/graph/helpers.h:1172: error:   conflict with ‘template<class FaceGraph> bool CGAL::is_empty(const FaceGraph&)’
/mnt/testsuite/include/CGAL/Polyhedral_mesh_domain_with_features_3.h:287: error:   in call to ‘is_empty’
```

  [1]: https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.11-Ic-71/Mesh_3_Examples/TestReport_lrineau_CentOS6-CXX11-Boost157.gz