### PR TITLE
Spatial searching: rework fuzzy items

### DIFF
--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -34,7 +34,6 @@
 
 #include <CGAL/Kd_tree.h>
 #include <CGAL/Fuzzy_sphere.h>
-#include <CGAL/Fuzzy_iso_box.h>
 #include <CGAL/Search_traits_d.h>
 
 #include <CGAL/Delaunay_triangulation_3.h>

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_iso_box.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_iso_box.h
@@ -3,15 +3,9 @@ namespace CGAL {
 /*!
 \ingroup RangeQueryItemClasses
 
-The class `Fuzzy_iso_box` implements fuzzy `d`-dimensional iso boxes. A fuzzy iso
-box with fuzziness value \f$ \epsilon\f$ has as inner and outer approximations
+The class `Fuzzy_iso_box` implements fuzzy `d`-dimensional (closed) iso boxes.
+A fuzzy iso box with fuzziness value \f$ \epsilon\f$ has as inner and outer approximations
 a box respectively eroded and dilated by a `d`-dim square with side length \f$ \epsilon\f$.
-
-\attention Points in the interior of the inner approximation are always reported and points
-that are not in the closure of the outer approximation are never reported. Other
-points may or may not be reported. Subsequently, points on the boundary of the
-inner and outer approximations may or may not be reported. Specifically when \f$ \epsilon = 0\f$,
-points on the boundary of the box may or may not be reported.
 
 \tparam Traits must be a model of the concept
 `SearchTraits`, for example `CGAL::Search_traits_2<CGAL::Simple_cartesian<double> >`.

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_iso_box.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_iso_box.h
@@ -6,14 +6,17 @@ namespace CGAL {
 The class `Fuzzy_iso_box` implements fuzzy `d`-dimensional (closed) iso boxes.
 A fuzzy iso box with fuzziness value \f$ \epsilon\f$ has as inner and outer approximations
 a box respectively eroded and dilated by a `d`-dim square with side length \f$ \epsilon\f$.
+Points are returned depending on their location respective to the approximations,
+as follows:
+- points in the inner approximation (boundary included) are always returned.
+- points in the outer approximation (boundary included) and not in the previous
+  category may or may not be returned.
+- points that do not fit in the two previous categories are never returned.
 
 \tparam Traits must be a model of the concept
 `SearchTraits`, for example `CGAL::Search_traits_2<CGAL::Simple_cartesian<double> >`.
 
 \cgalModels `FuzzyQueryItem`
-
-\sa `FuzzyQueryItem`
-
 */
 template< typename Traits >
 class Fuzzy_iso_box {

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_sphere.h
@@ -8,15 +8,6 @@ A fuzzy sphere with radius \f$ r\f$ and fuzziness value \f$ \epsilon\f$ has
 as inner approximation a sphere with radius \f$ r-\epsilon\f$ and
 as outer approximation a sphere with radius \f$ r+\epsilon\f$.
 
-\attention The fuzziness of a `Fuzzy_sphere` is specified by a parameter \f$ \epsilon\f$
-denoting a maximal allowed distance to the boundary of a sphere.
-If the distance to the boundary is greater than \f$ \epsilon\f$, points inside the
-object are always reported and points outside the sphere are never reported.
-Points whose distance to the boundary is less than or equal to \f$ \epsilon\f$
-may or may not be reported. Subsequently, points on the inner and outer spheres
-may or may not be reported. Specifically when \f$ \epsilon = 0\f$, points
-on the sphere of radius \f$ r\f$ may or may not be reported.
-
 \tparam Traits must be a model of the concept
 `SearchTraits`, for example `CGAL::Cartesian_d<double>`.
 

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Fuzzy_sphere.h
@@ -7,14 +7,20 @@ The class `Fuzzy_sphere` implements fuzzy `d`-dimensional spheres.
 A fuzzy sphere with radius \f$ r\f$ and fuzziness value \f$ \epsilon\f$ has
 as inner approximation a sphere with radius \f$ r-\epsilon\f$ and
 as outer approximation a sphere with radius \f$ r+\epsilon\f$.
+Points are returned depending on their location respective to the approximations,
+as follows:
+- points in the inner approximation (boundary included) are always returned.
+- points in the outer approximation (boundary included) and not in the previous
+  category may or may not be returned.
+- points that do not fit in the two previous categories are never returned.
+
+Note that if the fuzziness value is strictly greater than the radius, there is no
+inner approximation.
 
 \tparam Traits must be a model of the concept
 `SearchTraits`, for example `CGAL::Cartesian_d<double>`.
 
 \cgalModels `FuzzyQueryItem`
-
-\sa `FuzzyQueryItem`
-
 */
 template< typename Traits >
 class Fuzzy_sphere {

--- a/Spatial_searching/doc/Spatial_searching/Spatial_searching.txt
+++ b/Spatial_searching/doc/Spatial_searching/Spatial_searching.txt
@@ -148,19 +148,24 @@ GeneralDistance, Splitter, SpatialTree>`
 
 \subsection Spatial_searchingRangeSearching Range Searching
 
-<I>Exact range searching</I> and <I>approximate range searching</I> are
+<I>Exact range searching</I> and <I>approximate range searching</I> is
 supported using exact or fuzzy `d`-dimensional objects enclosing a
 region. The fuzziness of the query object is specified by a parameter
-\f$ \epsilon\f$ used to define inner and outer approximations of the query object.
-Points in the interior of the inner approximation are always reported and points
-that are not in the closure of the outer approximation are never reported. Other
-points may or may not be reported. For exact range searching,
-the fuzziness parameter \f$ \epsilon\f$ is set to zero.
+\f$ \epsilon\f$ used to define <em>inner</em> and <em>outer</em>
+approximations of the object. For example, in the class `Fuzzy_sphere`,
+the \f$ \epsilon\f$-inner and outer approximations of a sphere of radius \f$ r\f$
+are defined as the spheres of radius \f$ r-\epsilon\f$ and \f$ r+\epsilon\f$, respectively.
+When using fuzzy items, queries are reported as follows:
+- Points that are within the inner approximation are always reported.
+- Points that are within the outer approximation but not within the inner approximation
+might or might not be reported.
+- Points thare not within the outer approximation are never reported.
+
+For exact range searching the fuzziness parameter \f$ \epsilon\f$ is set to zero.
 
 The class `Kd_tree` implements range searching in the method `search`,
 which is a template method with an output iterator and a model of the
-concept `FuzzyQueryItem` as `Fuzzy_iso_box`
-or `Fuzzy_sphere`.
+concept `FuzzyQueryItem` such as `Fuzzy_iso_box` or `Fuzzy_sphere`.
 For range searching of large data sets, the user may set the parameter `bucket_size`
 used in building the `kd` tree to a large value (e.g. 100),
 because in general the query time will be less than using the default value.

--- a/Spatial_searching/doc/Spatial_searching/Spatial_searching.txt
+++ b/Spatial_searching/doc/Spatial_searching/Spatial_searching.txt
@@ -148,7 +148,7 @@ GeneralDistance, Splitter, SpatialTree>`
 
 \subsection Spatial_searchingRangeSearching Range Searching
 
-<I>Exact range searching</I> and <I>approximate range searching</I> is
+<I>Exact range searching</I> and <I>approximate range searching</I> are
 supported using exact or fuzzy `d`-dimensional objects enclosing a
 region. The fuzziness of the query object is specified by a parameter
 \f$ \epsilon\f$ used to define <em>inner</em> and <em>outer</em>

--- a/Spatial_searching/examples/Spatial_searching/iso_rectangle_2_query.cpp
+++ b/Spatial_searching/examples/Spatial_searching/iso_rectangle_2_query.cpp
@@ -48,7 +48,7 @@ main() {
   Fuzzy_iso_box approximate_range(p, q, 0.1);
   tree.search(std::back_inserter( result ), approximate_range);
   std::cout << "The points in the fuzzy box [[0.1, 0.3], [0.6, 0.9]]^2 are: "
-	    << std::endl;
+      << std::endl;
   std::copy (result.begin(), result.end(), std::ostream_iterator<Point_d>(std::cout,"\n") );
   std::cout << std::endl;
   return 0;

--- a/Spatial_searching/examples/Spatial_searching/iso_rectangle_2_query.cpp
+++ b/Spatial_searching/examples/Spatial_searching/iso_rectangle_2_query.cpp
@@ -47,8 +47,7 @@ main() {
   // using value 0.1 for fuzziness paramater
   Fuzzy_iso_box approximate_range(p, q, 0.1);
   tree.search(std::back_inserter( result ), approximate_range);
-  std::cout << "The points in the fuzzy box [[0.1, 0.3], [0.6, 0.9]]^2 are: "
-      << std::endl;
+  std::cout << "The points in the fuzzy box [[0.1, 0.3], [0.6, 0.9]]^2 are: " << std::endl;
   std::copy (result.begin(), result.end(), std::ostream_iterator<Point_d>(std::cout,"\n") );
   std::cout << std::endl;
   return 0;

--- a/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
@@ -96,59 +96,58 @@ namespace CGAL {
    
     public:
 
-    	// default constructor
-    	Fuzzy_iso_box(const SearchTraits& traits_=SearchTraits()):traits(traits_) {}
+    // default constructor
+    Fuzzy_iso_box(const SearchTraits& traits_=SearchTraits()):traits(traits_) {}
 
-        // constructor
-	Fuzzy_iso_box(const Point_d& p, const Point_d& q, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) 
-	  : traits(traits_), eps(epsilon)
-        {
-          construct<Point_d,typename SearchTraits::Construct_iso_box_d>(p,q);
-        }
+    // constructor
+    Fuzzy_iso_box(const Point_d& p, const Point_d& q, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits())
+      : traits(traits_), eps(epsilon)
+    {
+      CGAL_precondition(epsilon >= 0);
+      construct<Point_d,typename SearchTraits::Construct_iso_box_d>(p,q);
+    }
         
-        //additional constructor if SearchTraits = Search_traits_adapter
-        template <class Point>
-	Fuzzy_iso_box(const Point& p,const Point&q,FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits(),
-          typename boost::enable_if<typename internal::Is_from_point_from_adapter_traits<SearchTraits,Point>::type>::type* = 0) 
-	  : traits(traits_), eps(epsilon)
-        {
-          construct<Point,typename SearchTraits::Base::Construct_iso_box_d>(p,q);
-        }
+  //additional constructor if SearchTraits = Search_traits_adapter
+  template <class Point>
+  Fuzzy_iso_box(const Point& p,const Point&q,FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits(),
+                typename boost::enable_if<typename internal::Is_from_point_from_adapter_traits<SearchTraits,Point>::type>::type* = 0)
+    : traits(traits_), eps(epsilon)
+  {
+    CGAL_precondition(epsilon >= 0);
+    construct<Point,typename SearchTraits::Base::Construct_iso_box_d>(p,q);
+  }
 
-        bool contains(const Point_d& p) const {	
-	  Construct_cartesian_const_iterator_d construct_it=traits.construct_cartesian_const_iterator_d_object();
-	  Cartesian_const_iterator_d pit = construct_it(p);
-	  Cartesian_const_iterator_d minit= min_begin, maxit = max_begin; 
-		for (unsigned int i = 0; i < dim; ++i, ++pit, ++minit, ++maxit) {
-			if ( ((*pit) < (*minit)) || ((*pit) >= (*maxit)) ) return false;
-		}
-		return true; 
-        }
+  bool contains(const Point_d& p) const {
+    Construct_cartesian_const_iterator_d construct_it=traits.construct_cartesian_const_iterator_d_object();
+    Cartesian_const_iterator_d pit = construct_it(p);
+    Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
+    for (unsigned int i = 0; i < dim; ++i, ++pit, ++minit, ++maxit) {
+      if ( ((*pit) < (*minit)) || ((*pit) > (*maxit)) ) return false;
+    }
+    return true;
+  }
 
-	bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const { 
-	  Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;   
- 		for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
-        		if ( ((*maxit)-eps < rectangle.min_coord(i)) 
-			|| ((*minit)+eps >= rectangle.max_coord(i)) ) return false;
-    		}
-    		return true;                                     
-	}
+  bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {
+    // test whether the box eroded by 'eps' intersects 'rectangle'
+    Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
+    for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
+      if ( ((*maxit)-eps < rectangle.min_coord(i))
+           || ((*minit)+eps > rectangle.max_coord(i)) ) return false;
+    }
+    return true;
+  }
 
 
-	bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {  
-	  Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;   
-    		for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
-        		if (  ((*maxit)+eps < rectangle.max_coord(i) ) 
-			|| ((*minit)-eps >= rectangle.min_coord(i)) ) return false;
-    		}
-    		return true;
-  	} 
-
-	
-
-	
-
-  }; // class Fuzzy_iso_box
+  bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {
+    // test whether the box dilated by 'eps' contains 'rectangle'
+    Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
+    for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
+      if (  ((*maxit)+eps < rectangle.max_coord(i) )
+            || ((*minit)-eps > rectangle.min_coord(i)) ) return false;
+    }
+    return true;
+  }
+}; // class Fuzzy_iso_box
 
 } // namespace CGAL
 #endif // FUZZY_ISO_BOX_H

