### PR TITLE
Check_headers: Fix OpenMesh error

### DIFF
--- a/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
@@ -26,7 +26,6 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 
-#include <OpenMesh/Core/IO/MeshIO.hh>
 #include <CGAL/boost/graph/internal/OM_iterator_from_circulator.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/Iterator_range.h>

--- a/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h
@@ -21,7 +21,7 @@
 #define CGAL_BOOST_GRAPH_GRAPH_TRAITS_POLYMESH_ARRAYKERNELT_H
 
 // http://openmesh.org/Documentation/OpenMesh-Doc-Latest/classOpenMesh_1_1Concepts_1_1KernelT.html
-
+#include <OpenMesh/Core/IO/MeshIO.hh>
 #include <CGAL/boost/graph/properties_PolyMesh_ArrayKernelT.h>
 #include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
 

--- a/BGL/include/CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h
@@ -21,7 +21,7 @@
 #define CGAL_BOOST_GRAPH_GRAPH_TRAITS_TRIMESH_ARRAYKERNELT_H
 
 // http://openmesh.org/Documentation/OpenMesh-Doc-Latest/classOpenMesh_1_1Concepts_1_1KernelT.html
-
+#include <OpenMesh/Core/IO/MeshIO.hh>
 #include <CGAL/boost/graph/properties_TriMesh_ArrayKernelT.h>
 #include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
 


### PR DESCRIPTION
## Summary of Changes
This PR changes the inclusion order for MeshIO and Mesh types in OpenMesh graph_traits.
## Release Management

* Affected package(s): BGL
* Issue(s) solved (if any): fix #2731 

