### PR TITLE
Polyhedron demo: New widget for color computation

### DIFF
--- a/Polyhedron/demo/Polyhedron/Color_ramp.cpp
+++ b/Polyhedron/demo/Polyhedron/Color_ramp.cpp
@@ -120,12 +120,19 @@ Color_ramp::build_thermal()
   g_.rebuild(1,0);
   b_.rebuild(1,0);
 
-  r_.add(0.3,1);
-  r_.add(0.05,1);
+  r_.add(0.0,0);
+  r_.add(1,1);
   g_.add(0.05,0.8);
   g_.add(0.3,0.5);
-  b_.add(0.05,0.6);
-  b_.add(0.05,0.3);
+  b_.add(0.0,1.0);
+  b_.add(1.0,0.0);
+}
+void Color_ramp::
+build_red_to_green()
+{
+  r_.rebuild(1,0);
+  g_.rebuild(0,1);
+  b_.rebuild(0,0);
 }
 
 void

--- a/Polyhedron/demo/Polyhedron/Color_ramp.cpp
+++ b/Polyhedron/demo/Polyhedron/Color_ramp.cpp
@@ -87,6 +87,19 @@ Color_ramp::Color_ramp()
 { 
 }
 
+Color_ramp::Color_ramp(const double r0, const double r1,
+           const double g0, const double g1,
+           const double b0, const double b1)
+{
+  r_.rebuild(r0,r1);
+  g_.rebuild(g0,g1);
+  b_.rebuild(b0,b1);
+
+  r_.add(0.5,(std::max)(r0,r1));
+  g_.add(0.5,(std::max)(g0,g1));
+  b_.add(0.5,(std::max)(b0,b1));
+  }
+
 void 
 Color_ramp::build_red()
 {
@@ -126,13 +139,6 @@ Color_ramp::build_thermal()
   g_.add(0.3,0.5);
   b_.add(0.0,1.0);
   b_.add(1.0,0.0);
-}
-void Color_ramp::
-build_red_to_green()
-{
-  r_.rebuild(1,0);
-  g_.rebuild(0,1);
-  b_.rebuild(0,0);
 }
 
 void

--- a/Polyhedron/demo/Polyhedron/Color_ramp.h
+++ b/Polyhedron/demo/Polyhedron/Color_ramp.h
@@ -47,6 +47,7 @@ public :
 	void build_red();
 	void build_blue();
         void build_thermal();
+        void build_red_to_green();
   void print() const;
 
 private :

--- a/Polyhedron/demo/Polyhedron/Color_ramp.h
+++ b/Polyhedron/demo/Polyhedron/Color_ramp.h
@@ -37,7 +37,8 @@ class SCENE_COLOR_RAMP_EXPORT Color_ramp
 {
 public :
 	Color_ramp();
-	~Color_ramp() {}
+        Color_ramp(const double r0, const double r1, const double g0, const double g1,
+                   const double b0, const double b1);
 
 public :
   inline double r(double v) const;
@@ -47,7 +48,7 @@ public :
 	void build_red();
 	void build_blue();
         void build_thermal();
-        void build_red_to_green();
+
   void print() const;
 
 private :

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/CMakeLists.txt
@@ -1,0 +1,5 @@
+include( polyhedron_demo_macros )
+
+qt5_wrap_ui( display_propertyUI_FILES Display_property.ui )
+polyhedron_demo_plugin(display_property_plugin Display_property_plugin ${display_propertyUI_FILES})
+target_link_libraries(display_property_plugin scene_surface_mesh_item scene_color_ramp)

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -186,12 +186,12 @@
        <widget class="QComboBox" name="propertyBox">
         <item>
          <property name="text">
-          <string>Scaled Jacobian</string>
+          <string>Smallest Angle Per Face</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Smallest Angle Per Face</string>
+          <string>Scaled Jacobian</string>
          </property>
         </item>
        </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DisplayPropertyWidget</class>
+ <widget class="QDockWidget" name="DisplayPropertyWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>485</width>
+    <height>299</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Property Displaying</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
+      <item>
+       <widget class="QLabel" name="legendLabel">
+        <property name="text">
+         <string>RAMP DISPLAYING</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="3" column="2">
+         <widget class="QDoubleSpinBox" name="redMaxBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QDoubleSpinBox" name="greenMinBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QDoubleSpinBox" name="greenMaxBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Coef at Max</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="QPushButton" name="rampButton">
+          <property name="text">
+           <string>Replace Ramp</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Red Component: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QDoubleSpinBox" name="redMinBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QDoubleSpinBox" name="blueMinBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="QDoubleSpinBox" name="blueMaxBox">
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Ramp Extrema: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Blue Component: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Green Component: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Coef at Min</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="minBox"/>
+        </item>
+        <item row="1" column="2">
+         <widget class="QDoubleSpinBox" name="maxBox">
+          <property name="value">
+           <double>2.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+      <item>
+       <widget class="QComboBox" name="propertyBox">
+        <item>
+         <property name="text">
+          <string>Scaled Jacobian</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Smallest Angle Per Face</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="colorizeButton">
+        <property name="text">
+         <string>Colorize</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -313,7 +313,7 @@ private Q_SLOTS:
     }
   }
 
