### PR TITLE
Polyhedron demo: bug fix for writing binary PLY

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
@@ -183,7 +183,7 @@ bool Polyhedron_demo_ply_plugin::save(const CGAL::Three::Scene_item* item, QFile
   if (!ok)
     return false;
   
-  std::ofstream out(fileinfo.filePath().toUtf8().data());
+  std::ofstream out(fileinfo.filePath().toUtf8().data(), std::ios::binary);
   out.precision (std::numeric_limits<double>::digits10 + 2);
   
   // This plugin supports point sets


### PR DESCRIPTION

## Summary of Changes

For VC++ the stream must be opened in binary mode.

## Release Management

* Affected package(s): Polyhedron