--- a/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
@@ -122,7 +122,8 @@ namespace CGAL {
     Cartesian_const_iterator_d pit = construct_it(p);
     Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
     for (unsigned int i = 0; i < dim; ++i, ++pit, ++minit, ++maxit) {
-      if ( ((*pit) < (*minit)) || ((*pit) > (*maxit)) ) return false;
+      if ( ((*pit) < (*minit)) || ((*pit) > (*maxit)) )
+        return false;
     }
     return true;
   }
@@ -132,7 +133,8 @@ namespace CGAL {
     Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
     for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
       if ( ((*maxit)-eps < rectangle.min_coord(i))
-           || ((*minit)+eps > rectangle.max_coord(i)) ) return false;
+           || ((*minit)+eps > rectangle.max_coord(i)) )
+        return false;
     }
     return true;
   }
@@ -143,7 +145,8 @@ namespace CGAL {
     Cartesian_const_iterator_d minit= min_begin, maxit = max_begin;
     for (unsigned int i = 0; i < dim; ++i, ++minit, ++maxit) {
       if (  ((*maxit)+eps < rectangle.max_coord(i) )
-            || ((*minit)-eps > rectangle.min_coord(i)) ) return false;
+            || ((*minit)-eps > rectangle.min_coord(i)) )
+        return false;
     }
     return true;
   }

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -24,6 +24,7 @@
 
 #include <CGAL/license/Spatial_searching.h>
 
