### PR TITLE
Documentation pure header-only, for CGAL-4.12

### DIFF
--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -336,14 +336,14 @@ cmake -DCGAL_HEADER_ONLY=ON . # configure \cgal
 
 and we do not need to run `make` anymore.
 
-\subsubsection subsection_headeronly_without_configuration Header-only without CMake configuration
+\subsubsection subsection_headeronly_without_configuration Header-only without CMake Configuration
 
 Since \cgal 4.12, \cgal can be used in header-only mode, without even
-configuring \cgal libraries. In this case, the program using \cgal
-(example, test, demo, etc.) must be directly configured using CMake. The
-variable `CGAL_DIR` must point to the root directory of the CGAL source
-code (either the root of the unpacked release tarball, or the root of the
-Git repository).
+configuring \cgal\. The program using \cgal (example, test, demo, etc.)
+must be directly configured using CMake in any case, but then \cgal will be
+configured at the same time. The variable `CGAL_DIR` must point to the root
+directory of the \cgal source code (either the root of the unpacked release
+tarball, or the root of the Git working directory).
 
 So, using \cgal becomes now:
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -325,7 +325,7 @@ variable `BUILD_SHARED_LIBS` to `FALSE`. If you use
 
 \subsubsection subsection_headeronly_withconfiguration Header-only with CMake Configuration
 
-Since \cgal 4.9, \cgal can be used in headers only mode, i.e. without compiling the \cgal libraries and linking with these libraries when compiling examples, tests and demos. This possibility can be enabled by setting the value of the CMake variable `CGAL_HEADER_ONLY` to `ON`. CMake version 3.0.0 or higher is required to use this option.
+Since \cgal 4.9, \cgal can be used in header-only mode, i.e. without compiling the \cgal libraries and linking with these libraries when compiling examples, tests and demos. This possibility can be enabled by setting the value of the CMake variable `CGAL_HEADER_ONLY` to `ON`. CMake version 3.0.0 or higher is required to use this option.
 
 One advantage of using \cgal in header-only mode is that you do not need to compile and install \cgal libraries before compiling a given example or demo. Note that even in header-only mode we still need to run CMake on \cgal in order to generate different configuration files. So, setting up \cgal becomes now:
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -354,7 +354,7 @@ cmake -DCGAL_DIR=<CGAL-root> .
 
 \subsubsection subsection_headeronly_dependencies CGAL Dependencies
 
-\cgal can be used as a header-only library, but no all its dependencies are
+\cgal can be used as a header-only library, but not all its dependencies are
 header-only. The libraries \sc{Gmp} and \sc{Mpfr}, for example, are not
 header-only.
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -354,8 +354,8 @@ cmake -DCGAL_DIR=<CGAL-root> .
 
 \subsubsection subsection_headeronly_dependencies CGAL Dependencies
 
-\cgal can be used as a header-only library, but not all its dependencies are
-header-only. The libraries \sc{Gmp} and \sc{Mpfr}, for example, are not
+\cgal can be used as a header-only library, though not all its dependencies
+are header-only. The libraries \sc{Gmp} and \sc{Mpfr}, for example, are not
 header-only.
 
 \subsubsection subsection_headeronly_pbonwindows Possible Problem on Windows

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -339,8 +339,8 @@ and we do not need to run `make` anymore.
 \subsubsection subsection_headeronly_without_configuration Header-only without CMake Configuration
 
 Since \cgal 4.12, \cgal can be used in header-only mode, without even
-configuring \cgal\. The program using \cgal (example, test, demo, etc.)
-must be directly configured using CMake in any case, but then \cgal will be
+configuring \cgal\. Program using \cgal (example, test, demo, etc.)
+must be directly configured using CMake, and \cgal will be
 configured at the same time. The variable `CGAL_DIR` must point to the root
 directory of the \cgal source code (either the root of the unpacked release
 tarball, or the root of the Git working directory).

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -352,6 +352,12 @@ cd /path/to/your/code # go to the directory of the code source using \cgal
 cmake -DCGAL_DIR=<CGAL-root> .
 </PRE>
 
