### PR TITLE
Documentation:  Fix postprocessing

### DIFF
--- a/Documentation/doc/resources/1.8.13/DoxygenLayout.xml
+++ b/Documentation/doc/resources/1.8.13/DoxygenLayout.xml
@@ -4,7 +4,7 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
-    <tab type="classlist" visible="yes" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
+    <tab type="classlist" visible="no" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
     <tab type="examples" visible="no" title="" intro=""/>  
     <!-- <tab type="user" url="@ref how_to_cite_cgal" title="Acknowledging CGAL"/> -->
   </navindex>

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -2,6 +2,51 @@ body, table, div, p, dl {
     font: Lucida Grande,sans-serif;
 }
 
+.icon-namespace {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #FF0000;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
+.icon-class {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #0000FF;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
+.icon-concept {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #67489A;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
 .textsc {
     font-variant: small-caps;
 }

--- a/Documentation/doc/resources/1.8.14/DoxygenLayout.xml
+++ b/Documentation/doc/resources/1.8.14/DoxygenLayout.xml
@@ -4,7 +4,7 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
-    <tab type="classlist" visible="yes" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
+    <tab type="classlist" visible="no" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
     <tab type="examples" visible="no" title="" intro=""/>  
     <!-- <tab type="user" url="@ref how_to_cite_cgal" title="Acknowledging CGAL"/> -->
   </navindex>

--- a/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
@@ -48,6 +48,51 @@ h2 {
 }
 
 
+.icon-namespace {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #FF0000;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
+.icon-class {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #0000FF;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
+.icon-concept {
+    font-family: Arial, Helvetica;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #67489A;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
 h1.groupheader {
     font-size: 150%;
 }

--- a/Documentation/doc/resources/1.8.4/DoxygenLayout.xml
+++ b/Documentation/doc/resources/1.8.4/DoxygenLayout.xml
@@ -4,7 +4,7 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
-    <tab type="classlist" visible="yes" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
+    <tab type="classlist" visible="no" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
     <tab type="examples" visible="no" title="" intro=""/>  
     <!-- <tab type="user" url="@ref how_to_cite_cgal" title="Acknowledging CGAL"/> -->
   </navindex>

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -88,7 +88,7 @@ def clean_doc():
     duplicate_files.extend(package_glob('./*/geom.bib'))
     duplicate_files.extend(package_glob('./*/ftv2cl.png'))
     duplicate_files.extend(package_glob('./*/ftv2ns.png'))
-    
+
     for fn in duplicate_files:
         os.remove(fn)
 
@@ -149,6 +149,16 @@ def rearrange_img(i, dir_name):
                 img.attr("src","ftv2cpt.png")
     srcpath=img.attr("src")
     img.attr("src", "../Manual/" + srcpath.split('/')[-1])
+
+def rearrange_icon(i, dir_name):
+    icon = pq(this)
+    if icon.attr("class") == "icon-class":
+        parser=pq(this).parent().parent()
+        for link_class in ['a.el', 'a.elRef']:
+            links=parser(link_class)
+            if links.size()>0 and is_concept_file(path.join(dir_name, pq(links[0]).attr("href"))):
+                icon.attr("class","icon-concept")
+    srcpath=icon.attr("class")
 
 ###############################################################################
 ############################## Figure Numbering ###############################
@@ -232,12 +242,12 @@ def automagically_number_figures():
 
 def main():
     parser = argparse.ArgumentParser(
-        description='''This script makes adjustments to the doxygen output. 
-It replaces some text in specifically marked classes with the appropriate text for a concept, 
+        description='''This script makes adjustments to the doxygen output.
+It replaces some text in specifically marked classes with the appropriate text for a concept,
 removes some unneeded files, and performs minor repair on some glitches.''')
     parser.add_argument('--output', metavar='/path/to/doxygen/output', default="output")
     parser.add_argument('--resources', metavar='/path/to/cgal/Documentation/resources')
-    
+
     args = parser.parse_args()
     resources_absdir=args.resources
     os.chdir(args.output)
@@ -251,13 +261,18 @@ removes some unneeded files, and performs minor repair on some glitches.''')
     shutil.copy(path.join(resources_absdir,"ftv2cpt.png"),path.join("Manual", "ftv2cpt.png"))
 
     annotated_files=package_glob('./*/annotated.html')
+    print "beginning"
     for fn in annotated_files:
+      re_replace_in_file("<span class=\"icon\">N</span>", "<span class=\"icon-namespace\">N</span>", fn)
+      re_replace_in_file("<span class=\"icon\">C</span>", "<span class=\"icon-class\">C</span>", fn)
       dir_name=path.dirname(fn)
       d = pq(filename=fn, parser='html', encoding='utf-8')
       tr_tags = d('table.directory tr img')
       tr_tags.each(lambda i: rearrange_img(i, dir_name))
+      span_tags = d('table.directory tr span')
+      span_tags.each(lambda i: rearrange_icon(i, dir_name))
       write_out_html(d,fn)
-    
+    print "end"
     class_files=list(package_glob('./*/class*.html'))
     class_files.extend(package_glob('./*/struct*.html'))
     for fn in class_files:
@@ -300,9 +315,11 @@ removes some unneeded files, and performs minor repair on some glitches.''')
             table("tr").filter(lambda i: re.match(row_id + '*', pq(this).attr('id'))).remove()
             write_out_html(d, fn)
 
+    #Rewrite the code for index trees images
+
     filesjs_files=package_glob('./*/files.js')
     for fn in filesjs_files:
-        re_replace_in_file('^.*\[ "Concepts",.*$', '', fn)
+      re_replace_in_file('^.*\[ "Concepts",.*$', '', fn)
 
     #Rewrite the path of some images
     re_replace_in_file("'src','ftv2",
@@ -339,12 +356,12 @@ removes some unneeded files, and performs minor repair on some glitches.''')
     # remove %CGAL in navtree: this should be a fix in doxygen but for now it does not worth it
     re_replace_first_in_file('%CGAL','CGAL',glob.glob('./Manual/navtree.js')[0])
     clean_doc()
-    
+
     #remove links to CGAL in the bibliography
     citelist_files=package_glob('./*/citelist.html')
     for fn in citelist_files:
         re_replace_in_file('<a class=\"el\" href=\"namespaceCGAL.html\">CGAL</a>', 'CGAL', fn)
-    
+
     #add a section for Inherits from
     class_and_struct_files=list(package_glob('./*/class*.html'))
     class_and_struct_files.extend(package_glob('./*/struct*.html'))

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -158,7 +158,6 @@ def rearrange_icon(i, dir_name):
             links=parser(link_class)
             if links.size()>0 and is_concept_file(path.join(dir_name, pq(links[0]).attr("href"))):
                 icon.attr("class","icon-concept")
-    srcpath=icon.attr("class")
 
 ###############################################################################
 ############################## Figure Numbering ###############################
@@ -261,7 +260,6 @@ removes some unneeded files, and performs minor repair on some glitches.''')
     shutil.copy(path.join(resources_absdir,"ftv2cpt.png"),path.join("Manual", "ftv2cpt.png"))
 
     annotated_files=package_glob('./*/annotated.html')
-    print "beginning"
     for fn in annotated_files:
       re_replace_in_file("<span class=\"icon\">N</span>", "<span class=\"icon-namespace\">N</span>", fn)
       re_replace_in_file("<span class=\"icon\">C</span>", "<span class=\"icon-class\">C</span>", fn)
@@ -272,7 +270,6 @@ removes some unneeded files, and performs minor repair on some glitches.''')
       span_tags = d('table.directory tr span')
       span_tags.each(lambda i: rearrange_icon(i, dir_name))
       write_out_html(d,fn)
-    print "end"
     class_files=list(package_glob('./*/class*.html'))
     class_files.extend(package_glob('./*/struct*.html'))
     for fn in class_files:


### PR DESCRIPTION

## Summary of Changes
This PR 
- hides the broken index of the Manual page
- adds some postprocessing for 1.8.13 and 1.8.14 so the colors of the Namespace, Class and Concept nodes are modified the same way it is in 1.8.4
## Release Management

* Affected package(s): Documentation
* Issue(s) solved (if any): fix #2750


