### PR TITLE
Handle degenerate faces in self-intersection tests

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
@@ -115,5 +115,21 @@ int main(int argc, char** argv)
   std::cout << "Third test (Epec):" << std::endl;
   r += test_self_intersections<Epec>(filename, expected);
 
+  // Fourth test ----------------------------------------------------------------
+  expected = true;
+  filename = (argc > 7) ? argv[7] : "data_degeneracies/degtri_single.off";
+  if(argc > 7) {
+    assert(argc > 8);
+    std::stringstream ss(argv[8]);
+    ss >> std::boolalpha >> expected;
+    assert(!ss.fail());
+  }
+
+  std::cout << "Fourth test (Epic):" << std::endl;
+  r += test_self_intersections<Epic>(filename, expected);
+
+  std::cout << "Fourth test (Epec):" << std::endl;
+  r += test_self_intersections<Epec>(filename, expected);
+
   return r;
 }


### PR DESCRIPTION
Handle degenerate faces in `does_self_intersect()` and `self_intersections()`