### PR TITLE
Make Periodic_3_regular_triangulation_3 compatible with Alpha_Shapes_3

### DIFF
--- a/Alpha_shapes_2/doc/Alpha_shapes_2/Alpha_shapes_2.txt
+++ b/Alpha_shapes_2/doc/Alpha_shapes_2/Alpha_shapes_2.txt
@@ -108,7 +108,7 @@ such that the \f$ \alpha\f$-shape satisfies the following two properties,
 or at least the second one if there is no such \f$ \alpha\f$ that both
 are satisfied: <br>
 <ol>
-<li> The number of components equals a number of your choice, and
+<li> the number of components equals a number of your choice, and
 <li> all data points are either on the boundary or in the interior of the regularized version of
 the \f$ \alpha\f$-shape (no singular edges).
 </ol>

--- a/Alpha_shapes_2/doc/Alpha_shapes_2/CGAL/Alpha_shape_2.h
+++ b/Alpha_shapes_2/doc/Alpha_shapes_2/CGAL/Alpha_shape_2.h
@@ -371,8 +371,11 @@ size_type number_of_solid_components(const FT& alpha = get_alpha()) const;
 Returns an iterator pointing to the first element with \f$ \alpha\f$-value 
 such that the alpha shape satisfies the following two properties: 
 
-- `nb_components` equals the number of solid components and 
-- all data points are either on the boundary or in the interior of the regularized version of the alpha shape. 
+- All data points are either on the boundary or in the interior
+of the regularized version of the alpha shape.
+
+- The number of solid component of the alpha shape is equal to or
+smaller than `nb_components`.
 
 If no such value is found, the iterator points to the first element with 
 \f$ \alpha\f$-value such that the alpha shape satisfies the second property. 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
@@ -145,9 +145,9 @@ order of apparition in the alpha complex when alpha increases.
 
 Finally, it provides a function to determine 
 the smallest value \f$ \alpha\f$
-such that the alpha shape satisfies the following two properties <br>
+such that the alpha shape satisfies the following two properties: <br>
 <ol>
-<li> all data points are either on the boundary or in the interior
+<li> All data points are either on the boundary or in the interior
 of the regularized version of the alpha shape (no singular faces).
 <li> The number of components is equal or less than a given number.
 </ol>

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/Alpha_shapes_3.txt
@@ -198,10 +198,13 @@ We currently do not specify concepts for the underlying triangulation
 type. Models that work for a family of alpha-shapes are the instantiations
 of the classes `Delaunay_triangulation_3` and
 `Periodic_3_Delaunay_triangulation_3` (see
-example \ref AlphaShape_3DExampleForPeriodicAlphaShapes). A model that works for a fixed alpha-shape are the instantiations
+example \ref AlphaShape_3DExampleForPeriodicAlphaShapes).
+A model that works for a fixed alpha-shape are the instantiations
 of the class `Delaunay_triangulation_3`.
-A model that works for a weighted alpha-shape is 
-the class `Regular_triangulation_3`. The triangulation needs a geometric traits class 
+Models that work for a weighted alpha-shape are the instantiations
+of the classes `Regular_triangulation_3` and
+`Periodic_3_regular_triangulation_3`.
+The triangulation needs a geometric traits class
 and a triangulation data structure as template parameters.
 
 \subsection AlphaShape3D_ConceptAndModelsAlphaShapes Alpha Shapes
@@ -234,19 +237,20 @@ and `Fixed_alpha_shape_cell_base_3<Gt>`, respectively.
 
 \subsection AlphaShape3D_ConceptAndModelsTDS Triangulation data structure
 
-Additionally requirements are put when using `Regular_triangulation_3` or
-`Periodic_3_Delaunay_triangulation_3` as underlying triangulations:
+Additionally requirements are put when using weighted or
+periodic triangulations as underlying triangulation:
 <ul>
-<li> When using `Regular_triangulation_3` as underlying triangulation, the vertex
+<li> When using a weighted triangulation (`Regular_triangulation_3` or
+`Periodic_3_regular_triangulation_3`), the vertex
 and cell classes must be models to both `AlphaShapeVertex_3` and
 `RegularTriangulationVertexBase_3`, as well as
 `AlphaShapeCell_3` and `RegularTriangulationCellBase_3` respectively
-(see example \ref  AlphaShape_3DExampleforWeightedAlphaShapes).
-<li> When using `Periodic_3_Delaunay_triangulation_3` as underlying
-triangulation the vertex and cell classes need to be models to both
-`AlphaShapeVertex_3` and `Periodic_3TriangulationDSVertexBase_3`, as well as
-`AlphaShapeCell_3` and `Periodic_3TriangulationDSCellBase_3`
-(see example \ref  AlphaShape_3DExampleForPeriodicAlphaShapes).
+(see example: \ref AlphaShape_3DExampleforWeightedAlphaShapes).
+<li> When using a periodic triangulation (`Periodic_3_Delaunay_triangulation_3`
+or `Periodic_3_regular_triangulation_3`), the vertex and cell classes must
+be models to both `AlphaShapeVertex_3` and `Periodic_3TriangulationDSVertexBase_3`,
+as well as `AlphaShapeCell_3` and `Periodic_3TriangulationDSCellBase_3`
+(see example: \ref  AlphaShape_3DExampleForPeriodicAlphaShapes).
 </ul>
 
 \section Alpha_shapes_3AlphaShape3OrFixedAlphaShape3 Alpha_shape_3 vs. Fixed_alpha_shape_3
@@ -320,14 +324,15 @@ them with a traits with inexact constructions, the tag
 
 \subsection AlphaShape_3DExampleForPeriodicAlphaShapes Example for Periodic Alpha Shapes
 
-The following example shows how to use the periodic Delaunay
+The following example shows how to use a periodic Delaunay
 triangulation (Chapter \ref Chapter_3D_Periodic_Triangulations "3D Periodic Triangulations") as underlying
-triangulation for the alpha shape computation.
+triangulation for the alpha shape computation. Usage of a weighted Delaunay periodic
+triangulation is presented in the example: \ref Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp "ex_weighted_periodic_alpha_shapes_3.cpp".
 
 In order to define the original domain and to benefit from the
-built-in heuristic optimizations of the periodic Delaunay
-triangulation computation, it is recommended to first construct the
-triangulation and then construct the alpha shape from it. The alpha
+built-in heuristic optimizations of the periodic triangulation computation,
+it is recommended to first construct the triangulation and
+then construct the alpha shape from it. The alpha
 shape constructor that takes a point range can be used as well but in
 this case the original domain cannot be specified and the default unit
 cube will be chosen and no optimizations will be used.

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
@@ -17,8 +17,9 @@ The modifying functions `insert` and `remove` will overwrite
 the one inherited from the underlying triangulation class `Dt`.
 At the moment, only the static version is implemented.
 
-\tparam Dt must be either `Delaunay_triangulation_3`, `Regular_triangulation_3`
-or `Periodic_3_triangulation_3`. Note that `Dt::Geom_traits`, `Dt::Vertex`, and `Dt::Face`
+\tparam Dt must be either `Delaunay_triangulation_3`, `Regular_triangulation_3`,
+`Periodic_3_Delaunay_triangulation_3` or `Periodic_3_regular_triangulation_3`.
+Note that `Dt::Geom_traits`, `Dt::Vertex`, and `Dt::Face`
 must be model the concepts `AlphaShapeTraits_3`,
 `AlphaShapeVertex_3` and `AlphaShapeCell_3`, respectively.
 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
