### PR TITLE
Infrastructure: Fix condition for skipping tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
 compiler: clang-3.6
 install: 
   - echo "$PWD"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "TRUE" ]; then  travis_terminate 0; fi; done;fi
+  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - bash .travis/install.sh 
   - export CXX=clang++-3.6 CC=clang-3.6;
 before_script: 

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -54,6 +54,10 @@ ROOT="$PWD/.."
 NEED_3D=0
 for ARG in $(echo "$@")
 do
+#skip package maintenance
+  if [ "$ARG" = "Maintenance" ]; then
+    continue
+  fi
 cd $ROOT
 #install openmesh only if necessary
   if [ "$ARG" = "CHECK" ] || [ "$ARG" = BGL ] || [ "$ARG" = Convex_hull_3 ] ||\

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -10,7 +10,7 @@ env:
 compiler: clang-3.6
 install: 
   - echo "$PWD"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "TRUE" ]; then  travis_terminate 0; fi; done;fi
+  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - bash .travis/install.sh 
   - export CXX=clang++-3.6 CC=clang-3.6;
 before_script: 


### PR DESCRIPTION
## Summary of Changes

Only interrupt travis before script if all three packages in the job are ignored.
## Release Management
* Issue(s) solved (if any): fix #3112 

