### PR TITLE
Add CGAL_DEV_MODE

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -551,7 +551,7 @@ message( "== Generate version files (DONE) ==\n")
 #
 #--------------------------------------------------------------------------------------------------
 
-if( RUNNING_CGAL_AUTO_TEST )
+if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
   message("== Set up flags ==")
 
   # Ugly hack to be compatible with current CGAL testsuite process (as of

--- a/Installation/cmake/modules/CGALConfig_binary.cmake.in
+++ b/Installation/cmake/modules/CGALConfig_binary.cmake.in
@@ -186,7 +186,9 @@ include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 # Temporary? Change the CMAKE module path
 cgal_setup_module_path()
 
-if( RUNNING_CGAL_AUTO_TEST )
+if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
+  # Do not use -isystem for CGAL include paths
+  set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
   # Ugly hack to be compatible with current CGAL testsuite process (as of
   # Nov. 2017). -- Laurent Rineau
   include(CGAL_SetupFlags)

--- a/Installation/cmake/modules/CGALConfig_install.cmake.in
+++ b/Installation/cmake/modules/CGALConfig_install.cmake.in
@@ -158,7 +158,9 @@ include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 # Temporary? Change the CMAKE module path
 cgal_setup_module_path()
 
-if( RUNNING_CGAL_AUTO_TEST )
+if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
+  # Do not use -isystem for CGAL include paths
+  set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
   # Ugly hack to be compatible with current CGAL testsuite process (as of
   # Nov. 2017). -- Laurent Rineau
   include(CGAL_SetupFlags)

--- a/Installation/cmake/modules/CGAL_Common.cmake
+++ b/Installation/cmake/modules/CGAL_Common.cmake
@@ -1,8 +1,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/CGAL_Macros.cmake)
 
-option(CGAL_DEV_MODE "
-Activate the CGAL developers mode. \
-See https://github.com/CGAL/cgal/wiki/CGAL_DEV_MODE"
+option(CGAL_DEV_MODE
+  "Activate the CGAL developers mode. See https://github.com/CGAL/cgal/wiki/CGAL_DEV_MODE"
   FALSE)
 
 if(RUNNING_CGAL_AUTO_TEST)

--- a/Installation/cmake/modules/CGAL_Common.cmake
+++ b/Installation/cmake/modules/CGAL_Common.cmake
@@ -1,5 +1,10 @@
 include(${CMAKE_CURRENT_LIST_DIR}/CGAL_Macros.cmake)
 
+option(CGAL_DEV_MODE "
+Activate the CGAL developers mode. \
+See https://github.com/CGAL/cgal/wiki/CGAL_DEV_MODE"
+  FALSE)
+
 if(RUNNING_CGAL_AUTO_TEST)
 # Just to avoid a warning from CMake if that variable is set on the command line...
 endif()

--- a/Installation/cmake/modules/CGAL_SetupFlags.cmake
+++ b/Installation/cmake/modules/CGAL_SetupFlags.cmake
@@ -50,15 +50,11 @@ uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS_DEBUG      ${CGAL_EXE_LINKER_FLAGS_DE
 
 # Set a default build type if none is given
 if ( NOT CMAKE_BUILD_TYPE )
-  if( RUNNING_CGAL_AUTO_TEST )
+  if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
     typed_cache_set ( STRING "Build type: Release, Debug, RelWithDebInfo or MinSizeRel" CMAKE_BUILD_TYPE Debug   )
   else ()
     typed_cache_set ( STRING "Build type: Release, Debug, RelWithDebInfo or MinSizeRel" CMAKE_BUILD_TYPE Release )
   endif()
-endif()
-
-if( RUNNING_CGAL_AUTO_TEST )
-  add_definitions(-DCGAL_TEST_SUITE)
 endif()
 
 if ( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"

--- a/Installation/cmake/modules/UseCGAL.cmake
+++ b/Installation/cmake/modules/UseCGAL.cmake
@@ -18,7 +18,7 @@ if(NOT USE_CGAL_FILE_INCLUDED)
   set(USE_CGAL_FILE_INCLUDED 1)
 
   include(${CMAKE_CURRENT_LIST_DIR}/CGAL_Common.cmake)
-  if( RUNNING_CGAL_AUTO_TEST )
+  if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
     include(${CMAKE_CURRENT_LIST_DIR}/CGAL_SetupFlags.cmake)
   else()
     include(${CMAKE_CURRENT_LIST_DIR}/CGAL_display_flags.cmake)


### PR DESCRIPTION
*That is a bug-fix of PR #1436 (see the issue #2793).*

## Summary of Changes

Add a new CMake option `CGAL_DEV_MODE` that I have, for the moment, only document in our public wiki, at

  https://github.com/CGAL/cgal/wiki/CGAL_DEV_MODE

@sloriot:
 - is the documentation sufficient?
 - where should it be linked in the wiki?

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #2793 
