### PR TITLE
Surface_mesher: Change `Type` to `type` in the type generator

### DIFF
--- a/Surface_mesher/doc/Surface_mesher/CGAL/Surface_mesh_traits_generator_3.h
+++ b/Surface_mesher/doc/Surface_mesher/CGAL/Surface_mesh_traits_generator_3.h
@@ -4,7 +4,7 @@ namespace CGAL {
 /*!
 \ingroup PkgSurfaceMesher3Classes
 
-The class `Surface_mesh_traits_generator_3` provides a type `Type`,
+The class `Surface_mesh_traits_generator_3` provides a type `type`,
 that is a model of the concept `SurfaceMeshTraits_3` for the surface
 type `Surface`. 
 
@@ -35,7 +35,7 @@ public:
 /*!
 A model of the concept `SurfaceMeshTraits_3`. 
 */ 
-typedef unspecified_type Type; 
+typedef unspecified_type type;
 
 }; /* end Surface_mesh_traits_generator_3 */
 } /* end namespace CGAL */

--- a/Surface_mesher/doc/Surface_mesher/Concepts/SurfaceMeshTraits_3.h
+++ b/Surface_mesher/doc/Surface_mesher/Concepts/SurfaceMeshTraits_3.h
@@ -11,7 +11,7 @@ and to compute some intersection
 points if any exists. The concept `SurfaceMeshTraits_3` also includes a funcctor able to provide 
 a small set of initial points on the surface. 
 
-\cgalHasModel `CGAL::Surface_mesh_traits_generator_3::Type` 
+\cgalHasModel `CGAL::Surface_mesh_traits_generator_3::type`
 
 \sa `CGAL::make_surface_mesh()` 
 


### PR DESCRIPTION
Fix #2361
