### PR TITLE
Use of /permissive- with Visual Studio 2017

### DIFF
--- a/Mesh_3/include/CGAL/Implicit_to_labeling_function_wrapper.h
+++ b/Mesh_3/include/CGAL/Implicit_to_labeling_function_wrapper.h
@@ -276,7 +276,7 @@ public:
       ++i;
     }
 
-    std::vector<Bmask>::const_iterator iter = std::lower_bound(bmasks.begin(), bmasks.end(), bmask);
+    typename std::vector<Bmask>::const_iterator iter = std::lower_bound(bmasks.begin(), bmasks.end(), bmask);
     if (iter != bmasks.end() && *iter == bmask)
       return static_cast<return_type>(1 + (iter - bmasks.begin()));
     return 0;

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1428,7 +1428,7 @@ private:
       subdomain_index_ = c->subdomain_index();
       for(std::size_t i = 0; i < 4; ++i)
       {
-        const int ii = static_cast<const int>(i);//avoid warnings
+        const int ii = static_cast<int>(i);//avoid warnings
         surface_index_table_[i] = c->surface_patch_index(ii);
         facet_surface_center_[i] = c->get_facet_surface_center(ii);
         surface_center_index_table_[i] = c->get_facet_surface_center_index(ii);

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -164,7 +164,7 @@ class Nef_polyhedron_3 : public CGAL::Handle_for< Nef_polyhedron_3_rep<Kernel_, 
   typedef typename Kernel::Segment_3                  Segment_3;
   typedef typename Kernel::Aff_transformation_3       Aff_transformation_3;
 
-if _MSC_VER >= 1900
+#if _MSC_VER >= 1900
   // VC++ < 2017 has a problem to digest the following typedef,
   // and does not need the using statements -- AF
   // The left and right part of these typedefs have the same name. It is

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -164,8 +164,8 @@ class Nef_polyhedron_3 : public CGAL::Handle_for< Nef_polyhedron_3_rep<Kernel_, 
   typedef typename Kernel::Segment_3                  Segment_3;
   typedef typename Kernel::Aff_transformation_3       Aff_transformation_3;
 
-#ifndef _MSC_VER
-  // VC++ has a problem to digest the following typedef,
+if _MSC_VER >= 1900
+  // VC++ < 2017 has a problem to digest the following typedef,
   // and does not need the using statements -- AF
   // The left and right part of these typedefs have the same name. It is
   // very important to qualify the left part with the CGAL:: namespace, no

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -164,7 +164,7 @@ class Nef_polyhedron_3 : public CGAL::Handle_for< Nef_polyhedron_3_rep<Kernel_, 
   typedef typename Kernel::Segment_3                  Segment_3;
   typedef typename Kernel::Aff_transformation_3       Aff_transformation_3;
 
-#if _MSC_VER >= 1900
+#if (! defined _MSC_VER) || (_MSC_VER >= 1900)
   // VC++ < 2017 has a problem to digest the following typedef,
   // and does not need the using statements -- AF
   // The left and right part of these typedefs have the same name. It is

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -547,7 +547,7 @@ public:
       // retriangulated. This ensure that triangulations are compatible.
       // This edges were not constrained in the first mesh but are in the
       // second (ensuring compatibility)
-      std::map< Node_id,std::set<Node_id> >::iterator it_neighbors =
+      typename std::map< Node_id,std::set<Node_id> >::iterator it_neighbors =
         coplanar_constraints.find(node_id);
       if (it_neighbors!=coplanar_constraints.end())
       {
@@ -1004,7 +1004,7 @@ public:
                 vit->info() >= number_coplanar_vertices) continue;
             // \todo no need to insert constrained edges (they also are constrained
             // in the other mesh)!!
-            std::map< Node_id,std::set<Node_id> >::iterator res =
+            typename std::map< Node_id,std::set<Node_id> >::iterator res =
                 coplanar_constraints.insert(
                     std::make_pair(vit->info(),std::set<Node_id>())).first;
             //turn around the vertex and get incident edge


### PR DESCRIPTION
## Summary of Changes

In `Nef_polyhedron_3`, this PR fixes the use of `typedef`s for Visual Studio versions >= 2017, with and without the `/permissive-` flag.

The use of these typedefs is valid for VS>=2017, and needed when using VS2017 with `/permissive-`

## Release Management

* Affected package : `Nef_3`
* partially solves issue #2414
