### PR TITLE
Address the warning concerning SCL_SECURE for VC++

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
@@ -52,6 +52,7 @@
 #include <CGAL/CORE/BigFloat.h>
 #include <CGAL/CORE/Expr.h>
 #include <CGAL/tss.h>
+#include <sstream> 
 
 namespace CORE { 
 
@@ -919,16 +920,9 @@ BigFloatRep::toDecimal(unsigned int width, bool Scientific) const {
       } else { // L10 < 0
         decRep += '-';
       }
-      char eBuf[48]; // enought to hold long number L10
-      int ne = 0;
-      if ((ne = sprintf(eBuf, "%ld", labs(L10))) >= 0) {
-        eBuf[ne] = '\0';
-      } else {
-        //perror("BigFloat.cpp: Problem in outputing the exponent!");
-        core_error("BigFloat error: Problem in outputing the exponent",
-			__FILE__, __LINE__, true);
-      }
-      decRep += eBuf;
+      std::ostringstream oss;
+      oss << labs(L10);
+      decRep += oss.str();
       decOut.isScientific = true;
     }
   } else {

--- a/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
@@ -40,6 +40,7 @@
 #define CGAL_INLINE_FUNCTION
 #endif
 
+#include <CGAL/use.h>
 #include <CGAL/CORE/CoreAux.h>
 #include <gmp.h>
 

--- a/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
@@ -149,7 +149,7 @@ long gcd(long m, long n) {
   return p;
 }
 
-// char* core_itoa(int n, char* buffer)
+// char* core_itoa(int n, char* buffer, int buffer_size)
 //      returns a pointer to the null-terminated string in buffer
 // NOTES:
 // 0. Buffer size should be 17 bytes (resp., 33 bytes, 65 bytes) on 16-bit
@@ -161,8 +161,13 @@ long gcd(long m, long n) {
 // 3. A more general program should take a 3rd argument (the radix of
 //      output number).  We assume radix 10.
 CGAL_INLINE_FUNCTION
-char * core_itoa(int n, char* buffer) {
-	std::sprintf(buffer, "%d", n);
+char * core_itoa(int n, char* buffer, int buffer_size) {
+#if   defined(_MSC_VER)
+  sprintf_s(buffer, buffer_size, "%d", n);
+#else
+  CGAL_USE(buffer_size);
+  std::sprintf(buffer, "%d", n);
+#endif
 	return buffer;
 }
 
@@ -204,9 +209,9 @@ void core_error(std::string msg, std::string file, int lineno, bool err) {
   if (err) {
      char buf[65];
      // perror((std::string("CORE ERROR") + " (file " + file + ", line "
-     //        + core_itoa(lineno,buf) +"):" + msg + "\n").c_str());
+     //        + core_itoa(lineno,buf, 65) +"):" + msg + "\n").c_str());
      std::cerr << (std::string("CORE ERROR") + " (file " + file + ", line "
-             + core_itoa(lineno,buf) +"):" + msg + "\n").c_str();
+                   + core_itoa(lineno,buf, 65) +"):" + msg + "\n").c_str();
      std::exit(1); //Note: do not call abort()
   }
 }

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -454,7 +454,7 @@ message( STATUS "System: ${CMAKE_SYSTEM_NAME}" )
 
 if( MSVC )
   
-  uniquely_add_flags ( CGAL_CXX_FLAGS "-D_CRT_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_DEPRECATE;-D_CRT_SECURE_NO_WARNINGS;-D_SCL_SECURE_NO_WARNINGS" )
+  uniquely_add_flags ( CGAL_CXX_FLAGS "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS" )
   uniquely_add_flags ( CGAL_CXX_FLAGS "/fp:strict" )
   uniquely_add_flags ( CGAL_CXX_FLAGS "/fp:except-" )
   uniquely_add_flags ( CGAL_CXX_FLAGS "/wd4503" ) # Suppress warnings C4503 about "decorated name length exceeded"

--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -112,7 +112,7 @@ function(CGAL_setup_CGAL_dependencies target)
   # Now setup compilation flags
   if(MSVC)
     target_compile_options(${target} ${keyword}
-      "-D_CRT_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_DEPRECATE;-D_CRT_SECURE_NO_WARNINGS;-D_SCL_SECURE_NO_WARNINGS"
+      "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS"
       "/fp:strict"
       "/fp:except-"
       "/wd4503"  # Suppress warnings C4503 about "decorated name length exceeded"

--- a/Profiling_tools/include/CGAL/Real_timer_impl.h
+++ b/Profiling_tools/include/CGAL/Real_timer_impl.h
@@ -58,7 +58,7 @@ double Real_timer::get_real_time() const {
     // by the caller.
 #if   defined(_MSC_VER)
     struct _timeb  t;
-    _ftime(&t);
+    _ftime_s(&t);
     return double(t.time) + double(t.millitm) / 1000.0;
 #elif defined (__MINGW32__)
     struct timeb t;

--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -176,8 +176,7 @@ public:
 	break;
       }
     }while(true);
-
-    if(sscanf(buffer.c_str(), "%lf", &t) != 1) {
+    if(sscanf_s(buffer.c_str(), "%lf", &t) != 1) {
       // if a 'buffer' does not contain a double, set the fail bit.
       is.setstate(std::ios_base::failbit);
     }
@@ -229,8 +228,7 @@ public:
 	break;
       }
     }while(true);
-
-    if(sscanf(buffer.c_str(), "%f", &t) != 1) {
+    if(sscanf_s(buffer.c_str(), "%f", &t) != 1) {
       // if a 'buffer' does not contain a double, set the fail bit.
       is.setstate(std::ios_base::failbit);
     }


### PR DESCRIPTION
## Summary of Changes

Replace functions by "safe" functions that check that no buffer overflow can happen.

## Release Management

* Affected package(s):  ImageIO, Core, Stream_support
* Issue(s) solved (if any): fix #2818

