### PR TITLE
Documentation: Fix 1.8.13 column

### DIFF
--- a/Documentation/doc/scripts/testsuite.py
+++ b/Documentation/doc/scripts/testsuite.py
@@ -137,8 +137,8 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
         result = [(basename, pretty_name, res)]
         results2.extend(result)
 
-        os.chdir(args.doc_log_dir_master)
-        logs=sorted(glob.glob('./*.log'))
+    os.chdir(args.doc_log_dir_master)
+    logs=sorted(glob.glob('./*.log'))
 
     for log in logs:
         res=count_errors_and_warnings(log)


### PR DESCRIPTION
## Summary of Changes

In the python script construction the new rows, there were an indentation error in a for loop, which made the warning sum for 1.8.13 the same as the one from master.
## Release Management

* Affected package(s):Documentation


