### PR TITLE
Set the default value of CGAL_DEV_MODE from the env variable

### DIFF
--- a/Installation/cmake/modules/CGAL_Common.cmake
+++ b/Installation/cmake/modules/CGAL_Common.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/CGAL_Macros.cmake)
 
 option(CGAL_DEV_MODE
   "Activate the CGAL developers mode. See https://github.com/CGAL/cgal/wiki/CGAL_DEV_MODE"
-  FALSE)
+  $ENV{CGAL_DEV_MODE})
 
 if(RUNNING_CGAL_AUTO_TEST)
 # Just to avoid a warning from CMake if that variable is set on the command line...


### PR DESCRIPTION
If the environment variable `CGAL_DEV_MODE` is set to a "true" value,
according to CMake, then the `CGAL_DEV_MODE` CMake option is `ON` by
default.

https://cmake.org/Wiki/CMake/Language_Syntax#CMake_supports_boolean_variables.

> CMake considers an empty string, "FALSE", "OFF", "NO", or any string
> ending in "-NOTFOUND" to be false. [..] Other values are true.

That improves the PR #2799.
