### PR TITLE
Aos_2: data traits construct opposite

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <boost/utility/enable_if.hpp>
+#include <boost/mpl/has_xxx.hpp>
 
 #include <CGAL/Object.h>
 #include <CGAL/tags.h>
@@ -241,19 +242,11 @@ public:
   private:
     const Base_traits_2& m_base;
 
-    /*! Helper class template to find out whether the base geometry traits has
-     * a nested type named Are_mergeable_2.
+    /*! Generate a helper class template to find out whether the base geometry
+     * traits has a nested type named Are_mergeable_2.
      */
-    template <typename T>
-    struct has_are_mergeable_2 {
-      typedef char yes[1];
-      typedef char no[2];
-
-      template<typename U> static yes& test(typename U::Are_mergeable_2*);
-      template<typename U> static no& test(...);
-
-      static const bool value = (sizeof(test<T>(0)) == sizeof(yes));
-    };
+    BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_are_mergeable_2,
+                                      Are_mergeable_2, false)
 
     /*! Implementation of the predicate in case the base geometry traits class
      * has a nested type named Are_mergeable_2.
@@ -312,19 +305,10 @@ public:
   private:
     const Base_traits_2& m_base;
 
-    /*! Helper class template to find out whether the base geometry traits has
-     * a nested type named Merge_2.
+    /*! Generate a helper class template to find out whether the base geometry
+     * traits has a nested type named Merge_2.
      */
-    template <typename T>
-    struct has_merge_2 {
-      typedef char yes[1];
-      typedef char no[2];
-
-      template<typename U> static yes& test(typename U::Merge_2*);
-      template<typename U> static no& test(...);
-
-      static const bool value = (sizeof(test<T>(0)) == sizeof(yes));
-    };
+    BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_merge_2, Are_mergeable_2, false)
 
     /*! Implementation of the predicate in case the base geometry traits class
      * has a nested type named Merge_2.
@@ -405,19 +389,11 @@ public:
   private:
     const Base_traits_2& m_base;
 
-    /*! Helper class template to find out whether the base geometry traits has
-     * a nested type named Construct_opposite_2.
+    /*! Generate a helper class template to find out whether the base geometry
+     * traits has a nested type named Construct_opposite_2.
      */
-    template <typename T>
-    struct has_construct_opposite_2 {
-      typedef char yes[1];
-      typedef char no[2];
-
-      template<typename U> static yes& test(typename U::Construct_opposite_2*);
-      template<typename U> static no& test(...);
-
-      static const bool value = (sizeof(test<T>(0)) == sizeof(yes));
-    };
+    BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_construct_opposite_2,
+                                      Construct_opposite_2, false)
 
     /*! Implementation of the predicate in case the base geometry traits class
      * has a nested type named Construct_opposite_2.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
@@ -16,15 +16,13 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0+
 // 
-//
 // Author(s)     : Ron Wein          <wein@post.tau.ac.il>
-//                 Efi Fogel         <efif@post.tau.ac.il>
+//                 Efi Fogel         <efifogel@gmail.com>
 
 #ifndef CGAL_ARR_CURVE_DATA_TRAITS_2_H
 #define CGAL_ARR_CURVE_DATA_TRAITS_2_H
 
 #include <CGAL/license/Arrangement_on_surface_2.h>
-
 
 /*! \file
  * Definition of the Arr_curve_data_traits_2<> class template.
@@ -50,183 +48,148 @@ namespace CGAL {
  * the overlapping subcurve is obtained from the merge functor.
  * All other functors are inherited from the base ordinary traits class.
  */
