### PR TITLE
Polyhedron Demo Surface Reco. Plugin: Fix missing conversion from degrees to radiants

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -1151,7 +1151,8 @@ void Polyhedron_demo_surface_reconstruction_plugin::scale_space_reconstruction
                                           dialog.neighborhood_size (), dialog.samples(),
                                           dialog.scalespace_af(),
                                           dialog.generate_smoothed (),
-                                          dialog.longest_edge_2(), dialog.radius_ratio_bound_2(), dialog.beta_angle_2(),
+                                          dialog.longest_edge_2(), dialog.radius_ratio_bound_2(),
+                                          CGAL_PI * dialog.beta_angle_2 () / 180.,
                                           dialog.separate_shells (), dialog.force_manifold ());
 
       for (std::size_t i = 0; i < reco_items.size (); ++ i)


### PR DESCRIPTION
## Summary of Changes

The GUI offers a spin box in degrees, but the algorithms expects a value in radiants, and the conversion was not done in all cases…

## Release Management

* Affected package(s): Polyhedron demo