### PR TITLE
Fix facets_in_complex_2_to_triangle_mesh

### DIFF
--- a/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
+++ b/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
@@ -52,7 +52,7 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
   typedef typename boost::property_traits<VertexPointMap>::value_type Point_3;
   typedef typename C2T3::Triangulation Tr;
   typedef typename Tr::Vertex_handle Vertex_handle;
-  typedef typename Tr::Vertex_iterator Vertex_iterator;
+  typedef typename Tr::Finite_vertices_iterator Vertex_iterator;
   typedef typename Tr::Geom_traits::Vector_3 Vector;
   typedef typename Tr::Edge Edge;
   typedef typename Tr::Facet Facet;
@@ -129,8 +129,8 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
     int inum = 0;
     //add vertices
     std::vector<typename boost::graph_traits<TriangleMesh>::vertex_descriptor> vertices;
-    for(Vertex_iterator vit = tr.vertices_begin();
-        vit != tr.vertices_end();
+    for(Vertex_iterator vit = tr.finite_vertices_begin();
+        vit != tr.finite_vertices_end();
         ++vit)
     {
 


### PR DESCRIPTION
## Summary of Changes
Iterate only finite vertices to avoid adding the infinite vertex.

## Release Management

* Fix of #2254, (integrated in `master` for 4.12)
* Affected package(s):Surface_mesher