### PR TITLE
Polyhedron demo: add some OpenGL debugging information 

### DIFF
--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -508,9 +508,6 @@ void CGAL::QGLViewer::postDraw() {
   if (displayMessage_)
     drawText(10, height() - 10, message_);
 
-  // Restore GL state
-  glPopAttrib();
-  glPopMatrix();
 }
 
 /*! Called before draw() (instead of preDraw()) when viewer displaysInStereo().

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -221,6 +221,7 @@ void CGAL::QGLViewer::initializeGL() {
   format.setVersion(4,3);
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
   format.setSamples(0);
+  format.setOption(QSurfaceFormat::DebugContext);
   context()->setFormat(format);
   bool created = context()->create();
   if(!created || context()->format().profile() != QSurfaceFormat::CompatibilityProfile) {

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -12,6 +12,7 @@
 #include <QInputDialog>
 #include <cmath>
 #include <QApplication>
+#include <QOpenGLDebugLogger>
 
 #if defined(_WIN32)
 #include <QMimeData>
@@ -38,6 +39,7 @@ public:
   QTimer messageTimer;
   QOpenGLFunctions_4_3_Compatibility* _recentFunctions;
   bool is_2d_selection_mode;
+  QOpenGLDebugLogger *logger;
 
   //! The buffers used to draw the axis system
   QOpenGLBuffer buffer;
@@ -197,8 +199,18 @@ void Viewer::init()
   else
   {
     d->_recentFunctions = new QOpenGLFunctions_4_3_Compatibility();
-    d->_recentFunctions->initializeOpenGLFunctions();
-  }
+    d->logger = new QOpenGLDebugLogger(this);
+    if(!d->logger->initialize())
+      qDebug()<<"logger could not init.";
+    else{
+      connect(d->logger, SIGNAL(messageLogged(QOpenGLDebugMessage)), this, SLOT(messageLogged(QOpenGLDebugMessage)));
+      d->logger->startLogging();
+    }
+    
+    if(isOpenGL_4_3())
+    {
+      d->_recentFunctions->initializeOpenGLFunctions();
+    }
   glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDARBPROC)this->context()->getProcAddress("glDrawArraysInstancedARB");
   if(!glDrawArraysInstanced)
   {
@@ -1025,3 +1037,68 @@ void Viewer::setStaticImage(QImage image) { d->static_image = image; }
 
 const QImage& Viewer:: staticImage() const { return d->static_image; }
 
+void Viewer::messageLogged(QOpenGLDebugMessage msg)
+{
+  QString error;
+
+  // Format based on severity
+  switch (msg.severity())
+  {
+  case QOpenGLDebugMessage::NotificationSeverity:
+    return;
+    break;
+  case QOpenGLDebugMessage::HighSeverity:
+    error += "GL ERROR :";
+    break;
+  case QOpenGLDebugMessage::MediumSeverity:
+    error += "GL WARNING :";
+    break;
+  case QOpenGLDebugMessage::LowSeverity:
+    error += "GL NOTE :";
+    break;
+  default:
+    break;
+  }
+
+  error += " (";
+
+  // Format based on source
+#define CASE(c) case QOpenGLDebugMessage::c: error += #c; break
+  switch (msg.source())
+  {
+  CASE(APISource);
+  CASE(WindowSystemSource);
+  CASE(ShaderCompilerSource);
+  CASE(ThirdPartySource);
+  CASE(ApplicationSource);
+  CASE(OtherSource);
+  CASE(InvalidSource);
+  default:
+    break;
+  }
+#undef CASE
+
+  error += " : ";
+
+  // Format based on type
+#define CASE(c) case QOpenGLDebugMessage::c: error += #c; break
+  switch (msg.type())
+  {
+  CASE(ErrorType);
+  CASE(DeprecatedBehaviorType);
+  CASE(UndefinedBehaviorType);
+  CASE(PortabilityType);
+  CASE(PerformanceType);
+  CASE(OtherType);
+  CASE(MarkerType);
+  CASE(GroupPushType);
+  CASE(GroupPopType);
+  default:
+    break;
+  }
+#undef CASE
+
+  error += ")";
+  qDebug() << qPrintable(error) << "\n" << qPrintable(msg.message()) << "\n";
+}
+ #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -206,11 +206,8 @@ void Viewer::init()
       connect(d->logger, SIGNAL(messageLogged(QOpenGLDebugMessage)), this, SLOT(messageLogged(QOpenGLDebugMessage)));
       d->logger->startLogging();
     }
-    
-    if(isOpenGL_4_3())
-    {
-      d->_recentFunctions->initializeOpenGLFunctions();
-    }
+    d->_recentFunctions->initializeOpenGLFunctions();
+  }
   glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDARBPROC)this->context()->getProcAddress("glDrawArraysInstancedARB");
   if(!glDrawArraysInstanced)
   {

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1098,4 +1098,3 @@ void Viewer::messageLogged(QOpenGLDebugMessage msg)
   error += ")";
   qDebug() << qPrintable(error) << "\n" << qPrintable(msg.message()) << "\n";
 }
- #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -6,6 +6,7 @@
 #include <CGAL/Three/Viewer_config.h>
 #include <CGAL/Three/Scene_interface.h>
 #include <QOpenGLBuffer>
+#include <QOpenGLDebugMessage>
 #include <QOpenGLVertexArrayObject>
 #include <QOpenGLShaderProgram>
 #include <CGAL/Three/Viewer_interface.h>
@@ -116,6 +117,7 @@ public Q_SLOTS:
   {
     setMouseBinding(::Qt::ShiftModifier, ::Qt::LeftButton, CGAL::qglviewer::NO_CLICK_ACTION);
   }
+  void messageLogged(QOpenGLDebugMessage);
 
 protected:
   void paintEvent(QPaintEvent *)Q_DECL_OVERRIDE;


### PR DESCRIPTION
## Summary of Changes

Add a QOpenGLDebugLogger to the viewer to easily track errors and warning from OpenGL. 
Unfortunately this will probably not help us tracking context errors, as this system is dependant of the said context.
