### PR TITLE
Fix CDT_2 errors, using snapping of intersection points

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Bbox_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Bbox_2.h
@@ -95,6 +95,11 @@ updates `b` to be the bounding box of `b` and `c` and returns itself.
 */
 Bbox_2& operator+=(const Bbox_2 &c);
 
+/*!
+dilates the bounding box by a specified number of ULP.
+*/
+void dilate(int dist);
+  
 /// @}
 
 }; /* end Bbox_2 */

--- a/Kernel_23/doc/Kernel_23/CGAL/Bbox_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Bbox_3.h
@@ -109,6 +109,10 @@ updates `b` to be the bounding box of `b` and `c` and returns itself.
 */
 Bbox_3& operator+=(const Bbox_3 &c);
 
+/*!
+dilates the bounding box by a specified number of ULP.
+*/
+void dilate(int dist);
 /// @}
 
 }; /* end Bbox_3 */

--- a/Kernel_23/include/CGAL/Bbox_2.h
+++ b/Kernel_23/include/CGAL/Bbox_2.h
@@ -164,8 +164,8 @@ Bbox_2::dilate(int dist)
   using boost::math::float_advance;
   float_advance(rep[0],-dist);
   float_advance(rep[1],-dist);
+  float_advance(rep[2],dist);
   float_advance(rep[3],dist);
-  float_advance(rep[4],dist);
 }
   
 inline

--- a/Kernel_23/include/CGAL/Bbox_2.h
+++ b/Kernel_23/include/CGAL/Bbox_2.h
@@ -29,6 +29,7 @@
 #include <CGAL/IO/io.h>
 #include <CGAL/Dimension.h>
 #include <CGAL/array.h>
+#include <boost/math/special_functions/next.hpp>
 
 namespace CGAL {
 
@@ -75,6 +76,7 @@ public:
   inline Bbox_2     operator+(const Bbox_2 &b) const;
   inline Bbox_2&     operator+=(const Bbox_2 &b);
 
+  inline void dilate(int dist);
 };
 
 inline
@@ -155,7 +157,17 @@ Bbox_2::operator+=(const Bbox_2& b)
   rep[3] = (std::max)(ymax(), b.ymax());
   return *this;
 }
-
+inline
+void
+Bbox_2::dilate(int dist)
+{
+  using boost::math::float_advance;
+  float_advance(rep[0],-dist);
+  float_advance(rep[1],-dist);
+  float_advance(rep[3],dist);
+  float_advance(rep[4],dist);
+}
+  
 inline
 bool
 do_overlap(const Bbox_2 &bb1, const Bbox_2 &bb2)

--- a/Kernel_23/include/CGAL/Bbox_3.h
+++ b/Kernel_23/include/CGAL/Bbox_3.h
@@ -30,6 +30,7 @@
 #include <CGAL/IO/io.h>
 #include <CGAL/Dimension.h>
 #include <CGAL/array.h>
+#include <boost/math/special_functions/next.hpp>
 
 namespace CGAL {
 
@@ -77,6 +78,8 @@ public:
 
   Bbox_3  operator+(const Bbox_3& b) const;
   Bbox_3& operator+=(const Bbox_3& b);
+
+  void dilate(int dist);
 };
 
 inline
@@ -174,6 +177,20 @@ Bbox_3::operator+=(const Bbox_3& b)
   rep[5] = (std::max)(zmax(), b.zmax());
   return *this;
 }
+
+inline
+void
+Bbox_3::dilate(int dist)
+{
+  using boost::math::float_advance;
+  float_advance(rep[0],-dist);
+  float_advance(rep[1],-dist);
+  float_advance(rep[2],-dist);
+  float_advance(rep[3],dist);
+  float_advance(rep[4],dist);
+  float_advance(rep[5],dist);
+}
+
 
 inline
 bool

--- a/Kernel_23/include/CGAL/internal/Projection_traits_3.h
+++ b/Kernel_23/include/CGAL/internal/Projection_traits_3.h
@@ -801,6 +801,7 @@ public:
   typedef typename Rp::Construct_scaled_vector_3              Construct_scaled_vector_2;
   typedef typename Rp::Construct_triangle_3                   Construct_triangle_2;
   typedef typename Rp::Construct_line_3                       Construct_line_2;