+#include <CGAL/assertions.h>
 #include <CGAL/Kd_tree_rectangle.h>
 #include <CGAL/Search_traits_adapter.h>
 
@@ -32,134 +33,127 @@
 
 namespace CGAL {
 
-  namespace internal{
-    
-  template <class SearchTraits,class Point_d>
-  class Fuzzy_sphere_impl{
-    SearchTraits traits;
-    public:
+namespace internal{
 
-    typedef typename SearchTraits::FT FT;
-    typedef typename SearchTraits::Dimension Dimension;
-    private:
+template <class SearchTraits,class Point_d>
+class Fuzzy_sphere_impl
+{
+public:
+  typedef typename SearchTraits::FT FT;
+  typedef typename SearchTraits::Dimension Dimension;
 
-    Point_d c;
-    FT r;
-    FT eps;
+private:
+  SearchTraits traits;
 
-    public:
+  Point_d c;
+  FT sq_radius;
+  FT sq_inner_radius;
+  FT sq_outer_radius;
 
+public:
+  // default constructor
+  Fuzzy_sphere_impl(const SearchTraits& traits_=SearchTraits()):traits(traits_) {}
 
-    	// default constructor
-    	Fuzzy_sphere_impl(const SearchTraits& traits_=SearchTraits()):traits(traits_) {}
-		
+  // constructor
+  Fuzzy_sphere_impl(const Point_d& center, FT r, FT eps=FT(0),
+                    const SearchTraits& traits_ = SearchTraits())
+    : traits(traits_), c(center), sq_radius(r*r)
+  {
+    CGAL_precondition(r >= 0);
+    CGAL_precondition(eps >= 0);
 
-	// constructor
-	Fuzzy_sphere_impl(const Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) : 
-	traits(traits_),c(center), r(radius), eps(epsilon) 
-	{ 	// avoid problems if eps > r
-		if (eps>r) eps=r; 
-	}
-        	
-        bool contains(const typename SearchTraits::Point_d& p) const {
-		// test whether the distance between c and p is less than the radius
-		FT squared_radius = r*r;
-		FT distance=FT(0);
-		typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
-                  traits.construct_cartesian_const_iterator_d_object();
-                typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
-		                                                  pit = construct_it(p),
-                                                                  end = construct_it(c, 0);
-		for (; cit != end
-                       && (distance < squared_radius); ++cit, ++pit) {
-		  distance += 
-			((*cit)-(*pit))*((*cit)-(*pit));
-		}
-		
-		return (distance < squared_radius); 
-        }
-
-    bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {
-      // test whether the interior of a sphere
-      // with radius (r-eps) intersects 'rectangle', i.e.
-      // if the minimal distance of c to 'rectangle' is less than r-eps
-      FT distance = FT(0);
-      FT squared_radius = (r-eps)*(r-eps);
-      typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
-                  traits.construct_cartesian_const_iterator_d_object();
-                typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
-                                                                  end = construct_it(c, 0);
-		for (int i = 0; cit != end && (distance < squared_radius); ++cit, ++i) {
-			if ((*cit) < rectangle.min_coord(i))
-				distance += 
-				(rectangle.min_coord(i)-(*cit))*(rectangle.min_coord(i)-(*cit));
-			if ((*cit) > rectangle.max_coord(i))
-				distance += 
-				((*cit)-rectangle.max_coord(i))*((*cit)-rectangle.max_coord(i));
-		}
-		
-		return (distance < squared_radius);
-	}
-
-
-    bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const { 
-      // test whether the interior of a sphere
-      // with radius (r+eps) is contained by 'rectangle', i.e.
-      // if the maximal distance of c to the boundary of 'rectangle'
-      // is less than r+eps
-      FT distance=FT(0);
-      FT squared_radius = (r+eps)*(r+eps);	
-      typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
-          traits.construct_cartesian_const_iterator_d_object();
-      typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
-                                                        end = construct_it(c, 0);
-        for (int i = 0; cit != end && (distance < squared_radius) ; ++cit,++i) {
-		if ((*cit) <= (rectangle.min_coord(i)+rectangle.max_coord(i))/FT(2))
-			distance += 
-			(rectangle.max_coord(i)-(*cit))*(rectangle.max_coord(i)-(*cit));
-		else
-			distance += ((*cit)-rectangle.min_coord(i))*((*cit)-rectangle.min_coord(i));
-		}
-		
-		return (distance < squared_radius);
-	}
-  }; // class Fuzzy_sphere_impl
-
+    sq_inner_radius = (eps > r) ? 0 : (r - eps) * (r - eps);
+    sq_outer_radius = (r + eps) * (r + eps);
   }
-  
-  template <class SearchTraits>
-  class Fuzzy_sphere:
+
+  bool contains(const typename SearchTraits::Point_d& p) const {
+    // test whether the distance between c and p is less than the radius
+    FT distance=FT(0);
+    typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
+        traits.construct_cartesian_const_iterator_d_object();
+    typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
+        pit = construct_it(p), end = construct_it(c, 0);
+    for (; cit != end && (distance <= sq_radius); ++cit, ++pit) {
+      distance += ((*cit)-(*pit))*((*cit)-(*pit));
+    }
+
+    return (distance <= sq_radius);
+  }
+
+  bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {
+    // test whether the sphere with radius (r-eps) intersects 'rectangle', i.e.
+    // if the minimal distance of c to 'rectangle' is less than r-eps
+    FT distance = FT(0);
+    typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
+        traits.construct_cartesian_const_iterator_d_object();
+    typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
+        end = construct_it(c, 0);
+    for (int i = 0; cit != end && (distance <= sq_inner_radius); ++cit, ++i) {
+      if ((*cit) < rectangle.min_coord(i))
+        distance += (rectangle.min_coord(i)-(*cit))*(rectangle.min_coord(i)-(*cit));
+      if ((*cit) > rectangle.max_coord(i))
+        distance += ((*cit)-rectangle.max_coord(i))*((*cit)-rectangle.max_coord(i));
+    }
+
+    return (distance <= sq_inner_radius);
+  }
+
+
+  bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const {
+    // test whether the sphere with radius (r+eps) contains 'rectangle',
+    // i.e. if the maximal distance of c to the boundary of 'rectangle'
+    // is less than r+eps
+    FT distance=FT(0);
+    typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
+        traits.construct_cartesian_const_iterator_d_object();
+    typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
+        end = construct_it(c, 0);
+    for (int i = 0; cit != end && (distance <= sq_outer_radius) ; ++cit,++i) {
+      if ((*cit) <= (rectangle.min_coord(i)+rectangle.max_coord(i))/FT(2))
+        distance += (rectangle.max_coord(i)-(*cit))*(rectangle.max_coord(i)-(*cit));
+      else
+        distance += ((*cit)-rectangle.min_coord(i))*((*cit)-rectangle.min_coord(i));
+    }
+
+    return (distance <= sq_outer_radius);
+  }
+}; // class Fuzzy_sphere_impl
+
+}
+
+template <class SearchTraits>
+class Fuzzy_sphere:
     public internal::Fuzzy_sphere_impl<SearchTraits,typename SearchTraits::Point_d>
-  {
-    typedef internal::Fuzzy_sphere_impl<SearchTraits,typename SearchTraits::Point_d> Base;
-    typedef typename Base::FT FT;
-  public:
-    // constructors
-    Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){};
-    Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) : 
-      Base(center,radius,epsilon,traits_) {}
-  };
-  
-  //specialization for Search_traits_adapter
-  template <class K,class PM,class Base_traits>
-  class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> > :
+{
+  typedef internal::Fuzzy_sphere_impl<SearchTraits,typename SearchTraits::Point_d> Base;
+  typedef typename Base::FT FT;
+public:
+  // constructors
+  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
+  Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) :
+    Base(center,radius,epsilon,traits_) {}
+};
+
+//specialization for Search_traits_adapter
+template <class K,class PM,class Base_traits>
+class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> > :
     public internal::Fuzzy_sphere_impl<Search_traits_adapter<K,PM,Base_traits>,typename Base_traits::Point_d>
