### PR TITLE
Kernel_23: Update dependencies

### DIFF
--- a/Kernel_23/doc/Kernel_23/dependencies
+++ b/Kernel_23/doc/Kernel_23/dependencies
@@ -3,6 +3,7 @@ Kernel_d
 Polygon
 Convex_hull_2
 Triangulation_2
+Mesh_2
 Number_types
 Algebraic_foundations
 Circular_kernel_2


### PR DESCRIPTION
## Summary of Changes

Add a dependency because `DelaunayMeshTraits_2` is referenced [here](https://doc.cgal.org/latest/Kernel_23/classCGAL_1_1Projection__traits__xy__3.html)

## Release Management

* Affected package(s): Kernel_23

