### PR TITLE
OT Reconstruction: Fix test_vertex_edge bug by not copying the TDS

### DIFF
--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -1779,6 +1779,8 @@ public:
 
 
   /// \cond SKIP_IN_MANUAL
+  const Triangulation& tds() const { return m_dt; }
+  
   void extract_tds_output(Triangulation& rt2) const {
     rt2 = m_dt;
     //mark vertices

--- a/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/test_vertex_edge.cpp
+++ b/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/test_vertex_edge.cpp
@@ -67,14 +67,16 @@ void test_edge_collapse()
   CGAL::Optimal_transportation_reconstruction_2<K, Point_property_map, Mass_property_map>
     otr2(points, point_pmap, mass_pmap);
 
-  Rt_2 rt2;
-  otr2.extract_tds_output(rt2);
+  const Rt_2& rt2 = otr2.tds();
 
   FT min_priority = 1000;
   R_edge_2 contract_edge;
   for (Finite_edges_iterator ei = rt2.finite_edges_begin();
        ei != rt2.finite_edges_end(); ++ei) 
   {
+    if (rt2.is_pinned(*ei) || rt2.is_target_cyclic(*ei))
+      continue;
+    
     R_edge_2 cur_r_edge;
     if(!otr2.create_pedge(*ei, cur_r_edge))
       continue;


### PR DESCRIPTION
## Summary of Changes

Fix for https://github.com/CGAL/cgal/issues/2787, which was much trickier than I originally thought.

- the `std::bad_alloc` was happening in an orientation test in EPICK
- I found that one of the coordinates of the points in this test was `nan`
- I figured that it actually came from the fact that the point of the `infinite_vertex()` of a DT2 was used at some point. So there was also a bug in other platforms, but for some reason it was only producing a `nan` on this 32b architecture (on my personal computer, I got random values close to 0).
- In the tests, some internal functions of the algorithms are called but **using elements of a copy of the DT2** as parameters. So of course, tests like `if (v != m_dt.infinite_vertex())` can't work if `v` is not part of `m_dt`.
- After fixing this by not copying the triangulation, I found that an _assertion fail_ was triggered `CGAL_assertion(v != m_dt.infinite_vertex())`
- The test was actually doing something wrong: some tests should not be tested (namely the ones which are `pinned` and which are then adjacent to the infinite vertex). It is clear if we look at the method `push_to_mindex()` which does these tests before calling the function that is tested in our failing test file.

So I replaced the copy by a const ref and added the tests to avoid testing "bad" edges, and now it runs fine on the 32b platform and does not do anything fishy on the other platforms as well (I'm kind of surprised that it did not crash on more platforms before, but I guess having one random point used was not that important if the value was not a `nan`).

### Side note

I know there was, at some point, a project of initializing the infinite vertex to `nan` coordinates: I don't know if there was a good reason not to do it, or it's just in limbo because nobody had time to do it, but it would be a *really* good idea. This kind of bug would have been much easier to detect.

(What's worrying is we'll probably find more of these bugs if we do it.)

## Release Management

* Affected package(s): Optimal Transportation Reconstruction
* Issue(s) solved: fix https://github.com/CGAL/cgal/issues/2787

