### PR TITLE
Disallow in-source builds in git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,32 @@ message( "== CMake setup ==" )
 project(CGAL CXX C)
 
 # Minimal version of CMake:
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 
 set( CGAL_BRANCH_BUILD ON CACHE INTERNAL "Create CGAL from a Git branch" FORCE)
 
 include(${CMAKE_SOURCE_DIR}/Installation/cmake/modules/CGAL_SCM.cmake)
 CGAL_detect_git(${CMAKE_SOURCE_DIR})
+
+function(CGAL_error_if_detect_in_source_build)
+  # If in a Git repository, forbid in-source builds
+  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+  if("${srcdir}" STREQUAL "${bindir}")
+    message(FATAL_ERROR [=[
+############
+Since CGAL-4.12.1, you can no longer configure an in-source build in a Git
+repository. See this StackOverlow question and answers for a way to create
+a separate build directory:
+  https://stackoverflow.com/q/45518317/1728537
+############
+]=])
+  endif()
+endfunction()
+
+if ( "${CGAL_SCM_NAME}" STREQUAL "git" )
+  CGAL_error_if_detect_in_source_build()
+endif()
 
 # add option for duplicate file detection
 option( CGAL_REPORT_DUPLICATE_FILES "Switch on to start (naive) detection of duplicate source- and headerfiles in packages" OFF)

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -864,10 +864,8 @@ endif()
 if(NOT CGAL_HEADER_ONLY)
   create_CGALconfig_files()
 else()
-  if(NOT EXISTS "${CMAKE_BINARY_DIR}/CGALConfig.cmake")
-    configure_file("${CGAL_MODULES_DIR}/CGALConfig_binary_header_only.cmake.in"
-      "${CMAKE_BINARY_DIR}/CGALConfig.cmake"  @ONLY)
-  endif()
+  configure_file("${CGAL_MODULES_DIR}/CGALConfig_binary_header_only.cmake.in"
+    "${CMAKE_BINARY_DIR}/CGALConfig.cmake"  @ONLY)
 endif()
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary of Changes

This PR reverts partially a bad patch from #3021 (merged in CGAL-4.12). The idea was that, when using an in-source build in the Git repository, we want to avoid that the hard-coded `CGALConfig.cmake` is modified by the CMake configuration.

That patch was wrong, because it prevents any refresh of `CGALConfig.cmake`. And, in particular, when one switches to `CGAL_HEADER_ONY` in a build-directory where there was a previous configuration, we want to refresh `CGALConfig.cmake`.

The solution is to forbid in-source builds in the Git repo.

@maxGimeno That may change things for you, because you were the one reporting the issue https://github.com/CGAL/cgal/issues/3016. Now, in-source builds will be forbidden.

## Release Management

* Affected package(s): CMake s cripts
