### PR TITLE
fix the orientation of convex hull polyhedron of 4 points

### DIFF
--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -690,8 +690,12 @@ ch_quickhull_polyhedron_3(std::list<typename Traits::Point_3>& points,
       non_coplanar_quickhull_3(points, tds, traits);
       copy_face_graph(tds,P);
     }
-    else
-      make_tetrahedron(v0->point(),v1->point(),v2->point(),v3->point(),P);
+    else{
+      CGAL_assertion( traits.has_on_positive_side_3_object()(
+            construct_plane(v2->point(),v1->point(),v0->point()),
+            v3->point()) );
+      make_tetrahedron(v0->point(),v1->point(),v3->point(),v2->point(),P);
+    }
   }
   
 }

--- a/Convex_hull_3/test/Convex_hull_3/ch3_4points.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/ch3_4points.cpp
@@ -1,0 +1,20 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/convex_hull_3.h>
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef K::Point_3 Point_3;
+typedef CGAL::Polyhedron_3<K> Gm_polyhedron;
+
+int main()
+{
+  Point_3 points[] = { Point_3(1.0, 0.0, 0.0), Point_3(0.0, 1.0, 0.0), Point_3(0.0, 0.0, 1.0), Point_3(0.0, 0.0, 0.0) };
+  Gm_polyhedron P1;
+  CGAL::convex_hull_3(points, &points[4], P1);
+  CGAL_assertion( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
+
+  Point_3 points_bis[] = { Point_3(0.0, 1.0, 0.0), Point_3(1.0, 0.0, 0.0), Point_3(0.0, 0.0, 1.0), Point_3(0.0, 0.0, 0.0) };
+  CGAL::convex_hull_3(points_bis, &points_bis[4], P1);
+  CGAL_assertion( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
+}


### PR DESCRIPTION
## Summary of Changes

The tetrahedron was always incorrectly oriented by construction.

## Release Management

* Affected package(s): Convex_hull_3
* Issue(s) solved (if any): fix #2320 


