### PR TITLE
Polyhedron demo: Fix Polyhedron Lighting

### DIFF
--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.g
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.g
@@ -8,6 +8,7 @@ in VS_OUT
   vec4 fP;
   vec4 out_color;
   float dist[6];
+  vec4 vertex;
 } gs_in[3];
 
 out GS_OUT
@@ -23,9 +24,8 @@ uniform mat4 mvp_matrix;
 
 void main(void)
 {
-  mat4 inv_mvp = inverse(mvp_matrix);
-  vec4 norm1 = inv_mvp*gl_in[1].gl_Position - inv_mvp*gl_in[0].gl_Position;
-  vec4 norm2 = inv_mvp*gl_in[2].gl_Position - inv_mvp*gl_in[1].gl_Position;
+  vec4 norm1 = gs_in[1].vertex- gs_in[0].vertex;
+  vec4 norm2 = gs_in[2].vertex - gs_in[1].vertex;
 
   gl_Position = gl_in[0].gl_Position;
   gs_out.fP = gs_in[0].fP;

--- a/Polyhedron/demo/Polyhedron/resources/shader_flat.v
+++ b/Polyhedron/demo/Polyhedron/resources/shader_flat.v
@@ -8,6 +8,7 @@ out VS_OUT
   vec4 fP;
   vec4 out_color;
   float dist[6];
+  vec4 vertex;
 }vs_out;
 
 uniform mat4 mvp_matrix;
@@ -39,5 +40,6 @@ void main(void)
     compute_distances();
    vs_out.out_color=colors;
    vs_out.fP = mv_matrix * vertex;
+   vs_out.vertex = vertex;
    gl_Position = mvp_matrix * vertex;
 }


### PR DESCRIPTION
## Summary of Changes

Fixes the flat_shader used for unicolor polyhedron_items with OpenGL 4.3.
