### PR TITLE
SMP: Remove Core dependency

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -1,25 +1,14 @@
 include( polyhedron_demo_macros )
-
 if(EIGEN3_FOUND)
-  find_package(CGAL COMPONENTS Core)
+  qt5_wrap_ui(parameterizationUI_FILES Parameterization_widget.ui ARAP_dialog.ui OTE_dialog.ui)
+  polyhedron_demo_plugin(parameterization_plugin Parameterization_plugin ${parameterizationUI_FILES})
+  target_link_libraries(parameterization_plugin scene_polyhedron_item scene_textured_polyhedron_item scene_polyhedron_selection_item)
 
-  include(${CGAL_USE_FILE})
-
-  if(CGAL_Core_FOUND)
-    qt5_wrap_ui( parameterizationUI_FILES Parameterization_widget.ui ARAP_dialog.ui OTE_dialog.ui)
-    polyhedron_demo_plugin(parameterization_plugin Parameterization_plugin ${parameterizationUI_FILES})
-    target_link_libraries(parameterization_plugin ${CGAL_Core_LIBRARY} ${CGAL_Core_3RD_PARTY_LIBRARIES} scene_polyhedron_item scene_textured_polyhedron_item scene_polyhedron_selection_item)
-
-    polyhedron_demo_plugin(parameterization_sm_plugin Parameterization_plugin ${parameterizationUI_FILES})
-    target_link_libraries(parameterization_sm_plugin ${CGAL_Core_LIBRARY} ${CGAL_Core_3RD_PARTY_LIBRARIES} scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
-    target_compile_definitions(parameterization_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
-
-  else(CGAL_Core_FOUND)
-    message(STATUS "NOTICE: CGAL Core was not found. The Parameterization plugin will not be available.")
-  endif(CGAL_Core_FOUND)
-
+  polyhedron_demo_plugin(parameterization_sm_plugin Parameterization_plugin ${parameterizationUI_FILES})
+  target_link_libraries(parameterization_sm_plugin scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
+  target_compile_definitions(parameterization_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 else(EIGEN3_FOUND)
-  message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The Parameterization plugin will not be available.")
+  message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The parameterization plugin will not be available.")
 endif(EIGEN3_FOUND)
 
 qt5_wrap_ui( segmentationUI_FILES Mesh_segmentation_widget.ui)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -5,7 +5,7 @@ if(EIGEN3_FOUND)
   target_link_libraries(parameterization_plugin scene_polyhedron_item scene_textured_polyhedron_item scene_polyhedron_selection_item)
 
   polyhedron_demo_plugin(parameterization_sm_plugin Parameterization_plugin ${parameterizationUI_FILES})
-  target_link_libraries(parameterization_sm_plugin PUBLIC scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
+  target_link_libraries(parameterization_sm_plugin scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
   target_compile_definitions(parameterization_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 else(EIGEN3_FOUND)
   message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The Parameterization plugin will not be available.")

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -5,7 +5,7 @@ if(EIGEN3_FOUND)
   target_link_libraries(parameterization_plugin scene_polyhedron_item scene_textured_polyhedron_item scene_polyhedron_selection_item)
 
   polyhedron_demo_plugin(parameterization_sm_plugin Parameterization_plugin ${parameterizationUI_FILES})
-  target_link_libraries(parameterization_sm_plugin scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
+  target_link_libraries(parameterization_sm_plugin PUBLIC scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
   target_compile_definitions(parameterization_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 else(EIGEN3_FOUND)
   message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The Parameterization plugin will not be available.")

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -8,7 +8,7 @@ if(EIGEN3_FOUND)
   target_link_libraries(parameterization_sm_plugin scene_surface_mesh_item scene_textured_surface_mesh_item scene_surface_mesh_selection_item)
   target_compile_definitions(parameterization_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 else(EIGEN3_FOUND)
-  message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The parameterization plugin will not be available.")
+  message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The Parameterization plugin will not be available.")
 endif(EIGEN3_FOUND)
 
 qt5_wrap_ui( segmentationUI_FILES Mesh_segmentation_widget.ui)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -220,11 +220,13 @@ typedef boost::associative_property_map<Seam_edge_uhm>              Seam_edge_pm
 typedef boost::associative_property_map<Seam_vertex_uhm>            Seam_vertex_pmap;
 
 typedef CGAL::Seam_mesh<Base_face_graph,
-Seam_edge_pmap, Seam_vertex_pmap>                                   Seam_mesh;
+                        Seam_edge_pmap, Seam_vertex_pmap>           Seam_mesh;
 
 typedef boost::graph_traits<Seam_mesh>::vertex_descriptor           s_vertex_descriptor;
 typedef boost::graph_traits<Seam_mesh>::halfedge_descriptor         s_halfedge_descriptor;
 typedef boost::graph_traits<Seam_mesh>::face_descriptor             s_face_descriptor;
+
+typedef boost::graph_traits<Seam_mesh>::edges_size_type             s_edges_size_type;
 
 typedef boost::unordered_set<boost::graph_traits<Base_face_graph>::
 face_descriptor>                                                    Component;
@@ -748,7 +750,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
   }
 #endif
   Seam_mesh sMesh(tMesh, seam_edge_pm, seam_vertex_pm);
-  sMesh.set_seam_edges_number(seam_edges.size());
+  sMesh.set_seam_edges_number(static_cast<s_edges_size_type>(seam_edges.size()));
 
   // The parameterized values
   UV_uhm uv_uhm;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -571,12 +571,12 @@ private:
   {
     CGAL_precondition(roots.empty());
 
-    typedef CGAL::GMP_arithmetic_kernel                       AK;
-    typedef CGAL::Algebraic_kernel_d_1<AK::Rational>          Algebraic_kernel_d_1;
+    typedef CGAL::Gmpq                                        GMP_NT;
+    typedef CGAL::Algebraic_kernel_d_1<GMP_NT>                Algebraic_kernel_d_1;
     typedef typename Algebraic_kernel_d_1::Polynomial_1       Polynomial_1;
     typedef typename Algebraic_kernel_d_1::Algebraic_real_1   Algebraic_real_1;
-    typedef typename Algebraic_kernel_d_1::Multiplicity_type  Multiplicity_type;
     typedef typename Algebraic_kernel_d_1::Coefficient        Coefficient;
+    typedef typename Algebraic_kernel_d_1::Multiplicity_type  Multiplicity_type;
 
     typedef CGAL::Polynomial_traits_d<Polynomial_1>           Polynomial_traits_1;
 
@@ -584,26 +584,23 @@ private:
 
     Algebraic_kernel_d_1 ak_1;
     const Solve_1 solve_1 = ak_1.solve_1_object();
+
+    GMP_NT a3q(a3);
+    GMP_NT a2q(a2);
+    GMP_NT a1q(a1);
+    GMP_NT a0q(a0);
+
     typename Polynomial_traits_1::Construct_polynomial construct_polynomial_1;
     std::pair<CGAL::Exponent_vector, Coefficient> coeffs_x[1]
-      = {std::make_pair(CGAL::Exponent_vector(1,0),Coefficient(1))};
+      = {std::make_pair(CGAL::Exponent_vector(1,0), Coefficient(1))};
     Polynomial_1 x=construct_polynomial_1(coeffs_x, coeffs_x+1);
-
-    AK::Rational a3q(a3);
-    AK::Rational a2q(a2);
-    AK::Rational a1q(a1);
-    AK::Rational a0q(a0);
-
-    Polynomial_1 pol = a3q*CGAL::ipower(x,3) + a2q*CGAL::ipower(x,2)
-                       + a1q*x + a0q;
+    Polynomial_1 pol = a3q*CGAL::ipower(x,3) + a2q*CGAL::ipower(x,2) + a1q*x + a0q;
 
     std::vector<std::pair<Algebraic_real_1, Multiplicity_type> > ak_roots;
     solve_1(pol, std::back_inserter(ak_roots));
 
-    for(std::size_t i=0; i<ak_roots.size(); i++)
-    {
-      roots.push_back(ak_roots[i].first.to_double());
-    }
+    for(std::size_t i=0; i<ak_roots.size(); ++i)
+      roots.push_back(CGAL::to_double(ak_roots[i].first));
 
     return roots.size();
   }
@@ -613,12 +610,12 @@ private:
   // Solve the bivariate system
   // { C1 * a + 2 * lambda * a ( a^2 + b^2 - 1 ) = C2
   // { C1 * b + 2 * lambda * b ( a^2 + b^2 - 1 ) = C3
-  // using CGAL's algeabric kernel.
+  // using CGAL's algebraic kernel.
   int solve_bivariate_system(const NT C1, const NT C2, const NT C3,
                              std::vector<NT>& a_roots, std::vector<NT>& b_roots) const
   {
-    typedef CGAL::GMP_arithmetic_kernel                       AK;
-    typedef CGAL::Algebraic_kernel_d_2<AK::Rational>          Algebraic_kernel_d_2;
+    typedef CGAL::Gmpq                                        GMP_NT;
+    typedef CGAL::Algebraic_kernel_d_2<GMP_NT>                Algebraic_kernel_d_2;
     typedef typename Algebraic_kernel_d_2::Polynomial_2       Polynomial_2;
     typedef typename Algebraic_kernel_d_2::Algebraic_real_2   Algebraic_real_2;
     typedef typename Algebraic_kernel_d_2::Multiplicity_type  Multiplicity_type;
@@ -637,15 +634,15 @@ private:
 
     typename Polynomial_traits_2::Construct_polynomial construct_polynomial_2;
     std::pair<CGAL::Exponent_vector, Coefficient> coeffs_x[1]
-      = {std::make_pair(CGAL::Exponent_vector(1,0),Coefficient(1))};
+      = {std::make_pair(CGAL::Exponent_vector(1,0), Coefficient(1))};
     Polynomial_2 x=construct_polynomial_2(coeffs_x,coeffs_x+1);
     std::pair<CGAL::Exponent_vector, Coefficient> coeffs_y[1]
-      = {std::make_pair(CGAL::Exponent_vector(0,1),Coefficient(1))};
+      = {std::make_pair(CGAL::Exponent_vector(0,1), Coefficient(1))};
     Polynomial_2 y=construct_polynomial_2(coeffs_y,coeffs_y+1);
 
-    AK::Rational C1q(C1);
-    AK::Rational C2q(C2);
-    AK::Rational C3q(C3);
+    GMP_NT C1q(C1);
+    GMP_NT C2q(C2);
+    GMP_NT C3q(C3);
 
     Polynomial_2 pol1 = C1q * x + 2 * m_lambda * x * ( x*x + y*y - 1) - C2q;
     Polynomial_2 pol2 = C1q * y + 2 * m_lambda * y * ( x*x + y*y - 1) - C3q;
@@ -800,10 +797,10 @@ private:
 #else // !CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP
         solve_cubic_equation(a3_coeff, 0., (C1 - 2. * m_lambda), -C2, roots);
 #endif
-
         std::size_t ind = compute_root_with_lowest_energy(mesh, fd,
                                                           ctmap, lp, lpmap, uvmap,
                                                           C2_denom, C3, roots);
+
         a = roots[ind];
         b = C3 * C2_denom * a;
 #else // !CGAL_SMP_SOLVE_CUBIC_EQUATION, solve the bivariate system

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -65,12 +65,12 @@
 // -----------------------------------------------------------------------------
 
 #if !defined(CGAL_SMP_SOLVE_CUBIC_EQUATION) && !defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
-#error "Either 'CGAL_SMP_SOLVE_CUBIC_EQUATION' or 'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' should be defined."
+#error "Either 'CGAL_SMP_SOLVE_CUBIC_EQUATION' or 'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' must be defined."
 #endif
 
 #if defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
 #if !defined(CGAL_USE_GMP) || !defined(CGAL_USE_MPFI)
-#error "'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' cannot be defined if GMP or MPFI are not present."
+#error "'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' cannot be defined if GMP or MPFI is not present."
 #endif
 #endif
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -44,6 +44,43 @@
 #include <CGAL/Default.h>
 #include <CGAL/number_utils.h>
 
+// Below are two macros that can be used to improve the accuracy of optimal Lt
+// matrices.
+// Note that at least one of these macros should be defined. If:
+//
+// - CGAL_SMP_SOLVE_CUBIC_EQUATION is defined: a cubic equation is solved instead of the
+//   complete bivariate system. Although less accurate, it is usually sufficient.
+// - CGAL_SMP_SOLVE_CUBIC_EQUATION and CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP are defined:
+//   the same cubic is solved but using GMP and CGAL's algebraic kernel.
+// - CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP is defined: a bivariate system is solved,
+//   using GMP and CGAL's algebraic kernel.
+//
+// Using CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP requires GMP, MPFI, and linking CGAL
+// with Core and MPFI. This can be simply done in 'CMakeLists.txt' by using:
+// 'find_package(CGAL QUIET COMPONENTS Core MPFI)'
+
+// -----------------------------------------------------------------------------
+#define CGAL_SMP_SOLVE_CUBIC_EQUATION
+//#define CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP
+// -----------------------------------------------------------------------------
+
+#if !defined(CGAL_SMP_SOLVE_CUBIC_EQUATION) && !defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
+#error "Either 'CGAL_SMP_SOLVE_CUBIC_EQUATION' or 'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' should be defined."
+#endif
+
+#if defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
+#if !defined(CGAL_USE_GMP) || !defined(CGAL_USE_MPFI)
+#error "'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' cannot be defined if GMP or MPFI are not present."
+#endif
+#endif
+
+#ifdef CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP
+#include <CGAL/GMP_arithmetic_kernel.h>
+#include <CGAL/Algebraic_kernel_d_2.h>
+#elif defined(CGAL_SMP_SOLVE_CUBIC_EQUATION)
+#include <CGAL/Kernel/Conic_misc.h> // used to solve conic equations
+#endif
+
 #include <boost/foreach.hpp>
 #include <boost/function_output_iterator.hpp>
 #include <boost/functional/hash.hpp>
@@ -63,41 +100,6 @@
 //       (this produces C2=0 which is problematic to compute a & b)
 // @todo Add distortion measures
 // @todo Parallelize the local phase?
-
-// Below are two macros that can be used to improve the accuracy of optimal Lt
-// matrices.
-// Note that at least one of these macros should be defined. If:
-//
-// - CGAL_SMP_SOLVE_CUBIC_EQUATION is defined: a cubic equation is solved instead of the
-//   complete bivariate system. Although less accurate, it is usually sufficient.
-// - CGAL_SMP_SOLVE_CUBIC_EQUATION and CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP are defined:
-//   the same cubic is solved but using GMP and CGAL's algebraic kernel.
-// - CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP is defined: a bivariate system is solved,
-//   using GMP and CGAL's algebraic kernel.
-//
-// Using CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP requires GMP, MPFI, and linking CGAL
-// with Core and MPFI. This can be simply done in 'CMakeLists.txt' by using:
-// 'find_package(CGAL QUIET COMPONENTS Core MPFI)'
-
-#define CGAL_SMP_SOLVE_CUBIC_EQUATION
-//#define CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP
-
-#if !defined(CGAL_SMP_SOLVE_CUBIC_EQUATION) && !defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
-#error "Either 'CGAL_SMP_SOLVE_CUBIC_EQUATION' or 'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' should be defined."
-#endif
-
-#if defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
-#if !defined(CGAL_USE_GMP) || !defined(CGAL_USE_MPFI)
-#error "'CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP' cannot be defined if GMP or MPFI are not present."
-#endif
-#endif
-
-#ifdef CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP
-#include <CGAL/GMP_arithmetic_kernel.h>
-#include <CGAL/Algebraic_kernel_d_2.h>
-#elif defined(CGAL_SMP_SOLVE_CUBIC_EQUATION)
-#include <CGAL/Kernel/Conic_misc.h> // used to solving conic equations
-#endif
 
 namespace CGAL {
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -76,7 +76,7 @@
 //   using GMP and CGAL's algebraic kernel.
 //
 // Using CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP requires GMP, MPFI, and linking CGAL
-// with Core and MPFI. This can be simply be done in 'CMakeLists.txt' by using:
+// with Core and MPFI. This can be simply done in 'CMakeLists.txt' by using:
 // 'find_package(CGAL QUIET COMPONENTS Core MPFI)'
 
 #define CGAL_SMP_SOLVE_CUBIC_EQUATION

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -547,8 +547,8 @@ private:
   }
 
   // Solves the cubic equation a3 x^3 + a2 x^2 + a1 x + a0 = 0.
-  int solve_cubic_equation(const NT a3, const NT a2, const NT a1, const NT a0,
-                           std::vector<NT>& roots) const
+  std::size_t solve_cubic_equation(const NT a3, const NT a2, const NT a1, const NT a0,
+                                   std::vector<NT>& roots) const
   {
     CGAL_precondition(roots.empty());
     NT r1 = 0, r2 = 0, r3 = 0; // roots of the cubic equation
@@ -567,9 +567,9 @@ private:
 
 #if defined(CGAL_SMP_SOLVE_CUBIC_EQUATION) && defined(CGAL_SMP_SOLVE_EQUATIONS_WITH_GMP)
   // Solves the equation a3 x^3 + a2 x^2 + a1 x + a0 = 0, using CGAL's algebraic kernel.
-  int solve_cubic_equation_with_AK(const NT a3, const NT a2,
-                                   const NT a1, const NT a0,
-                                   std::vector<NT>& roots) const
+  std::size_t solve_cubic_equation_with_AK(const NT a3, const NT a2,
+                                           const NT a1, const NT a0,
+                                           std::vector<NT>& roots) const
   {
     CGAL_precondition(roots.empty());
 
@@ -613,8 +613,8 @@ private:
   // { C1 * a + 2 * lambda * a ( a^2 + b^2 - 1 ) = C2
   // { C1 * b + 2 * lambda * b ( a^2 + b^2 - 1 ) = C3
   // using CGAL's algebraic kernel.
-  int solve_bivariate_system(const NT C1, const NT C2, const NT C3,
-                             std::vector<NT>& a_roots, std::vector<NT>& b_roots) const
+  std::size_t solve_bivariate_system(const NT C1, const NT C2, const NT C3,
+                                     std::vector<NT>& a_roots, std::vector<NT>& b_roots) const
   {
     typedef CGAL::Gmpq                                        GMP_NT;
     typedef CGAL::Algebraic_kernel_d_2<GMP_NT>                Algebraic_kernel_d_2;

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 2.8.11)
 include_directories (BEFORE . include ../../include)
 
 # Find CGAL
-find_package(CGAL QUIET COMPONENTS Core)
+find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 


### PR DESCRIPTION
## Summary of Changes

Rework the way different solvers can be selected in the ARAP parameterization method. Default linking to Core is removed in SMP/test/ and in the polyhedron demo.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any): Fix #2672 
* Feature/Small Feature (if any): --

