### PR TITLE
TDS_3 - add missing `const` in doc of `copy_tds()`

### DIFF
--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
@@ -248,11 +248,11 @@ a handle to the vertex created in `this` that is the copy of `v` is returned,
 otherwise `Vertex_handle()` is returned.
 
  - A model of `ConvertVertex` must provide two operator()'s that are responsible for converting the source vertex `v_src` into the target vertex:
-  - `Vertex operator()(const TDS_src::Vertex& v_src);` This operator is used to create the vertex from `v_src`.
-  - `void operator()(const TDS_src::Vertex& v_src, Vertex& v_tgt);` This operator is meant to be used in case heavy data should transferred to `v_tgt`. 
+  - `Vertex operator()(const TDS_src::Vertex& v_src) const;` This operator is used to create the vertex from `v_src`.
+  - `void operator()(const TDS_src::Vertex& v_src, Vertex& v_tgt) const;` This operator is meant to be used in case heavy data should transferred to `v_tgt`.
  - A model of ConvertCell must provide two operator()'s that are responsible for converting the source cell `c_src` into the target cell:
-  - `Cell operator()(const TDS_src::Cell& c_src);` This operator is used to create the cell from `c_src`.
-  - `void operator()(const TDS_src::Cell& c_src, Cell& c_tgt);` This operator is meant to be used in case heavy data should transferred to `c_tgt`.
+  - `Cell operator()(const TDS_src::Cell& c_src) const;` This operator is used to create the cell from `c_src`.
+  - `void operator()(const TDS_src::Cell& c_src, Cell& c_tgt) const;` This operator is meant to be used in case heavy data should transferred to `c_tgt`.
 
 \pre The optional argument `v` is a vertex of `tds_src` or is `Vertex_handle()`.
 */


### PR DESCRIPTION
## Summary of Changes

The documentation of `ConvertVertex` and `ConvertCell` in `tds.copy_tds()` was missing some `const`

## Release Management

* Affected package(s): TDS_3, documentation only