+\subsubsection subsection_headeronly_dependencies CGAL Dependencies
+
+\cgal can be used as a header-only library, but no all its dependencies are
+header-only. The libraries \sc{Gmp} and \sc{Mpfr}, for example, are not
+header-only.
+
 \subsubsection subsection_headeronly_pbonwindows Possible Problem on Windows
 
 There is one possible problem when using \cgal in header-only mode on a Windows operating system when compiling a program using several modules (executable programs or dynamic-link libraries DLL). If two different modules use the same static variable, this variable is defined independently in each of these modules. If one module modifies the value of this variable, it will not be modified in the other module, which could induce an unexpected behavior. In \cgal, this concerns only a few specific variables: the <A HREF="https://doc.cgal.org/latest/Generator/classCGAL_1_1Random.html">default random</A>, the <A HREF="https://doc.cgal.org/latest/STL_Extension/group__PkgStlExtensionAssertions.html">failure behavior</A>, <A HREF="https://doc.cgal.org/latest/Stream_support/group__PkgIOstreams.html">IO mode</A>. One example is the following: if you change the default random in one DLL, then if you use the default random in another DLL, you will not obtain the modified default random but the original one.

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -321,7 +321,9 @@ can choose to produce static libraries instead by setting the CMake
 variable `BUILD_SHARED_LIBS` to `FALSE`. If you use
 `cmake-gui`, a tick box for that variable is available to set it.
 
-\subsection subsection_headeronly Header-only option
+\subsection subsection_headeronly Header-only Option
+
+\subsubsection subsection_headeronly_withconfiguration Header-only with CMake Configuration
 
 Since \cgal 4.9, \cgal can be used in headers only mode, i.e. without compiling the \cgal libraries and linking with these libraries when compiling examples, tests and demos. This possibility can be enabled by setting the value of the CMake variable `CGAL_HEADER_ONLY` to `ON`. CMake version 3.0.0 or higher is required to use this option.
 
@@ -333,6 +335,24 @@ cmake -DCGAL_HEADER_ONLY=ON . # configure \cgal
 </PRE>
 
 and we do not need to run `make` anymore.
+
+\subsubsection subsection_headeronly_without_configuration Header-only without CMake configuration
+
+Since \cgal 4.12, \cgal can be used in header-only mode, without even
+configuring \cgal libraries. In this case, the program using \cgal
+(example, test, demo, etc.) must be directly configured using CMake. The
+variable `CGAL_DIR` must point to the root directory of the CGAL source
+code (either the root of the unpacked release tarball, or the root of the
+Git repository).
+
+So, using \cgal becomes now:
+
+<PRE>
+cd /path/to/your/code # go to the directory of the code source using \cgal
+cmake -DCGAL_DIR=<CGAL-root> .
+</PRE>
+
+\subsubsection subsection_headeronly_pbonwindows Possible Problem on Windows
 
 There is one possible problem when using \cgal in header-only mode on a Windows operating system when compiling a program using several modules (executable programs or dynamic-link libraries DLL). If two different modules use the same static variable, this variable is defined independently in each of these modules. If one module modifies the value of this variable, it will not be modified in the other module, which could induce an unexpected behavior. In \cgal, this concerns only a few specific variables: the <A HREF="https://doc.cgal.org/latest/Generator/classCGAL_1_1Random.html">default random</A>, the <A HREF="https://doc.cgal.org/latest/STL_Extension/group__PkgStlExtensionAssertions.html">failure behavior</A>, <A HREF="https://doc.cgal.org/latest/Stream_support/group__PkgIOstreams.html">IO mode</A>. One example is the following: if you change the default random in one DLL, then if you use the default random in another DLL, you will not obtain the modified default random but the original one.
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -339,8 +339,8 @@ and we do not need to run `make` anymore.
 \subsubsection subsection_headeronly_without_configuration Header-only without CMake Configuration
 
 Since \cgal 4.12, \cgal can be used in header-only mode, without even
-configuring \cgal\. Program using \cgal (example, test, demo, etc.)
-must be directly configured using CMake, and \cgal will be
+configuring \cgal\. Programs using \cgal (examples, tests, demos, etc.)
+must be directly configured using CMake. In this case, \cgal will be
 configured at the same time. The variable `CGAL_DIR` must point to the root
 directory of the \cgal source code (either the root of the unpacked release
 tarball, or the root of the Git working directory).

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -27,7 +27,7 @@ Release date: April 2018
 ### Header-only mode
 
 - Since CGAL-4.9, it was possible to use CGAL by configuring it using
