### PR TITLE
Fix new -Wcatch-value warnings (gcc>=8.0)

### DIFF
--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
@@ -317,7 +317,7 @@ bool Traits_base_test<Geom_traits_T>::perform()
       test_result &= result;
     }
 
-    catch (CGAL::Precondition_exception /* e */)
+    catch (CGAL::Precondition_exception& /* e */)
     {
       if (m_violation_tested != PRECONDITION)
       {
@@ -326,7 +326,7 @@ bool Traits_base_test<Geom_traits_T>::perform()
       }
     }
 
-    catch (CGAL::Postcondition_exception /* e */)
+    catch (CGAL::Postcondition_exception& /* e */)
     {
       if (m_violation_tested != POSTCONDITION)
       {
@@ -335,7 +335,7 @@ bool Traits_base_test<Geom_traits_T>::perform()
       }
     }
 
-    catch (CGAL::Warning_exception /* e */)
+    catch (CGAL::Warning_exception& /* e */)
     {
       if (m_violation_tested != WARNING)
       {
@@ -344,7 +344,7 @@ bool Traits_base_test<Geom_traits_T>::perform()
       }
     }
 
-    catch (CGAL::Assertion_exception /* e */)
+    catch (CGAL::Assertion_exception& /* e */)
     {
       if (m_violation_tested != ASSERTION)
       {

--- a/Convex_hull_3/benchmark/Convex_hull_3/is_on_positive_side.cpp
+++ b/Convex_hull_3/benchmark/Convex_hull_3/is_on_positive_side.cpp
@@ -121,7 +121,7 @@ struct Is_on_positive_side_of_plane_3<Kernel,2>{
     try{
       return ck_plane.has_on_positive_side(to_CK(s));
     }
-    catch (Uncertain_conversion_exception){
+    catch (Uncertain_conversion_exception&){
       std::cerr << "ERROR Interval filtering failure\n";
       exit(EXIT_FAILURE);
     }

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -239,7 +239,7 @@ public:
         ck_plane=new typename CK::Plane_3(to_CK(p),to_CK(q),to_CK(r));
       return ck_plane->has_on_positive_side(to_CK(s));
     }
-    catch (Uncertain_conversion_exception){
+    catch (Uncertain_conversion_exception&){
       if (pk_plane==NULL)
         pk_plane=new typename PK::Plane_3(to_PK(p),to_PK(q),to_PK(r));
       return pk_plane->has_on_positive_side(to_PK(s));

--- a/Filtered_kernel/include/CGAL/Filtered_construction.h
+++ b/Filtered_kernel/include/CGAL/Filtered_construction.h
@@ -58,7 +58,7 @@ public:
     {
       return From_Filtered( Filter_construction(To_Filtered(a1)) );
     }
-    catch (Uncertain_conversion_exception)
+    catch (Uncertain_conversion_exception&)
     {
       Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
       return From_Exact( Exact_construction(To_Exact(a1)) );
@@ -74,7 +74,7 @@ public:
       return From_Filtered( Filter_construction(To_Filtered(a1),
 						To_Filtered(a2)) );
     }
-    catch (Uncertain_conversion_exception)
+    catch (Uncertain_conversion_exception&)
     {
       Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
       return From_Exact( Exact_construction(To_Exact(a1),
@@ -93,7 +93,7 @@ public:
 						To_Filtered(a2),
 						To_Filtered(a3)) );
     }
-    catch (Uncertain_conversion_exception)
+    catch (Uncertain_conversion_exception&)
     {
       Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
       return From_Exact( Exact_construction(To_Exact(a1),

--- a/Filtered_kernel/include/CGAL/Filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Filtered_predicate.h
@@ -168,7 +168,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -193,7 +193,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -215,7 +215,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -237,7 +237,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -259,7 +259,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -282,7 +282,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -305,7 +305,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -330,7 +330,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -355,7 +355,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -382,7 +382,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -409,7 +409,7 @@ Filtered_predicate<EP,AP,C2E,C2A,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);

--- a/Filtered_kernel/include/CGAL/Filtered_predicate_with_state.h
+++ b/Filtered_kernel/include/CGAL/Filtered_predicate_with_state.h
@@ -137,7 +137,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -169,7 +169,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -192,7 +192,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -215,7 +215,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -238,7 +238,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -262,7 +262,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -286,7 +286,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -312,7 +312,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -337,7 +337,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -365,7 +365,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -393,7 +393,7 @@ Filtered_predicate_with_state<EP,AP,C2E,C2A,O1,Protection>::
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -817,7 +817,7 @@ struct Lazy_construction_bbox
     Protect_FPU_rounding<Protection> P;
     try {
       return ac(CGAL::approx(l1));
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       return ec(CGAL::exact(l1));
@@ -866,7 +866,7 @@ struct Lazy_construction_nt {
     Protect_FPU_rounding<Protection> P;                                 \
     try {                                                               \
       return new Lazy_rep_##n<AT, ET, AC, EC, To_interval<ET>, BOOST_PP_ENUM_PARAMS(n, L) >(ac, ec, BOOST_PP_ENUM_PARAMS(n, l)); \
-    } catch (Uncertain_conversion_exception) {                          \
+    } catch (Uncertain_conversion_exception&) {                          \
       CGAL_BRANCH_PROFILER_BRANCH(tmp);                                 \
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return new Lazy_rep_0<AT,ET,To_interval<ET> >(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) )); \
@@ -1092,7 +1092,7 @@ public:
     try {
       // we suppose that R1 is a Lazy<Something>
       r1 = R1(new Lazy_rep_2_1<AC, EC, E2A, L1, L2, R1>(ac, ec, l1, l2));
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       typename R1::ET et;
@@ -1162,7 +1162,7 @@ public:
       // lv->approx() is a std::pair<R1::AT, R2::AT>;
       r1 = R1(Handle_1(new Lazy_rep_1<void, void, First<std::pair<typename R1::AT, typename R2::AT> >, First<std::pair<typename R1::ET, typename R2::ET> >, E2A, Lazy_pair>(First<std::pair<typename R1::AT, typename R2::AT> >(), First<std::pair<typename R1::ET, typename R2::ET> >(), lv)));
       r2 = R2(Handle_2(new Lazy_rep_1<void, void, Second<std::pair<typename R1::AT, typename R2::AT> >, Second<std::pair<typename R1::ET, typename R2::ET> >, E2A, Lazy_pair>(Second<std::pair<typename R1::AT, typename R2::AT> >(), Second<std::pair<typename R1::ET, typename R2::ET> >(), lv)));
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       typename R1::ET et1, et2;
@@ -1219,7 +1219,7 @@ public:
         std::cerr << "we need  more casts" << std::endl;
       }
 
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       // TODO: Instead of using a vector, write an iterator adapter
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
@@ -1298,7 +1298,7 @@ public:
       std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#1)" << std::endl;
       std::cerr << "dynamic type of the Object : " << lo.approx().type().name() << std::endl;
 
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       ET eto = ec(CGAL::exact(l1));
@@ -1352,7 +1352,7 @@ CGAL_Kernel_obj(Point_3)
       std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#1)" << std::endl;
       std::cerr << "dynamic type of the Object : " << lo.approx().type().name() << std::endl;
 
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       ET eto = ec(CGAL::exact(l1), CGAL::exact(l2));
@@ -1385,7 +1385,7 @@ CGAL_Kernel_obj(Point_3)
       std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#1)" << std::endl;
       std::cerr << "dynamic type of the Object : " << lo.approx().type().name() << std::endl;
 
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
       ET eto = ec(CGAL::exact(l1), CGAL::exact(l2), CGAL::exact(l3));
@@ -1560,7 +1560,7 @@ struct Lazy_construction_variant {
       boost::apply_visitor(visitor, *approx_v);
       
       return res;
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
 
@@ -1609,7 +1609,7 @@ struct Lazy_construction_variant {
       boost::apply_visitor(visitor, *approx_v);
       
       return res;
-    } catch (Uncertain_conversion_exception) {
+    } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
 
@@ -1661,7 +1661,7 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
     Protect_FPU_rounding<Protection> P;                                 \
     try {                                                               \
       return result_type( Handle(new Lazy_rep_##n<AT, ET, AC, EC, E2A, BOOST_PP_ENUM_PARAMS(n, L)>(ac, ec, BOOST_PP_ENUM_PARAMS(n, l)))); \
-    } catch (Uncertain_conversion_exception) {                          \
+    } catch (Uncertain_conversion_exception&) {                          \
       CGAL_BRANCH_PROFILER_BRANCH(tmp);                                 \
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \
@@ -1729,7 +1729,7 @@ struct result<F( BOOST_PP_ENUM_PARAMS(n, T) )> { \
     Protect_FPU_rounding<Protection> P;                                   \
     try {                                                                 \
       return result_type( Handle(new Lazy_rep_##n<AT, ET, AC, EC, E2A, BOOST_PP_ENUM_PARAMS(n, L)>(ac, ec, BOOST_PP_ENUM_PARAMS(n, l)))); \
-    } catch (Uncertain_conversion_exception) {                          \
+    } catch (Uncertain_conversion_exception&) {                          \
       CGAL_BRANCH_PROFILER_BRANCH(tmp);                                 \
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_object.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_object.h
@@ -128,7 +128,7 @@ _test_cls_object(const R&)
     use(k);
     assert(false);
   }
-  catch (CGAL::Bad_object_cast) {}
+  catch (CGAL::Bad_object_cast&) {}
 
 
   std::cout << "done" << std::endl;

--- a/Nef_2/include/CGAL/Filtered_extended_homogeneous.h
+++ b/Nef_2/include/CGAL/Filtered_extended_homogeneous.h
@@ -402,7 +402,7 @@ int orientation(const Extended_point<RT>& p1,
                              p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                              p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(or2);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(or2);
     res = orientation_coeff2(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                              p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                              p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw());
@@ -414,7 +414,7 @@ int orientation(const Extended_point<RT>& p1,
                              p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                              p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(or1);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(or1);
     res = orientation_coeff1(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                              p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                              p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw());
@@ -426,7 +426,7 @@ int orientation(const Extended_point<RT>& p1,
                              p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                              p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(or0);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(or0);
     res = orientation_coeff0(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                              p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                              p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw());
@@ -451,7 +451,7 @@ int compare_x(const Extended_point<RT>& p1,
   try { INCTOTAL(cmpx1); Protect_FPU_rounding<true> Protection;
     res = compare_expr(p1.mxD(),p1.hwD(),p2.mxD(),p2.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmpx1);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmpx1);
     res = compare_expr(p1.mx(),p1.hw(),p2.mx(),p2.hw());
   }
   if ( res != 0 ) return res;
@@ -459,7 +459,7 @@ int compare_x(const Extended_point<RT>& p1,
   try { INCTOTAL(cmpx0); Protect_FPU_rounding<true> Protection;
     res = compare_expr(p1.nxD(),p1.hwD(),p2.nxD(),p2.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmpx0);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmpx0);
     res = compare_expr(p1.nx(),p1.hw(),p2.nx(),p2.hw());
   }
   return res;
@@ -476,7 +476,7 @@ int compare_y(const Extended_point<RT>& p1,
   try { INCTOTAL(cmpy1); Protect_FPU_rounding<true> Protection;
     res = compare_expr(p1.myD(),p1.hwD(),p2.myD(),p2.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmpy1);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmpy1);
     res = compare_expr(p1.my(),p1.hw(),p2.my(),p2.hw());
   }
   if ( res != 0 ) return res;
@@ -484,7 +484,7 @@ int compare_y(const Extended_point<RT>& p1,
   try { INCTOTAL(cmpy0); Protect_FPU_rounding<true> Protection;
     res = compare_expr(p1.nyD(),p1.hwD(),p2.nyD(),p2.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmpy0);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmpy0);
     res = compare_expr(p1.ny(),p1.hw(),p2.ny(),p2.hw());
   }
   return res;
@@ -621,7 +621,7 @@ int compare_pair_dist(
                        p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                        p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmppd2);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmppd2);
     res = cmppd_coeff2(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                        p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                        p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),
@@ -635,7 +635,7 @@ int compare_pair_dist(
                        p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                        p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmppd1);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmppd1);
     res = cmppd_coeff1(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                        p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                        p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),
@@ -649,7 +649,7 @@ int compare_pair_dist(
                        p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                        p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
   }
-  catch (Uncertain_conversion_exception) { INCEXCEPTION(cmppd0);
+  catch (Uncertain_conversion_exception&) { INCEXCEPTION(cmppd0);
     res = cmppd_coeff0(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                        p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                        p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),
@@ -885,7 +885,7 @@ int orientation(const Extended_direction<RT>& d1,
                      p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                      p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                      p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
-  } catch (Uncertain_conversion_exception) { INCEXCEPTION(ord2);
+  } catch (Uncertain_conversion_exception&) { INCEXCEPTION(ord2);
     res = coeff2_dor(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                      p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                      p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),
@@ -898,7 +898,7 @@ int orientation(const Extended_direction<RT>& d1,
                      p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                      p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                      p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
-  } catch (Uncertain_conversion_exception) { INCEXCEPTION(ord1);
+  } catch (Uncertain_conversion_exception&) { INCEXCEPTION(ord1);
     res = coeff1_dor(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                      p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                      p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),
@@ -910,7 +910,7 @@ int orientation(const Extended_direction<RT>& d1,
                      p2.mxD(),p2.nxD(),p2.myD(),p2.nyD(),p2.hwD(),
                      p3.mxD(),p3.nxD(),p3.myD(),p3.nyD(),p3.hwD(),
                      p4.mxD(),p4.nxD(),p4.myD(),p4.nyD(),p4.hwD());
-  } catch (Uncertain_conversion_exception) { INCEXCEPTION(ord0);
+  } catch (Uncertain_conversion_exception&) { INCEXCEPTION(ord0);
     res = coeff0_dor(p1.mx(),p1.nx(),p1.my(),p1.ny(),p1.hw(),
                      p2.mx(),p2.nx(),p2.my(),p2.ny(),p2.hw(),
                      p3.mx(),p3.nx(),p3.my(),p3.ny(),p3.hw(),

--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_filter_NT.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_filter_NT.h
@@ -55,7 +55,7 @@ struct Cartesian_filter_NT : public Base_
 				  try {
 					  typename P1::result_type res=p1(u...); // don't forward as u may be reused
 					  if(is_certain(res)) return get_certain(res);
-				  } catch (Uncertain_conversion_exception) {}
+				  } catch (Uncertain_conversion_exception&) {}
 			    }
 			    return p2(std::forward<U>(u)...);
 		    }
@@ -66,7 +66,7 @@ struct Cartesian_filter_NT : public Base_
 				  try {
 					  typename P1::result_type res=p1();
 					  if(is_certain(res)) return get_certain(res);
-				  } catch (Uncertain_conversion_exception) {}
+				  } catch (Uncertain_conversion_exception&) {}
 			    }
 			    return p2();
 		    }
@@ -76,7 +76,7 @@ struct Cartesian_filter_NT : public Base_
 				  try { \
 					  typename P1::result_type res=p1(BOOST_PP_ENUM_PARAMS(N,t)); \
 					  if(is_certain(res)) return get_certain(res); \
-				  } catch (Uncertain_conversion_exception) {} \
+				  } catch (Uncertain_conversion_exception&) {} \
 			    } \
 			    return p2(BOOST_PP_ENUM_PARAMS(N,t)); \
 		    }

--- a/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
@@ -96,7 +96,7 @@ public:
 	  if (is_certain(res))
 	    return get_certain(res);
 	}
-      catch (Uncertain_conversion_exception) {}
+      catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
@@ -119,7 +119,7 @@ public:
 	  if (is_certain(res)) \
 	    return get_certain(res); \
 	} \
-      catch (Uncertain_conversion_exception) {} \
+      catch (Uncertain_conversion_exception&) {} \
     } \
     CGAL_BRANCH_PROFILER_BRANCH(tmp); \
     Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST); \

--- a/Number_types/test/Number_types/Interval_nt.cpp
+++ b/Number_types/test/Number_types/Interval_nt.cpp
@@ -334,7 +334,7 @@ bool is_valid_test()
     DEBUG( std::cout << "is_valid( " << d << " ) = " << tmpflag << std::endl; )
     flag = flag && !tmpflag;
   }
-  catch (CGAL::Assertion_exception)
+  catch (CGAL::Assertion_exception&)
   {}
 
   return flag;

--- a/Number_types/test/Number_types/Interval_nt_new.cpp
+++ b/Number_types/test/Number_types/Interval_nt_new.cpp
@@ -113,16 +113,16 @@ int main() {
         // OVERLAP
         I=Interval(1,3);
         J=Interval(2,4); // TODO: must explicitly convert to bool to get exception
-        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I> J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I<=J),CGAL::Uncertain_conversion_exception);  
-        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J>=I),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J<=I),CGAL::Uncertain_conversion_exception);
+        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I> J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I<=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J>=I),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J<=I),CGAL::Uncertain_conversion_exception&);
 
         // I<=J
         I=Interval(1,2);
