### PR TITLE
Polyhedron_demo : Robustify split_polyhedron_plugin 

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -162,7 +162,18 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionSplitPolyhedra_tr
         CGAL::Face_filtered_graph<FaceGraph> filter_graph(*item->face_graph(), i, pidmap);
         FaceGraph* new_graph = new FaceGraph();
         CGAL::copy_face_graph(filter_graph, *new_graph);
-        new_polyhedra.push_back(new_graph);
+        if(!is_valid(*new_graph))
+        {
+          QMessageBox::warning(mw, tr("Error"),
+                             tr("The component %1 could not be extracted. "
+                                "The original mesh is probably not manifold, "
+                                "you should try to remove the self intersections with the "
+                                "Repair Polyhedron plugin and then try again.").arg(i));
+          delete new_graph;
+          continue;
+        }
+        else
+          new_polyhedra.push_back(new_graph);
       }
 
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -10,6 +10,7 @@
 #include <CGAL/gl.h>
 
 #include <QAction>
+#include <QApplication>
 #include <QMainWindow>
 #include <QObject>
 
@@ -100,9 +101,11 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveIsolatedVertices_t
 
 void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveIsolatedVertices_triggered()
 {
+  QApplication::setOverrideCursor((Qt::WaitCursor));
   const Scene_interface::Item_id index = scene->mainSelectionIndex();
   on_actionRemoveIsolatedVertices_triggered<Scene_polyhedron_item>(index);
   on_actionRemoveIsolatedVertices_triggered<Scene_surface_mesh_item>(index);
+  QApplication::restoreOverrideCursor();
 }
 
 template <typename Item>
@@ -124,9 +127,11 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveDegenerateFaces_tr
 
 void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveDegenerateFaces_triggered()
 {
+  QApplication::setOverrideCursor((Qt::WaitCursor));
   const Scene_interface::Item_id index = scene->mainSelectionIndex();
   on_actionRemoveDegenerateFaces_triggered<Scene_polyhedron_item>(index);
   on_actionRemoveDegenerateFaces_triggered<Scene_surface_mesh_item>(index);
+  QApplication::restoreOverrideCursor();
 }
 
 template <typename Item>
@@ -148,9 +153,11 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveSelfIntersections_
 
 void Polyhedron_demo_repair_polyhedron_plugin::on_actionRemoveSelfIntersections_triggered()
 {
+  QApplication::setOverrideCursor((Qt::WaitCursor));
   const Scene_interface::Item_id index = scene->mainSelectionIndex();
   on_actionRemoveSelfIntersections_triggered<Scene_polyhedron_item>(index);
   on_actionRemoveSelfIntersections_triggered<Scene_surface_mesh_item>(index);
+  QApplication::restoreOverrideCursor();
 }
 
 #include "Repair_polyhedron_plugin.moc"


### PR DESCRIPTION
## Summary of Changes
This PR robustifies the split_polyhedron_plugin by checking if the extracted connected components are valid. If this is not the case, a warning popup appears to alert the user and ask to call Remove self intersections.

