### PR TITLE
Fix counting iterator warnings

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
@@ -33,7 +33,7 @@
 #include <CGAL/boost/graph/named_function_params.h>
 
 #include <boost/graph/graph_concepts.hpp>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arrangement_2.h>
 #include <CGAL/Arr_accessor.h>

--- a/Arrangement_on_surface_2/include/CGAL/graph_traits_Dual_Arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/graph_traits_Dual_Arrangement_2.h
@@ -425,7 +425,7 @@ public:
 } //namespace CGAL
 
 #include <boost/graph/graph_concepts.hpp>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 
 namespace boost {
 

--- a/Convex_hull_2/test/Convex_hull_2/ch2_point_with_info.cpp
+++ b/Convex_hull_2/test/Convex_hull_2/ch2_point_with_info.cpp
@@ -2,7 +2,7 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/convex_hull_2.h>
 #include <CGAL/convex_hull_traits_2.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 
 #include <boost/foreach.hpp>
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
@@ -23,7 +23,7 @@
 #include <CGAL/number_utils.h>
 #include <CGAL/NewKernel_d/store_kernel.h>
 #include <boost/iterator/transform_iterator.hpp>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 namespace CGAL {
 template <class R_> class Hyperplane {
 	typedef typename Get_type<R_, FT_tag>::type FT_;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
@@ -20,7 +20,7 @@
 #ifndef CGAL_KD_TYPE_SPHERE_H
 #define CGAL_KD_TYPE_SPHERE_H
 #include <CGAL/NewKernel_d/store_kernel.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 namespace CGAL {
 template <class R_> class Sphere {
 	typedef typename Get_type<R_, FT_tag>::type FT_;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
@@ -20,7 +20,7 @@
 #ifndef CGAL_KD_TYPE_WP_H
 #define CGAL_KD_TYPE_WP_H
 #include <CGAL/NewKernel_d/store_kernel.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 namespace CGAL {
 namespace KerD {
 template <class R_> class Weighted_point {

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -42,7 +42,7 @@
 #include <sstream>
 
 //boost --------------
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
 //---------------------

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
@@ -20,7 +20,7 @@
 #include <CGAL/Polygon_mesh_processing/bbox.h>
 #include <CGAL/Polygon_mesh_processing/distance.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Spatial_sort_traits_adapter_3.h>
 #include <CGAL/property_map.h>

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -55,7 +55,7 @@
 
 #include <CGAL/assertions.h>
 
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 
 /*

--- a/Segment_Delaunay_graph_Linf_2/include/CGAL/Segment_Delaunay_graph_Linf_2.h
+++ b/Segment_Delaunay_graph_Linf_2/include/CGAL/Segment_Delaunay_graph_Linf_2.h
@@ -54,7 +54,7 @@
 #include <CGAL/spatial_sort.h>
 #include <CGAL/Spatial_sort_traits_adapter_2.h>
 
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 
 /*
   Conventions:

--- a/Spatial_searching/benchmark/Spatial_searching/nearest_neighbor_searching_inplace_50.cpp
+++ b/Spatial_searching/benchmark/Spatial_searching/nearest_neighbor_searching_inplace_50.cpp
@@ -7,7 +7,7 @@
 #include <cmath>
 #include <iostream>
 #include <fstream>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 
 
 typedef CGAL::Simple_cartesian<double> Kernel;

--- a/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_inplace.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_inplace.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/Search_traits_adapter.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <utility>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;

--- a/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_pmap.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_with_point_with_info_pmap.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/Search_traits_adapter.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <utility>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;

--- a/Spatial_sorting/examples/Spatial_sorting/sp_sort_using_property_map_3.cpp
+++ b/Spatial_sorting/examples/Spatial_sorting/sp_sort_using_property_map_3.cpp
@@ -2,7 +2,7 @@
 #include <CGAL/spatial_sort.h>
 #include <CGAL/Spatial_sort_traits_adapter_3.h>
 #include <vector>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 
 typedef CGAL::Simple_cartesian<double>                  Kernel;
 typedef Kernel::Point_3                                 Point_3;

--- a/Spatial_sorting/examples/Spatial_sorting/sp_sort_using_property_map_d.cpp
+++ b/Spatial_sorting/examples/Spatial_sorting/sp_sort_using_property_map_d.cpp
@@ -1,7 +1,7 @@
 #include <CGAL/Cartesian_d.h>
 #include <CGAL/spatial_sort.h>
 #include <CGAL/Spatial_sort_traits_adapter_d.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <vector>
 
 typedef CGAL::Cartesian_d<double>           Kernel;

--- a/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
@@ -26,7 +26,7 @@
 
 #include <CGAL/Spatial_sort_traits_adapter_2.h>
 #include <CGAL/property_map.h>
-#include <boost/iterator/counting_iterator.hpp>
+#include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <vector>
 #include <iterator>
 


### PR DESCRIPTION
## Summary of Changes

Fix for https://github.com/CGAL/cgal/issues/2468. As I was getting tired of this warning, I wrote a file `CGAL/counting_iterator.h` that just does the inclusion surrounded by the warning deactivation, but then I realized that it already existed (for the very same reason, I guess), see in `Installation/include/CGAL/boost/iterator/counting_iterator.h`. It was already used by some CGAL headers.

So this PR replaces all occurrences of the boost inclusion in CGAL files by this one, which should fix the problem everywhere and prevent it from happening again. We should always use it from now on.

## Release Management

* Affected package(s):
  - Arrangement on Surface 2
  - Convex hull 2
  - NewKernel D
  - Point Set Shape Detection 3
  - Polyhedron demo
  - Segment Delaunay Graph 2 (+ Linf 2)
  - Spatial Searching
  - Spatial Sorting
  - Triangulation 2
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2468 (and more...)