-  void closure()
+  void closure()Q_DECL_OVERRIDE
   {
     dock_widget->hide();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -94,15 +94,13 @@ private Q_SLOTS:
     QApplication::setOverrideCursor(Qt::WaitCursor);
     SMesh& smesh = *item->face_graph();
     smesh.collect_garbage();
-    typedef boost::property_map<SMesh, boost::vertex_point_t>::type PMap;
-    PMap pmap = get(boost::vertex_point, smesh);
     switch(dock_widget->propertyBox->currentIndex())
     {
     case 0:
-      displayScaledJacobian(smesh);
+      displayAngles(smesh);
       break;
     default:
-      displayAngles(smesh);
+      displayScaledJacobian(smesh);
       break;
     }
     QApplication::restoreOverrideCursor();
@@ -293,15 +291,6 @@ private Q_SLOTS:
     switch(dock_widget->propertyBox->currentIndex())
     {
     case 0:
-      dock_widget->minBox->setMinimum(-1000);
-      dock_widget->minBox->setMaximum(1000);
-      dock_widget->minBox->setValue(0);
-
-      dock_widget->maxBox->setMinimum(-1000);
-      dock_widget->maxBox->setMaximum(1000);
-      dock_widget->maxBox->setValue(2);
-      break;
-    default:
       dock_widget->minBox->setMinimum(0);
       dock_widget->minBox->setMaximum(360);
       dock_widget->minBox->setValue(0);
@@ -310,7 +299,17 @@ private Q_SLOTS:
       dock_widget->maxBox->setMaximum(360);
       dock_widget->maxBox->setValue(60);
       break;
+    default:
+      dock_widget->minBox->setMinimum(-1000);
+      dock_widget->minBox->setMaximum(1000);
+      dock_widget->minBox->setValue(0);
+
+      dock_widget->maxBox->setMinimum(-1000);
+      dock_widget->maxBox->setMaximum(1000);
+      dock_widget->maxBox->setValue(2);
+      break;
     }
+    replaceRamp();
   }
 
   void closure()Q_DECL_OVERRIDE

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -1,0 +1,451 @@
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include <QApplication>
+#include <QObject>
+#include <QAction>
+#include <QMainWindow>
+#include <QInputDialog>
+#include "Messages_interface.h"
+#include "Scene_surface_mesh_item.h"
+#include "Color_ramp.h"
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include "ui_Display_property.h"
+
+#define VERDICT_DBL_MIN 1.0E-30
+#define VERDICT_DBL_MAX 1.0E+30
+
+class DockWidget :
+    public QDockWidget,
+    public Ui::DisplayPropertyWidget
+{
+public:
+  DockWidget(QString name, QWidget *parent)
+    :QDockWidget(name,parent)
+  {
+    setupUi(this);
+  }
+};
+
+typedef boost::graph_traits<SMesh>::halfedge_descriptor halfedge_descriptor;
+typedef boost::graph_traits<SMesh>::face_descriptor face_descriptor;
+
+class DisplayPropertyPlugin :
+    public QObject,
+    public CGAL::Three::Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+public:
+
+  bool applicable(QAction*) const Q_DECL_OVERRIDE
+  {
+    CGAL::Three::Scene_item* item = scene->item(scene->mainSelectionIndex());
+    return qobject_cast<Scene_surface_mesh_item*>(item);
+  }
+
+  QList<QAction*> actions() const Q_DECL_OVERRIDE
+  {
+    return _actions;
+  }
+
+  void init(QMainWindow* mw, CGAL::Three::Scene_interface* sc, Messages_interface* mi) Q_DECL_OVERRIDE
+  {
+    this->scene = sc;
+    this->mw = mw;
+
+    QAction *actionDisplayAngles= new QAction(QString("Display Properties"), mw);
+
+    actionDisplayAngles->setProperty("submenuName", "Color");
+
+    if(actionDisplayAngles) {
+      connect(actionDisplayAngles, SIGNAL(triggered()),
+              this, SLOT(openDialog()));
+      _actions << actionDisplayAngles;
+
+    }
+    dock_widget = new DockWidget("Property Displaying", mw);
+    dock_widget->setVisible(false);
+    addDockWidget(dock_widget);
+    connect(dock_widget->colorizeButton, SIGNAL(clicked(bool)),
+            this, SLOT(colorize()));
+
+    connect(dock_widget->rampButton, SIGNAL(clicked(bool)),
+            this, SLOT(replaceRamp()));
+
+    connect(dock_widget->propertyBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(on_propertyBox_currentIndexChanged(int)));
+    on_propertyBox_currentIndexChanged(0);
+
+  }
+private Q_SLOTS:
+  void openDialog()
+  {
+    if(dock_widget->isVisible()) { dock_widget->hide(); }
+    else                         { replaceRamp(); dock_widget->show(); }
+  }
+
+  void colorize()
+  {
+    Scene_surface_mesh_item* item =
+        qobject_cast<Scene_surface_mesh_item*>(scene->item(scene->mainSelectionIndex()));
+    if(!item)
+      return;
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    SMesh& smesh = *item->face_graph();
+    smesh.collect_garbage();
+    typedef boost::property_map<SMesh, boost::vertex_point_t>::type PMap;
+    PMap pmap = get(boost::vertex_point, smesh);
+    switch(dock_widget->propertyBox->currentIndex())
+    {
+    case 0:
+      displayScaledJacobian(smesh);
+      break;
+    default:
+      displayAngles(smesh);
+      break;
+    }
+    QApplication::restoreOverrideCursor();
+    item->invalidateOpenGLBuffers();
+    item->itemChanged();
+  }
+
+  void displayScaledJacobian(SMesh& smesh)
+  {
+
+    //compute and store the jacobian per face
+    std::vector<float> jacobians;
+    jacobians.reserve(num_faces(smesh));
+    float res_min = VERDICT_DBL_MAX,
+        res_max = -VERDICT_DBL_MAX;
+    for(boost::graph_traits<SMesh>::face_iterator fit = faces(smesh).begin();
+        fit != faces(smesh).end();
+        ++fit)
+    {
+      jacobians.push_back(scaled_jacobian(*fit, smesh));
+      if(jacobians.back() > res_max)
+        res_max = jacobians.back();
+      if(jacobians.back() < res_min)
+        res_min = jacobians.back();
+
+      QApplication::processEvents();
+    }
+    //scale a color ramp between min and max
+    float max = maxBox;
+    float min = minBox;
+    //fill f:color pmap
+    SMesh::Property_map<face_descriptor, CGAL::Color> fcolors =
+        smesh.add_property_map<face_descriptor, CGAL::Color >("f:color", CGAL::Color()).first;
+    int index =0;
+    for(boost::graph_traits<SMesh>::face_iterator fit = faces(smesh).begin();
+        fit != faces(smesh).end();
+        ++fit)
+    {
+      if(min == max)
+        --min;
+      float f = (jacobians[index]-min)/(max-min);
+      if(f<min)
+        f = min;
+      if(f>max)
+        f = max;
+      CGAL::Color color(
+            255*color_ramp.r(f),
+            255*color_ramp.g(f),
+            255*color_ramp.b(f));
+      ++index;
+      fcolors[*fit] = color;
+    }
+    dock_widget->minBox->setValue(res_min);
+    dock_widget->maxBox->setValue(res_max);
+  }
+
+  void displayAngles(SMesh& smesh)
+  {
+    typedef boost::property_map<SMesh, boost::vertex_point_t>::type PMap;
+    PMap pmap = get(boost::vertex_point, smesh);
+    //compute and store smallest angle per face
+    std::vector<float> angles;
+    float res_min = VERDICT_DBL_MAX,
+        res_max = -VERDICT_DBL_MAX;
+    angles.reserve(num_faces(smesh));
+    for(boost::graph_traits<SMesh>::face_iterator fit = faces(smesh).begin();
+        fit != faces(smesh).end();
+        ++fit)
+    {
+      bool is_face_triangle = is_triangle(halfedge(*fit, smesh), smesh);
+      bool normal_is_ok;
+      EPICK::Vector_3 normal(0,0,0);
+
+      EPICK::Orientation orientation;
+      if(!is_face_triangle)
+      {
+        face_descriptor f = *fit;
+        CGAL::Halfedge_around_face_circulator<SMesh>
+            he(halfedge(f, smesh), smesh),
+            he_end(he);
+        do{
+          normal_is_ok = true;
+
+          //Initializes the facet orientation
+
+          EPICK::Point_3 S,T;
+          T = get(pmap, source(*he, smesh));
+          S = get(pmap, target(*he, smesh));
+          EPICK::Vector_3 V1((T-S).x(), (T-S).y(), (T-S).z());
+          S = get(pmap,source(next(*he,smesh), smesh));
+          T = get(pmap, target(next(*he,smesh), smesh));
+          EPICK::Vector_3 V2((T-S).x(), (T-S).y(), (T-S).z());
+
+          if(normal == EPICK::Vector_3(0,0,0))
+            normal_is_ok = false;
+          {
+            normal = CGAL::cross_product(V1, V2);
+          }
+          if(normal_is_ok)
+          {
+            orientation = EPICK::Orientation_3()(V1, V2, normal);
+            if( orientation == CGAL::COPLANAR )
+              normal_is_ok = false;
+          }
+        }while( ++he != he_end && !normal_is_ok);
+      }
+
+      std::vector<float> local_angles;
+      local_angles.reserve(degree(*fit, smesh));
+      BOOST_FOREACH(halfedge_descriptor hd,
+                    halfedges_around_face(halfedge(*fit, smesh),smesh))
+      {
+        halfedge_descriptor hdn = next(hd, smesh);
+        EPICK::Vector_3 v1(get(pmap, source(hd, smesh)), get(pmap, target(hd, smesh))),
+            v2(get(pmap, target(hdn, smesh)), get(pmap, source(hdn, smesh)));
+        float norm1(CGAL::approximate_sqrt(v1.squared_length())), norm2(CGAL::approximate_sqrt(v2.squared_length()));
+        float dot_prod = v1*v2;
+        float angle = std::acos(dot_prod/(norm1*norm2));
+        if(is_face_triangle || !normal_is_ok)
+          local_angles.push_back(angle * 180/CGAL_PI);
+        else
+        {
+          bool is_convex = true;
+          EPICK::Orientation res = EPICK::Orientation_3()(v1, v2, normal) ;
+          if(res!= orientation && res != CGAL::ZERO)
+            is_convex = false;
+          local_angles.push_back(is_convex ? angle * 180/CGAL_PI : 360 - angle * 180/CGAL_PI );
+        }
+      }
+      std::sort(local_angles.begin(), local_angles.end());
+      angles.push_back(local_angles.front());
+      if(angles.back() > res_max)
+        res_max = angles.back();
+      if(angles.back() < res_min)
+        res_min = angles.back();
+      QApplication::processEvents();
+    }
+    //scale a color ramp between min and max
+
+    float max = maxBox;
+    float min = minBox;
+
+    //fill f:color pmap
+    SMesh::Property_map<face_descriptor, CGAL::Color> fcolors =
+        smesh.add_property_map<face_descriptor, CGAL::Color >("f:color", CGAL::Color()).first;
+    int index =0;
+    for(boost::graph_traits<SMesh>::face_iterator fit = faces(smesh).begin();
+        fit != faces(smesh).end();
+        ++fit)
+    {
+      if(min == max)
+        --min;
+      float f = (angles[index]-min)/(max-min);
+      if(f<0)
+        f = 0;
+      if(f>1)
+        f = 1;
+      CGAL::Color color(
+            255*color_ramp.r(f),
+            255*color_ramp.g(f),
+            255*color_ramp.b(f));
+      ++index;
+      fcolors[*fit] = color;
+    }
+    dock_widget->minBox->setValue(res_min);
+    dock_widget->maxBox->setValue(res_max);
+  }
+
+  void replaceRamp()
+  {
+    double rm = dock_widget->redMinBox->value();
+    double rM = dock_widget->redMaxBox->value();
+
+    double gm = dock_widget->greenMinBox->value();
+    double gM = dock_widget->greenMaxBox->value();
+
+    double bm = dock_widget->blueMinBox->value();
+    double bM = dock_widget->blueMaxBox->value();
+
+    color_ramp = Color_ramp(rm, rM, gm, gM, bm, bM);
+    displayLegend();
+    minBox = dock_widget->minBox->value();
+    maxBox = dock_widget->maxBox->value();
+  }
+
+  void on_propertyBox_currentIndexChanged(int)
+  {
+    switch(dock_widget->propertyBox->currentIndex())
+    {
+    case 0:
+      dock_widget->minBox->setMinimum(-1000);
+      dock_widget->minBox->setMaximum(1000);
+      dock_widget->minBox->setValue(0);
+
+      dock_widget->maxBox->setMinimum(-1000);
+      dock_widget->maxBox->setMaximum(1000);
+      dock_widget->maxBox->setValue(2);
+      break;
+    default:
+      dock_widget->minBox->setMinimum(0);
+      dock_widget->minBox->setMaximum(360);
+      dock_widget->minBox->setValue(0);
+
+      dock_widget->maxBox->setMinimum(0);
+      dock_widget->maxBox->setMaximum(360);
+      dock_widget->maxBox->setValue(60);
+      break;
+    }
+  }
+
+  void closure()
+  {
+    dock_widget->hide();
+  }
+
+private:
+  void displayLegend()
+  {
+    // Create an legend_ and display it
+    const int height = 256;
+    const int width = 256;
+    const int cell_width = width/3;
+    const int top_margin = 5;
+    const int left_margin = (width-cell_width)/2;
+    const int drawing_height = height - top_margin * 2;
+    const int text_height = 20;
+
+    legend_ = QPixmap(width, height + text_height);
+    legend_.fill(QColor(200, 200, 200));
+
+    QPainter painter(&legend_);
+    painter.setPen(Qt::black);
+    painter.setBrush(QColor(200, 200, 200));
+
+    // Build legend_ data
+    double min_value(dock_widget->minBox->value()),
+        max_value(dock_widget->maxBox->value());
+    std::vector<double> graduations(100);
+    for(int i=0; i<100; ++i)
+      graduations[i] = i/100.0;
+
+    // draw
+    int i=0;
+    for (std::vector<double>::iterator it = graduations.begin(), end = graduations.end();
+         it != end; ++it, i+=2)
+    {
+      QColor color(255*color_ramp.r(*it),
+                   255*color_ramp.g(*it),
+                   255*color_ramp.b(*it));
+      painter.fillRect(left_margin,
+                       drawing_height - top_margin - i,
+                       cell_width,
+                       2,
+                       color);
+    }
+
+    // draw right vertical line
+    painter.setPen(Qt::blue);
+
+    painter.drawLine(QPoint(left_margin + cell_width+10, drawing_height - top_margin),
+                     QPoint(left_margin + cell_width+10,
+                            drawing_height - top_margin - static_cast<int>(graduations.size())*2));
+
+
+    // draw min value and max value
+    painter.setPen(Qt::blue);
+    QRect min_text_rect(left_margin + cell_width+10,drawing_height - top_margin,
+                        50, text_height);
+    painter.drawText(min_text_rect, Qt::AlignCenter, tr("%1").arg(min_value, 0, 'f', 1));
+
+    QRect max_text_rect(left_margin + cell_width+10, drawing_height - top_margin - 200,
+                        50, text_height);
+    painter.drawText(max_text_rect, Qt::AlignCenter, tr("%1").arg(max_value, 0, 'f', 1));
+
+    dock_widget->legendLabel->setPixmap(legend_);
+  }
+  double scaled_jacobian( const face_descriptor& f , const SMesh mesh);
+  QList<QAction*> _actions;
+  Color_ramp color_ramp;
+  DockWidget* dock_widget;
+  float minBox;
+  float maxBox;
+  QPixmap legend_;
+};
+
+  /// Code based on the verdict module of vtk
+
+  /*=========================================================================
+  Copyright (c) 2006 Sandia Corporation.
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+
+  double DisplayPropertyPlugin::scaled_jacobian( const face_descriptor& f , const SMesh mesh)
+  {
+    boost::property_map<SMesh, boost::vertex_point_t>::type
+        pmap = get(boost::vertex_point, mesh);
+    std::vector<double> corner_areas(degree(f, mesh));
+    std::vector<EPICK::Vector_3> edges;
+    BOOST_FOREACH(halfedge_descriptor hd, CGAL::halfedges_around_face(halfedge(f, mesh), mesh))
+    {
+      edges.push_back(EPICK::Vector_3(get(pmap, source(hd, mesh)), get(pmap, target(hd, mesh))));
+    }
+    BOOST_FOREACH(halfedge_descriptor hd, CGAL::halfedges_around_face(halfedge(f, mesh), mesh))
+    {
+      std::vector<EPICK::Vector_3> corner_normals;
+      for(std::size_t i = 0; i < edges.size(); ++i)
+      {
+        corner_normals.push_back(CGAL::cross_product(edges[i], edges[(i+1)%(edges.size())]));
+      }
+
+
+      EPICK::Vector_3 unit_center_normal = CGAL::Polygon_mesh_processing::compute_face_normal(f, mesh);
+      unit_center_normal *= 1.0/CGAL::approximate_sqrt(unit_center_normal.squared_length());
+
+      for(std::size_t i = 0; i < corner_areas.size(); ++i)
+      {
+        corner_areas[i] =  unit_center_normal*corner_normals[i];
+      }
+    }
+    std::vector<double> length;
+    for(std::size_t i=0; i<edges.size(); ++i)
+    {
+      length.push_back(CGAL::approximate_sqrt(edges[i].squared_length()));
+      if( length[i] < VERDICT_DBL_MIN)
+        return 0.0;
+    }
+    double min_scaled_jac = VERDICT_DBL_MAX;
+    for(std::size_t i=0; i<edges.size(); ++i)
+    {
+      double scaled_jac = corner_areas[i] / (length[i] * length[(i+edges.size()-1)%(edges.size())]);
+      min_scaled_jac = (std::min)( scaled_jac, min_scaled_jac );
+    }
+
+    if( min_scaled_jac > 0 )
+      return (double) (std::min)( min_scaled_jac, VERDICT_DBL_MAX );
+    return (double) (std::max)( min_scaled_jac, -VERDICT_DBL_MAX );
+
+  }
+
+
+#include "Display_property_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -169,7 +169,7 @@ private Q_SLOTS:
     boost::tie(fangle, non_init) = smesh.add_property_map<face_descriptor, double>("f:angle", 0);
     if(non_init)
     {
-      float res_min = ARBITRARY_DBL_MAX,
+      double res_min = ARBITRARY_DBL_MAX,
           res_max = -ARBITRARY_DBL_MAX;
       for(boost::graph_traits<SMesh>::face_iterator fit = faces(smesh).begin();
           fit != faces(smesh).end();

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1294,7 +1294,7 @@ void Viewer::paintEvent(QPaintEvent *)
 {
   if(!d->initialized)
     initializeGL();
-    paintGL();
+  paintGL();
 }
 
 void Viewer::paintGL()

--- a/Three/demo/Three/Example_plugin/Dock_widget_plugin.cpp
+++ b/Three/demo/Three/Example_plugin/Dock_widget_plugin.cpp
@@ -85,7 +85,7 @@ private Q_SLOTS:
   }
   //! [action]
   //! [closure]
-  void closure()
+  void closure()Q_DECL_OVERRIDE
   {
     dock_widget->hide();
   }


### PR DESCRIPTION
## Summary of Changes
Adds a widget that allows to colorize a surface_mesh according to the smallest angle of each of its faces, or according to their scaled jacobian.
## Release Management