### PR TITLE
Add write_inp(FaceGraph)

### DIFF
--- a/BGL/examples/BGL_surface_mesh/write_inp.cpp
+++ b/BGL/examples/BGL_surface_mesh/write_inp.cpp
@@ -13,7 +13,7 @@ typedef CGAL::Surface_mesh<Point>                            Mesh;
 
 typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
 
-int main(int argc, char* argv[]) 
+int main() 
 {
   Mesh sm;
   CGAL::make_quad(Point(0,0,0), Point(1,0,0),Point(1,1,0),Point(0,1,0), sm);

--- a/BGL/examples/BGL_surface_mesh/write_inp.cpp
+++ b/BGL/examples/BGL_surface_mesh/write_inp.cpp
@@ -1,0 +1,25 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/io.h>
+#include <iostream>
+#include <fstream>
+
+#include <boost/graph/connected_components.hpp>
+#include <boost/foreach.hpp>
+
+typedef CGAL::Simple_cartesian<double>                       Kernel;
+typedef Kernel::Point_3                                      Point;
+typedef CGAL::Surface_mesh<Point>                            Mesh;
+
+typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+
+int main(int argc, char* argv[]) 
+{
+  Mesh sm;
+  CGAL::make_quad(Point(0,0,0), Point(1,0,0),Point(1,1,0),Point(0,1,0), sm);
+  CGAL::make_quad(Point(0,0,1), Point(1,0,1),Point(1,1,1),Point(0,1,1), sm);
+
+  std::ofstream out("out.inp");
+  CGAL::write_inp(out, sm, "out.inp", "S4R");
+  return 0;
+}

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -207,7 +207,6 @@ bool write_inp(std::ostream& os,
   typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::vertices_size_type vertices_size_type;
-  typedef typename boost::graph_traits<FaceGraph>::faces_size_type faces_size_type;
 
   typedef typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::const_type VPM;
   typedef typename boost::property_traits<VPM>::value_type Point_3;

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -225,7 +225,7 @@ bool write_inp(std::ostream& os,
   n = 1;
   os << "*Element, type=" << type << std::endl;
   BOOST_FOREACH(face_descriptor f, faces(g)){
-    os << n;
+    os << n++;
     BOOST_FOREACH(vertex_descriptor v, vertices_around_face(halfedge(f,g),g)){
       os << ", " << reindex[v];
     }

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -213,8 +213,6 @@ bool write_inp(std::ostream& os,
   typedef typename boost::property_traits<VPM>::value_type Point_3;
 
   VPM vpm = get(CGAL::vertex_point,g);
-  vertices_size_type nv = static_cast<vertices_size_type>(std::distance(vertices(g).first, vertices(g).second));
-  faces_size_type nf = static_cast<faces_size_type>(std::distance(faces(g).first, faces(g).second));
 
   os << "*Part, name=" << name << "\n*Node\n";
   boost::container::flat_map<vertex_descriptor,vertices_size_type> reindex;

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -197,6 +197,46 @@ bool read_off(const char* fname,
   return false;
 }
 
+  
+template <typename FaceGraph>
+bool write_inp(std::ostream& os,
+               const FaceGraph& g,
+               std::string name,
+               std::string type)
+{
+  typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
+  typedef typename boost::graph_traits<FaceGraph>::vertices_size_type vertices_size_type;
+  typedef typename boost::graph_traits<FaceGraph>::faces_size_type faces_size_type;
+
+  typedef typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::const_type VPM;
+  typedef boost::property_traits<VPM>::value_type Point_3;
+
+  VPM vpm = get(CGAL::vertex_point,g);
+  vertices_size_type nv = static_cast<vertices_size_type>(std::distance(vertices(g).first, vertices(g).second));
+  faces_size_type nf = static_cast<faces_size_type>(std::distance(faces(g).first, faces(g).second));
+
+  os << "*Part, name=" << name << "\n*Node\n";
+  boost::container::flat_map<vertex_descriptor,vertices_size_type> reindex;
+  int n = 1;
+  BOOST_FOREACH(vertex_descriptor v, vertices(g)){
+    Point_3 p =  get(vpm,v);
+    os << n << ", " << p.x() << ", " << p.y() << ", " << p.z() << '\n';
+    reindex[v]=n++;
+  }
+  n = 1;
+  os << "*Element, type=" << type << std::endl;
+  BOOST_FOREACH(face_descriptor f, faces(g)){
+    os << n;
+    BOOST_FOREACH(vertex_descriptor v, vertices_around_face(halfedge(f,g),g)){
+      os << ", " << reindex[v];
+    }
+    os << '\n';
+  }
+  os << "*End Part"<< std::endl;
+  return os.good();
+}
+
 
 } // namespace CGAL
 

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -210,7 +210,7 @@ bool write_inp(std::ostream& os,
   typedef typename boost::graph_traits<FaceGraph>::faces_size_type faces_size_type;
 
   typedef typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::const_type VPM;
-  typedef boost::property_traits<VPM>::value_type Point_3;
+  typedef typename boost::property_traits<VPM>::value_type Point_3;
 
   VPM vpm = get(CGAL::vertex_point,g);
   vertices_size_type nv = static_cast<vertices_size_type>(std::distance(vertices(g).first, vertices(g).second));


### PR DESCRIPTION
## Summary of Changes

Add a function that generates an Abaqus `*.inp` file for a `FaceGraph`.
I am not sure if the parameter for `type` is needed. `S4R` means quad mesh but not sure what the `R`means.  See [here](http://imechanica.org/files/l2-elements.pdf).

## Release Management

* Affected package(s):


