### PR TITLE
Autorefine bugfixes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -801,7 +801,7 @@ public:
                 //       parts of a mesh (ex: a square in crossing the interior
                 //       of a larger). In practice, we could say this is not an
                 //       issue if anyway the whole patch would be dropped.
-                //       Note that this remark is value for all cases where
+                //       Note that this remark is valid for all cases where
                 //       all_fixed is set to false.
                 if (patch_id_p1==patch_id_p2 || patch_id_q1==patch_id_q2)
                 {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -339,7 +339,9 @@ public:
       Node_id node_id,
       TriangleMesh& tm)
   {
-    mesh_to_vertex_to_node_id[&tm].insert(std::make_pair(target(h,tm),node_id));
+    CGAL_assertion_code(bool insert_ok = )
+    mesh_to_vertex_to_node_id[&tm].insert(std::make_pair(target(h,tm),node_id)).second;
+    CGAL_assertion(insert_ok || mesh_to_vertex_to_node_id[&tm][target(h,tm)]==node_id);
   }
 
   void new_node_added_triple_face(std::size_t node_id,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -340,7 +340,8 @@ public:
       TriangleMesh& tm)
   {
     CGAL_assertion_code(bool insert_ok = )
-    mesh_to_vertex_to_node_id[&tm].insert(std::make_pair(target(h,tm),node_id)).second;
+    mesh_to_vertex_to_node_id[&tm].insert(std::make_pair(target(h,tm),node_id))
+    CGAL_assertion_code(.second);
     CGAL_assertion(insert_ok || mesh_to_vertex_to_node_id[&tm][target(h,tm)]==node_id);
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -195,6 +195,7 @@ class Intersection_of_triangle_meshes
   Node_vector nodes;
   Node_visitor visitor;
   Faces_to_nodes_map         f_to_node;      //Associate a pair of triangles to their intersection points
+  std::vector<Node_id> extra_terminal_nodes; //used only for autorefinement
   CGAL_assertion_code(bool doing_autorefinement;)
 // member functions
   void filter_intersections(const TriangleMesh& tm_f,
@@ -1051,6 +1052,13 @@ class Intersection_of_triangle_meshes
       }
     }
 
+    CGAL_assertion(extra_terminal_nodes.empty() || doing_autorefinement);
+    // these nodes are created by pinchements along an edge of the surface.
+    // the node ids being the same for the two edges, the degree of the node
+    // in the graph is two while it should be 3
+    BOOST_FOREACH(Node_id id, extra_terminal_nodes)
+      graph[id].make_terminal();
+
     //visitor call
     visitor.annotate_graph(graph);
 
@@ -1187,6 +1195,7 @@ class Intersection_of_triangle_meshes
               ++current_node;
               nodes.add_new_node(get(nodes.vpm1, target(h1,tm)));
               visitor.new_node_added(node_id,ON_VERTEX,h1,h2,tm,tm,true,false);
+              extra_terminal_nodes.push_back(node_id);
             }
             else
               node_id = insert_res.first->second;


### PR DESCRIPTION
Fix for the case when the input surface is pinched along an edge
This happens when you have a ridge and some edges perpendicular to the ridge are duplicated on each side of the ridge. You then have some volume trapped by the intersection polyline.

This PR also ships a fix when using exact constructions with autorefinement.