### PR TITLE
Include OpenGL ES for arm

### DIFF
--- a/GraphicsView/include/CGAL/Qt/debug_impl.h
+++ b/GraphicsView/include/CGAL/Qt/debug_impl.h
@@ -75,10 +75,14 @@ void opengl_check_errors(unsigned int line)
      std::cerr << "The framebuffer object is not complete." << "@" << line << std::endl;
    if(error == GL_OUT_OF_MEMORY)
      std::cerr << "There is not enough memory left to execute the command." << "@" << line << std::endl;
+#ifdef GL_STACK_UNDERFLOW
    if(error == GL_STACK_UNDERFLOW)
      std::cerr << "An attempt has been made to perform an operation that would cause an internal stack to underflow." << "@" << line << std::endl;
+#endif
+#ifdef GL_STACK_OVERFLOW
    if(error == GL_STACK_OVERFLOW)
      std::cerr << "An attempt has been made to perform an operation that would cause an internal stack to overflow." << "@" << line << std::endl;
+#endif
    error = ::glGetError();
  }
 }

--- a/Installation/include/CGAL/gl.h
+++ b/Installation/include/CGAL/gl.h
@@ -30,7 +30,11 @@
 #    include <OpenGL/gl.h>
 #  endif
 #else
-#  include <GL/gl.h>
+#  ifdef __arm__
+#    include <GLES3/gl3.h>
+#  else
+#    include <GL/gl.h>
+#  endif
 #endif
 
 #endif // CGAL_GL_H


### PR DESCRIPTION
## Summary of Changes

If we compile CGAL with having Qt present on arm, Qt will use OpenGL ES
headers. But CGAL/gl.h includes specifically include <GL/gl.h> which are
the desktop headers. They cannot be mixed.

However I am not sure whether there should be a differentiation between OpenGL ES 2 and 3 though. I just used 3 since that what I have here. Please give feedback in case you want me to change something.

## Release Management

* Affected package(s): cgal 4.11
* Feature/Small Feature (if any): let compile on arm(v7) with Qt present