### PR TITLE
Fix Algebraic_kernel_d testsuite

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -224,14 +224,20 @@ protected:
     
     //! orders pair items by ids
     struct Pair_id_order {
-
+#ifdef CGAL_ALGEBRAIC_KERNEL_DONT_SWAP
+        template<class T1, class T2>
+        const std::pair<T1, T2>& operator()(const std::pair<T1, T2>& p) const {
+          return p;
+        }
+#else      
         template<class T1, class T2>
         std::pair<T1, T2> operator()(const std::pair<T1, T2>& p) const {
             
-            if(p.first.id() > p.second.id())
-                return std::make_pair(p.second, p.first);
-            return p;
+          if(p.first.id() > p.second.id())
+            return std::make_pair(p.second, p.first);
+          return p;
         }
+ #endif
     };
     
     class Curve_creator {

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/Curve_pair_analysis_2.cpp
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/Curve_pair_analysis_2.cpp
@@ -25,6 +25,9 @@
 
 #include <sstream>
 
+// In the testsuite we do not want that pairs of Curve_analysis_2 are ordered
+#define CGAL_ALGEBRAIC_KERNEL_DONT_SWAP 1
+
 #if CGAL_ACK_USE_EXACUS
 #include <AcX/Algebraic_curve_2.h>
 #include <AcX/Algebraic_curve_pair_2.h>

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/Real_embeddable_traits_extension.cpp
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/Real_embeddable_traits_extension.cpp
@@ -30,7 +30,7 @@
 #include <CGAL/GMP_arithmetic_kernel.h>
 #include <CGAL/LEDA_arithmetic_kernel.h>
 #include <CGAL/CORE_arithmetic_kernel.h>
-
+#include <CGAL/use.h>
 //#include <CGAL/Sqrt_extension.h> // used in this file
 
 
@@ -54,6 +54,8 @@ void test_real_embeddable_extension(const NT_&){
     const Floor floor = Floor();
     typedef typename Floor::argument_type Argument_type;
     typedef typename Floor::result_type   Result_type;
+    CGAL_USE_TYPE(Argument_type);
+    CGAL_USE_TYPE(Result_type);
     CGAL_static_assertion(( ::boost::is_same<NT, Argument_type>::value));  
     CGAL_static_assertion(( ::boost::is_same<Integer, Result_type>::value));
     assert(Integer(42) == floor(NT(42)));
@@ -64,6 +66,8 @@ void test_real_embeddable_extension(const NT_&){
     const Floor_log2_abs floor_log2_abs = Floor_log2_abs();
     typedef typename Floor_log2_abs::argument_type Argument_type;
     typedef typename Floor_log2_abs::result_type   Result_type;
+    CGAL_USE_TYPE(Argument_type);
+    CGAL_USE_TYPE(Result_type);
     CGAL_static_assertion(( ::boost::is_same<NT, Argument_type>::value));  
     CGAL_static_assertion(( ::boost::is_same<long, Result_type>::value));
     
@@ -89,6 +93,8 @@ void test_real_embeddable_extension(const NT_&){
     const Ceil ceil = Ceil();
     typedef typename Ceil::argument_type Argument_type;
     typedef typename Ceil::result_type   Result_type;
+    CGAL_USE_TYPE(Argument_type);
+    CGAL_USE_TYPE(Result_type);
     CGAL_static_assertion(( ::boost::is_same<NT, Argument_type>::value));  
     CGAL_static_assertion(( ::boost::is_same<Integer, Result_type>::value));
     assert(Integer(42) == ceil(NT(42)));
@@ -99,6 +105,8 @@ void test_real_embeddable_extension(const NT_&){
     const Ceil_log2_abs ceil_log2_abs = Ceil_log2_abs();
     typedef typename Ceil_log2_abs::argument_type Argument_type;
     typedef typename Ceil_log2_abs::result_type   Result_type;
+    CGAL_USE_TYPE(Argument_type);
+    CGAL_USE_TYPE(Result_type);
     CGAL_static_assertion(( ::boost::is_same<NT, Argument_type>::value));  
     CGAL_static_assertion(( ::boost::is_same<long, Result_type>::value));
     

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/include/CGAL/_test_algebraic_kernel_2.h
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/include/CGAL/_test_algebraic_kernel_2.h
@@ -101,6 +101,8 @@ void test_algebraic_kernel_2(const AlgebraicKernel_2& ak_2) {
   {                                                             \
     typedef typename Name::argument_type AT_;                   \
     typedef typename Name::result_type   RT_;                   \
+    CGAL_USE_TYPE(AT_);                                           \
+    CGAL_USE_TYPE(RT_);                                           \
     {CGAL_static_assertion(( ::boost::is_same<AT,AT_>::value));}  \
     {CGAL_static_assertion(( ::boost::is_same<RT,RT_>::value));}  \
   }
@@ -109,6 +111,9 @@ void test_algebraic_kernel_2(const AlgebraicKernel_2& ak_2) {
     typedef typename Name::first_argument_type AT1_;                    \
     typedef typename Name::second_argument_type AT2_;                   \
     typedef typename Name::result_type   RT_;                           \
+    CGAL_USE_TYPE(AT1_);                                                 \
+    CGAL_USE_TYPE(AT2_);                                                \
+    CGAL_USE_TYPE(RT_);                                                 \
     {CGAL_static_assertion(( ::boost::is_same<AT1,AT1_>::value));}        \
     {CGAL_static_assertion(( ::boost::is_same<AT2,AT2_>::value));}        \
     {CGAL_static_assertion(( ::boost::is_same<RT,RT_>::value));}          \


### PR DESCRIPTION
## Summary of Changes

`Curve_pair_analysis_2` sorts the pair based on a pointer comparison. Instead of fixing all `assert` in the testsuite, we don't swap in the testsuite. 

## Release Management

* Affected package(s): Algebraic_kernel_d
* Issue(s) solved (if any):  [cgal-develop] Tracking down the bug of Curve_pair_analysis_2


