### PR TITLE
Speed Improvement/Refactoring nef polyhedron 3.

### DIFF
--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -712,6 +712,10 @@ protected:
             }
         CGAL_assertion(ct.is_valid());
 
+        Finite_face_iterator fi;
+        for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi)
+            fi->info() = false; // Mark faces unvisited
+
         CGAL_NEF_TRACEN("number of finite triangles " << ct.number_of_faces());
 
         Face_handle infinite = ct.infinite_face();
@@ -728,9 +732,8 @@ protected:
         CGAL_assertion(!ct.is_infinite(first));
         traverse_triangulation(first, first->index(opposite));
 
-        Finite_face_iterator fi;
         for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi) {
-                if(fi->info() == false) continue;
+                if(!fi->info()) continue; // Skip unvisited faces
                 CTVertex_handle p=fi->vertex(0);
                 CTVertex_handle q=fi->vertex(1);
                 CTVertex_handle r=fi->vertex(2);
@@ -759,7 +762,7 @@ protected:
     }
 
     void traverse_triangulation(Face_handle f, int parent) {
-       f->info() = true;
+       f->info() = true; // Mark face as visited
        descend_triangulation(f,ct.cw(parent));
        descend_triangulation(f,ct.ccw(parent));
     }

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -802,7 +802,7 @@ protected:
           Halffacet_const_handle f = opposite_facet->twin();
 
           int s = sides(f);
-          if(s > 4 || has_holes(f)) {
+          if(s > 3 || has_holes(f)) {
               Vector_3 orth = f->plane().orthogonal_vector();
               int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;
               c = CGAL::abs(orth[2]) > CGAL::abs(orth[c]) ? 2 : c;
@@ -820,27 +820,14 @@ protected:
                   CGAL_error_msg( "wrong value");
           } else {
               B.begin_facet();
-              Halffacet_cycle_const_iterator fc = f->facet_cycles_begin();
-              SHalfedge_const_handle se(fc);
+              SHalfedge_const_handle se(f->facet_cycles_begin());
               CGAL_assertion(se != 0);
               SHalfedge_around_facet_const_circulator hc(se),he(hc);
-              int t = 0, fv;
               CGAL_For_all(hc,he) {
                   Vertex_const_handle cv = hc->source()->center_vertex();
                   CGAL_NEF_TRACEN("   add vertex " << cv->point());
-                  int i=VI[cv];
-                  B.add_vertex_to_facet(i);
-                  if(s==4) {
-                      if(t==0) fv=i;
-                      if(++t==3) {
-                        B.end_facet();
-                        B.begin_facet();
-                        B.add_vertex_to_facet(i);
-                      }
-                  }
+                  B.add_vertex_to_facet(VI[cv]);
               }
-              if(s==4)
-                  B.add_vertex_to_facet(fv);
               B.end_facet();
           }
       }

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -66,6 +66,7 @@
 #include <CGAL/Projection_traits_xy_3.h>
 #include <CGAL/Projection_traits_yz_3.h>
 #include <CGAL/Projection_traits_xz_3.h>
+#include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <CGAL/Constrained_triangulation_face_base_2.h>
 #include <list>
 
