### PR TITLE
Bugfix: pair not compatible with Circle_3 (clang)

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
@@ -37,7 +37,14 @@ class CircleC3 {
   typedef typename R_::Direction_3              Direction_3;
   typedef typename R_::FT                       FT;
 
-  typedef std::pair<Sphere_3, Plane_3>             Rep;
+  struct Rep
+  {
+    Sphere_3 first;
+    Plane_3 second;
+    Rep () : first(), second() { }
+    Rep (const Sphere_3& s, const Plane_3& p) : first(s), second(p) { }
+  };
+  
   typedef typename R_::template Handle<Rep>::type  Base;
   Base base;  
 


### PR DESCRIPTION
## Summary of Changes

While working on a branch we are currently developing, @danston found a bug in the Cartesian kernel that was actually the same as https://github.com/CGAL/cgal/pull/561 but with `Circle_3`. The fix is very similar, we use an internal `struct` that is the same as a `std::pair` and it fixes it.

## Release Management

* Affected package(s): pretty much all of them…
