### PR TITLE
T3: Fix missing bound check in the sequential insertion phase of parallel triangulations

### DIFF
--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -381,7 +381,7 @@ public:
       // Insert "num_points_seq" points sequentially
       // (or more if dim < 3 after that)
       size_t num_points_seq = (std::min)(num_points, (size_t)100);
-      while (dimension() < 3 || i < num_points_seq)
+      while (i < num_points_seq || (dimension() < 3 && i < num_points))
       {
         hint = insert(points[i], hint);
         ++i;
@@ -464,7 +464,7 @@ private:
         // Insert "num_points_seq" points sequentially
         // (or more if dim < 3 after that)
         size_t num_points_seq = (std::min)(num_points, (size_t)100);
-        while (dimension() < 3 || i < num_points_seq)
+        while (i < num_points_seq || (dimension() < 3 && i < num_points))
         {
           hint = insert(points[indices[i]], hint);
           if (hint != Vertex_handle()) hint->info() = infos[indices[i]];

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -360,7 +360,7 @@ namespace CGAL {
         // Insert "num_points_seq" points sequentially
         // (or more if dim < 3 after that)
         size_t num_points_seq = (std::min)(num_points, (size_t)100);
-        while (dimension() < 3 || i < num_points_seq)
+        while (i < num_points_seq || (dimension() < 3 && i < num_points))
         {
           Locate_type lt;
           Cell_handle c;
@@ -483,7 +483,7 @@ namespace CGAL {
         // Insert "num_points_seq" points sequentially
         // (or more if dim < 3 after that)
         size_t num_points_seq = (std::min)(num_points, (size_t)100);
-        while (dimension() < 3 || i < num_points_seq)
+        while (i < num_points_seq || (dimension() < 3 && i < num_points))
         {
           Locate_type lt;
           Cell_handle c;


### PR DESCRIPTION
## Summary of Changes

If the input point set is degenerate, `dimension() < 3` might always be `true` and we will eventually try to read beyond the end of the input point range.

## Release Management

* Affected package(s): `Triangulation_3`
* Issue(s) solved (if any): fix #2922 
* Feature/Small Feature (if any): --

