### PR TITLE
Faster to_interval(Gmpq)

### DIFF
--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -88,14 +88,19 @@ template <> class Real_embeddable_traits< Gmpq >
       : public CGAL::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
-          mpfr_t y;
-          mpfr_init2 (y, 53); /* Assume IEEE-754 */
-          mpfr_set_q (y, x.mpq(), GMP_RNDD);
-          double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
-          mpfr_set_q (y, x.mpq(), GMP_RNDU);
-          double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
-          mpfr_clear (y);
-          return std::pair<double, double>(i, s);
+	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
+	  int r = mpfr_set_q (y, x.mpq(), MPFR_RNDA);
+	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
+	  if (r == 0 && !isinf (i))
+	    return std::pair<double, double>(i, i);
+	  else
+	    {
+	      double s = nextafter (i, 0);
+	      if (i < 0)
+		return std::pair<double, double>(i, s);
+	      else
+		return std::pair<double, double>(s, i);
+	    }
         }
     };
 };

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -88,6 +88,7 @@ template <> class Real_embeddable_traits< Gmpq >
       : public CGAL::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
+#if MPFR_VERSION_MAJOR >= 3
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_q (y, x.mpq(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
@@ -101,6 +102,16 @@ template <> class Real_embeddable_traits< Gmpq >
 	      else
 		return std::pair<double, double>(s, i);
 	    }
+#else
+          mpfr_t y;
+          mpfr_init2 (y, 53); /* Assume IEEE-754 */
+          mpfr_set_q (y, x.mpq(), GMP_RNDD);
+          double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
+          mpfr_set_q (y, x.mpq(), GMP_RNDU);
+          double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
+          mpfr_clear (y);
+          return std::pair<double, double>(i, s);
+#endif
         }
     };
 };

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -91,7 +91,7 @@ template <> class Real_embeddable_traits< Gmpq >
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_q (y, x.mpq(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
-	  if (r == 0 && !isinf (i))
+	  if (r == 0 && is_finite (i))
 	    return std::pair<double, double>(i, i);
 	  else
 	    {

--- a/Number_types/include/CGAL/Gmpz.h
+++ b/Number_types/include/CGAL/Gmpz.h
@@ -129,21 +129,31 @@ public:
         : public CGAL::unary_function< Type, std::pair< double, double > > {
     public:
         std::pair<double, double> operator()( const Type& x ) const {
-
+#if MPFR_VERSION_MAJOR >= 3
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_z (y, x.mpz(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
 	  if (r == 0 && is_finite (i))
 	    return std::pair<double, double>(i, i);
 	  else
-	    {
-	      double s = nextafter (i, 0);
-	      if (i < 0)
-		return std::pair<double, double>(i, s);
-	      else
-		return std::pair<double, double>(s, i);
-	    }
-        }
+	  {
+	    double s = nextafter (i, 0);
+	    if (i < 0)
+	      return std::pair<double, double>(i, s);
+	    else
+	      return std::pair<double, double>(s, i);
+	  }
+#else
+	  mpfr_t y;
+	  mpfr_init2 (y, 53); /* Assume IEEE-754 */
+	  mpfr_set_z (y, x.mpz(), GMP_RNDD);
+	  double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
+	  mpfr_set_z (y, x.mpz(), GMP_RNDU);
+	  double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
+	  mpfr_clear (y);
+	  return std::pair<double, double>(i, s);
+#endif
+	}
     };
 };
 

--- a/Number_types/include/CGAL/Gmpz.h
+++ b/Number_types/include/CGAL/Gmpz.h
@@ -130,14 +130,19 @@ public:
     public:
         std::pair<double, double> operator()( const Type& x ) const {
 
-            mpfr_t y;
-            mpfr_init2 (y, 53); /* Assume IEEE-754 */
-            mpfr_set_z (y, x.mpz(), GMP_RNDD);
-            double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
-            mpfr_set_z (y, x.mpz(), GMP_RNDU);
-            double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
-            mpfr_clear (y);
-            return std::pair<double, double>(i, s);
+	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
+	  int r = mpfr_set_z (y, x.mpz(), MPFR_RNDA);
+	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
+	  if (r == 0 && !isinf (i))
+	    return std::pair<double, double>(i, i);
+	  else
+	    {
+	      double s = nextafter (i, 0);
+	      if (i < 0)
+		return std::pair<double, double>(i, s);
+	      else
+		return std::pair<double, double>(s, i);
+	    }
         }
     };
 };

--- a/Number_types/include/CGAL/Gmpz.h
+++ b/Number_types/include/CGAL/Gmpz.h
@@ -133,7 +133,7 @@ public:
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_z (y, x.mpz(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
-	  if (r == 0 && !isinf (i))
+	  if (r == 0 && is_finite (i))
 	    return std::pair<double, double>(i, i);
 	  else
 	    {

--- a/Number_types/include/CGAL/double.h
+++ b/Number_types/include/CGAL/double.h
@@ -138,8 +138,7 @@ inline double sse2fabs(double a)
   __m128d temp = _mm_set1_pd(a);
   
   temp = _mm_and_pd(temp, absMask.m);
-  _mm_store_sd(&a, temp);
-  return a;
+  return _mm_cvtsd_f64 (temp);
 }
 
 #endif

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -207,14 +207,19 @@ class Real_embeddable_traits< mpq_class >
         : public CGAL::unary_function< mpq_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpq_class& x ) const {
-            mpfr_t y;
-            mpfr_init2 (y, 53); /* Assume IEEE-754 */
-            mpfr_set_q (y, x.get_mpq_t(), GMP_RNDD);
-            double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
-            mpfr_set_q (y, x.get_mpq_t(), GMP_RNDU);
-            double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
-            mpfr_clear (y);
-            return std::pair<double, double>(i, s);
+	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
+	  int r = mpfr_set_q (y, x.get_mpq_t(), MPFR_RNDA);
+	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
+	  if (r == 0 && !isinf (i))
+	    return std::pair<double, double>(i, i);
+	  else
+	    {
+	      double s = nextafter (i, 0);
+	      if (i < 0)
+		return std::pair<double, double>(i, s);
+	      else
+		return std::pair<double, double>(s, i);
+	    }
         }
     };
 };

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -210,7 +210,7 @@ class Real_embeddable_traits< mpq_class >
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_q (y, x.get_mpq_t(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
-	  if (r == 0 && !isinf (i))
+	  if (r == 0 && is_finite (i))
 	    return std::pair<double, double>(i, i);
 	  else
 	    {

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -207,6 +207,7 @@ class Real_embeddable_traits< mpq_class >
         : public CGAL::unary_function< mpq_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpq_class& x ) const {
+#if MPFR_VERSION_MAJOR >= 3
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_q (y, x.get_mpq_t(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
@@ -220,6 +221,16 @@ class Real_embeddable_traits< mpq_class >
 	      else
 		return std::pair<double, double>(s, i);
 	    }
+#else
+	  mpfr_t y;
+	  mpfr_init2 (y, 53); /* Assume IEEE-754 */
+	  mpfr_set_q (y, x.get_mpq_t(), GMP_RNDD);
+	  double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
+	  mpfr_set_q (y, x.get_mpq_t(), GMP_RNDU);
+	  double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
+	  mpfr_clear (y);
+	  return std::pair<double, double>(i, s);
+#endif
         }
     };
 };

--- a/Number_types/include/CGAL/mpz_class.h
+++ b/Number_types/include/CGAL/mpz_class.h
@@ -271,6 +271,7 @@ public:
         : public CGAL::unary_function< mpz_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpz_class& x ) const {
+#if MPFR_VERSION_MAJOR >= 3
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_z (y, x.get_mpz_t(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
@@ -284,6 +285,16 @@ public:
 	      else
 		return std::pair<double, double>(s, i);
 	    }
+#else
+	  mpfr_t y;
+	  mpfr_init2 (y, 53); /* Assume IEEE-754 */
+	  mpfr_set_z (y, x.get_mpz_t(), GMP_RNDD);
+	  double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
+	  mpfr_set_z (y, x.get_mpz_t(), GMP_RNDU);
+	  double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
+	  mpfr_clear (y);
+	  return std::pair<double, double>(i, s);
+#endif
         }
     };
 };

