### PR TITLE
Travis: Time enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,95 +10,95 @@ matrix:
   - compiler: clang-3.6
     env: PACKAGE='CHECK' 
   - compiler: clang-3.6
-    env: PACKAGE='Advancing_front_surface_reconstruction Algebraic_foundations Algebraic_kernel_d ' 
+    env: PACKAGE='AABB_tree Advancing_front_surface_reconstruction Algebraic_foundations ' 
   - compiler: clang-3.6
-    env: PACKAGE='Algebraic_kernel_for_circles Algebraic_kernel_for_spheres Alpha_shapes_2 ' 
+    env: PACKAGE='Algebraic_kernel_d Algebraic_kernel_for_circles Algebraic_kernel_for_spheres ' 
   - compiler: clang-3.6
-    env: PACKAGE='Alpha_shapes_3 Apollonius_graph_2 Arithmetic_kernel ' 
+    env: PACKAGE='Alpha_shapes_2 Alpha_shapes_3 Apollonius_graph_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Arrangement_on_surface_2 Barycentric_coordinates_2 BGL ' 
+    env: PACKAGE='Arithmetic_kernel Arrangement_on_surface_2 Barycentric_coordinates_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Boolean_set_operations_2 Bounding_volumes Box_intersection_d ' 
+    env: PACKAGE='BGL Boolean_set_operations_2 Bounding_volumes ' 
   - compiler: clang-3.6
-    env: PACKAGE='Cartesian_kernel CGAL_Core CGAL_ImageIO ' 
+    env: PACKAGE='Box_intersection_d Cartesian_kernel CGAL_Core ' 
   - compiler: clang-3.6
-    env: PACKAGE='CGAL_ipelets Circular_kernel_2 Circular_kernel_3 ' 
+    env: PACKAGE='CGAL_ImageIO CGAL_ipelets Circular_kernel_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Circulator Classification Combinatorial_map ' 
+    env: PACKAGE='Circular_kernel_3 Circulator Classification ' 
   - compiler: clang-3.6
-    env: PACKAGE='Cone_spanners_2 Convex_decomposition_3 Convex_hull_2 ' 
+    env: PACKAGE='Combinatorial_map Cone_spanners_2 Convex_decomposition_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Convex_hull_3 Convex_hull_d Distance_2 ' 
+    env: PACKAGE='Convex_hull_2 Convex_hull_3 Convex_hull_d ' 
   - compiler: clang-3.6
-    env: PACKAGE='Distance_3 Envelope_2 Envelope_3 ' 
+    env: PACKAGE='Distance_2 Distance_3 Envelope_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Filtered_kernel Generalized_map Generator ' 
+    env: PACKAGE='Envelope_3 Filtered_kernel Generalized_map ' 
   - compiler: clang-3.6
-    env: PACKAGE='Geomview GraphicsView HalfedgeDS ' 
+    env: PACKAGE='Generator Geomview GraphicsView ' 
   - compiler: clang-3.6
-    env: PACKAGE='Hash_map Homogeneous_kernel Inscribed_areas ' 
+    env: PACKAGE='HalfedgeDS Hash_map Homogeneous_kernel ' 
   - compiler: clang-3.6
-    env: PACKAGE='Installation Interpolation Intersections_2 ' 
+    env: PACKAGE='Inscribed_areas Installation Interpolation ' 
   - compiler: clang-3.6
-    env: PACKAGE='Intersections_3 Interval_skip_list Interval_support ' 
+    env: PACKAGE='Intersections_2 Intersections_3 Interval_skip_list ' 
   - compiler: clang-3.6
-    env: PACKAGE='Inventor Jet_fitting_3 Kernel_23 ' 
+    env: PACKAGE='Interval_support Inventor Jet_fitting_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Kernel_d LEDA Linear_cell_complex ' 
+    env: PACKAGE='Kernel_23 Kernel_d LEDA ' 
   - compiler: clang-3.6
