### PR TITLE
Try to robustify Straight Skeleton

### DIFF
--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -179,7 +179,7 @@ Straight_skeleton_builder_2<Gt,Ss,V>::IsPseudoSplitEvent( EventPtr const& aEvent
   }
   
   if ( rPseudoSplitEvent )
-    rPseudoSplitEvent->SetTimeAndPoint(aEvent->time(),aEvent->point());
+    rPseudoSplitEvent->SetTimeAndPoint(aEvent->exact_time(),aEvent->exact_point());
   
   return rPseudoSplitEvent ;
 }

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_events_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_events_2.h
@@ -26,6 +26,7 @@
 #include<ostream>
 
 #include <CGAL/Straight_skeleton_2/Straight_skeleton_aux.h>
+#include <CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h>
 
 namespace CGAL {
 
@@ -74,10 +75,12 @@ public:
 
   Triedge const&          triedge   () const { return mTriedge   ; }
   Trisegment_2_ptr const& trisegment() const { return mTrisegment; }
-  Point_2 const&          point     () const { return mP         ; }
-  FT                      time      () const { return mTime      ; }
+  Point_2 const&          point     () const { return mP.pt         ; } // TODO_INEXACT
+  CGAL_SS_i::Rational_point<Point_2, FT> const& exact_point() const { return mP; }
+  FT                      time      () const { return mTime.to_nt()      ; } // TODO_INEXACT
+  CGAL_SS_i::Rational_time<FT> exact_time      () const { return mTime; }
 
-  void SetTimeAndPoint( FT aTime, Point_2 const& aP ) { mTime = aTime ; mP = aP ; }
+  void SetTimeAndPoint( CGAL_SS_i::Rational_time<FT> aTime, CGAL_SS_i::Rational_point<Point_2, FT> const& aP ) { mTime = aTime ; mP = aP ; }
 
   friend std::ostream& operator<< ( std::ostream& ss, Self const& e )
   {
@@ -96,8 +99,8 @@ private :
 
   Triedge          mTriedge ;
   Trisegment_2_ptr mTrisegment ;
-  Point_2          mP ;
-  FT               mTime ;
+  CGAL_SS_i::Rational_point<Point_2, FT> mP ;
+  Rational_time<FT> mTime ;
 } ;
 
 template<class SSkel_, class Traits_>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -38,10 +38,7 @@
 #include <boost/optional/optional.hpp>
 #include <boost/none.hpp>
 
-
-#ifdef CGAL_USE_CORE
-#  include <CGAL/CORE_BigFloat.h>  
-#endif
+#include <CGAL/Straight_skeleton_2/nt_utils.h>
 
 namespace CGAL {
 

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -32,6 +32,7 @@
 #include <CGAL/Unfiltered_predicate_adaptor.h>
 #include <CGAL/Filtered_predicate.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Root_of_traits.h>
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/intrusive_ptr.hpp>
@@ -209,21 +210,31 @@ public:
 
 //  TODO need an overload for false_type
 template <class NT>
-bool is_sum_of_roots_zero_impl(const NT& a, const NT& b, const NT& c, const NT& d,
-                               const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d,
-                               boost::mpl::true_)
+bool is_sum_of_4_roots_zero_impl(const NT& a, const NT& b, const NT& c, const NT& d,
+                                 const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d,
+                                 boost::mpl::true_)
 {
   return a * sqrt(ext_a) + b * sqrt(ext_b) + c * sqrt(ext_c) + d * sqrt(ext_d) == 0;
 }
 
 template <class NT>
-bool is_sum_of_roots_zero(const NT& a, const NT& b, const NT& c, const NT& d,
+bool is_sum_of_4_roots_zero(const NT& a, const NT& b, const NT& c, const NT& d,
                           const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d)
 {
   typedef typename is_same_or_derived<Field_with_sqrt_tag,
                                       typename Algebraic_structure_traits<NT>::Algebraic_category>::type AT_tag;
-  return is_sum_of_roots_zero_impl(a,b,c,d, ext_a, ext_b, ext_c, ext_d,
-                                   AT_tag());
+  return is_sum_of_4_roots_zero_impl(a,b,c,d, ext_a, ext_b, ext_c, ext_d,
+                                     AT_tag());
+}
+
+template <class NT>
+bool is_sum_of_2_roots_zero(const NT& a, const NT& b,
+                            const NT& ext_a, const NT& ext_b)
+{
+  typedef typename CGAL::Root_of_traits<NT>::Root_of_2 RO_2;
+
+  return CGAL::compare(RO_2(a) * CGAL::make_sqrt(ext_a),
+                       RO_2(-b) * CGAL::make_sqrt(ext_b)) == EQUAL;
 }
 
 // Represents numbers of the form N/(d0*sqrt(r0)+d1*sqrt(r1)+d2*sqrt(r2))

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -298,15 +298,15 @@ class Rational_time
     CORE::Expr assemble() const
     {
       return CORE::Expr( to_BigFloat(mN) ) / (
-        CORE::Expr(to_BigFloat(mD0)) * sqrt(to_BigFloat(mR0)) +
-        CORE::Expr(to_BigFloat(mD1)) * sqrt(to_BigFloat(mR1)) +
-        CORE::Expr(to_BigFloat(mD2)) * sqrt(to_BigFloat(mR2)) );
+        CORE::Expr(to_BigFloat(mD0)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR0))) +
+        CORE::Expr(to_BigFloat(mD1)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR1))) +
+        CORE::Expr(to_BigFloat(mD2)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR2))) );
     }
 
     Comparison_result
     compare(const Rational_time<NT>& other) const
     {
-      return CGAL::sign( assemble() - other.assemble() );
+      return CGAL::compare( assemble(), other.assemble() );
     }
 
     Sign
@@ -340,7 +340,7 @@ class Rational_time< NT, true >
 
     CGAL::Quotient<NT> to_quotient() const { return CGAL::Quotient<NT>(n(),d()) ; }
 