-  {
-    typedef Search_traits_adapter<K,PM,Base_traits> SearchTraits;
-    typedef internal::Fuzzy_sphere_impl<SearchTraits,typename Base_traits::Point_d> Base;
-    typedef typename Base_traits::FT FT;
-  public:
-    // constructors
-    Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){};
-    Fuzzy_sphere(const typename Base_traits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) : 
-      Base(center,radius,epsilon,traits_) {}
-    Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
-                 const SearchTraits& traits_=SearchTraits(),
-                 typename boost::disable_if<
-                  boost::is_same<typename Base_traits::Point_d,
-                                 typename SearchTraits::Point_d> >::type* = 0)
-      : Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
-  };
-  
+{
+  typedef Search_traits_adapter<K,PM,Base_traits> SearchTraits;
+  typedef internal::Fuzzy_sphere_impl<SearchTraits,typename Base_traits::Point_d> Base;
+  typedef typename Base_traits::FT FT;
+public:
+  // constructors
+  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
+  Fuzzy_sphere(const typename Base_traits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) :
+    Base(center,radius,epsilon,traits_) {}
+  Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
+               const SearchTraits& traits_=SearchTraits(),
+               typename boost::disable_if<
+               boost::is_same<typename Base_traits::Point_d,
+               typename SearchTraits::Point_d> >::type* = 0)
+    : Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
+};
+
 } // namespace CGAL
 #endif // FUZZY_SPHERE_H

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -62,7 +62,7 @@ public:
     CGAL_precondition(r >= 0);
     CGAL_precondition(eps >= 0);
 
-    sq_inner_radius = (eps > r) ? 0 : (r - eps) * (r - eps);
+    sq_inner_radius = (eps > r) ? -1. : (r - eps) * (r - eps);
     sq_outer_radius = (r + eps) * (r + eps);
   }
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -62,7 +62,7 @@ public:
     CGAL_precondition(r >= 0);
     CGAL_precondition(eps >= 0);
 
-    sq_inner_radius = (eps > r) ? -1. : (r - eps) * (r - eps);
+    sq_inner_radius = (eps > r) ? FT(-1.) : (r - eps) * (r - eps);
     sq_outer_radius = (r + eps) * (r + eps);
   }
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -74,7 +74,7 @@ public:
     typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
         pit = construct_it(p), end = construct_it(c, 0);
     for (; cit != end && (distance <= sq_radius); ++cit, ++pit) {
-      distance += ((*cit)-(*pit))*((*cit)-(*pit));
+      distance += CGAL::square((*cit)-(*pit));
     }
 
     return (distance <= sq_radius);
@@ -87,12 +87,12 @@ public:
     typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
         traits.construct_cartesian_const_iterator_d_object();
     typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
