### PR TITLE
Polyhedron demo: add length of polylines

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -171,6 +171,11 @@ public Q_SLOTS:
     ui_widget.instructionsLabel->setText(s);
   }
 
+  void printMessage(QString s)
+  {
+    print_message(s);
+  }
+
   void selection_action() {
     dock_widget->show();
     dock_widget->raise();
@@ -803,6 +808,7 @@ public Q_SLOTS:
     selection_item_map.insert(std::make_pair(poly_item, selection_item));
     connect(this, SIGNAL(save_handleType()),selection_item, SLOT(save_handleType()));
     connect(selection_item, SIGNAL(updateInstructions(QString)), this, SLOT(setInstructions(QString)));
+    connect(selection_item, SIGNAL(printMessage(QString)), this, SLOT(printMessage(QString)));
     connect(this, SIGNAL(set_operation_mode(int)),selection_item, SLOT(set_operation_mode(int)));
     QObject* scene_ptr = dynamic_cast<QObject*>(scene);
     if (scene_ptr)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -1629,13 +1629,20 @@ void Scene_polyhedron_selection_item_priv::computeAndDisplayPath()
   path.append(vop);
 
   // Display path
+  double path_length = 0;
   QList<vertex_on_path>::iterator path_it;
   for(path_it = path.begin(); path_it!=path.end()-1; ++path_it)
   {
     std::pair<fg_halfedge_descriptor, bool> h = halfedge((path_it+1)->vertex,path_it->vertex,*item->polyhedron());
     if(h.second)
+    {
+      VPmap vpm = get(CGAL::vertex_point,*polyhedron());
+      Point p1(get(vpm, (path_it+1)->vertex)), p2(get(vpm, path_it->vertex));
+          path_length += CGAL::sqrt(Vector(p1,p2).squared_length());
       item->temp_selected_edges.insert(edge(h.first, *item->polyhedron()));
+    }
   }
+  item->printMessage(QString("New path length: %1").arg(path_length));
 }
 
 void Scene_polyhedron_selection_item_priv::addVertexToPath(fg_vertex_descriptor vh, vertex_on_path &first)
@@ -2115,7 +2122,7 @@ void Scene_polyhedron_selection_item::clearHL()
 }
 void Scene_polyhedron_selection_item::selected_HL(const std::set<fg_vertex_descriptor>& m)
 {
-  HL_selected_edges.clear();
+//  HL_selected_edges.clear();
   HL_selected_facets.clear();
   HL_selected_vertices.clear();
   HL_selected_vertices.insert(*m.begin());

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -812,6 +812,7 @@ Q_SIGNALS:
   void updateInstructions(QString);
   void simplicesSelected(CGAL::Three::Scene_item*);
   void isCurrentlySelected(Scene_facegraph_item_k_ring_selection*);
+  void printMessage(QString);
 
 public Q_SLOTS:
 

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -342,9 +342,18 @@ Scene_polylines_item::toolTip() const {
             .arg(polylines.size());
     if(polylines.size() == 1 )
     {
-      QString vertices_info = tr("<p>Number of vertices: %1</p>")
-                              .arg(polylines.front().size());
+      double length = 0;
+      for(std::size_t i=1; i<polylines.front().size(); ++i)
+      {
+        K::Vector_3 vec(polylines.front()[i-1], polylines.front()[i]);
+        length += CGAL::sqrt(vec.squared_length());
+      }
+      QString vertices_info = tr("<p>Number of vertices: %1<br />"
+                                 "Polyline's length: %1</p>")
+          .arg(polylines.front().size())
+          .arg(length);
      s.append(vertices_info);
+
     }
     return s;
 }

--- a/Polyhedron/demo/Polyhedron/Statistics_on_item_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Statistics_on_item_dialog.ui
@@ -20,7 +20,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Statistics on Polyhedron</string>
+   <string>Statistics</string>
   </property>
   <property name="modal">
    <bool>false</bool>


### PR DESCRIPTION
## Summary of Changes
In the polyline_item's tooltip, if there is only one polyline, add the length of this polyline.
## Release Management
* Issue(s) solved (if any): fix #2556 


