### PR TITLE
Installation: better check_headers (for Travis)

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -44,8 +44,6 @@
 
 namespace CGAL {
 
-error
-
 /// \addtogroup PkgAABB_tree
 /// @{
 

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -44,6 +44,8 @@
 
 namespace CGAL {
 
+error
+
 /// \addtogroup PkgAABB_tree
 /// @{
 

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1122,13 +1122,13 @@ because IPE_FOUND is false.")
     endif()
 
     if(CGAL_ENABLE_CHECK_HEADERS)
-      set(falg "-fsyntax-only")
+      set(flag "-fsyntax-only")
     else()
-      set(falg "-E")
+      set(flag "-E")
     endif()
     if(NOT DEFINED CGAL_CHECK_SYNTAX_ONLY)
       execute_process(COMMAND 
-        ${CMAKE_CXX_COMPILER} -x c++ ${falg} ${CGAL_MODULES_DIR}/config/support/test_syntaxonly.cpp
+        ${CMAKE_CXX_COMPILER} -x c++ ${flag} ${CGAL_MODULES_DIR}/config/support/test_syntaxonly.cpp
         ERROR_QUIET
         RESULT_VARIABLE ok)
       if(ok EQUAL 0)
@@ -1139,7 +1139,7 @@ because IPE_FOUND is false.")
     endif(NOT DEFINED CGAL_CHECK_SYNTAX_ONLY)
 
     if(NOT CGAL_CHECK_SYNTAX_ONLY)
-      message(FATAL_ERROR "Your compiler does not seem to support ${falg}.
+      message(FATAL_ERROR "Your compiler does not seem to support ${flag}.
 You must disable CGAL_ENABLE_CHECK_HEADERS.")
     endif()
 
@@ -1277,7 +1277,7 @@ LEDA_FOUND is false.")
             separate_arguments(CMD
               UNIX_COMMAND
               "${CMAKE_CXX_COMPILER} ${compile_options_str}
-${include_options_str} -x c++ ${falg} -H \
+${include_options_str} -x c++ ${flag} -H \
 ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}"
               # The header Algebraic_kernel_rs_gmpz_d_1.h is skipped on purpose: it
               # depends on RS.

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1282,12 +1282,22 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}"
               # The header Algebraic_kernel_rs_gmpz_d_1.h is skipped on purpose: it
               # depends on RS.
               )
+            # CMD2 is CMD without the -H option
+            separate_arguments(CMD2
+              UNIX_COMMAND
+              "${CMAKE_CXX_COMPILER} ${compile_options_str}
+${include_options_str} -x c++ ${flag} \
+${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}"
+              # The header Algebraic_kernel_rs_gmpz_d_1.h is skipped on purpose: it
+              # depends on RS.
+              )
             set(chk_header_name
               ${CGAL_BINARY_DIR}/package_info/${package}/check_headers/check_${header2})
             add_custom_command(OUTPUT ${chk_header_name}
               COMMAND ${CMAKE_COMMAND}
               -DCERR:STRING=${chk_header_name}
               "-DCMD:STRING=${CMD}"
+              "-DCMD2:STRING=${CMD2}"
               -P "${CGAL_MODULES_DIR}/run_cmd_redirection_cerr.cmake"
               DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}
               DEPENDS ${CGAL_MODULES_DIR}/run_cmd_redirection_cerr.cmake

--- a/Installation/cmake/modules/run_cmd_redirection_cerr.cmake
+++ b/Installation/cmake/modules/run_cmd_redirection_cerr.cmake
@@ -17,15 +17,19 @@ endif()
 
 execute_process(
   COMMAND ${CMD}
-  ERROR_VARIABLE err
+  ERROR_FILE "${CERR}"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE error_result)
-
-file(WRITE ${CERR} "${err}")
-
 if(error_result)
-  string(REPLACE ";" " " CMD_STR "${CMD}")
-  message(SEND_ERROR 
+  if(CMD2)
+    file(REMOVE ${CERR})
+    execute_process(COMMAND ${CMD2})
+    message(SEND_ERROR)
+  else()
+    file(READ ${CERR} err)
+    file(REMOVE ${CERR})
+    string(REPLACE ";" " " CMD_STR "${CMD}")
+    message(SEND_ERROR
 "The command
   ${CMD_STR} > ${CERR}
 ended with the error code ${error_result},
@@ -34,4 +38,5 @@ ${output}
 and the following error output:
 ${err}"
 )
+  endif()
 endif()

--- a/Installation/cmake/modules/run_cmd_redirection_cerr.cmake
+++ b/Installation/cmake/modules/run_cmd_redirection_cerr.cmake
@@ -15,11 +15,16 @@ if(NOT CERR)
     "The variable `CERR` should be defined to the output error file!")
 endif()
 
+# Create the file before using it
+file(WRITE ${CERR})
+
+# Execute the command ${CMD} with stderr redirected to the file ${CERR}
 execute_process(
   COMMAND ${CMD}
   ERROR_FILE "${CERR}"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE error_result)
+
 if(error_result)
   if(CMD2)
     file(REMOVE ${CERR})

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -29,7 +29,7 @@ do
 done
 
 cmake -DCGAL_HEADER_ONLY=FALSE -DCGAL_ENABLE_CHECK_HEADERS=TRUE -DDOXYGEN_EXECUTABLE="$DOX_PATH" -DCGAL_COPY_DEPENDENCIES=TRUE -DCMAKE_CXX_FLAGS="-std=c++11" ..
-make -j$(nproc --all) packages_dependencies
+make -j$(nproc --all) -k packages_dependencies
 echo " Checks finished"
 for pkg_path in $CGAL_ROOT/*
 do


### PR DESCRIPTION
## Summary of Changes

- When there is an error in `check_headers`, now the same file is recompiled without `-H`, to display the error without the display of all the included headers.

- In Travis, that check is now triggered with `make -k`, so that the compilation continue with the other headers, in case of an error.

- I have introduced a compilation error on purpose in `<CGAL/AABB_tree.h>` to check the feature.

## Release Management

* Affected package(s): Installation, Travis

