### PR TITLE
win32 fix concerning bzip headers in the classification plugin CMakeLists.txt

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -8,6 +8,9 @@ if(EIGEN3_FOUND)
   find_package(Boost OPTIONAL_COMPONENTS serialization iostreams)
 
   if( WIN32 )
+# to avoid a warning with old cmake
+    set(_Boost_BZIP2_HEADERS             "boost/iostreams/filter/bzip2.hpp")
+    set(_Boost_ZLIB_HEADERS              "boost/iostreams/filter/zlib.hpp")
     find_package( Boost OPTIONAL_COMPONENTS zlib)
     if( Boost_ZLIB_FOUND )
       set(classification_linked_libraries ${classification_linked_libraries}


### PR DESCRIPTION

## Summary of Changes

Set two variables in CMakeLists.txt

## Release Management

* Affected package(s): Polyhedron demo
* Issue(s) solved (if any): fix #2690