--- a/Number_types/include/CGAL/mpz_class.h
+++ b/Number_types/include/CGAL/mpz_class.h
@@ -271,14 +271,19 @@ public:
         : public CGAL::unary_function< mpz_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpz_class& x ) const {
-            mpfr_t y;
-            mpfr_init2 (y, 53); /* Assume IEEE-754 */
-            mpfr_set_z (y, x.get_mpz_t(), GMP_RNDD);
-            double i = mpfr_get_d (y, GMP_RNDD); /* EXACT but can overflow */
-            mpfr_set_z (y, x.get_mpz_t(), GMP_RNDU);
-            double s = mpfr_get_d (y, GMP_RNDU); /* EXACT but can overflow */
-            mpfr_clear (y);
-            return std::pair<double, double>(i, s);
+	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
+	  int r = mpfr_set_z (y, x.get_mpz_t(), MPFR_RNDA);
+	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
+	  if (r == 0 && !isinf (i))
+	    return std::pair<double, double>(i, i);
+	  else
+	    {
+	      double s = nextafter (i, 0);
+	      if (i < 0)
+		return std::pair<double, double>(i, s);
+	      else
+		return std::pair<double, double>(s, i);
+	    }
         }
     };
 };

--- a/Number_types/include/CGAL/mpz_class.h
+++ b/Number_types/include/CGAL/mpz_class.h
@@ -274,7 +274,7 @@ public:
 	  MPFR_DECL_INIT (y, 53); /* Assume IEEE-754 */
 	  int r = mpfr_set_z (y, x.get_mpz_t(), MPFR_RNDA);
 	  double i = mpfr_get_d (y, MPFR_RNDA); /* EXACT but can overflow */
-	  if (r == 0 && !isinf (i))
+	  if (r == 0 && is_finite (i))
 	    return std::pair<double, double>(i, i);
 	  else
 	    {


### PR DESCRIPTION
## Summary of Changes

Make conversion to interval through MPFR3 faster. Keep old code for compatibility with centos with mpfr-2.2 or 2.4.

## Release Management

* Affected package(s): Number_types