### PR TITLE
BGL: Use Named Parameters in OFF I/O

### DIFF
--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -32,24 +32,36 @@
 
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/boost/graph/helpers.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/boost/graph/named_function_params.h>
 
 namespace CGAL {
 /*!
    \ingroup PkgBGLIOFct
     writes the graph `g` in the OFF format.
+    
+    \cgalNamedParamsBegin
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `g`.
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `FaceGraph`\cgalParamEnd
+    * \cgalNamedParamsEnd
+    
     \sa Overloads of this function for specific models of the concept `FaceGraph`.
 
   */ 
-template <typename FaceGraph>
+template <typename FaceGraph, typename NamedParameters>
 bool write_off(std::ostream& os,
-               const FaceGraph& g)
+               const FaceGraph& g,
+               const NamedParameters& np)
 {
   typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::vertices_size_type vertices_size_type;
   typedef typename boost::graph_traits<FaceGraph>::faces_size_type faces_size_type;
 
-  typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::const_type vpm = get(CGAL::vertex_point,g);
+  typename Polygon_mesh_processing::GetVertexPointMap<FaceGraph, NamedParameters>::const_type
+      vpm = choose_param(get_param(np, internal_np::vertex_point),
+                         get_const_property_map(CGAL::vertex_point, g));
   vertices_size_type nv = static_cast<vertices_size_type>(std::distance(vertices(g).first, vertices(g).second));
   faces_size_type nf = static_cast<faces_size_type>(std::distance(faces(g).first, faces(g).second));
 
@@ -78,21 +90,45 @@ bool write_off(std::ostream& os,
     \sa Overloads of this function for specific models of the concept `FaceGraph`.
 
   */ 
+template <typename FaceGraph, typename NamedParameters>
+bool write_off(const char* fname,
+               const FaceGraph& g,
+               const NamedParameters& np)
+{
+  std::ofstream out(fname);
+  if(out.good()){
+    return write_off(out,g, np);
+  }
+  return false;
+}
+
+template <typename FaceGraph, typename NamedParameters>
+bool write_off(const std::string& fname,
+               const FaceGraph& g,
+               const NamedParameters& np)
+{ return write_off(fname.c_str(), g, np); }
+
+
+template <typename FaceGraph>
+bool write_off(std::ostream& os,
+               const FaceGraph& g)
+{
+  return write_off(os, g, 
+                   parameters::all_default());
+}
 template <typename FaceGraph>
 bool write_off(const char* fname,
                const FaceGraph& g)
 {
-  std::ofstream out(fname);
-  if(out.good()){
-    return write_off(out,g);
-  }
-  return false;
+  return write_off(fname,g,
+                   parameters::all_default());
 }
 
 template <typename FaceGraph>
 bool write_off(const std::string& fname,
                const FaceGraph& g)
-{ return write_off(fname.c_str(), g); }
+{ return write_off(fname, g, 
+                   parameters::all_default()); }
 
   namespace internal { namespace read_off_tools {
   
@@ -122,14 +158,21 @@ inline std::string next_non_comment(std::istream& is)
 /*!
    \ingroup PkgBGLIOFct
     reads the graph `g` from data in the OFF format. Ignores comment lines which start with a hash, and lines with whitespace.
+    
+    \cgalNamedParamsBegin
+    *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `g`.
+    *       If this parameter is omitted, an internal property map for
+    *       `CGAL::vertex_point_t` should be available in `FaceGraph`\cgalParamEnd
+    * \cgalNamedParamsEnd
     \sa Overloads of this function for specific models of the concept `FaceGraph`.
     \pre The data must represent a 2-manifold
     \attention The graph `g` is not cleared, and the data from the stream are added.
 
   */ 
-template <typename FaceGraph>
+template <typename FaceGraph, typename NamedParameters>
 bool read_off(std::istream& is,
-              FaceGraph& g)
+              FaceGraph& g,
+              NamedParameters np)
 {
   using namespace internal::read_off_tools;
 
@@ -137,9 +180,11 @@ bool read_off(std::istream& is,
   typedef typename boost::graph_traits<FaceGraph>::vertices_size_type vertices_size_type;
   typedef typename boost::graph_traits<FaceGraph>::faces_size_type faces_size_type;
 
-  typedef typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::type Vpm;
+  typedef typename Polygon_mesh_processing::GetVertexPointMap<FaceGraph, NamedParameters>::type Vpm;
   typedef  typename boost::property_traits<Vpm>::value_type Point_3;
-  Vpm vpm = get(CGAL::vertex_point,g);
+  
+  Vpm vpm = choose_param(get_param(np, internal_np::vertex_point),
+                         get_property_map(CGAL::vertex_point, g));
   vertices_size_type nv, nvf;
   faces_size_type nf;
   int ignore;
@@ -182,6 +227,12 @@ bool read_off(std::istream& is,
   return true;
 }
 
+template <typename FaceGraph>
+bool read_off(std::istream& is,
+              FaceGraph& g)
+{
+  return read_off(is, g, parameters::all_default());
+}
 
 /*!
    \ingroup PkgBGLIOFct
@@ -191,36 +242,52 @@ bool read_off(std::istream& is,
     \attention The graph `g` is not cleared, and the data from the stream are added.
 
   */ 
-template <typename FaceGraph>
+template <typename FaceGraph, typename NamedParameters>
 bool read_off(const char* fname,
-              FaceGraph& g)
+              FaceGraph& g,
+              NamedParameters np)
 {
   std::ifstream in(fname);
   if(in.good()){
-    return read_off(in, g);
+    return read_off(in, g, np);
   }
   return false;
 }
 
 template <typename FaceGraph>
-bool read_off(const std::string& fname,
+bool read_off(const char* fname,
               FaceGraph& g)
-{ return read_off(fname.c_str(), g); }  
+{
+  return read_off(fname, g, parameters::all_default());
+}
+
+template <typename FaceGraph, typename NamedParameters>
+bool read_off(const std::string& fname,
+              FaceGraph& g,
+              NamedParameters np)
+{ return read_off(fname.c_str(), g, np); }  
 
 template <typename FaceGraph>
+bool read_off(const std::string& fname,
+              FaceGraph& g)
+{ return read_off(fname, g, parameters::all_default()); }  
+
+template <typename FaceGraph, typename NamedParameters>
 bool write_inp(std::ostream& os,
                const FaceGraph& g,
                std::string name,
-               std::string type)
+               std::string type,
+               const NamedParameters& np)
 {
   typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::vertices_size_type vertices_size_type;
 
-  typedef typename boost::property_map<FaceGraph, CGAL::vertex_point_t>::const_type VPM;
+  typedef typename Polygon_mesh_processing::GetVertexPointMap<FaceGraph, NamedParameters>::const_type VPM;
   typedef typename boost::property_traits<VPM>::value_type Point_3;
 
-  VPM vpm = get(CGAL::vertex_point,g);
+  VPM vpm = choose_param(get_param(np, internal_np::vertex_point),
+                         get_const_property_map(CGAL::vertex_point, g));
 
   os << "*Part, name=" << name << "\n*Node\n";
   boost::container::flat_map<vertex_descriptor,vertices_size_type> reindex;

--- a/BGL/include/CGAL/boost/graph/io.h
+++ b/BGL/include/CGAL/boost/graph/io.h
@@ -309,8 +309,15 @@ bool write_inp(std::ostream& os,
   os << "*End Part"<< std::endl;
   return os.good();
 }
-
-
+// conveniance overload
+template <typename FaceGraph>
+bool write_inp(std::ostream& os,
+               const FaceGraph& g,
+               std::string name,
+               std::string type)
+{
+  return write_inp(os, g, name, type, parameters::all_default());
+}
 } // namespace CGAL
 
 #endif // CGAL_BOOST_GRAPH_IO_H

--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -23,14 +23,6 @@
 
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Origin.h>
-#include <CGAL/Default_diagonalize_traits.h>
-
-#if defined(CGAL_EIGEN3_ENABLED)
-#include <CGAL/Eigen_svd.h>
-#elif defined(CGAL_LAPACK_ENABLED)
-#include <CGAL/Lapack_svd.h>
-#endif
-
 
 #include <CGAL/property_map.h>
 #include <CGAL/boost/graph/properties.h>
@@ -41,6 +33,15 @@
 #include <boost/version.hpp>
 
 namespace CGAL {
+
+  // forward declarations to avoid dependency to Solver_interface
+  template <typename FT, unsigned int dim>
+  class Default_diagonalize_traits;
+  class Eigen_svd;
+  class Lapack_svd;
+  //
+  
+  
   //helper classes
   template<typename PolygonMesh, typename PropertyTag>
   class property_map_selector

--- a/BGL/package_info/BGL/dependencies
+++ b/BGL/package_info/BGL/dependencies
@@ -19,5 +19,4 @@ Number_types
 Profiling_tools
 Property_map
 STL_Extension
-Solver_interface
 Stream_support

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_2/surface_mesh/IO.h
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_2/surface_mesh/IO.h
@@ -33,9 +33,13 @@
 
 
 bool read_mesh(Surface_mesh& mesh, const std::string& filename);
+template<typename NamedParameters>
+bool read_off(Surface_mesh& mesh, const std::string& filename, NamedParameters& np);
 bool read_off(Surface_mesh& mesh, const std::string& filename);
 
 bool write_mesh(const Surface_mesh& mesh, const std::string& filename);
+template<typename NamedParameters>
+bool write_off(const Surface_mesh& mesh, const std::string& filename, const NamedParameters& np);
 bool write_off(const Surface_mesh& mesh, const std::string& filename);
 
 

--- a/Point_set_3/package_info/Point_set_3/dependencies
+++ b/Point_set_3/package_info/Point_set_3/dependencies
@@ -10,6 +10,5 @@ Point_set_processing_3
 Profiling_tools
 Property_map
 STL_Extension
-Solver_interface
 Stream_support
 Surface_mesh

--- a/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
+++ b/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
@@ -24,18 +24,18 @@
 
 #include <CGAL/license/Polyhedron.h>
 
-
 #include <CGAL/basic.h>
 #include <CGAL/Inverse_index.h>
 #include <iostream>
 
 namespace CGAL {
 
-template <class Polyhedron, class Writer>
+template <class Polyhedron, class Writer, class Vpm>
 void
 generic_print_polyhedron( std::ostream&     out, 
                           const Polyhedron& P,
-                          Writer&           writer) {
+                          Writer&           writer,
+                          const Vpm& vpm ) {
     // writes P to `out' in the format provided by `writer'.
     typedef typename Polyhedron::Vertex_const_iterator                  VCI;
     typedef typename Polyhedron::Facet_const_iterator                   FCI;
@@ -45,10 +45,10 @@ generic_print_polyhedron( std::ostream&     out,
                          P.size_of_vertices(),
                          P.size_of_halfedges(),
                          P.size_of_facets());
-    for( VCI vi = P.vertices_begin(); vi != P.vertices_end(); ++vi) {
-        writer.write_vertex( ::CGAL::to_double( vi->point().x()),
-                             ::CGAL::to_double( vi->point().y()),
-                             ::CGAL::to_double( vi->point().z()));
+    BOOST_FOREACH(typename boost::graph_traits<Polyhedron>::vertex_descriptor vi, vertices(P)) {
+        writer.write_vertex( ::CGAL::to_double( get(vpm, vi).x()),
+                             ::CGAL::to_double( get(vpm, vi).y()),
+                             ::CGAL::to_double( get(vpm, vi).z()));
     }
     typedef Inverse_index< VCI> Index;
     Index index( P.vertices_begin(), P.vertices_end());
@@ -69,6 +69,15 @@ generic_print_polyhedron( std::ostream&     out,
     writer.write_footer();
 }
 
+template <class Polyhedron, class Writer>
+void
+generic_print_polyhedron( std::ostream&     out, 
+                          const Polyhedron& P,
+                          Writer&           writer) 
+{
+  generic_print_polyhedron(out, P, writer,
+                           get_property_map(CGAL::vertex_point, P));
+}
 } //namespace CGAL
 #endif // CGAL_IO_GENERIC_PRINT_POLYHEDRON_H //
 // EOF //

--- a/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
+++ b/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
@@ -24,6 +24,10 @@
 
 #include <CGAL/license/Polyhedron.h>
 
+#include <CGAL/boost/graph/named_function_params.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/property_map.h>
+#include <boost/graph/graph_traits.hpp>
 #include <CGAL/basic.h>
 #include <CGAL/Inverse_index.h>
 #include <iostream>

--- a/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
+++ b/Polyhedron_IO/include/CGAL/IO/generic_print_polyhedron.h
@@ -28,6 +28,7 @@
 #include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/property_map.h>
 #include <boost/graph/graph_traits.hpp>
+
 #include <CGAL/basic.h>
 #include <CGAL/Inverse_index.h>
 #include <iostream>
@@ -80,7 +81,7 @@ generic_print_polyhedron( std::ostream&     out,
                           Writer&           writer) 
 {
   generic_print_polyhedron(out, P, writer,
-                           get_property_map(CGAL::vertex_point, P));
+                           get(CGAL::vertex_point, P));
 }
 } //namespace CGAL
 #endif // CGAL_IO_GENERIC_PRINT_POLYHEDRON_H //

--- a/Polyhedron_IO/include/CGAL/IO/print_OFF.h
+++ b/Polyhedron_IO/include/CGAL/IO/print_OFF.h
@@ -49,7 +49,7 @@ void print_polyhedron_with_header_OFF( std::ostream& out,
                                        const Polyhedron& P,
                                        const File_header_OFF& header) 
 {
-  print_polyhedron_with_header_OFF(out, P, header);
+  print_polyhedron_with_header_OFF(out, P, header, get(CGAL::vertex_point, P));
 }
 
 template <class Polyhedron>

--- a/Polyhedron_IO/include/CGAL/IO/print_OFF.h
+++ b/Polyhedron_IO/include/CGAL/IO/print_OFF.h
@@ -33,16 +33,24 @@
 
 namespace CGAL {
 
-template <class Polyhedron>
+template <class Polyhedron, class Vpm>
 void print_polyhedron_with_header_OFF( std::ostream& out, 
                                        const Polyhedron& P,
-                                       const File_header_OFF& header) {
+                                       const File_header_OFF& header,
+                                       const Vpm& vpm) {
     File_writer_OFF  writer( header);
     writer.header().set_polyhedral_surface( true);
     writer.header().set_halfedges( P.size_of_halfedges());
-    generic_print_polyhedron( out, P, writer);
+    generic_print_polyhedron( out, P, writer, vpm);
 }
 
+template <class Polyhedron>
+void print_polyhedron_with_header_OFF( std::ostream& out, 
+                                       const Polyhedron& P,
+                                       const File_header_OFF& header) 
+{
+  print_polyhedron_with_header_OFF(out, P, header);
+}
 
 template <class Polyhedron>
 void print_polyhedron_OFF( std::ostream& out, 

--- a/Subdivision_method_3/package_info/Subdivision_method_3/dependencies
+++ b/Subdivision_method_3/package_info/Subdivision_method_3/dependencies
@@ -10,6 +10,5 @@ Number_types
 Profiling_tools
 Property_map
 STL_Extension
-Solver_interface
 Stream_support
 Subdivision_method_3

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2032,13 +2032,17 @@ private: //------------------------------------------------------- private data
     return os.good();
   }
 
+  template <typename P>
+  bool write_off(std::ostream& os, const Surface_mesh<P>& sm) {
+    return write_off(os, sm, CGAL::parameters::all_default());
+  }
   /// \relates Surface_mesh
   /// 
   /// This operator calls `write_off(std::ostream& os, const CGAL::Surface_mesh& sm)`.
    template <typename P>
   std::ostream& operator<<(std::ostream& os, const Surface_mesh<P>& sm)
   {
-    write_off(os, sm);
+    write_off(os, sm, CGAL::parameters::all_default());
     return os;
   }
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -55,6 +55,8 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/IO/File_scanner_OFF.h>
 #include <CGAL/Handle_hash_function.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/boost/graph/named_function_params.h>
 
 namespace CGAL {
 
@@ -1977,9 +1979,11 @@ private: //------------------------------------------------------- private data
   /// \relates Surface_mesh
   /// Inserts the surface mesh in an output stream in Ascii OFF format. 
   /// Only the \em point property is inserted in the stream.
+  /// If an alternative vertex_point map is given through `np`, 
+  /// then it  will be used instead of the default one.
   /// \pre `operator<<(std::ostream&,const P&)` must be defined.
-  template <typename P>
-  bool write_off(std::ostream& os, const Surface_mesh<P>& sm) {
+  template <typename P, typename NamedParameters>
+  bool write_off(std::ostream& os, const Surface_mesh<P>& sm, const NamedParameters& np) {
     typedef Surface_mesh<P> Mesh;
     typedef typename Mesh::Vertex_index Vertex_index;
     typedef typename Mesh::Face_index Face_index;
@@ -1996,10 +2000,14 @@ private: //------------------------------------------------------- private data
     else
       os << "COFF\n" << sm.number_of_vertices() << " " << sm.number_of_faces() << " 0\n";
     std::vector<int> reindex;
+    typename Polygon_mesh_processing::GetVertexPointMap<Surface_mesh<P>, NamedParameters>::const_type
+        vpm = choose_param(get_param(np, internal_np::vertex_point),
+                           get_const_property_map(CGAL::vertex_point, sm));
     reindex.resize(sm.num_vertices());
     int n = 0;
     BOOST_FOREACH(Vertex_index v, sm.vertices()){
-      os << sm.point(v);
+      
+      os << get(vpm, v);
       if(has_vcolors)
       {
         CGAL::Color color = vcolors[v];
@@ -2058,12 +2066,14 @@ private: //------------------------------------------------------- private data
   /// format and appends it to the surface mesh `sm`.
   /// The operator reads the point property as well as "v:normal", "v:color", and "f:color".
   /// Vertex texture coordinates are ignored.
+  /// If an alternative vertex_point map is given through `np`, 
+  /// then it  will be used instead of the default one.
   /// \pre `operator>>(std::istream&,const P&)` must be defined.
   /// \pre The data in the stream must represent a two-manifold. If this is not the case
   ///      the `failbit` of `is` is set and the mesh cleared.
 
-  template <typename P>
-  bool read_off(std::istream& is, Surface_mesh<P>& sm)
+  template <typename P, typename NamedParameters>
+  bool read_off(std::istream& is, Surface_mesh<P>& sm, NamedParameters np)
   {
    typedef Surface_mesh<P> Mesh;
    typedef typename Kernel_traits<P>::Kernel K;
@@ -2071,6 +2081,9 @@ private: //------------------------------------------------------- private data
    typedef typename Mesh::Face_index Face_index;
    typedef typename Mesh::Vertex_index Vertex_index;
    typedef typename Mesh::size_type size_type;
+    typename CGAL::Polygon_mesh_processing::GetVertexPointMap<Surface_mesh<P>, NamedParameters>::type
+        vpm = choose_param(get_param(np, CGAL::internal_np::vertex_point),
+                           get_property_map(CGAL::vertex_point, sm));
     int n, f, e;
     std::string off;
     is >> sm_skip_comments;
@@ -2097,7 +2110,11 @@ private: //------------------------------------------------------- private data
     for(int i=0; i < n; i++){
       is >> sm_skip_comments;
       is >> p;
-      Vertex_index vi= sm.add_vertex(p);
+      
+      Vertex_index vi = sm.add_vertex();
+      put(vpm, vi, p);
+      
+      
       vertexmap[i] = vi;
       if(v_has_normals){
         is >> v;
@@ -2167,6 +2184,11 @@ private: //------------------------------------------------------- private data
   }
 
 
+  template <typename P>
+  bool read_off(std::istream& is, Surface_mesh<P>& sm)
+  {
+    return read_off(is, sm, parameters::all_default());
+  }
  
   /// \relates Surface_mesh
   /// This operator calls `read_off(std::istream& is, CGAL::Surface_mesh& sm)`.


### PR DESCRIPTION
## Summary of Changes
Add NamedParameters to the off I/O functions.
## Release Management

* Affected package(s):BGL Polyhedron_3 Surface_mesh LCC 
* Issue(s) solved (if any): fix #3049


