### PR TITLE
Box intersection d : minor bug fix and doc enhancement

### DIFF
--- a/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_d.h
+++ b/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_d.h
@@ -12,15 +12,14 @@ need to provide a unique `id`-number. The policy parameter
 `IdPolicy` offers several choices. The template parameters have to 
 comply with the following requirements: 
 
-<UL> 
-<LI>`NT`: number type for the box boundaries, needs to be a model 
-of the `Assignable` and the `LessThanComparable` concept. 
-<LI>`int D`: the dimension of the box. 
-<LI>`IdPolicy`: specifies how the `id`-number will be 
-provided. Can be one of the following types, where 
+\tparam NT is the number type for the box boundaries. It must meet the requierements
+of the concepts `Assignable` and `LessThanComparable`.
+\tparam D is an integer and the dimension of the box.
+\tparam IdPolicy specifies how the `id`-number will be
+provided and can be one of the following types, where
 `ID_EXPLICIT` is the default for this parameter: 
 <UL> 
-<LI>`ID_NONE`: no `id`-number is provided. Can be useful 
+<LI>`ID_NONE`: no `id`-number is provided. This can be useful
 if `Box_d` is used as a base class for a different 
 implementation of `id`-numbers than the ones provided 
 here. 
@@ -32,15 +31,14 @@ the old one, which is the behavior needed by the
 `box_self_intersection_d()` algorithm. This is therefore 
 the safe default implementation. 
 <LI>`ID_FROM_BOX_ADDRESS`: casts the address of the box into a 
-`std::ptrdiff_t` to create the `id`-number. Works fine 
+`std::ptrdiff_t` to create the `id`-number. This works fine
 if the intersection algorithms work effectively with pointers 
 to boxes, but not in the case where the algorithms work with 
 box values, because the algorithms modify the order of the 
 boxes, and the `box_self_intersection_d()` algorithm 
 creates copies of the boxes that would not have identical 
 `id`-numbers. 
-</UL> 
-</UL> 
+</UL>
 
 \cgalModels `BoxIntersectionBox_d`
 

--- a/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_traits_d.h
+++ b/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_traits_d.h
@@ -16,11 +16,9 @@ the `Box_parameter` type required in the
 `Box_parameter` to be of type `const B&`, while for the other 
 cases it just uses the pointer type. 
 
-<UL> 
-<LI>`BoxHandle`: either a class type `B`, a pointer `B*`, or a 
-const-pointer `const B*`, where `B` is a model of the 
-`BoxIntersectionBox_d` concept. 
-</UL> 
+\tparam BoxHandle is either a class type `B`, a pointer `B*`, or a
+                  const-pointer `const B*`, where `B` is a model of the
+                  `BoxIntersectionBox_d` concept.
 
 \cgalModels `BoxIntersectionTraits_d`
 

--- a/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_with_handle_d.h
+++ b/Box_intersection_d/doc/Box_intersection_d/CGAL/Box_intersection_d/Box_with_handle_d.h
@@ -19,9 +19,9 @@ of the `Assignable` and the `LessThanComparable` concept.
 \tparam D the dimension of the box.
 \tparam Handle Handle concept, e.g., a pointer, an iterator, or a circulator.
 \tparam IdPolicy specifies how the `id`-number will be
-provided. Can be one of the following types, where
+provided and can be one of the following types, where
 `ID_FROM_HANDLE` is the default for this parameter:
-  - `ID_NONE`: no `id`-number is provided. Can be useful
+  - `ID_NONE`: no `id`-number is provided. This can be useful
     to have this class as a base class for different
     implementations of `id`-numbers than the ones provided
     here.
@@ -33,7 +33,7 @@ provided. Can be one of the following types, where
     `CGAL::box_self_intersection_d()` algorithm. This is therefore
 the safe default implementation.
   - `ID_FROM_BOX_ADDRESS`: casts the address of the box into a
-    `std::ptrdiff_t` to create the `id`-number. Works fine
+    `std::ptrdiff_t` to create the `id`-number. This works fine
     if the intersection algorithms work effectively with pointers
     to boxes, but not in the case where the algorithms work with
     box values, because the algorithms modify the order of the

