### PR TITLE
Shape Detection: avoid index out of range with large bitmap sizes

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Shape_base.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Shape_base.h
@@ -168,7 +168,7 @@ namespace CGAL {
         u = (u < 0) ? 0 : (((std::size_t)u >= u_extent) ? (int)u_extent - 1 : u);
         v = (v < 0) ? 0 : (((std::size_t)v >= v_extent) ? (int)v_extent - 1 : v);
 
-        bitmap[v * int(u_extent) + u] = true;
+        bitmap[size_t(v) * u_extent + size_t(u)] = true;
       }
 
       // Iterate through the bitmap
@@ -251,7 +251,7 @@ namespace CGAL {
         u = (u < 0) ? 0 : (((std::size_t)u >= u_extent) ? (int)u_extent - 1 : u);
         v = (v < 0) ? 0 : (((std::size_t)v >= v_extent) ? (int)v_extent - 1 : v);
 
-        count[bitmap[v * int(u_extent) + u]]++;
+        count[bitmap[size_t(v) * u_extent + size_t(u)]]++;
       }
 
       // Find largest component. Start at index 2 as 0/1 are reserved for
@@ -271,7 +271,7 @@ namespace CGAL {
         u = (u < 0) ? 0 : (((std::size_t)u >= u_extent) ? (int)u_extent - 1 : u);
         v = (v < 0) ? 0 : (((std::size_t)v >= v_extent) ? (int)v_extent - 1 : v);
 
-        if (bitmap[v * int(u_extent) + u] == largest)
+        if (bitmap[size_t(v) * u_extent + size_t(u)] == largest)
           comp_indices.push_back(indices[i]);
       }
 


### PR DESCRIPTION
With large u and v, the product u * v exceeds the capacity of an int.  The result when coerced to size_t can be an out of range index into bitmap.
Avoid this by casting u and v to size_t before multiplying.

## Release Management

* Affected package(s): Point set shape detection
* Issue(s) solved (if any): fix #2408 

