### PR TITLE
Infrastructure: Enhance dependency managing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_script:
 - cd ..
 script: 
 - cd ./.travis
-- if [ -n "$CGAL_DEBUG_TRAVIS" ]; then  bash -x -e ./build_package.sh $PACKAGE; else bash -e ./build_package.sh $PACKAGE; fi
+- bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_script:
 - cd ..
 script: 
 - cd ./.travis
-- bash -x -e ./build_package.sh $PACKAGE
+- if [ -n "$CGAL_DEBUG_TRAVIS" ]; then  bash -x -e ./build_package.sh $PACKAGE; else bash -e ./build_package.sh $PACKAGE; fi
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+[ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 
 CXX_FLAGS="-DCGAL_NDEBUG"
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+[ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 DONE=0
 while [ $DONE = 0 ]
 do

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -25,7 +25,7 @@ before_script:
 - cd ..
 script: 
 - cd ./.travis
-- bash -x -e ./build_package.sh $PACKAGE
+- if [ -n "$CGAL_DEBUG_TRAVIS" ]; then  bash -x -e ./build_package.sh $PACKAGE; else bash -e ./build_package.sh $PACKAGE; fi
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -25,7 +25,7 @@ before_script:
 - cd ..
 script: 
 - cd ./.travis
-- if [ -n "$CGAL_DEBUG_TRAVIS" ]; then  bash -x -e ./build_package.sh $PACKAGE; else bash -e ./build_package.sh $PACKAGE; fi
+- bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -1,6 +1,6 @@
 #This script must be called from the CGAL root.
 set -e
-set -x
+[ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 while test $# -gt 0
 do
     case "$1" in

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -37,13 +37,11 @@ do
   if [ -f "$pkg_path/package_info/$pkg/dependencies" ]; then
     PKG_DIFF=$(grep -Fxv -f "$pkg_path/package_info/$pkg/dependencies.old" "$pkg_path/package_info/$pkg/dependencies" || true)
     if [ -n "$PKG_DIFF" ]; then
-      HAS_DIFF=TRUE
-      echo "Differences in $pkg: $PKG_DIFF are new and not committed."
+      TOTAL_RES="Differences in $pkg: $PKG_DIFF are new and not committed.\n $TOTAL_RES"
     fi
     PKG_DIFF=$(grep -Fxv -f "$pkg_path/package_info/$pkg/dependencies" "$pkg_path/package_info/$pkg/dependencies.old" || true)
     if [ -n "$PKG_DIFF" ]; then
-      HAS_DIFF=TRUE
-      echo "Differences in $pkg: $PKG_DIFF have disappeared."
+      TOTAL_RES="Differences in $pkg: $PKG_DIFF have disappeared.\n $TOTAL_RES"
     fi
     if [ -f $pkg_path/package_info/$pkg/dependencies.old ]; then
       rm $pkg_path/package_info/$pkg/dependencies.old
@@ -53,7 +51,8 @@ done
 echo " Checks finished"
 cd $CGAL_ROOT
 rm -r dep_check_build
-if [ -n "$HAS_DIFF" ]; then
+if [ -n "$TOTAL_RES" ]; then
+  echo "$TOTAL_RES"
   echo " You can run cmake with options CGAL_ENABLE_CHECK_HEADERS and CGAL_COPY_DEPENDENCIES ON, make the target packages_dependencies and commit the new dependencies files,"
   echo " or simply manually edit the problematic files."
   exit 1


### PR DESCRIPTION
## Summary of Changes
The errors due to dependency modification are painful to detect in the over spammed report of travis. 
With this PR, each change reported by the check is listed in the end, so we don't have to grep PKG_DIFF and search for one that is not empty anymore.

