### PR TITLE
Polyhedron demo: Fix Cut_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -328,7 +328,7 @@ public:
       .arg(this->color().name())
       .arg(tree_size);
   }
-  
+
 
   // Indicate if rendering mode is supported
   bool supportsRenderingMode(RenderingMode m) const {
@@ -961,7 +961,7 @@ using namespace CGAL::Three;
 class Polyhedron_demo_cut_plugin :
   public QObject,
   public Polyhedron_demo_plugin_interface,
-  public Polyhedron_demo_io_plugin_interface 
+  public Polyhedron_demo_io_plugin_interface
 {
   Q_OBJECT
   Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
@@ -971,7 +971,7 @@ class Polyhedron_demo_cut_plugin :
 public:
   Polyhedron_demo_cut_plugin() : QObject(), edges_item(0) {
   }
-  
+
   virtual ~Polyhedron_demo_cut_plugin();
 
   bool applicable(QAction*) const {
@@ -1017,15 +1017,15 @@ public:
 
   virtual bool save(const CGAL::Three::Scene_item* item, QFileInfo fileinfo)
   {  // This plugin supports edges items
-    const Scene_edges_item* edges_item = 
+    const Scene_edges_item* edges_item =
       qobject_cast<const Scene_edges_item*>(item);
-    
+
     if(!edges_item){
       return false;
     }
-    
+
     std::ofstream out(fileinfo.filePath().toUtf8());
-    
+
     return (out && edges_item->save(out));
   }
 
@@ -1090,6 +1090,13 @@ public Q_SLOTS:
       action->setChecked(false);
       return;
     }
+  }
+
+  void deleteTree()
+  {
+    Scene_item* item = qobject_cast<Scene_item*>(sender());
+    if(item)
+      deleteTrees(item);
   }
   void deleteTrees(CGAL::Three::Scene_item* sender)
   {
@@ -1264,6 +1271,8 @@ void Polyhedron_demo_cut_plugin::apply(Item* item, QMap< QObject*, Facets_tree*>
     PPMAP<Mesh> pmap(item->polyhedron());
     Facets_traits traits;
     traits.set_shared_data(mesh, pmap); //Mandatory for SMesh. If not provided, mesh and PPmap are taken default, saying NULL in tree.traversal().
+    connect(item, SIGNAL(item_is_about_to_be_changed()),
+            this, SLOT(deleteTree()));
     f_trees[item] = new Facets_tree(traits);
     //filter facets to ignore degenerated ones
 


### PR DESCRIPTION
## Summary of Changes
Delete trees whenever invalidateOpenGLBuffers is changed, as it deletes the item's tree.

## Release Management
* Issue(s) solved (if any): fix #2520 


