### PR TITLE
Installation: Fix minimum version numbers

### DIFF
--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -152,7 +152,7 @@ installation manual. The \cgal manual must be downloaded separately from
 \section seccompilers Supported Compilers 
 
 In order to build the \cgal libraries, you need a \cpp compiler. 
-\cgal \cgalReleaseNumber is supported for the following compilers/operating systems:
+\cgal \cgalReleaseNumber is supported, that is continuously tested, for the following compilers/operating systems:
 
 
 | Compiler | Operating System |
@@ -160,8 +160,10 @@ In order to build the \cgal libraries, you need a \cpp compiler.
 |\sc{Gnu} `g++` 4.1 or later\cgalFootnote{<A HREF="http://gcc.gnu.org/">`http://gcc.gnu.org/`</A>} | Linux / MacOS X |
 |          | \sc{MS} Windows | 
 |\sc{MS} Visual `C++` 12.0, 14.0, 15.0 (\sc{Visual Studio} 2013, 2015, and 2017)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows |
-| `Clang` \cgalFootnote{<A HREF="http://clang.llvm.org/">`http://clang.llvm.org/`</A>} compiler version 3.5 and 3.6.2 | Linux / MacOS X |
-| Apple `Clang` compiler version 6.0 and 4.2 | MacOS X |
+| `Clang` \cgalFootnote{<A HREF="http://clang.llvm.org/">`http://clang.llvm.org/`</A>} compiler version 6.0.0 | Linux  |
+| Apple `Clang` compiler version 7.0.2 | MacOS X |
+
+It may work for older versions of the above listed compilers.
 
 
 \section secconfigwithcmake Configuring CGAL with CMake 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -41,11 +41,6 @@ make
 where the second line creates a `CMakeLists.txt` file (check
 its options in Section \ref seccreate_cgal_CMakeLists for various details).
 
-Note that, until CGAL 4.6, \ref seccreate_cgal_CMakeLists only recognized
-source files ending in `.cpp` or `.C`; if the above fails on the `cmake` command
-or produces an empty `Makefile`, check whether your source files go by such a name.
-Recent versions find all source files ending in
-`.cc`, `.cp`, `.cxx`, `.cpp`, `.CPP`, `.c++`, or `.C`.
 
 In a less ideal world, you probably have to install CMake, a makefile
 generator, and third party libraries. That is what this manual is about.
@@ -105,7 +100,7 @@ It is a self extracting executable that installs the \cgal source, and that allo
 to select and download some precompiled third party libraries. However, you will need to compile
 the library using your favorite compiler.
 
-A <a href="https://www.cgal.org/windows_installation.html">tutorial</a> is provided on how to proceed with Microsoft Visual Studio 2010.
+A <a href="https://www.cgal.org/windows_installation.html">tutorial</a> is provided on how to proceed with Microsoft Visual Studio.
 
 
 
@@ -163,9 +158,9 @@ In order to build the \cgal libraries, you need a \cpp compiler.
 | Compiler | Operating System |
 | :------- | :--------------- |
 |\sc{Gnu} `g++` 4.1 or later\cgalFootnote{<A HREF="http://gcc.gnu.org/">`http://gcc.gnu.org/`</A>} | Linux / MacOS X |
-|          | \sc{MS} Windows 95/98/2000/XP/NT4 | 
+|          | \sc{MS} Windows 10 | 
 | \sc{Intel} `C++` 15.0\cgalFootnote{<A HREF="http://software.intel.com/en-us/intel-compilers/">`http://software.intel.com/en-us/intel-compilers/`</A>} | Linux  |
-|\sc{MS} Visual `C++` 10.0, 11.0, 12.0, 14.0 (\sc{Visual Studio} 2010, 2012, 2013, and 2015)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows 95/98/2000/XP/NT4/Vista/7/8 |
+|\sc{MS} Visual `C++` 12.0, 14.0, 19.0 (\sc{Visual Studio} 2013, 2015, and 2017)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows 10 |
 | `Clang` \cgalFootnote{<A HREF="http://clang.llvm.org/">`http://clang.llvm.org/`</A>} compiler version 3.5 and 3.6.2 | Linux / MacOS X |
 | Apple `Clang` compiler version 6.0 and 4.2 | MacOS X |
 
@@ -381,8 +376,8 @@ libCGAL_Core, libCGAL_ImageIO, and libCGAL_Qt5).
 \cgal heavily uses the \stl, and in particular adopted
 many of its design ideas. You can find online
 documentation for the \stl at various web sites, for instance, 
