### PR TITLE
Demo parameterization plugin : avoid conversion warning

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -317,7 +317,7 @@ uv = graph->add_property_map<halfedge_descriptor,std::pair<float, float> >("h:uv
     }
   }
 
-  int number_of_components()const{return components->size();}
+  int number_of_components()const{return static_cast<int>(components->size());}
   int current_component()const{return m_current_component;}
   void set_current_component(int n){m_current_component = n;}
 


### PR DESCRIPTION
## Summary of Changes

Avoid a conversion warning (`std::size_t` to `int`) for msvc 2013

## Release Management

* Affected package(s): 3D demo
* Issue(s) solved (if any): fix #2683

