### PR TITLE
Mesh_3: the "maximal number of vertices" feature

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -32,6 +32,8 @@
 
 #include <CGAL/Mesh_3/config.h>
 
+#include <CGAL/Mesh_error_code.h>
+
 #include <CGAL/Mesh_3/Dump_c3t3.h>
 
 #include<CGAL/Mesh_3/Refine_facets_3.h>
@@ -212,7 +214,9 @@ public:
   Mesher_3(C3T3&               c3t3,
            const MeshDomain&   domain,
            const MeshCriteria& criteria,
-           int mesh_topology = 0);
+           int mesh_topology = 0,
+           std::size_t maximal_number_of_vertices = 0,
+           Mesh_error_code* error_code = 0);
 
   /// Destructor
   ~Mesher_3() 
@@ -274,6 +278,12 @@ private:
 
   Refinement_stage refinement_stage;
 
+  /// Maximal number of vertices
+  std::size_t maximal_number_of_vertices_;
+
+  /// Pointer to the error code
+  Mesh_error_code* error_code_;
+
 private:
   // Disabled copy constructor
   Mesher_3(const Self& src);
@@ -288,7 +298,9 @@ template<class C3T3, class MC, class MD>
 Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                                const MD& domain,
                                const MC& criteria,
-                               int mesh_topology)
+                               int mesh_topology,
+                               std::size_t maximal_number_of_vertices,
+                               Mesh_error_code* error_code)
 : Base(c3t3.bbox(),
        Concurrent_mesher_config::get().locking_grid_num_cells_per_axis)
 , r_oracle_(domain)
@@ -298,12 +310,14 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                  domain,
                  null_mesher_,
                  c3t3,
-                 mesh_topology)
+                 mesh_topology,
+                 maximal_number_of_vertices)
 , cells_mesher_(c3t3.triangulation(),
                 criteria.cell_criteria_object(),
                 domain,
                 facets_mesher_,
-                c3t3)
+                c3t3,
+                maximal_number_of_vertices)
 , null_visitor_()
 , facets_visitor_(&cells_mesher_, &null_visitor_)
 #ifndef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE
@@ -312,6 +326,8 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
 , cells_visitor_(&facets_mesher_, &facets_visitor_)
 #endif
 , r_c3t3_(c3t3)