@@ -670,7 +671,7 @@ protected:
   template<typename Kernel>
   class Triangulation_handler2 {
 
-    typedef typename CGAL::Triangulation_vertex_base_2<Kernel>               Vb;
+    typedef typename CGAL::Triangulation_vertex_base_with_info_2<Vertex_const_handle,Kernel> Vb;
     typedef typename CGAL::Constrained_triangulation_face_base_2<Kernel>     Fb;
     typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>             TDS;
     typedef typename CGAL::Constrained_triangulation_2<Kernel,TDS>           CT;
@@ -683,7 +684,6 @@ protected:
 
     CT ct;
     CGAL::Unique_hash_map<Face_handle, bool> visited;
-    CGAL::Unique_hash_map<CTVertex_handle, Vertex_const_handle> ctv2v;
     Halffacet_const_handle f;
     Plane_3 supporting_plane;
 
@@ -701,7 +701,7 @@ protected:
             Vertex_const_handle v=sfc->source()->source();
             CGAL_NEF_TRACEN("  insert point" << v->point());
 	    CTVertex_handle ctv = ct.insert(v->point());
-	    ctv2v[ctv] = v;
+	    ctv->info() = v;
             Vertex_const_handle t=sfc->source()->twin()->source();
             CGAL_NEF_TRACEN("  insert constraint" << v->point()
 	                     << "->" << t->point());
@@ -735,15 +735,16 @@ protected:
 	Plane_3 plane(p->point(),
 		      q->point(),
 		      r->point());
+
 	pib.begin_facet();
 	if(same_orientation(plane)) {
-	  pib.add_vertex_to_facet(VI[ctv2v[p]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[q]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[r]]);
+	  pib.add_vertex_to_facet(VI[p->info()]);
+	  pib.add_vertex_to_facet(VI[q->info()]);
+	  pib.add_vertex_to_facet(VI[r->info()]);
 	} else {
-	  pib.add_vertex_to_facet(VI[ctv2v[p]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[r]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[q]]);
+	  pib.add_vertex_to_facet(VI[p->info()]);
+	  pib.add_vertex_to_facet(VI[r->info()]);
+	  pib.add_vertex_to_facet(VI[q->info()]);
 	}
 	pib.end_facet();
       }

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -673,10 +673,10 @@ protected:
   class Triangulation_handler2 {
 
     typedef typename CGAL::Triangulation_vertex_base_with_info_2<Vertex_const_handle,Kernel> Vb;
-    typedef typename CGAL::Triangulation_face_base_with_info_2<bool,Kernel> Info;
-    typedef typename CGAL::Constrained_triangulation_face_base_2<Kernel,Info>     Fb;
-    typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>             TDS;
-    typedef typename CGAL::Constrained_triangulation_2<Kernel,TDS>           CT;
+    typedef typename CGAL::Triangulation_face_base_with_info_2<bool,Kernel>                  Info;
+    typedef typename CGAL::Constrained_triangulation_face_base_2<Kernel,Info>                Fb;
+    typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>                             TDS;
+    typedef typename CGAL::Constrained_triangulation_2<Kernel,TDS>                           CT;
 
     typedef typename CT::Face_handle           Face_handle;
     typedef typename CT::Vertex_handle         CTVertex_handle;
@@ -694,61 +694,62 @@ protected:
 
     template<typename PIB, typename Index>
     void handle_triangles(PIB& pib, Index& VI) {
-      Halffacet_cycle_const_iterator fci;
-      for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
-	if(fci.is_shalfedge()) {
-          SHalfedge_around_facet_const_circulator sfc(fci), send(sfc);
-	  CGAL_For_all(sfc,send) {
-            Vertex_const_handle v=sfc->source()->source();
-            CGAL_NEF_TRACEN("  insert point" << v->point());
-	    CTVertex_handle ctv = ct.insert(v->point());
-	    ctv->info() = v;
-            Vertex_const_handle t=sfc->source()->twin()->source();
-            CGAL_NEF_TRACEN("  insert constraint" << v->point()
-	                     << "->" << t->point());
-	    ct.insert_constraint(v->point(),t->point());
-          }
-        }
-      }
-      CGAL_assertion(ct.is_valid());
+        Halffacet_cycle_const_iterator fci;
+        for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
+                if(fci.is_shalfedge()) {
+                        SHalfedge_around_facet_const_circulator sfc(fci), send(sfc);
+                        CGAL_For_all(sfc,send) {
+                            Vertex_const_handle v=sfc->source()->source();
+                            CGAL_NEF_TRACEN("  insert point" << v->point());
+                            CTVertex_handle ctv = ct.insert(v->point());
+                            ctv->info() = v;
+                            Vertex_const_handle t=sfc->source()->twin()->source();
+                            CGAL_NEF_TRACEN("  insert constraint" << v->point()
+                                            << "->" << t->point());
+                            ct.insert_constraint(v->point(),t->point());
+                        }
+                    }
+            }
+        CGAL_assertion(ct.is_valid());
 
