### PR TITLE
Subdivision: Use named parameters from the BGL package

### DIFF
--- a/Subdivision_method_3/examples/Subdivision_method_3/CatmullClark_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/CatmullClark_subdivision.cpp
@@ -16,7 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>    PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
-namespace params = CGAL::Polygon_mesh_processing::parameters;
+namespace params = CGAL::parameters;
 
 int main(int argc, char** argv) {
   if (argc > 4) {

--- a/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Customized_subdivision.cpp
@@ -16,7 +16,7 @@ typedef CGAL::Simple_cartesian<double>      Kernel;
 typedef CGAL::Surface_mesh<Kernel::Point_3> PolygonMesh;
 using namespace std;
 using namespace CGAL;
-namespace params = CGAL::Polygon_mesh_processing::parameters;
+namespace params = CGAL::parameters;
 
 // ======================================================================
 template <class Poly>

--- a/Subdivision_method_3/examples/Subdivision_method_3/DooSabin_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/DooSabin_subdivision.cpp
@@ -18,7 +18,7 @@ typedef CGAL::Polyhedron_3<Kernel>                PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
-namespace params = CGAL::Polygon_mesh_processing::parameters;
+namespace params = CGAL::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {

--- a/Subdivision_method_3/examples/Subdivision_method_3/Loop_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Loop_subdivision.cpp
@@ -16,7 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>     PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
-namespace params = CGAL::Polygon_mesh_processing::parameters;
+namespace params = CGAL::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {

--- a/Subdivision_method_3/examples/Subdivision_method_3/Sqrt3_subdivision.cpp
+++ b/Subdivision_method_3/examples/Subdivision_method_3/Sqrt3_subdivision.cpp
@@ -16,7 +16,7 @@ typedef CGAL::Surface_mesh<Kernel::Point_3>     PolygonMesh;
 
 using namespace std;
 using namespace CGAL;
-namespace params = CGAL::Polygon_mesh_processing::parameters;
+namespace params = CGAL::parameters;
 
 int main(int argc, char **argv) {
   if (argc > 4) {

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_hosts_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_hosts_3.h
@@ -31,8 +31,8 @@
 
 #include <CGAL/circulator.h>
 
-#include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
-#include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
+#include <CGAL/boost/graph/named_function_params.h>
+#include <CGAL/boost/graph/named_params_helper.h>
 
 #include <CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h>
 
@@ -46,7 +46,7 @@ namespace Subdivision_method_3 {
 */
 /// @{
 
-namespace parameters = Polygon_mesh_processing::parameters;
+namespace parameters = CGAL::parameters;
 
 // -----------------------------------------------------------------------------
 

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_methods_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_methods_3.h
@@ -29,8 +29,8 @@
 
 #include <CGAL/circulator.h>
 
-#include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
-#include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
+#include <CGAL/boost/graph/named_function_params.h>
+#include <CGAL/boost/graph/named_params_helper.h>
 
 #include <CGAL/Subdivision_method_3/subdivision_hosts_3.h>
 #include <CGAL/Subdivision_method_3/subdivision_masks_3.h>
@@ -89,12 +89,12 @@ Catmull-Clark subdivision.
 */
 /// @{
 
-namespace parameters = Polygon_mesh_processing::parameters;
+namespace parameters = CGAL::parameters;
 
 // -----------------------------------------------------------------------------
 
 #ifndef DOXYGEN_RUNNING
-// backward compatibility
+// Backward compatibility
 template <class PolygonMesh>
 void CatmullClark_subdivision(PolygonMesh& pmesh, int step = 1) {
   PQQ(pmesh, CatmullClark_mask_3<PolygonMesh>(&pmesh, get(vertex_point,pmesh)), step);

--- a/Subdivision_method_3/package_info/Subdivision_method_3/dependencies
+++ b/Subdivision_method_3/package_info/Subdivision_method_3/dependencies
@@ -7,7 +7,6 @@ Interval_support
 Kernel_23
 Modular_arithmetic
 Number_types
-Polygon_mesh_processing
 Profiling_tools
 Property_map
 STL_Extension


### PR DESCRIPTION
## Summary of Changes

Use named parameters from the BGL package. That will remove the dependency from Subdivision (LGPL) to PMP (GPL).

## Release Management

* Affected package(s): Subdivision_method_3

