### PR TITLE
Polyhedron demo: Fix Bbox computation in facegraph_items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -396,6 +396,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::dock_widget_visibility_changed(bool
         Scene_facegraph_item* item = convert_to_plain_facegraph(i, edit_item);
         item->setRenderingMode(last_RM);
         updateSelectionItems(item);
+        item->itemChanged();
       }
     }
   }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1414,7 +1414,7 @@ invalidateOpenGLBuffers()
     d->init();
     Base::invalidateOpenGLBuffers();
     are_buffers_filled = false;
-
+    is_bbox_computed = false;
     d->invalidate_stats();
     d->killIds();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -921,7 +921,7 @@ void Scene_surface_mesh_item::compute_bbox()const
   }
   _bbox = Bbox(bbox.xmin(),bbox.ymin(),bbox.zmin(),
                bbox.xmax(),bbox.ymax(),bbox.zmax());
-
+  is_bbox_computed = true;
 }
 
 void Scene_surface_mesh_item::itemAboutToBeDestroyed(Scene_item *item)
@@ -1109,6 +1109,7 @@ void Scene_surface_mesh_item::invalidateOpenGLBuffers()
   d->smesh_->collect_garbage();
   are_buffers_filled = false;
   d->invalidate_stats();
+  is_bbox_computed = false;
 }
 
 


### PR DESCRIPTION
## Summary of Changes
The `Scene_surface_mesh_item` was not setting `is_bbox_computed` to `true` after computing its bbox, 
and the bbox was not invalidated in `invalidateOpenGLBuffers()` neither in it nor in the `Scene_polyhedron_item`.
This PR also adds a call to `item->itemChanged()` after validating a deformation, to trigger the update of the `Info` view.
## Release Management
* Issue(s) solved (if any): fix #2959 


