### PR TITLE
PMP - fix isotropic remeshing with isolated vertices

### DIFF
--- a/BGL/doc/BGL/Concepts/HalfedgeGraph.h
+++ b/BGL/doc/BGL/Concepts/HalfedgeGraph.h
@@ -97,4 +97,4 @@ returns a special halfedge that is not equal to any other halfedge.
  */
 template <typename HalfedgeGraph>
 boost::graph_traits<HalfedgeGraph>::halfedge_descriptor
-null_halfedge(const HalfedgeGraph& g);
+null_halfedge();


### PR DESCRIPTION
## Summary of Changes

This PR fixes `PMP::isotropic_remeshing()`, that can now deal with data that include isolated vertices.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #2488 

