### PR TITLE
Polyhedron demo: Fix tooltip for selection item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -285,6 +285,7 @@ public Q_SLOTS:
     }
 
     selection_item->select_boundary();
+    filter_operations();
   }
 
   void on_Add_to_selection_button_clicked()
@@ -328,6 +329,7 @@ public Q_SLOTS:
       return;
     }
     selection_item->inverse_selection();
+    filter_operations();
   }
   // Isolated component related functions
   void on_Select_isolated_components_button_clicked() {

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2247,3 +2247,21 @@ void Scene_polyhedron_selection_item::select_boundary()
   invalidateOpenGLBuffers();
   redraw();
 }
+
+QString 
+Scene_polyhedron_selection_item::toolTip() const
+{
+  if(!poly_item->polyhedron())
+    return QString();
+
+  return QObject::tr("<p>Selection <b>%1</b> (mode: %5, color: %6)</p>"
+                     "<p>Number of vertices: %2<br />"
+                     "Number of edges: %3<br />"
+                     "Number of faces: %4</p>")
+    .arg(this->name())
+    .arg(selected_vertices.size())
+    .arg(selected_edges.size())
+    .arg(selected_facets.size())
+    .arg(this->renderingModeName())
+    .arg(this->color().name());
+}

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -828,6 +828,7 @@ public Q_SLOTS:
   void validateMoveVertex();
   void compute_normal_maps();
   void clearHL();
+  QString toolTip() const;
 
   // slots are called by signals of polyhedron_k_ring_selector
   void selected(const std::set<fg_vertex_descriptor>& m)


### PR DESCRIPTION
## Summary of Changes

Fix selection_item's tooltip so it shows the number of selected simplices instead of the number of simplices of the original mesh.

