### PR TITLE
Polyhedron demo: Add a verbose option

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -125,13 +125,14 @@ MainWindow::~MainWindow()
   delete ui;
   delete statistics_ui;
 }
-MainWindow::MainWindow(QWidget* parent)
+MainWindow::MainWindow(bool verbose, QWidget* parent)
   : CGAL::Qt::DemosMainWindow(parent)
 {
   ui = new Ui::MainWindow;
   ui->setupUi(this);
   menuBar()->setNativeMenuBar(false);
   menu_map[ui->menuOperations->title()] = ui->menuOperations;
+  this->verbose = verbose;
   // remove the Load Script menu entry, when the demo has not been compiled with QT_SCRIPT_LIB
 #if !defined(QT_SCRIPT_LIB)
   ui->menuBar->removeAction(ui->actionLoadScript);
@@ -540,7 +541,8 @@ bool MainWindow::load_plugin(QString fileName, bool blacklisted)
         }
       }
       QDebug qdebug = qDebug();
-      qdebug << "### Loading \"" << fileName.toUtf8().data() << "\"... ";
+      if(verbose)
+        qdebug << "### Loading \"" << fileName.toUtf8().data() << "\"... ";
       QPluginLoader loader;
       loader.setFileName(fileinfo.absoluteFilePath());
       QObject *obj = loader.instance();
@@ -560,6 +562,7 @@ bool MainWindow::load_plugin(QString fileName, bool blacklisted)
       else {
         //qdebug << "error: " << qPrintable(loader.errorString());
         pluginsStatus_map[name] = loader.errorString();
+
       }
       PathNames_map[fileinfo.absoluteDir().absolutePath()].push_back(name);
       return true;
@@ -621,8 +624,9 @@ void MainWindow::loadPlugins()
 
   QSet<QString> loaded;
   Q_FOREACH (QDir pluginsDir, plugins_directories) {
-    qDebug("# Looking for plugins in directory \"%s\"...",
-           qPrintable(pluginsDir.absolutePath()));
+    if(verbose)
+      qDebug("# Looking for plugins in directory \"%s\"...",
+             qPrintable(pluginsDir.absolutePath()));
     Q_FOREACH(QString fileName, pluginsDir.entryList(QDir::Files))
     {
       QString abs_name = pluginsDir.absoluteFilePath(fileName);
@@ -1518,8 +1522,11 @@ void MainWindow::on_actionLoad_triggered()
     Q_FOREACH(const QString& filter, split_filters) {
       FilterPluginMap::iterator it = filterPluginMap.find(filter);
       if(it != filterPluginMap.end()) {
-        qDebug() << "Duplicate Filter: " << it.value()->name();
-        qDebug() << "This filter will not be available.";
+        if(verbose)
+        {
+          qDebug() << "Duplicate Filter: " << it.value()->name();
+          qDebug() << "This filter will not be available.";
+        }
       } else {
         filterPluginMap[filter] = plugin;
       }

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -68,7 +68,7 @@ public:
    * Then it creates and initializes the scene and do the
    * connexions with the UI. Finally it loads the plugins.*/
 
-  MainWindow(QWidget* parent = 0);
+  MainWindow(bool verbose = false,QWidget* parent = 0);
   ~MainWindow();
 
   /*! Finds an IO plugin.
@@ -415,6 +415,7 @@ private:
 
   QDialog *statistics_dlg;
   Ui::Statistics_on_item_dialog* statistics_ui;
+  bool verbose;
   void insertActionBeforeLoadPlugin(QMenu*, QAction *actionToInsert);
 
 #ifdef QT_SCRIPT_LIB
@@ -430,7 +431,6 @@ public:
   void evaluate_script_quiet(QString script, 
                              const QString & fileName = QString());
 #endif
-
 private Q_SLOTS:
   void set_facegraph_mode_adapter(bool is_polyhedron);
 };

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
@@ -61,12 +61,7 @@ Polyhedron_demo::Polyhedron_demo(int& argc, char **argv,
   parser.addOption(verbose);
   parser.addPositionalArgument("files", tr("Files to open"), "[files...]");
   parser.process(*this);
-  if(parser.isSet(verbose)) {
-    d_ptr->mainWindow.reset(new MainWindow(true));
-  }
-  else{
-    d_ptr->mainWindow.reset(new MainWindow);
-  }
+  d_ptr->mainWindow.reset(new MainWindow(parser.isSet(verbose)));
   MainWindow& mainWindow = *d_ptr->mainWindow;
   
   mainWindow.setWindowTitle(main_window_title);

--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo.cpp
@@ -56,12 +56,19 @@ Polyhedron_demo::Polyhedron_demo(int& argc, char **argv,
   QCommandLineOption no_autostart("no-autostart",
                                   tr("Ignore the autostart.js file, if any."));
   parser.addOption(no_autostart);
+  QCommandLineOption verbose("verbose",
+                                   tr("Print the paths explored byt the application searching for plugins."));
+  parser.addOption(verbose);
   parser.addPositionalArgument("files", tr("Files to open"), "[files...]");
   parser.process(*this);
-
-  d_ptr->mainWindow.reset(new MainWindow);
+  if(parser.isSet(verbose)) {
+    d_ptr->mainWindow.reset(new MainWindow(true));
+  }
+  else{
+    d_ptr->mainWindow.reset(new MainWindow);
+  }
   MainWindow& mainWindow = *d_ptr->mainWindow;
-
+  
   mainWindow.setWindowTitle(main_window_title);
   mainWindow.show();
 


### PR DESCRIPTION
## Summary of Changes

With this PR, all the logs for the plugins loading are hidden, unless the demo has been launched with the --verbose option. Logs for the scripts are unaffected.
## Release Management

* Issue(s) solved (if any): fix #2439 


