### PR TITLE
Force 53 bits of precision

### DIFF
--- a/CGAL_ImageIO/test/CGAL_ImageIO/test_trilinear_interpolation.cpp
+++ b/CGAL_ImageIO/test/CGAL_ImageIO/test_trilinear_interpolation.cpp
@@ -15,6 +15,8 @@
 typedef unsigned char Word;
 
 int main() {
+  CGAL::Set_ieee_double_precision pfr;
+
   CGAL::Image_3 image(_createImage(2, 2, 2, 1,
 				   1., 1., 1.,
 				   1, WK_FIXED, SGN_UNSIGNED));


### PR DESCRIPTION
## Summary of Changes

Tries to fix the runtime error:
```
test_trilinear_interpolation: /home/cgal_tester/build/src/cmake/platforms/Fedora-32-Release/test/CGAL_ImageIO/test_trilinear_interpolation.cpp:110: int main(): Assertion `value2 == value3' failed.
```
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.11-Ic-71/CGAL_ImageIO/TestReport_lrineau_Fedora-32-Release.gz

_Please use the following template to help us managing pull requests._

## Release Management

* Affected package(s): CGAL_imageIO

