### PR TITLE
Shape detection: fix undocumented breaking change

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -144,6 +144,9 @@ Release date: April 2018
 
 ### Point Set Shape Detection
 
+-   **Breaking change**:
+    `CGAL::Shape_detection_3::Efficient_RANSAC_traits` is now called
+    `CGAL::Shape_detection_3::Shape_detection_traits`.
 -   New algorithm: `CGAL::Region_growing`. This is a deterministic
     alternative to RANSAC for plane detection.
 -   **Breaking change**: the API of `CGAL::regularize_planes()` is

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3.h
@@ -42,8 +42,4 @@
 #include <CGAL/Shape_detection_3/Sphere.h>
 #include <CGAL/Shape_detection_3/property_maps.h>
 
-#ifndef CGAL_NO_DEPRECATED_CODE
-#include <CGAL/Shape_detection_3/Efficient_RANSAC_traits.h>
-#endif
-
 #endif //CGAL_SHAPE_DETECTION_3_H

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3.h
@@ -32,7 +32,6 @@
 
 #include <CGAL/license/Point_set_shape_detection_3.h>
 
-
 #include <CGAL/Shape_detection_3/Efficient_RANSAC.h>
 #include <CGAL/Shape_detection_3/Region_growing.h>
 #include <CGAL/Shape_detection_3/Shape_detection_traits.h>
@@ -42,5 +41,9 @@
 #include <CGAL/Shape_detection_3/Torus.h>
 #include <CGAL/Shape_detection_3/Sphere.h>
 #include <CGAL/Shape_detection_3/property_maps.h>
