### PR TITLE
Polyhedron demo: fix VTK plugin name filters

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -287,11 +287,11 @@ public:
 
 #ifdef USE_SURFACE_MESH
   QString nameFilters() const {
-    return "VTK PolyData files (Surface_mesh) (*.vtk);; VTK XML PolyData (Surface_mesh) (*.vtp);; VTK XML UnstructuredGrid (Surface_mesh)(*.vtu)"; }
+    return "VTK PolyData files Surface_mesh (*.vtk);; VTK XML PolyData Surface_mesh (*.vtp);; VTK XML UnstructuredGrid Surface_mesh(*.vtu)"; }
   QString name() const { return "vtk_sm_plugin"; }
 #else
   QString nameFilters() const {
-    return "VTK PolyData files (Polyhedron) (*.vtk);; VTK XML PolyData (Polyhedron) (*.vtp);; VTK XML UnstructuredGrid (Polyhedron)(*.vtu)"; }
+    return "VTK PolyData files Polyhedron (*.vtk);; VTK XML PolyData Polyhedron (*.vtp);; VTK XML UnstructuredGrid Polyhedron(*.vtu)"; }
   QString name() const { return "vtk_plugin"; }
 #endif
   bool canSave(const CGAL::Three::Scene_item* item)


### PR DESCRIPTION
The VTK name filters are messed up because of the parenthesis around Polyhedron and Surface_mesh in their description. This PR fixes it.