-    env: PACKAGE='MacOSX Maintenance Matrix_search ' 
+    env: PACKAGE='Linear_cell_complex MacOSX Maintenance ' 
   - compiler: clang-3.6
-    env: PACKAGE='Mesh_2 Mesh_3 Mesher_level ' 
+    env: PACKAGE='Matrix_search Mesh_2 Mesh_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Minkowski_sum_2 Minkowski_sum_3 Modifier ' 
+    env: PACKAGE='Mesher_level Minkowski_sum_2 Minkowski_sum_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Modular_arithmetic Nef_2 Nef_3 ' 
+    env: PACKAGE='Modifier Modular_arithmetic Nef_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Nef_S2 NewKernel_d Number_types ' 
+    env: PACKAGE='Nef_3 Nef_S2 NewKernel_d ' 
   - compiler: clang-3.6
-    env: PACKAGE='OpenNL Operations_on_polyhedra Optimal_transportation_reconstruction_2 ' 
+    env: PACKAGE='Number_types OpenNL Operations_on_polyhedra ' 
   - compiler: clang-3.6
-    env: PACKAGE='Optimisation_basic Partition_2 Periodic_2_triangulation_2 ' 
+    env: PACKAGE='Optimal_transportation_reconstruction_2 Optimisation_basic Partition_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Periodic_3_triangulation_3 Point_set_2 Point_set_3 ' 
+    env: PACKAGE='Periodic_2_triangulation_2 Periodic_3_triangulation_3 Point_set_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Point_set_processing_3 Point_set_shape_detection_3 Poisson_surface_reconstruction_3 ' 
+    env: PACKAGE='Point_set_3 Point_set_processing_3 Point_set_shape_detection_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polygon Polygon_mesh_processing Polyhedron ' 
+    env: PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_IO ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polyhedron_IO Polyline_simplification_2 Polynomial ' 
+    env: PACKAGE='Polygon_mesh_processing Polyhedron Polyhedron_IO ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polytope_distance_d Principal_component_analysis Principal_component_analysis_LGPL ' 
+    env: PACKAGE='Polyline_simplification_2 Polynomial Polytope_distance_d ' 
   - compiler: clang-3.6
-    env: PACKAGE='Profiling_tools Property_map QP_solver ' 
+    env: PACKAGE='Principal_component_analysis Principal_component_analysis_LGPL Profiling_tools ' 
   - compiler: clang-3.6
-    env: PACKAGE='Random_numbers Ridges_3 Scale_space_reconstruction_3 ' 
+    env: PACKAGE='Property_map QP_solver Random_numbers ' 
   - compiler: clang-3.6
-    env: PACKAGE='Scripts SearchStructures Segment_Delaunay_graph_2 ' 
+    env: PACKAGE='Ridges_3 Scale_space_reconstruction_3 Scripts ' 
   - compiler: clang-3.6
-    env: PACKAGE='Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 Skin_surface_3 ' 
+    env: PACKAGE='SearchStructures Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Snap_rounding_2 Solver_interface Spatial_searching ' 
+    env: PACKAGE='Set_movable_separability_2 Skin_surface_3 Snap_rounding_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Spatial_sorting STL_Extension Straight_skeleton_2 ' 
+    env: PACKAGE='Solver_interface Spatial_searching Spatial_sorting ' 
   - compiler: clang-3.6
-    env: PACKAGE='Stream_lines_2 Stream_support Subdivision_method_3 ' 
+    env: PACKAGE='STL_Extension Straight_skeleton_2 Stream_lines_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh Surface_mesh_deformation Surface_mesher ' 
+    env: PACKAGE='Stream_support Subdivision_method_3 Surface_mesh ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_parameterization Surface_mesh_segmentation Surface_mesh_shortest_path ' 
+    env: PACKAGE='Surface_mesh_deformation Surface_mesher Surface_mesh_parameterization ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_simplification Surface_mesh_skeletonization Surface_sweep_2 ' 
+    env: PACKAGE='Surface_mesh_segmentation Surface_mesh_shortest_path Surface_mesh_simplification ' 
   - compiler: clang-3.6
