### PR TITLE
Polyhedron demo: Fix MCF whithout Eigen

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -226,9 +226,6 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
   add_item(scene_edit_box_item Plugins/PCA/Scene_edit_box_item.cpp )
   add_item(scene_image_item Scene_image_item.cpp)
   add_item(scene_surface_mesh_item Scene_surface_mesh_item.cpp)
-  add_item(scene_mcf_poly_item Plugins/PMP/Scene_mcf_item.cpp)
-  add_item(scene_mcf_sm_item Plugins/PMP/Scene_mcf_item.cpp)
-  target_compile_definitions(scene_mcf_sm_item PUBLIC "-DUSE_SURFACE_MESH" )
 
   # special
 
@@ -273,6 +270,9 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND OPENGL_FOUND AND QGLVIEWER_FOUND)
       ${editionUI_FILES})
     target_link_libraries(scene_edit_polyhedron_item PUBLIC scene_polyhedron_item scene_surface_mesh_item scene_polyhedron_and_sm_item_k_ring_selection
       scene_basic_objects)
+    add_item(scene_mcf_poly_item Plugins/PMP/Scene_mcf_item.cpp)
+    add_item(scene_mcf_sm_item Plugins/PMP/Scene_mcf_item.cpp)
+    target_compile_definitions(scene_mcf_sm_item PUBLIC "-DUSE_SURFACE_MESH" )
   endif()
 
   add_item(scene_implicit_function_item Scene_implicit_function_item.cpp )

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -30,6 +30,26 @@ if(EIGEN3_FOUND)
 
     polyhedron_demo_plugin(hole_filling_polyline_plugin Hole_filling_polyline_plugin)
     target_link_libraries(hole_filling_polyline_plugin PUBLIC scene_surface_mesh_item scene_polyhedron_item scene_polylines_item)
+    
+    qt5_wrap_ui( Mean_curvature_flow_skeleton_pluginUI_FILES  Mean_curvature_flow_skeleton_plugin.ui)
+    polyhedron_demo_plugin(mean_curvature_flow_skeleton_plugin Mean_curvature_flow_skeleton_plugin ${Mean_curvature_flow_skeleton_pluginUI_FILES})
+    target_link_libraries(mean_curvature_flow_skeleton_plugin PUBLIC
+        scene_polyhedron_item 
+        scene_points_with_normal_item
+        scene_polylines_item
+        scene_mcf_poly_item
+        demo_framework)
+        
+    qt5_wrap_ui( Mean_curvature_flow_skeleton_pluginUI_FILES  Mean_curvature_flow_skeleton_plugin.ui)
+    polyhedron_demo_plugin(mean_curvature_flow_skeleton_sm_plugin Mean_curvature_flow_skeleton_plugin ${Mean_curvature_flow_skeleton_pluginUI_FILES})
+    target_link_libraries(mean_curvature_flow_skeleton_sm_plugin
+      PUBLIC
+        scene_surface_mesh_item
+        scene_points_with_normal_item
+        scene_polylines_item
+        scene_mcf_sm_item
+        demo_framework)
+    target_compile_definitions(mean_curvature_flow_skeleton_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
   else()
     message(STATUS "NOTICE: The hole filling and fairing plugins require Eigen 3.2 (or higher) and will not be available.")
   endif()
@@ -52,27 +72,6 @@ polyhedron_demo_plugin(join_and_split_sm_plugin Join_and_split_polyhedra_plugin)
 target_link_libraries(join_and_split_sm_plugin PUBLIC scene_surface_mesh_item scene_surface_mesh_selection_item)
 target_compile_definitions(join_and_split_sm_plugin  PUBLIC "-DUSE_SURFACE_MESH")
 
-qt5_wrap_ui( Mean_curvature_flow_skeleton_pluginUI_FILES  Mean_curvature_flow_skeleton_plugin.ui)
-polyhedron_demo_plugin(mean_curvature_flow_skeleton_plugin Mean_curvature_flow_skeleton_plugin ${Mean_curvature_flow_skeleton_pluginUI_FILES})
-target_link_libraries(mean_curvature_flow_skeleton_plugin PUBLIC
-    scene_polyhedron_item 
-    scene_points_with_normal_item
-    scene_polylines_item
-    scene_mcf_poly_item
-    demo_framework)
-    
-
-
-qt5_wrap_ui( Mean_curvature_flow_skeleton_pluginUI_FILES  Mean_curvature_flow_skeleton_plugin.ui)
-polyhedron_demo_plugin(mean_curvature_flow_skeleton_sm_plugin Mean_curvature_flow_skeleton_plugin ${Mean_curvature_flow_skeleton_pluginUI_FILES})
-target_link_libraries(mean_curvature_flow_skeleton_sm_plugin
-  PUBLIC
-    scene_surface_mesh_item
-    scene_points_with_normal_item
-    scene_polylines_item
-    scene_mcf_sm_item
-    demo_framework)
-target_compile_definitions(mean_curvature_flow_skeleton_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 
 
 qt5_wrap_ui( point_inside_polyhedronUI_FILES Point_inside_polyhedron_widget.ui)


### PR DESCRIPTION
## Summary of Changes
Update the CMakeLists.txt of the demo so MeanCurvatureFlow skeleton plugin and item are not compiled if Eigen was not found.

## Release Management

* Issue(s) solved (if any): fix #2996