+, maximal_number_of_vertices_(maximal_number_of_vertices)
+, error_code_(error_code)
 {
   facets_mesher_.set_lock_ds(this->get_lock_data_structure());
   facets_mesher_.set_worksharing_ds(this->get_worksharing_data_structure());
@@ -323,7 +339,8 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
 
 template<class C3T3, class MC, class MD>
 double
-Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
+Mesher_3<C3T3,MC,MD>::
+refine_mesh(std::string dump_after_refine_surface_prefix)
 {
   CGAL::Real_timer timer;
   timer.start();
@@ -335,6 +352,8 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
   // to `refine_mesh`, for example by inserting new vertices in the
   // triangulation.
   r_c3t3_.clear_cells_and_facets_from_c3t3();
+
+  const Triangulation& r_tr = r_c3t3_.triangulation();
 
 #ifndef CGAL_MESH_3_VERBOSE
   // Scan surface and refine it
@@ -380,18 +399,21 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
 
   dump_c3t3(r_c3t3_, dump_after_refine_surface_prefix);
 
-  // Then scan volume and refine it
-  cells_mesher_.scan_triangulation();
-  refinement_stage = REFINE_ALL;
+  if(maximal_number_of_vertices_ == 0 ||
+     r_tr.number_of_vertices() < maximal_number_of_vertices_)
+  {
+    // Then scan volume and refine it
+    cells_mesher_.scan_triangulation();
+    refinement_stage = REFINE_ALL;
 #ifdef CGAL_MESH_3_PROFILING
-  std::cerr << "Refining cells..." << std::endl;
-  t.reset();
+    std::cerr << "Refining cells..." << std::endl;
+    t.reset();
 #endif
-  cells_mesher_.refine(cells_visitor_);
+    cells_mesher_.refine(cells_visitor_);
 #ifdef CGAL_MESH_3_PROFILING
-  double cell_ref_time = t.elapsed();
-  std::cerr << "==== Cell refinement: " << cell_ref_time << " seconds ===="
-            << std::endl << std::endl;
+    double cell_ref_time = t.elapsed();
+    std::cerr << "==== Cell refinement: " << cell_ref_time << " seconds ===="
+              << std::endl << std::endl;
 # ifdef CGAL_MESH_3_EXPORT_PERFORMANCE_DATA
     // If it's parallel but the refinement is forced to sequential, we don't
     // output the value
@@ -402,12 +424,12 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
 #endif
 
 #if defined(CGAL_MESH_3_VERBOSE) || defined(CGAL_MESH_3_PROFILING)
-  std::cerr
-    << "Vertices: " << r_c3t3_.triangulation().number_of_vertices() << std::endl
-    << "Facets  : " << r_c3t3_.number_of_facets_in_complex() << std::endl
-    << "Tets    : " << r_c3t3_.number_of_cells_in_complex() << std::endl;
+    std::cerr
+      << "Vertices: " << r_c3t3_.triangulation().number_of_vertices() << std::endl
+      << "Facets  : " << r_c3t3_.number_of_facets_in_complex() << std::endl
+      << "Tets    : " << r_c3t3_.number_of_cells_in_complex() << std::endl;
 #endif
-
+  } // end test of `maximal_number_of_vertices`
 #else // ifdef CGAL_MESH_3_VERBOSE
   std::cerr << "Start surface scan...";
   initialize();
@@ -416,7 +438,6 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
   elapsed_time += timer.time();
   timer.stop(); timer.reset(); timer.start();
 
-  const Triangulation& r_tr = r_c3t3_.triangulation();
   int nbsteps = 0;
 
   std::cerr << "Refining Surface...\n";
@@ -427,7 +448,9 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
   std::cerr << "(" << r_tr.number_of_vertices() << ","
             << nbsteps << "," << cells_mesher_.debug_info() << ")";
 
-  while ( ! facets_mesher_.is_algorithm_done() )
+  while ( ! facets_mesher_.is_algorithm_done() &&
+          ( maximal_number_of_vertices_ == 0 ||
+            maximal_number_of_vertices_ >= r_tr.number_of_vertices()) )
   {
     facets_mesher_.one_step(facets_visitor_);
     std::cerr
@@ -463,7 +486,9 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
   std::cerr << "(" << r_tr.number_of_vertices() << ","
             << nbsteps << "," << cells_mesher_.debug_info() << ")";
 
-  while ( ! cells_mesher_.is_algorithm_done() )
+  while ( ! cells_mesher_.is_algorithm_done()  &&
+          ( maximal_number_of_vertices_ == 0 ||
+            maximal_number_of_vertices_ >= r_tr.number_of_vertices()) )
   {
     cells_mesher_.one_step(cells_visitor_);
     std::cerr
@@ -480,6 +505,13 @@ Mesher_3<C3T3,MC,MD>::refine_mesh(std::string dump_after_refine_surface_prefix)
   std::cerr << "Total refining time: " << timer.time()+elapsed_time << "s" << std::endl;
   std::cerr << std::endl;
 #endif
+
+  if(maximal_number_of_vertices_ != 0 &&
+     r_tr.number_of_vertices() >= maximal_number_of_vertices_ &&
+     error_code_ != 0)
+  {
+    *error_code_ = MAXIMAL_NUMBER_OF_VERTICES_REACHED;
+  }
 
   timer.stop();
   elapsed_time += timer.time();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -510,7 +510,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
      r_tr.number_of_vertices() >= maximal_number_of_vertices_ &&
      error_code_ != 0)
   {
-    *error_code_ = MAXIMAL_NUMBER_OF_VERTICES_REACHED;
+    *error_code_ = CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED;
   }
 
   timer.stop();

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -394,7 +394,7 @@ public:
   }
 
   // Tells if the refinement process of cells is currently finished
-  bool no_longer_element_to_refine_impl() const
+  bool no_longer_element_to_refine_impl()
   {
     if(m_maximal_number_of_vertices_ !=0 &&
        triangulation_ref_impl().number_of_vertices() >=

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -350,7 +350,8 @@ public:
                  const Criteria& criteria,
                  const MeshDomain& oracle,
                  Previous_& previous,
-                 C3T3& c3t3);
+                 C3T3& c3t3,
+                 std::size_t maximal_number_of_vertices);
   // For parallel
   Refine_cells_3(Tr& triangulation,
                  const Criteria& criteria,
@@ -358,7 +359,8 @@ public:
                  Previous_& previous,
                  C3T3& c3t3,
                  Lock_data_structure *lock_ds,
-                 WorksharingDataStructureType *worksharing_ds);
+                 WorksharingDataStructureType *worksharing_ds,
+                 std::size_t maximal_number_of_vertices);
 
   // Destructor
   virtual ~Refine_cells_3() { }
@@ -389,6 +391,18 @@ public:
   Cell_handle get_next_element_impl()
   {
     return this->extract_element_from_container_value(Container_::get_next_element_impl());
+  }
+
+  // Tells if the refinement process of cells is currently finished
+  bool no_longer_element_to_refine_impl() const
+  {
+    if(m_maximal_number_of_vertices_ !=0 &&
+       triangulation_ref_impl().number_of_vertices() >=
+       m_maximal_number_of_vertices_)
+    {
+      return true;
+    }
+    return Container_::no_longer_element_to_refine_impl();
   }
 
   // Gets the point to insert from the element to refine
@@ -572,6 +586,9 @@ private:
   /// The mesh result
   C3T3& r_c3t3_;
 
+  /// Maximal allowed number of vertices
+  std::size_t m_maximal_number_of_vertices_;
+
 private:
   // Disabled copy constructor
   Refine_cells_3(const Self& src);
@@ -589,7 +606,8 @@ Refine_cells_3(Tr& triangulation,
                const Cr& criteria,
                const MD& oracle,
                P_& previous,
-               C3T3& c3t3)
+               C3T3& c3t3,
+               std::size_t maximal_number_of_vertices)
   : Mesher_level<Tr, Self, Cell_handle, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct >(previous)
   , C_()