+
+#ifndef CGAL_NO_DEPRECATED_CODE
+#include <CGAL/Shape_detection_3/Efficient_RANSAC_traits.h>
+#endif
 
 #endif //CGAL_SHAPE_DETECTION_3_H

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC_traits.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC_traits.h
@@ -1,0 +1,203 @@
+// Copyright (c) 2015 INRIA Sophia-Antipolis (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0+
+//
+//
+// Author(s)     : Sven Oesau, Yannick Verdie, Clément Jamin, Pierre Alliez
+//
+
+#ifndef CGAL_SHAPE_DETECTION_3_EFFICIENT_RANSAC_TRAITS_H
+#define CGAL_SHAPE_DETECTION_3_EFFICIENT_RANSAC_TRAITS_H
+
+#include <CGAL/license/Point_set_shape_detection_3.h>
+
+
+#include <CGAL/Search_traits_3.h>
+
+/// \cond SKIP_IN_MANUAL
+
+namespace CGAL {
+  namespace Shape_detection_3 {
+    /*!
+      \ingroup PkgPointSetShapeDetection3
+      \brief %Default traits class to use the shape detection class `Efficient_RANSAC`.
+      \cgalModels `Shape_detection_3::Traits`
+
+      \tparam Gt a model of the concept `#Kernel` with `Gt::FT` being `float` or `double`.
+
+      \tparam InputRange is a model of `Range` with random access iterators, 
+              providing input points and normals through the following two property maps.
+
+      \tparam InputPointMap is a model of `ReadablePropertyMap` with `std::iterator_traits<Input_range::iterator>::%value_type` as key type and `Geom_traits::Point_3` as value type.
+
+
+      \tparam InputNormalMap is a model of `ReadablePropertyMap` with `std::iterator_traits<Input_range::iterator>::%value_type` as key type and `Geom_traits::Vector_3` as value type.
+    */
+  template <class Gt,
+            class InputRange,
+            class InputPointMap,
+            class InputNormalMap>
+  struct
+  CGAL_DEPRECATED_MSG("CGAL::Shape_detection_3::Efficient_RANSAC_traits<> is now called CGAL::Shape_detection_3::Shape_detection_traits<>, please update your code")
+  Efficient_RANSAC_traits {
+    ///
+    typedef typename Gt::FT FT;
+    ///
+    typedef typename Gt::Point_3 Point_3;
+    ///
+    typedef typename Gt::Vector_3 Vector_3;
+    ///
+    typedef typename Gt::Sphere_3 Sphere_3;
+    ///
+    typedef typename Gt::Segment_3 Segment_3;
+    ///
+    typedef typename Gt::Line_3 Line_3;
+    ///
+    typedef typename Gt::Circle_2 Circle_2;
+    ///
+    typedef typename Gt::Plane_3 Plane_3;
+    ///
+    typedef typename Gt::Point_2 Point_2;
+    ///
+    typedef typename Gt::Vector_2 Vector_2;
+    ///
+    typedef InputRange Input_range;
+    ///
+    typedef InputPointMap Point_map;
+    ///
+    typedef InputNormalMap Normal_map;
+    ///
+    typedef CGAL::Search_traits_3<Gt> Search_traits;
+    ///
+    Efficient_RANSAC_traits(const Gt& gt =  Gt())
+      : m_gt(gt) {}
+
+    typedef typename Gt::Construct_point_3 Construct_point_3;
+    Construct_point_3 construct_point_3_object() const 
+    { return m_gt.construct_point_3_object(); }
+
+    typedef typename Gt::Construct_vector_3 Construct_vector_3;
+    Construct_vector_3 construct_vector_3_object() const
+    { return m_gt.construct_vector_3_object(); }
+
+    typedef typename Gt::Construct_point_2 Construct_point_2;
+    Construct_point_2 construct_point_2_object() const 
+    { return m_gt.construct_point_2_object(); }
+
+    typedef typename Gt::Construct_vector_2 Construct_vector_2;
+    Construct_vector_2 construct_vector_2_object() const
+    { return m_gt.construct_vector_2_object(); }
+
+    typedef typename Gt::Construct_sphere_3 Construct_sphere_3;
+    Construct_sphere_3 construct_sphere_3_object() const
+    { return m_gt.construct_sphere_3_object(); }
+    
+    typedef typename Gt::Construct_line_3 Construct_line_3;
+    Construct_line_3 construct_line_3_object() const
+    { return m_gt.construct_line_3_object(); }
+
+    typedef typename Gt::Construct_circle_2 Construct_circle_2;
+    Construct_circle_2 construct_circle_2_object() const
+    { return m_gt.construct_circle_2_object(); }
+    
+    typedef typename Gt::Construct_point_on_3 Construct_point_on_3;
+    Construct_point_on_3 construct_point_on_3_object() const
+    { return m_gt.construct_point_on_3_object(); }
+
+    typedef typename Gt::Compute_x_2 Compute_x_2;
+    Compute_x_2 compute_x_2_object() const
+    { return m_gt.compute_x_2_object(); }
+
+    typedef typename Gt::Compute_y_2 Compute_y_2;
+    Compute_y_2 compute_y_2_object() const
+    { return m_gt.compute_y_2_object(); }
+
+    typedef typename Gt::Compute_x_3 Compute_x_3;
+    Compute_x_3 compute_x_3_object() const
+    { return m_gt.compute_x_3_object(); }
+    
+    typedef typename Gt::Compute_y_3 Compute_y_3;
+    Compute_y_3 compute_y_3_object() const
+    { return m_gt.compute_y_3_object(); }
+    
+    typedef typename Gt::Compute_z_3 Compute_z_3;
+    Compute_z_3 compute_z_3_object() const
+    { return m_gt.compute_z_3_object(); }
+
+    typedef typename Gt::Compute_squared_length_3 Compute_squared_length_3;
+    Compute_squared_length_3 compute_squared_length_3_object() const
+    { return m_gt.compute_squared_length_3_object(); }
+
+    typedef typename Gt::Compute_squared_length_2 Compute_squared_length_2;
+    Compute_squared_length_2 compute_squared_length_2_object() const
+    { return m_gt.compute_squared_length_2_object(); }
+    
+    typedef typename Gt::Construct_scaled_vector_3 Construct_scaled_vector_3;
+    Construct_scaled_vector_3 construct_scaled_vector_3_object() const
+    { return m_gt.construct_scaled_vector_3_object(); }
+    
+    typedef typename Gt::Construct_sum_of_vectors_3 Construct_sum_of_vectors_3;
+    Construct_sum_of_vectors_3 construct_sum_of_vectors_3_object() const
+    { return m_gt.construct_sum_of_vectors_3_object(); }
+
+    typedef typename Gt::Construct_translated_point_3 Construct_translated_point_3;
+    Construct_translated_point_3 construct_translated_point_3_object() const
+    { return m_gt.construct_translated_point_3_object(); }
+    
+    typedef typename Gt::Compute_scalar_product_3 Compute_scalar_product_3;
+    Compute_scalar_product_3 compute_scalar_product_3_object() const
+    { return m_gt.compute_scalar_product_3_object(); }
+    
+    typedef typename Gt::Construct_cross_product_vector_3 Construct_cross_product_vector_3;
+    Construct_cross_product_vector_3 construct_cross_product_vector_3_object() const
+    { return m_gt.construct_cross_product_vector_3_object(); }
+
+    typedef typename Gt::Construct_center_3 Construct_center_3;
+    Construct_center_3 construct_center_3_object() const
+    { return m_gt.construct_center_3_object(); }
+
+    typedef typename Gt::Construct_center_2 Construct_center_2;
+    Construct_center_2 construct_center_2_object() const
+    { return m_gt.construct_center_2_object(); }
+
+    typedef typename Gt::Compute_squared_radius_3 Compute_squared_radius_3;
+    Compute_squared_radius_3 compute_squared_radius_3_object() const
+    { return m_gt.compute_squared_radius_3_object(); }
+
+    typedef typename Gt::Compute_squared_radius_2 Compute_squared_radius_2;
+    Compute_squared_radius_2 compute_squared_radius_2_object() const
+    { return m_gt.compute_squared_radius_2_object(); }
+    
+    typedef typename Gt::Collinear_2 Collinear_2;
+    Collinear_2 collinear_2_object() const
+    { return m_gt.collinear_2_object(); }
+
+    ///
+    typedef typename Gt::Intersect_3 Intersect_3;
+    ///
+    Intersect_3 intersection_3_object() const
+    { return m_gt.intersection_3_object(); }
+    
+  private:
+    Gt m_gt;
+  };
+
+} } // end of namespace CGAL::Shape_detection_3
+
+/// \endcond
+
+#endif // CGAL_SHAPE_DETECTION_3_EFFICIENT_RANSAC_TRAITS_H

