### PR TITLE
Fix a perturber bug

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1514,7 +1514,8 @@ private:
           c3t3.remove_from_complex(Facet(c,i));
 
         c->set_facet_surface_center(i, facet_surface_center_[old_i]);
-        c->set_facet_surface_center_index(i, surface_center_index_table_[old_i]);
+        const Facet mirror = c3t3.triangulation().mirror_facet(Facet(c, i));
+        mirror.first->set_facet_surface_center(mirror.second, facet_surface_center_[old_i]);
       }
     }
 

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1534,7 +1534,8 @@ private:
             c3t3.remove_from_complex(Facet(c, i));
 
           c->set_facet_surface_center(i, facet_surface_center_[0]);
-          c->set_facet_surface_center_index(i, surface_center_index_table_[0]);
+          const Facet mirror = c3t3.triangulation().mirror_facet(Facet(c, i));
+          mirror.first->set_facet_surface_center(mirror.second, facet_surface_center_[0]);
           return;
         }
       }

--- a/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
@@ -65,6 +65,9 @@
 
 #include <boost/format.hpp>
 #ifdef CGAL_MESH_3_USE_RELAXED_HEAP
+#  error This option CGAL_MESH_3_USE_RELAXED_HEAP is no longer supported
+// The reason is that the Boost relaxed heap does not ensure a strict order
+// of the priority queue.
 #include <boost/pending/relaxed_heap.hpp>
 #else
 #include <CGAL/Modifiable_priority_queue.h>


### PR DESCRIPTION
## Summary of Changes

The `facet_surface_center` of facet was not always restored correctly,
after an aborted move, and that eventually led to use of uninitialized
memory... and a crash.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #1944 

