### PR TITLE
P2T2: Precautionary template parameter renaming 

### DIFF
--- a/GraphicsView/demo/Periodic_2_triangulation_2/Periodic_2_Delaunay_triangulation_2.cpp
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/Periodic_2_Delaunay_triangulation_2.cpp
@@ -30,7 +30,8 @@
 #include "ui_Periodic_2_triangulation_2.h"
 #include <CGAL/Qt/DemosMainWindow.h>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel     EPIC;
+//typedef CGAL::Exact_predicates_inexact_constructions_kernel     EPIC;
+struct EPIC : public CGAL::Exact_predicates_inexact_constructions_kernel {};
 typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<EPIC>  Gt;
 typedef Gt::Point_2                                             Point_2;
 typedef Gt::Iso_rectangle_2                                     Iso_rectangle_2;

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_Delaunay_triangulation_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_Delaunay_triangulation_traits_2.h
@@ -32,19 +32,19 @@
 
 #include <CGAL/internal/Has_boolean_tags.h>
 
-namespace CGAL
-{
+namespace CGAL {
 
-template < class K, class Off = typename CGAL::Periodic_2_offset_2 >
+template <class K_,
+          class Off_ = typename CGAL::Periodic_2_offset_2>
 class Periodic_2_Delaunay_triangulation_traits_base_2
-  : public Periodic_2_triangulation_traits_2<K, Off>
+  : public Periodic_2_triangulation_traits_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K, Off>  Self;
-  typedef Periodic_2_triangulation_traits_2<K, Off>                Base;
+  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K_, Off_>  Self;
+  typedef Periodic_2_triangulation_traits_2<K_, Off_>                Base;
 
 public:
-  typedef K                                   Kernel;
-  typedef Off                                 Offset;
+  typedef K_                                  Kernel;
+  typedef Off_                                Offset;
 
   typedef typename Base::RT                   RT;
   typedef typename Base::FT                   FT;
@@ -54,36 +54,36 @@ public:
 
 public:
   Periodic_2_Delaunay_triangulation_traits_base_2(const Iso_rectangle_2& domain,
-                                                  const K& k)
+                                                  const Kernel& k)
     : Base(domain, k)
   { }
 
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Compare_distance_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Compare_distance_2>
       Compare_distance_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Side_of_oriented_circle_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Side_of_oriented_circle_2>
       Side_of_oriented_circle_2;
 
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Construct_circumcenter_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Construct_circumcenter_2>
       Construct_circumcenter_2;
-
-  using Base::construct_point_2_object;
 
   Compare_distance_2 compare_distance_2_object() const {
     return Compare_distance_2(this->Base::compare_distance_2_object(),
-                              construct_point_2_object());
+                              this->construct_point_2_object());
   }
   Side_of_oriented_circle_2 side_of_oriented_circle_2_object() const {
-    return Side_of_oriented_circle_2(this->Base::side_of_oriented_circle_2_object(), construct_point_2_object());
+    return Side_of_oriented_circle_2(this->Base::side_of_oriented_circle_2_object(),
+                                     this->construct_point_2_object());
   }
 
   Construct_circumcenter_2 construct_circumcenter_2_object() const {
-    return Construct_circumcenter_2(this->Base::construct_circumcenter_2_object(), construct_point_2_object());
+    return Construct_circumcenter_2(this->Base::construct_circumcenter_2_object(),
+                                    this->construct_point_2_object());
   }
 };
 
-template < typename K,
-           typename Off = CGAL::Periodic_2_offset_2,
-           bool Has_filtered_predicates = internal::Has_filtered_predicates<K>::value >
+template <class K_,
+          class Off_ = CGAL::Periodic_2_offset_2,
+          bool Has_filtered_predicates_ = internal::Has_filtered_predicates<K_>::value >
 class Periodic_2_Delaunay_triangulation_traits_2;
 
 } //namespace CGAL
