### PR TITLE
SM shortest paths: Fix locate with a custom VertexPoint Pmap

### DIFF
--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -2773,6 +2773,12 @@ public:
   \param outTree Output parameter to store the computed `AABB_tree`
   */
   template <class AABBTraits>
+  void build_aabb_tree(AABB_tree<AABBTraits>& outTree) const
+  {
+    build_aabb_tree(m_graph, outTree, m_vertexPointMap);
+  }
+
+  template <class AABBTraits>
   void build_aabb_tree(AABB_tree<AABBTraits>& outTree, Vertex_point_map vertexPointMap) const
   {
     build_aabb_tree(m_graph, outTree, vertexPointMap);

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -2612,10 +2612,11 @@ public:
   /// \cond
 
   template <class AABBTraits>
-  static Face_location locate(const Point_3& location, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
+  static Face_location locate(const Point_3& location, const Triangle_mesh& tm,
+                              Vertex_point_map vertexPointMap, const Traits& traits = Traits())
   {
     AABB_tree<AABBTraits> tree;
-    build_aabb_tree(tm, tree);
+    build_aabb_tree(tm, tree, vertexPointMap);
     return locate(location, tree, tm, vertexPointMap, traits);
   }
 
@@ -2676,10 +2677,11 @@ public:
   /// \cond
 
   template <class AABBTraits>
-  static Face_location locate(const Ray_3& ray, const Triangle_mesh& tm, Vertex_point_map vertexPointMap, const Traits& traits = Traits())
+  static Face_location locate(const Ray_3& ray, const Triangle_mesh& tm,
+                              Vertex_point_map vertexPointMap, const Traits& traits = Traits())
   {
     AABB_tree<AABBTraits> tree;
-    build_aabb_tree(tm, tree);
+    build_aabb_tree(tm, tree, vertexPointMap);
     return locate(ray, tree, tm, vertexPointMap, traits);
   }
 
@@ -2771,19 +2773,20 @@ public:
   \param outTree Output parameter to store the computed `AABB_tree`
   */
   template <class AABBTraits>
-  void build_aabb_tree(AABB_tree<AABBTraits>& outTree) const
+  void build_aabb_tree(AABB_tree<AABBTraits>& outTree, Vertex_point_map vertexPointMap) const
   {
-    build_aabb_tree(m_graph, outTree);
+    build_aabb_tree(m_graph, outTree, vertexPointMap);
   }
 
   /// \cond
 
   template <class AABBTraits>
-  static void build_aabb_tree(const Triangle_mesh& tm, AABB_tree<AABBTraits>& outTree)
+  static void build_aabb_tree(const Triangle_mesh& tm, AABB_tree<AABBTraits>& outTree,
+                              Vertex_point_map vertexPointMap)
   {
     face_iterator facesStart, facesEnd;
     boost::tie(facesStart, facesEnd) = faces(tm);
-    outTree.rebuild(facesStart, facesEnd, tm);
+    outTree.rebuild(facesStart, facesEnd, tm, vertexPointMap);
     outTree.build();
   }
   /// \endcond


### PR DESCRIPTION
## Summary of Changes
The package `SM_shortest_path` offers a locate function which builds an `AABB` tree to find the closest point on the face graph. It is possible to pass a custom Vertex Point Property map when calling `locate()`, but this map was not used when constructing the `AABB` tree.

Added an overload to `build_aabb_tree()` for convience (uses the default VPM).

## Release Management

* Affected package(s): `Surface_mesh_shortest_path`
* Issue(s) solved (if any): -- 
* Feature/Small Feature (if any): --

