### PR TITLE
Fix infinite loop in spatial sorting

### DIFF
--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_2.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_2.h
@@ -116,10 +116,14 @@ public:
         RandomAccessIterator m3 = 
 	  internal::fixed_hilbert_split (m2, m4, Cmp< y, !upy> (ymed,_k));
 
-        sort<y, upy, upx> (m0, m1, ymin, xmin, ymed, xmed);
-        sort<x, upx, upy> (m1, m2, xmin, ymed, xmed, ymax);
-        sort<x, upx, upy> (m2, m3, xmed, ymed, xmax, ymax);
-        sort<y,!upy,!upx> (m3, m4, ymed, xmax, ymin, xmed);
+        if (m1!=m4)
+          sort<y, upy, upx> (m0, m1, ymin, xmin, ymed, xmed);
+        if (m1!=m0 || m2!=m4)
+          sort<x, upx, upy> (m1, m2, xmin, ymed, xmed, ymax);
+        if (m2!=m0 || m3!=m4)
+          sort<x, upx, upy> (m2, m3, xmed, ymed, xmax, ymax);
+        if (m3!=m0)
+          sort<y,!upy,!upx> (m3, m4, ymed, xmax, ymin, xmed);
     }
 
     template <class RandomAccessIterator>

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_3.h
@@ -141,14 +141,22 @@ public:
 	  internal::fixed_hilbert_split (m6, m8, Cmp< z, !upz> (zmed,_k));
 
 
-        sort<z, upz, upx, upy> (m0, m1, zmin, xmin, ymin, zmed, xmed, ymed);
-        sort<y, upy, upz, upx> (m1, m2, ymin, zmed, xmin, ymed, zmax, xmed);
-        sort<y, upy, upz, upx> (m2, m3, ymed, zmed, xmin, ymax, zmax, xmed);
-        sort<x, upx,!upy,!upz> (m3, m4, xmin, ymax, zmed, xmed, ymed, zmin);
-        sort<x, upx,!upy,!upz> (m4, m5, xmed, ymax, zmed, xmax, ymed, zmin);
-        sort<y,!upy, upz,!upx> (m5, m6, ymax, zmed, xmax, ymed, zmax, xmed);
-        sort<y,!upy, upz,!upx> (m6, m7, ymed, zmed, xmax, ymin, zmax, xmed);
-        sort<z,!upz,!upx, upy> (m7, m8, zmed, xmax, ymin, zmin, xmed, ymed);
+        if (m1!=m8)
+          sort<z, upz, upx, upy> (m0, m1, zmin, xmin, ymin, zmed, xmed, ymed);
+        if (m1!=m0 || m2!=m8)
+          sort<y, upy, upz, upx> (m1, m2, ymin, zmed, xmin, ymed, zmax, xmed);
+        if (m2!=m0 || m3!=m8)
+          sort<y, upy, upz, upx> (m2, m3, ymed, zmed, xmin, ymax, zmax, xmed);
+        if (m3!=m0 || m4!=m8)
+          sort<x, upx,!upy,!upz> (m3, m4, xmin, ymax, zmed, xmed, ymed, zmin);
+        if (m4!=m0 || m5!=m8)
+          sort<x, upx,!upy,!upz> (m4, m5, xmed, ymax, zmed, xmax, ymed, zmin);
+        if (m5!=m0 || m6!=m8)
+          sort<y,!upy, upz,!upx> (m5, m6, ymax, zmed, xmax, ymed, zmax, xmed);
+        if (m6!=m0 || m7!=m8)
+          sort<y,!upy, upz,!upx> (m6, m7, ymed, zmed, xmax, ymin, zmax, xmed);
+        if (m7!=m0)
+          sort<z,!upz,!upx, upy> (m7, m8, zmed, xmax, ymin, zmin, xmed, ymed);
     }
 
     template <class RandomAccessIterator>

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_d.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_d.h
@@ -117,19 +117,22 @@ public:
      /////////////start recursive calls
      last_dir = (direction + _dimension -1) % _dimension;
      // first step is special