@@ -438,13 +438,13 @@ size_type number_of_solid_components(const FT& alpha = get_alpha()) const;
 
 /*!
 Returns an iterator pointing to smallest \f$ \alpha\f$ value 
-such that the alpha shape satisfies the following two properties: 
+such that the alpha shape satisfies the following two properties:
 
-all data points are either on the boundary or in the interior 
-of the regularized version of the alpha shape. 
+- All data points are either on the boundary or in the interior
+of the regularized version of the alpha shape.
 
-The number of solid component of the alpha shape is equal to or 
-smaller than `nb_components`. 
+- The number of solid component of the alpha shape is equal to or
+smaller than `nb_components`.
 */ 
 Alpha_iterator find_optimal_alpha(size_type nb_components) const; 
 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
@@ -12,8 +12,9 @@ represents connectivity and order among its faces. Each
 \f$ k\f$-dimensional face of the `Dt` is associated with 
 a classification that specifies its status in the alpha complex, alpha being fixed. 
 
-\tparam Dt must be either `Delaunay_triangulation_3`, `Regular_triangulation_3`
-or `Periodic_3_triangulation_3`. Note that `Dt::Geom_traits`, `Dt::Vertex`, and `Dt::Face`
+\tparam Dt must be either `Delaunay_triangulation_3`, `Regular_triangulation_3`,
+`Periodic_3_Delaunay_triangulation_3` or `Periodic_3_regular_triangulation_3`.
+Note that `Dt::Geom_traits`, `Dt::Vertex`, and `Dt::Face`
 must be model the concepts `AlphaShapeTraits_3`,
 `AlphaShapeVertex_3` and `AlphaShapeFace_3`, respectively.
 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/examples.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/examples.txt
@@ -5,5 +5,6 @@
 \example Alpha_shapes_3/ex_fixed_weighted_alpha_shapes_3.cpp
 \example Alpha_shapes_3/ex_periodic_alpha_shapes_3.cpp
 \example Alpha_shapes_3/ex_weighted_alpha_shapes_3.cpp
+\example Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
 \example Alpha_shapes_2/ex_alpha_projection_traits.cpp
 */

--- a/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
@@ -1,0 +1,103 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Alpha_shape_3.h>
+#include <CGAL/Periodic_3_regular_triangulation_traits_3.h>
+#include <CGAL/Periodic_3_regular_triangulation_3.h>
+
+#include <CGAL/Random.h>
+#include <CGAL/point_generators_3.h>
+
+#include <fstream>
+#include <iostream>
+
+
+// Traits
+typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
+typedef CGAL::Periodic_3_regular_triangulation_traits_3<K>   PK;
+
+// Vertex type
+typedef CGAL::Periodic_3_triangulation_ds_vertex_base_3<>    DsVb;
+typedef CGAL::Regular_triangulation_vertex_base_3<PK,DsVb>   Vb;
+typedef CGAL::Alpha_shape_vertex_base_3<PK,Vb>               AsVb;
+// Cell type
+typedef CGAL::Periodic_3_triangulation_ds_cell_base_3<>      DsCb;
+typedef CGAL::Regular_triangulation_cell_base_3<PK,DsCb>     Cb;
+typedef CGAL::Alpha_shape_cell_base_3<PK,Cb>                 AsCb;
+
+typedef CGAL::Triangulation_data_structure_3<AsVb,AsCb>      Tds;
+typedef CGAL::Periodic_3_regular_triangulation_3<PK,Tds>     P3RT3;
+typedef CGAL::Alpha_shape_3<P3RT3>                           Alpha_shape_3;
+
+typedef P3RT3::Bare_point                                    Bare_point;
+typedef P3RT3::Weighted_point                                Weighted_point;
+
+int main()
+{
+  typedef CGAL::Creator_uniform_3<double, Bare_point> Creator;
+  CGAL::Random random(8);
+  CGAL::Random_points_in_cube_3<Bare_point, Creator> in_cube(1, random);
+  std::vector<Weighted_point> pts;
+
+  // read input
+  std::ifstream is("./data/bunny_1000");
+  int n;
+  is >> n;
+  std::cout << "Reading " << n << " points " << std::endl;
+  Bare_point bp;
+  for( ; n>0 ; n--) {
+    is >> bp;
+    Weighted_point p(bp, 0.01 * random.get_double(0., 0.015625));
+    pts.push_back(p);
+  }
+
+/*
+  // Generating 1000 random points
+  for(int i=0; i<1000 ; i++) {
+    Weighted_point p(*in_cube++, random.get_double(0., 0.015625));
+//    Weighted_point p(*in_cube++, 0.);
+    std::cout << "inserting: " << i << " || " << p << std::endl;
+    pts.push_back(p);
+  }
+*/
+
+  // Define the periodic cube
+  P3RT3 prt(PK::Iso_cuboid_3(-0.1,0.,-0.1, 0.1,0.2,0.1));
+
+  // Heuristic for inserting large point sets (if pts is reasonably large)
+  prt.insert(pts.begin(), pts.end(), true);
+
+  // As prt won't be modified anymore switch to 1-sheeted cover if possible
+  if(prt.is_triangulation_in_1_sheet())
+  {
+    std::cout << "Switching to 1-sheeted covering" << std::endl;
+    prt.convert_to_1_sheeted_covering();
+  }
+
+  std::cout << "Periodic Regular computed." << std::endl;
+
+  // compute alpha shape
+  Alpha_shape_3 as(prt);
+  std::cout << "Alpha shape computed in REGULARIZED mode by default." << std::endl;
+
+   // find optimal alpha values
+  Alpha_shape_3::NT alpha_solid = as.find_alpha_solid();
+  Alpha_shape_3::Alpha_iterator opt = as.find_optimal_alpha(1);
+  std::cout << "Smallest alpha value to get a solid through data points is " << alpha_solid << std::endl;
+  std::cout << "Optimal alpha value to get one connected component is " << *opt << std::endl;
+  as.set_alpha(*opt);
+//  assert(as.number_of_solid_components() == 1);
+
+  CGAL::Geomview_stream gv(CGAL::Bbox_3(-0.1,0.,-0.1, 0.1,0.2,0.1));
+  gv.set_bg_color(CGAL::Color(0, 200, 200));
+  gv.clear();
+
+  gv << as;
+  gv.set_wired(true);
+  gv << as;
+
+  char ch;
+  std::cout << "Enter any character to quit" << std::endl;
+  std::cin >> ch;
+
+  return 0;
+}

--- a/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
@@ -42,7 +42,7 @@ int main()
   Bare_point bp;
   for( ; n>0 ; n--) {
     is >> bp;
-    Weighted_point p(bp, 0.0001 * random.get_double(0., 0.015625));
+    Weighted_point p(bp, 0.0001 * random.get_double(0., 0.015625)); // arbitrary weights
     pts.push_back(p);
   }
 
@@ -71,19 +71,7 @@ int main()
   std::cout << "Smallest alpha value to get a solid through data points is " << alpha_solid << std::endl;
   std::cout << "Optimal alpha value to get one connected component is " << *opt << std::endl;
   as.set_alpha(*opt);
-//  assert(as.number_of_solid_components() == 1);
-
-  CGAL::Geomview_stream gv(CGAL::Bbox_3(-0.1,0.,-0.1, 0.1,0.2,0.1));
-  gv.set_bg_color(CGAL::Color(0, 200, 200));
-  gv.clear();
-
-  gv << as;
-  gv.set_wired(true);
-  gv << as;
-
-  char ch;
-  std::cout << "Enter any character to quit" << std::endl;
-  std::cin >> ch;
+  assert(as.number_of_solid_components() == 1);
 
   return 0;
 }

--- a/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/ex_weighted_periodic_alpha_shapes_3.cpp
@@ -5,11 +5,9 @@
 #include <CGAL/Periodic_3_regular_triangulation_3.h>
 
 #include <CGAL/Random.h>
