### PR TITLE
Polyhedron demo: minor fixes

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -628,7 +628,9 @@ public Q_SLOTS:
   void on_SelectionOrEuler_changed(int index)
   {
     Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
-    if(selection_item)
+    if(!selection_item)
+      return;
+    else
       selection_item->on_Ctrlz_pressed();
     last_mode = index;
     switch(index)

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -181,6 +181,7 @@ public :
      if(isChildLocked(item))
       return;
      update_group_number(item,0);
+     item->moveToGroup(0);
      children.removeOne(item);
     }
     //!Moves a child up in the list.


### PR DESCRIPTION
## Summary of Changes

This PR fixes some bugs in the demo:
- Removing a child from a group now sets its parent_group to NULL, which avoids segfault when testing parentGroup() after the deletion of the said group.
- Switching the selection type (selection/edition) tab in the selection plugin does not cause a Segfault when there is no existing selection item anymore.