### PR TITLE
Polyhedron demo: remove pushButton from selection plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -430,13 +430,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pushButton">
-              <property name="text">
-               <string>PushButton</string>
-              </property>
-             </widget>
-            </item>
-            <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
                <enum>Qt::Vertical</enum>


### PR DESCRIPTION
## Summary of Changes

There was one default button added by mistake.

## Release Management

* Affected package(s): Polyhedron demo
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2395
