### PR TITLE
Fix reading of ASCII STL

### DIFF
--- a/Polyhedron_IO/include/CGAL/IO/STL_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/STL_reader.h
@@ -47,6 +47,7 @@ namespace CGAL{
     char line[80];
     int i = 0, ni = 0;
 
+      // read the 5 first characters to check if the first word is "solid"
       boost::uint8_t c;
       for(; i < 5; i++){
         input.read(reinterpret_cast<char*>(&c), sizeof(c));
@@ -59,6 +60,8 @@ namespace CGAL{
         // But it might still be binary, so we have to find out if it is followed
         // by an (optional) name and then the keyword "facet"
         // When we find "facet" we conclude that it is really Ascii
+
+        // first skip whitespaces after solid
         do {
           input.read(reinterpret_cast<char*>(&c), sizeof(c));
           line[i++]=c;
@@ -87,7 +90,7 @@ namespace CGAL{
         
         // we continue to read what comes after the name
         
-        // now c is whitespace
+        // now c is whitespace, skip other whitespaces
         do {
           input.read(reinterpret_cast<char*>(&c), sizeof(c));
           line[i++]=c;
@@ -103,8 +106,8 @@ namespace CGAL{
           input.read(reinterpret_cast<char*>(&c), sizeof(c));
           line[i++]=c;
         }while(! isspace(c) && ( i < 80));
-#       ifdef CGAL_DEBUG_BINARY_HEADER
           s = std::string(line+ni, (i-1) - ni);
+#       ifdef CGAL_DEBUG_BINARY_HEADER
           std::cout << "|" << s  << "|" << std::endl;
 #       endif
         if(s == facet){

--- a/Polyhedron_IO/test/Polyhedron_IO/stl2off.cpp
+++ b/Polyhedron_IO/test/Polyhedron_IO/stl2off.cpp
@@ -44,6 +44,7 @@ int main()
   read("data/triangle.stl", 3, 1);
 
   
+  read("data/ascii-tetrahedron.stl", 4, 4);
   read("data/binary-tetrahedron-nice-header.stl", 4, 4);
   read("data/binary-tetrahedron-non-standard-header-1.stl", 4, 4);
   read("data/binary-tetrahedron-non-standard-header-2.stl", 4, 4);


### PR DESCRIPTION
A critical instruction was hidden within the patch of #2657

I do have a question for @afabri:
Your patch will not work as soon as the optional name after solid is too long. Indeed, you require that _facet_ is found before reaching the 80th character (as it's the limit of the header in binary format). Shall we consider this as an issue?