### PR TITLE
CSS tweaks, for CGAL-4.12

### DIFF
--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -206,6 +206,14 @@ dl.requires dt a, dl.todo dt a, dl.bug dt a, dl.test dt a
     color: black;
 }
 
+div.toc {
+    width: auto;
+}
+
+.ui-resizable-e {
+    background-repeat: repeat-y;
+}
+
 div.cgal_figure_caption {
 	text-align: center;
 }

--- a/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
@@ -206,6 +206,14 @@ dl.requires dt a, dl.todo dt a, dl.bug dt a, dl.test dt a
     color: black;
 }
 
+div.toc {
+    width: auto;
+}
+
+.ui-resizable-e {
+    background-repeat: repeat-y;
+}
+
 div.cgal_figure_caption {
 	text-align: center;
 }


### PR DESCRIPTION
## Summary of Changes

This PR fixes:
   - a bug in Doxygen 1.13 CSS: the vertical bar separating the navtree from the content is now fully from the top to the bottom,
   - an annoying feature: now the floating table of content is no longer limited to a width of 200 pixels.

## Release Management

* Affected package(s): Doxygen documentation

