### PR TITLE
Shape detection: robustify RANSAC (for 4.11)

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -350,7 +350,7 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
           0);
 
         m_available_octree_sizes[s] = subsetSize;
-        m_direct_octrees[s]->createTree();
+        m_direct_octrees[s]->createTree(m_options.cluster_epsilon);
 
         remainingPoints -= subsetSize;
       }
@@ -358,7 +358,7 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
       m_global_octree = new Indexed_octree(
         m_traits, m_input_iterator_first, m_input_iterator_beyond,
         m_point_pmap, m_normal_pmap);
-      m_global_octree->createTree();
+      m_global_octree->createTree(m_options.cluster_epsilon);
 
       return true;
     }
@@ -435,6 +435,8 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
       const Parameters &options = Parameters()
       ///< %Parameters for shape detection.
                 ) {
+      m_options = options;
+
       // No shape types for detection or no points provided, exit
       if (m_shape_factories.size() == 0 ||
           (m_input_iterator_beyond - m_input_iterator_first) == 0)
@@ -460,8 +462,6 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
           (bbox.xmax() - bbox.xmin()) * (bbox.xmax() - bbox.xmin())
         + (bbox.ymax() - bbox.ymin()) * (bbox.ymax() - bbox.ymin()) 
         + (bbox.zmax() - bbox.zmin()) * (bbox.zmax() - bbox.zmin()));
-
-      m_options = options;
 
       // Epsilon or cluster_epsilon have been set by the user?
       // If not, derive from bounding box diagonal
@@ -502,6 +502,11 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
 
       std::size_t generated_candidates = 0;
       std::size_t failed_candidates = 0;
+      std::size_t limit_failed_candidates = (std::max)(std::size_t(10000),
+                                                       std::size_t(m_input_iterator_beyond
+                                                                   - m_input_iterator_first)
+                                                       / std::size_t(100));
+
       bool force_exit = false;
       bool keep_searching = true;
       
@@ -565,8 +570,10 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
                 }
             }
 
-            if (failed_candidates >= 10000)
+            if (failed_candidates >= limit_failed_candidates)
+            {
               force_exit = true;
+            }
             
             keep_searching = (stop_probability(m_options.min_points,
               m_num_available_points - num_invalid, 
@@ -673,6 +680,12 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
             const std::vector<std::size_t> &indices_points_best_candidate =
               best_candidate->indices_of_assigned_points();
 
+            // update generated candidates to reflect removal of points
+            generated_candidates = std::pow (1.f - (indices_points_best_candidate.size() /
+                                                    float(m_num_available_points - num_invalid)), 3.f)
+              * generated_candidates;
+
+            //2.3 Remove the points from the subtrees
             for (std::size_t i = 0;i<indices_points_best_candidate.size();i++) {
               m_shape_index[indices_points_best_candidate.at(i)] =
                 int(m_extracted_shapes->size()) - 1;
@@ -692,9 +705,6 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
               }
             }
 
-            //2.3 Remove the points from the subtrees        
-
-            generated_candidates--;
             failed_candidates = 0;
             best_expected = 0;
 

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -681,9 +681,9 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
               best_candidate->indices_of_assigned_points();
 
             // update generated candidates to reflect removal of points
-            generated_candidates = std::pow (1.f - (indices_points_best_candidate.size() /
-                                                    float(m_num_available_points - num_invalid)), 3.f)
-              * generated_candidates;
+            generated_candidates = std::size_t(std::pow (1.f - (indices_points_best_candidate.size() /
+                                                                float(m_num_available_points - num_invalid)), 3.f)
+                                               * generated_candidates);
 
             //2.3 Remove the points from the subtrees
             for (std::size_t i = 0;i<indices_points_best_candidate.size();i++) {

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
@@ -277,10 +277,21 @@ namespace CGAL {
       // | 3.| 2.|
       // +---+---+
       // z max before z min, then y max before y min, then x max before x min
-      void createTree() {
+      void createTree(double cluster_epsilon_for_max_level_recomputation = -1.) {
         buildBoundingCube();
         std::size_t count = 0;
         m_max_level = 0;
+
+        if (cluster_epsilon_for_max_level_recomputation > 0.)
+        {
+          FT bbox_diagonal = (FT) CGAL::sqrt(
+            (m_bBox.xmax() - m_bBox.xmin()) * (m_bBox.xmax() - m_bBox.xmin())
+            + (m_bBox.ymax() - m_bBox.ymin()) * (m_bBox.ymax() - m_bBox.ymin()) 
+            + (m_bBox.zmax() - m_bBox.zmin()) * (m_bBox.zmax() - m_bBox.zmin()));
+
+          m_set_max_level = std::size_t (std::log2 (bbox_diagonal
+                                                    / cluster_epsilon_for_max_level_recomputation));
+        }
 
         std::stack<Cell *> stack;
         m_root = new Cell(0, this->size() - 1, m_center, 0);

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Octree.h
@@ -289,8 +289,9 @@ namespace CGAL {
             + (m_bBox.ymax() - m_bBox.ymin()) * (m_bBox.ymax() - m_bBox.ymin()) 
             + (m_bBox.zmax() - m_bBox.zmin()) * (m_bBox.zmax() - m_bBox.zmin()));
 
-          m_set_max_level = std::size_t (std::log2 (bbox_diagonal
-                                                    / cluster_epsilon_for_max_level_recomputation));
+          m_set_max_level = std::size_t (std::log (bbox_diagonal
+                                                    / cluster_epsilon_for_max_level_recomputation)
+                                         / std::log (2.0));
         }
 
         std::stack<Cell *> stack;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.ui
@@ -247,6 +247,12 @@
           <property name="toolTip">
            <string>Probability to overlook the largest primitive in one extraction iteration</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="minimum">
+           <double>0.000010000000000</double>
+          </property>
           <property name="maximum">
            <double>1.000000000000000</double>
           </property>


### PR DESCRIPTION
(Same as https://github.com/CGAL/cgal/pull/2568 but for CGAL 4.11 release.)

Fixes #2119.