### PR TITLE
Shape Detection: Fix Infinite Loop

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC.h
@@ -734,6 +734,9 @@ shape. The implementation follows \cgalCite{schnabel2007efficient}.
   
             candidates.resize(end);
           }
+        else if (!keep_searching)
+          ++ generated_candidates;
+        
         keep_searching = (stop_probability(m_options.min_points,
             m_num_available_points - num_invalid,
             generated_candidates, 


### PR DESCRIPTION
## Summary of Changes

There exists a very specific an rare case in RANSAC where no new candidate shapes are generated but no candidates are integrated nor discarded, which leads to a constant stop criterion, which leads to an infinite loop.

This is the least invasive fix that I managed to do: if the search is over but no shape was either integrated or discarded, we increase the stop criterion to unlock the situation. It works experimentally and does not modify other cases (and statistically, RANSAC gives the same distribution of shapes and assigned points with and without the fix).

## Release Management

* Affected package(s): Point Set Shape Detection 3

