### PR TITLE
Some BGL examples require OpenMesh : change CMakeLists

### DIFF
--- a/BGL/examples/BGL_OpenMesh/CMakeLists.txt
+++ b/BGL/examples/BGL_OpenMesh/CMakeLists.txt
@@ -37,7 +37,7 @@ if ( OpenMesh_FOUND )
 include( UseOpenMesh )
 else()
 
-  message(STATUS "These examples require OpenMesh and will not be compiled.")
+  message(STATUS "NOTICE: These examples require OpenMesh and will not be compiled.")
   return()
 
 endif()

--- a/BGL/examples/BGL_OpenMesh/CMakeLists.txt
+++ b/BGL/examples/BGL_OpenMesh/CMakeLists.txt
@@ -36,7 +36,10 @@ find_package( OpenMesh QUIET )
 if ( OpenMesh_FOUND )
 include( UseOpenMesh )
 else()
-  message(STATUS "Examples that use OpenMesh will not be compiled.")
+
+  message(STATUS "These examples require OpenMesh and will not be compiled.")
+  return()
+
 endif()
 
 # include for local directory


### PR DESCRIPTION
## Summary of Changes

BGL_OpenMesh examples require OpenMesh, and the testsuite should highlight that OpenMesh was not found

## Release Management

* Affected package(s) : BGL examples
* Issue(s) solved (if any): fix #2317 

@lrineau @sloriot Is this commit enough to fix the color of the testsuite result color?
