### PR TITLE
Polyhedron demo - fix isotropic remeshing plugin

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -617,6 +617,10 @@ namespace internal {
       std::cout << "Collapse short edges (" << low << ", " << high << ")..."
                 << std::endl;
 #endif
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
+      std::cout << "Fill bimap...";
+      std::cout.flush();
+#endif
       double sq_low = low*low;
       double sq_high = high*high;
 
@@ -627,6 +631,9 @@ namespace internal {
         if( (sqlen < sq_low) && is_collapse_allowed(e) )
           short_edges.insert(short_edge(halfedge(e, mesh_), sqlen));
       }
+#ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
+      std::cout << "done." << std::endl;
+#endif
 
       unsigned int nb_collapses = 0;
       while (!short_edges.empty())

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1437,7 +1437,7 @@ private:
       if (GeomTraits().collinear_3_object()(p,q,r))
         return CGAL::NULL_VECTOR;
       else
-        return PMP::compute_face_normal(f, mesh_);
+        return PMP::compute_face_normal(f, mesh_, parameters::vertex_point_map(vpmap_));
     }
 
     template <typename FaceRange>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -189,6 +189,9 @@ namespace internal {
       patch_ids_map = CGAL::internal::add_property(Face_property_tag("PMP_patch_id"), pmesh);
       if (do_init)
       {
+#ifdef CGAL_PMP_REMESHING_VERBOSE
+        std::cout << "Compute connected components property map." << std::endl;
+#endif
         nb_cc
           = PMP::connected_components(pmesh,
                                       patch_ids_map,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1918,7 +1918,6 @@ private:
     Patch_id_to_index_map patch_id_to_index_map;
     Triangle_list input_triangles_;
     Patch_id_list input_patch_ids_;
-    Patch_id_to_index_map patch_id_to_index_map_;
     Halfedge_status_pmap halfedge_status_pmap_;
     bool protect_constraints_;
     FacePatchMap patch_ids_map_;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -348,11 +348,9 @@ public Q_SLOTS:
 
      reset_face_ids(pmesh);
 
-     Patch_id_pmap fpmap;
+     Patch_id_pmap fpmap = get(CGAL::face_patch_id_t<int>(), pmesh);
      bool fpmap_valid = false;
-     if(boost::graph_has_property<FaceGraph, CGAL::face_patch_id_t<int>()>::type::value)
      {
-       fpmap = get(CGAL::face_patch_id_t<int>(), *poly_item->polyhedron());
        BOOST_FOREACH(face_descriptor f, faces(pmesh))
        {
          if (get(fpmap, f) != 1)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -467,7 +467,7 @@ public Q_SLOTS:
 #ifdef USE_SURFACE_MESH
         selection_item->polyhedron_item()->setColor(
               selection_item->polyhedron_item()->color());
-        selection_item->polyhedron_item()->setItemIsMulticolor(false);
+        selection_item->polyhedron_item()->setItemIsMulticolor(fpmap_valid);
         selection_item->polyhedron_item()->polyhedron()->collect_garbage();
 #else
         if(!selection_item->polyhedron_item()->isItemMulticolor())

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -9,10 +9,14 @@
 
 #ifdef USE_SURFACE_MESH
 #include "Scene_surface_mesh_item.h"
+#include <CGAL/Mesh_3/properties_Surface_mesh.h>
 #else
 #include "Scene_polyhedron_item.h"
 #include "Polyhedron_type.h"
+#include <CGAL/Mesh_3/properties_Polyhedron_3.h>
 #endif
+
+#include <CGAL/Mesh_3/properties.h>
 
 #include "Scene_polyhedron_selection_item.h"
 
@@ -342,7 +346,7 @@ public Q_SLOTS:
       typedef boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
       typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
-      const FaceGraph& pmesh = (poly_item != NULL)
+      FaceGraph& pmesh = (poly_item != NULL)
         ? *poly_item->polyhedron()
         : *selection_item->polyhedron();
 


### PR DESCRIPTION
## Summary of Changes

In the `isotropic_remeshing_plugin`, the `Patch_id_map` that `get(..., pmesh)` returns was given as a parameter to `PMP::isotropic_remeshing()`, however it had been initialized or not.

The consequence was that `PMP::isotropic_remeshing()` "thought" it was using a valid `face_patch_map` and hence failed to make valid collapisibility/topology checks next to constrained edges.
The proper behavior when the face patch map is not provided (or invalid) is to compute the connected components from constrained edges. This is automatically done inside the remeshing function.

Now we use the face_patch_map only when it is valid, i.e. with not all its values `== 1` (because `1` is the default value both for `Polyhedron_3` and `Surface_mesh`.

## Release Management

* Affected packages : Polyhedron demo (and minor changes in PMP)
