### PR TITLE
Mesh_3, T2, T3: fix dependencies by moving files

### DIFF
--- a/Installation/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
+++ b/Installation/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
@@ -1,12 +1,9 @@
-//=============================================================================
-// Copyright (C) 2001-2005 by Computer Graphics Group, RWTH Aachen
-// Copyright (C) 2011 by Graphics & Geometry Group, Bielefeld University
-// Copyright (C) 2014 GeometryFactory
+// Copyright (C) 2014-2018  GeometryFactory Sarl
 //
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
 //
 // Licensees holding a valid commercial license may use this file in
 // accordance with the commercial license agreement provided with the software.
@@ -16,14 +13,11 @@
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: GPL-3.0+
+// SPDX-License-Identifier: LGPL-3.0+
 //
 
 #ifndef CGAL_SURFACE_MESH_FWD_H
 #define CGAL_SURFACE_MESH_FWD_H
-
-#include <CGAL/license/Surface_mesh.h>
-
 
 /// \file Surface_mesh_fwd.h
 /// Forward declarations of the Surface_mesh package.

--- a/Mesh_3/include/CGAL/Triangle_accessor_3.h
+++ b/Mesh_3/include/CGAL/Triangle_accessor_3.h
@@ -30,7 +30,7 @@
 
 
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/Surface_mesh.h>
+#include <CGAL/Surface_mesh/Surface_mesh_fwd.h>
 #include <CGAL/boost/graph/Graph_with_descriptor_with_graph.h>
 
 namespace CGAL {

--- a/Mesh_3/package_info/Mesh_3/dependencies
+++ b/Mesh_3/package_info/Mesh_3/dependencies
@@ -39,7 +39,6 @@ Solver_interface
 Spatial_searching
 Spatial_sorting
 Stream_support
-Surface_mesh
 TDS_3
 Triangulation_3
 Union_find

--- a/TDS_2/include/CGAL/Triangulation_utils_2.h
+++ b/TDS_2/include/CGAL/Triangulation_utils_2.h
@@ -24,7 +24,7 @@
 #ifndef CGAL_TRIANGULATION_UTILS_2_H
 #define CGAL_TRIANGULATION_UTILS_2_H
 
-#include <CGAL/license/Triangulation_2.h>
+#include <CGAL/license/TDS_2.h>
 
 
 #include <CGAL/triangulation_assertions.h>

--- a/TDS_2/package_info/TDS_2/dependencies
+++ b/TDS_2/package_info/TDS_2/dependencies
@@ -7,4 +7,3 @@ Profiling_tools
 STL_Extension
 Stream_support
 TDS_2
-Triangulation_2

--- a/TDS_3/include/CGAL/Triangulation_simplex_3.h
+++ b/TDS_3/include/CGAL/Triangulation_simplex_3.h
@@ -23,7 +23,7 @@
 #ifndef CGAL_TRIANGULATION_SIMPLEX_3_H
 #define CGAL_TRIANGULATION_SIMPLEX_3_H
 
-#include <CGAL/license/Triangulation_3.h>
+#include <CGAL/license/TDS_3.h>
 
 
 #include <CGAL/assertions.h>

--- a/TDS_3/include/CGAL/Triangulation_utils_3.h
+++ b/TDS_3/include/CGAL/Triangulation_utils_3.h
@@ -21,7 +21,7 @@
 #ifndef CGAL_TRIANGULATION_UTILS_3_H
 #define CGAL_TRIANGULATION_UTILS_3_H
 
-#include <CGAL/license/Triangulation_3.h>
+#include <CGAL/license/TDS_3.h>
 
 
 #include <CGAL/basic.h>

--- a/TDS_3/include/CGAL/internal/Dummy_tds_3.h
+++ b/TDS_3/include/CGAL/internal/Dummy_tds_3.h
@@ -22,7 +22,7 @@
 #ifndef CGAL_INTERNAL_TRIANGULATION_DUMMY_TDS_3_H
 #define CGAL_INTERNAL_TRIANGULATION_DUMMY_TDS_3_H
 
-#include <CGAL/license/Triangulation_3.h>
+#include <CGAL/license/TDS_3.h>
 
 
 namespace CGAL { namespace internal {

--- a/TDS_3/include/CGAL/internal/Triangulation_ds_circulators_3.h
+++ b/TDS_3/include/CGAL/internal/Triangulation_ds_circulators_3.h
@@ -21,7 +21,7 @@
 #ifndef CGAL_INTERNAL_TRIANGULATION_DS_CIRCULATORS_3_H
 #define CGAL_INTERNAL_TRIANGULATION_DS_CIRCULATORS_3_H
 
-#include <CGAL/license/Triangulation_3.h>
+#include <CGAL/license/TDS_3.h>
 
 
 #include <CGAL/triangulation_assertions.h>

--- a/TDS_3/include/CGAL/internal/Triangulation_ds_iterators_3.h
+++ b/TDS_3/include/CGAL/internal/Triangulation_ds_iterators_3.h
@@ -21,7 +21,7 @@
 #ifndef CGAL_INTERNAL_TRIANGULATION_DS_ITERATORS_3_H
 #define CGAL_INTERNAL_TRIANGULATION_DS_ITERATORS_3_H
 
-#include <CGAL/license/Triangulation_3.h>
+#include <CGAL/license/TDS_3.h>
 
 
 #include <utility>

--- a/TDS_3/package_info/TDS_3/dependencies
+++ b/TDS_3/package_info/TDS_3/dependencies
@@ -10,4 +10,3 @@ Profiling_tools
 STL_Extension
 Stream_support
 TDS_3
-Triangulation_3


### PR DESCRIPTION
## Summary of Changes

Before the patch Mesh_3 was dependent on Surface_mesh. And the split between TDS_23 and Triangulation_23 was wrong.

## Release Management

* Affected package(s): T2, T3, Mesh_3

