### PR TITLE
Polygon Mesh Processing documenation - Correct spelling mistake

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -225,7 +225,7 @@ Mathematically speaking, the intersection with an infinitesimally small ball
 centered in the output volume is a topological ball. At the surface level this means
 that no non-manifold vertex or edge is allowed in the output. For example, it
 is not possible to compute the union of two cubes that are disjoint but sharing an edge.
-In case you have to deal with such scenarii, you should consider using the
+In case you have to deal with such scenarios, you should consider using the
 package \ref PkgNef3Summary.
 
 It is possible to update the input so that it contains the result (in-place operation).


### PR DESCRIPTION
## Summary of Changes
Change the word 'scenarii' to 'scenarios'

## Release Management

* Affected package(s): PMP documentation
* Feature/Small Feature (if any): none

