### PR TITLE
PSP, PMP: Fix some \ref 

### DIFF
--- a/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
@@ -49,8 +49,7 @@ with normal. The latter can be represented as, e.g., a class derived
 from the \cgal 3D point, or as a `std::pair<Point_3<K>, Vector_3<K>>`, 
 or as a `boost::tuple<..,Point_3<K>, ..., Vector_3<K> >`.
 
-The following classes described in Chapter \ref chapterProperty_map
-"CGAL and Boost Property Maps"
+The following classes described in Chapter \ref PkgProperty_mapSummary
 provide property maps for the implementations of points with normals
 listed above:
 
@@ -101,7 +100,7 @@ The following functions are available:
 
 Note that the %PLY format handles both ASCII and binary formats. In
 addition, %PLY and %LAS are extensible formats that can embed additional
-properties. These can also be read by \cgal (see section \ref
+properties. These can also be read by \cgal (see Section \ref
 Point_set_processing_3Properties_io).
 
 \subsubsection Point_set_processing_3Example_io Example
@@ -505,7 +504,7 @@ points that are on sharp edges:
 The function `structure_point_set()` generates a structured version of
 the input point set assigned to a set of planes. Such an input can be
 produced by a shape detection algorithm (see \ref
-Chapter_Point_Set_Shape_Detection). Point set structuring is based on
+PkgPointSetShapeDetection3Summary). Point set structuring is based on
 the article \cgalCite{cgal:la-srpss-13}.
 
 - __Planes__: inliers of each detected plane are replaced by sets of

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -27,7 +27,7 @@ A polygon mesh can have any number of connected components, and also some self-i
 In this package, a polygon mesh is considered to have the topology of a 2-manifold.
 
 \subsection PMPAPI API
-This package follows the BGL API described in \ref chapterBGL.
+This package follows the BGL API described in \ref PkgBGLSummary.
 It can thus be used either with `Polyhedron_3`, `Surface_mesh`, or
 any class model of the concept `FaceGraph`. Each function or class of this package
 details the requirements on the input polygon mesh.


### PR DESCRIPTION


Fix some \ref  so that the links go to the package overview