### PR TITLE
Algebraic kernel d RS-Fix compatibility of MPFR, MPFI and RS.

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/RS/rs2_calls.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/rs2_calls.h
@@ -35,7 +35,7 @@
 #define CGALRS_PTR(a)   void *a
 #endif
 
-// RS3 does not work with MPFR 3.1.3 to 3.1.5. In case RS3 is enabled and
+// RS3 does not work with MPFR 3.1.3 to 3.1.6. In case RS3 is enabled and
 // the version of MPFR is one of those buggy versions, abort the compilation
 // and instruct the user to update MPFR or don't use RS3.
 #ifdef CGAL_USE_RS3
@@ -43,8 +43,8 @@
 BOOST_STATIC_ASSERT_MSG(
         MPFR_VERSION_MAJOR!=3 ||
         MPFR_VERSION_MINOR!=1 ||
-        MPFR_VERSION_PATCHLEVEL<3 || MPFR_VERSION_PATCHLEVEL>5,
-        "RS3 does not work with MPFR versions 3.1.3 to 3.1.5. "#
+        MPFR_VERSION_PATCHLEVEL<3 || MPFR_VERSION_PATCHLEVEL>6,
+        "RS3 does not work with MPFR versions 3.1.3 to 3.1.6. "
         "Please update MPFR or disable RS3.");
 #endif // CGAL_USE_RS3
 

--- a/Installation/cmake/modules/FindMPFI.cmake
+++ b/Installation/cmake/modules/FindMPFI.cmake
@@ -22,38 +22,20 @@ if( GMP_FOUND AND MPFR_FOUND )
                DOC "Directory containing the MPFI library"
                )
 
-  get_dependency_version( MPFR )
-  message( STATUS "MPFR version is ${MPFR_VERSION}." )
-  IS_VERSION_LESS("${MPFR_VERSION}" "4.0.0" _MPFR_OLD)
+  if( MPFI_LIBRARIES )
+    get_filename_component(MPFI_LIBRARIES_DIR ${MPFI_LIBRARIES} PATH CACHE )
+  endif( MPFI_LIBRARIES )
 