-    env: PACKAGE='TDS_2 TDS_3 Testsuite ' 
+    env: PACKAGE='Surface_mesh_skeletonization Surface_sweep_2 TDS_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Three Triangulation Triangulation_2 ' 
+    env: PACKAGE='TDS_3 Testsuite Three ' 
   - compiler: clang-3.6
-    env: PACKAGE='Triangulation_3 Union_find Visibility_2 ' 
+    env: PACKAGE='Triangulation Triangulation_2 Triangulation_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Voronoi_diagram_2 wininst ' 
+    env: PACKAGE='Union_find Visibility_2 Voronoi_diagram_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polyhedron_demo' 
+    env: PACKAGE='wininst ' 
 install: 
   - bash .travis/install.sh 
   - if [[ "$CXX" = "clang++" ]]; then export CXX=clang++-3.6 CC=clang-3.6; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,93 +10,93 @@ matrix:
   - compiler: clang-3.6
     env: PACKAGE='CHECK' 
   - compiler: clang-3.6
-    env: PACKAGE='AABB_tree Advancing_front_surface_reconstruction Algebraic_foundations ' 
+    env: PACKAGE='Advancing_front_surface_reconstruction Algebraic_foundations Algebraic_kernel_d ' 
   - compiler: clang-3.6
-    env: PACKAGE='Algebraic_kernel_d Algebraic_kernel_for_circles Algebraic_kernel_for_spheres ' 
+    env: PACKAGE='Algebraic_kernel_for_circles Algebraic_kernel_for_spheres Alpha_shapes_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Alpha_shapes_2 Alpha_shapes_3 Apollonius_graph_2 ' 
+    env: PACKAGE='Alpha_shapes_3 Apollonius_graph_2 Arithmetic_kernel ' 
   - compiler: clang-3.6
-    env: PACKAGE='Arithmetic_kernel Arrangement_on_surface_2 Barycentric_coordinates_2 ' 
+    env: PACKAGE='Arrangement_on_surface_2 Barycentric_coordinates_2 BGL ' 
   - compiler: clang-3.6
-    env: PACKAGE='BGL Boolean_set_operations_2 Bounding_volumes ' 
+    env: PACKAGE='Boolean_set_operations_2 Bounding_volumes Box_intersection_d ' 
   - compiler: clang-3.6
-    env: PACKAGE='Box_intersection_d Cartesian_kernel CGAL_Core ' 
+    env: PACKAGE='Cartesian_kernel CGAL_Core CGAL_ImageIO ' 
   - compiler: clang-3.6
-    env: PACKAGE='CGAL_ImageIO CGAL_ipelets Circular_kernel_2 ' 
+    env: PACKAGE='CGAL_ipelets Circular_kernel_2 Circular_kernel_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Circular_kernel_3 Circulator Classification ' 
+    env: PACKAGE='Circulator Classification Combinatorial_map ' 
   - compiler: clang-3.6
-    env: PACKAGE='Combinatorial_map Cone_spanners_2 Convex_decomposition_3 ' 
+    env: PACKAGE='Cone_spanners_2 Convex_decomposition_3 Convex_hull_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Convex_hull_2 Convex_hull_3 Convex_hull_d ' 
+    env: PACKAGE='Convex_hull_3 Convex_hull_d Distance_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Distance_2 Distance_3 Envelope_2 ' 
+    env: PACKAGE='Distance_3 Envelope_2 Envelope_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Envelope_3 Filtered_kernel Generalized_map ' 
+    env: PACKAGE='Filtered_kernel Generalized_map Generator ' 
   - compiler: clang-3.6
-    env: PACKAGE='Generator Geomview GraphicsView ' 
+    env: PACKAGE='Geomview GraphicsView HalfedgeDS ' 
   - compiler: clang-3.6
-    env: PACKAGE='HalfedgeDS Hash_map Homogeneous_kernel ' 
+    env: PACKAGE='Hash_map Homogeneous_kernel Inscribed_areas ' 
   - compiler: clang-3.6
