### PR TITLE
Eigen_sparse_matrix: add missing method

### DIFF
--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -180,7 +180,12 @@ public:
       m_triplets.push_back(Triplet(i,j,val));
   }
 
-  /// Read access to a matrix coefficient: a_ij.
+  /// Read access to a matrix coefficient.
+  ///
+  /// Complexity:
+  /// - O(log(n)) if the matrix is already built.
+  /// - O(n) if the matrix is not built.
+  /// n being the number of entries in the matrix.
   ///
   /// @commentheading Preconditions:
   /// - 0 <= i < row_dimension().

--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -180,6 +180,20 @@ public:
       m_triplets.push_back(Triplet(i,j,val));
   }
 
+  /// Read access to a matrix coefficient: a_ij.
+  ///
+  /// @commentheading Preconditions:
+  /// - 0 <= i < row_dimension().
+  /// - 0 <= j < column_dimension().
+  NT get_coef (unsigned int i, unsigned int j) const 
+  {    
+    CGAL_precondition(i < row_dimension());
+    CGAL_precondition(j < column_dimension());
+
+    NT val = m_matrix.coeffRef(i,j);
+    return val;
+  }
+
   void assemble_matrix() const
   {
     m_matrix.setFromTriplets(m_triplets.begin(), m_triplets.end());

--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -200,34 +200,14 @@ public:
         val = m_matrix.coeffRef(i,j);
     else
     {
-        // with lambda
-        auto pred = [i, j](const Triplet& triplet)
-        {
-            return triplet.row() == i && triplet.col() == j;
-        };
-        typename std::vector<Triplet>::iterator it;
-        it = std::find_if(m_triplets.begin(), m_triplets.end(), pred);
-        Triplet tr = *it;
-        val = tr.value();
-
-        /*
-        // with a functor
-        struct WantedTriplet
-        {
-            unsigned int i_, j_;
-            WantedTriplet(const unsigned int& i, const unsigned int& j) : i_(i), j_(j) {}
-            bool operator()(const Triplet& triplet) const
-            {
-                return triplet.row() == i_ && triplet.col() == j_;
-            }
-        };
-        typename std::vector<Triplet>::iterator it;
-        it = std::find_if(m_triplets.begin(), m_triplets.end(), WantedTriplet(i, j));
-        Triplet tr = *it;
-        val = tr.value();
-        */
+      for(std::size_t t=0; t<m_triplets.size(); ++t)
+      {
+        if(m_triplets[t].col() == j &&
+           m_triplets[t].row() == i)
+          val = m_triplets[t].value();
+      }
     }
-    return  val;
+    return val;
   }
 
   void assemble_matrix() const

--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -185,13 +185,44 @@ public:
   /// @commentheading Preconditions:
   /// - 0 <= i < row_dimension().
   /// - 0 <= j < column_dimension().
-  NT get_coef (unsigned int i, unsigned int j) const 
-  {    
+  NT get_coef (unsigned int i, unsigned int j) const
+  {
     CGAL_precondition(i < row_dimension());
     CGAL_precondition(j < column_dimension());
 
-    NT val = m_matrix.coeffRef(i,j);
-    return val;
+    NT val;
+    if (m_is_already_built)
+        val = m_matrix.coeffRef(i,j);
+    else
+    {
+        // with lambda
+        auto pred = [i, j](const Triplet& triplet)
+        {
+            return triplet.row() == i && triplet.col() == j;
+        };
+        typename std::vector<Triplet>::iterator it;
+        it = std::find_if(m_triplets.begin(), m_triplets.end(), pred);
+        Triplet tr = *it;
+        val = tr.value();
+
+        /*
+        // with a functor
+        struct WantedTriplet
+        {
+            unsigned int i_, j_;
+            WantedTriplet(const unsigned int& i, const unsigned int& j) : i_(i), j_(j) {}
+            bool operator()(const Triplet& triplet) const
+            {
+                return triplet.row() == i_ && triplet.col() == j_;
+            }
+        };
+        typename std::vector<Triplet>::iterator it;
+        it = std::find_if(m_triplets.begin(), m_triplets.end(), WantedTriplet(i, j));
+        Triplet tr = *it;
+        val = tr.value();
+        */
+    }
+    return  val;
   }
 
   void assemble_matrix() const

--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -195,19 +195,18 @@ public:
     CGAL_precondition(i < row_dimension());
     CGAL_precondition(j < column_dimension());
 
-    NT val;
     if (m_is_already_built)
-        val = m_matrix.coeffRef(i,j);
+        return m_matrix.coeffRef(i,j);
     else
     {
       for(std::size_t t=0; t<m_triplets.size(); ++t)
       {
         if(m_triplets[t].col() == j &&
            m_triplets[t].row() == i)
-          val = m_triplets[t].value();
+          return m_triplets[t].value();
       }
     }
-    return val;
+    return 0;
   }
 
   void assemble_matrix() const

--- a/Solver_interface/include/CGAL/Eigen_matrix.h
+++ b/Solver_interface/include/CGAL/Eigen_matrix.h
@@ -195,18 +195,22 @@ public:
     CGAL_precondition(i < row_dimension());
     CGAL_precondition(j < column_dimension());
 
+    if(m_is_symmetric && j > i)
+      std::swap(i, j);
+
     if (m_is_already_built)
-        return m_matrix.coeffRef(i,j);
+      return m_matrix.coeffRef(i,j);
     else
     {
+      NT val = 0;
       for(std::size_t t=0; t<m_triplets.size(); ++t)
       {
         if(m_triplets[t].col() == j &&
            m_triplets[t].row() == i)
-          return m_triplets[t].value();
+          val += m_triplets[t].value();
       }
+      return val;
     }
-    return 0;
   }
 
   void assemble_matrix() const


### PR DESCRIPTION
## Summary of Changes

This is a small fix to add missing _get_coef_ method from the Eigen_sparse_matrix struct. It already exists in the doc of the SparseLinearAlgebraTraits_d concept.

