### PR TITLE
PSP: Fix PLY reading properties other than those of vertices

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -446,7 +446,11 @@ namespace internal {
                       m_properties = &m_face_properties;
                     }
                   else
-                    continue;
+                    {
+                      reading_faces = false;
+                      reading_vertices = false;
+                      continue;
+                    }
                 }
             
             }


### PR DESCRIPTION
## Summary of Changes

When reading `elements` in a PLY header, vertices and faces where correctly handled but other elements were not ignored, leading to their properties being assigned to vertices (or faces, depending on the order). This PR makes other elements ignored. It is based on `master` as the code is quite different in `4.11` and this release requires another fix (I'm doing it right now).

## Release Management

* Affected package(s): Point Set Processing, Point Set 3, Polyhedron demo
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/3012
