### PR TITLE
Triangulation_23: fix wrong return type in spatial_sort functor

### DIFF
--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -434,7 +434,8 @@ private:
   template<class Construct_bare_point, class Container>
   struct Index_to_Bare_point
   {
-    const Bare_point& operator()(const std::size_t& i) const
+    typename boost::result_of<const Construct_bare_point(const Weighted_point&)>::type
+    operator()(const std::size_t& i) const
     {
       return cp(c[i]);
     }

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -425,7 +425,8 @@ namespace CGAL {
     template<class Construct_bare_point, class Container>
     struct Index_to_Bare_point
     {
-      const Bare_point& operator()(const std::size_t& i) const
+      typename boost::result_of<const Construct_bare_point(const Weighted_point&)>::type
+      operator()(const std::size_t& i) const
       {
         return cp(c[i]);
       }

--- a/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
@@ -6,6 +6,9 @@
 #include <CGAL/Regular_triangulation_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
 
+#include <iostream>
+#include <functional>
+#include <utility>
 #include <vector>
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel            K;

--- a/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
@@ -1,184 +1,222 @@
-
 #include "test_dependencies.h"
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
 #include <CGAL/Regular_triangulation_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
+
 #include <vector>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel            K;
-typedef K                                                              Traits;
-typedef CGAL::Regular_triangulation_vertex_base_3<Traits>  Vbb;
-typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, Traits,Vbb>  Vb;
-typedef CGAL::Triangulation_data_structure_3<Vb,CGAL::Regular_triangulation_cell_base_3<Traits> > Tds;
-typedef CGAL::Regular_triangulation_3<Traits, Tds>                     Regular;
-typedef K::Weighted_point_3                                            Weighted_point;
-typedef K::Point_3                                                     Point;
+typedef CGAL::Exact_predicates_exact_constructions_kernel            K;
+
+template <typename K>
+struct Tester
+{
+  typedef K                                                                 Traits;
+  typedef CGAL::Regular_triangulation_vertex_base_3<Traits>                 Vbb;
+  typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, Traits,Vbb> Vb;
+  typedef CGAL::Regular_triangulation_cell_base_3<Traits>                   Cb;
+  typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                      Tds;
+
+  typedef CGAL::Regular_triangulation_3<Traits, Tds>                        RT;
+  typedef typename RT::Bare_point                                           Bare_point;
+  typedef typename RT::Weighted_point                                       Weighted_point;
 
 #ifdef CGAL_LINKED_WITH_TBB
-typedef CGAL::Spatial_lock_grid_3<CGAL::Tag_priority_blocking>         Lock_ds;
-typedef CGAL::Triangulation_data_structure_3<Vb, 
-  CGAL::Regular_triangulation_cell_base_3<Traits>, CGAL::Parallel_tag> Tds_parallel;
-typedef CGAL::Regular_triangulation_3<Traits, Tds_parallel, Lock_ds>   RT_parallel;
+  typedef CGAL::Spatial_lock_grid_3<CGAL::Tag_priority_blocking>           Lock_ds;
+  typedef CGAL::Triangulation_data_structure_3<Vb, Cb, CGAL::Parallel_tag> Tds_parallel;
+  typedef CGAL::Regular_triangulation_3<Traits, Tds_parallel, Lock_ds>     RT_parallel;
 #endif
 
-template <bool is_const>
-void test_iterator_on_pair(){
-  typedef std::vector< std::pair<Weighted_point,unsigned> > Container;
-  typedef typename boost::mpl::if_< boost::mpl::bool_<is_const>,boost::add_const<Container>::type,Container >::type Cast_type;
-  Container points;
-  
-
-  points.push_back( std::make_pair( Weighted_point(Point(0,0,0),1),0  ) );
-  points.push_back( std::make_pair( Weighted_point(Point(1,0,0),2),1  ) );
-  points.push_back( std::make_pair( Weighted_point(Point(0,1,0),3),2  ) );
-  points.push_back( std::make_pair( Weighted_point(Point(0,0,1),4),3  ) );
-  points.push_back( std::make_pair( Weighted_point(Point(2,2,2),5),4  ) );
-  points.push_back( std::make_pair( Weighted_point(Point(-1,0,1),6),5 ) );
-
-  
-  Regular R( static_cast<Cast_type&>(points).begin(),static_cast<Cast_type&>(points).end() );
-
-  assert( R.number_of_vertices() == 6 );
-
-  // check that the info was correctly set.
-  Regular::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert(points[vit->info()].first == vit->point());
-
-#ifdef CGAL_LINKED_WITH_TBB
+  template <bool is_const>
+  void test_iterator_on_pair() const
   {
-  // Construct the locking data-structure, using the bounding-box of the points
-  typename RT_parallel::Lock_data_structure locking_ds(
-    CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
-  // Contruct the triangulation in parallel
-  RT_parallel R(
-    static_cast<Cast_type&>(points).begin(), 
-    static_cast<Cast_type&>(points).end(),
-    &locking_ds);
+    typedef std::vector<std::pair<Weighted_point, unsigned> >              Container;
+    typedef typename boost::mpl::if_<boost::mpl::bool_<is_const>,
+                                     typename boost::add_const<Container>::type,
+                                     Container>::type                      Cast_type;
 
-  assert(R.number_of_vertices() == 6);
+    Container points;
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.160385, 0.599679, 0.374932), -0.118572), 0));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.17093, 0.82228, 0.51697), -0.0226131), 1));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.15773, 0.66293, 0.458541), -0.0753074), 2));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.388417, 0.685989, 0.401349), -0.0616195), 3));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.380061, 0.852124, 0.538984), -0.0145638), 4));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.0402467, 0.519724, 0.417205), -0.0698374), 5));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.0270472, 0.360373, 0.358776), -0.0109982), 6));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.257734, 0.383432, 0.301584), -0.0601458), 7));
+    points.push_back(std::make_pair(Weighted_point(Bare_point(0.142091, 0.643406, 0.61943), -0.251061), 8));
 
