### PR TITLE
Update release scripts

### DIFF
--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -2,8 +2,9 @@
 # DESTINATION the path where the release is created, default is /tmp
 # PUBLIC=[ON/OFF] indicates if a public release should be built, default is OFF
 # VERBOSE=[ON/OFF] makes the script more verbose, default is OFF
-# CGAL_VERSION=release id used to update version.h, VERSION and the release directory. Can be 4.12-Ic-33, 4.12-I-32, 4.12, ...
-# CGAL_VERSION_NR=release string used to update version.h. Must be something like 1041200033
+# CGAL_VERSION=release id used to update version.h, VERSION and the release directory. Can be 4.12-Ic-33, 4.12-I-32, 4.12, ... 
+#   Must be followed by -beta<beta_number> if the release is a beta.
+# CGAL_VERSION_NR=release string used to update version.h. Must be something like 1041200033 , or 10412009<beta number>0
 # TESTSUITE=indicate if the release is meant to be used by the testsuite, default if OFF
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/Installation/include/CGAL/version.h)
@@ -123,7 +124,7 @@ string(REPLACE "CGAL_RELEASE_DATE 20170101" "CGAL_RELEASE_DATE ${TODAY}" file_co
 string(REPLACE "CGAL_VERSION ${CGAL_VERSION_INPUT}" "CGAL_VERSION ${CGAL_VERSION}" file_content "${file_content}")
 #  update CGAL_VERSION_NR
 if (CGAL_VERSION_NR)
-  string(REGEX REPLACE "CGAL_VERSION_NR 10[0-9][0-9][0-9][0-9]0000" "CGAL_VERSION_NR ${CGAL_VERSION_NR}" file_content "${file_content}")
+  string(REGEX REPLACE "CGAL_VERSION_NR 10[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" "CGAL_VERSION_NR ${CGAL_VERSION_NR}" file_content "${file_content}")
 endif()
 file(WRITE ${release_dir}/include/CGAL/version.h "${file_content}")
 

--- a/Scripts/developer_scripts/create_new_release
+++ b/Scripts/developer_scripts/create_new_release
@@ -22,6 +22,7 @@ NO_TESTUITE=""           # If set, the LATEST file is not updated
 NO_SCM=""                # If set, git pull is not called.
 SOURCES_DIR="$PWD/trunk" # SVN working copy directory, default is "$PWD/trunk"
 VERBOSE=""               # Verbose mode (displays log to standard err)
+BETA=""                  #If set, will change the release number and version number accordingly.
 SCM=svn
 
 SOURCES_DIR_HAS_BEEN_SET=
@@ -32,7 +33,7 @@ printerr() {
 }
 
 usage() {
-    printerr "Usage : $0 [--help] [--rpm] [--public] [--do-it] <packages dir> [<candidates dir>]"
+    printerr "Usage : $0 [--help] [--rpm] [--public] [--do-it] [--beta <n>] <packages dir> [<candidates dir>]"
     printerr
     printerr '  --help           : prints this usage help'
     printerr '  --rpm            : also build the corresponding SRPMs'
@@ -47,6 +48,8 @@ usage() {
     printerr '  --no-testsuite   : when used with --do-it, the tag is made, files are published,'
     printerr '                     but the LATEST file is not updated.'
     printerr '  --verbose        : print log to standard output, instead of the log file'
+    printerr '  --beta <n>       : followed by a number. When used with --public, will modify 
+    the release number and the release version name to include beta<n>'
     printerr '  <packages dir>   : the directory containing the packages [default is trunk]'
     printerr '  <candidates dir> : the directory containing the candidate packages [no default]'
 }
@@ -91,6 +94,16 @@ while [ $1 ]; do
             VERBOSE="y"
             shift; continue
         ;;
+        --beta)
+            shift;
+            BETA=$1
+            re='^[0-9]+$'
+            if ! [[ $BETA =~ $re ]] ; then
+               echo "error: --beta must be followed by an integer." >&2; exit 1
+            fi
+            shift;
+            continue
+        ;;
         -*)
             printerr "Unrecognized option : $1"
             exit
@@ -111,7 +124,6 @@ while [ $1 ]; do
         ;;
     esac
 done
-
 
 # The internal release number is extracted/updated from this file :
 VERSION_FILE="version_number"
@@ -290,10 +302,16 @@ fi
 # Build public release version
 if [ -n "$DO_PUBLIC" ]; then
     echo "Making the public version of the tarball"
-    public_release_number="1${major_nr}${minor_nr}${bugfix_nr}1000"
+    if [ -n "$BETA" ]; then
+      public_release_number="1${major_nr}${minor_nr}${bugfix_nr}09${BETA}0"
+    else
+      public_release_number="1${major_nr}${minor_nr}${bugfix_nr}1000"
+    fi
     public_release_version="${MAJOR_NUMBER}.${MINOR_NUMBER}${BUGFIX_STRING}"
     if [ -r "${NUMBERS_DIR}/public_release_name" ]; then
 	public_release_name=`cat "${NUMBERS_DIR}/public_release_name"`
+    elif [ -n "$BETA" ]; then
+	public_release_name="CGAL-${public_release_version}-beta${$BETA}"
     else
 	public_release_name="CGAL-${public_release_version}"
     fi

--- a/Scripts/developer_scripts/create_new_release
+++ b/Scripts/developer_scripts/create_new_release
@@ -308,10 +308,10 @@ if [ -n "$DO_PUBLIC" ]; then
       public_release_number="1${major_nr}${minor_nr}${bugfix_nr}1000"
     fi
     public_release_version="${MAJOR_NUMBER}.${MINOR_NUMBER}${BUGFIX_STRING}"
-    if [ -r "${NUMBERS_DIR}/public_release_name" ]; then
-	public_release_name=`cat "${NUMBERS_DIR}/public_release_name"`
-    elif [ -n "$BETA" ]; then
+    if [ -n "$BETA" ]; then
 	public_release_name="CGAL-${public_release_version}-beta${$BETA}"
+    elif [ -r "${NUMBERS_DIR}/public_release_name" ]; then
+	public_release_name=`cat "${NUMBERS_DIR}/public_release_name"`
     else
 	public_release_name="CGAL-${public_release_version}"
     fi


### PR DESCRIPTION

## Summary of Changes
This PR fixes a possible mistake in cgal_create_release_with_cmake (in a regex) and add an argument to specify a beta number in create_new_release.sh.

## Release Management

* Issue(s) solved (if any): fix #2881 

