### PR TITLE
Polyhedron demo: CGAL meeting fixes 

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1093,8 +1093,17 @@ CGAL::Three::Scene_item* MainWindow::loadItem(QFileInfo fileinfo, CGAL::Three::P
     throw std::invalid_argument(QString("File %1 is not a readable file.")
                                 .arg(fileinfo.absoluteFilePath()).toStdString());
   }
+  //test if the file is empty.
+  QFile test(fileinfo.absoluteFilePath());
 
+  test.open( QIODevice::WriteOnly|QIODevice::Append);
+  if (test.pos() == 0) {
+    QMessageBox::warning(this, tr("Error"),
+                         tr("The file you are trying to load is empty.\n"));
+    return 0;
+  }
   QApplication::setOverrideCursor(Qt::WaitCursor);
+
   item = loader->load(fileinfo);
   QApplication::restoreOverrideCursor();
   if(!item) {

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1719,6 +1719,7 @@ void MainWindow::on_actionSetBackgroundColor_triggered()
   QColor c =  QColorDialog::getColor();
   if(c.isValid()) {
     viewer->setBackgroundColor(c);
+    viewer->update();
   }
 }
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow(QWidget* parent)
 {
   ui = new Ui::MainWindow;
   ui->setupUi(this);
+  menuBar()->setNativeMenuBar(false);
   menu_map[ui->menuOperations->title()] = ui->menuOperations;
   // remove the Load Script menu entry, when the demo has not been compiled with QT_SCRIPT_LIB
 #if !defined(QT_SCRIPT_LIB)

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -44,8 +44,8 @@ struct Scene_points_with_normal_item_priv
     normal_Slider = new QSlider(Qt::Horizontal);
     normal_Slider->setValue(20);
     point_Slider = new QSlider(Qt::Horizontal);
-    point_Slider->setValue(2);
     point_Slider->setMinimum(1);
+    point_Slider->setValue(2);
     point_Slider->setMaximum(25);
   }
   Scene_points_with_normal_item_priv(Scene_points_with_normal_item* parent)
@@ -369,6 +369,10 @@ void Scene_points_with_normal_item_priv::compute_normals_and_vertices() const
     normals.resize(0);
     colors_points.resize(0);
 
+    if(item->point_set()->number_of_points() < 30 )
+      point_Slider->setValue(5);
+    else
+      point_Slider->setValue(2);
     //Shuffle container to allow quick display random points
     std::random_shuffle (m_points->begin(), m_points->first_selected());
     if (m_points->nb_selected_points() != 0)


### PR DESCRIPTION
## Summary of Changes
This PR fixes some points :
- Don't use the native menuBar because it is buggy on MacOs
- Check if a file is empty before reading it as we know it won't work
- Update the viewer when we change the background
- Increase the initial point size of a point item when there are less than 30 points in it.

