### PR TITLE
Fix for doc bug, github issue #2346

### DIFF
--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDataStructure_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDataStructure_2.h
@@ -551,7 +551,6 @@ void dim_down(Face_handle f, int i);
 
 
 /*!
-\cgalModifBegin
 creates a new vertex `v` and uses it to star a hole.
  
 Given a set of faces 'F' describing a simply connected hole (i.e., a topological disk), 
@@ -561,16 +560,13 @@ range `[face_begin, face_end[` of `Face_handle`s over the connected faces in `F`
 to the new vertex `v` is returned.
  
 \pre `tds.dimension() = 2` and the set of faces has the topology of a disk.
-\cgalModifEnd
 */
 template< class FaceIt >
 Vertex_handle insert_in_hole(FaceIt face_begin, FaceIt face_end); 
 
 /*!
-\cgalModifBegin
 same as above, except that `new_v` will be used as the new vertex, which must have been 
-allocated previously with e.g. `create_vertex`.
-\cgalModifEnd
+allocated previously, for example with `create_vertex`.
 */
 template< class FaceIt >
 void insert_in_hole(Vertex_handle new_v, FaceIt face_begin, FaceIt face_end);  


### PR DESCRIPTION
## Summary of Changes

Removed the macros `\cgalModifBegin` and `\cgalModifEnd` from the file `TDS_2/doc/Concepts/TriangulationDataStructure_2`.
Modified the comment of one of the overloads of the function `insert_in_hole()` to avoid line break.

## Release Management

* Affected package: documentation for TDS_2
* Issue solved: fix #2346 
* Small Feature: the documentation is relevant to [this small feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_function_insert_in_hole_to_Triangulation_data_structure_2).
* The small feature was integrated in CGAL 4.10, so the base I used for the fix is `releases/CGAL-4.10-branch`.
