### PR TITLE
Bug-fix for Mesher::one_step()

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -673,11 +673,13 @@ one_step()
       case REFINE_FACETS:
         facets_mesher_.scan_edges();
         refinement_stage = REFINE_FACETS_AND_EDGES;
-        break;
+        if (!facets_mesher_.is_algorithm_done()) break;
+        CGAL_FALLTHROUGH;
       case REFINE_FACETS_AND_EDGES:
         facets_mesher_.scan_vertices();
         refinement_stage = REFINE_FACETS_AND_EDGES_AND_VERTICES;
-        break;
+        if (!facets_mesher_.is_algorithm_done()) break;
+        CGAL_FALLTHROUGH;
       default:
         facets_visitor_.activate();
         cells_mesher_.scan_triangulation();


### PR DESCRIPTION
## Summary of Changes

In issue #2453:
> I am trying to mesh in the demo a given Polyhedron (the problem is the same with Surface_mesh with a very small tetrahedron size, and the output mesh is always more or less the same, with very few simplices compared to what I expect.

Actually, the demo uses a loop:
```C++
while( !mesher->is_algorithm_done() )
  mesher->one_step();
```

Because of that bug in `one_step()`, `is_algorithm_done()` could return
`true` even before the cells mesher level has scanned the triangulation
for bad cells. That will be fixed, now.

## Release Management
The bug is since CGAL-4.11.

* Affected package(s): Mesh_3, Polyhedron demo
* Issue(s) solved (if any): fix one point of #2453


