### PR TITLE
BGL: fix orientation of make_icosahedron()

### DIFF
--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -737,7 +737,7 @@ bool is_degenerate_triangle_face(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates a triangulated regular prism, cw oriented,
+ * \brief Creates a triangulated regular prism, outward oriented,
  * having `nb_vertices` vertices in each of its bases and adds it to the graph `g`.
  * If `center` is (0, 0, 0), then the first point of the prism is (`radius`, `height`, 0)
  * \param nb_vertices the number of vertices per base. It must be greater than or equal to 3.
@@ -831,7 +831,7 @@ make_regular_prism(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates a pyramid, cw oriented, having `nb_vertices` vertices in its base and adds it to the graph `g`.
+ * \brief Creates a pyramid, outward oriented, having `nb_vertices` vertices in its base and adds it to the graph `g`.
  *
  * If `center` is (0, 0, 0), then the first point of the base is (`radius`, 0`, 0)
  * \param nb_vertices the number of vertices in the base. It must be greater than or equal to 3.
@@ -917,7 +917,7 @@ make_pyramid(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates an icosahedron, cw oriented, centered in `center` and adds it to the graph `g`.
+ * \brief Creates an icosahedron, outward oriented, centered in `center` and adds it to the graph `g`.
  * \param g the graph in which the icosahedron will be created.
  * \param center the center of the sphere in which the icosahedron is inscribed.
  * \param radius the radius of the sphere in which the icosahedron is inscribed.

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -958,48 +958,48 @@ make_icosahedron(
 
   std::vector<vertex_descriptor> face;
   face.resize(3);
-  face[1] = v_vertices[0]; face[0] = v_vertices[11]; face[2] = v_vertices[5];
+  face[1] = v_vertices[0]; face[0] = v_vertices[5]; face[2] = v_vertices[11];
   Euler::add_face(face, g);
-  face[1] = v_vertices[0]; face[0] = v_vertices[5]; face[2] = v_vertices[1];
+  face[1] = v_vertices[0]; face[0] = v_vertices[1]; face[2] = v_vertices[5];
   Euler::add_face(face, g);
-  face[1] = v_vertices[0]; face[0] = v_vertices[1]; face[2] = v_vertices[7];
+  face[1] = v_vertices[0]; face[0] = v_vertices[7]; face[2] = v_vertices[1];
   Euler::add_face(face, g);
-  face[1] = v_vertices[0]; face[0] = v_vertices[7]; face[2] = v_vertices[10];
+  face[1] = v_vertices[0]; face[0] = v_vertices[10]; face[2] = v_vertices[7];
   Euler::add_face(face, g);
-  face[1] = v_vertices[0]; face[0] = v_vertices[10]; face[2] = v_vertices[11];
-  Euler::add_face(face, g);
-
-  face[1] = v_vertices[1] ; face[0] = v_vertices[5] ; face[2] = v_vertices[9];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[5] ; face[0] = v_vertices[11]; face[2] = v_vertices[4];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[11]; face[0] = v_vertices[10]; face[2] = v_vertices[2];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[10]; face[0] = v_vertices[7] ; face[2] = v_vertices[6];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[7] ; face[0] = v_vertices[1] ; face[2] = v_vertices[8];
+  face[1] = v_vertices[0]; face[0] = v_vertices[11]; face[2] = v_vertices[10];
   Euler::add_face(face, g);
 
-  face[1] = v_vertices[3] ; face[0] = v_vertices[9] ; face[2] = v_vertices[4];
+  face[1] = v_vertices[1] ; face[0] = v_vertices[9] ; face[2] = v_vertices[5];
   Euler::add_face(face, g);
-  face[1] = v_vertices[3] ; face[0] = v_vertices[4] ; face[2] = v_vertices[2];
+  face[1] = v_vertices[5] ; face[0] = v_vertices[4]; face[2] = v_vertices[11];
   Euler::add_face(face, g);
-  face[1] = v_vertices[3] ; face[0] = v_vertices[2] ; face[2] = v_vertices[6];
+  face[1] = v_vertices[11]; face[0] = v_vertices[2]; face[2] = v_vertices[10];
   Euler::add_face(face, g);
-  face[1] = v_vertices[3] ; face[0] = v_vertices[6] ; face[2] = v_vertices[8];
+  face[1] = v_vertices[10]; face[0] = v_vertices[6] ; face[2] = v_vertices[7];
   Euler::add_face(face, g);
-  face[1] = v_vertices[3] ; face[0] = v_vertices[8] ; face[2] = v_vertices[9];
+  face[1] = v_vertices[7] ; face[0] = v_vertices[8] ; face[2] = v_vertices[1];
   Euler::add_face(face, g);
 
-  face[1] = v_vertices[4] ; face[0] = v_vertices[9] ; face[2] = v_vertices[5] ;
-  Euler::add_face(face, g);
-  face[1] = v_vertices[2] ; face[0] = v_vertices[4] ; face[2] = v_vertices[11];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[6] ; face[0] = v_vertices[2] ; face[2] = v_vertices[10];
-  Euler::add_face(face, g);
-  face[1] = v_vertices[8] ; face[0] = v_vertices[6] ; face[2] = v_vertices[7] ;
-  Euler::add_face(face, g);
-  face[1] = v_vertices[9] ; face[0] = v_vertices[8] ; face[2] = v_vertices[1] ;
+  face[1] = v_vertices[3] ; face[0] = v_vertices[4] ; face[2] = v_vertices[9];
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[3] ; face[0] = v_vertices[2] ; face[2] = v_vertices[4];
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[3] ; face[0] = v_vertices[6] ; face[2] = v_vertices[2];
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[3] ; face[0] = v_vertices[8] ; face[2] = v_vertices[6];
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[3] ; face[0] = v_vertices[9] ; face[2] = v_vertices[8];
+  Euler::add_face(face, g);                                                  
+                                                                             
+  face[1] = v_vertices[4] ; face[0] = v_vertices[5] ; face[2] = v_vertices[9] ;
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[2] ; face[0] = v_vertices[11] ; face[2] = v_vertices[4];
+  Euler::add_face(face, g);                                                   
+  face[1] = v_vertices[6] ; face[0] = v_vertices[10] ; face[2] = v_vertices[2];
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[8] ; face[0] = v_vertices[7] ; face[2] = v_vertices[6] ;
+  Euler::add_face(face, g);                                                  
+  face[1] = v_vertices[9] ; face[0] = v_vertices[1] ; face[2] = v_vertices[8] ;
   Euler::add_face(face, g);
 
   return halfedge(v_vertices[1], v_vertices[0], g).first;

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -737,7 +737,7 @@ bool is_degenerate_triangle_face(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates a triangulated regular prism
+ * \brief Creates a triangulated regular prism, cw oriented,
  * having `nb_vertices` vertices in each of its bases and adds it to the graph `g`.
  * If `center` is (0, 0, 0), then the first point of the prism is (`radius`, `height`, 0)
  * \param nb_vertices the number of vertices per base. It must be greater than or equal to 3.
@@ -831,7 +831,7 @@ make_regular_prism(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates a pyramid having `nb_vertices` vertices in its base and adds it to the graph `g`.
+ * \brief Creates a pyramid, cw oriented, having `nb_vertices` vertices in its base and adds it to the graph `g`.
  *
  * If `center` is (0, 0, 0), then the first point of the base is (`radius`, 0`, 0)
  * \param nb_vertices the number of vertices in the base. It must be greater than or equal to 3.
@@ -917,7 +917,7 @@ make_pyramid(
 
 /**
  * \ingroup PkgBGLHelperFct
- * \brief Creates an icosahedron centered in `center` and adds it to the graph `g`.
+ * \brief Creates an icosahedron, cw oriented, centered in `center` and adds it to the graph `g`.
  * \param g the graph in which the icosahedron will be created.
  * \param center the center of the sphere in which the icosahedron is inscribed.
  * \param radius the radius of the sphere in which the icosahedron is inscribed.


### PR DESCRIPTION

## Summary of Changes

Orient icosahedron CW to fit the orientation of other helpers.

## Release Management

* Affected package(s):BGL
* Issue(s) solved (if any): fix #2975 

