### PR TITLE
Improve CMake scripts,  continued

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -378,6 +378,7 @@ set( CGAL_MODULES_REL_DIR cmake/modules )
 set( CGAL_MODULES_DIR     ${CGAL_INSTALLATION_PACKAGE_DIR}/${CGAL_MODULES_REL_DIR} )
 
 include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake)
 cgal_setup_module_path()
 
 message( STATUS "CGAL_REFERENCE_CACHE_DIR=${CGAL_REFERENCE_CACHE_DIR}" )

--- a/Installation/cmake/modules/CGALConfig_binary.cmake.in
+++ b/Installation/cmake/modules/CGALConfig_binary.cmake.in
@@ -190,3 +190,5 @@ if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
   # Nov. 2017). -- Laurent Rineau
   include(CGAL_SetupFlags)
 endif()
+
+include("${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake")

--- a/Installation/cmake/modules/CGALConfig_install.cmake.in
+++ b/Installation/cmake/modules/CGALConfig_install.cmake.in
@@ -165,3 +165,4 @@ if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
   # Nov. 2017). -- Laurent Rineau
   include(CGAL_SetupFlags)
 endif()
+include("${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake")

--- a/Installation/cmake/modules/CGAL_SetupFlags.cmake
+++ b/Installation/cmake/modules/CGAL_SetupFlags.cmake
@@ -50,7 +50,7 @@ uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS_DEBUG      ${CGAL_EXE_LINKER_FLAGS_DE
 
 # Set a default build type if none is given
 if ( NOT CMAKE_BUILD_TYPE )
-  if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
+  if( RUNNING_CGAL_AUTO_TEST )
     typed_cache_set ( STRING "Build type: Release, Debug, RelWithDebInfo or MinSizeRel" CMAKE_BUILD_TYPE Debug   )
   else ()
     typed_cache_set ( STRING "Build type: Release, Debug, RelWithDebInfo or MinSizeRel" CMAKE_BUILD_TYPE Release )

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -22,9 +22,11 @@ function(CGAL_run_at_the_end_of_configuration variable access value current_list
   # Warn when CMAKE_BUILD_TYPE is empty or Debug
   if(DEFINED CMAKE_BUILD_TYPE AND ( NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug") )
     set(keyword WARNING)
+    set(type warning)
     if(RUNNING_CGAL_AUTO_TEST)
       # No warning in the CMake test suite, but a status message
-      set(keyword )
+      set(keyword)
+      set(type notice)
     endif()
     if(NOT CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE)
       message(${keyword} "\
@@ -33,7 +35,7 @@ CGAL performance notice:\n\
 The variable CMAKE_BUILD_TYPE is set to \"${CMAKE_BUILD_TYPE}\". For \
 performance reasons, you should set CMAKE_BUILD_TYPE to \"Release\".\n\
 Set CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE to TRUE if you want to \
-disable this warning.\n\
+disable this ${type}.\n\
 =======================================================================\
 ")
     endif()

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -1,0 +1,28 @@
+function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
+  if(value)
+    # Only do something at the end of the CMake process
+    return()
+  endif()
+  # Warn when CMAKE_BUILD_TYPE is empty or Debug
+  if(DEFINED CMAKE_BUILD_TYPE AND ( NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug") )
+    set(keyword WARNING)
+    if(RUNNING_CGAL_AUTO_TEST)
+      # No warning in the CMake test suite, but a status message
+      set(keyword )
+    endif()
+    if(NOT CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE)
+      message(${keyword} "\
+=======================================================================\n\
+CGAL performance notice:\n\
+The variable CMAKE_BUILD_TYPE is set to \"${CMAKE_BUILD_TYPE}\".  That \
+value should be used only for debugging. For performance reasons, you \
+should set CMAKE_BUILD_TYPE to \"Release\".\n\
+Set CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE to TRUE if you want to \
+disable this warning.\n\
+=======================================================================\
+")
+    endif()
+  endif()
+endfunction()
+
+variable_watch("CMAKE_CURRENT_LIST_DIR" CGAL_run_at_the_end_of_configuration)

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -1,5 +1,16 @@
+# This module install a hook (with `variable_watch()`) on CMAKE_CURRENT_LIST_DIR
+# 
+# That uses the non-documented fact that CMAKE_CURRENT_LIST_DIR is cleared
+# by CMake at the end of the configuration process. So, if the value of
+# that variable gets empty, that means that CMake has reached the end of
+# the configuration.
+#
+# See https://stackoverflow.com/a/43300621/1728537 for the starting point.
+
 function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
   if(NOT access STREQUAL "MODIFIED_ACCESS" OR value)
+    # Only do something at the end of the CMake process, when the value of
+    # variable CMAKE_CURRENT_LIST_DIR is changed to the empty string.
     return()
   endif()
   # Warn when CMAKE_BUILD_TYPE is empty or Debug

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -7,6 +7,12 @@
 #
 # See https://stackoverflow.com/a/43300621/1728537 for the starting point.
 
+get_property(PROPERTY_CGAL_run_at_the_end_of_configuration_INCLUDED
+  GLOBAL PROPERTY CGAL_run_at_the_end_of_configuration_INCLUDED)
+if(PROPERTY_CGAL_run_at_the_end_of_configuration_INCLUDED)
+  return()
+endif()
+
 function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
   if(NOT access STREQUAL "MODIFIED_ACCESS" OR value)
     # Only do something at the end of the CMake process, when the value of
@@ -36,3 +42,5 @@ disable this warning.\n\
 endfunction()
 
 variable_watch("CMAKE_CURRENT_LIST_DIR" CGAL_run_at_the_end_of_configuration)
+
+set_property(GLOBAL PROPERTY CGAL_run_at_the_end_of_configuration_INCLUDED TRUE)

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -1,6 +1,5 @@
 function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
-  if(value)
-    # Only do something at the end of the CMake process
+  if(NOT access STREQUAL "MODIFIED_ACCESS" OR value)
     return()
   endif()
   # Warn when CMAKE_BUILD_TYPE is empty or Debug

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -30,9 +30,8 @@ function(CGAL_run_at_the_end_of_configuration variable access value current_list
       message(${keyword} "\
 =======================================================================\n\
 CGAL performance notice:\n\
-The variable CMAKE_BUILD_TYPE is set to \"${CMAKE_BUILD_TYPE}\".  That \
-value should be used only for debugging. For performance reasons, you \
-should set CMAKE_BUILD_TYPE to \"Release\".\n\
+The variable CMAKE_BUILD_TYPE is set to \"${CMAKE_BUILD_TYPE}\". For \
+performance reasons, you should set CMAKE_BUILD_TYPE to \"Release\".\n\
 Set CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE to TRUE if you want to \
 disable this warning.\n\
 =======================================================================\

--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -139,3 +139,5 @@ include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 cgal_setup_module_path()
 
 set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
+
+include("${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake")


### PR DESCRIPTION
## Summary of Changes

- With `CGAL_DEV_MODE`, the default of `CMAKE_BUILD_TYPE` is now "Release" instead of "Debug"
- Add a warning at the end of the configuration, when `CMAKE_BUILD_TYPE` is either empty or "Debug".

## Release Management

* Affected package(s): CMake, all CGAL

@sgiraudot @MaelRL Could you try again, now?

As for the default `CMAKE_BUILD_TYPE`, I found out that we can set a variable `CMAKE_BUILD_TYPE_INIT` to initialize it, but it has to be set before the call to `project(..)`. Do we want that?
