### PR TITLE
Surface_mesh_simplification: Add a missing typedef

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Midpoint_placement.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Midpoint_placement.h
@@ -34,7 +34,9 @@ namespace Surface_mesh_simplification
 class Midpoint_placement
 {
 public:
-    
+
+  typedef ECM_ ECM;
+  
   Midpoint_placement()
   {}
   


### PR DESCRIPTION
## Summary of Changes

Add `typedef .. ECM` so that one can wrap the `Midpoint_placement`, for example in a `Bounded_normal_change_placement`

## Release Management

* Affected package(s): Surface_mesh_simplification

