### PR TITLE
fix sudo make install error because of incorrect file name

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -858,7 +858,7 @@ create_CGALconfig_files()
 # DESTINATION option is mandatory; skipping it breaks CPack!
 
 if(CGAL_INSTALL_DOC_DIR)
-  install(FILES AUTHORS CHANGES LICENSE LICENSE.FREE_USE LICENSE.GPL LICENSE.LGPL DESTINATION ${CGAL_INSTALL_DOC_DIR} )
+  install(FILES AUTHORS changes.md LICENSE LICENSE.FREE_USE LICENSE.GPL LICENSE.LGPL DESTINATION ${CGAL_INSTALL_DOC_DIR} )
 endif()
 
 #install all includes collected in trunk et cetera


### PR DESCRIPTION
If you look in https://github.com/CGAL/cgal/tree/master/Installation, you will realize the file "CHANGE" does not exist, hence if `sudo make install` there will be errors like

```
-- Installing: /home/ubuntu/cgal/install/share/doc/CGAL-4.12-I-900/AUTHORS
CMake Error at Installation/cmake_install.cmake:41 (file):
  file INSTALL cannot find "/home/ubuntu/cgal/Installation/CHANGES".
Call Stack (most recent call first):
  cmake_install.cmake:42 (include)


Makefile:107: recipe for target 'install' failed
```

Change "CHANGE" to "changes.md" solves the problem