-    env: PACKAGE='Inscribed_areas Installation Interpolation ' 
+    env: PACKAGE='Installation Interpolation Intersections_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Intersections_2 Intersections_3 Interval_skip_list ' 
+    env: PACKAGE='Intersections_3 Interval_skip_list Interval_support ' 
   - compiler: clang-3.6
-    env: PACKAGE='Interval_support Inventor Jet_fitting_3 ' 
+    env: PACKAGE='Inventor Jet_fitting_3 Kernel_23 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Kernel_23 Kernel_d LEDA ' 
+    env: PACKAGE='Kernel_d LEDA Linear_cell_complex ' 
   - compiler: clang-3.6
-    env: PACKAGE='Linear_cell_complex MacOSX Maintenance ' 
+    env: PACKAGE='MacOSX Maintenance Matrix_search ' 
   - compiler: clang-3.6
-    env: PACKAGE='Matrix_search Mesh_2 Mesh_3 ' 
+    env: PACKAGE='Mesh_2 Mesh_3 Mesher_level ' 
   - compiler: clang-3.6
-    env: PACKAGE='Mesher_level Minkowski_sum_2 Minkowski_sum_3 ' 
+    env: PACKAGE='Minkowski_sum_2 Minkowski_sum_3 Modifier ' 
   - compiler: clang-3.6
-    env: PACKAGE='Modifier Modular_arithmetic Nef_2 ' 
+    env: PACKAGE='Modular_arithmetic Nef_2 Nef_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Nef_3 Nef_S2 NewKernel_d ' 
+    env: PACKAGE='Nef_S2 NewKernel_d Number_types ' 
   - compiler: clang-3.6
-    env: PACKAGE='Number_types OpenNL Operations_on_polyhedra ' 
+    env: PACKAGE='OpenNL Operations_on_polyhedra Optimal_transportation_reconstruction_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Optimal_transportation_reconstruction_2 Optimisation_basic Partition_2 ' 
+    env: PACKAGE='Optimisation_basic Partition_2 Periodic_2_triangulation_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Periodic_2_triangulation_2 Periodic_3_triangulation_3 Point_set_2 ' 
+    env: PACKAGE='Periodic_3_triangulation_3 Point_set_2 Point_set_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Point_set_3 Point_set_processing_3 Point_set_shape_detection_3 ' 
+    env: PACKAGE='Point_set_processing_3 Point_set_shape_detection_3 Poisson_surface_reconstruction_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_mesh_processing ' 
+    env: PACKAGE='Polygon Polygon_mesh_processing Polyhedron ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polyhedron Polyhedron_IO Polyline_simplification_2 ' 
+    env: PACKAGE='Polyhedron_IO Polyline_simplification_2 Polynomial ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polynomial Polytope_distance_d Principal_component_analysis ' 
+    env: PACKAGE='Polytope_distance_d Principal_component_analysis Principal_component_analysis_LGPL ' 
   - compiler: clang-3.6
-    env: PACKAGE='Principal_component_analysis_LGPL Profiling_tools Property_map ' 
+    env: PACKAGE='Profiling_tools Property_map QP_solver ' 
   - compiler: clang-3.6
-    env: PACKAGE='QP_solver Random_numbers Ridges_3 ' 
+    env: PACKAGE='Random_numbers Ridges_3 Scale_space_reconstruction_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Scale_space_reconstruction_3 Scripts SearchStructures ' 
+    env: PACKAGE='Scripts SearchStructures Segment_Delaunay_graph_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 ' 
+    env: PACKAGE='Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 Skin_surface_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Skin_surface_3 Snap_rounding_2 Solver_interface ' 
+    env: PACKAGE='Snap_rounding_2 Solver_interface Spatial_searching ' 
   - compiler: clang-3.6
