### PR TITLE
Polyhedron demo: fix Merge_point_sets_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Merge_point_sets_plugin.cpp
@@ -57,7 +57,7 @@ void Polyhedron_demo_merge_point_sets_plugin::on_actionMergePointSets_triggered(
 {
   QApplication::setOverrideCursor(Qt::WaitCursor);
   CGAL::Three::Scene_interface::Item_id mainSelectionIndex
-    = scene->mainSelectionIndex();
+    = scene->selectionIndices().first();
   Scene_points_with_normal_item* mainSelectionItem
     = qobject_cast<Scene_points_with_normal_item*>(scene->item(mainSelectionIndex));
 


### PR DESCRIPTION
## Summary of Changes
Fix segfault by using `selectionIndices().first()` instead of `mainSelectionIndex()`.
## Release Management
* Issue(s) solved (if any): fix #2451 

