### PR TITLE
The class std::iterator got deprecated. 

### DIFF
--- a/STL_Extension/include/CGAL/internal/boost/array_binary_tree.hpp
+++ b/STL_Extension/include/CGAL/internal/boost/array_binary_tree.hpp
@@ -20,7 +20,7 @@
 #ifndef CGAL_INTERNAL_ARRAY_BINARY_TREE_HPP
 #define CGAL_INTERNAL_ARRAY_BINARY_TREE_HPP
 
-#include <boost/iterator.hpp>
+#include <iterator>
 #include <functional>
 #include <boost/config.hpp>
 
@@ -52,12 +52,12 @@ public:
 
   struct children_type {
     struct iterator
-        : ::boost::iterator<std::forward_iterator_tag,
-            //JT: the iterator type is "forward" and not "bidirectional",
-            //because it does not implement unary operator--
-            ArrayBinaryTreeNode,
-            difference_type, array_binary_tree_node*, ArrayBinaryTreeNode&>
     { // replace with iterator_adaptor implementation -JGS
+      typedef std::forward_iterator_tag Category;
+      typedef ArrayBinaryTreeNode value_type;
+      typedef size_type difference_type
+      typedef ArrayBinaryTreeNode* Pointer;
+      typedef ArrayBinaryTreeNode& Reference;
 
       inline iterator() : i(0), n(0) { }
       inline iterator(const iterator& x) : r(x.r), i(x.i), n(x.n), id(x.id) { }


### PR DESCRIPTION

## Summary of Changes

It only served to define some nested types.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):

