### PR TITLE
Surface_mesh_parameterization: Fix CMakeLists.txt for orbifold example

### DIFF
--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
@@ -61,7 +61,7 @@ if ( CGAL_FOUND )
     create_single_source_cgal_program( "square_border_parameterizer.cpp" )
     
     if(SuiteSparse_FOUND)
-      target_link_libraries(orbifold ${SuiteSparse_LIBRARIES})
+      target_link_libraries(orbifold PRIVATE ${SuiteSparse_LIBRARIES})
     endif()
 
   else(EIGEN3_FOUND)


### PR DESCRIPTION
## Summary of Changes
Fixes the cmake warning on the Ubuntu test platform.
## Release Management
* Affected package(s):Surface_mesh_parameterization

