### PR TITLE
Fix VC performance warning

### DIFF
--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_profile_link.cpp
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_profile_link.cpp
@@ -65,7 +65,7 @@ void test(const char* fname)
 {
   Mesh m;
   std::ifstream input(fname);
-  assert( ! input.bad()) );
+  assert( ! input.bad() );
   input >> m;
   assert(num_vertices(m)!=0);
   A a;

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_profile_link.cpp
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_profile_link.cpp
@@ -65,7 +65,7 @@ void test(const char* fname)
 {
   Mesh m;
   std::ifstream input(fname);
-  assert( bool(input) );
+  assert( ! input.bad()) );
   input >> m;
   assert(num_vertices(m)!=0);
   A a;


### PR DESCRIPTION

## Summary of Changes

Fix for VC  `warning C4800: 'void *' : forcing value to bool 'true' or 'false'`

## Release Management

* Affected package(s): Surface_mesh_simplification
* Issue(s) solved (if any): fix #2350 
