### PR TITLE
Cartesian kernel: improve plane point() computation

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -1762,10 +1762,10 @@ namespace CartesianKernelFunctors {
         // to avoid badly defined vectors with coordinates all close
         // to 0 when the plane is almost horizontal, we ignore the
         // smallest coordinate instead of always ignoring Z
-        if (CGAL::possibly(a <= b && a <= c))
+        if (CGAL::possibly(CGAL_AND (a <= b, a <= c)))
           return Vector_3(FT(0), -h.c(), h.b());
 
-        if (CGAL::possibly(b <= a && b <= c))
+        if (CGAL::possibly(CGAL_AND (b <= a, b <= c)))
           return Vector_3(-h.c(), FT(0), h.a());
 
         return Vector_3(-h.b(), h.a(), FT(0));

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -264,9 +264,20 @@ point_on_planeC3(const FT &pa, const FT &pb, const FT &pc, const FT &pd,
                  FT &x, FT &y, FT &z)
 {
   x = y = z = 0;
-  if (! CGAL_NTS is_zero(pa))      x = -pd/pa;
-  else if (! CGAL_NTS is_zero(pb)) y = -pd/pb;
-  else                             z = -pd/pc;
+  
+  FT abs_pa = CGAL::abs(pa);
+  FT abs_pb = CGAL::abs(pb);
+  FT abs_pc = CGAL::abs(pc);
+  
+  // to avoid badly defined point with an overly large coordinate when
+  //  the plane is almost orthogonal to one axis, we use the largest
+  //  scalar coordinate instead of always using the first non-null
+  if (CGAL::possibly(abs_pa >= abs_pb && abs_pa >= abs_pc))
+    x = -pd/pa;
+  else if (CGAL::possibly(abs_pb >= abs_pa && abs_pb >= abs_pc))
+    y = -pd/pb;
+  else
+    z = -pd/pc;
 }
 
 template <class FT>

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -272,9 +272,9 @@ point_on_planeC3(const FT &pa, const FT &pb, const FT &pc, const FT &pd,
   // to avoid badly defined point with an overly large coordinate when
   //  the plane is almost orthogonal to one axis, we use the largest
   //  scalar coordinate instead of always using the first non-null
-  if (CGAL::possibly(abs_pa >= abs_pb && abs_pa >= abs_pc))
+  if (CGAL::possibly(CGAL_AND (abs_pa >= abs_pb, abs_pa >= abs_pc)))
     x = -pd/pa;
-  else if (CGAL::possibly(abs_pb >= abs_pa && abs_pb >= abs_pc))
+  else if (CGAL::possibly(CGAL_AND (abs_pb >= abs_pa, abs_pb >= abs_pc)))
     y = -pd/pb;
   else
     z = -pd/pc;


### PR DESCRIPTION
## Summary of Changes

This fix is similar to https://github.com/CGAL/cgal/pull/2122: when computing `Plane_3::point()` (which is supposed to return one point lying on the plane - any point, there is no more constraint), the current code uses a division by the first non-null coordinate: if a coordinate is close to 0 (but non-null), the point's corresponding coordinate goes far away and becomes badly defined.

This leads, for example, to wrong and clearly unusable values for the `Plane_3::to_2d()` method (which internally uses `Plane_3::point()` as the origin of the 2D base), as was reported in https://github.com/CGAL/cgal/issues/2733.

In this fix, we simply check for the largest coordinate (in norm) and use it, to make sure that we always get the coordinate that is the closest to the origin (this is, again, very similar to what I did in https://github.com/CGAL/cgal/pull/2122). This fixes cases like https://github.com/CGAL/cgal/issues/2733 without affecting the other cases

## Release Management

* Affected package(s): Cartesian Kernel
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2733

