### PR TITLE
Polyhedron demo: Fix polyhedron flat shading and silent make install in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_script:
 - cd build 
 - cmake -DCGAL_HEADER_ONLY=ON -DQt5_DIR="/opt/qt55/lib/cmake/Qt5" -DQt5Svg_DIR="/opt/qt55/lib/cmake/Qt5Svg" -DQt5OpenGL_DIR="/opt/qt55/lib/cmake/Qt5OpenGL" -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG .. 
 - make 
-- sudo make install
+- sudo make install &>/dev/null
 - cd .. 
 script: 
 - cd ./.travis

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -15,7 +15,7 @@ before_script:
 - cd build 
 - cmake -DCGAL_HEADER_ONLY=ON -DQt5_DIR="/opt/qt55/lib/cmake/Qt5" -DQt5Svg_DIR="/opt/qt55/lib/cmake/Qt5Svg" -DQt5OpenGL_DIR="/opt/qt55/lib/cmake/Qt5OpenGL" -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG .. 
 - make 
-- sudo make install
+- sudo make install &>/dev/null
 - cd .. 
 script: 
 - cd ./.travis

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.f
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.f
@@ -32,16 +32,10 @@ void main(void)
   vec3 V = -fs_in.fP.xyz;
 
   vec3 N;
-  vec3 X = dFdx(fs_in.fP.xyz);
-  vec3 Y = dFdy(fs_in.fP.xyz);
-  vec3 normal=normalize(cross(X,Y));
-  if(dot(normal, fs_in.normal) <0)
-    normal = - normal;
-
-  if(normal == highp vec3(0.0,0.0,0.0))
+  if(fs_in.normal == highp vec3(0.0,0.0,0.0))
        N = highp vec3(0.0,0.0,0.0);
    else
-       N = normalize(normal);
+       N = fs_in.normal;
   L = normalize(L);
   V = normalize(V);
 

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.g
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.g
@@ -48,7 +48,7 @@ EmitVertex();
   // and the last vertex is the provoking vertex by default
   vec3 normal = cross(norm1.xyz, norm2.xyz);
 
-  gs_out.normal = mat3(mv_matrix)* normal;
+  gs_out.normal = normalize(mat3(mv_matrix)* normal);
   gs_out.color = gs_in[2].out_color;
 
   for(int i=0; i< 6; ++i)


### PR DESCRIPTION
## Summary of Changes
For very small polyhedron items, the flat shading was failing, I think because of dFdx() and dFdy(). 
This PR also add the flag --silent to the make install in travis, to avoid the log to be unreadable because of its size.
