### PR TITLE
Define CGAL_NORETURN also for VC++ 

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -527,9 +527,12 @@ using std::max;
 // Macro to specify a 'noreturn' attribute.
 #if defined(__GNUG__) || __has_attribute(__noreturn__)
 #  define CGAL_NORETURN  __attribute__ ((__noreturn__))
-#else
+#elif defined (_MSC_VER)
+#  define CGAL_NORETURN __declspec(noreturn)
+#else  
 #  define CGAL_NORETURN
 #endif
+
 
 // Macro CGAL_ASSUME
 // Call a builtin of the compiler to pass a hint to the compiler

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -63,9 +63,9 @@ namespace CGAL {
 // =====================
 // failure functions
 // -----------------
-CGAL_EXPORT void assertion_fail      ( const char*, const char*, int, const char* = "") CGAL_NORETURN;
-CGAL_EXPORT void precondition_fail   ( const char*, const char*, int, const char* = "") CGAL_NORETURN;
-CGAL_EXPORT void postcondition_fail  ( const char*, const char*, int, const char* = "") CGAL_NORETURN;
+CGAL_EXPORT CGAL_NORETURN void assertion_fail      ( const char*, const char*, int, const char* = "") ;
+CGAL_EXPORT CGAL_NORETURN void precondition_fail   ( const char*, const char*, int, const char* = "") ;
+CGAL_EXPORT CGAL_NORETURN void postcondition_fail  ( const char*, const char*, int, const char* = "") ;
 
 // warning function
 // ----------------


### PR DESCRIPTION
...and move the macro before the functions.

## Release Management

* Affected package(s):  STL_extensions (assertions.h)
* Issue(s) solved (if any): fix #2826 

