### PR TITLE
Use Doxygen 1.8.13 for official CGAL doc.

### DIFF
--- a/Maintenance/public_release/scripts/prepare_release
+++ b/Maintenance/public_release/scripts/prepare_release
@@ -35,7 +35,7 @@ printf "Copy documentation to doc_html/ and doc_html_online/...\n"
 [ -d "/srv/CGAL/www/${PUBLIC_RELEASE_NAME#CGAL-}/Manual" ] || mkdir -p "/srv/CGAL/www/${PUBLIC_RELEASE_NAME#CGAL-}/Manual"
 
 cp "$PUBLIC_RELEASE_DIR"/*(.) "${RELEASE_CANDIDATES_DIR}/$PUBLIC_RELEASE_NAME"
-rsync -a "$MANUAL_TESTS_DIR/$INTERNAL_RELEASE"/output/* "$DEST_DIR/doc_html/"
+rsync -a "$MANUAL_TESTS_DIR/$INTERNAL_RELEASE"/output2/* "$DEST_DIR/doc_html/"
 pushd "$DEST_DIR/doc_html/Manual/search"
   for i in g n c s i; do sed -i "s/..\/BGL$i/..\/BGL\/$i/g" *; done
 popd

--- a/Scripts/developer_scripts/run_doxygen_testsuite
+++ b/Scripts/developer_scripts/run_doxygen_testsuite
@@ -65,7 +65,7 @@ export PATH
 cd "$PWD/doc/scripts"
 bash -$- ./process_doc.sh /home/cgal-testsuite/local/bin/doxygen /home/mgimeno/bin/doxygen /srv/CGAL/www/Members/Manual_doxygen_test
 if head -2 ../../.scm-branch | grep -q cgal/master; then
-    rsync -a --delete "/srv/CGAL/www/Members/Manual_doxygen_test/${CGAL_RELEASE_ID}/output1/" /srv/CGAL/www/doc/master/
+    rsync -a --delete "/srv/CGAL/www/Members/Manual_doxygen_test/${CGAL_RELEASE_ID}/output2/" /srv/CGAL/www/doc/master/
 fi
 rm -rf "${CGAL_DOC_BUILD}"
 # Then gzip the log file, to save space


### PR DESCRIPTION
## Summary of Changes
The scripts that take care of the documentation now use results from Doxygen 1.8.13.
## Release Management
* Issue(s) solved (if any): fix #2706

