### PR TITLE
Fix cmap output builder

### DIFF
--- a/Operations_on_polyhedra/include/CGAL/internal/corefinement/Combinatorial_map_output_builder.h
+++ b/Operations_on_polyhedra/include/CGAL/internal/corefinement/Combinatorial_map_output_builder.h
@@ -132,7 +132,7 @@ void sew_2_marked_darts( Combinatorial_map_3& final_map,
   if ( final_map.template attribute<0>(dart_1)->point() != nodes[ src_index ] )
     std::swap(dart_1,dart_2);
 
-  int nb_segs=polyline_info.second-1,k=1;
+  int nb_segs=polyline_info.second+1,k=1;
 
   do {
     CGAL_precondition( final_map.template is_sewable<2>(dart_1,dart_2) );


### PR DESCRIPTION
Fix the class `Combinatorial_output_builder` used in old version of corefinement