-      CGAL_NEF_TRACEN("number of finite triangles " << ct.number_of_faces());
+        CGAL_NEF_TRACEN("number of finite triangles " << ct.number_of_faces());
 
-      Face_handle infinite = ct.infinite_face();
-      CTVertex_handle ctv = infinite->vertex(1);
-      if(ct.is_infinite(ctv)) ctv = infinite->vertex(2);
-      CGAL_assertion(!ct.is_infinite(ctv));
+        Face_handle infinite = ct.infinite_face();
+        CTVertex_handle ctv = infinite->vertex(1);
+        if(ct.is_infinite(ctv)) ctv = infinite->vertex(2);
+        CGAL_assertion(!ct.is_infinite(ctv));
 
-      Face_handle opposite;
-      Face_circulator vc(ctv,infinite);
-      do { opposite = vc++;
-      } while(!ct.is_constrained(Edge(vc,vc->index(opposite))));
-      Face_handle first = vc;
+        Face_handle opposite;
+        Face_circulator vc(ctv,infinite);
+        do { opposite = vc++;
+        } while(!ct.is_constrained(Edge(vc,vc->index(opposite))));
+        Face_handle first = vc;
 
-      CGAL_assertion(!ct.is_infinite(first));
-      traverse_triangulation(first, first->index(opposite));
-    Finite_face_iterator fi;
-    for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi) {
-       if(fi->info() == false) continue;
-	   CTVertex_handle p=fi->vertex(0);
-	   CTVertex_handle q=fi->vertex(1);
-	   CTVertex_handle r=fi->vertex(2);
-	Plane_3 plane(p->point(),
-		      q->point(),
-		      r->point());
+        CGAL_assertion(!ct.is_infinite(first));
+        traverse_triangulation(first, first->index(opposite));
 
-	pib.begin_facet();
-	if(same_orientation(plane)) {
-	  pib.add_vertex_to_facet(VI[p->info()]);
-	  pib.add_vertex_to_facet(VI[q->info()]);
-	  pib.add_vertex_to_facet(VI[r->info()]);
-	} else {
-	  pib.add_vertex_to_facet(VI[p->info()]);
-	  pib.add_vertex_to_facet(VI[r->info()]);
-	  pib.add_vertex_to_facet(VI[q->info()]);
-	}
-	pib.end_facet();
-      }
+        Finite_face_iterator fi;
+        for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi) {
+                if(fi->info() == false) continue;
+                CTVertex_handle p=fi->vertex(0);
+                CTVertex_handle q=fi->vertex(1);
+                CTVertex_handle r=fi->vertex(2);
+                Plane_3 plane(p->point(),
+                              q->point(),
+                              r->point());
+
+                pib.begin_facet();
+                if(same_orientation(plane)) {
+                        pib.add_vertex_to_facet(VI[p->info()]);
+                        pib.add_vertex_to_facet(VI[q->info()]);
+                        pib.add_vertex_to_facet(VI[r->info()]);
+                    } else {
+                        pib.add_vertex_to_facet(VI[p->info()]);
+                        pib.add_vertex_to_facet(VI[r->info()]);
+                        pib.add_vertex_to_facet(VI[q->info()]);
+                    }
+                pib.end_facet();
+            }
     }
 
     void descend_triangulation(Face_handle f, int i) {
@@ -766,11 +767,11 @@ protected:
     }
 
     bool same_orientation(Plane_3 p1) const {
-      if(p1.a() != 0)
-	return CGAL::sign(p1.a()) == CGAL::sign(supporting_plane.a());
-      if(p1.b() != 0)
-	return CGAL::sign(p1.b()) == CGAL::sign(supporting_plane.b());
-      return CGAL::sign(p1.c()) == CGAL::sign(supporting_plane.c());
+        if(p1.a() != 0)
+            return CGAL::sign(p1.a()) == CGAL::sign(supporting_plane.a());
+        if(p1.b() != 0)
+            return CGAL::sign(p1.b()) == CGAL::sign(supporting_plane.b());
+        return CGAL::sign(p1.c()) == CGAL::sign(supporting_plane.c());
     }
   };
  

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -732,11 +732,9 @@ protected:
 
       CGAL_assertion(!ct.is_infinite(first));
       traverse_triangulation(first, first->index(opposite));
