### PR TITLE
Fix hashing of edge_descriptor for OpenMesh

### DIFF
--- a/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
@@ -47,45 +47,6 @@
 #endif
 namespace CGAL { namespace internal {
 
-
-template<typename Halfedge_handle>
-class OMesh_edge {
-public:
-  OMesh_edge() : halfedge_() {}
-  explicit OMesh_edge(const Halfedge_handle& h) : halfedge_(h) {}
-  Halfedge_handle halfedge() const { return halfedge_; }
-  bool is_valid() const { return halfedge_.is_valid(); }
-
-  bool
-  operator==(const OMesh_edge& other) {
-    if(halfedge_ == other.halfedge_) {
-      return true;
-    } else if(halfedge_ != Halfedge_handle()) {
-      return opposite() == other.halfedge_;
-    } else {
-      return false;
-    }
-  }
-
-  bool operator<(const OMesh_edge& other) const
-  { 
-    return this->idx() < other.idx();
-  }
-
-  bool
-  operator!=(const OMesh_edge& other) { return !(*this == other); }
-
-  Halfedge_handle
-  opposite() const { return Halfedge_handle((halfedge_.idx() & 1) ? halfedge_.idx()-1 : halfedge_.idx()+1); }
-
-  OMesh_edge
-  opposite_edge() const { return OMesh_edge(Halfedge_handle((halfedge_.idx() & 1) ? halfedge_.idx()-1 : halfedge_.idx()+1)); }
-
-  unsigned int idx() const { return halfedge_.idx() / 2; }
-private:
-  Halfedge_handle halfedge_;
-};
-
 template <typename Halfedge_handle, typename OMeshEdge>
 struct Convert_omesh_edge
 {

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -22,6 +22,49 @@
 
 #include <OpenMesh/Core/Mesh/Handles.hh>
 
+namespace CGAL { namespace internal {
+
+
+template<typename Halfedge_handle>
+class OMesh_edge {
+public:
+  OMesh_edge() : halfedge_() {}
+  explicit OMesh_edge(const Halfedge_handle& h) : halfedge_(h) {}
+  Halfedge_handle halfedge() const { return halfedge_; }
+  bool is_valid() const { return halfedge_.is_valid(); }
+
+  bool
+  operator==(const OMesh_edge& other) const {
+    if(halfedge_ == other.halfedge_) {
+      return true;
+    } else if(halfedge_ != Halfedge_handle()) {
+      return opposite() == other.halfedge_;
+    } else {
+      return false;
+    }
+  }
+
+  bool operator<(const OMesh_edge& other) const
+  {
+    return this->idx() < other.idx();
+  }
+
+  bool
+  operator!=(const OMesh_edge& other) { return !(*this == other); }
+
+  Halfedge_handle
+  opposite() const { return Halfedge_handle((halfedge_.idx() & 1) ? halfedge_.idx()-1 : halfedge_.idx()+1); }
+
+  OMesh_edge
+  opposite_edge() const { return OMesh_edge(Halfedge_handle((halfedge_.idx() & 1) ? halfedge_.idx()-1 : halfedge_.idx()+1)); }
+
+  unsigned int idx() const { return halfedge_.idx() / 2; }
+private:
+  Halfedge_handle halfedge_;
+};
+
+} } // CGAL::internal
+
 #if OM_VERSION < 0x60200
 
 namespace OpenMesh {
@@ -31,6 +74,11 @@ inline std::size_t hash_value(const BaseHandle& h) { return h.idx(); }
 } // namespace OpenMesh
 #endif
 
+namespace OpenMesh {
+
+inline std::size_t hash_value(const CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle>& h) { return h.idx(); }
+
+} // namespace OpenMesh
 
 #ifndef OM_HAS_HASH
 
@@ -85,6 +133,17 @@ struct hash<OpenMesh::EdgeHandle >
 {
 
   std::size_t operator()(const OpenMesh::EdgeHandle& h) const
+  {
+    return h.idx();
+  }
+};
+
+template <>
+struct hash<CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle> >
+  : public std::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
+{
+
+  std::size_t operator()(const CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle>& h) const
   {
     return h.idx();
   }


### PR DESCRIPTION
There was a missing const in `operator==()` and the hash function/specialization was not available.
