### PR TITLE
Improvement of self-intersection removal using local remeshing

### DIFF
--- a/BGL/include/CGAL/boost/graph/parameters_interface.h
+++ b/BGL/include/CGAL/boost/graph/parameters_interface.h
@@ -27,6 +27,7 @@ CGAL_add_named_parameter(face_index_t, face_index, face_index_map)
 CGAL_add_named_parameter(edge_is_constrained_t, edge_is_constrained, edge_is_constrained_map)
 CGAL_add_named_parameter(first_index_t, first_index, first_index)
 CGAL_add_named_parameter(number_of_iterations_t, number_of_iterations, number_of_iterations)
+CGAL_add_named_parameter(verbosity_level_t, verbosity_level, verbosity_level)
 
 CGAL_add_named_parameter(metis_options_t, METIS_options, METIS_options)
 CGAL_add_named_parameter(vertex_partition_id_t, vertex_partition_id, vertex_partition_id_map)

--- a/BGL/include/CGAL/boost/graph/parameters_interface.h
+++ b/BGL/include/CGAL/boost/graph/parameters_interface.h
@@ -63,6 +63,7 @@ CGAL_add_named_parameter(nb_points_per_area_unit_t, nb_points_per_area_unit, num
 CGAL_add_named_parameter(nb_points_per_distance_unit_t, nb_points_per_distance_unit, number_of_points_per_distance_unit)
 CGAL_add_named_parameter(outward_orientation_t, outward_orientation, outward_orientation)
 CGAL_add_named_parameter(overlap_test_t, overlap_test, do_overlap_test_of_bounded_sides)
+CGAL_add_named_parameter(preserve_genus_t, preserve_genus, preserve_genus)
 
 // List of named parameters that we use in the package 'Surface Mesh Simplification'
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)

--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -623,8 +623,8 @@ void expand_face_selection_for_removal(const FaceRange& faces_to_be_deleted,
 
 //todo: take non-manifold vertices into account.
 template<class PolygonMesh, class FaceRange>
-bool is_selection_a_topologial_disk(const FaceRange& face_selection,
-                       PolygonMesh& pm)
+bool is_selection_a_topological_disk(const FaceRange& face_selection,
+                                           PolygonMesh& pm)
 {
   typedef typename boost::graph_traits<PolygonMesh>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::face_descriptor face_descriptor;

--- a/BGL/test/BGL/test_cgal_bgl_named_params.cpp
+++ b/BGL/test/BGL/test_cgal_bgl_named_params.cpp
@@ -84,6 +84,8 @@ void test(const NamedParameters& np)
 
     // Internal named parameters
   assert(get_param(np, CGAL::internal_np::weight_calculator).v == 39);
+  assert(get_param(np, CGAL::internal_np::preserve_genus).v == 40);
+  assert(get_param(np, CGAL::internal_np::verbosity_level).v == 41);
 
 
   // Test types
@@ -146,6 +148,8 @@ void test(const NamedParameters& np)
 
     // Internal named parameters
   check_same_type<39>(get_param(np, CGAL::internal_np::weight_calculator));
+  check_same_type<40>(get_param(np, CGAL::internal_np::preserve_genus));
+  check_same_type<41>(get_param(np, CGAL::internal_np::verbosity_level));
 }
 
 int main()
@@ -193,6 +197,8 @@ int main()
                          .random_seed(A<37>(37))
                          .do_project(A<38>(38))
                          .weight_calculator(A<39>(39))
+                         .preserve_genus(A<40>(40))
+                         .verbosity_level(A<41>(41))
        );
 
   return EXIT_SUCCESS;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -1525,7 +1525,7 @@ remove_self_intersections_one_step(TriangleMesh& tm,
         }
       }
 
-      if(!is_selection_a_topologial_disk(cc_faces, tm))
+      if(!is_selection_a_topological_disk(cc_faces, tm))
       {
         // check if the selection contains cycles of border halfedges
         bool only_border_edges = true;


### PR DESCRIPTION
## Summary of Changes

- No longer use `Euler::add_face()` that can lead to bugs depending on the insertion sequence
- Compactify the domain to be remeshed
- Allow change of genus
- clean up debug message
- better usage of named parameter
- fix an incorrectly named function in PMP


## Release Management

* Affected package(s): PMP, BGL, Demo

