### PR TITLE
BGL: Remove PMP dependency in partition_graph.h

### DIFF
--- a/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
+++ b/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
@@ -24,8 +24,8 @@
 #include <CGAL/boost/graph/copy_face_graph.h>
 #include <CGAL/boost/graph/Face_filtered_graph.h>
 #include <CGAL/boost/graph/helpers.h>
-#include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
-#include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
+#include <CGAL/boost/graph/named_function_params.h>
+#include <CGAL/boost/graph/named_params_helper.h>
 
 #include <CGAL/assertions.h>
 


### PR DESCRIPTION
## Summary of Changes

I left obsolete includes in one of the partition headers in #2723. This PR fixes that.

@afabri BGL still includes PMP in https://github.com/CGAL/cgal/blob/master/BGL/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h#L27.

## Release Management

* Affected package(s): `BGL`
* Issue(s) solved (if any): fix #2934 
* Feature/Small Feature (if any):

