### PR TITLE
Polyhedron_demo: Fix some crashes when saving an item.

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1588,6 +1588,14 @@ void MainWindow::on_actionSaveAs_triggered()
     QString ext1, ext2;
     QRegExp extensions("\\(\\*\\..+\\)");
     QStringList filter_ext;
+    if(filters.empty())
+    {
+      QMessageBox::warning(this,
+                           tr("Cannot save"),
+                           tr("The selected object %1 cannot be saved.")
+                           .arg(item->name()));
+      return;
+    }
     Q_FOREACH(QString s, filters.first().split(";;"))
     {
       int pos = extensions.indexIn(s);


### PR DESCRIPTION
## Summary of Changes
If the filters are empty, filters.first().split(";;") will trigger an assertion and probably segfault, so this PR adds a check before that. If it is empty, it will trigger the warning and return.

## Release Management
