### PR TITLE
Declare several operator() used for comparisons const

### DIFF
--- a/Generator/include/CGAL/Random_polygon_2_sweep.h
+++ b/Generator/include/CGAL/Random_polygon_2_sweep.h
@@ -88,11 +88,11 @@ class Vertex_data ;
 template <class ForwardIterator, class PolygonTraits>
 class Less_segments {
     Vertex_data<ForwardIterator, PolygonTraits> *m_vertex_data;
-    bool less_than_in_tree(Vertex_index i, Vertex_index j);
+    bool less_than_in_tree(Vertex_index i, Vertex_index j) const;
   public:
     Less_segments(Vertex_data<ForwardIterator, PolygonTraits> *vertex_data)
     : m_vertex_data(vertex_data) {}
-   bool operator()(Vertex_index i, Vertex_index j);
+   bool operator()(Vertex_index i, Vertex_index j) const;
 };
 
 template <class ForwardIterator, class PolygonTraits>
@@ -144,7 +144,7 @@ public:
 namespace i_generator_polygon {
 template <class ForwardIterator, class PolygonTraits>
 bool Less_segments<ForwardIterator, PolygonTraits>::
-operator()(Vertex_index i, Vertex_index j)
+operator()(Vertex_index i, Vertex_index j) const
 {
     if (m_vertex_data->edges[j.as_int()].is_in_tree) {
         return less_than_in_tree(i,j);
@@ -155,7 +155,7 @@ operator()(Vertex_index i, Vertex_index j)
 
 template <class ForwardIterator, class PolygonTraits>
 bool Less_segments<ForwardIterator, PolygonTraits>::
-less_than_in_tree(Vertex_index new_edge, Vertex_index tree_edge)
+less_than_in_tree(Vertex_index new_edge, Vertex_index tree_edge) const
 {
 #if defined(CGAL_POLY_GENERATOR_DEBUG)
     std::cout << "less_than_in_tree" << std::endl;

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_simplicity.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_simplicity.h
@@ -101,10 +101,10 @@ template <class VertexData>
 class Less_segments {
     typedef VertexData         Vertex_data;
     Vertex_data *m_vertex_data;
-    bool less_than_in_tree(Vertex_index i, Vertex_index j);
+    bool less_than_in_tree(Vertex_index i, Vertex_index j) const;
   public:
     Less_segments(Vertex_data *vertex_data) : m_vertex_data(vertex_data) {}
-    bool operator()(Vertex_index i, Vertex_index j);
+    bool operator()(Vertex_index i, Vertex_index j) const;
 };
 
 // The data in Edge_data is attached to an edge when it is (about to be)
@@ -199,7 +199,7 @@ class Less_vertex_data {
 public:
     Less_vertex_data(VertexData *vd)
     : m_vertex_data(vd) {}
-    bool operator()(Vertex_index i, Vertex_index j);
+    bool operator()(Vertex_index i, Vertex_index j) const;
 };
 
 } // end of namespace i_polygon
@@ -209,7 +209,7 @@ public:
 namespace i_polygon {
 template <class VertexData>
 bool Less_segments<VertexData>::
-operator()(Vertex_index i, Vertex_index j)
+operator()(Vertex_index i, Vertex_index j) const
 {
     if (m_vertex_data->edges[j.as_int()].is_in_tree) {
         return less_than_in_tree(i,j);
@@ -220,7 +220,7 @@ operator()(Vertex_index i, Vertex_index j)
 
 template <class VertexData>
 bool Less_segments<VertexData>::
-less_than_in_tree(Vertex_index new_edge, Vertex_index tree_edge)
+less_than_in_tree(Vertex_index new_edge, Vertex_index tree_edge) const
 {
     CGAL_polygon_precondition(
        m_vertex_data->edges[tree_edge.as_int()].is_in_tree);
@@ -244,7 +244,7 @@ less_than_in_tree(Vertex_index new_edge, Vertex_index tree_edge)
 
 template <class VertexData>
 bool Less_vertex_data<VertexData>::
-operator()(Vertex_index i, Vertex_index j)
+operator()(Vertex_index i, Vertex_index j) const
 {
     return m_vertex_data->less_xy_2(
             m_vertex_data->point(i), m_vertex_data->point(j));

--- a/Snap_rounding_2/include/CGAL/Snap_rounding_2.h
+++ b/Snap_rounding_2/include/CGAL/Snap_rounding_2.h
@@ -137,7 +137,7 @@ struct Hot_pixel_dir_cmp {
 
   Traits_ m_gt;
 
-  bool operator()(const Hot_pixel * h1, const Hot_pixel * h2);
+  bool operator()(const Hot_pixel * h1, const Hot_pixel * h2) const;
 };
 
 #ifdef CGAL_SR_DEBUG
@@ -502,7 +502,7 @@ operator()(const Hot_pixel * h1, const Hot_pixel * h2) const
 // segment intersect
 template<class Traits_>
 bool Hot_pixel_dir_cmp<Traits_>::operator ()(const Hot_pixel * h1,
-                                             const Hot_pixel * h2)
+                                             const Hot_pixel * h2) const
 {
   typedef typename Traits_::Compare_x_2         Compare_x_2;
   typedef typename Traits_::Compare_y_2         Compare_y_2;


### PR DESCRIPTION
## Summary of Changes

Latest version of g++ generates an error if an `operator()` used as compare function is not  `const`.

## Release Management

* Affected package(s):  Polygon, Generator, Snap_rounding