-
-      Finite_face_iterator fi = ct.finite_faces_begin();
-
-      while(fi != ct.finite_faces_end() && visited[fi] == false) ++fi;
-      while(fi != ct.finite_faces_end()) {
+    Finite_face_iterator fi;
+    for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi) {
+       if(visited[fi] == false) continue;
 	Plane_3 plane(fi->vertex(0)->point(),
 		      fi->vertex(1)->point(),
 		      fi->vertex(2)->point());
@@ -751,9 +749,6 @@ protected:
 	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(1)]]);
 	}
 	pib.end_facet();
-	do {
-	  ++fi;
-	} while(fi != ct.finite_faces_end() && visited[fi] == false);
       }
     }
 

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -697,21 +697,14 @@ protected:
 	if(fci.is_shalfedge()) {
           SHalfedge_around_facet_const_circulator sfc(fci), send(sfc);
 	  CGAL_For_all(sfc,send) {
-            CGAL_NEF_TRACEN("  insert point" << sfc->source()->source()->point());
-	    CTVertex_handle ctv = ct.insert(sfc->source()->source()->point());
-	    ctv2v[ctv] = sfc->source()->source();
-          }
-        }
-      }
-
-      for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
-	if(fci.is_shalfedge()) {
-          SHalfedge_around_facet_const_circulator sfc(fci), send(sfc);
-	  CGAL_For_all(sfc,send) {
-            CGAL_NEF_TRACEN("  insert constraint" << sfc->source()->source()->point()
-	                     << "->" << sfc->source()->twin()->source()->point());
-	    ct.insert_constraint(sfc->source()->source()->point(),
-	                         sfc->source()->twin()->source()->point());
+            Vertex_const_handle v=sfc->source()->source();
+            CGAL_NEF_TRACEN("  insert point" << v->point());
+	    CTVertex_handle ctv = ct.insert(v->point());
+	    ctv2v[ctv] = v;
+            Vertex_const_handle t=sfc->source()->twin()->source();
+            CGAL_NEF_TRACEN("  insert constraint" << v->point()
+	                     << "->" << t->point());
+	    ct.insert_constraint(v->point(),t->point());
           }
         }
       }

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -787,12 +787,11 @@ protected:
 
       const Object_index<Vertex_const_iterator>& VI;
       Polyhedron_incremental_builder_3<HDS>& B;
-      const SNC_const_decorator& D;
       
     public:
       Visitor(Polyhedron_incremental_builder_3<HDS>& BB,
 	      const SNC_const_decorator& sd,
-	      Object_index<Vertex_const_iterator>& vi) : VI(vi), B(BB), D(sd){}
+              Object_index<Vertex_const_iterator>& vi) : VI(vi), B(BB) {}
 
       void visit(Halffacet_const_handle opposite_facet) {
 

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -746,15 +746,6 @@ protected:
       } 
     } 
  
