### PR TITLE
Use CGAL::cpp11::is_enum

### DIFF
--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -48,6 +48,7 @@
 #include <CGAL/Sqrt_extension_fwd.h>
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/tss.h>
+#include <CGAL/type_traits.h>
 
 #include <CGAL/IO/io.h>
 
@@ -368,7 +369,7 @@ public :
   // Also check that ET and AT are constructible from T?
   template<class T>
   Lazy_exact_nt (T i, typename boost::enable_if<boost::mpl::and_<
-      boost::mpl::or_<boost::is_arithmetic<T>, boost::is_enum<T> >,
+      boost::mpl::or_<boost::is_arithmetic<T>, cpp11::is_enum<T> >,
       boost::mpl::not_<boost::is_same<T,ET> > >,void*>::type=0)
     : Base(new Lazy_exact_Cst<ET,T>(i)) {}
 

--- a/STL_Extension/include/CGAL/type_traits.h
+++ b/STL_Extension/include/CGAL/type_traits.h
@@ -36,4 +36,19 @@ struct is_same_or_derived :
 
 }
 
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS) && !defined(BOOST_NO_0X_HDR_TYPE_TRAITS)
+#include <type_traits>
+namespace CGAL {
+namespace cpp11{
+  using std::is_enum;
+} }
+#else
+#include <boost/type_traits/is_enum.hpp>
+namespace CGAL {
+namespace cpp11 {
+  using boost::is_enum;
+}
+}
 #endif
+
+#endif // CGAL_TYPE_TRAITS_H


### PR DESCRIPTION
To work around a bug observed with boost 1.62 with c++11 ON.

Fixes [this error](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-46/Surface_mesher/TestReport_lrineau_Debian-Testing.gz)