### PR TITLE
Bounding volumes: Fix wrong dimension doc

### DIFF
--- a/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_2.h
+++ b/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_2.h
@@ -42,7 +42,7 @@ public:
 /*!
 is the constant 2, i.e.\ the dimension of \f$ \mathbb{R}^2\f$. 
 */ 
-typedef unspecified_type D; 
+static const int D;
 
 /// @} 
 

--- a/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_3.h
+++ b/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_3.h
@@ -35,7 +35,7 @@ public:
 /*!
 is the constant 3, i.e.\ the dimension of \f$ \mathbb{R}^3\f$. 
 */ 
-typedef unspecified_type D; 
+static const int D;
 
 /// @} 
 

--- a/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_d.h
+++ b/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_d.h
@@ -17,6 +17,8 @@ a model for concept `MinSphereOfSpheresTraits`. It uses the
 type `FT` of concept `MinSphereOfSpheresTraits`: It must be 
 either `double` or `float`, or an exact number type. 
 
+\tparam Dim is the dimension.
+
 \tparam UseSqrt fulfills the 
 requirements of type `Use_square_roots` of concept 
 `MinSphereOfSpheresTraits`: It must be either `Tag_true` or `Tag_false`
@@ -28,7 +30,7 @@ concept `MinSphereOfSpheresTraits`: It must be either
 and it defaults to `Default_algorithm`.
 
 */
-template< typename K, typename FT, typename Dim, typename UseSqrt, typename Algorithm >
+template< typename K, typename FT, int Dim, typename UseSqrt, typename Algorithm >
 class Min_sphere_of_spheres_d_traits_d {
 public:
 

--- a/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_d.h
+++ b/Bounding_volumes/doc/Bounding_volumes/CGAL/Min_sphere_of_spheres_d_traits_d.h
@@ -38,7 +38,7 @@ public:
 /*!
 is the constant `Dim`. 
 */ 
-typedef unspecified_type D; 
+static const int D;
 
 /// @} 
 

--- a/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
+++ b/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
@@ -22,7 +22,7 @@ public:
 specifies the dimension of the spheres you want to 
 compute the minsphere of. 
 */ 
-typedef unspecified_type D; 
+static const int D;
 
 /// @} 
 


### PR DESCRIPTION
## Summary of Changes

The dimension is documented as a type (unspecified), which is wrong and does not make any sense. This PR makes it consistent with the code (dimension is `static const int` in every case).

## Release Management

* Affected package(s): Bounding Volumes
* Issue(s) solved: fix https://github.com/CGAL/cgal/issues/2225