-  CMake, but without compiling the CGAL libraries. With CGAL-4.11, it is
+  CMake, but without compiling the CGAL libraries. With CGAL-4.12, it is
   now possible to use CGAL header-only, without even configuring it. CMake
   is then used only to configure programs using CGAL.
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -26,7 +26,7 @@ Release date: April 2018
 
 ### Header-only mode
 
-- Since CGAL-4.9, it was possible to use CGAL by configuring it using
+- Since CGAL-4.9, it has been possible to use CGAL by configuring it using
   CMake, but without compiling the CGAL libraries. With CGAL-4.12, it is
   now possible to use CGAL header-only, without even configuring it. CMake
   is then used only to configure programs using CGAL.

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -24,6 +24,13 @@ Release date: April 2018
     to `Release` manually, to avoid using CGAL libraries without any
     compile-time optimization.
 
+### Header-only mode
+
+- Since CGAL-4.9, it was possible to use CGAL by configuring it using
+  CMake, but without compiling the CGAL libraries. With CGAL-4.11, it is
+  now possible to use CGAL header-only, without even configuring it. CMake
+  is then used only to configure programs using CGAL.
+
 ### 2D Movable Separability of Sets (new package)
 
 -   A new package called "2D Movable Separability of Sets" has been

--- a/Maintenance/public_release/announcement/mailing-beta.eml
+++ b/Maintenance/public_release/announcement/mailing-beta.eml
@@ -1,14 +1,14 @@
-Subject: CGAL 4.12 Beta 1 Released, Computational Geometry Algorithms Library
+Subject: CGAL 4.12 Beta 2 Released, Computational Geometry Algorithms Library
 Content-Type: text/plain; charset="utf-8"
 Body: 
 
-The CGAL Open Source Project is pleased to announce the release 4.12 Beta 1
+The CGAL Open Source Project is pleased to announce the release 4.12 Beta 2
 of CGAL, the Computational Geometry Algorithms Library.
 
 
-CGAL version 4.12 Beta 1 is a public testing release. It should provide
+CGAL version 4.12 Beta 2 is a public testing release. It should provide
 a solid ground to report bugs that need to be tackled before the
-release of the final version of CGAL 4.12 in September.
+release of the final version of CGAL 4.12 in April.
 
 
 *WARNING*: This release features an important change of the CMake scripts
@@ -19,8 +19,19 @@ optimization. Please read the first paragraph of the release notes
 carefully.
 
 
+Note that, since the release CGAL-4.12 Beta 1, the header-only mode of CGAL
+has been modified, and documented.
+
+
 Besides fixes and general enhancement to existing packages, the following
 has changed since CGAL 4.11:
+
+
+Using CGAL Header-only
+
+- It is now possible to use CGAL without configuring it with CMake, as a
+  header-only library. Note that, even if CGAL is header-only, its
+  dependencies (such as GMP and MPFR) are not all header-only.
 
 
 2D Movable Separability of Sets (new package)
@@ -39,6 +50,7 @@ has changed since CGAL 4.11:
     orientations of the feasible molds and the corresponding motions
     needed to remove the casted object from the mold.
 
+
 Classification (new package)
 
 -   This package offers an algorithm that classifies a data set into a
@@ -46,6 +58,7 @@ Classification (new package)
     etc.). A flexible API is provided so that users can classify any
     type of data, compute their own local features on the input data
     set, and define their own labels.
+
 
 Kinetic Data Structures (removed package)
 


### PR DESCRIPTION
## Summary of Changes

Document pure header-only.

The new documentation is in the ["section 7.3 Header-only Option" of the installation manual][doc].

I have split that section into two:
- 7.3.1 Header-only with CMake Configuration
- 7.3.3 Possible Problem on Windows
and I have added:
- 7.3.2 Header-only without CMake configuration

[doc]: https://cgal.geometryfactory.com/~lrineau/Documentation-CMake_pure_header_only-GF/Manual/installation.html#subsection_headeronly

## Release Management

* Affected package(s): Doc
* Issue(s) solved (if any): fix #2656 

@CGAL/geometryfactory Please do a quick review. I want to merge this PR as soon as possible, before tomorrow evening.
