### PR TITLE
PSP:  make read_ply_points faster for VC++ < 2017

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -165,6 +165,11 @@ namespace internal {
       c = static_cast<unsigned char>(s);
     }
 
+    void read_ascii(std::istream& stream, double& d) const
+    {
+      stream >> iformat(d);
+    }
+
     // Default template when Type is not a char type
     template <typename Type>
     void read_ascii (std::istream& stream, Type& t) const


### PR DESCRIPTION
## Summary of Changes

VC++ < 2017 has a slow   istream >> double

## Release Management

* Affected package(s): Point set processing


