### PR TITLE
Fix some deprecation-related issues

### DIFF
--- a/CGAL_ipelets/demo/CGAL_ipelets/mst.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/mst.cpp
@@ -69,7 +69,7 @@ VertexIndexMap vertex_id_map;
 typedef boost::associative_property_map<VertexIndexMap> VertexIdPropertyMap;
 VertexIdPropertyMap vertex_index_pmap(vertex_id_map);
 
-void mstIpelet::protected_run(int fn)
+void mstIpelet::protected_run(int /*fn*/)
 {
   std::list<Point_2> pt_list;
 

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Circular_kernel.cpp
@@ -24,7 +24,8 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
+
 #include <CGAL/Cartesian.h>
 #include <CGAL/Algebraic_kernel_for_circles_2_2.h>
 #include <CGAL/Circular_kernel_2.h>

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Exact_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Exact_circular_kernel.cpp
@@ -24,7 +24,8 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
+
 #include <CGAL/basic.h>
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/intersections.h>

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Filtered_bbox_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Filtered_bbox_circular_kernel.cpp
@@ -24,7 +24,8 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
+
 #include <CGAL/Cartesian.h>
 #include <CGAL/Algebraic_kernel_for_circles_2_2.h>
 #include <CGAL/Circular_kernel_2.h>

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Lazy_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Lazy_circular_kernel.cpp
@@ -24,7 +24,7 @@
 // and a STREP (FET Open) Project under Contract No  IST-006413 
 // (ACS -- Algorithms for Complex Shapes)
 
-#define CGAL_NO_DEPRECATION_WARNINGS 1
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/basic.h>
 #include <CGAL/Exact_circular_kernel_2.h>

--- a/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_deprecated_test.cpp
+++ b/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_deprecated_test.cpp
@@ -1,8 +1,7 @@
 #include <cstdlib>
 
-#ifndef CGAL_NO_DEPRECATED_CODE
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
-#define CGAL_NO_DEPRECATION_WARNINGS 1
 #define CGAL_CMAP_DART_DEPRECATED 1
 
 #include <CGAL/Combinatorial_map.h>
@@ -88,12 +87,3 @@ int main()
   std::cout<<" Success."<<std::endl;
   return EXIT_SUCCESS;
 }
-
-#else // CGAL_NO_DEPRECATED_CODE
-
-int main()
-{
-  return EXIT_SUCCESS;
-}
-
-#endif // CGAL_NO_DEPRECATED_CODE

--- a/Convex_hull_d/test/Convex_hull_d/chull_d-test.cpp
+++ b/Convex_hull_d/test/Convex_hull_d/chull_d-test.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/basic.h>
 #include <CGAL/Homogeneous.h>

--- a/Convex_hull_d/test/Convex_hull_d/delaunay_d-test.cpp
+++ b/Convex_hull_d/test/Convex_hull_d/delaunay_d-test.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/basic.h>
 #include <CGAL/Homogeneous_d.h>

--- a/Generator/test/Generator/generic_random_test.cpp
+++ b/Generator/test/Generator/generic_random_test.cpp
@@ -50,11 +50,11 @@ typedef CGAL::Mesh_polyhedron_3<K>::type                          Polyhedron;
 // Domain
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K>           Mesh_domain;
 typedef Mesh_domain::Corner_index                                 Corner_index;
-typedef Mesh_domain::Curve_segment_index                          Curve_segment_index;
+typedef Mesh_domain::Curve_index                                  Curve_index;
 
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type             Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-          Tr, Corner_index, Curve_segment_index>                  C3t3;
+          Tr, Corner_index, Curve_index>                          C3t3;
 typedef CGAL::Mesh_criteria_3<Tr>                                 Mesh_criteria;
 typedef C3t3::Point                                               Point;
 

--- a/Installation/include/CGAL/internal/deprecation_warning.h
+++ b/Installation/include/CGAL/internal/deprecation_warning.h
@@ -20,7 +20,7 @@
 
 // Including this header will cause compilation to fail
 // if CGAL_NO_DEPRECATED_CODE is defined. If this is not the case, it will issue
-// a warning during compilation unless CGAL_NO_DEPRECATION_WARNINGS.
+// a warning during compilation, unless CGAL_NO_DEPRECATION_WARNINGS is defined.
 
 // CGAL_DEPRECATED_HEADER, CGAL_REPLACEMENT_HEADER, and
 // CGAL_DEPRECATED_MESSAGE_DETAILS can be defined