-        end = construct_it(c, 0);
+                                                      end = construct_it(c, 0);
     for (int i = 0; cit != end && (distance <= sq_inner_radius); ++cit, ++i) {
       if ((*cit) < rectangle.min_coord(i))
-        distance += (rectangle.min_coord(i)-(*cit))*(rectangle.min_coord(i)-(*cit));
+        distance += CGAL::square(rectangle.min_coord(i)-(*cit));
       if ((*cit) > rectangle.max_coord(i))
-        distance += ((*cit)-rectangle.max_coord(i))*((*cit)-rectangle.max_coord(i));
+        distance += CGAL::square((*cit)-rectangle.max_coord(i));
     }
 
     return (distance <= sq_inner_radius);
@@ -107,12 +107,12 @@ public:
     typename SearchTraits::Construct_cartesian_const_iterator_d construct_it=
         traits.construct_cartesian_const_iterator_d_object();
     typename SearchTraits::Cartesian_const_iterator_d cit = construct_it(c),
-        end = construct_it(c, 0);
+                                                      end = construct_it(c, 0);
     for (int i = 0; cit != end && (distance <= sq_outer_radius) ; ++cit,++i) {
       if ((*cit) <= (rectangle.min_coord(i)+rectangle.max_coord(i))/FT(2))
-        distance += (rectangle.max_coord(i)-(*cit))*(rectangle.max_coord(i)-(*cit));
+        distance += CGAL::square(rectangle.max_coord(i)-(*cit));
       else
-        distance += ((*cit)-rectangle.min_coord(i))*((*cit)-rectangle.min_coord(i));
+        distance += CGAL::square((*cit)-rectangle.min_coord(i));
     }
 
     return (distance <= sq_outer_radius);

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -136,8 +136,8 @@ public:
 
 //specialization for Search_traits_adapter
 template <class K,class PM,class Base_traits>
-class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> > :
-    public internal::Fuzzy_sphere_impl<Search_traits_adapter<K,PM,Base_traits>,typename Base_traits::Point_d>
+class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> >
+  : public internal::Fuzzy_sphere_impl<Search_traits_adapter<K,PM,Base_traits>,typename Base_traits::Point_d>
 {
   typedef Search_traits_adapter<K,PM,Base_traits> SearchTraits;
   typedef internal::Fuzzy_sphere_impl<SearchTraits,typename Base_traits::Point_d> Base;
@@ -150,8 +150,8 @@ public:
   Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
                const SearchTraits& traits_=SearchTraits(),
                typename boost::disable_if<
-               boost::is_same<typename Base_traits::Point_d,
-               typename SearchTraits::Point_d> >::type* = 0)
+                 boost::is_same<typename Base_traits::Point_d,
+                                typename SearchTraits::Point_d> >::type* = 0)
     : Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
 };
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -62,7 +62,7 @@ public:
     CGAL_precondition(r >= 0);
     CGAL_precondition(eps >= 0);
 
-    sq_inner_radius = (eps > r) ? FT(-1.) : (r - eps) * (r - eps);
+    sq_inner_radius = (eps > r) ? FT(-1) : (r - eps) * (r - eps);
     sq_outer_radius = (r + eps) * (r + eps);
   }
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -91,7 +91,7 @@ public:
     for (int i = 0; cit != end && (distance <= sq_inner_radius); ++cit, ++i) {
       if ((*cit) < rectangle.min_coord(i))
         distance += CGAL::square(rectangle.min_coord(i)-(*cit));
-      if ((*cit) > rectangle.max_coord(i))
+      else if ((*cit) > rectangle.max_coord(i))
         distance += CGAL::square((*cit)-rectangle.max_coord(i));
     }
 

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -50,8 +50,8 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
 
   std::cout << "test with center: " << center << " radius: " << radius << " eps: " << fuzziness << "... ";
 
-  const FT inner_radius = (fuzziness > radius) ? 0 : (radius - fuzziness);
-  const FT sq_inner_radius = inner_radius * inner_radius;
+  const FT inner_radius = radius - fuzziness;
+  const FT sq_inner_radius = (inner_radius < 0) ? -1 : inner_radius * inner_radius;
   const FT outer_radius = radius + fuzziness;
   const FT sq_outer_radius = outer_radius * outer_radius;
 
@@ -106,14 +106,19 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
     all_points.remove(get_point(*pt));
   }
 
-  for(std::list<Point>::const_iterator pt=all_points.begin(); (pt != all_points.end()); ++pt)
+  // note: if eps > r, the squared radius is set to '-1'. We cannot have missed
+  // any point because there is no inner approximation.
+  if(sq_inner_radius >= 0.)
   {
-    // all points with a distance d <= r - eps must have been reported
-    bool is_correct = (CGAL::squared_distance(center,*pt) > sq_inner_radius);
-    if(!is_correct)
-      std::cout << "missed " << *pt << " with distance = " << CGAL::squared_distance(center,*pt) << std::endl;
+    for(std::list<Point>::const_iterator pt=all_points.begin(); (pt != all_points.end()); ++pt)
+    {
+      // all points with a distance d <= r - eps must have been reported
+      bool is_correct = (CGAL::squared_distance(center,*pt) > sq_inner_radius);
+      if(!is_correct)
+        std::cout << "missed " << *pt << " with distance = " << CGAL::squared_distance(center,*pt) << std::endl;
 
-    assert(is_correct);
+      assert(is_correct);
+    }
   }
 
   std::cout << "done" << std::endl;

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -52,7 +52,7 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
   std::cout << "test with center: " << center << " radius: " << radius << " eps: " << fuzziness << "... ";
 
   const FT inner_radius = radius - fuzziness;
-  const FT sq_inner_radius = (inner_radius < 0) ? -1 : inner_radius * inner_radius;
+  const FT sq_inner_radius = (inner_radius < FT(0)) ? FT(-1) : inner_radius * inner_radius;
   const FT outer_radius = radius + fuzziness;
   const FT sq_outer_radius = outer_radius * outer_radius;
 
@@ -110,7 +110,7 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
 
   // note: if eps > r, the squared radius is set to '-1'. We cannot have missed
   // any point because there is no inner approximation.
