### PR TITLE
Mesh_3: import newest improvements

### DIFF
--- a/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
+++ b/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
@@ -26,6 +26,7 @@
 #include <CGAL/boost/graph/iterator.h>
 #include <boost/iterator/transform_iterator.hpp>
 
+#include <CGAL/boost/graph/Graph_with_descriptor_with_graph_fwd.h>
 
 namespace CGAL
 {

--- a/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph_fwd.h
+++ b/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph_fwd.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2017  GeometryFactory (France).  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+//
+//
+// Author(s)     : Laurent Rineau
+
+#ifndef CGAL_BOOST_GRAPH_GWDWG_FWD_H
+#define CGAL_BOOST_GRAPH_GWDWG_FWD_H
+
+namespace CGAL
+{
+  template<typename Graph_>
+  struct Graph_with_descriptor_with_graph;
+}
+
+#endif // CGAL_BOOST_GRAPH_GWDWG_FWD_H

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!-- $Id$
      $URL$
 -->
@@ -195,6 +195,10 @@ and <code>src/</code> directories).
        that exports Mesh_complex_3_in_triangulation_3
        facets into a MutableFaceGraph.
      </li>
+     <li><b>Breaking change:</b>The
+       concept <code>MeshDomainWithFeatures_3</code> has been modified, to
+       improve the performance and the reliability of the sampling of 1D
+       curves of the domain.</li>
    </ul>
 <!-- Surface Reconstruction -->
 <!-- Geometry Processing -->

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -7923,6 +7923,14 @@ public:
   bool operator()(const Kernel::Iso_cuboid_3&c, 
                   const Kernel::Point_3&p); 
 
+  /*!
+    return true iff the line segment `ab` is inside the union of the
+    bounded sides of `s1` and `s2`.
+  */
+  bool operator()(const Kernel::Sphere_3& s1,
+                  const Kernel::Sphere_3& s2,
+                  const Kernel::Point_3& a,
+                  const Kernel::Point_3& b);
 
   /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -7924,7 +7924,7 @@ public:
                   const Kernel::Point_3&p); 
 
   /*!
-    return true iff the line segment `ab` is inside the union of the
+    returns true iff the line segment `ab` is inside the union of the
     bounded sides of `s1` and `s2`.
   */
   bool operator()(const Kernel::Sphere_3& s1,

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -3239,6 +3239,47 @@ namespace CommonKernelFunctors {
       );
       return c.rep().has_on_bounded_side(p); 
     }
+
+    bool operator()(const Sphere_3& s1, const Sphere_3& s2,
+                    const Point_3& a, const Point_3& b) const
+    {
+      typedef typename K::Circle_3    Circle_3;
+      typedef typename K::Point_3     Point_3;
+      typedef typename K::Segment_3   Segment_3;
+      typedef typename K::Plane_3     Plane_3;
+      typedef typename K::Intersect_3 Intersect_3;
+
+      const Has_on_bounded_side_3& has_on_bounded_side = *this;
+
+      const bool a_in_s1 = has_on_bounded_side(s1, a);
+      const bool a_in_s2 = has_on_bounded_side(s2, a);
+
+      if(!(a_in_s1 || a_in_s2)) return false;
+
+      const bool b_in_s1 = has_on_bounded_side(s1, b);
+      const bool b_in_s2 = has_on_bounded_side(s2, b);
+
+      if(!(b_in_s1 || b_in_s2)) return false;
+
+      if(a_in_s1 && b_in_s1) return true;
+      if(a_in_s2 && b_in_s2) return true;
+
+      if(!K().do_intersect_3_object()(s1, s2)) return false;
+      const Circle_3 circ(s1, s2);
+      const Plane_3& plane = circ.supporting_plane();
+      typename CGAL::cpp11::result_of<Intersect_3(Plane_3, Segment_3)>::type
+        optional = K().intersect_3_object()(plane, Segment_3(a, b));
+      CGAL_kernel_assertion_msg(bool(optional) == true,
+                                "the segment does not intersect the supporting"
+                                " plane");
+      using boost::get;
+      const Point_3* p = get<Point_3>(&*optional);
+      CGAL_kernel_assertion_msg(p != 0,
+                                "the segment intersection with the plane is "
+                                "not a point");
+      return squared_distance(circ.center(), *p) < circ.squared_radius();
+    }
+
   };
 
   template <typename K>

--- a/Mesh_3/doc/Mesh_3/CGAL/Compact_mesh_cell_base_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Compact_mesh_cell_base_3.h
@@ -22,7 +22,7 @@ default parameter value `void`.
 
 \cgalModels `MeshCellBase_3`
 
-\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>` 
+\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>` 
 \sa `CGAL::Mesh_cell_base_3<Gt, MD, Cb>`
 
 */

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_cell_base_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_cell_base_3.h
@@ -28,7 +28,7 @@ of the concept `RegularTriangulationCellBaseWithWeightedCircumcenter_3` and defa
 
 \cgalModels `MeshCellBase_3`
 
-\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>` 
+\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>` 
 \sa `CGAL::Compact_mesh_cell_base_3<Gt, MD, Tds>`
 
 */

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -19,8 +19,8 @@ vertex and cell base class are models of the concepts
 \tparam  CornerIndex is the type of the indices for corners. It must match the `Corner_index` of the model 
 of the `MeshDomainWithFeatures_3` concept used for mesh generation. 
 
-\tparam CurveSegmentIndex is the type of the indices for curves segments. 
-It must match the `Curve_segment_index` types of the model 
+\tparam CurveIndex is the type of the indices for curves. 
+It must match the `Curve_index` types of the model 
 of the `MeshDomainWithFeatures_3` concept used for mesh generation. 
 
 Those two last template parameters defaults to `int`, so that they can be ignored 
@@ -37,7 +37,7 @@ is a model of the concept `MeshDomain_3`).
 \sa `MeshVertexBase_3` 
 
 */
