### PR TITLE
Move file from BGL to Nef_3

### DIFF
--- a/BGL/doc/BGL/Doxyfile.in
+++ b/BGL/doc/BGL/Doxyfile.in
@@ -10,7 +10,6 @@ INPUT += ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/Euler_operations.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/Graph_with_descriptor_with_graph.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/Face_filtered_graph.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/Dual.h \
-         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/Seam_mesh.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/io.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/partition.h \

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -689,7 +689,6 @@ user might encounter.
 - `CGAL::expand_face_selection_for_removal()`
 
 ## Conversion Functions ##
-- `CGAL::convert_nef_polyhedron_to_polygon_mesh()`
 - `CGAL::split_graph_into_polylines()`
 
 ## Graph Adaptors ##

--- a/BGL/package_info/BGL/dependencies
+++ b/BGL/package_info/BGL/dependencies
@@ -16,13 +16,8 @@ Kernel_23
 Kernel_d
 Modular_arithmetic
 Number_types
-Polygon
-Polygon_mesh_processing
 Profiling_tools
 Property_map
 STL_Extension
 Solver_interface
-Spatial_sorting
 Stream_support
-TDS_2
-Triangulation_2

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -1,0 +1,13 @@
+namespace CGAL {
+
+/// \ingroup PkgNef3IOFunctions
+/// Converts an objet of type `Nef_polyhedron_3` into a polygon mesh model of `MutableFaceGraph`.
+/// Note that contrary to `Nef_polyhedron_3::convert_to_polyhedron()`, the output is not triangulated
+/// (but faces with more than one connected component of the boundary).
+/// The polygon mesh can be triangulated by setting `triangulate_all_faces` to `true` or by calling the function `triangulate_faces()`.
+/// \pre `Polygon_mesh` must have an internal point property map with value type being `Nef_polyhedron_3::Point_3`.
+/// \pre `nef.simple()`
+  
+  template <class Nef_polyhedron, class Polygon_mesh>
+  void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_mesh& pm, bool triangulate_all_faces = false);
+}

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -59,6 +59,7 @@ a simple OpenGL visualization for debugging and illustrations.
 
 ## Functions ##
 - `CGAL::OFF_to_nef_3()`
+- `CGAL::convert_nef_polyhedron_to_polygon_mesh()`
 - \link PkgNef3IOFunctions `CGAL::operator<<()` \endlink
 - \link PkgNef3IOFunctions `CGAL::operator>>()` \endlink
 

--- a/Nef_3/doc/Nef_3/dependencies
+++ b/Nef_3/doc/Nef_3/dependencies
@@ -10,3 +10,4 @@ Polyhedron
 Number_types
 BGL
 Surface_mesh
+Polygon_mesh_processing

--- a/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -1,10 +1,10 @@
 // Copyright (c) 2016 GeometryFactory (France).
 // All rights reserved.
 //
-// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public License as
-// published by the Free Software Foundation; either version 3 of the License,
-// or (at your option) any later version.
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
 //
 // Licensees holding a valid commercial license may use this file in
 // accordance with the commercial license agreement provided with the software.
@@ -14,13 +14,15 @@
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 //
 //
 // Author(s)     : Sebastien Loriot
 
 #ifndef CGAL_BOOST_GRAPH_NEF_POLYHEDRON_TO_POLYGON_MESH_H
 #define CGAL_BOOST_GRAPH_NEF_POLYHEDRON_TO_POLYGON_MESH_H
+
+#include <CGAL/license/Nef_3.h>
 
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/algorithm.h>
@@ -341,13 +343,7 @@ void collect_polygon_mesh_info(
 
 } //end of namespace nef_to_pm
 
-/// \ingroup PkgBGL
-/// Converts an objet of type `Nef_polyhedron_3` into a polygon mesh model of `MutableFaceGraph`.
-/// Note that contrary to `Nef_polyhedron_3::convert_to_polyhedron()`, the output is not triangulated
-/// (but faces with more than one connected component of the boundary).
-/// The polygon mesh can be triangulated by setting `triangulate_all_faces` to `true` or by calling the function `triangulate_faces()`.
-/// \pre `Polygon_mesh` must have an internal point property map with value type being `Nef_polyhedron_3::Point_3`.
-/// \pre `nef.simple()`
+
 template <class Nef_polyhedron, class Polygon_mesh>
 void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_mesh& pm, bool triangulate_all_faces = false)
 {

--- a/Nef_3/package_info/Nef_3/dependencies
+++ b/Nef_3/package_info/Nef_3/dependencies
@@ -23,6 +23,7 @@ Nef_3
 Nef_S2
 Number_types
 Polygon
+Polygon_mesh_processing
 Polyhedron
 Polyhedron_IO
 Profiling_tools


### PR DESCRIPTION

## Summary of Changes

Move `<BGL/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h>` from BGL to Nef_3, without changing the directory. Also move the documentation.

## Release Management

* Affected package(s): BGL, Nef_3
* Issue(s) solved (if any): fix #2934 