@@ -56,11 +56,11 @@
 #  define CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS \
             CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
             CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE \
-            " Please use `" CGAL_REPLACEMENT_HEADER "` instead.\n"
+            " Please use `" CGAL_REPLACEMENT_HEADER "` instead. "
 #else
 #  define CGAL_INTERNAL_DEPRECATED_MESSAGE_HEADERS \
             CGAL_INTERNAL_DEPRECATED_MESSAGE_DEPRECATED_HEADER \
-            CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE "\n"
+            CGAL_INTERNAL_NO_DEPRECATED_CODE_MESSAGE " "
 #endif
 
 // if more details are given, print them

--- a/Installation/include/CGAL/internal/disable_deprecation_warnings_and_errors.h
+++ b/Installation/include/CGAL/internal/disable_deprecation_warnings_and_errors.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 GeometryFactory (France). All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0+
+//
+// Author: Mael Rouxel-Labbé
+
+// Some tests are explicitely used to check the sanity of deprecated code and should not
+// give warnings/errors on plateforms that defined CGAL_NO_DEPRECATED_CODE CGAL-wide
+// (or did not disable deprecation warnings).
+
+#if !defined(CGAL_NO_DEPRECATION_WARNINGS)
+  #define CGAL_NO_DEPRECATION_WARNINGS
+#endif
+
+#if defined(CGAL_NO_DEPRECATED_CODE)
+  #undef CGAL_NO_DEPRECATED_CODE
+#endif

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_complex_sm.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_complex_sm.cpp
@@ -27,7 +27,7 @@ typedef CGAL::Sequential_tag Concurrency_tag;
 typedef CGAL::Mesh_triangulation_3<Mesh_domain,K,Concurrency_tag>::type Tr;
 
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
+  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index>                C3t3;
 
 // Criteria
 typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;

--- a/Mesh_3/include/CGAL/Implicit_to_labeling_function_wrapper.h
+++ b/Mesh_3/include/CGAL/Implicit_to_labeling_function_wrapper.h
@@ -111,7 +111,13 @@ public:
 
   /// Constructor
   Implicit_vector_to_labeling_function_wrapper(const std::vector<Function_*>& v)
-    : function_vector_(v) {}
+    : function_vector_(v)
+  {
+    if ( v.size() > 8 )
+    {
+      CGAL_error_msg("We support at most 8 functions !");
+    }
+  }
 
   // Default copy constructor and assignment operator are ok
 
