### PR TITLE
Mesh_3: Add access function to the stored polyhedra 

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -352,6 +352,12 @@ public:
   void detect_borders(std::vector<Polyhedron>& p);
   void detect_borders() { detect_borders(stored_polyhedra); };
 
+  // non-documented, provided to the FEniCS project
+  const std::vector<Polyhedron>& polyhedra()const
+  {
+    return stored_polyhedra;
+  }
+  
 private:
   void load_from_file(const char* filename) {
     // Create input polyhedron

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -66,6 +66,9 @@ struct Polyhedron_with_features_tester : public Tester<K>
     Mesh_domain domain(polyhedron, &CGAL::get_default_random());
     domain.detect_features();
 
+    // non-documented, provided to the FEniCS project
+    const std::vector<Polyhedron>& polyhedra = domain.polyhedra();
+    
     // Set mesh criteria
     Edge_criteria edge_criteria(0.2);
     Facet_criteria facet_criteria(30, 0.2, 0.02);

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -29,6 +29,7 @@
 #include <CGAL/IO/File_medit.h>
 #include <CGAL/IO/File_tetgen.h>
 #include <CGAL/IO/File_binary_mesh_3.h>
+#include <CGAL/use.h>
 
 #include <fstream>
 
@@ -68,6 +69,7 @@ struct Polyhedron_with_features_tester : public Tester<K>
 
     // non-documented, provided to the FEniCS project
     const std::vector<Polyhedron>& polyhedra = domain.polyhedra();
+    CGAL_USE(polyhedra);
     
     // Set mesh criteria
     Edge_criteria edge_criteria(0.2);


### PR DESCRIPTION

## Summary of Changes

We add the function `CGAL::Polyhedral_mesh_domain_with_features_3::polyhedra()`. 

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #2766


