### PR TITLE
Kd_tree::search_any_point: don't check outer_range_contains

### DIFF
--- a/Spatial_searching/include/CGAL/Kd_tree_node.h
+++ b/Spatial_searching/include/CGAL/Kd_tree_node.h
@@ -245,10 +245,11 @@ namespace CGAL {
 	Kd_tree_rectangle<FT,D> b_upper(b);
 	node->split_bbox(b, b_upper);
 
-	if (q.inner_range_intersects(b))
+	if (q.inner_range_intersects(b)) {
 	  result = node->lower()->search_any_point(q,b);
-        if(result)
-          return result;
+	  if(result)
+	    return result;
+	}
 	if (q.inner_range_intersects(b_upper))
 	  result = node->upper()->search_any_point(q,b_upper);
       }

--- a/Spatial_searching/include/CGAL/Kd_tree_node.h
+++ b/Spatial_searching/include/CGAL/Kd_tree_node.h
@@ -244,23 +244,13 @@ namespace CGAL {
 	// after splitting b denotes the lower part of b
 	Kd_tree_rectangle<FT,D> b_upper(b);
 	node->split_bbox(b, b_upper);
-                             
-	if (q.outer_range_contains(b)){ 	
-          result = node->lower()->any_tree_item();
-	}else{
-	  if (q.inner_range_intersects(b)){ 
-	    result = node->lower()->search_any_point(q,b);
-          }
-        }
-        if(result){
+
+	if (q.inner_range_intersects(b))
+	  result = node->lower()->search_any_point(q,b);
+        if(result)
           return result;
-        }
-	if  (q.outer_range_contains(b_upper)){     
-	  result = node->upper()->any_tree_item();
-	}else{
-	  if (q.inner_range_intersects(b_upper)) 
-	    result = node->upper()->search_any_point(q,b_upper);
-        }
+	if (q.inner_range_intersects(b_upper))
+	  result = node->upper()->search_any_point(q,b_upper);
       }
       return result;				
     }


### PR DESCRIPTION
## Summary of Changes

This is purely a performance patch. For my use case, in 2D, using a custom point type with a custom distance (sup norm), this is measurably faster. And intuitively it makes sense that checking if a subtree is entirely contained in the query is more useful for search (report all points) than search_any (report one arbitrary point). But if someone else uses search_any, they are welcome to benchmark this on their testcase. It is certainly possible to find types and distributions for which the patch makes performance worse, but I expect them to be rather contrived.

## Release Management

* Affected package(s): Spatial_searching