### PR TITLE
fix incorrect INTERFACE_INCLUDE_DIRECTORIES that causes compilation error for downstream project

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -107,7 +107,7 @@ function(CGAL_setup_CGAL_dependencies target)
       $<BUILD_INTERFACE:${dir}>)
   endforeach()
   target_include_directories(${target} ${keyword}
-    $<INSTALL_INTERFACE:include/CGAL>)
+    $<INSTALL_INTERFACE:include>)
 
   # Now setup compilation flags
   if(MSVC)


### PR DESCRIPTION
## Summary of Changes

Prior to the change, even with the below simplest code will have compilation error

CMakeLists

```cmake
cmake_minimum_required(VERSION 3.9)

project(Example)

set(PROJECT_SRCS ${PROJECT_SOURCE_DIR}/main.cpp)

find_package( CGAL REQUIRED )

add_executable(${PROJECT_NAME} ${PROJECT_SRCS})

target_link_libraries(${PROJECT_NAME} CGAL::CGAL)
```

main.cpp

```c++
#include "CGAL/remove_outliers.h"

int main(){
return 0;
}

```

Compilation error

```
In file included from /usr/include/c++/5/cstddef:45:0,
                 from /usr/include/boost/config/select_stdlib_config.hpp:18,
                 from /usr/include/boost/config.hpp:44,
                 from /usr/include/CGAL/config.h:111,
                 from /usr/include/CGAL/license/Point_set_processing_3.h:27,
                 from /usr/include/CGAL/remove_outliers.h:24,
                 from /home/hypevr/test/main.cpp:1:
/usr/include/CGAL/stddef.h:19:2: error: #error You have added .../path/to/CGAL-x.y/include/CGAL to the INCLUDE path. You should use .../path/to/CGAL-x.y/include instead.
 #error You have added .../path/to/CGAL-x.y/include/CGAL to the INCLUDE path. Yo
  ^
In file included from /usr/include/unistd.h:229:0,
                 from /usr/include/boost/config/stdlib/libstdcpp3.hpp:78,
                 from /usr/include/boost/config.hpp:48,
                 from /usr/include/CGAL/config.h:111,
                 from /usr/include/CGAL/license/Point_set_processing_3.h:27,
                 from /usr/include/CGAL/remove_outliers.h:24,
                 from /home/hypevr/test/main.cpp:1:
/usr/include/CGAL/stddef.h:19:2: error: #error You have added .../path/to/CGAL-x.y/include/CGAL to the INCLUDE path. You should use .../path/to/CGAL-x.y/include instead.
 #error You have added .../path/to/CGAL-x.y/include/CGAL to the INCLUDE path. Yo
  ^
In file included from /usr/include/stdlib.h:32:0,
                 from /usr/include/c++/5/cstdlib:72,
                 from /usr/include/boost/config/platform/linux.hpp:15,
                 from /usr/include/boost/config.hpp:57,
                 from /usr/include/CGAL/config.h:111,
                 from /usr/include/CGAL/license/Point_set_processing_3.h:27,
                 from /usr/include/CGAL/remove_outliers.h:24,
                 from /home/hypevr/test/main.cpp:1:

```

Based on the error message I back tracked in `CGALExports.cmake`

```cmake
set_target_properties(CGAL::CGAL PROPERTIES
  INTERFACE_COMPILE_OPTIONS "-frounding-math"
  INTERFACE_INCLUDE_DIRECTORIES "/usr/include/x86_64-linux-gnu;/usr/include;/usr/include;${_IMPORT_PREFIX}/include/CGAL"
  INTERFACE_LINK_LIBRARIES "/usr/lib/x86_64-linux-gnu/libgmp.so;/usr/lib/x86_64-linux-gnu/libmpfr.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so"
  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "/usr/include/x86_64-linux-gnu;/usr/include;/usr/include"
)
```

in the `INTERFACE_INCLUDE_DIRECTORIES` section there is an extra `${_IMPORT_PREFIX}/include/CGAL`. 

In order to remove this from the upstream, this PR is required to fix it.