### PR TITLE
Fix compilation errors with new implement of assert() in glibc

### DIFF
--- a/AABB_tree/test/AABB_tree/aabb_test_singleton_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_singleton_tree.cpp
@@ -39,8 +39,8 @@ int main()
     tree.accelerate_distance_queries();
     tree.all_intersections(triangle_query, devnull);
     tree.all_intersected_primitives(triangle_query, devnull);
-    assert(tree.any_intersected_primitive(triangle_query));
-    assert(tree.any_intersection(triangle_query));
+    assert(bool(tree.any_intersected_primitive(triangle_query)));
+    assert(bool(tree.any_intersection(triangle_query)));
     const CGAL::Bbox_3 bbox = tree.bbox();
     assert(bbox == CGAL::Bbox_3(0, 0, 0, 2, 2, 2));
     tree.clear();

--- a/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_cls_alpha_shape_3.h
+++ b/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_cls_alpha_shape_3.h
@@ -190,7 +190,7 @@ _test_cls_alpha_shape_3()
   a1.clear();
   L.clear();
   std::ifstream is("./data/fin", std::ios::in);
-  assert(is);
+  assert(bool(is));
   file_input(is,L);
   a1.set_mode(Alpha_shape_3::REGULARIZED);
   std::size_t  n = a1.make_alpha_shape(L.begin(), L.end());

--- a/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_weighted_alpha_shape_3.h
+++ b/Alpha_shapes_3/test/Alpha_shapes_3/include/CGAL/_test_weighted_alpha_shape_3.h
@@ -136,7 +136,7 @@ _test_weighted_alpha_shape_3()
   A.clear();
   L.clear();
   std::ifstream is("./data/fin", std::ios::in);