@@ -600,6 +618,7 @@ Refine_cells_3(Tr& triangulation,
   , r_criteria_(criteria)
   , r_oracle_(oracle)
   , r_c3t3_(c3t3)
+  , m_maximal_number_of_vertices_(maximal_number_of_vertices)
 {
 }
 
@@ -613,7 +632,8 @@ Refine_cells_3(Tr& triangulation,
                P_& previous,
                C3T3& c3t3,
                Lock_data_structure *lock_ds,
-               WorksharingDataStructureType *worksharing_ds)
+               WorksharingDataStructureType *worksharing_ds,
+               std::size_t maximal_number_of_vertices)
   : Mesher_level<Tr, Self, Cell_handle, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct >(previous, lock_ds, worksharing_ds)
   , C_()
@@ -624,6 +644,7 @@ Refine_cells_3(Tr& triangulation,
   , r_criteria_(criteria)
   , r_oracle_(oracle)
   , r_c3t3_(c3t3)
+  , m_maximal_number_of_vertices_(maximal_number_of_vertices)
 {
 }
 

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -294,7 +294,7 @@ public:
   void scan_triangulation_impl_amendement() const {}
 
   // Tells if the refinement process of cells is currently finished
-  bool no_longer_element_to_refine_impl() const
+  bool no_longer_element_to_refine_impl()
   {
     if(m_maximal_number_of_vertices_ !=0 &&
        r_tr_.number_of_vertices() >=

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -282,15 +282,30 @@ class Refine_facets_3_base
 public:
   Refine_facets_3_base(Tr& tr, Complex3InTriangulation3& c3t3,
                        const MeshDomain& oracle,
-                       const Criteria& criteria)
+                       const Criteria& criteria,
+                       std::size_t maximal_number_of_vertices)
     : r_tr_(tr)
     , r_criteria_(criteria)
     , r_oracle_(oracle)
     , r_c3t3_(c3t3)
+    , m_maximal_number_of_vertices_(maximal_number_of_vertices)
   {}
 
   void scan_triangulation_impl_amendement() const {}
 
+  // Tells if the refinement process of cells is currently finished
+  bool no_longer_element_to_refine_impl() const
+  {
+    if(m_maximal_number_of_vertices_ !=0 &&
+       r_tr_.number_of_vertices() >=
+       m_maximal_number_of_vertices_)
+    {
+      return true;
+    }
+    return Container_::no_longer_element_to_refine_impl();
+  }
+
+  // Gets the point to insert from the element to refine
   /// Gets the point to insert from the element to refine
   Bare_point refinement_point_impl(const Facet& facet) const
   {
@@ -604,6 +619,8 @@ protected:
   const MeshDomain& r_oracle_;
   /// The mesh result
   Complex3InTriangulation3& r_c3t3_;
+  /// Maximal allowed number of vertices
+  std::size_t m_maximal_number_of_vertices_;
 }; // end class template Refine_facets_3_base
 
 /************************************************
@@ -767,7 +784,8 @@ public:
                   const MeshDomain& oracle,
                   Previous_level_& previous,
                   C3T3& c3t3,
-                  int mesh_topology);
+                  int mesh_topology,
+                  std::size_t maximal_number_of_vertices);
   // For parallel
   Refine_facets_3(Tr& triangulation,
                   const Criteria& criteria,
@@ -775,7 +793,8 @@ public:
                   Previous_level_& previous,
                   C3T3& c3t3,
                   Lock_data_structure *lock_ds,
-                  WorksharingDataStructureType *worksharing_ds);
+                  WorksharingDataStructureType *worksharing_ds,
+                  std::size_t maximal_number_of_vertices);
 
   /// Destructor
   virtual ~Refine_facets_3() { }
@@ -860,7 +879,6 @@ public:
   std::size_t queue_size() const { return this->size(); }
 #endif
 
-
 private:
   // private types
   typedef typename Tr::Cell_handle Cell_handle;
@@ -887,8 +905,10 @@ Refine_facets_3(Tr& triangulation,
                 const MD& oracle,
                 P_& previous,
                 C3T3& c3t3,
-                int mesh_topology)
-  : Rf_base(triangulation, c3t3, oracle, criteria, mesh_topology)
+                int mesh_topology,
+                std::size_t maximal_number_of_vertices)
+  : Rf_base(triangulation, c3t3, oracle, criteria, mesh_topology,
+            maximal_number_of_vertices)
   , Mesher_level<Tr, Self, Facet, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct>(previous)
   , No_after_no_insertion()
@@ -906,8 +926,9 @@ Refine_facets_3(Tr& triangulation,
                 P_& previous,
                 C3T3& c3t3,
                 Lock_data_structure *lock_ds,
-                WorksharingDataStructureType *worksharing_ds)
-  : Rf_base(triangulation, c3t3, oracle, criteria)
+                WorksharingDataStructureType *worksharing_ds,
+                std::size_t maximal_number_of_vertices)
+  : Rf_base(triangulation, c3t3, oracle, criteria, maximal_number_of_vertices)
   , Mesher_level<Tr, Self, Facet, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct>(previous)
   , No_after_no_insertion()

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -302,11 +302,13 @@ public:
                               C3t3& c3t3,
                               const Mesh_domain& oracle,
                               const Criteria& criteria,
-                              int mesh_topology)
+                              int mesh_topology,
+                              std::size_t maximal_number_of_vertices)
     : Base(triangulation,
            c3t3,
            oracle,
-           criteria)
+           criteria,
+           maximal_number_of_vertices)
     , m_manifold_info_initialized(false)
     , m_bad_vertices_initialized(false)
     , m_with_manifold_criterion((mesh_topology & MANIFOLD_WITH_BOUNDARY) != 0)
@@ -430,6 +432,13 @@ public:
     if(Base::no_longer_element_to_refine_impl())
     {
       if(!m_with_manifold_criterion) return true;
+
+      if(this->m_maximal_number_of_vertices_ !=0 &&
+         this->r_tr_.number_of_vertices() >=
+         this->m_maximal_number_of_vertices_)
+      {
+        return true;
+      }
 
       // Note: with Parallel_tag, `m_bad_vertices` and `m_bad_edges`
       // are always empty.

--- a/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
+++ b/Mesh_3/include/CGAL/Mesh_3/global_parameters.h
@@ -92,6 +92,8 @@ BOOST_PARAMETER_NAME( (dump_after_glob_opt_prefix, tag ) dump_after_glob_opt_pre
 BOOST_PARAMETER_NAME( (dump_after_perturb_prefix, tag ) dump_after_perturb_prefix_)
 BOOST_PARAMETER_NAME( (dump_after_exude_prefix, tag ) dump_after_exude_prefix_)
 BOOST_PARAMETER_NAME( (number_of_initial_points, tag) number_of_initial_points_)
+BOOST_PARAMETER_NAME( (maximal_number_of_vertices, tag ) maximal_number_of_vertices_)
+BOOST_PARAMETER_NAME( (pointer_to_error_code, tag ) pointer_to_error_code_)
 
 CGAL_PRAGMA_DIAG_POP
 } // end namespace parameters

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -675,6 +675,15 @@ public:
   Corner_index corner_index(const Index& index) const
   { return boost::get<Corner_index>(index); }
 
+  /// @cond DEVELOPERS
+#ifndef CGAL_NO_DEPRECATED_CODE
+  CGAL_DEPRECATED_MSG("deprecated: use curve_index() instead")
+  Curve_index curve_segment_index(const Index& index) const {
+    return curve_index(index);
+  }
+#endif // CGAL_NO_DEPRECATED_CODE
+  /// @endcond
+
   /// Insert a bunch of edges into domain
   ///   + InputIterator type should have begin() and end() function
   ///   + InputIterator::iterator value type must be Point_3

--- a/Mesh_3/include/CGAL/Mesh_error_code.h
+++ b/Mesh_3/include/CGAL/Mesh_error_code.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2012 GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+
+#ifndef CGAL_MESH_ERROR_CODE_H
+#define CGAL_MESH_ERROR_CODE_H
+
+#include <string>
+#include <sstream>
+
+namespace CGAL {
+
+enum Mesh_error_code {
+  NO_ERROR = 0,
+  MAXIMAL_NUMBER_OF_VERTICES_REACHED
+};
+
+std::string mesh_error_string(const Mesh_error_code& error_code) {
+  switch(error_code) {
+  case NO_ERROR:
+    return "no error";
+  case MAXIMAL_NUMBER_OF_VERTICES_REACHED:
+    return "the maximal number of vertices has been reached";
+  default:
+    std::stringstream str("");
+    str << "unknown error (error_code="
+        << error_code
+        << ")";
+    return str.str();
+  }
+}
+
+}
+
+#endif // CGAL_MESH_ERROR_CODE_H

--- a/Mesh_3/include/CGAL/Mesh_error_code.h
+++ b/Mesh_3/include/CGAL/Mesh_error_code.h
@@ -26,15 +26,16 @@
 namespace CGAL {
 
 enum Mesh_error_code {
-  NO_ERROR = 0,
-  MAXIMAL_NUMBER_OF_VERTICES_REACHED
+  CGAL_MESH_3_NO_ERROR = 0,
+  CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED
 };
 
+inline
 std::string mesh_error_string(const Mesh_error_code& error_code) {
   switch(error_code) {
-  case NO_ERROR:
+  case CGAL_MESH_3_NO_ERROR:
     return "no error";
-  case MAXIMAL_NUMBER_OF_VERTICES_REACHED:
+  case CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED:
     return "the maximal number of vertices has been reached";
   default:
     std::stringstream str("");

--- a/Mesh_3/include/CGAL/Mesh_error_code.h
+++ b/Mesh_3/include/CGAL/Mesh_error_code.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012 GeometryFactory Sarl (France).
+// Copyright (c) 2012,2017 GeometryFactory Sarl (France).
 // All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org).
@@ -17,6 +17,8 @@
 
 #ifndef CGAL_MESH_ERROR_CODE_H
 #define CGAL_MESH_ERROR_CODE_H
+
+#include <CGAL/license/Mesh_3.h>
 
 #include <string>
 #include <sstream>

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -33,6 +33,7 @@
 #include <CGAL/Mesh_3/Dump_c3t3.h>
 #include <CGAL/Mesh_3/global_parameters.h>
 #include <CGAL/Mesh_3/Mesher_3.h>
+#include <CGAL/Mesh_error_code.h>
 #include <CGAL/optimize_mesh_3.h>
 
 namespace CGAL {
@@ -207,6 +208,8 @@ namespace parameters {
         , dump_after_exude_prefix()
         , number_of_initial_points()
         , nonlinear_growth_of_balls(false)
+        , maximal_number_of_vertices(0)
+        , pointer_to_error_code(0)
       {}
 
       std::string dump_after_init_prefix;
@@ -217,6 +220,8 @@ namespace parameters {
       std::string dump_after_exude_prefix;
       int number_of_initial_points;
       bool nonlinear_growth_of_balls;
+      std::size_t maximal_number_of_vertices;
+      Mesh_error_code* pointer_to_error_code;
 
     }; // end struct Mesh_3_options
 
@@ -354,6 +359,8 @@ CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (dump_after_perturb_prefix_, (std::string), "" )
                             (dump_after_exude_prefix_, (std::string), "" )
                             (number_of_initial_points_, (int), -1)
+                            (maximal_number_of_vertices_, (std::size_t), 0)
+                            (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
                             )
                            )
   { 
@@ -366,6 +373,8 @@ CGAL_MESH_3_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
     options.dump_after_perturb_prefix=dump_after_perturb_prefix_;
     options.dump_after_exude_prefix=dump_after_exude_prefix_;
     options.number_of_initial_points=number_of_initial_points_;
+    options.maximal_number_of_vertices=maximal_number_of_vertices_;
+    options.pointer_to_error_code=pointer_to_error_code_;
 
     return options;
   }
@@ -502,7 +511,9 @@ void refine_mesh_3_impl(C3T3& c3t3,
   dump_c3t3(c3t3, mesh_options.dump_after_init_prefix);
 
   // Build mesher and launch refinement process
-  Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology);
+  Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology,
+                 mesh_options.maximal_number_of_vertices,
+                 mesh_options.pointer_to_error_code);
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 


### PR DESCRIPTION
## Summary of Changes

This PR imports from the old branch `Mesh_3-experimental-GF` the feature that allows to set a maximal number of vertices. That maximal number will end-up the refinement process forcibly, and an error code is set.

## Release Management

* Affected package(s): Mesh-3
* Feature/Small Feature (if any): none... that is not yet documented.


Question for @cjamin: for the moment it only works if the `Parallel_tag` is not used. Do you see a way to implement something similar in the parallel mode?