-  // check that the info was correctly set.
-  RT_parallel::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert(points[vit->info()].first == vit->point());
-  }
+    RT R(static_cast<Cast_type&>(points).begin(), static_cast<Cast_type&>(points).end());
+    assert(R.number_of_vertices() == 9);
+
+    R.clear();
+    R.insert(static_cast<Cast_type&>(points).begin(), static_cast<Cast_type&>(points).end());
+    assert(R.number_of_vertices() == 9);
+
+    // check that the info was correctly set.
+    typename RT::Finite_vertices_iterator vit;
+    for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
+      assert(points[vit->info()].first == vit->point());
+
+  #ifdef CGAL_LINKED_WITH_TBB
+    {
+      // Construct the locking data-structure, using the bounding-box of the points
+      typename RT_parallel::Lock_data_structure locking_ds(CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
+
+      // Contruct the triangulation in parallel
+      RT_parallel R(static_cast<Cast_type&>(points).begin(), static_cast<Cast_type&>(points).end(), &locking_ds);
+      assert(R.number_of_vertices() == 9);
+
+      R.clear();
+      R.insert(static_cast<Cast_type&>(points).begin(), static_cast<Cast_type&>(points).end(), &locking_ds);
+      assert(R.number_of_vertices() == 9);
+
+      // check that the info was correctly set.
+      typename RT_parallel::Finite_vertices_iterator vit;
+      for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit) {
+        assert(points[vit->info()].first == vit->point());
+      }
+    }
 #endif
-}
+  }
 
-void toto(int){}
-
-template <bool is_const>
-void test_zip_iterator(){
-  typedef std::vector< Weighted_point > Container;
-  Container points;
-  typedef typename boost::mpl::if_< boost::mpl::bool_<is_const>,boost::add_const<Container>::type,Container >::type Cast_type;
-  
-  points.push_back( Weighted_point(Point(0,0,0),1) );
-  points.push_back( Weighted_point(Point(1,0,0),2) );
-  points.push_back( Weighted_point(Point(0,1,0),3) );
-  points.push_back( Weighted_point(Point(0,0,1),4) );
-  points.push_back( Weighted_point(Point(2,2,2),5) );
-  points.push_back( Weighted_point(Point(-1,0,1),6) );
-  
-  std::vector<unsigned> indices;
-  indices.push_back(0);
-  indices.push_back(1);
-  indices.push_back(2);
-  indices.push_back(3);
-  indices.push_back(4);
-  indices.push_back(5); 
-
-  Regular R( boost::make_zip_iterator(boost::make_tuple( static_cast<Cast_type&>(points).begin(),indices.begin() )),
-             boost::make_zip_iterator(boost::make_tuple( static_cast<Cast_type&>(points).end(),indices.end() ) )  );
-  assert( R.number_of_vertices() == 6 );
-
-  // check that the info was correctly set.
-  Regular::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert( points[ vit->info() ] == vit->point() );
-  
-#ifdef CGAL_LINKED_WITH_TBB
+  template <bool is_const>
+  void test_zip_iterator() const
   {
-  // Construct the locking data-structure, using the bounding-box of the points
-  typename RT_parallel::Lock_data_structure locking_ds(
-    CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
-  // Contruct the triangulation in parallel
-  RT_parallel R(
-    boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).begin(), indices.begin())),
-    boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).end(), indices.end())),
-    &locking_ds);
+    typedef std::vector<Weighted_point>                                   Container;
+    typedef typename boost::mpl::if_<boost::mpl::bool_<is_const>,
+                                     typename boost::add_const<Container>::type,
+                                     Container >::type                    Cast_type;
 
