### PR TITLE
Fix wrong uses of std::numeric_limits::min() (4.11)

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
@@ -622,12 +622,12 @@ namespace CGAL {
       }
         
       const Bbox_3 &buildBoundingCube() {
-        FT min[] = {(std::numeric_limits<FT>::max)(),
-                    (std::numeric_limits<FT>::max)(),
-                    (std::numeric_limits<FT>::max)()};
-        FT max[] = {(std::numeric_limits<FT>::min)(),
-                    (std::numeric_limits<FT>::min)(),
-                    (std::numeric_limits<FT>::min)()};
+        FT min[] = {std::numeric_limits<FT>::infinity(),
+                    std::numeric_limits<FT>::infinity(),
+                    std::numeric_limits<FT>::infinity()};
+        FT max[] = {-std::numeric_limits<FT>::infinity(),
+                    -std::numeric_limits<FT>::infinity(),
+                    -std::numeric_limits<FT>::infinity()};
 
         for (std::size_t i = 0;i<this->size();i++) {
           Point_3 p = get(m_point_pmap, *this->at(i));

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
@@ -15,7 +15,7 @@ typedef CGAL::Polyhedron_3<K> Polyhedron;
 
 double max_coordinate(const Polyhedron& poly)
 {
-  double max_coord = (std::numeric_limits<double>::min)();
+  double max_coord = -std::numeric_limits<double>::infinity();
   BOOST_FOREACH(Polyhedron::Vertex_handle v, vertices(poly))
   {
     Point p = v->point();

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example_OM.cpp
@@ -26,7 +26,7 @@ double max_coordinate(const Mesh& mesh)
   typedef boost::property_map<Mesh,CGAL::vertex_point_t>::type VPmap;
   VPmap vpmap = get(CGAL::vertex_point,mesh);
 
-  double max_coord = std::numeric_limits<double>::min();
+  double max_coord = -std::numeric_limits<double>::infinity();
   BOOST_FOREACH(vertex_descriptor v, vertices(mesh))
   {
     Point p = get(vpmap, v);

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
@@ -129,12 +129,12 @@ public:
     const PPM ppmap = get(vertex_point, mesh);
 
     // Get mesh's bounding box
-    double xmin = (std::numeric_limits<double>::max)();
-    double ymin = (std::numeric_limits<double>::max)();
-    double zmin = (std::numeric_limits<double>::max)();
-    double xmax = (std::numeric_limits<double>::min)();
-    double ymax = (std::numeric_limits<double>::min)();
-    double zmax = (std::numeric_limits<double>::min)();
+    double xmin = std::numeric_limits<double>::infinity();
+    double ymin = std::numeric_limits<double>::infinity();
+    double zmin = std::numeric_limits<double>::infinity();
+    double xmax = -std::numeric_limits<double>::infinity();
+    double ymax = -std::numeric_limits<double>::infinity();
+    double zmax = -std::numeric_limits<double>::infinity();
 
     BOOST_FOREACH(vertex_descriptor vd, vertices) {
       const Point_3& position = get(ppmap,vd);
@@ -226,10 +226,10 @@ public:
 
     // Project onto longest bounding box axes,
     // Set extrema vertices' (u,v) in unit square and mark them as "parameterized"
-    double umin = (std::numeric_limits<double>::max)();
-    double umax = (std::numeric_limits<double>::min)();
-    double vmin = (std::numeric_limits<double>::max)();
-    double vmax = (std::numeric_limits<double>::min)();
+    double umin = std::numeric_limits<double>::infinity();
+    double umax = -std::numeric_limits<double>::infinity();
+    double vmin = std::numeric_limits<double>::infinity();
+    double vmax = -std::numeric_limits<double>::infinity();
 
     BOOST_FOREACH(vertex_descriptor vd, vertices) {
       const Point_3& position = get(ppmap, vd);


### PR DESCRIPTION
## Summary of Changes

Second part of #2564, because `SMP` was restructured with CGAL-4.11.

## Release Management

* Affected package(s): `SMP`
* Issue(s) solved (if any): fixes  #2563.
* Feature/Small Feature (if any): --