@@ -93,34 +93,36 @@ class Periodic_2_Delaunay_triangulation_traits_2;
 
 namespace CGAL {
 
-template < class K, class Off>
-class Periodic_2_Delaunay_triangulation_traits_2<K, Off, false>
-  : public Periodic_2_Delaunay_triangulation_traits_base_2<K, Off>
+template <class K_, class Off_>
+class Periodic_2_Delaunay_triangulation_traits_2<K_, Off_, false>
+  : public Periodic_2_Delaunay_triangulation_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K, Off> Base;
+  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K_, Off_> Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                        Kernel;
+  typedef typename Kernel::Iso_rectangle_2                          Iso_rectangle_2;
 
   Periodic_2_Delaunay_triangulation_traits_2(const Iso_rectangle_2& domain = Iso_rectangle_2(0,0,1,1),
-                                             const K& k = K())
+                                             const Kernel& k = Kernel())
     : Base(domain, k)
   { }
 };
 
-template < typename K, typename Off >
-class Periodic_2_Delaunay_triangulation_traits_2<K, Off, true>
+template <typename K_, typename Off_>
+class Periodic_2_Delaunay_triangulation_traits_2<K_, Off_, true>
     : public Periodic_2_Delaunay_triangulation_filtered_traits_2<
-               K, Off, internal::Has_static_filters<K>::value>
+               K_, Off_, internal::Has_static_filters<K_>::value>
 {
   typedef Periodic_2_Delaunay_triangulation_filtered_traits_2<
-            K, Off, internal::Has_static_filters<K>::value>      Base;
+            K_, Off_, internal::Has_static_filters<K_>::value>      Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                        Kernel;
+  typedef typename Kernel::Iso_rectangle_2                          Iso_rectangle_2;
 
   Periodic_2_Delaunay_triangulation_traits_2(const Iso_rectangle_2& domain = Iso_rectangle_2(0,0,1,1),
-                                             const K& k = K())
+                                             const Kernel& k = Kernel())
     : Base(domain, k)
   { }
 };

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_traits_2.h
@@ -33,52 +33,54 @@
 
 namespace CGAL {
 
-template < class K, class Off = typename CGAL::Periodic_2_offset_2 >
+template <class K_,
+          class Off_ = typename CGAL::Periodic_2_offset_2 >
 class Periodic_2_triangulation_traits_base_2
-  : public K
+  : public K_
 {
-  typedef Periodic_2_triangulation_traits_base_2<K, Off>           Self;
-  typedef K                                                        Base;
+  typedef Periodic_2_triangulation_traits_base_2<K_, Off_>         Self;
+  typedef K_                                                       Base;
 
-public: // Undocumented
-  typedef K                                Kernel;
-  typedef Off                              Offset;
+public:
+  typedef K_                                    Kernel;
+  typedef Off_                                  Offset;
 
-  typedef typename K::FT                   FT;
-  typedef typename K::RT                   RT;
-  typedef typename K::Point_2              Point_2;
-  typedef typename K::Segment_2            Segment_2;
-  typedef typename K::Triangle_2           Triangle_2;
-  typedef Offset                           Periodic_2_offset_2;
-  typedef typename K::Iso_rectangle_2      Iso_rectangle_2;
+  typedef typename Kernel::FT                   FT;
+  typedef typename Kernel::RT                   RT;
+  typedef typename Kernel::Point_2              Point_2;
+  typedef typename Kernel::Segment_2            Segment_2;
+  typedef typename Kernel::Triangle_2           Triangle_2;
+  typedef typename Kernel::Iso_rectangle_2      Iso_rectangle_2;
 
-  typedef Periodic_2_construct_point_2<Self, typename K::Construct_point_2>
+  typedef Offset                                Periodic_2_offset_2;
+
+  typedef Periodic_2_construct_point_2<Self, typename Kernel::Construct_point_2>
       Construct_point_2;
 
   // Triangulation predicates
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Less_x_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Less_x_2>
       Less_x_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Less_y_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Less_y_2>
       Less_y_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Compare_x_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Compare_x_2>
       Compare_x_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Compare_y_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Compare_y_2>
       Compare_y_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Orientation_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Orientation_2>
       Orientation_2;
 
   // Triangulation constructions
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Construct_segment_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Construct_segment_2>
       Construct_segment_2;
-  typedef Functor_with_offset_points_adaptor_2<Self, typename K::Construct_triangle_2>
+  typedef Functor_with_offset_points_adaptor_2<Self, typename Kernel::Construct_triangle_2>
       Construct_triangle_2;
 
   // Constructor
   virtual ~Periodic_2_triangulation_traits_base_2() { }
 
   Periodic_2_triangulation_traits_base_2(const Iso_rectangle_2& domain,
-                                         const K& k)
-    : K(k), _domain(domain)
+                                         const Kernel& k)
+    : Base(k), _domain(domain)
   { }
 
   // Access
@@ -87,32 +89,32 @@ public: // Undocumented
 
   // Operations
   Construct_point_2 construct_point_2_object() const {
-    return Construct_point_2(&_domain, this->K::construct_point_2_object());
+    return Construct_point_2(&_domain, this->Kernel::construct_point_2_object());
   }
 
     // Predicates
   Less_x_2 less_x_2_object() const {
-    return Less_x_2(this->K::less_x_2_object(), construct_point_2_object());
+    return Less_x_2(this->Kernel::less_x_2_object(), construct_point_2_object());
   }
   Less_y_2 less_y_2_object() const {
-    return Less_y_2(this->K::less_y_2_object(), construct_point_2_object());
+    return Less_y_2(this->Kernel::less_y_2_object(), construct_point_2_object());
   }
   Compare_x_2 compare_x_2_object() const {
-    return Compare_x_2(this->K::compare_x_2_object(), construct_point_2_object());
+    return Compare_x_2(this->Kernel::compare_x_2_object(), construct_point_2_object());
   }
   Compare_y_2 compare_y_2_object() const {
-    return Compare_y_2(this->K::compare_y_2_object(), construct_point_2_object());
+    return Compare_y_2(this->Kernel::compare_y_2_object(), construct_point_2_object());
   }
   Orientation_2 orientation_2_object() const {
-    return Orientation_2(this->K::orientation_2_object(), construct_point_2_object());
+    return Orientation_2(this->Kernel::orientation_2_object(), construct_point_2_object());
   }
 
     // Constructions
   Construct_segment_2 construct_segment_2_object() const {
-    return Construct_segment_2(this->K::construct_segment_2_object(), construct_point_2_object());
+    return Construct_segment_2(this->Kernel::construct_segment_2_object(), construct_point_2_object());
   }
   Construct_triangle_2 construct_triangle_2_object() const {
-    return Construct_triangle_2(this->K::construct_triangle_2_object(), construct_point_2_object());
+    return Construct_triangle_2(this->Kernel::construct_triangle_2_object(), construct_point_2_object());
   }
 
 protected:
@@ -121,9 +123,9 @@ protected:
 
 
 // Forward declaration for the filtered traits
-template < typename K,
-           typename Off = CGAL::Periodic_2_offset_2,
-           bool Has_filtered_predicates = internal::Has_filtered_predicates<K>::value >
+template <class K_,
+          class Off_ = CGAL::Periodic_2_offset_2,
+          bool Has_filtered_predicates = internal::Has_filtered_predicates<K_>::value >
 class Periodic_2_triangulation_traits_2;
 
 } // namespace CGAL
