### PR TITLE
Fix link error of demo/Polyhedron, in Debug and CGAL_HEADER_ONLY

### DIFF
--- a/CGAL_Core/include/CGAL/export/CORE.h
+++ b/CGAL_Core/include/CGAL/export/CORE.h
@@ -47,7 +47,8 @@
 // If CGAL_EXPORTS is defined, one are building the CGAL library, and we do
 // not want artificial dll-imports of Core symbols (because of
 // auto-linking).
-#if ( ! defined(CGAL_EXPORTS) ) && defined(CGAL_BUILD_SHARED_LIBS)
+#if ( ! defined(CGAL_EXPORTS) ) && defined(CGAL_BUILD_SHARED_LIBS) \
+  && ( ! defined(CGAL_HEADER_ONLY) )
 
 #  if defined(CGAL_Core_EXPORTS) // defined by CMake or in cpp files of the dll
 

--- a/CGAL_ImageIO/include/CGAL/export/ImageIO.h
+++ b/CGAL_ImageIO/include/CGAL/export/ImageIO.h
@@ -23,7 +23,7 @@
 #include <CGAL/config.h>
 #include <CGAL/export/helpers.h>
 
-#if defined(CGAL_BUILD_SHARED_LIBS)
+#if defined(CGAL_BUILD_SHARED_LIBS) && ! defined(CGAL_HEADER_ONLY)
 
 #  if defined(CGAL_ImageIO_EXPORTS) // defined by CMake or in cpp files of the dll
 

--- a/GraphicsView/include/CGAL/export/Qt.h
+++ b/GraphicsView/include/CGAL/export/Qt.h
@@ -26,7 +26,8 @@
 #include <CGAL/config.h>
 #include <CGAL/export/helpers.h>
 
-#if defined(CGAL_BUILD_SHARED_LIBS) || defined(CGAL_USE_Qt5_RESOURCES)
+#if ( defined(CGAL_BUILD_SHARED_LIBS) && ( ! defined(CGAL_HEADER_ONLY) ) ) \
+  || defined(CGAL_USE_Qt5_RESOURCES)
 
 #  if defined(CGAL_Qt5_EXPORTS) || defined(CGAL_USE_Qt5_RESOURCES)
 // defined by CMake or in cpp files of the dll

--- a/Installation/include/CGAL/export/CGAL.h
+++ b/Installation/include/CGAL/export/CGAL.h
@@ -23,7 +23,7 @@
 #include <CGAL/config.h>
 #include <CGAL/export/helpers.h>
 
-#if defined(CGAL_BUILD_SHARED_LIBS)
+#if defined(CGAL_BUILD_SHARED_LIBS) && ! defined(CGAL_HEADER_ONLY)
 
 #  if defined(CGAL_EXPORTS) // defined by CMake or in cpp files of the dll
 


### PR DESCRIPTION
On Windows (MSVC), compiling the Polyhedron demo, in Debug, with `CGAL_HEADER_ONLY` produces linker error on the `demo_framework` DLL. This PR fixes the issue.

