### PR TITLE
Triangulation - fix doc

### DIFF
--- a/Triangulation/doc/Triangulation/CGAL/Regular_triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Regular_triangulation.h
@@ -52,11 +52,6 @@ A point in Euclidean space with an associated weight.
 */
 typedef RegularTriangulationTraits_::Weighted_point_d Weighted_point;
 
-/*!
-A point in Euclidean space (with no associated weight).
-*/
-typedef RegularTriangulationTraits_::Bare_point_d Bare_point;
-
 /// @}
 
 /// \name Creation

--- a/Triangulation/doc/Triangulation/CGAL/Regular_triangulation_traits_adapter.h
+++ b/Triangulation/doc/Triangulation/CGAL/Regular_triangulation_traits_adapter.h
@@ -36,6 +36,11 @@ public:
   /// @{
 
   /*!
+  The base traits.
+  */
+  typedef RTTraits                                  Base;
+  
+  /*!
   The weighted point type.
   */
   typedef typename K::Weighted_point_d              Point_d;


### PR DESCRIPTION
## Summary of Changes

2 small fixes to the doc:
* Remove the non-existing type `Regular_triangulation::Bare_point`
* Document `Regular_triangulation_traits_adapter::Base`

## Release Management

* Affected package(s): Triangulation

