### PR TITLE
STL_Extension: Fix a leftover std::unary_function

### DIFF
--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -141,7 +141,7 @@ struct hash<OpenMesh::EdgeHandle >
 
 template <>
 struct hash<CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle> >
-  : public std::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
+  : public CGAL::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
 {
 
   std::size_t operator()(const CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle>& h) const

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -22,6 +22,7 @@
 #define CGAL_HASH_OPENMESH_H
 
 #include <OpenMesh/Core/Mesh/Handles.hh>
+#include <CGAL/algorith.h>
 
 namespace CGAL { namespace internal {
 

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -22,7 +22,7 @@
 #define CGAL_HASH_OPENMESH_H
 
 #include <OpenMesh/Core/Mesh/Handles.hh>
-#include <CGAL/algorith.h>
+#include <CGAL/algorithm.h>
 
 namespace CGAL { namespace internal {
 


### PR DESCRIPTION
## Summary of Changes

Looking at the commit dates, both changes made it into the same master batch.

## Release Management

* Affected package(s): `STL_Extensions`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

