### PR TITLE
Mesh 2 : fix the use of Lloyd from any CDT_2

### DIFF
--- a/Mesh_2/doc/Mesh_2/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/doc/Mesh_2/CGAL/lloyd_optimize_mesh_2.h
@@ -101,13 +101,13 @@ lloyd_optimize_mesh_2(cdt,
 
 \endcode
 
-\sa `Mesh_optimization_return_code` 
+\sa `CGAL::Mesh_optimization_return_code` 
 \sa `CGAL::refine_Delaunay_mesh_2()`
 
 */
 
 template<typename CDT, typename PointIterator>
-Mesh_optimization_return_code
+CGAL::Mesh_optimization_return_code
 lloyd_optimize_mesh_2(CDT& cdt,
   double parameters::time_limit=0,
   std::size_t parameters::max_iteration_number=0,

--- a/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
@@ -307,7 +307,8 @@ private:
     // Find the minimum value
     do
     {
-      min_sqr = (std::min)(min_sqr, sq_circumradius(face));
+      if (!cdt_.is_infinite(face))
+        min_sqr = (std::min)(min_sqr, sq_circumradius(face));
       face++;
     }
     while(face != end);

--- a/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
@@ -307,8 +307,7 @@ private:
     // Find the minimum value
     do
     {
-      if(face->is_in_domain())
-        min_sqr = (std::min)(min_sqr, sq_circumradius(face));
+      min_sqr = (std::min)(min_sqr, sq_circumradius(face));
       face++;
     }
     while(face != end);


### PR DESCRIPTION

## Summary of Changes

This PR fixes the use of `CGAL::lloyd_optimize_mesh_2()` when used on a `CDT_2` that was not constructed using `Mesh_2`.
Formerly, the convergence test `check_convergence()` was returning `true` all the time because no facet was tagged as "in the domain".
The convergence test should not suffer from that change, mainly because constrained vertices are not considered.

## Release Management

* Affected package : Mesh_2 (smoothing only)

Thanks @gdamiand for the bug report!