-  if(sq_inner_radius >= 0.)
+  if(sq_inner_radius >= FT(0))
   {
     for(std::list<Point>::const_iterator pt=all_points.begin(); (pt != all_points.end()); ++pt)
     {

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -151,6 +151,8 @@ void run(std::list<Point> all_points, // intentional copy
 
 int main()
 {
+  CGAL::Set_ieee_double_precision pfr;
+
   CGAL::Random rnd = CGAL::get_default_random();
   std::cout << "seed: " << rnd.get_seed() << std::endl;
 

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -17,6 +17,7 @@
 #include <CGAL/iterator.h>
 #include <CGAL/Origin.h>
 #include <CGAL/point_generators_2.h>
+#include <CGAL/Random.h>
 #include <CGAL/use.h>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
@@ -45,7 +46,8 @@ template <class SearchTraits>
 void run_with_fuzziness(std::list<Point> all_points, // intentional copy
                         const Point& center,
                         const FT radius,
-                        const FT fuzziness)
+                        const FT fuzziness,
+                        CGAL::Random& rnd)
 {
   typedef CGAL::Fuzzy_sphere<SearchTraits> Fuzzy_circle;
 
@@ -60,12 +62,12 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
   // (in general all the constructed points won't be exactly on the boundary,
   // but as long as some are, that's okay)
   std::size_t N = all_points.size();
-  Random_points_on_circle_iterator rpocit(inner_radius);
+  Random_points_on_circle_iterator rpocit(inner_radius, rnd);
   for(std::size_t i=0, max=N/10; i<max; ++i)
     all_points.push_back(*rpocit++ + Vector(CGAL::ORIGIN, center));
 
   // same for the outer approximation boundary
-  Random_points_on_circle_iterator rpocit2(outer_radius);
+  Random_points_on_circle_iterator rpocit2(outer_radius, rnd);
   for(std::size_t i=0, max = N/10; i<max; ++i)
     all_points.push_back(*rpocit2++ + Vector(CGAL::ORIGIN, center));
 
@@ -127,38 +129,41 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
 }
 
 template <class SearchTraits>
-void run(std::list<Point> all_points) // intentional copy
+void run(std::list<Point> all_points, // intentional copy
+         CGAL::Random& rnd)
 {
   Point center(0.25, 0.25);
 
   // add some interesting points
   all_points.push_back(center);
 
-  run_with_fuzziness<SearchTraits>(all_points, center, 0. /*radius*/, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0.125 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0.25 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 1. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 1. /*radius*/, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 1. /*radius*/, 0.25 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 10. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 100. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, center, 0. /*radius*/, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0.125 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 0.25 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 0.25 /*radius*/, 1. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 1. /*radius*/, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 1. /*radius*/, 0.25 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 10. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, center, 10. /*radius*/, 100. /*fuzziness*/, rnd);
 }
 
 int main()
 {
-  const int N=1000;
+  CGAL::Random rnd = CGAL::get_default_random();
+  std::cout << "seed: " << rnd.get_seed() << std::endl;
 
   // generator for random data points in the square ( (-1,-1), (1,1) )
   Random_points_iterator rpit(1.0);
 
   // construct list containing N random points
+  const int N=1000;
   std::list<Point> all_points(N_Random_points_iterator(rpit,0),
                               N_Random_points_iterator(N));
 
-  run<Traits>(all_points);
-  run<Traits_with_info>(all_points);
+  run<Traits>(all_points, rnd);
+  run<Traits_with_info>(all_points, rnd);
 
   return 0;
 }

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -17,6 +17,7 @@
 #include <CGAL/iterator.h>
 #include <CGAL/Origin.h>
 #include <CGAL/point_generators_2.h>
+#include <CGAL/use.h>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 
@@ -84,6 +85,7 @@ void run_with_fuzziness(std::list<Point> all_points, // intentional copy
   V vec;
   vec.resize(result.size());
   typename V::iterator it = tree.search(vec.begin(), default_range);
+  CGAL_USE(it);
   assert(it == vec.end());
   result.clear();
 

--- a/Spatial_searching/test/Spatial_searching/Circular_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Circular_query.cpp
@@ -155,7 +155,7 @@ int main()
   std::cout << "seed: " << rnd.get_seed() << std::endl;
 
   // generator for random data points in the square ( (-1,-1), (1,1) )
-  Random_points_iterator rpit(1.0);
+  Random_points_iterator rpit(1.0, rnd);
 
   // construct list containing N random points
   const int N=1000;

--- a/Spatial_searching/test/Spatial_searching/Iso_rectangle_2_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Iso_rectangle_2_query.cpp
@@ -1,98 +1,158 @@
-// file: Iso_rectangle_2_query.C
+// test whether box queries are computed correctly for random data
+//
+// 1) generate list of query points using report_all
+// 2) remove and check reported points from these list
+// 3) check if no remaining points should have been reported
 
 #include <CGAL/Simple_cartesian.h>
-#include <cassert>
+
+#include "Point_with_info.h"
+
 #include <CGAL/Kd_tree.h>
 #include <CGAL/Search_traits_2.h>
 #include <CGAL/Search_traits_adapter.h>
-#include <CGAL/point_generators_2.h>
 #include <CGAL/Fuzzy_iso_box.h>
-#include <CGAL/iterator.h>
-#include "Point_with_info.h"
 
+#include <CGAL/iterator.h>
+#include <CGAL/point_generators_2.h>
+
+#include <cassert>
 #include <vector>
 #include <iostream>
 
-typedef CGAL::Simple_cartesian<double> K;
-typedef K::Point_2 Point;
-typedef K::Vector_2 Vector;
-typedef K::Iso_rectangle_2 Iso_rectangle;
-typedef CGAL::Random_points_in_square_2<Point> Random_points_iterator;
-typedef CGAL::Counting_iterator<Random_points_iterator> N_Random_points_iterator;
-typedef CGAL::Search_traits_2<K> Traits;
-typedef Point_with_info_helper<Point>::type                                   Point_with_info;
-typedef Point_property_map<Point>                                             Ppmap;
-typedef CGAL::Search_traits_adapter<Point_with_info,Ppmap,Traits>             Traits_with_info;
+typedef CGAL::Simple_cartesian<double>                                K;
+typedef K::FT                                                         FT;
+typedef K::Point_2                                                    Point;
+typedef K::Vector_2                                                   Vector;
+typedef K::Iso_rectangle_2                                            Iso_rectangle;
 
-template <class SearchTraits>
-void run(std::list<Point> all_points)
+typedef CGAL::Random_points_in_square_2<Point>                        Random_points_iterator;
+typedef CGAL::Counting_iterator<Random_points_iterator>               N_Random_points_iterator;
+typedef CGAL::Search_traits_2<K>                                      Traits;
+typedef Point_with_info_helper<Point>::type                           Point_with_info;
+typedef Point_property_map<Point>                                     Ppmap;
+typedef CGAL::Search_traits_adapter<Point_with_info,Ppmap,Traits>     Traits_with_info;
+
+template <class SearchTraits, class Tree>
+void run_with_fuzziness(std::list<Point> all_points, const Tree& tree,
+                        const Point& p, const Point& q, const FT fuzziness)
 {
   typedef CGAL::Fuzzy_iso_box<SearchTraits> Fuzzy_box;
 
-  // Insert also the N points in the tree
-  CGAL::Kd_tree<SearchTraits> tree(
-    boost::make_transform_iterator(all_points.begin(),Create_point_with_info<typename SearchTraits::Point_d>()),
-    boost::make_transform_iterator(all_points.end(),Create_point_with_info<typename SearchTraits::Point_d>())
-  );
+  tree.search(CGAL::Emptyset_iterator(), Fuzzy_box(p,q)); //test compilation when Point != Traits::Point_d
 
-  Point p(0.1, 0.2);
-  Point q(0.3, 0.5);
   typename SearchTraits::Point_d pp(p);
   typename SearchTraits::Point_d qq(q);
 
+  std::cout << "test with box: [" << p << " || " << q << "] and eps: " << fuzziness << "... ";
 
-  Iso_rectangle ic(p,q);
-
-  Fuzzy_box default_range(pp,qq);
-
+  // approximate range searching
   std::list<typename SearchTraits::Point_d> result;
-  // Searching the box ic
-  tree.search( std::back_inserter( result ), default_range);
+  Fuzzy_box approximate_range(pp, qq, fuzziness);
+  tree.search(std::back_inserter(result), approximate_range);
+  std::cout << result.size() << " hits... Verifying correctness...";
 
-  tree.search(CGAL::Emptyset_iterator(), Fuzzy_box(p,q) ); //test compilation when Point != Traits::Point_d
-
-  // test the results of the default query
-  std::list<Point> copy_all_points(all_points);
-  for (typename std::list<typename SearchTraits::Point_d>::iterator pt=result.begin(); (pt != result.end()); ++pt) {
-    assert(! ic.has_on_unbounded_side(get_point(*pt)) || ic.has_on_boundary(get_point(*pt)));
-    copy_all_points.remove(get_point(*pt));
-  }
-
-  for (std::list<Point>::iterator pt=copy_all_points.begin(); (pt != copy_all_points.end()); ++pt) {
-    assert(ic.has_on_unbounded_side(*pt) || ic.has_on_boundary(*pt));
-  }
-
-
-  result.clear();
-  // approximate range searching using value 0.1 for fuzziness parameter
-  Fuzzy_box approximate_range(pp,qq,0.05);
-  Iso_rectangle inner_ic(p+ 0.05*Vector(1,1),q-0.05*Vector(1,1));
-  Iso_rectangle outer_ic(p- 0.05*Vector(1,1),q+0.05*Vector(1,1));
-
-  tree.search(std::back_inserter( result ), approximate_range);
   // test the results of the approximate query
-  for (typename std::list<typename SearchTraits::Point_d>::iterator pt=result.begin(); (pt != result.end()); ++pt) {
-    // a point we found may be slighlty outside the isorectangle
-    assert(! outer_ic.has_on_unbounded_side(get_point(*pt)) || outer_ic.has_on_boundary(get_point(*pt)));
+  Iso_rectangle inner_ic(p + fuzziness*Vector(1,1), q - fuzziness*Vector(1,1));
+  Iso_rectangle outer_ic(p - fuzziness*Vector(1,1), q + fuzziness*Vector(1,1));
+
+  // If the fuziness is greater than half of the largest dimension of the box,
+  // then the inner box does not exist
+  const FT max_box_edge_length = (std::max)(q[1] - p[1], q[0] - p[0]);
+  const bool is_inner_c_empty = (fuzziness > 0.5 * max_box_edge_length);
+  if(is_inner_c_empty)
+    std::cout << " (empty inner box)... ";
+
+  for (typename std::list<typename SearchTraits::Point_d>::iterator pt=result.begin(); (pt != result.end()); ++pt)
+  {
+    // a point can only be reported if it is in the outer box
+    bool is_correct = outer_ic.has_on_bounded_side(get_point(*pt)) || outer_ic.has_on_boundary(get_point(*pt));
+    if(!is_correct)
+      std::cout << get_point(*pt) << " should have not been reported" << std::endl;
+    assert(is_correct);
     all_points.remove(get_point(*pt));
   }
 
-  for (std::list<Point>::iterator pt=all_points.begin(); (pt != all_points.end()); ++pt) {
-    assert(inner_ic.has_on_unbounded_side(*pt) || inner_ic.has_on_boundary(*pt));
+  // nothing to test if the inner box is empty because everything is on the unbounded side
+  if(!is_inner_c_empty)
+  {
+    for (std::list<Point>::iterator pt=all_points.begin(); (pt != all_points.end()); ++pt)
+    {
+      // all points that have not been reported must be outside the inner box
+      bool is_correct = inner_ic.has_on_unbounded_side(*pt);
+      if(!is_correct)
+        std::cout << *pt << " should have been reported" << std::endl;
+
+      assert(is_correct);
+    }
   }
+
   std::cout << "done" << std::endl;
 }
 
-int main() {
+template <class SearchTraits>
+void run(std::list<Point> all_points) // intentional copy
+{
+  // Insert also the N points in the tree
+  CGAL::Kd_tree<SearchTraits> tree(
+    boost::make_transform_iterator(all_points.begin(), Create_point_with_info<typename SearchTraits::Point_d>()),
+    boost::make_transform_iterator(all_points.end(), Create_point_with_info<typename SearchTraits::Point_d>())
+  );
 
+  // bigger box
+  Point p0(-10., -10.);
+  Point q0( 10.,  10.);
+
+  // a subset
+  Point p1(-CGAL_PI/10., -CGAL_PI/10.);
+  Point q1( CGAL_PI/10.,  CGAL_PI/10.);
+
+  // another subset
+  Point p2(0.1, 0.2);
+  Point q2(0.3, 0.4);
+
+  // degenerate
+  Point p3(0., 0.);
+  Point q3(0., 0.);
+
+  run_with_fuzziness<SearchTraits>(all_points, tree, p0, q0, 0. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p0, q0, 0.1 /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p0, q0, 1. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p0, q0, 10. /*fuzziness*/);
+
+  run_with_fuzziness<SearchTraits>(all_points, tree, p1, q1, 0. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p1, q1, 0.1 /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p1, q1, 1. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p1, q1, 10. /*fuzziness*/);
+
+  run_with_fuzziness<SearchTraits>(all_points, tree, p2, q2, 0. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p2, q2, 0.1 /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p2, q2, 0.4 /*fuzziness*/);
+
+  run_with_fuzziness<SearchTraits>(all_points, tree, p3, q3, 0. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p3, q3, 0.33 /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, tree, p3, q3, 1. /*fuzziness*/);
+}
+
+int main()
+{
   const int N=10000;
 
   // generator for random data points in the square ( (-1,-1), (1,1) )
-  Random_points_iterator rpit( 1.0);
+  Random_points_iterator rpit(1.0);
 
   // construct list containing N random points
   std::list<Point> all_points(N_Random_points_iterator(rpit,0),
-            N_Random_points_iterator(N));
+                              N_Random_points_iterator(N));
+
+  // add some interesting points
+  all_points.push_back(Point(0., 0.));
+  all_points.push_back(Point(-CGAL_PI/10.+0.1, -CGAL_PI/10.+0.1));
+  all_points.push_back(Point(1., 1.));
+  all_points.push_back(Point(0., 1.));
+  all_points.push_back(Point(0.3, 0.4));
+  all_points.push_back(Point(0.2, 0.3));
+  all_points.push_back(Point(0., 0.1));
 
   run<Traits>(all_points);
   run<Traits_with_info>(all_points);

--- a/Spatial_searching/test/Spatial_searching/Iso_rectangle_2_query.cpp
+++ b/Spatial_searching/test/Spatial_searching/Iso_rectangle_2_query.cpp
@@ -36,7 +36,8 @@ typedef CGAL::Search_traits_adapter<Point_with_info,Ppmap,Traits>     Traits_wit
 template <class SearchTraits>
 void run_with_fuzziness(std::list<Point> all_points,
                         const Point& p, const Point& q,
-                        const FT fuzziness)
+                        const FT fuzziness,
+                        CGAL::Random& rnd)
 {
   typedef CGAL::Fuzzy_iso_box<SearchTraits> Fuzzy_box;
 
@@ -54,14 +55,13 @@ void run_with_fuzziness(std::list<Point> all_points,
     std::cout << " (empty inner box)... ";
 
   // Insert a bunch of points on the boundary of the inner approximation
-  CGAL::Random random;
   std::size_t N = all_points.size();
 
   if(!is_inner_c_empty)
   {
     for(std::size_t i=0, max=N/10; i<max; ++i)
     {
-      double x = random.get_double(-1., 1.);
+      double x = rnd.get_double(-1., 1.);
       all_points.push_back(Point(x, p.y() + fuzziness));
       all_points.push_back(Point(p.x() + fuzziness, x));
     }
@@ -70,7 +70,7 @@ void run_with_fuzziness(std::list<Point> all_points,
   // same for the outer boundary
   for(std::size_t i=0, max=N/10; i<max; ++i)
   {
-    double x = random.get_double(-1., 1.);
+    double x = rnd.get_double(-1., 1.);
     all_points.push_back(Point(x, q.y() + fuzziness));
     all_points.push_back(Point(q.x() + fuzziness, x));
   }
@@ -120,7 +120,8 @@ void run_with_fuzziness(std::list<Point> all_points,
 }
 
 template <class SearchTraits>
-void run(std::list<Point> all_points) // intentional copy
+void run(std::list<Point> all_points, // intentional copy
+         CGAL::Random& rnd)
 {
   // bigger box
   Point p0(-10., -10.);
@@ -138,31 +139,34 @@ void run(std::list<Point> all_points) // intentional copy
   Point p3(0., 0.);
   Point q3(0., 0.);
 
-  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 0.1 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 1. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 10. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 0.1 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 1. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p0, q0, 10. /*fuzziness*/, rnd);
 
-  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 0.1 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 1. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 10. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 0.1 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 1. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p1, q1, 10. /*fuzziness*/, rnd);
 
-  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0.1 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0.4 /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0.1 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p2, q2, 0.4 /*fuzziness*/, rnd);
 
-  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 0. /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 0.33 /*fuzziness*/);
-  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 1. /*fuzziness*/);
+  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 0. /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 0.33 /*fuzziness*/, rnd);
+  run_with_fuzziness<SearchTraits>(all_points, p3, q3, 1. /*fuzziness*/, rnd);
 }
 
 int main()
 {
   const int N=10000;
 
+  CGAL::Random rnd = CGAL::get_default_random();
+  std::cout << "seed: " << rnd.get_seed() << std::endl;
+
   // generator for random data points in the square ( (-1,-1), (1,1) )
-  Random_points_iterator rpit(1.0);
+  Random_points_iterator rpit(1.0, rnd);
 
   // construct list containing N random points
   std::list<Point> all_points(N_Random_points_iterator(rpit,0),
@@ -177,8 +181,8 @@ int main()
   all_points.push_back(Point(0.2, 0.3));
   all_points.push_back(Point(0., 0.1));
 
-  run<Traits>(all_points);
-  run<Traits_with_info>(all_points);
+  run<Traits>(all_points, rnd);
+  run<Traits_with_info>(all_points, rnd);
 
   return 0;
 }

--- a/Spatial_searching/test/Spatial_searching/Point_with_info.h
+++ b/Spatial_searching/test/Spatial_searching/Point_with_info.h
@@ -1,4 +1,4 @@
-#include <boost/iterator/transform_iterator.hpp>
+#include <boost/property_map/property_map.hpp>
 
 template <class Pt>
 struct My_point_with_info


### PR DESCRIPTION
## Summary of Changes

More serious attempt at fixing inconsistencies in the code and documentation of fuzzy items after some bad commits (c0cbdab and 5ed7255) and the revert (#1808).

#### Before:
- Points in the _interior_ of the inner approximation are always returned
- Points in the _interior_ of the outer approximation and not in the interior of the inner approximation may or may not be returned
- Everything else is never returned

When there is no fuzziness, points on the boundary of the object are not returned. Also:
- Half open boxes so the "interior" is a little weird and buggy
- Inconsistencies between the doc and the code (doc was vague before, I made it wrong with commits mentioned above).

#### After:
- Points in the inner approximation are always returned (boundary included)
- Points in the outer approximation and not in the inner approximation may or may not be returned (boundary of the outer approximation included)
- Everything else is never returned

When there is no fuzziness, points on the boundary of the object are returned.


#### Also:
- Fixed a bug in the `Fuzzy_iso_box`
- Minor improvements on speed by caching stuff
- Test fuzzy items exhaustively

cc: @mglisse @efifogel 

## Release Management

* Affected package(s): `Spatial_searching:`
* Issue(s) solved (if any): fix #2729
* Feature/Small Feature (if any): --

