### PR TITLE
Alpha_shapes: class template has already been defined.

### DIFF
--- a/Alpha_shapes_2/include/CGAL/internal/Lazy_alpha_nt_2.h
+++ b/Alpha_shapes_2/include/CGAL/internal/Lazy_alpha_nt_2.h
@@ -45,7 +45,7 @@ namespace internal {
 //
 template < class Input_traits, class Kernel_approx, class Kernel_exact,
            class Weighted_tag >
-class Is_traits_point_convertible
+class Is_traits_point_convertible_2
 {
   typedef typename Kernel_traits<typename Input_traits::Point_2>::Kernel   Kernel_input;
 
@@ -60,7 +60,7 @@ public:
 };
 
 template < class Input_traits, class Kernel_approx, class Kernel_exact >
-class Is_traits_point_convertible<Input_traits, Kernel_approx, Kernel_exact,
+class Is_traits_point_convertible_2<Input_traits, Kernel_approx, Kernel_exact,
                                   ::CGAL::Tag_true /* Weighted_tag */>
 {
   typedef typename Kernel_traits<typename Input_traits::Point_2>::Kernel   Kernel_input;
@@ -157,7 +157,7 @@ class Lazy_alpha_nt_2
   Approx_point to_approx(const Input_point& wp) const
   {
     // The traits class' Point_2 must be convertible using the Cartesian converter
-    CGAL_static_assertion((Is_traits_point_convertible<
+    CGAL_static_assertion((Is_traits_point_convertible_2<
                             Input_traits, Kernel_approx, Kernel_exact, Weighted_tag>::value));
 
     To_approx converter;
@@ -167,7 +167,7 @@ class Lazy_alpha_nt_2
   Exact_point to_exact(const Input_point& wp) const
   {
     // The traits class' Point_2 must be convertible using the Cartesian converter
-    CGAL_static_assertion((Is_traits_point_convertible<
+    CGAL_static_assertion((Is_traits_point_convertible_2<
                             Input_traits, Kernel_approx, Kernel_exact, Weighted_tag>::value));
 
     To_exact converter;

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -45,7 +45,7 @@ namespace internal{
 //
 template < class Input_traits, class Kernel_approx, class Kernel_exact,
            class Weighted_tag >
-class Is_traits_point_convertible
+class Is_traits_point_convertible_3
 {
   typedef typename Kernel_traits<typename Input_traits::Point_3>::Kernel   Kernel_input;
 
@@ -60,7 +60,7 @@ public:
 };
 
 template < class Input_traits, class Kernel_approx, class Kernel_exact >
-class Is_traits_point_convertible<Input_traits, Kernel_approx, Kernel_exact,
+class Is_traits_point_convertible_3<Input_traits, Kernel_approx, Kernel_exact,
                                   ::CGAL::Tag_true /* Weighted_tag */>
 {
   typedef typename Kernel_traits<typename Input_traits::Point_3>::Kernel   Kernel_input;
@@ -148,7 +148,7 @@ class Lazy_alpha_nt_3{
   Approx_point to_approx(const Input_point& wp) const
   {
     // The traits class' Point_3 must be convertible using the Cartesian converter
-    CGAL_static_assertion((Is_traits_point_convertible<
+    CGAL_static_assertion((Is_traits_point_convertible_3<
                             Input_traits, Kernel_approx, Kernel_exact, Weighted_tag>::value));
 
     To_approx converter;
@@ -158,7 +158,7 @@ class Lazy_alpha_nt_3{
   Exact_point to_exact(const Input_point& wp) const
   {
     // The traits class' Point_3 must be convertible using the Cartesian converter
-    CGAL_static_assertion((Is_traits_point_convertible<
+    CGAL_static_assertion((Is_traits_point_convertible_3<
                             Input_traits, Kernel_approx, Kernel_exact, Weighted_tag>::value));
 
     To_exact converter;


### PR DESCRIPTION
## Summary of Changes

`CGAL::internal::Is_traits_point_convertible` is defined twice, namely in `Lazy_alpha_nt_2/3.h` and the two are slighlty different. The fix is to postfix with the dimension.

## Release Management

* Affected package(s): Alpha_shape_2/3
* Issue(s) solved (if any): bugreport by a user

