### PR TITLE
More fixes for GNU 8.0.1: fallthrough warnings  and constness

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_2.h
@@ -145,19 +145,19 @@ friend class Scaling_repC2<R>;
             {
               case 0: return t11;
               case 1: return t12;
-              case 2: return t13;
+              default: return t13;
             }
     case 1: switch (j)
             {
               case 0: return t21;
               case 1: return t22;
-              case 2: return t23;
+              default: return t23;
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
-              case 2: return FT(1);
+              default: return FT(1);
             }
     }
     return FT(0);

--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
@@ -162,28 +162,28 @@ public:
               case 0: return t11;
               case 1: return t12;
               case 2: return t13;
-              case 3: return t14;
+              default: return t14;
             }
     case 1: switch (j)
             {
               case 0: return t21;
               case 1: return t22;
               case 2: return t23;
-              case 3: return t24;
+              default: return t24;
             }
     case 2: switch (j)
             {
               case 0: return t31;
               case 1: return t32;
               case 2: return t33;
-              case 3: return t34;
+              default: return t34;
             }
     case 3: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(0);
-              case 3: return FT(1);
+              default: return FT(1);
             }
     }
   return FT(0);

--- a/Cartesian_kernel/include/CGAL/Cartesian/Rotation_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Rotation_rep_2.h
@@ -149,19 +149,19 @@ public:
             {
               case 0: return cosinus_;
               case 1: return -sinus_;
-              case 2: return FT(0);
+              default: return FT(0);
             }
     case 1: switch (j)
             {
               case 0: return sinus_;
               case 1: return cosinus_;
-              case 2: return FT(0);
+              default: return FT(0);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
-              case 2: return FT(1);
+              default: return FT(1);
             }
     }
     return FT(0);

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Edge_sorter.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Edge_sorter.h
@@ -43,7 +43,7 @@ public:
 	typedef Point_comparison Compare_points;
 	Compare_points comp;
 	Compare_halfedges_in_reflex_edge_sorter() {}
-	bool operator()(Halfedge_handle e0, Halfedge_handle e1) 
+	bool operator()(Halfedge_handle e0, Halfedge_handle e1) const
 	{
 		return comp(e0->source()->point(), e1->source()->point());
 	}

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
@@ -917,21 +917,24 @@ cartesian(int i, int j) const
               case 0: return FT(_cos) / FT(_den);
               case 1: return - FT(_sin) / FT(_den);
               case 2: return RT(0);
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
               case 0: return FT(_sin) / FT(_den);
               case 1: return FT(_cos) / FT(_den);
               case 2: return FT(0);
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
+              default: CGAL_ASSUME(false);
             }
   }
-  return FT(0);
+  CGAL_ASSUME(false);
 }
 
 template < class R >
@@ -947,21 +950,24 @@ homogeneous(int i, int j) const
               case 0: return _sf_num;
               case 1: return RT(0);
               case 2: return RT(0);
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
               case 0: return RT(0);
               case 1: return _sf_num;
               case 2: return RT(0);
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
               case 0: return RT(0);
               case 1: return RT(0);
               case 2: return _sf_den;
+              default: CGAL_ASSUME(false);
             }
   }
-  return RT(0);
+  CGAL_ASSUME(false);
 }
 
 template <class R>
@@ -977,21 +983,24 @@ cartesian(int i, int j) const
               case 0: return FT(_sf_num) / FT(_sf_den);
               case 1: return FT(0);
               case 2: return FT(0);
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(_sf_num) / FT(_sf_den);
               case 2: return FT(0);
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
+              default: CGAL_ASSUME(false);
             }
   }
-  return FT(0);
+ CGAL_ASSUME(false);
 }
 
 template < class R >
@@ -1008,21 +1017,24 @@ homogeneous(int i, int j) const
               case 0: return l.b()*l.b() - l.a()*l.a();
               case 1: return l.a()*l.b()*mRT2;
               case 2: return l.a()*l.c()*mRT2;
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
               case 0: return l.a()*l.b()*mRT2;
               case 1: return l.a()*l.a() - l.b()*l.b();
               case 2: return l.b()*l.c()*mRT2;
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
               case 0: return RT(0);
               case 1: return RT(0);
               case 2: return l.a()*l.a() + l.b()*l.b();
+              default: CGAL_ASSUME(false);
             }
   }
-  return RT(0);
+  CGAL_ASSUME(false);
 }
 
 template <class R>
@@ -1039,21 +1051,24 @@ cartesian(int i, int j) const
               case 0: return FT( l.b()-l.a() ) / FT( l.a()+l.b());
               case 1: return FT( homogeneous(0,1)) / de;
               case 2: return FT( homogeneous(0,2)) / de;
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
               case 0: return FT( homogeneous(1,0)) / de;
               case 1: return FT( l.a()-l.b() ) / FT( l.a()+l.b());
               case 2: return FT( homogeneous(1,2)) / de;
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
+              default: CGAL_ASSUME(false);
             }
   }