--- a/Point_set_shape_detection_3/test/Point_set_shape_detection_3/CMakeLists.txt
+++ b/Point_set_shape_detection_3/test/Point_set_shape_detection_3/CMakeLists.txt
@@ -35,6 +35,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_torus_connected_component.cpp" )
   create_single_source_cgal_program( "test_torus_parameters.cpp" )
   create_single_source_cgal_program( "test_scene.cpp" )
+  create_single_source_cgal_program( "deprecated_test_scene.cpp" )
 
 else()
   

--- a/Point_set_shape_detection_3/test/Point_set_shape_detection_3/deprecated_test_scene.cpp
+++ b/Point_set_shape_detection_3/test/Point_set_shape_detection_3/deprecated_test_scene.cpp
@@ -1,0 +1,167 @@
+#define  CGAL_NO_DEPRECATION_WARNINGS
+
+#include "generators.h"
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/IO/read_xyz_points.h>
+#include <CGAL/Simple_cartesian.h>
+
+#include <CGAL/Shape_detection_3.h>
+#include <CGAL/Shape_detection_3/Efficient_RANSAC_traits.h> // Deprecated
+#include <CGAL/regularize_planes.h>
+#include <CGAL/Point_with_normal_3.h>
+#include <CGAL/property_map.h>
+
+
+template <class K>
+bool test_scene() {
+  typedef typename K::FT                                      FT;
+  typedef CGAL::Point_with_normal_3<K>                        Pwn;
+  typedef std::vector<Pwn>                                    Pwn_vector;
+  typedef CGAL::Identity_property_map<Pwn>                    Point_map;
+  typedef CGAL::Normal_of_point_with_normal_map<K>            Normal_map;
+
+  typedef CGAL::Shape_detection_3::Efficient_RANSAC_traits<   // Deprecated
+    K, Pwn_vector, Point_map, Normal_map>                     Traits;
+
+  typedef CGAL::Shape_detection_3::Efficient_RANSAC<Traits>
+                                                              Efficient_ransac;
+
+  typedef typename Efficient_ransac::Point_index_range        Point_index_range;
+
+  typedef CGAL::Shape_detection_3::Plane<Traits>              Plane;
+  typedef CGAL::Shape_detection_3::Cone<Traits>               Cone;
+  typedef CGAL::Shape_detection_3::Cylinder<Traits>           Cylinder;
+  typedef CGAL::Shape_detection_3::Sphere<Traits>             Sphere;
+  typedef CGAL::Shape_detection_3::Torus<Traits>              Torus;
+
+  Pwn_vector points;
+
+  // Loads point set from a file. 
+  // read_xyz_points_and_normals takes an OutputIterator for storing the points
+  // and a property map to store the normal vector with each point.
+  std::ifstream stream("data/cube.pwn");
+
+  if (!stream ||
+    !CGAL::read_xyz_points(stream,
+      std::back_inserter(points),
+      CGAL::parameters::point_map(Point_map()).
+      normal_map(Normal_map())))
+  {
+    std::cerr << "Error: cannot read file cube.pwn" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+
+  Efficient_ransac ransac;
+
+  ransac.template add_shape_factory<Cone>();
+
+  ransac.clear_shape_factories();
+
+  ransac.template add_shape_factory<Cone>();
+  ransac.template add_shape_factory<Cylinder>();
+  ransac.template add_shape_factory<Plane>();
+  ransac.template add_shape_factory<Sphere>();
+  ransac.template add_shape_factory<Torus>();
+
+  ransac.set_input(points);
+
+  ransac.preprocess();
+
+  ransac.clear_octrees();
+
+  if (!ransac.detect()) {
+    std::cout << " aborted" << std::endl;
+    return false;
+  }
+
+  typename Efficient_ransac::Shape_range shapes = ransac.shapes();
+
+  typename Efficient_ransac::Shape_range::iterator it = shapes.begin();
+  
+  FT average_distance = 0;
+
+  // Iterate through all shapes and access each point.
+  while (it != shapes.end()) {
+    boost::shared_ptr<typename Efficient_ransac::Shape> shape = *it;
+
+    // Sums distances of points to detected shapes.
+    FT sum_distances = 0;
+
+    // Iterates through point indices assigned to each detected shape.
+    std::vector<std::size_t>::const_iterator
+      index_it = (*it)->indices_of_assigned_points().begin();
+
+    while (index_it != (*it)->indices_of_assigned_points().end()) {
+
+      // Retrieves point
+      const Pwn &p = *(points.begin() + (*index_it));
+
+      // Adds Euclidean distance between point and shape.
+      sum_distances += CGAL::sqrt((*it)->squared_distance(p));
+
+      // Proceeds with next point.
+      index_it++;
+    }
+
+    // Computes average distance.
+    average_distance += sum_distances / shape->indices_of_assigned_points().size();
+    
+    // Proceeds with next detected shape.
+    it++;
+  }
+
+  // Check coverage. For this scene it should not fall below 85%
+  double coverage = double(points.size() - ransac.number_of_unassigned_points()) / double(points.size());
+  if (coverage < 0.75) {
+    std::cout << " failed (coverage = " << coverage << " < 0.75)" << std::endl;
+
+    return false;
+  }
+
+
+  // Check average distance. It should not lie above 0.02.
+  average_distance = average_distance / shapes.size();
+  std::cout << average_distance << " " << std::endl;
+  if (average_distance > 0.01) {
+    std::cout << " failed" << std::endl;
+
+    return false;
+  }
+
+  // Test regularization
+  typename Efficient_ransac::Plane_range planes = ransac.planes();
+  CGAL::regularize_planes (points,
+                           Point_map(),
+                           planes,
+                           CGAL::Shape_detection_3::Plane_map<Traits>(),
+                           CGAL::Shape_detection_3::Point_to_shape_index_map<Traits>(points, planes),
+                           true, true, true, true,
+                           (FT)50., (FT)0.01);
+  
+  Point_index_range pts = ransac.indices_of_unassigned_points();
+
+  std::cout << " succeeded" << std::endl;
+
+  return true;
+}
+
+
+int main() {
+  bool success = true;
+
+  std::cout << "test_scene<CGAL::Simple_cartesian<float>> ";
+  if (!test_scene<CGAL::Simple_cartesian<float> >()) 
+    success = false;
+
+  std::cout << "test_scene<CGAL::Simple_cartesian<double>> ";
+  if (!test_scene<CGAL::Simple_cartesian<double> >())
+    success = false;
+
+  std::cout << "test_scene<CGAL::Exact_predicates_inexact_constructions_kernel> ";
+  if (!test_scene<CGAL::Exact_predicates_inexact_constructions_kernel>()) 
+    success = false;
+
+  return (success) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary of Changes

`Efficient_RANSAC_traits` was renamed `Shape_detection_traits`, but this breaking change was not documented and no backward-compatibility was provided.

This PR:
- updates `CHANGES.md`
- reintroduces back the class with the old name along with a deprecated warning

## Release Management

* Affected package(s): Shape Detection
