### PR TITLE
Parameterization:  Remove VC++ compiler option; Remove a macro concerning Eigen

### DIFF
--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -21,7 +21,6 @@
 
 #include <CGAL/basic.h> // include basic.h before testing #defines
 
-#define EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
 #include <Eigen/Sparse>
 
 namespace CGAL {

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -19,8 +19,6 @@ if ( CGAL_FOUND )
 
   # VisualC++ optimization for applications dealing with large data
   if (MSVC)
-    # Use /FR to turn on IntelliSense
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FR")
 
     # Allow Windows applications to use up to 3GB of RAM
     SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")


### PR DESCRIPTION
## Summary of Changes

The compiler option `/FR` leads to an [ICE in the testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-34/Surface_mesh_parameterization/TestReport_afabri_x64_Cygwin-Windows10_MSVC2013-Debug-64bits.gz) for just `#include <Eigen/Sparse>`.

I at the same time removed the line `#define EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET`, as according to Gael Guennebaud this package is stable now. 

## Release Management

* Affected package(s): Surface_mesh_parameterization


