### PR TITLE
resizeHeight no longer exist

### DIFF
--- a/Documentation/doc/resources/1.8.13/header_package.html
+++ b/Documentation/doc/resources/1.8.13/header_package.html
@@ -21,7 +21,6 @@
 <script type="text/javascript" src="navtree.js"></script>
 <script type="text/javascript">
   $(document).ready(initResizable);
-  $(window).load(resizeHeight);
 </script>
 <link href="$relpath^../Manual/search/search.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="$relpath^../Manual/search/searchdata.js"></script>


### PR DESCRIPTION
## Summary of Changes

Remove:
```javascript
  $(window).load(resizeHeight);
```
from our Doxygen javascripts.

I have verified in the template in Doxygen 1.8.13 and that line no longer exists.

... And it makes the script crash and report an error in the browser
console.

Check for example:
https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-4.12-Ic-103/master/Mesh_2/index.html
(update the CGAL version if needed)

and open the browser console to see the javascript error. For example, on Chrome:

![spectacle j17678](https://user-images.githubusercontent.com/5746675/33315988-9c8a6dda-d432-11e7-8596-2946e4deab2d.png)

This PR #2637 deals with the error, and the warning is the subject of the issue #2633, for which we still do not have a pull-request.

## Release Management

* Affected package(s): Documentation


