### PR TITLE
PSP: Fix PLY reading properties other than those of vertices (4.11)

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -347,7 +347,10 @@ namespace internal {
                       reading_properties = true;
                     }
                   else
-                    continue;
+                    {
+                      reading_properties = false;
+                      continue;
+                    }
                 }
             
             }


### PR DESCRIPTION
## Summary of Changes

(Same as https://github.com/CGAL/cgal/pull/3013 but for `4.11`, when PLY faces were not handled yet.)

## Release Management

* Affected package(s): Point Set Processing, Point Set 3, Polyhedron demo
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/3012