### PR TITLE
don’t assign same point to shape twice

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Region_growing.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Region_growing.h
@@ -597,7 +597,8 @@ shape. The implementation follows \cgalCite{cgal:lm-clscm-12}.
 
               m_shape_index[neighbor_index] = class_index;
               propagation = true;
-              index_container_current_ring.insert(neighbor_index);
+              if (neighbor_index != i)
+                index_container_current_ring.insert(neighbor_index);
             }
           }
 


### PR DESCRIPTION
## Summary of Changes

Region growing sometimes includes a point more than once in the list of points assigned to a shape.  This change may not be complete or the best way to fix this, but it did solve the problem in my situation.

## Release Management

Possible fix for #2483

