### PR TITLE
Polygon: avoid segfaulting when the polygon/range is empty

### DIFF
--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -49,6 +49,8 @@ bool is_simple_2(ForwardIterator first,
                       ForwardIterator last,
                       const PolygonTraits& traits)
 {
+    if (first == last) return true;
+
     return is_simple_polygon(first, last, traits);
 }
 

--- a/Polygon/test/Polygon/AlgorithmTest.cpp
+++ b/Polygon/test/Polygon/AlgorithmTest.cpp
@@ -66,10 +66,6 @@ void test_polygon(const R&, const Point&, const char* FileName)
     CGAL::Orientation orientation =
 	CGAL::orientation_2(polygon.begin(), polygon.end());
 
-    polygon.clear();
-    assert(CGAL::is_simple_2(polygon.begin(), polygon.end()));
-    assert(CGAL::is_convex_2(polygon.begin(), polygon.end()));
-
     cout << "left   = " << *left << endl;
     cout << "right  = " << *right << endl;
     cout << "top    = " << *top << endl;
@@ -120,6 +116,9 @@ void test_polygon(const R&, const Point&, const char* FileName)
 	cout << "the orientation is collinear" << endl;
 	break;
     }
+
+    polygon.clear();
+    assert(CGAL::is_convex_2(polygon.begin(), polygon.end()));
 }
 
 //-----------------------------------------------------------------------//

--- a/Polygon/test/Polygon/AlgorithmTest.cpp
+++ b/Polygon/test/Polygon/AlgorithmTest.cpp
@@ -66,6 +66,10 @@ void test_polygon(const R&, const Point&, const char* FileName)
     CGAL::Orientation orientation =
 	CGAL::orientation_2(polygon.begin(), polygon.end());
 
+    polygon.clear();
+    assert(CGAL::is_simple_2(polygon.begin(), polygon.end()));
+    assert(CGAL::is_convex_2(polygon.begin(), polygon.end()));
+
     cout << "left   = " << *left << endl;
     cout << "right  = " << *right << endl;
     cout << "top    = " << *top << endl;

--- a/Polygon/test/Polygon/SimplicityTest.cpp
+++ b/Polygon/test/Polygon/SimplicityTest.cpp
@@ -63,6 +63,9 @@ void TestDegenerateCases()
 
   polygon.push_back(Point(1,2));
   assert(CGAL::is_simple_2(polygon.begin(), polygon.end()));
+
+  polygon.clear();
+  assert(CGAL::is_simple_2(polygon.begin(), polygon.end()));
 }
 
 int main()


### PR DESCRIPTION
## Summary of Changes

Currently, `is_simple()` and similar segfault if called on an empty polygon / range. This PR checks for emptiness. `True` is chosen for symmetry with `is_convex`, which returns `true` when the polygon/range is empty.

## Release Management

* Affected package(s): `Polygon`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