-  return FT(0);
+  GAL_ASSUME(false);
 }
 
 } //namespace CGAL

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
@@ -1068,7 +1068,7 @@ cartesian(int i, int j) const
               default: CGAL_ASSUME(false);
             }
   }
-  GAL_ASSUME(false);
+  CGAL_ASSUME(false);
 }
 
 } //namespace CGAL

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
@@ -916,25 +916,26 @@ cartesian(int i, int j) const
             {
               case 0: return FT(_cos) / FT(_den);
               case 1: return - FT(_sin) / FT(_den);
-              case 2: return RT(0);
-              default: CGAL_ASSUME(false);
+              case 2: return FT(0);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
               case 0: return FT(_sin) / FT(_den);
               case 1: return FT(_cos) / FT(_den);
               case 2: return FT(0);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return FT(0);
 }
 
 template < class R >
@@ -950,24 +951,25 @@ homogeneous(int i, int j) const
               case 0: return _sf_num;
               case 1: return RT(0);
               case 2: return RT(0);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
               case 0: return RT(0);
               case 1: return _sf_num;
               case 2: return RT(0);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
               case 0: return RT(0);
               case 1: return RT(0);
               case 2: return _sf_den;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return RT(0);
 }
 
 template <class R>
@@ -983,24 +985,25 @@ cartesian(int i, int j) const
               case 0: return FT(_sf_num) / FT(_sf_den);
               case 1: return FT(0);
               case 2: return FT(0);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(_sf_num) / FT(_sf_den);
               case 2: return FT(0);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
- CGAL_ASSUME(false);
+ CGAL_assume(false);
+ return FT(0);
 }
 
 template < class R >
@@ -1017,24 +1020,25 @@ homogeneous(int i, int j) const
               case 0: return l.b()*l.b() - l.a()*l.a();
               case 1: return l.a()*l.b()*mRT2;
               case 2: return l.a()*l.c()*mRT2;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
               case 0: return l.a()*l.b()*mRT2;
               case 1: return l.a()*l.a() - l.b()*l.b();
               case 2: return l.b()*l.c()*mRT2;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
               case 0: return RT(0);
               case 1: return RT(0);
               case 2: return l.a()*l.a() + l.b()*l.b();
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return RT(0);
 }
 
 template <class R>
@@ -1051,24 +1055,25 @@ cartesian(int i, int j) const
               case 0: return FT( l.b()-l.a() ) / FT( l.a()+l.b());
               case 1: return FT( homogeneous(0,1)) / de;
               case 2: return FT( homogeneous(0,2)) / de;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
               case 0: return FT( homogeneous(1,0)) / de;
               case 1: return FT( l.a()-l.b() ) / FT( l.a()+l.b());
               case 2: return FT( homogeneous(1,2)) / de;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
               case 0: return FT(0);
               case 1: return FT(0);
               case 2: return FT(1);
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return FT(0);
 }
 
 } //namespace CGAL

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
@@ -551,6 +551,7 @@ homogeneous(int i, int j) const
               case 1: return t01;
               case 2: return t02;
               case 3: return t03;
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
@@ -558,6 +559,7 @@ homogeneous(int i, int j) const
               case 1: return t11;
               case 2: return t12;
               case 3: return t13;
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
@@ -565,6 +567,7 @@ homogeneous(int i, int j) const
               case 1: return t21;
               case 2: return t22;
               case 3: return t23;
+              default: CGAL_ASSUME(false);
             }
     case 3: switch (j)
             {
@@ -572,9 +575,10 @@ homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return t33;
+              default: CGAL_ASSUME(false);
             }
   }
-  return RT0;
+  CGAL_ASSUME(false);
 }
 
 template < class R >
@@ -695,6 +699,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return tv.hx();
+              default: CGAL_ASSUME(false);
             }
     case 1: switch (j)
             {
@@ -702,6 +707,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return tv.hw();
               case 2: return RT0;
               case 3: return tv.hy();
+              default: CGAL_ASSUME(false);
             }
     case 2: switch (j)
             {
@@ -709,6 +715,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return tv.hw();
               case 3: return tv.hz();
+              default: CGAL_ASSUME(false);
             }
     case 3: switch (j)
             {
@@ -716,9 +723,10 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return tv.hw();
+              default: CGAL_ASSUME(false);
             }
   }
-  return RT0;
+  CGAL_ASSUME(false);
 }
 
 template < class R >

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
@@ -551,7 +551,7 @@ homogeneous(int i, int j) const
               case 1: return t01;
               case 2: return t02;
               case 3: return t03;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
@@ -559,7 +559,7 @@ homogeneous(int i, int j) const
               case 1: return t11;
               case 2: return t12;
               case 3: return t13;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
@@ -567,7 +567,7 @@ homogeneous(int i, int j) const
               case 1: return t21;
               case 2: return t22;
               case 3: return t23;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 3: switch (j)
             {
@@ -575,10 +575,11 @@ homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return t33;
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return RT0;
 }
 
 template < class R >