@@ -134,34 +136,36 @@ class Periodic_2_triangulation_traits_2;
 namespace CGAL
 {
 
-template < class K, class Off >
-class Periodic_2_triangulation_traits_2<K, Off, false>
-  : public Periodic_2_triangulation_traits_base_2<K, Off>
+template <class K_, class Off_>
+class Periodic_2_triangulation_traits_2<K_, Off_, false>
+  : public Periodic_2_triangulation_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_triangulation_traits_base_2<K, Off> Base;
+  typedef Periodic_2_triangulation_traits_base_2<K_, Off_>        Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                      Kernel;
+  typedef typename Kernel::Iso_rectangle_2                        Iso_rectangle_2;
 
   Periodic_2_triangulation_traits_2(const Iso_rectangle_2& domain = Iso_rectangle_2(0,0,1,1),
-                                    const K& k = K())
+                                    const Kernel& k = Kernel())
     : Base(domain, k)
   { }
 };
 
-template < class K, class Off >
-class Periodic_2_triangulation_traits_2<K, Off, true>
+template <class K_, class Off_>
+class Periodic_2_triangulation_traits_2<K_, Off_, true>
   : public Periodic_2_triangulation_filtered_traits_2<
-             K, Off, internal::Has_static_filters<K>::value>
+             K_, Off_, internal::Has_static_filters<K_>::value>
 {
   typedef Periodic_2_triangulation_filtered_traits_2<
-            K, Off, internal::Has_static_filters<K>::value>  Base;
+            K_, Off_, internal::Has_static_filters<K_>::value>  Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                   Kernel;
+  typedef typename Kernel::Iso_rectangle_2                     Iso_rectangle_2;
 
   Periodic_2_triangulation_traits_2(const Iso_rectangle_2& domain = Iso_rectangle_2(0,0,1,1),
-                                    const K& k = K())
+                                    const Kernel& k = Kernel())
     : Base(domain, k)
   { }
 };

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_Delaunay_triangulation_filtered_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_Delaunay_triangulation_filtered_traits_2.h
@@ -36,29 +36,30 @@
 namespace CGAL {
 
 // The first template item is supposed to be a Filtered_kernel-like kernel.
-template < typename K, typename Off >
+template < typename K_, typename Off_>
 class Periodic_2_Delaunay_triangulation_filtered_traits_base_2
-  : public Periodic_2_Delaunay_triangulation_traits_base_2<K, Off>
+  : public Periodic_2_Delaunay_triangulation_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K, Off> Base;
+  typedef Periodic_2_Delaunay_triangulation_traits_base_2<K_, Off_> Base;
+  typedef K_                                                        Kernel;
 
   // Exact traits is based on the exact kernel.
-  typedef Periodic_2_Delaunay_triangulation_traits_2<typename K::Exact_kernel,
-                                                     Off>      Exact_traits;
+  typedef Periodic_2_Delaunay_triangulation_traits_2<typename Kernel::Exact_kernel, Off_>
+                                                                    Exact_traits;
   // Filtering traits is based on the filtering kernel.
-  typedef Periodic_2_Delaunay_triangulation_traits_2<typename K::Approximate_kernel,
-                                                     Off>      Filtering_traits;
+  typedef Periodic_2_Delaunay_triangulation_traits_2<typename Kernel::Approximate_kernel, Off_>
+                                                                    Filtering_traits;
 private:
-  typedef typename K::C2E C2E;
-  typedef typename K::C2F C2F;
+  typedef typename Kernel::C2E                C2E;
+  typedef typename Kernel::C2F                C2F;
 
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef typename Kernel::Iso_rectangle_2    Iso_rectangle_2;
 
 public:
   virtual ~Periodic_2_Delaunay_triangulation_filtered_traits_base_2() { }
 
   Periodic_2_Delaunay_triangulation_filtered_traits_base_2(const Iso_rectangle_2& domain,
-                                                           const K& k)
+                                                           const Kernel& k)
     :
       Base(domain, k),
       Delaunay_traits_e(C2E()(domain)),
