### PR TITLE
Fix the determinism of the computation of point and base vectors

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -1771,10 +1771,10 @@ namespace CartesianKernelFunctors {
         // to avoid badly defined vectors with coordinates all close
         // to 0 when the plane is almost horizontal, we ignore the
         // smallest coordinate instead of always ignoring Z
-        if (CGAL::possibly(CGAL_AND (a <= b, a <= c)))
+        if (a <= b && a <= c)
           return Vector_3(FT(0), -h.c(), h.b());
 
-        if (CGAL::possibly(CGAL_AND (b <= a, b <= c)))
+        if (b <= a && b <= c)
           return Vector_3(-h.c(), FT(0), h.a());
 
         return Vector_3(-h.b(), h.a(), FT(0));

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -272,9 +272,9 @@ point_on_planeC3(const FT &pa, const FT &pb, const FT &pc, const FT &pd,
   // to avoid badly defined point with an overly large coordinate when
   //  the plane is almost orthogonal to one axis, we use the largest
   //  scalar coordinate instead of always using the first non-null
-  if (CGAL::possibly(CGAL_AND (abs_pa >= abs_pb, abs_pa >= abs_pc)))
+  if (abs_pa >= abs_pb && abs_pa >= abs_pc)
     x = -pd/pa;
-  else if (CGAL::possibly(CGAL_AND (abs_pb >= abs_pa, abs_pb >= abs_pc)))
+  else if (abs_pb >= abs_pa && abs_pb >= abs_pc)
     y = -pd/pb;
   else
     z = -pd/pc;


### PR DESCRIPTION
`possibly` will return true in case the evaluation lead to true or false
as possible values. If the exact value is computed or interval refined,
false could be the true value which has a consequence will give a
different result for point or base vector.