### PR TITLE
A fix for MSVC 2017 15.7 with /permissive-

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -306,13 +306,13 @@ public:
         switch(Traits::longest_axis(bbox))
         {
         case AT::CGAL_AXIS_X: // sort along x
-          std::nth_element(first, middle, beyond, boost::bind(less_x,_1,_2,m_traits));
+          std::nth_element(first, middle, beyond, boost::bind(Traits::less_x,_1,_2,m_traits));
           break;
         case AT::CGAL_AXIS_Y: // sort along y
-          std::nth_element(first, middle, beyond, boost::bind(less_y,_1,_2,m_traits));
+          std::nth_element(first, middle, beyond, boost::bind(Traits::less_y,_1,_2,m_traits));
           break;
         case AT::CGAL_AXIS_Z: // sort along z
-          std::nth_element(first, middle, beyond, boost::bind(less_z,_1,_2,m_traits));
+          std::nth_element(first, middle, beyond, boost::bind(Traits::less_z,_1,_2,m_traits));
           break;
         default:
           CGAL_error();

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -291,7 +291,8 @@ public:
    */
   class Sort_primitives
   {
-  const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& m_traits;
+    typedef AABB_traits<GeomTraits,AABBPrimitive,BboxMap> Traits;
+    const Traits& m_traits;
   public:
     Sort_primitives(const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& traits)
       : m_traits(traits) {}
@@ -302,7 +303,7 @@ public:
                     const typename AT::Bounding_box& bbox) const
       {
         PrimitiveIterator middle = first + (beyond - first)/2;
-        switch(longest_axis(bbox))
+        switch(Traits::longest_axis(bbox))
         {
         case AT::CGAL_AXIS_X: // sort along x
           std::nth_element(first, middle, beyond, boost::bind(less_x,_1,_2,m_traits));


### PR DESCRIPTION
## Summary of Changes

A fix for MSVC 2017 15.7 (Preview 4) with `/permissive-`

MSVC is probably right that it was not a valid C++ code: the previous
version called a static member function of the enclosing class, without
qualification, and that static member function was defined *after*.

@mglisse An interesting exercise of reading the norm. From what I ready [in cppreference][1]:
> c) if this class is nested, the body of the enclosing class until the declaration of this class and the entire body of the base class(es) of the enclosing class.

The part "until the declaration of this class" is the critical argument, in my opinion. As far as I understand, in the first pass of the Two Pass Name Lookup, the code is ill-formed.

[1]: http://en.cppreference.com/w/cpp/language/unqualified_lookup#Class_definition

## Release Management

* Affected package(s): AABB_tree
* Issue(s) solved (if any): fix #2414 

