### PR TITLE
Derecursify functions in Constrained Delaunay and Constrained Triangulation

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -742,9 +742,9 @@ propagating_flip(Face_handle f,int i, int depth)
 
   Face_handle ni = f->neighbor(i);
   flip(f, i); // flip for constrained triangulations
-  propagating_flip(f,i);
+  propagating_flip(f,i, depth+1);
   i = ni->index(f->vertex(i));
-  propagating_flip(ni,i);
+  propagating_flip(ni,i, depth+1);
 #endif
 }
 #else 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -649,45 +649,53 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
 // if a vertex vc of t lies on segment ab
 // or if ab intersect some constrained edges
 {
-  CGAL_triangulation_precondition( vaa != vbb);
-  Vertex_handle vi;
+  std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
+  stack.push(std::make_pair(vaa,vbb));
 
-  Face_handle fr;
-  int i;
-  if(includes_edge(vaa,vbb,vi,fr,i)) {
-    mark_constraint(fr,i);
-    if (vi != vbb)  {
-      insert_constraint(vi,vbb);
+  while(! stack.empty()){
+    boost::tie(vaa,vbb) = stack.top();
+    stack.pop();
+    CGAL_triangulation_precondition( vaa != vbb);
+    Vertex_handle vi;
+
+    Face_handle fr;
+    int i;
+    if(includes_edge(vaa,vbb,vi,fr,i)) {
+      mark_constraint(fr,i);
+      if (vi != vbb)  {
+        stack.push(std::make_pair(vi,vbb));
+      }
+      continue;
     }
-    return;
-  }
       
-  List_faces intersected_faces;
-  List_edges conflict_boundary_ab, conflict_boundary_ba;
+    List_faces intersected_faces;
+    List_edges conflict_boundary_ab, conflict_boundary_ba;
      
-  bool intersection  = find_intersected_faces( vaa, vbb,
-			                       intersected_faces,
-					       conflict_boundary_ab,
-					       conflict_boundary_ba,
-					       vi);
-  if ( intersection) {
-    if (vi != vaa && vi != vbb) {
-      insert_constraint(vaa,vi); 
-      insert_constraint(vi,vbb); 
-     }
-    else insert_constraint(vaa,vbb);
-    return;
-  }
+    bool intersection  = find_intersected_faces( vaa, vbb,
+                                                 intersected_faces,
+                                                 conflict_boundary_ab,
+                                                 conflict_boundary_ba,
+                                                 vi);
+    if ( intersection) {
+      if (vi != vaa && vi != vbb) {
+        stack.push(std::make_pair(vaa,vi));
+        stack.push(std::make_pair(vi,vbb));
+      }
+      else{
+        stack.push(std::make_pair(vaa,vbb));
+      }
+      continue;
+    }
 
-  //no intersection
-  triangulate_hole(intersected_faces,
-		   conflict_boundary_ab,
-		   conflict_boundary_ba);
+    //no intersection
+    triangulate_hole(intersected_faces,
+                     conflict_boundary_ab,
+                     conflict_boundary_ba);
 
-  if (vi != vbb) {
-    insert_constraint(vi,vbb); 
+    if (vi != vbb) {
+      stack.push(std::make_pair(vi,vbb));
+    }
   }
-  return;
 
 }
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -773,7 +773,14 @@ insert_subconstraint(Vertex_handle vaa,
   // insert the subconstraint [vaa vbb] 
   // it will eventually be splitted into several subconstraints
 {
-  CGAL_triangulation_precondition( vaa != vbb);
+  std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
+  stack.push(std::make_pair(vaa,vbb));
+
+  while(! stack.empty()){
+    boost::tie(vaa,vbb) = stack.top();
+    stack.pop();
+    CGAL_triangulation_precondition( vaa != vbb);
+  
   Vertex_handle vi;
 
   Face_handle fr;
@@ -782,7 +789,7 @@ insert_subconstraint(Vertex_handle vaa,
     this->mark_constraint(fr,i);
     if (vi != vbb)  {
       hierarchy.split_constraint(vaa,vbb,vi);
-      insert_subconstraint(vi,vbb, out);
+      stack.push(std::make_pair(vi,vbb));
     }
     return;
   }
@@ -800,10 +807,10 @@ insert_subconstraint(Vertex_handle vaa,
   if ( intersection) {
     if (vi != vaa && vi != vbb) {
       hierarchy.split_constraint(vaa,vbb,vi);
-      insert_subconstraint(vaa,vi, out); 
-      insert_subconstraint(vi,vbb, out); 
+      stack.push(std::make_pair(vaa,vi)); 
+      stack.push(std::make_pair(vi,vbb)); 
      }
-    else insert_subconstraint(vaa,vbb,out);  
+    else stack.push(std::make_pair(vaa,vbb));  
 
     
     return;
@@ -846,9 +853,9 @@ insert_subconstraint(Vertex_handle vaa,
 
   if (vi != vbb) {
     hierarchy.split_constraint(vaa,vbb,vi);
-    insert_subconstraint(vi,vbb, out); 
+    stack.push(std::make_pair(vi,vbb)); 
   }
-  return;
+  }
 }
 
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -781,79 +781,79 @@ insert_subconstraint(Vertex_handle vaa,
     stack.pop();
     CGAL_triangulation_precondition( vaa != vbb);
   
-  Vertex_handle vi;
+    Vertex_handle vi;
 
-  Face_handle fr;
-  int i;
-  if(this->includes_edge(vaa,vbb,vi,fr,i)) {
-    this->mark_constraint(fr,i);
-    if (vi != vbb)  {
-      hierarchy.split_constraint(vaa,vbb,vi);
-      stack.push(std::make_pair(vi,vbb));
+    Face_handle fr;
+    int i;
+    if(this->includes_edge(vaa,vbb,vi,fr,i)) {
+      this->mark_constraint(fr,i);
+      if (vi != vbb)  {
+        hierarchy.split_constraint(vaa,vbb,vi);
+        stack.push(std::make_pair(vi,vbb));
+      }
+      continue;
     }
-    continue;
-  }
       
-  List_faces intersected_faces;
-  List_edges conflict_boundary_ab, conflict_boundary_ba;
+    List_faces intersected_faces;
+    List_edges conflict_boundary_ab, conflict_boundary_ba;
      
-  bool intersection  = this->find_intersected_faces( 
-    vaa, vbb,
-    intersected_faces,
-    conflict_boundary_ab,
-    conflict_boundary_ba,
-    vi);
+    bool intersection  = this->find_intersected_faces( 
+                                                      vaa, vbb,
+                                                      intersected_faces,
+                                                      conflict_boundary_ab,
+                                                      conflict_boundary_ba,
+                                                      vi);
 
-  if ( intersection) {
-    if (vi != vaa && vi != vbb) {
-      hierarchy.split_constraint(vaa,vbb,vi);
-      stack.push(std::make_pair(vaa,vi)); 
-      stack.push(std::make_pair(vi,vbb)); 
-     }
-    else stack.push(std::make_pair(vaa,vbb));  
+    if ( intersection) {
+      if (vi != vaa && vi != vbb) {
+        hierarchy.split_constraint(vaa,vbb,vi);
+        stack.push(std::make_pair(vaa,vi)); 
+        stack.push(std::make_pair(vi,vbb)); 
+      }
+      else stack.push(std::make_pair(vaa,vbb));  
 
-    continue;
-  }
+      continue;
+    }
 
 
-  //no intersection
+    //no intersection
 
-  List_edges edges(conflict_boundary_ab);
-  std::copy(conflict_boundary_ba.begin(), conflict_boundary_ba.end(), std::back_inserter(edges));
+    List_edges edges(conflict_boundary_ab);
+    std::copy(conflict_boundary_ba.begin(), conflict_boundary_ba.end(), std::back_inserter(edges));
 
-  // edges may contain mirror edges. They no longer exist after triangulate_hole
-  // so we have to remove them before calling get_bounded_faces
-  if(! edges.empty()){
+    // edges may contain mirror edges. They no longer exist after triangulate_hole
+    // so we have to remove them before calling get_bounded_faces
+    if(! edges.empty()){
 
 #if defined(BOOST_MSVC) && (BOOST_VERSION == 105500)
-    std::set<Face_handle> faces(intersected_faces.begin(), intersected_faces.end());
+      std::set<Face_handle> faces(intersected_faces.begin(), intersected_faces.end());
 #else
-    boost::container::flat_set<Face_handle> faces(intersected_faces.begin(), intersected_faces.end());
+      boost::container::flat_set<Face_handle> faces(intersected_faces.begin(), intersected_faces.end());
 #endif
-    typename List_edges::iterator it2;
-    for(typename List_edges::iterator it = edges.begin(); it!= edges.end();){
-      if(faces.find(it->first) != faces.end()){
-        typename List_edges::iterator it2 = it;
-        ++it;
-        edges.erase(it2);
-      }else {
-        ++it;
+      typename List_edges::iterator it2;
+      for(typename List_edges::iterator it = edges.begin(); it!= edges.end();){
+        if(faces.find(it->first) != faces.end()){
+          typename List_edges::iterator it2 = it;
+          ++it;
+          edges.erase(it2);
+        }else {
+          ++it;
+        }
       }
     }
-  }
 
-  this->triangulate_hole(intersected_faces,
-                         conflict_boundary_ab,
-                         conflict_boundary_ba);
+    this->triangulate_hole(intersected_faces,
+                           conflict_boundary_ab,
+                           conflict_boundary_ba);
 
-  this->get_bounded_faces(edges.begin(),
-                          edges.end(),
-                          out);
+    this->get_bounded_faces(edges.begin(),
+                            edges.end(),
+                            out);
 
-  if (vi != vbb) {
-    hierarchy.split_constraint(vaa,vbb,vi);
-    stack.push(std::make_pair(vi,vbb)); 
-  }
+    if (vi != vbb) {
+      hierarchy.split_constraint(vaa,vbb,vi);
+      stack.push(std::make_pair(vi,vbb)); 
+    }
   }
 }
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -791,7 +791,7 @@ insert_subconstraint(Vertex_handle vaa,
       hierarchy.split_constraint(vaa,vbb,vi);
       stack.push(std::make_pair(vi,vbb));
     }
-    return;
+    continue;
   }
       
   List_faces intersected_faces;
@@ -812,8 +812,7 @@ insert_subconstraint(Vertex_handle vaa,
      }
     else stack.push(std::make_pair(vaa,vbb));  
 
-    
-    return;
+    continue;
   }
 
 


### PR DESCRIPTION
## Summary of Changes
Derecursify `Constrained_triangulation_2::insert_constraint(Vertex_handle,Vertex_handle)` 
Increment parameter `depth` of `Constrained_Delaunay_triangulation_2::propagating_flip(,,depth)` when going into recursion.

## Release Management

* Affected package(s):  Triangulation_2

