### PR TITLE
Fix <CGAL/Polygon_mesh_processing/measure.h>

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -34,6 +34,10 @@
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/Kernel/global_functions_3.h>
 
+#include <CGAL/Lazy.h> // needed for CGAL::exact(FT)/CGAL::exact(Lazy_exact_nt<T>)
+
+#include <utility>
+
 #ifdef DOXYGEN_RUNNING
 #define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
 #define CGAL_PMP_NP_CLASS NamedParameters

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -1,10 +1,10 @@
+#include <CGAL/Polygon_mesh_processing/measure.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/Polygon_mesh_processing/measure.h>
 #include <CGAL/Polygon_mesh_processing/bbox.h>
 
 #include <CGAL/Bbox_3.h>


### PR DESCRIPTION
## Summary of Changes

Fix `<CGAL/Polygon_mesh_processing/measure.h>` that requires `CGAL::exact(FT)` from `<CGAL/Lazy.h>`. `exact(FT)` is not called by ADL (because most of the number types, such as `double`, are not in the CGAL namespace, and that is why the function must be declared before its use.

Fixes #2654.

The addition of `<utility>` is from a merge conflict with `master`.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #2654

