### PR TITLE
Convex_hull_3: Remove dependency on Polyhedron_3

### DIFF
--- a/Convex_hull_3/doc/Convex_hull_3/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/doc/Convex_hull_3/CGAL/Convex_hull_traits_3.h
@@ -8,10 +8,11 @@ The class `Convex_hull_traits_3` serves as a traits class for the function
 function when `R` is a kernel with exact predicates but inexact constructions 
 (note that the type `Plane_3` is a triple of `Point_3` and not `R::Plane_3`). 
 
-\tparam PolygonMesh must be a model of  the concept `MutableFaceGraph`
+\tparam PolygonMesh must be a model of  the concept `MutableFaceGraph`. It has as default `Polyhedron_'3`.
 \cgalModels `ConvexHullTraits_3`
 \cgalModels `IsStronglyConvexTraits_3` 
 
+\attention The user must include the header file of the polygon mesh type, even for the default type.
 */
   template< typename R, typename PolygonMesh = Polyhedron_3<R> >
 class Convex_hull_traits_3 {

--- a/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
@@ -23,6 +23,8 @@ is a kernel with exact predicates but inexact constructions
 (in practice we check `R::Has_filtered_predicates_tag` is `Tag_true` and `R::FT` is a floating point type), 
 then the default traits class of `::convex_hull_3()` is `Convex_hull_traits_3<R>`, and `R` otherwise. 
 
+\attention The user must include the header file of the `Polygon_mesh` type.
+
 \cgalHeading{Implementation}
 
 The algorithm implemented by these functions is the quickhull algorithm of 
@@ -55,6 +57,7 @@ is a kernel with exact predicates but inexact constructions
 (in practice we check `R::Has_filtered_predicates_tag` is `Tag_true` and `R::FT` is a floating point type), 
 then the default traits class of `convex_hull_3()` is `Convex_hull_traits_3<R>`, and `R` otherwise. 
 
+\attention The user must include the header file of the `Polygon_mesh` type.
 */
 
 template <class InputIterator, class Traits>

--- a/Convex_hull_3/examples/Convex_hull_3/lloyd_algorithm.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/lloyd_algorithm.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Convex_hull_3/dual/halfspace_intersection_3.h>
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/convex_hull_3.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Timer.h>
 #include <CGAL/point_generators_3.h>
 

--- a/Convex_hull_3/examples/Convex_hull_3/quickhull_3.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/quickhull_3.cpp
@@ -4,12 +4,13 @@
 #include <CGAL/convex_hull_3.h>
 #include <vector>
 #include <fstream>
+#include <CGAL/HalfedgeDS_default.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
 typedef CGAL::Polyhedron_3<K>                     Polyhedron_3;
 typedef K::Point_3                                Point_3;
 typedef CGAL::Surface_mesh<Point_3>               Surface_mesh;
-
+typedef CGAL::HalfedgeDS_default<K, CGAL::HalfedgeDS_items_3> HDS;
 
 int main(int argc, char* argv[])
 {
@@ -27,14 +28,15 @@ int main(int argc, char* argv[])
   CGAL::convex_hull_3(points.begin(), points.end(), poly);
 
   std::cout << "The convex hull contains " << poly.size_of_vertices() << " vertices" << std::endl;
-
-  Surface_mesh sm;
   
+  Surface_mesh sm;
   CGAL::convex_hull_3(points.begin(), points.end(), sm);
 
   std::cout << "The convex hull contains " << num_vertices(sm) << " vertices" << std::endl;
 
-  
+  HDS hds;
+  CGAL::convex_hull_3(points.begin(), points.end(), hds);
+
 
   return 0;
 }

--- a/Convex_hull_3/examples/Convex_hull_3/quickhull_3.cpp
+++ b/Convex_hull_3/examples/Convex_hull_3/quickhull_3.cpp
@@ -4,13 +4,13 @@
 #include <CGAL/convex_hull_3.h>
 #include <vector>
 #include <fstream>
-#include <CGAL/HalfedgeDS_default.h>
+
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;
 typedef CGAL::Polyhedron_3<K>                     Polyhedron_3;
 typedef K::Point_3                                Point_3;
 typedef CGAL::Surface_mesh<Point_3>               Surface_mesh;
-typedef CGAL::HalfedgeDS_default<K, CGAL::HalfedgeDS_items_3> HDS;
+
 
 int main(int argc, char* argv[])
 {
@@ -33,10 +33,6 @@ int main(int argc, char* argv[])
   CGAL::convex_hull_3(points.begin(), points.end(), sm);
 
   std::cout << "The convex hull contains " << num_vertices(sm) << " vertices" << std::endl;
-
-  HDS hds;
-  CGAL::convex_hull_3(points.begin(), points.end(), hds);
-
 
   return 0;
 }

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -27,7 +27,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/Polyhedron_3.h>
+#include <CGAL/HalfedgeDS_default.h>
 #include <CGAL/Convex_hull_3/dual/Convex_hull_traits_dual_3.h>
 #include <CGAL/Origin.h>
 #include <CGAL/convex_hull_3.h>
@@ -41,6 +41,7 @@
 #include <boost/unordered_map.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <boost/foreach.hpp>
+#include <deque>
 
 namespace CGAL
 {
@@ -60,13 +61,15 @@ namespace CGAL
               typedef typename Kernel::RT RT;
 
               // Typedefs for dual
-              typedef typename Polyhedron_dual::Facet Facet;
-              typedef typename Polyhedron_dual::Facet_const_handle
+
+              typedef typename boost::graph_traits<Polyhedron_dual>::face_descriptor 
                 Facet_const_handle;
-              typedef typename Polyhedron_dual::Facet_const_iterator
+              typedef typename boost::graph_traits<Polyhedron_dual>::face_iterator
                 Facet_const_iterator;
-              typedef typename Polyhedron_dual::Vertex_const_iterator
-                Vertex_const_iterator;
+              typedef typename boost::graph_traits<Polyhedron_dual>::vertex_descriptor
+                Vertex_const_descriptor;
+              typedef typename boost::graph_traits<Polyhedron_dual>::halfedge_descriptor
+                Halfedge_const_descriptor;
 
               // typedef and type for primal
               typedef typename boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
@@ -85,9 +88,8 @@ namespace CGAL
               size_t n = 0;
 
               // First, computing the primal vertices
-              for (Facet_const_iterator it = _dual.facets_begin();
-                   it != _dual.facets_end(); ++it, ++n) {
-                typename Facet::Halfedge_const_handle h = it->halfedge();
+              BOOST_FOREACH (Facet_const_handle fd, faces(_dual)){               
+                Halfedge_const_descriptor h = fd->halfedge();
                 // Build the dual plane corresponding to the current facet
                 Plane_3 p1 = h->vertex()->point();
                 Plane_3 p2 = h->next()->vertex()->point();
@@ -119,23 +121,21 @@ namespace CGAL
                             origin.z() + pp->z());
 
                 vertex_descriptor vd = add_vertex(primal);
-                primal_vertices[it] = vd;
+                primal_vertices[fd] = vd;
                 put(vpm, vd, ppp);
+                ++n;
               }
 
               // Then, add facets to the primal polyhedron
               // To do this, for each dual vertex, we circulate around this vertex
               // and we add an edge between each facet we encounter
 
-              for (Vertex_const_iterator it = _dual.vertices_begin();
-                   it != _dual.vertices_end(); ++it) {
-                std::vector<vertex_descriptor> vertices;
-                typename Polyhedron_dual::Halfedge_around_vertex_const_circulator
-                  h0 = it->vertex_begin(), hf = h0;
-                  do {
-                    vertices.push_back(primal_vertices[hf->facet()]);
-                  } while (--hf != h0);
-                  Euler::add_face(vertices,primal);
+              BOOST_FOREACH (Vertex_const_descriptor vd, vertices( _dual)) {
+                std::deque<vertex_descriptor> vertices;
+                BOOST_FOREACH(Halfedge_const_descriptor hd, halfedges_around_target(vd, _dual)){
+                  vertices.push_front(primal_vertices[face(hd, _dual)]);
+                }
+                Euler::add_face(vertices,primal);
               }
             }
 
@@ -249,7 +249,7 @@ namespace CGAL
         // Types
         typedef typename Kernel_traits<typename std::iterator_traits<PlaneIterator>::value_type>::Kernel K;
         typedef Convex_hull_3::Convex_hull_traits_dual_3<K> Hull_traits_dual_3;
-        typedef Polyhedron_3<Hull_traits_dual_3> Polyhedron_dual_3;
+        typedef HalfedgeDS_default<Hull_traits_dual_3, HalfedgeDS_items_3 > Polyhedron_dual_3;
 
         // if a point inside is not provided find one using linear programming
         if (!origin) {

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -64,8 +64,6 @@ namespace CGAL
 
               typedef typename boost::graph_traits<Polyhedron_dual>::face_descriptor 
                 Facet_const_handle;
-              typedef typename boost::graph_traits<Polyhedron_dual>::face_iterator
-                Facet_const_iterator;
               typedef typename boost::graph_traits<Polyhedron_dual>::vertex_descriptor
                 Vertex_const_descriptor;
               typedef typename boost::graph_traits<Polyhedron_dual>::halfedge_descriptor

--- a/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
@@ -25,7 +25,7 @@
 #include <CGAL/license/Convex_hull_3.h>
 
 
-#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_3_fwd.h>
 #include <CGAL/Convex_hull_face_base_2.h>
 #include <CGAL/Projection_traits_xy_3.h>
 #include <CGAL/Projection_traits_xz_3.h>

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -53,7 +53,7 @@
 #include <CGAL/internal/Exact_type_selector.h>
 #include <CGAL/boost/graph/copy_face_graph.h>
 #include <CGAL/boost/graph/graph_traits_Triangulation_data_structure_2.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
+#include <CGAL/Polyhedron_3_fwd.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 
 #include <boost/unordered_map.hpp>
@@ -65,6 +65,7 @@
 
 namespace CGAL {
 
+  
 namespace internal{  namespace Convex_hull_3{
 
 //struct to select the default traits class for computing convex hull

--- a/Convex_hull_3/include/CGAL/convex_hull_3_to_polyhedron_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3_to_polyhedron_3.h
@@ -30,11 +30,14 @@
 #define CGAL_REPLACEMENT_HEADER "<CGAL/convex_hull_3_to_face_graph.h>"
 #include <CGAL/internal/deprecation_warning.h>
 
-#include <CGAL/Polyhedron_incremental_builder_3.h>
-#include <CGAL/Modifier_base.h>
+//#include <CGAL/Polyhedron_incremental_builder_3.h>
+//#include <CGAL/Modifier_base.h>
+
+#include <CGAL/Polyhedron_3_fwd.h>
 
 namespace CGAL {
 
+#if 0
 template <class HDS,class Triangulation>
 class Convex_hull_modifier_from_triangulation_3 : public CGAL::Modifier_base<HDS> {
   typedef std::map<typename Triangulation::Vertex_handle,unsigned> Vertex_map;
@@ -88,12 +91,12 @@ public:
     B.end_surface();
   }
 };
-
+#endif
+  
 template<class Triangulation_3,class Polyhedron_3>
 CGAL_DEPRECATED void convex_hull_3_to_polyhedron_3(const Triangulation_3& T,Polyhedron_3& P){
-  P.clear();
-  Convex_hull_modifier_from_triangulation_3<typename Polyhedron_3::HalfedgeDS,Triangulation_3> modifier(T);
-  P.delegate(modifier);
+  clear(P);
+  link_to_face_graph(T,T.infinite_vertex(), P);
 }
 
 } //namespace CGAL

--- a/Convex_hull_3/include/CGAL/convex_hull_3_to_polyhedron_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3_to_polyhedron_3.h
@@ -30,68 +30,10 @@
 #define CGAL_REPLACEMENT_HEADER "<CGAL/convex_hull_3_to_face_graph.h>"
 #include <CGAL/internal/deprecation_warning.h>
 
-//#include <CGAL/Polyhedron_incremental_builder_3.h>
-//#include <CGAL/Modifier_base.h>
 
 #include <CGAL/Polyhedron_3_fwd.h>
 
 namespace CGAL {
-
-#if 0
-template <class HDS,class Triangulation>
-class Convex_hull_modifier_from_triangulation_3 : public CGAL::Modifier_base<HDS> {
-  typedef std::map<typename Triangulation::Vertex_handle,unsigned> Vertex_map;
-  
-  const Triangulation& t;
-  template <class Builder>
-  static unsigned get_vertex_index( Vertex_map& vertex_map,
-                                    typename Triangulation::Vertex_handle vh,
-                                    Builder& builder,
-                                    unsigned& vindex)
-  {
-    std::pair<typename Vertex_map::iterator,bool>
-      res=vertex_map.insert(std::make_pair(vh,vindex));
-    if (res.second){
-      builder.add_vertex(vh->point());
-      ++vindex;
-    }
-    return res.first->second;
-  }
-  
-public:
-  Convex_hull_modifier_from_triangulation_3(const Triangulation& t_):t(t_) 
-  {
-    CGAL_assertion(t.dimension()==3);
-  }
-  void operator()( HDS& hds) {
-    // Postcondition: `hds' is a valid polyhedral surface.
-
-    CGAL::Polyhedron_incremental_builder_3<HDS> B( hds, true);
-    std::vector<typename Triangulation::Cell_handle>  ch_facets;
-    Vertex_map vertex_map;
-    t.incident_cells(t.infinite_vertex(),std::back_inserter(ch_facets));
-    std::size_t nb_facets=ch_facets.size();
-    //start the surface
-    B.begin_surface( nb_facets, nb_facets);
-    unsigned vindex=0;
-    for (typename std::vector<typename Triangulation::Cell_handle>::const_iterator it=
-          ch_facets.begin();it!=ch_facets.end();++it)
-    {
-      unsigned ifv_index= (*it)->index(t.infinite_vertex());
-      bool is_even=ifv_index%2==0;
-      unsigned i0=get_vertex_index(vertex_map,(*it)->vertex((ifv_index + (is_even?3:1) )%4),B,vindex);
-      unsigned i1=get_vertex_index(vertex_map,(*it)->vertex((ifv_index + 2            )%4),B,vindex);
-      unsigned i2=get_vertex_index(vertex_map,(*it)->vertex((ifv_index + (is_even?1:3) )%4),B,vindex);
-      B.begin_facet();
-      B.add_vertex_to_facet( i0 );
-      B.add_vertex_to_facet( i1 );
-      B.add_vertex_to_facet( i2 );
-      B.end_facet();      
-    }
-    B.end_surface();
-  }
-};
-#endif
   
 template<class Triangulation_3,class Polyhedron_3>
 CGAL_DEPRECATED void convex_hull_3_to_polyhedron_3(const Triangulation_3& T,Polyhedron_3& P){

--- a/Convex_hull_3/package_info/Convex_hull_3/dependencies
+++ b/Convex_hull_3/package_info/Convex_hull_3/dependencies
@@ -18,7 +18,6 @@ Kernel_23
 Modifier
 Modular_arithmetic
 Number_types
-Polyhedron
 Polyhedron_IO
 Profiling_tools
 Property_map

--- a/Convex_hull_3/package_info/Convex_hull_3/dependencies
+++ b/Convex_hull_3/package_info/Convex_hull_3/dependencies
@@ -15,10 +15,8 @@ Intersections_2
 Intersections_3
 Interval_support
 Kernel_23
-Modifier
 Modular_arithmetic
 Number_types
-Polyhedron_IO
 Profiling_tools
 Property_map
 QP_solver

--- a/Convex_hull_3/test/Convex_hull_3/convex_hull_traits_3_fp_bug.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/convex_hull_traits_3_fp_bug.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
 #include <CGAL/convex_hull_3.h>
 #include <fstream>
 #include <cassert>

--- a/Convex_hull_3/test/Convex_hull_3/quickhull_degenerate_test_3.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/quickhull_degenerate_test_3.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
+#include <CGAL/Polyhedron_3.h>
 
 #include <fstream>
 #include <vector>

--- a/Convex_hull_3/test/Convex_hull_3/quickhull_test_3.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/quickhull_test_3.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Cartesian.h>
+#include <CGAL/Polyhedron_3.h>
 
 #include <CGAL/Convex_hull_traits_3.h>
 #include <CGAL/convex_hull_3.h>

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_default.h
@@ -29,6 +29,8 @@
 #include <CGAL/HalfedgeDS_items_2.h>
 #include <CGAL/HalfedgeDS_list.h>
 #include <CGAL/memory.h>
+#include <CGAL/boost/graph/graph_traits_HalfedgeDS_default.h>
+
 
 namespace CGAL {
 

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_items_2.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_items_2.h
@@ -47,7 +47,24 @@ public:
         typedef HalfedgeDS_face_base< Refs>                    Face;
     };
 };
+  
+class HalfedgeDS_items_3 {
+public:
+    template < class Refs, class Traits>
+    struct Vertex_wrapper {
+        typedef typename Traits::Point_3 Point;
+        typedef HalfedgeDS_vertex_base< Refs, Tag_true, Point> Vertex;
+    };
+    template < class Refs, class Traits>
+    struct Halfedge_wrapper {
+        typedef HalfedgeDS_halfedge_base< Refs>                Halfedge;
+    };
+    template < class Refs, class Traits>
+    struct Face_wrapper {
+        typedef HalfedgeDS_face_base< Refs>                    Face;
 
+    };
+};
 } //namespace CGAL
 #endif // CGAL_HALFEDGEDS_ITEMS_2_H //
 // EOF //

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
@@ -137,9 +137,9 @@ public:
     typedef typename Halfedge_list::const_iterator     Halfedge_const_iterator;
 
     typedef N_step_adaptor_derived<Halfedge_iterator, 2>
-                                                  Edge_iterator;
+                                                       Edge_iterator;
     typedef N_step_adaptor_derived<Halfedge_const_iterator, 2>
-                                                  Edge_const_iterator;
+                                                       Edge_const_iterator;
   
     typedef In_place_list<Face,false,Face_allocator>   Face_list;
     typedef typename Face_list::iterator               Face_handle;

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
@@ -30,6 +30,7 @@
 #include <CGAL/HalfedgeDS_items_decorator.h>
 #include <CGAL/memory.h>
 #include <CGAL/Unique_hash_map.h>
+#include <CGAL/N_step_adaptor_derived.h>
 #include <cstddef>
 
 namespace CGAL {
@@ -135,6 +136,11 @@ public:
     typedef typename Halfedge_list::iterator           Halfedge_iterator;
     typedef typename Halfedge_list::const_iterator     Halfedge_const_iterator;
 
+    typedef N_step_adaptor_derived<Halfedge_iterator, 2>
+                                                  Edge_iterator;
+    typedef N_step_adaptor_derived<Halfedge_const_iterator, 2>
+                                                  Edge_const_iterator;
+  
     typedef In_place_list<Face,false,Face_allocator>   Face_list;
     typedef typename Face_list::iterator               Face_handle;
     typedef typename Face_list::const_iterator         Face_const_handle;

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_vector.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_vector.h
@@ -32,6 +32,7 @@
 #include <CGAL/basic.h>
 #include <CGAL/memory.h>
 #include <CGAL/HalfedgeDS_items_decorator.h>
+#include <CGAL/N_step_adaptor_derived.h>
 #include <algorithm>
 #include <vector>
 #include <map>
@@ -75,7 +76,7 @@ public:
     typedef typename Face_alloc_rebind::other          Face_allocator;
 
 #ifdef CGAL__HALFEDGEDS_USE_INTERNAL_VECTOR
-    typedef internal::vector<Vertex, Vertex_allocator>    Vertex_vector;
+    typedef internal::vector<Vertex, Vertex_allocator> Vertex_vector;
     typedef typename Vertex_vector::iterator           Vertex_I;
     typedef typename Vertex_vector::const_iterator     Vertex_CI;
     typedef typename Vertex_vector::iterator           Vertex_iterator;
@@ -87,7 +88,12 @@ public:
     typedef typename Halfedge_vector::iterator         Halfedge_iterator;
     typedef typename Halfedge_vector::const_iterator   Halfedge_const_iterator;
 
-    typedef internal::vector<Face, Face_allocator>        Face_vector;
+    typedef N_step_adaptor_derived<Halfedge_iterator, 2>
+                                                       Edge_iterator;
+    typedef N_step_adaptor_derived<Halfedge_const_iterator, 2>
+                                                       Edge_const_iterator;
+  
+    typedef internal::vector<Face, Face_allocator>     Face_vector;
     typedef typename Face_vector::iterator             Face_I;
     typedef typename Face_vector::const_iterator       Face_CI;
     typedef typename Face_vector::iterator             Face_iterator;

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -179,7 +179,6 @@ public:
   typedef CGAL::Prevent_deref<typename HDS::Halfedge_iterator>   halfedge_iterator;
 
 
-
   typedef boost::transform_iterator<
     internal::Construct_edge<typename HDS::Halfedge_handle>,
     edge_iterator_i,

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -1,3 +1,23 @@
+// Copyright (c) 20018  GeometryFactory (France).  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0+
+//
+//
+// Author(s)     : Andreas Fabri
+
 #ifndef CGAL_GRAPH_TRAITS_HALFEDGEDS_DEFAULT_H
 #define CGAL_GRAPH_TRAITS_HALFEDGEDS_DEFAULT_H
 

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -1,0 +1,507 @@
+#ifndef CGAL_GRAPH_TRAITS_HALFEDGEDS_DEFAULT_H
+#define CGAL_GRAPH_TRAITS_HALFEDGEDS_DEFAULT_H
+
+#include <CGAL/boost/graph/graph_traits_HalfedgeDS.h>
+#include <CGAL/Iterator_range.h>
+#include <CGAL/HalfedgeDS_decorator.h>
+
+namespace CGAL {
+
+template <class Traits_, class HalfedgeDSItems, 
+          class Alloc>
+class HalfedgeDS_default;
+}; // namespace CGAL
+
+namespace boost {
+
+  
+
+template<class T, class I, class A>
+struct graph_traits< CGAL::HalfedgeDS_default<T,I,A> >
+   : CGAL::HDS_graph_traits< CGAL::HalfedgeDS_default<T,I,A> >
+{
+  typedef typename T::Point_3 vertex_property_type;
+};
+
+template<class T, class I, class A>
+struct graph_traits< CGAL::HalfedgeDS_default<T,I,A> const >
+   : CGAL::HDS_graph_traits< CGAL::HalfedgeDS_default<T,I,A> > // See NOTE above!
+{};
+
+} // namespace boost
+
+namespace CGAL {
+  
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertices_size_type
+num_vertices(const HalfedgeDS_default<T,I,A>& p)
+{
+  return p.size_of_vertices();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edges_size_type
+num_edges(const HalfedgeDS_default<T,I,A>& p)
+{
+  return p.size_of_halfedges() / 2;
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::degree_size_type
+degree(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor v
+       , const HalfedgeDS_default<T,I,A>&)
+{
+  return v->vertex_degree();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::degree_size_type
+out_degree(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor v
+           , const HalfedgeDS_default<T,I,A>&)
+{
+  return v->vertex_degree();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::degree_size_type
+in_degree(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor v
+          , const HalfedgeDS_default<T,I,A>&)
+{
+  return v->vertex_degree();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::degree_size_type
+degree(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::face_descriptor f
+       , const HalfedgeDS_default<T,I,A>&)
+{
+  return f->facet_degree();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor
+source(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_descriptor e
+       , const HalfedgeDS_default<T,I,A> & )
+{
+  return e.halfedge()->opposite()->vertex();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor
+target(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_descriptor e
+       , const HalfedgeDS_default<T,I,A> & )
+{
+  return e.halfedge()->vertex();
+}
+
+template<class T, class I, class A>
+std::pair<
+  typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_descriptor
+  , bool>
+edge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor u
+     , typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor v
+     , const HalfedgeDS_default<T,I,A> &)
+{
+  typedef HalfedgeDS_default<T,I,A> P;
+  typedef boost::graph_traits< P > Traits;
+  typedef typename Traits::halfedge_descriptor halfedge_descriptor;
+    typedef typename Traits::edge_descriptor edge;
+
+  // circulate around the inedges of u
+  halfedge_descriptor c(u->halfedge()), d(u->halfedge());
+  if(c != halfedge_descriptor()) {
+    do {
+      if(c->opposite()->vertex() == v) {
+        return std::make_pair(edge(c->opposite()), true);
+      }
+      c = c->next()->opposite();
+    } while (c != d);
+  }
+
+  return std::make_pair(edge(), false);
+}
+
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_iterator>
+vertices( const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_iterator Iter;
+  HalfedgeDS_default<T,I,A>& ncp = const_cast<HalfedgeDS_default<T,I,A>&>(p);
+  return make_range( Iter(ncp.vertices_begin()), Iter(ncp.vertices_end()) );
+}
+
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_iterator>
+edges( const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_iterator_i Iter_i;
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edge_iterator Iter;
+  HalfedgeDS_default<T,I,A>& ncp = const_cast<HalfedgeDS_default<T,I,A>&>(p);
+  return make_range( Iter(Iter_i(ncp.halfedges_begin())), Iter(Iter_i(ncp.halfedges_end()) ));
+}
+
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::in_edge_iterator>
+in_edges( typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor u
+          , const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::in_edge_iterator Iter;
+  return make_range(Iter(halfedge(u,p),p), Iter(halfedge(u,p),p,1));
+}
+
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::out_edge_iterator>
+out_edges( typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor u
+           , const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::out_edge_iterator Iter;
+  return make_range(Iter(halfedge(u,p),p), Iter(halfedge(u,p),p,1));
+}
+
+//
+// MutableHalfedgeGraph
+// 
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor
+add_vertex(HalfedgeDS_default<T,I,A>& g)
+{
+  return g.vertices_push_back(typename HalfedgeDS_default<T,I,A>::Vertex());
+}
+
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor
+add_vertex(const typename boost::graph_traits<HalfedgeDS_default<T,I,A> >::vertex_property_type& p
+           , HalfedgeDS_default<T,I,A>& g)
+{
+  return g.vertices_push_back(typename HalfedgeDS_default<T,I,A>::Vertex(p));
+}
+
+template<class T, class I, class A>
+void
+remove_vertex(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor v
+             , HalfedgeDS_default<T,I,A>& g)
+{
+  g.vertices_erase(v);
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor
+add_edge(HalfedgeDS_default<T,I,A>& g)
+{ 
+  return typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor(
+    g.edges_push_back(typename HalfedgeDS_default<T,I,A>::Halfedge(), 
+                            typename HalfedgeDS_default<T,I,A>::Halfedge()));
+}
+
+template<class T, class I, class A>
+void
+remove_edge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor e
+            , HalfedgeDS_default<T,I,A>& g)
+{
+  g.edges_erase(e.halfedge());
+}
+
+
+template<class T, class I, class A>
+void
+set_target(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h1
+         , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor v
+         , HalfedgeDS_default<T,I,A>&)
+{
+  // set_face has become private in the halfedge provided by
+  // polyhedron for unknown reasons, although it used to be public
+  // once.
+
+  // We sneak in anyway. Inheritance can't keep us out.
+  typedef typename HalfedgeDS_default<T,I,A>::Halfedge::Base Sneak;
+  static_cast<Sneak&>(*h1).set_vertex(v);
+}
+
+template<class T, class I, class A>
+void
+set_next(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h1
+         , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h2
+         , HalfedgeDS_default<T,I,A>&)
+{
+  typedef typename HalfedgeDS_default<T,I,A>::Halfedge::Base Sneak;
+  static_cast<Sneak&>(*h1).set_next(h2);
+  static_cast<Sneak&>(*h2).set_prev(h1);
+}
+
+//
+// MutableFaceGraph 
+//
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor
+add_face(HalfedgeDS_default<T,I,A>& g)
+{
+  return g.faces_push_back(typename HalfedgeDS_default<T,I,A>::Face());
+}
+
+template<class T, class I, class A, class InputIterator>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor
+add_face(InputIterator begin, InputIterator end, HalfedgeDS_default<T,I,A>& g)
+{
+  return g.add_facet(begin, end);
+}
+
+template<class T, class I, class A>
+void
+remove_face(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor f
+            , HalfedgeDS_default<T,I,A>& g) 
+{
+  g.faces_erase(f);
+}
+
+template<class T, class I, class A>
+void
+set_face(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+  , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor f
+  , const HalfedgeDS_default<T,I,A>&)
+{
+  // set_face has become private in the halfedge provided by
+  // polyhedron for unknown reasons, although it used to be public
+  // once.
+
+  // We sneak in anyway. Inheritance can't keep us out.
+  typedef typename HalfedgeDS_default<T,I,A>::Halfedge::Base Sneak;
+  static_cast<Sneak&>(*h).set_face(f);
+}
+
+template<class T, class I, class A>
+void
+set_halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor f
+  , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+  , HalfedgeDS_default<T,I,A>& g)
+{
+  typedef typename HalfedgeDS_default<T,I,A> Hds;
+  CGAL::HalfedgeDS_decorator<Hds> D(g);
+  D.set_face_halfedge(f, h);
+}
+
+template<class T, class I, class A>
+void
+set_halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor v
+  , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+  , const HalfedgeDS_default<T,I,A>&)
+{
+  typedef typename HalfedgeDS_default<T,I,A>::Vertex::Base Sneak;
+  static_cast<Sneak&>(*v).set_halfedge(h);
+}
+
+
+//
+// HalfedgeGraph
+//
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor
+edge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+     , const HalfedgeDS_default<T,I,A>&)
+{ 
+  return typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor(h);
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor e
+         , const HalfedgeDS_default<T,I,A>&)
+{ 
+  return e.halfedge();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor v
+         , const HalfedgeDS_default<T,I,A>&)
+{ 
+  return v->halfedge();
+}
+
+template<class T, class I, class A>
+std::pair< typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+           , bool>
+halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor u
+         , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor v
+         , const HalfedgeDS_default<T,I,A>& g)
+{ 
+  std::pair< typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::edge_descriptor
+             , bool> e = edge(u, v, g);
+  return std::make_pair(e.first.halfedge(), e.second);
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+opposite(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+         , const HalfedgeDS_default<T,I,A>&)
+{
+  return h->opposite();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor
+source(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+         , const HalfedgeDS_default<T,I,A>& g)
+{
+  return target(opposite(h, g), g);
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::vertex_descriptor
+target(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+         , const HalfedgeDS_default<T,I,A>&)
+{
+  return h->vertex();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+next(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor outedge
+     , const HalfedgeDS_default<T,I,A>&)
+{
+  return outedge->next();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+prev(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor outedge
+     , const HalfedgeDS_default<T,I,A>&)
+{
+  return outedge->prev();
+}
+
+
+//
+// HalfedgeListGraph
+//
+
+template<class T, class I, class A>
+Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_iterator>
+halfedges(const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_iterator Iter;
+  HalfedgeDS_default<T,I,A>& ncp = const_cast<HalfedgeDS_default<T,I,A>&>(p);
+  return make_range(Iter(ncp.halfedges_begin()), Iter(ncp.halfedges_end()));
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedges_size_type
+num_halfedges(const HalfedgeDS_default<T,I,A>& p)
+{
+  return p.size_of_halfedges();
+}
+
+// FaceGraph
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor
+face(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
+     , const HalfedgeDS_default<T,I,A>&) 
+{
+  return h->face();
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor
+halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_descriptor f
+         , const HalfedgeDS_default<T,I,A>&) 
+{
+  return f->halfedge();
+}
+
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::face_iterator >
+faces(const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::face_iterator face_iterator;
+  HalfedgeDS_default<T,I,A>& ncp = const_cast<HalfedgeDS_default<T,I,A>&>(p);
+  return make_range( face_iterator(ncp.faces_begin()), face_iterator(ncp.faces_end()));
+}
+
+template<class T, class I, class A>
+typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::faces_size_type
+num_faces(const HalfedgeDS_default<T,I,A>& p)
+{
+  return p.size_of_faces();
+}
+namespace internal {
+
+template<typename Handle, typename ValueType, typename Reference>
+struct HDS_Point_accessor
+  : boost::put_get_helper< Reference, HDS_Point_accessor<Handle, ValueType, Reference> >
+{
+  typedef boost::lvalue_property_map_tag category;
+  typedef Reference                      reference;
+  typedef ValueType                      value_type;
+  typedef Handle                         key_type;
+
+  reference operator[](Handle h) const { return h->point(); }
+};
+
+} // namespace internal
+
+template <class T>
+struct HDS_property_map;
+  
+template <>
+struct HDS_property_map<vertex_point_t>
+{
+  template<class T, class I, class A>
+  struct bind_
+  {
+    typedef internal::HDS_Point_accessor<
+      typename boost::graph_traits<
+        HalfedgeDS_default<T, I, A>
+        >::vertex_descriptor,
+      typename T::Point_3, typename T::Point_3&> type;
+
+    typedef internal::HDS_Point_accessor<
+      typename boost::graph_traits<
+        HalfedgeDS_default<T, I, A>
+        >::vertex_descriptor,
+      typename T::Point_3, const typename T::Point_3&> const_type;
+  };
+};
+  
+}// namespace CGAL
+namespace boost {
+
+// property_map dispatcher into Polyhedron
+template<class T, class I, class A, class Tag>
+struct property_map<CGAL::HalfedgeDS_default<T,I,A>, Tag>
+{
+  typedef typename CGAL::HDS_property_map<Tag>::
+      template bind_<T,I,A> map_gen;
+  typedef typename map_gen::type       type;
+  typedef typename map_gen::const_type const_type;
+};
+
+// property_map dispatcher into const Polyhedron
+template<class T, class I, class A, class Tag>
+struct property_map<const CGAL::HalfedgeDS_default<T,I,A>, Tag>
+{
+  typedef typename CGAL::HDS_property_map<Tag>::
+      template bind_<T,I,A> map_gen;
+  typedef typename map_gen::type       type;
+  typedef typename map_gen::const_type const_type;
+};
+
+} // namespace boost
+
+namespace CGAL {
+
+// generalized 2-ary get functions
+template<class Gt, class I, class A, class PropertyTag>
+typename boost::property_map< CGAL::HalfedgeDS_default<Gt,I,A>, PropertyTag >::const_type
+get(PropertyTag, CGAL::HalfedgeDS_default<Gt,I,A> const&)
+{ return typename boost::property_map< CGAL::HalfedgeDS_default<Gt,I,A>, PropertyTag >::const_type(); }
+
+template<class Gt, class I, class A, class PropertyTag>
+typename boost::property_map< CGAL::HalfedgeDS_default<Gt,I,A>, PropertyTag >::type
+get(PropertyTag, CGAL::HalfedgeDS_default<Gt,I,A>&)
+{ return typename boost::property_map< CGAL::HalfedgeDS_default<Gt,I,A>, PropertyTag >::type(); }
+
+
+} // namespace CGAL
+#endif

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -278,7 +278,7 @@ set_halfedge(typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::face_des
   , typename boost::graph_traits< HalfedgeDS_default<T,I,A> >::halfedge_descriptor h
   , HalfedgeDS_default<T,I,A>& g)
 {
-  typedef typename HalfedgeDS_default<T,I,A> Hds;
+  typedef HalfedgeDS_default<T,I,A> Hds;
   CGAL::HalfedgeDS_decorator<Hds> D(g);
   D.set_face_halfedge(f, h);
 }

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -1,4 +1,4 @@
-// Copyright (c) 20018  GeometryFactory (France).  All rights reserved.
+// Copyright (c) 2018  GeometryFactory (France).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org); you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public License as

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -4,6 +4,7 @@
 #include <CGAL/boost/graph/graph_traits_HalfedgeDS.h>
 #include <CGAL/Iterator_range.h>
 #include <CGAL/HalfedgeDS_decorator.h>
+#include <CGAL/HalfedgeDS_default.h>
 
 namespace CGAL {
 

--- a/HalfedgeDS/package_info/HalfedgeDS/dependencies
+++ b/HalfedgeDS/package_info/HalfedgeDS/dependencies
@@ -1,4 +1,5 @@
 Algebraic_foundations
+BGL
 Circulator
 HalfedgeDS
 Hash_map
@@ -8,5 +9,6 @@ Kernel_23
 Modular_arithmetic
 Number_types
 Profiling_tools
+Property_map
 STL_Extension
 Stream_support

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -57,8 +57,8 @@ Release date: April 2018
 
 ### 3D Convex Hull
 
--   **Breaking change**: The header <CGAL/convex_hull_3.h> no longer
-    includes <CGAL/Polyhedron_3.h>, as the convex hull function works
+-   **Breaking change**: The header `<CGAL/convex_hull_3.h>` no longer
+    includes `<CGAL/Polyhedron_3.h>`, as the convex hull function works
     with any model of the concept `MutableFaceGraph`.
 
 ### 2D Arrangements

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -54,6 +54,13 @@ Release date: April 2018
     will have to keep using the source code available in CGAL-4.11 or
     earlier.
 
+
+### 3D Convex Hull
+
+-   **Breaking change**: The header <CGAL/convex_hull_3.h> no longer
+    includes <CGAL/Polyhedron_3.h>, as the convex hull function works
+    with any model of the concept `MutableFaceGraph`.
+
 ### 2D Arrangements
 
 -   When removing an edge from an arrangement and the user has requested to

--- a/Installation/include/CGAL/Polyhedron_3_fwd.h
+++ b/Installation/include/CGAL/Polyhedron_3_fwd.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2018  GeometryFactory Sarl
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0+
+//
+
+#ifndef CGAL_POLYHEDRON_3_FWD_H
+#define CGAL_POLYHEDRON_3_FWD_H
+
+#include <CGAL/memory.h>
+
+/// \file Polyhedron_3_fwd.h
+/// Forward declarations of the Polyhedron_3 package.
+
+#ifndef DOXYGEN_RUNNING
+namespace CGAL {
+
+  class Polyhedron_items_3;
+
+  template < class T, class I, class A>
+  class HalfedgeDS_default;
+
+  template < class PolyhedronTraits_3,
+             class PolyhedronItems_3 = Polyhedron_items_3,
+             template < class T, class I, class A>
+             class T_HDS = HalfedgeDS_default, 
+             class Alloc = CGAL_ALLOCATOR(int)
+             >
+  class Polyhedron_3;
+  
+} // CGAL
+#endif
+
+#endif /* CGAL_POLYHEDRON_3_FWD_H */
+
+

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Voronoi_covariance_3/voronoi_covariance_3.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Voronoi_covariance_3/voronoi_covariance_3.h
@@ -37,6 +37,8 @@
 #include <CGAL/Convex_hull_3/dual/halfspace_intersection_3.h>
 #endif
 
+#include <CGAL/HalfedgeDS_default.h>
+
 /// \cond SKIP_IN_MANUAL
 
 namespace CGAL {
@@ -144,7 +146,7 @@ namespace CGAL {
                     typedef typename K::Plane_3 Plane;
                     typedef typename K::Point_3 Point;
                     typedef typename K::Vector_3 Vector;
-                    typedef typename CGAL::Convex_hull_traits_3<K> Traits;
+                    typedef typename CGAL::Convex_hull_traits_3<K, HalfedgeDS_default<K,HalfedgeDS_items_3> > Traits;
                     typedef typename Traits::Polygon_mesh Polyhedron;
 
                     std::list<Vertex_handle> vertices;
@@ -176,16 +178,15 @@ namespace CGAL {
                        boost::make_optional(Point(CGAL::ORIGIN)));
 
                     // apply f to the triangles on the boundary of P
-                    for (typename Polyhedron::Facet_iterator it = P.facets_begin();
-                         it != P.facets_end(); ++it)
+                    BOOST_FOREACH(typename boost::graph_traits<Polyhedron>::face_descriptor fd, faces(P))
                     {
-                        typename Polyhedron::Halfedge_around_facet_circulator
-                            h0 = it->facet_begin(), hf = h0--, hs = cpp11::next(hf);
+                      Halfedge_around_face_circulator<Polyhedron>
+                        h0(halfedge(fd,P),P), hf = h0--, hs = cpp11::next(hf);
 
                         while(hs != h0)
                         {
-                            f (h0->vertex()->point(), hf->vertex()->point(),
-                               hs->vertex()->point());
+                          f ((*h0)->vertex()->point(), (*hf)->vertex()->point(),
+                             (*hs)->vertex()->point());
                             ++hs; ++hf;
                         }
                     }

--- a/Point_set_processing_3/package_info/Point_set_processing_3/dependencies
+++ b/Point_set_processing_3/package_info/Point_set_processing_3/dependencies
@@ -9,7 +9,6 @@ Distance_2
 Distance_3
 Filtered_kernel
 Generator
-HalfedgeDS
 Hash_map
 Installation
 Intersections_2
@@ -18,14 +17,11 @@ Interval_support
 Jet_fitting_3
 Kernel_23
 Kernel_d
-Modifier
 Modular_arithmetic
 Number_types
 Point_set_2
 Point_set_processing_3
 Polygon
-Polyhedron
-Polyhedron_IO
 Principal_component_analysis
 Principal_component_analysis_LGPL
 Profiling_tools

--- a/Point_set_processing_3/test/Point_set_processing_3/normal_estimation_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/normal_estimation_test.cpp
@@ -9,9 +9,6 @@
 //----------------------------------------------------------
 // normal_estimation_test points1.xyz points2.xyz...
 
-// With iterator debugging this testsuite takes to long and the process gets killed
-//#define _HAS_ITERATOR_DEBUGGING 0
-
 // CGAL
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Timer.h>

--- a/Polyhedron/include/CGAL/Polyhedron_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3.h
@@ -24,7 +24,7 @@
 
 #include <CGAL/license/Polyhedron.h>
 
-
+#include <CGAL/Polyhedron_3_fwd.h>
 #include <CGAL/basic.h>
 #include <algorithm>
 #include <cstddef>
@@ -465,10 +465,10 @@ public:
 
 
 template < class PolyhedronTraits_3,
-           class PolyhedronItems_3 = Polyhedron_items_3,
+           class PolyhedronItems_3,
            template < class T, class I, class A>
-           class T_HDS = HalfedgeDS_default,
-           class Alloc = CGAL_ALLOCATOR(int)>
+           class T_HDS,
+           class Alloc>
 class Polyhedron_3 {
     //
     // DEFINITION
@@ -553,11 +553,15 @@ public:
     typedef Iterator_project<Face_const_iterator, Proj_plane,
         const Plane_3&, const Plane_3*>           Plane_const_iterator;
 
+  typedef typename HDS::Edge_iterator Edge_iterator;
+    typedef typename HDS::Edge_const_iterator Edge_const_iterator;
+  /*
     typedef N_step_adaptor_derived<Halfedge_iterator, 2>
                                                   Edge_iterator;
     typedef N_step_adaptor_derived<Halfedge_const_iterator, 2>
                                                   Edge_const_iterator;
-
+  */
+  
     // All face related types get a related facet type name.
     typedef Face                                  Facet;
     typedef Face_handle                           Facet_handle;


### PR DESCRIPTION

## Summary of Changes

- The halfspace intersection function now uses `HalfedgeDS_default` instead of  `Polyhedron_3` internally.
- In order to use the convex hull functions with `Polyhedron_3` as default, the user is in charge to include the header file.

## Release Management

* Affected package(s): Convex_hull_3

