### PR TITLE
Use reference type from the pmap and fix warnings

### DIFF
--- a/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
@@ -181,7 +181,7 @@ three components of the Catmull-Clark subdivision method.
 
 \code{.cpp}
 
-template <class PolygonMesh, class Mask>
+template <class PolygonMesh, class Mask, class NamedParameters>
 void PQQ(PolygonMesh& p, Mask mask, NamedParameters np)
 
 \endcode
@@ -327,16 +327,16 @@ and \f$ \sqrt{3}\f$ subdivision.
 \code{.cpp}
 
 namespace Subdivision_method_3 {
-template <class PolygonMesh, class Mask>
+template <class PolygonMesh, class Mask, class NamedParameters>
 void PQQ(PolygonMesh& pmesh, Mask mask, NamedParameters np);
 
-template <class PolygonMesh, class Mask>
+template <class PolygonMesh, class Mask, class NamedParameters>
 void PTQ(PolygonMesh& pmesh, Mask mask, NamedParameters np);
 
-template <class PolygonMesh,  class Mask>
+template <class PolygonMesh,  class Mask, class NamedParameters>
 void DQQ(PolygonMesh& pmesh, Mask mask, NamedParameters np)
 
-template <class PolygonMesh,  class Mask>
+template <class PolygonMesh,  class Mask, class NamedParameters>
 void Sqrt3(PolygonMesh& pmesh, Mask mask, NamedParameters np)
 }
 

