### PR TITLE
Polyhedron demo: Fix some missing redraw

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -102,6 +102,8 @@ Scene::replaceItem(Scene::Item_id index, CGAL::Three::Scene_item* item, bool emi
             this, SLOT(itemChanged()));
     connect(item, SIGNAL(itemVisibilityChanged()),
             this, SLOT(itemVisibilityChanged()));
+    connect(item, SIGNAL(redraw()),
+            this, SLOT(callDraw()));
     CGAL::Three::Scene_group_item* group =
             qobject_cast<CGAL::Three::Scene_group_item*>(m_entries[index]);
     if(group)


### PR DESCRIPTION
## Summary of Changes
The signal redraw() was connected only in addItem() but not in replaceItem(), which means that after a reload or a deformation, all the actions that called redraw() and not itemChanged() were not updating the viewer.


