### PR TITLE
Fix wrong uses of std::numeric_limits::min() (4.10)

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
@@ -622,12 +622,12 @@ namespace CGAL {
       }
         
       const Bbox_3 &buildBoundingCube() {
-        FT min[] = {(std::numeric_limits<FT>::max)(),
-                    (std::numeric_limits<FT>::max)(),
-                    (std::numeric_limits<FT>::max)()};
-        FT max[] = {(std::numeric_limits<FT>::min)(),
-                    (std::numeric_limits<FT>::min)(),
-                    (std::numeric_limits<FT>::min)()};
+        FT min[] = {std::numeric_limits<FT>::infinity(),
+                    std::numeric_limits<FT>::infinity(),
+                    std::numeric_limits<FT>::infinity()};
+        FT max[] = {-std::numeric_limits<FT>::infinity(),
+                    -std::numeric_limits<FT>::infinity(),
+                    -std::numeric_limits<FT>::infinity()};
 
         for (std::size_t i = 0;i<this->size();i++) {
           Point_3 p = get(m_point_pmap, *this->at(i));

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
@@ -17,7 +17,7 @@ typedef CGAL::Polyhedron_3<K> Polyhedron;
 
 double max_coordinate(const Polyhedron& poly)
 {
-  double max_coord = (std::numeric_limits<double>::min)();
+  double max_coord = -std::numeric_limits<double>::infinity();
   BOOST_FOREACH(Polyhedron::Vertex_handle v, vertices(poly))
   {
     Point p = v->point();

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
@@ -26,7 +26,7 @@ double max_coordinate(const Mesh& mesh)
   typedef boost::property_map<Mesh,CGAL::vertex_point_t>::type VPmap;
   VPmap vpmap = get(CGAL::vertex_point,mesh);
 
-  double max_coord = std::numeric_limits<double>::min();
+  double max_coord = -std::numeric_limits<double>::infinity();
   BOOST_FOREACH(vertex_descriptor v, vertices(mesh))
   {
     Point p = get(vpmap, v);

--- a/Surface_mesh_parameterization/include/CGAL/Two_vertices_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Two_vertices_parameterizer_3.h
@@ -129,12 +129,12 @@ Two_vertices_parameterizer_3<Adaptor>::parameterize_border(Adaptor& mesh)
         return Parameterizer_traits_3<Adaptor>::ERROR_BORDER_TOO_SHORT;
 
     // Get mesh's bounding box
-    double xmin = (std::numeric_limits<double>::max)() ;
-    double ymin = (std::numeric_limits<double>::max)() ;
-    double zmin = (std::numeric_limits<double>::max)() ;
-    double xmax = (std::numeric_limits<double>::min)() ;
-    double ymax = (std::numeric_limits<double>::min)() ;
-    double zmax = (std::numeric_limits<double>::min)() ;
+    double xmin = std::numeric_limits<double>::infinity();
+    double ymin = std::numeric_limits<double>::infinity();
+    double zmin = std::numeric_limits<double>::infinity();
+    double xmax = -std::numeric_limits<double>::infinity();
+    double ymax = -std::numeric_limits<double>::infinity();
+    double zmax = -std::numeric_limits<double>::infinity();
     for (it = mesh.mesh_vertices_begin(); it != mesh.mesh_vertices_end(); it++)
     {
         Point_3 position = mesh.get_vertex_position(it);
@@ -226,10 +226,11 @@ Two_vertices_parameterizer_3<Adaptor>::parameterize_border(Adaptor& mesh)
     // Project onto longest bounding box axes,
     // Set extrema vertices' (u,v) in unit square and mark them as "parameterized"
     Vertex_handle vxmin = NULL ;
-    double  umin  =  (std::numeric_limits<double>::max)() ;
-    double vmin =  (std::numeric_limits<double>::max)(), vmax=  (std::numeric_limits<double>::min)();
     Vertex_handle vxmax = NULL ;
-    double  umax  =  (std::numeric_limits<double>::min)() ;
+    double umin = std::numeric_limits<double>::infinity();
+    double umax = -std::numeric_limits<double>::infinity();
+    double vmin = std::numeric_limits<double>::infinity();
+    double vmax = -std::numeric_limits<double>::infinity();
     for (it = mesh.mesh_vertices_begin(); it != mesh.mesh_vertices_end(); it++)
     {
         Point_3  position = mesh.get_vertex_position(it);


### PR DESCRIPTION
## Summary of Changes

Various packages wrongly assumed that `min()` returns the lowest possible value.

## Release Management

* Affected package(s): `Point_set_shape_detection_3`, `PMP`, `SMP`
* Issue(s) solved (if any): Partial fix of #2563 
* Feature/Small Feature (if any): --

