### PR TITLE
Triangulation_2: fix a warning in  test/.../_test_line_face_circulator.h

### DIFF
--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_line_face_circulator.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_line_face_circulator.h
@@ -91,7 +91,7 @@ _test_line_face_circulator( const Tri & )
  typename std::vector<Point>::iterator mit;
  typename std::vector<Point>::iterator tit;
  int i; 
- Locate_type(lt);
+ Locate_type lt;
 
  // insert points p - create Vertex_handle vector
  std::vector<Vertex_handle> v;


### PR DESCRIPTION
## Summary of Changes

Address [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.12-Ic-173/Triangulation_2/TestReport_gimeno_Fedora-rawhide.gz)
```
test/Triangulation_2/include/CGAL/_test_line_face_circulator.h:94:13: warning: unnecessary parentheses in declaration of 'lt' [-Wparentheses]
  Locate_type(lt);
             ^
```

## Release Management

* Affected package(s): Triangulation_2

