### PR TITLE
Polyhedron demo: Fix edge selection -> face selection conversion

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -573,7 +573,8 @@ public Q_SLOTS:
       BOOST_FOREACH(Scene_polyhedron_selection_item::fg_edge_descriptor ed, selection_item->selected_edges)
       {
         selection_item->selected_facets.insert(face(halfedge(ed, poly), poly));
-        selection_item->selected_facets.insert(face(opposite(halfedge(ed, poly), poly), poly));
+        if(!is_border_edge(halfedge(ed,poly), poly))
+          selection_item->selected_facets.insert(face(opposite(halfedge(ed, poly), poly), poly));
       }
       selection_item->invalidateOpenGLBuffers();
       selection_item->itemChanged();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -121,6 +121,7 @@ public:
 
     connect(ui_widget.Select_all_button,  SIGNAL(clicked()), this, SLOT(on_Select_all_button_clicked()));
     connect(ui_widget.Select_all_NTButton,  SIGNAL(clicked()), this, SLOT(on_Select_all_NTButton_clicked()));
+    connect(ui_widget.Select_boundaryButton,  SIGNAL(clicked()), this, SLOT(on_Select_boundaryButton_clicked()));
     connect(ui_widget.Add_to_selection_button,  SIGNAL(clicked()), this, SLOT(on_Add_to_selection_button_clicked()));
     connect(ui_widget.Clear_button,  SIGNAL(clicked()), this, SLOT(on_Clear_button_clicked()));
     connect(ui_widget.Clear_all_button,  SIGNAL(clicked()), this, SLOT(on_Clear_all_button_clicked()));
@@ -242,6 +243,20 @@ public Q_SLOTS:
     selection_item->select_all_NT();
   }
 
+  // Select Boundary
+  void on_Select_boundaryButton_clicked() {
+    Scene_polyhedron_selection_item* selection_item = getSelectedItem<Scene_polyhedron_selection_item>();
+    if(!selection_item)
+      selection_item = onTheFlyItem();
+    if(!selection_item)
+    {
+      print_message("Error: there is no selected polyhedron selection item!");
+      return;
+    }
+
+    selection_item->select_boundary();
+  }
+
   void on_Add_to_selection_button_clicked()
   {
 
@@ -359,19 +374,29 @@ public Q_SLOTS:
       {
         ui_widget.Select_all_NTButton->show();
         ui_widget.Add_to_selection_button->hide();
+        ui_widget.Select_boundaryButton->hide();
+        Q_EMIT set_operation_mode(-1);
+      }
+      else if(index == 2)
+      {
+        ui_widget.Select_all_NTButton->hide();
+        ui_widget.Add_to_selection_button->hide();
+        ui_widget.Select_boundaryButton->show();
         Q_EMIT set_operation_mode(-1);
       }
       else if(index == 4)
       {
         it->second->setPathSelection(true);
-        ui_widget.Add_to_selection_button->show();
         ui_widget.Select_all_NTButton->hide();
+        ui_widget.Add_to_selection_button->show();
+        ui_widget.Select_boundaryButton->show();
         Q_EMIT set_operation_mode(-2);
       }
       else
       {
         ui_widget.Add_to_selection_button->hide();
         ui_widget.Select_all_NTButton->hide();
+        ui_widget.Select_boundaryButton->hide();
         it->second->setPathSelection(false);
         Q_EMIT set_operation_mode(-1);
       }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>613</width>
-    <height>334</height>
+    <height>342</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -153,11 +153,22 @@
                  </spacer>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="Select_all_NTButton">
-                  <property name="text">
-                   <string>Select All Non Triangle</string>
-                  </property>
-                 </widget>
+                 <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <item>
+                   <widget class="QPushButton" name="Select_all_NTButton">
+                    <property name="text">
+                     <string>Select All Non Triangle</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="Select_boundaryButton">
+                    <property name="text">
+                     <string>Select Boundary Edges</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                 <item>
                  <widget class="QPushButton" name="Add_to_selection_button">

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2249,3 +2249,17 @@ bool Scene_polyhedron_selection_item::shouldDisplayIds(CGAL::Three::Scene_item *
   return d->item->polyhedron_item() == current_item;
   return false;
 }
+
+void Scene_polyhedron_selection_item::select_boundary()
+{
+  Face_graph* fg = polyhedron_item()->face_graph();
+  BOOST_FOREACH(halfedge_descriptor hd, halfedges(*fg))
+  {
+    if(is_border_edge(hd, *fg))
+    {
+      selected_edges.insert(edge(hd, *fg));
+    }
+  }
+  invalidateOpenGLBuffers();
+  redraw();
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2253,7 +2253,7 @@ bool Scene_polyhedron_selection_item::shouldDisplayIds(CGAL::Three::Scene_item *
 void Scene_polyhedron_selection_item::select_boundary()
 {
   Face_graph* fg = polyhedron_item()->face_graph();
-  BOOST_FOREACH(halfedge_descriptor hd, halfedges(*fg))
+  BOOST_FOREACH(fg_halfedge_descriptor hd, halfedges(*fg))
   {
     if(is_border_edge(hd, *fg))
     {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -440,6 +440,8 @@ public:
       break;
     }
   }
+
+  void select_boundary();
   void select_all_NT();
   // select all of vertex, facet or edge (use fg_vertex_descriptor, fg_face_descriptor, fg_edge_descriptor as template argument)
   template<class HandleType>


### PR DESCRIPTION
## Summary of Changes
- Only call the opposite of the selected halfedge if it is not a border halfedge.
- Add a button to select the whole boundary if in edge selection mode.

* Issue(s) solved (if any): fix #2778

