### PR TITLE
Fix clang 6.0 warnings

### DIFF
--- a/Algebraic_foundations/include/CGAL/Test/_test_algebraic_structure.h
+++ b/Algebraic_foundations/include/CGAL/Test/_test_algebraic_structure.h
@@ -922,18 +922,20 @@ void test_algebraic_structure(){
         w[0]= AS (10);
         w[1]= AS (-8);
         w[2]= AS (-2);
-        std::pair<int,int> equal_pair(0,0);
-        // functor
-        // find_only_equal_pair is not yet implemented
-//        equal_pair = find_only_equal_pair(v.begin(),v.end(),
+
+//      functor
+//      find_only_equal_pair is not yet implemented
+//      std::pair<int,int> equal_pair(0,0);
+//
+//      equal_pair = find_only_equal_pair(v.begin(),v.end(),
 //                                          w.begin(),w.end());
-//        assert(1 == equal_pair.first);
-//        assert(2 == equal_pair.second);
+//      assert(1 == equal_pair.first);
+//      assert(2 == equal_pair.second);
         //function
-//        equal_pair = NiX::find_only_equal_pair(v.begin(),v.end(),
+//      equal_pair = NiX::find_only_equal_pair(v.begin(),v.end(),
 //                                               w.begin(),w.end());
-//        assert(1 == equal_pair.first);
-//        assert(2 == equal_pair.second);
+//      assert(1 == equal_pair.first);
+//      assert(2 == equal_pair.second);
         
     } 
 }

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
@@ -2857,7 +2857,6 @@ protected:
         // run over all event points within the joint x-range of two arcs
         // looking whether a particular event is made of both curves, i.e.,
         // grabbing all 2-curve events
-        std::pair<int, int> ipair;
         int arcno1, arcno2, mult;
 
         typename CGAL::Polynomial_traits_d<

--- a/STL_Extension/test/STL_Extension/test_namespaces.cpp
+++ b/STL_Extension/test/STL_Extension/test_namespaces.cpp
@@ -8,6 +8,7 @@
 #include <CGAL/array.h>
 #include <CGAL/tuple.h>
 #include <CGAL/algorithm.h>
+#include <CGAL/use.h>
 
 int main()
 {
@@ -17,9 +18,13 @@ int main()
   CGAL::cpp0x::tuple<double, int> tuple;
   CGAL::cpp11::tuple<double, int> tuple2;
 
+  CGAL_USE(tuple);
+  CGAL_USE(tuple2);
+
 #ifndef CGAL_NO_DEPRECATED_CODE
   CGAL::copy_n(arr.begin(), 3, arr2.begin());
 #endif // not CGAL_NO_DEPRECATED_CODE
+  
   CGAL::cpp0x::copy_n(arr.begin(), 3, arr2.begin());
   CGAL::cpp11::copy_n(arr.begin(), 3, arr2.begin());
   

--- a/Skin_surface_3/test/Skin_surface_3/subdivision_test.cpp
+++ b/Skin_surface_3/test/Skin_surface_3/subdivision_test.cpp
@@ -56,11 +56,7 @@ public:
   {
     std::cout << filename << std::endl;
 
-    Skin_surface_3 skin_surface = create_skin_surface(filename, .5);
-
-    Polyhedron p;
-    //construct_and_subdivide_mesh(skin_surface, p);
-    //p.clear();
+    Skin_surface_3 skin_surface = create_skin_surface(filename, s);
 
     Polyhedron_skin p_skin;
     construct_and_subdivide_mesh(skin_surface, p_skin);


### PR DESCRIPTION
## Release Management

* Affected package(s): Arrangement_2, STL_Extensions, Skin_surface, Algebraic_foundations
* Issue(s) solved (if any): fix #2970