@@ -121,9 +122,9 @@ protected:
   Filtering_traits Delaunay_traits_f;
 };
 
-template < typename K,
-           typename Off = CGAL::Periodic_2_offset_2,
-           bool Has_static_filters = internal::Has_static_filters<K>::value >
+template <class K_,
+          class Off_ = CGAL::Periodic_2_offset_2,
+          bool Has_static_filters_ = internal::Has_static_filters<K_>::value>
 class Periodic_2_Delaunay_triangulation_filtered_traits_2;
 
 } // namespace CGAL
@@ -132,32 +133,34 @@ class Periodic_2_Delaunay_triangulation_filtered_traits_2;
 
 namespace CGAL {
 
-template<class K, class Off>
-class Periodic_2_Delaunay_triangulation_filtered_traits_2<K, Off, false>
-  : public Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K, Off>
+template<class K_, class Off_>
+class Periodic_2_Delaunay_triangulation_filtered_traits_2<K_, Off_, false>
+  : public Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K, Off> Base;
+  typedef Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K_, Off_> Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                                 Kernel;
+  typedef typename Kernel::Iso_rectangle_2                                   Iso_rectangle_2;
 
   Periodic_2_Delaunay_triangulation_filtered_traits_2(const Iso_rectangle_2& domain,
-                                                      const K& k)
+                                                      const Kernel& k)
     : Base(domain, k)
   { }
 };
 
