### PR TITLE
Add boost iostream to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ addons:
       - libboost-system1.55-dev 
       - libboost-program-options1.55-dev 
       - libboost-thread1.55-dev 
+      - libboost-iostreams1.55-dev
       - libgmp-dev 
       - libmpfr-dev 
       - libmpfi-dev 

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -33,6 +33,7 @@ addons:
       - libboost-system1.55-dev 
       - libboost-program-options1.55-dev 
       - libboost-thread1.55-dev 
+      - libboost-iostreams1.55-dev
       - libgmp-dev 
       - libmpfr-dev 
       - libmpfi-dev 


### PR DESCRIPTION
## Summary of Changes
Change the travis configuration to add boost-iostreams.

## Release Management
* Issue(s) solved (if any): fix #2702 

