### PR TITLE
Mesh 3 : document manifold criterion

### DIFF
--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -169,6 +169,11 @@ and <code>src/</code> directories).
        that exports Mesh_complex_3_in_triangulation_3
        facets into a MutableFaceGraph.
      </li>
+     <li>
+       Add the ability to ensure that the output mesh surface describes a manifold,
+       when the input surface is a manifold. New named parameters <code>manifold()</code>,
+       <code>manifold_with_boundary()</code>, and <code>non_manifold()</code> are added.
+     </li>
    </ul>
 <!-- Surface Reconstruction -->
 <!-- Geometry Processing -->

--- a/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
@@ -78,10 +78,11 @@ if parameter `features` is not specified.
 of 0 and 1-dimensional features in the mesh. 
 </UL> 
 
-- <b>`manifold`</b> allows the user to monitor the meshing algorithm,
+- <b>`manifold`</b> allows the user to drive the meshing algorithm,
 and ensure that the output mesh surface follows the given manifold criterion.
 It can be activated with `parameters::manifold()`, `parameters::manifold_with_boundary()`
-and `parameters::non_manifold()`.
+and `parameters::non_manifold()`. Note that the meshing algorithm cannot generate a manifold
+surface if the input surface is not manifold.
 
 The four additional parameters are optimization parameters. 
 They control which optimization processes are performed 

--- a/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
@@ -78,10 +78,10 @@ if parameter `features` is not specified.
 of 0 and 1-dimensional features in the mesh. 
 </UL> 
 
-- <b>`manifold`</b> allows the user ********
+- <b>`manifold`</b> allows the user to monitor the meshing algorithm,
+and ensure that the output mesh surface follows the given manifold criterion.
 It can be activated with `parameters::manifold()`, `parameters::manifold_with_boundary()`
 and `parameters::non_manifold()`.
-@todo give details
 
 The four additional parameters are optimization parameters. 
 They control which optimization processes are performed 

--- a/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
@@ -78,6 +78,11 @@ if parameter `features` is not specified.
 of 0 and 1-dimensional features in the mesh. 
 </UL> 
 
+- <b>`manifold`</b> allows the user ********
+It can be activated with `parameters::manifold()`, `parameters::manifold_with_boundary()`
+and `parameters::non_manifold()`.
+@todo give details
+
 The four additional parameters are optimization parameters. 
 They control which optimization processes are performed 
 and allow the user to tune the parameters of the optimization processes. 
@@ -109,7 +114,6 @@ parameters of this optimizer. If one parameter is not set, the default value of
 `exude_mesh_3()` is used for this parameter, except for the time bound which is set to be 
 equal to the refinement CPU time. 
 
-
 The optimization parameters can be passed in an arbitrary order. If one parameter 
 is not passed, its default value is used. The default values are 
 `no_lloyd()`, `no_odt()`, `perturb()` and `exude()`. 
@@ -131,6 +135,9 @@ optimization processes.
 \sa `refine_mesh_3()` 
 \sa `parameters::features()` 
 \sa `parameters::no_features()` 
+\sa `parameters::manifold()`
+\sa `parameters::manifold_with_boundary()`
+\sa `parameters::non_manifold()`
 \sa `exude_mesh_3()` 
 \sa `perturb_mesh_3()`
 \sa `lloyd_optimize_mesh_3()` 
@@ -142,7 +149,7 @@ optimization processes.
 \sa `parameters::lloyd()` 
 \sa `parameters::no_lloyd()` 
 \sa `parameters::odt()` 
-\sa `parameters::no_odt()` 
+\sa `parameters::no_odt()`
 
 */
 
@@ -155,6 +162,7 @@ parameters::internal::Features_options features = parameters::features(domain),
 parameters::internal::Lloyd_options lloyd = parameters::no_lloyd(),
 parameters::internal::Odt_options odt = parameters::no_odt(),
 parameters::internal::Perturb_options perturb = parameters::perturb(),
