### PR TITLE
Workaround conversion warning

### DIFF
--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -1268,7 +1268,7 @@ private:
       propagateRight = rightSide;
     }
 
-    if (node->level() <= num_faces(m_graph))
+    if (node->level() <= static_cast<std::size_t>(num_faces(m_graph)))
     {
       if (propagateLeft)
       {


### PR DESCRIPTION
The level type is hard-coded as `std::size_t` while `num_faces()` returns a type from `graph_traits` that might be signed (which causes the warning I have).
