### PR TITLE
P3RT3: Fix `Is_Gabriel` (4.11)

### DIFF
--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
@@ -1124,9 +1124,9 @@ is_Gabriel(const Cell_handle c, int i, int j) const
     int i1 = cc->index(v1);
     int i2 = cc->index(v2);
     int i3 = fcirc->second;
-    Offset off1 = int_to_off(cc->offset(i1));
-    Offset off2 = int_to_off(cc->offset(i2));
-    Offset off3 = int_to_off(cc->offset(i3));
+    Offset off1 = get_offset(cc, i1);
+    Offset off2 = get_offset(cc, i2);
+    Offset off3 = get_offset(cc, i3);
     if(side_of_bounded_sphere(
           v1->point(), v2->point(), cc->vertex(fcirc->second)->point(),
           off1, off2, off3) == ON_BOUNDED_SIDE ) return false;

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
@@ -827,9 +827,9 @@ public:
       int i1 = cc->index(v1);
       int i2 = cc->index(v2);
       int i3 = fcirc->second;
-      Offset off1 = int_to_off(cc->offset(i1));
-      Offset off2 = int_to_off(cc->offset(i2));
-      Offset off3 = int_to_off(cc->offset(i3));
+      Offset off1 = get_offset(cc, i1);
+      Offset off2 = get_offset(cc, i2);
+      Offset off3 = get_offset(cc, i3);
       if(side_of_bounded_power_sphere(v1->point(), v2->point(), cc->vertex(i3)->point(),
                                       off1, off2, off3) == ON_BOUNDED_SIDE)
         return false;


### PR DESCRIPTION
## Summary of Changes

Offsets should be obtained via get_offset() to have valid offsets even in a 27-sheeted periodic triangulation. This is the same as #2612, but for regular triangulations, which were introduced with CGAL 4.11. 

## Release Management

* Affected package(s): Periodic_3_triangulation_3
* Issue(s) solved (if any): fix #2610
* Feature/Small Feature (if any): --