+  typedef typename Rp::Construct_bbox_3                       Construct_bbox_2;
 
   struct Less_xy_2 {
     typedef bool result_type;
@@ -984,6 +985,9 @@ public:
     
   Construct_line_2  construct_line_2_object() const
     {return Construct_line_2();}
+
+  Construct_bbox_2  construct_bbox_2_object() const
+    {return Construct_bbox_2();}
 
   Compute_scalar_product_2 compute_scalar_product_2_object() const
     {return Compute_scalar_product_2();}

--- a/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
@@ -80,7 +80,8 @@ typedef unspecified_type Compute_squared_distance_2;
 A function object whose
 `operator()` computes the bounding box of a point.
 
-`Point_2 operator()(Point_2 p);` Returns the bounding box of `p`. 
+`unspecified_type operator()(Point_2 p);` Returns the bounding box of `p`.
+The result type is either `Bbox_2` or `Bbox_3` (for projection traits classes).
 */ 
 typedef unspecified_type Compute_bounding_box_2; 
 

--- a/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
@@ -76,6 +76,14 @@ between `p` and `l`.
 */ 
 typedef unspecified_type Compute_squared_distance_2; 
 
+/*!
+A function object whose
+`operator()` computes the bounding box of a point.
+
+`Point_2 operator()(Point_2 p);` Returns the bounding box of `p`. 
+*/ 
+typedef unspecified_type Compute_bounding_box_2; 
+
 /// @} 
 
 /// \name Access to Constructor Objects 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -37,6 +37,9 @@
 
 #include <boost/mpl/if.hpp>
 #include <boost/iterator/filter_iterator.hpp>
+#include <boost/math/special_functions/next.hpp>
+#include <boost/type_traits/is_floating_point.hpp>
+
 namespace CGAL {
 
 struct No_intersection_tag{};
@@ -1422,9 +1425,68 @@ intersection(const Gt& gt,
 	     const typename Gt::Point_2& pc, 
 	     const typename Gt::Point_2& pd,
 	     typename Gt::Point_2& pi,
-	     Exact_predicates_tag)
+	     Exact_predicates_tag,
+	     CGAL::Tag_false /* not a FT is not floating-point */)
 {
   return compute_intersection(gt,pa,pb,pc,pd,pi);
+}
+
+template<class Gt>
+inline bool
+intersection(const Gt& gt,
+	     const typename Gt::Point_2& pa,
+	     const typename Gt::Point_2& pb,
+	     const typename Gt::Point_2& pc,
+	     const typename Gt::Point_2& pd,
+	     typename Gt::Point_2& pi,
+	     Exact_predicates_tag,
+	     CGAL::Tag_true /* FT is a floating-point type */)
+{
+  const bool result = compute_intersection(gt,pa,pb,pc,pd,pi);
+  if(!result) return result;
+  if(pi == pa || pi == pb || pi == pc || pi == pd) {
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+    std::cerr << "  CT_2::intersection: intersection is an existing point "
+              << pi << std::endl;
+#endif
+    return result;
+  }
+
+  using boost::math::float_advance;
+#ifdef CGAL_CDT_2_INTERSECTION_SNAPPING_ULP_DISTANCE
+  const int dist = CGAL_CDT_2_INTERSECTION_SNAPPING_ULP_DISTANCE;
+#else
+  const int dist = 4;
+#endif
+  const Bbox_2 bbox(float_advance(pi.x(), -dist), float_advance(pi.y(), -dist),
+                    float_advance(pi.x(), +dist), float_advance(pi.y(), +dist));
+  if(do_overlap(bbox, pa.bbox())) pi = pa;
+  if(do_overlap(bbox, pb.bbox())) pi = pb;
+  if(do_overlap(bbox, pc.bbox())) pi = pc;
+  if(do_overlap(bbox, pd.bbox())) pi = pd;
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  if(pi == pa || pi == pb || pi == pc || pi == pd) {
+    std::cerr << "  CT_2::intersection: intersection SNAPPED to an existing point "
+              << pi << std::endl;
+  }
+#endif
+  return result;
+}
+
+template<class Gt>
+inline bool
+intersection(const Gt& gt,
+	     const typename Gt::Point_2& pa,
+	     const typename Gt::Point_2& pb,
+	     const typename Gt::Point_2& pc,
+	     const typename Gt::Point_2& pd,
+	     typename Gt::Point_2& pi,
+	     Exact_predicates_tag exact_predicates_tag)
+{
+  typedef typename Gt::FT FT;
+  return intersection(gt,pa,pb,pc,pd,pi,
+                      exact_predicates_tag,
+                      Boolean_tag<boost::is_floating_point<FT>::value>());
 }
 
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -37,7 +37,8 @@
 
 #include <boost/mpl/if.hpp>
 #include <boost/iterator/filter_iterator.hpp>
-#include <boost/math/special_functions/next.hpp>
+
+#include <boost/utility/result_of.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 
 namespace CGAL {
@@ -1452,18 +1453,20 @@ intersection(const Gt& gt,
     return result;
   }
 
-  using boost::math::float_advance;
+
 #ifdef CGAL_CDT_2_INTERSECTION_SNAPPING_ULP_DISTANCE
   const int dist = CGAL_CDT_2_INTERSECTION_SNAPPING_ULP_DISTANCE;
 #else
   const int dist = 4;
 #endif
-  const Bbox_2 bbox(float_advance(pi.x(), -dist), float_advance(pi.y(), -dist),
-                    float_advance(pi.x(), +dist), float_advance(pi.y(), +dist));
-  if(do_overlap(bbox, pa.bbox())) pi = pa;
-  if(do_overlap(bbox, pb.bbox())) pi = pb;
-  if(do_overlap(bbox, pc.bbox())) pi = pc;
-  if(do_overlap(bbox, pd.bbox())) pi = pd;
+  typedef typename Gt::Construct_bbox_2 Construct_bbox_2;
+  Construct_bbox_2 bbox = gt.construct_bbox_2_object();
+  typename boost::result_of<const Construct_bbox_2(const typename Gt::Point_2&)>::type bb(bbox(pi));
+  bb.dilate(dist);
+  if(do_overlap(bb, bbox(pa))) pi = pa;
+  if(do_overlap(bb, bbox(pb))) pi = pb;
+  if(do_overlap(bb, bbox(pc))) pi = pc;
+  if(do_overlap(bb, bbox(pd))) pi = pd;
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   if(pi == pa || pi == pb || pi == pc || pi == pd) {
     std::cerr << "  CT_2::intersection: intersection SNAPPED to an existing point "

--- a/Triangulation_2/include/CGAL/internal/Triangulation_2_projection_traits_base_3.h
+++ b/Triangulation_2/include/CGAL/internal/Triangulation_2_projection_traits_base_3.h
@@ -379,6 +379,7 @@ public:
   typedef typename K::Construct_circumcenter_3      Construct_circumcenter_2;
 
   typedef typename K::Compute_area_3                Compute_area_2;
+  typedef typename K::Construct_bbox_3              Construct_bbox_2;
 
   Less_x_2
   less_x_2_object() const
@@ -464,6 +465,9 @@ public:
   Compute_area_2 compute_area_2_object() const
   {return Compute_area_2();}
 
+
+  Construct_bbox_2  construct_bbox_2_object() const
+    {return Construct_bbox_2();}
 
 
   // Special functor, not in the Kernel concept


### PR DESCRIPTION
## Summary of Changes

When `Constrained_triangulation_2` computes the intersection of two
segments, with a floating-point number type, and with
`Exact_predicates_tag`, the computed intersection point is snapped to an
extremity of the two segments, if it is closest to 4 ulp (with the l-inf
distance).



That value `4` can be changed by defining the macro
`CGAL_CDT_2_INTERSECTION_SNAPPING_ULP_DISTANCE` to another value.


I have benched on a crazy data set of 56000 segments, intersecting, and with duplicated (or almost duplicated) segments. I did not found more than 0.1s of difference, in a run of 50.0s, and the difference was not always in the same direction.

## Release Management

That is a bug-fix, but I wonder if it should be backported to 4.11.2 and 4.12.1, because that modifies the behavior of the code.

What is more, that choice of the distance (4 ulp in the l-infinity distance) is kind of arbitrary. That means about 3 bits of precision, out of 53 (if the number type is `double`).

Anyway, if one wants to backport the patch, it is only one commit, affecting only one file (and only one function `intersection(geom_traits, a,b, c, d, tag)` in that file.

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #2999

@mglisse Do you have any clue why that distance of 4 ulp fixed all the problematic data sets we had, but not 3? I imagine that there is real reason it worked with that value, and there might data sets where it fails.

Cc @afabri, how worked with me on the issue.
