### PR TITLE
STL_extension: Introduce CGAL::iterator 

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -33,7 +33,7 @@
 #define CGAL_ALGEBRAIC_CURVE_KERNEL_D_2_H
 
 #include <limits>
-
+#include <CGAL/iterator.h>
 #include <CGAL/assertions.h>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/optional.hpp>
@@ -1802,8 +1802,8 @@ public:
      */
     class X_critical_points_2 : 
         public CGAL::binary_function< Curve_analysis_2,
-            std::iterator<std::output_iterator_tag, Algebraic_real_2>,
-            std::iterator<std::output_iterator_tag, Algebraic_real_2> > {
+            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2>,
+            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2> > {
        
     public:
         
@@ -1881,8 +1881,8 @@ public:
      */
     class Y_critical_points_2 :
         public CGAL::binary_function< Curve_analysis_2,
-            std::iterator<std::output_iterator_tag, Algebraic_real_2>,
-            std::iterator<std::output_iterator_tag, Algebraic_real_2> > {
+            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2>,
+            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2> > {
         
 
     public:

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
@@ -29,7 +29,7 @@
 
 #include <CGAL/config.h>
 #include <CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h>
-
+#include <CGAL/iterator.h>
 namespace CGAL {
 
 namespace internal {
@@ -1432,7 +1432,7 @@ public:
     CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
     
     //! the result type
-    typedef std::iterator< std::output_iterator_tag, CGAL::Object > 
+    typedef CGAL::iterator< std::output_iterator_tag, CGAL::Object > 
     result_type;
     
     //! the arity of the functor
@@ -1888,7 +1888,7 @@ public:
     CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
     
     //! the result type
-    typedef std::iterator< std::output_iterator_tag, CGAL::Object > 
+    typedef CGAL::iterator< std::output_iterator_tag, CGAL::Object > 
     result_type;
 
     //! the arity of the functor
@@ -2511,7 +2511,7 @@ public:
     typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
     
     //! the result type
-    typedef std::iterator< std::output_iterator_tag, Coordinate_2 >
+    typedef CGAL::iterator< std::output_iterator_tag, Coordinate_2 >
          result_type;
 
     //! the arity of the functor
@@ -2576,7 +2576,7 @@ public:
     typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
     
     //! the result type
-    typedef std::iterator< std::output_iterator_tag, Coordinate_2 >
+    typedef CGAL::iterator< std::output_iterator_tag, Coordinate_2 >
              result_type;
 
     //! the arity of the functor

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
@@ -31,6 +31,7 @@
  */
 
 #include <CGAL/config.h>
+#include <CGAL/iterator.h>
 #include <CGAL/Handle_with_policy.h>
 
 // TODO remove polynomial_traits
@@ -57,8 +58,8 @@ template < class CurvedKernelViaAnalysis_2,
            typename CurvedKernelViaAnalysis_2::Construct_arc_2 >
 struct Make_x_monotone_2 :
     public CGAL::binary_function< typename CurvedKernelViaAnalysis_2::Curve_2,
-            std::iterator<std::output_iterator_tag, CGAL::Object>,
-            std::iterator<std::output_iterator_tag, CGAL::Object> > {
+            CGAL::iterator<std::output_iterator_tag, CGAL::Object>,
+            CGAL::iterator<std::output_iterator_tag, CGAL::Object> > {
 
     //!\name Public types
     //!@{

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Sweep_curves_adapter_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Sweep_curves_adapter_2.h
@@ -33,7 +33,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/none.hpp>
-
+#include <CGAL/iterator.h>
 #include <CGAL/Handle_with_policy.h>
 
 #include <CGAL/Arr_enums.h>
@@ -693,7 +693,7 @@ class Make_x_monotone_2
     typedef typename SweepCurvesAdapter_2::Generic_arc_2 Generic_arc_2;
    
 public:
-    typedef std::iterator<std::output_iterator_tag, Generic_arc_2> 
+    typedef CGAL::iterator<std::output_iterator_tag, Generic_arc_2> 
       result_type;
     
     //! standard constructor

--- a/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
@@ -32,6 +32,7 @@
 #include <CGAL/Qt/GraphicsItem.h>
 #include <CGAL/Qt/Converter.h>
 #include <CGAL/Fuzzy_iso_box.h>
+#include <CGAL/iterator.h>
 
 #include <QGraphicsScene>
 #include <QPainter>
@@ -53,7 +54,7 @@ class PointsInKdTreeGraphicsItem : public GraphicsItem
   // Instead of first collecting points into a container, and then draw them
   // we use an output iterator that draws them on the fly
   template <typename K>
-  class Draw : public std::iterator<std::output_iterator_tag, void, void, void, void> {
+  class Draw : public CGAL::iterator<std::output_iterator_tag, void, void, void, void> {
     QPainter* painter;
     QMatrix* matrix;
     Converter<K> convert;

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -93,20 +93,20 @@ Iterator_range<Prevent_deref<I> > make_prevent_deref_range(const I& begin, const
   return Iterator_range<Prevent_deref<I> >(make_prevent_deref(begin), make_prevent_deref(end));
 }
 
-  template<typename _Category, typename _Tp, typename _Distance = std::ptrdiff_t,
-         typename _Pointer = _Tp*, typename _Reference = _Tp&>
+template<typename Category, typename Tp, typename Distance = std::ptrdiff_t,
+         typename Pointer = Tp*, typename Reference = Tp&>
 struct iterator
 {
   /// One of the iterator_tags tag types.
-  typedef _Category  iterator_category;
+  typedef Category  iterator_category;
   /// The type "pointed to" by the iterator.
-  typedef _Tp        value_type;
+  typedef Tp        value_type;
   /// Distance between iterators is represented as this type.
-  typedef _Distance  difference_type;
+  typedef Distance  difference_type;
   /// This type represents a pointer-to-value_type.
-  typedef _Pointer   pointer;
+  typedef Pointer   pointer;
   /// This type represents a reference-to-value_type.
-  typedef _Reference reference;
+  typedef Reference reference;
 };
 
   

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -93,6 +93,23 @@ Iterator_range<Prevent_deref<I> > make_prevent_deref_range(const I& begin, const
   return Iterator_range<Prevent_deref<I> >(make_prevent_deref(begin), make_prevent_deref(end));
 }
 
+  template<typename _Category, typename _Tp, typename _Distance = std::ptrdiff_t,
+         typename _Pointer = _Tp*, typename _Reference = _Tp&>
+struct iterator
+{
+  /// One of the iterator_tags tag types.
+  typedef _Category  iterator_category;
+  /// The type "pointed to" by the iterator.
+  typedef _Tp        value_type;
+  /// Distance between iterators is represented as this type.
+  typedef _Distance  difference_type;
+  /// This type represents a pointer-to-value_type.
+  typedef _Pointer   pointer;
+  /// This type represents a reference-to-value_type.
+  typedef _Reference reference;
+};
+
+  
 // +----------------------------------------------------------------+
 // | Emptyset_iterator
 // +----------------------------------------------------------------+
@@ -100,7 +117,7 @@ Iterator_range<Prevent_deref<I> > make_prevent_deref_range(const I& begin, const
 // +----------------------------------------------------------------+
 
 struct Emptyset_iterator
-  : public std::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
 {
   template< class T >
   Emptyset_iterator& operator=(const T&) { return *this; }
@@ -120,7 +137,7 @@ struct Emptyset_iterator
 
 template < class Container >
 class Insert_iterator
-  : public std::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
 {
 protected:
   Container *container;
@@ -161,7 +178,7 @@ inserter(Container &x)
 
 template < class T >
 class Oneset_iterator
-  : public std::iterator< std::bidirectional_iterator_tag,
+  : public CGAL::iterator< std::bidirectional_iterator_tag,
 			  void, void, void, void >
 {
   T* t;
@@ -268,7 +285,7 @@ private:
 
 // Undocumented, because there is some hope to merge it into Counting_iterator
 class Counting_output_iterator
-  : public std::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
 {
   std::size_t *c;
 public:
@@ -286,7 +303,7 @@ public:
 };
 
 template < class I,
-           class Val = typename std::iterator_traits<I>::value_type >
+           class Val = typename CGAL::iterator_traits<I>::value_type >
 class Counting_iterator {
 protected:
   I            nt;    // The internal iterator.
@@ -646,7 +663,7 @@ bool operator!=(const Filter_iterator<I,P>& it1,
 
 template <class I1,class Op>
 class Join_input_iterator_1 : public 
-std::iterator<typename std::iterator_traits<I1>::iterator_category, 
+CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
 	      typename Op::result_type, 
 	      typename std::iterator_traits<I1>::difference_type, 
 	      typename Op::result_type*,
@@ -732,7 +749,7 @@ public:
 
 template <class I1,class I2,class Op>
 class Join_input_iterator_2 : public 
-std::iterator<typename std::iterator_traits<I1>::iterator_category, 
+CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
 	      typename Op::result_type, 
 	      typename std::iterator_traits<I1>::difference_type, 
 	      typename Op::result_type*,
@@ -825,7 +842,7 @@ public:
 
 template <class I1,class I2,class I3,class Op>
 class Join_input_iterator_3 : public 
-std::iterator<typename std::iterator_traits<I1>::iterator_category, 
+CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
 	      typename Op::result_type, 
 	      typename std::iterator_traits<I1>::difference_type, 
 	      typename Op::result_type*,
@@ -1203,7 +1220,7 @@ public:
 
 template<typename _Iterator, typename Predicate>
     class Filter_output_iterator
-    : public std::iterator<std::output_iterator_tag, void, void, void, void>
+    : public CGAL::iterator<std::output_iterator_tag, void, void, void, void>
     {
     protected:
       _Iterator iterator;

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -303,7 +303,7 @@ public:
 };
 
 template < class I,
-           class Val = typename CGAL::iterator_traits<I>::value_type >
+           class Val = typename std::iterator_traits<I>::value_type >
 class Counting_iterator {
 protected:
   I            nt;    // The internal iterator.


### PR DESCRIPTION
... as replacement for the deprecated `std::iterator`.  It is only an implementation detail, that is we do not document it. 

## Release Management

* Affected package(s): `STL_extension`, ` Algebraic_kernel_d`, `Arrangement_on_surface_2`, `GraphicsView` 
* Issue(s) solved (if any): fix #2832

