### PR TITLE
Bug fix in GMap test.

### DIFF
--- a/Generalized_map/test/Generalized_map/Generalized_map_2_test.h
+++ b/Generalized_map/test/Generalized_map/Generalized_map_2_test.h
@@ -22,6 +22,7 @@
 #define CGAL_GENERALIZED_MAP_2_TEST 1
 
 #include <CGAL/Generalized_map_operations.h>
+#include <CGAL/Random.h>
 
 #include <CGAL/IO/Polyhedron_iostream.h>
 #include <iostream>
@@ -57,6 +58,28 @@ void trace_display_msg(const char*
   std::cout<<"***************** "<<msg<<"***************** "<<std::endl;
 #endif
 }
+
+template<typename GMap, typename Info=typename GMap::Dart_info>
+struct InitDartInfo
+{
+  static void run(GMap& gmap)
+  {
+    long long int nb=0;
+    for(typename GMap::Dart_range::iterator it=gmap.darts().begin(),
+        itend=gmap.darts().end(); it!=itend; ++it)
+    {
+      nb=CGAL::get_default_random().get_int(0,20000);
+      gmap.info(it)=Info(nb);
+    }
+  }
+};
+
+template<typename GMap>
+struct InitDartInfo<GMap, CGAL::Void>
+{
+  static void run(GMap&)
+  {}
+};
 
 template<typename GMAP>
 bool check_number_of_cells_2(GMAP& gmap, unsigned int nbv, unsigned int nbe,

--- a/Generalized_map/test/Generalized_map/Generalized_map_3_test.h
+++ b/Generalized_map/test/Generalized_map/Generalized_map_3_test.h
@@ -115,6 +115,7 @@ bool test_GMAP_3()
     return false;
 
   trace_test_begin();
+  InitDartInfo<GMAP>::run(gmap);
   GMAP gmap2(gmap);
   if ( !check_number_of_cells_3(gmap2, 12, 20, 9, 2, 1) )
     return false;

--- a/Generalized_map/test/Generalized_map/Generalized_map_4_test.h
+++ b/Generalized_map/test/Generalized_map/Generalized_map_4_test.h
@@ -116,6 +116,7 @@ bool test_GMAP_4()
     return false;
 
   trace_test_begin();
+  InitDartInfo<GMAP>::run(gmap);
   GMAP gmap2(gmap);
   if ( !check_number_of_cells_4(gmap2, 12, 20, 9, 2, 2, 1) )
     return false;

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Linear_cell_complex_for_generalized_map.h>
 #include <CGAL/Cell_attribute_with_point.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Random.h>
 
 #include <iostream>
 #include <fstream>
@@ -345,6 +346,7 @@ struct InitDartInfo
     for(typename Map::Dart_range::iterator it=map.darts().begin(),
         itend=map.darts().end(); it!=itend; ++it)
     {
+      nb=CGAL::get_default_random().get_int(0,20000);
       map.info(it)=Info(nb);
     }
   }


### PR DESCRIPTION

_Please use the following template to help us managing pull requests._



## Summary of Changes

Initialise dart info when non void, in GMap test.
Modify the same code for GMap to use random value and not always 0.

## Release Management

* Affected package(s): GMap, CMap
* Issue(s) solved (if any):  #2751


