### PR TITLE
Polyhedron_demo: Add decimals for smaller distance in outliers plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>428</width>
+    <width>448</width>
     <height>147</height>
    </rect>
   </property>
@@ -92,6 +92,9 @@
    </item>
    <item row="0" column="1">
     <widget class="QDoubleSpinBox" name="m_distanceThreshold">
+     <property name="decimals">
+      <number>6</number>
+     </property>
      <property name="minimum">
       <double>0.000000000000000</double>
      </property>


### PR DESCRIPTION
## Summary of Changes
Add greater precision to the distance spinbox of the dialog in point_set_outliers_removal_plugin.
## Release Management

* Affected package(s):Polyhedron_demo

