### PR TITLE
Mesh_3 plugin: fix a bug that could lead to a size close to 0

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -363,6 +363,15 @@ struct Sizing_field_with_aabb_tree
             std::cout << " gdist = " << gdist;
 #endif
 
+            if (new_sqd * 1e10 < CGAL::squared_distance(curr_segment.source(),
+                                                        curr_segment.target()))
+            {
+#ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
+              std::cerr << "  too close, compared to possible rounding errors, "
+                        << "SKIPPED\n";
+#endif
+              continue;
+            }
             if (CGAL_NTS sqrt(new_sqd) > 0.9 * gdist)
               continue;
             if (sqd_intersection == -1 || new_sqd < sqd_intersection)


### PR DESCRIPTION
## Summary of Changes

Fix a bug in Mesh_3, that mades the Mesh_3 plugin of the polyhedron demo crash on `anchor.off`.

## Release Management

* Affected package(s): Mesh_3, Polyhedron demo
* Issue(s) solved (if any): fix #2284 