-  assert(is);
+  assert(bool(is));
   file_input(is,L);
   A.set_mode(Alpha_shape_3::REGULARIZED);
   std::size_t  n = A.make_alpha_shape(L.begin(), L.end());

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits.cpp
@@ -36,7 +36,7 @@ typedef CGAL::Apollonius_graph_2<Traits>          Apollonius_graph;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   Apollonius_graph ag;
   Apollonius_graph::Site_2 site;

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_exact_traits_sqrt.cpp
@@ -58,7 +58,7 @@ typedef CGAL::Apollonius_graph_2<Traits> Apollonius_graph;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   Apollonius_graph ag;
   Apollonius_graph::Site_2 site;

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_filtered_traits_no_hidden.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_filtered_traits_no_hidden.cpp
@@ -34,7 +34,7 @@ typedef CGAL::Apollonius_graph_2<Traits,Agds>    Apollonius_graph;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   Apollonius_graph ag;
   Apollonius_graph::Site_2 site;

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_hierarchy.cpp
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/ag2_hierarchy.cpp
@@ -44,7 +44,7 @@ typedef CGAL::Apollonius_graph_hierarchy_2<Traits> Apollonius_graph;
 int main()
 {
   std::ifstream ifs("data/hierarchy.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   Apollonius_graph ag;
   Apollonius_graph::Site_2 site;

--- a/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
@@ -841,24 +841,24 @@ bool test_algo_generic(InputStream& is)
   //--------------------------------------------------------------------
   {
     std::ofstream ofs("ag_testsuite.tmp");
-    assert( ofs );
+    assert( bool(ofs) );
     ag.file_output(ofs);
     ofs.close();
 
     std::ifstream ifs("ag_testsuite.tmp");
-    assert( ifs );
+    assert( bool(ifs) );
     ag.file_input(ifs);
     ifs.close();
     assert( ag.is_valid() );
   }
   {
     std::ofstream ofs("ag_testsuite.tmp");
-    assert( ofs );
+    assert( bool(ofs) );
     ofs << ag;
     ofs.close();
 
     std::ifstream ifs("ag_testsuite.tmp");
-    assert( ifs );
+    assert( bool(ifs) );
     ifs >> ag;
     ifs.close();
     assert( ag.is_valid() );

--- a/Apollonius_graph_2/test/Apollonius_graph_2/test_ag2.cpp
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/test_ag2.cpp
@@ -59,7 +59,7 @@ int main()
   {
     std::ifstream ifs_algo("./data/algo.dat");
 
-    assert( ifs_algo );
+    assert( bool(ifs_algo) );
 
     std::cout << "testing the Apollonius graph class"
 	      << " with filtered traits..." << std::flush;

--- a/Apollonius_graph_2/test/Apollonius_graph_2/test_ag_hierarchy_2.cpp
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/test_ag_hierarchy_2.cpp
@@ -62,7 +62,7 @@ int main()
   {
     std::ifstream ifs_hierarchy("./data/hierarchy.dat");
 
-    assert( ifs_hierarchy );
+    assert( bool(ifs_hierarchy) );
 
     std::cout << "testing the Apollonius graph hierarchy class"
 	      << " with filtered traits..." << std::flush;

--- a/Apollonius_graph_2/test/Apollonius_graph_2/test_ag_traits_2.cpp
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/test_ag_traits_2.cpp
@@ -63,7 +63,7 @@ int main()
   {
     std::ifstream ifs_traits("./data/traits.dat");
 
-    assert( ifs_traits );
+    assert( bool(ifs_traits) );
 
     std::cout << "testing the filtered traits class..." << std::flush;
 

--- a/Bounding_volumes/test/Bounding_volumes/test_Min_circle.cpp
+++ b/Bounding_volumes/test/Bounding_volumes/test_Min_circle.cpp
@@ -446,10 +446,10 @@ main( int argc, char* argv[])
         int               n, x, y;
         std::ifstream     in( argv[ 1]);
         in >> n;
-        assert( in);
+        assert( bool(in) );
         for ( int i = 0; i < n; ++i) {
             in >> x >> y;
-            assert( in);
+            assert( bool(in) );
             points.push_back( Point( x, y)); }
     
         // compute and check min_circle

--- a/Bounding_volumes/test/Bounding_volumes/test_Min_ellipse_2.cpp
+++ b/Bounding_volumes/test/Bounding_volumes/test_Min_ellipse_2.cpp
@@ -654,10 +654,10 @@ main( int argc, char* argv[])
         int               n, x, y;
         std::ifstream     in( argv[ 1]);
         in >> n;
-        assert( in);
+        assert( bool(in) );
         for ( int i = 0; i < n; ++i) {
             in >> x >> y;
-            assert( in);
+            assert( bool(in) );
             points.push_back( Point( x, y)); }
     
         // compute and check min_ellipse

--- a/Convex_hull_3/test/Convex_hull_3/convex_hull_traits_3_fp_bug.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/convex_hull_traits_3_fp_bug.cpp
@@ -11,7 +11,7 @@ int main()
   std::set<K::Point_3> pointset;
   std::ifstream input("convex_hull_traits_3_fp_bug.xyz");
 
-  assert(input);
+  assert(bool(input));
   while ( input >> p )
     pointset.insert(p);
 

--- a/Mesh_3/test/Mesh_3/test_c3t3_io.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3_io.cpp
@@ -340,21 +340,21 @@ struct Test_c3t3_io {
                 << "\n******end******" << std::endl;
     }
     stream.seekg(0);
-    assert(stream);
+    assert(bool(stream));
     C3t3 c3t3_bis;
     stream >> c3t3_bis;
     std::cout << "Content of c3t3_bis:\n"
               << "*****begin*****\n"
               << c3t3_bis
               << "\n******end******" << std::endl;
-    assert(stream);
+    assert(bool(stream));
 
     {
       std::ostringstream ss_c3t3, ss_c3t3_bis;
       ss_c3t3 << c3t3;
       ss_c3t3_bis << c3t3_bis;
-      assert(ss_c3t3);
-      assert(ss_c3t3_bis);
+      assert(bool(ss_c3t3));
+      assert(bool(ss_c3t3_bis));
       assert(ss_c3t3.str() == ss_c3t3_bis.str());
       if(!check_equality(c3t3, c3t3_bis)) return false;
     }
@@ -366,9 +366,9 @@ struct Test_c3t3_io {
                              (std::ios_base::in | std::ios_base::binary)
                              : std::ios_base::in));
       CGAL::Mesh_3::save_binary_file(ss, c3t3, binary);
-      assert(ss);
+      assert(bool(ss));
       CGAL::Mesh_3::load_binary_file(ss, c3t3_bis);
-      assert(ss);
+      assert(bool(ss));
     }
     if(!check_equality(c3t3, c3t3_bis)) return false;
 
@@ -387,9 +387,9 @@ struct Test_c3t3_io {
       std::ifstream input(filename.c_str(),
                           binary ? (std::ios_base::in | std::ios_base::binary)
                           : std::ios_base::in);
-      assert(input);
+      assert(bool(input));
       CGAL::Mesh_3::load_binary_file(input, c3t3_bis);
-      assert(input);
+      assert(bool(input));
     }
     if(!check_equality(c3t3, c3t3_bis)) return false;
 

--- a/Mesh_3/test/Mesh_3/test_labeled_mesh_domain_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_labeled_mesh_domain_3.cpp
@@ -153,7 +153,7 @@ private:
 	  {
 		  Segment_3 s(Point_3(CGAL::ORIGIN), Point_3(1.5, 0., 0.));
 		  Surface_patch p = do_intersect_surface(s);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }
@@ -167,7 +167,7 @@ private:
 	  {
 		  Ray_3 r(Point_3(CGAL::ORIGIN), Vector_3(1., 0., 0.));
 		  Surface_patch p = do_intersect_surface(r);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }
@@ -181,7 +181,7 @@ private:
 	  {
 		  Line_3 l(Point_3(CGAL::ORIGIN), Point_3(1.5, 0., 0.));
 		  Surface_patch p = do_intersect_surface(l);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }

--- a/Mesh_3/test/Mesh_3/test_mesh_3_labeled_mesh_domain_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_labeled_mesh_domain_3.cpp
@@ -152,7 +152,7 @@ private:
 	  {
 		  Segment_3 s(Point_3(CGAL::ORIGIN), Point_3(1.5, 0., 0.));
 		  Surface_patch p = do_intersect_surface(s);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }
@@ -166,7 +166,7 @@ private:
 	  {
 		  Ray_3 r(Point_3(CGAL::ORIGIN), Vector_3(1., 0., 0.));
 		  Surface_patch p = do_intersect_surface(r);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }
@@ -180,7 +180,7 @@ private:
 	  {
 		  Line_3 l(Point_3(CGAL::ORIGIN), Point_3(1.5, 0., 0.));
 		  Surface_patch p = do_intersect_surface(l);
-		  assert(p);
+		  assert(bool(p));
 		  Surface_patch_index pi = *p;
 		  assert(pi.first == 0 && pi.second == 1);
 	  }

--- a/Mesh_3/test/Mesh_3/test_mesh_criteria_creation.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_criteria_creation.cpp
@@ -154,7 +154,7 @@ int main()
   assert( ! fc14.facet_criteria_object()(f) );
   
   Mc fc15(facet_topology = CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH);
-  assert( fc15.facet_criteria_object()(f) );
+  assert( bool(fc15.facet_criteria_object()(f)) );
   
   // -----------------------------------
   // Test cell criteria

--- a/Number_types/test/Number_types/quotient_io.cpp
+++ b/Number_types/test/Number_types/quotient_io.cpp
@@ -13,7 +13,7 @@ main()
   std::ofstream T;
   std::ifstream U;
   S.open("quotient_in");
-  assert( S );
+  assert( bool(S) );
 
   std::vector<CGAL::Quotient<double> >   V1;
   std::vector<CGAL::Quotient<double> >   V2;
@@ -23,14 +23,14 @@ main()
   S.close();
 
   T.open("quotient_out");
-  assert( T );
+  assert( bool(T) );
   std::copy( V1.begin(), 
              V1.end(), 
              std::ostream_iterator<CGAL::Quotient<double> >(T,"\n") );
   T.close();
 
   U.open("quotient_out");
-  assert( T );
+  assert( bool(U) );
   std::copy( std::istream_iterator<CGAL::Quotient<double> >(U),
              std::istream_iterator<CGAL::Quotient<double> >(),
              std::back_inserter(V2) );

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_alpha_shape_3.h
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_alpha_shape_3.h
@@ -57,7 +57,7 @@ _test_cls_alpha_shape_3()
   
   // test a bigger alpha_shapes
   std::ifstream is("./data/P3DT3_alpha_shape_test.pts", std::ios::in);
-  assert(is);
+  assert(bool(is));
   file_input(is, L);
 
   Iso_cuboid domain(FT(-0.1),FT(-0.1),FT(-0.1), FT(0.2),FT(0.2),FT(0.2));

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
@@ -58,7 +58,7 @@ public:
     P3RT3 p3rt3(iso_cuboid);
 
     std::ofstream stream("p3rt3_ir_point_set");
-    assert(stream);
+    assert(bool(stream));
     std::ifstream input_stream(path.c_str());
 
     std::vector<Weighted_point_3> insert_set;

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
@@ -65,7 +65,7 @@ public:
     stream >> z;
     assert(stream && !stream.eof());
     stream >> w;
-    assert(stream);
+    assert(bool(stream));
     return Weighted_point_3(Point_3(x, y, z), w);
   }
 
@@ -348,7 +348,7 @@ public:
     P3RT3 p3rt3(Iso_cuboid(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5));
 
     std::ifstream stream(filename);
-    assert(stream);
+    assert(bool(stream));
 
     unsigned cnt = 1;
     while (stream && !(stream.eof()))

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_coref_epic_points_identity.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_coref_epic_points_identity.cpp
@@ -14,11 +14,11 @@ int main(int argc, char** argv)
   {
     Surface_mesh sm1, sm2;
     std::ifstream input(argv[2*i+1]);
-    assert(input);
+    assert(bool(input));
     input >> sm1;
     input.close();
     input.open(argv[2*(i+1)]);
-    assert(input);
+    assert(bool(input));
     input >> sm2;
     input.close();
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
@@ -20,11 +20,11 @@ int main(int argc, char** argv)
     std::cout << "  with Surface_mesh\n";
     Surface_mesh sm1, sm2;
     std::ifstream input(argv[2*i+1]);
-    assert(input);
+    assert(bool(input));
     input >> sm1;
     input.close();
     input.open(argv[2*(i+1)]);
-    assert(input);
+    assert(bool(input));
     input >> sm2;
     input.close();
 
@@ -36,11 +36,11 @@ int main(int argc, char** argv)
     std::cout << "  with Polyhedron_3\n";
     Polyhedron_3 P, Q;
     input.open(argv[2*i+1]);
-    assert(input);
+    assert(bool(input));
     input >> P;
     input.close();
     input.open(argv[2*(i+1)]);
-    assert(input);
+    assert(bool(input));
     input >> Q;
 
     CGAL::Polygon_mesh_processing::corefine(P, Q);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
               << " expected res is " << argv[2*(i+1)] << "\n";
 
     std::ifstream input(argv[2*i+1]);
-    assert(input);
+    assert(bool(input));
     Surface_mesh sm;
     input >> sm;
     bool res = atoi(argv[2*(i+1)])>0;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-count-sites.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-count-sites.cpp
@@ -20,7 +20,7 @@ using namespace std;
 
 int main() {
   ifstream ifs("data/sitesx.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-fast-sp-polygon.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-fast-sp-polygon.cpp
@@ -22,7 +22,7 @@ typedef CGAL::Segment_Delaunay_graph_2<Gt>  SDG2;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   //polygon points
   std::vector<Gt::Point_2> points;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-fast-sp.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-fast-sp.cpp
@@ -23,7 +23,7 @@ typedef CGAL::Segment_Delaunay_graph_2<Gt>  SDG2;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-filtered-traits.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-filtered-traits.cpp
@@ -23,7 +23,7 @@ typedef CGAL::Segment_Delaunay_graph_hierarchy_2<Gt>  SDG2;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-info-set.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-info-set.cpp
@@ -197,7 +197,7 @@ int main()
 {
 
   std::ifstream ifs("data/sitesxx.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2 sdg;
   Site_2 site;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-red-blue-info.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-red-blue-info.cpp
@@ -99,7 +99,7 @@ int main()
 {
 
   std::ifstream ifs("data/sitesxx.rb.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2 sdg;
   Site_2 site;

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-voronoi-edges.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-voronoi-edges.cpp
@@ -23,7 +23,7 @@ using namespace std;
 int main()
 {
   ifstream ifs("data/sites2.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_info.h
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_info.h
@@ -14,7 +14,7 @@ bool test_info(SDG& sdg, const char* fname)
   CGAL::Random r(static_cast<int>(0));
 
   std::ifstream ifs(fname);
-  assert( ifs );
+  assert( bool(ifs) );
 
   sdg.clear();
   typename SDG::Site_2  site;

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_types.h
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_types.h
@@ -362,7 +362,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
       sdg.clear();
 
       std::ifstream ifs( ifname_full.c_str() );
-      assert( ifs );
+      assert( bool(ifs) );
       Site_2 t;
       while ( ifs >> t ) {
 	sdg.insert(t);
@@ -524,7 +524,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
     size_type nv1 = sdg.number_of_vertices();
 
     std::ofstream ofs(ofname);
-    assert( ofs );
+    assert( bool(ofs) );
     sdg.file_output(ofs);
     assert( sdg.is_valid() );
     ofs.close();
@@ -532,7 +532,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
     sdg.clear();
 
     std::ifstream ifs(ofname);
-    assert( ifs );
+    assert( bool(ifs) );
     sdg.file_input(ifs);
     assert( sdg.is_valid() );
     ifs.close();

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/print-sdg-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/print-sdg-linf.cpp
@@ -26,7 +26,7 @@ int main( int argc, char *argv[] ) {
   }
 
   ifstream ifs( (argc == 1) ? "data/sites2.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-count-sites-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-count-sites-linf.cpp
@@ -24,7 +24,7 @@ int main( int argc, char *argv[] ) {
   }
 
   ifstream ifs( (argc == 1) ? "data/sitesx.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-fast-sp-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-fast-sp-linf.cpp
@@ -23,7 +23,7 @@ typedef CGAL::Segment_Delaunay_graph_Linf_2<Gt>  SDG2;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-fast-sp-polygon-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-fast-sp-polygon-linf.cpp
@@ -22,7 +22,7 @@ typedef CGAL::Segment_Delaunay_graph_Linf_2<Gt>  SDG2;
 int main()
 {
   std::ifstream ifs("data/sites.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   //polygon points
   std::vector<Gt::Point_2> points;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-filtered-traits-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-filtered-traits-linf.cpp
@@ -27,7 +27,7 @@ int main( int argc, char *argv[] )
   }
 
   std::ifstream ifs( (argc == 1) ? "data/sites.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-info-set-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-info-set-linf.cpp
@@ -200,7 +200,7 @@ int main( int argc, char *argv[] )
   }
 
   std::ifstream ifs( (argc == 1) ? "data/sitesxx.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2 sdg;
   Site_2 site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-red-blue-info-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-red-blue-info-linf.cpp
@@ -101,7 +101,7 @@ int main()
 {
 
   std::ifstream ifs("data/sitesxx.rb.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2 sdg;
   Site_2 site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-voronoi-edges-exact-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-voronoi-edges-exact-linf.cpp
@@ -53,7 +53,7 @@ int main( int argc, char *argv[] ) {
   }
 
   ifstream ifs( (argc == 1) ? "data/sites2.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-voronoi-edges-linf.cpp
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/sdg-voronoi-edges-linf.cpp
@@ -26,7 +26,7 @@ int main( int argc, char *argv[] ) {
   }
 
   ifstream ifs( (argc == 1) ? "data/sites2.cin" : argv[1] );
-  assert( ifs );
+  assert( bool(ifs) );
 
   SDG2          sdg;
   SDG2::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_info.h
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_info.h
@@ -14,7 +14,7 @@ bool test_info(SDG& sdg, const char* fname)
   CGAL::Random r(static_cast<int>(0));
 
   std::ifstream ifs(fname);
-  assert( ifs );
+  assert( bool(ifs) );
 
   sdg.clear();
   typename SDG::Site_2  site;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_types.h
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_types.h
@@ -362,7 +362,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
       sdg.clear();
 
       std::ifstream ifs( ifname_full.c_str() );
-      assert( ifs );
+      assert( bool(ifs) );
       Site_2 t;
       while ( ifs >> t ) {
 	sdg.insert(t);
@@ -524,7 +524,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
     size_type nv1 = sdg.number_of_vertices();
 
     std::ofstream ofs(ofname);
-    assert( ofs );
+    assert( bool(ofs) );
     sdg.file_output(ofs);
     assert( sdg.is_valid() );
     ofs.close();
@@ -532,7 +532,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
     sdg.clear();
 
     std::ifstream ifs(ofname);
-    assert( ifs );
+    assert( bool(ifs) );
     sdg.file_input(ifs);
     assert( sdg.is_valid() );
     ifs.close();

--- a/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
     // ...
     {
         std::ifstream fin ("data/regular_remove_3");
-        assert(fin);
+        assert(bool(fin));
         std:: cout << " test `data/regular_remove_3'" << std::endl;
         while (test_case (fin)) 
             // semicolon

--- a/Voronoi_diagram_2/examples/Voronoi_diagram_2/vd_2_point_location.cpp
+++ b/Voronoi_diagram_2/examples/Voronoi_diagram_2/vd_2_point_location.cpp
@@ -41,7 +41,7 @@ void print_endpoint(Halfedge_handle e, bool is_src) {
 int main()
 {
   std::ifstream ifs("data/data1.dt.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   VD vd;
 
@@ -52,7 +52,7 @@ int main()
   assert( vd.is_valid() );
 
   std::ifstream ifq("data/queries1.dt.cin");
-  assert( ifq );
+  assert( bool(ifq) );
 
   Point_2 p;
   while ( ifq >> p ) {

--- a/Voronoi_diagram_2/examples/Voronoi_diagram_2/vd_2_point_location_sdg_linf.cpp
+++ b/Voronoi_diagram_2/examples/Voronoi_diagram_2/vd_2_point_location_sdg_linf.cpp
@@ -43,7 +43,7 @@ void print_endpoint(Halfedge_handle e, bool is_src) {
 int main()
 {
   std::ifstream ifs("data/data1.svd.cin");
-  assert( ifs );
+  assert( bool(ifs) );
 
   VD vd;
 
@@ -54,7 +54,7 @@ int main()
   assert( vd.is_valid() );
 
   std::ifstream ifq("data/queries1.svd.cin");
-  assert( ifq );
+  assert( bool(ifq) );
 
   Point_2 p;
   while ( ifq >> p ) {

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/include/vda_test_vda.h
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/include/vda_test_vda.h
@@ -509,12 +509,12 @@ void test_vda(const VDA& vda)
 #ifndef VDA_TEST_RT
   // testing file I/O
   std::ofstream ofs("tmp.vd.cgal");
-  assert( ofs );
+  assert( bool(ofs) );
   ofs << vda;
   ofs.close();
 
   std::ifstream ifs("tmp.vd.cgal");
-  assert( ifs );
+  assert( bool(ifs) );
   ifs >> vda_copy;
   ifs.close();
 


### PR DESCRIPTION
## Summary of Changes

In glibc 2.25 and 2.26, the implementation of `assert()` triggers
compilation errors with values that are not comparable to an `int`, such
a iostream, or `optional`.

That is the "bug" https://sourceware.org/bugzilla/show_bug.cgi?id=21972

In my opinion that is not really a bug: the value test by `assert` is
supposed to be an integral value, and not something explicitly
convertible to `bool`.

This commit uses an explicit conversion to `bool`, in all problematic
calls to `assert()`.

The problem was seen on my platform, Linux Fedora 26.

## Release Management

* Affected package(s): a lot!

**The branch is against `master`, but it should be backported to `4.10.1` and `4.11`. There are conflicts, about missing files.**
