### PR TITLE
Fix a compilation error (on CentOS5)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -765,25 +765,6 @@ polylines_to_protect(const CGAL::Image_3& cgal_image,
   polylines_to_protect<P, Image_word_type>(cgal_image, polylines, 0, 0);
 }
 
-
-template <typename P,
-          typename Image_word_type,
-          typename PolylineInputIterator>
-void
-polylines_to_protect(const CGAL::Image_3& cgal_image,
-                     std::vector<std::vector<P> >& polylines,
-                     PolylineInputIterator existing_polylines_begin,
-                     PolylineInputIterator existing_polylines_end)
-{
-  polylines_to_protect<P>
-    (cgal_image,
-     polylines,
-     (Image_word_type*)0,
-     CGAL::Null_subdomain_index(),
-     existing_polylines_begin,
-     existing_polylines_end);
-}
-
 template <typename P,
           typename Image_word_type,
           typename Null_subdomain_index,
@@ -805,6 +786,24 @@ polylines_to_protect(const CGAL::Image_3& cgal_image,
      null,
      CGAL::Identity<Image_word_type>(),
      internal::Mesh_3::Returns_midpoint<K, Image_word_type>(),
+     existing_polylines_begin,
+     existing_polylines_end);
+}
+
+template <typename P,
+          typename Image_word_type,
+          typename PolylineInputIterator>
+void
+polylines_to_protect(const CGAL::Image_3& cgal_image,
+                     std::vector<std::vector<P> >& polylines,
+                     PolylineInputIterator existing_polylines_begin,
+                     PolylineInputIterator existing_polylines_end)
+{
+  polylines_to_protect<P>
+    (cgal_image,
+     polylines,
+     (Image_word_type*)0,
+     CGAL::Null_subdomain_index(),
      existing_polylines_begin,
      existing_polylines_end);
 }


### PR DESCRIPTION
## Summary of Changes

There is a compilation error with g++ 4.1 on CentOS 5:
```
[100%] Building CXX object CMakeFiles/mesh_3D_image_with_features.dir/mesh_3D_image_with_features.cpp.o
/usr/bin/c++   -DCGAL_MESH_3_NO_DEPRECATED_C3T3_ITERATORS -DCGAL_MESH_3_NO_DEPRECATED_SURFACE_INDEX -DCGAL_TEST_SUITE -DCGAL_TEST_SUITE=1 -DCGAL_USE_GMP -DCGAL_USE_MPFR -DCGAL_USE_ZLIB -DCGAL_USE_ZLIB=1 -Wall -frounding-math -I/home/cgal_tester/build/src/cmake/platforms/CentOS5/test/Mesh_3_Examples/../../include -I/home/cgal_tester/build/src/cmake/platforms/CentOS5/test/Mesh_3_Examples -isystem /home/cgal_tester/build/src/cmake/platforms/CentOS5/include -isystem /mnt/testsuite/include -isystem /usr/local/include    -Wall -frounding-math -o CMakeFiles/mesh_3D_image_with_features.dir/mesh_3D_image_with_features.cpp.o -c /home/cgal_tester/build/src/cmake/platforms/CentOS5/test/Mesh_3_Examples/mesh_3D_image_with_features.cpp
/mnt/testsuite/include/CGAL/Mesh_3/polylines_to_protect.h: In function ‘void CGAL::polylines_to_protect(const CGAL::Image_3&, std::vector<std::vector<IC, std::allocator<_CharT> >, std::allocator<std::vector<IC, std::allocator<_CharT> > > >&, PolylineInputIterator, PolylineInputIterator) [with P = CGAL::Point_3<CGAL::Epick>, Image_word_type = unsigned char, PolylineInputIterator = __gnu_cxx::__normal_iterator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >*, std::vector<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >, std::allocator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > > > > >]’:
/home/cgal_tester/build/src/cmake/platforms/CentOS5/test/Mesh_3_Examples/mesh_3D_image_with_features.cpp:62:   instantiated from here
/mnt/testsuite/include/CGAL/Mesh_3/polylines_to_protect.h:778: error: no matching function for call to ‘polylines_to_protect(const CGAL::Image_3&, std::vector<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >, std::allocator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > > > >&, unsigned char*, CGAL::Null_subdomain_index, __gnu_cxx::__normal_iterator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >*, std::vector<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >, std::allocator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > > > > >&, __gnu_cxx::__normal_iterator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >*, std::vector<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > >, std::allocator<std::vector<CGAL::Point_3<CGAL::Epick>, std::allocator<CGAL::Point_3<CGAL::Epick> > > > > >&)’
```
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-116/Mesh_3_Examples/TestReport_lrineau_CentOS5.gz

Swapping the two function templates fixes the issue.

The error was introduced by PR #2583 in `master`, for 4.12.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #2583

Cc @MaelRL who spotted the red cell in the testsuite results.
