### PR TITLE
Polyhedron demo: minor fixes for selection items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -177,6 +177,7 @@ public Q_SLOTS:
     Scene_face_graph_item* poly_item = getSelectedItem<Scene_face_graph_item>();
     if(!poly_item || selection_item_map.find(poly_item) != selection_item_map.end()) { return; }
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
+    new_item->setName(QString("%1 (selection)").arg(poly_item->name()));
     connectItem(new_item);
   }
 
@@ -185,6 +186,7 @@ public Q_SLOTS:
     if(!poly_item)
       return NULL;
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
+    new_item->setName(QString("%1 (selection)").arg(poly_item->name()));
     connectItem(new_item);
     return new_item;
 
@@ -294,6 +296,7 @@ public Q_SLOTS:
     // all other arrangements (putting inside selection_item_map), setting names etc,
     // other params (e.g. k_ring) will be set inside new_item_created
     Scene_polyhedron_selection_item* new_item = new Scene_polyhedron_selection_item(poly_item, mw);
+    new_item->setName(QString("%1 (selection)").arg(poly_item->name()));
     ui_widget.selectionOrEuler->setCurrentIndex(last_mode);
     connectItem(new_item);
   }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item_decorator.cpp
@@ -22,7 +22,7 @@ Scene_polyhedron_item_decorator::toolTip() const
   if(!poly_item->polyhedron())
     return QString();
 
-  return QObject::tr("<p>Polyhedron <b>%1</b> (mode: %5, color: %6)</p>"
+  return QObject::tr("<p>Selection <b>%1</b> (mode: %5, color: %6)</p>"
                      "<p>Number of vertices: %2<br />"
                      "Number of edges: %3<br />"
                      "Number of faces: %4</p>")


### PR DESCRIPTION
## Summary of Changes

Scene_selection_items had lost their name, this PR restores it. They also displayed Polyhedron in their tooltip, now it says Selection.
## Release Management

* Affected package(s):Polyhedron demo