-<A HREF="http://www.sgi.com/tech/stl/">`http://www.sgi.com/tech/stl/`</A>, <A HREF="http://www.cplusplus.com/reference/">`http://www.cplusplus.com/reference/`</A>,
-or <A HREF="http://msdn.microsoft.com/en-us/library/1fe2x6kt(VS.100).aspx">`http://msdn.microsoft.com/en-us/library/1fe2x6kt(VS.100).aspx`</A>.
+<A HREF="http://www.cplusplus.com/reference/">`http://www.cplusplus.com/reference/`</A>,
+or <A HREF="https://msdn.microsoft.com/en-us/library/1fe2x6kt(v=vs.140).aspx">`https://msdn.microsoft.com/en-us/library/1fe2x6kt(v=vs.140).aspx`</A>.
 
 The \stl comes with the compiler, so there is nothing to install.
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -158,9 +158,9 @@ In order to build the \cgal libraries, you need a \cpp compiler.
 | Compiler | Operating System |
 | :------- | :--------------- |
 |\sc{Gnu} `g++` 4.1 or later\cgalFootnote{<A HREF="http://gcc.gnu.org/">`http://gcc.gnu.org/`</A>} | Linux / MacOS X |
-|          | \sc{MS} Windows 10 | 
+|          | \sc{MS} Windows | 
 | \sc{Intel} `C++` 15.0\cgalFootnote{<A HREF="http://software.intel.com/en-us/intel-compilers/">`http://software.intel.com/en-us/intel-compilers/`</A>} | Linux  |
-|\sc{MS} Visual `C++` 12.0, 14.0, 19.0 (\sc{Visual Studio} 2013, 2015, and 2017)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows 10 |
+|\sc{MS} Visual `C++` 12.0, 14.0, 15.0 (\sc{Visual Studio} 2013, 2015, and 2017)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows |
 | `Clang` \cgalFootnote{<A HREF="http://clang.llvm.org/">`http://clang.llvm.org/`</A>} compiler version 3.5 and 3.6.2 | Linux / MacOS X |
 | Apple `Clang` compiler version 6.0 and 4.2 | MacOS X |
 
@@ -242,11 +242,11 @@ generators are added with each release.
 Since the choice of the generator determines the type of build files to generate, in some cases
 you choose a particular generator as a mean to choose a specific compiler (because they use different 
 build files). For example, the following generates solution files for
-use in Visual \cpp 11.0 on a 64bit machine:
+use in Visual \cpp 15.0 on a 64bit machine:
 
 <PRE>
 cd CGAL-\cgalReleaseNumber
-cmake -G"Visual Studio 11 Win64" . 
+cmake -G"Visual Studio 15 2017 Win64" . 
 </PRE>
 
 In other cases, however, the generator doesn't directly identify a

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -159,7 +159,6 @@ In order to build the \cgal libraries, you need a \cpp compiler.
 | :------- | :--------------- |
 |\sc{Gnu} `g++` 4.1 or later\cgalFootnote{<A HREF="http://gcc.gnu.org/">`http://gcc.gnu.org/`</A>} | Linux / MacOS X |
 |          | \sc{MS} Windows | 
-| \sc{Intel} `C++` 15.0\cgalFootnote{<A HREF="http://software.intel.com/en-us/intel-compilers/">`http://software.intel.com/en-us/intel-compilers/`</A>} | Linux  |
 |\sc{MS} Visual `C++` 12.0, 14.0, 15.0 (\sc{Visual Studio} 2013, 2015, and 2017)\cgalFootnote{<A HREF="http://msdn.microsoft.com/en-us/vstudio/">`http://msdn.microsoft.com/en-us/vstudio/`</A>} | \sc{MS} Windows |
 | `Clang` \cgalFootnote{<A HREF="http://clang.llvm.org/">`http://clang.llvm.org/`</A>} compiler version 3.5 and 3.6.2 | Linux / MacOS X |
 | Apple `Clang` compiler version 6.0 and 4.2 | MacOS X |


### PR DESCRIPTION

## Summary of Changes

- Fixed links
- Remove a paragraph "Before 4.6 blabla"
- Upgrade minimum VC++

### Todo

- [x] The g++ and clang versions
- [x] The cmake generators for VC
- [x]  What is the minimum version of boost (answer: that is still 1.48).
- [x]  Check the [Windows tutorial](https://www.cgal.org/download/windows.html)

## Release Management

* Affected package(s): Installation Manual
* Issue(s) solved (if any): fix #3078