### PR TITLE
Prefix CMake options with `CGAL_`

### DIFF
--- a/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
@@ -52,12 +52,12 @@ if ( CGAL_FOUND )
   include( ${CGAL_USE_FILE} )
 
   # Activate concurrency ? (turned OFF by default)
-  option(ACTIVATE_CONCURRENT_MESH_3
+  option(CGAL_ACTIVATE_CONCURRENT_MESH_3
     "Activate parallelism in Mesh_3"
     OFF)
     
   # And add -DCGAL_CONCURRENT_MESH_3 if that option is ON
-  if( ACTIVATE_CONCURRENT_MESH_3 )
+  if( CGAL_ACTIVATE_CONCURRENT_MESH_3 )
     add_definitions( -DCGAL_CONCURRENT_MESH_3 )
     find_package( TBB REQUIRED )	
   else()

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -22,15 +22,15 @@ if ( CGAL_FOUND )
   find_package(Boost)
 
   # Activate concurrency ? (turned OFF by default)
-  option(ACTIVATE_CONCURRENT_MESH_3
+  option(CGAL_ACTIVATE_CONCURRENT_MESH_3
     "Activate parallelism in Mesh_3"
     OFF)
     
   # And add -DCGAL_CONCURRENT_MESH_3 if that option is ON
-  if( ACTIVATE_CONCURRENT_MESH_3 OR ENV{ACTIVATE_CONCURRENT_MESH_3} )
+  if( CGAL_ACTIVATE_CONCURRENT_MESH_3 OR ENV{CGAL_ACTIVATE_CONCURRENT_MESH_3} )
     add_definitions( -DCGAL_CONCURRENT_MESH_3 )
     find_package( TBB REQUIRED )
-  else( ACTIVATE_CONCURRENT_MESH_3 OR ENV{ACTIVATE_CONCURRENT_MESH_3} )
+  else( CGAL_ACTIVATE_CONCURRENT_MESH_3 OR ENV{CGAL_ACTIVATE_CONCURRENT_MESH_3} )
     option( LINK_WITH_TBB
       "Link with TBB anyway so we can use TBB timers for profiling"
       ON)

--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -33,11 +33,11 @@ if ( CGAL_FOUND )
   endif()
 
   # Activate concurrency?
-  option(ACTIVATE_CONCURRENT_PSP3
+  option(CGAL_ACTIVATE_CONCURRENT_PSP3
          "Enable concurrency"
          OFF)
      
-  if( ACTIVATE_CONCURRENT_PSP3 OR ENV{ACTIVATE_CONCURRENT_PSP3} )
+  if( CGAL_ACTIVATE_CONCURRENT_PSP3 OR ENV{CGAL_ACTIVATE_CONCURRENT_PSP3} )
     find_package( TBB REQUIRED )
   endif()
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -94,12 +94,12 @@ endif()
 
 
 # Activate concurrency ? (turned OFF by default)
-option(ACTIVATE_CONCURRENT_MESH_3
+option(CGAL_ACTIVATE_CONCURRENT_MESH_3
   "Activate parallelism in Mesh_3"
   OFF)
 
 # And add -DCGAL_CONCURRENT_MESH_3 if that option is ON
-if( ACTIVATE_CONCURRENT_MESH_3 OR ENV{ACTIVATE_CONCURRENT_MESH_3} )
+if( CGAL_ACTIVATE_CONCURRENT_MESH_3 OR ENV{CGAL_ACTIVATE_CONCURRENT_MESH_3} )
   add_definitions( -DCGAL_CONCURRENT_MESH_3 )
   if(NOT TBB_FOUND)
     find_package( TBB REQUIRED )
@@ -108,7 +108,7 @@ if( ACTIVATE_CONCURRENT_MESH_3 OR ENV{ACTIVATE_CONCURRENT_MESH_3} )
     endif()
   endif()
 
-else( ACTIVATE_CONCURRENT_MESH_3 OR ENV{ACTIVATE_CONCURRENT_MESH_3} )
+else( CGAL_ACTIVATE_CONCURRENT_MESH_3 OR ENV{CGAL_ACTIVATE_CONCURRENT_MESH_3} )
   option( LINK_WITH_TBB
     "Link with TBB anyway so we can use TBB timers for profiling"
     ON)

--- a/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
@@ -30,15 +30,15 @@ if(Qt5_FOUND)
 endif(Qt5_FOUND)
 
 # Activate concurrency ? (turned OFF by default)
-option(ACTIVATE_CONCURRENT_TRIANGULATION_3
+option(CGAL_ACTIVATE_CONCURRENT_TRIANGULATION_3
   "Activate parallelism in Triangulation_3"
   OFF)
   
 # And add -DCGAL_CONCURRENT_TRIANGULATION_3 if that option is ON
-if( ACTIVATE_CONCURRENT_TRIANGULATION_3 )
+if( CGAL_ACTIVATE_CONCURRENT_TRIANGULATION_3 )
   add_definitions( -DCGAL_CONCURRENT_TRIANGULATION_3 )
   find_package( TBB REQUIRED )
-else( ACTIVATE_CONCURRENT_TRIANGULATION_3 )
+else( CGAL_ACTIVATE_CONCURRENT_TRIANGULATION_3 )
   option( LINK_WITH_TBB
     "Link with TBB anyway so we can use TBB timers for profiling"
     ON)


### PR DESCRIPTION
## Summary of Changes

Prefix CMake options `ACTIVATE_CONCURRENT_<something>` with `CGAL_`.

- in `examples/Mesh_3/`,
- in `examples/Point_set_processing_3/`,
- in `demo/Polyhedron/`, and
- in `demo/Triangulation_3/`.

Cc @afabri 

## Release Management

* Targets CGAL-4.12-beta2
* Affected package(s): Mesh_3, Triangulation_3, Polyhedron demo, Point_set_processing_3
