### PR TITLE
BGL: Add missing requirement in FaceGraph Concept

### DIFF
--- a/BGL/doc/BGL/Concepts/FaceGraph.h
+++ b/BGL/doc/BGL/Concepts/FaceGraph.h
@@ -8,6 +8,8 @@ maintain faces described by halfedges, to provide access from a face to
 an incident halfedge, and to provide access from a halfedge to its incident
 face. 
 
+Two faces incident to a same edge must be different.
+
 \cgalAssociatedTypesBegin
 
 \cgalAssociatedTypeBegin{boost::graph_traits<FaceGraph>::%face_descriptor} A face descriptor corresponds to a unique face in an abstract graph instance.


### PR DESCRIPTION
## Summary of Changes
Adds to the FaceGraph Concept that two faces incident to a same edge must be different.

## Release Management

* Affected package(s):BGL