-parameters::internal::Exude_options exude = parameters::exude()); 
+parameters::internal::Exude_options exude = parameters::exude(),
+parameters::internal::Manifold_options manifold = parameters::non_manifold()); 
 
 } /* namespace CGAL */

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -166,7 +166,10 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::manifold()` provides ****************
+  The function `parameters::manifold()` is used to monitor the
+  meshing algorithm for surfaces.
+  It ensures that the surface of the output mesh is a manifold surface
+    without boundaries.
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::manifold_with_boundary()`
@@ -177,7 +180,10 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::non_manifold()` provides ****************
+  The function `parameters::non_manifold()` is used to monitor the
+  meshing algorithm for surfaces.
+  It does not ensure that the surface of the output mesh is a manifold surface.
+  The manifold property of output mesh may nevertheless result from the choice of appropriate meshing criteria.
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::manifold_with_boundary()`
@@ -188,7 +194,10 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::manifold_with_boundary()` provides ****************
+  The function `parameters::manifold_with_boundary()` is used to monitor the
+  meshing algorithm for surfaces.
+  It ensures that the surface of the output mesh is a manifold surface which
+    may have boundaries.
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::non_manifold()`

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -84,10 +84,11 @@ functions for each optimization parameter
 to generate appropriate value of this parameter. 
 
 \cgalHeading{Named Parameters}
-- <b>`manifold`</b> allows the user to monitor the meshing algorithm,
+- <b>`manifold`</b> allows the user to drive the meshing algorithm,
 and ensure that the output mesh surface follows the given manifold criterion.
 It can be activated with `parameters::manifold()`, `parameters::manifold_with_boundary()`
-and `parameters::non_manifold()`.
+and `parameters::non_manifold()`. Note that the meshing algorithm cannot generate a manifold
+surface if the input surface is not manifold.
 
 - <b>`lloyd`</b>  `parameters::lloyd()` and `parameters::no_lloyd()` are designed to 
 trigger or not a call to `lloyd_optimize_mesh_3()` function and to set the 
@@ -167,7 +168,7 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::manifold()` is used to monitor the
+  The function `parameters::manifold()` is used to drive the
   meshing algorithm for surfaces.
   It ensures that the surface of the output mesh is a manifold surface
     without boundaries.
@@ -181,7 +182,7 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::non_manifold()` is used to monitor the
+  The function `parameters::non_manifold()` is used to drive the
   meshing algorithm for surfaces.
   It does not ensure that the surface of the output mesh is a manifold surface.
   The manifold property of output mesh may nevertheless result from the choice of appropriate meshing criteria.