-     sort( places[0], places[1], start, last_dir,cmin,cmax);
+     if (places[1]!=end)
+       sort( places[0], places[1], start, last_dir,cmin,cmax);
      cmin[last_dir] = med[last_dir];
      cmax[last_dir] = maxi[last_dir];
      
 
      for(int i=1; i<two_to_dim-1; i +=2){
        //std::cout<<i<<";"<<start[0]<<start[1]<<start[2]<<start[3]<<"/"<<dir[i+1]<<std::endl;
-       sort( places[i  ], places[i+1], start, dir[i+1],cmin,cmax);
+       if (places[i]!=begin || places[i+1]!=end)
+         sort( places[i  ], places[i+1], start, dir[i+1],cmin,cmax);
        cmax[ dir[i+1] ] =  (cmin[ dir[i+1]]==mini[ dir[i+1]])
 	                    ? maxi[ dir[i+1] ] : mini[ dir[i+1] ];
        cmin[ dir[i+1] ] =  med[ dir[i+1] ];
 
-       sort( places[i+1], places[i+2], start, dir[i+1],cmin,cmax);
+       if (places[i+1]!=begin || places[i+2]!=end)
+         sort( places[i+1], places[i+2], start, dir[i+1],cmin,cmax);
        cmin[ dir[i+1] ] =  cmax[ dir[i+1] ];
        cmax[ dir[i+1] ] =  med[ dir[i+1] ];
        cmax[ last_dir ] = (cmax[last_dir]==maxi[last_dir])
@@ -139,7 +142,8 @@ public:
      }
 
      //last step is special
-     sort( places[two_to_dim-1], places[two_to_dim], start, last_dir,cmin,cmax);
+     if (places[two_to_dim-1]!=begin)
+       sort( places[two_to_dim-1], places[two_to_dim], start, last_dir,cmin,cmax);
     }
 
 

--- a/Spatial_sorting/test/Spatial_sorting/test_hilbert.cpp
+++ b/Spatial_sorting/test/Spatial_sorting/test_hilbert.cpp
@@ -48,8 +48,9 @@ int main ()
 
         CGAL::Random_points_in_square_2<Point_2> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_2; ++i)
+        for (int i = 0; i < nb_points_2 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -107,8 +108,9 @@ int main ()
 
         CGAL::Random_points_in_square_2<Point_2> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_2; ++i)
+        for (int i = 0; i < nb_points_2 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -167,8 +169,9 @@ int main ()
 
         CGAL::Random_points_in_cube_3<Point_3> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -228,8 +231,9 @@ int main ()
 
         CGAL::Random_points_in_cube_3<Point_3> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -288,8 +292,9 @@ int main ()
 
         CGAL::Random_points_on_sphere_3<Point_3> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -319,8 +324,9 @@ int main ()
 
         CGAL::Random_points_on_sphere_3<Point_3> gen (2.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++ + Vector_3(3,5,5));
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -350,8 +356,9 @@ int main ()
 
         CGAL::Random_points_on_sphere_3<Point_3> gen (1.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -381,8 +388,9 @@ int main ()
 
         CGAL::Random_points_on_sphere_3<Point_3> gen (2.0, random);
 
-        for (int i = 0; i < nb_points_3; ++i)
+        for (int i = 0; i < nb_points_3 - 1; ++i)
             v.push_back (*gen++ + Vector_3(3,5,5));
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -413,8 +421,9 @@ int main ()
 
         CGAL::Random_points_in_cube_d<Point> gen (dim, 1.0, random);
 
-        for (int i = 0; i < nb_points_d; ++i)
+        for (int i = 0; i < nb_points_d - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -445,8 +454,9 @@ int main ()
 
         CGAL::Random_points_in_cube_d<Point> gen (dim, 1.0, random);
 
-        for (int i = 0; i < nb_points_d; ++i)
+        for (int i = 0; i < nb_points_d - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -477,8 +487,9 @@ int main ()
 
         CGAL::Random_points_in_cube_d<Point> gen (dim, 1.0, random);
 
-        for (int i = 0; i < nb_points_d; ++i)
+        for (int i = 0; i < nb_points_d - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -510,8 +521,9 @@ int main ()
 
         CGAL::Random_points_in_cube_d<Point> gen (dim, 1.0, random);
 
-        for (int i = 0; i < nb_points_d; ++i)
+        for (int i = 0; i < nb_points_d - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 
@@ -633,8 +645,9 @@ int main ()
 
         CGAL::Random_points_in_cube_d<Point> gen (dim, 1.0, random);
 
-        for (int i = 0; i < nb_points_d; ++i)
+        for (int i = 0; i < nb_points_d - 1; ++i)
             v.push_back (*gen++);
+        v.push_back(v[0]); //insert twice the same point
 
         std::cout << "done." << std::endl;
 


### PR DESCRIPTION
Avoid trying to sort a range that we just sorted.

Trying to sort a range of 2 identical points exhibits the infinite loop.
