### PR TITLE
Random_numbers: Add overload for uniform_smallint

### DIFF
--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -84,6 +84,7 @@ public:
   }
 
 
+
   template <typename IntType>
   IntType
   uniform_smallint(IntType lower, IntType upper)
@@ -93,6 +94,16 @@ public:
     boost::variate_generator<boost::rand48&, boost::uniform_smallint<IntType> > generator(rng,dist);
     
     return generator();
+  }
+
+  // Overload to avoid a warning with VC++
+  template <>
+  inline
+  std::size_t
+  uniform_smallint(std::size_t lower, std::size_t upper)
+  {
+    return uniform_smallint(static_cast<boost::rand48::result_type>(lower),
+                            static_cast<boost::rand48::result_type>(upper));
   }
 
   template <typename IntType>

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -97,7 +97,6 @@ public:
   }
 
   // Overload to avoid a warning with VC++
-  template <>
   inline
   std::size_t
   uniform_smallint(std::size_t lower, std::size_t upper)

--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -90,21 +90,15 @@ public:
   uniform_smallint(IntType lower, IntType upper)
   {
     // uniform_smallint has a closed interval, CGAL a halfopen
-    boost::uniform_smallint<IntType> dist(lower,upper-1);
-    boost::variate_generator<boost::rand48&, boost::uniform_smallint<IntType> > generator(rng,dist);
+    typedef boost::rand48::result_type result_type;
+    boost::uniform_smallint<result_type> dist(static_cast<result_type>(lower),
+                                              static_cast<result_type>(upper-1));
+    boost::variate_generator<boost::rand48&, boost::uniform_smallint<result_type> > generator(rng,dist);
     
     return generator();
   }
 
-  // Overload to avoid a warning with VC++
-  inline
-  std::size_t
-  uniform_smallint(std::size_t lower, std::size_t upper)
-  {
-    return uniform_smallint(static_cast<boost::rand48::result_type>(lower),
-                            static_cast<boost::rand48::result_type>(upper));
-  }
-
+  
   template <typename IntType>
   IntType
   uniform_smallint(IntType lower)


### PR DESCRIPTION
## Summary of Changes

Add on overload for `std::size_t`.

An alternative would have been to add 4267  to the disabled warnings in [`Random.h`](https://github.com/CGAL/cgal/blob/master/Random_numbers/include/CGAL/Random.h#L36)

## Release Management

* Affected package(s): Random_numbers
* Issue(s) solved (if any): fix #2555 