--- a/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
@@ -251,8 +251,8 @@ class CatmullClark_mask_3 {
 };
 
   void edge_node(halfedge_descriptor edge, Point_3& pt) {
-    Point_3& p1 = get(vpm,target(edge, pmesh));
-    Point_3& p2 = get(vpm,source(edge, pmesh));
+    Point_3 p1 = get(vpm,target(edge, pmesh));
+    Point_3 p2 = get(vpm,source(edge, pmesh));
     Point_3 f1, f2;
     face_node(face(edge,pmesh), f1);
     face_node(face(opposite(edge,pmesh),pmesh), f2);
@@ -266,11 +266,11 @@ class CatmullClark_mask_3 {
     typename boost::graph_traits<PolygonMesh>::degree_size_type n = degree(vertex,pmesh);
 
     FT Q[] = {0.0, 0.0, 0.0}, R[] = {0.0, 0.0, 0.0};
-    Point_3& S = get(vpm,vertex);
+    Point_3 S = get(vpm,vertex);
 
     Point_3 q;
     for (int i = 0; i < n; i++, ++vcir) {
-      Point_3& p2 = get(vpm, target(opposite(*vcir,pmesh),pmesh));
+      Point_3 p2 = get(vpm, target(opposite(*vcir,pmesh),pmesh));
       R[0] += (S[0]+p2[0])/2;
       R[1] += (S[1]+p2[1])/2;
       R[2] += (S[2]+p2[2])/2;
@@ -454,15 +454,15 @@ is listed below, where `ept` returns the new point splitting
 \code{.cpp}
 
   void border_node(halfedge_descriptor edge, Point_3& ept, Point_3& vpt) {
-    Point_3& ep1 = get(vpm, target(edge, pmesh));
-    Point_3& ep2 = get(vpm, target(opposite(edge, pmesh), pmesh));
+    Point_3 ep1 = get(vpm, target(edge, pmesh));
+    Point_3 ep2 = get(vpm, target(opposite(edge, pmesh), pmesh));
     ept = Point_3((ep1[0]+ep2[0])/2, (ep1[1]+ep2[1])/2, (ep1[2]+ep2[2])/2);
 
     Halfedge_around_target_circulator<Poly> vcir(edge, pmesh);
-    Point_3& vp1  = get(vpm,target(opposite(*vcir, pmesh ), pmesh));
-    Point_3& vp0  = get(vpm, target(*vcir, pmesh));
+    Point_3 vp1  = get(vpm,target(opposite(*vcir, pmesh ), pmesh));
+    Point_3 vp0  = get(vpm, target(*vcir, pmesh));
     --vcir;
-    Point_3& vp_1 = get(vpm, target(opposite(*vcir, pmesh), pmesh));
+    Point_3 vp_1 = get(vpm, target(opposite(*vcir, pmesh), pmesh));
     vpt = Point_3((vp_1[0] + 6*vp0[0] + vp1[0])/8,
                   (vp_1[1] + 6*vp0[1] + vp1[1])/8,
                   (vp_1[2] + 6*vp0[2] + vp1[2])/8 );

--- a/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
@@ -150,12 +150,6 @@ in the internal container are sequentially ordered (e.g.
 This implies that the iterators traverse the primitives in
 the order of their creations/insertions.
 
-\attention The four subdivision techniques have been made to work with
-`Surface_mesh` despite `Surface_mesh` not necessarily inserting new elements at
-the end of its containers (see Section \ref sectionSurfaceMesh_properties of the
-`Surface_mesh`). However, it is required that the `Surface_mesh` passed as input
-is garbage-free, which can be achieved by first calling `Surface_mesh::collect_garbage()`.
-
 Section \ref secRefHost gives detailed explanations on this
 two restrictions.
 

--- a/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/Subdivision_method_3.txt
@@ -127,12 +127,12 @@ There is only one line deserving a detailed explanation:
 
 \code{.cpp}
 
-Subdivision_method_3::CatmullClark_subdivision(pmesh, d);
+Subdivision_method_3::CatmullClark_subdivision(pmesh, params::number_of_iterations(d));
 
 \endcode
 
 `Subdivision_method_3` specifies the namespace of the
-subdivision functions. `CatmullClark_subdivision(P, d)` computes the
+subdivision functions. `CatmullClark_subdivision(P, params::number_of_iterations(d))` computes the
 Catmull-Clark subdivision surface of the polygon mesh `pmesh` after
 `d` iterations of the refinements. The polygon mesh  `pmesh` is
 passed by reference, and is modified (i.e.\ subdivided) by the
@@ -188,7 +188,7 @@ three components of the Catmull-Clark subdivision method.
 \code{.cpp}
 
 template <class PolygonMesh, class Mask>
-void PQQ(PolygonMesh& p, Mask mask, int depth)
+void PQQ(PolygonMesh& p, Mask mask, NamedParameters np)
 
 \endcode
 
@@ -203,8 +203,7 @@ new points by cooperating with the `mask`.
 To implement Catmull-Clark subdivision,
 `Mask`, the <I>geometry policy</I>, has to realize the
 geometry masks of Catmull-Clark subdivision.
-The parameter `depth` specifies the iterations of the refinement
-on the control mesh.
+The number of iterations as well as the vertex point map can be specified using the named parameter `np`.
 
 To implement the geometry masks, we need to know how
 a refinement host communicates with its geometry masks.
@@ -305,7 +304,7 @@ call `PQQ()` with the Catmull-Clark masks that we have just defined.
 
 \code{.cpp}
 
-PQQ(pmesh, CatmullClark_mask_3(pmesh), depth);
+PQQ(pmesh, CatmullClark_mask_3(pmesh), params::number_of_iterations(depth));
 
 \endcode
 
@@ -335,16 +334,16 @@ and \f$ \sqrt{3}\f$ subdivision.
 
 namespace Subdivision_method_3 {
 template <class PolygonMesh, class Mask>
-void PQQ(PolygonMesh& pmesh, Mask mask, int step);
+void PQQ(PolygonMesh& pmesh, Mask mask, NamedParameters np);
 
 template <class PolygonMesh, class Mask>
-void PTQ(PolygonMesh& pmesh, Mask mask, int step);
+void PTQ(PolygonMesh& pmesh, Mask mask, NamedParameters np);
 
 template <class PolygonMesh,  class Mask>
-void DQQ(PolygonMesh& pmesh, Mask mask, int step)
+void DQQ(PolygonMesh& pmesh, Mask mask, NamedParameters np)
 
 template <class PolygonMesh,  class Mask>
-void Sqrt3(PolygonMesh& pmesh, Mask mask, int step)
+void Sqrt3(PolygonMesh& pmesh, Mask mask, NamedParameters np)
 }
 
 \endcode
@@ -533,24 +532,24 @@ based on that kernel.
 \code{.cpp}
 
 namespace Subdivision_method_3 {
-  template <class PolygonMesh>
-  void CatmullClark_subdivision(PolygonMesh& pmesh, int step = 1) {
-    PQQ(pmesh, CatmullClark_mask_3<PolygonMesh>(pmesh), step);
+  template <class PolygonMesh, class NamedParameters>
+  void CatmullClark_subdivision(PolygonMesh& pmesh, NamedParameters np) {
+    PQQ(pmesh, CatmullClark_mask_3<PolygonMesh>(pmesh), np);
   }
 
-  template <class PolygonMesh>
-  void Loop_subdivision(PolygonMesh& pmesh, int step = 1) {
-    PTQ(pmesh, Loop_mask_3<PolygonMesh>(pmesh) , step);
+  template <class PolygonMesh, class NamedParameters>
+  void Loop_subdivision(PolygonMesh& pmesh, NamedParameters np) {
+    PTQ(pmesh, Loop_mask_3<PolygonMesh>(pmesh) , np);
   }
 
-  template <class PolygonMesh>
-  void DooSabin_subdivision(PolygonMesh& pmesh, int step = 1) {
-    DQQ(pmesh, DooSabin_mask_3<PolygonMesh>(pmesh), step);
+  template <class PolygonMesh, class NamedParameters>
+  void DooSabin_subdivision(PolygonMesh& pmesh, NamedParameters np) {
+    DQQ(pmesh, DooSabin_mask_3<PolygonMesh>(pmesh), np);
   }
 
-  template <class PolygonMesh>
-  void Sqrt3_subdivision(PolygonMesh& pmesh, int step = 1) {
-    Sqrt3(pmesh, Sqrt3_mask_3<PolygonMesh>(pmesh), step);
+  template <class PolygonMesh, class NamedParameters>
+  void Sqrt3_subdivision(PolygonMesh& pmesh, NamedParameters np) {
+    Sqrt3(pmesh, Sqrt3_mask_3<PolygonMesh>(pmesh), np);
   }
 }
 

--- a/Subdivision_method_3/examples/Subdivision_method_3/CatmullClark_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/CatmullClark_subdivision.cpp
@@ -16,6 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>    PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
+namespace params = CGAL::Polygon_mesh_processing::parameters;
 
 int main(int argc, char** argv) {
   if (argc > 4) {
@@ -40,7 +41,7 @@ int main(int argc, char** argv) {
 
   Timer t;
   t.start();
-  Subdivision_method_3::CatmullClark_subdivision(pmesh, d);
+  Subdivision_method_3::CatmullClark_subdivision(pmesh, params::number_of_iterations(d));
   std::cerr << "Done (" << t.time() << " s)" << std::endl;
 
   std::ofstream out(out_file);

--- a/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
@@ -28,6 +28,7 @@ class WLoop_mask_3 {
 
   typedef typename boost::property_map<PolygonMesh, vertex_point_t>::type Vertex_pmap;
   typedef typename boost::property_traits<Vertex_pmap>::value_type Point;
+  typedef typename boost::property_traits<Vertex_pmap>::reference Point_ref;
 
   PolygonMesh& pmesh;
   Vertex_pmap vpm;
@@ -38,10 +39,10 @@ public:
   {}
 
   void edge_node(halfedge_descriptor hd, Point& pt) {
-    Point& p1 = get(vpm, target(hd,pmesh));
-    Point& p2 = get(vpm, target(opposite(hd,pmesh),pmesh));
-    Point& f1 = get(vpm, target(next(hd,pmesh),pmesh));
-    Point& f2 = get(vpm, target(next(opposite(hd,pmesh),pmesh),pmesh));
+    Point_ref p1 = get(vpm, target(hd,pmesh));
+    Point_ref p2 = get(vpm, target(opposite(hd,pmesh),pmesh));
+    Point_ref f1 = get(vpm, target(next(hd,pmesh),pmesh));
+    Point_ref f2 = get(vpm, target(next(opposite(hd,pmesh),pmesh),pmesh));
 
     pt = Point((3*(p1[0]+p2[0])+f1[0]+f2[0])/8,
                (3*(p1[1]+p2[1])+f1[1]+f2[1])/8,
@@ -49,12 +50,12 @@ public:
   }
   void vertex_node(vertex_descriptor vd, Point& pt) {
     double R[] = {0.0, 0.0, 0.0};
-    Point& S = get(vpm,vd);
+    Point_ref S = get(vpm,vd);
 
     std::size_t n = 0;
     BOOST_FOREACH(halfedge_descriptor hd, halfedges_around_target(vd, pmesh)){
       ++n;
-      Point& p = get(vpm, target(opposite(hd,pmesh),pmesh));
+      Point_ref p = get(vpm, target(opposite(hd,pmesh),pmesh));
       R[0] += p[0]; 	R[1] += p[1]; 	R[2] += p[2];
     }
 
@@ -72,15 +73,15 @@ public:
   }
 
   void border_node(halfedge_descriptor hd, Point& ept, Point& vpt) {
-    Point& ep1 = get(vpm, target(hd,pmesh));
-    Point& ep2 = get(vpm, target(opposite(hd,pmesh),pmesh));
+    Point_ref ep1 = get(vpm, target(hd,pmesh));
+    Point_ref ep2 = get(vpm, target(opposite(hd,pmesh),pmesh));
     ept = Point((ep1[0]+ep2[0])/2, (ep1[1]+ep2[1])/2, (ep1[2]+ep2[2])/2);
 
     Halfedge_around_target_circulator<Poly> vcir(hd,pmesh);
-    Point& vp1  = get(vpm, target(opposite(*vcir,pmesh),pmesh));
-    Point& vp0  = get(vpm, target(*vcir,pmesh));
+    Point_ref vp1  = get(vpm, target(opposite(*vcir,pmesh),pmesh));
+    Point_ref vp0  = get(vpm, target(*vcir,pmesh));
     --vcir;
-    Point& vp_1 = get(vpm,target(opposite(*vcir,pmesh),pmesh));
+    Point_ref vp_1 = get(vpm,target(opposite(*vcir,pmesh),pmesh));
     vpt = Point((vp_1[0] + 6*vp0[0] + vp1[0])/8,
                 (vp_1[1] + 6*vp0[1] + vp1[1])/8,
                 (vp_1[2] + 6*vp0[2] + vp1[2])/8 );

--- a/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
@@ -16,6 +16,7 @@ typedef CGAL::Simple_cartesian<double>      Kernel;
 typedef CGAL::Surface_mesh<Kernel::Point_3> PolygonMesh;
 using namespace std;
 using namespace CGAL;
+namespace params = CGAL::Polygon_mesh_processing::parameters;
 
 // ======================================================================
 template <class Poly>
@@ -109,7 +110,7 @@ int main(int argc, char **argv) {
 
   Timer t;
   t.start();
-  Subdivision_method_3::PTQ(pmesh, WLoop_mask_3<PolygonMesh>(pmesh), d);
+  Subdivision_method_3::PTQ(pmesh, WLoop_mask_3<PolygonMesh>(pmesh), params::number_of_iterations(d));
   std::cerr << "Done (" << t.time() << " s)" << std::endl;
 
   std::ofstream out(out_file);

--- a/Subdivision_method_3/examples/Subdivision_method_3/DooSabin_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/DooSabin_subdivision.cpp
@@ -18,6 +18,7 @@ typedef CGAL::Polyhedron_3<Kernel>                PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
+namespace params = CGAL::Polygon_mesh_processing::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {
@@ -42,7 +43,7 @@ int main(int argc, char **argv) {
 
   Timer t;
   t.start();
-  Subdivision_method_3::DooSabin_subdivision(pmesh, d);
+  Subdivision_method_3::DooSabin_subdivision(pmesh, params::number_of_iterations(d));
   std::cerr << "Done (" << t.time() << " s)" << std::endl;
 
   std::ofstream out(out_file);

--- a/Subdivision_method_3/examples/Subdivision_method_3/Loop_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Loop_subdivision.cpp
@@ -16,6 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>     PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
+namespace params = CGAL::Polygon_mesh_processing::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {
@@ -40,7 +41,7 @@ int main(int argc, char **argv) {
 
   Timer t;
   t.start();
-  Subdivision_method_3::Loop_subdivision(pmesh,d);
+  Subdivision_method_3::Loop_subdivision(pmesh, params::number_of_iterations(d));
   std::cerr << "Done (" << t.time() << " s)" << std::endl;
 
   std::ofstream out(out_file);

--- a/Subdivision_method_3/examples/Subdivision_method_3/Sqrt3_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Sqrt3_subdivision.cpp
@@ -16,6 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>     PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
+namespace params = CGAL::Polygon_mesh_processing::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {
@@ -40,7 +41,7 @@ int main(int argc, char **argv) {
 
   Timer t;
   t.start();
-  Subdivision_method_3::Sqrt3_subdivision(pmesh,d);
+  Subdivision_method_3::Sqrt3_subdivision(pmesh, params::number_of_iterations(d));
   std::cerr << "Done (" << t.time() << " s)" << std::endl;
 
   std::ofstream out(out_file);

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -292,10 +292,8 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   std::size_t num_f = p_faces.size();
 
   std::vector<halfedge_descriptor> border_halfedges;
-  size_t num_be = 0 ;
   BOOST_FOREACH(edge_descriptor ed, p_edges){
     if(is_border(ed,p)){
-      ++num_be;
       border_halfedges.push_back(halfedge(ed,p));
     }
   }

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -89,7 +89,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
 
   std::vector<bool> v_onborder(num_vertex);
   face_iterator fitr = faces(p).first;
-  for (size_t i = 0; i < num_facet; i++, ++fitr)
+  for (typename boost::graph_traits<Poly>::faces_size_type i = 0; i < num_facet; i++, ++fitr)
     mask.face_node(*fitr, face_point_buffer[i]);
 
 
@@ -111,7 +111,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   }
 
   vertex_iterator vitr = vertices(p).first;
-  for (size_t i = 0; i < num_vertex; i++, ++vitr)
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_vertex; i++, ++vitr)
     if (!v_onborder[v_index[*vitr]]) mask.vertex_node(*vitr, vertex_point_buffer[i]);
 
   // Build the connectivity using insert_vertex() and insert_edge()
@@ -123,7 +123,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   //    the new inserted vertex of step 3
   // Step 1.
   edge_iterator eitr = edges(p).first;
-  for (size_t i = 0; i < num_edge; i++, ++eitr) {
+  for (typename boost::graph_traits<Poly>::edges_size_type i = 0; i < num_edge; i++, ++eitr) {
     vertex_descriptor vh = insert_vertex(p, halfedge(*eitr,p));
     put(vpm, vh, edge_point_buffer[i]);
   }
@@ -131,7 +131,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
 
   // TODO: the topoloy modification can be done by a template function
   //       and that gives the user a chance to create new topological masks.
-  for (size_t i = 0; i < num_facet; i++, ++fitr) {
+  for (typename boost::graph_traits<Poly>::faces_size_type i = 0; i < num_facet; i++, ++fitr) {
     // Step 2.
     Halfedge_around_facet_circulator hcir_begin(halfedge(*fitr,p),p);
     Halfedge_around_facet_circulator hcir = hcir_begin;
@@ -161,7 +161,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   // Update the geometry data of the newly inserted vertices by the
   // vertices buffer
   vitr = vertices(p).first;
-  for (size_t i = 0; i < num_vertex; i++, ++vitr)
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_vertex; i++, ++vitr)
     put(vpm, *vitr, vertex_point_buffer[i]);
 
 //  CGAL_postcondition(p.is_valid());
@@ -223,7 +223,7 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
     }
   }
   vertex_iterator vitr = vertices(p).first;
-  for (size_t i = 0; i < num_vertex; i++, ++vitr)
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_vertex; i++, ++vitr)
     if (!v_onborder[i]) mask.vertex_node(*vitr, vertex_point_buffer[i]);
 
   // Build the connectivity using insert_vertex() and insert_edge()
@@ -235,12 +235,12 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   //    the new inserted vertex of step 3
   // Step 1.
   edge_iterator eitr = edges(p).first;
-  for (size_t i = 0; i < num_edge; i++, ++eitr) {
+  for (typename boost::graph_traits<Poly>::edges_size_type i = 0; i < num_edge; i++, ++eitr) {
     vertex_descriptor vh = insert_vertex(p, halfedge(*eitr,p));
     put(vpm,vh, edge_point_buffer[i]);
   }
   face_iterator fitr = faces(p).first;
-  for (size_t i = 0; i < num_facet; i++, ++fitr) {
+  for (typename boost::graph_traits<Poly>::faces_size_type i = 0; i < num_facet; i++, ++fitr) {
     // Step 2.
     Halfedge_around_face_circulator hcir_begin(halfedge(*fitr,p),p);
     Halfedge_around_face_circulator hcir = hcir_begin;
@@ -261,7 +261,7 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   // Update the geometry data of the newly inserted vertices by the
   // vertices buffer
   vitr = vertices(p).first;
-  for (size_t i = 0; i < num_vertex; i++, ++vitr)
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_vertex; i++, ++vitr)
     put(vpm, *vitr, vertex_point_buffer[i]);
 
 //  CGAL_postcondition(p.is_valid());
@@ -312,13 +312,13 @@ void DQQ_1step_impl(Poly& p, VertexPointMap vpm, Mask mask, CGAL::Tag_false) {
 
   // Build the connectivity using insert_vertex() and insert_edge()
   pi = 0;
-  for (size_t i = 0; i < num_v; ++i) {
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_v; ++i) {
     vertex_descriptor vh = *vitr;
     ++vitr;
 
     Halfedge_around_target_circulator<Poly> vcir(vh,p);
-    size_t vn = degree(vh,p);
-    for (size_t j = 0; j < vn; ++j) {
+    typename boost::graph_traits<Poly>::degree_size_type vn = degree(vh,p);
+    for (typename boost::graph_traits<Poly>::degree_size_type j = 0; j < vn; ++j) {
       halfedge_descriptor e = *vcir;
       ++vcir;
       if (! is_border(e,p)) {
@@ -328,7 +328,7 @@ void DQQ_1step_impl(Poly& p, VertexPointMap vpm, Mask mask, CGAL::Tag_false) {
     }
 
     vcir = Halfedge_around_target_circulator<Poly>(vh,p);
-    for (size_t j = 0; j < vn; ++j) {
+    for (typename boost::graph_traits<Poly>::vertices_size_type j = 0; j < vn; ++j) {
       if (! is_border(*vcir,p)) {
         halfedge_descriptor e1 = prev(*vcir, p);
         ++vcir;
@@ -343,7 +343,7 @@ void DQQ_1step_impl(Poly& p, VertexPointMap vpm, Mask mask, CGAL::Tag_false) {
   }
 
   edge_iterator eitr = edges(p).first;
-  for (size_t i = 0; i < num_e; ++i) {
+  for (typename boost::graph_traits<Poly>::edges_size_type i = 0; i < num_e; ++i) {
     halfedge_descriptor eh = halfedge(*eitr,p);
     ++eitr;
     if (! is_border(edge(eh,p),p)) {
@@ -378,7 +378,7 @@ void DQQ_1step_impl(Poly& p, VertexPointMap vpm, Mask mask, CGAL::Tag_false) {
   }
 
   vitr = vertices(p).first;
-  for (size_t i = 0; i < num_v-num_be; ++i) {
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_v-num_be; ++i) {
     vertex_descriptor vh = *vitr;
     ++vitr;
     Euler::remove_center_vertex(halfedge(vh,p),p);
@@ -624,7 +624,7 @@ void Sqrt3_1step(Poly& p, VertexPointMap vpm, Mask mask,
   // insert the new subdividing points
   face_iterator b,e;
   boost::tie(b,e) = faces(p);
-  for(std::size_t i=0, cpt_id=0; i < num_f; ++i, ++b){
+  for(typename boost::graph_traits<Poly>::faces_size_type i=0, cpt_id=0; i < num_f; ++i, ++b){
     face_descriptor fd = *b;
     halfedge_descriptor hd = face_halfedge_border[i];
     if(refine_border && hd != boost::graph_traits<Poly>::null_halfedge()) {
@@ -650,7 +650,7 @@ void Sqrt3_1step(Poly& p, VertexPointMap vpm, Mask mask,
 
   // flip the old edges (except the border edges)
   edge_iterator eitr = edges(p).first;
-  for (size_t i = 0; i < num_e; ++i) {
+  for (typename boost::graph_traits<Poly>::edges_size_type i = 0; i < num_e; ++i) {
     halfedge_descriptor e = halfedge(*eitr,p);
     ++eitr; // move to next edge before flip since flip destroys current edge
     if (! is_border(edge(e,p),p)) {

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -303,12 +303,17 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
 
   // Build the point_buffer
   int pi = 0;
+  int vi=0;
+  std::vector<bool> is_border_vertex(num_v, false);
   BOOST_FOREACH(vertex_descriptor vd, p_vertices){
     BOOST_FOREACH(halfedge_descriptor hd, halfedges_around_target(vd,p)){
       if (! is_border(hd,p)){
         mask.corner_node(hd, point_buffer[pi++]);
       }
+      else
+        is_border_vertex[vi]=true;
     }
+    ++vi;
   }
 
   // Reserve to avoid rellocations during insertions
@@ -365,7 +370,7 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
     }
   }
 
-  // After this point, the original border edges are in front!
+
   BOOST_FOREACH(halfedge_descriptor eeh, border_halfedges){
     halfedge_descriptor eh = eeh;
     if (is_border(eh,p)){
@@ -383,10 +388,11 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   }
 
   vitr = p_vertices.begin();
-  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_v-num_be; ++i) {
+  for (typename boost::graph_traits<Poly>::vertices_size_type i = 0; i < num_v; ++i) {
     vertex_descriptor vh = *vitr;
     ++vitr;
-    Euler::remove_center_vertex(halfedge(vh,p),p);
+    if (!is_border_vertex[i])
+      Euler::remove_center_vertex(halfedge(vh,p),p);
   }
 
   delete []point_buffer;

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -45,6 +45,16 @@ namespace Subdivision_method_3 {
 
 namespace internal {
 
+template <class PolygonMesh>
+void call_reserve(PolygonMesh& pm, std::size_t v, std::size_t e, std::size_t f)
+{
+  typedef boost::graph_traits<PolygonMesh> GT;
+  reserve(pm,
+          static_cast<typename GT::vertices_size_type>(v),
+          static_cast<typename GT::edges_size_type>(e),
+          static_cast<typename GT::faces_size_type>(f));
+}
+
 template <class Poly, class VertexPointMap, class Mask>
 void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   typedef typename boost::graph_traits<Poly>::vertex_descriptor       vertex_descriptor;
@@ -73,7 +83,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   // of the corresponding iterator to the begin of the iterator.
 
   // We need to reserve the memory to prevent reallocation.
-  reserve(p,num_v+num_e+num_f, 4*2*num_e, 4*num_e/2);
+  call_reserve(p,num_v+num_e+num_f, 4*2*num_e, 4*num_e/2);
 
   typedef typename boost::property_traits<VertexPointMap>::value_type Point;
 
@@ -196,7 +206,7 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   // of the corresponding iterator to the begin of the iterator.
 
   // We need to reserve the memory to prevent reallocation.
-  reserve(p,num_v + num_e, 2*2*num_e, 4*num_e/2);
+  call_reserve(p,num_v + num_e, 2*2*num_e, 4*num_e/2);
 
   Point* vertex_point_buffer = new Point[num_v + num_e];
   Point* edge_point_buffer = vertex_point_buffer + num_v;
@@ -315,7 +325,7 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   }
 
   // Reserve to avoid rellocations during insertions
-  reserve(p,num_v+num_e+num_f, 2*num_e, (2+4+2)*num_e);
+  call_reserve(p,num_v+num_e+num_f, 2*num_e, (2+4+2)*num_e);
 
   // Build the connectivity using insert_vertex() and insert_edge()
   pi = 0;
@@ -433,7 +443,7 @@ void Sqrt3_1step(Poly& p, VertexPointMap vpm, Mask mask,
   Point* cpt = new Point[new_pts_size];
 
   // size of the subdivided mesh
-  reserve(p,num_v + new_pts_size, (num_e + 2*num_f + new_pts_size)*2, 3*num_f);
+  call_reserve(p,num_v + new_pts_size, (num_e + 2*num_f + new_pts_size)*2, 3*num_f);
 
   // keep in memory whether a face is incident to the border and, if so, which
   // halfedge corresponds to THE (there can only be one) border edge.

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -577,12 +577,12 @@ public:
   /// computes the \f$ \sqrt{3}\f$ vertex-point `pt` of the vertex `vd`.
   void vertex_node(vertex_descriptor vertex, Point& pt) {
     Halfedge_around_target_circulator<Mesh> vcir(vertex, *(this->pmesh));
-    const size_t n = degree(vertex, *(this->pmesh));
+    const typename boost::graph_traits<Mesh>::degree_size_type n = degree(vertex, *(this->pmesh));
 
     const FT a = (FT) ((4.0-2.0*std::cos(2.0*CGAL_PI/(double)n))/9.0);
 
     Vector cv = ((FT)(1.0-a)) * (get(this->vpmap, vertex) - CGAL::ORIGIN);
-    for (size_t i = 1; i <= n; ++i, --vcir) {
+    for (typename boost::graph_traits<Mesh>::degree_size_type i = 1; i <= n; ++i, --vcir) {
       cv = cv + (a/FT(n))*(get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)))-CGAL::ORIGIN);
     }
 

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -92,6 +92,8 @@ public:
   typedef typename Base::FT                          FT;
   typedef typename Base::Point                       Point;
   typedef typename Base::Vector                      Vector;
+
+  typedef typename boost::property_traits<VertexPointMap>::reference Point_ref;
 #endif
 
 public:
@@ -116,8 +118,8 @@ public:
   }
 
   void edge_node(halfedge_descriptor edge, Point& pt) {
-    const Point& p1 = get(this->vpmap, target(edge, *(this->pmesh)));
-    const Point& p2 = get(this->vpmap, source(edge, *(this->pmesh)));
+    const Point_ref p1 = get(this->vpmap, target(edge, *(this->pmesh)));
+    const Point_ref p2 = get(this->vpmap, source(edge, *(this->pmesh)));
     pt = Point((p1[0]+p2[0])/2, (p1[1]+p2[1])/2, (p1[2]+p2[2])/2);
   }
 
@@ -172,6 +174,8 @@ public:
   typedef typename Base::FT                          FT;
   typedef typename Base::Point                       Point;
   typedef typename Base::Vector                      Vector;
+
+  typedef typename boost::property_traits<VertexPointMap>::reference Point_ref;
 #endif
 
 public:
@@ -212,7 +216,7 @@ public:
     typename boost::graph_traits<Mesh>::degree_size_type n = degree(vertex, *(this->pmesh));
 
     FT Q[] = {0.0, 0.0, 0.0}, R[] = {0.0, 0.0, 0.0};
-    Point& S = get(this->vpmap,vertex);
+    const Point_ref S = get(this->vpmap,vertex);
 
     Point q;
     for (unsigned int i = 0; i < n; i++, ++vcir) {

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -118,8 +118,8 @@ public:
   }
 
   void edge_node(halfedge_descriptor edge, Point& pt) {
-    const Point_ref p1 = get(this->vpmap, target(edge, *(this->pmesh)));
-    const Point_ref p2 = get(this->vpmap, source(edge, *(this->pmesh)));
+    Point_ref p1 = get(this->vpmap, target(edge, *(this->pmesh)));
+    Point_ref p2 = get(this->vpmap, source(edge, *(this->pmesh)));
     pt = Point((p1[0]+p2[0])/2, (p1[1]+p2[1])/2, (p1[2]+p2[2])/2);
   }
 
@@ -200,8 +200,8 @@ public:
 
   /// computes the Catmull-Clark edge-point `pt` of the edge `edge`.
   void edge_node(halfedge_descriptor edge, Point& pt) {
-    const Point& p1 = get(this->vpmap,target(edge, *(this->pmesh)));
-    const Point& p2 = get(this->vpmap,source(edge, *(this->pmesh)));
+    Point_ref p1 = get(this->vpmap,target(edge, *(this->pmesh)));
+    Point_ref p2 = get(this->vpmap,source(edge, *(this->pmesh)));
     Point f1, f2;
     this->face_node(face(edge, *(this->pmesh)), f1);
     this->face_node(face(opposite(edge, *(this->pmesh)), *(this->pmesh)), f2);
@@ -216,11 +216,11 @@ public:
     typename boost::graph_traits<Mesh>::degree_size_type n = degree(vertex, *(this->pmesh));
 
     FT Q[] = {0.0, 0.0, 0.0}, R[] = {0.0, 0.0, 0.0};
-    const Point_ref S = get(this->vpmap,vertex);
+    Point_ref S = get(this->vpmap,vertex);
 
     Point q;
     for (typename boost::graph_traits<Mesh>::degree_size_type i = 0; i < n; i++, ++vcir) {
-      const Point& p2 = get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
+      Point_ref p2 = get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
       R[0] += (S[0] + p2[0]) / 2;
       R[1] += (S[1] + p2[1]) / 2;
       R[2] += (S[2] + p2[2]) / 2;
@@ -240,15 +240,15 @@ public:
   /// computes the Catmull-Clark edge-point `ept` and the Catmull-Clark
   /// vertex-point `vpt` of the border edge `edge`.
   void border_node(halfedge_descriptor edge, Point& ept, Point& vpt) {
-    const Point& ep1 = get(this->vpmap,target(edge, *(this->pmesh)));
-    const Point& ep2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
+    Point_ref ep1 = get(this->vpmap,target(edge, *(this->pmesh)));
+    Point_ref ep2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
     ept = Point((ep1[0]+ep2[0])/2, (ep1[1]+ep2[1])/2, (ep1[2]+ep2[2])/2);
 
     Halfedge_around_target_circulator<Mesh> vcir(edge, *(this->pmesh));
-    const Point& vp1  = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
-    const Point& vp0  = get(this->vpmap, target(*vcir, *(this->pmesh)));
+    Point_ref vp1  = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
+    Point_ref vp0  = get(this->vpmap, target(*vcir, *(this->pmesh)));
     --vcir;
-    const Point& vp_1 = get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
+    Point_ref vp_1 = get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
     vpt = Point((vp_1[0] + 6*vp0[0] + vp1[0])/8,
                 (vp_1[1] + 6*vp0[1] + vp1[1])/8,
                 (vp_1[2] + 6*vp0[2] + vp1[2])/8 );
@@ -299,6 +299,7 @@ public:
   typedef typename Base::FT                          FT;
   typedef typename Base::Point                       Point;
   typedef typename Base::Vector                      Vector;
+  typedef typename boost::property_traits<VertexPointMap>::reference Point_ref;
 #endif
 
   typedef Halfedge_around_face_circulator<Mesh> Halfedge_around_facet_circulator;
@@ -326,10 +327,10 @@ public:
 
   /// computes the Loop edge-point `pt` of the edge `edge`.
   void edge_node(halfedge_descriptor edge, Point& pt) {
-    const Point& p1 = get(this->vpmap,target(edge, *(this->pmesh)));
-    const Point& p2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
-    const Point& f1 = get(this->vpmap,target(next(edge, *(this->pmesh)), *(this->pmesh)));
-    const Point& f2 = get(this->vpmap,target(next(opposite(edge, *(this->pmesh)), *(this->pmesh)), *(this->pmesh)));
+    Point_ref p1 = get(this->vpmap,target(edge, *(this->pmesh)));
+    Point_ref p2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
+    Point_ref f1 = get(this->vpmap,target(next(edge, *(this->pmesh)), *(this->pmesh)));
+    Point_ref f2 = get(this->vpmap,target(next(opposite(edge, *(this->pmesh)), *(this->pmesh)), *(this->pmesh)));
 
     pt = Point((3*(p1[0]+p2[0])+f1[0]+f2[0])/8,
                (3*(p1[1]+p2[1])+f1[1]+f2[1])/8,
@@ -342,10 +343,10 @@ public:
     size_t n = circulator_size(vcir);
 
     FT R[] = {0.0, 0.0, 0.0};
-    const Point& S = get(this->vpmap,vertex);
+    Point_ref S = get(this->vpmap,vertex);
 
     for (size_t i = 0; i < n; i++, ++vcir) {
-      const Point& p = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
+      Point_ref p = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
       R[0] += p[0]; 	R[1] += p[1]; 	R[2] += p[2];
     }
     if (n == 6) {
@@ -364,15 +365,15 @@ public:
 
   /// computes the Loop edge-point `ept` and the Loop vertex-point `vpt` of the border edge `edge`.
   void border_node(halfedge_descriptor edge, Point& ept, Point& vpt) {
-    const Point& ep1 = get(this->vpmap,target(edge, *(this->pmesh)));
-    const Point& ep2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
+    Point_ref ep1 = get(this->vpmap,target(edge, *(this->pmesh)));
+    Point_ref ep2 = get(this->vpmap,target(opposite(edge, *(this->pmesh)), *(this->pmesh)));
     ept = Point((ep1[0]+ep2[0])/2, (ep1[1]+ep2[1])/2, (ep1[2]+ep2[2])/2);
 
     Halfedge_around_vertex_circulator vcir(edge, *(this->pmesh));
-    const Point& vp1  = get(this->vpmap,target(opposite(*vcir, *(this->pmesh) ), *(this->pmesh)));
-    const Point& vp0  = get(this->vpmap,target(*vcir, *(this->pmesh)));
+    Point_ref vp1  = get(this->vpmap,target(opposite(*vcir, *(this->pmesh) ), *(this->pmesh)));
+    Point_ref vp0  = get(this->vpmap,target(*vcir, *(this->pmesh)));
     --vcir;
-    const Point& vp_1 = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
+    Point_ref vp_1 = get(this->vpmap,target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
     vpt = Point((vp_1[0] + 6*vp0[0] + vp1[0])/8,
                 (vp_1[1] + 6*vp0[1] + vp1[1])/8,
                 (vp_1[2] + 6*vp0[2] + vp1[2])/8 );
@@ -460,6 +461,7 @@ public:
   typedef typename Base::FT                          FT;
   typedef typename Base::Point                       Point;
   typedef typename Base::Vector                      Vector;
+  typedef typename boost::property_traits<VertexPointMap>::reference Point_ref;
 #endif
 
 public:

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -219,7 +219,7 @@ public:
     const Point_ref S = get(this->vpmap,vertex);
 
     Point q;
-    for (unsigned int i = 0; i < n; i++, ++vcir) {
+    for (typename boost::graph_traits<Mesh>::degree_size_type i = 0; i < n; i++, ++vcir) {
       const Point& p2 = get(this->vpmap, target(opposite(*vcir, *(this->pmesh)), *(this->pmesh)));
       R[0] += (S[0] + p2[0]) / 2;
       R[1] += (S[1] + p2[1]) / 2;

--- a/Subdivision_method_3/test/Subdivision_method_3/test_Subdivision_method_3.cpp
+++ b/Subdivision_method_3/test/Subdivision_method_3/test_Subdivision_method_3.cpp
@@ -338,7 +338,7 @@ void test_Subdivision_surface_3_SM_NP() {
 
     // some arbitrary new coordinates (different from the internal vpm)
     BOOST_FOREACH(vertex_descriptor vd, vertices(P)) {
-      const Point& pt = get(vpm, vd);
+      boost::property_traits<VPM>::reference pt = get(vpm, vd);
       Vector v = pt - Point(0., 0., -3.);
       put(apm, vd, pt + 0.5*v);
     }


### PR DESCRIPTION
At the same time I updated examples that were using an undocumented API