### PR TITLE
Polyhedron_demo: Robustify Mean_curvature_flow_skeleton_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -241,6 +241,9 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   add_item(scene_edit_box_item Plugins/PCA/Scene_edit_box_item.cpp )
   add_item(scene_image_item Scene_image_item.cpp)
   add_item(scene_surface_mesh_item Scene_surface_mesh_item.cpp)
+  add_item(scene_mcf_poly_item Plugins/PMP/Scene_mcf_item.cpp)
+  add_item(scene_mcf_sm_item Plugins/PMP/Scene_mcf_item.cpp)
+  target_compile_definitions(scene_mcf_sm_item PUBLIC "-DUSE_SURFACE_MESH" )
 
   # special
   target_link_libraries(scene_polyhedron_transform_item scene_polyhedron_item)

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1791,8 +1791,6 @@ void MainWindow::recurseExpand(QModelIndex index)
     {
         recurseExpand(index.child(0,0));
     }
-
-    QString name = scene->item(scene->getIdFromModelIndex(index))->name();
         CGAL::Three::Scene_group_item* group =
                 qobject_cast<CGAL::Three::Scene_group_item*>(scene->item(scene->getIdFromModelIndex(index)));
         if(group && group->isExpanded())

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(mean_curvature_flow_skeleton_plugin
     scene_polyhedron_item 
     scene_points_with_normal_item
     scene_polylines_item
+    scene_mcf_poly_item
     demo_framework)
     
 
@@ -68,6 +69,7 @@ target_link_libraries(mean_curvature_flow_skeleton_sm_plugin
     scene_surface_mesh_item
     scene_points_with_normal_item
     scene_polylines_item
+    scene_mcf_sm_item
     demo_framework)
 target_compile_definitions(mean_curvature_flow_skeleton_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -618,7 +618,6 @@ if(!contracted_item)
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
-  on_actionSkeletonize();
   // update scene
   Scene_points_with_normal_item* fixedPointsItem = new Scene_points_with_normal_item;
   fixedPointsItem->setName(QString("fixed points of %1").arg(contracted_item->name()));

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -905,7 +905,10 @@ Polyhedron_demo_mean_curvature_flow_skeleton_plugin::getMCFItem()
                                                scene->mainSelectionIndex(),
                                                QString("%1 (mcf)").arg(item->name()));
       connect(item, &Scene_face_graph_item::aboutToBeDestroyed,
-              [mcf]{if(mcf) {mcf->InputMeshItemIndex = -1; mcf->input_triangle_mesh = NULL;}});
+              [mcf, this]{
+        if(scene->item_id(mcf) != -1){
+          scene->erase(scene->item_id(mcf));
+      }});
       scene->setSelectedItem(scene->addItem(mcf));
       item->setVisible(false);
       scene->itemChanged(item);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -339,6 +339,8 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionMCFSkeleton_t
 {
   dockWidget->show();
   dockWidget->raise();
+  double diag = scene->len_diagonal();
+  init_ui(diag);
   getMCFItem();
 }
 
@@ -919,9 +921,6 @@ Polyhedron_demo_mean_curvature_flow_skeleton_plugin::getMCFItem()
       Face_graph* pMesh = item->face_graph();
 
       if(!pMesh) return NULL;
-
-      double diag = scene->len_diagonal();
-      init_ui(diag);
       Scene_mcf_item* mcf = new Scene_mcf_item(item->face_graph(),
                                                scene->mainSelectionIndex(),
                                                QString("%1 (mcf)").arg(item->name()));

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -14,6 +14,7 @@
 #include <CGAL/Mesh_3/properties_Polyhedron_3.h>
 #endif
 
+#include "Scene_mcf_item.h"
 #include "Scene_points_with_normal_item.h"
 #include "Scene_polylines_item.h"
 #include "Scene.h"
@@ -95,70 +96,6 @@ struct Polyline_visitor
   
   void end_polyline(){}
 };
-
-#ifdef USE_SURFACE_MESH
-class Q_DECL_EXPORT Scene_mcf_item_sm
-#else
-class Q_DECL_EXPORT Scene_mcf_item_poly
-#endif
-    : public CGAL::Three::Scene_group_item
-{
-  Q_OBJECT
-public:
-#ifdef USE_SURFACE_MESH
-  Scene_mcf_item_sm(Face_graph* graph,
-                    Scene_interface::Item_id id,
-                    QString name)
-#else
-  Scene_mcf_item_poly(Face_graph* graph,
-                      Scene_interface::Item_id id,
-                      QString name)
-#endif
-  {
-    mcs = NULL;
-    meso_skeleton = NULL;
-    input_triangle_mesh = graph;
-    fixedPointsItemIndex = -1;
-    skeletonItemIndex = -1;
-    nonFixedPointsItemIndex = -1;
-    poleLinesItemIndex = -1;
-    contractedItemIndex = -1;
-    InputMeshItemIndex = id;
-    meso_skeleton = NULL;
-    this->setName(name);
-  }
-#ifdef USE_SURFACE_MESH
-  ~Scene_mcf_item_sm()
-#else
-  ~Scene_mcf_item_poly()
-#endif
-  {
-    if(mcs)
-      delete mcs;
-    if(meso_skeleton)
-      delete meso_skeleton;
-  }
-
-public:
-  Mean_curvature_skeleton* mcs;
-  Face_graph* meso_skeleton; // a copy of the meso_skeleton that is displayed
-  Face_graph* input_triangle_mesh;
-
-  int fixedPointsItemIndex;
-  int nonFixedPointsItemIndex;
-  int poleLinesItemIndex;
-  int skeletonItemIndex;
-  int contractedItemIndex;
-  int InputMeshItemIndex;
-
-  Skeleton skeleton_curve;
-}; // end class Scene_mcf_item
-
-#ifdef USE_SURFACE_MESH
-typedef Scene_mcf_item_sm Scene_mcf_item;
-#else
-typedef Scene_mcf_item_poly Scene_mcf_item;
-#endif
 
 using namespace CGAL::Three;
 class Polyhedron_demo_mean_curvature_flow_skeleton_plugin :

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -907,6 +907,8 @@ Polyhedron_demo_mean_curvature_flow_skeleton_plugin::getMCFItem()
       connect(item, &Scene_face_graph_item::aboutToBeDestroyed,
               [mcf]{if(mcf) {mcf->InputMeshItemIndex = -1; mcf->input_triangle_mesh = NULL;}});
       scene->setSelectedItem(scene->addItem(mcf));
