### PR TITLE
Add missing const

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
@@ -142,7 +142,7 @@ public:
     return !equals(p);
   }
 
-  bool operator == (const Self& p)
+  bool operator == (const Self& p) const
   {
     return equals(p);
   }


### PR DESCRIPTION
Missing const to compare two `One_root_point`

## Release Management

* Affected package(s): Arrangement_2


