### PR TITLE
Region Growing: fix badly initialized class_index (lead to duplicate indices)

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Region_growing.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Region_growing.h
@@ -540,7 +540,7 @@ shape. The implementation follows \cgalCite{cgal:lm-clscm-12}.
         if (m_shape_index[i] != -1)
           continue;
 
-        m_shape_index[i] = class_index++;
+        m_shape_index[i] = ++ class_index;
         
         int conti = 0; 	//for accelerate least_square fitting 
 


### PR DESCRIPTION
## Summary of Changes

The first point of the first shape detected was assigned index `-1`, which is the value used for unassigned points, which lead to unexpected behavior (duplicate indices). The class index should be initialized to `0`, not `-1` (increment _before_ assigning to point).

## Release Management

* Affected package(s): Point Set Shape Detection
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2483

