### PR TITLE
Triangulation_2: Make CDT_2 less verbose

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+Release 4.13
+------------
+### 2D Triangulations
+
+-   Added a new type of intersection to deal with insertion of a constraints 
+    intersecting in a Constrained_triangulation_2.
+
 Release 4.12
 ------------
 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -46,9 +46,12 @@ There are three versions of constrained triangulations
 <LI>In the basic version, the constrained triangulation 
 does not handle intersecting constraints, and the set of input 
 constraints is required to be a set of polylines that do not intersect 
-except possibly at their endpoints. Any number of constrained edges 
-may share the same endpoint. Constrained edges may be vertical or
-have zero length. 
+except possibly at their endpoints.
+An exception of type `Intersection_of_constraints_exception`
+is thrown upon insertion of a constraint intersecting in
+its interior an already inserted constraint.
+Any number of constrained edges may share the same endpoint.
+Constrained edges may be vertical or have zero length.
 <LI>The two other versions support intersecting input constraints. 
 In those versions, input constraints may consist of 
 intersecting, overlapping or partially 
@@ -329,7 +332,9 @@ Note that `t` is first cleared.
 */ 
 istream& operator>>(istream& is,Constrained_triangulation_2<Traits,Tds> Ct& t); 
 
-//! Exception thrown for `intersect()` when called with the tag `No_intersection_tag`.
-//! Then, if constraints intersect, an exception of this type will be thrown.
+/*! Exception used by constrained triangulations configured with
+the tag `No_intersection_tag`. It is thrown upon insertion of a constraint
+that is intersecting an already inserted constraint in its interior.
+*/
 class Intersection_of_constraints_exception;
 } /* end namespace CGAL */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -13,7 +13,7 @@ struct No_intersection_tag{};
 \ingroup PkgTriangulation2TriangulationClasses
 
 Intersection tag for constrained triangulations, when input constraints should not intersect.
-Will throw a `To_be_renamed_exception` if constraints do intersect.
+Will throw a `Intersection_of_constraints_exception` if constraints do intersect.
 */
 struct Throw_on_intersection_tag{};
 
@@ -338,5 +338,5 @@ istream& operator>>(istream& is,Constrained_triangulation_2<Traits,Tds> Ct& t);
 
 //! Exception thrown for `intersect()` when called with the tag `Throw_on_intersection_tag`.
 //! Then, if constraints intersect, an exception of this type will be thrown.
-class To_be_renamed_exception;
+class Intersection_of_constraints_exception;
 } /* end namespace CGAL */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -9,6 +9,13 @@ Intersection tag for constrained triangulations, when input constraints do not i
 */
 struct No_intersection_tag{};
 
+/*!
+\ingroup PkgTriangulation2TriangulationClasses
+
+Intersection tag for constrained triangulations, when input constraints should not intersect.
+Will throw a `To_be_renamed_exception` if constraints do intersect.
+*/
+struct Throw_on_intersection_tag{};
 
 /*!
 \ingroup PkgTriangulation2TriangulationClasses
@@ -328,4 +335,8 @@ Note that `t` is first cleared.
 \relates Constrained_triangulation_2 
 */ 
 istream& operator>>(istream& is,Constrained_triangulation_2<Traits,Tds> Ct& t); 
+
+//! Exception thrown for `intersect()` when called with the tag `Throw_on_intersection_tag`.
+//! Then, if constraints intersect, an exception of this type will be thrown.
+class To_be_renamed_exception;
 } /* end namespace CGAL */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -9,13 +9,6 @@ Intersection tag for constrained triangulations, when input constraints do not i
 */
 struct No_intersection_tag{};
 
-/*!
-\ingroup PkgTriangulation2TriangulationClasses
-
-Intersection tag for constrained triangulations, when input constraints should not intersect.
-Will throw a `Intersection_of_constraints_exception` if constraints do intersect.
-*/
-struct Throw_on_intersection_tag{};
 
 /*!
 \ingroup PkgTriangulation2TriangulationClasses
@@ -336,7 +329,7 @@ Note that `t` is first cleared.
 */ 
 istream& operator>>(istream& is,Constrained_triangulation_2<Traits,Tds> Ct& t); 
 
-//! Exception thrown for `intersect()` when called with the tag `Throw_on_intersection_tag`.
+//! Exception thrown for `intersect()` when called with the tag `No_intersection_tag`.
 //! Then, if constraints intersect, an exception of this type will be thrown.
 class Intersection_of_constraints_exception;
 } /* end namespace CGAL */

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -452,10 +452,6 @@ protected:
 			  Vertex_handle vaa,
 			  Vertex_handle vbb,
 			  No_intersection_tag);
