### PR TITLE
Polyhedron demo : export surface_mesh_selection_item for external plugins

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -385,7 +385,9 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
     scene_polylines_item
     scene_basic_objects
     scene_polyhedron_selection_item
+    scene_surface_mesh_selection_item
     scene_polyhedron_item_decorator
+    scene_surface_mesh_item_decorator
     scene_polyhedron_and_sm_item_k_ring_selection
     scene_poly_item_k_ring_selection
     scene_sm_item_k_ring_selection


### PR DESCRIPTION
## Summary of Changes

Export the selection item for `Surface_mesh`.
This is needed for external plugins using the selection plugin with `Surface_mesh_item`

## Release Management

* Affected package(s): CGAL demo