@@ -131,12 +131,12 @@ int main() {
         assert( (J>=I));
         assert(!(I> J));
         assert(!(J< I));
-        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(J<=I),CGAL::Uncertain_conversion_exception);
+        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J> I),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(J<=I),CGAL::Uncertain_conversion_exception&);
 
         // degenerated I
         I=Interval(1,1);
@@ -151,12 +151,12 @@ int main() {
         // "I==J"
         I=Interval(1,2);
         J=Interval(1,2);
-        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I> J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception);
-        CGAL_catch_error((bool)(I<=J),CGAL::Uncertain_conversion_exception);
+        CGAL_catch_error((bool)(I==J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I!=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I< J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I> J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I>=J),CGAL::Uncertain_conversion_exception&);
+        CGAL_catch_error((bool)(I<=J),CGAL::Uncertain_conversion_exception&);
     }
     {// external functions on Intervals
      // functions (abs, square, sqrt, pow)

--- a/STL_Extension/test/STL_Extension/test_Uncertain.cpp
+++ b/STL_Extension/test/STL_Extension/test_Uncertain.cpp
@@ -79,7 +79,7 @@ void test()
         // -- Laurent Rineau, 2013/03/26
 	CGAL_assertion_code( ok = false );
 	try { CGAL::get_certain(u); }
-	catch (CGAL::Assertion_exception) { ok = true; }
+  catch (CGAL::Assertion_exception&) { ok = true; }
 	bool_assert(ok);
 
 	ok = false;
@@ -90,7 +90,7 @@ void test()
 	  CGAL_USE(t);
 #endif
 	}
