### PR TITLE
Point set 2: make method dfs non-recursive

### DIFF
--- a/Point_set_2/include/CGAL/Point_set_2.h
+++ b/Point_set_2/include/CGAL/Point_set_2.h
@@ -326,25 +326,35 @@ public:
   
   void dfs(Vertex_handle v,const Circle& C, std::list<Vertex_handle>& L)
   {
-    L.push_back(v);
-    mark_vertex(v);
-    
-    // get incident vertices of v ...
-    Vertex_circulator vc = incident_vertices(v);
-    Vertex_circulator start =vc;
-     
-    Vertex_handle act;
-     
-    // go through the vertices ...
-    do {
-      act = vc;
- 
-       if (! is_infinite(act)) {
-        if (!is_marked(act) && ! (tr_circleptori(C,act->point())==ON_UNBOUNDED_SIDE) ) 
-           dfs(act,C,L);       
-       }             
-       vc++;
-    } while (vc != start);     
+    std::stack<Vertex_handle> todo;
+    todo.push(v);
+
+    while (!todo.empty())
+    {
+      Vertex_handle current = todo.top();
+      todo.pop();
+
+      if (is_marked(current))
+        continue;
+      
+      L.push_back(current);
+      mark_vertex(current);
+
+      // get incident vertices of v ...
+      Vertex_circulator vc = incident_vertices(current);
+      Vertex_circulator start =vc;
+      Vertex_handle act;
+      // go through the vertices ...
+      do {
+        act = vc;
+        
+        if (! is_infinite(act)) {
+          if (!is_marked(act) && ! (tr_circleptori(C,act->point())==ON_UNBOUNDED_SIDE) )
+            todo.push(act);
+        }             
+        vc++;
+      } while (vc != start);
+    }
   }
 
 

--- a/Point_set_2/include/CGAL/Point_set_2.h
+++ b/Point_set_2/include/CGAL/Point_set_2.h
@@ -250,7 +250,7 @@ public:
      Point p = v->point();
      
      // "unmark" the vertices ...
-     init_dfs();
+     init_search();
 
      MAP_TYPE                                        priority_number;              // here we save the priorities ...
      internal::compare_vertices<Vertex_handle,Numb_type,MAP_TYPE>    
@@ -293,7 +293,6 @@ public:
   } 
    
    
-  // dfs
   // for marking nodes in search procedures
   size_type cur_mark;
    
@@ -305,7 +304,7 @@ public:
      mark.clear();
   }
   
-  void init_dfs()
+  void init_search()
   {
      cur_mark++; 
      if (cur_mark == (std::numeric_limits<size_type>::max)()) init_vertex_marks();
@@ -324,7 +323,7 @@ public:
     return (mark[vh] == cur_mark);
   }
   
-  void dfs(Vertex_handle v,const Circle& C, std::list<Vertex_handle>& L)
+  void search(Vertex_handle v,const Circle& C, std::list<Vertex_handle>& L)
   {
     std::stack<Vertex_handle> todo;
     todo.push(v);
@@ -385,10 +384,10 @@ public:
        v = insert(p); 
      }
      
-     init_dfs();
+     init_search();
      
      std::list<Vertex_handle> L;
-     dfs(v,C,L);
+     search(v,C,L);
      
      if (new_v)
      { L.pop_front();   //first one was inserted in range_search ...


### PR DESCRIPTION
## Summary of Changes

One method of `Point_set_2` is recursive and may lead to stack overflow. Simply replacing it with an `std::stack` (with an additional check when destacking) solves the issue. I tested it locally.

## Release Management

* Affected package(s): Point Set 2
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2410

