### PR TITLE
Mesh 2: fix clusters (issue #2456)

### DIFF
--- a/Mesh_2/include/CGAL/Mesh_2/Clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Clusters.h
@@ -325,6 +325,16 @@ update_cluster(Cluster& c, iterator it, Vertex_handle va,
   c.vertices.erase(vb);
   c.vertices[vm] = reduction;
 
+  if(false == reduction) {
+    for(typename Cluster::Vertices_map::iterator
+          it = c.vertices.begin(),
+          end = c.vertices.end();
+        it != end; ++it)
+    {
+      it->second = false;
+    }
+  }
+
   if(vb==c.smallest_angle.first)
     c.smallest_angle.first = vm;
   if(vb==c.smallest_angle.second)

--- a/Mesh_2/include/CGAL/Mesh_2/Clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Clusters.h
@@ -357,6 +357,13 @@ update_cluster(Cluster& c, iterator it, Vertex_handle va,
     c.rmin = squared_distance(c.smallest_angle.first->point(),
                               c.smallest_angle.second->point())/FT(4);
   cluster_map.insert(Cluster_map_value_type(va,c));
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+  std::cerr << "Cluster at " << va->point() << " is updated.  "
+            << "\n  vm: " << vm->point()
+            << "\n  reduction: " << reduction
+            << "\n  min_sq_len: " << c.minimum_squared_length
+            << "\n";
+#endif // CGAL_MESH_2_DEBUG_CLUSTERS
 }
 
 template <typename Tr>

--- a/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
@@ -75,7 +75,7 @@ class Refine_edges_base_with_clusters :
   Clusters<Tr>& clusters;
 
   bool va_has_a_cluster, vb_has_a_cluster;
-  bool cluster_splitted;
+  mutable bool cluster_splitted;
   Cluster ca, cb;
   clusters_iterator ca_it, cb_it;
 
@@ -114,6 +114,10 @@ public:
         { // both ends are clusters
           va_has_a_cluster = true;
           vb_has_a_cluster = true;
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+          std::cerr << "midpoint(" << this->va->point()
+                    << " , " << this->vb->point() << ")\n";
+#endif // CGAL_MESH_2_DEBUG_CLUSTERS
           return midpoint(this->va->point(), this->vb->point());
         }
       else {
@@ -128,13 +132,17 @@ public:
       return split_cluster_point(this->vb,this->va,cb);
     }else{
       // no cluster
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+      std::cerr << "midpoint(" << this->va->point()
+                << " , " << this->vb->point() << ")\n";
+#endif // CGAL_MESH_2_DEBUG_CLUSTERS
       return midpoint(this->va->point(), this->vb->point());
     }
   };
 
   void after_insertion_impl(const Vertex_handle& v)
   {
-#ifdef CGAL_MESH_2_DEBUG_CLUSTERS    
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
     std::cerr << "update_clusters" << std::endl;
     std::cerr << "va_has_a_cluster=" << va_has_a_cluster
               << std::endl
@@ -236,7 +244,7 @@ private:
     return ((CGAL::min)(a, (CGAL::min)(b, c)));
   }
 
-  Point split_cluster_point(Vertex_handle va, Vertex_handle vb, Cluster& c)
+  Point split_cluster_point(Vertex_handle va, Vertex_handle vb, const Cluster& c) const
   {
     typename Geom_traits::Construct_vector_2 vector =
       this->tr.geom_traits().construct_vector_2_object();
@@ -257,8 +265,17 @@ private:
     const Point& a = va->point();
     const Point& b = vb->point();
 
-    if( c.is_reduced() )
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+    std::cerr << "split_cluster_point(" << va->point()
+              << " , " << vb->point() << ")\n"
+              << "  reduced: " << c.is_reduced() << "\nresult:  ";
+#endif // CGAL_MESH_2_DEBUG_CLUSTERS
+    if( c.is_reduced() ) {
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+      std::cerr << midpoint(a, b) << " (midpoint)\n";
+#endif  // CGAL_MESH_2_DEBUG_CLUSTERS
       return midpoint(a, b);
+    }
     else
       {
         const Point m = midpoint(a, b);
@@ -277,6 +294,9 @@ private:
         if( squared_distance(i,m) > squared_distance(m,i2) )
           i = i2;
         //here i is the best point for splitting
+#ifdef CGAL_MESH_2_DEBUG_CLUSTERS
+        std::cerr << i << std::endl;
+#endif  // CGAL_MESH_2_DEBUG_CLUSTERS
         return i;
       }
   }


### PR DESCRIPTION
## Summary of Changes

When two clusters share a subsegment, the subsegment is split at its
middle, instead of using the length imposed by the clusters. If the
clusters were partially refined before that subsegment is split, one
must reset the clusters, because the minimal length may have changed.

This PR:
  - fixes the bug,
  - add more debug output, in conditionals `CGAL_MESH_2_DEBUG_CLUSTERS`.

## Release Management

* Affected package(s): Mesh_2
* Issue(s) solved (if any): fix #2456 
* Feature/Small Feature (if any):

