### PR TITLE
Travis: Fix install.sh

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,4 +21,5 @@ libboost-system1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev
 qt55base qt55script qt55svg qt55tools qt55graphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
 || DONE=0 && sudo apt-get update
 done
+exit 0
 


### PR DESCRIPTION
## Summary of Changes
Sometimes, install.sh runs fine but exits with code 100. I suppose it is caused by a warning about ppas that are not well secured, which does not trigger a failure for the || operator, but does when exiting the script with a non 0 code. 
I added exit 0 at the end of the file, to insure that if the script executed until the end, then we don't consider any error.
