### PR TITLE
Scripts: Fix check_licenses

### DIFF
--- a/Scripts/developer_scripts/check_licenses
+++ b/Scripts/developer_scripts/check_licenses
@@ -59,7 +59,7 @@ fi
 mkdir $DIR
 rm -f $PREFIX1* $PREFIX2*
 
-if [ ! -f INSTALL ]; then
+if [ ! -f INSTALL.md ]; then
 	echo This script should be run from the top-level directory of an internal or external release.
 	exit 1
 fi


### PR DESCRIPTION
## Summary of Changes
In the script check_licenses, the existance of the file INSTALL is checked to decide if we are in the right directory, but this file is now named INSTALL.md. 
## Release Management

* Affected package(s):Scripts
