### PR TITLE
C3T3 doc fix : `number_of_corners()`

### DIFF
--- a/Mesh_3/doc/Mesh_3/Concepts/MeshComplexWithFeatures_3InTriangulation_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshComplexWithFeatures_3InTriangulation_3.h
@@ -156,12 +156,6 @@ Returns the number of vertices which are corners of the complex.
 size_type number_of_corners() const; 
 
 /*!
-
-Returns the number of vertices which are corners of the complex with index `index`. 
-*/ 
-size_type number_of_corners(Corner_index index) const; 
-
-/*!
 Returns `true` 
 iff edge `e` belongs to some curve segment. 
 */ 

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -286,6 +286,10 @@ public:
   {
     return corners_.size();
   }
+  size_type number_of_corners() const
+  {
+    return corners_.size();
+  }
 
   void rescan_after_load_of_triangulation();
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes 2 doc bugs in the `MeshComplexWithFeatures_3InTriangulation_3` (package `Mesh_3`).

- `number_of_corners(corner_index)` is documented but makes no sense because there cannot be 2 corners with the same index, so I remove it from the doc
- `number_of_corners()` was documented but not implemented. Now it's both.

## Release Management

* Affected package : Mesh_3

