### PR TITLE
Triangulation_2: Fix Constrained Delaunay demo. 

### DIFF
--- a/GraphicsView/demo/Triangulation_2/TriangulationCircumcircle.h
+++ b/GraphicsView/demo/Triangulation_2/TriangulationCircumcircle.h
@@ -90,11 +90,11 @@ TriangulationCircumcircle<T>::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
   if(dt->dimension() != 2){
     circle->hide();
-	hint = Vertex_handle();
+    hint = Vertex_handle();
     return;
   }
   if (hint == Vertex_handle()){
-	  hint = dt->infinite_vertex();
+    hint = dt->infinite_vertex();
   }
   typename T::Point p = typename T::Point(event->scenePos().x(), event->scenePos().y());
   fh = dt->locate(p, hint->face());

--- a/GraphicsView/demo/Triangulation_2/TriangulationCircumcircle.h
+++ b/GraphicsView/demo/Triangulation_2/TriangulationCircumcircle.h
@@ -33,6 +33,7 @@ protected:
 private:
 
   DT * dt;
+  typedef typename DT::Vertex_handle Vertex_handle;
   typename DT::Vertex_handle hint;
   typename DT::Face_handle fh;
   QGraphicsScene *scene_;
@@ -89,7 +90,11 @@ TriangulationCircumcircle<T>::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
   if(dt->dimension() != 2){
     circle->hide();
+	hint = Vertex_handle();
     return;
+  }
+  if (hint == Vertex_handle()){
+	  hint = dt->infinite_vertex();
   }
   typename T::Point p = typename T::Point(event->scenePos().x(), event->scenePos().y());
   fh = dt->locate(p, hint->face());


### PR DESCRIPTION
## Summary of Changes

The `hint` was outdated after `cdt.clear()`, leading to a segfault.
In order to reproduce: generate points, switch on circumcircle, clear, add points.

## Release Management

* Affected package(s): Triangulation_2