-  assert(R.number_of_vertices() == 6);
+    Container points;
+    points.push_back(Weighted_point(Bare_point(0,0,0),1));
+    points.push_back(Weighted_point(Bare_point(1,0,0),2));
+    points.push_back(Weighted_point(Bare_point(0,1,0),3));
+    points.push_back(Weighted_point(Bare_point(0,0,1),4));
+    points.push_back(Weighted_point(Bare_point(2,2,2),5));
+    points.push_back(Weighted_point(Bare_point(-1,0,1),6));
 
-  // check that the info was correctly set.
-  RT_parallel::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert(points[vit->info()] == vit->point());
-  }
+    std::vector<unsigned> indices;
+    indices.push_back(0);
+    indices.push_back(1);
+    indices.push_back(2);
+    indices.push_back(3);
+    indices.push_back(4);
+    indices.push_back(5);
+
+    RT R(boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).begin(), indices.begin())),
+         boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).end(), indices.end())));
+    assert(R.number_of_vertices() == 6);
+
+    // check that the info was correctly set.
+    typename RT::Finite_vertices_iterator vit;
+    for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
+      assert(points[ vit->info() ] == vit->point());
+
+#ifdef CGAL_LINKED_WITH_TBB
+    {
+      // Construct the locking data-structure, using the bounding-box of the points
+      typename RT_parallel::Lock_data_structure locking_ds(CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
+
+      // Contruct the triangulation in parallel
+      RT_parallel R(boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).begin(), indices.begin())),
+                    boost::make_zip_iterator(boost::make_tuple(static_cast<Cast_type&>(points).end(), indices.end())),
+                    &locking_ds);
+      assert(R.number_of_vertices() == 6);
+
+      // check that the info was correctly set.
+      typename RT_parallel::Finite_vertices_iterator vit;
+      for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit) {
+        assert(points[vit->info()] == vit->point());
+      }
+    }
 #endif
-}
+  }
 
