### PR TITLE
Triangulation_2: Fix template parameter in RT_2's graph traits

### DIFF
--- a/BGL/test/BGL/graph_concept_Triangulation_2.cpp
+++ b/BGL/test/BGL/graph_concept_Triangulation_2.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/boost/graph/graph_traits_Triangulation_2.h>
 #include <CGAL/boost/graph/graph_traits_Constrained_triangulation_2.h>
 #include <CGAL/boost/graph/graph_traits_Delaunay_triangulation_2.h>
+#include <CGAL/boost/graph/graph_traits_Regular_triangulation_2.h>
 #include <CGAL/boost/graph/graph_traits_Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/boost/graph/graph_traits_Constrained_triangulation_plus_2.h>
 #include <CGAL/boost/graph/graph_traits_Triangulation_hierarchy_2.h>
@@ -11,6 +12,7 @@
 typedef CGAL::Simple_cartesian<double> Kernel;
 typedef CGAL::Triangulation_2<Kernel> Triangulation;
 typedef CGAL::Delaunay_triangulation_2<Kernel> DT2;
+typedef CGAL::Regular_triangulation_2<Kernel> RT2;
 typedef CGAL::Constrained_triangulation_2<Kernel> CT2;
 typedef CGAL::Constrained_Delaunay_triangulation_2<Kernel> CDT2;
 typedef CGAL::Constrained_triangulation_plus_2<CDT2> CDTP2;
@@ -27,6 +29,7 @@ int main()
 {
   concept_check_triangulation<Triangulation>();
   concept_check_triangulation<DT2>();
+  concept_check_triangulation<RT2>();
   concept_check_triangulation<CT2>();
   concept_check_triangulation<CDT2>();
   concept_check_triangulation<CDTP2>();

--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -56,7 +56,7 @@ class Regular_triangulation_2
 
 public:
   typedef Self                                 Triangulation;
-  typedef Triangulation_2<Gt, Tds>             Tr_Base;
+  typedef Triangulation_2<Gt, Tds>             Triangulation_base;
   typedef Tds                                  Triangulation_data_structure;
   typedef Gt                                   Geom_traits;
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -56,6 +56,7 @@ class Regular_triangulation_2
 
 public:
   typedef Self                                 Triangulation;
+  typedef Triangulation_2<Gt, Tds>             Tr_Base;
   typedef Tds                                  Triangulation_data_structure;
   typedef Gt                                   Geom_traits;
 

--- a/Triangulation_2/include/CGAL/boost/graph/graph_traits_Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/boost/graph/graph_traits_Regular_triangulation_2.h
@@ -57,7 +57,7 @@ namespace boost {
     typedef CGAL::detail::Edge<CGAL::Regular_triangulation_2<GT,TDS>, typename CGAL::Regular_triangulation_2<GT,TDS>::Edge>  edge_descriptor;
     typedef typename CGAL::Regular_triangulation_2<GT,TDS>::All_edges_iterator  edge_iterator;
 
-    typedef CGAL::detail::T2_halfedge_descriptor<typename Regular_triangulation::Triangulation> halfedge_descriptor;
+    typedef CGAL::detail::T2_halfedge_descriptor<typename Regular_triangulation::Tr_Base> halfedge_descriptor;
 
     typedef typename Regular_triangulation::All_halfedges_iterator  halfedge_iterator;
 

--- a/Triangulation_2/include/CGAL/boost/graph/graph_traits_Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/boost/graph/graph_traits_Regular_triangulation_2.h
@@ -57,7 +57,7 @@ namespace boost {
     typedef CGAL::detail::Edge<CGAL::Regular_triangulation_2<GT,TDS>, typename CGAL::Regular_triangulation_2<GT,TDS>::Edge>  edge_descriptor;
     typedef typename CGAL::Regular_triangulation_2<GT,TDS>::All_edges_iterator  edge_iterator;
 
-    typedef CGAL::detail::T2_halfedge_descriptor<typename Regular_triangulation::Tr_Base> halfedge_descriptor;
+    typedef CGAL::detail::T2_halfedge_descriptor<typename Regular_triangulation::Triangulation_base> halfedge_descriptor;
 
     typedef typename Regular_triangulation::All_halfedges_iterator  halfedge_iterator;
 


### PR DESCRIPTION
## Summary of Changes

For some reason, the typedef `Triangulation` in `Regular_triangulation_2` is not the base triangulation `Triangulation_2`, but a typedef to `Self`. Consequently, the `halfedge_descriptor` in the graph traits of `Regular_triangulation_2` is wrong and cannot compile.

Although it's not documented, I left `typedef Self Triangulation` in case it's used somewhere (but I couldn't find it anywhere in CGAL) as it could create a nasty bug. Base is typedef'd by `Tr_Base` for consistency with the base typedef in (P3)T3 classes.

Added `RT2` to `graph_concept_Triangulation_2`, but the T2 graph traits are missing proper tests...

## Release Management

* Affected package(s): `Triangulation_2`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