--- a/Box_intersection_d/doc/Box_intersection_d/CGAL/box_intersection_d.h
+++ b/Box_intersection_d/doc/Box_intersection_d/CGAL/box_intersection_d.h
@@ -46,8 +46,26 @@ namespace CGAL {
   An important special application of this algorithm is the test for 
   self-intersections where the second box sequence is an identical copy 
   of the first sequence including the preserved `id`-number. We 
-  offer a specialized implementation 
-  `box_self_intersection_all_pairs` for this application. 
+  offer a specialized implementation `box_self_intersection_all_pairs_d()`
+  for this application.
+
+\cgalHeading{Requirements}
+
+  <UL>
+  <LI>`ForwardIterator1`, and \f$ \ldots\f$ `2`, must meet
+  the requirements of `ForwardIterator` and both value types must be the same.
+  We call this value type `Box_handle` in the following.
+  <LI>`Callback` must be of the `BinaryFunction` concept.
+  The `Box_handle` must be convertible to both argument types. The
+  return type is not used and can be `void`.
+  <LI>The `Box_handle` must be a model of the `Assignable` concept.
+  <LI>In addition, if the default box traits is used the `Box_handle` must
+  be a class type `T` or a pointer to a class type `T`, where
+  `T` must be a model of the `BoxIntersectionBox_d` concept.
+  In both cases, the default box traits specializes to a suitable
+  implementation.
+  <LI>`BoxTraits` must be of the `BoxIntersectionTraits_d` concept.
+  </UL>
 
   \sa \link PkgBoxIntersectionD_box_intersection_d `CGAL::box_intersection_d()` \endlink
   \sa \link PkgBoxIntersectionD_box_self_intersection_d `CGAL::box_self_intersection_d()` \endlink
@@ -62,6 +80,40 @@ namespace CGAL {
   \f$ O(nm)\f$ where \f$ n\f$ is the size of the first sequence and \f$ m\f$ is the 
   size of the second sequence. 
 */
+
+/*!
+  \ingroup PkgBoxIntersectionD_box_intersection_all_pairs_d
+
+  Invocation of box intersection with default box traits
+  `Box_intersection_d::Box_traits_d<Box_handle>`, where
+  `Box_handle` corresponds to the iterator value type of
+  `ForwardIterator1`.
+
+*/
+template< class ForwardIterator1,
+          class ForwardIterator2,
+          class Callback >
+void box_intersection_all_pairs_d(
+  ForwardIterator1 begin1, ForwardIterator1 end1,
+  ForwardIterator2 begin2, ForwardIterator2 end2,
+  Callback callback,
+  CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
+
+/*!
+  \ingroup PkgBoxIntersectionD_box_intersection_all_pairs_d
+
+  Invocation with custom box traits.
+
+*/
+template< class ForwardIterator1,
+          class ForwardIterator2,
+          class Callback, class BoxTraits >
+void box_intersection_all_pairs_d(
+  ForwardIterator1 begin1, ForwardIterator1 end1,
+  ForwardIterator2 begin2, ForwardIterator2 end2,
+  Callback callback,
+  BoxTraits box_traits,
+  CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
 
 /*!
   \addtogroup  PkgBoxIntersectionD_box_intersection_d
@@ -112,7 +164,7 @@ namespace CGAL {
   concept and that the box handle, i.e., the iterators value type, is 
   identical to the box type or a pointer to the box type. 
 
-  An important special application of this algorithm is the test for 
+  An important special application of this algorithm is the test for
   self-intersections where the second box sequence is an identical copy 
   of the first sequence including the preserved `id`-number. Note 
   that this implies that the address of the box is not sufficient for 
@@ -130,12 +182,16 @@ namespace CGAL {
   values `Box_intersection_d::COMPLETE` and 
   `Box_intersection_d::BIPARTITE`. 
 
+  \warning The two sequences of boxes passed to `box_intersection_d()` can be
+  ranges created from the same container, but these ranges must not contain
+  any common element.
+
 \cgalHeading{Requirements}
 
   <UL> 
-  <LI>`RandomAccessIterator1`, and \f$ \ldots\f$ `2`, must be 
-  mutable random-access iterators and both value types must be 
-  the same. We call this value type `Box_handle` in the following. 
+  <LI>`RandomAccessIterator1`, and \f$ \ldots\f$ `2`, must meet
+  the requirements of `RandomAccessIterator` and both value types must be the same.
+  We call this value type `Box_handle` in the following.
   <LI>`Callback` must be of the `BinaryFunction` concept. 
   The `Box_handle` must be convertible to both argument types. The 
   return type is not used and can be `void`. 
@@ -209,44 +265,6 @@ namespace CGAL {
 */
 
 /*!
-  \ingroup PkgBoxIntersectionD_box_intersection_all_pairs_d
-
-  Invocation of box intersection with default box traits
-  `Box_intersection_d::Box_traits_d<Box_handle>`, where
-  `Box_handle` corresponds to the iterator value type of
-  `ForwardIterator1`.
-
-*/
-template< class ForwardIterator1, 
-          class ForwardIterator2, 
-          class Callback >
-void box_intersection_all_pairs_d(
-  ForwardIterator1 begin1, ForwardIterator1 end1,
-  ForwardIterator2 begin2, ForwardIterator2 end2,
-  Callback callback,
-  CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
-
-/*!
-  \ingroup PkgBoxIntersectionD_box_intersection_all_pairs_d
-
-  Invocation with custom box traits.
-
-*/
-template< class ForwardIterator1,
-          class ForwardIterator2,
-          class Callback, class BoxTraits >
-void box_intersection_all_pairs_d(
-  ForwardIterator1 begin1, ForwardIterator1 end1,
-  ForwardIterator2 begin2, ForwardIterator2 end2,
-  Callback callback,
-  BoxTraits box_traits,
-  CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
-
-} /* namespace CGAL */
-
-namespace CGAL {
-
-/*!
   \ingroup PkgBoxIntersectionD_box_intersection_d
 
   Invocation of box intersection with default box traits
@@ -297,7 +315,7 @@ namespace CGAL {
   inferior to the fast `box_self_intersection_d()` algorithm. 
 
   The sequence of boxes is given with a forward iterator range. The 
-  sequences are not modified. For each intersecting pair of boxes a 
+  sequence is not modified. For each intersecting pair of boxes a
   `callback` function object is called with the two intersecting 
   boxes as argument. 
 
@@ -330,7 +348,7 @@ namespace CGAL {
 \cgalHeading{Requirements}
 
   <UL> 
-  <LI>`ForwardIterator` must be a forward iterator. We call its 
+  <LI>`ForwardIter` must meet the requirements of `ForwardIterator`. We call its
   value type `Box_handle` in the following. 
   <LI>`Callback` must be of the `BinaryFunction` concept. 
   The `Box_handle` must be convertible to both argument types. The 
@@ -365,13 +383,11 @@ namespace CGAL {
   Invocation of box intersection with default box traits
   `Box_intersection_d::Box_traits_d<Box_handle>`, where
   `Box_handle` corresponds to the iterator value type of
-  `ForwardIterator`.
-
-
+  `ForwardIter`.
 */
-template< class ForwardIterator, class Callback >
+template< class ForwardIter, class Callback >
 void box_self_intersection_all_pairs_d(
-  ForwardIterator begin, ForwardIterator end,
+  ForwardIter begin, ForwardIter end,
   Callback callback,
   CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
 
@@ -381,10 +397,10 @@ void box_self_intersection_all_pairs_d(
 
 
 */
-template< class ForwardIterator,
+template< class ForwardIter,
           class Callback, class BoxTraits >
 void box_self_intersection_all_pairs_d(
-  ForwardIterator begin, ForwardIterator end,
+  ForwardIter begin, ForwardIter end,
   Callback callback,
   BoxTraits box_traits,
   CGAL::Box_intersection_d::Topology topology = CGAL::Box_intersection_d::CLOSED);
@@ -430,16 +446,17 @@ namespace CGAL {
   `Box_intersection_d::HALF_OPEN` and 
   `Box_intersection_d::CLOSED`. 
 
-  In addition, a box has a unique `id`-number. It is used to order 
-  boxes consistently in each dimension even if boxes have identical 
-  coordinates. In consequence, the algorithm guarantees that a pair of 
-  intersecting boxes is reported only once. This self-intersection 
-  function creates internally a second copy of the box sequence. The 
-  copying has to preserve the `id`-number of boxes. Note that this 
-  implies that the address of the box is not sufficient for the 
-  `id`-number if boxes are copied by value. Boxes of equal 
-  `id`-number are not reported as intersecting pairs since they are 
-  always intersecting trivially. 
+  In addition, a box has a unique `id`-number. It is used to order
+  boxes consistently in each dimension even if boxes have identical
+  coordinates. In consequence, the algorithm guarantees that a pair of
+  intersecting boxes is reported only once. Boxes of equal
+  `id`-number are not reported as intersecting pairs since they are
+  always intersecting trivially.
+
+  \warning This self-intersection function creates internally a second copy
+  of the box sequence. Note that this implies that an `id`-number based on the address
+  of the box is not acceptable if boxes are copied by value and one must either
+  pass boxes by pointer or use another type of box `id`-number such as `ID_EXPLICIT`.
 
   The algorithm uses a traits class of the `BoxIntersectionTraits_d` 
   concept to access the boxes. A default traits class is provided that 

--- a/Box_intersection_d/doc/Box_intersection_d/Concepts/BoxIntersectionTraits_d.h
+++ b/Box_intersection_d/doc/Box_intersection_d/Concepts/BoxIntersectionTraits_d.h
@@ -8,6 +8,7 @@ functions to the dimension, the `id`-number, and the boundaries of
 the boxes manipulated in these algorithms. 
 
 \cgalRefines `Assignable` 
+\cgalRefines `DefaultConstructible`
 
 \cgalHasModel CGAL::Box_intersection_d::Box_traits_d
 

--- a/Box_intersection_d/include/CGAL/box_intersection_d.h
+++ b/Box_intersection_d/include/CGAL/box_intersection_d.h
@@ -179,13 +179,14 @@ template< class RandomAccessIter, class Callback, class BoxTraits >
 void box_self_intersection_d(
     RandomAccessIter begin, RandomAccessIter end,
     Callback callback,
-    BoxTraits box_traits)
+    BoxTraits box_traits,
+    std::ptrdiff_t cutoff,
+    Box_intersection_d::Topology topology)
 {
     typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
     std::vector< val_t> i( begin, end);
     box_intersection_d( begin, end, i.begin(), i.end(),
-                        callback, box_traits, 10, 
-                        Box_intersection_d::CLOSED,
+                        callback, box_traits, cutoff, topology,
                         Box_intersection_d::COMPLETE);
 }
 
@@ -196,26 +197,17 @@ void box_self_intersection_d(
     BoxTraits box_traits,
     std::ptrdiff_t cutoff)
 {
-    typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
-    std::vector< val_t> i( begin, end);
-    box_intersection_d( begin, end, i.begin(), i.end(),
-                        callback, box_traits, cutoff, 
-                        Box_intersection_d::CLOSED,
-                        Box_intersection_d::COMPLETE);
+    return box_self_intersection_d(begin, end, callback, box_traits, cutoff,
+                                   Box_intersection_d::CLOSED);
 }
 
 template< class RandomAccessIter, class Callback, class BoxTraits >
 void box_self_intersection_d(
     RandomAccessIter begin, RandomAccessIter end,
     Callback callback,
-    BoxTraits box_traits,
-    std::ptrdiff_t cutoff,
-    Box_intersection_d::Topology topology)
+    BoxTraits box_traits)
 {
-    typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
-    std::vector< val_t> i( begin, end);
-    box_intersection_d( begin, end, i.begin(), i.end(),
-        callback, box_traits, cutoff, topology, Box_intersection_d::COMPLETE);
+    return box_self_intersection_d(begin, end, callback, box_traits, 10);
 }
 
 // Specialized call with default box traits, specialized for self-intersection.
@@ -227,20 +219,18 @@ void box_self_intersection_d(
 {
     typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
     typedef Box_intersection_d::Box_traits_d< val_t>  Box_traits;
-    box_self_intersection_d(begin, end, callback,
-                            Box_traits(), 10, Box_intersection_d::CLOSED);
+    box_self_intersection_d(begin, end, callback, Box_traits());
 }
 
 template< class RandomAccessIter, class Callback >
 void box_self_intersection_d(
     RandomAccessIter begin, RandomAccessIter end,
     Callback callback,
-    std::ptrdiff_t)
+    std::ptrdiff_t cutoff)
 {
     typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
     typedef Box_intersection_d::Box_traits_d< val_t>  Box_traits;
-    box_self_intersection_d(begin, end, callback,
-                            Box_traits(), 10, Box_intersection_d::CLOSED);
+    box_self_intersection_d(begin, end, callback, Box_traits(), cutoff);
 }
 
 template< class RandomAccessIter, class Callback >

--- a/Box_intersection_d/include/CGAL/box_intersection_d.h
+++ b/Box_intersection_d/include/CGAL/box_intersection_d.h
@@ -183,6 +183,9 @@ void box_self_intersection_d(
     std::ptrdiff_t cutoff,
     Box_intersection_d::Topology topology)
 {
+    // Copying rather than calling 'box_intersection_d(begin, end, begin, end, ...'
+    // is necessary because the 'std::partition' and range splits on the first range
+    // would be messed up by sorts on the second range otherwise.
     typedef typename std::iterator_traits<RandomAccessIter>::value_type val_t;
     std::vector< val_t> i( begin, end);
     box_intersection_d( begin, end, i.begin(), i.end(),

--- a/Box_intersection_d/test/Box_intersection_d/test_box_grid.cpp
+++ b/Box_intersection_d/test/Box_intersection_d/test_box_grid.cpp
@@ -116,7 +116,7 @@ void test_box_intersection() {
                               std::ptrdiff_t(1), 
                               CGAL::Box_intersection_d::HALF_OPEN,
                               CGAL::Box_intersection_d::COMPLETE);
-    check_result( "Box self inters. 3x3+2, half-open", result, check5, 2);
+    check_result( "Box inters. 3x3+2, half-open", result, check5, 2);
     
     // compare this with the bipartite case
     // self intersect 3x3+2 query boxes, half-open boxes


### PR DESCRIPTION
## Summary of Changes

One of the overloads of `box_self_intersection_d` did not propagate the value of  `cutoff`.

Also minor fixes and enhancements to the documentation to make it clearer when address-based IDs shouldn't be used.

## Release Management

* Affected package(s): `Box_intersection_d`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

