### PR TITLE
Point Set 3: Reinitialize properties when reusing memory

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -412,7 +412,9 @@ public:
     else
       {
         -- m_nb_removed;
-        return m_indices.end() - m_nb_removed - 1;
+        iterator out = m_indices.end() - m_nb_removed - 1;
+        m_base.reset(*out);
+        return out;
       }
   }
 


### PR DESCRIPTION
## Summary of Changes

When a point is removed, it is in reality only swapped with the end element and the `garbage_begin()` iterator is decremented. When adding a point, this garbage is reused to avoid reallocation. The problem is that properties are not reset, which is not intuitive (especially because properties are given default values).

This fixes it.

(I based it on 4.11 because it relies on a method that was introduced in 4.11.)

## Release Management

* Affected package(s): Point_set_3

