### PR TITLE
Number_types: Call std::isfinite() if possible

### DIFF
--- a/Number_types/include/CGAL/double.h
+++ b/Number_types/include/CGAL/double.h
@@ -169,10 +169,13 @@ template <> class Real_embeddable_traits< double >
       : public CGAL::unary_function< Type, bool > {
       public :
         bool operator()( const Type& x ) const {
-#ifdef CGAL_CFG_IEEE_754_BUG
+
+#if defined CGAL_CFG_IEEE_754_BUG
           Type d = x;
           IEEE_754_double* p = reinterpret_cast<IEEE_754_double*>(&d);
           return is_finite_by_mask_double( p->c.H );
+#elif !defined CGAL_CFG_NO_CPP0X_ISFINITE
+          return std::isfinite(x);
 #elif defined CGAL_CFG_NUMERIC_LIMITS_BUG
           return (x == x) && (is_valid(x-x));
 #else

--- a/Number_types/include/CGAL/float.h
+++ b/Number_types/include/CGAL/float.h
@@ -119,10 +119,13 @@ public:
       : public CGAL::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x ) const {
-#ifdef CGAL_CFG_IEEE_754_BUG
+
+#if defined CGAL_CFG_IEEE_754_BUG
           Type f = x;
           IEEE_754_float* p = reinterpret_cast<IEEE_754_float*>(&f);
           return is_finite_by_mask_float( p->c );
+#elif !defined CGAL_CFG_NO_CPP0X_ISFINITE
+          return std::isfinite(x);
 #else
           return (x == x) && (is_valid(x-x));
 #endif


### PR DESCRIPTION
## Summary of Changes

See Issue #2092 

## Release Management

* Affected package(s): Number_types