-#include <CGAL/point_generators_3.h>
 
 #include <fstream>
 #include <iostream>
-
 
 // Traits
 typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
@@ -33,10 +31,8 @@ typedef P3RT3::Weighted_point                                Weighted_point;
 
 int main()
 {
-  typedef CGAL::Creator_uniform_3<double, Bare_point> Creator;
   CGAL::Random random(8);
-  CGAL::Random_points_in_cube_3<Bare_point, Creator> in_cube(1, random);
-  std::vector<Weighted_point> pts;
+  std::list<Weighted_point> pts;
 
   // read input
   std::ifstream is("./data/bunny_1000");
@@ -46,19 +42,9 @@ int main()
   Bare_point bp;
   for( ; n>0 ; n--) {
     is >> bp;
-    Weighted_point p(bp, 0.01 * random.get_double(0., 0.015625));
+    Weighted_point p(bp, 0.0001 * random.get_double(0., 0.015625));
     pts.push_back(p);
   }
-
-/*
-  // Generating 1000 random points
-  for(int i=0; i<1000 ; i++) {
-    Weighted_point p(*in_cube++, random.get_double(0., 0.015625));
-//    Weighted_point p(*in_cube++, 0.);
-    std::cout << "inserting: " << i << " || " << p << std::endl;
-    pts.push_back(p);
-  }
-*/
 
   // Define the periodic cube
   P3RT3 prt(PK::Iso_cuboid_3(-0.1,0.,-0.1, 0.1,0.2,0.1));

--- a/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
@@ -787,6 +787,7 @@ private:
   //---------------------------------------------------------------------
 public:  
 #ifdef CGAL_USE_GEOMVIEW
+  void show_triangulation_edges(Geomview_stream &gv) const;
   void show_alpha_shape_faces(Geomview_stream &gv) const;
 #endif
 

--- a/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
@@ -745,43 +745,37 @@ public:
   // starting point for searching 
   // takes O(#alpha_shape) time
 
-
   //------------------- GEOMETRIC PRIMITIVES ----------------------------
 private:
   NT squared_radius(const Cell_handle& s) const
-    {
-      return Compute_squared_radius_3()(*this)(
-	  this->point(s,0), this->point(s,1),
-	  this->point(s,2), this->point(s,3));
-    }
+  {
+    return Compute_squared_radius_3()(*this)(point(s,0), point(s,1),
+                                             point(s,2), point(s,3));
+  }
 
   NT squared_radius(const Cell_handle& s, const int& i) const
-    {
-      return Compute_squared_radius_3()(*this) (
-	  this->point(s,vertex_triple_index(i,0)),
-	  this->point(s,vertex_triple_index(i,1)),
-	  this->point(s,vertex_triple_index(i,2)) );
-    }
+  {
+    return Compute_squared_radius_3()(*this)(point(s,vertex_triple_index(i,0)),
+                                             point(s,vertex_triple_index(i,1)),
+                                             point(s,vertex_triple_index(i,2)));
+  }
 
   NT squared_radius(const Facet& f) const {
     return squared_radius(f.first, f.second);
   }
 
-  NT squared_radius(const Cell_handle& s, 
-			    const int& i, const int& j) const
-    {
-      return Compute_squared_radius_3()(*this)(
-	  this->point(s,i), this->point(s,j));
-    }
+  NT squared_radius(const Cell_handle& s, const int& i, const int& j) const
+  {
+    return Compute_squared_radius_3()(*this)(point(s,i), point(s,j));
+  }
 
   NT squared_radius(const Edge& e) const {
-   return  squared_radius(e.first,e.second,e.third);
+   return squared_radius(e.first,e.second,e.third);
   }
 
   NT squared_radius(const Vertex_handle& v) const {
     return  Compute_squared_radius_3()(*this)(v->point()); 
   }
-
 
   //---------------------------------------------------------------------
 

--- a/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
@@ -148,12 +148,6 @@ public:
   using Dt::finite_vertices_end;
   using Dt::finite_cells_begin;
   using Dt::finite_cells_end;
-  using Dt::VERTEX;
-  using Dt::EDGE;
-  using Dt::FACET;
-  using Dt::CELL;
-  using Dt::OUTSIDE_CONVEX_HULL;
-  using Dt::OUTSIDE_AFFINE_HULL;
   using Dt::vertex_triple_index;
   using Dt::is_infinite;
   using Dt::is_Gabriel;
@@ -161,14 +155,21 @@ public:
   using Dt::incident_vertices;
   using Dt::incident_facets;
   using Dt::locate;
+  using Dt::point;
 
-  enum Classification_type {EXTERIOR, 
-			    SINGULAR, 
-			    REGULAR,
-			    INTERIOR};
- 
+  using Dt::VERTEX;
+  using Dt::EDGE;
+  using Dt::FACET;
+  using Dt::CELL;
+  using Dt::OUTSIDE_CONVEX_HULL;
+  using Dt::OUTSIDE_AFFINE_HULL;
+
+  enum Classification_type {EXTERIOR,
+                            SINGULAR,
+                            REGULAR,
+                            INTERIOR};
+
   enum Mode {GENERAL, REGULARIZED};
-
 
   typedef CGAL::Alpha_status< NT >          Alpha_status;
   typedef Compact_container<Alpha_status>   Alpha_status_container;

--- a/Alpha_shapes_3/include/CGAL/IO/alpha_shape_geomview_ostream_3.h
+++ b/Alpha_shapes_3/include/CGAL/IO/alpha_shape_geomview_ostream_3.h
@@ -12,20 +12,19 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$
-// $Id$
-// 
-//
 // Author(s)     : Tran Kai Frank DA <Frank.Da@sophia.inria.fr>
+//                 Mael Rouxel-Labbé
 
 #ifndef CGAL_IO_ALPHA_SHAPE_GEOMVIEW_OSTREAM_3_H
 #define CGAL_IO_ALPHA_SHAPE_GEOMVIEW_OSTREAM_3_H
 
 #include <CGAL/license/Alpha_shapes_3.h>
 
-
 #include <CGAL/IO/Geomview_stream.h>
 #include <CGAL/Alpha_shape_3.h>
+
+#include <map>
+#include <utility>
 
 // TODO :
 // - Check the correctness when dimension < 3.
@@ -36,85 +35,134 @@
 namespace CGAL {
 //-------------------------------------------------------------------
 
-// This one is to show the edges of a 3D triangulation.
-// template < class GT, class TDS >
-// void
-// show_triangulation_edges(Geomview_stream &gv, 
-//                          const Alpha_shape_3<GT,TDS> &T)
-// {
-//   // Header.
-//   gv.set_ascii_mode();
-//   gv << "(geometry " << gv.get_new_id("triangulationedge")
-//      << " {appearance {}{ SKEL \n"
-//      << T.number_of_vertices() << T.number_of_finite_edges() << "\n";
-
-//   // Finite vertices coordinates.
-//   std::map<Alpha_shape_3<GT, TDS>::Vertex_handle, int> V;
-//   int inum = 0;
-//   for( Alpha_shape_3<GT, TDS>::Vertex_iterator
-// 	  vit = T.finite_vertices_begin(); vit != T.vertices_end(); ++vit) {
-//     V[vit] = inum++;
-//     gv << vit->point() << "\n";
-//   }
-  
-//   // Finite edges indices.
-//   for( Alpha_shape_3<GT, TDS>::Edge_iterator
-// 	  eit = T.finite_edges_begin(); eit != T.edges_end(); ++eit) {
-//       gv << 2
-//          << V[(*eit).first->vertex((*eit).second)]
-//          << V[(*eit).first->vertex((*eit).third)]
-//          << "\n"; // without color.
-//       // << 4 << drand48() << drand48() << drand48() << 1.0; // random color
-//   }
-// }
-
-
-//-------------------------------------------------------------------
-// This one outputs the facets.
-template < class Dt,class EACT >
+template<class Dt,class EACT>
 void
-Alpha_shape_3<Dt,EACT>::show_alpha_shape_faces(Geomview_stream &gv) const
+Alpha_shape_3<Dt,EACT>::
+show_triangulation_edges(Geomview_stream &gv) const
 {
-  // Finite vertices coordinates.
-  typename Alpha_shape_3<Dt,EACT>::Alpha_shape_vertices_iterator Vlist_it,
-    Vlist_begin = Alpha_shape_vertices_begin(),
-    Vlist_end = Alpha_shape_vertices_end();
+  // To become unordered when CGAL's Point_3/Weighted_point_3 has a hash function
+  typedef typename std::map<Point, int> PMap;
 
-  std::map<typename Alpha_shape_3<Dt,EACT>::Vertex_handle, int> V;
-  int number_of_vertex = 0;
-  for( Vlist_it = Vlist_begin; Vlist_it != Vlist_end; Vlist_it++) {
-    V[*Vlist_it] = number_of_vertex++;
+  // Used to keep the insertion order in memory
+  typedef typename std::vector<typename PMap::iterator> PMapIterVector;
+
+  PMap P;
+  PMapIterVector PIV;
+  int number_of_points = 0;
+
+  for(Finite_edges_iterator eit=finite_edges_begin(); eit!=finite_edges_end(); ++eit)
+  {
+    Point p = point(eit->first, eit->second);
+    Point q = point(eit->first, eit->third);
+
+    std::pair<typename PMap::iterator, bool> is_p_insert_successful =
+      P.insert(std::make_pair(p, number_of_points));
+
+    if(is_p_insert_successful.second)
+    {
+      ++number_of_points;
+      PIV.push_back(is_p_insert_successful.first);
+    }
+
+    std::pair<typename PMap::iterator, bool> is_q_insert_successful =
+      P.insert(std::make_pair(q, number_of_points));
+
+    if(is_q_insert_successful.second)
+    {
+      ++number_of_points;
+      PIV.push_back(is_q_insert_successful.first);
+    }
   }
 
+  // Header
+  gv.set_ascii_mode();
+  gv << "(geometry " << gv.get_new_id("triangulation_edges")
+     << " {appearance {}{ SKEL \n"
+     << number_of_points << this->number_of_finite_edges() << "\n";
+
+  // Vertices
+  typename PMapIterVector::iterator Pit, Pbegin = PIV.begin(), Pend = PIV.end();
+  for(Pit = Pbegin; Pit != Pend; ++Pit)
+    gv << this->geom_traits().construct_point_3_object()((*Pit)->first);
+
+  // Finite edges indices
+  for(Finite_edges_iterator eit=finite_edges_begin(); eit!=finite_edges_end(); ++eit) {
+    gv << 2
+       << P[point(eit->first, eit->second)]
+       << P[point(eit->first, eit->third)]
+       << "\n"; // without color
+    // << 4 << drand48() << drand48() << drand48() << 1.0; // random color
+  }
+}
+
+//-------------------------------------------------------------------
+// This function outputs the facets.
+template<class Dt,class EACT>
+void
+Alpha_shape_3<Dt,EACT>::
+show_alpha_shape_faces(Geomview_stream &gv) const
+{
+  // To become unordered when CGAL's Point_3/Weighted_point_3 has a hash function
+  typedef typename std::map<Point, int> PMap;
+
+  // Used to keep the insertion order in memory
+  typedef typename std::vector<typename PMap::iterator> PMapIterVector;
 
   typename Alpha_shape_3<Dt,EACT>::Alpha_shape_facets_iterator Flist_it,
     Flist_begin = Alpha_shape_facets_begin(),
     Flist_end = Alpha_shape_facets_end();
 
-  std::map<typename Alpha_shape_3<Dt,EACT>::Facet, int> F;
-  int number_of_facets = 0;
-  for( Flist_it = Flist_begin; Flist_it != Flist_end; Flist_it++) {
-    F[*Flist_it] = number_of_facets++;
+  PMap P;
+  PMapIterVector PIV;
+  int number_of_points = 0;
+  int number_of_facets = std::distance(Flist_begin, Flist_end);
+
+  for(Flist_it = Flist_begin; Flist_it != Flist_end; Flist_it++)
+  {
+    // Collect the points
+    // Note that we cannot simply loop over the vertices using e.g.
+    // Alpha_shape_vertices_begin() because v->point() might not always
+    // be the correct point position (see periodic triangulations for example);
+    // we must instead use tr.point(c,i)
+    for(int i=0; i<4; i++)
+    {
+      if(i != Flist_it->second)
+      {
+        Point p = point(Flist_it->first, i);
+        std::pair<typename PMap::iterator, bool> is_insert_successful =
+            P.insert(std::make_pair(p, number_of_points));
+
+        if(is_insert_successful.second)
+        {
+          ++number_of_points;
+          PIV.push_back(is_insert_successful.first);
+        }
+      }
+    }
   }
 
-  // Header.
+  // Header
   gv.set_binary_mode();
   gv << "(geometry " << gv.get_new_id("alpha_shape")
      << " {appearance {}{ OFF BINARY\n"
-     << number_of_vertex << number_of_facets << 0;
+     << number_of_points << number_of_facets << 0;
 
-  for( Vlist_it = Vlist_begin; Vlist_it != Vlist_end; Vlist_it++) {
-    gv << this->geom_traits().construct_point_3_object()((*Vlist_it)->point());
-  }
-  
-  // Finite facets indices.
-  for( Flist_it = Flist_begin; Flist_it != Flist_end; Flist_it++){
-      gv << 3;
-      for (int i=0; i<4; i++)
-          if (i != (*Flist_it).second)
-	      gv << V[(*Flist_it).first->vertex(i)];
-      gv << 0; // without color.
-      // gv << 4 << drand48() << drand48() << drand48() << 1.0; // random color
+  std::cout << number_of_points << " " << number_of_facets << std::endl;
+
+  // Vertices
+  typename PMapIterVector::iterator Pit, Pbegin = PIV.begin(), Pend = PIV.end();
+  for(Pit = Pbegin; Pit != Pend; ++Pit)
+    gv << this->geom_traits().construct_point_3_object()((*Pit)->first);
+
+  // Finite facets indices
+  for(Flist_it = Flist_begin; Flist_it != Flist_end; Flist_it++)
+  {
+    gv << 3;
+    for(int i=0; i<4; i++)
+      if(i != Flist_it->second)
+        gv << P[point(Flist_it->first, i)];
+    gv << 0; // without color
+//    gv << 4 << drand48() << drand48() << drand48() << 1.0; // random color
   }
 }
 
@@ -122,22 +170,22 @@ Alpha_shape_3<Dt,EACT>::show_alpha_shape_faces(Geomview_stream &gv) const
 
 template < class Dt,class EACT >
 Geomview_stream&
-operator<<( Geomview_stream &gv, Alpha_shape_3<Dt,EACT>& A)
+operator<<(Geomview_stream &gv, Alpha_shape_3<Dt,EACT>& A)
 {
-    bool ascii_bak = gv.get_ascii_mode();
-    bool raw_bak = gv.set_raw(true);
+  bool ascii_bak = gv.get_ascii_mode();
+  bool raw_bak = gv.set_raw(true);
 
-//     if (gv.get_wired())
-//         show_alpha_shape_edges(gv, T);
-//     else
-        A.show_alpha_shape_faces(gv);
+  if(gv.get_wired())
+    A.show_triangulation_edges(gv);
+  else
+    A.show_alpha_shape_faces(gv);
 
-    // Footer.
-    gv << "}})";
+  // Footer
+  gv << "}})";
 
-    gv.set_raw(raw_bak);
-    gv.set_ascii_mode(ascii_bak);
-    return gv;
+  gv.set_raw(raw_bak);
+  gv.set_ascii_mode(ascii_bak);
+  return gv;
 }
 
 //-------------------------------------------------------------------

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Periodic_3_triangulation_3.txt
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Periodic_3_triangulation_3.txt
@@ -455,8 +455,9 @@ of a 3D regular triangulation.
 
 \subsection Periodic_3_triangulation_3PeriodicAlphaShapes Periodic Alpha Shapes
 
-It is possible to use the class `Periodic_3_Delaunay_triangulation_3`
-as underlying triangulation for computing alpha shapes. For an example see
+It is possible to use the classes `Periodic_3_Delaunay_triangulation_3`
+and `Periodic_3_regular_triangulation_3` as underlying triangulations
+to compute alpha shapes. Examples of usage can be found in
 Section \ref AlphaShape_3DExampleForPeriodicAlphaShapes of the chapter on
 3D alpha shapes.
 

--- a/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/simple_example.cpp
+++ b/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/simple_example.cpp
@@ -66,7 +66,7 @@ int main(int, char**)
   oFileT << T;
 
   std::ofstream to_off("output_regular.off"); // as a .off file
-  write_triangulation_to_off(to_off, T);
+  CGAL::write_triangulation_to_off(to_off, T);
 
   std::ofstream d_to_off("output_dual.off");
   draw_dual_to_off(d_to_off, T);

--- a/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/simple_regular_example.cpp
+++ b/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/simple_regular_example.cpp
@@ -67,7 +67,7 @@ int main(int, char**)
   oFileT << T;
 
   std::ofstream to_off("output_regular.off");
-  write_triangulation_to_off(to_off, T);
+  CGAL::write_triangulation_to_off(to_off, T);
 
   std::ofstream d_to_off("output_regular_dual.off"); // as a .off file
   draw_dual_to_off(d_to_off, T);

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
@@ -791,22 +791,6 @@ private:
     std::vector<Point> hidden;
   };
 #endif //CGAL_CFG_OUTOFLINE_TEMPLATE_MEMBER_DEFINITION_BUG
-
-  // unused and undocumented types and functions required to be
-  // compatible to Alpha_shape_3
-public:
-  typedef Cell_iterator   Finite_cells_iterator;
-  typedef Facet_iterator  Finite_facets_iterator;
-  typedef Edge_iterator   Finite_edges_iterator;
-  typedef Vertex_iterator Finite_vertices_iterator;
-
-  int dimension() const { return 3; }
-  template < class T >
-  bool is_infinite(const T&, int = 0, int = 0) const { return false; }
-  size_type number_of_finite_cells() const { return number_of_cells(); }
-  size_type number_of_finite_facets() const { return number_of_facets(); }
-  size_type number_of_finite_edges() const { return number_of_edges(); }
-  size_type number_of_finite_vertices() const { return number_of_vertices(); }
 };
 
 template < class GT, class Tds >

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_traits_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_traits_3.h
@@ -75,6 +75,10 @@ public:
   typedef Functor_with_offset_weighted_points_adaptor<Self, typename K::Compare_power_distance_3>
       Compare_power_distance_3;
 
+  // Undocumented, requried for Is_Gabriel (Alpha shapes)
+  typedef Functor_with_offset_weighted_points_adaptor<Self, typename K::Power_side_of_bounded_power_sphere_3>
+      Power_side_of_bounded_power_sphere_3;
+
   // Required for Periodic_3_regular_remove_traits
   typedef Functor_with_offset_weighted_points_adaptor<Self, typename K::Coplanar_orientation_3>
        Coplanar_orientation_3;
@@ -99,6 +103,11 @@ public:
   }
 
   // predicates
+  Power_side_of_bounded_power_sphere_3 power_side_of_bounded_power_sphere_3_object() const {
+    return Power_side_of_bounded_power_sphere_3(
+      this->Base::power_side_of_bounded_power_sphere_3_object(),
+      construct_point_3_object(), construct_weighted_point_3_object());
+  }
   Power_side_of_oriented_power_sphere_3 power_side_of_oriented_power_sphere_3_object() const {
     return Power_side_of_oriented_power_sphere_3(
       this->Base::power_side_of_oriented_power_sphere_3_object(),

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -205,19 +205,37 @@ public:
 
 public:
   enum Iterator_type {
-    STORED=0,
+    STORED = 0,
     UNIQUE, //1
     STORED_COVER_DOMAIN, //2
     UNIQUE_COVER_DOMAIN };//3
 
   enum Locate_type {
-    VERTEX=0,
+    VERTEX = 0,
     EDGE, //1
     FACET, //2
     CELL, //3
     EMPTY , //4
     OUTSIDE_CONVEX_HULL, // unused, for compatibility with Alpha_shape_3
     OUTSIDE_AFFINE_HULL }; // unused, for compatibility with Alpha_shape_3
+
+  // unused and undocumented types and functions required to be
+  // compatible with Alpha_shape_3 / Periodic_3_mesh_3
+public:
+  typedef Cell_iterator                        Finite_cells_iterator;
+  typedef Facet_iterator                       Finite_facets_iterator;
+  typedef Edge_iterator                        Finite_edges_iterator;
+  typedef Vertex_iterator                      Finite_vertices_iterator;
+
+  int dimension() const { return (number_of_vertices() == 0) ? -2 : 3; }
+
+  template<class T>
+  bool is_infinite(const T&, int = 0, int = 0) const { return false; }
+
+  size_type number_of_finite_cells() const { return number_of_cells(); }
+  size_type number_of_finite_facets() const { return number_of_facets(); }
+  size_type number_of_finite_edges() const { return number_of_edges(); }
+  size_type number_of_finite_vertices() const { return number_of_vertices(); }
 
 private:
   Geometric_traits  _gt;
@@ -364,16 +382,6 @@ public:
   size_type number_of_vertices() const {
     if(is_1_cover()) return _tds.number_of_vertices();
     else return _tds.number_of_vertices()/27;
-  }
-
-  size_type number_of_finite_cells() const {
-    return number_of_cells();
-  }
-  size_type number_of_finite_facets() const {
-    return number_of_facets();
-  }
-  size_type number_of_finite_edges() const {
-    return number_of_edges();
   }
 
   size_type number_of_stored_cells() const {

--- a/Periodic_3_triangulation_3/include/CGAL/periodic_3_triangulation_3_io.h
+++ b/Periodic_3_triangulation_3/include/CGAL/periodic_3_triangulation_3_io.h
@@ -28,6 +28,8 @@
 #include <iostream>
 #include <utility>
 
+namespace CGAL {
+
 template <class Stream, class Triangulation>
 Stream &write_triangulation_to_off(Stream &out, Triangulation &t) {
   typedef typename Triangulation::Point Point;
@@ -136,5 +138,7 @@ Stream& draw_dual_to_off(Stream &os, Triangulation &t) {
   }
   return os;
 }
+
+} // namespace CGAL
 
 #endif //CGAL_PERIODIC_3_TRIANGULATION_3_IO_H

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
@@ -20,6 +20,7 @@ if ( CGAL_FOUND )
 
   create_single_source_cgal_program( "test_p3rt3_as_p3t3.cpp" )
   create_single_source_cgal_program( "test_p3rt3_insert_remove_point_set.cpp" )
+  create_single_source_cgal_program( "test_p3rt3_versus_rt3.cpp" )
   create_single_source_cgal_program( "test_periodic_3_alpha_shape_3.cpp" )
   create_single_source_cgal_program( "test_periodic_3_delaunay_3.cpp" )
   create_single_source_cgal_program( "test_periodic_3_delaunay_hierarchy_3.cpp" )

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_alpha_shape_3.h
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_alpha_shape_3.h
@@ -12,11 +12,6 @@
 // This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 //
-// $URL$ 
-// $Id$ 
-// $Date$
-// 
-//
 // Author(s)     : Mariette Yvinec <Mariette.Yvinec@sophia.inria.fr>
 //                 Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
 
@@ -34,12 +29,12 @@ file_input(std::ifstream& is, std::list<Point>& L, int nb=0)
   CGAL::set_ascii_mode(is);
   int n;
   is >> n;
-  if (nb != 0 && nb <= n) n=nb;
+  if(nb != 0 && nb <= n) n=nb;
   std::cout << "Reading " << n << " points" << std::endl;
   Point p;
-  for( ; n>0 ; n--)    {
-      is >> p;
-      L.push_back(p);
+  for(; n>0; n--) {
+    is >> p;
+    L.push_back(p);
   }
   std::cout << "Points inserted" << std::endl;
   return true;
@@ -60,30 +55,37 @@ _test_cls_alpha_shape_3()
   std::list<Point> L;
   bool verbose = false;
   
-// test a bigger alpha_shapes
+  // test a bigger alpha_shapes
   std::ifstream is("./data/P3DT3_alpha_shape_test.pts", std::ios::in);
   assert(is);
-  file_input(is,L);
-  Iso_cuboid domain(FT(-0.1),FT(-0.1),FT(-0.1),FT(0.2),FT(0.2),FT(0.2));
-  std::cout<< "Create triangulation with domain "<<domain<<std::endl;
-  Triangulation dt( domain ); 
+  file_input(is, L);
+
+  Iso_cuboid domain(FT(-0.1),FT(-0.1),FT(-0.1), FT(0.2),FT(0.2),FT(0.2));
+  Triangulation dt(domain);
+  std::cout << "Create triangulation with domain " << domain << std::endl;
   std::size_t n = dt.insert(L.begin(),L.end());
+
   Alpha_shape_3 a1(dt,0, Alpha_shape_3::REGULARIZED);
-  if(verbose) show_alpha_values(a1);
-  std::cout << "Alpha Shape computed: "  << n << " points" << std::endl;
+  if(verbose)
+    show_alpha_values(a1);
+
+  std::cout << "Alpha Shape computed: " << n << " points" << std::endl;
   std::cout << " test number_of_components - find_optimal_alpha "<< std::endl;
+
   Alpha_iterator opt = a1.find_optimal_alpha(1);
-  Alpha_iterator previous = opt; --previous;
+  Alpha_iterator previous = opt;
+  --previous;
+
   if(verbose) {
-    std::cerr << " optimal  de 1 " << *opt
-	      << "nb of componants " << a1.number_of_solid_components(*opt)
-	      << std::endl;
-    std::cerr << " previous        " << *previous 
-	      << "nb of componants " 
-	      << a1.number_of_solid_components(*previous) << std::endl;
+    std::cerr << " optimal de 1 " << *opt
+              << "nb of componants " << a1.number_of_solid_components(*opt)
+              << std::endl;
+    std::cerr << " previous " << *previous
+              << "nb of componants "
+              << a1.number_of_solid_components(*previous) << std::endl;
   }
-  assert (a1.number_of_solid_components(*opt) == 1);
-  assert (a1.number_of_solid_components(*previous) > 1);
+  assert(a1.number_of_solid_components(*opt) == 1);
+  assert(a1.number_of_solid_components(*previous) > 1);
 }
 
 template <class AS>
@@ -96,42 +98,45 @@ _test_cls_alpha_shape_3_exact()
   typedef typename AS::FT FT;
   typedef typename AS::Point Point;
   typedef typename AS::Alpha_iterator Alpha_iterator;
+
   bool verbose = false;
   std::vector<Point> L, Lc;
-  L.push_back(Point(0,0,0));
-  L.push_back(Point(1,2,3));
-  Lc.push_back(Point(0,0,0));
-  FT a(1);
-  FT b(2);
-  FT c(3);
-  FT d(8);
-  Lc.push_back(Point(a/d,b/d,c/d));
+
+  L.push_back(Point(0, 0, 0));
+  L.push_back(Point(1, 2, 3));
+  Lc.push_back(Point(0, 0, 0));
+
+  FT a(1), b(2), c(3), d(8);
+  Lc.push_back(Point(a/d, b/d, c/d));
 
   Triangulation dt1(L.begin(), L.end(),
-      typename Triangulation::Iso_cuboid(0,0,0,8,8,8));
-  Alpha_shape_3 a1( dt1, 0, Alpha_shape_3::REGULARIZED);
-  if(verbose) show_triangulation(a1);
-  assert(a1.number_of_alphas() == 6 );
+                    typename Triangulation::Iso_cuboid(0,0,0, 8,8,8));
+  Alpha_shape_3 a1(dt1, 0, Alpha_shape_3::REGULARIZED);
 
-  std::cout << "REGULARIZED  mode" << std::endl;
-  std::cout << "test_classify_and_iterators" 
-	    << std::endl;
+  if(verbose)
+    show_triangulation(a1);
+  assert(a1.number_of_alphas() == 6);
+
+  std::cout << "REGULARIZED mode" << std::endl;
+  std::cout << "test_classify_and_iterators" << std::endl;
+
   Alpha_iterator alpha_it = a1.alpha_begin();
-  for (;alpha_it != a1.alpha_end();alpha_it++){
+  for(;alpha_it != a1.alpha_end();alpha_it++) {
     a1.set_alpha(*alpha_it);
-    if (verbose) {
+    if(verbose) {
       std::cerr << std::endl;
       std::cerr << "alpha value " << * alpha_it << std::endl;
       std::cerr << std::endl;
-     }
+    }
     count_faces(a1, verbose);
   }
 
   if(verbose) show_alpha_values(a1);
-  if (verbose)     a1.print_maps();
-  if (verbose)   a1.print_alphas();
+  if(verbose) a1.print_maps();
+  if(verbose) a1.print_alphas();
+
   std::cout << "test filtration " << std::endl;
-  test_filtration(a1,verbose);
+  test_filtration(a1, verbose);
 
   a1.set_mode(Alpha_shape_3::GENERAL);
   std::cout << "GENERAL mode" << std::endl;
@@ -139,20 +144,19 @@ _test_cls_alpha_shape_3_exact()
   if(verbose) show_alpha_values(a1);
   if(verbose) a1.print_maps();
   if(verbose) a1.print_alphas();
-  assert(a1.number_of_alphas() == 21) ;
-	 std::cout << "test_classify_and_iterators" 
-	    << std::endl;
- 
-  for(alpha_it = a1.alpha_begin();alpha_it!=a1.alpha_end();alpha_it++){
+  assert(a1.number_of_alphas() == 21);
+  std::cout << "test_classify_and_iterators" << std::endl;
+
+  for(alpha_it = a1.alpha_begin();alpha_it!=a1.alpha_end();alpha_it++) {
     a1.set_alpha(*alpha_it);
-    if (verbose) {
+    if(verbose) {
       std::cerr << std::endl;
       std::cerr << "alpha value " << * alpha_it << std::endl;
     }
     count_faces(a1, verbose);
   }
   std::cout << "test filtration " << std::endl;
-  test_filtration(a1,verbose);
+  test_filtration(a1, verbose);
 
   // alpha values 0
   //              21
@@ -164,18 +168,18 @@ _test_cls_alpha_shape_3_exact()
 
   a1.set_mode(Alpha_shape_3::REGULARIZED);
   std::cout << "REGULARIZED mode" << std::endl;
-  std::cout << "test number_of_components - find_optimal_alpha "
-	    <<  std::endl;
-  if (verbose) {
+  std::cout << "test number_of_components - find_optimal_alpha " << std::endl;
+
+  if(verbose) {
     std::cerr << std::endl;
     std::cerr << "REGULARIZED mode" << std::endl;
     a1.print_maps();
     a1.print_alphas();
 
     for(alpha_it = a1.alpha_begin();alpha_it!=a1.alpha_end();alpha_it++)
-      std::cerr << "alpha  " << *alpha_it << "\t" 
-		<< "number of solid componenst " 
-		<< a1.number_of_solid_components(*alpha_it) <<  std::endl;
+      std::cerr << "alpha " << *alpha_it << "\t"
+                << "number of solid componenst "
+                << a1.number_of_solid_components(*alpha_it) << std::endl;
   }
 
   // alpha  21       number of solid components 54
@@ -185,40 +189,41 @@ _test_cls_alpha_shape_3_exact()
   // alpha  30.4444  number of solid components  3
   // alpha  30.7949  number of solid components  1
 
-  assert( *(a1.find_optimal_alpha(1)) == a1.get_nth_alpha(6));
-  assert( *(a1.find_optimal_alpha(5)) == a1.get_nth_alpha(5));
-  assert (a1.number_of_solid_components(*(a1.find_optimal_alpha(1))) == 1);
-  assert (a1.number_of_solid_components(*(a1.find_optimal_alpha(4))) == 3);
-  assert (a1.get_nth_alpha(3) == *(a1.alpha_lower_bound(26)));
-  assert (a1.get_nth_alpha(4) == *(a1.alpha_upper_bound(26)));
-  test_filtration(a1,verbose);
+  assert(*(a1.find_optimal_alpha(1)) == a1.get_nth_alpha(6));
+  assert(*(a1.find_optimal_alpha(5)) == a1.get_nth_alpha(5));
+  assert(a1.number_of_solid_components(*(a1.find_optimal_alpha(1))) == 1);
+  assert(a1.number_of_solid_components(*(a1.find_optimal_alpha(4))) == 3);
+  assert(a1.get_nth_alpha(3) == *(a1.alpha_lower_bound(26)));
+  assert(a1.get_nth_alpha(4) == *(a1.alpha_upper_bound(26)));
+  test_filtration(a1, verbose);
 
   std::cout << std::endl;
   std::cout << "test additionnal creators and set mode" << std::endl;
+
   Triangulation dt2(Lc.begin(), Lc.end());
-  Alpha_shape_3 a2(dt2, 0,  Alpha_shape_3::REGULARIZED);
+  Alpha_shape_3 a2(dt2, 0, Alpha_shape_3::REGULARIZED);
   if(verbose) show_alpha_values(a2);
   if(verbose) a2.print_maps();
   if(verbose) a2.print_alphas();
-  assert(a2.number_of_alphas() == 6) ;
-  
+  assert(a2.number_of_alphas() == 6);
+
   Triangulation dt3(Lc.begin(), Lc.end());
-  Alpha_shape_3 a3(dt3, 0,  Alpha_shape_3::GENERAL);
-  assert(a3.number_of_alphas() == 21) ;
+  Alpha_shape_3 a3(dt3, 0, Alpha_shape_3::GENERAL);
+  assert(a3.number_of_alphas() == 21);
 
   Triangulation dt4(Lc.begin(), Lc.end());
   Alpha_shape_3 a4(dt4);
-  assert(a4.number_of_alphas() == 6) ;
+  assert(a4.number_of_alphas() == 6);
 
-  Alpha_shape_3 a5(0,  Alpha_shape_3::GENERAL);
+  Alpha_shape_3 a5(0, Alpha_shape_3::GENERAL);
   a5.make_alpha_shape(Lc.begin(), Lc.end());
-  assert(a5.number_of_alphas() == 21) ;
+  assert(a5.number_of_alphas() == 21);
 
   a1.set_mode(Alpha_shape_3::REGULARIZED);
-  assert(a1.number_of_alphas() == 6) ;
+  assert(a1.number_of_alphas() == 6);
 
   a1.set_mode(Alpha_shape_3::GENERAL);
-  assert(a1.number_of_alphas() == 21) ;
+  assert(a1.number_of_alphas() == 21);
 }
 
-#endif //  CGAL_TEST_CLS_ALPHA_SHAPE_3_H
+#endif // CGAL_TEST_CLS_ALPHA_SHAPE_3_H

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_as_p3t3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_as_p3t3.cpp
@@ -1,23 +1,3 @@
-// Copyright (c) 2015  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Aymeric Pelle
-
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
@@ -1,26 +1,4 @@
-
 //#define REALLY_VERBOSE
-
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Aymeric PELLE <aymeric.pelle@sophia.inria.fr>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2017  INRIA Sophia-Antipolis (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// Author(s)     : Mael Rouxel-Labbé
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include <CGAL/Periodic_3_regular_triangulation_3.h>
+#include <CGAL/Periodic_3_regular_triangulation_traits_3.h>
+
+#include <CGAL/Triangulation_vertex_base_with_info_3.h>
+#include <CGAL/Regular_triangulation_3.h>
+
+#include <CGAL/periodic_3_triangulation_3_io.h>
+#include <CGAL/IO/Triangulation_off_ostream_3.h>
+
+#include <algorithm>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+// A basic test to check that P3RT3 and RT3 produces the same regular triangulations
+// In the case of RT3, the fake periodic domain is obtained by addding 26 copies
+// of the same input point set (similarly to how we copy in P3RT3 when it cannot
+// yet be converted to 1 sheet)
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel       Epick;
+typedef CGAL::Periodic_3_regular_triangulation_traits_3<Epick>    PRTT_Inexact;
+
+typedef CGAL::Periodic_3_regular_triangulation_3<PRTT_Inexact>    P3RT3;
+
+typedef P3RT3::Iso_cuboid                                         Iso_cuboid;
+typedef P3RT3::Offset                                             Offset;
+typedef P3RT3::Weighted_point                                     Weighted_point;
+
+// The info() is a unique color per point + a boolean to mark those in the "fake"
+// canonical domain (the cuboid surrounded by 26 copies)
+typedef CGAL::Regular_triangulation_vertex_base_3<Epick>          Vb0;
+typedef CGAL::Triangulation_vertex_base_with_info_3<
+                std::pair<int, bool>, Epick, Vb0>                 Vb;
+typedef CGAL::Regular_triangulation_cell_base_3<Epick>            Cb;
+typedef CGAL::Triangulation_data_structure_3<Vb, Cb>              Tds;
+
+typedef CGAL::Regular_triangulation_3<Epick, Tds>                 RT3;
+typedef RT3::Vertex_handle                                        Vertex_handle;
+typedef RT3::Finite_vertices_iterator                             Finite_vertices_iterator;
+typedef RT3::Finite_cells_iterator                                Finite_cells_iterator;
+
+int main (int, char**)
+{
+  Iso_cuboid iso_cuboid(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5);
+  P3RT3 p3rt3(iso_cuboid);
+
+  std::ifstream input_stream("data/p3rt3_point_set__s7_n800");
+
+  std::vector<Weighted_point> points_for_p3rt3;
+  points_for_p3rt3.reserve(800);
+
+  while(points_for_p3rt3.size() != 800)
+  {
+    Weighted_point p;
+    input_stream >> p;
+    points_for_p3rt3.push_back(p);
+  }
+  p3rt3.insert(points_for_p3rt3.begin(), points_for_p3rt3.end(), true /*large point set*/);
+  std::cout << "--- built periodic regular triangulation" << std::endl;
+
+  // Non-periodic
+  RT3 rt3;
+
+  int id = 0;
+  for(int l=0; l<800; ++l)
+  {
+    for(int i=-1; i<2; i++)
+    {
+      for(int j=-1; j<2; j++)
+      {
+        for(int k=-1; k<2; k++)
+        {
+          Vertex_handle v = rt3.insert(
+                              p3rt3.geom_traits().construct_weighted_point_3_object()(
+                                points_for_p3rt3[l], Offset(i, j, k)));
+
+          if(v != Vertex_handle())
+            v->info() = std::make_pair(id /*unique id*/,
+                                       (i==0 && j==0 && k==0) /*canonical domain?*/);
+        }
+      }
+    }
+    id++;
+  }
+  std::cout << "--- built regular triangulation" << std::endl;
+
+//  std::ofstream out_p3rt3("out_p3rt3.off");
+//  std::ofstream out_rt3("out_rt3.off");
+//  CGAL::write_triangulation_to_off(out_p3rt3, p3rt3);
+//  CGAL::export_triangulation_3_to_off(out_rt3, rt3);
+
+  // ---------------------------------------------------------------------------
+
+  // compare vertices
+  std::set<int> unique_vertices_from_rt3;
+
+  Finite_vertices_iterator vit = rt3.finite_vertices_begin();
+  for(; vit!=rt3.finite_vertices_end(); ++vit)
+  {
+    if(vit->info().second) // is in the canonical domain
+      unique_vertices_from_rt3.insert(vit->info().first);
+  }
+
+  std::cout << unique_vertices_from_rt3.size() << " unique vertices (rt3)" << std::endl;
+  std::cout << p3rt3.number_of_vertices() << " unique vertices (p3rt3)" << std::endl;
+  CGAL_assertion(unique_vertices_from_rt3.size() == p3rt3.number_of_vertices());
+
+  // compare cells
+  std::set<std::set<int> > unique_cells_from_rt3;
+
+  Finite_cells_iterator cit = rt3.finite_cells_begin();
+  for(; cit!=rt3.finite_cells_end(); ++cit)
+  {
+    std::set<int> cell;
+    bool has_a_point_in_canonical_domain = false;
+
+    for(int i=0; i<4; i++)
+    {
+      Vertex_handle v = cit->vertex(i);
+      cell.insert(v->info().first);
+
+      if(v->info().second)
+        has_a_point_in_canonical_domain = true;
+    }
+
+    if(has_a_point_in_canonical_domain)
+      unique_cells_from_rt3.insert(cell);
+  }
+
+  std::cout << unique_cells_from_rt3.size() << " unique cells (rt3)" << std::endl;
+  std::cout << p3rt3.number_of_cells() << " unique cells (p3rt3)" << std::endl;
+  CGAL_assertion(unique_cells_from_rt3.size() == p3rt3.number_of_cells());
+
+  std::cout << "EXIT SUCCESS" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
@@ -1,19 +1,3 @@
-// Copyright (c) 2017  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// Author(s)     : Mael Rouxel-Labbé
-
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_alpha_shape_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_alpha_shape_3.cpp
@@ -1,26 +1,3 @@
-// Copyright (c) 1999-2003,2009  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Mariette Yvinec <Mariette.Yvinec@sophia.inria.fr>
-//                 Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
-
-
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Periodic_3_Delaunay_triangulation_traits_3.h>

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_delaunay_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_delaunay_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Nico Kruithof
-//                 Manuel Caroli
-
 #include <iostream>
 #include <fstream>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_delaunay_hierarchy_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_delaunay_hierarchy_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL: svn+ssh://mcaroli@scm.gforge.inria.fr/svn/cgal/trunk/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_delaunay_3.cpp $
-// $Id: test_periodic_3_delaunay_3.cpp 48874 2009-04-23 13:54:38Z mcaroli $
-//
-//
-// Author(s)     : Nico Kruithof
-//                 Manuel Caroli
-
 #include <iostream>
 #include <fstream>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_offset_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_offset_3.cpp
@@ -1,23 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Manuel Caroli
-
 #include <iostream>
 #include <fstream>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Aymeric PELLE <aymeric.pelle@sophia.inria.fr>
-
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_traits_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_traits_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Aymeric PELLE <aymeric.pelle@sophia.inria.fr>
-
 #include "test_periodic_3_regular_triangulation_traits_3.h"
 
 int main (int, char**)

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_3.cpp
@@ -1,25 +1,3 @@
-// Copyright (c) 1998, 2015  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Francois Rebufat
-//                 Manuel Caroli
-//                 Aymeric Pelle
-
 #include <iostream>
 
 #include <CGAL/Timer.h>

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_tds.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_tds.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-//
-//
-// Author(s)     : Francois Rebufat
-//                 Manuel Caroli
-
 #include <CGAL/Timer.h>
 #include <CGAL/Triangulation_data_structure_3.h>
 #include <CGAL/Periodic_3_Delaunay_triangulation_traits_3.h>

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_C_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_C_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
-
 #define TEST_CARTESIAN 1
 #define KERNEL CGAL::Cartesian< FT >
 #define LAZY_KERNEL CGAL::Cartesian< LFT >

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_H_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_H_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
-
 #define KERNEL CGAL::Homogeneous< FT >
 #define LAZY_KERNEL CGAL::Homogeneous< LFT >
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_SC_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_SC_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
-
 #define TEST_CARTESIAN 1
 #define KERNEL CGAL::Simple_cartesian< FT >
 #define LAZY_KERNEL CGAL::Simple_cartesian< LFT >

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_SH_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_triangulation_traits_SH_3.cpp
@@ -1,24 +1,3 @@
-// Copyright (c) 1998  INRIA Sophia-Antipolis (France).
-// All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-//
-// Licensees holding a valid commercial license may use this file in
-// accordance with the commercial license agreement provided with the software.
-//
-// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
-// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-//
-// $URL$
-// $Id$
-// $Date$
-//
-//
-// Author(s)     : Manuel Caroli <Manuel.Caroli@sophia.inria.fr>
-
 #define KERNEL CGAL::Simple_homogeneous< FT >
 #define LAZY_KERNEL CGAL::Simple_homogeneous< LFT >
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_off_ostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_off_ostream_3.h
@@ -37,7 +37,6 @@ export_triangulation_3_to_off(std::ostream & os,
 {
   typedef Triangulation_3<GT,TDS>                       Tr;
   typedef typename Tr::Vertex_handle                    Vertex_handle;
-  typedef typename Tr::Vertex_iterator                  Vertex_iterator;
   typedef typename Tr::Finite_vertices_iterator         Finite_vertex_iterator;
   typedef typename Tr::All_cells_iterator               Cells_iterator;
   typedef typename Tr::Finite_cells_iterator            Finite_cells_iterator;
@@ -48,7 +47,7 @@ export_triangulation_3_to_off(std::ostream & os,
   
   // write the vertices
   std::map<Vertex_handle, int> index_of_vertex;
-  int i = 0;
+  std::size_t i = 0;
   for(Finite_vertex_iterator it = tr.finite_vertices_begin(); 
       it != tr.finite_vertices_end(); ++it, ++i)
   {


### PR DESCRIPTION
## Summary of Changes

The `Is_Gabriel` function (and some other minor details) were missing for P3RT3 to be usable in Alpha Shapes 3D. An example is added and the doc is modified.

Geomview's functions that output Alpha Shapes are fixed to work with periodic triangulations.

I have also added a test to `Periodic_3_triangulation_3` to check that a fake periodic triangulation built using `Regular_triangulation_3` gives the same thing as if it were built with `Periodic_3_regular_triangulation_3`.

## Release Management

* Affected package(s): `Alpha Shapes 3D`, `Periodic_3_triangulation_3`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

