### PR TITLE
Polyhedron demo: Save as enhancement

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1606,12 +1606,19 @@ void MainWindow::on_actionSaveAs_triggered()
       continue;
     }
     QString caption = tr("Save %1 to File...").arg(item->name());
+    QString dir = item->property("source filename").toString();
+    if(dir.isEmpty())
+      dir = QString("%1/%2").arg(last_saved_dir).arg(item->name());
+    if(dir.isEmpty())
+      dir = item->name();
     QString filename =
         QFileDialog::getSaveFileName(this,
                                      caption,
-                                     QString("%1").arg(item->name()),
+                                     dir,
                                      filters.join(";;"),
                                      &sf);
+    
+    last_saved_dir = QFileInfo(dir).absoluteDir().path();
     extensions.indexIn(sf.split(";;").first());
     ext1 = extensions.cap();
     //remove `)`

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1628,7 +1628,13 @@ void MainWindow::on_actionSaveAs_triggered()
     if(filename.isEmpty())
       continue;
 
-    ext2 = filename.split(".").last();
+    QStringList filename_split = filename.split(".");
+    int fs_size = filename_split.size();
+    ext2 = filename_split.last();
+    
+    if(fs_size > 2 &&
+       ext2 == filename_split[filename.split(".").size()-2])
+      filename.chop(ext2.size()+1);
     QStringList final_extensions;
     Q_FOREACH(QString s, filter_ext)
     {

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1579,10 +1579,13 @@ void MainWindow::on_actionSaveAs_triggered()
     item = scene->item(id);
     QVector<CGAL::Three::Polyhedron_demo_io_plugin_interface*> canSavePlugins;
     QStringList filters;
+      QString sf;
     Q_FOREACH(CGAL::Three::Polyhedron_demo_io_plugin_interface* plugin, io_plugins) {
       if(plugin->canSave(item)) {
         canSavePlugins << plugin;
         filters += plugin->saveNameFilters();
+        if(plugin->isDefaultLoader(item))
+          sf = plugin->saveNameFilters().split(";;").first();
       }
     }
     QString ext1, ext2;
@@ -1603,7 +1606,6 @@ void MainWindow::on_actionSaveAs_triggered()
       continue;
     }
     QString caption = tr("Save %1 to File...").arg(item->name());
-    QString sf;
     QString filename =
         QFileDialog::getSaveFileName(this,
                                      caption,

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -402,6 +402,7 @@ private:
   QTreeView* sceneView;
   Ui::MainWindow* ui;
   QVector<CGAL::Three::Polyhedron_demo_io_plugin_interface*> io_plugins;
+  QString last_saved_dir;
   QMap<QString,QString> default_plugin_selection;
   // typedef to make Q_FOREACH work
   typedef QPair<CGAL::Three::Polyhedron_demo_plugin_interface*, QString> PluginNamePair;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -23,6 +23,13 @@ class Polyhedron_demo_off_plugin :
   Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.IOPluginInterface/1.0")
 
 public:
+  bool isDefaultLoader(const Scene_item *item) const 
+  { 
+    if(qobject_cast<const Scene_polyhedron_item*>(item)
+       || qobject_cast<const Scene_polygon_soup_item*>(item)) 
+      return true; 
+    return false;
+  }
   QString name() const { return "off_plugin"; }
   QString nameFilters() const { return "OFF files (*.off);;Wavefront OBJ (*.obj)"; }
   bool canLoad() const;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
@@ -22,6 +22,12 @@ class Polyhedron_demo_ply_plugin :
   Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.IOPluginInterface/1.0")
 
 public:
+  bool isDefaultLoader(const CGAL::Three::Scene_item *item) const 
+  { 
+    if(qobject_cast<const Scene_points_with_normal_item*>(item)) 
+      return true; 
+    return false;
+  }
   QString name() const { return "ply_plugin"; }
   QString nameFilters() const { return "PLY files (*.ply)"; }
   bool canLoad() const;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Surface_mesh_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Surface_mesh_io_plugin.cpp
@@ -24,6 +24,13 @@ class SurfaceMeshIoPlugin :
   Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
   Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.IOPluginInterface/1.0")
 public:
+  bool isDefaultLoader(const CGAL::Three::Scene_item *item) const 
+  { 
+    if(qobject_cast<const Scene_surface_mesh_item*>(item))
+      return true; 
+    return false;
+  }
+  
   void init(QMainWindow*, CGAL::Three::Scene_interface*, Messages_interface* m)
   {
     this->message = m;

--- a/Three/include/CGAL/Three/Polyhedron_demo_io_plugin_interface.h
+++ b/Three/include/CGAL/Three/Polyhedron_demo_io_plugin_interface.h
@@ -68,6 +68,11 @@ public:
   //!contained in fileinfo. Returns false if error.
   //! This must be overriden.
   virtual bool save(const Scene_item*, QFileInfo fileinfo) = 0;
+  
+  //! If this returns `true`, then the loader will be chosen as defaultin the
+  //! list of available loaders when saving a file, which means it will be the 
+  //! first in the list.
+  virtual bool isDefaultLoader(const Scene_item*) const { return false; }
 };
 }
 }


### PR DESCRIPTION
## Summary of Changes
- Adds a function to IO plugins interface.
  It decides if the plugin should be the default plugin for saving a given item.
- Set off_plugin as default saver for polygon soups and polyhedron_items, surface_mesh_io_plugin for surface_mesh_items and PLY_plugin for point_with_normals_items.
  This means their first nameFilter(OFF for the 2 first, PLY for the latter) will be the first choice when saving an item.

- When saving a file, if it was loaded, will use its loading-path as default for saving. If it was not loaded, will use the last path used for saving in the current session as default path for saving. If none of the previous cases are applicable, use the same default path as before (which must be the build dir of the demo I think).

## Release Management

* Issue(s) solved (if any): fix #2334 