-    template<typename Triangle_3>
-    bool get_next_triangle(Triangle_3& tr) {
-      while(fi != ct.finite_faces_end() && visited[fi] == false) ++fi;
-      if(fi == ct.finite_faces_end()) return false;
-      tr = Triangle_3(fi->vertex(0)->point(), fi->vertex(1)->point(), fi->vertex(2)->point());
-      ++fi;
-      return true;
-    }
-
     bool same_orientation(Plane_3 p1) const {
       if(p1.a() != 0)
 	return CGAL::sign(p1.a()) == CGAL::sign(supporting_plane.a());

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -734,9 +734,7 @@ protected:
                 CTVertex_handle p=fi->vertex(0);
                 CTVertex_handle q=fi->vertex(1);
                 CTVertex_handle r=fi->vertex(2);
-                Plane_3 plane(p->point(),
-                              q->point(),
-                              r->point());
+                Plane_3 plane(p->point(),q->point(),r->point());
 
                 pib.begin_facet();
                 if(same_orientation(plane)) {

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -798,10 +798,7 @@ protected:
 	CGAL_NEF_TRACEN("Build_polyhedron: visit facet " << opposite_facet->plane());
  
 	CGAL_assertion(Infi_box::is_standard(opposite_facet->plane()));
-	
-	SHalfedge_const_handle se;
-	Halffacet_cycle_const_iterator fc;
-     	
+
 	Halffacet_const_handle f = opposite_facet->twin();
 
         if(needs_triangulation(f)) {
@@ -824,14 +821,14 @@ protected:
 	} else {
 
 	  B.begin_facet();
-	  fc = f->facet_cycles_begin();
-	  se = SHalfedge_const_handle(fc);
-	  CGAL_assertion(se!=0);
-	  SHalfedge_around_facet_const_circulator hc_start(se);
-	  SHalfedge_around_facet_const_circulator hc_end(hc_start);
-	  CGAL_For_all(hc_start,hc_end) {
-	    CGAL_NEF_TRACEN("   add vertex " << hc_start->source()->center_vertex()->point());
-	    B.add_vertex_to_facet(VI[hc_start->source()->center_vertex()]);
+          Halffacet_cycle_const_iterator fc = f->facet_cycles_begin();
+          SHalfedge_const_handle se(fc);
+          CGAL_assertion(se != 0);
+          SHalfedge_around_facet_const_circulator hc(se),he(hc);
+          CGAL_For_all(hc,he) {
+            Vertex_const_handle cv = hc->source()->center_vertex();
+            CGAL_NEF_TRACEN("   add vertex " << cv->point());
+            B.add_vertex_to_facet(VI[cv]);
 	  }
 	  B.end_facet();
 	}

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -745,16 +745,18 @@ protected:
       }
     }
 
+    void descend_triangulation(Face_handle f, int i) {
+        Face_handle h=f->neighbor(i);
+        if(!ct.is_constrained(Edge(f,i)) && !visited[h]) {
+                Face_handle child(h);
+                traverse_triangulation(child,child->index(f));
+        }
+    }
+
     void traverse_triangulation(Face_handle f, int parent) {
-      visited[f] = true;
-      if(!ct.is_constrained(Edge(f,ct.cw(parent))) && !visited[f->neighbor(ct.cw(parent))]) {
-	Face_handle child(f->neighbor(ct.cw(parent)));
-	traverse_triangulation(child, child->index(f));
-      }
-      if(!ct.is_constrained(Edge(f,ct.ccw(parent))) && !visited[f->neighbor(ct.ccw(parent))]) {
-	Face_handle child(f->neighbor(ct.ccw(parent)));
-	traverse_triangulation(child, child->index(f));
-      }
+       visited[f]=true;
+       descend_triangulation(f,ct.cw(parent));
+       descend_triangulation(f,ct.ccw(parent));
     }
 
     bool same_orientation(Plane_3 p1) const {

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -685,17 +685,17 @@ protected:
     typedef typename CT::Edge                  Edge;
 
     CT ct;
-    Halffacet_const_handle f;
     Plane_3 supporting_plane;
+    Halffacet_const_handle facet;
 
   public:
     Triangulation_handler2(Halffacet_const_handle f) : 
-      supporting_plane(f->plane()), f(f) {}
+      supporting_plane(f->plane()), facet(f) {}
 
     template<typename PIB, typename Index>
     void handle_triangles(PIB& pib, Index& VI) {
         Halffacet_cycle_const_iterator fci;
-        for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
+        for(fci=facet->facet_cycles_begin(); fci!=facet->facet_cycles_end(); ++fci) {
             if(fci.is_shalfedge()) {
                 SHalfedge_around_facet_const_circulator sfc(fci), send(sfc);
                 CGAL_For_all(sfc,send) {

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -802,7 +802,7 @@ protected:
           Halffacet_const_handle f = opposite_facet->twin();
 
           int s = sides(f);
-          if(s > 3 || has_holes(f)) {
+          if(s > 4 || has_holes(f)) {
               Vector_3 orth = f->plane().orthogonal_vector();
               int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;
               c = CGAL::abs(orth[2]) > CGAL::abs(orth[c]) ? 2 : c;

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -818,6 +818,26 @@ protected:
                   th.handle_triangles(B, VI);
               } else
                   CGAL_error_msg( "wrong value");
+          } else if(s == 4) {
+              SHalfedge_const_handle se(f->facet_cycles_begin());
+              CGAL_assertion(se != 0);
+              SHalfedge_around_facet_const_circulator hc(se);
+              Vertex_const_handle cv0 = (  hc)->source()->center_vertex();
+              Vertex_const_handle cv1 = (++hc)->source()->center_vertex();
+              Vertex_const_handle cv2 = (++hc)->source()->center_vertex();
+              Vertex_const_handle cv3 = (++hc)->source()->center_vertex();
+              int i0=VI[cv0],i1=VI[cv1],i2=VI[cv2],i3=VI[cv3];
+              Point_3 p0=cv0->point(),p1=cv1->point(),p2=cv2->point(),p3=cv3->point();
+              Vector_3 p1p0 = p1-p0,p3p2 = p3-p2;
+              if(CGAL::cross_product(p2-p1,p3p2) * CGAL::cross_product(p0-p3,p1p0)
+               < CGAL::cross_product(p1p0,p1-p2) * CGAL::cross_product(p3p2,p3-p0))
+              {
+                  build_triangle(i0,i1,i2);
+                  build_triangle(i0,i2,i3);
+              } else {
+                  build_triangle(i0,i1,i3);
+                  build_triangle(i3,i1,i2);
+              }
           } else {
               B.begin_facet();
               SHalfedge_const_handle se(f->facet_cycles_begin());
@@ -830,6 +850,15 @@ protected:
               }
               B.end_facet();
           }
+      }
+
+      inline void build_triangle(int i0,int i1,int i2)
+      {
+           B.begin_facet();
+           B.add_vertex_to_facet(i0);
+           B.add_vertex_to_facet(i1);
+           B.add_vertex_to_facet(i2);
+           B.end_facet();
       }
 
       inline int sides(Halffacet_const_handle f)

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -678,6 +678,7 @@ protected:
     typedef typename CT::Face_handle           Face_handle;
     typedef typename CT::Vertex_handle         CTVertex_handle;
     typedef typename CT::Finite_faces_iterator Finite_face_iterator;
+    typedef typename CT::Face_circulator       Face_circulator;
     typedef typename CT::Edge                  Edge;
 
     CT ct;
@@ -712,16 +713,16 @@ protected:
 
       CGAL_NEF_TRACEN("number of finite triangles " << ct.number_of_faces());
 
-      typename CT::Face_handle infinite = ct.infinite_face();
-      typename CT::Vertex_handle ctv = infinite->vertex(1);
+      Face_handle infinite = ct.infinite_face();
+      CTVertex_handle ctv = infinite->vertex(1);
       if(ct.is_infinite(ctv)) ctv = infinite->vertex(2);
       CGAL_assertion(!ct.is_infinite(ctv));
 
-      typename CT::Face_handle opposite;
-      typename CT::Face_circulator vc(ctv,infinite);
+      Face_handle opposite;
+      Face_circulator vc(ctv,infinite);
       do { opposite = vc++;
-      } while(!ct.is_constrained(typename CT::Edge(vc,vc->index(opposite))));
-      typename CT::Face_handle first = vc;
+      } while(!ct.is_constrained(Edge(vc,vc->index(opposite))));
+      Face_handle first = vc;
 
       CGAL_assertion(!ct.is_infinite(first));
       traverse_triangulation(first, first->index(opposite));

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -828,9 +828,9 @@ protected:
               Vertex_const_handle cv3 = (++hc)->source()->center_vertex();
               int i0=VI[cv0],i1=VI[cv1],i2=VI[cv2],i3=VI[cv3];
               Point_3 p0=cv0->point(),p1=cv1->point(),p2=cv2->point(),p3=cv3->point();
-              Vector_3 p1p0 = p1-p0,p3p2 = p3-p2;
-              if(CGAL::cross_product(p2-p1,p3p2) * CGAL::cross_product(p0-p3,p1p0)
-               < CGAL::cross_product(p1p0,p1-p2) * CGAL::cross_product(p3p2,p3-p0))
+              Vector_3 v1 = p0-p1,v2 = p1-p2,v3 = p2-p3,v4 = p3-p0;
+              if(CGAL::cross_product(v2,v3) * CGAL::cross_product(v4,v1)
+               < CGAL::cross_product(v1,v2) * CGAL::cross_product(v3,v4))
               {
                   build_triangle(i0,i1,i2);
                   build_triangle(i0,i2,i3);

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -804,11 +804,7 @@ protected:
      	
 	Halffacet_const_handle f = opposite_facet->twin();
 
-	SHalfedge_around_facet_const_circulator 
-	  sfc1(f->facet_cycles_begin()), sfc2(sfc1);
-	
-	if(++f->facet_cycles_begin() != f->facet_cycles_end() ||
-	   ++(++(++sfc1)) != sfc2) {
+        if(needs_triangulation(f)) {
 	  Vector_3 orth = f->plane().orthogonal_vector();
 	  int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;
 	  c = CGAL::abs(orth[2]) > CGAL::abs(orth[c]) ? 2 : c;
@@ -839,6 +835,14 @@ protected:
 	  }
 	  B.end_facet();
 	}
+      }
+
+      inline bool needs_triangulation(Halffacet_const_handle f)
+      {
+          SHalfedge_around_facet_const_circulator
+            sfc1(f->facet_cycles_begin()), sfc2(sfc1);
+          return ++f->facet_cycles_begin() != f->facet_cycles_end() ||
+                  ++(++(++sfc1)) != sfc2;
       }
 
       void visit(SFace_const_handle) {}

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -729,18 +729,21 @@ protected:
     Finite_face_iterator fi;
     for(fi=ct.finite_faces_begin();fi!=ct.finite_faces_end(); ++fi) {
        if(visited[fi] == false) continue;
-	Plane_3 plane(fi->vertex(0)->point(),
-		      fi->vertex(1)->point(),
-		      fi->vertex(2)->point());
+	   CTVertex_handle p=fi->vertex(0);
+	   CTVertex_handle q=fi->vertex(1);
+	   CTVertex_handle r=fi->vertex(2);
+	Plane_3 plane(p->point(),
+		      q->point(),
+		      r->point());
 	pib.begin_facet();
 	if(same_orientation(plane)) {
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(0)]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(1)]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(2)]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[p]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[q]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[r]]);
 	} else {
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(0)]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(2)]]);
-	  pib.add_vertex_to_facet(VI[ctv2v[fi->vertex(1)]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[p]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[r]]);
+	  pib.add_vertex_to_facet(VI[ctv2v[q]]);
 	}
 	pib.end_facet();
       }


### PR DESCRIPTION
## Summary of Changes

I would like to propose some changes which measurably improve the performance (1.3x faster in my tests) of converting a Nef_polyhedron_3 to a Polyhedron_3. This is primarily achieved by removing the unique hash maps and using `Triangulation_vertex_base_with_info_2`, and `Triangulation_face_base_with_info_2` to decorate the facets themselves with the required data, and save the lookup in the hash maps altogether.

Whilst trying to understand the implementation of `Nef_polyhedron_3::Triangulation_handler2` i noticed the code wasn't very clear or easy to understand, so I have also done some refactoring to make the code clearer. (These changes are easier to see by looking at the individual commits, rather than the PR as a whole.) 

## Release Management

* Affected package(s): The `Nef_polyhedron_3::Triangulation_handler2` class and the `convert_to_polyhedron()` function.
* Feature/Small Feature (if any): 1.3x performance improvement when calling `convert_to_polyhedron()`

