### PR TITLE
Surface_mesh_parameterization: inline get_error_message()

### DIFF
--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Error_code.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Error_code.h
@@ -45,7 +45,7 @@ enum Error_code
 /// \brief Get the message corresponding to an error code.
 /// \param error_code The code returned by `parameterize()`
 /// \return The string describing the error code.
-const char* get_error_message(int error_code)
+inline const char* get_error_message(int error_code)
 {
   // Messages corresponding to Error_code list above. Must be kept in sync!
   static const char* error_message[ERROR_WRONG_PARAMETER+1] = {


### PR DESCRIPTION

## Summary of Changes
`inline`  function to avoid an "already defined" error.

## Release Management

* Affected package(s): Surface_mesh_parameterization
* Issue(s) solved (if any): raised on [stackoverflow](https://stackoverflow.com/questions/49732958/multiple-definition-of-cgalsurface-mesh-parameterizationget-error-messagei)