-template< typename Tr, typename CornerIndex, typename CurveSegmentIndex >
+template< typename Tr, typename CornerIndex, typename CurveIndex >
 class Mesh_complex_3_in_triangulation_3 {
 public:
 
@@ -65,9 +65,9 @@ typedef Tr::Cell::Subdomain_index Subdomain_index;
 typedef CornerIndex Corner_index; 
 
 /*!
-Curve segment index type. 
+Curve index type. 
 */ 
-typedef CurveSegmentIndex Curve_segment_index; 
+typedef CurveIndex Curve_index; 
 
 /// @} 
 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_criteria_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_criteria_3.h
@@ -115,7 +115,7 @@ The description of each parameter is as follows:
 
 - `edge_size`: a scalar field (resp. a constant) providing a space varying 
 (resp. a uniform) 
-upper bound for the lengths of curve segment edges. This parameter has to be set to a positive 
+upper bound for the lengths of curve edges. This parameter has to be set to a positive 
 value when 1-dimensional features protection is used.
 
 - `facet_angle`: a lower bound for the angles (in degrees) of the 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -35,9 +35,9 @@ public:
 typedef int Corner_index; 
 
 /*!
-`Curve_segment_index` type. 
+`Curve_index` type. 
 */ 
-typedef int Curve_segment_index; 
+typedef int Curve_index; 
 
 /// @} 
 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_edge_criteria_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_edge_criteria_3.h
@@ -33,7 +33,7 @@ typedef Tr::Geom_traits::FT FT;
 /*!
 Returns an object to serve as criteria for edges. 
 The argument `length_bound` is an upper bound 
-for the length of the edges which are used to discretize the curve segments. 
+for the length of the edges which are used to discretize the curves. 
 Note that if one parameter is set to 0, then its corresponding criteria is ignored. 
 */ 
 Mesh_edge_criteria_3( 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_topology.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_facet_topology.h
@@ -11,13 +11,13 @@ be checked on each surface facet during the mesh refinement process.
 */
 enum Mesh_facet_topology {
   FACET_VERTICES_ON_SURFACE = 1, //!< Each vertex of the facet have 
-                                 //!< to be on the surface, on a curve segment, or on a corner.
+                                 //!< to be on the surface, on a curve, or on a corner.
   FACET_VERTICES_ON_SAME_SURFACE_PATCH, //!< The three vertices of a facet belonging 
                                         //!< to a surface patch `s` have to be on 
-                                        //!< the same surface patch `s`, on a curve segment or on a corner.
+                                        //!< the same surface patch `s`, on a curve or on a corner.
   /*!
     The three vertices of a facet belonging to a surface patch `s`
-    have to be on the same surface patch `s`, or on a curve segment
+    have to be on the same surface patch `s`, or on a curve 
     incident to the surface patch `s` or on a corner incident to the
     surface patch `s`.
   */

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_triangulation_3.h
@@ -32,7 +32,7 @@ and defaults to `Compact_mesh_cell_base_3<Gt, MD>`.
          will have type `Robust_weighted_circumcenter_filtered_traits_3<Gt>`.
 
 \sa `make_mesh_3()`
-\sa `Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>`
+\sa `Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>`
 
 */
 template< typename MD, typename Gt,

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_vertex_base_3.h
@@ -21,7 +21,7 @@ of the concept `TriangulationVertexBase_3` and defaults to
 
 \cgalModels `MeshVertexBase_3` 
 
-\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>` 
+\sa `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>` 
 
 */
 template< typename Gt, typename MD, typename Vb >

--- a/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
@@ -43,7 +43,7 @@ respectively.
 \tparam MeshDomain_3 is required to be a model of 
 the concept `MeshDomain_3`, or of the refined concept 
 `MeshDomainWithFeatures_3` 
-if the domain has corners and curve segments that need to be accurately represented in the mesh. 
+if the domain has corners and curves that need to be accurately represented in the mesh. 
 The argument `domain` 
 is the sole link through which the domain 
 to be discretized is known by the mesh generation algorithm. 

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -198,7 +198,7 @@ parameters::internal::Exude_options exude(
 The function `parameters::features()` provides a value of internal type `Features` 
 to specify if 0 and 1-dimensional features have to be taken into account. 
 The provided value is a default value that triggers the representation 
-of corners and curve segments in the mesh when the domain is a model 
+of corners and curves in the mesh when the domain is a model 
 of `MeshDomainWithFeatures_3`. 
 
 Provides a `Features_options` value such that 
@@ -284,7 +284,7 @@ parameters::internal::Exude_options no_exude();
 The function `parameters::no_features()` allows the user to prevent the handling 
 of 0 and 1-dimensional features. This is useful when the 
 domain is a model of `MeshDomainWithFeatures_3` 
-and the user does not want corners and curve segments 
+and the user does not want corners and curves 
 to be accurately represented 
 in the mesh. 
 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshComplexWithFeatures_3InTriangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshComplexWithFeatures_3InTriangulation_3.h
@@ -16,7 +16,7 @@ faces of the triangulation,
 we call 
 respectively <I>subdomains</I>, 
 <I>surface patches</I> 
-<I>curve segments</I> and <I>corners</I> the faces 
+<I>curves</I> and <I>corners</I> the faces
 of the complex with respective dimensions \f$ 3\f$, \f$ 2\f$, \f$ 1\f$ and \f$ 0\f$. 
 The triangulations faces are called respectively 
 cells, facets, edges and vertices. 
@@ -24,9 +24,9 @@ cells, facets, edges and vertices.
 Each subdomain of the embedded 3D complex is a union of 
 triangulation cells. 
 Likewise, each surface patch is a union of 
-triangulation facets and each curve segment is a union of triangulation edges. 
+triangulation facets and each curve is a union of triangulation edges.
 The corners form a subset of the triangulation vertices. 
-Note that subdomains, surface patches and and curved segments are not 
+Note that subdomains, and surface patches are not
 necessarily connected. Likewise each corner may be related to several 
 mesh vertices. 
 Triangulation facets that belong to some 
@@ -35,7 +35,7 @@ surface patch are called surface facets.
 The concept `MeshComplexWithFeatures_3InTriangulation_3` allows us to mark and retrieve the 
 cells of the triangulation belonging to the subdomains, 
 the facets of the triangulation belonging to surface patches, 
-the edges belonging to curve segments and the vertices that are corners of the embedded complex. 
+the edges belonging to curves and the vertices that are corners of the embedded complex.
 
 Within the mesh generation functions, 
 the concept `MeshComplexWithFeatures_3InTriangulation_3` is the concept describing 
@@ -43,12 +43,12 @@ the data structure used to maintain the current approximation of the input domai
 At the end of the meshing process, the data structure encodes the resulting mesh. 
 In particular, each subdomain (resp. surface patch) of the input domain 
 is then approximated by a subdomain (resp. a surface patch) of the embedded complex 
-while the curve segments and corners represent the \f$ 1\f$ and \f$ 0\f$-dimensional features 
+while the curves and corners represent the \f$ 1\f$ and \f$ 0\f$-dimensional features
 of the input complex. 
 
 \cgalRefines `MeshComplex_3InTriangulation_3` 
 
-\cgalHasModel `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>`
+\cgalHasModel `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>`
 
 \sa `MeshComplex_3InTriangulation_3` 
 \sa `MeshDomainWithFeatures_3` 
@@ -62,11 +62,11 @@ public:
 /// @{
 
 /*!
-A type for indexes of curve segment. The type must match the type 
-`MeshDomainWithFeatures_3::Curve_segment_index` 
+A type for indexes of curve. The type must match the type
+`MeshDomainWithFeatures_3::Curve_index`
 when the concept is used for mesh generation. 
 */ 
-typedef unspecified_type Curve_segment_index; 
+typedef unspecified_type Curve_index;
 
 /*!
 A type for indexes of corners. 
@@ -78,9 +78,9 @@ typedef unspecified_type Corner_index;
 
 /*!
 An iterator type to visit the edges 
-of the triangulation belonging to curve segments. 
+of the triangulation belonging to curves.
 */ 
-typedef unspecified_type Edges_in_complex_iterator; 
+typedef unspecified_type Edges_in_complex_iterator;
 
 /*!
 An iterator type to visit the vertices 
@@ -95,16 +95,16 @@ typedef unspecified_type Vertices_in_complex_iterator;
 
 /*!
 
-Adds edge `e` as an element of the curve segment with index `index`. 
+Adds edge `e` as an element of the curve with index `index`.
 */ 
-void add_to_complex(Edge e, const Curve_segment_index& index); 
+void add_to_complex(Edge e, const Curve_index& index);
 
 /*!
 
 Same as above with `e=(v1,v2)`. 
 */ 
 void add_to_complex(const Vertex_handle& v1, 
-const Vertex_handle& v2, const Curve_segment_index& index); 
+const Vertex_handle& v2, const Curve_index& index);
 
 /*!
 
@@ -139,15 +139,15 @@ void remove_from_complex(const Vertex_handle& v);
 
 /*!
 
-Returns the number of edges which belong to curve segments. 
+Returns the number of edges which belong to curves.
 */ 
 size_type number_of_edges() const; 
 
 /*!
 
-Returns the number of edges which belong to curve segment with index `index`. 
+Returns the number of edges which belong to curve with index `index`.
 */ 
-size_type number_of_edges(Curve_segment_index index) const; 
+size_type number_of_edges(Curve_index index) const;
 
 /*!
 
@@ -163,7 +163,7 @@ size_type number_of_corners(Corner_index index) const;
 
 /*!
 Returns `true` 
-iff edge `e` belongs to some curve segment. 
+iff edge `e` belongs to some curve.
 */ 
 bool is_in_complex(const Edge& e) const; 
 
@@ -182,16 +182,16 @@ bool is_in_complex(const Vertex_handle& v) const;
 
 /*!
 
-Returns `Curve_segment_index` of edge `e`. The default `Curve_segment_index` 
-value is returned if edge `e` does not belong to any curve segment. 
+Returns `Curve_index` of edge `e`. The default `Curve_index`
+value is returned if edge `e` does not belong to any curve.
 */ 
-Curve_segment_index curve_segment_index(const Edge& e); 
+Curve_index curve_index(const Edge& e);
 
 /*!
 
 Same as above with `e=(v1,v2)`. 
 */ 
-Curve_segment_index curve_segment_index(const Vertex_handle& v1, const Vertex_handle& v2); 
+Curve_index curve_index(const Vertex_handle& v1, const Vertex_handle& v2);
 
 /*!
 
@@ -207,7 +207,7 @@ Corner_index corner_index(const Vertex_handle& v);
 
 /*!
 
-Returns an `Edges_in_complex_iterator` to visit the edges of the triangulation belonging to curve segments. 
+Returns an `Edges_in_complex_iterator` to visit the edges of the triangulation belonging to curves. 
 */ 
 Edges_in_complex_iterator edges_in_complex_begin() const; 
 
@@ -219,22 +219,22 @@ Edge_in_complex_iterator edges_in_complex_end() const;
 
 /*!
 
-Returns an `Edges_in_complex_iterator` to visit the edges of the triangulation belonging to curve segments 
+Returns an `Edges_in_complex_iterator` to visit the edges of the triangulation belonging to curves 
 of index `index`. 
 */ 
-Edges_in_complex_iterator edges_in_complex_begin(Curve_segment_index index) const; 
+Edges_in_complex_iterator edges_in_complex_begin(Curve_index index) const;
 
 /*!
 
 Returns the past-the-end iterator for the above iterator. 
 */ 
-Edge_in_complex_iterator edges_in_complex_end(Curve_segment_index index) const; 
+Edge_in_complex_iterator edges_in_complex_end(Curve_index index) const;
 
 /*!
 
 Fills `out` with the vertices of the triangulation that are adjacent to vertex `v` 
-through an edge belonging to some curve segment. 
-The value type of `out` must be `std::pair<Vertex_handle,Curve_segment_index>`. 
+through an edge belonging to some curve.
+The value type of `out` must be `std::pair<Vertex_handle,Curve_index>`.
 \pre `c3t3.in_dimension(v) < 2` 
 */ 
 template <typename OutputIterator> 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshComplex_3InTriangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshComplex_3InTriangulation_3.h
@@ -42,7 +42,7 @@ the current approximation of each subdomain
 and each boundary surface patch. 
 The data structure encodes the final mesh at the end of the meshing process. 
 
-\cgalHasModel `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>` 
+\cgalHasModel `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>` 
 
 \sa `MeshDomain_3` 
 \sa `MeshComplexWithFeatures_3InTriangulation_3` 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -7,8 +7,13 @@ While the concept
 `MeshDomain_3` only exposes the 2-dimensional and 3-dimensional features of
 the domain through different queries, the concept `MeshDomainWithFeatures_3` also exposes 0 and
 1-dimensional features. The exposed features of the domain are respectively called
-subdomains, surface patches, curve segments
+subdomains, surface patches, curves
 and corners according to their respective dimensions 3,2,1 and 0.
+
+Each curve is assumed to be bounded, with only one connected component, and
+without auto-intersection. Each curve is also assumed to be
+oriented. Therefore it is possible to defined the signed geodesic distance
+between two ordered points on the same curve.
 
 \cgalRefines `MeshDomain_3`
 
@@ -37,13 +42,13 @@ Numerical type.
 typedef unspecified_type FT;
 
 /*!
-Type of indices for curve segments (\f$ 1\f$-dimensional features)
+Type of indices for curves (\f$ 1\f$-dimensional features)
 of the input domain.
 Must be a model of CopyConstructible, Assignable, DefaultConstructible and
 LessThanComparable. The default constructed value must be the value of an edge which
 does not approximate a 1-dimensional feature of the input domain.
 */
-typedef unspecified_type Curve_segment_index;
+typedef unspecified_type Curve_index;
 
 /*!
 Type of indices for corners (i.e.\ 0-dimensional features)
@@ -56,30 +61,22 @@ typedef unspecified_type Corner_index;
 /// @}
 
 /*! \name Operations
-Each connected component of a curve segment is assumed
-to be oriented. The orientation is defined by the ordering
-of the two incident corners at the origin and endpoint.
-Therefore it is possible
-to defined the signed geodesic distance between two ordered
-points on the same connected component of a curve segment.
-A cycle is a connected component of a curve segment incident to
-0 or 1 corner.
 
-\note `construct_point_on_curve segment` is assumed to return
-a uniquely defined point. Therefore it is not possible to handle as a single
-curve segment, a singular curve with several branches incident
-to the same point.
 */
 /// @{
 
 /*!
 
-Returns a point on the curve segment with index `ci`
+Returns a point on the curve with index `ci`
 at signed geodesic distance `d` from point `p`.
-\pre Point `p` is supposed to be on curve segment `ci`. If ` d > 0`, the signed geodesic distance from `p` to the endpoint of the connected component of `ci` including \f$ p\f$, should be greater than \f$ d\f$. If ` d < 0`, the signed geodesic distance from `p` to the origin of the connected component should be less than \f$ d\f$ from the origin of the connected component.
+\pre Point `p` is supposed to be on curve `ci`. If ` d > 0`, the signed
+geodesic distance from `p` to the endpoint of `ci` should be greater than
+\f$ d\f$. If ` d < 0`, the signed geodesic distance from `p` to the origin
+of the curve should be less than \f$ d\f$ from the origin.
+
 */
-Point_3 construct_point_on_curve_segment(
-const Point_3& p, const Curve_segment_index& ci, FT d) const;
+Point_3 construct_point_on_curve(
+const Point_3& p, const Curve_index& ci, FT d) const;
 
 /// @}
 
@@ -87,57 +84,55 @@ const Point_3& p, const Curve_segment_index& ci, FT d) const;
 /// @{
 
 /*!
-Returns the length of the curve segment, on the curve with index
-\c  curve_index, from \c p to \c q
+Returns the length of the curve segment from \c p to \c q, on the curve
+with index \c curve_index.
 
-If the curve connected component containing \c p and \c q is a cycle,
-the orientation identifies which portion of the cycle
-corresponds to the arc, otherwise \c orientation must be compatible
-with the orientation of \c p and \c q on the curve segment.
+If the curve with index \c curve_index is a loop, the
+orientation identifies which portion of the loop corresponds to the curve
+segment, otherwise \c orientation must be compatible with the orientation
+of \c p and \c q on the curve.
 */
-FT arc_length(const Point_3& p, const Point_3 q,
-              const Curve_segment_index& curve_index,
-              CGAL::Orientation orientation) const;
+FT curve_segment_length(const Point_3& p, const Point_3 q,
+                        const Curve_index& curve_index,
+                        CGAL::Orientation orientation) const;
 /*!
 
 Returns `CGAL::POSITIVE` if the signed geodesic distance from
-`p` to `q` on the way through `r` along cycle with index `ci`
+`p` to `q` on the way through `r` along loop with index `ci`
 is positive, `CGAL::NEGATIVE` if the distance is negative.
 \pre `p != q && p != r && r != q`
 */
-CGAL::Sign distance_sign_along_cycle(const Point_3& p, const Point_3& q,
-const Point_3& r, const Curve_segment_index& ci) const;
+CGAL::Sign distance_sign_along_loop(const Point_3& p, const Point_3& q,
+const Point_3& r, const Curve_index& ci) const;
 
 /*!
 Returns the sign of the geodesic distance from `p` to `q`, on the curve
 with index `ci`.
 */
 CGAL::Sign distance_sign(const Point_3& p, const Point_3& q,
-                         const Curve_segment_index& ci) const;
+                         const Curve_index& ci) const;
 
 /*!
-Returns the length of the connected component of curve with index
-\c curve_index that includes the point \c p
+Returns the length of curve with index
+\c curve_index
 */
-FT curve_segment_length(const Point_3& p,
-                        const Curve_segment_index& curve_index) const;
+FT curve_length(const Curve_index& curve_index) const;
 /*!
-Returns `true` if the portion of the curve segment of index \c index,
+Returns `true` if the portion of the curve of index \c index,
 between the points \c c1 and \c c2, is covered by the spheres of
 centers \c c1 and \c c2 and squared radii \c sq_r1 and \c sq_r2
-respectively. The points \c c1 and \c c2 are assumed to lie on the curve
-segment.
+respectively. The points \c c1 and \c c2 are assumed to lie on the curve.
 */
-bool is_curve_segment_covered(const Curve_segment_index& index,
+bool is_curve_segment_covered(const Curve_index& index,
                               CGAL::Orientation orientation,
                               const Point_3& c1, const Point_3& c2,
                               const FT sq_r1, const FT sq_r2) const;
 /*!
 
-Returns `true` if the connected component of curve segment
-`ci` including point `p` is a cycle.
+Returns `true` if the curve
+`ci` is a loop.
 */
-bool is_cycle(const Point_3& p, const Curve_segment_index& ci) const;
+bool is_loop(const Curve_index& ci) const;
 
 /// @}
 
@@ -154,21 +149,21 @@ get_corners(OutputIterator corners) const;
 
 /*!
 
-Fills `curves` with the curve segments
+Fills `curves` with the curves
 of the input domain.
 `curves` value type must be
-`CGAL::cpp11::tuple<Curve_segment_index,std::pair<Point_3,%Index>,std::pair<Point_3,%Index> >`.
-If the curve segment corresponding to an entry
-in curves is not a cycle, the pair of associated points should
+`CGAL::cpp11::tuple<Curve_index,std::pair<Point_3,%Index>,std::pair<Point_3,%Index> >`.
+If the curve corresponding to an entry
+in curves is not a loop, the pair of associated points should
 belong to
-two corners incident on the curve segment.
-If it is a cycle, then the same `Point_3` should be given twice and must be any
-point on the cycle.
+two corners incident on the curve.
+If it is a loop, then the same `Point_3` should be given twice and must be any
+point on the loop.
 The `%Index` values associated to the points are their indices w.r.t.\ their dimension.
 */
 template <typename OutputIterator>
 OutputIterator
-get_curve_segments(OutputIterator curves) const;
+get_curves(OutputIterator curves) const;
 
 /// @}
 
@@ -177,17 +172,17 @@ get_curve_segments(OutputIterator curves) const;
 
 /*!
 
-Returns the index to be stored at a vertex lying on the curve segment identified
-by `curve_segment_index`.
+Returns the index to be stored at a vertex lying on the curve identified
+by `curve_index`.
 */
-Index index_from_curve_segment_index(const Curve_segment_index& curve_segment_index) const;
+Index index_from_curve_index(const Curve_index& curve_index) const;
 
 /*!
 
-Returns the `Curve_segment_index` of the curve segment where lies a vertex with
+Returns the `Curve_index` of the curve where lies a vertex with
 dimension 1 and index `index`.
 */
-Curve_segment_index curve_segment_index(const Index& index) const;
+Curve_index curve_index(const Index& index) const;
 
 /*!
 

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -11,8 +11,8 @@ subdomains, surface patches, curves
 and corners according to their respective dimensions 3,2,1 and 0.
 
 Each curve is assumed to be bounded, with only one connected component, and
-without auto-intersection. Each curve is also assumed to be
-oriented. Therefore it is possible to defined the signed geodesic distance
+without auto-intersections. Each curve is also assumed to be
+oriented. Therefore it is possible to define the signed geodesic distance
 between two ordered points on the same curve.
 
 \cgalRefines `MeshDomain_3`
@@ -42,7 +42,7 @@ Numerical type.
 typedef unspecified_type FT;
 
 /*!
-Type of indices for curves (\f$ 1\f$-dimensional features)
+Type of indices for curves (i.e. \f$ 1\f$-dimensional features)
 of the input domain.
 Must be a model of CopyConstructible, Assignable, DefaultConstructible and
 LessThanComparable. The default constructed value must be the value of an edge which
@@ -51,7 +51,7 @@ does not approximate a 1-dimensional feature of the input domain.
 typedef unspecified_type Curve_index;
 
 /*!
-Type of indices for corners (i.e.\ 0-dimensional features)
+Type of indices for corners (i.e.\f$ 0\f$--dimensional features)
 of the input domain.
 Must be a model of CopyConstructible, Assignable, DefaultConstructible and
 LessThanComparable.
@@ -69,10 +69,10 @@ typedef unspecified_type Corner_index;
 
 Returns a point on the curve with index `ci`
 at signed geodesic distance `d` from point `p`.
-\pre Point `p` is supposed to be on curve `ci`. If ` d > 0`, the signed
+\pre Point `p` is supposed to be on curve `ci`. If `d > 0`, the signed
 geodesic distance from `p` to the endpoint of `ci` should be greater than
-\f$ d\f$. If ` d < 0`, the signed geodesic distance from `p` to the origin
-of the curve should be less than \f$ d\f$ from the origin.
+`d`. If ` d < 0`, the signed geodesic distance from `p` to the origin
+of the curve should be less than `d`.
 
 */
 Point_3 construct_point_on_curve(
@@ -92,7 +92,7 @@ orientation identifies which portion of the loop corresponds to the curve
 segment, otherwise \c orientation must be compatible with the orientation
 of \c p and \c q on the curve.
 */
-FT curve_segment_length(const Point_3& p, const Point_3 q,
+FT curve_segment_length(const Point_3& p, const Point_3& q,
                         const Curve_index& curve_index,
                         CGAL::Orientation orientation) const;
 /*!
@@ -154,9 +154,9 @@ of the input domain.
 `curves` value type must be
 `CGAL::cpp11::tuple<Curve_index,std::pair<Point_3,%Index>,std::pair<Point_3,%Index> >`.
 If the curve corresponding to an entry
-in curves is not a loop, the pair of associated points should
+in `curves` is not a loop, the pair of associated points should
 belong to
-two corners incident on the curve.
+two corners incident to the curve.
 If it is a loop, then the same `Point_3` should be given twice and must be any
 point on the loop.
 The `%Index` values associated to the points are their indices w.r.t.\ their dimension.

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -42,6 +42,11 @@ Numerical type.
 typedef unspecified_type FT;
 
 /*!
+Point type.
+*/
+typedef unspecified_type Point_3;
+
+/*!
 Type of indices for curves (i.e. \f$ 1\f$-dimensional features)
 of the input domain.
 Must be a model of CopyConstructible, Assignable, DefaultConstructible and

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -113,6 +113,8 @@ const Point_3& r, const Curve_index& ci) const;
 /*!
 Returns the sign of the geodesic distance from `p` to `q`, on the curve
 with index `ci`.
+If the curve with index `ci` is a loop, the function `distance_sign_along_loop()`
+must be used instead.
 */
 CGAL::Sign distance_sign(const Point_3& p, const Point_3& q,
                          const Curve_index& ci) const;

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -88,11 +88,10 @@ const Point_3& p, const Curve_segment_index& ci, FT d) const;
 
 /*!
 Returns the length of the curve segment, on the curve with index
-\c  curve_index, from \c p to \c q, in the orientation
-\c orientation
+\c  curve_index, from \c p to \c q
 
 If the curve connected component containing \c p and \c q is a cycle,
-the orientation gives identifies which portion of the cycle
+the orientation identifies which portion of the cycle
 corresponds to the arc, otherwise \c orientation must be compatible
 with the orientation of \c p and \c q on the curve segment.
 */

--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -87,26 +87,52 @@ const Point_3& p, const Curve_segment_index& ci, FT d) const;
 /// @{
 
 /*!
-Returns the signed geodesic distance
-between points `p` and `q` along the input curve segment
-with index `ci`.
-\pre Points `p` and `q` belong to the same connected component of the curve segment with index `ci`.
-*/
-FT geodesic_distance(const Point_3& p,
-const Point_3& q, const Curve_segment_index& ci) const;
+Returns the length of the curve segment, on the curve with index
+\c  curve_index, from \c p to \c q, in the orientation
+\c orientation
 
+If the curve connected component containing \c p and \c q is a cycle,
+the orientation gives identifies which portion of the cycle
+corresponds to the arc, otherwise \c orientation must be compatible
+with the orientation of \c p and \c q on the curve segment.
+*/
+FT arc_length(const Point_3& p, const Point_3 q,
+              const Curve_segment_index& curve_index,
+              CGAL::Orientation orientation) const;
 /*!
 
 Returns `CGAL::POSITIVE` if the signed geodesic distance from
-`p`
-to `q` on the way through \f$ r\f$
-along cycle with index `ci`
-is positive, `CGAL::NEGATIVE` if the distance is negative, and `CGAL::ZERO` if `(p = q = r)`.
-\pre Points `p`, `q` and `r` belongs to the same connected component of curve segment `ci` and this component is a cycle.
+`p` to `q` on the way through `r` along cycle with index `ci`
+is positive, `CGAL::NEGATIVE` if the distance is negative.
+\pre `p != q && p != r && r != q`
 */
 CGAL::Sign distance_sign_along_cycle(const Point_3& p, const Point_3& q,
 const Point_3& r, const Curve_segment_index& ci) const;
 
+/*!
+Returns the sign of the geodesic distance from `p` to `q`, on the curve
+with index `ci`.
+*/
+CGAL::Sign distance_sign(const Point_3& p, const Point_3& q,
+                         const Curve_segment_index& ci) const;
+
+/*!
+Returns the length of the connected component of curve with index
+\c curve_index that includes the point \c p
+*/
+FT curve_segment_length(const Point_3& p,
+                        const Curve_segment_index& curve_index) const;
+/*!
+Returns `true` if the portion of the curve segment of index \c index,
+between the points \c c1 and \c c2, is covered by the spheres of
+centers \c c1 and \c c2 and squared radii \c sq_r1 and \c sq_r2
+respectively. The points \c c1 and \c c2 are assumed to lie on the curve
+segment.
+*/
+bool is_curve_segment_covered(const Curve_segment_index& index,
+                              CGAL::Orientation orientation,
+                              const Point_3& c1, const Point_3& c2,
+                              const FT sq_r1, const FT sq_r2) const;
 /*!
 
 Returns `true` if the connected component of curve segment
@@ -116,7 +142,7 @@ bool is_cycle(const Point_3& p, const Curve_segment_index& ci) const;
 
 /// @}
 
-/// \name Retrieval of the input features and their incidences
+/// \name Retrieval of the input features
 /// @{
 
 /*!
@@ -144,16 +170,6 @@ The `%Index` values associated to the points are their indices w.r.t.\ their dim
 template <typename OutputIterator>
 OutputIterator
 get_curve_segments(OutputIterator curves) const;
-
-/*!
-Returns `true` if the curve segment with index `csi` is incident to the surface patch with index `spi`.
-*/
-bool are_incident_surface_patch_curve_segment(Surface_patch_index spi, Curve_segment_index csi);
-
-/*!
-Returns `true` if the corner with index `ci` is incident to the surface patch with index `spi`.
-*/
-bool are_incident_surface_patch_corner(Surface_patch_index spi, Corner_index ci);
 
 /// @}
 

--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -46,7 +46,7 @@ or with respect to some user customized quality criteria.
 The meshing engine used in this mesh generator
 is based on Delaunay refinement \cgalCite{c-gqmgc-93}, \cgalCite{r-draq2d-95}, \cgalCite{s-tmgdr-98}.
 It uses the notion of restricted Delaunay triangulation
-to approximate 1-dimensional curve segments and surface patches \cgalCite{cgal:bo-pgsms-05}.
+to approximate 1-dimensional curves and surface patches \cgalCite{cgal:bo-pgsms-05}.
 Before the refinement, a mechanism of protecting balls is set up on 1-dimensional features, if any,
 to ensure a fair representation
 of those features in the mesh, and also to guarantee the termination of the refinement process,
@@ -77,14 +77,14 @@ some 3D faces may have dangling 2D or 1D faces in their boundary faces.
 In the rest of the documentation, we will refer to the
 input 3D complex as the input domain. The faces of the input domain 
 with dimension 0, 1, 2 and 3 are called respectively
-<I>corners</I>, <I>curve segments</I>, <I>surface patches</I> and <I>subdomains</I>
+<I>corners</I>, <I>curves</I>, <I>surface patches</I> and <I>subdomains</I>
 to clearly distinguish them from the faces of the mesh
 that are called vertices, edges, facets and cells.
 
 Note that the input complex faces are not required to be linear nor smooth.
 Surface patches, for instance, may be smooth surface patches, 
 or portions of surface meshes with boundaries.
-Curve segments may be for instance straight segments, curved segments
+Curves may be for instance straight segments, parameterized curves
 or polylines. Each of those features will be accurately represented in the final mesh.
 
 The 0 and 1-dimensional features of the input domain are usually singular points
@@ -102,7 +102,7 @@ in the final mesh.
 Note also that input complex faces are not required to be connected.
 Faces of the input domain are identified by indexes.
 If a subdomain is not connected, its different components receive the same index.
-Likewise different surface patches, segment curves or corners may share the same index.
+Likewise different surface patches, curves or corners may share the same index.
 Each connected component of a feature will be accurately represented
 in the final mesh.
 Note however that the occurrence of multiply connected faces in the
@@ -143,7 +143,7 @@ This \cgal component also provides a function to convert the reconstructed mesh 
 - `facets_in_complex_3_to_triangle_mesh()`
 
 The 3D triangulation provides approximations of the
-subdomains, surface patches and curve segments
+subdomains, surface patches and curves
 and corners, according to the restricted
 Delaunay triangulation paradigm. This means that each subdomain
 is approximated by the union of the tetrahedral cells
@@ -376,11 +376,11 @@ the concept `MeshDomainWithFeatures_3` provides
 the incidence
 graph of 0, 1 and 2-dimensional features,
 and a member function to construct
-sample points on curve segments.
+sample points on curves.
 
 Using the parameter of type `Features`, the user
 whose domain is a model of `MeshDomainWithFeatures_3` 
-can choose to have the corners and curve segments of the domain
+can choose to have the corners and curves of the domain
 represented in the mesh or not.
 The type `Features` of this parameter is an internal undescribed type.
 The library provides functions to construct appropriate values of that type.
@@ -428,7 +428,7 @@ provides an upper bound for the distance between the circumcenter
 of a surface facet and the center of a surface Delaunay ball of this facet.
 <LI><I>`facet_topology`.</I> This parameters controls the set of topological constraints
 which have to be verified by each surface facet. By default, each vertex of a surface
-facet has to be located on a surface patch, on a curve segment, or on a corner. It can
+facet has to be located on a surface patch, on a curve, or on a corner. It can
 also be set to check whether the three vertices of a surface facet belongs to the same
 surface patch. This has to be done cautiously, as such a criteria needs that each surface
 patches intersection is an input 1-dimensional feature.

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -79,7 +79,7 @@ related to the template parameters of some models of the main concepts:
 
 ## Classes ##
 
-- `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveSegmentIndex>`
+- `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>`
 - `CGAL::Mesh_triangulation_3<MD,Gt,Concurrency_tag,Vertex_base,Cell_base>`
 - `CGAL::Mesh_vertex_base_3<Gt,MD,Vb>`
 - `CGAL::Compact_mesh_cell_base_3<Gt,MD,Tds>`

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_complex.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_complex.cpp
@@ -25,7 +25,7 @@ typedef CGAL::Sequential_tag Concurrency_tag;
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -23,7 +23,7 @@ typedef CGAL::Sequential_tag Concurrency_tag;
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_lipschitz_sizing.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_lipschitz_sizing.cpp
@@ -26,7 +26,7 @@ typedef CGAL::Sequential_tag Concurrency_tag;
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_surface_inside.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_surface_inside.cpp
@@ -21,7 +21,7 @@ typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,CGAL::Sequential_tag>::type Tr;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/examples/Mesh_3/mesh_two_implicit_spheres_with_balls.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_two_implicit_spheres_with_balls.cpp
@@ -32,7 +32,7 @@ typedef CGAL::Sequential_tag Concurrency_tag;
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
@@ -17,7 +17,7 @@ typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1616,9 +1616,6 @@ is_sampling_dense_enough(const Vertex_handle& v1, const Vertex_handle& v2,
   using CGAL::Mesh_3::internal::min_intersection_factor;
   CGAL_precondition(c3t3_.curve_segment_index(v1,v2) == curve_index);
 
-  typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
-    c3t3_.triangulation().geom_traits().construct_point_3_object();
-
   // Get sizes
   FT size_v1 = get_radius(v1);
   FT size_v2 = get_radius(v2);

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -216,12 +216,12 @@ private:
 			     const Curve_segment_index& curve_index,
 			     ErasedVeOutIt out);
   
-  /// Returns true if balls of \c va and \c vb intersect, and (va,vb) is not
+  /// Returns `true` if balls of \c va and \c vb intersect, and (va,vb) is not
   /// an edge of the complex
   bool non_adjacent_but_intersect(const Vertex_handle& va,
                                   const Vertex_handle& vb) const;
   
-  /// Returns true if balls of \c va and \c vb intersect
+  /// Returns `true` if balls of \c va and \c vb intersect
   bool do_balls_intersect(const Vertex_handle& va,
                           const Vertex_handle& vb) const;
   
@@ -230,7 +230,7 @@ private:
                                  const bool special_ball = false);
   
   
-  /// Returns true if balls of v1 and v2 intersect "enough".
+  /// Returns `true` if balls of v1 and v2 intersect "enough".
   /// \param orientation Orientation of the curve segment between \c v1 and
   ///        \c v2, given the orientation of the curve of index
   ///        \c curve_index
@@ -325,7 +325,7 @@ private:
   ErasedVeOutIt
   repopulate_edges_around_corner(const Vertex_handle& v, ErasedVeOutIt out);
   
-  /// Returns true if edge with index \c curve_index is already treated
+  /// Returns `true` if edge with index \c curve_index is already treated
   bool is_treated(const Curve_segment_index& curve_index) const
   {
     return ( treated_edges_.find(curve_index) != treated_edges_.end() );

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -105,7 +105,7 @@ void debug_dump_c3t3(const std::string filename, const C3t3& c3t3)
 
 
 template <typename C3T3, typename MeshDomain, typename SizingFunction>
-class Protect_edges_sizing_field
+class Protect_edges_sizing_field : public CGAL::Mesh_3::internal::Debug_messages_tools
 {
   typedef Protect_edges_sizing_field          Self;
   
@@ -360,28 +360,6 @@ private:
       CGAL_error_msg(msg.str().c_str());
     }
     return s;
-  }
-
-  template <typename Vertex_handle>
-  static std::string disp_vert(Vertex_handle v, Tag_true) {
-    std::stringstream ss;
-    ss << (void*)(&*v) << "[ts=" << v->time_stamp() << "]"
-       << "(" << v->point() <<")";
-    return ss.str();
-  }
-
-  template <typename Vertex_handle>
-  static std::string disp_vert(Vertex_handle v, Tag_false) {
-    std::stringstream ss;
-    ss << (void*)(&*v) << "(" << v->point() <<")";
-    return ss.str();
-  }
-
-  template <typename Vertex_handle>
-  static std::string disp_vert(Vertex_handle v)
-  {
-    typedef typename std::iterator_traits<Vertex_handle>::value_type Vertex;
-    return disp_vert(v, CGAL::internal::Has_timestamp<Vertex>());
   }
 
 private:

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -124,7 +124,7 @@ public:
   typedef typename C3T3::Triangulation        Triangulation;
   typedef typename C3T3::Edge                 Edge;
   
-  typedef typename MeshDomain::Curve_segment_index  Curve_segment_index;
+  typedef typename MeshDomain::Curve_index          Curve_index;
   typedef typename MeshDomain::Corner_index         Corner_index;
   typedef typename MeshDomain::Index                Index;
   
@@ -141,9 +141,9 @@ public:
   }
   
 private:
-  typedef std::vector<std::pair<Curve_segment_index,Bare_point> >    Incident_edges;
-  typedef std::vector<Vertex_handle>                                 Vertex_vector;
-  typedef std::vector<std::pair<Vertex_handle,Curve_segment_index> > Incident_vertices;
+  typedef std::vector<std::pair<Curve_index,Bare_point> >    Incident_edges;
+  typedef std::vector<Vertex_handle>                         Vertex_vector;
+  typedef std::vector<std::pair<Vertex_handle,Curve_index> > Incident_vertices;
   
 private:
   /// Insert corners of the mesh
@@ -196,7 +196,7 @@ private:
   template <typename ErasedVeOutIt>
   ErasedVeOutIt insert_balls(const Vertex_handle& vp,
 			     const Vertex_handle& vq,
-			     const Curve_segment_index& curve_index,
+			     const Curve_index& curve_index,
                              const CGAL::Orientation orientation,
 			     ErasedVeOutIt out);
 
@@ -213,7 +213,7 @@ private:
 			     const FT size_q,
 			     const FT pq_length,
 			     const CGAL::Orientation orientation,
-			     const Curve_segment_index& curve_index,
+			     const Curve_index& curve_index,
 			     ErasedVeOutIt out);
   
   /// Returns `true` if balls of \c va and \c vb intersect, and (va,vb) is not
@@ -234,10 +234,10 @@ private:
   /// \param orientation Orientation of the curve segment between \c v1 and
   ///        \c v2, given the orientation of the curve of index
   ///        \c curve_index
-  /// \pre `c3t3.curve_segment_index(v1, v2) == curve_index`
+  /// \pre `c3t3.curve_index(v1, v2) == curve_index`
   bool is_sampling_dense_enough(const Vertex_handle& v1,
                                 const Vertex_handle& v2,
-                                const Curve_segment_index& curve_index,
+                                const Curve_index& curve_index,
                                 const CGAL::Orientation orientation) const;
   
   /// Takes an iterator on Vertex_handle as input and check if the sampling
@@ -256,11 +256,11 @@ private:
   /// \c start to \c next is oriented in the same orientation as the curve
   /// segment with index \c curve_index, or `CGAL::NEGATIVE` otherwise.
   ///
-  /// \pre `c3t3.curve_segment_index(v1, v2) == curve_index`
+  /// \pre `c3t3.curve_index(v1, v2) == curve_index`
   CGAL::Orientation
   orientation_of_walk(const Vertex_handle& start,
                       const Vertex_handle& next,
-                      Curve_segment_index curve_index) const;
+                      Curve_index curve_index) const;
   
   /// Walk along edge from \c start, following the direction \c start to 
   /// \c next, and fills \c out with the vertices which do not fullfill 
@@ -270,23 +270,23 @@ private:
   ///        \c v2, given the orientation of the curve of index
   ///        \c curve_index
   ///
-  /// \pre `c3t3.curve_segment_index(v1, v2) == curve_index`
+  /// \pre `c3t3.curve_index(v1, v2) == curve_index`
   template <typename ErasedVeOutIt>
   ErasedVeOutIt
   walk_along_edge(const Vertex_handle& start,
                   const Vertex_handle& next,
-                  Curve_segment_index curve_index,
+                  Curve_index curve_index,
                   const CGAL::Orientation orientation,
                   ErasedVeOutIt out) const;
   
   /// Returns next vertex along edge, i.e vertex after \c start, following
   /// the direction from \c previous to \c start
   /// \pre (previous,start) is in c3t3
-  /// \pre `c3t3.curve_segment_index(start, previous) == curve_index`
+  /// \pre `c3t3.curve_index(start, previous) == curve_index`
   Vertex_handle
-  next_vertex_along_curve_segment(const Vertex_handle& start,
-                                  const Vertex_handle& previous,
-                                  const Curve_segment_index& curve_index) const;
+  next_vertex_along_curve(const Vertex_handle& start,
+                          const Vertex_handle& previous,
+                          const Curve_index& curve_index) const;
 
   /// Replace vertices between ]begin,last[ by new vertices, along curve
   /// identified by \c curve_index
@@ -299,7 +299,7 @@ private:
   template <typename InputIterator, typename ErasedVeOutIt>
   ErasedVeOutIt repopulate(InputIterator begin,
 			   InputIterator last,
-                           const Curve_segment_index& curve_index,
+                           const Curve_index& curve_index,
                            const CGAL::Orientation orientation,
 			   ErasedVeOutIt out);
 
@@ -307,7 +307,7 @@ private:
   ErasedVeOutIt
   analyze_and_repopulate(InputIterator begin,
                          InputIterator last,
-                         const Curve_segment_index& index,
+                         const Curve_index& index,
                          const CGAL::Orientation orientation,
 			 ErasedVeOutIt out);
   
@@ -316,7 +316,7 @@ private:
   bool is_sizing_field_correct(const Vertex_handle& v1,
                                const Vertex_handle& v2,
                                const Vertex_handle& v3,
-                               const Curve_segment_index& index,
+                               const Curve_index& index,
                                const CGAL::Orientation orientation) const;
 
   /// Repopulate all incident curve around corner \c v
@@ -326,13 +326,13 @@ private:
   repopulate_edges_around_corner(const Vertex_handle& v, ErasedVeOutIt out);
   
   /// Returns `true` if edge with index \c curve_index is already treated
-  bool is_treated(const Curve_segment_index& curve_index) const
+  bool is_treated(const Curve_index& curve_index) const
   {
     return ( treated_edges_.find(curve_index) != treated_edges_.end() );
   }
   
   /// Set edge with index \c curve_index as treated
-  void set_treated(const Curve_segment_index& curve_index)
+  void set_treated(const Curve_index& curve_index)
   {
     treated_edges_.insert(curve_index);
   }
@@ -409,7 +409,7 @@ private:
   SizingFunction size_;
   FT minimal_size_;
   Weight minimal_weight_;
-  std::set<Curve_segment_index> treated_edges_;
+  std::set<Curve_index> treated_edges_;
   std::set<Vertex_handle> unchecked_vertices_;
   int refine_balls_iteration_nb;
   bool nonlinear_growth_of_balls;
@@ -852,19 +852,19 @@ Protect_edges_sizing_field<C3T3, MD, Sf>::
 insert_balls_on_edges()
 {
   // Get features
-  typedef CGAL::cpp11::tuple<Curve_segment_index,
+  typedef CGAL::cpp11::tuple<Curve_index,
                              std::pair<Bare_point,Index>,
                              std::pair<Bare_point,Index> >    Feature_tuple;
   typedef std::vector<Feature_tuple>                          Input_features;
   
   Input_features input_features;
-  domain_.get_curve_segments(std::back_inserter(input_features));
+  domain_.get_curves(std::back_inserter(input_features));
   
   // Interate on edges
   for ( typename Input_features::iterator fit = input_features.begin(),
        end = input_features.end() ; fit != end ; ++fit )
   {
-    const Curve_segment_index& curve_index = CGAL::cpp11::get<0>(*fit);
+    const Curve_index& curve_index = CGAL::cpp11::get<0>(*fit);
     if ( ! is_treated(curve_index) )
     {
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
@@ -877,7 +877,7 @@ insert_balls_on_edges()
       const Index& q_index = CGAL::cpp11::get<2>(*fit).second;
       
       Vertex_handle vp,vq;
-      if ( ! domain_.is_cycle(p, curve_index) )
+      if ( ! domain_.is_loop(curve_index) )
       {
         vp = get_vertex_corner_from_point(p,p_index);
         vq = get_vertex_corner_from_point(q,q_index);
@@ -897,12 +897,12 @@ insert_balls_on_edges()
           // with the third of the distance from 'p' to 'q'.
           FT p_size = query_size(p, 1, p_index);
 
-          FT curve_lenght = domain_.curve_segment_length(p, curve_index);
+          FT curve_lenght = domain_.curve_length(curve_index);
 
           Bare_point other_point =
-            domain_.construct_point_on_curve_segment(p,
-                                                     curve_index,
-                                                     curve_lenght / 2);
+            domain_.construct_point_on_curve(p,
+                                             curve_index,
+                                             curve_lenght / 2);
           p_size = (std::min)(p_size,
                               compute_distance(p, other_point) / 3);
           vp = smart_insert_point(p,
@@ -958,7 +958,7 @@ ErasedVeOutIt
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 insert_balls(const Vertex_handle& vp,
              const Vertex_handle& vq,
-             const Curve_segment_index& curve_index,
+             const Curve_index& curve_index,
              const CGAL::Orientation orientation,
 	     ErasedVeOutIt out)
 {
@@ -972,13 +972,13 @@ insert_balls(const Vertex_handle& vp,
   const FT sp = get_radius(vp);
   const FT sq = get_radius(vq);
 
-  CGAL_assertion(vp != vq || domain_.is_cycle(p, curve_index));
+  CGAL_assertion(vp != vq || domain_.is_loop(curve_index));
   
   // Compute geodesic distance
   const FT pq_length = (vp == vq) ?
-    domain_.curve_segment_length(p, curve_index)
+    domain_.curve_length(curve_index)
     :
-    domain_.arc_length(p, q, curve_index, orientation);
+    domain_.curve_segment_length(p, q, curve_index, orientation);
 
   // Insert balls
   return
@@ -999,7 +999,7 @@ insert_balls(const Vertex_handle& vp,
              const FT sq,
              const FT d,
              const CGAL::Orientation d_sign,
-             const Curve_segment_index& curve_index,
+             const Curve_index& curve_index,
 	     ErasedVeOutIt out)
 {
   typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
@@ -1078,16 +1078,17 @@ insert_balls(const Vertex_handle& vp,
                 << n << "\n  between points ("
                 << vp->point() << ") and (" << vq->point()
                 << ") (arc length: "
-                << domain_.arc_length(wp2p(vp->point()), wp2p(vq->point()),
-                                      curve_index, d_sign)
+                << domain_.curve_segment_length(wp2p(vp->point()),
+                                                wp2p(vq->point()),
+                                                curve_index, d_sign)
                 << ")\n";
 #endif
       const Bare_point new_point =
-        domain_.construct_point_on_curve_segment(wp2p(vp->point()),
-                                                 curve_index,
-                                                 d_sign * d / 2);
+        domain_.construct_point_on_curve(wp2p(vp->point()),
+                                         curve_index,
+                                         d_sign * d / 2);
       const int dim = 1; // new_point is on edge
-      const Index index = domain_.index_from_curve_segment_index(curve_index);
+      const Index index = domain_.index_from_curve_index(curve_index);
       const FT point_weight = CGAL::square(size_(new_point, dim, index));
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "  middle point: " << new_point << std::endl;
@@ -1167,14 +1168,14 @@ insert_balls(const Vertex_handle& vp,
   {
     // New point position
     Bare_point new_point =
-      domain_.construct_point_on_curve_segment(p, curve_index, pt_dist);
+      domain_.construct_point_on_curve(p, curve_index, pt_dist);
     
     // Weight (use as size the min between norm_step_size and linear interpolation)
     FT current_size = (std::min)(norm_step_size, sp + CGAL::abs(pt_dist)/d*(sq-sp));
     FT point_weight = current_size * current_size;
     
     // Index and dimension
-    Index index = domain_.index_from_curve_segment_index(curve_index);
+    Index index = domain_.index_from_curve_index(curve_index);
     int dim = 1; // new_point is on edge
     
     // Insert point into c3t3
@@ -1552,7 +1553,7 @@ check_and_fix_vertex_along_edge(const Vertex_handle& v, ErasedVeOutIt out)
   // mesh is only two balls on the cycle: then each ball has only one
   // neighbor.
 
-  const Curve_segment_index& curve_index = incident_vertices.front().second;
+  const Curve_index& curve_index = incident_vertices.front().second;
   CGAL_assertion(incident_vertices.back().second== curve_index);
 
   // Walk along edge to find the edge piece which is not correctly sampled
@@ -1610,25 +1611,25 @@ template <typename C3T3, typename MD, typename Sf>
 bool
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 is_sampling_dense_enough(const Vertex_handle& v1, const Vertex_handle& v2,
-                         const Curve_segment_index& curve_index,
+                         const Curve_index& curve_index,
                          const CGAL::Orientation orientation) const
 {
   using CGAL::Mesh_3::internal::min_intersection_factor;
-  CGAL_precondition(c3t3_.curve_segment_index(v1,v2) == curve_index);
+  CGAL_precondition(c3t3_.curve_index(v1,v2) == curve_index);
 
   // Get sizes
   FT size_v1 = get_radius(v1);
   FT size_v2 = get_radius(v2);
 
   CGAL_assertion(get_dimension(v1) != 1 ||
-                 curve_index == domain_.curve_segment_index(v1->index()));
+                 curve_index == domain_.curve_index(v1->index()));
   CGAL_assertion(get_dimension(v2) != 1 ||
-                 curve_index == domain_.curve_segment_index(v2->index()));
+                 curve_index == domain_.curve_index(v2->index()));
 
-  FT arc_length = domain_.arc_length(v1->point().point(),
-                                     v2->point().point(),
-                                     curve_index,
-                                     orientation);
+  FT arc_length = domain_.curve_segment_length(v1->point().point(),
+                                               v2->point().point(),
+                                               curve_index,
+                                               orientation);
   // Sufficient condition so that the curve portion between v1 and v2 is
   // inside the union of the two balls.
   if(arc_length > (size_v1 + size_v2)) {
@@ -1678,19 +1679,19 @@ CGAL::Orientation
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 orientation_of_walk(const Vertex_handle& start,
                     const Vertex_handle& next,
-                    Curve_segment_index curve_index) const
+                    Curve_index curve_index) const
 {
   typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
     c3t3_.triangulation().geom_traits().construct_point_3_object();
 
-  if(domain_.is_cycle(wp2p(start->point()), curve_index)) {
+  if(domain_.is_loop(curve_index)) {
     // if the curve is a cycle, the direction is the direction passing
     // through the next vertex, and the next-next vertex
     return
-      (domain_.distance_sign_along_cycle
+      (domain_.distance_sign_along_loop
        (wp2p(start->point()),
         wp2p(next->point()),
-        wp2p(next_vertex_along_curve_segment(next,start,curve_index)->point()),
+        wp2p(next_vertex_along_curve(next,start,curve_index)->point()),
         curve_index));
   } else {
     // otherwise, the sign is just the sign of the geodesic distance
@@ -1704,7 +1705,7 @@ template <typename ErasedVeOutIt>
 ErasedVeOutIt
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 walk_along_edge(const Vertex_handle& start, const Vertex_handle& next,
-                Curve_segment_index curve_index,
+                Curve_index curve_index,
                 const CGAL::Orientation orientation,
                 ErasedVeOutIt out) const
 {
@@ -1736,7 +1737,7 @@ walk_along_edge(const Vertex_handle& start, const Vertex_handle& next,
     
     // Get next vertex along edge
     Vertex_handle next =
-      next_vertex_along_curve_segment(current,previous,curve_index);
+      next_vertex_along_curve(current,previous,curve_index);
     previous = current;
     current = next;
   }
@@ -1748,16 +1749,13 @@ walk_along_edge(const Vertex_handle& start, const Vertex_handle& next,
 template <typename C3T3, typename MD, typename Sf>
 typename Protect_edges_sizing_field<C3T3, MD, Sf>::Vertex_handle
 Protect_edges_sizing_field<C3T3, MD, Sf>::
-next_vertex_along_curve_segment(const Vertex_handle& start,
-                                const Vertex_handle& previous,
-                                const Curve_segment_index& curve_index) const
+next_vertex_along_curve(const Vertex_handle& start,
+                        const Vertex_handle& previous,
+                        const Curve_index& curve_index) const
 {
-  typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
-    c3t3_.triangulation().geom_traits().construct_point_3_object();
-
-  CGAL_USE(curve_index); CGAL_USE(wp2p);
-  CGAL_precondition( c3t3_.curve_segment_index(start, previous) == curve_index);
-  CGAL_precondition( domain_.is_cycle(wp2p(start->point()), curve_index) ||
+  CGAL_USE(curve_index);
+  CGAL_precondition( c3t3_.curve_index(start, previous) == curve_index);
+  CGAL_precondition( domain_.is_loop(curve_index) ||
                      (! c3t3_.is_in_complex(start)) );
 
   Incident_vertices incident_vertices;
@@ -1786,7 +1784,7 @@ template <typename InputIterator, typename ErasedVeOutIt>
 ErasedVeOutIt
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 repopulate(InputIterator begin, InputIterator last,
-	   const Curve_segment_index& index,
+	   const Curve_index& index,
            const CGAL::Orientation orientation,
            ErasedVeOutIt out)
 {
@@ -1851,7 +1849,7 @@ template <typename InputIterator, typename ErasedVeOutIt>
 ErasedVeOutIt
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 analyze_and_repopulate(InputIterator begin, InputIterator last,
-		       const Curve_segment_index& index,
+		       const Curve_index& index,
                        const CGAL::Orientation orientation,
                        ErasedVeOutIt out)
 {
@@ -1928,7 +1926,7 @@ Protect_edges_sizing_field<C3T3, MD, Sf>::
 is_sizing_field_correct(const Vertex_handle& v1,
                         const Vertex_handle& v2,
                         const Vertex_handle& v3,
-                        const Curve_segment_index& curve_index,
+                        const Curve_index& curve_index,
                         const CGAL::Orientation orientation) const
 {
   typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
@@ -1937,10 +1935,10 @@ is_sizing_field_correct(const Vertex_handle& v1,
   FT s1 = get_radius(v1);
   FT s2 = get_radius(v2);
   FT s3 = get_radius(v3);
-  FT D = domain_.arc_length(wp2p(v1->point()), wp2p(v3->point()),
-                            curve_index, orientation);
-  FT d = domain_.arc_length(wp2p(v1->point()), wp2p(v2->point()),
-                            curve_index, orientation);
+  FT D = domain_.curve_segment_length(wp2p(v1->point()), wp2p(v3->point()),
+                                      curve_index, orientation);
+  FT d = domain_.curve_segment_length(wp2p(v1->point()), wp2p(v2->point()),
+                                      curve_index, orientation);
   
   return ( s2 >= (s1 + d/D*(s3-s1)) );
 }
@@ -1954,9 +1952,6 @@ repopulate_edges_around_corner(const Vertex_handle& v, ErasedVeOutIt out)
 {
   CGAL_precondition(c3t3_.is_in_complex(v));
 
-  typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
-    c3t3_.triangulation().geom_traits().construct_point_3_object();
-
   Incident_vertices incident_vertices;
   c3t3_.adjacent_vertices_in_complex(v, std::back_inserter(incident_vertices));
   
@@ -1964,12 +1959,12 @@ repopulate_edges_around_corner(const Vertex_handle& v, ErasedVeOutIt out)
        vend = incident_vertices.end() ; vit != vend ; ++vit )
   {
     const Vertex_handle& next = vit->first;
-    const Curve_segment_index& curve_index = vit->second;
+    const Curve_index& curve_index = vit->second;
     
     // if `v` is incident to a cycle, it might be that the full cycle,
     // including the edge `[next, v]`, has already been processed by
     // `analyze_and_repopulate()` walking in the other direction.
-    if(domain_.is_cycle(wp2p(v->point()), curve_index) &&
+    if(domain_.is_loop(curve_index) &&
        !c3t3_.is_in_complex(v, next)) continue;
 
 

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1815,10 +1815,6 @@ repopulate(InputIterator begin, InputIterator last,
   {
     c3t3_.remove_from_complex(*previous++, *current++);
   }
-  // Keep a point between current and last
-  typename C3T3::Triangulation::Geom_traits::Construct_point_3 wp2p =
-    c3t3_.triangulation().geom_traits().construct_point_3_object();
-  Bare_point point_through = wp2p((*previous)->point());
 
   // Remove last edge
   c3t3_.remove_from_complex(*previous, *current);

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -191,7 +191,7 @@ private:
   /// on curve identified by \c curve_index
   ///
   /// \param orientation Orientation of the curve segment between \c vp and
-  ///        \c vp, given the orientation of the curve of index
+  ///        \c vq, given the orientation of the curve of index
   ///        \c curve_index
   template <typename ErasedVeOutIt>
   ErasedVeOutIt insert_balls(const Vertex_handle& vp,
@@ -252,7 +252,7 @@ private:
   check_and_fix_vertex_along_edge(const Vertex_handle& v, ErasedVeOutIt out);
 
   /// Given two vertices \c start and \c next inserted on the curve with
-  /// index \c curve_index, return `CGAL::POSITIVE` if the curve arc from
+  /// index \c curve_index, returns `CGAL::POSITIVE` if the curve arc from
   /// \c start to \c next is oriented in the same orientation as the curve
   /// segment with index \c curve_index, or `CGAL::NEGATIVE` otherwise.
   ///

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
@@ -101,7 +101,7 @@ protected:
       case 1: 
         {
           ++nb_vertices_on_curves;
-          const typename MeshDomain::Curve_segment_index curve_id =
+          const typename MeshDomain::Curve_index curve_id =
             domain->curve_segment_index(v->index());
           Index_set set;
           domain->get_incidences(curve_id, std::back_inserter(set));

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
@@ -16,12 +16,6 @@
 // $Id$
 //
 // Author(s)     : Laurent Rineau
-//
-//******************************************************************************
-// File Description :
-//
-//
-//******************************************************************************
 
 #ifndef CGAL_MESH_3_FACET_TOPOLOGICAL_CRITERION_WITH_ADJACENCY_H
 #define CGAL_MESH_3_FACET_TOPOLOGICAL_CRITERION_WITH_ADJACENCY_H

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Facet_topological_criterion_with_adjacency.h
@@ -102,7 +102,7 @@ protected:
         {
           ++nb_vertices_on_curves;
           const typename MeshDomain::Curve_index curve_id =
-            domain->curve_segment_index(v->index());
+            domain->curve_index(v->index());
           Index_set set;
           domain->get_incidences(curve_id, std::back_inserter(set));
           if(std::find(set.begin(), set.end(), patch_index) == set.end())

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
@@ -25,6 +25,7 @@
 #include <CGAL/license/Mesh_3.h>
 
 #include <CGAL/property_map.h>
+#include <CGAL/Mesh_3/properties.h>
 #include <boost/mpl/has_xxx.hpp>
 
 namespace CGAL { namespace Mesh_3 {

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
@@ -205,7 +205,7 @@ public:
     else if (dim == 1)
     {
 #ifdef CGAL_MESH_3_EXPERIMENTAL_USE_PATCHES_IDS
-      const typename MeshDomain::Curve_segment_index& curve_id =
+      const typename MeshDomain::Curve_index& curve_id =
         m_domain.curve_segment_index(index);
       const Patches_ids& ids = patches_ids_map[curve_id];
       

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -124,16 +124,15 @@ struct Sizing_field_with_aabb_tree
       domain.get_corner_incident_curves(pair.second,
                                         std::inserter(incident_curves,
                                                       incident_curves.end()));
-      // For each incident cycles, insert a point on the cycle, as far as
+      // For each incident loops, insert a point on the loop, as far as
       // possible.
       BOOST_FOREACH(Curve_index curve_index, incident_curves) {
-        if(domain.is_cycle(pair.first, curve_index)) {
-          FT curve_lenght = domain.curve_segment_length(pair.first,
-                                                        curve_index);
+        if(domain.is_loop(curve_index)) {
+          FT curve_lenght = domain.curve_length(curve_index);
           Point_3 other_point =
-            domain.construct_point_on_curve_segment(pair.first,
-                                                    curve_index,
-                                                    curve_lenght / 2);
+            domain.construct_point_on_curve(pair.first,
+                                            curve_index,
+                                            curve_lenght / 2);
           dt.insert(other_point);
         }
       }
@@ -143,7 +142,7 @@ struct Sizing_field_with_aabb_tree
       return;//there is no surface --> no surface patches
 
     //fill incidences with patches
-    curves_incident_patches.resize(domain.maximal_curve_segment_index()+1);
+    curves_incident_patches.resize(domain.maximal_curve_index()+1);
     corners_incident_patches.resize(corners.size());
     for (Curve_index curve_id = 1;
          std::size_t(curve_id) < curves_incident_patches.size();
@@ -294,7 +293,7 @@ struct Sizing_field_with_aabb_tree
     } 
     else { // dim == 1
       const typename MeshDomain::Curve_index& curve_id = 
-        domain.curve_segment_index(id);
+        domain.curve_index(id);
       if(!aabb_tree.empty()) {
         const Patches_ids& ids = curves_incident_patches[curve_id];
 

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -51,7 +51,7 @@ struct Sizing_field_with_aabb_tree
 
   typedef typename MeshDomain::Index               Index;
   typedef typename MeshDomain::Corner_index        Corner_index;
-  typedef typename MeshDomain::Curve_segment_index Curve_index;
+  typedef typename MeshDomain::Curve_index         Curve_index;
   typedef typename MeshDomain::Surface_patch_index Patch_index;
 
   typedef boost::container::flat_set<Curve_index> Curves_ids;
@@ -293,7 +293,7 @@ struct Sizing_field_with_aabb_tree
       return result;
     } 
     else { // dim == 1
-      const typename MeshDomain::Curve_segment_index& curve_id = 
+      const typename MeshDomain::Curve_index& curve_id = 
         domain.curve_segment_index(id);
       if(!aabb_tree.empty()) {
         const Patches_ids& ids = curves_incident_patches[curve_id];

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -30,6 +30,7 @@
 #include <CGAL/Mesh_3/Protect_edges_sizing_field.h> // for weight_modifier
 
 #include <boost/foreach.hpp>
+#include <boost/container/flat_set.hpp>
 #if defined(CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY) || defined(CGAL_NO_ASSERTIONS) == 0
 #  include <sstream>
 #  include <boost/format.hpp>
@@ -37,7 +38,7 @@
 
 #include "AABB_filtered_projection_traits.h"
 
-template <typename GeomTraits, typename MeshDomain, typename Patches_ids,
+template <typename GeomTraits, typename MeshDomain,
           typename Input_facets_AABB_tree = typename MeshDomain::AABB_tree,
           typename Get_curve_index_ = CGAL::Default,
           typename Get_facet_patch_id_ = CGAL::Default
@@ -45,12 +46,24 @@ template <typename GeomTraits, typename MeshDomain, typename Patches_ids,
 struct Sizing_field_with_aabb_tree
 {
   typedef GeomTraits Kernel_;
-  typedef typename MeshDomain::Index Index;
-  typedef std::vector<Patches_ids> Patches_ids_map;
-  typedef CGAL::Delaunay_triangulation_3<Kernel_> Dt;
   typedef typename Kernel_::FT FT;
   typedef typename Kernel_::Point_3 Point_3;
-  typedef std::map<Point_3, Patches_ids> Corners;
+
+  typedef typename MeshDomain::Index               Index;
+  typedef typename MeshDomain::Corner_index        Corner_index;
+  typedef typename MeshDomain::Curve_segment_index Curve_index;
+  typedef typename MeshDomain::Surface_patch_index Patch_index;
+
+  typedef boost::container::flat_set<Curve_index> Curves_ids;
+  typedef boost::container::flat_set<Patch_index> Patches_ids;
+
+  typedef std::map<Point_3, Corner_index> Corners_indices;
+  typedef std::vector<Point_3>     Corners;
+  typedef std::vector<Curves_ids>  Corners_incident_curves;
+  typedef std::vector<Patches_ids> Corners_incident_patches;
+  typedef std::vector<Patches_ids> Curves_incident_patches;
+
+  typedef CGAL::Delaunay_triangulation_3<Kernel_> Dt;
 
   typedef Input_facets_AABB_tree Input_facets_AABB_tree_;
   typedef typename Input_facets_AABB_tree_::Primitive Input_facets_AABB_tree_primitive_;
@@ -66,30 +79,99 @@ struct Sizing_field_with_aabb_tree
     CGAL::Mesh_3::Get_facet_patch_id<typename Input_facets_AABB_tree::Primitive>
     >::type Get_facet_patch_id;
 
-  template <typename InputCornersIterator>
-  Sizing_field_with_aabb_tree(typename Kernel_::FT d, 
-                              InputCornersIterator corners_begin,
-                              InputCornersIterator corners_end,
-                              const Input_facets_AABB_tree_& aabb_tree,
-                              const MeshDomain& domain,
-                              const Patches_ids_map& patches_ids_map,
-                              Get_curve_index get_curve_index
-                              = Get_curve_index(),
-                              Get_facet_patch_id get_facet_patch_id
-                              = Get_facet_patch_id())
+  Sizing_field_with_aabb_tree
+  (typename Kernel_::FT d,
+   const Input_facets_AABB_tree_& aabb_tree,
+   const MeshDomain& domain,
+   Get_curve_index get_curve_index = Get_curve_index(),
+   Get_facet_patch_id get_facet_patch_id = Get_facet_patch_id()
+   )
     : d_(d), aabb_tree(aabb_tree), 
-      domain(domain), patches_ids_map(patches_ids_map),
-      get_curve_index(get_curve_index),
-      get_facet_patch_id(get_facet_patch_id),
+      domain(domain),
       dt(),
-      corners(corners_begin, corners_end)
+      get_curve_index(get_curve_index),
+      get_facet_patch_id(get_facet_patch_id)
   {
-    typedef typename 
-      std::iterator_traits<InputCornersIterator>::value_type Pair;
-
-    BOOST_FOREACH(const Pair& p, std::make_pair(corners_begin, corners_end))
     {
-      dt.insert(p.first);
+      Corner_index maximal_corner_index = 0;
+      typedef std::pair<Corner_index, Point_3> Corner_index_and_point;
+      std::vector<Corner_index_and_point > corners_tmp;
+      domain.get_corners(std::back_inserter(corners_tmp));
+      BOOST_FOREACH(const Corner_index_and_point& pair, corners_tmp)
+      {
+        // Fill `corners_indices`
+        if(pair.first > maximal_corner_index) maximal_corner_index = pair.first;
+        corners_indices.
+          insert(typename Corners_indices::value_type(pair.second, pair.first));
+      }
+      corners.resize(maximal_corner_index+1);
+      BOOST_FOREACH(const Corner_index_and_point& pair, corners_tmp)
+      {
+        // Fill `corners`
+        corners[pair.first] = pair.second;
+      }
+    }
+
+    //fill incidences of corners with curves
+    corners_incident_curves.resize(corners.size());
+    BOOST_FOREACH(const typename Corners_indices::value_type& pair,
+      corners_indices)
+    {
+      dt.insert(pair.first);
+
+      // Fill `corners_incident_curves[corner_id]`
+      Curves_ids& incident_curves = corners_incident_curves[pair.second];
+      domain.get_corner_incident_curves(pair.second,
+                                        std::inserter(incident_curves,
+                                                      incident_curves.end()));
+      // For each incident cycles, insert a point on the cycle, as far as
+      // possible.
+      BOOST_FOREACH(Curve_index curve_index, incident_curves) {
+        if(domain.is_cycle(pair.first, curve_index)) {
+          FT curve_lenght = domain.curve_segment_length(pair.first,
+                                                        curve_index);
+          Point_3 other_point =
+            domain.construct_point_on_curve_segment(pair.first,
+                                                    curve_index,
+                                                    curve_lenght / 2);
+          dt.insert(other_point);
+        }
+      }
+    }
+
+    if (aabb_tree.empty())
+      return;//there is no surface --> no surface patches
+
+    //fill incidences with patches
+    curves_incident_patches.resize(domain.maximal_curve_segment_index()+1);
+    corners_incident_patches.resize(corners.size());
+    for (Curve_index curve_id = 1;
+         std::size_t(curve_id) < curves_incident_patches.size();
+         ++curve_id)
+    {
+      const typename MeshDomain::Surface_patch_index_set& incident_patches =
+        domain.get_incidences(curve_id);
+
+      // Fill `curves_incident_patches[curve_id]`
+      curves_incident_patches[curve_id].
+        insert(boost::container::ordered_unique_range,
+               incident_patches.begin(), incident_patches.end());
+    }
+    BOOST_FOREACH(const typename Corners_indices::value_type& pair,
+                  corners_indices)
+    {
+      // Get `corners_incident_curves[corner_id]`
+      Curves_ids& incident_curves = corners_incident_curves[pair.second];
+
+      // Fill `corners_incident_patches[corner_id]`
+      Patches_ids& incident_patches = corners_incident_patches[pair.second];
+      BOOST_FOREACH(Curve_index curve_index, incident_curves) {
+        const Patches_ids& curve_incident_patches =
+          curves_incident_patches[curve_index];
+        incident_patches.insert(boost::container::ordered_unique_range,
+                                curve_incident_patches.begin(),
+                                curve_incident_patches.end());
+      }
     }
   }
 
@@ -101,16 +183,16 @@ struct Sizing_field_with_aabb_tree
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
     if(dim <= 1) {
       std::cerr << "Sizing("  << p << ", dim=" << dim 
-                << ", index=#" << id << "): ";
+                << ", index=#" << CGAL::oformat(id) << "): ";
     }
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-    double result;
+    double result = d_;
     if(dim == 0) {
       if(dt.dimension() < 1) {
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-        std::cerr << d_ << "(dt.dimension() < 1)\n";
+        std::cerr << result << "(dt.dimension() < 1)\n";
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-        return d_;
+        return result;
       }
       typename Dt::Point nearest;
 
@@ -145,15 +227,15 @@ struct Sizing_field_with_aabb_tree
       }
       const FT dist = CGAL_NTS sqrt(CGAL::squared_distance( nearest, p));
       // std::cerr << (std::min)(dist / FT(1.5), d_) << "\n";
-      result = (std::min)(dist / FT(2), d_);
+      result = (std::min)(dist / FT(2), result);
 
       // now search in the AABB tree
-      typename Corners::const_iterator ids_it = corners.find(p);
-      if(ids_it == corners.end()) {
+      typename Corners_indices::const_iterator ids_it = corners_indices.find(p);
+      if(ids_it == corners_indices.end()) {
         std::cerr << "ERROR at " << __FILE__ << " line " << __LINE__ << "\n";
       }
-      else {
-        const Patches_ids& ids = ids_it->second;
+      else if(!aabb_tree.empty()) {
+        const Patches_ids& ids = corners_incident_patches[ids_it->second];
         CGAL_assertion(! ids.empty());
 
         CGAL::Mesh_3::Filtered_projection_traits<
@@ -185,12 +267,12 @@ struct Sizing_field_with_aabb_tree
                                "Ids are { ")
               % group(setprecision(17),result)
               % group(setprecision(17),p)
-              % get(get_facet_patch_id,
-                    projection_traits.closest_point_and_primitive().second)
+              % CGAL::oformat(get(get_facet_patch_id,
+                                  projection_traits.closest_point_and_primitive().second))
               % group(setprecision(17),
                       projection_traits.closest_point_and_primitive().first);
-            BOOST_FOREACH(int i, ids) {
-              s << i << " ";
+            BOOST_FOREACH(Patch_index i, ids) {
+              s << CGAL::oformat(i) << " ";
             }
             s << "}\n";
             std::cerr << s.str();
@@ -202,105 +284,105 @@ struct Sizing_field_with_aabb_tree
           std::cerr << result << " (projection not found)\n";
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
         }
-      }
-    }
+      } // end if(corners.find(p) != corners.end()) and !aabb_tree.empty()
+    } // end if(dim == 0)
     else if(dim != 1) {
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-      std::cerr << d_ << "\n";
+      std::cerr << result << "\n";
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-      return d_;
+      return result;
     } 
     else { // dim == 1
       const typename MeshDomain::Curve_segment_index& curve_id = 
         domain.curve_segment_index(id);
-      const Patches_ids& ids = patches_ids_map[curve_id];
+      if(!aabb_tree.empty()) {
+        const Patches_ids& ids = curves_incident_patches[curve_id];
 
-      CGAL_assertion(! ids.empty());
+        CGAL_assertion(! ids.empty());
 
-      //Compute distance to surface patches
-      CGAL::Mesh_3::Filtered_projection_traits
-      <
-        typename Input_facets_AABB_tree_::AABB_traits
-        , Get_facet_patch_id
-        > projection_traits(ids.begin(), ids.end(),
-                            aabb_tree.traits(),
-                            get_facet_patch_id);
+        //Compute distance to surface patches
+        CGAL::Mesh_3::Filtered_projection_traits
+          <
+            typename Input_facets_AABB_tree_::AABB_traits
+          , Get_facet_patch_id
+          > projection_traits(ids.begin(), ids.end(),
+                              aabb_tree.traits(),
+                              get_facet_patch_id);
 
-      aabb_tree.traversal(p, projection_traits);
+        aabb_tree.traversal(p, projection_traits);
 
-      if(!projection_traits.found()) {
+        if(!projection_traits.found()) {
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-        std::cerr << d_ << " (projection not found)\n";
+          std::cerr << result << " (projection not found)\n";
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-        return d_;
-      }
+          return result;
+        }
 
-      CGAL_assertion(ids.count(get(get_facet_patch_id,
-                                   projection_traits.closest_point_and_primitive().second)) == 0);
+        CGAL_assertion(ids.count(get(get_facet_patch_id,
+                                     projection_traits.closest_point_and_primitive().second)) == 0);
 
-      result = 
-        (std::min)(0.9 / CGAL::sqrt(CGAL::Mesh_3::internal::weight_modifier) * 
-                   CGAL_NTS 
-                   sqrt(CGAL::squared_distance(p, 
-                                               projection_traits.closest_point())),
-                   d_);
+        result =
+          (std::min)(0.9 / CGAL::sqrt(CGAL::Mesh_3::internal::weight_modifier) *
+                     CGAL_NTS
+                     sqrt(CGAL::squared_distance(p,
+                                                 projection_traits.closest_point())),
+                     result);
       
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-      {
-        std::stringstream s;
+        {
+          std::stringstream s;
        
-        s << boost::format("\nSizing field is %1% at point (%2%)"
-                           " on curve #%3% !\n"
-                           "Closest face id: %4%\n"
-                           "Ids are { ")
-          % result % p % curve_id
-          % get(get_facet_patch_id,
-                projection_traits.closest_point_and_primitive().second);
-        BOOST_FOREACH(int i, ids) {
-          s << i << " ";
+          s << boost::format("\nSizing field is %1% at point (%2%)"
+                             " on curve #%3% !\n"
+                             "Closest face id: %4%\n"
+                             "Ids are { ")
+            % result % p % curve_id
+            % CGAL::oformat(get(get_facet_patch_id,
+                                projection_traits.closest_point_and_primitive().second));
+          BOOST_FOREACH(Patch_index i, ids) {
+            s << CGAL::oformat(i) << " ";
+          }
+          s << "}\n";
+          std::cerr << s.str();
+          std::cerr << result << " (result)\n";
         }
-        s << "}\n";
-        std::cerr << s.str();
-        std::cerr << result << " (result)\n";
-      }
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
 #ifndef CGAL_NO_ASSERTIONS
-      if(result <= 0) {
-        std::stringstream s;
+        if(result <= 0) {
+          std::stringstream s;
        
-        s << boost::format("Sizing field is %1% at point (%2%)"
-                           " on curve #%3% !\n"
-                           "Closest face id: %4%\n"
-                           "Ids are { ")
-          % result % p % curve_id
-          % get(get_facet_patch_id,
-                projection_traits.closest_point_and_primitive().second);
-        BOOST_FOREACH(int i, ids) {
-          s << i << " ";
+          s << boost::format("Sizing field is %1% at point (%2%)"
+                             " on curve #%3% !\n"
+                             "Closest face id: %4%\n"
+                             "Ids are { ")
+            % result % p % curve_id
+            % CGAL::oformat(get(get_facet_patch_id,
+                                projection_traits.closest_point_and_primitive().second));
+          BOOST_FOREACH(Patch_index i, ids) {
+            s << CGAL::oformat(i) << " ";
+          }
+          s << "}\n";
+          CGAL_assertion_msg(result <=0, s.str().c_str());
         }
-        s << "}\n";
-        CGAL_assertion_msg(result <=0, s.str().c_str());
-      }
 #ifdef PROTECTION_DEBUG
-      else if (result <= (d_ / 1e7)) {
-        std::stringstream s;
-        s << boost::format("Sizing field is %1% at point (%2%)"
-                           " on curve #%3% !\n"
-                           "Closest face id: %4%\n"
-                           "Ids are { ")
-          % result % p % curve_id
-          % get(get_facet_patch_id,
-                projection_traits.closest_point_and_primitive().second);
-        BOOST_FOREACH(int i, ids) {
-          s << i << " ";
+        else if (result <= (d_ / 1e7)) {
+          std::stringstream s;
+          s << boost::format("Sizing field is %1% at point (%2%)"
+                             " on curve #%3% !\n"
+                             "Closest face id: %4%\n"
+                             "Ids are { ")
+            % result % p % curve_id
+            % projection_traits.closest_point_and_primitive().second->patch_id();
+          BOOST_FOREACH(Patch_index i, ids) {
+            s << CGAL::oformat(i) << " ";
+          }
+          s << "}\n";
+          std::cerr << "ERROR at " << __FILE__ << " line " << __LINE__ << " :\n"
+                    << s.str() << std::endl;
         }
-        s << "}\n";
-        std::cerr << "ERROR at " << __FILE__ << " line " << __LINE__ << " :\n"
-                  << s.str() << std::endl;
-      }
 #endif // PROTECTION_DEBUG
 #endif // CGAL_NO_ASSERTIONS
-
+      } // end if(!aabb_tree.empty())
       //Compute distance to the curves, and exclude the one on which p lies
       CGAL::Mesh_3::Filtered_projection_traits<typename Input_curves_AABB_tree_::AABB_traits,
                                                Get_curve_index >
@@ -328,9 +410,10 @@ struct Sizing_field_with_aabb_tree
                                                            std::back_inserter(prims));
 
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-      std::cout << std::endl;
-      std::cout << "P = " << p << std::endl;
-      std::cout << "PRIMITIVES FOUND : " << prims.size() << std::endl;
+      std::cerr << std::endl;
+      std::cerr << "p = " << p << std::endl;
+      std::cerr << "curr_ortho_plane = " << curr_ortho_plane << std::endl;
+      std::cerr << "PRIMITIVES FOUND : " << prims.size() << std::endl;
 #endif
 
       Point_3 closest_intersection;
@@ -351,15 +434,13 @@ struct Sizing_field_with_aabb_tree
           if (const Point_3* pp = boost::get<Point_3>(&*int_res))
           {
             FT new_sqd = CGAL::squared_distance(p, *pp);
-            FT gdist = (std::min)(CGAL::abs(domain.geodesic_distance(p, *pp, curve_id)),
-              CGAL::abs(domain.geodesic_distance(*pp, p, curve_id)));
+            FT gdist = CGAL::abs(domain.signed_geodesic_distance(p, *pp, curve_id));
 
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-            std::cout << "Intersection point : Point_3(" << *pp << ") ";
-            std::cout << " new_sqd = " << new_sqd ;
-            std::cout << " gdist = " << gdist << std::endl;;
+            std::cerr << "Intersection point : Point_3(" << *pp << ") ";
+            std::cerr << "\n  new_sqd = " << new_sqd ;
+            std::cerr << "\n  gdist = " << gdist << "\n";
 #endif
-
             if (new_sqd * 1e10 < CGAL::squared_distance(curr_segment.source(),
                                                         curr_segment.target()))
             {
@@ -440,7 +521,7 @@ struct Sizing_field_with_aabb_tree
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
         }
       }
-    }
+    } // end dim == 1
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
     std::cerr << result << std::endl;
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
@@ -450,11 +531,14 @@ private:
   typename Kernel_::FT d_;
   const Input_facets_AABB_tree_& aabb_tree;
   const MeshDomain& domain;
-  const Patches_ids_map& patches_ids_map;
-  Get_curve_index get_curve_index;
-  Get_facet_patch_id get_facet_patch_id;
   Dt dt;
-  Corners corners;
+  Corners          corners;
+  Corners_indices  corners_indices;
+  Curves_incident_patches    curves_incident_patches;
+  Corners_incident_patches  corners_incident_patches;
+  Corners_incident_curves   corners_incident_curves;
+  Get_curve_index     get_curve_index;
+  Get_facet_patch_id  get_facet_patch_id;
 };
 
 #endif // CGAL_MESH_3_SIZING_FIELD_WITH_AABB_TREE_H

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -17,12 +17,6 @@
 //
 // Author(s)     : Laurent Rineau
 //
-//******************************************************************************
-// File Description :
-//
-//
-//******************************************************************************
-
 
 #ifndef CGAL_MESH_3_SIZING_FIELD_WITH_AABB_TREE_H
 #define CGAL_MESH_3_SIZING_FIELD_WITH_AABB_TREE_H

--- a/Mesh_3/include/CGAL/Mesh_3/properties.h
+++ b/Mesh_3/include/CGAL/Mesh_3/properties.h
@@ -18,10 +18,10 @@
 //
 // Author(s)     : Andreas Fabri
 
-#ifndef CGAL_POLYGON_MESH_PROCESSING_PROPERTIES_H
-#define CGAL_POLYGON_MESH_PROCESSING_PROPERTIES_H
+#ifndef CGAL_MESH_3_PROPERTIES_H
+#define CGAL_MESH_3_PROPERTIES_H
 
-#include <CGAL/license/Polygon_mesh_processing.h>
+#include <CGAL/license/Mesh_3.h>
 
 namespace CGAL
 {
@@ -44,4 +44,4 @@ struct face_patch_id_t {
 };
 } //end namespace CGAL
 
-#endif //CGAL_POLYGON_MESH_PROCESSING_PROPERTIES_H
+#endif //CGAL_MESH_3_PROPERTIES_H

--- a/Mesh_3/include/CGAL/Mesh_3/utilities.h
+++ b/Mesh_3/include/CGAL/Mesh_3/utilities.h
@@ -27,12 +27,41 @@
 
 #include <CGAL/license/Mesh_3.h>
 
+#include <CGAL/Has_timestamp.h>
+#include <iterator>
+#include <string>
+#include <sstream>
 
 namespace CGAL {
 
 namespace Mesh_3 {
 namespace internal {
   
+struct Debug_messages_tools {
+  template <typename Vertex_handle>
+  static std::string disp_vert(Vertex_handle v, Tag_true) {
+    std::stringstream ss;
+    ss.precision(17);
+    ss << (void*)(&*v) << "[ts=" << v->time_stamp() << "]"
+       << "(" << v->point() <<")";
+    return ss.str();
+  }
+
+  template <typename Vertex_handle>
+  static std::string disp_vert(Vertex_handle v, Tag_false) {
+    std::stringstream ss;
+    ss.precision(17);
+    ss << (void*)(&*v) << "(" << v->point() <<")";
+    return ss.str();
+  }
+
+  template <typename Vertex_handle>
+  static std::string disp_vert(Vertex_handle v)
+  {
+    typedef typename std::iterator_traits<Vertex_handle>::value_type Vertex;
+    return disp_vert(v, CGAL::internal::Has_timestamp<Vertex>());
+  }
+};
 
 /**
  * @class First_of

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -52,6 +52,7 @@ template <typename Tr,
 class Mesh_complex_3_in_triangulation_3 :
   public Mesh_3::Mesh_complex_3_in_triangulation_3_base<
     Tr, typename Tr::Concurrency_tag>
+  , public CGAL::Mesh_3::internal::Debug_messages_tools
 {
 public:
   typedef typename Tr::Concurrency_tag                   Concurrency_tag;
@@ -553,8 +554,8 @@ private:
   {
     CGAL_precondition(!is_in_complex(edge));
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
-    std::cerr << "Add edge ( " << edge.left->point()
-              << " , " << edge.right->point() << " ), curve_index=" << index
+    std::cerr << "Add edge ( " << disp_vert(edge.left)
+              << " , " << disp_vert(edge.right) << " ), curve_index=" << index
               << " to c3t3.\n";
 #endif // CGAL_MESH_3_PROTECTION_DEBUG
     std::pair<typename Edge_map::iterator, bool> it = edges_.insert(edge);
@@ -721,8 +722,8 @@ is_valid(bool verbose) const
 
     if ( ! do_intersect(sphere(p, sq_rp), sphere(q, sq_rq)) )
     {
-      std::cerr << "Point p[" << p << "], dim=" << it->right->in_dimension()
-                << " and q[" << q << "], dim=" << it->left->in_dimension()
+      std::cerr << "Point p[" << disp_vert(it->right) << "], dim=" << it->right->in_dimension()
+                << " and q[" << disp_vert(it->left) << "], dim=" << it->left->in_dimension()
                 << " form an edge but do not intersect !\n";
       return false;
     }

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -75,7 +75,7 @@ public:
   typedef CurveIndex                                      Curve_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  typedef CurveIndex Curve_segment_index CGAL_DEPRECATED;
+  typedef CurveIndex Curve_segment_index;
 #endif
 
   typedef typename Base::Triangulation                    Triangulation;

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -75,7 +75,7 @@ public:
   typedef CurveIndex                                      Curve_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  CGAL_DEPRECATED typedef CurveIndex                      Curve_segment_index;
+  typedef CurveIndex Curve_segment_index CGAL_DEPRECATED;
 #endif
 
   typedef typename Base::Triangulation                    Triangulation;

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -48,7 +48,7 @@ namespace CGAL {
 
 template <typename Tr,
           typename CornerIndex = int,
-          typename CurveSegmentIndex = int>
+          typename CurveIndex = int>
 class Mesh_complex_3_in_triangulation_3 :
   public Mesh_3::Mesh_complex_3_in_triangulation_3_base<
     Tr, typename Tr::Concurrency_tag>
@@ -59,7 +59,7 @@ public:
 
 private:
   typedef Mesh_complex_3_in_triangulation_3<
-    Tr,CornerIndex,CurveSegmentIndex>                             Self;
+    Tr,CornerIndex,CurveIndex>                                    Self;
   typedef Mesh_3::Mesh_complex_3_in_triangulation_3_base<
                                           Tr,Concurrency_tag>     Base;
 
@@ -72,7 +72,11 @@ public:
   typedef typename Base::Vertex_handle                    Vertex_handle;
   typedef typename Base::Cell_handle                      Cell_handle;
   typedef CornerIndex                                     Corner_index;
-  typedef CurveSegmentIndex                               Curve_segment_index;
+  typedef CurveIndex                                      Curve_index;
+
+#ifndef CGAL_NO_DEPRECATED_CODE
+  CGAL_DEPRECATED typedef CurveIndex                      Curve_segment_index;
+#endif
 
   typedef typename Base::Triangulation                    Triangulation;
   typedef typename Base::Subdomain_index                  Subdomain_index;
@@ -83,12 +87,12 @@ private:
   // Type to store the edges:
   //  - a set of std::pair<Vertex_handle,Vertex_handle> (ordered at insertion)
   //  - which allows fast lookup from one Vertex_handle
-  //  - each element of the set has an associated info (Curve_segment_index) value
+  //  - each element of the set has an associated info (Curve_index) value
   typedef boost::bimaps::bimap<
     boost::bimaps::multiset_of<Vertex_handle>,
     boost::bimaps::multiset_of<Vertex_handle>,
     boost::bimaps::set_of_relation<>,
-    boost::bimaps::with_info<Curve_segment_index> >   Edge_map;
+    boost::bimaps::with_info<Curve_index> >           Edge_map;
 
   typedef typename Edge_map::value_type               Internal_edge;
 
@@ -156,10 +160,10 @@ public:
 
 
   /**
-   * Add edge e to complex, with Curve_segment_index index
+   * Add edge e to complex, with Curve_index index
    */
   void add_to_complex(const Edge& e,
-                      const Curve_segment_index& index)
+                      const Curve_index& index)
   {
     add_to_complex(e.first->vertex(e.second),
                    e.first->vertex(e.third),
@@ -167,11 +171,11 @@ public:
   }
 
   /**
-   * Add edge (v1,v2) to complex, with Curve_segment_index index
+   * Add edge (v1,v2) to complex, with Curve_index index
    */
   void add_to_complex(const Vertex_handle& v1,
                       const Vertex_handle& v2,
-                      const Curve_segment_index& index)
+                      const Curve_index& index)
   {
     add_to_complex(make_internal_edge(v1,v2), index);
   }
@@ -315,22 +319,34 @@ public:
   }
 
   /**
-   * Returns Curve_segment_index of edge \c e
+   * Returns Curve_index of edge \c e
    */
-  Curve_segment_index curve_segment_index(const Edge& e) const
+  Curve_index curve_index(const Edge& e) const
   {
-    return curve_segment_index(e.first->vertex(e.second),
-                               e.first->vertex(e.third));
+    return curve_index(e.first->vertex(e.second),
+                       e.first->vertex(e.third));
   }
 
-  /**
-   * Returns Curve_segment_index of edge \c (v1,v2)
-   */
-  Curve_segment_index curve_segment_index(const Vertex_handle& v1,
-                                          const Vertex_handle& v2) const
+  Curve_index curve_index(const Vertex_handle& v1,
+                          const Vertex_handle& v2) const
   {
     return curve_index(make_internal_edge(v1,v2));
   }
+
+#ifndef CGAL_NO_DEPRECATED_CODE
+  CGAL_DEPRECATED
+  Curve_index curve_segment_index(const Edge& e) const
+  {
+    return curve_index(e);
+  }
+
+  CGAL_DEPRECATED
+  Curve_index curve_segment_index(const Vertex_handle& v1,
+                                  const Vertex_handle& v2) const
+  {
+    return curve_index(v1, v2);
+  }
+#endif // CGAL_NO_DEPRECATED_CODE
 
   /**
    * Returns Corner_index of vertex \c v
@@ -371,7 +387,7 @@ public:
 
   /**
    * Fills \c out with incident edges (1-dimensional features of \c v.
-   * OutputIterator value type is std::pair<Vertex_handle,Curve_segment_index>
+   * OutputIterator value type is std::pair<Vertex_handle,Curve_index>
    * \pre v->in_dimension() < 2
    */
   template <typename OutputIterator>
@@ -394,18 +410,18 @@ private:
   class Edge_iterator_not_in_complex
   {
     const Self& c3t3_;
-    const Curve_segment_index index_;
+    const Curve_index index_;
   public:
     Edge_iterator_not_in_complex(const Self& c3t3,
-                                 const Curve_segment_index& index = Curve_segment_index())
+                                 const Curve_index& index = Curve_index())
     : c3t3_(c3t3)
     , index_(index) { }
 
     template <typename Iterator>
     bool operator()(Iterator it) const
     {
-      if ( index_ == Curve_segment_index() ) { return ! c3t3_.is_in_complex(*it); }
-      else { return c3t3_.curve_segment_index(*it) != index_;  }
+      if ( index_ == Curve_index() ) { return ! c3t3_.is_in_complex(*it); }
+      else { return c3t3_.curve_index(*it) != index_;  }
     }
   };
 
@@ -486,7 +502,7 @@ public:
 
   /// Returns a Facets_in_complex_iterator to the first facet of the 1D complex
   Edges_in_complex_iterator
-  edges_in_complex_begin(const Curve_segment_index& index) const
+  edges_in_complex_begin(const Curve_index& index) const
   {
     return CGAL::filter_iterator(this->triangulation().finite_edges_end(),
                                  Edge_iterator_not_in_complex(*this,index),
@@ -494,7 +510,7 @@ public:
   }
 
   /// Returns past-the-end iterator on facet of the 1D complex
-  Edges_in_complex_iterator edges_in_complex_end(const Curve_segment_index& = Curve_segment_index()) const
+  Edges_in_complex_iterator edges_in_complex_end(const Curve_index& = Curve_index()) const
   {
     return CGAL::filter_iterator(this->triangulation().finite_edges_end(),
                                  Edge_iterator_not_in_complex(*this));
@@ -544,13 +560,13 @@ private:
    */
   bool is_in_complex(const Internal_edge& edge) const
   {
-    return (curve_index(edge) != Curve_segment_index() );
+    return (curve_index(edge) != Curve_index() );
   }
 
   /**
-   * Add edge \c edge to complex, with Curve_segment_index index
+   * Add edge \c edge to complex, with Curve_index index
    */
-  void add_to_complex(const Internal_edge& edge, const Curve_segment_index& index)
+  void add_to_complex(const Internal_edge& edge, const Curve_index& index)
   {
     CGAL_precondition(!is_in_complex(edge));
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
@@ -571,13 +587,13 @@ private:
   }
 
   /**
-   * Returns Curve_segment_index of edge \c edge
+   * Returns Curve_index of edge \c edge
    */
-  Curve_segment_index curve_index(const Internal_edge& edge) const
+  Curve_index curve_index(const Internal_edge& edge) const
   {
     typename Edge_map::const_iterator it = edges_.find(edge);
     if ( edges_.end() != it ) { return it->info; }
-    return Curve_segment_index();
+    return Curve_index();
   }
 
 private:

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -538,7 +538,7 @@ public:
   typedef int                     Corner_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  CGAL_DEPRECATED typedef Curve_index Curve_segment_index;
+  typedef Curve_index Curve_segment_index CGAL_DEPRECATED;
 #endif
 
   typedef typename Base::R         Gt;

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -604,11 +604,11 @@ public:
   template <typename OutputIterator>
   OutputIterator get_curve_segments(OutputIterator out) const;
 
-  /// Return the length of the arc of curve, on the curve with index
+  /// Returns the length of the arc of curve, on the curve with index
   /// \c  curve_index, from \c p to \c q, in the orientation
   /// \c orientation
   ///
-  /// If the curve connected component containing \c p and \q is a cycle,
+  /// If the curve connected component containing \c p and \c q is a cycle,
   /// the orientation gives identifies which portion of the cycle
   /// corresponds to the arc, otherwise \c orientation must be compatible
   /// with the orientation of \c p and \c q on the curve segment.
@@ -616,7 +616,7 @@ public:
                 const Curve_segment_index& curve_index,
                 CGAL::Orientation orientation) const;
 
-  /// Return the length of the connected component of curve with index
+  /// Returns the length of the connected component of curve with index
   /// \c curve_index including point \c p
   FT curve_segment_length(const Point_3& p,
                           const Curve_segment_index& curve_index) const;

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -538,7 +538,7 @@ public:
   typedef int                     Corner_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  typedef Curve_index Curve_segment_index CGAL_DEPRECATED;
+  typedef Curve_index Curve_segment_index;
 #endif
 
   typedef typename Base::R         Gt;

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -92,13 +92,13 @@ public:
     return points_.back();
   }
 
-  /// Returns true if the polyline is not degenerated
+  /// Returns `true` if the polyline is not degenerated
   bool is_valid() const
   {
     return points_.size() > 1;
   }
 
-  /// Returns true if polyline is a cycle
+  /// Returns `true` if polyline is a cycle
   bool is_cycle() const
   {
     return start_point() == end_point();
@@ -644,10 +644,10 @@ public:
   CGAL::Sign distance_sign(const Point_3& p, const Point_3& q,
                            const Curve_segment_index& index) const;
 
-  /// Returns true if curve \c curve_index is a cycle
+  /// Returns `true` if curve \c curve_index is a cycle
   bool is_cycle(const Point_3&, const Curve_segment_index& index) const;
 
-  /// Returns true if the portion of the curve segment of index \c index,
+  /// Returns `true` if the portion of the curve segment of index \c index,
   /// between the points \c c1 and \c c2, is covered by the spheres of
   /// centers \c c1 and \c c2 and squared radii \c sq_r1 and \c sq_r2
   /// respectively.

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -604,7 +604,7 @@ public:
   template <typename OutputIterator>
   OutputIterator get_curve_segments(OutputIterator out) const;
 
-  /// Returns the length of the arc of curve, on the curve with index
+  /// Returns the length of the curve segment, on the curve with index
   /// \c  curve_index, from \c p to \c q, in the orientation
   /// \c orientation
   ///

--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -530,7 +530,7 @@ public:
       {
         if (vit->is_feature_vertex()) { continue; }
         const Patch_id patch_id = vit->halfedge()->face()->patch_id();
-        CGAL_assertion(static_cast<std::size_t>(patch_id) <= nb_of_patch_plus_one);
+        CGAL_assertion(std::size_t(patch_id) <= nb_of_patch_plus_one);
         typename Tr::Vertex_handle tr_v = tr.nearest_power_vertex(vit->point());
         if (tr_v != typename Tr::Vertex_handle()) {
           typedef typename IGT::Sphere_3 Sphere_3;
@@ -941,8 +941,8 @@ merge_duplicated_points(const PointSet& duplicated_points)
       HVcirc itend = it;
       do {
         if(!it->is_border()) {
-          CGAL_assertion(static_cast<std::size_t>(it->face()->patch_id())
-                         < this->nb_of_patch_plus_one());
+          CGAL_assertion(std::size_t(it->face()->patch_id()) <
+                         this->nb_of_patch_plus_one());
           patches.insert(Pt_patch_pair(Point_and_mesh(vit->point(), &p),
                                        it->face()->patch_id()));
         }
@@ -967,12 +967,12 @@ merge_duplicated_points(const PointSet& duplicated_points)
     // loop will end with the first iterator when the point differs from
     // the point of the range).
     Patch_iterator it = range_begin;
-    CGAL_assertion(static_cast<std::size_t>(it->second) < new_ids.size());
+    CGAL_assertion(std::size_t(it->second) < new_ids.size());
     Patch_id min_id_around_p = new_ids[it->second];
     ++it;
     for (; it != patches.end() && it->first == range_begin->first; ++it)
     {
-      CGAL_assertion(static_cast<std::size_t>(it->second) < new_ids.size());
+      CGAL_assertion(std::size_t(it->second) < new_ids.size());
       min_id_around_p = (std::min)(min_id_around_p, new_ids[it->second]);
     }
     const Patch_iterator range_end = it;
@@ -980,7 +980,7 @@ merge_duplicated_points(const PointSet& duplicated_points)
     // In a second loop on the equal-range, update new_ids around p
     for (it = range_begin; it != range_end; ++it)
     {
-      CGAL_assertion(static_cast<std::size_t>(it->second) < new_ids.size());
+      CGAL_assertion(std::size_t(it->second) < new_ids.size());
       new_ids[it->second] = min_id_around_p;
     }
     pit = range_end;

--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -579,9 +579,10 @@ public:
 
         // here we have a new free vertex on patch #`patch_id`
 
-        if(random.uniform_smallint(std::size_t(0),
-                                   nb_of_free_vertices_on_patch[patch_id])
-           < needed_vertices_on_patch[patch_id])
+        if(random.uniform_smallint(
+               boost::uint32_t(0),
+               boost::uint32_t(nb_of_free_vertices_on_patch[patch_id]))
+           < boost::uint32_t(needed_vertices_on_patch[patch_id]))
         {
           several_vertices_on_patch[patch_id].push_back(vit);
           --needed_vertices_on_patch[patch_id];

--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -313,7 +313,7 @@ public:
   /// @{
   /// The types are `int` or types compatible with `int`.
   typedef typename Base::Corner_index         Corner_index;
-  typedef typename Base::Curve_segment_index  Curve_segment_index;
+  typedef typename Base::Curve_index          Curve_index;
   typedef typename Base::Surface_patch_index  Surface_patch_index;
   typedef typename Base::Subdomain_index      Subdomain_index;
   /// @}
@@ -338,7 +338,7 @@ public:
   typedef CGAL::Tag_true           Has_features;
 
   typedef std::vector<Point_3> Bare_polyline;
-  typedef Mesh_3::Polyline_with_context<Surface_patch_index, Curve_segment_index,
+  typedef Mesh_3::Polyline_with_context<Surface_patch_index, Curve_index,
                                         Bare_polyline > Polyline_with_context;
   /// @endcond
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -46,6 +46,8 @@
 #include <CGAL/Mesh_3/Profile_counter.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/Mesh_3/properties.h>
+#include <CGAL/Surface_mesh/Surface_mesh_fwd.h>
+#include <CGAL/boost/graph/Graph_with_descriptor_with_graph_fwd.h>
 
 #include <boost/optional.hpp>
 #include <boost/none.hpp>

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -227,7 +227,7 @@ public:
   typedef typename Base::Subdomain_index      Subdomain_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  typedef Curve_index Curve_segment_index CGAL_DEPRECATED; ///< Backward-compatibility
+  typedef Curve_index Curve_segment_index; ///< Backward-compatibility
 #endif
 
   typedef typename boost::property_map<Polyhedron,

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -227,7 +227,7 @@ public:
   typedef typename Base::Subdomain_index      Subdomain_index;
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  CGAL_DEPRECATED typedef Curve_index Curve_segment_index; ///< Backward-compatibility
+  typedef Curve_index Curve_segment_index CGAL_DEPRECATED; ///< Backward-compatibility
 #endif
 
   typedef typename boost::property_map<Polyhedron,

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -222,9 +222,13 @@ public:
   // Index types
   typedef typename Base::Index                Index;
   typedef typename Base::Corner_index         Corner_index;
-  typedef typename Base::Curve_segment_index  Curve_segment_index;
+  typedef typename Base::Curve_index          Curve_index;
   typedef typename Base::Surface_patch_index  Surface_patch_index;
   typedef typename Base::Subdomain_index      Subdomain_index;
+
+#ifndef CGAL_NO_DEPRECATED_CODE
+  CGAL_DEPRECATED typedef Curve_index Curve_segment_index; ///< Backward-compatibility
+#endif
 
   typedef typename boost::property_map<Polyhedron,
                                        face_patch_id_t<Patch_id>
@@ -244,7 +248,7 @@ public:
   typedef CGAL::Tag_true           Has_features;
 
   typedef std::vector<Point_3> Bare_polyline;
-  typedef Mesh_3::Polyline_with_context<Surface_patch_index, Curve_segment_index,
+  typedef Mesh_3::Polyline_with_context<Surface_patch_index, Curve_index,
                                         Bare_polyline > Polyline_with_context;
   /// Constructors
   Polyhedral_mesh_domain_with_features_3(const Polyhedron& p,

--- a/Mesh_3/include/CGAL/internal/Mesh_3/get_index.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/get_index.h
@@ -64,7 +64,7 @@ struct Read_mesh_domain_index {
       return  ci;
       break;
     case 1: 
-      typename MT::Curve_segment_index si;
+      typename MT::Curve_index si;
       if(is_ascii(is)) is >> si;
       else CGAL::read(is, si);
       return  si;
@@ -83,7 +83,7 @@ struct Write_mesh_domain_index {
 
   typedef Mesh_domain MT; // was named "mesh traits" previously
   typedef typename MT::Corner_index Ci;
-  typedef typename MT::Curve_segment_index  Si;
+  typedef typename MT::Curve_index  Si;
 
   void
   operator()(std::ostream& os, int dimension,

--- a/Mesh_3/test/Mesh_3/test_c3t3_io.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3_io.cpp
@@ -19,7 +19,7 @@ struct MD_homogeneous_types {
   typedef CGAL::Tag_false Has_features;
   typedef int Subdomain_index;
   typedef int Surface_patch_index;
-  typedef int Curve_segment_index;
+  typedef int Curve_index;
   typedef int Corner_index;
   typedef int Index;
 
@@ -27,8 +27,8 @@ struct MD_homogeneous_types {
   static Subdomain_index get_sub_domain_index_2() { return 2; }
   static Surface_patch_index get_surface_patch_index_1() { return 3; }
   static Surface_patch_index get_surface_patch_index_2() { return 4; }
-  static Curve_segment_index get_curve_segment_index_1() { return 5; }
-  static Curve_segment_index get_curve_segment_index_2() { return 6; }
+  static Curve_index get_curve_index_1() { return 5; }
+  static Curve_index get_curve_index_2() { return 6; }
   static Corner_index get_corner_index_1() { return 7; }
   static Corner_index get_corner_index_2() { return 8; }
 
@@ -44,18 +44,18 @@ struct MD_heterogeneous_types {
   enum Subdomain_index_enum { Z = 0, A, B, C, D};
   typedef Subdomain_index_enum Subdomain_index;
   typedef std::pair<int, int> Surface_patch_index;
-  typedef int Curve_segment_index;
+  typedef int Curve_index;
   typedef double Corner_index;
   typedef boost::variant<Subdomain_index,
                          Surface_patch_index,
-                         Curve_segment_index,
+                         Curve_index,
                          Corner_index> Index;
   static Subdomain_index get_sub_domain_index_1() { return A; }
   static Subdomain_index get_sub_domain_index_2() { return B; }
   static Surface_patch_index get_surface_patch_index_1() { return std::make_pair(1, 2); }
   static Surface_patch_index get_surface_patch_index_2() { return std::make_pair(3, 4); }
-  static Curve_segment_index get_curve_segment_index_1() { return 5; }
-  static Curve_segment_index get_curve_segment_index_2() { return 6; }
+  static Curve_index get_curve_index_1() { return 5; }
+  static Curve_index get_curve_index_2() { return 6; }
   static Corner_index get_corner_index_1() { return 7.; }
   static Corner_index get_corner_index_2() { return 8.; }
 
@@ -201,7 +201,7 @@ template <typename Mesh_domain>
 struct Test_c3t3_io {
   typedef typename Mesh_domain::Subdomain_index Subdomain_index;
   typedef typename Mesh_domain::Surface_patch_index Surface_patch_index;
-  typedef typename Mesh_domain::Curve_segment_index Curve_segment_index;
+  typedef typename Mesh_domain::Curve_index Curve_index;
   typedef typename Mesh_domain::Corner_index Corner_index;
   typedef typename Mesh_domain::Index Index;
 
@@ -209,7 +209,7 @@ struct Test_c3t3_io {
   typedef CGAL::Mesh_complex_3_in_triangulation_3<
     Tr,
     Corner_index,
-    Curve_segment_index
+    Curve_index
     > C3t3;
 
   typedef typename Tr::Point Point;
@@ -422,8 +422,8 @@ struct Test_c3t3_io {
     c3t3.add_to_complex(c2, Mesh_domain::get_sub_domain_index_2());
     c3t3.add_to_complex(f1, Mesh_domain::get_surface_patch_index_1());
     c3t3.add_to_complex(f2, Mesh_domain::get_surface_patch_index_2());
-    c3t3.add_to_complex(e1, Mesh_domain::get_curve_segment_index_1());
-    c3t3.add_to_complex(e2, Mesh_domain::get_curve_segment_index_2());
+    c3t3.add_to_complex(e1, Mesh_domain::get_curve_index_1());
+    c3t3.add_to_complex(e2, Mesh_domain::get_curve_index_2());
     c3t3.add_to_complex(v1, Mesh_domain::get_corner_index_1());
     c3t3.add_to_complex(v2, Mesh_domain::get_corner_index_2());
 
@@ -433,9 +433,9 @@ struct Test_c3t3_io {
     v2->set_dimension(0);
     v2->set_index(Mesh_domain::get_corner_index_2());
     v3->set_dimension(1);
-    v3->set_index(Mesh_domain::get_curve_segment_index_1());
+    v3->set_index(Mesh_domain::get_curve_index_1());
     v4->set_dimension(1);
-    v4->set_index(Mesh_domain::get_curve_segment_index_2());
+    v4->set_index(Mesh_domain::get_curve_index_2());
     v5->set_dimension(2);
     v5->set_index(Mesh_domain::get_surface_patch_index_1());
     v6->set_dimension(3);

--- a/Mesh_3/test/Mesh_3/test_c3t3_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3_with_features.cpp
@@ -45,7 +45,7 @@ struct Tester
   typedef CGAL::Mesh_domain_with_polyline_features_3<Base_domain>     Md;
   typedef typename CGAL::Mesh_triangulation_3<Md>::type               Tr;
   typedef CGAL::Mesh_complex_3_in_triangulation_3<
-    Tr, typename Md::Corner_index, typename Md::Curve_segment_index>  C3t3;
+    Tr, typename Md::Corner_index, typename Md::Curve_index>          C3t3;
 
   typedef typename Tr::Bare_point       Bare_point;
   typedef typename Tr::Weighted_point   Weighted_point;
@@ -61,7 +61,7 @@ struct Tester
   typedef typename C3t3::Edges_in_complex_iterator      Edge_iterator;
   typedef typename C3t3::Vertices_in_complex_iterator   Vertices_iterator;
   
-  typedef typename C3t3::Curve_segment_index  Curve_segment_index;
+  typedef typename C3t3::Curve_index          Curve_index;
   typedef typename C3t3::Corner_index         Corner_index;
   typedef typename C3t3::Index                Index;
 
@@ -99,9 +99,9 @@ struct Tester
 
     Corner_index corner_index (1);
     Corner_index corner_index_bis (2);
-    Curve_segment_index curve_segment_index (1);
-    Curve_segment_index curve_segment_index_bis (2);
-    Index vertex_index (curve_segment_index);
+    Curve_index curve_index (1);
+    Curve_index curve_index_bis (2);
+    Index vertex_index (curve_index);
 
     //-------------------------------------------------------
     // Add edge to c3t3 and verify
@@ -116,7 +116,7 @@ struct Tester
     const Vertex_handle& ev1 = e.first->vertex(e.second);
     const Vertex_handle& ev2 = e.first->vertex(e.third);
     
-    c3t3.add_to_complex(e,curve_segment_index);
+    c3t3.add_to_complex(e,curve_index);
 
     std::cerr << "\tNumber of edges in c3t3: "
               << c3t3.number_of_edges_in_complex() << std::endl;
@@ -129,7 +129,7 @@ struct Tester
                                                                         c3t3.edges_in_complex_end())));
     assert(c3t3.is_in_complex(e));
     assert(c3t3.is_in_complex(ev1, ev2));
-    assert(c3t3.curve_segment_index(e) == curve_segment_index);
+    assert(c3t3.curve_index(e) == curve_index);
 
     //-------------------------------------------------------
     // Remove cell from c3t3 and verify
@@ -146,8 +146,8 @@ struct Tester
     assert(c3t3.number_of_edges_in_complex() == 0);
     assert(! c3t3.is_in_complex(e));
     assert(! c3t3.is_in_complex(ev1, ev2));
-    assert(c3t3.curve_segment_index(e) == Curve_segment_index());
-    assert(c3t3.curve_segment_index(ev1, ev2) == Curve_segment_index());
+    assert(c3t3.curve_index(e) == Curve_index());
+    assert(c3t3.curve_index(ev1, ev2) == Curve_index());
     
     //-------------------------------------------------------
     // Add corner to c3t3 and verify
@@ -191,9 +191,9 @@ struct Tester
     //-------------------------------------------------------
     std::cerr << "Insert 1 curve segment (3 edges + 2 corners) in c3t3" << std::endl;
 
-    c3t3.add_to_complex(vp1,vp2,curve_segment_index);
-    c3t3.add_to_complex(vp2,vp3,curve_segment_index);
-    c3t3.add_to_complex(vp3,vp4,curve_segment_index);
+    c3t3.add_to_complex(vp1,vp2,curve_index);
+    c3t3.add_to_complex(vp2,vp3,curve_index);
+    c3t3.add_to_complex(vp3,vp4,curve_index);
     c3t3.add_to_complex(vp1,corner_index);
     c3t3.add_to_complex(vp4,corner_index);
     c3t3.set_dimension(vp1,0);
@@ -229,7 +229,7 @@ struct Tester
     //-------------------------------------------------------
     // Check adjacencies
     //-------------------------------------------------------
-    std::vector<std::pair<Vertex_handle,Curve_segment_index> > incident_vertices;
+    std::vector<std::pair<Vertex_handle,Curve_index> > incident_vertices;
     c3t3.adjacent_vertices_in_complex(vp1,std::back_inserter(incident_vertices));
     
     assert(incident_vertices.size() == 1);
@@ -259,7 +259,7 @@ struct Tester
     c3t3_bis.triangulation().insert(points.begin(),points.end());
     
     Edge e_bis = *(c3t3_bis.triangulation().finite_edges_begin());
-    c3t3_bis.add_to_complex(e_bis,curve_segment_index_bis);
+    c3t3_bis.add_to_complex(e_bis,curve_index_bis);
     Vertex_handle v_bis = ++c3t3_bis.triangulation().finite_vertices_begin();
     c3t3_bis.add_to_complex(v_bis,corner_index_bis);
     
@@ -317,24 +317,24 @@ struct Tester
     std::cout << "Test edge iterators\n";
     const Edge& edge_to_modify = *(c3t3.edges_in_complex_begin());
     c3t3.remove_from_complex(edge_to_modify);
-    c3t3.add_to_complex(edge_to_modify,curve_segment_index_bis);
+    c3t3.add_to_complex(edge_to_modify,curve_index_bis);
     
     typename C3t3::Edges_in_complex_iterator curve_eit =
-      c3t3.edges_in_complex_begin(curve_segment_index);
+      c3t3.edges_in_complex_begin(curve_index);
     typename C3t3::Edges_in_complex_iterator curve_eit_bis =
-      c3t3.edges_in_complex_begin(curve_segment_index_bis);
+      c3t3.edges_in_complex_begin(curve_index_bis);
     typename C3t3::Edges_in_complex_iterator eend =
       c3t3.edges_in_complex_end();
     
-    std::cout << "\tNumber of edges of index '" << curve_segment_index << "': "
+    std::cout << "\tNumber of edges of index '" << curve_index << "': "
               << std::distance(curve_eit,eend) << std::endl;
-    std::cout << "\tNumber of edges of index '" << curve_segment_index_bis << "': "
+    std::cout << "\tNumber of edges of index '" << curve_index_bis << "': "
               << std::distance(curve_eit_bis,eend) << std::endl;
     
     assert ( std::distance(curve_eit,eend) == 2 );
     assert ( std::distance(curve_eit_bis,eend) == 1 );
-    assert ( c3t3.curve_segment_index(*curve_eit) == curve_segment_index );
-    assert ( c3t3.curve_segment_index(*curve_eit_bis) == curve_segment_index_bis );
+    assert ( c3t3.curve_index(*curve_eit) == curve_index );
+    assert ( c3t3.curve_index(*curve_eit_bis) == curve_index_bis );
     
     //-------------------------------------------------------
     // Test vertex iterators

--- a/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
@@ -133,12 +133,12 @@ public:
     
     const FT geod (1.3);
     Point r = domain_.construct_point_on_curve_segment(p,curve_index,geod);
-    const FT& pq_geo = domain_.geodesic_distance(p,q,curve_index);
+    const FT& pq_geo = domain_.signed_geodesic_distance(p,q,curve_index);
     
     assert(CGAL::squared_distance(p,r) < CGAL::square(geod));
-    assert(near_equal(domain_.geodesic_distance(p,r,curve_index), geod));
-    assert(near_equal(domain_.geodesic_distance(r,q,curve_index), pq_geo - geod));
-    assert(near_equal(domain_.geodesic_distance(q,r,curve_index), geod - pq_geo));
+    assert(near_equal(domain_.signed_geodesic_distance(p,r,curve_index), geod));
+    assert(near_equal(domain_.signed_geodesic_distance(r,q,curve_index), pq_geo - geod));
+    assert(near_equal(domain_.signed_geodesic_distance(q,r,curve_index), geod - pq_geo));
   }
   
 private:

--- a/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
@@ -51,7 +51,7 @@ class Domain_with_polyline_tester
   typedef std::list<Polyline> Polylines;
   
   typedef Mesh_domain::Corner_index         Ci;
-  typedef Mesh_domain::Curve_segment_index  Csi;
+  typedef Mesh_domain::Curve_index          Csi;
   typedef Mesh_domain::Index                Index;
   
   typedef std::vector<std::pair<Ci, Point> >        Corners_vector;
@@ -64,7 +64,7 @@ public:
     : p1_(1,0,0), p2_(1,1,0), p3_(1,2,0.1), p4_(0.9, 0.9, 1)
   { }
   
-  void build_curve_segment()
+  void build_curve()
   {
     Polylines polylines (1);
     Polyline& polyline = polylines.front();
@@ -90,7 +90,7 @@ public:
     domain_.add_features(polylines.begin(),polylines.end());    
   }
   
-  void test_curve_segment_corners() const
+  void test_curve_corners() const
   {
     Corners_vector corners;
     domain_.get_corners(std::back_inserter(corners));
@@ -108,7 +108,7 @@ public:
     assert(corners.size() == 1);
   }
   
-  void test_curve_segments() const
+  void test_curves() const
   {
     std::pair<Point,Point> extremities = get_extremities();
     
@@ -129,10 +129,10 @@ public:
     std::pair<Point,Point> extremities = get_extremities();
     const Point& p = extremities.first;
     const Point& q = extremities.second;
-    const Csi& curve_index = get_curve_segment_index();
+    const Csi& curve_index = get_curve_index();
     
     const FT geod (1.3);
-    Point r = domain_.construct_point_on_curve_segment(p,curve_index,geod);
+    Point r = domain_.construct_point_on_curve(p,curve_index,geod);
     const FT& pq_geo = domain_.signed_geodesic_distance(p,q,curve_index);
     
     assert(CGAL::squared_distance(p,r) < CGAL::square(geod));
@@ -144,12 +144,12 @@ public:
 private:
   std::pair<Point,Point> get_extremities() const
   {
-    Curves_vector curve_segments;
-    domain_.get_curve_segments(std::back_inserter(curve_segments));
-    assert(curve_segments.size() == 1);
+    Curves_vector curves;
+    domain_.get_curves(std::back_inserter(curves));
+    assert(curves.size() == 1);
     
-    const Point& p = get_first_point(curve_segments.front());
-    const Point& q = get_second_point(curve_segments.front());
+    const Point& p = get_first_point(curves.front());
+    const Point& q = get_second_point(curves.front());
     
     return std::make_pair(p,q);
   }
@@ -164,16 +164,16 @@ private:
     return CGAL::cpp11::get<2>(tuple).first;
   }
   
-  Csi get_curve_segment_index() const
+  Csi get_curve_index() const
   {
-    Curves_vector curve_segments;
-    domain_.get_curve_segments(std::back_inserter(curve_segments));
-    assert(curve_segments.size() == 1);
+    Curves_vector curves;
+    domain_.get_curves(std::back_inserter(curves));
+    assert(curves.size() == 1);
     
-    return get_curve_segment_index(curve_segments.front());
+    return get_curve_index(curves.front());
   }
   
-  Csi get_curve_segment_index(const Curve_tuple& tuple) const
+  Csi get_curve_index(const Curve_tuple& tuple) const
   {
     return CGAL::cpp11::get<0>(tuple);
   }
@@ -193,10 +193,10 @@ int main()
 {
   std::cout << "Test curve segments" << std::endl;
   Domain_with_polyline_tester domain_tester;
-  domain_tester.build_curve_segment();
+  domain_tester.build_curve();
   
-  domain_tester.test_curve_segment_corners();
-  domain_tester.test_curve_segments();
+  domain_tester.test_curve_corners();
+  domain_tester.test_curves();
   domain_tester.test_geodesic_distance();
   
   std::cout << "Test cycles" << std::endl;

--- a/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
@@ -28,7 +28,7 @@ typedef Tr::Geom_traits                                    Gt;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr,
                                                 Mesh_domain::Corner_index,
-                                                Mesh_domain::Curve_segment_index> C3t3;
+                                                Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
@@ -22,7 +22,7 @@ typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Mesh Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
@@ -61,7 +61,7 @@ struct Polyhedral_complex_tester : public Tester<K>
     typedef CGAL::Mesh_complex_3_in_triangulation_3<
       Tr,
       typename Mesh_domain::Corner_index,
-      typename Mesh_domain::Curve_segment_index> C3t3;
+      typename Mesh_domain::Curve_index> C3t3;
     typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 
     //Input

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -47,7 +47,7 @@ struct Polyhedron_with_features_tester : public Tester<K>
     typedef CGAL::Mesh_complex_3_in_triangulation_3 <
       Tr,
       typename Mesh_domain::Corner_index,
-      typename Mesh_domain::Curve_segment_index > C3t3;
+      typename Mesh_domain::Curve_index > C3t3;
 
     typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
     typedef typename Mesh_criteria::Edge_criteria Edge_criteria;

--- a/Mesh_3/test/Mesh_3/test_meshing_polylines_only.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polylines_only.cpp
@@ -20,7 +20,7 @@ typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/test/Mesh_3/test_meshing_unit_tetrahedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_unit_tetrahedron.cpp
@@ -26,7 +26,7 @@ struct Polyhedron_tester : public Tester<K>
       Concurrency_tag>::type Tr;
     typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr,
       typename Mesh_domain::Corner_index,
-      typename Mesh_domain::Curve_segment_index> C3t3;
+      typename Mesh_domain::Curve_index> C3t3;
 
     // Criteria
     typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -218,7 +218,7 @@ struct Fake_mesh_domain {
   typedef CGAL::Tag_true Has_features;
   typedef int Subdomain_index;
   typedef std::pair<int,int> Surface_patch_index;
-  typedef int Curve_segment_index;
+  typedef int Curve_index;
   typedef int Corner_index;
   typedef boost::variant<Subdomain_index,Surface_patch_index> Index;
 };
@@ -231,7 +231,7 @@ typedef CGAL::Regular_triangulation_3<Fake_gt, Fake_tds> Fake_tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
   Fake_tr,
   Fake_mesh_domain::Corner_index,
-  Fake_mesh_domain::Curve_segment_index> Fake_c3t3;
+  Fake_mesh_domain::Curve_index> Fake_c3t3;
 
 template <class Vb = CGAL::Triangulation_vertex_base_3<Kernel> >
 struct Fake_CDT_3_vertex_base : public Vb

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -272,7 +272,6 @@ edge_criteria(double edge_size, Mesh_fnt::Polyhedral_domain_tag)
       <
       Kernel
       , Domain
-      , Set_of_patch_ids
       , typename Domain::AABB_tree
       , CGAL::Default
       , typename internal::Get_facet_patch_id_selector<Domain>::type
@@ -288,11 +287,8 @@ edge_criteria(double edge_size, Mesh_fnt::Polyhedral_domain_tag)
     }
     Mesh_sizing_field* sizing_field_ptr =
       new Mesh_sizing_field(edge_size,
-                            domain_->corners_incidences_map().begin(),
-                            domain_->corners_incidences_map().end(),
                             domain_->aabb_tree(),
-                            *domain_,
-                            *patches_ids_vector_p);
+                            *domain_);
     // The sizing field object, as well as the `patch_ids_vector` are
     // allocated on the heap, and the following `boost::any` object,
     // containing two shared pointers, is used to make the allocated

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -277,11 +277,11 @@ edge_criteria(double edge_size, Mesh_fnt::Polyhedral_domain_tag)
       , typename internal::Get_facet_patch_id_selector<Domain>::type
       > Mesh_sizing_field; // type of sizing field for 0D and 1D features
     typedef std::vector<Set_of_patch_ids> Patches_ids_vector;
-    typedef typename Domain::Curve_segment_index Curve_segment_index;
-    const Curve_segment_index max_index = domain_->maximal_curve_segment_index();
+    typedef typename Domain::Curve_index Curve_index;
+    const Curve_index max_index = domain_->maximal_curve_index();
     Patches_ids_vector* patches_ids_vector_p =
       new Patches_ids_vector(max_index+1);
-    for(Curve_segment_index curve_id = 1; curve_id <= max_index; ++curve_id)
+    for(Curve_index curve_id = 1; curve_id <= max_index; ++curve_id)
     {
       (*patches_ids_vector_p)[curve_id] = domain_->get_incidences(curve_id);
     }


### PR DESCRIPTION
## Summary of Changes

This imports recent developments of Mesh_3 that were existing in another private repository.

* **major** Improvement of `<CGAL/Mesh_3/Protect_edges_sizing_field.h>`, that now verifies that the set of curve is actually covered by the set of balls (cc @clebreto)
* Improvement of debug message
* Refactoring of the (yet) undocumented `Sizing_field_with_aabb_tree` (API breakage too)
* Add `K::Has_on_bounded_side_3(Sphere_3, Sphere_3, Point_3, Point_3)` in the kernel

## Release Management

* Affected package(s): Mesh_3, Kernel
* Small Feature (if any): [`Features/Small Features/Fix concept MeshDomainWithFeatures_3`](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Fix_concept_MeshDomainWithFeatures_3)
* Small Feature pre-approved 19 September 2017.

------------------
<s>TODO:
  - [x] move `Has_on_bounded_side_sphere_sphere_seg<K>` into the kernel,
  - [x] document changes to the concept `MeshDomainWithFeatures_3`
  - [x] add the small feature
</s>
