### PR TITLE
Property map: fix get() not returning the default value

### DIFF
--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -496,7 +496,7 @@ private:
     launch_feature_computation (new Feature_adder_verticality<VectorMap> (this, normal_map, 0));
   }
 
-  void generate_normal_based_features(const CGAL::Default_property_map<Iterator, typename GeomTraits::Vector_3>&)
+  void generate_normal_based_features(const CGAL::Constant_property_map<Iterator, typename GeomTraits::Vector_3>&)
   {
     generate_multiscale_feature_variant_0<Verticality> ();
   }
@@ -544,7 +544,7 @@ private:
                                                                      2, 25.f * float(i), 12.5f));
   }
 
-  void generate_color_based_features(const CGAL::Default_property_map<Iterator, RGB_Color>&)
+  void generate_color_based_features(const CGAL::Constant_property_map<Iterator, RGB_Color>&)
   {
   }
 
@@ -581,7 +581,7 @@ private:
       launch_feature_computation (new Feature_adder_echo<EchoMap> (this, echo_map, i));
   }
 
-  void generate_echo_based_features(const CGAL::Default_property_map<Iterator, std::size_t>&)
+  void generate_echo_based_features(const CGAL::Constant_property_map<Iterator, std::size_t>&)
   {
   }
 
@@ -615,10 +615,10 @@ private:
   }
 
   template <typename T>
-  Default_property_map<Iterator, T>
+  Constant_property_map<Iterator, T>
   get_parameter (const Default&)
   {
-    return Default_property_map<Iterator, T>();
+    return Constant_property_map<Iterator, T>();
   }
 
   template<typename VectorMap, typename ColorMap, typename EchoMap>

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -440,20 +440,29 @@ make_property_map(const std::vector<T>& v)
 }
 
 /// \ingroup PkgProperty_map
-/// Property map that only returns the default value type
-/// \cgalModels `ReadablePropertyMap`
-template<class InputIterator, class ValueType>
-struct Default_property_map{
+/// Property map that returns a fixed value.
+/// Note that this value is chosen when the map is constructed and cannot
+/// be changed afterwards. Specifically, the free function `put()` does nothing.
+///
+/// \cgalModels `ReadWritePropertyMap`
+template<class KeyType, class ValueType>
+struct Default_property_map
+{
   const ValueType default_value;
-  
-  typedef typename InputIterator::value_type key_type;
-  typedef boost::readable_property_map_tag category;
 
-  Default_property_map(const ValueType& default_value = ValueType()) : default_value (default_value) { }
+  typedef KeyType                                       key_type;
+  typedef ValueType                                     value_type;
+  typedef boost::read_write_property_map_tag            category;
+
+  Default_property_map(const value_type& default_value = value_type()) : default_value (default_value) { }
 
   /// Free function that returns `pm.default_value`.
   inline friend value_type
   get (const Default_property_map& pm, const key_type&){ return pm.default_value; }
+
+  /// Free function that does nothing.
+  inline friend void
+  put (const Default_property_map&, const key_type&, const value_type&) { }
 };
 
 /// \ingroup PkgProperty_map

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -446,7 +446,7 @@ make_property_map(const std::vector<T>& v)
 ///
 /// \cgalModels `ReadWritePropertyMap`
 template<class KeyType, class ValueType>
-struct Default_property_map
+struct Constant_property_map
 {
   const ValueType default_value;
 
@@ -454,15 +454,15 @@ struct Default_property_map
   typedef ValueType                                     value_type;
   typedef boost::read_write_property_map_tag            category;
 
-  Default_property_map(const value_type& default_value = value_type()) : default_value (default_value) { }
+  Constant_property_map(const value_type& default_value = value_type()) : default_value (default_value) { }
 
   /// Free function that returns `pm.default_value`.
   inline friend value_type
-  get (const Default_property_map& pm, const key_type&){ return pm.default_value; }
+  get (const Constant_property_map& pm, const key_type&){ return pm.default_value; }
 
   /// Free function that does nothing.
   inline friend void
-  put (const Default_property_map&, const key_type&, const value_type&) { }
+  put (const Constant_property_map&, const key_type&, const value_type&) { }
 };
 
 /// \ingroup PkgProperty_map

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -450,10 +450,10 @@ struct Default_property_map{
   typedef boost::readable_property_map_tag category;
 
   Default_property_map(const ValueType& default_value = ValueType()) : default_value (default_value) { }
-  
-  /// Free function to use a get the value from an iterator using Input_iterator_property_map.
-  inline friend ValueType
-  get (const Default_property_map&, const key_type&){ return ValueType(); }
+
+  /// Free function that returns `pm.default_value`.
+  inline friend value_type
+  get (const Default_property_map& pm, const key_type&){ return pm.default_value; }
 };
 
 /// \ingroup PkgProperty_map


### PR DESCRIPTION
## Summary of Changes

`Default_property_map` should return the value that is chosen in the constructor. 

I also extended it to be a writable property map, with the idea that we don't have (or I can't find) a nice dummy property map that is also writable. It would then replace custom pmaps such as [No_mark](https://github.com/CGAL/cgal/blob/2cec8e6aca6cab7b5e733fc88ac6baed99560d0c/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h#L39).

## Release Management

* Affected package(s): `Property_map`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