-	catch (CGAL::Uncertain_conversion_exception) { ok = true; }
+	catch (CGAL::Uncertain_conversion_exception&) { ok = true; }
 	bool_assert(ok);
 
 	U u2 = CGAL::make_uncertain(u);
@@ -293,7 +293,7 @@ void test_bool()
           bool_assert(indet.is_same(CGAL_OR(ufalse, indet)));
           bool_assert(indet.is_same(CGAL_OR(indet, ufalse)));
 
-        } catch (CGAL::Uncertain_conversion_exception) {
+        } catch (CGAL::Uncertain_conversion_exception&) {
 #ifndef CGAL_CFG_NO_STATEMENT_EXPRESSIONS
          std::abort();
 #endif
@@ -302,16 +302,16 @@ void test_bool()
 	// Test exceptions
 	bool ok = false;
 	try { bool b = indet; CGAL_USE(b); }
-	catch (CGAL::Uncertain_conversion_exception) { ok = true; }
+	catch (CGAL::Uncertain_conversion_exception&) { ok = true; }
 	bool_assert(ok);
 	// The following must throw.
 	ok = false;
 	try { U u = indet && utrue; u = indet || ufalse; }
-	catch (CGAL::Uncertain_conversion_exception) { ok = true; }
+	catch (CGAL::Uncertain_conversion_exception&) { ok = true; }
 	bool_assert(ok);
 	// The following must not throw.
 	try { bool b = utrue; b = ufalse; CGAL_USE(b); }
-	catch (CGAL::Uncertain_conversion_exception) { bool_assert(false); }
+	catch (CGAL::Uncertain_conversion_exception&) { bool_assert(false); }
 
 	// certainly, possibly
 	bool_assert(CGAL::certainly(true));

--- a/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
+++ b/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
@@ -317,7 +317,7 @@ sign(TMC_Vertex_handle vit) const
       if (is_certain(result))
         return result;
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
   }
   CGAL_BRANCH_PROFILER_BRANCH(tmp);
   Protect_FPU_rounding<false> P(CGAL_FE_TONEAREST);