-template<class K, class Off>
-class Periodic_2_Delaunay_triangulation_filtered_traits_2<K, Off, true>
-  : public Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K, Off>
+template<class K_, class Off_>
+class Periodic_2_Delaunay_triangulation_filtered_traits_2<K_, Off_, true>
+  : public Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K, Off > Base;
+  typedef Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K_, Off_> Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                                       Kernel;
+  typedef typename Kernel::Iso_rectangle_2                                         Iso_rectangle_2;
 
   Periodic_2_Delaunay_triangulation_filtered_traits_2(const Iso_rectangle_2& domain,
-                                                      const K& k)
+                                                      const Kernel& k)
     : Base(domain, k)
   { }
 };

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_Delaunay_triangulation_statically_filtered_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_Delaunay_triangulation_statically_filtered_traits_2.h
@@ -28,19 +28,20 @@
 
 namespace CGAL {
 
-template< typename K,
-          typename Off = typename CGAL::Periodic_2_offset_2>
+template<class K_,
+         class Off_ = typename CGAL::Periodic_2_offset_2>
 class Periodic_2_Delaunay_triangulation_statically_filtered_traits_2
-  : public Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K, Off>
+  : public Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K, Off> Self;
-  typedef Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K, Off>       Base;
+  typedef Periodic_2_Delaunay_triangulation_statically_filtered_traits_2<K_, Off_> Self;
+  typedef Periodic_2_Delaunay_triangulation_filtered_traits_base_2<K_, Off_>       Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                                       Kernel;
+  typedef typename Kernel::Iso_rectangle_2                                         Iso_rectangle_2;
 
   Periodic_2_Delaunay_triangulation_statically_filtered_traits_2(const Iso_rectangle_2& domain,
-                                                                 const K& k)
+                                                                 const Kernel& k)
     : Base(domain, k)
   { }
 

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_construct_point_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_construct_point_2.h
@@ -26,13 +26,12 @@
 
 namespace CGAL {
 
-template < typename K, typename Construct_point_2_base>
+template < typename K_, typename Construct_point_2_base_>
 class Periodic_2_construct_point_2
-  : public Construct_point_2_base
+  : public Construct_point_2_base_
 {
-  typedef Construct_point_2_base             Base;
-
-  typedef K                                  Kernel;
+  typedef Construct_point_2_base_            Base;
+  typedef K_                                 Kernel;
 
   typedef typename Kernel::Point_2           Point;
   typedef typename Kernel::Offset            Offset;
@@ -40,7 +39,7 @@ class Periodic_2_construct_point_2
 
 public:
   Periodic_2_construct_point_2(const Iso_rectangle_2* dom,
-                               const Construct_point_2_base& cp)
+                               const Base& cp)
     : Base(cp), _dom(dom)
   { }
 

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_triangulation_filtered_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_triangulation_filtered_traits_2.h
@@ -37,12 +37,14 @@ namespace CGAL
 {
 // The Offset_converter is parametrized by a usual kernel converter,
 // and adds the conversions for Offsets.
-template < typename Converter >
+template <typename Converter_>
 struct Offset_converter_2
-  : public Converter
+  : public Converter_
 {
-  typedef typename Converter::Source_kernel Source_kernel;
-  typedef typename Converter::Target_kernel Target_kernel;
+  typedef Converter_                        Base;
+
+  typedef typename Base::Source_kernel      Source_kernel;
+  typedef typename Base::Target_kernel      Target_kernel;
 
   typedef typename Periodic_2_triangulation_traits_base_2<Source_kernel>::Offset   Source_off;
   typedef typename Periodic_2_triangulation_traits_base_2<Source_kernel>::Point_2  Source_pt;
@@ -50,35 +52,36 @@ struct Offset_converter_2
   typedef typename Periodic_2_triangulation_traits_base_2<Target_kernel>::Offset   Target_off;
   typedef typename Periodic_2_triangulation_traits_base_2<Target_kernel>::Point_2  Target_pt;
 
-  using Converter::operator();
+  using Base::operator();
 
   Target_off operator()(const Source_off &off) const { return off; }
 };
 
 // The argument is supposed to be a Filtered_kernel like kernel.
-template < typename K, typename Off >
+template <class K_, typename Off_>
 class Periodic_2_triangulation_filtered_traits_base_2
-  : public Periodic_2_triangulation_traits_base_2<K, Off>
+  : public Periodic_2_triangulation_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_triangulation_traits_base_2<K, Off> Base;
+  typedef Periodic_2_triangulation_traits_base_2<K_, Off_> Base;
+  typedef K_                                               Kernel;
 
-  typedef typename K::Exact_kernel                         EKernel;
-  typedef typename K::Approximate_kernel                   AKernel;
-  typedef typename K::C2E                                  C2E;
-  typedef typename K::C2F                                  C2F;
+  typedef typename Kernel::Exact_kernel                    EKernel;
+  typedef typename Kernel::Approximate_kernel              AKernel;
+  typedef typename Kernel::C2E                             C2E;
+  typedef typename Kernel::C2F                             C2F;
 
   // Exact traits is based on the exact kernel.
-  typedef Periodic_2_triangulation_traits_2<EKernel, Off>  Exact_traits;
+  typedef Periodic_2_triangulation_traits_2<EKernel, Off_> Exact_traits;
   // Filtering traits is based on the filtering kernel.
-  typedef Periodic_2_triangulation_traits_2<AKernel, Off>  Filtering_traits;
+  typedef Periodic_2_triangulation_traits_2<AKernel, Off_> Filtering_traits;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef typename Kernel::Iso_rectangle_2 Iso_rectangle_2;
 
   virtual ~Periodic_2_triangulation_filtered_traits_base_2() { }
 
   Periodic_2_triangulation_filtered_traits_base_2(const Iso_rectangle_2& domain,
-                                                  const K& k)
+                                                  const Kernel& k)
     : Base(domain, k),
       traits_e(C2E()(domain)),
       traits_f(C2F()(domain))
@@ -167,44 +170,45 @@ protected:
   Filtering_traits traits_f;
 };
 