@@ -195,7 +196,7 @@ namespace parameters {
   /*!
   \ingroup PkgMesh_3Parameters
 
-  The function `parameters::manifold_with_boundary()` is used to monitor the
+  The function `parameters::manifold_with_boundary()` is used to drive the
   meshing algorithm for surfaces.
   It ensures that the surface of the output mesh is a manifold surface which
     may have boundaries.

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -185,7 +185,8 @@ namespace parameters {
   The function `parameters::non_manifold()` is used to drive the
   meshing algorithm for surfaces.
   It does not ensure that the surface of the output mesh is a manifold surface.
-  The manifold property of output mesh may nevertheless result from the choice of appropriate meshing criteria.
+  The manifold property of the output mesh might nevertheless result from an appropriate
+  choice of meshing criteria.
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::manifold_with_boundary()`

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -84,9 +84,10 @@ functions for each optimization parameter
 to generate appropriate value of this parameter. 
 
 \cgalHeading{Named Parameters}
-- <b>`manifold`</b> `parameters::manifold()`, `parameters::manifold_with_boundary()`,
-`parameters::non_manifold()`
-@todo : document
+- <b>`manifold`</b> allows the user to monitor the meshing algorithm,
+and ensure that the output mesh surface follows the given manifold criterion.
+It can be activated with `parameters::manifold()`, `parameters::manifold_with_boundary()`
+and `parameters::non_manifold()`.
 
 - <b>`lloyd`</b>  `parameters::lloyd()` and `parameters::no_lloyd()` are designed to 
 trigger or not a call to `lloyd_optimize_mesh_3()` function and to set the 

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -172,6 +172,12 @@ namespace parameters {
   meshing algorithm for surfaces.
   It ensures that the surface of the output mesh is a manifold surface
     without boundaries.
+  The manifold property of the output mesh can be achieved only if the input surface
+  is a manifold.
+  Note that the meshing algorithm provably terminates only if the input
+  sharp edges have been protected, using the
+  feature protection (see \ref Mesh_3Protectionof0and1dimensionalExposed).
+
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::manifold_with_boundary()`
@@ -200,7 +206,13 @@ namespace parameters {
   The function `parameters::manifold_with_boundary()` is used to drive the
   meshing algorithm for surfaces.
   It ensures that the surface of the output mesh is a manifold surface which
-    may have boundaries.
+  may have boundaries.
+  The manifold property of the output mesh can be achieved only if the input surface
+  is a manifold.
+  Note that the meshing algorithm provably terminates only if the input
+  sharp edges have been protected, using the
+  feature protection (see \ref Mesh_3Protectionof0and1dimensionalExposed).
+
   \sa `CGAL::make_mesh_3()`
   \sa `CGAL::refine_mesh_3()`
   \sa `CGAL::parameters::non_manifold()`

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -84,6 +84,10 @@ functions for each optimization parameter
 to generate appropriate value of this parameter. 
 
 \cgalHeading{Named Parameters}
+- <b>`manifold`</b> `parameters::manifold()`, `parameters::manifold_with_boundary()`,
+`parameters::non_manifold()`
+@todo : document
+
 - <b>`lloyd`</b>  `parameters::lloyd()` and `parameters::no_lloyd()` are designed to 
 trigger or not a call to `lloyd_optimize_mesh_3()` function and to set the 
 parameters of this optimizer. If one parameter is not set, the default value of 
@@ -126,6 +130,9 @@ some optimization processes. Also beware that the default behavior does involve 
 optimization processes. 
 
 \sa `CGAL::make_mesh_3()` 
+\sa `CGAL::parameters::manifold`
+\sa `CGAL::parameters::manifold_with_boundary`
+\sa `CGAL::parameters::non_manifold`
 \sa `CGAL::exude_mesh_3()` 
 \sa `CGAL::perturb_mesh_3()` 
 \sa `CGAL::lloyd_optimize_mesh_3()` 
@@ -137,7 +144,7 @@ optimization processes.
 \sa `CGAL::parameters::lloyd` 
 \sa `CGAL::parameters::no_lloyd` 
 \sa `CGAL::parameters::odt` 
-\sa `CGAL::parameters::no_odt` 
+\sa `CGAL::parameters::no_odt`
 
 */
 
@@ -150,9 +157,44 @@ MeshCriteria mesh_criteria,
 parameters::internal::Lloyd_options lloyd = parameters::no_lloyd(),
 parameters::internal::Odt_options odt = parameters::no_odt(),
 parameters::internal::Perturb_options perturb = parameters::perturb(),
-parameters::internal::Exude_options exude = parameters::exude()); 
+parameters::internal::Exude_options exude = parameters::exude(),
+parameters::internal::Manifold_options manifold = parameters::non_manifold()
+); 
 
 namespace parameters {
+
+  /*!
+  \ingroup PkgMesh_3Parameters
+
+  The function `parameters::manifold()` provides ****************
+  \sa `CGAL::make_mesh_3()`
+  \sa `CGAL::refine_mesh_3()`
+  \sa `CGAL::parameters::manifold_with_boundary()`
+  \sa `CGAL::parameters::non_manifold()`
+  */
+  parameters::internal::Manifold_options manifold();
+
+  /*!
+  \ingroup PkgMesh_3Parameters
+
+  The function `parameters::non_manifold()` provides ****************
+  \sa `CGAL::make_mesh_3()`
+  \sa `CGAL::refine_mesh_3()`
+  \sa `CGAL::parameters::manifold_with_boundary()`
+  \sa `CGAL::parameters::manifold()`
+  */
+  parameters::internal::Manifold_options non_manifold();
+
+  /*!
+  \ingroup PkgMesh_3Parameters
+
+  The function `parameters::manifold_with_boundary()` provides ****************
+  \sa `CGAL::make_mesh_3()`
+  \sa `CGAL::refine_mesh_3()`
+  \sa `CGAL::parameters::non_manifold()`
+  \sa `CGAL::parameters::manifold()`
+  */
+  parameters::internal::Manifold_options manifold_with_boundary();
 
 /*!
 \ingroup PkgMesh_3Parameters

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -127,9 +127,9 @@ and their associated classes:
 - `CGAL::parameters::no_lloyd`
 - `CGAL::parameters::odt`
 - `CGAL::parameters::no_odt`
-- `CGAL::parameters::manifold()`
-- `CGAL::parameters::manifold_with_boundary()`
-- `CGAL::parameters::non_manifold()`
+- `CGAL::parameters::manifold`
+- `CGAL::parameters::manifold_with_boundary`
+- `CGAL::parameters::non_manifold`
 
 ## Enumerations ##
 

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -127,6 +127,9 @@ and their associated classes:
 - `CGAL::parameters::no_lloyd`
 - `CGAL::parameters::odt`
 - `CGAL::parameters::no_odt`
+- `CGAL::parameters::manifold()`
+- `CGAL::parameters::manifold_with_boundary()`
+- `CGAL::parameters::non_manifold()`
 
 ## Enumerations ##
 

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain.cpp
@@ -67,8 +67,8 @@ int main(int argc, char*argv[])
   // Set tetrahedron size (keep cell_radius_edge_ratio), ignore facets
   Mesh_criteria new_criteria(cell_radius_edge_ratio=3, cell_size=0.03);
 
-  // Mesh refinement
-  CGAL::refine_mesh_3(c3t3, domain, new_criteria);
+  // Mesh refinement (and make the output manifold)
+  CGAL::refine_mesh_3(c3t3, domain, new_criteria, manifold());
 
   // Output
   medit_file.open("out_2.mesh");

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -211,7 +211,8 @@ public:
   /// Constructor
   Mesher_3(C3T3&               c3t3,
            const MeshDomain&   domain,
-           const MeshCriteria& criteria);
+           const MeshCriteria& criteria,
+           int mesh_topology = 0);
 
   /// Destructor
   ~Mesher_3() 
@@ -286,7 +287,8 @@ private:
 template<class C3T3, class MC, class MD>
 Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                                const MD& domain,
-                               const MC& criteria)
+                               const MC& criteria,
+                               int mesh_topology)
 : Base(c3t3.bbox(),
        Concurrent_mesher_config::get().locking_grid_num_cells_per_axis)
 , r_oracle_(domain)
@@ -295,7 +297,8 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                  criteria.facet_criteria_object(),
                  domain,
                  null_mesher_,
-                 c3t3)
+                 c3t3,
+                 mesh_topology)
 , cells_mesher_(c3t3.triangulation(),
                 criteria.cell_criteria_object(),
                 domain,

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -766,7 +766,8 @@ public:
                   const Criteria& criteria,
                   const MeshDomain& oracle,
                   Previous_level_& previous,
-                  C3T3& c3t3);
+                  C3T3& c3t3,
+                  int mesh_topology);
   // For parallel
   Refine_facets_3(Tr& triangulation,
                   const Criteria& criteria,
@@ -885,8 +886,9 @@ Refine_facets_3(Tr& triangulation,
                 const Cr& criteria,
                 const MD& oracle,
                 P_& previous,
-                C3T3& c3t3)
-  : Rf_base(triangulation, c3t3, oracle, criteria)
+                C3T3& c3t3,
+                int mesh_topology)
+  : Rf_base(triangulation, c3t3, oracle, criteria, mesh_topology)
   , Mesher_level<Tr, Self, Facet, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct>(previous)
   , No_after_no_insertion()

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -38,59 +38,6 @@ namespace CGAL {
 
 namespace Mesh_3 {
 
-BOOST_MPL_HAS_XXX_TRAIT_DEF(Has_manifold_criterion)
-
-template <typename Criteria,
-          bool has_Has_manifold_criterion =
-          has_Has_manifold_criterion<Criteria>::value>
-struct Has_manifold_criterion :
-    public CGAL::Boolean_tag<Criteria::Has_manifold_criterion::value>
-// when Criteria has the nested type Has_manifold_criterion
-{};
-
-template <typename Criteria>
-struct Has_manifold_criterion<Criteria, false> : public CGAL::Tag_false
-// when Criteria does not have the nested type Has_manifold_criterion
-{};
-
-
-
-template <typename Criteria>
-bool get_with_manifold(const Criteria&, CGAL::Tag_false)
-{
-  return false;
-}
-
-template <typename Criteria>
-bool get_with_manifold(const Criteria& c, CGAL::Tag_true)
-{
-  return (c.topology() & MANIFOLD_WITH_BOUNDARY) != 0;
-}
-
-template <typename Criteria>
-bool get_with_manifold(const Criteria& c)
-{
-  return get_with_manifold(c, Has_manifold_criterion<Criteria>());
-}
-
-template <typename Criteria>
-bool get_with_boundary(const Criteria&, CGAL::Tag_false)
-{
-  return false;
-}
-
-template <typename Criteria>
-bool get_with_boundary(const Criteria& c, CGAL::Tag_true)
-{
-  return (c.topology() & NO_BOUNDARY) == 0;
-}
-
-template <typename Criteria>
-bool get_with_boundary(const Criteria& c)
-{
-  return get_with_boundary(c, Has_manifold_criterion<Criteria>());
-}
-
 template<class Tr,
          class Criteria,
          class MeshDomain,
@@ -354,15 +301,16 @@ public:
   Refine_facets_manifold_base(Tr& triangulation,
                               C3t3& c3t3,
                               const Mesh_domain& oracle,
-                              const Criteria& criteria)
+                              const Criteria& criteria,
+                              int mesh_topology)
     : Base(triangulation,
            c3t3,
            oracle,
            criteria)
     , m_manifold_info_initialized(false)
     , m_bad_vertices_initialized(false)
-    , m_with_manifold_criterion(get_with_manifold(criteria))
-    , m_with_boundary(get_with_boundary(criteria))
+    , m_with_manifold_criterion((mesh_topology & MANIFOLD_WITH_BOUNDARY) != 0)
+    , m_with_boundary((mesh_topology & NO_BOUNDARY) == 0)
   {
 #ifdef CGAL_MESH_3_DEBUG_CONSTRUCTORS
     std::cerr << "CONS: Refine_facets_manifold_base";

--- a/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
+++ b/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
@@ -83,6 +83,8 @@ BOOST_PARAMETER_NAME( (do_freeze, tag) do_freeze_)
 BOOST_PARAMETER_NAME( (max_iteration_number, tag) max_iteration_number_ )
 BOOST_PARAMETER_NAME( (convergence, tag) convergence_)
 
+BOOST_PARAMETER_NAME( (mesh_topology, tag) mesh_topology_)
+
 BOOST_PARAMETER_NAME( (dump_after_init_prefix, tag ) dump_after_init_prefix_)
 BOOST_PARAMETER_NAME( (dump_after_refine_surface_prefix, tag ) dump_after_refine_surface_prefix_)
 BOOST_PARAMETER_NAME( (dump_after_refine_prefix, tag ) dump_after_refine_prefix_)

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -413,13 +413,16 @@ BOOST_PARAMETER_FUNCTION(
       (lloyd_param, (parameters::internal::Lloyd_options), parameters::no_lloyd())
       (mesh_options_param, (parameters::internal::Mesh_3_options), 
                            parameters::internal::Mesh_3_options())
+      (manifold_options_param, (parameters::internal::Manifold_options),
+                               parameters::internal::Manifold_options())
     )
   )
 )
 {
   make_mesh_3_impl(c3t3, domain, criteria,
                    exude_param, perturb_param, odt_param, lloyd_param,
-                   features_param.features(), mesh_options_param);
+                   features_param.features(), mesh_options_param,
+                   manifold_options_param);
 }
 CGAL_PRAGMA_DIAG_POP
 
@@ -444,7 +447,9 @@ void make_mesh_3_impl(C3T3& c3t3,
                       const parameters::internal::Lloyd_options& lloyd,
                       const bool with_features,
                       const parameters::internal::Mesh_3_options& 
-                        mesh_options = parameters::internal::Mesh_3_options())
+                        mesh_options = parameters::internal::Mesh_3_options(),
+                      const parameters::internal::Manifold_options&
+                        manifold_options = parameters::internal::Manifold_options())
 {
 #ifdef CGAL_MESH_3_INITIAL_POINTS_NO_RANDOM_SHOOTING
   CGAL::get_default_random() = CGAL::Random(0);
@@ -467,7 +472,8 @@ void make_mesh_3_impl(C3T3& c3t3,
   // Build mesher and launch refinement process
   // Don't reset c3t3 as we just created it
   refine_mesh_3(c3t3, domain, criteria,
-                exude, perturb, odt, lloyd, parameters::no_reset_c3t3(), mesh_options);
+                exude, perturb, odt, lloyd, parameters::no_reset_c3t3(), mesh_options,
+                manifold_options);
 }
 
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -180,17 +180,17 @@ namespace parameters {
     // Manifold
     struct Manifold_options {
       enum {
-        NON_MANIFOLD = -1,
+        NON_MANIFOLD = 0,
         MANIFOLD_WITH_BOUNDARY = 8,
         NO_BOUNDARY = 16,
         MANIFOLD = 24
       };
       
-      Manifold_options(const int& topology)
+      Manifold_options(const int topology)
         : mesh_topology(topology)
       {}
       Manifold_options()
-        : mesh_topology(MANIFOLD)
+        : mesh_topology(NON_MANIFOLD)
       {}
 
       int mesh_topology;
@@ -502,7 +502,7 @@ void refine_mesh_3_impl(C3T3& c3t3,
   dump_c3t3(c3t3, mesh_options.dump_after_init_prefix);
 
   // Build mesher and launch refinement process
-  Mesher mesher (c3t3, domain, criteria);
+  Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology);
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -177,6 +177,25 @@ namespace parameters {
       , Global_optimization_options_base() {}
     };
 
+    // Manifold
+    struct Manifold_options {
+      enum {
+        NON_MANIFOLD = -1,
+        MANIFOLD_WITH_BOUNDARY = 8,
+        NO_BOUNDARY = 16,
+        MANIFOLD = 24
+      };
+      
+      Manifold_options(const int& topology)
+        : mesh_topology(topology)
+      {}
+      Manifold_options()
+        : mesh_topology(MANIFOLD)
+      {}
+
+      int mesh_topology;
+    };
+
     // Various Mesh_3 option
     struct Mesh_3_options {
       Mesh_3_options() 
@@ -288,7 +307,38 @@ CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
   }
   
   inline internal::Lloyd_options no_lloyd() { return internal::Lloyd_options(false); }
-  
+
+  // -----------------------------------
+  // Manifold options ------------------
+  // -----------------------------------
+  BOOST_PARAMETER_FUNCTION((internal::Manifold_options), manifold_options, tag,
+                           (optional
+                            (mesh_topology_, (int), -1)
+                           )
+                          )
+  {
+    internal::Manifold_options options;
+    options.mesh_topology = mesh_topology_;
+    return options;
+  }
+
+  inline internal::Manifold_options manifold()
+  {
+    return internal::Manifold_options(
+            internal::Manifold_options::MANIFOLD);
+  }
+  inline internal::Manifold_options manifold_with_boundary()
+  {
+    return internal::Manifold_options(
+            internal::Manifold_options::MANIFOLD_WITH_BOUNDARY);
+  }
+  inline internal::Manifold_options non_manifold()
+  {
+    return internal::Manifold_options(
+            internal::Manifold_options::NON_MANIFOLD);
+  }
+
+  // -----------------------------------
   // Mesh options
   // -----------------------------------
 
@@ -358,6 +408,7 @@ CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
   BOOST_PARAMETER_NAME( lloyd_param )
   BOOST_PARAMETER_NAME( reset_param )
   BOOST_PARAMETER_NAME( mesh_options_param )
+  BOOST_PARAMETER_NAME( manifold_options_param )
 
 CGAL_PRAGMA_DIAG_POP
 } // end namespace parameters
@@ -381,6 +432,8 @@ BOOST_PARAMETER_FUNCTION(
       (reset_param, (parameters::Reset), parameters::reset_c3t3())
       (mesh_options_param, (parameters::internal::Mesh_3_options), 
                            parameters::internal::Mesh_3_options())
+      (manifold_options_param, (parameters::internal::Manifold_options),
+                           parameters::internal::Manifold_options())
     )
   )
 )
@@ -393,7 +446,8 @@ BOOST_PARAMETER_FUNCTION(
                             odt_param,
                             lloyd_param,
                             reset_param(),
-                            mesh_options_param);
+                            mesh_options_param,
+                            manifold_options_param);
 }
 
 CGAL_PRAGMA_DIAG_POP
@@ -426,9 +480,13 @@ void refine_mesh_3_impl(C3T3& c3t3,
                         const parameters::internal::Lloyd_options& lloyd,
                         bool reset_c3t3,
                         const parameters::internal::Mesh_3_options& 
-                          mesh_options = parameters::internal::Mesh_3_options())
+                          mesh_options = parameters::internal::Mesh_3_options(),
+                        const parameters::internal::Manifold_options&
+                          manifold_options = parameters::internal::Manifold_options())
 {
   typedef Mesh_3::Mesher_3<C3T3, MeshCriteria, MeshDomain> Mesher;
+
+  //TODO : do something with the manifold_options
 
   // Reset c3t3 (i.e. remove weights) if needed
   if ( reset_c3t3 )

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
@@ -97,7 +97,9 @@ public:
     C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
                                         no_perturb(),
                                         no_exude(),
-      mesh_3_options(number_of_initial_points = 30));
+      mesh_3_options(number_of_initial_points = 30),
+      non_manifold()
+      );
 
     // Verify
     this->verify_c3t3_volume(c3t3, 1236086 * 0.95, 1236086 * 1.05);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -326,8 +326,7 @@ launch()
   Mesh_criteria criteria(edge_criteria(p_.edge_sizing, Tag()),
                          Facet_criteria(p_.facet_angle,
                                         p_.facet_sizing,
-                                        p_.facet_approx,
-                                        topology(p_.manifold)),
+                                        p_.facet_approx),
                          Cell_criteria(p_.tet_shape,
                                        p_.tet_sizing));
 
@@ -335,7 +334,8 @@ launch()
   initialize(criteria, Tag());
 
   // Build mesher and launch refinement process
-  mesher_ = new Mesher(c3t3_, *domain_, criteria);
+  mesher_ = new Mesher(c3t3_, *domain_, criteria,
+                       topology(p_.manifold) & CGAL::MANIFOLD);
 
 #ifdef CGAL_MESH_3_PROFILING
   CGAL::Real_timer t;


### PR DESCRIPTION
## Summary of Changes

This PR documents the manifold criterion for `Mesh_3`
It is not a "simple" mesh criterion as the others, and can be combined with the others, including the topology criterion for facets.

## Release Management

* Affected package : Mesh_3
* Issue solved : fix #2009
* Feature/Small Feature : [Mesh_3 manifold criterion](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Mesh_3_manifold_criterion)

pre-approved --Laurent Rineau 17:03, 3 October 2017 (CEST)


