### PR TITLE
Remove our CSS hacks, to "fix" the compilation with Doxygen 1.8.13

### DIFF
--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -178,35 +178,6 @@ div.groupText {
     font: 200% Tahoma, Arial,sans-serif;
 }
 
-/* fix the back button by hacking the layout */
-/* this becomes unnecessary with the latest doxygen, r834 */
-#top {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 1;
-}
-
-#footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-}
-
-#doc-content {
-    /* this is the header/footer padding */
-    /* so the content does not hide behind them */
-    padding-top: 91px;
-    padding-bottom: 32px;
-    overflow: visible;
-}
-
-#side-nav {
-    position: fixed;
-}
-
 #titlearea {
     background: white;
 }

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -182,20 +182,6 @@ div.groupText {
     background: white;
 }
 
-/* this adjusts the anchors inside the doc-content div by the height of */
-/* the header. this is necessary because anchors are not adjusted by the */
-/* height of the position: fixed top div. */
-#doc-content a.anchor {
-    position: absolute; 
-    padding-top: 91px; 
-    margin-top: -91px;
-}
-
-#doc-content .anchor {
-    padding-top: 91px; 
-    margin-top: -91px;
-}
-
 #MSearchResultsWindow {
     z-index: 2;
 }

--- a/Documentation/doc/resources/1.8.13/header.html
+++ b/Documentation/doc/resources/1.8.13/header.html
@@ -11,6 +11,7 @@
 <!-- <link href="$relpath^../Manual/tabs.css" rel="stylesheet" type="text/css"/> -->
 <script type="text/javascript" src="$relpath^../Manual/jquery.js"></script>
 <script type="text/javascript" src="$relpath^../Manual/dynsections.js"></script>
+<script src="$relpath$../Manual/hacks.js" type="text/javascript"></script>
 $treeview
 $search
 $mathjax


### PR DESCRIPTION
Our custom CSS for Doxygen interferes badly with Doxygen internals. If we remove them, the result seems better, with Doxygen 1.8.13.

That should probably be backported to 4.11/4.10.

Fix #1995.