-template < typename K,
-           typename Off = typename CGAL::Periodic_2_offset_2,
-           bool Has_static_filters = internal::Has_static_filters<K>::value >
+template <class K_,
+          class Off_ = typename CGAL::Periodic_2_offset_2,
+          bool Has_static_filters_ = internal::Has_static_filters<K_>::value >
 class Periodic_2_triangulation_filtered_traits_2;
 
 } //namespace CGAL
 
 #include <CGAL/internal/Periodic_2_triangulation_statically_filtered_traits_2.h>
 
-namespace CGAL
-{
+namespace CGAL {
 
-template < typename K, typename Off >
-class Periodic_2_triangulation_filtered_traits_2<K, Off, false>
-  : public Periodic_2_triangulation_filtered_traits_base_2<K, Off>
+template <class K_, class Off_>
+class Periodic_2_triangulation_filtered_traits_2<K_, Off_, false>
+  : public Periodic_2_triangulation_filtered_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_triangulation_filtered_traits_base_2<K, Off> Base;
+  typedef Periodic_2_triangulation_filtered_traits_base_2<K_, Off_> Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                        Kernel;
+  typedef typename Kernel::Iso_rectangle_2                          Iso_rectangle_2;
 
   Periodic_2_triangulation_filtered_traits_2(const Iso_rectangle_2& domain,
-                                             const K& k)
+                                             const Kernel& k)
     : Base(domain, k)
   { }
 };
 
-template < typename K, typename Off >
-class Periodic_2_triangulation_filtered_traits_2<K, Off, true>
-  : public Periodic_2_triangulation_statically_filtered_traits_2<K, Off>
+template <class K_, class Off_>
+class Periodic_2_triangulation_filtered_traits_2<K_, Off_, true>
+  : public Periodic_2_triangulation_statically_filtered_traits_2<K_, Off_>
 {
-  typedef Periodic_2_triangulation_statically_filtered_traits_2<K, Off> Base;
+  typedef Periodic_2_triangulation_statically_filtered_traits_2<K_, Off_> Base;
 
 public:
-  typedef typename K::Iso_rectangle_2 Iso_rectangle_2;
+  typedef K_                                                              Kernel;
+  typedef typename Kernel::Iso_rectangle_2                                Iso_rectangle_2;
 
   Periodic_2_triangulation_filtered_traits_2(const Iso_rectangle_2& domain,
-                                             const K& k)
+                                             const Kernel& k)
     : Base(domain, k)
   { }
 };

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_triangulation_statically_filtered_traits_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Periodic_2_triangulation_statically_filtered_traits_2.h
@@ -37,19 +37,20 @@
 
 namespace CGAL {
 
-template< typename K,
-          typename Off = typename CGAL::Periodic_2_offset_2>
+template<class K_,
+         class Off_ = typename CGAL::Periodic_2_offset_2>
 class Periodic_2_triangulation_statically_filtered_traits_2
-  : public Periodic_2_triangulation_filtered_traits_base_2<K, Off>
+  : public Periodic_2_triangulation_filtered_traits_base_2<K_, Off_>
 {
-  typedef Periodic_2_triangulation_statically_filtered_traits_2<K, Off>   Self;
-  typedef Periodic_2_triangulation_filtered_traits_base_2<K, Off>         Base;
+  typedef Periodic_2_triangulation_statically_filtered_traits_2<K_, Off_>   Self;
+  typedef Periodic_2_triangulation_filtered_traits_base_2<K_, Off_>         Base;
 
 public:
-  typedef typename K::Iso_rectangle_2     Iso_rectangle_2;
+  typedef K_                                                                Kernel;
+  typedef typename Kernel::Iso_rectangle_2                                  Iso_rectangle_2;
 
   Periodic_2_triangulation_statically_filtered_traits_2(const Iso_rectangle_2& domain,
-                                                        const K& k)
+                                                        const Kernel& k)
     : Base(domain, k)
   { }
 

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Static_filters/Periodic_2_orientation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Static_filters/Periodic_2_orientation_2.h
@@ -81,21 +81,18 @@
   }
 */
 