-    env: PACKAGE='Spatial_searching Spatial_sorting STL_Extension ' 
+    env: PACKAGE='Spatial_sorting STL_Extension Straight_skeleton_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Straight_skeleton_2 Stream_lines_2 Stream_support ' 
+    env: PACKAGE='Stream_lines_2 Stream_support Subdivision_method_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Subdivision_method_3 Surface_mesh Surface_mesh_deformation ' 
+    env: PACKAGE='Surface_mesh Surface_mesh_deformation Surface_mesher ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesher Surface_mesh_parameterization Surface_mesh_segmentation ' 
+    env: PACKAGE='Surface_mesh_parameterization Surface_mesh_segmentation Surface_mesh_shortest_path ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_shortest_path Surface_mesh_simplification Surface_mesh_skeletonization ' 
+    env: PACKAGE='Surface_mesh_simplification Surface_mesh_skeletonization Surface_sweep_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_sweep_2 TDS_2 TDS_3 ' 
+    env: PACKAGE='TDS_2 TDS_3 Testsuite ' 
   - compiler: clang-3.6
-    env: PACKAGE='Testsuite Three Triangulation ' 
+    env: PACKAGE='Three Triangulation Triangulation_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Triangulation_2 Triangulation_3 Union_find ' 
+    env: PACKAGE='Triangulation_3 Union_find Visibility_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Visibility_2 Voronoi_diagram_2 wininst ' 
+    env: PACKAGE='Voronoi_diagram_2 wininst ' 
   - compiler: clang-3.6
     env: PACKAGE='Polyhedron_demo' 
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,3 +119,4 @@ notifications:
   email:
     on_success: change # default: always
     on_failure: always # default: always
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,41 +64,39 @@ matrix:
   - compiler: clang-3.6
     env: PACKAGE='Point_set_3 Point_set_processing_3 Point_set_shape_detection_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_IO ' 
+    env: PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_mesh_processing ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polygon_mesh_processing Polyhedron Polyhedron_IO ' 
+    env: PACKAGE='Polyhedron Polyhedron_IO Polyline_simplification_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Polyline_simplification_2 Polynomial Polytope_distance_d ' 
+    env: PACKAGE='Polynomial Polytope_distance_d Principal_component_analysis ' 
   - compiler: clang-3.6
-    env: PACKAGE='Principal_component_analysis Principal_component_analysis_LGPL Profiling_tools ' 
+    env: PACKAGE='Principal_component_analysis_LGPL Profiling_tools Property_map ' 
   - compiler: clang-3.6
-    env: PACKAGE='Property_map QP_solver Random_numbers ' 
+    env: PACKAGE='QP_solver Random_numbers Ridges_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Ridges_3 Scale_space_reconstruction_3 Scripts ' 
+    env: PACKAGE='Scale_space_reconstruction_3 Scripts SearchStructures ' 
   - compiler: clang-3.6
-    env: PACKAGE='SearchStructures Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 ' 
+    env: PACKAGE='Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 ' 
   - compiler: clang-3.6
-    env: PACKAGE='Set_movable_separability_2 Skin_surface_3 Snap_rounding_2 ' 
+    env: PACKAGE='Skin_surface_3 Snap_rounding_2 Solver_interface ' 
   - compiler: clang-3.6
-    env: PACKAGE='Solver_interface Spatial_searching Spatial_sorting ' 
+    env: PACKAGE='Spatial_searching Spatial_sorting STL_Extension ' 
   - compiler: clang-3.6
-    env: PACKAGE='STL_Extension Straight_skeleton_2 Stream_lines_2 ' 
+    env: PACKAGE='Straight_skeleton_2 Stream_lines_2 Stream_support ' 
   - compiler: clang-3.6
-    env: PACKAGE='Stream_support Subdivision_method_3 Surface_mesh ' 
+    env: PACKAGE='Subdivision_method_3 Surface_mesh Surface_mesh_deformation ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_deformation Surface_mesher Surface_mesh_parameterization ' 
+    env: PACKAGE='Surface_mesher Surface_mesh_parameterization Surface_mesh_segmentation ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_segmentation Surface_mesh_shortest_path Surface_mesh_simplification ' 
+    env: PACKAGE='Surface_mesh_shortest_path Surface_mesh_simplification Surface_mesh_skeletonization ' 
   - compiler: clang-3.6
