### PR TITLE
Change argument order to be consistent with other selection functions

### DIFF
--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -410,6 +410,7 @@ user might encounter.
 - `CGAL::expand_vertex_selection()`
 - `CGAL::reduce_vertex_selection()`
 - `CGAL::select_incident_faces()`
+- `CGAL::expand_face_selection_for_removal()`
 
 ## Conversion Functions ##
 - `CGAL::convert_nef_polyhedron_to_polygon_mesh()`

--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -544,8 +544,8 @@ reduce_vertex_selection(
  *
  **/
 template<class TriangleMesh, class FaceRange, class IsSelectedMap>
-void expand_face_selection_for_removal(TriangleMesh& tm,
-                                       const FaceRange& faces_to_be_deleted,
+void expand_face_selection_for_removal(const FaceRange& faces_to_be_deleted,
+                                       TriangleMesh& tm,
                                        IsSelectedMap is_selected)
 {
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor vertex_descriptor;

--- a/BGL/test/BGL/test_Manifold_face_removal.cpp
+++ b/BGL/test/BGL/test_Manifold_face_removal.cpp
@@ -41,8 +41,8 @@ int main()
     ++index;
   }
 
-  expand_face_selection_for_removal(sm,
-                                    faces_to_remove,
+  expand_face_selection_for_removal(faces_to_remove,
+                                    sm,
                                     boost::make_assoc_property_map(is_selected_map));
 
   index=0;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -514,8 +514,8 @@ public Q_SLOTS:
         }
         ++index;
       }
-      CGAL::expand_face_selection_for_removal(*selection_item->polyhedron(),
-                                        selection_item->selected_facets,
+      CGAL::expand_face_selection_for_removal(selection_item->selected_facets,
+                                              *selection_item->polyhedron(),
                                         boost::make_assoc_property_map(is_selected_map));
 
       BOOST_FOREACH(fg_face_descriptor fh, faces(*selection_item->polyhedron()))


### PR DESCRIPTION
In the other functions the range is the first argument and the graph the second (while it was the converse for the new function introduced in 4.12).

At the same time I add a missing reference in the classified reference manual.