### PR TITLE
Fix link errors in the building of the Debian packages

### DIFF
--- a/CGAL_Core/src/CGAL_Core/CMakeLists.txt
+++ b/CGAL_Core/src/CGAL_Core/CMakeLists.txt
@@ -21,10 +21,12 @@ if(NOT CGAL_HEADER_ONLY)
    # CGAL_Core does not depend on CGAL in either DEBUG or RELEASE, but we
    # still link it.
    target_link_libraries( CGAL_Core CGAL ${CGAL_3RD_PARTY_LIBRARIES} )
+   target_link_libraries( CGAL_Core ${CGAL_Core_3RD_PARTY_LIBRARIES} )
 
    add_dependencies( CGAL_Core CGAL )
 else()
   target_link_libraries( CGAL_Core INTERFACE ${CGAL_3RD_PARTY_LIBRARIES} )
+  target_link_libraries( CGAL_Core INTERFACE ${CGAL_Core_3RD_PARTY_LIBRARIES} )
 endif()
 
 message("libCGAL_Core is configured")

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -628,8 +628,13 @@ if(CGAL_DISABLE_GMP)
     "#error GMP is disabled by the CMake option CGAL_DISABLE_GMP")
 else()
   list(APPEND      CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES GMP MPFR)
-  # Where CMake is run several times, to avoid duplicates
+  if(WITH_GMPXX)
+    list(APPEND      CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES GMPXX)
+  endif()
+
+  # When CMake is run several times, to avoid duplicates
   list (REMOVE_DUPLICATES CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)
+
   file(REMOVE "${CMAKE_BINARY_DIR}/include/gmp.h")
 endif()
 hide_variable(CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)


### PR DESCRIPTION
## Summary of Changes

- The Debian package uses `-DCGAL_ENABLE_PRECONFIG=OFF` and
  `WITH_GMPXX=ON`. In that setup, GMPXX must be in the "essential" 3rd
  party libraries.

- The CGAL_Core library must be linked with its
  dependencies (compilation error with `-zdefs`).

## Release Management

With CMake flags or linker flags that are not tested by our testsuite process.

* Affected package(s): all
