### PR TITLE
Circular_kernel_2: Fix the circle reading in the `.dxf ` file reader

### DIFF
--- a/Circular_kernel_2/benchmark/dxf_to_bff/dxf_converter.h
+++ b/Circular_kernel_2/benchmark/dxf_to_bff/dxf_converter.h
@@ -122,7 +122,7 @@ private:
   is >> n;
   assert(n == 40);
   is >> r;
- NT1 x(cx),y(cy),gr(r);
+  NT1 x(cx), y(cy), gr(r*r);
   os<<"Circle_2 ("<<"Point_2("<<"Rational(" <<x.numerator()<< ", "<<x.denominator()<<")"<< ", "<<"Rational(" <<y.numerator()<< ", "<<y.denominator()<<")""),"<<"Rational(" <<gr.numerator()<< ", "<<gr.denominator()<<")"<<")"<<std::endl;
 //  circ = typename K::Construct_circle_2()(Point_2(cx,cy), r*r);
 }

--- a/Circular_kernel_2/include/CGAL/IO/Dxf_reader.h
+++ b/Circular_kernel_2/include/CGAL/IO/Dxf_reader.h
@@ -23,9 +23,8 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-// Descriptions of the file format can be found at
+// Description of the file format can be found at the following address:
 // http://www.autodesk.com/techpubs/autocad/acad2000/dxf/
-// http://www.tnt.uni-hannover.de/soft/compgraph/fileformats/docs/DXF.ascii
 
 #ifndef CGAL_IO_DXF_READER_H
 #define CGAL_IO_DXF_READER_H
@@ -136,8 +135,8 @@ private:
   is >> n;
   CGAL_assertion(n == 40);
   is >> iformat(r);
-  FT rft(r);
-  circ = typename K::Construct_circle_2()(Point_2(cx,cy), rft);
+  FT sqr_ft(r*r);
+  circ = typename K::Construct_circle_2()(Point_2(cx,cy), sqr_ft);
 }
 
   void
@@ -162,7 +161,7 @@ private:
   is >> iformat(r);
 
   center = typename K::Construct_point_2()(cx,cy);
-  rft = FT(r);
+  rft = FT(r); // intentionally not squared
 }
 
 

--- a/Circular_kernel_2/include/CGAL/IO/Dxf_reader_doubles.h
+++ b/Circular_kernel_2/include/CGAL/IO/Dxf_reader_doubles.h
@@ -139,9 +139,8 @@ private:
   is >> n;
   CGAL_assertion(n == 40);
   is >> iformat(r);
-  FT rft(r);
-
-  circ = CGAL::make_array(cx,cy,rft);
+  FT sqr_ft(r*r);
+  circ = CGAL::make_array(cx,cy,sqr_ft);
 }
 
 

--- a/Circular_kernel_2/include/CGAL/IO/Dxf_variant_reader.h
+++ b/Circular_kernel_2/include/CGAL/IO/Dxf_variant_reader.h
@@ -24,9 +24,8 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-// Descriptions of the file format can be found at
+// Description of the file format can be found at the following address:
 // http://www.autodesk.com/techpubs/autocad/acad2000/dxf/
-// http://www.tnt.uni-hannover.de/soft/compgraph/fileformats/docs/DXF.ascii
 
 #ifndef CGAL_IO_DXF_VARIANT_READER_H
 #define CGAL_IO_DXF_VARIANT_READER_H

--- a/Straight_skeleton_2/include/CGAL/IO/Dxf_writer.h
+++ b/Straight_skeleton_2/include/CGAL/IO/Dxf_writer.h
@@ -17,9 +17,8 @@
 //
 // Author(s)     : Fernando Cacciola
 //
-// Descriptions of the file format can be found at
+// Description of the file format can be found at the following address:
 // http://www.autodesk.com/techpubs/autocad/acad2000/dxf/
- 
 
 #ifndef CGAL_IO_DXF_WRITER_H
 #define CGAL_IO_DXF_WRITER_H


### PR DESCRIPTION
In the `.dxf` [file format doc](https://www.autodesk.com/techpubs/autocad/acad2000/dxf/), it is said that the radius of a circle is a length (non-squared). However, the `Construct_circle_2` constructor requires the squared radius in argument. Thus `r` -> `r * r` a couple of times.

## Release Management

* Affected package(s): `Circular_kernel_2`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): -- 

