### PR TITLE
STL_extension:  Fix #2587 concerning &* 

### DIFF
--- a/STL_Extension/include/CGAL/vector.h
+++ b/STL_Extension/include/CGAL/vector.h
@@ -66,7 +66,7 @@ public:
 
     // Allows construction of const_iterator from iterator
     template < class A, class B, class C>
-    vector_iterator( const vector_iterator<A,B,C>& i) : ptr( &*i) {}
+    vector_iterator( const vector_iterator<A,B,C>& i) : ptr(i.operator->()) {}
 
     // OPERATIONS Forward Category
     // ---------------------------


### PR DESCRIPTION
... applied to a `CGAL::internal::vector_iterator`

## Release Management

* Affected package(s): STL_extension, HalfedgeDS, Partition_2
* Issue(s) solved (if any): fix #2587

