### PR TITLE
Improve internal autorefinement function

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -595,15 +595,31 @@ public:
               nodes);
             if ( q2_is_between_p1p2 ){
              //case 1
-             uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_p2]);
              patches_to_keep.reset(patch_id_q2);
-             patches_to_keep.reset(patch_id_q1);
+             if (patch_id_p1<patch_id_q1)
+             {
+               uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_p2]);
+               patches_to_keep.reset(patch_id_q1);
+             }
+             else
+             {
+               uf.unify_sets(patch_handles[patch_id_q1], patch_handles[patch_id_p2]);
+               patches_to_keep.reset(patch_id_p1);
+             }
             }
             else{
               //case 2
-              uf.unify_sets(patch_handles[patch_id_q1], patch_handles[patch_id_q2]);
-              patches_to_keep.reset(patch_id_p1);
               patches_to_keep.reset(patch_id_p2);
+              if (patch_id_p1<patch_id_q1)
+              {
+                uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_q2]);
+                patches_to_keep.reset(patch_id_q1);
+              }
+              else
+              {
+                uf.unify_sets(patch_handles[patch_id_q1], patch_handles[patch_id_q2]);
+                patches_to_keep.reset(patch_id_p1);
+              }
             }
             continue;
           }
@@ -626,15 +642,16 @@ public:
                 nodes);
               if ( q1_is_between_p1p2 ){
                 // case 3
-                uf.unify_sets(patch_handles[patch_id_q1], patch_handles[patch_id_q2]);
                 patches_to_keep.reset(patch_id_p1);
                 patches_to_keep.reset(patch_id_p2);
+                patches_to_keep.reset(patch_id_q1);
+                patches_to_keep.reset(patch_id_q2);
               }
               else{
                 // case 4
-                uf.unify_sets(patch_handles[patch_id_p2], patch_handles[patch_id_q1]);
-                patches_to_keep.reset(patch_id_q2);
+                uf.unify_sets(patch_handles[patch_id_q1], patch_handles[patch_id_p2]);
                 patches_to_keep.reset(patch_id_p1);
+                patches_to_keep.reset(patch_id_q2);
               }
               continue;
             }
@@ -657,14 +674,15 @@ public:
                   nodes);
                 if ( q2_is_between_p1p2 )
                 {  //case 5
-                  uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_p2]);
+                  patches_to_keep.reset(patch_id_p1);
+                  patches_to_keep.reset(patch_id_p2);
                   patches_to_keep.reset(patch_id_q1);
                   patches_to_keep.reset(patch_id_q2);
                 }else{
                   //case 6
-                  uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_q2]);
-                  patches_to_keep.reset(patch_id_p2);
+                  uf.unify_sets(patch_handles[patch_id_q2], patch_handles[patch_id_p1]);
                   patches_to_keep.reset(patch_id_q1);
+                  patches_to_keep.reset(patch_id_p2);
                 }
                 continue;
               }
@@ -686,15 +704,31 @@ public:
                     nodes);
                   if ( q1_is_between_p1p2 ){
                     //case 7
-                    uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_p2]);
                     patches_to_keep.reset(patch_id_q1);
-                    patches_to_keep.reset(patch_id_q2);
+                    if(patch_id_p2<patch_id_q2)
+                    {
+                      uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_p2]);
+                      patches_to_keep.reset(patch_id_q2);
+                    }
+                    else
+                    {
+                      uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_q2]);
+                      patches_to_keep.reset(patch_id_p2);
+                    }
                   }
                   else{
                     //case 8
-                    uf.unify_sets(patch_handles[patch_id_p1], patch_handles[patch_id_q1]);
-                    patches_to_keep.reset(patch_id_p2);
-                    patches_to_keep.reset(patch_id_q2);
+                    patches_to_keep.reset(patch_id_p1);
+                    if(patch_id_p2<patch_id_q2)
+                    {
+                      uf.unify_sets(patch_handles[patch_id_p2], patch_handles[patch_id_q1]);
+                      patches_to_keep.reset(patch_id_q2);
+                    }
+                    else
+                    {
+                      uf.unify_sets(patch_handles[patch_id_q2], patch_handles[patch_id_q1]);
+                      patches_to_keep.reset(patch_id_p2);
+                    }
                   }
                   continue;
                 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -802,7 +802,7 @@ public:
                 //       issue if anyway the whole patch would be dropped.
                 //       Note that this remark is value for all cases where
                 //       all_fixed is set to false.