+      item->setVisible(false);
+      scene->itemChanged(item);
       return mcf;
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -106,7 +106,9 @@ class Q_DECL_EXPORT Scene_mcf_item_poly
   Q_OBJECT
 public:
 #ifdef USE_SURFACE_MESH
-  Scene_mcf_item_sm(Face_graph* graph)
+  Scene_mcf_item_sm(Face_graph* graph,
+                    Scene_interface::Item_id id,
+                    QString name)
 #else
   Scene_mcf_item_poly(Face_graph* graph,
                       Scene_interface::Item_id id,
@@ -966,7 +968,7 @@ Polyhedron_demo_mean_curvature_flow_skeleton_plugin::getMCFItem()
       Scene_mcf_item* mcf = new Scene_mcf_item(item->face_graph(),
                                                scene->mainSelectionIndex(),
                                                QString("%1 (mcf)").arg(item->name()));
-      connect(item, &Scene_polyhedron_item::aboutToBeDestroyed,
+      connect(item, &Scene_face_graph_item::aboutToBeDestroyed,
               [mcf]{if(mcf) {mcf->InputMeshItemIndex = -1; mcf->input_triangle_mesh = NULL;}});
       scene->setSelectedItem(scene->addItem(mcf));
       return mcf;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -175,6 +175,9 @@ public:
   }
 
   void init_ui(double diag) {
+    on_checkbox_toggled(false);
+    connect(ui->is_medially_centered, SIGNAL(toggled(bool)),
+            this, SLOT(on_checkbox_toggled(bool)));
     ui->omega_H->setValue(0.1);
     ui->omega_H->setSingleStep(0.1);
     ui->omega_H->setDecimals(3);
@@ -309,6 +312,7 @@ public Q_SLOTS:
   void on_actionSkeletonize();
   void on_actionConverge();
   void on_actionUpdateBBox(bool);
+  void on_checkbox_toggled(bool);
   void on_actionSegment();
   void on_actionItemAboutToBeDestroyed(CGAL::Three::Scene_item*);
 
@@ -325,6 +329,12 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionMCFSkeleton_t
   dockWidget->show();
   dockWidget->raise();
   getMCFItem();
+}
+
+void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_checkbox_toggled(bool b)
+{
+  ui->omega_P->setEnabled(b);
+  ui->label_omega_P->setEnabled(b);
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionUpdateBBox(bool)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -543,6 +543,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionContract()
 
   update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
+  scene->setSelectedItem(scene->item_id(item));
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionCollapse()
@@ -568,6 +569,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionCollapse()
 
   update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
+  scene->setSelectedItem(scene->item_id(item));
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSplit()
@@ -593,6 +595,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSplit()
 
   update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
+  scene->setSelectedItem(scene->item_id(item));
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
@@ -931,6 +934,7 @@ Polyhedron_demo_mean_curvature_flow_skeleton_plugin::createContractedItem(Scene_
   item->contractedItemIndex = scene->addItem(contracted_item);
   scene->changeGroup(contracted_item, item);
   item->lockChild(contracted_item);
+  scene->setSelectedItem(scene->item_id(item));
 
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
 #include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
+#include <CGAL/Three/Scene_group_item.h>
 #include "ui_Mean_curvature_flow_skeleton_plugin.h"
 #include <CGAL/Mesh_3/properties.h>
 #ifdef USE_SURFACE_MESH
@@ -71,30 +72,91 @@ struct Polyline_visitor
 {
   typedef std::vector<Point> Polyline;
   typedef std::vector<std::size_t> Polyline_of_ids;
-
+  
   std::list<Polyline>& polylines;
   Skeleton& skeleton;
-
+  
   Polyline_visitor(std::list<Polyline>& lines, Skeleton& skeleton)
     : polylines(lines),
       skeleton(skeleton)
   {}
-
+  
   void start_new_polyline()
   {
     Polyline V;
     polylines.push_back(V);
   }
-
+  
   void add_node(boost::graph_traits<Skeleton>::vertex_descriptor vd)
   {
     Polyline& polyline = polylines.back();
     polyline.push_back(skeleton[vd].point);
   }
-
+  
   void end_polyline(){}
 };
 
+#ifdef USE_SURFACE_MESH
+class Q_DECL_EXPORT Scene_mcf_item_sm
+#else
+class Q_DECL_EXPORT Scene_mcf_item_poly
+#endif
+    : public CGAL::Three::Scene_group_item
+{
+  Q_OBJECT
+public:
+#ifdef USE_SURFACE_MESH
+  Scene_mcf_item_sm(Face_graph* graph)
+#else
+  Scene_mcf_item_poly(Face_graph* graph,
+                      Scene_interface::Item_id id,
+                      QString name)
+#endif
+  {
+    mcs = NULL;
+    meso_skeleton = NULL;
+    input_triangle_mesh = graph;
+    fixedPointsItemIndex = -1;
+    skeletonItemIndex = -1;
+    nonFixedPointsItemIndex = -1;
+    poleLinesItemIndex = -1;
+    contractedItemIndex = -1;
+    InputMeshItemIndex = id;
+    meso_skeleton = NULL;
+    this->setName(name);
+  }
+#ifdef USE_SURFACE_MESH
+  ~Scene_mcf_item_sm()
+#else
+  ~Scene_mcf_item_poly()
+#endif
+  {
+    if(mcs)
+      delete mcs;
+    if(meso_skeleton)
+      delete meso_skeleton;
+  }
+
+public:
+  Mean_curvature_skeleton* mcs;
+  Face_graph* meso_skeleton; // a copy of the meso_skeleton that is displayed
+  Face_graph* input_triangle_mesh;
+
+  int fixedPointsItemIndex;
+  int nonFixedPointsItemIndex;
+  int poleLinesItemIndex;
+  int skeletonItemIndex;
+  int contractedItemIndex;
+  int InputMeshItemIndex;
+
+  Skeleton skeleton_curve;
+}; // end class Scene_mcf_item
+
+#ifdef USE_SURFACE_MESH
+typedef Scene_mcf_item_sm Scene_mcf_item;
+#else
+typedef Scene_mcf_item_poly Scene_mcf_item;
+#endif
 
 using namespace CGAL::Three;
 class Polyhedron_demo_mean_curvature_flow_skeleton_plugin :
@@ -113,7 +175,7 @@ public:
 
     this->mw = mainWindow;
     this->scene = scene_interface;
-    mcs = NULL;
+
     dockWidget = NULL;
     ui = NULL;
 
@@ -248,98 +310,38 @@ public:
   // check if the Mean_curvature_skeleton exists
   // or has the same polyheron item
   // check if the mesh is a watertight triangle mesh
-  bool check_mesh(Scene_face_graph_item* item) {
-    double omega_H = ui->omega_H->value();
-    double omega_P = ui->omega_P->value();
-    double min_edge_length = ui->min_edge_length->value();
-    double delta_area = ui->delta_area->value();
-    bool is_medially_centered = ui->is_medially_centered->isChecked();
+  bool check_mesh(Scene_mcf_item* item) {
+    Face_graph *pMesh = item->input_triangle_mesh;
 
-    Face_graph *pMesh = item->polyhedron();
-
-    if (mcs == NULL)
+    if (item->mcs == NULL)
     {
       if (!is_mesh_valid(pMesh))
       {
         return false;
       }
+      createContractedItem(item);
 
-      mcs = new Mean_curvature_skeleton(*pMesh);
-      meso_skeleton = new Face_graph(*pMesh);
-      input_triangle_mesh = pMesh;
-      //set algorithm parameters
-      mcs->set_quality_speed_tradeoff(omega_H);
-      mcs->set_medially_centered_speed_tradeoff(omega_P);
-      mcs->set_min_edge_length(min_edge_length);
-      mcs->set_is_medially_centered(is_medially_centered);
-      mcs->set_area_variation_factor(delta_area);
-
-      Scene_face_graph_item* contracted_item = new Scene_face_graph_item( meso_skeleton );
-      contracted_item->setName(QString("contracted mesh of %1").arg(item->name()));
-      contracted_item->setItemIsMulticolor(false); //avoids segfault if item was a multicolor surface_mesh
-      InputMeshItemIndex = scene->mainSelectionIndex();
-
-      contractedItemIndex = scene->addItem(contracted_item);
-
-      item->setVisible(false);
-
-      fixedPointsItemIndex = -1;
-      nonFixedPointsItemIndex = -1;
-      poleLinesItemIndex = -1;
+      item->fixedPointsItemIndex = -1;
+      item->nonFixedPointsItemIndex = -1;
+      item->poleLinesItemIndex = -1;
     }
     else
     {
-      if (input_triangle_mesh != pMesh)
-      {
-        if (!is_mesh_valid(pMesh))
-        {
-          return false;
-        }
-
-        delete mcs;
-
-        mcs = new Mean_curvature_skeleton(*pMesh);
-        meso_skeleton = new Face_graph(*pMesh);
-        input_triangle_mesh = pMesh;
-        //set algorithm parameters
-        mcs->set_quality_speed_tradeoff(omega_H);
-        mcs->set_medially_centered_speed_tradeoff(omega_P);
-        mcs->set_min_edge_length(min_edge_length);
-        mcs->set_is_medially_centered(is_medially_centered);
-        mcs->set_area_variation_factor(delta_area);
-
-        Scene_face_graph_item* contracted_item = new Scene_face_graph_item(meso_skeleton);
-        contracted_item->setName(QString("contracted mesh of %1").arg(item->name()));
-        contracted_item->setItemIsMulticolor(false); //avoids segfault if item was a multicolor surface_mesh
-
-        InputMeshItemIndex = scene->mainSelectionIndex();
-
-        contractedItemIndex = scene->addItem(contracted_item);
-
-        item->setVisible(false);
-
-        fixedPointsItemIndex = -1;
-        nonFixedPointsItemIndex = -1;
-        poleLinesItemIndex = -1;
-      }
-      else
-      {
-        mcs->set_quality_speed_tradeoff(omega_H);
-        mcs->set_medially_centered_speed_tradeoff(omega_P);
-        mcs->set_min_edge_length(min_edge_length);
-        mcs->set_area_variation_factor(delta_area);
-        mcs->set_is_medially_centered(is_medially_centered);
-      }
+      item->mcs->set_quality_speed_tradeoff(ui->omega_H->value());
+      item->mcs->set_medially_centered_speed_tradeoff(ui->omega_P->value());
+      item->mcs->set_min_edge_length(ui->min_edge_length->value());
+      item->mcs->set_area_variation_factor(ui->delta_area->value());
+      item->mcs->set_is_medially_centered(ui->is_medially_centered->isChecked());
     }
     return true;
   }
 
-  void update_meso_skeleton()
+  void update_meso_skeleton(Scene_mcf_item* item)
   {
-    clear(*meso_skeleton);
-    copy_face_graph(mcs->meso_skeleton(), *meso_skeleton);
-    scene->item(contractedItemIndex)->invalidateOpenGLBuffers();
-    scene->itemChanged(contractedItemIndex);
+    clear(*item->meso_skeleton);
+    copy_face_graph(item->mcs->meso_skeleton(), *item->meso_skeleton);
+    scene->item(item->contractedItemIndex)->invalidateOpenGLBuffers();
+    scene->itemChanged(item->contractedItemIndex);
   }
 
   void update_parameters(Mean_curvature_skeleton* mcs)
@@ -372,46 +374,18 @@ public Q_SLOTS:
   void on_actionItemAboutToBeDestroyed(CGAL::Three::Scene_item*);
 
 private:
-  Mean_curvature_skeleton* mcs;
-  Face_graph* meso_skeleton; // a copy of the meso_skeleton that is displayed
-  Face_graph* input_triangle_mesh;
+  Scene_mcf_item *getMCFItem();
+  void createContractedItem(Scene_mcf_item* item);
   QDockWidget* dockWidget;
   Ui::Mean_curvature_flow_skeleton_plugin* ui;
 
-  int fixedPointsItemIndex;
-  int nonFixedPointsItemIndex;
-  int poleLinesItemIndex;
-  int contractedItemIndex;
-  int InputMeshItemIndex;
-
-  Skeleton skeleton_curve;
 }; // end Polyhedron_demo_mean_curvature_flow_skeleton_plugin
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionMCFSkeleton_triggered()
 {
   dockWidget->show();
   dockWidget->raise();
-
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
-
-  if(item)
-  {
-    Face_graph* pMesh = item->polyhedron();
-
-    if(!pMesh) return;
-
-    double diag = scene->len_diagonal();
-    init_ui(diag);
-
-    fixedPointsItemIndex = -1;
-    nonFixedPointsItemIndex = -1;
-    poleLinesItemIndex = -1;
-    contractedItemIndex = -1;
-    InputMeshItemIndex = -1;
-  }
+  getMCFItem();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionUpdateBBox(bool)
@@ -422,35 +396,37 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionUpdateBBox(bo
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
 {
-  if (num_vertices(skeleton_curve)==0 ) on_actionSkeletonize();
-  if (num_vertices(skeleton_curve)==0 ) return;
+  Scene_mcf_item* item = getMCFItem();
+
+  if(!item)
+  {
+    return;
+  }
+
+  if (num_vertices(item->skeleton_curve)==0 ) on_actionSkeletonize();
+  if (num_vertices(item->skeleton_curve)==0 ) { QApplication::restoreOverrideCursor(); return;}
+  QApplication::setOverrideCursor(Qt::WaitCursor);
 
   QTime time;
   time.start();
-  QApplication::setOverrideCursor(Qt::WaitCursor);
- 
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
 
     // init the polyhedron simplex indices
-  CGAL::set_halfedgeds_items_id(*input_triangle_mesh);
+  CGAL::set_halfedgeds_items_id(*item->input_triangle_mesh);
   boost::property_map<Face_graph, boost::vertex_index_t>::type 
-    vimap = get(boost::vertex_index, *input_triangle_mesh);
+    vimap = get(boost::vertex_index, *item->input_triangle_mesh);
 
   //for each input vertex compute its distance to the skeleton
-  std::vector<double> distances(num_vertices(*input_triangle_mesh));
+  std::vector<double> distances(num_vertices(*item->input_triangle_mesh));
   
-  Face_graph *smesh = item->polyhedron();
+  Face_graph *smesh = item->input_triangle_mesh;
 
   boost::property_map<Face_graph,CGAL::vertex_point_t>::type vpm
     = get(CGAL::vertex_point,*smesh);
 
-  BOOST_FOREACH(boost::graph_traits<Skeleton>::vertex_descriptor v, vertices(skeleton_curve) )
+  BOOST_FOREACH(boost::graph_traits<Skeleton>::vertex_descriptor v, vertices(item->skeleton_curve) )
   {
-    const Point& skel_pt = skeleton_curve[v].point;
-    BOOST_FOREACH(vertex_descriptor mesh_v, skeleton_curve[v].vertices)
+    const Point& skel_pt = item->skeleton_curve[v].point;
+    BOOST_FOREACH(vertex_descriptor mesh_v, item->skeleton_curve[v].vertices)
     {
       const Point& mesh_pt = get(vpm,mesh_v);
       distances[get(vimap,mesh_v)] = std::sqrt(CGAL::squared_distance(skel_pt, mesh_pt));
@@ -458,30 +434,30 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
   }
 
   // create a property-map for sdf values
-  std::vector<double> sdf_values( num_faces(*input_triangle_mesh) );
-  Facet_with_id_pmap<Face_graph,double> sdf_property_map(*input_triangle_mesh, sdf_values);
+  std::vector<double> sdf_values( num_faces(*item->input_triangle_mesh) );
+  Facet_with_id_pmap<Face_graph,double> sdf_property_map(*item->input_triangle_mesh, sdf_values);
 
   // compute sdf values with skeleton
-  BOOST_FOREACH(boost::graph_traits<Face_graph>::face_descriptor f, faces(*input_triangle_mesh))
+  BOOST_FOREACH(boost::graph_traits<Face_graph>::face_descriptor f, faces(*item->input_triangle_mesh))
   {
     double dist = 0;
-    BOOST_FOREACH(boost::graph_traits<Face_graph>::halfedge_descriptor hd, halfedges_around_face(halfedge(f, *input_triangle_mesh), *input_triangle_mesh))
-      dist+=distances[get(vimap,target(hd, *input_triangle_mesh))];
+    BOOST_FOREACH(boost::graph_traits<Face_graph>::halfedge_descriptor hd, halfedges_around_face(halfedge(f, *item->input_triangle_mesh), *item->input_triangle_mesh))
+      dist+=distances[get(vimap,target(hd, *item->input_triangle_mesh))];
     sdf_property_map[f] = dist / 3.;
   }
 
   // post-process the sdf values
-  CGAL::sdf_values_postprocessing(*input_triangle_mesh, sdf_property_map);
+  CGAL::sdf_values_postprocessing(*item->input_triangle_mesh, sdf_property_map);
 
   // create a property-map for segment-ids (it is an adaptor for this case)
-  std::vector<std::size_t> segment_ids( num_faces(*input_triangle_mesh) );
-  Facet_with_id_pmap<Face_graph,std::size_t> segment_property_map(*input_triangle_mesh, segment_ids);
+  std::vector<std::size_t> segment_ids( num_faces(*item->input_triangle_mesh) );
+  Facet_with_id_pmap<Face_graph,std::size_t> segment_property_map(*item->input_triangle_mesh, segment_ids);
 
   // segment the mesh using default parameters
   std::cout << "Number of segments: "
-            << CGAL::segmentation_from_sdf_values(*input_triangle_mesh, sdf_property_map, segment_property_map) <<"\n";
+            << CGAL::segmentation_from_sdf_values(*item->input_triangle_mesh, sdf_property_map, segment_property_map) <<"\n";
 
-  Face_graph* segmented_polyhedron = new Face_graph(*input_triangle_mesh);
+  Face_graph* segmented_polyhedron = new Face_graph(*item->input_triangle_mesh);
 
   Scene_face_graph_item* item_segmentation = new Scene_face_graph_item(segmented_polyhedron);
   int i=0;
@@ -491,11 +467,15 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
   {
     put(fpim, fd, static_cast<int>(segment_ids[i++] ));
   }
-  scene->item(InputMeshItemIndex)->setVisible(false);
   item_segmentation->setItemIsMulticolor(true);
   item_segmentation->invalidateOpenGLBuffers();
   scene->addItem(item_segmentation);
   item_segmentation->setName(QString("segmentation"));
+  scene->changeGroup(item_segmentation, item);
+  Scene_item* parent = scene->item(item->InputMeshItemIndex);
+  if(parent)
+    parent->setVisible(false);
+  scene->setSelectedItem(scene->item_id(item));
 
   QApplication::restoreOverrideCursor();
 }
@@ -544,14 +524,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionContract()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item = getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -563,25 +536,19 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionContract()
   std::cout << "Contract...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  update_parameters(mcs);
-  mcs->contract_geometry();
+  update_parameters(item->mcs);
+  item->mcs->contract_geometry();
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
-  update_meso_skeleton();
+  update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionCollapse()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item =
+    getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -593,26 +560,20 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionCollapse()
   std::cout << "Collapse...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  update_parameters(mcs);
-  std::size_t num_collapses = mcs->collapse_edges();
+  update_parameters(item->mcs);
+  std::size_t num_collapses = item->mcs->collapse_edges();
   std::cout << "collapsed " << num_collapses << " edges.\n";
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
-  update_meso_skeleton();
+  update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSplit()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item =
+    getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -624,26 +585,19 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSplit()
   std::cout << "Split...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  update_parameters(mcs);
-  std::size_t num_split = mcs->split_faces();
+  update_parameters(item->mcs);
+  std::size_t num_split = item->mcs->split_faces();
   std::cout << "split " << num_split << " triangles.\n";
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
-  update_meso_skeleton();
+  update_meso_skeleton(item);
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item = getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -655,16 +609,15 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   std::cout << "Detect degeneracy...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  update_parameters(mcs);
-  mcs->detect_degeneracies();
+  update_parameters(item->mcs);
+  item->mcs->detect_degeneracies();
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
   Scene_points_with_normal_item* fixedPointsItem = new Scene_points_with_normal_item;
   fixedPointsItem->setName(QString("fixed points of %1").arg(item->name()));
-
   std::vector<Point> fixedPoints;
-  mcs->fixed_points(fixedPoints);
+  item->mcs->fixed_points(fixedPoints);
 
   Point_set *ps = fixedPointsItem->point_set();
   for (size_t i = 0; i < fixedPoints.size(); ++i)
@@ -674,33 +627,28 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
   }
   ps->select_all ();
 
-  if (fixedPointsItemIndex == -1)
+  if (item->fixedPointsItemIndex == -1)
   {
-    fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    item->fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    scene->changeGroup(fixedPointsItem, item);
+    item->lockChild(fixedPointsItem);
   }
   else
   {
-    Scene_item* temp = scene->replaceItem(fixedPointsItemIndex, fixedPointsItem, false);
+    Scene_item* temp = scene->replaceItem(item->fixedPointsItemIndex, fixedPointsItem, false);
     delete temp;
   }
   // update scene
-  update_meso_skeleton();
-  scene->item(fixedPointsItemIndex)->invalidateOpenGLBuffers();
-  scene->itemChanged(fixedPointsItemIndex);
-  scene->setSelectedItem(index);
+  update_meso_skeleton(item);
+  scene->item(item->fixedPointsItemIndex)->invalidateOpenGLBuffers();
+  scene->itemChanged(item->fixedPointsItemIndex);
+  scene->setSelectedItem(scene->item_id(item));
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item = getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -712,22 +660,28 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
   std::cout << "Run one iteration...\n";
+  Scene_face_graph_item* contracted_item = NULL;
+if(item->contractedItemIndex != -1)
+    contracted_item = qobject_cast<Scene_face_graph_item*>(scene->item(item->contractedItemIndex));
+scene->setSelectedItem(scene->item_id(item));
+//todo : create a new contracted item
+if(!contracted_item)
+{
+  createContractedItem(item);
+  contracted_item = qobject_cast<Scene_face_graph_item*>(scene->item(item->contractedItemIndex));
+}
 
-  update_parameters(mcs);
-  mcs->contract();
+  update_parameters(item->mcs);
+  item->mcs->contract();
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
-  CGAL::Three::Scene_interface::Item_id contracted_item_index = scene->mainSelectionIndex();
-  Scene_face_graph_item* contracted_item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(contracted_item_index));
-
+  on_actionSkeletonize();
   // update scene
   Scene_points_with_normal_item* fixedPointsItem = new Scene_points_with_normal_item;
   fixedPointsItem->setName(QString("fixed points of %1").arg(contracted_item->name()));
-
   std::vector<Point> fixedPoints;
-  mcs->fixed_points(fixedPoints);
+  item->mcs->fixed_points(fixedPoints);
 
   Point_set *ps = fixedPointsItem->point_set();
   for (size_t i = 0; i < fixedPoints.size(); ++i)
@@ -737,13 +691,15 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
   }
   ps->select_all();
   
-  if (fixedPointsItemIndex == -1)
+  if (item->fixedPointsItemIndex == -1)
   {
-    fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    item->fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    scene->changeGroup(fixedPointsItem, item);
+    item->lockChild(fixedPointsItem);
   }
   else
   {
-    Scene_item* temp = scene->replaceItem(fixedPointsItemIndex, fixedPointsItem, false);
+    Scene_item* temp = scene->replaceItem(item->fixedPointsItemIndex, fixedPointsItem, false);
     delete temp;
   }
 
@@ -764,6 +720,8 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
   if (nonFixedPointsItemIndex == -1)
   {
     nonFixedPointsItemIndex = scene->addItem(nonFixedPointsItem);
+    scene->changeGroup(nonFixedPointsItem, item);
+    item->lockChild(nonFixedPointsItem);
   }
   else
   {
@@ -776,10 +734,9 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
 #ifdef DRAW_POLE_LINE
   // draw lines connecting surface points and their correspondent poles
   Scene_polylines_item* poleLinesItem = new Scene_polylines_item();
-
-  Face_graph* pMesh = item->polyhedron();
+  Face_graph* pMesh = item->input_triangle_mesh;
   std::vector<Point> pole_points;
-  mcs->poles(pole_points);
+  item->mcs->poles(pole_points);
   vertex_iterator vb, ve;
   int id = 0;
   for (boost::tie(vb, ve) = vertices(*pMesh); vb != ve; ++vb)
@@ -796,9 +753,11 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
     poleLinesItem->polylines.push_back(line);
   }
 
-  if (poleLinesItemIndex == -1)
+  if (item->poleLinesItemIndex == -1)
   {
-    poleLinesItemIndex = scene->addItem(poleLinesItem);
+    item->poleLinesItemIndex = scene->addItem(poleLinesItem);
+    scene->changeGroup(poleLinesItem, item);
+    item->lockChild(poleLinesItem);
   }
   else
   {
@@ -806,21 +765,14 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
   }
 #endif
 
-  update_meso_skeleton();
-  scene->setSelectedItem(index);
+  update_meso_skeleton(item);
+  scene->setSelectedItem(scene->item_id(item));
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item = getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -831,9 +783,9 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
   time.start();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  update_parameters(mcs);
+  update_parameters(item->mcs);
 
-  mcs->convert_to_skeleton(skeleton_curve);
+  item->mcs->convert_to_skeleton(item->skeleton_curve);
 
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
@@ -842,46 +794,46 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
   Scene_polylines_item* skeleton = new Scene_polylines_item();
   skeleton->setColor(QColor(175, 0, 255));
 
-  Polyline_visitor polyline_visitor(skeleton->polylines, skeleton_curve);
-  CGAL::split_graph_into_polylines( skeleton_curve,
+  Polyline_visitor polyline_visitor(skeleton->polylines, item->skeleton_curve);
+  CGAL::split_graph_into_polylines( item->skeleton_curve,
                                     polyline_visitor,
                                     CGAL::internal::IsTerminalDefault() );
 
   skeleton->setName(QString("skeleton curve of %1").arg(item->name()));
-  scene->addItem(skeleton);
   skeleton->invalidateOpenGLBuffers();
+  if(item->skeletonItemIndex == -1)
+  {
+    item->skeletonItemIndex = scene->addItem(skeleton);
+    scene->changeGroup(skeleton, item);
+    item->lockChild(skeleton);
+  }
+  else
+  {
+    scene->replaceItem(item->skeletonItemIndex, skeleton, false);
+  }
 
   // set the fixed points and contracted mesh as invisible
-  if (fixedPointsItemIndex >= 0)
+  if (item->fixedPointsItemIndex >= 0)
   {
-    scene->item(fixedPointsItemIndex)->setVisible(false);
-    scene->itemChanged(fixedPointsItemIndex);
+    scene->item(item->fixedPointsItemIndex)->setVisible(false);
+    scene->itemChanged(item->fixedPointsItemIndex);
   }
-  scene->item(contractedItemIndex)->setVisible(false);
-  scene->itemChanged(contractedItemIndex);
-  // display the original mesh in transparent mode
-  item->setVisible(false);
-  if (InputMeshItemIndex >= 0)
+  scene->item(item->contractedItemIndex)->setVisible(false);
+  scene->itemChanged(item->contractedItemIndex);
+  if (item->InputMeshItemIndex >= 0)
   {
-    scene->item(InputMeshItemIndex)->setVisible(true);
-    scene->item(InputMeshItemIndex)->setPointsMode();
-    scene->itemChanged(InputMeshItemIndex);
+    scene->item(item->InputMeshItemIndex)->setVisible(true);
+    scene->item(item->InputMeshItemIndex)->setPointsMode();
+    scene->itemChanged(item->InputMeshItemIndex);
   }
-
+  scene->setSelectedItem(scene->item_id(item));
   // update scene
   QApplication::restoreOverrideCursor();
 }
 
 void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
 {
-  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-  if (!check_item_index(index))
-  {
-    return;
-  }
-
-  Scene_face_graph_item* item =
-    qobject_cast<Scene_face_graph_item*>(scene->item(index));
+  Scene_mcf_item* item = getMCFItem();
 
   if (!item || !check_mesh(item))
   {
@@ -892,7 +844,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
   time.start();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  mcs->contract_until_convergence();
+  item->mcs->contract_until_convergence();
 
   std::cout << "ok (" << time.elapsed() << " ms, " << ")" << std::endl;
 
@@ -901,7 +853,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
   fixedPointsItem->setName(QString("fixed points of %1").arg(item->name()));
 
   std::vector<Point> fixedPoints;
-  mcs->fixed_points(fixedPoints);
+  item->mcs->fixed_points(fixedPoints);
 
   Point_set *ps = fixedPointsItem->point_set();
   for (size_t i = 0; i < fixedPoints.size(); ++i)
@@ -911,31 +863,112 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
   }
   ps->select_all();
   
-  if (fixedPointsItemIndex == -1)
+  if (item->fixedPointsItemIndex == -1)
   {
-    fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    item->fixedPointsItemIndex = scene->addItem(fixedPointsItem);
+    scene->changeGroup(fixedPointsItem, item);
+    item->lockChild(fixedPointsItem);
   }
   else
   {
-    Scene_item* temp = scene->replaceItem(fixedPointsItemIndex, fixedPointsItem, false);
+    Scene_item* temp = scene->replaceItem(item->fixedPointsItemIndex, fixedPointsItem, false);
     delete temp;
   }
 
-  scene->item(fixedPointsItemIndex)->invalidateOpenGLBuffers();
-  scene->itemChanged(fixedPointsItemIndex);
-  update_meso_skeleton();
-  scene->setSelectedItem(index);
+  scene->item(item->fixedPointsItemIndex)->invalidateOpenGLBuffers();
+  scene->itemChanged(item->fixedPointsItemIndex);
+  update_meso_skeleton(item);
+  scene->setSelectedItem(scene->item_id(item));
 
   QApplication::restoreOverrideCursor();
 }
 
-void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionItemAboutToBeDestroyed(CGAL::Three::Scene_item* /* item */)
+void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionItemAboutToBeDestroyed(CGAL::Three::Scene_item* corpse )
 {
-  if (mcs != NULL)
+  Scene_mcf_item *mcf= qobject_cast<Scene_mcf_item*>(corpse);
+
+  if(mcf)
   {
-    delete mcs;
-    mcs = NULL;
+    mcf->mcs = NULL;
+    mcf->meso_skeleton = NULL;
+    mcf->input_triangle_mesh = NULL;
+    mcf->fixedPointsItemIndex = -1;
+    mcf->nonFixedPointsItemIndex = -1;
+    mcf->poleLinesItemIndex = -1;
+    mcf->contractedItemIndex = -1;
+    mcf->InputMeshItemIndex = -1;
+    mcf->meso_skeleton = NULL;
+    mcf->input_triangle_mesh = NULL;
   }
+}
+
+void
+Polyhedron_demo_mean_curvature_flow_skeleton_plugin::createContractedItem(Scene_mcf_item* item)
+{
+  if(!item)
+    return;
+  if(item->mcs == NULL)
+    delete item->mcs;
+  double omega_H = ui->omega_H->value();
+  double omega_P = ui->omega_P->value();
+  double min_edge_length = ui->min_edge_length->value();
+  double delta_area = ui->delta_area->value();
+  bool is_medially_centered = ui->is_medially_centered->isChecked();
+
+  item->mcs = new Mean_curvature_skeleton(*item->input_triangle_mesh);
+  item->meso_skeleton = new Face_graph(*item->input_triangle_mesh);
+  //set algorithm parameters
+  item->mcs->set_quality_speed_tradeoff(omega_H);
+  item->mcs->set_medially_centered_speed_tradeoff(omega_P);
+  item->mcs->set_min_edge_length(min_edge_length);
+  item->mcs->set_is_medially_centered(is_medially_centered);
+  item->mcs->set_area_variation_factor(delta_area);
+
+  Scene_face_graph_item* contracted_item = new Scene_face_graph_item(item->meso_skeleton);
+  contracted_item->setName(QString("contracted mesh of %1").arg(item->name()));
+  contracted_item->setItemIsMulticolor(false); //avoids segfault if item was a multicolor surface_mesh
+
+  item->contractedItemIndex = scene->addItem(contracted_item);
+  scene->changeGroup(contracted_item, item);
+  item->lockChild(contracted_item);
+
+}
+
+Scene_mcf_item*
+Polyhedron_demo_mean_curvature_flow_skeleton_plugin::getMCFItem()
+{
+  Q_FOREACH(int index, scene->selectionIndices())
+  {
+    Scene_mcf_item* mcf = qobject_cast<Scene_mcf_item*>(scene->item(index));
+    if(mcf)
+      return mcf;
+  }
+
+  //if the selected item is not an MCF but is a face_graph_item,
+  //then create and add a new MCF
+  if(scene->mainSelectionIndex() != -1)
+  {
+    Scene_face_graph_item* item =
+        qobject_cast<Scene_face_graph_item*>(scene->item(
+                                               scene->mainSelectionIndex()));
+    if(item)
+    {
+      Face_graph* pMesh = item->face_graph();
+
+      if(!pMesh) return NULL;
+
+      double diag = scene->len_diagonal();
+      init_ui(diag);
+      Scene_mcf_item* mcf = new Scene_mcf_item(item->face_graph(),
+                                               scene->mainSelectionIndex(),
+                                               QString("%1 (mcf)").arg(item->name()));
+      connect(item, &Scene_polyhedron_item::aboutToBeDestroyed,
+              [mcf]{if(mcf) {mcf->InputMeshItemIndex = -1; mcf->input_triangle_mesh = NULL;}});
+      scene->setSelectedItem(scene->addItem(mcf));
+      return mcf;
+    }
+  }
+  return NULL;
 }
 
 #include "Mean_curvature_flow_skeleton_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -178,6 +178,17 @@ public:
     on_checkbox_toggled(false);
     connect(ui->is_medially_centered, SIGNAL(toggled(bool)),
             this, SLOT(on_checkbox_toggled(bool)));
+    connect(ui->helpButton, &QPushButton::clicked,
+            [this]{QMessageBox::about(mw, QString("Help"),
+                                    QString("This widget gives access to the low level steps of the mean curvature flow sketonization algorithm. "
+                                            "The algorithm is iterative. Each iteration consist in calls to Contract, Collapse, Split, "
+                                            "and Degeneracy (repectively mesh contraction, edge collapse, edge split, and degenerate edge"
+                                            "removal). The skeleton extraction can be called at any time but for a better result it should be"
+                                            "called when the iterations are converging. A segmentation of the surface can be extracted using"
+                                            "the distance of the mesh to the skeleton computed.\n"
+                                             "All operations can be applied to a polyhedron item or "
+                                            "to a surface mesh item. The generated mcf group must be selected in "
+                                            "order to continue an on-going set of operations. "));});
     ui->omega_H->setValue(0.1);
     ui->omega_H->setSingleStep(0.1);
     ui->omega_H->setDecimals(3);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
@@ -6,20 +6,64 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>490</width>
-    <height>262</height>
+    <width>483</width>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>DockWidget</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout_3">
+   <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1,0,0,0">
     <item>
      <widget class="QCheckBox" name="is_medially_centered">
       <property name="text">
        <string>Is medially centered</string>
       </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>Help</string>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+      <property name="checkable">
+       <bool>false</bool>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>425</width>
+            <height>127</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;- Select an item called &lt;span style=&quot; font-style:italic;&quot;&gt;name&lt;/span&gt;(mcf) to apply a step to it, or select a face_graph item to create a new mcf from it. &lt;/p&gt;&lt;p&gt;- Run iterations until you are satisfied of the result.&lt;/p&gt;&lt;p&gt;- You can create a skeleton without running any iteration, but it will probably not be acceptable. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>
@@ -162,19 +206,6 @@
        </widget>
       </item>
      </layout>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
@@ -14,7 +14,7 @@
    <string>DockWidget</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1,0,0,0">
+   <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0">
     <item>
      <widget class="QCheckBox" name="is_medially_centered">
       <property name="text">
@@ -23,48 +23,28 @@
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="title">
-       <string>Help</string>
-      </property>
-      <property name="flat">
-       <bool>false</bool>
-      </property>
-      <property name="checkable">
-       <bool>false</bool>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <widget class="QScrollArea" name="scrollArea">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>425</width>
-            <height>127</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This widget gives access to the low level steps of the mean curvature flow sketonization algorithm. The algorithm is iterative. Each iteration consist in calls to &lt;span style=&quot; font-style:italic;&quot;&gt;Contract&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Collapse&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Split&lt;/span&gt;, and &lt;span style=&quot; font-style:italic;&quot;&gt;Degeneracy&lt;/span&gt; (repectively mesh contraction, edge collapse, edge split, and degenerate edge removal). The skeleton extraction can be called at any time but for a better result it should be called when the iterations are converging. A segmentation of the surface can be extracted using the distance of the mesh to the skeleton computed.&lt;/p&gt;&lt;p&gt;All operations can be applied to a polyhedron item or to a surface mesh item. The generated mcf group must be selected in order to continue an on-going set of operations. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+     <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="helpButton">
+        <property name="text">
+         <string>Help</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_6">

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
@@ -52,7 +52,7 @@
            <item>
             <widget class="QLabel" name="label_2">
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;- Select an item called &lt;span style=&quot; font-style:italic;&quot;&gt;name&lt;/span&gt;(mcf) to apply a step to it, or select a face_graph item to create a new mcf from it. &lt;/p&gt;&lt;p&gt;- Run iterations until you are satisfied of the result.&lt;/p&gt;&lt;p&gt;- You can create a skeleton without running any iteration, but it will probably not be acceptable. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This widget gives access to the low level steps of the mean curvature flow sketonization algorithm. The algorithm is iterative. Each iteration consist in calls to &lt;span style=&quot; font-style:italic;&quot;&gt;Contract&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Collapse&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Split&lt;/span&gt;, and &lt;span style=&quot; font-style:italic;&quot;&gt;Degeneracy&lt;/span&gt; (repectively mesh contraction, edge collapse, edge split, and degenerate edge removal). The skeleton extraction can be called at any time but for a better result it should be called when the iterations are converging. A segmentation of the surface can be extracted using the distance of the mesh to the skeleton computed.&lt;/p&gt;&lt;p&gt;All operations can be applied to a polyhedron item or to a surface mesh item. The generated mcf group must be selected in order to continue an on-going set of operations. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.cpp
@@ -1,0 +1,26 @@
+#include "Scene_mcf_item.h"
+
+Scene_mcf_item::Scene_mcf_item(Face_graph* graph,
+                  Scene_interface::Item_id id,
+                  QString name)
+{
+  mcs = NULL;
+  meso_skeleton = NULL;
+  input_triangle_mesh = graph;
+  fixedPointsItemIndex = -1;
+  skeletonItemIndex = -1;
+  nonFixedPointsItemIndex = -1;
+  poleLinesItemIndex = -1;
+  contractedItemIndex = -1;
+  InputMeshItemIndex = id;
+  meso_skeleton = NULL;
+  this->setName(name);
+}
+
+Scene_mcf_item::~Scene_mcf_item()
+{
+  if(mcs)
+    delete mcs;
+  if(meso_skeleton)
+    delete meso_skeleton;
+}

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.h
@@ -1,0 +1,50 @@
+#ifndef SCENE_MCF_ITEM_H
+#define SCENE_MCF_ITEM_H
+
+#ifdef scene_mcf_item_EXPORTS
+#  define SCENE_MCF_ITEM_EXPORT Q_DECL_EXPORT
+#else
+#  define SCENE_MCF_ITEM_EXPORT Q_DECL_IMPORT
+#endif
+
+#include <CGAL/Three/Scene_group_item.h>
+#include <CGAL/extract_mean_curvature_flow_skeleton.h>
+#ifdef USE_SURFACE_MESH
+#include "SMesh_type.h"
+typedef SMesh Face_graph;
+#else
+#include "Polyhedron_type.h"
+typedef Polyhedron Face_graph;
+#endif
+
+typedef CGAL::Mean_curvature_flow_skeletonization<Face_graph>      Mean_curvature_skeleton;
+typedef Mean_curvature_skeleton::Skeleton Skeleton;
+
+struct Scene_mcf_item_priv;
+// This class represents a polyhedron in the OpenGL scene
+class SCENE_MCF_ITEM_EXPORT Scene_mcf_item
+        : public CGAL::Three::Scene_group_item {
+    Q_OBJECT
+public:
+
+  Scene_mcf_item(Face_graph* graph,
+                    Scene_interface::Item_id id,
+                    QString name);
+
+  ~Scene_mcf_item();
+
+public:
+  Mean_curvature_skeleton* mcs;
+  Face_graph* meso_skeleton; // a copy of the meso_skeleton that is displayed
+  Face_graph* input_triangle_mesh;
+
+  int fixedPointsItemIndex;
+  int nonFixedPointsItemIndex;
+  int poleLinesItemIndex;
+  int skeletonItemIndex;
+  int contractedItemIndex;
+  int InputMeshItemIndex;
+
+  Skeleton skeleton_curve;
+}; // end class Scene_mcf_item
+#endif // SCENE_MCF_ITEM_H

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_mcf_item.h
@@ -1,11 +1,14 @@
 #ifndef SCENE_MCF_ITEM_H
 #define SCENE_MCF_ITEM_H
 
-#ifdef scene_mcf_item_EXPORTS
+
+
+#if defined( scene_mcf_poly_item_EXPORTS ) || defined( scene_mcf_sm_item_EXPORTS )
 #  define SCENE_MCF_ITEM_EXPORT Q_DECL_EXPORT
 #else
 #  define SCENE_MCF_ITEM_EXPORT Q_DECL_IMPORT
 #endif
+
 
 #include <CGAL/Three/Scene_group_item.h>
 #include <CGAL/extract_mean_curvature_flow_skeleton.h>

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -112,13 +112,28 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
       }
       erase(children);
     }
+    CGAL::Three::Scene_group_item* parent = m_entries[index]->parentGroup();
+    bool is_locked = false;
+    if(parent)
+    {
+      is_locked = parent->isChildLocked(m_entries[index]);
+      parent->unlockChild(m_entries[index]);
+      parent->removeChild(m_entries[index]);
+    }
     std::swap(m_entries[index], item);
+    if(parent)
+    {
+      changeGroup(m_entries[index], parent);
+      if(is_locked)
+        parent->lockChild(m_entries[index]);
+    }
+
     Q_EMIT newItem(index);
     if ( item->isFinite() && !item->isEmpty() &&
          m_entries[index]->isFinite() && !m_entries[index]->isEmpty() &&
          item->bbox()!=m_entries[index]->bbox() )
     {
-    Q_EMIT updated_bbox(true);
+      Q_EMIT updated_bbox(true);
     }
 
     if(emit_item_about_to_be_destroyed) {

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -158,6 +158,11 @@ Scene::Item_id
 Scene::erase(Scene::Item_id index)
 {
   CGAL::Three::Scene_item* item = m_entries[index];
+  if(qobject_cast<Scene_group_item*>(item))
+  {
+    setSelectedItemsList(QList<Scene_interface::Item_id>()<<item_id(item));
+    return erase(selectionIndices());
+  }
   if(item->parentGroup()
      && item->parentGroup()->isChildLocked(item))
     return -1;


### PR DESCRIPTION
## Summary of Changes

This PR is a rework of this plugin, using group items to store variables that were hold by the plugin before, allowing it to manage several items and avoiding segfaults. 
It also adds a label to wxplain how it works, so the user is not surprised anymore when he/she asks for a skeletonization before runing any iteration.

## Release Management

* Affected package(s):Polyhedron_demo