@@ -699,7 +700,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return tv.hx();
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 1: switch (j)
             {
@@ -707,7 +708,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return tv.hw();
               case 2: return RT0;
               case 3: return tv.hy();
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 2: switch (j)
             {
@@ -715,7 +716,7 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return tv.hw();
               case 3: return tv.hz();
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
     case 3: switch (j)
             {
@@ -723,10 +724,11 @@ Translation_repH3<R>::homogeneous(int i, int j) const
               case 1: return RT0;
               case 2: return RT0;
               case 3: return tv.hw();
-              default: CGAL_ASSUME(false);
+              default: CGAL_assume(false);
             }
   }
-  CGAL_ASSUME(false);
+  CGAL_assume(false);
+  return RT0;
 }
 
 template < class R >

--- a/Intersections_2/include/CGAL/Segment_2_Segment_2_intersection.h
+++ b/Intersections_2/include/CGAL/Segment_2_Segment_2_intersection.h
@@ -129,31 +129,31 @@ do_intersect(const typename K::Segment_2 &seg1,
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(A2,B2))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(A1,A2,B1,B2, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(A1,A2,B1,B2, k);
                     }
                 }
             case EQUAL:
                 return true;
-            case LARGER:
+            default: // LARGER
                 switch(make_certain(compare_xy(B2,A1))) {
                 case SMALLER:
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(B2,A2))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(B1,B2,A1,A2, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(B1,B2,A1,A2, k);
                     }
                 }
@@ -166,31 +166,31 @@ do_intersect(const typename K::Segment_2 &seg1,
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(A2,B1))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(A1,A2,B2,B1, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(A1,A2,B2,B1, k);
                     }
                 }
             case EQUAL:
                 return true;
-            case LARGER:
+            default: // LARGER
                 switch(make_certain(compare_xy(B1,A1))) {
                 case SMALLER:
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(B1,A2))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(B2,B1,A1,A2, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(B2,B1,A1,A2, k);
                     }
                 }
@@ -205,31 +205,31 @@ do_intersect(const typename K::Segment_2 &seg1,
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(A1,B2))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(A2,A1,B1,B2, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(A2,A1,B1,B2, k);
                     }
                 }
             case EQUAL:
                 return true;
-            case LARGER:
+            default: // LARGER
                 switch(make_certain(compare_xy(B2,A2))) {
                 case SMALLER:
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(B2,A1))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(B1,B2,A2,A1, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(B1,B2,A2,A1, k);
                     }
                 }
@@ -242,31 +242,31 @@ do_intersect(const typename K::Segment_2 &seg1,
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(A1,B1))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(A2,A1,B2,B1, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(A2,A1,B2,B1, k);
                     }
                 }
             case EQUAL:
                 return true;
-            case LARGER:
+            default: // LARGER
                 switch(make_certain(compare_xy(B1,A2))) {
                 case SMALLER:
                     return false;
                 case EQUAL:
                     return true;
-                case LARGER:
+                default: // LARGER
                     switch(make_certain(compare_xy(B1,A1))) {
                     case SMALLER:
                         return seg_seg_do_intersect_crossing(B2,B1,A2,A1, k);
                     case EQUAL:
                         return true;
-                    case LARGER:
+                    default: // LARGER
                         return seg_seg_do_intersect_contained(B2,B1,A2,A1, k);
                     }
                 }

--- a/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
+++ b/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
@@ -129,8 +129,8 @@ private:
         return 1;
       case LEFT_TURN:
         return 2;
+      default: CGAL_ASSUME(false);
       }
-
       return -1;
     }
 
@@ -223,6 +223,7 @@ private:
                 == Visibility_2::orientation_2(geom_traits, s2, t2, s1);
           else
             return true;
+        default: CGAL_ASSUME(false);
         }
       case LEFT_TURN:
         switch (Visibility_2::orientation_2(geom_traits, s1, t1, s2)) {
@@ -240,6 +241,7 @@ private:
                 == Visibility_2::orientation_2(geom_traits, s2, t2, s1);
           else
             return true;
+        default: CGAL_ASSUME(false);
         }
       }
 

--- a/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
+++ b/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
@@ -129,7 +129,7 @@ private:
         return 1;
       case LEFT_TURN:
         return 2;
-      default: CGAL_ASSUME(false);
+      default: CGAL_assume(false);
       }
       return -1;
     }
@@ -223,7 +223,7 @@ private:
                 == Visibility_2::orientation_2(geom_traits, s2, t2, s1);
           else
             return true;
-        default: CGAL_ASSUME(false);
+        default: CGAL_assume(false);
         }
       case LEFT_TURN:
         switch (Visibility_2::orientation_2(geom_traits, s1, t1, s2)) {
@@ -241,7 +241,7 @@ private:
                 == Visibility_2::orientation_2(geom_traits, s2, t2, s1);
           else
             return true;
-        default: CGAL_ASSUME(false);
+        default: CGAL_assume(false);
         }
       }
 


### PR DESCRIPTION
## Summary of Changes

- Replace the third `case` with `default` in ternary `switch`. 
- Declare an `operator<()`  const

## Release Management

* Affected package(s): Kernel_23, Intersections_2, Convex_decomposition_3


