### PR TITLE
Property_map: Fix make_property_map(std::vector&) for an empty vector

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -356,7 +356,7 @@ public:
       is_intersection(intersection_edges);
     std::size_t nb_patches =
       PMP::connected_components(tm,
-                                bind_property_maps(fids,make_property_map(&patch_ids[0])),
+                                bind_property_maps(fids,make_property_map(patch_ids)),
                                 params::edge_is_constrained_map(
                                     is_intersection)
                                 .face_index_map(fids));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -150,6 +150,9 @@ public:
     typedef typename boost::range_value<
       PolygonRange>::type           Polygon;
 
+    if(boost::begin(polygons) == boost::end(polygons)){
+      return true;
+    }
     //check there is no duplicated ordered edge, and
     //check there is no polygon with twice the same vertex
     std::set< std::pair<V_ID, V_ID> > edge_set;

--- a/Property_map/include/CGAL/property_map.h
+++ b/Property_map/include/CGAL/property_map.h
@@ -415,6 +415,9 @@ inline
 typename Pointer_property_map<T>::type
 make_property_map(std::vector<T>& v)
 {
+  if(v.empty()){
+    return make_property_map(static_cast<T*>(NULL));
+  }
   return make_property_map(&v[0]);
 }
 

--- a/Property_map/test/Property_map/CMakeLists.txt
+++ b/Property_map/test/Property_map/CMakeLists.txt
@@ -49,6 +49,8 @@ include_directories( BEFORE ../../include )
 
 include( CGAL_CreateSingleSourceCGALProgram )
 
+create_single_source_cgal_program( "test_property_map.cpp" )
+
 create_single_source_cgal_program( "dynamic_property_map.cpp" )
 
 create_single_source_cgal_program( "dynamic_properties_test.cpp" )

--- a/Property_map/test/Property_map/test_property_map.cpp
+++ b/Property_map/test/Property_map/test_property_map.cpp
@@ -1,0 +1,10 @@
+
+#include <vector>
+#include <CGAL/property_map.h>
+
+int main()
+{
+  std::vector<int> v;
+  CGAL::make_property_map(v);
+  return 0;
+}


### PR DESCRIPTION

## Release Management

* Affected package(s): Property_map
* Issue(s) solved (if any): fix #2737


