### PR TITLE
Surface mesh: reinit connectivies when reusing garbage memory

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -61,6 +61,9 @@ public:
     /// Extend the number of elements by one.
     virtual void push_back() = 0;
 
+    /// Reset element to default value
+    virtual void reset(size_t idx) = 0;
+
     virtual bool transfer(const Base_property_array& other) = 0;
 
     /// Let two elements swap their storage place.
@@ -117,6 +120,11 @@ public: // virtual interface of Base_property_array
     virtual void push_back()
     {
         data_.push_back(value_);
+    }
+
+    virtual void reset(size_t idx)
+    {
+        data_[idx] = value_;
     }
 
     bool transfer(const Base_property_array& other)
@@ -395,6 +403,13 @@ public:
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->push_back();
         ++size_;
+    }
+
+    // reset element to its default property values
+    void reset(size_t idx)
+    {
+        for (std::size_t i=0; i<parrays_.size(); ++i)
+            parrays_[i]->reset(idx);
     }
 
     // swap elements i0 and i1 in all arrays

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -840,7 +840,7 @@ public:
         vertices_freelist_ = (size_type)vconn_[Vertex_index(vertices_freelist_)].halfedge_;
         --removed_vertices_;
         vremoved_[Vertex_index(idx)] = false;
-        vconn_[Vertex_index(idx)] = Vertex_connectivity();
+        vprops_.reset(Vertex_index(idx));
         return Vertex_index(idx);
       } else {
         vprops_.push_back();
@@ -872,7 +872,7 @@ public:
         edges_freelist_ = (size_type)hconn_[Halfedge_index(edges_freelist_)].next_halfedge_;
         --removed_edges_;
         eremoved_[Edge_index(Halfedge_index(idx))] = false;
-        hconn_[Halfedge_index(idx)] = Halfedge_connectivity();
+        hprops_.reset(Halfedge_index(idx));
         return Halfedge_index(idx);
       } else {
         eprops_.push_back();
@@ -908,7 +908,7 @@ public:
         size_type idx = faces_freelist_;
         faces_freelist_ = (size_type)fconn_[Face_index(faces_freelist_)].halfedge_;
         --removed_faces_;
-        fconn_[Face_index(idx)] = Face_connectivity();
+        fprops_.reset(Face_index(idx));
         fremoved_[Face_index(idx)] = false;
         return Face_index(idx);
       } else {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -840,6 +840,7 @@ public:
         vertices_freelist_ = (size_type)vconn_[Vertex_index(vertices_freelist_)].halfedge_;
         --removed_vertices_;
         vremoved_[Vertex_index(idx)] = false;
+        vconn_[Vertex_index(idx)] = Vertex_connectivity();
         return Vertex_index(idx);
       } else {
         vprops_.push_back();
@@ -871,6 +872,7 @@ public:
         edges_freelist_ = (size_type)hconn_[Halfedge_index(edges_freelist_)].next_halfedge_;
         --removed_edges_;
         eremoved_[Edge_index(Halfedge_index(idx))] = false;
+        hconn_[Halfedge_index(idx)] = Halfedge_connectivity();
         return Halfedge_index(idx);
       } else {
         eprops_.push_back();
@@ -906,6 +908,7 @@ public:
         size_type idx = faces_freelist_;
         faces_freelist_ = (size_type)fconn_[Face_index(faces_freelist_)].halfedge_;
         --removed_faces_;
+        fconn_[Face_index(idx)] = Face_connectivity();
         fremoved_[Face_index(idx)] = false;
         return Face_index(idx);
       } else {


### PR DESCRIPTION
## Summary of Changes

When removing simplices from a `CGAL::Surface_mesh` object, they are not deleted and their memory can be reused later on. The problem is that the connectivity structure of a newly added simplex is not reinitialized, which can lead to problems.

For example, if you remove an isolated vertex (which should not pose any structure issue) and add a new one, the new one will be considered adjacent to a random face because the connectivity structure was used to keep track of removed vertices. Although it is said in the manual that removing isolated vertices could leave the surface mesh in an invalid state, it seems counter-intuitive to get an invalid state after _adding_ a new vertex (especially if the previous removed vertex was isolated).

This PR adds a reinitialization step of the connectivity structures just after their addition, in the case garbage memory is reused. It does not break what is currently working and it decreases the chances of running into an unexpected behavior. I benched it and I saw no visible slowing down.

## Release Management

* Affected package(s): Surface_mesh

