### PR TITLE
Polyhedron demo: Make Polyline from non manifold edges

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 
 polyhedron_demo_plugin(orient_soup_plugin Orient_soup_plugin)
-target_link_libraries(orient_soup_plugin PUBLIC scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item)
+target_link_libraries(orient_soup_plugin PUBLIC scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item scene_polylines_item)
 
 
 polyhedron_demo_plugin(inside_out_plugin Inside_out_plugin)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 
 polyhedron_demo_plugin(orient_soup_plugin Orient_soup_plugin)
-target_link_libraries(orient_soup_plugin PUBLIC scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item scene_polylines_item)
+target_link_libraries(orient_soup_plugin PUBLIC scene_polygon_soup_item scene_polyhedron_item scene_surface_mesh_item scene_polylines_item scene_points_with_normal_item)
 
 
 polyhedron_demo_plugin(inside_out_plugin Inside_out_plugin)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -352,7 +352,7 @@ void Polyhedron_demo_orient_soup_plugin::createPointsAndPolyline()
     }
     QApplication::restoreOverrideCursor();
     if(!items_created)
-      QMessageBox::information(mw, "Nothing Non-manifold", "No non-manifold edge nore vertex was found.");
+      QMessageBox::information(mw, "Nothing Non-manifold", "No non-manifold edge nor vertex was found.");
   }  
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -195,7 +195,7 @@ void Polyhedron_demo_orient_soup_plugin::orientSM()
 
     if(item)
     {
-      int create_items = QMessageBox::question(mw, "Orient Mesh", "Do you wish to extract the eventual non manifold simplicies ?");
+      int create_items = QMessageBox::question(mw, "Orient Mesh", "Do you wish to extract the potential non manifold simplicies ?");
       if(create_items == QMessageBox::Yes)
       {
         createPointsAndPolyline();
@@ -309,6 +309,7 @@ void Polyhedron_demo_orient_soup_plugin::createPointsAndPolyline()
     Scene_points_with_normal_item* points = new Scene_points_with_normal_item();
     std::vector<std::size_t> nm_vertices;
     getNMPoints(nm_vertices, item);
+    bool items_created = false;
     if(nm_vertices.empty())
     {
       delete points;
@@ -316,7 +317,7 @@ void Polyhedron_demo_orient_soup_plugin::createPointsAndPolyline()
     }
     else
     {
-      
+        items_created = true;
       BOOST_FOREACH(std::size_t id, nm_vertices)
       {
         points->point_set()->insert(item->points()[id]);
@@ -343,12 +344,15 @@ void Polyhedron_demo_orient_soup_plugin::createPointsAndPolyline()
       poly->setColor(QColor(Qt::red));
       
       scene->addItem(poly);
+      items_created = true;
     }
     else
     {
-      messages->information("Non non-manifold edges were found.");
+      messages->information(tr("There is no non-manifold edge in this soup."));
     }
     QApplication::restoreOverrideCursor();
+    if(!items_created)
+      QMessageBox::information(mw, "Nothing Non-manifold", "No non-manifold edge nore vertex was found.");
   }  
 }
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -298,8 +298,6 @@ void Polyhedron_demo_orient_soup_plugin::displayNonManifoldEdges()
 void Polyhedron_demo_orient_soup_plugin::createPointsAndPolyline()
 {
   
-  typedef std::pair<std::size_t, std::vector<std::size_t> > V_ID_and_P_IDs;
-  
   const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
   
   Scene_polygon_soup_item* item =

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -920,3 +920,9 @@ void Scene_polygon_soup_item::itemAboutToBeDestroyed(Scene_item *item)
     }
   }
 }
+
+const Polygon_soup::Edges& 
+Scene_polygon_soup_item::non_manifold_edges() const
+{
+  return d->soup->non_manifold_edges;
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.h
@@ -108,6 +108,7 @@ public:
     typedef Kernel::Point_3 Point_3;
     typedef Polygon_soup::Points Points;
     typedef Polygon_soup::Polygons Polygons;
+    typedef Polygon_soup::Edges Edges;
 
     Scene_polygon_soup_item();
     ~Scene_polygon_soup_item();
@@ -151,6 +152,7 @@ public:
 
     const Points& points() const;
     const Polygons& polygons() const;
+    const Edges& non_manifold_edges() const;
 
 public Q_SLOTS:
     void shuffle_orientations();


### PR DESCRIPTION
## Summary of Changes

Add an action to Orient_polygon_soup_plugin that creates a polyline from non manifold edges of a soup,
and another action for non-manifold vertices to points.
## Release Management