-    env: PACKAGE='Surface_mesh_skeletonization Surface_sweep_2 TDS_2 ' 
+    env: PACKAGE='Surface_sweep_2 TDS_2 TDS_3 ' 
   - compiler: clang-3.6
-    env: PACKAGE='TDS_3 Testsuite Three ' 
+    env: PACKAGE='Testsuite Three Triangulation ' 
   - compiler: clang-3.6
-    env: PACKAGE='Triangulation Triangulation_2 Triangulation_3 ' 
+    env: PACKAGE='Triangulation_2 Triangulation_3 Union_find ' 
   - compiler: clang-3.6
-    env: PACKAGE='Union_find Visibility_2 Voronoi_diagram_2 ' 
-  - compiler: clang-3.6
-    env: PACKAGE='wininst ' 
+    env: PACKAGE='Visibility_2 Voronoi_diagram_2 wininst ' 
 install: 
   - bash .travis/install.sh 
   - if [[ "$CXX" = "clang++" ]]; then export CXX=clang++-3.6 CC=clang-3.6; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp 
 dist: trusty 
 sudo: required 
+git: 
+ depth: 3
 matrix:
  include: 
   - compiler: gcc 
@@ -110,7 +112,6 @@ before_script:
 - make 
 - sudo make install &>/dev/null
 - cd ..
-- sudo bash ./.travis/install_openmesh.sh
 script: 
 - cd ./.travis
 - bash -x -e ./build_package.sh $PACKAGE

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -55,7 +55,7 @@ cd $ROOT
 for ARG in $(echo "$@")
 do
 #install openmesh only if necessary
-  if [ "$ARG" = BGL ] || [ "$ARG" = Convex_hull_3 ] ||\
+  if [ "$ARG" = "CHECK" ] || [ "$ARG" = BGL ] || [ "$ARG" = Convex_hull_3 ] ||\
      [ "$ARG" = Polygon_mesh_processing ] || [ "$ARG" = Property_map ] ||\
      [ "$ARG" = Surface_mesh_deformation ] || [ "$ARG" = Surface_mesh_shortest_path ] ||\
      [ "$ARG" = Surface_mesh_simplification ]; then

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -54,6 +54,15 @@ NEED_3D=0
 cd $ROOT
 for ARG in $(echo "$@")
 do
+#install openmesh only if necessary
+  if [ "$ARG" = BGL ] || [ "$ARG" = Convex_hull_3 ] ||\
+     [ "$ARG" = Polygon_mesh_processing ] || [ "$ARG" = Property_map ] ||\
+     [ "$ARG" = Surface_mesh_deformation ] || [ "$ARG" = Surface_mesh_shortest_path ] ||\
+     [ "$ARG" = Surface_mesh_simplification ]; then
+    sudo bash .travis/install_openmesh.sh
+  fi
+
+
   if [ "$ARG" = "CHECK" ]
   then
     cd .travis
@@ -118,6 +127,7 @@ do
     exit 0
   fi
   IFS=$old_IFS
+
   if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$ARG" != Polyhedron_demo ]; then
     DO_IGNORE=FALSE
     . $ROOT/.travis/test_package.sh "$ROOT" "$ARG"

--- a/.travis/generate_travis.sh
+++ b/.travis/generate_travis.sh
@@ -75,6 +75,7 @@ do
 		echo "$LINE" >> .travis.yml
 	fi
 done
+echo "" >> .travis.yml
 IFS=$' '
 #check if there are differences between the files
 if ! cmp -s ./.travis.yml ./.travis.old;

--- a/.travis/generate_travis.sh
+++ b/.travis/generate_travis.sh
@@ -59,8 +59,8 @@ do
 echo "  - compiler: clang-3.6" >> .travis.yml
 echo "    env: PACKAGE='$package' " >> .travis.yml
 done
