### PR TITLE
add missing const to compare_endpoints_xy_2 () operator taking x-mono…

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_Bezier_curve_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_Bezier_curve_traits_2.h
@@ -784,7 +784,7 @@ public:
      * \return SMALLER if the curve is directed right;
      *         LARGER if the curve is directed left.
      */
-    Comparison_result operator() (const X_monotone_curve_2& cv)
+    Comparison_result operator() (const X_monotone_curve_2& cv) const
     {
       if (cv.is_directed_right())
         return (SMALLER);


### PR DESCRIPTION
…tone-curve as a parameter

## Summary of Changes

Allows use of the () operator for compare_endpoints_xy_2 functor

## Release Management

* Affected packages: Arrangement_on_surface_2 (Arr_Bezier_curve_traits_2)

