### PR TITLE
remove extra `#` beneath logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/CGAL/cgal.svg?branch=master)](https://travis-ci.org/CGAL/cgal)
 
-#![CGAL](Installation/doc_html/images/cgal_2013_grey.png)
+![CGAL](Installation/doc_html/images/cgal_2013_grey.png)
 
 The Computational Geometry Algorithms Library (CGAL) is a C++ library that
 aims to provide easy access to efficient and reliable algorithms in


### PR DESCRIPTION
## Summary of Changes

GitHub renders a `#` sign beneath the logo because images cannot be headings.  See [new rendering here](https://github.com/svenevs/cgal/blob/patch-2/README.md) :smile:  Current [`REAMDE.md` from `master`](https://github.com/CGAL/cgal/blob/master/README.md) for comparison.

## Release Management

* Affected package(s): N/A
* Issue(s) solved (if any): N/A
* Feature/Small Feature (if any): N/A