-echo "  - compiler: clang-3.6" >> .travis.yml
-echo "    env: PACKAGE='Polyhedron_demo' " >> .travis.yml
+#echo "  - compiler: clang-3.6" >> .travis.yml
+#echo "    env: PACKAGE='Polyhedron_demo' " >> .travis.yml
 
 #writes the end of the file
 COPY=0

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -12,12 +12,13 @@ do
   DONE=1 && sudo -E apt-add-repository -y "ppa:hedges/qt5.5" ||  DONE=0 && sleep 5
 done
 
-for pkg in clang-3.6 zsh flex bison cmake graphviz libboost1.55-dev libboost-system1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev libboost-iostreams1.55-dev libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev qt55base qt55script qt55svg qt55tools qt55graphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev
+DONE=0
+while [ $DONE = 0 ]
 do
-  DONE=0
-  while [ $DONE = 0 ]
-  do
-    DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install $pkg || DONE=0 && sudo apt-get update
-  done
+  DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-3.6 zsh \
+flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  libboost1.55-dev \
+libboost-system1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev libboost-iostreams1.55-dev \
+qt55base qt55script qt55svg qt55tools qt55graphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
+|| DONE=0 && sudo apt-get update
 done
 

--- a/.travis/packages.txt
+++ b/.travis/packages.txt
@@ -1,4 +1,3 @@
-AABB_tree 
 Advancing_front_surface_reconstruction 
 Algebraic_foundations 
 Algebraic_kernel_d 

--- a/.travis/packages.txt
+++ b/.travis/packages.txt
@@ -81,7 +81,6 @@ Point_set_processing_3
 Point_set_shape_detection_3 
 Poisson_surface_reconstruction_3 
 Polygon 
-Polygon_IO 
 Polygon_mesh_processing 
 Polyhedron 
 Polyhedron_IO 

--- a/.travis/packages.txt
+++ b/.travis/packages.txt
@@ -1,3 +1,4 @@
+AABB_tree 
 Advancing_front_surface_reconstruction 
 Algebraic_foundations 
 Algebraic_kernel_d 
@@ -80,6 +81,7 @@ Point_set_processing_3
 Point_set_shape_detection_3 
 Poisson_surface_reconstruction_3 
 Polygon 
+Polygon_IO 
 Polygon_mesh_processing 
 Polyhedron 
 Polyhedron_IO 

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -1,6 +1,8 @@
 language: cpp 
 dist: trusty 
 sudo: required 
+git: 
+ depth: 3
 matrix:
  include:
   PACKAGES_MATRIX
@@ -17,7 +19,6 @@ before_script:
 - make 
 - sudo make install &>/dev/null
 - cd ..
-- sudo bash ./.travis/install_openmesh.sh
 script: 
 - cd ./.travis
 - bash -x -e ./build_package.sh $PACKAGE

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -26,3 +26,4 @@ notifications:
   email:
     on_success: change # default: always
     on_failure: always # default: always
+

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -35,7 +35,7 @@ for pkg_path in $CGAL_ROOT/*
 do
   pkg=$(basename $pkg_path)
   if [ -f "$pkg_path/package_info/$pkg/dependencies" ]; then
-    PKG_DIFF=$(diff -N -w  "$pkg_path/package_info/$pkg/dependencies.old" "$pkg_path/package_info/$pkg/dependencies")
+    PKG_DIFF=$(diff -N -w  "$pkg_path/package_info/$pkg/dependencies.old" "$pkg_path/package_info/$pkg/dependencies" || true)
     if [ -n "$PKG_DIFF" ]; then
       HAS_DIFF=TRUE
       echo "Differences in $pkg: $PKG_DIFF"


### PR DESCRIPTION
## Summary of Changes
This PR removes the polyhedron_demo from the travis matrix, as it timeouts too often. 
It also optimizes the installation script so it doesn't take 5min+ anymore, reduces the depth of the CGAL clone to 3 instead of default 50, and it only installs openMesh for the jobs that need it. 

A run that doesn't touch any dependency, is done in ~50min.
## Release Management

