### PR TITLE
Polyhedron_demo: Shuffle_polygon_soup for Surface_mesh

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -295,7 +295,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   target_link_libraries(scene_implicit_function_item scene_color_ramp)
 
   add_item(scene_polygon_soup_item Scene_polygon_soup_item.cpp)
-  target_link_libraries(scene_polygon_soup_item scene_polyhedron_item)
+  target_link_libraries(scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item)
 
   add_item(scene_nef_polyhedron_item Scene_nef_polyhedron_item.cpp)
   target_link_libraries(scene_nef_polyhedron_item scene_polyhedron_item scene_surface_mesh_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -24,14 +24,16 @@ public:
   void init(QMainWindow* mainWindow,
             CGAL::Three::Scene_interface* scene_interface,
             Messages_interface* m);
-            bool applicable(QAction* action) const {
+  bool applicable(QAction* action) const {
     Q_FOREACH(CGAL::Three::Scene_interface::Item_id index, scene->selectionIndices()) {
       if(qobject_cast<Scene_polygon_soup_item*>(scene->item(index)))
         return true;
       else
-        if (action==actionShuffle && 
-            qobject_cast<Scene_polyhedron_item*>(scene->item(index)))
-            return true;
+        if (action==actionShuffle &&
+            qobject_cast<Scene_polyhedron_item*>(scene->item(index))
+            ||qobject_cast<Scene_surface_mesh_item*>(scene->item(index))
+            )
+          return true;
     }
     return false;
   }
@@ -45,6 +47,9 @@ public Q_SLOTS:
   void displayNonManifoldEdges();
 
 private:
+  template<class Item>
+  void apply_shuffle(Item* item,
+                     const CGAL::Three::Scene_interface::Item_id& index);
   CGAL::Three::Scene_interface* scene;
   Messages_interface* messages;
   QMainWindow* mw;
@@ -125,7 +130,7 @@ void Polyhedron_demo_orient_soup_plugin::orientPoly()
 {
   Q_FOREACH(CGAL::Three::Scene_interface::Item_id index, scene->selectionIndices())
   {
-    Scene_polygon_soup_item* item = 
+    Scene_polygon_soup_item* item =
       qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
 
     if(item)
@@ -207,41 +212,55 @@ void Polyhedron_demo_orient_soup_plugin::orientSM()
 
 void Polyhedron_demo_orient_soup_plugin::shuffle()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  
-  Scene_polygon_soup_item* item = 
-    qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
+  BOOST_FOREACH(CGAL::Three::Scene_interface::Item_id index, scene->selectionIndices())
+  {
+    Scene_polygon_soup_item* soup_item =
+        qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
 
-  if(item) {
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-    item->shuffle_orientations();
-    QApplication::restoreOverrideCursor();
-  }
-  else {
-    Scene_polyhedron_item* poly_item = 
-      qobject_cast<Scene_polyhedron_item*>(scene->item(index));
-    if(poly_item) {
+    if(soup_item) {
       QApplication::setOverrideCursor(Qt::WaitCursor);
-      item = new Scene_polygon_soup_item();
-      item->setName(poly_item->name());
-      item->setRenderingMode(poly_item->renderingMode());
-      item->setVisible(poly_item->visible());
-      item->setProperty("source filename", poly_item->property("source filename"));
-      item->load(poly_item);
-      item->shuffle_orientations();
-      item->setColor(poly_item->color());
-      scene->replaceItem(index, item);
-      delete poly_item;
+      soup_item->shuffle_orientations();
       QApplication::restoreOverrideCursor();
+      continue;
+    }
+
+    Scene_polyhedron_item* poly_item =
+        qobject_cast<Scene_polyhedron_item*>(scene->item(index));
+    if(poly_item) {
+      apply_shuffle(poly_item, index);
+      continue;
+    }
+    Scene_surface_mesh_item* sm_item =
+        qobject_cast<Scene_surface_mesh_item*>(scene->item(index));
+    if(sm_item) {
+      apply_shuffle(sm_item, index);
     }
   }
+}
+
+template<class Item>
+void Polyhedron_demo_orient_soup_plugin::apply_shuffle( Item* root_item,
+                                                        const CGAL::Three::Scene_interface::Item_id& index)
+{
+  QApplication::setOverrideCursor(Qt::WaitCursor);
+  Scene_polygon_soup_item* item = new Scene_polygon_soup_item();
+  item->setName(root_item->name());
+  item->setRenderingMode(root_item->renderingMode());
+  item->setVisible(root_item->visible());
+  item->setProperty("source filename", root_item->property("source filename"));
+  item->load(root_item);
+  item->shuffle_orientations();
+  item->setColor(root_item->color());
+  scene->replaceItem(index, item);
+  delete root_item;
+  QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_orient_soup_plugin::displayNonManifoldEdges()
 {
   const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
   
-  Scene_polygon_soup_item* item = 
+  Scene_polygon_soup_item* item =
     qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
 
   if(item)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -30,8 +30,8 @@ public:
         return true;
       else
         if (action==actionShuffle &&
-            qobject_cast<Scene_polyhedron_item*>(scene->item(index))
-            ||qobject_cast<Scene_surface_mesh_item*>(scene->item(index))
+            (qobject_cast<Scene_polyhedron_item*>(scene->item(index))
+            ||qobject_cast<Scene_surface_mesh_item*>(scene->item(index)))
             )
           return true;
     }

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -3,7 +3,6 @@
 #include "Scene_polygon_soup_item_config.h"
 #include  <CGAL/Three/Scene_item.h>
 #include "Polyhedron_type.h"
-
 #include "SMesh_type.h"
 
 #include <boost/foreach.hpp>
@@ -99,6 +98,7 @@ struct Polygon_soup
 
 
 class Scene_polyhedron_item;
+class Scene_surface_mesh_item;
 
 class SCENE_POLYGON_SOUP_ITEM_EXPORT Scene_polygon_soup_item 
         : public CGAL::Three::Scene_item
@@ -118,6 +118,7 @@ public:
 
     bool load(std::istream& in);
     void load(Scene_polyhedron_item*);
+    void load(Scene_surface_mesh_item*);
     bool isDataColored();
 
     bool save(std::ostream& out) const;


### PR DESCRIPTION
## Summary of Changes

This PR completes the Orient_polygon_soup_plugin by implementing the shuffling for surface_mesh and adds a load function to the polygon_soup_item that takes a surface_mesh_item as argument.
## Release Management

* Affected package(s):Polyhedron_demo
