### PR TITLE
Use std::uncaught_exceptions() when available

### DIFF
--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -99,9 +99,14 @@ inline bool possibly(Uncertain<bool> c);
 #else // no CGAL_NO_ASSERTIONS
 #  define CGAL_assertion(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
-#  define CGAL_destructor_assertion(EX) \
-   (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
-#  define CGAL_assertion_msg(EX,MSG) \
+#  if __cpp_lib_uncaught_exceptions // C++17
+#    define CGAL_destructor_assertion(EX) \
+     (CGAL::possibly(EX)||(std::uncaught_exceptions() > 0)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
+#  else // use C++03 `std::uncaught_exception()`
+#    define CGAL_destructor_assertion(EX) \
+     (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
+#  endif // use C++03 `std::uncaught_exception()`
+#  define CGAL_assertion_msg(EX,MSG)                                    \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__, MSG))
 #  define CGAL_assertion_code(CODE) CODE
 #  define CGAL_assume(EX) CGAL_assertion(EX)


### PR DESCRIPTION
## Summary of Changes

That should fix the following warning.
```
[ 50%] Building CXX object CMakeFiles/dynamic_properties_test.dir/dynamic_properties_test.cpp.o
/usr/local/bin/c++   -DCGAL_TEST_SUITE=1 -DCGAL_USE_GMP -DCGAL_USE_MPFR -I/home/cgal_tester/build/src/cmake/platforms/Ubuntu-latest-GCC6-CXX1z/test/Property_map/../../include -isystem /usr/include/x86_64-linux-gnu -I/home/cgal_tester/build/src/cmake/platforms/Ubuntu-latest-GCC6-CXX1z/test/Property_map -I/home/cgal_tester/build/src/cmake/platforms/Ubuntu-latest-GCC6-CXX1z/include -I/mnt/testsuite/include  -DDONT_USE_BOOST_PROGRAM_OPTIONS -Wall -Wextra -std=c++1z -frounding-math   -Wall -frounding-math -o CMakeFiles/dynamic_properties_test.dir/dynamic_properties_test.cpp.o -c /home/cgal_tester/build/src/cmake/platforms/Ubuntu-latest-GCC6-CXX1z/test/Property_map/dynamic_properties_test.cpp
In file included from /mnt/testsuite/include/CGAL/basic.h:43,
                 from /mnt/testsuite/include/CGAL/Cartesian/Cartesian_base.h:29,
                 from /mnt/testsuite/include/CGAL/Simple_cartesian.h:29,
                 from /mnt/testsuite/include/CGAL/Exact_predicates_inexact_constructions_kernel.h:29,
                 from /home/cgal_tester/build/src/cmake/platforms/Ubuntu-latest-GCC6-CXX1z/test/Property_map/dynamic_properties_test.cpp:2:
/mnt/testsuite/include/CGAL/Polyhedron_incremental_builder_3.h: In destructor 'CGAL::Polyhedron_incremental_builder_3<HalfedgeDS_>::~Polyhedron_incremental_builder_3()':
/mnt/testsuite/include/CGAL/assertions.h:104:30: warning: 'bool std::uncaught_exception()' is deprecated [-Wdeprecated-declarations]
    (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
                              ^~~~~~~~~~~~~~~~~~
/mnt/testsuite/include/CGAL/Polyhedron_incremental_builder_3.h:204:9: note: in expansion of macro 'CGAL_destructor_assertion'
         CGAL_destructor_assertion( check_protocoll == 0);
         ^~~~~~~~~~~~~~~~~~~~~~~~~
```
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-168/Property_map/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz

## Release Management

* Affected package(s): STL_Extensions
* Issue(s) solved (if any): fix #2806

