### PR TITLE
Document breaking change

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -165,6 +165,13 @@ and <code>src/</code> directories).
       Generation. See the full changelog for details.
     </li>
   </ul>
+  <h3>Surface Mesh</h3>
+  <ul>
+    <li>
+      <b>Breaking change</b>: <code>operator >>(std::istream&, Surface_mesh&)</code>
+      no longer clears the surface mesh.
+    </li>
+  </ul>
   <h3>Triangulated Surface Mesh Parameterization (breaking change)</h3>
   <ul>
     <li>

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2155,7 +2155,8 @@ private: //------------------------------------------------------- private data
 
  
   /// \relates Surface_mesh
-  /// This operator calls `read_off(std::istream& , CGAL::Surface_mesh)`.
+  /// This operator calls `read_off(std::istream& , CGAL::Surface_mesh& sm)`.
+  /// \attention Up to CGAL 4.10 this operator called `sm.clear()`.
   template <typename P>
   std::istream& operator>>(std::istream& is, Surface_mesh<P>& sm)
   {


### PR DESCRIPTION

## Summary of Changes

Document that ` operator>>(std::istream, CGAL::Surface_mesh& sm)` does not call `sm.clear()`. 

This change was introduced to make it behave identical to ` read_off(..)`

## Release Management

* Affected package(s): Surface_mesh