-    NT to_nt() const { return mN / d() ; }
+    NT to_nt() const { return mN / mD ; }
 
     friend std::ostream& operator << ( std::ostream& os, Rational_time<NT> const& rat )
     {
@@ -418,16 +418,16 @@ class Rational_time_4
     CORE::Expr assemble() const
     {
       return CORE::Expr( to_BigFloat(mN) ) / (
-        CORE::Expr(to_BigFloat(mD0)) * sqrt(to_BigFloat(mR0)) +
-        CORE::Expr(to_BigFloat(mD1)) * sqrt(to_BigFloat(mR1)) +
-        CORE::Expr(to_BigFloat(mD2)) * sqrt(to_BigFloat(mR2)) +
-        CORE::Expr(to_BigFloat(mD3)) * sqrt(to_BigFloat(mR3)) );
+        CORE::Expr(to_BigFloat(mD0)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR0))) +
+        CORE::Expr(to_BigFloat(mD1)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR1))) +
+        CORE::Expr(to_BigFloat(mD2)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR2))) +
+        CORE::Expr(to_BigFloat(mD3)) * CORE::sqrt(CORE::Expr(to_BigFloat(mR3))) );
     }
 
     Comparison_result
     compare(const Rational_time<NT>& other) const
     {
-      return CGAL::sign( assemble() - other.assemble() );
+      return CGAL::compare( assemble(), other.assemble() );
     }
 
     Sign
@@ -461,7 +461,7 @@ class Rational_time_4< NT, true >
 
     CGAL::Quotient<NT> to_quotient() const { return CGAL::Quotient<NT>(n(),d()) ; }
 
-    NT to_nt() const { CGAL_assertion(d()!=0); return mN / d() ; }
+    NT to_nt() const { CGAL_assertion(mD!=0); return mN / mD ; }
 
     friend std::ostream& operator << ( std::ostream& os, Rational_time_4<NT> const& rat )
     {

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -208,13 +208,27 @@ public:
   }
 };
 
-//  TODO need an overload for false_type
+template <class NT>
+bool is_sum_of_4_roots_zero(const NT& a, const NT& b, const NT& c, const NT& d,
+                          const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d);
+
 template <class NT>
 bool is_sum_of_4_roots_zero_impl(const NT& a, const NT& b, const NT& c, const NT& d,
                                  const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d,
                                  boost::mpl::true_)
 {
   return a * sqrt(ext_a) + b * sqrt(ext_b) + c * sqrt(ext_c) + d * sqrt(ext_d) == 0;
+}
+
+template <class NT>
+bool is_sum_of_4_roots_zero_impl(const NT& a, const NT& b, const NT& c, const NT& d,
+                                 const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d,
+                                 boost::mpl::false_)
+{
+  return is_sum_of_4_roots_zero(CORE::Expr(to_BigFloat(a)), CORE::Expr(to_BigFloat(b)),
+                                CORE::Expr(to_BigFloat(c)), CORE::Expr(to_BigFloat(d)),
+                                CORE::Expr(to_BigFloat(ext_a)), CORE::Expr(to_BigFloat(ext_b)),
+                                CORE::Expr(to_BigFloat(ext_c)), CORE::Expr(to_BigFloat(ext_d)));
 }
 
 template <class NT>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -207,6 +207,25 @@ public:
   }
 };
 
+//  TODO need an overload for false_type
+template <class NT>
+bool is_sum_of_roots_zero_impl(const NT& a, const NT& b, const NT& c, const NT& d,
+                               const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d,
+                               boost::mpl::true_)
+{
+  return a * sqrt(ext_a) + b * sqrt(ext_b) + c * sqrt(ext_c) + d * sqrt(ext_d) == 0;
+}
+
+template <class NT>
+bool is_sum_of_roots_zero(const NT& a, const NT& b, const NT& c, const NT& d,
+                          const NT& ext_a, const NT& ext_b, const NT& ext_c, const NT& ext_d)
+{
+  typedef typename is_same_or_derived<Field_with_sqrt_tag,
+                                      typename Algebraic_structure_traits<NT>::Algebraic_category>::type AT_tag;
+  return is_sum_of_roots_zero_impl(a,b,c,d, ext_a, ext_b, ext_c, ext_d,
+                                   AT_tag());
+}
+
 // Represents numbers of the form N/(d0*sqrt(r0)+d1*sqrt(r1)+d2*sqrt(r2))
 // used to represent the time of trisegments
 template<class NT, bool has_sqrt = is_same_or_derived<Field_with_sqrt_tag,

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/debug.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/debug.h
@@ -24,6 +24,7 @@
 
 
 #include <CGAL/config.h>
+#include <CGAL/MP_Float.h>
 
 #ifdef CGAL_USE_CORE
 #  include <CGAL/CORE_BigFloat.h>
