### PR TITLE
Polyhedron_demo: Fix Qt warning about duplicate filters

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Selection_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Selection_io_plugin.cpp
@@ -12,11 +12,12 @@ class Polyhedron_demo_selection_io_plugin :
 public:
 #ifdef USE_SURFACE_MESH
     QString name() const { return "selection_io_sm_plugin"; }
+    QString nameFilters() const { return "Selection files (Surface_mesh) (*.selection.txt)"; }
 #else
     QString name() const { return "selection_io_plugin"; }
+    QString nameFilters() const { return "Selection files (Polyhedron) (*.selection.txt)"; }
 #endif
 
-    QString nameFilters() const { return "Selection files (*.selection.txt)"; }
 
     bool canLoad() const { return true; }
     CGAL::Three::Scene_item* load(QFileInfo fileinfo) {

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -285,11 +285,13 @@ public:
   typedef boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
   typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
-  QString nameFilters() const {
-    return "VTK PolyData files (*.vtk);; VTK XML PolyData (*.vtp);; VTK XML UnstructuredGrid (*.vtu)"; }
 #ifdef USE_SURFACE_MESH
+  QString nameFilters() const {
+    return "VTK PolyData files (Surface_mesh) (*.vtk);; VTK XML PolyData (Surface_mesh) (*.vtp);; VTK XML UnstructuredGrid (Surface_mesh)(*.vtu)"; }
   QString name() const { return "vtk_sm_plugin"; }
 #else
+  QString nameFilters() const {
+    return "VTK PolyData files (Polyhedron) (*.vtk);; VTK XML PolyData (Polyhedron) (*.vtp);; VTK XML UnstructuredGrid (Polyhedron)(*.vtu)"; }
   QString name() const { return "vtk_plugin"; }
 #endif
   bool canSave(const CGAL::Three::Scene_item* item)


### PR DESCRIPTION
## Summary of Changes

This PR modifies the nameFilters of the affected IO plugins to avoid duplication.
## Release Management

* Issue(s) solved (if any): fix #2294 