@@ -359,7 +359,7 @@ sign(const Bare_point &p, const Cell_info &info) const
       if (is_certain(result))
         return result;
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
   }
   CGAL_BRANCH_PROFILER_BRANCH(tmp);
   Protect_FPU_rounding<false> P(CGAL_FE_TONEAREST);
@@ -634,7 +634,7 @@ compare(Cell_info &info1, const Bare_point &p1,
       if (is_certain(result))
         return result;
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
   }
   CGAL_BRANCH_PROFILER_BRANCH(tmp);
   Protect_FPU_rounding<false> P(CGAL_FE_TONEAREST);
@@ -702,7 +702,7 @@ locate_in_tmc(const Bare_point &p0, TMC_Cell_handle start) const
       try {
         o = TMC_Geom_traits().orientation_3_object()(*pts[0], *pts[1],
                                                      *pts[2], *pts[3]);
-      } catch (Uncertain_conversion_exception) {
+      } catch (Uncertain_conversion_exception&) {
         Protect_FPU_rounding<false> P(CGAL_FE_TONEAREST);
         typedef Exact_predicates_exact_constructions_kernel EK;
         Cartesian_converter<typename Bare_point::R, EK> converter_ek;

--- a/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
+++ b/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
@@ -1215,7 +1215,7 @@ orientation(Tmc_Cell_handle ch)
 
   // filtered kernel
   o = _tmc.geom_traits().orientation_3_object()(pts[0], pts[1], pts[2], pts[3]);
-  } catch (Uncertain_conversion_exception) {
+  } catch (Uncertain_conversion_exception&) {
     Protect_FPU_rounding<false> P(CGAL_FE_TONEAREST);
     typedef Exact_predicates_exact_constructions_kernel EK;
     typedef Cartesian_converter<EK, Tmc_traits>         Exact_converter;

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -125,7 +125,7 @@ public:
       if ( fr )
         return From_Filtered(fr);
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
 
     Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
     EC_result_type er = Exact_construction(To_Exact(a1)) ;
@@ -143,7 +143,7 @@ public:
       if ( fr )
         return From_Filtered(fr);
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
     
     Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
     EC_result_type er = Exact_construction(To_Exact(a1), To_Exact(a2)) ;
@@ -161,7 +161,7 @@ public:
       if ( fr )
         return From_Filtered(fr);
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
     
     Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
     EC_result_type er = Exact_construction(To_Exact(a1), To_Exact(a2), To_Exact(a3)) ;
@@ -180,7 +180,7 @@ public:
       if ( fr )
         return From_Filtered(fr);
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
     
     Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
     EC_result_type er = Exact_construction(To_Exact(a1), To_Exact(a2), To_Exact(a3), To_Exact(a4)) ;
@@ -199,7 +199,7 @@ public:
       if ( fr )
         return From_Filtered(fr);
     }
-    catch (Uncertain_conversion_exception) {}
+    catch (Uncertain_conversion_exception&) {}
     
     Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
     EC_result_type er = Exact_construction(To_Exact(a1), To_Exact(a2), To_Exact(a3), To_Exact(a4), To_Exact(a5)) ;


### PR DESCRIPTION
## Summary of Changes

This PR takes references to exceptions instead of values to fix warnings on GCC 8;
## Release Management

* Issue(s) solved (if any): fix #2285 
