### PR TITLE
Polyhedron_demo: Enhance the plugins management in Preferences

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1669,9 +1669,9 @@ void MainWindow::on_actionPreferences_triggered()
   //QStandardItemModel* iStandardModel = new QStandardItemModel(this);
 
   std::vector<QTreeWidgetItem*> items;
-  QBrush successBrush(QColor(Qt::green)),
-      errorBrush(QColor(Qt::red)),
-      ignoredBrush(QColor(Qt::lightGray));
+  QBrush successBrush(Qt::green),
+      errorBrush(Qt::red),
+      ignoredBrush(Qt::lightGray);
 
   //add blacklisted plugins
   Q_FOREACH (QString path, PathNames_map.keys())

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -389,6 +389,7 @@ private:
   /// plugin black-list
   QSet<QString> plugin_blacklist;
   QMap<QString, std::vector<QString> > PathNames_map; //For each non-empty plugin directory, contains a vector of plugin names
+  QMap<QString, QString > pluginsStatus_map; //For each non-empty plugin directory, contains a vector of plugin names
   Scene* scene;
   Viewer* viewer;
   QSortFilterProxyModel* proxyModel;

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -388,7 +388,7 @@ private:
   void setMenus(QString, QString, QAction *a);
   /// plugin black-list
   QSet<QString> plugin_blacklist;
-  QList<QDir> plugins_directories;
+  QMap<QString, std::vector<QString> > PathNames_map; //For each non-empty plugin directory, contains a vector of plugin names
   Scene* scene;
   Viewer* viewer;
   QSortFilterProxyModel* proxyModel;

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -380,7 +380,7 @@ protected:
   QList<int> getSelectedSceneItemIndices() const;
 private:
   void updateMenus();
-  void load_plugin(QString names, bool blacklisted);
+  bool load_plugin(QString names, bool blacklisted);
   void recurseExpand(QModelIndex index);
   QMap<QString, QMenu*> menu_map;
   QString get_item_stats();
@@ -388,6 +388,7 @@ private:
   void setMenus(QString, QString, QAction *a);
   /// plugin black-list
   QSet<QString> plugin_blacklist;
+  QList<QDir> plugins_directories;
   Scene* scene;
   Viewer* viewer;
   QSortFilterProxyModel* proxyModel;

--- a/Polyhedron/demo/Polyhedron/Preferences.ui
+++ b/Polyhedron/demo/Polyhedron/Preferences.ui
@@ -54,10 +54,32 @@
     </widget>
    </item>
    <item>
-    <widget class="QListView" name="listView">
+    <widget class="QTreeWidget" name="treeWidget">
+     <property name="alternatingRowColors">
+      <bool>false</bool>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
+     <property name="headerHidden">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="headerVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">2</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
## Summary of Changes

Add a hierarchy to the list of plugins in the Preferences dialog based on their location :

![preferences-screenshot](https://user-images.githubusercontent.com/11310805/28768328-7c98b4fa-75d7-11e7-96a2-b4e6ba45698c.png)

Edit : 
now, it looks like this : 
![preferences-screenshot](https://user-images.githubusercontent.com/11310805/33491370-5fddb3d0-d6ba-11e7-8b3f-83d62dca796b.png)
 and items have a tooltip if they are not green, saying why they were not loaded. (Apparently, my screenshot manager does not capture the cursor neither the tooltips, sorry.)

## Release Management

* Affected package(s):Polyhedron_demo
