### PR TITLE
Polyhedron demo: reset points order before saving

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -572,7 +572,9 @@ bool Scene_points_with_normal_item::read_las_point_set(std::istream& stream)
 bool Scene_points_with_normal_item::write_las_point_set(std::ostream& stream) const
 {
   Q_ASSERT(d->m_points != NULL);
-
+  
+  d->m_points->reset_indices();
+  
   return stream &&
     CGAL::write_las_point_set (stream, *(d->m_points));
 }
@@ -606,6 +608,8 @@ bool Scene_points_with_normal_item::write_ply_point_set(std::ostream& stream, bo
 {
   Q_ASSERT(d->m_points != NULL);
 
+  d->m_points->reset_indices();
+  
   if (!stream)
     return false;
 
@@ -636,6 +640,8 @@ bool Scene_points_with_normal_item::write_off_point_set(std::ostream& stream) co
 {
   Q_ASSERT(d->m_points != NULL);
 
+  d->m_points->reset_indices();
+
   return stream &&
     CGAL::write_off_point_set (stream, *(d->m_points));
 }
@@ -659,6 +665,8 @@ bool Scene_points_with_normal_item::read_xyz_point_set(std::istream& stream)
 bool Scene_points_with_normal_item::write_xyz_point_set(std::ostream& stream) const
 {
   Q_ASSERT(d->m_points != NULL);
+
+  d->m_points->reset_indices();
 
   return stream &&
     CGAL::write_xyz_point_set (stream, *(d->m_points));

--- a/Polyhedron/demo/Polyhedron/include/Point_set_3.h
+++ b/Polyhedron/demo/Polyhedron/include/Point_set_3.h
@@ -127,6 +127,14 @@ public:
   const_iterator end() const { return this->m_indices.end(); }
   std::size_t size() const { return this->m_base.size(); }
 
+  void reset_indices()
+  {
+    unselect_all();
+    
+    for (std::size_t i = 0; i < this->m_base.size(); ++ i)
+      this->m_indices[i] = i;
+  }
+  
   bool add_radius()
   {
     bool out = false;


### PR DESCRIPTION
## Summary of Changes

In order to handle the quick display of point sets (only displaying a random fraction of the points when moving the camera), indices of points are shuffled. But as result, when saving a point set, even unaltered, the points have a different order than in the input file, which can be disturbing for users.

This PR resets the indices before saving.

## Release Management

* Affected package(s): Polyhedron demo