### PR TITLE
Fix Fedora_32 errors in the testsuite

### DIFF
--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -67,7 +67,7 @@ if (CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND QGLVIEWER_FOUND AND TARGET Q
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS periodic_3_triangulation_3_demo)
 
   target_link_libraries(periodic_3_triangulation_3_demo PRIVATE
-    CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL Qt5::Help ${QGLVIEWER_LIBRARIES})
+    CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL  ${QGLVIEWER_LIBRARIES})
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(periodic_3_triangulation_3_demo)

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
@@ -59,7 +59,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND QGLVIEWER_FOUND AND TARGET 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Periodic_Lloyd_3 )
 
   target_link_libraries( Periodic_Lloyd_3 PRIVATE
-    CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL Qt5::Help
+    CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL
     ${QGLVIEWER_LIBRARIES} )
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)


### PR DESCRIPTION
## Summary of Changes
Remove Qt5::Help from CMakeLists because it causes errors and it is not used.

## Release Management

* Affected package(s):Periodic_3_Triangulation_3 demos