-  Vertex_handle intersect(Face_handle f, int i,
-                          Vertex_handle vaa,
-                          Vertex_handle vbb,
-                          No_intersection_tag);
   Vertex_handle intersect(Face_handle f, int i, 
 			  Vertex_handle vaa,
 			  Vertex_handle vbb,
@@ -864,26 +860,6 @@ intersect(Face_handle f, int i,
 	  Vertex_handle vbb) 
 {
   return intersect(f, i, vaa, vbb, Itag());
-}
-
-template <class Gt, class Tds, class Itag >
-typename Constrained_triangulation_2<Gt,Tds,Itag>::Vertex_handle 
-Constrained_triangulation_2<Gt,Tds,Itag>::
-intersect(Face_handle , int ,
-          Vertex_handle ,
-          Vertex_handle ,
-	  No_intersection_tag)
-{
-  //SL: I added that to be able to throw while we find a better solution
-  #ifdef CGAL_CT2_WANTS_TO_HAVE_EXTRA_ACTION_FOR_INTERSECTING_CONSTRAINTS
-  CGAL_CDT2_EXTRA_ACTION_FOR_INTERSECTING_CONSTRAINTS
-  #endif
-  
-  std::cerr << " sorry, this triangulation does not deal with"
-            <<    std::endl
-            << " intersecting constraints" << std::endl;
-  CGAL_triangulation_assertion(false);
-  return Vertex_handle() ;
 }
 
 template <class Gt, class Tds, class Itag >

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -108,7 +108,7 @@ public:
   {
     const char* what() const throw ()
     {
-      return "the constraint and subconstraint edge are intersecting.";
+      return "Intersection of constraints while using No_intersection_tag";
     }
   };
 
@@ -894,8 +894,8 @@ intersect(Face_handle f, int i,
   "using a Constrained_triangulation_plus_2 class\n"
   "would avoid cascading intersection computation\n"
   " and be much more efficient\n"
-  "define CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS "
-  "to disable this warning.\n");
+  "This message is shown only when not using "
+  "CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS.\n");
 #endif
   const Point& pa = vaa->point();
   const Point& pb = vbb->point();

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -913,12 +913,15 @@ intersect(Face_handle f, int i,
 // split constraint edge (f,i) 
 // and return the Vertex_handle of the new Vertex
 { 
+#ifndef CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS
   CGAL_warning_msg(false,
-  "You are using an exact number types\n"
+  "You are using an exact number type\n"
   "using a Constrained_triangulation_plus_2 class\n"
   "would avoid cascading intersection computation\n"
-  " and be much more efficient\n");
-
+  " and be much more efficient\n"
+  "define CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS "
+  "to disable this warning.\n");
+#endif
   const Point& pa = vaa->point();
   const Point& pb = vbb->point();
   const Point& pc = f->vertex(cw(i))->point();

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -105,7 +105,7 @@ public:
   };
 
 
-  class To_be_renamed_exception : public std::exception
+  class Intersection_of_constraints_exception : public std::exception
   {
     const char* what() const throw ()
     {
@@ -896,7 +896,7 @@ intersect(Face_handle , int ,
           Throw_on_intersection_tag)
 {
 
-  throw To_be_renamed_exception();
+  throw Intersection_of_constraints_exception();
   return Vertex_handle() ;
 }
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -43,7 +43,6 @@
 namespace CGAL {
 
 struct No_intersection_tag{};
-struct Throw_on_intersection_tag{};
 struct Exact_intersections_tag{}; // to be used with an exact number type
 struct Exact_predicates_tag{}; // to be used with filtered exact number
 
@@ -456,7 +455,7 @@ protected:
   Vertex_handle intersect(Face_handle f, int i,
                           Vertex_handle vaa,
                           Vertex_handle vbb,
-                          Throw_on_intersection_tag);
+                          No_intersection_tag);
   Vertex_handle intersect(Face_handle f, int i, 
 			  Vertex_handle vaa,
 			  Vertex_handle vbb,
@@ -893,7 +892,7 @@ Constrained_triangulation_2<Gt,Tds,Itag>::
 intersect(Face_handle , int ,
           Vertex_handle ,
           Vertex_handle ,
-          Throw_on_intersection_tag)
+          No_intersection_tag)
 {
 
   throw Intersection_of_constraints_exception();

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -105,8 +105,7 @@ public:
   };
 
 
-  //! Exception thrown for `intersect()` when called with the tag `Throw_on_intersection_tag`.
-  class Is_intersecting_exception : public std::exception
+  class To_be_renamed_exception : public std::exception
   {
     const char* what() const throw ()
     {
@@ -897,7 +896,7 @@ intersect(Face_handle , int ,
           Throw_on_intersection_tag)
 {
 
-  throw Is_intersecting_exception();
+  throw To_be_renamed_exception();
   return Vertex_handle() ;
 }
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -888,14 +888,14 @@ intersect(Face_handle f, int i,
 // split constraint edge (f,i) 
 // and return the Vertex_handle of the new Vertex
 { 
-#ifndef CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS
+#ifndef CGAL_NO_CDT_2_WARNING
   CGAL_warning_msg(false,
-  "You are using an exact number type\n"
+  "You are using an exact number type,\n"
   "using a Constrained_triangulation_plus_2 class\n"
   "would avoid cascading intersection computation\n"
   " and be much more efficient\n"
-  "This message is shown only when not using "
-  "CGAL_NO_WARNING_WHEN_USING_CDT_PLUS_WHILE_INTERSECTING_CONSTRAINTS.\n");
+  "This message is shown only if CGAL_NO_CDT_2_WARNING"
+  "is not defined.\n");
 #endif
   const Point& pa = vaa->point();
   const Point& pb = vbb->point();


### PR DESCRIPTION
## Summary of Changes

This PR makes the CDT_2 less verbose by moving some error streamed information to a compilation warning, and it adds an overload for the `intersect()` function that use a new tag to throw an exception when the constrained edges intersect.
## Release Management

* Affected package(s):Triangulation_2
* Issue(s) solved (if any): fix #2752 
* Feature/Small Feature (if any): [New_Exception_in_Constrained_triangulation_2](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/New_Exception_in_Constrained_triangulation_2)

