### PR TITLE
Scripts: fix release creation

### DIFF
--- a/Maintenance/infrastructure/cgal.geometryfactory.com/bin/create_release
+++ b/Maintenance/infrastructure/cgal.geometryfactory.com/bin/create_release
@@ -77,5 +77,5 @@ ln -s "$1" "$HOME/CGAL/last-release-branch"
 # "$HOME/bin/update_manual_tools"
 
 # Launch create_new_release, from the branch itself
-[ -z "$DRY_RUN" ] && exec "$HOME/CGAL/last-release-branch/Scripts/developer_scripts/create_new_release" --no-scm-update "$@"
+[ -z "$DRY_RUN" ] && exec bash -$- "$HOME/CGAL/last-release-branch/Scripts/developer_scripts/create_new_release" --no-scm-update "$@"
 #                       --no-scm-update because branches have already been updated

--- a/Scripts/developer_scripts/create_new_release
+++ b/Scripts/developer_scripts/create_new_release
@@ -221,6 +221,21 @@ if [ -n "$DO_IT" -a -e "${HTML_DIR}/${release_name}.tar.gz" ]; then
     exit 1
 fi
 
+function cleanup() {
+    # Remove local directory and tarball
+    rm -rf ./"${release_name}"
+    rm ${release_name}.tar.gz
+    if [ -n "$DO_PUBLIC" ]; then
+        [ -d "${public_release_name}" ] && rm -rf  ./"${public_release_name}"
+        rm -rf doc
+        #  rm -rf doc_tex
+        rm -rf doc_html
+        rm -f "${public_release_name}.tar.gz" "${public_release_name}.zip"
+    fi
+}
+
+trap cleanup EXIT
+
 # Create the release
 if [ -n "$CANDIDATES_DIR_HAS_BEEN_SET" ]; then
     ${SOURCES_DIR}/Scripts/developer_scripts/create_internal_release -a ${SOURCES_DIR} -c ${CANDIDATES_DIR} -r ${release_name} -n ${release_number}
@@ -282,7 +297,7 @@ if [ -n "$DO_PUBLIC" ]; then
     else
 	public_release_name="CGAL-${public_release_version}"
     fi
-    mv ${release_name} $public_release_name
+    mv -T ${release_name} $public_release_name
 
     cd ${public_release_name}
     rm -rf bench* Bench* test package_info developer_scripts doc winutils include/CGAL/Test include/CGAL/Testsuite/
@@ -334,15 +349,4 @@ if [ -n "$DO_PUBLIC" ]; then
   docker start -a ${container_id}
   docker cp ${container_id}:/nsis_release/${public_release_name}-Setup.exe "${HTML_DIR}/${release_name}-public/"
   docker rm ${container_id}
-fi
-
-# Remove local directory and tarball
-rm -rf "${release_name}"
-rm ${release_name}.tar.gz
-if [ -n "$DO_PUBLIC" ]; then
-  rm -rf  ./"${public_release_name}"
-  rm -rf doc
-#  rm -rf doc_tex
-  rm -rf doc_html
-  rm  "${public_release_name}.tar.gz" "${public_release_name}.zip"
 fi

--- a/wininst/developer_scripts/script_cgal.nsi
+++ b/wininst/developer_scripts/script_cgal.nsi
@@ -149,8 +149,6 @@ Section "!Main CGAL" MAIN_Idx
   File /nonfatal /r "${CGAL_SRC}\auxiliary\*.*"
   SetOutPath "$INSTDIR\cmake"
   File /r "${CGAL_SRC}\cmake\*.*"
-  SetOutPath "$INSTDIR\config"
-  File /r "${CGAL_SRC}\config\*.*"
   SetOutPath "$INSTDIR\doc_html"
   File /r "${CGAL_SRC}\doc_html\*.*"
   SetOutPath "$INSTDIR\include"
@@ -166,7 +164,7 @@ Section "!Main CGAL" MAIN_Idx
 
   SetOutPath "$INSTDIR"
   File "${CGAL_SRC}\AUTHORS"
-  File "${CGAL_SRC}\CHANGES"
+  File "${CGAL_SRC}\changes.md"
   File "${CGAL_SRC}\CMakeLists.txt"
   File "${CGAL_SRC}\INSTALL.md"
   File "${CGAL_SRC}\LICENSE"


### PR DESCRIPTION
This PR fixes issues in our release creation scripts, when a public release was created:
  - if the docker container creating the NSIS installer failed, then the script stopped, without cleaning directories,
  - that made the next public release contain temporary tarball files,
  - and then it got bigger and bigger. For `CGAL-4.12-I-141-public`, the tarball size was > 900MB!
