### PR TITLE
Travis: Fixes

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -51,9 +51,9 @@ old_IFS=$IFS
 IFS=$' '
 ROOT="$PWD/.."
 NEED_3D=0
-cd $ROOT
 for ARG in $(echo "$@")
 do
+cd $ROOT
 #install openmesh only if necessary
   if [ "$ARG" = "CHECK" ] || [ "$ARG" = BGL ] || [ "$ARG" = Convex_hull_3 ] ||\
      [ "$ARG" = Polygon_mesh_processing ] || [ "$ARG" = Property_map ] ||\

--- a/.travis/install_openmesh.sh
+++ b/.travis/install_openmesh.sh
@@ -2,8 +2,7 @@
 mkdir -p openmesh
 cd openmesh
 wget -O openmesh.tar.gz https://www.openmesh.org/media/Releases/6.3/OpenMesh-6.3.tar.gz
-tar xf openmesh.tar.gz --strip-components=1 &>/dev/null
-
+tar xf openmesh.tar.gz --strip-components=1
 sed -i '94i #include <sys/time.h>' src/OpenMesh/Tools/Utils/conio.cc
 
 mkdir build

--- a/.travis/install_openmesh.sh
+++ b/.travis/install_openmesh.sh
@@ -2,7 +2,7 @@
 mkdir -p openmesh
 cd openmesh
 wget -O openmesh.tar.gz https://www.openmesh.org/media/Releases/6.3/OpenMesh-6.3.tar.gz
-tar xvf openmesh.tar.gz --strip-components=1
+tar xf openmesh.tar.gz --strip-components=1 &>/dev/null
 
 sed -i '94i #include <sys/time.h>' src/OpenMesh/Tools/Utils/conio.cc
 

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -51,7 +51,7 @@ echo " Checks finished"
 cd $CGAL_ROOT
 rm -r dep_check_build
 if [ -n "$HAS_DIFF" ]; then
-  echo " You should run cmake with options CGAL_CHECK_HEADERS and CGAL_COPY_DEPENDENCIES ON, make the target packages_dependencies and commit the new dependencies files."
+  echo " You should run cmake with options CGAL_ENABLE_CHECK_HEADERS and CGAL_COPY_DEPENDENCIES ON, make the target packages_dependencies and commit the new dependencies files."
   exit 1
 else
   echo "The dependencies are up to date."


### PR DESCRIPTION
## Summary of Changes
Remove the verbose option in install_openmesh.sh so the logs are less polluted.
Also fix the name of the cmake variable that computes dependences.