-struct Auto_count : public std::unary_function<const Weighted_point&,std::pair<Weighted_point,unsigned> >{
-  mutable unsigned i;
-  Auto_count() : i(0){}
-  std::pair<Weighted_point,unsigned> operator()(const Weighted_point& p) const {
-    return std::make_pair(p,i++);
+  struct Auto_count
+    : public std::unary_function<const Weighted_point&,
+                                 std::pair<Weighted_point,
+                                 unsigned> >
+  {
+    mutable unsigned i;
+    Auto_count() : i(0){}
+    std::pair<Weighted_point,unsigned> operator()(const Weighted_point& p) const
+    {
+      return std::make_pair(p,i++);
+    }
+  };
+
+  template <bool is_const>
+  void test_transform_iterator() const
+  {
+    typedef std::vector< Weighted_point >                                   Container;
+    typedef typename boost::mpl::if_<boost::mpl::bool_<is_const>,
+                                     typename boost::add_const<Container>::type,
+                                     Container >::type                      Cast_type;
+
+    Container points;
+    points.push_back(Weighted_point(Bare_point(0,0,0),1));
+    points.push_back(Weighted_point(Bare_point(1,0,0),2));
+    points.push_back(Weighted_point(Bare_point(0,1,0),3));
+    points.push_back(Weighted_point(Bare_point(0,0,1),4));
+    points.push_back(Weighted_point(Bare_point(2,2,2),5));
+    points.push_back(Weighted_point(Bare_point(-1,0,1),6));
+
+    RT R(boost::make_transform_iterator(static_cast<Cast_type&>(points).begin(), Auto_count()),
+         boost::make_transform_iterator(static_cast<Cast_type&>(points).end(), Auto_count()));
+
+    assert(R.number_of_vertices() == 6);
+
+    // check that the info was correctly set.
+    typename RT::Finite_vertices_iterator vit;
+    for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
+      assert(points[ vit->info() ] == vit->point());
+
+#ifdef CGAL_LINKED_WITH_TBB
+    {
+      // Construct the locking data-structure, using the bounding-box of the points
+      typename RT_parallel::Lock_data_structure locking_ds(CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
+
+      // Contruct the triangulation in parallel
+      RT_parallel R(boost::make_transform_iterator(static_cast<Cast_type&>(points).begin(), Auto_count()),
+                    boost::make_transform_iterator(static_cast<Cast_type&>(points).end(), Auto_count()),
+                    &locking_ds);
+      assert(R.number_of_vertices() == 6);
+
+      // check that the info was correctly set.
+      typename RT_parallel::Finite_vertices_iterator vit;
+      for(vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit) {
+        assert(points[vit->info()] == vit->point());
+      }
+    }
+#endif
+  }
+
+  void operator()() const
+  {
+    test_iterator_on_pair<false>();
+    test_iterator_on_pair<true>();
+    test_zip_iterator<false>();
+    test_zip_iterator<true>();
+    test_transform_iterator<false>();
+    test_transform_iterator<true>();
   }
 };
 
-template <bool is_const>
-void test_transform_iterator(){
-  typedef std::vector< Weighted_point > Container;
-  Container points;
-  typedef typename boost::mpl::if_< boost::mpl::bool_<is_const>,boost::add_const<Container>::type,Container >::type Cast_type;
-  
-  points.push_back( Weighted_point(Point(0,0,0),1) );
-  points.push_back( Weighted_point(Point(1,0,0),2) );
-  points.push_back( Weighted_point(Point(0,1,0),3) );
-  points.push_back( Weighted_point(Point(0,0,1),4) );
-  points.push_back( Weighted_point(Point(2,2,2),5) );
-  points.push_back( Weighted_point(Point(-1,0,1),6) );
-
-  Regular R( boost::make_transform_iterator(static_cast<Cast_type&>(points).begin(),Auto_count()),
-             boost::make_transform_iterator(static_cast<Cast_type&>(points).end(),  Auto_count() )  );
-
-  assert( R.number_of_vertices() == 6 );
-
-  // check that the info was correctly set.
-  Regular::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert( points[ vit->info() ] == vit->point() );  
-  
-#ifdef CGAL_LINKED_WITH_TBB
-  {
-  // Construct the locking data-structure, using the bounding-box of the points
-  typename RT_parallel::Lock_data_structure locking_ds(
-    CGAL::Bbox_3(-1., 0., 0., 2, 2, 2), 50);
-  // Contruct the triangulation in parallel
-  RT_parallel R(
-    boost::make_transform_iterator(static_cast<Cast_type&>(points).begin(), Auto_count()),
-    boost::make_transform_iterator(static_cast<Cast_type&>(points).end(), Auto_count()),
-    &locking_ds);
-
-  assert(R.number_of_vertices() == 6);
-
-  // check that the info was correctly set.
-  RT_parallel::Finite_vertices_iterator vit;
-  for (vit = R.finite_vertices_begin(); vit != R.finite_vertices_end(); ++vit)
-    assert(points[vit->info()] == vit->point());
-  }
-#endif
-}
-
 int main()
 {
-  test_iterator_on_pair<false>();
-  test_iterator_on_pair<true>();
-  test_zip_iterator<false>();
-  test_zip_iterator<true>();
-  test_transform_iterator<false>();
-  test_transform_iterator<true>();
-  return 0;
-}
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel Epick;
+  typedef CGAL::Exact_predicates_exact_constructions_kernel   Epeck;
 
+  std::cerr << "TESTING WITH Exact_predicates_inexact_constructions_kernel...\n";
+  Tester<Epick> test_epic;
+  test_epic();
+
+  std::cerr << "TESTING WITH Exact_predicates_exact_constructions_kernel...\n";
+  Tester<Epeck> test_epec;
+  test_epec();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary of Changes

A functor in `Regular_triangulation_23` expected the return type of `Construct_point_3(const Weighted_point_3&)` to be a `const Point_3&`. This is not the case with EPECK, which uses a lazy representation and builds points on the fly, resulting in taking references to temporaries.

## Release Management

* Affected package(s): Triangulation_23
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

