### PR TITLE
Surface_mesh: Added missing 'explicit' on SM_Edge_index constructor

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -198,7 +198,7 @@ namespace CGAL {
 
         SM_Edge_index() : halfedge_(-1) { }
 
-        SM_Edge_index(size_type idx) : halfedge_(idx * 2) { }
+        explicit SM_Edge_index(size_type idx) : halfedge_(idx * 2) { }
 
         explicit SM_Edge_index(SM_Halfedge_index he) : halfedge_(he) { }
 


### PR DESCRIPTION
## Summary of Changes

Constructors of the index classes of `Surface_mesh` should be explicit (to avoid dangerous implicit conversions!).

## Release Management

* Affected package(s): `Surface_mesh`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

