### PR TITLE
Polyhedron_demo: No shift for Edit_box

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Edit_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Edit_box_plugin.cpp
@@ -118,19 +118,19 @@ void Edit_box_plugin::exportToPoly()
   Polyhedron::Point_3 points[8];
   for(int i=0; i<8; ++i)
   {
-    points[i] = Polyhedron::Point_3(item->point(i,0),item->point(i,2), item->point(i,1))-offset;
+    points[i] = Polyhedron::Point_3(item->point(i,0),item->point(i,1), item->point(i,2))-offset;
   }
 
   if(mw->property("is_polyhedron_mode").toBool()){
     Scene_polyhedron_item* poly_item = new Scene_polyhedron_item();
     CGAL::make_hexahedron(points[0],
-                          points[1],
-                          points[2],
                           points[3],
-                          points[4],
+                          points[2],
+                          points[1],
                           points[5],
-                          points[6],
+                          points[4],
                           points[7],
+                          points[6],
                           *poly_item->polyhedron());
     CGAL::Polygon_mesh_processing::triangulate_faces(*poly_item->polyhedron());
     item->setName("Edit box");
@@ -141,13 +141,13 @@ void Edit_box_plugin::exportToPoly()
   }else{
  Scene_surface_mesh_item* poly_item = new Scene_surface_mesh_item();
     CGAL::make_hexahedron(points[0],
-                          points[1],
-                          points[2],
                           points[3],
-                          points[4],
+                          points[2],
+                          points[1],
                           points[5],
-                          points[6],
+                          points[4],
                           points[7],
+                          points[6],
                           *poly_item->polyhedron());
     CGAL::Polygon_mesh_processing::triangulate_faces(*poly_item->polyhedron());
     item->setName("Edit box");

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -1022,9 +1022,11 @@ void Scene_edit_box_item_priv::reset_selection()
 }
 
 //intercept events for picking
-bool Scene_edit_box_item::eventFilter(QObject *, QEvent *event)
+bool Scene_edit_box_item::eventFilter(QObject *obj, QEvent *event)
 {
-  QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
+  QGLViewer* viewer = qobject_cast<QGLViewer*>(obj);
+  if(!viewer)
+    return false;
   if(event->type() == QEvent::MouseButtonPress)
   {
     QMouseEvent* e = static_cast<QMouseEvent*>(event);

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -1024,12 +1024,12 @@ void Scene_edit_box_item_priv::reset_selection()
 //intercept events for picking
 bool Scene_edit_box_item::eventFilter(QObject *, QEvent *event)
 {
+  QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
   if(event->type() == QEvent::MouseButtonPress)
   {
     QMouseEvent* e = static_cast<QMouseEvent*>(event);
-    if(e->modifiers() == Qt::ShiftModifier)
+    if(e->modifiers() == Qt::NoModifier)
     {
-      QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
       Viewer_interface* v_i = dynamic_cast<Viewer_interface*>(viewer);
       //pick
       int type, picked;
@@ -1082,10 +1082,10 @@ bool Scene_edit_box_item::eventFilter(QObject *, QEvent *event)
 
         viewer->setManipulatedFrame(d->remodel_frame);
         viewer->setMouseBinding(
-              Qt::ShiftModifier,
-              Qt::LeftButton,
-              QGLViewer::FRAME,
-              QGLViewer::TRANSLATE);
+                    Qt::NoModifier,
+                    Qt::LeftButton,
+                    QGLViewer::FRAME,
+                    QGLViewer::TRANSLATE);
       }
       else
       {
@@ -1097,7 +1097,7 @@ bool Scene_edit_box_item::eventFilter(QObject *, QEvent *event)
   else if(event->type() == QEvent::MouseMove)
   {
     QMouseEvent* e = static_cast<QMouseEvent*>(event);
-    if(e->modifiers() == Qt::ShiftModifier)
+    if(e->modifiers() == Qt::NoModifier)
     {
       if(d->selection_on)
       {
@@ -1126,25 +1126,17 @@ bool Scene_edit_box_item::eventFilter(QObject *, QEvent *event)
   {
     d->reset_selection();
     QApplication::setOverrideCursor(QCursor());
-  }
-
-  else if(event->type() == QEvent::KeyPress)
-  {
-     QKeyEvent* e = static_cast<QKeyEvent*>(event);
-     if(e->key() == Qt::Key_Shift)
-     {
-       d->ready_to_hl= true;
-       QTimer::singleShot(0, this, SLOT(highlight()));
-     }
+    viewer->setMouseBinding(
+                Qt::NoModifier,
+                Qt::LeftButton,
+                QGLViewer::CAMERA,
+                QGLViewer::ROTATE);
   }
   else if(event->type() == QEvent::KeyRelease)
   {
      QKeyEvent* e = static_cast<QKeyEvent*>(event);
-     if(e->key() == Qt::Key_Shift)
-       QTimer::singleShot(0, this, SLOT(clearHL()));
-     else if(e->key() == Qt::Key_Control)
+     if(e->key() == Qt::Key_Control)
      {
-
        QApplication::setOverrideCursor(QCursor());
      }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
@@ -110,7 +110,7 @@ public:
     is_edit_mode = b;
     QGLViewer* viewer = *QGLViewer::QGLViewerPool().begin();
     //for highlighting
-    viewer->setMouseTracking(b);
+    viewer->setMouseTracking(true);
   }
 
   void init(Scene_facegraph_item* poly_item, QMainWindow* mw, Active_handle::Type aht, int k_ring) {


### PR DESCRIPTION
## Summary of Changes
Remove the need for shift to manipulate the Editable box, which avoids problems with a selection_item.
## Release Management

* Affected package(s):Polyhedron_demo

