### PR TITLE
Polyhedron demo: Fix triangulation of facets

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -248,6 +248,9 @@ typedef Polygon_soup::Polygon_3 Facet;
 void
 Scene_polygon_soup_item_priv::triangulate_polygon(Polygons_iterator pit, int polygon_id) const
 {
+  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  EPICK::Vector_3 offset(off.x,off.y,off.z);
+  
     //Computes the normal of the facet
     const Point_3& pa = soup->points[pit->at(0)];
     const Point_3& pb = soup->points[pit->at(1)];
@@ -267,7 +270,7 @@ Scene_polygon_soup_item_priv::triangulate_polygon(Polygons_iterator pit, int pol
     do {
       FT::PointAndId pointId;
 
-      pointId.point = soup->points[pit->at(it)];
+      pointId.point = soup->points[pit->at(it)]+offset;
       pointId.id = pit->at(it);
       pointIds.push_back(pointId);
     } while( ++it != it_end );

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -248,7 +248,7 @@ typedef Polygon_soup::Polygon_3 Facet;
 void
 Scene_polygon_soup_item_priv::triangulate_polygon(Polygons_iterator pit, int polygon_id) const
 {
-  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  const CGAL::qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
   EPICK::Vector_3 offset(off.x,off.y,off.z);
   
     //Computes the normal of the facet

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -480,7 +480,7 @@ Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_itera
     diagonal = item->diagonalBbox();
   else
     diagonal = 0.0;
-  FT triangulation(fit,normal,poly,diagonal);
+  FT triangulation(fit,normal,poly,diagonal,offset);
 
   if(triangulation.cdt->dimension() != 2 )
   {
@@ -515,9 +515,9 @@ Scene_polyhedron_item_priv::triangulate_facet(Scene_polyhedron_item::Facet_itera
 
     if(is_multicolor || !no_flat || !is_recent)
     {
-      push_back_xyz(ffit->vertex(0)->point()+offset, positions_facets);
-      push_back_xyz(ffit->vertex(1)->point()+offset, positions_facets);
-      push_back_xyz(ffit->vertex(2)->point()+offset, positions_facets);
+      push_back_xyz(ffit->vertex(0)->point(), positions_facets);
+      push_back_xyz(ffit->vertex(1)->point(), positions_facets);
+      push_back_xyz(ffit->vertex(2)->point(), positions_facets);
       if(!draw_two_sides)
       {
         push_back_xyz(normal, normals_flat);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -421,13 +421,16 @@ void
 Scene_polyhedron_selection_item_priv::triangulate_facet(fg_face_descriptor fit,const Vector normal,
                                                    std::vector<float> &p_facets,std::vector<float> &p_normals ) const
 {
+  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  Kernel::Vector_3 offset(off.x,off.y,off.z);
+  
   typedef FacetTriangulator<Face_graph, Kernel, fg_vertex_descriptor> FT;
   double diagonal;
   if(item->poly_item->diagonalBbox() != std::numeric_limits<double>::infinity())
     diagonal = item->poly_item->diagonalBbox();
   else
     diagonal = 0.0;
-  FT triangulation(fit,normal,poly,diagonal);
+  FT triangulation(fit,normal,poly,diagonal, offset);
     //iterates on the internal faces to add the vertices to the positions
     //and the normals to the appropriate vectors
     for(FT::CDT::Finite_faces_iterator

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -421,7 +421,7 @@ void
 Scene_polyhedron_selection_item_priv::triangulate_facet(fg_face_descriptor fit,const Vector normal,
                                                    std::vector<float> &p_facets,std::vector<float> &p_normals ) const
 {
-  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  const CGAL::qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
   Kernel::Vector_3 offset(off.x,off.y,off.z);
   
   typedef FacetTriangulator<Face_graph, Kernel, fg_vertex_descriptor> FT;

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -815,7 +815,9 @@ Scene_surface_mesh_item_priv::triangulate_facet(face_descriptor fd,
     diagonal = item->diagonalBbox();
   else
     diagonal = 0.0;
-  FT triangulation(fd,normal,smesh_,diagonal);
+  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  EPICK::Vector_3 offset(off.x,off.y,off.z);
+  FT triangulation(fd,normal,smesh_,diagonal, offset);
   //iterates on the internal faces
   for(FT::CDT::Finite_faces_iterator
        ffit = triangulation.cdt->finite_faces_begin(),
@@ -834,14 +836,14 @@ Scene_surface_mesh_item_priv::triangulate_facet(face_descriptor fd,
       else
         color = 0;
 
-      addFlatData(ffit->vertex(0)->point(),
+      addFlatData(ffit->vertex(0)->point()-offset,
                   (*fnormals)[fd],
                   color);
-      addFlatData(ffit->vertex(1)->point(),
+      addFlatData(ffit->vertex(1)->point()-offset,
                   (*fnormals)[fd],
                   color);
 
-      addFlatData(ffit->vertex(2)->point(),
+      addFlatData(ffit->vertex(2)->point()-offset,
                   (*fnormals)[fd],
                   color);
     }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -815,7 +815,7 @@ Scene_surface_mesh_item_priv::triangulate_facet(face_descriptor fd,
     diagonal = item->diagonalBbox();
   else
     diagonal = 0.0;
-  const qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(QGLViewer::QGLViewerPool().first())->offset();
+  const CGAL::qglviewer::Vec off = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
   EPICK::Vector_3 offset(off.x,off.y,off.z);
   FT triangulation(fd,normal,smesh_,diagonal, offset);
   //iterates on the internal faces

--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -50,15 +50,16 @@ public:
 
   //Constructor
   FacetTriangulator(typename boost::graph_traits<Mesh>::face_descriptor fd,
-                  const Vector& normal,
+                    const Vector& normal,
                     Mesh *poly,
-                  const double item_diag)
+                    const double item_diag,
+                    Vector offset = Vector(0,0,0))
   {
     std::vector<PointAndId> idPoints;
     BOOST_FOREACH(halfedge_descriptor he_circ, halfedges_around_face( halfedge(fd, *poly), *poly))
     {
       PointAndId idPoint;
-      idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly));
+      idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly))+offset;
       idPoint.id = source(he_circ, *poly);
       idPoints.push_back(idPoint);
 
@@ -70,13 +71,14 @@ public:
                     const std::vector<typename Kernel::Point_3>& more_points,
                     const Vector& normal,
                     Mesh *poly,
-                    const double item_diag)
+                    const double item_diag,
+                    Vector offset = Vector(0,0,0))
   {
    std::vector<PointAndId> idPoints;
    BOOST_FOREACH(halfedge_descriptor he_circ, halfedges_around_face( halfedge(fd, *poly), *poly))
    {
     PointAndId idPoint;
-    idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly));
+    idPoint.point = get(boost::vertex_point,*poly,source(he_circ, *poly))+offset;
     idPoint.id = source(he_circ, *poly);
     idPoints.push_back(idPoint);
 


### PR DESCRIPTION
## Summary of Changes
If the coordinates of the points of a mesh are too big, their triangulation may fail due to exceding the precision of double. To restrain these cases, this PR applies the viewer's offset to the pointsbefore they are inserted in the CDT2. 