### PR TITLE
Polyhedron_demo : Add a check before trying to load a cdt_3 to avoid crashing

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -430,7 +430,28 @@ Polyhedron_demo_c3t3_binary_io_plugin::
 try_load_a_cdt_3(std::istream& is, C3t3& c3t3)
 {
   std::cerr << "Try load a CDT_3...";
-  CGAL::set_binary_mode(is);
+  std::string s;
+  if(!(is >> s)) return false;
+  bool binary = (s == "binary");
+  if(binary) {
+    if(!(is >> s)) return false;
+  }
+  if (s != "CGAL" ||
+      !(is >> s) ||
+      s != "c3t3") 
+  {
+    return false;
+  }
+  std::getline(is, s);
+  if(s != "") {
+    if(s != std::string(" ") + CGAL::Get_io_signature<Fake_CDT_3>()()) {
+      std::cerr << "load_binary_file:"
+                << "\n  expected format: " << CGAL::Get_io_signature<Fake_CDT_3>()()
+                << "\n       got format:" << s << std::endl;
+      return false;
+    }
+  }
+  if(binary) CGAL::set_binary_mode(is);
   if(CGAL::file_input<
        Fake_CDT_3,
        C3t3::Triangulation,


### PR DESCRIPTION
## Summary of Changes
Check if the c3t3 type is really Fake_c3t3 before trying to load an input .mesh. 

As I still have no clue what example file is supposed to be a "Fake_c3t3" I could not test I didn't break anything.

## Release Management

* Issue(s) solved (if any): fix #2858