@@ -121,18 +127,13 @@ public:
   /// Operator ()
   return_type operator()(const Point_3& p, const bool = true) const
   {
-    int nb_func = function_vector_.size();
-    if ( nb_func > 8 )
-    {
-      CGAL_error_msg("We support at most 8 functions !");
-    }
-
+    const int nb_func = static_cast<int>(function_vector_.size());
     char bits = 0;
     for ( int i = 0 ; i < nb_func ; ++i )
     {
       // Insert value into bits : we compute fi(p) and insert result at
       // bit i of bits
-      bits |= ( ((*function_vector_[i])(p) < 0) << i );
+      bits = char(bits | ( ((*function_vector_[i])(p) < 0) << i ));
     }
 
     return ( static_cast<return_type>(bits) );

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -300,6 +300,9 @@ public:
     : m_func(func), m_quality(quality)
   {}
 
+  virtual ~MeshRefinementWorkItem()
+  {}
+
   void run()
   {
     m_func();

--- a/Mesh_3/test/Mesh_3/test_backward_compatibility.cpp
+++ b/Mesh_3/test/Mesh_3/test_backward_compatibility.cpp
@@ -18,7 +18,7 @@
 //
 // Author(s)     : Laurent Rineau
 
-#ifndef CGAL_NO_DEPRECATED_CODE
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <boost/optional.hpp>
 
@@ -155,11 +155,3 @@ int main()
 
   return 0;
 }
-
-#else // CGAL_NO_DEPRECATED_CODE
-#include <iostream>
-int main() { 
-  std::cerr << "CGAL_NO_DEPRECATED_CODE is defined. Nothing to test.\n";
-  return 0; 
-}
-#endif // CGAL_NO_DEPRECATED_CODE

--- a/Mesh_3/test/Mesh_3/test_mesh_3_implicit_vector_to_labeled_function_wrapper.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_implicit_vector_to_labeled_function_wrapper.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS 1
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Mesh_3/Implicit_to_labeled_function_wrapper.h>

--- a/Mesh_3/test/Mesh_3/test_mesh_3_labeled_mesh_domain_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_labeled_mesh_domain_3.cpp
@@ -23,7 +23,7 @@
 // File Description : 
 //******************************************************************************
 
-#define CGAL_NO_DEPRECATION_WARNINGS 1
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include "test_meshing_utilities.h"
 #include <CGAL/Mesh_3/Labeled_mesh_domain_3.h>

--- a/Mesh_3/test/Mesh_3/test_mesh_implicit_domains.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_implicit_domains.cpp
@@ -6,9 +6,6 @@
 // subdomain.
 //******************************************************************************
 
-
-#define CGAL_NO_DEPRECATION_WARNINGS 1
-
 #include "debug.h"
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -16,8 +13,8 @@
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
 
-#include <CGAL/Mesh_3/Implicit_to_labeled_function_wrapper.h>
-#include <CGAL/Mesh_3/Labeled_mesh_domain_3.h>
+#include <CGAL/Implicit_to_labeling_function_wrapper.h>
+#include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
 #include "implicit_functions.h"
 
@@ -30,12 +27,12 @@ template <typename Concurrency_tag>
 void test()
 {  
   // Domain
-  typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-  typedef FT_to_point_function_wrapper<K::FT, K::Point_3> Function;
-  typedef CGAL::Mesh_3::Implicit_vector_to_labeled_function_wrapper<Function, K>
-                                                          Function_wrapper;
-  typedef Function_wrapper::Function_vector Function_vector;
-  typedef CGAL::Mesh_3::Labeled_mesh_domain_3<Function_wrapper, K> Mesh_domain;
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel      K;
+  typedef FT_to_point_function_wrapper<K::FT, K::Point_3>          Function;
+  typedef CGAL::Implicit_vector_to_labeling_function_wrapper<Function, K>
+                                                                   Function_wrapper;
+  typedef Function_wrapper::Function_vector                        Function_vector;
+  typedef CGAL::Labeled_mesh_domain_3<Function_wrapper, K>         Mesh_domain;
 
   // Triangulation
   typedef typename CGAL::Mesh_triangulation_3<

--- a/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_analysis_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_analysis_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // analysis_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_bilateral_smoothing_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_bilateral_smoothing_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // bilateral_smoothing_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_edge_aware_upsample_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_edge_aware_upsample_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // edge_aware_upsample_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_hierarchy_simplification_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_hierarchy_simplification_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <limits>
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_jet_pointer_as_property_map.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_jet_pointer_as_property_map.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_normal_estimation_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_normal_estimation_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // normal_estimation_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_read_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_read_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/property_map.h>

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_read_test_with_different_pmaps.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_read_test_with_different_pmaps.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/property_map.h>

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_remove_outliers_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_remove_outliers_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // remove_outliers_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_smoothing_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_smoothing_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // smoothing_test.cpp
 

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_structuring_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_structuring_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Point_with_normal_3.h>

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_vcm_all_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_vcm_all_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/vcm_estimate_edges.h>

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_vcm_plane_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_vcm_plane_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/vcm_estimate_normals.h>

--- a/Point_set_processing_3/test/Point_set_processing_3/deprecated_wlop_simplify_and_regularize_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/deprecated_wlop_simplify_and_regularize_test.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // wlop_simplify_and_regularize_test.cpp
 

--- a/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC_traits.h
+++ b/Point_set_shape_detection_3/include/CGAL/Shape_detection_3/Efficient_RANSAC_traits.h
@@ -25,6 +25,12 @@
 
 #include <CGAL/license/Point_set_shape_detection_3.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Efficient_RANSAC_traits.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Shape_detection_traits.h>"
+#define CGAL_DEPRECATED_MESSAGE_DETAILS \
+  "CGAL::Shape_detection_3::Efficient_RANSAC_traits<> has been replaced by the class "\
+  "CGAL::Shape_detection_3::Shape_detection_traits<>."
+#include <CGAL/internal/deprecation_warning.h>
 
 #include <CGAL/Search_traits_3.h>
 
@@ -51,9 +57,7 @@ namespace CGAL {
             class InputRange,
             class InputPointMap,
             class InputNormalMap>
-  struct
-  CGAL_DEPRECATED_MSG("CGAL::Shape_detection_3::Efficient_RANSAC_traits<> is now called CGAL::Shape_detection_3::Shape_detection_traits<>, please update your code")
-  Efficient_RANSAC_traits {
+  struct Efficient_RANSAC_traits {
     ///
     typedef typename Gt::FT FT;
     ///

--- a/Point_set_shape_detection_3/test/Point_set_shape_detection_3/deprecated_test_scene.cpp
+++ b/Point_set_shape_detection_3/test/Point_set_shape_detection_3/deprecated_test_scene.cpp
@@ -1,4 +1,4 @@
-#define  CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include "generators.h"
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -361,7 +361,7 @@ tweak_criteria(Mesh_criteria& c, Mesh_fnt::Polyhedral_domain_tag) {
   typedef CGAL::Mesh_3::Facet_topological_criterion_with_adjacency<Tr,
        Domain, typename Facet_criteria::Visitor> New_topo_adj_crit;
 
-  if((int(c.facet_criteria().topology()) &
+  if((int(c.facet_criteria_object().topology()) &
       CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH_WITH_ADJACENCY_CHECK) != 0)
   {
     c.add_facet_criterion(new New_topo_adj_crit(this->domain_));

--- a/STL_Extension/test/STL_Extension/test_N_tuple.cpp
+++ b/STL_Extension/test/STL_Extension/test_N_tuple.cpp
@@ -1,13 +1,13 @@
-#define CGAL_NO_DEPRECATION_WARNINGS 1
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Twotuple.h>
 #include <CGAL/Threetuple.h>
 #include <CGAL/Fourtuple.h>
 #include <CGAL/Sixtuple.h>
 #include <CGAL/use.h>
+
 int main()
 {
-#ifndef CGAL_NO_DEPRECATED_CODE
   CGAL::Twotuple<int> d2, t2(0,1);
   CGAL::Threetuple<int> d3, t3(0,1,2);
   CGAL::Fourtuple<int> d4, t4(0,1,2,3);
@@ -17,6 +17,6 @@ int main()
   CGAL_USE(d3); CGAL_USE(t3);
   CGAL_USE(d4); CGAL_USE(t4);
   CGAL_USE(d6); CGAL_USE(t6);
-#endif
+
   return 0;
 }

--- a/STL_Extension/test/STL_Extension/test_namespaces.cpp
+++ b/STL_Extension/test/STL_Extension/test_namespaces.cpp
@@ -1,4 +1,5 @@
-#define CGAL_NO_DEPRECATION_WARNINGS 1 // because CGAL::copy_n is deprecated
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h> // because CGAL::copy_n is deprecated
+
 #include <boost/config.hpp>
 
 #if defined(BOOST_MSVC)
@@ -21,10 +22,8 @@ int main()
   CGAL_USE(tuple);
   CGAL_USE(tuple2);
 
-#ifndef CGAL_NO_DEPRECATED_CODE
   CGAL::copy_n(arr.begin(), 3, arr2.begin());
-#endif // not CGAL_NO_DEPRECATED_CODE
-  
+
   CGAL::cpp0x::copy_n(arr.begin(), 3, arr2.begin());
   CGAL::cpp11::copy_n(arr.begin(), 3, arr2.begin());
   

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -571,11 +571,6 @@ public: // internal methods
                                           OutputItCells fit);
 
 public:
-
-#ifndef CGAL_NO_DEPRECATED_CODE
-  CGAL_DEPRECATED Vertex_handle move_point(Vertex_handle v, const Point & p);
-#endif
-
   template <class OutputIteratorBoundaryFacets,
             class OutputIteratorCells,
             class OutputIteratorInternalFacets>
@@ -1277,31 +1272,6 @@ insert_and_give_new_cells(const Point& p,
   else *fit++ = v->cell(); // dimension = 0
   return v;
 }
-
-#ifndef CGAL_NO_DEPRECATED_CODE
-template < class Gt, class Tds, class Lds >
-typename Delaunay_triangulation_3<Gt,Tds,Default,Lds>::Vertex_handle
-Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
-move_point(Vertex_handle v, const Point & p)
-{
-    CGAL_triangulation_precondition(! is_infinite(v));
-    CGAL_triangulation_expensive_precondition(is_vertex(v));
-
-    // Dummy implementation for a start.
-
-    // Remember an incident vertex to restart
-    // the point location after the removal.
-    Cell_handle c = v->cell();
-    Vertex_handle old_neighbor = c->vertex(c->index(v) == 0 ? 1 : 0);
-    CGAL_triangulation_assertion(old_neighbor != v);
-
-    remove(v);
-
-    if (dimension() <= 0)
-        return insert(p);
-    return insert(p, old_neighbor->cell());
-}
-#endif
 
 template <class Gt, class Tds, class Lds >
 template <class DelaunayTriangulation_3>

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -827,10 +827,6 @@ namespace CGAL {
       CGAL_triangulation_expensive_postcondition(is_valid());
     }
 
-
-    // DISPLACEMENT
-    Vertex_handle move_point(Vertex_handle v, const Weighted_point & p);
-
     // Displacement works only for regular triangulation
     // without hidden points at any time
     Vertex_handle move_if_no_collision(Vertex_handle v, const Weighted_point & p);
@@ -2431,30 +2427,6 @@ namespace CGAL {
     }
 
     return removed;
-  }
-
-  // Again, verbatim copy from Delaunay.
-  template < class Gt, class Tds, class Lds >
-  typename Regular_triangulation_3<Gt,Tds,Lds>::Vertex_handle
-    Regular_triangulation_3<Gt,Tds,Lds>::
-    move_point(Vertex_handle v, const Weighted_point & p)
-  {
-    CGAL_triangulation_precondition(! is_infinite(v));
-    CGAL_triangulation_expensive_precondition(is_vertex(v));
-
-    // Dummy implementation for a start.
-
-    // Remember an incident vertex to restart
-    // the point location after the removal.
-    Cell_handle c = v->cell();
-    Vertex_handle old_neighbor = c->vertex(c->index(v) == 0 ? 1 : 0);
-    CGAL_triangulation_assertion(old_neighbor != v);
-
-    remove(v);
-
-    if (dimension() <= 0)
-      return insert(p);
-    return insert(p, old_neighbor->cell());
   }
 
   // Displacement works only for regular triangulation

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -355,10 +355,6 @@ public:
     return n - this->number_of_vertices();
   }
 
-#ifndef CGAL_NO_DEPRECATED_CODE
-  CGAL_DEPRECATED Vertex_handle move_point(Vertex_handle v, const Point & p);
-#endif
-
   Vertex_handle move_if_no_collision(Vertex_handle v, const Point &p);
   Vertex_handle move(Vertex_handle v, const Point &p);
 
@@ -718,34 +714,6 @@ remove_and_give_new_cells(Vertex_handle v, OutputItCells fit)
     v = u;
   }
 }
-
-#ifndef CGAL_NO_DEPRECATED_CODE
-template < class Tr >
-typename Triangulation_hierarchy_3<Tr>::Vertex_handle
-Triangulation_hierarchy_3<Tr>::
-move_point(Vertex_handle v, const Point & p)
-{
-  CGAL_triangulation_precondition(v != Vertex_handle());
-  Vertex_handle old, ret;
-
-  for (std::size_t l = 0; l < maxlevel; ++l) {
-    Vertex_handle u = v->up();
-    Vertex_handle w = hierarchy[l]->move_point(v, p);
-    if (l == 0) {
-	ret = w;
-    }
-    else {
-        set_up_down(w, old);
-    }
-    if (u == Vertex_handle())
-	break;
-    old = w;
-    v = u;
-  }
-
-  return ret;
-}
-#endif
 
 template <class Tr>
 typename Triangulation_hierarchy_3<Tr>::Vertex_handle

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -24,8 +24,17 @@
 
 #include <CGAL/license/Triangulation_3.h>
 
+// Commented because the class is actually used by Delaunay_triangulation_hierarchy_3.h
 // #define CGAL_DEPRECATED_HEADER "<CGAL/Triangulation_hierarchy_3.h>"
 // #include <CGAL/internal/deprecation_warning.h>
+
+// This class is deprecated, but must be kept for backward compatibility.
+//
+// It would be better to move its content to the Delaunay_triangulation_3
+// specializations for Fast_location and make Triangulation_hierarchy_3 the
+// empty nutshell instead.
+//
+// Then, later, maybe merge the Compact/Fast codes in a cleaner factorized way.
 
 #include <CGAL/basic.h>
 #include <CGAL/internal/Has_nested_type_Bare_point.h>
@@ -54,14 +63,6 @@
 #endif //CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 
 namespace CGAL {
-
-// This class is deprecated, but must be kept for backward compatibility.
-//
-// It would be better to move its content to the Delaunay_triangulation_3
-// specializations for Fast_location and make Triangulation_hierarchy_3 the
-// empty nutshell instead.
-//
-// Then, later, maybe merge the Compact/Fast codes in a cleaner factorized way.
 
 template < class Tr >
 class Triangulation_hierarchy_3

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -618,33 +618,6 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T3_13.number_of_vertices()==22);
   assert(T3_13.dimension()==3);
 
-#ifndef CGAL_NO_DEPRECATED_CODE
-  {
-    std::cout << "    Testing move_point()" << std::endl;
-    Cls T;
-    std::list<Vertex_handle> L;
-    for (i=0; i<22; ++i)
-      L.push_back(T.insert(q[i]));
-    assert(T.is_valid());
-    assert(T.number_of_vertices()==22);
-    assert(T.dimension()==3);
-
-    for (i=0; i<100; ++i) {
-      assert(!L.empty());
-      Vertex_handle v = L.front();
-      L.pop_front();
-      size_type nbv = T.number_of_vertices();
-      L.push_back(T.move_point(v, q[(3*i)%22]));
-
-      if (nbv != T.number_of_vertices())
-        L.pop_back(); // it means we move onto an already existing point.
-
-      assert(T.is_valid());
-      assert(T.number_of_vertices()<=22);
-    }
-  }
-#endif
-
   {
     std::cout << "    Testing move()" << std::endl;
     Cls T;

--- a/Triangulation_3/test/Triangulation_3/test_delaunay_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_delaunay_3.cpp
@@ -19,7 +19,7 @@
 //
 // Author(s)     : Francois Rebufat
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include "test_dependencies.h"
 

--- a/Triangulation_3/test/Triangulation_3/test_delaunay_hierarchy_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_delaunay_hierarchy_3.cpp
@@ -19,8 +19,6 @@
 //
 // Author(s)     : Mariette Yvinec, Sylvain Pion
 
-#define CGAL_NO_DEPRECATION_WARNINGS
-
 #include <CGAL/Delaunay_triangulation_3.h>
 
 bool del=true;

--- a/Triangulation_3/test/Triangulation_3/test_delaunay_hierarchy_3_old.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_delaunay_hierarchy_3_old.cpp
@@ -19,8 +19,6 @@
 //
 // Author(s)     : Mariette Yvinec, Sylvain Pion
 
-#define CGAL_NO_DEPRECATION_WARNINGS
-
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_hierarchy_3.h>
 

--- a/Triangulation_3/test/Triangulation_3/test_regular_traits_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_traits_3.cpp
@@ -20,7 +20,7 @@
 //
 // Author(s)     : Mariette Yvinec
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <cassert>
 #include <CGAL/Regular_triangulation_euclidean_traits_3.h>


### PR DESCRIPTION
## Summary of Changes

Most tests that intentionally use deprecated code define `CGAL_NO_DEPRECATION_WARNINGS`, which does not do much to prevent the compilation from failing if `CGAL_NO_DEPRECATION_CODE` is enabled (e.g. [there](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-Ic-6/Mesh_3/TestReport_lrineau_Ubuntu-Latest-NO_DEPRECATED_CODE.gz)).

- A file to disable deprecation warnings/errors is added rather than simply guarding the tests with `#ifndef CGAL_NO_DEPRECATION_CODE` because the test plateform with `CGAL_NO_DEPRECATED_CODE` seems different from others. The code is tested then.
- 4.12 because a lot of deprecated tests were added with 4.12 (`PSP_3`).

Fixed some deprecated code being used along the way.

## Release Management

* Affected package(s): `Convex_hull_d`, `Circular_kernel_2`, `Installation`, `Mesh_3`, `Point_set_processing_3/shape_detection_3`, `Triangulation_3`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