-template <class Traits_, class XMonotoneCurveData_, 
-          class Merge_ = _Default_merge_func<XMonotoneCurveData_>,
-          class CurveData_ = XMonotoneCurveData_,
-          class Convert_ = _Default_convert_func<CurveData_,
-                                                 XMonotoneCurveData_> >
-class Arr_curve_data_traits_2 : public Traits_ 
-{
+template <typename Traits_, typename XMonotoneCurveData_,
+          typename Merge_ = _Default_merge_func<XMonotoneCurveData_>,
+          typename CurveData_ = XMonotoneCurveData_,
+          typename Convert_ =
+            _Default_convert_func<CurveData_, XMonotoneCurveData_> >
+class Arr_curve_data_traits_2 : public Traits_ {
 public:
+  typedef Traits_                                    Base_traits_2;
+  typedef XMonotoneCurveData_                        X_monotone_curve_data;
+  typedef Merge_                                     Merge;
+  typedef CurveData_                                 Curve_data;
+  typedef Convert_                                   Convert;
 
-  typedef Traits_                                     Base_traits_2;
-  typedef XMonotoneCurveData_                         X_monotone_curve_data;
-  typedef Merge_                                      Merge;
-  typedef CurveData_                                  Curve_data;
-  typedef Convert_                                    Convert;
-  
-  typedef typename Base_traits_2::Curve_2             Base_curve_2;
-  typedef typename Base_traits_2::X_monotone_curve_2  Base_x_monotone_curve_2;
-  typedef typename Base_traits_2::Point_2             Point_2;
+  typedef typename Base_traits_2::Curve_2            Base_curve_2;
+  typedef typename Base_traits_2::X_monotone_curve_2 Base_x_monotone_curve_2;
+  typedef typename Base_traits_2::Point_2            Point_2;
 
-  typedef typename Base_traits_2::Has_left_category   Has_left_category;
-  typedef typename Base_traits_2::Has_merge_category  Base_has_merge_category;
-  typedef Tag_true                                    Has_merge_category;
+  typedef typename Base_traits_2::Has_left_category  Has_left_category;
+  typedef typename Base_traits_2::Has_merge_category Base_has_merge_category;
+  typedef Tag_true                                   Has_merge_category;
   typedef typename Base_traits_2::Has_do_intersect_category
-                                                      Has_do_intersect_category;
+                                                     Has_do_intersect_category;
 
-  typedef typename internal::Arr_complete_left_side_category< Base_traits_2 >::Category
-                                                      Left_side_category;
-  typedef typename internal::Arr_complete_bottom_side_category< Base_traits_2 >::Category
-                                                      Bottom_side_category;
-  typedef typename internal::Arr_complete_top_side_category< Base_traits_2 >::Category
-                                                      Top_side_category;
-  typedef typename internal::Arr_complete_right_side_category< Base_traits_2 >::Category
-                                                      Right_side_category;
+  typedef typename internal::Arr_complete_left_side_category<Base_traits_2>::
+  Category                                           Left_side_category;
+  typedef typename internal::Arr_complete_bottom_side_category<Base_traits_2>::
+  Category                                           Bottom_side_category;
+  typedef typename internal::Arr_complete_top_side_category<Base_traits_2>::
+  Category                                           Top_side_category;
+  typedef typename internal::Arr_complete_right_side_category<Base_traits_2>::
+  Category                                           Right_side_category;
 
   // Representation of a curve with an addtional data field:
-  typedef _Curve_data_ex<Base_curve_2, Curve_data>    Curve_2;
-  
-  // Representation of an x-monotone curve with an addtional data field:
-  typedef _Curve_data_ex<Base_x_monotone_curve_2,
-                         X_monotone_curve_data>       X_monotone_curve_2;
+  typedef _Curve_data_ex<Base_curve_2, Curve_data>   Curve_2;
 
-  typedef typename Base_traits_2::Multiplicity        Multiplicity;
-  
+  // Representation of an x-monotone curve with an addtional data field:
+  typedef _Curve_data_ex<Base_x_monotone_curve_2, X_monotone_curve_data>
+                                                     X_monotone_curve_2;
+
+  typedef typename Base_traits_2::Multiplicity       Multiplicity;
+
 public:
-  
   /// \name Construction.
   //@{
 
   /*! Default constructor. */
-  Arr_curve_data_traits_2 ()
-  {}
-  
+  Arr_curve_data_traits_2() {}
+
   /*! Constructor from a base-traits class. */
-  Arr_curve_data_traits_2 (const Base_traits_2 & traits) :
-    Base_traits_2 (traits)
-  {}
+  Arr_curve_data_traits_2(const Base_traits_2& traits) : Base_traits_2(traits) {}
   //@}
 
   /// \name Overriden functors.
   //@{
 
-  class Make_x_monotone_2
-  {
+  class Make_x_monotone_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Make_x_monotone_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
-    
-    /*!
-     * Cut the given curve into x-monotone subcurves and insert them to the
+    Make_x_monotone_2(const Base_traits_2& base) : m_base(base) {}
+
+    /*! Cut the given curve into x-monotone subcurves and insert them to the
      * given output iterator. As segments are always x_monotone, only one
      * x-monotone curve will be contained in the iterator.
      * \param cv The curve.
      * \param oi The output iterator, whose value-type is X_monotone_curve_2.
      * \return The past-the-end iterator.
      */
-    template<class OutputIterator>
-    OutputIterator operator() (const Curve_2& cv, OutputIterator oi) const
+    template<typename OutputIterator>
+    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const
     {
       // Make the original curve x-monotone.
-      std::list<CGAL::Object>       base_objects;
-    
-      base->make_x_monotone_2_object() (cv,
-                                        std::back_inserter (base_objects));
+      std::list<CGAL::Object> base_objects;
+      m_base.make_x_monotone_2_object()(cv, std::back_inserter(base_objects));
 
       // Attach the data to each of the resulting x-monotone curves.
-      typename std::list<CGAL::Object>::const_iterator  it;
-      const Base_x_monotone_curve_2  *base_x_curve;
-      X_monotone_curve_data           xdata = Convert()(cv.data());
-
-      for (it = base_objects.begin(); it != base_objects.end(); ++it)
+      const Base_x_monotone_curve_2* base_x_curve;
+      X_monotone_curve_data xdata = Convert()(cv.data());
+      for (typename std::list<CGAL::Object>::const_iterator it =
+             base_objects.begin(); it != base_objects.end(); ++it)
       {
-        base_x_curve = object_cast<Base_x_monotone_curve_2> (&(*it));
-        if (base_x_curve != NULL)
-        {
+        base_x_curve = object_cast<Base_x_monotone_curve_2>(&(*it));
+        if (base_x_curve != NULL) {
           // Current object is an x-monotone curve: Attach data to it.
-          *oi = make_object (X_monotone_curve_2 (*base_x_curve,
-                                                 xdata));
+          *oi++ = make_object(X_monotone_curve_2(*base_x_curve, xdata));
         }
-        else
-        {
+        else {
           // Current object is an isolated point: Leave it as is.
-          CGAL_assertion (object_cast<Point_2> (&(*it)) != NULL);
-          *oi = *it;
+          CGAL_assertion(object_cast<Point_2>(&(*it)) != NULL);
+          *oi++ = *it;
         }
-        ++oi;
       }
 
-      return (oi);
+      return oi;
     }
   };
 
-  /*! Get a Make_x_monotone_2 functor object. */
-  Make_x_monotone_2 make_x_monotone_2_object () const
-  {
-    return Make_x_monotone_2 (this);
-  }
+  /*! Obtain a Make_x_monotone_2 functor object. */
+  Make_x_monotone_2 make_x_monotone_2_object() const
+  { return Make_x_monotone_2(*this); }
 
-  class Split_2
-  {
+  class Split_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Split_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
+    Split_2(const Base_traits_2& base) : m_base(base) {}
 
-    /*!
-     * Split a given x-monotone curve at a given point into two sub-curves.
+    /*! Split a given x-monotone curve at a given point into two sub-curves.
      * \param cv The curve to split
      * \param p The split point.
      * \param c1 Output: The left resulting subcurve (p is its right endpoint).
      * \param c2 Output: The right resulting subcurve (p is its left endpoint).
      * \pre p lies on cv but is not one of its end-points.
      */
-    void operator() (const X_monotone_curve_2& cv, const Point_2 & p,
-                     X_monotone_curve_2& c1, X_monotone_curve_2& c2) const
+    void operator()(const X_monotone_curve_2& cv, const Point_2& p,
+                    X_monotone_curve_2& c1, X_monotone_curve_2& c2) const
     {
       // Split the original curve.
-      base->split_2_object() (cv, p, c1, c2);
+      m_base.split_2_object()(cv, p, c1, c2);
 
       // Attach data to the split curves.
-      c1.set_data (cv.data());
-      c2.set_data (cv.data());
-
-      return;
+      c1.set_data(cv.data());
+      c2.set_data(cv.data());
     }
   };
 
-  /*! Get a Split_2 functor object. */
-  Split_2 split_2_object () const
-  {
-    return Split_2 (this);
-  }
+  /*! Obtain a Split_2 functor object. */
+  Split_2 split_2_object() const { return Split_2(*this); }
 
-  class Intersect_2
-  {
+  class Intersect_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Intersect_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
+    Intersect_2(const Base_traits_2& base) : m_base(base) {}
 
-    /*!
-     * Find the intersections of the two given curves and insert them to the
+    /*! Find the intersections of the two given curves and insert them to the
      * given output iterator. As two segments may itersect only once, only a
      * single will be contained in the iterator.
      * \param cv1 The first curve.
@@ -234,221 +197,170 @@ public:
      * \param oi The output iterator.
      * \return The past-the-end iterator.
      */
-    template<class OutputIterator>
-    OutputIterator operator() (const X_monotone_curve_2& cv1,
-                               const X_monotone_curve_2& cv2,
-                               OutputIterator oi) const
+    template<typename OutputIterator>
+    OutputIterator operator()(const X_monotone_curve_2& cv1,
+                              const X_monotone_curve_2& cv2,
+                              OutputIterator oi) const
     {
       // Use the base functor to obtain all intersection objects.
-      std::list<CGAL::Object>                   base_objects;
-
-      base->intersect_2_object() (cv1, cv2,
-                                  std::back_inserter (base_objects));
+      std::list<CGAL::Object> base_objects;
+      m_base.intersect_2_object()(cv1, cv2, std::back_inserter(base_objects));
 
       // Stop if the list is empty:
-      if (base_objects.empty())
-        return (oi);
+      if (base_objects.empty()) return oi;
 
       // Go over all intersection objects and prepare the output.
-      typename std::list<CGAL::Object>::const_iterator  it;
-      const Base_x_monotone_curve_2                    *base_cv;
-
-      for (it = base_objects.begin(); it != base_objects.end(); ++it)
+      const Base_x_monotone_curve_2* base_cv;
+      for (typename std::list<CGAL::Object>::const_iterator it =
+             base_objects.begin(); it != base_objects.end(); ++it)
       {
-        if ((base_cv = object_cast<Base_x_monotone_curve_2> (&(*it))) != NULL)
-        {
+        if ((base_cv = object_cast<Base_x_monotone_curve_2>(&(*it))) != NULL) {
           // The current intersection object is an overlapping x-monotone
           // curve: Merge the data fields of both intersecting curves and
           // associate the result with the overlapping curve.
-          X_monotone_curve_2  cv (*base_cv,
-                                  Merge() (cv1.data(), cv2.data()));
-
-          *oi = make_object (cv);
+          X_monotone_curve_2 cv(*base_cv, Merge() (cv1.data(), cv2.data()));
+          *oi++ = make_object(cv);
         }
-        else
-        {
+        else {
           // The current intersection object is an intersection point:
           // Copy it as is.
-          *oi = *it;
+          *oi++ = *it;
         }
-        ++oi;
       }
 
-      return (oi);
+      return oi;
     }
   };
 
-  /*! Get an Intersect_2 functor object. */
-  Intersect_2 intersect_2_object () const
-  {
-    return Intersect_2 (this);
-  }
+  /*! Obtain an Intersect_2 functor object. */
+  Intersect_2 intersect_2_object() const { return Intersect_2(*this); }
 
-  class Are_mergeable_2
-  {
+  class Are_mergeable_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Are_mergeable_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
+    Are_mergeable_2(const Base_traits_2& base) : m_base(base) {}
 
-    /*!
-     * Check whether it is possible to merge two given x-monotone curves.
+    /*! Check whether it is possible to merge two given x-monotone curves.
      * \param cv1 The first curve.
      * \param cv2 The second curve.
      * \return (true) if the two curves are mergeable; (false) otherwise.
      */
-    bool operator() (const X_monotone_curve_2& cv1,
-                     const X_monotone_curve_2& cv2) const
-    {
-      return (_are_mergeable_base_imp (cv1, cv2, Base_has_merge_category()));
-    }
+    bool operator()(const X_monotone_curve_2& cv1,
+                    const X_monotone_curve_2& cv2) const
+    { return (_are_mergeable_base_imp(cv1, cv2, Base_has_merge_category())); }
 
   private:
-
-    /*!
-     * Implementation of the base predicate in case the HasMerge tag is true.
+    /*! Implementation of the base predicate in case the HasMerge tag is true.
      */
-    bool _are_mergeable_base_imp (const X_monotone_curve_2& cv1,
-                                  const X_monotone_curve_2& cv2,
-                                  Tag_true) const
+    bool _are_mergeable_base_imp(const X_monotone_curve_2& cv1,
+                                 const X_monotone_curve_2& cv2,
+                                 Tag_true) const
     {
       // In case the two base curves are not mergeable, the extended curves
       // are not mergeable as well.
-      if (! (base->are_mergeable_2_object() (cv1, cv2)))
-        return (false);
+      if (! (m_base.are_mergeable_2_object()(cv1, cv2))) return false;
 
       // In case the two base curves are mergeable, check that they have the
       // same data fields.
       return (cv1.data() == cv2.data());
     }
 
-    /*!
-     * Implementation of the base predicate in case the HasMerge tag is false.
+    /*! Implementation of the base predicate in case the HasMerge tag is false.
      */
-    bool _are_mergeable_base_imp (const X_monotone_curve_2& ,
-                                  const X_monotone_curve_2& ,
-                                  Tag_false) const
-    {
-      // Curve merging is not supported:
-      return (false);
-    }
+    bool _are_mergeable_base_imp(const X_monotone_curve_2& /* cv1 */,
+                                 const X_monotone_curve_2& /* cv2 */,
+                                 Tag_false) const
+    { return false; }
   };
-  
-  /*! Get an Are_mergeable_2 functor object. */
-  Are_mergeable_2 are_mergeable_2_object () const
-  {
-    return Are_mergeable_2 (this);
-  }
+
+  /*! Obtain an Are_mergeable_2 functor object. */
+  Are_mergeable_2 are_mergeable_2_object() const
+  { return Are_mergeable_2(*this); }
 
   /*! \class Merge_2
    * A functor that merges two x-monotone arcs into one.
    */
-  class Merge_2
-  {
+  class Merge_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Merge_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
+    Merge_2(const Base_traits_2& base) : m_base(base) {}
 
-    /*!
-     * Merge two given x-monotone curves into a single curve (segment).
+    /*! Merge two given x-monotone curves into a single curve (segment).
      * \param cv1 The first curve.
      * \param cv2 The second curve.
      * \param c Output: The merged curve.
      * \pre The two curves are mergeable.
      */
-    void operator() (const X_monotone_curve_2& cv1,
-                     const X_monotone_curve_2& cv2,
-                     X_monotone_curve_2& c) const
+    void operator()(const X_monotone_curve_2& cv1,
+                    const X_monotone_curve_2& cv2,
+                    X_monotone_curve_2& c) const
     {
-      // The function is implemented based on the base Has_merge category.
-      _merge_imp (cv1, cv2, c, Base_has_merge_category());
+      // Dispatch based on the base Has_merge category.
+      _merge_imp(cv1, cv2, c, Base_has_merge_category());
     }
 
   private:
-
-    /*!
-     * Implementation of the operator() in case the HasMerge tag is true.
+    /*! Implementation of the operator() in case the HasMerge tag is true.
      */
-    void _merge_imp (const X_monotone_curve_2& cv1,
-                     const X_monotone_curve_2& cv2,
-                     X_monotone_curve_2& c,
-                     Tag_true) const
-    {      
+    void _merge_imp(const X_monotone_curve_2& cv1,
+                    const X_monotone_curve_2& cv2,
+                    X_monotone_curve_2& c,
+                    Tag_true) const
+    {
       // Merge the two base curve.
-      Base_x_monotone_curve_2  base_cv;
+      Base_x_monotone_curve_2 base_cv;
 
-      base->merge_2_object() (cv1, cv2, base_cv);
+      m_base.merge_2_object()(cv1, cv2, base_cv);
 
       // Attach data from one of the curves.
-      CGAL_precondition (cv1.data() == cv2.data());
+      CGAL_precondition(cv1.data() == cv2.data());
 
-      c = X_monotone_curve_2 (base_cv, cv1.data());
-      return;
+      c = X_monotone_curve_2(base_cv, cv1.data());
     }
 
-    /*!
-     * Implementation of the operator() in case the HasMerge tag is false.
+    /*! Implementation of the operator() in case the HasMerge tag is false.
+     * This function should never be called!
      */
-    void _merge_imp (const X_monotone_curve_2& ,
-                     const X_monotone_curve_2& ,
-                     X_monotone_curve_2& ,
-                     Tag_false) const
-    {
-      // This function should never be called!
-      CGAL_error_msg("Merging curves is not supported.");
-    }
+    void _merge_imp(const X_monotone_curve_2& /* cv1 */,
+                    const X_monotone_curve_2& /* cv2 */,
+                    X_monotone_curve_2& /* c */, Tag_false) const
+    { CGAL_error_msg("Merging curves is not supported."); }
   };
 
-  /*! Get a Merge_2 functor object. */
-  Merge_2 merge_2_object () const
-  {
-    return Merge_2 (this);
-  }
+  /*! Obtain a Merge_2 functor object. */
+  Merge_2 merge_2_object() const { return Merge_2(*this); }
 
-  class Construct_x_monotone_curve_2
-  {
+  class Construct_x_monotone_curve_2 {
   private:
-    const Base_traits_2 * base;
+    const Base_traits_2& m_base;
 
   public:
-
     /*! Constructor. */
-    Construct_x_monotone_curve_2 (const Base_traits_2 * _base) :
-      base (_base)
-    {}
+    Construct_x_monotone_curve_2(const Base_traits_2& base) : m_base(base) {}
 
-    /*!
-     * Return an x-monotone curve connecting the two given endpoints.
+    /*! Obtain an x-monotone curve connecting the two given endpoints.
      * \param p The first point.
      * \param q The second point.
      * \pre p and q must not be the same.
      * \return An x-monotone curve connecting p and q.
      */
-    X_monotone_curve_2 operator() (const Point_2& p, const Point_2& q) const
+    X_monotone_curve_2 operator()(const Point_2& p, const Point_2& q) const
     {
       Base_x_monotone_curve_2  base_cv =
-        base->construct_x_monotone_curve_2_object() (p, q);
-
-      return (X_monotone_curve_2 (base_cv, X_monotone_curve_data()));
+        m_base.construct_x_monotone_curve_2_object()(p, q);
+      return (X_monotone_curve_2(base_cv, X_monotone_curve_data()));
     }
   };
 
-  /*! Get a Construct_x_monotone_curve_2 functor object. */
-  Construct_x_monotone_curve_2 construct_x_monotone_curve_2_object () const
-  {
-    return Construct_x_monotone_curve_2 (this);
-  }
+  /*! Obtain a Construct_x_monotone_curve_2 functor object. */
+  Construct_x_monotone_curve_2 construct_x_monotone_curve_2_object() const
+  { return Construct_x_monotone_curve_2(*this); }
   //@}
 
 };

--- a/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
@@ -427,8 +427,8 @@ public:
                                 X_monotone_curve_2>::type
     construct_opposite(const X_monotone_curve_2& cv) const
     {
-      X_monotone_curve_2 new_cv = m_base.construct_opposite_2_object()(cv);
-      new_cv.set_data(cv.data());
+      X_monotone_curve_2 new_cv(m_base.construct_opposite_2_object()(cv),
+                                cv.data());
       return new_cv;
     }
 

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
@@ -1358,6 +1358,8 @@ test_algebraic_traits_core()
 test_algebraic_traits_gmp()
 test_algebraic_traits_leda()
 
+compile_and_run(test_data_traits)
+
 compile_and_run(test_insertion)
 compile_and_run(test_unbounded_rational_insertion)
 compile_and_run(test_unbounded_rational_direct_insertion)

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test_base
@@ -1686,6 +1686,8 @@ test_algebraic_traits_core
 test_algebraic_traits_gmp
 test_algebraic_traits_leda
 
+compile_and_run test_data_traits
+
 compile_and_run test_insertion
 compile_and_run test_unbounded_rational_insertion
 compile_and_run test_unbounded_rational_direct_insertion

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_data_traits.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_data_traits.cpp
@@ -1,0 +1,38 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Arr_segment_traits_2.h>
+#include <CGAL/Arr_curve_data_traits_2.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel    Kernel;
+typedef Kernel::Point_2                                      Point_2;
+typedef Kernel::Segment_2                                    Segment_2;
+typedef CGAL::Arr_segment_traits_2<Kernel>                   Segment_traits_2;
+typedef CGAL::Arr_curve_data_traits_2<Segment_traits_2, int> Traits_2;
+typedef Traits_2::X_monotone_curve_2                         X_monotone_curve_2;
+
+int main()
+{
+  Point_2 p1 = Point_2(0.0, 0.0);
+  Point_2 p2 = Point_2(1.0, 0.0);
+  Point_2 p3 = Point_2(2.0, 0.0);
+  Segment_2 s1 = Segment_2(p1, p2);
+  Segment_2 s2 = Segment_2(p2, p3);
+
+  Traits_2 traits;
+  X_monotone_curve_2 c1 = X_monotone_curve_2(s1, 1);
+  X_monotone_curve_2 fc1 = traits.construct_opposite_2_object()(c1);
+
+  if (c1.data() !=  fc1.data()) return 1;
+
+  X_monotone_curve_2 c2 = X_monotone_curve_2(s2, 1);
+  X_monotone_curve_2 mc;
+  if (!traits.are_mergeable_2_object()(c1, c2)) return 1;
+  traits.merge_2_object()(c1, c2, mc);
+  if (c1.data() !=  mc.data()) return 1;
+
+  X_monotone_curve_2 sc1, sc2;
+  traits.split_2_object()(mc, p2, sc1, sc2);
+  if (mc.data() !=  sc1.data()) return 1;
+  if (sc1.data() !=  sc2.data()) return 1;
+
+  return 0;
+}

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_data_traits.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_data_traits.cpp
@@ -18,21 +18,40 @@ int main()
   Segment_2 s2 = Segment_2(p2, p3);
 
   Traits_2 traits;
-  X_monotone_curve_2 c1 = X_monotone_curve_2(s1, 1);
+  X_monotone_curve_2 c1 = X_monotone_curve_2(s1, 1234);
   X_monotone_curve_2 fc1 = traits.construct_opposite_2_object()(c1);
 
-  if (c1.data() !=  fc1.data()) return 1;
+  if (c1.data() !=  fc1.data()) {
+    std::cerr << "Construct opposite failed: "
+              << c1.data() << " != " << fc1.data() << std::endl;
+    return 1;
+  }
+  std::cout << "Construct opposite data: " << c1.data() << std::endl;
 
-  X_monotone_curve_2 c2 = X_monotone_curve_2(s2, 1);
+  X_monotone_curve_2 c2 = X_monotone_curve_2(s2, 1234);
   X_monotone_curve_2 mc;
   if (!traits.are_mergeable_2_object()(c1, c2)) return 1;
   traits.merge_2_object()(c1, c2, mc);
-  if (c1.data() !=  mc.data()) return 1;
+  if (c1.data() !=  mc.data()) {
+    std::cerr << "Merge failed: "
+              << c1.data() << " != " << mc.data() << std::endl;
+    return 1;
+  }
+  std::cout << "Merge data: " << c1.data() << std::endl;
 
   X_monotone_curve_2 sc1, sc2;
   traits.split_2_object()(mc, p2, sc1, sc2);
-  if (mc.data() !=  sc1.data()) return 1;
-  if (sc1.data() !=  sc2.data()) return 1;
+  if (mc.data() !=  sc1.data()) {
+    std::cerr << "Split failed (original curve and split curve data differ): "
+              << mc.data() << " != " << sc1.data() << std::endl;
+    return 1;
+  }
+  if (sc1.data() !=  sc2.data()) {
+    std::cerr << "Split failed (data of split curves differ): "
+              << sc1.data() << " != " << sc2.data() << std::endl;
+    return 1;
+  }
+  std::cout << "Split data: " << sc1.data() << std::endl;
 
   return 0;
 }

--- a/Installation/changes.html
+++ b/Installation/changes.html
@@ -183,7 +183,7 @@ and <code>src/</code> directories).
  <h3>3D Surface Mesh Generation</h3>
    <ul>
      <li>
-       Add the function facets_in_complex_2_to_triangle_mesh() 
+       Add the function facets_in_complex_2_to_triangle_mesh()
        that exports Surface_mesh_complex_2_in_triangulation_3
        facets into a MutableFaceGraph.
      </li>
@@ -191,7 +191,7 @@ and <code>src/</code> directories).
   <h3>3D Mesh Generation</h3>
    <ul>
      <li>
-       Add the function facets_in_complex_3_to_triangle_mesh() 
+       Add the function facets_in_complex_3_to_triangle_mesh()
        that exports Mesh_complex_3_in_triangulation_3
        facets into a MutableFaceGraph.
      </li>
@@ -247,6 +247,14 @@ and <code>src/</code> directories).
   </ul>
 <!-- end of the div for 4.12 -->
 </div>
+<h3>2D Arrangements</h3>
+  <ul>
+    <li>Fixed the <code>Construct_opposite_2</code> functor required by the
+      concept <code>ArrangementDirectionalXMonotoneTraits_2</code> when using
+      the <code>Arr_curve_data_traits_2</code> class template to attach data
+      to curves.
+    </li>
+  </ul>
 
 <h2 id="release4.11">Release 4.11 </h2>
 <div>
@@ -547,7 +555,7 @@ and <code>src/</code> directories).
       concept <code>MutableFaceGraph</code>. This class can thus now be
       used in all BGL functions and algorithms.
     </li>
-    <li>Helper functions to create an icosahedron, a regular prism and a 
+    <li>Helper functions to create an icosahedron, a regular prism and a
       pyramid have been added.
     </li>
     <li>


### PR DESCRIPTION
This cleans the code of the `Arr_curve_data_traits_2<Tr, ...>` class template and fixes a bug in the code. Any instance of this template is a model of the `ArrangementTraits_2` concept and serves as a decorator class that allows the extension of curves defined by the base traits-class (the `Tr` parameter). The fix adds a wrapper to the `Construct_opposite_2` functor required by the concept `ArrangementDirectionalXMonotoneTraits_2`. The `()` operator of this functor accepts an x-monotone curve and returns its opposite curve. The wrapper attaches the data attached to the input curve to the output curve.

The implementation uses a helper class to detect the presence of a functor with the same name in the base geometry class. While at it, I've changed the code of the Are_mergeable_2 and Merge_2 wrappers to use similar technique, instead of the using the tags defined in the base traits class). In the future, I plan to use the same technique everywhere and render the tags obsolete.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): fix #2063
* Feature/Small Feature (if any): None

