### PR TITLE
Fix compilation error with VC2017 and -permissive-   

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -480,7 +480,7 @@ struct Tracer_polyline_incomplete {
       }
 
       CGAL_assertion(la >= 0 && la < n);
-      CGAL_assertion(r.first < la && r.second > la);
+      CGAL_assertion( (r.first < la) && (r.second > la) );
       *out++ = OutputIteratorValueType(r.first, la, r.second);
 
       ranges.push(std::make_pair(r.first, la));


### PR DESCRIPTION

## Summary of Changes

Put parenthesis around subexpressions.

It looks like a compiler bug though. Independently from this PR I will try to boil it down in order to make a bug report.


## Release Management

* Affected package(s): Polygon_mesh_processing, Mesh_3
* Issue(s) solved (if any): [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/results-4.12-Ic-224.shtml)


