### PR TITLE
Fix for VC++ 2013

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -1803,10 +1803,21 @@ namespace CartesianKernelFunctors {
     result_type
     operator()(const Triangle_2& t) const
     {
+      Bbox_2 bb = this->operator()(t.vertex(0));
+      bb += this->operator()(t.vertex(1));
+      bb += this->operator()(t.vertex(2));
+      return bb;
+      /*
+	  Microsoft (R) C/C++ Optimizing Compiler Version 18.00.40629.0 for x64 
+	  produces a segfault of this functor for Simple_cartesian<Interval_nt<0>>
+	  with the original version of the code below
+	  Note that it also worked for 18.00.21005.1
+
       typename K::Construct_bbox_2 construct_bbox_2;
       return construct_bbox_2(t.vertex(0))
 	   + construct_bbox_2(t.vertex(1))
 	   + construct_bbox_2(t.vertex(2));
+      */
     }
 
     result_type


### PR DESCRIPTION
## Summary of Changes

Workaround for ` Construct_bbox_2::operator()(Triangle_2)`  with ` Simple_cartesian<…Interval_nt<0>>` .

Shows up in the master testsuite for 4.12, e.g. [here](https://cgal.geometryfactory.com/CGAL/testsuite/results-4.12-I-102.shtml) 

It looks like a compiler error. Versions  VC > 2013   don't have this problem.  