-  get_dependency_version( MPFI )
-  message( STATUS "MPFI version is ${MPFI_VERSION}." )
-  IS_VERSION_LESS("${MPFI_VERSION}" "1.5.2" _MPFI_OLD)
+  if( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
+    include( MPFIConfig OPTIONAL )
+  endif( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
 
-  if( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
-    message(
-      STATUS
-      "MPFI<1.5.2 requires MPFR<4.0.0; MPFI>=1.5.2 requires MPFR>=4.0.0" )
-    set( MPFI_FOUND FALSE )
+  include(FindPackageHandleStandardArgs)
 
-  else( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
-
-    if( MPFI_LIBRARIES )
-      get_filename_component(MPFI_LIBRARIES_DIR ${MPFI_LIBRARIES} PATH CACHE )
-    endif( MPFI_LIBRARIES )
-
-    if( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
-      include( MPFIConfig OPTIONAL )
-    endif( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
-
-    include(FindPackageHandleStandardArgs)
-
-    find_package_handle_standard_args( MPFI
-                                       "DEFAULT_MSG"
-                                       MPFI_LIBRARIES
-                                       MPFI_INCLUDE_DIR )
-
-  endif( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+  find_package_handle_standard_args( MPFI
+                                     "DEFAULT_MSG"
+                                     MPFI_LIBRARIES
+                                     MPFI_INCLUDE_DIR )
 
 else( GMP_FOUND AND MPFR_FOUND )
 
@@ -62,5 +44,24 @@ else( GMP_FOUND AND MPFR_FOUND )
 endif( GMP_FOUND AND MPFR_FOUND )
 
 if( MPFI_FOUND )
-  set( MPFI_USE_FILE "CGAL_UseMPFI" )
+  get_dependency_version( MPFR )
+  IS_VERSION_LESS("${MPFR_VERSION}" "4.0.0" _MPFR_OLD)
+
+  get_dependency_version( MPFI )
+  IS_VERSION_LESS("${MPFI_VERSION}" "1.5.2" _MPFI_OLD)
+
+  if( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+
+    message(
+      STATUS
+      "MPFI<1.5.2 requires MPFR<4.0.0; MPFI>=1.5.2 requires MPFR>=4.0.0" )
+
+    set( MPFI_FOUND FALSE )
+
+  else( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+
+    set( MPFI_USE_FILE "CGAL_UseMPFI" )
+
+  endif( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+
 endif( MPFI_FOUND )

--- a/Installation/cmake/modules/FindMPFI.cmake
+++ b/Installation/cmake/modules/FindMPFI.cmake
@@ -1,6 +1,6 @@
 find_package( GMP QUIET )
 
-if( GMP_FOUND )
+if( GMP_FOUND AND MPFR_FOUND )
 
   if( MPFI_INCLUDE_DIR AND MPFI_LIBRARIES )
     set( MPFI_FOUND TRUE )
@@ -22,23 +22,44 @@ if( GMP_FOUND )
                DOC "Directory containing the MPFI library"
                )
 
-  if( MPFI_LIBRARIES )
-    get_filename_component(MPFI_LIBRARIES_DIR ${MPFI_LIBRARIES} PATH CACHE )
-  endif( MPFI_LIBRARIES )
+  get_dependency_version( MPFR )
+  message( STATUS "MPFR version is ${MPFR_VERSION}." )
+  IS_VERSION_LESS("${MPFR_VERSION}" "4.0.0" _MPFR_OLD)
 
-  if( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
-    include( MPFIConfig OPTIONAL )
-  endif( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
+  get_dependency_version( MPFI )
+  message( STATUS "MPFI version is ${MPFI_VERSION}." )
+  IS_VERSION_LESS("${MPFI_VERSION}" "1.5.2" _MPFI_OLD)
 
-  include(FindPackageHandleStandardArgs)
+  if( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+    message(
+      STATUS
+      "MPFI<1.5.2 requires MPFR<4.0.0; MPFI>=1.5.2 requires MPFR>=4.0.0" )
+    set( MPFI_FOUND FALSE )
 
-  find_package_handle_standard_args(MPFI "DEFAULT_MSG" MPFI_LIBRARIES MPFI_INCLUDE_DIR )
+  else( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
 
-else( GMP_FOUND )
+    if( MPFI_LIBRARIES )
+      get_filename_component(MPFI_LIBRARIES_DIR ${MPFI_LIBRARIES} PATH CACHE )
+    endif( MPFI_LIBRARIES )
+
+    if( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
+      include( MPFIConfig OPTIONAL )
+    endif( NOT MPFI_INCLUDE_DIR OR NOT MPFI_LIBRARIES_DIR )
+
+    include(FindPackageHandleStandardArgs)
+
+    find_package_handle_standard_args( MPFI
+                                       "DEFAULT_MSG"
+                                       MPFI_LIBRARIES
+                                       MPFI_INCLUDE_DIR )
+
+  endif( ( _MPFR_OLD AND NOT _MPFI_OLD ) OR ( NOT _MPFR_OLD AND _MPFI_OLD ) )
+
+else( GMP_FOUND AND MPFR_FOUND )
 
   message( STATUS "MPFI needs GMP and MPFR" )
 
-endif( GMP_FOUND )
+endif( GMP_FOUND AND MPFR_FOUND )
 
 if( MPFI_FOUND )
   set( MPFI_USE_FILE "CGAL_UseMPFI" )


### PR DESCRIPTION
## Summary of Changes

1. Check that MPFR and MPFI versions are compatible. This is done at CMake level.
2. Forbid the compilation of code using RS if the version of MPFR is between 3.1.3 and 3.1.6 (this modifies the previous code, where version 3.1.6 was not forbidden).
3. Fix a typo in the static assertion of the previous item.

## Release Management

* Affected package(s): Algebraic_kernel_RS, Number_types_Gmpfi
* Issue(s) solved (if any): #2797
* Feature/Small Feature (if any):
