### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -270,8 +270,8 @@ struct Mpzf {
 //#endif
 
   mp_limb_t* data_; /* data_[0] is never 0 (except possibly for 0). */
-  inline mp_limb_t*& data() { return data_; };
-  inline mp_limb_t const* data() const { return data_; };
+  inline mp_limb_t*& data() { return data_; }
+  inline mp_limb_t const* data() const { return data_; }
 
 #ifdef CGAL_MPZF_USE_CACHE
   mp_limb_t cache[cache_size + 1];


### PR DESCRIPTION
## Summary of Changes

Remove two semicolons that are not required at this position and can trigger warnings in code that includes CGAL when compiling with MSVC.
