### PR TITLE
Ridges_3: Remove dependency on Bounding_volumes

### DIFF
--- a/Ridges_3/include/CGAL/Ridges.h
+++ b/Ridges_3/include/CGAL/Ridges.h
@@ -28,8 +28,6 @@
 #include <map>
 
 #include <CGAL/basic.h>
-#include <CGAL/Min_sphere_d.h>
-#include <CGAL/Optimisation_d_traits_3.h>
 #include <CGAL/barycenter.h>
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/assertions.h>
@@ -356,11 +354,15 @@ Ridge_approximation(const TriangleMesh &p,
   BOOST_FOREACH(vertex_descriptor v, vertices(p)){
     points.push_back(get(vpm,v));
   }
-  
-  CGAL::Min_sphere_d<CGAL::Optimisation_d_traits_3<Kernel> > 
-    min_sphere(points.begin(), points.end());
-  squared_model_size = min_sphere.squared_radius();
-  //maybe better to use CGAL::Min_sphere_of_spheres_d ?? but need to create spheres?
+
+  Bbox_3 bb = bbox_3(points.begin(), points.end());
+  double width = bb.xmax() - bb.xmin();
+  double yw =  bb.ymax() - bb.ymin();
+  width = (std::max)(width,yw);
+  double zw =  bb.zmax() - bb.zmin();
+  width = (std::max)(width,zw);
+           
+  squared_model_size = (width*width)/4.0 ;
 
   tag_order = Ridge_order_3;
 }

--- a/Ridges_3/include/CGAL/Ridges.h
+++ b/Ridges_3/include/CGAL/Ridges.h
@@ -33,6 +33,7 @@
 #include <CGAL/assertions.h>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/foreach.hpp>
+#include <CGAL/Bbox_3.h>
 
 namespace CGAL {
  

--- a/Ridges_3/package_info/Ridges_3/dependencies
+++ b/Ridges_3/package_info/Ridges_3/dependencies
@@ -1,13 +1,11 @@
 Algebraic_foundations
 BGL
-Bounding_volumes
 Circulator
 Installation
 Interval_support
 Kernel_23
 Modular_arithmetic
 Number_types
-Optimisation_basic
 Principal_component_analysis_LGPL
 Profiling_tools
 Property_map


### PR DESCRIPTION
## Summary of Changes

Replace the estimation of the size of the domain with a bbox instead of  the smallest enclosing sphere. (ok given by @pougetma)

## Release Management

* Affected package(s): Ridges_3