@@ -269,12 +270,10 @@ inline std::string newn2str( char const* name, VH const& v, Triedge const& aTrie
 #endif
 
 #ifdef CGAL_STRAIGHT_SKELETON_TRAITS_ENABLE_TRACE
-bool sEnableTraitsTrace = false ;
-#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE sEnableTraitsTrace = true ;
-#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE_IF(cond) if ((cond)) sEnableTraitsTrace = true ;
-#  define CGAL_STSKEL_TRAITS_DISABLE_TRACE sEnableTraitsTrace = false;
+#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE 1
+#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE_IF(cond) if ((cond))
+#  define CGAL_STSKEL_TRAITS_DISABLE_TRACE 0
 #  define CGAL_STSKEL_TRAITS_TRACE(m) \
-     if ( sEnableTraitsTrace ) \
      { \
        std::ostringstream ss ; \
        ss << m ; \
@@ -282,9 +281,9 @@ bool sEnableTraitsTrace = false ;
        Straight_skeleton_traits_external_trace(s); \
      }
 #else
-#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE
+#  define CGAL_STSKEL_TRAITS_ENABLE_TRACE 0
 #  define CGAL_STSKEL_TRAITS_ENABLE_TRACE_IF(cond)
-#  define CGAL_STSKEL_TRAITS_DISABLE_TRACE
+#  define CGAL_STSKEL_TRAITS_DISABLE_TRACE 1
 #  define CGAL_STSKEL_TRAITS_TRACE(m)
 #endif
 
@@ -350,8 +349,6 @@ template<> char const* kernel_type<CORE::Expr>          () { return "Expr" ;    
 #define CGAL_STSKEL_ASSERT_CONSTRUCTION_RESULT(expr,K,cons,error)
 
 #endif
-
-#undef CGAL_STSKEL_ENABLE_TRACE
 
 #endif // CGAL_STRAIGHT_SKELETON_DEBUG_H //
 // EOF //

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/nt_utils.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/nt_utils.h
@@ -1,0 +1,133 @@
+// Copyright (c) 2006 Fernando Luis Cacciola Carballal. All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0+
+//
+// Author(s)     : Fernando Cacciola <fernando_cacciola@ciudad.com.ar>
+
+#ifndef CGAL_STRAIGHT_SKELETON_NT_UTILS_H
+#define CGAL_STRAIGHT_SKELETON_NT_UTILS_H 1
+
+
+
+#ifdef CGAL_USE_CORE
+#  include <CGAL/CORE_BigFloat.h>
+#endif
+
+namespace CGAL{
+
+namespace CGAL_SS_i {
+
+#ifdef CGAL_USE_CORE
+
+#ifdef CGAL_USE_GMPXX
+inline CORE::BigFloat to_BigFloat( mpq_class const& n )
+{
+  return CORE::BigFloat( CORE::BigRat(n.get_mpq_t()) );
+}
+#else
+inline CORE::BigFloat to_BigFloat( CGAL::Gmpq const& n )
+{
+  return CORE::BigFloat( CORE::BigRat(n.mpq()) );
+}
+#endif
+
+template<class NT>
+inline CORE::BigFloat to_BigFloat( NT const& n )
+{
+  return to_BigFloat( CGAL::exact(n) );
+}
+
+template<>
+inline CORE::BigFloat to_BigFloat<MP_Float>( MP_Float const& b )
+{
+  if (b.is_zero())
+    return CORE::BigFloat::getZero();
+
+  typedef MP_Float::exponent_type exponent_type;
+
+  const int                    log_limb         = 8 * sizeof(MP_Float::limb);
+  const MP_Float::V::size_type limbs_per_double = 2 + 53/log_limb;
+
+  exponent_type exp = b.max_exp();
+  int steps = static_cast<int>((std::min)(limbs_per_double, b.v.size()));
+
+  CORE::BigFloat d_exp_1 = CORE::BigFloat::exp2(-log_limb);
+
+  CORE::BigFloat d_exp   = CORE::BigFloat::getOne() ;
+
+  CORE::BigFloat d       = CORE::BigFloat::getZero();
+
+  for ( exponent_type i = exp - 1; i > exp - 1 - steps; i--)
+  {
+    d_exp *= d_exp_1;
+    d += d_exp * CORE::BigFloat(b.of_exp(i));
+  }
+
+  return d * CORE::BigFloat::exp2( static_cast<int>(exp * log_limb) );
+}
+
+
+#endif
+
+template<class NT>
+inline NT inexact_sqrt_implementation( NT const& n, CGAL::Null_functor /*no_sqrt*/ )
+{
+
+#ifdef CGAL_USE_CORE
+
+  CORE::BigFloat nn = to_BigFloat(n) ;
+  CORE::BigFloat s  = CORE::sqrt(nn);
+  return NT(s.doubleValue());
+
+#else
+
+  double nn = CGAL::to_double(n) ;
+
+  if ( !CGAL_NTS is_valid(nn) || ! CGAL_NTS is_finite(nn) )
+    nn = std::numeric_limits<double>::max BOOST_PREVENT_MACRO_SUBSTITUTION () ;
+
+  CGAL_precondition(nn > 0);
+
+  double s = CGAL_NTS sqrt(nn);
+
+  return NT(s);
+
+#endif
+}
+
+template<class NT, class Sqrt>
+inline NT inexact_sqrt_implementation( NT const& n, Sqrt sqrt_f )
+{
+  return sqrt_f(n);
+}
+
+template<class NT>
+inline NT inexact_sqrt( NT const& n )
+{
+  typedef CGAL::Algebraic_structure_traits<NT> AST;
+  typedef typename AST::Sqrt Sqrt;
+  return inexact_sqrt_implementation(n,Sqrt());
+}
+
+inline Quotient<MP_Float> inexact_sqrt( Quotient<MP_Float> const& q )
+{
+  CGAL_precondition(q > 0);
+  return Quotient<MP_Float>(CGAL_SS_i::inexact_sqrt(q.numerator()*q.denominator()), q.denominator() );
+}
+
+} } // end of CGAL::CGAL_SS_i namespace
+
+#endif // CGAL_STRAIGHT_SKELETON_NT_UTILS_H

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/test.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/test.h
@@ -108,6 +108,11 @@ inline bool is_possibly_inexact_distance_clearly_not_zero ( Lazy_exact_nt<NT> co
 }  
 #endif
 
+template<class NT>
+inline bool is_possibly_inexact_distance_clearly_not_zero ( NT const& n )
+{
+  return is_possibly_inexact_distance_clearly_not_zero( to_double(n), 1e-8 ) ;
+}
 
 inline bool is_possibly_inexact_distance_clearly_not_zero ( double n )
 {

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
@@ -611,17 +611,19 @@ private :
     }
   }
 
-  boost::tuple<FT,Point_2> ConstructEventTimeAndPoint( Trisegment_2_ptr const& aS ) const
+  boost::tuple<CGAL_SS_i::Rational_time<FT>, CGAL_SS_i::Rational_point<Point_2, FT> >
+  ConstructEventTimeAndPoint( Trisegment_2_ptr const& aS ) const
   {
-    boost::optional< boost::tuple<FT,Point_2> > r = Construct_ss_event_time_and_point_2(mTraits)(aS);
+    boost::optional< boost::tuple<CGAL_SS_i::Rational_time<FT>,CGAL_SS_i::Rational_point<Point_2, FT> > > r =
+      Construct_ss_event_time_and_point_2(mTraits)(aS);
     CGAL_postcondition_msg(!!r, "Unable to compute skeleton node coordinates");
     return *r ;  
   }
 
   void SetEventTimeAndPoint( Event& aE )
   {
-    FT      lTime ;
-    Point_2 lP ;
+    CGAL_SS_i::Rational_time<FT>      lTime ;
+    CGAL_SS_i::Rational_point<Point_2, FT> lP ;
     boost::tie(lTime,lP) = ConstructEventTimeAndPoint(aE.trisegment());
     
     aE.SetTimeAndPoint(lTime,lP);

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_traits_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_traits_2.h
@@ -234,7 +234,7 @@ struct Construct_ss_event_time_and_point_2 : Functor_base_2<K>
     FT      t(0) ;
     Point_2 i = ORIGIN ;
 
-    optional< Rational<FT> > ot = compute_offset_lines_isec_timeC2(aTrisegment);
+    optional< Rational_time<FT> > ot = compute_offset_lines_isec_timeC2(aTrisegment);
 
     if ( !!ot && certainly( CGAL_NTS certified_is_not_zero(ot->d()) ) )
     {
@@ -263,7 +263,7 @@ struct Construct_ss_event_time_and_point_2 : Functor_base_2<K>
     FT      t(0) ;
     Point_2 i = ORIGIN ;
 
-    optional< Rational<FT> > ot = compute_offset_lines_isec_timeC2(aTrisegment);
+    optional< Rational_time<FT> > ot = compute_offset_lines_isec_timeC2(aTrisegment);
 
     if ( !!ot && certainly( CGAL_NTS certified_is_not_zero(ot->d()) ) )
     {

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_traits_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_traits_2.h
@@ -26,6 +26,7 @@
 #include <CGAL/Filtered_construction.h>
 #include <CGAL/Straight_skeleton_2/Straight_skeleton_aux.h>
 #include <CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h>
+#include <CGAL/Straight_skeleton_2/debug.h>
 #include <CGAL/predicates/Straight_skeleton_pred_ftC2.h>
 #include <CGAL/constructions/Straight_skeleton_cons_ftC2.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
@@ -259,7 +259,7 @@ private:
   int             mID ;
   Halfedge_handle mHE;
   Triedge         mEventTriedge ;
-  Point_2         mP;
+  Point_2         mP; //TODO_INEXACT for non input vertices (i.e. is_contour == false)
   FT              mTime ;
   unsigned char   mFlags ;
 };

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -395,9 +395,13 @@ optional< Rational< typename K::FT> > compute_normal_offset_lines_isec_timeC2 ( 
          +(l1->b()*l0->a()*l2->c())
          -(l0->b()*l1->a()*l2->c());
 
-    FT r0 = CGAL_SS_i :: inexact_sqrt(square(l0->a())+square(l0->b()));
-    FT r1 = CGAL_SS_i :: inexact_sqrt(square(l1->a())+square(l1->b()));
-    FT r2 = CGAL_SS_i :: inexact_sqrt(square(l2->a())+square(l2->b()));
+    FT sum_sq_0 = square(l0->a()) + square(l0->b());
+    FT sum_sq_1 = square(l1->a()) + square(l1->b());
+    FT sum_sq_2 = square(l2->a()) + square(l2->b());
+
+    FT r0 = CGAL_SS_i::inexact_sqrt(sum_sq_0);
+    FT r1 = CGAL_SS_i::inexact_sqrt(sum_sq_1);
+    FT r2 = CGAL_SS_i::inexact_sqrt(sum_sq_2);
 
     den = r0 * (l2->b()*l1->a() - l2->a()*l1->b()) +
           r1 * (l2->a()*l0->b() - l2->b()*l0->a()) +
@@ -657,9 +661,13 @@ optional< Point_2<K> > construct_normal_offset_lines_isecC2 ( intrusive_ptr< Tri
   
   if ( l0 && l1 && l2 )
   {
-    FT r0 = CGAL_SS_i :: inexact_sqrt(square(l0->a())+square(l0->b()));
-    FT r1 = CGAL_SS_i :: inexact_sqrt(square(l1->a())+square(l1->b()));
-    FT r2 = CGAL_SS_i :: inexact_sqrt(square(l2->a())+square(l2->b()));
+    FT sum_sq_0 = square(l0->a()) + square(l0->b());
+    FT sum_sq_1 = square(l1->a()) + square(l1->b());
+    FT sum_sq_2 = square(l2->a()) + square(l2->b());
+
+    FT r0 = CGAL_SS_i::inexact_sqrt(sum_sq_0);
+    FT r1 = CGAL_SS_i::inexact_sqrt(sum_sq_1);
+    FT r2 = CGAL_SS_i::inexact_sqrt(sum_sq_2);
 
     FT den = r0 * ( l2->a()*l1->b() - l1->a()*l2->b()) +
              r1 * ( l0->a()*l2->b() - l0->b()*l2->a()) +

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -331,35 +331,62 @@ optional< Rational_time_4< typename K::FT> > compute_normal_offset_lines_isec_ti
     FT sum_sq_2 = square(l2->a()) + square(l2->b());
     FT sum_sq_3 = square(l3->a()) + square(l3->b());
 
-    const FT a0b1_a1b1 = l0->a()*l1->b() - l1->a()*l0->b(),
-             a0b2_a2b0 = l0->a()*l2->b() - l2->a()*l0->b(),
+    const FT a0b2_a2b0 = l0->a()*l2->b() - l2->a()*l0->b(),
+             a2b1_a1b2 = l2->a()*l1->b() - l1->a()*l2->b(),
+             a0b3_a3b0 = l0->a()*l3->b() - l3->a()*l0->b(),
+             a1b3_a3b1 = l1->a()*l3->b() - l3->a()*l1->b();
+
+    if ( is_sum_of_roots_zero(a0b2_a2b0, a2b1_a1b2, - a0b3_a3b0, a1b3_a3b1,
+                              sum_sq_1 * sum_sq_3, sum_sq_0 * sum_sq_3, sum_sq_1 * sum_sq_2, sum_sq_0 * sum_sq_2) )
+    {
+      // bisectors are coplanar
+      return boost::none;
+    }
+
+    const FT a0b1_a1b0 = l0->a()*l1->b() - l1->a()*l0->b(),
              a2b0_a0b2 = l2->a()*l0->b() - l0->a()*l2->b(),
              a1b2_a2b1 = l1->a()*l2->b() - l2->a()*l1->b(),
              a3b0_a0b3 = l3->a()*l0->b() - l0->a()*l3->b(),
-             a1b3_a3b1 = l1->a()*l3->b() - l3->a()*l1->b(),
-             a0b3_a3b0 = l0->a()*l3->b() - l3->a()*l0->b(),
              a3b1_a1b3 = l3->a()*l1->b() - l1->a()*l3->b(),
-             a2b1_a0b2 = l2->a()*l1->b() - l1->a()*l2->b(),
              a2b3_a3b2 = l2->a()*l3->b() - l3->a()*l2->b(),
-             d01_exp1 = (a0b1_a1b1 * l3->c() + a3b0_a0b3 * l1->c() + a1b3_a3b1 * l0->c()) * sum_sq_2,
-             d01_exp2 = (a0b1_a1b1 * l2->c() + a2b0_a0b2 * l1->c() + a1b2_a2b1 * l0->c()) * sum_sq_3,
+             d01_exp1 = (a0b1_a1b0 * l3->c() + a3b0_a0b3 * l1->c() + a1b3_a3b1 * l0->c()) * sum_sq_2,
+             d01_exp2 = (a0b1_a1b0 * l2->c() + a2b0_a0b2 * l1->c() + a1b2_a2b1 * l0->c()) * sum_sq_3,
              two(2);
 
-   const FT num = ( (a0b1_a1b1 * (a0b1_a1b1 * l2->c() + two * a2b0_a0b2 * l1->c() + two * a1b2_a2b1 * l0->c()) ) * l2->c()
-                +   (a0b2_a2b0 * (a0b2_a2b0 * l1->c() + two * a2b1_a0b2 * l0->c() ) ) * l1->c()
-                +    square(a1b2_a2b1 * l0->c()) ) * sum_sq_3
-                + (( -a0b1_a1b1 * (a0b1_a1b1 * l3->c() + two * a3b0_a0b3 * l1->c() + two * a1b3_a3b1 * l0->c()) ) * l3->c()
-                + (  -a0b3_a3b0 * (a0b3_a3b0 * l1->c() + two * a3b1_a1b3 * l0->c())) * l1->c()
-                +   - square(a1b3_a3b1 * l0->c())) * sum_sq_2,
-            d0 =  a1b2_a2b1 * d01_exp2 - a1b3_a3b1 * d01_exp1,
-            d1 = -a0b2_a2b0 * d01_exp2 + a0b3_a3b0 * d01_exp1,
-            d2 = -a0b1_a1b1 * ( a0b2_a2b0 * l3->c() + a3b0_a0b3 * l2->c() + a2b3_a3b2 * l0->c() ),
-            d3 =  a0b1_a1b1 * ( a1b2_a2b1 * l3->c() + a3b1_a1b3 * l2->c() + a2b3_a3b2 * l1->c() );
+    const FT n1 = -(a0b1_a1b0*l2->c()-a0b2_a2b0*l1->c()+a1b2_a2b1*l0->c()),
+             n2 = -(-a0b1_a1b0*l3->c()+a0b3_a3b0*l1->c()-a1b3_a3b1*l0->c());
 
-    return boost::make_optional(
-      Rational_time_4<FT>(num,
-                         d0, d1, d2, d3,
-                         sum_sq_0, sum_sq_1, sum_sq_1 * sum_sq_2 * sum_sq_3, sum_sq_0 * sum_sq_2* sum_sq_3) );
+    if ( n1 * n1 * sum_sq_3 != n2 * n2 * sum_sq_2) // TODO write this in another form?
+    {
+      const FT num = ( (a0b1_a1b0 * (a0b1_a1b0 * l2->c() + two * a2b0_a0b2 * l1->c() + two * a1b2_a2b1 * l0->c()) ) * l2->c()
+                   +   (a0b2_a2b0 * (a0b2_a2b0 * l1->c() + two * a2b1_a1b2 * l0->c() ) ) * l1->c()
+                   +    square(a1b2_a2b1 * l0->c()) ) * sum_sq_3
+                   + (( -a0b1_a1b0 * (a0b1_a1b0 * l3->c() + two * a3b0_a0b3 * l1->c() + two * a1b3_a3b1 * l0->c()) ) * l3->c()
+                   + (  -a0b3_a3b0 * (a0b3_a3b0 * l1->c() + two * a3b1_a1b3 * l0->c())) * l1->c()
+                   +   - square(a1b3_a3b1 * l0->c())) * sum_sq_2,
+               d0 =  a1b2_a2b1 * d01_exp2 - a1b3_a3b1 * d01_exp1,
+               d1 = -a0b2_a2b0 * d01_exp2 + a0b3_a3b0 * d01_exp1,
+               d2 = -a0b1_a1b0 * ( a0b2_a2b0 * l3->c() + a3b0_a0b3 * l2->c() + a2b3_a3b2 * l0->c() ),
+               d3 =  a0b1_a1b0 * ( a1b2_a2b1 * l3->c() + a3b1_a1b3 * l2->c() + a2b3_a3b2 * l1->c() );
+
+      return boost::make_optional(
+        Rational_time_4<FT>(num,
+                            d0, d1, d2, d3,
+                            sum_sq_0, sum_sq_1, sum_sq_1 * sum_sq_2 * sum_sq_3, sum_sq_0 * sum_sq_2* sum_sq_3) );
+    }
+    else
+    {
+      const FT num = n1 * sum_sq_3 ,
+               d0 = -a1b2_a2b1 * sum_sq_3,
+               d1 =  a0b2_a2b0 * sum_sq_3,
+               d2 =  a3b0_a0b3,
+               d3 =  a1b3_a3b1;
+
+      return boost::make_optional(
+        Rational_time_4<FT>(num,
+                            d0, d1, d2, d3,
+                            sum_sq_0, sum_sq_1, sum_sq_1 * sum_sq_2 * sum_sq_3, sum_sq_0 * sum_sq_2* sum_sq_3) );
+    }
   }
 
   return boost::none;

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -336,8 +336,8 @@ optional< Rational_time_4< typename K::FT> > compute_normal_offset_lines_isec_ti
              a0b3_a3b0 = l0->a()*l3->b() - l3->a()*l0->b(),
              a1b3_a3b1 = l1->a()*l3->b() - l3->a()*l1->b();
 
-    if ( is_sum_of_roots_zero(a0b2_a2b0, a2b1_a1b2, - a0b3_a3b0, a1b3_a3b1,
-                              sum_sq_1 * sum_sq_3, sum_sq_0 * sum_sq_3, sum_sq_1 * sum_sq_2, sum_sq_0 * sum_sq_2) )
+    if ( is_sum_of_4_roots_zero(a0b2_a2b0, a2b1_a1b2, - a0b3_a3b0, a1b3_a3b1,
+                                sum_sq_1 * sum_sq_3, sum_sq_0 * sum_sq_3, sum_sq_1 * sum_sq_2, sum_sq_0 * sum_sq_2) )
     {
       // bisectors are coplanar
       return boost::none;
@@ -356,7 +356,7 @@ optional< Rational_time_4< typename K::FT> > compute_normal_offset_lines_isec_ti
     const FT n1 = -(a0b1_a1b0*l2->c()-a0b2_a2b0*l1->c()+a1b2_a2b1*l0->c()),
              n2 = -(-a0b1_a1b0*l3->c()+a0b3_a3b0*l1->c()-a1b3_a3b1*l0->c());
 
-    if ( n1 * n1 * sum_sq_3 != n2 * n2 * sum_sq_2) // TODO write this in another form?
+    if ( !is_sum_of_2_roots_zero(n1, -n2, sum_sq_3, sum_sq_2) )
     {
       const FT num = ( (a0b1_a1b0 * (a0b1_a1b0 * l2->c() + two * a2b0_a0b2 * l1->c() + two * a1b2_a2b1 * l0->c()) ) * l2->c()
                    +   (a0b2_a2b0 * (a0b2_a2b0 * l1->c() + two * a2b1_a1b2 * l0->c() ) ) * l1->c()

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -35,12 +35,24 @@ Uncertain<Trisegment_collinearity> certified_trisegment_collinearity ( Segment_2
                                                                      , Segment_2<K> const& e1
                                                                      , Segment_2<K> const& e2
                                                                      );
-#ifdef CGAL_USE_CORE  
+#ifdef CGAL_USE_CORE
+
+#ifdef CGAL_USE_GMPXX
+inline CORE::BigFloat to_BigFloat( mpq_class const& n )
+{
+  return CORE::BigFloat( CORE::BigRat(n.get_mpq_t()) );
+}
+#else
+inline CORE::BigFloat to_BigFloat( CGAL::Gmpq const& n )
+{
+  return CORE::BigFloat( CORE::BigRat(n.mpq()) );
+}
+#endif
 
 template<class NT>
 inline CORE::BigFloat to_BigFloat( NT const& n )
 {
-  return CORE::BigFloat( CGAL::to_double(n) ) ;
+  return to_BigFloat( CGAL::exact(n) );
 }
 
 template<>

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -24,6 +24,7 @@
 
 
 #include <CGAL/predicates/Straight_skeleton_pred_ftC2.h>
+#include <CGAL/Straight_skeleton_2/nt_utils.h>
 
 namespace CGAL { 
 
@@ -35,106 +36,6 @@ Uncertain<Trisegment_collinearity> certified_trisegment_collinearity ( Segment_2
                                                                      , Segment_2<K> const& e1
                                                                      , Segment_2<K> const& e2
                                                                      );
-#ifdef CGAL_USE_CORE
-
-#ifdef CGAL_USE_GMPXX
-inline CORE::BigFloat to_BigFloat( mpq_class const& n )
-{
-  return CORE::BigFloat( CORE::BigRat(n.get_mpq_t()) );
-}
-#else
-inline CORE::BigFloat to_BigFloat( CGAL::Gmpq const& n )
-{
-  return CORE::BigFloat( CORE::BigRat(n.mpq()) );
-}
-#endif
-
-template<class NT>
-inline CORE::BigFloat to_BigFloat( NT const& n )
-{
-  return to_BigFloat( CGAL::exact(n) );
-}
-
-template<>
-inline CORE::BigFloat to_BigFloat<MP_Float>( MP_Float const& b )
-{
-  if (b.is_zero())
-    return CORE::BigFloat::getZero();
-    
-  typedef MP_Float::exponent_type exponent_type;
-
-  const int                    log_limb         = 8 * sizeof(MP_Float::limb);
-  const MP_Float::V::size_type limbs_per_double = 2 + 53/log_limb;
-    
-  exponent_type exp = b.max_exp();
-  int steps = static_cast<int>((std::min)(limbs_per_double, b.v.size()));
-  
-  CORE::BigFloat d_exp_1 = CORE::BigFloat::exp2(-log_limb);
-  
-  CORE::BigFloat d_exp   = CORE::BigFloat::getOne() ;
-  
-  CORE::BigFloat d       = CORE::BigFloat::getZero();
-
-  for ( exponent_type i = exp - 1; i > exp - 1 - steps; i--) 
-  {
-    d_exp *= d_exp_1;
-    d += d_exp * CORE::BigFloat(b.of_exp(i));
-  }
-
-  return d * CORE::BigFloat::exp2( static_cast<int>(exp * log_limb) );
-}
-
-
-#endif
-
-
-
-template<class NT> 
-inline NT inexact_sqrt_implementation( NT const& n, CGAL::Null_functor /*no_sqrt*/ )
-{
-
-#ifdef CGAL_USE_CORE
-
-  CORE::BigFloat nn = to_BigFloat(n) ;
-  CORE::BigFloat s  = CORE::sqrt(nn);
-  return NT(s.doubleValue());
-  
-#else
-
-  double nn = CGAL::to_double(n) ;
-  
-  if ( !CGAL_NTS is_valid(nn) || ! CGAL_NTS is_finite(nn) )
-    nn = std::numeric_limits<double>::max BOOST_PREVENT_MACRO_SUBSTITUTION () ;
-    
-  CGAL_precondition(nn > 0);
-  
-  double s = CGAL_NTS sqrt(nn);
-  
-  return NT(s);
-  
-#endif
-}
-
-template<class NT, class Sqrt>
-inline NT inexact_sqrt_implementation( NT const& n, Sqrt sqrt_f )
-{
-  return sqrt_f(n);
-}
-
-template<class NT>
-inline NT inexact_sqrt( NT const& n )
-{
-  typedef CGAL::Algebraic_structure_traits<NT> AST;
-  typedef typename AST::Sqrt Sqrt; 
-  return inexact_sqrt_implementation(n,Sqrt());
-}
-
-inline Quotient<MP_Float> inexact_sqrt( Quotient<MP_Float> const& q )
-{
-  CGAL_precondition(q > 0);
-  return Quotient<MP_Float>(CGAL_SS_i::inexact_sqrt(q.numerator()*q.denominator()), q.denominator() );
-}
-
 
 // Given an oriented 2D straight line segment 'e', computes the normalized coefficients (a,b,c) of the
 // supporting line.

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -374,33 +374,20 @@ optional< Rational_time_4< typename K::FT> > compute_normal_offset_lines_isec_ti
 template<class K>
 optional< Point_2<K> > compute_oriented_midpoint ( Segment_2<K> const& e0, Segment_2<K> const& e1 )
 {
-  bool ok = false ;
-  
-  typedef typename K::FT FT ;
-  
-  FT delta01 = CGAL::squared_distance(e0.target(),e1.source());
-  FT delta10 = CGAL::squared_distance(e1.target(),e0.source());
-  
-  Point_2<K> mp ;
-   
-  if ( CGAL_NTS is_finite(delta01) &&  CGAL_NTS is_finite(delta10) )
-  {
-    if ( delta01 <= delta10 )
-         mp = CGAL::midpoint(e0.target(),e1.source());
-    else mp = CGAL::midpoint(e1.target(),e0.source());
-    
-    CGAL_STSKEL_TRAITS_TRACE("Computing oriented midpoint between:"
-                             << "\ne0: " << s2str(e0)
-                             << "\ne1: " << s2str(e1)
-                             << "\nmp=" << p2str(mp)
-                            );
-                            
-    ok = CGAL_NTS is_finite(mp.x()) && CGAL_NTS is_finite(mp.y());
-  }
-  
+  Point_2<K> mp = CGAL::compare_distance(e0.target(), e1.source(), e1.target(), e0.source())
+                ? CGAL::midpoint(e0.target(),e1.source())
+                : CGAL::midpoint(e1.target(),e0.source());
+
+  CGAL_STSKEL_TRAITS_TRACE("Computing oriented midpoint between:"
+                           << "\ne0: " << s2str(e0)
+                           << "\ne1: " << s2str(e1)
+                           << "\nmp=" << p2str(mp)
+                          );
+
+  bool ok = CGAL_NTS is_finite(mp.x()) && CGAL_NTS is_finite(mp.y());
+
   return cgal_make_optional(ok,mp);
 }
-
 
 //
 // Given 3 oriented straight line segments: e0, e1, e2 and the corresponding offseted segments: e0*, e1* and e2*,

--- a/Straight_skeleton_2/include/CGAL/predicates/Polygon_offset_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Polygon_offset_pred_ftC2.h
@@ -39,7 +39,7 @@ Uncertain<Comparison_result> compare_offset_against_isec_timeC2 ( typename K::FT
 {
   typedef typename K::FT FT ;
   
-  typedef Rational<FT> Rational ;
+  typedef Rational_time<FT> Rational ;
   typedef Quotient<FT> Quotient ;
   
   typedef optional<Rational> Optional_rational ;

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -398,7 +398,9 @@ oriented_side_of_event_point_wrt_bisectorC2_new ( intrusive_ptr< Trisegment_2<K>
   Optional_rational t_event = compute_offset_lines_isec_timeC2(event);
   Optional_rational_4 t_l0l1_e0e1 = compute_offset_lines_isec_timeC2<K>(ee0, ee1, e0, e1);
 
-  Comparison_result time_sign = t_l0l1_e0e1->compare(*t_event);
+  bool bisectors_are_parallel = t_l0l1_e0e1==boost::none;
+
+  Comparison_result time_sign = bisectors_are_parallel ? SMALLER : t_l0l1_e0e1->compare(*t_event);
 
 #ifdef SS_DEBUG_NEW_PREDICATES
 std::cout << "t_event " << t_event->to_nt() << "\n";
@@ -424,12 +426,12 @@ std::cout << "t_l0l1_e0e1 " << t_l0l1_e0e1->to_nt() << "\n";
 
     Point_2 bisector_pt = v01_event
                         ? validate( compute_oriented_midpoint(e0, e1) )
-                        : e1.source() ;
+                        : e1.source();
 
     Line_2 l0 = validate(compute_line_ceoffC2(e0)) ;
     Line_2 l1 = validate(compute_line_ceoffC2(e1)) ;
 
-    // (a,b,c) is a line perpedincular to the primary edge through bisector_pt.
+    // (a,b,c) is a line perpendicular to the primary edge through bisector_pt.
     // If e0 and e1 are collinear this line is the actual perpendicular bisector.
     FT a = primary_is_0 ? -l0.b() : -l1.b(),
        b = primary_is_0 ? l0.a() : l1.a(),
@@ -472,6 +474,11 @@ std::cout << "t_l0l1_e0e1 " << t_l0l1_e0e1->to_nt() << "\n";
     // we want to evaluate the sign of (v1/ sqrt(sq_norm1) + v2/sqrt(sq_norm2))
     //TODO: expand the computation here instead of relying on Sqrt_extension?
     common_pt_position = CGAL::compare(v1 * make_sqrt(FT(1)/sq_norm1), - v2 * make_sqrt(FT(1)/sq_norm2));
+  }
+
+  if (bisectors_are_parallel)
+  {
+    return common_pt_position;
   }
 
 #ifdef SS_DEBUG_NEW_PREDICATES

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -382,6 +382,8 @@ oriented_side_of_event_point_wrt_bisectorC2_new ( intrusive_ptr< Trisegment_2<K>
   std::cout << "e1==event->e2() " << (e1==event->e2())  << "\n";
 #endif
 
+// TODO: optimisation in case e0/e1 is in event --> same algo but using a Rational_time instead of Rational_time_4
+
   //TODO handle degenerate cases
 CGAL_assertion ( !certainly( are_edges_parallelC2(e0,e1) ) );
 
@@ -391,8 +393,13 @@ CGAL_assertion ( !certainly( are_edges_parallelC2(e0,e1) ) );
   typedef optional<Rational_time<FT> > Optional_rational;
   typedef optional<Rational_time_4<FT> > Optional_rational_4;
 
+  const Segment_2<K>& ee0 = event->collinearity() == TRISEGMENT_COLLINEARITY_NONE
+                          ? event->e0() : event->collinear_edge();
+  const Segment_2<K>& ee1 = event->collinearity() == TRISEGMENT_COLLINEARITY_NONE
+                          ? event->e1() : event->non_collinear_edge();
+
   Optional_rational t_event = compute_offset_lines_isec_timeC2(event);
-  Optional_rational_4 t_l0l1_e0e1 = compute_offset_lines_isec_timeC2<K>(event->e0(), event->e1(), e0, e1);
+  Optional_rational_4 t_l0l1_e0e1 = compute_offset_lines_isec_timeC2<K>(ee0, ee1, e0, e1);
 
   Comparison_result time_sign = t_l0l1_e0e1->compare(*t_event);
 
@@ -405,10 +412,10 @@ std::cout << "t_l0l1_e0e1 " << t_l0l1_e0e1->to_nt() << "\n";
     return ON_ORIENTED_BOUNDARY;
 
   typename cpp11::result_of<typename K::Intersect_2(Line_2,Line_2)>::type
-    res = typename K::Intersect_2()(Line_2(event->e0()),
-                                    Line_2(event->e1()));
+    res = typename K::Intersect_2()(Line_2(ee0),
+                                    Line_2(ee1));
 
-  CGAL_assertion( res != boost::none); // TODO handle deg case
+  CGAL_assertion( res != boost::none);
   const Point_2* event_pt = boost::get<Point_2>(&(*res));
   CGAL_assertion(event_pt != NULL);
 

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -179,7 +179,7 @@ template<class K, class FT>
 Uncertain<bool> exist_offset_lines_isec2 ( intrusive_ptr< Trisegment_2<K> > const& tri, optional<FT> const& aMaxTime )
 {
   
-  typedef Rational<FT>       Rational ;
+  typedef Rational_time<FT>       Rational ;
   typedef optional<Rational> Optional_rational ;
   typedef Quotient<FT>       Quotient ;
   
@@ -241,8 +241,7 @@ Uncertain<Comparison_result> compare_offset_lines_isec_timesC2 ( intrusive_ptr< 
 {
   typedef typename K::FT FT ;
 
-  typedef Rational<FT>       Rational ;
-  typedef Quotient<FT>       Quotient ;
+  typedef Rational_time<FT>       Rational ;
   typedef optional<Rational> Optional_rational ;
   
   Uncertain<Comparison_result> rResult = Uncertain<Comparison_result>::indeterminate();
@@ -252,11 +251,10 @@ Uncertain<Comparison_result> compare_offset_lines_isec_timesC2 ( intrusive_ptr< 
   
   if ( mt_ && nt_ )
   {
-    Quotient mt = mt_->to_quotient();
-    Quotient nt = nt_->to_quotient();
-   
-    if ( CGAL_NTS certified_is_positive(mt) && CGAL_NTS certified_is_positive(nt) ) 
-      rResult = CGAL_NTS certified_compare(mt,nt);
+    // study sign?
+    CGAL_assertion(mt_.get().to_nt()>=0);
+    CGAL_assertion(nt_.get().to_nt()>=0);
+    rResult = mt_.get().compare(nt_.get());
   }
   
   return rResult ;
@@ -489,9 +487,8 @@ Uncertain<bool> are_events_simultaneousC2 ( intrusive_ptr< Trisegment_2<K> > con
   
   typedef Point_2<K> Point_2 ;
   
-  typedef Rational<FT> Rational ;
-  typedef Quotient<FT> Quotient ;
-  
+  typedef Rational_time<FT> Rational ;
+
   typedef optional<Rational> Optional_rational ;
   typedef optional<Point_2>  Optional_point_2 ;
   
@@ -499,32 +496,26 @@ Uncertain<bool> are_events_simultaneousC2 ( intrusive_ptr< Trisegment_2<K> > con
 
   Optional_rational lt_ = compute_offset_lines_isec_timeC2(l);
   Optional_rational rt_ = compute_offset_lines_isec_timeC2(r);
-  
+
   if ( lt_ && rt_ )
   {
-    Quotient lt = lt_->to_quotient();
-    Quotient rt = rt_->to_quotient();
-
-    if ( CGAL_NTS certified_is_positive(lt) && CGAL_NTS certified_is_positive(rt) ) 
+    CGAL_assertion(lt_.get().to_nt()>=0);
+    CGAL_assertion(rt_.get().to_nt()>=0);
+    if ( lt_.get().compare(rt_.get()) == EQUAL )
     {
-      Uncertain<bool> equal_times = CGAL_NTS certified_is_equal(lt,rt);
-      
-      if ( is_certain(equal_times) )
-      {
-        if ( equal_times )
-        {
-          Optional_point_2 li = construct_offset_lines_isecC2(l);
-          Optional_point_2 ri = construct_offset_lines_isecC2(r);
-  
-          if ( li && ri )
-            rResult = CGAL_NTS logical_and( CGAL_NTS certified_is_equal(li->x(),ri->x())
-                                          , CGAL_NTS certified_is_equal(li->y(),ri->y())
-                                          ) ;
-        }
-        else rResult = false;
-      }
-    }
+      Optional_point_2 li = construct_offset_lines_isecC2(l);
+      Optional_point_2 ri = construct_offset_lines_isecC2(r);
 
+//TODO Not a predicate
+      if ( li && ri )
+        rResult = CGAL_NTS logical_and( CGAL_NTS certified_is_equal(li->x(),ri->x())
+                                      , CGAL_NTS certified_is_equal(li->y(),ri->y())
+                                      ) ;
+      else
+        rResult = false;
+    }
+    else
+      rResult = false;
   }
   return rResult;
 }

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -293,6 +293,7 @@ Uncertain<bool> is_edge_facing_pointC2 ( optional< Point_2<K> > const& aP, Segme
 template<class K>
 inline Uncertain<bool> is_edge_facing_offset_lines_isecC2 ( intrusive_ptr< Trisegment_2<K> > const& tri, Segment_2<K> const& aEdge )
 {
+  // TODO: not a predicate??
   return is_edge_facing_pointC2(construct_offset_lines_isecC2(tri),aEdge);
 }
 

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -198,7 +198,7 @@ Uncertain<bool> exist_offset_lines_isec2 ( intrusive_ptr< Trisegment_2<K> > cons
     Optional_rational t = compute_offset_lines_isec_timeC2(tri) ;
     if ( t )
     {
-      Uncertain<bool> d_is_zero = CGAL_NTS certified_is_zero(t->d()) ;
+      Uncertain<bool> d_is_zero = CGAL_NTS certified_is_zero(t->d()) ; // TODO_INEXACT
       if ( is_certain(d_is_zero) )
       {
         if ( !d_is_zero )
@@ -272,7 +272,25 @@ Uncertain<Comparison_result> compare_offset_lines_isec_timesC2 ( intrusive_ptr< 
 // Returns true if the point aP is on the positive side of the line supporting the edge
 //
 template<class K>
-Uncertain<bool> is_edge_facing_pointC2 ( optional< Point_2<K> > const& aP, Segment_2<K> const& aEdge )
+Uncertain<bool> is_edge_facing_pointC2 ( optional< Rational_point<typename K::Point_2, typename K::FT> > const& aP, Segment_2<K> const& aEdge )
+{
+  typedef typename K::FT FT ;
+
+  Uncertain<bool> rResult = Uncertain<bool>::indeterminate();
+  if ( aP )
+  {
+    FT a,b,c ;
+    // TODO use a Kernel predicate
+    line_from_pointsC2(aEdge.source().x(),aEdge.source().y(),aEdge.target().x(),aEdge.target().y(),a,b,c);
+    rResult = certified_side_of_oriented_lineC2(a,b,c,aP->pt.x(),aP->pt.y()) == make_uncertain(POSITIVE) ; // TODO_INEXACT
+  }
+  return rResult ;
+}
+
+// Returns true if the point aP is on the positive side of the line supporting the edge
+//
+template<class K>
+Uncertain<bool> is_edge_facing_input_pointC2 ( optional< typename K::Point_2 > const& aP, Segment_2<K> const& aEdge )
 {
   typedef typename K::FT FT ;
   


### PR DESCRIPTION
Some predicates used in the straight skeleton require several square roots. This robustifies one predicate and increases the precision of 2 constructions used in predicates.