-                if (patch_id_p1!=patch_id_p2 && patch_id_q1==patch_id_q2)
+                if (patch_id_p1==patch_id_p2 || patch_id_q1==patch_id_q2)
                 {
                   all_fixed = false;
                   continue;
@@ -821,8 +821,8 @@ public:
               if ( is_dangling_edge(ids.first, ids.second, h1, tm, is_node_of_degree_one) ||
                    is_dangling_edge(ids.first, ids.second, h2, tm, is_node_of_degree_one) )
               {
-                // save reason as above
-                if (patch_id_p1!=patch_id_p2 && patch_id_q1==patch_id_q2)
+                // same reason as above
+                if (patch_id_p1==patch_id_p2 || patch_id_q1==patch_id_q2)
                 {
                   all_fixed = false;
                   continue;
@@ -843,7 +843,7 @@ public:
               if (!p1_is_between_q1q2){
                 //case (e4)
                 //TODO: This is a "tangency" along an edge here, there is
-                //      not much we can do but if on of the two sheets is dropped
+                //      not much we can do but if one of the two sheets is dropped
                 all_fixed = false;
                 continue;
               }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -870,7 +870,7 @@ public:
         typename EK::Point_3 p = nodes.to_exact(get(vpm,f_vertices[0])),
                              q = nodes.to_exact(get(vpm,f_vertices[1])),
                              r = nodes.to_exact(get(vpm,f_vertices[2]));
-
+///TODO use a positive normal and remove all work around to guarantee that triangulation of coplanar patches are compatible
         CDT_traits traits(typename EK::Construct_normal_3()(p,q,r));
         CDT cdt(traits);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -845,7 +845,7 @@ class Intersection_of_triangle_meshes
         std::map<face_descriptor, std::vector< face_descriptor> > triple_intersections;
         for(std::size_t j=i+1; j<nb_faces;++j)
         {
-          if (p.second[j] < p.second[i]) continue;
+          if (p.second[j] <= p.second[i]) continue;
           typename Faces_to_nodes_map::iterator find_it =
             f_to_node.find(std::make_pair(make_sorted_pair(p.second[i],
                                            p.second[j]),0));// TODO 0 is the value in case there are no coplanar intersection point

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -353,6 +353,8 @@ class Intersection_of_triangle_meshes
     }
 
     Key key(ipt.type_1, ipt.type_2, h1, h2);
+    if (&tm1==&tm2 && h1>h2)
+      key=Key(ipt.type_2, ipt.type_1, h2, h1);
 
     std::pair<typename std::map<Key,Node_id>::iterator,bool> res=
       coplanar_node_map.insert(std::make_pair(key,current_node+1));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
@@ -165,6 +165,7 @@ private:
   Double_to_exact double_to_exact;
   Exact_to_double exact_to_double;
   Exact_kernel        ek;
+  Exact_kernel::Intersect_3 exact_intersection;
   std::vector<vertex_descriptor> tm1_vertices, tm2_vertices;
 
 public:
@@ -254,7 +255,7 @@ public:
                to_exact( get(vpm, target(next(h3,tm),tm))));
     typename cpp11::result_of<
       Exact_kernel::Intersect_3(Plane_3, Plane_3, Plane_3)
-    >::type inter_res = intersection(p1, p2, p3);
+    >::type inter_res = exact_intersection(p1, p2, p3);
 
     CGAL_assertion(inter_res != boost::none);
     const Exact_kernel::Point_3* pt =

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
@@ -234,6 +234,35 @@ public:
         to_exact( get(vpm_a, target(h_a,tm_a)) ) ) );
   }
 
+  // use to resolve intersection of 3 faces in autorefinement only
+  void add_new_node(halfedge_descriptor h1,
+                    halfedge_descriptor h2,
+                    halfedge_descriptor h3,
+                    const TriangleMesh& tm,
+                    const VertexPointMap& vpm)
+  {
+    // TODO Far from optimal!
+    typedef Exact_kernel::Plane_3 Plane_3;
+    Plane_3 p1(to_exact( get(vpm, source(h1,tm)) ),
+               to_exact( get(vpm, target(h1,tm)) ),
+               to_exact( get(vpm, target(next(h1,tm),tm)))),
+            p2(to_exact( get(vpm, source(h2,tm)) ),
+               to_exact( get(vpm, target(h2,tm)) ),
+               to_exact( get(vpm, target(next(h2,tm),tm)))),
+            p3(to_exact( get(vpm, source(h3,tm)) ),
+               to_exact( get(vpm, target(h3,tm)) ),
+               to_exact( get(vpm, target(next(h3,tm),tm))));
+    typename cpp11::result_of<
+      Exact_kernel::Intersect_3(Plane_3, Plane_3, Plane_3)
+    >::type inter_res = intersection(p1, p2, p3);
+
+    CGAL_assertion(inter_res != boost::none);
+    const Exact_kernel::Point_3* pt =
+      boost::get<Exact_kernel::Point_3>(&(*inter_res));
+    CGAL_assertion(pt!=NULL);
+    add_new_node(*pt);
+  }
+
   void add_new_node(halfedge_descriptor edge_1, face_descriptor face_2)
   {
     add_new_node(edge_1, face_2, tm1, tm2, vpm1, vpm2);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
@@ -1730,7 +1730,9 @@ surface_self_intersection(const TriangleMesh& tm,
                               vertex_point);
 
 // surface intersection algorithm call
-  Corefinement::Intersection_of_triangle_meshes<TriangleMesh,Vpm>
+  typedef Corefinement::Default_surface_intersection_visitor<TriangleMesh,
+                                                             true>      Visitor;
+  Corefinement::Intersection_of_triangle_meshes<TriangleMesh,Vpm, Visitor>
     functor(tm, vpm);
 
   polyline_output=functor(polyline_output, true);


### PR DESCRIPTION
This brings a few improvements for the non-documented autorefinement functionality in case 3 faces intersect in a point (that is not a common vertex).
More than 3 faces intersecting and coplanar faces are not handled for now.

