### PR TITLE
PMP corefinement : improve doc

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -132,8 +132,10 @@ bool recursive_does_bound_a_volume(const TriangleMesh& tm,
  *                      as a named parameter, then it must be initialized.
  * @tparam NamedParameters a sequence of \ref namedparameters
  *
- * @param tm a triangulated surface mesh
+ * @param tm a closed triangulated surface mesh
  * @param np optional sequence of \ref namedparameters among the ones listed below
+ *
+ * @pre `CGAL::is_closed(tm)`
  *
  * \cgalNamedParamsBegin
  *   \cgalParamBegin{vertex_point_map}
@@ -142,9 +144,7 @@ bool recursive_does_bound_a_volume(const TriangleMesh& tm,
  *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{face_index_map}
- *     a property map containing the index of each face of `tm1` (`tm2`).
- *     Note that if the property map is writable, the indices of the faces
- *     of `tm1` and `tm2` will be set after the corefinement is done.
+ *     a property map containing the index of each face of `tm`.
  *   \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -454,7 +454,10 @@ boolean_operation(      TriangleMesh& tm1,
   *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
   *     constrained-or-not status of each edge of `tm1` (`tm2`).
   *   \cgalParamEnd
-  *   \cgalParamBegin{face_index_map} a property map containing the index of each face of `tm1` (`tm2`) \cgalParamEnd
+  *   \cgalParamBegin{face_index_map} a property map containing the index of each face of `tm1` (`tm2`).
+  *     Note that if the property map is writable, the indices of the faces
+  *     of `tm1` and `tm2` will be set after the corefinement is done.
+  *   \cgalParamEnd
   * \cgalNamedParamsEnd
   *
   * @param np_out optional sequence of \ref namedparameters among the ones listed below


### PR DESCRIPTION
## Summary of Changes

This PR improves the doc of the corefinement functions 
- add a precondition that `tm` is closed in `does_bound_a_volume()`
- move the piece of doc about filling `face_index_map` property maps to the corefinement operators

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #2543 