-namespace CGAL
-{
-namespace internal
-{
-namespace Static_filters_predicates
-{
+namespace CGAL {
+namespace internal {
+namespace Static_filters_predicates {
 
-template < class K, class Orientation_2_base >
+template <class K_, class Orientation_2_base_>
 class Periodic_2_orientation_2
-  : public Orientation_2_base
+  : public Orientation_2_base_
 {
-  typedef Orientation_2_base                      Base;
+  typedef Orientation_2_base_                     Base;
 
 public:
-  typedef K                                       Kernel;
+  typedef K_                                      Kernel;
 
   typedef typename Kernel::FT FT;
   typedef typename Kernel::Point_2                Point_2;
@@ -111,7 +108,7 @@ public:
   typedef typename Base::result_type  result_type;
 
   Periodic_2_orientation_2(const Iso_rectangle_2 * const dom,
-                           const Orientation_2_base& o2b)
+                           const Base& o2b)
     : Base(o2b), _dom(dom)
   { }
 

--- a/Periodic_2_triangulation_2/include/CGAL/internal/Static_filters/Periodic_2_side_of_oriented_circle_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/internal/Static_filters/Periodic_2_side_of_oriented_circle_2.h
@@ -32,21 +32,18 @@
 
 #include <CGAL/Periodic_2_offset_2.h>
 
-namespace CGAL
-{
-namespace internal
-{
-namespace Static_filters_predicates
-{
+namespace CGAL {
+namespace internal {
+namespace Static_filters_predicates {
 
-template < class K, class Side_of_oriented_circle_2_base >
+template <class K_, class Side_of_oriented_circle_2_base_>
 class Periodic_2_side_of_oriented_circle_2
-  : public Side_of_oriented_circle_2_base
+  : public Side_of_oriented_circle_2_base_
 {
-  typedef Side_of_oriented_circle_2_base                Base;
+  typedef Side_of_oriented_circle_2_base_               Base;
 
 public:
-  typedef K                                             Kernel;
+  typedef K_                                            Kernel;
 
   typedef typename Kernel::FT                           FT;
   typedef typename Kernel::Point_2                      Point_2;
@@ -60,7 +57,7 @@ public:
   typedef typename Base::result_type  result_type;
 
   Periodic_2_side_of_oriented_circle_2(const Iso_rectangle_2 * dom,
-                                       const Side_of_oriented_circle_2_base& socb)
+                                       const Base& socb)
     : Base(socb), _dom(dom)
   { }
 


### PR DESCRIPTION
## Summary of Changes

MSCV has some weird bug when compiling code like:

```
template<K>
struct T : K { T() : K() { }  };
```
if `K` defines a typedef `K` in one its bases.

This was encountered in #2369 ( https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-27/Periodic_2_triangulation_2_Demo/TestReport_jtournois_x64_Cygwin-Windows10_MSVC2015-Debug-64bits.gz ) but a simplification of the typedef ( fecfaac ) made it a non-issue.

A good workaround is to use safer template parameter names. Commit fecfaac is reverted so that the sanity of the template parameter names can be checked.

## Release Management

* Affected package(s): `Periodic_2_triangulation_2`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

