### PR TITLE
Surface_mesh: Derivation, boost::graph_traits and boost::property_map

### DIFF
--- a/Surface_mesh/doc/Surface_mesh/examples.txt
+++ b/Surface_mesh/doc/Surface_mesh/examples.txt
@@ -5,6 +5,7 @@
 \example Surface_mesh/sm_memory.cpp
 \example Surface_mesh/sm_bgl.cpp
 \example Surface_mesh/sm_kruskal.cpp
+\example Surface_mesh/sm_derivation.cpp
 @cond 
 \example Surface_mesh/sm_do_intersect.cpp
 \example Surface_mesh/sm_aabbtree.cpp

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -17,6 +17,7 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  create_single_source_cgal_program( "sm_derivation.cpp" )
   create_single_source_cgal_program( "sm_join.cpp" )
   create_single_source_cgal_program( "sm_aabbtree.cpp" )
   create_single_source_cgal_program( "sm_bgl.cpp" )

--- a/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+
+typedef CGAL::Simple_cartesian<double> K;
+typedef K::Point_3 Point_3;
+
+namespace My {
+
+  struct Mesh: public CGAL::Surface_mesh<Point_3> {
+    typedef CGAL::Surface_mesh<Point_3> Base;
+    std::string name;
+  };
+
+} // namespace My
+
+
+namespace boost {
+
+  template <>
+  struct graph_traits<My::Mesh>
+    : public boost::graph_traits<My::Mesh::Base>
+  {};
+
+  template <typename T>
+  struct property_map<My::Mesh, T>
+  {
+    typedef typename property_map<My::Mesh::Base, T>::type type;
+    typedef typename property_map<My::Mesh::Base, T>::const_type const_type;
+  };
+};
+
+
+int main()
+{
+  My::Mesh mesh;
+  CGAL::make_triangle(Point_3(0,0,0), Point_3(1,0,0), Point_3(0,1,0), mesh);
+  typedef boost::graph_traits<My::Mesh>::vertex_descriptor vertex_descriptor;
+
+  typedef boost::property_map<My::Mesh,CGAL::vertex_point_t>::type Point_property_map;
+  Point_property_map ppm = get(CGAL::vertex_point, mesh);
+
+  for(vertex_descriptor vd : vertices(mesh)){
+    if (vd != boost::graph_traits<My::Mesh>::null_vertex()){
+      std::cout << vd << << " at " << get(ppm, vd) << std::endl;
+    }
+  }
+
+  return 0;
+}
+
+ 
+
+
+ 

--- a/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-
+#include <boost/foreach.hpp>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/bbox.h>
@@ -45,7 +45,7 @@ int main()
   typedef boost::property_map<My::Mesh,CGAL::vertex_point_t>::type Point_property_map;
   Point_property_map ppm = get(CGAL::vertex_point, mesh);
 
-  for(vertex_descriptor vd : vertices(mesh)){
+  BOOST_FOREACH(vertex_descriptor vd , vertices(mesh)){
     if (vd != boost::graph_traits<My::Mesh>::null_vertex()){
       std::cout << vd << " at " << get(ppm, vd) << std::endl;
     }

--- a/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_derivation.cpp
@@ -2,6 +2,7 @@
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/bbox.h>
 
 typedef CGAL::Simple_cartesian<double> K;
 typedef K::Point_3 Point_3;
@@ -25,17 +26,20 @@ namespace boost {
 
   template <typename T>
   struct property_map<My::Mesh, T>
-  {
-    typedef typename property_map<My::Mesh::Base, T>::type type;
-    typedef typename property_map<My::Mesh::Base, T>::const_type const_type;
-  };
+    : public boost::property_map<My::Mesh::Base, T>
+  {};
+  
+  template <typename T>
+  struct graph_has_property<My::Mesh, T>
+    : public boost::graph_has_property<My::Mesh::Base, T>
+  {};
 };
 
 
 int main()
 {
   My::Mesh mesh;
-  CGAL::make_triangle(Point_3(0,0,0), Point_3(1,0,0), Point_3(0,1,0), mesh);
+  CGAL::make_triangle(Point_3(0,0,0), Point_3(1,0,0), Point_3(1,1,1), mesh);
   typedef boost::graph_traits<My::Mesh>::vertex_descriptor vertex_descriptor;
 
   typedef boost::property_map<My::Mesh,CGAL::vertex_point_t>::type Point_property_map;
@@ -43,10 +47,11 @@ int main()
 
   for(vertex_descriptor vd : vertices(mesh)){
     if (vd != boost::graph_traits<My::Mesh>::null_vertex()){
-      std::cout << vd << << " at " << get(ppm, vd) << std::endl;
+      std::cout << vd << " at " << get(ppm, vd) << std::endl;
     }
   }
-
+  std::cout << CGAL::Polygon_mesh_processing::bbox(mesh) << std::endl;
+  
   return 0;
 }
 


### PR DESCRIPTION


## Summary of Changes

Add an example that shows that one has to provide specializations for `boost::graph_traits` and `boost::property_map` so that BGL-style algorithms work on a class derived from `Surface_mesh`.

## Release Management

* Affected package(s): Surface_mesh   (no code change, only an example)
* Issue(s) solved (if any): Question was raised by a user in a private mail
