### PR TITLE
Solver Interface: deprecate CGAL::Diagonalize_traits

### DIFF
--- a/Bounding_volumes/doc/Bounding_volumes/CGAL/Approximate_min_ellipsoid_d.h
+++ b/Bounding_volumes/doc/Bounding_volumes/CGAL/Approximate_min_ellipsoid_d.h
@@ -137,6 +137,8 @@ for display in Maplesoft's Maple.
 
 \cgalExample{Approximate_min_ellipsoid_d/ellipsoid_for_maple.cpp} 
 
+\note This class requires the \ref thirdpartyEigen library.
+
 */
 template< typename Traits >
 class Approximate_min_ellipsoid_d {

--- a/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
+++ b/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
@@ -13,6 +13,7 @@
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{1.1}
+\cgalPkgDependsOn{\ref thirdpartyEigen}
 \cgalPkgBib{cgal:fghhs-bv}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
 \cgalPkgDemo{2D Bounding Volumes,bounding_volumes_2.zip}

--- a/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
@@ -12,10 +12,18 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0 QUIET) #(3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+  
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})
-    create_single_source_cgal_program( "${cppfile}" )
+    if(NOT (${cppfile} STREQUAL "ellipsoid.cpp") OR EIGEN3_FOUND)
+      create_single_source_cgal_program( "${cppfile}" )
+    endif()
   endforeach()
 
 else()

--- a/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
+++ b/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
@@ -16,10 +16,18 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0 QUIET) #(3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+  
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})
-    create_single_source_cgal_program( "${cppfile}" )
+    if(NOT (${cppfile} STREQUAL "Approximate_min_ellipsoid_d.cpp") OR EIGEN3_FOUND)
+      create_single_source_cgal_program( "${cppfile}" )
+    endif()
   endforeach()
 
 else()

--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -25,6 +25,14 @@ find_package(CGAL QUIET COMPONENTS Core)
 if ( CGAL_FOUND )
   include( ${CGAL_USE_FILE} )
 
+  find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  else()
+    message(STATUS "NOTICE: This project requires the Eigen library, and will not be compiled.")
+    return()
+  endif()
+
   find_package(IPE 6)
 
   if ( IPE_FOUND )

--- a/Classification/examples/Classification/CMakeLists.txt
+++ b/Classification/examples/Classification/CMakeLists.txt
@@ -39,6 +39,16 @@ find_package(TBB QUIET)
 
 find_package(OpenCV QUIET)
 
+# Use Eigen
+find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)
+if (NOT EIGEN3_FOUND)
+  message(STATUS "This project requires the Eigen library, and will not be compiled.")
+  return()
+else()
+  include( ${EIGEN3_USE_FILE} )
+endif()
+
+
 # include for local directory
 include_directories( BEFORE include )
 

--- a/Classification/include/CGAL/Classification/Local_eigen_analysis.h
+++ b/Classification/include/CGAL/Classification/Local_eigen_analysis.h
@@ -184,10 +184,9 @@ public:
     algorithm. Possible values are `Parallel_tag` (default value is %CGAL
     is linked with TBB) or `Sequential_tag` (default value otherwise).
     \tparam DiagonalizeTraits model of `DiagonalizeTraits` used for
-    matrix diagonalization. It can be omitted: if Eigen 3 (or greater)
-    is available and `CGAL_EIGEN3_ENABLED` is defined then an overload
-    using `Eigen_diagonalize_traits` is provided. Otherwise, the
-    internal implementation `Diagonalize_traits` is used.
+    matrix diagonalization. It can be omitted if Eigen 3 (or greater)
+    is available and `CGAL_EIGEN3_ENABLED` is defined. In that case,
+    an overload using `Eigen_diagonalize_traits` is provided.
 
     \param input point range.
     \param point_map property map to access the input points.

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -87,10 +87,8 @@ namespace Classification {
   is linked with TBB) or `Sequential_tag` (default value otherwise).
   \tparam DiagonalizeTraits model of `DiagonalizeTraits` used for
   matrix diagonalization. It can be omitted: if Eigen 3 (or greater)
-  is available and `CGAL_EIGEN3_ENABLED` is defined then an overload
-  using `Eigen_diagonalize_traits` is provided. Otherwise, the
-  internal implementation `Diagonalize_traits` is used.
-
+  is available and `CGAL_EIGEN3_ENABLED` is defined: in that case, an
+  overload using `Eigen_diagonalize_traits` is provided.
 */
 template <typename GeomTraits,
           typename PointRange,

--- a/Classification/include/CGAL/Classification/Point_set_neighborhood.h
+++ b/Classification/include/CGAL/Classification/Point_set_neighborhood.h
@@ -30,7 +30,6 @@
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Fuzzy_sphere.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <CGAL/Default_diagonalize_traits.h>
 #include <CGAL/centroid.h>
 #include <CGAL/grid_simplify_point_set.h>
 #include <CGAL/squared_distance_3.h>

--- a/Generator/examples/Generator/CMakeLists.txt
+++ b/Generator/examples/Generator/CMakeLists.txt
@@ -16,10 +16,20 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0 QUIET) #(3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+  
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})
-    create_single_source_cgal_program( "${cppfile}" )
+    if(NOT (${cppfile} STREQUAL "random_points_in_tetrahedral_mesh_3.cpp")
+        OR NOT (${cppfile} STREQUAL "random_points_on_tetrahedral_mesh_3.cpp")
+        OR EIGEN3_FOUND)
+      create_single_source_cgal_program( "${cppfile}" )
+    endif()
   endforeach()
 
 else()

--- a/Generator/test/Generator/CMakeLists.txt
+++ b/Generator/test/Generator/CMakeLists.txt
@@ -16,10 +16,18 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0 QUIET) #(3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})
-    create_single_source_cgal_program( "${cppfile}" )
+    if(NOT (${cppfile} STREQUAL "generic_random_test.cpp") OR EIGEN3_FOUND)
+      create_single_source_cgal_program( "${cppfile}" )
+    endif()
   endforeach()
 
 else()

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -13,6 +13,14 @@ find_package(CGAL COMPONENTS Qt5 Core)
 
 include(${CGAL_USE_FILE})
 
+find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
+if (EIGEN3_FOUND)
+  include( ${EIGEN3_USE_FILE} )
+else()
+  message(STATUS "NOTICE: This project requires the Eigen library, and will not be compiled.")
+  return()
+endif()
+
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 
 include_directories (BEFORE ../../include)

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -81,6 +81,19 @@ Release date: September 2018
     `<CGAL/Mesh_3/Labeled_mesh_domain_3.h>`, that were deprecated since
     CGAL 4.5, are now removed.
 
+-   **Breaking change**: `CGAL::lloyd_optimize_mesh_3` now depends on
+    the _Eigen_ library.
+
+### Estimation of Local Differential Properties of Point-Sampled Surfaces Reference
+
+-   **Breaking change**: `CGAL::Monge_via_jet_fitting` now depends on
+    the _Eigen_ library.
+
+### Bounding Volumes
+
+-   **Breaking change**: `CGAL::Approximate_min_ellipsoid_d` now
+    depends on the _Eigen_ library.
+
 ### CGAL and the Boost Graph Library (BGL)
 
 -   Add helper function `CGAL::is_valid_polygon_mesh` that checks the
@@ -88,6 +101,13 @@ Release date: September 2018
 
 -   Improve the function `CGAL::Euler::collapse_edge` so that the target
     vertex of the collapsed edge is always kept after the collapse.
+
+### CGAL and Solvers
+
+-   **Breaking change**: `CGAL::Diagonalize_traits` is now deprecated
+    and shouldn't be used, `CGAL::Eigen_diagonalize_traits` (along
+    with the _Eigen_ library) should be used instead.
+
 
 
 Release 4.12

--- a/Jet_fitting_3/doc/Jet_fitting_3/CGAL/Monge_via_jet_fitting.h
+++ b/Jet_fitting_3/doc/Jet_fitting_3/CGAL/Monge_via_jet_fitting.h
@@ -29,6 +29,7 @@ algebra algorithm required by the fitting method.  The scalar type, `SvdTraits::
 \sa `Eigen_svd`
 \sa `Monge_form`
 
+\note This class requires the \ref thirdpartyEigen library.
 */
 template< typename DataKernel, typename LocalKernel, typename SvdTraits >
 class Monge_via_jet_fitting {

--- a/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{3.3}
-\cgalPkgDependsOn{\ref PkgSolverSummary} 
+\cgalPkgDependsOn{\ref PkgSolverSummary and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:pc-eldp}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
 \cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}

--- a/Mesh_3/doc/Mesh_3/CGAL/lloyd_optimize_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/lloyd_optimize_mesh_3.h
@@ -100,6 +100,7 @@ lloyd_optimize_mesh_3(c3t3,
 \sa `CGAL::perturb_mesh_3()` 
 \sa `CGAL::odt_optimize_mesh_3()` 
 
+\note This function requires the \ref thirdpartyEigen library.
 */
 
 template<typename C3T3, typename MeshDomain_3>

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -42,7 +42,7 @@
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{3.5}
-\cgalPkgDependsOn{\ref PkgTriangulation3Summary}
+\cgalPkgDependsOn{\ref PkgTriangulation3Summary and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:rty-m3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
 \cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -39,6 +39,15 @@ if ( CGAL_FOUND )
     endif( LINK_WITH_TBB )
   endif()
   
+  # Use Eigen
+  find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)
+  if (NOT EIGEN3_FOUND)
+    message(STATUS "This project requires the Eigen library, and will not be compiled.")
+    return()
+  else()
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+  
  set(VTK_LIBS "")
       find_package(VTK QUIET COMPONENTS vtkImagingGeneral  vtkIOImage NO_MODULE)
       if(VTK_FOUND)

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -19,6 +19,15 @@ if ( CGAL_FOUND )
   include_directories (BEFORE ../../include)
   include_directories (BEFORE ../../../AABB_tree/include)
 
+  # Use Eigen
+  find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)
+  if (NOT EIGEN3_FOUND)
+    message(STATUS "This project requires the Eigen library, and will not be compiled.")
+    return()
+  else()
+    include( ${EIGEN3_USE_FILE} )
+  endif()
+  
   create_single_source_cgal_program( "test_backward_compatibility.cpp" )
   create_single_source_cgal_program( "test_boost_has_xxx.cpp" )
   create_single_source_cgal_program( "test_c3t3.cpp" )

--- a/Point_set_processing_3/doc/Point_set_processing_3/NamedParameters.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/NamedParameters.txt
@@ -49,7 +49,7 @@ No default value.
 \cgalNPBegin{diagonalize_traits} \anchor PSP_diagonalize_traits
  is the solver used for diagonalizing covariance matrices.\n
 \b Type: a class model of `DiagonalizeTraits`.\n
-\b Default: if \ref thirdpartyEigen "Eigen" 3.2 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined, then `CGAL::Eigen_diagonalize_traits` is used. Otherwise, the fallback `CGAL::Diagonalize_traits` is used (note that it is significantly slower, so using Eigen is strongly advised).\n
+\b Default: `CGAL::Eigen_diagonalize_traits` if \ref thirdpartyEigen "Eigen" 3.2 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined.\n
 \cgalNPEnd
 
 \cgalNPBegin{svd_traits} \anchor PSP_svd_traits

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/CMakeLists.txt
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/CMakeLists.txt
@@ -23,12 +23,18 @@ if ( CGAL_FOUND )
 
   include_directories (BEFORE "../../include")
 
-  create_single_source_cgal_program( "shape_detection_basic.cpp" )
-  create_single_source_cgal_program( "shape_detection_with_callback.cpp" )
+  # Use Eigen
+  find_package(Eigen3 3.1.0 QUIET) #(3.1.0 or greater)
+  if (EIGEN3_FOUND)
+    include( ${EIGEN3_USE_FILE} )
+    create_single_source_cgal_program( "shape_detection_basic.cpp" )
+    create_single_source_cgal_program( "shape_detection_with_callback.cpp" )
+    create_single_source_cgal_program( "plane_regularization.cpp" )
+  endif()
+
   create_single_source_cgal_program( "efficient_RANSAC_custom_shape.cpp" )
   create_single_source_cgal_program( "efficient_RANSAC_parameters.cpp" )
   create_single_source_cgal_program( "efficient_RANSAC_point_access.cpp" )
-  create_single_source_cgal_program( "plane_regularization.cpp" )
 
 else()
   

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -22,7 +22,6 @@
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <CGAL/Default_diagonalize_traits.h>
 #include <CGAL/compute_average_spacing.h>
 #include <CGAL/grid_simplify_point_set.h>
 #include <CGAL/jet_smooth_point_set.h>

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -20,6 +20,14 @@ include_directories( ./ )
 find_package(CGAL COMPONENTS Qt5)
 include( ${CGAL_USE_FILE} )
 
+find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
+if (EIGEN3_FOUND)
+  include( ${EIGEN3_USE_FILE} )
+else()
+  message(STATUS "NOTICE: This project requires the Eigen library, and will not be compiled.")
+  return()
+endif()
+
 # Find Qt5 itself
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL)
 

--- a/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_2.h
+++ b/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_2.h
@@ -13,7 +13,7 @@ The tag `tag` identifies the dimension to be considered from the objects. For po
 
 The class `K` is the kernel in which the value type of the  `InputIterator` is defined. It can be omitted and deduced automatically from the value type. 
 
-The class `DiagonalizeTraits_` is a model of `DiagonalizeTraits`. It can be omitted: if Eigen 3 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined then an overload using `Eigen_diagonalize_traits` is provided. Otherwise, the internal implementation `Diagonalize_traits` is used.
+The class `DiagonalizeTraits_` is a model of `DiagonalizeTraits`. It can be omitted if Eigen 3 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined: in that case, an overload using `Eigen_diagonalize_traits` is provided.
 
 \cgalHeading{Requirements}
 

--- a/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_3.h
+++ b/Principal_component_analysis/doc/Principal_component_analysis/CGAL/linear_least_squares_fitting_3.h
@@ -65,10 +65,9 @@ value type of `InputIterator` is defined. It can be omitted and deduced
 automatically from the value type.
 
 The class `DiagonalizeTraits_` is a model of `DiagonalizeTraits`. It
-can be omitted: if Eigen 3 (or greater) is available and
-`CGAL_EIGEN3_ENABLED` is defined then an overload using
-`Eigen_diagonalize_traits` is provided. Otherwise, the internal
-implementation `Diagonalize_traits` is used.
+can be omitted if Eigen 3 (or greater) is available and
+`CGAL_EIGEN3_ENABLED` is defined: in that case, an overload using
+`Eigen_diagonalize_traits` is provided.
 
 \note This function is significantly faster when using
 `Eigen_diagonalize_traits` and it is strongly advised to use this

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_circles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_circles_2.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // Example program for the linear_least_square_fitting function on a set of circles in 2D
 
 #include <CGAL/Cartesian.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_circles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_circles_2.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // Example program for the linear_least_square_fitting function on a set of circles in 2D
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // Example program for the linear_least_square_fitting function on set of cuboids in 3D
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_cuboids_3.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // Example program for the linear_least_square_fitting function on set of cuboids in 3D
 #include <CGAL/Cartesian.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_2.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 #include <CGAL/Cartesian.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_2.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 #include <CGAL/Cartesian.h>
 #include <CGAL/algorithm.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_3.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_points_3.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_rectangles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_rectangles_2.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_rectangles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_rectangles_2.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_2.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_2.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_segments_3.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
@@ -1,6 +1,6 @@
 // Example program for the linear_least_square_fitting function
 
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_spheres_3.cpp
@@ -1,5 +1,7 @@
 // Example program for the linear_least_square_fitting function
 
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>
 #ifdef CGAL_EIGEN3_ENABLED

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // Example program for the linear_least_square_fitting function
 // on a set of tetrahedra in 3D
 

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_tetrahedra_3.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // Example program for the linear_least_square_fitting function
 // on a set of tetrahedra in 3D

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_2.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // test for the linear_least_square_fitting() functions.
 #include <CGAL/Cartesian.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_2.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_2.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // test for the linear_least_square_fitting() functions.
 #include <CGAL/Cartesian.h>
 #include <CGAL/algorithm.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
@@ -1,3 +1,5 @@
+#define CGAL_NO_DEPRECATION_WARNINGS
+
 // Example program for the linear_least_square_fitting function on set of triangles in 3D
 #include <CGAL/Cartesian.h>
 #include <CGAL/linear_least_squares_fitting_3.h>

--- a/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_linear_least_squares_fitting_triangles_3.cpp
@@ -1,4 +1,4 @@
-#define CGAL_NO_DEPRECATION_WARNINGS
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
 // Example program for the linear_least_square_fitting function on set of triangles in 3D
 #include <CGAL/Cartesian.h>

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Weighted_PCA_smoother.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Weighted_PCA_smoother.h
@@ -61,11 +61,10 @@ namespace Scale_space_reconstruction_3
 
  *  \tparam DiagonalizeTraits model of `DiagonalizeTraits` that
  *  determines how to diagonalize a weighted covariance matrix to
- *  approximate a weighted point set. It can be omitted: if Eigen 3
- *  (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined
- *  then an overload using `Eigen_diagonalize_traits` is
- *  provided. Otherwise, the internal implementation
- *  `Diagonalize_traits` is used.
+ *  approximate a weighted point set. It can be omitted if Eigen 3 (or
+ *  greater) is available and `CGAL_EIGEN3_ENABLED` is defined: in
+ *  that case, an overload using `Eigen_diagonalize_traits` is
+ *  provided.
  *  \tparam ConcurrencyTag indicates whether to use concurrent
  *  processing. It can be omitted: if TBB (or greater) is available
  *  and `CGAL_LINKED_WITH_TBB` is defined then `Parallel_tag` is

--- a/Solver_interface/doc/Solver_interface/Concepts/DiagonalizeTraits.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/DiagonalizeTraits.h
@@ -17,8 +17,6 @@ follows:
 \tparam FT Number type
 \tparam dim Dimension of the matrices and vectors
 
-\cgalHasModel `CGAL::Default_diagonalize_traits`
-\cgalHasModel `CGAL::Diagonalize_traits`
 \cgalHasModel `CGAL::Eigen_diagonalize_traits`
 */
 

--- a/Solver_interface/doc/Solver_interface/PackageDescription.txt
+++ b/Solver_interface/doc/Solver_interface/PackageDescription.txt
@@ -31,10 +31,8 @@
 
 ## Classes ##
 
-- `CGAL::Diagonalize_traits`
 - `CGAL::Eigen_solver_traits`
 - `CGAL::Eigen_diagonalize_traits`
-- `CGAL::Default_diagonalize_traits`
 - `CGAL::Eigen_vector`
 - `CGAL::Eigen_matrix`
 - `CGAL::Eigen_sparse_matrix`

--- a/Solver_interface/doc/Solver_interface/Solver_interface.txt
+++ b/Solver_interface/doc/Solver_interface/Solver_interface.txt
@@ -26,22 +26,11 @@ Library (MKL)</a>.
 The concept `DiagonalizeTraits<T,dim>` defines an interface for the
 diagonalization and computation of eigenvectors and eigenvalues of a
 symmetric matrix. `T` is the number type and `dim` is the dimension of
-the matrices and vector (set to 3 by default). We provide two models
-for this concept:
-
-- `Eigen_diagonalize_traits<T,dim>` uses the \ref thirdpartyEigen library.
-- `Diagonalize_traits<T,dim>` is an internal implementation that does not
-depend on another library.
-
-Although both models achieve the same computation,
-`Eigen_diagonalize_traits<T,dim>` is more precise and faster: it
-should thus be used if the \ref thirdpartyEigen library is
-available. The eigenvalues are stored in ascending order and
-eigenvectors are stored in accordance.
+the matrices and vector (set to 3 by default). We provide the model
+`Eigen_diagonalize_traits<T,dim>` that uses the \ref thirdpartyEigen library.
 
 This is an example of an eigen decomposition of a matrix using this
 class:
-
 
 \cgalExample{Solver_interface/diagonalize_matrix.cpp}
 

--- a/Solver_interface/doc/Solver_interface/Solver_interface.txt
+++ b/Solver_interface/doc/Solver_interface/Solver_interface.txt
@@ -34,9 +34,10 @@ for this concept:
 depend on another library.
 
 Although both models achieve the same computation,
-`Eigen_diagonalize_traits<T,dim>` is faster and should thus be used if the
-\ref thirdpartyEigen library is available. The eigenvalues are stored
-in ascending order and eigenvectors are stored in accordance.
+`Eigen_diagonalize_traits<T,dim>` is more precise and faster: it
+should thus be used if the \ref thirdpartyEigen library is
+available. The eigenvalues are stored in ascending order and
+eigenvectors are stored in accordance.
 
 This is an example of an eigen decomposition of a matrix using this
 class:

--- a/Solver_interface/examples/Solver_interface/diagonalize_matrix.cpp
+++ b/Solver_interface/examples/Solver_interface/diagonalize_matrix.cpp
@@ -1,22 +1,13 @@
 #include <iostream>
 
-#ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_diagonalize_traits.h>
-#else
-#include <CGAL/Diagonalize_traits.h>
-#endif
 
 typedef double                                          FT;
 typedef CGAL::cpp11::array<FT, 6>                       Eigen_matrix;
 typedef CGAL::cpp11::array<FT, 3>                       Eigen_vector;
 typedef CGAL::cpp11::array<FT, 9>                       Eigen_three_vectors;
 
-// If Eigen is enabled, use it, otherwise fallback to the internal model
-#ifdef CGAL_EIGEN3_ENABLED
 typedef CGAL::Eigen_diagonalize_traits<FT, 3>           Diagonalize_traits;
-#else
-typedef CGAL::Diagonalize_traits<FT, 3>                 Diagonalize_traits;
-#endif
 
 int main(void)
 {

--- a/Solver_interface/include/CGAL/Default_diagonalize_traits.h
+++ b/Solver_interface/include/CGAL/Default_diagonalize_traits.h
@@ -26,6 +26,8 @@
 #include <CGAL/Diagonalize_traits.h>
 #endif
 
+/// \cond SKIP_IN_MANUAL
+
 namespace CGAL {
 
 /// \ingroup PkgSolver
@@ -83,5 +85,7 @@ public:
 };
 
 } // namespace CGAL
+
+/// \endcond
 
 #endif // CGAL_DEFAULT_DIAGONALIZE_TRAITS_H

--- a/Solver_interface/include/CGAL/Diagonalize_traits.h
+++ b/Solver_interface/include/CGAL/Diagonalize_traits.h
@@ -26,13 +26,9 @@
 #include <CGAL/number_type_config.h>
 #include <CGAL/double.h>
 
-#ifdef CGAL_TEST_SUITE
-#define CGAL_WARNING_DIAGONALIZE_TRAITS
-#else
 #define CGAL_WARNING_DIAGONALIZE_TRAITS \
-  CGAL_DEPRECATED_MSG("CGAL::Diagonalize_traits is an outdated class that can \
-lead to precision issues, using CGAL::Eigen_diagonalize_traits is strongly advised")
-#endif
+  CGAL_DEPRECATED_MSG("CGAL::Diagonalize_traits is a deprecated class that can \
+lead to precision issues, please use CGAL::Eigen_diagonalize_traits")
 
 namespace CGAL {
 

--- a/Solver_interface/include/CGAL/Diagonalize_traits.h
+++ b/Solver_interface/include/CGAL/Diagonalize_traits.h
@@ -30,6 +30,8 @@
   CGAL_DEPRECATED_MSG("CGAL::Diagonalize_traits is a deprecated class that can \
 lead to precision issues, please use CGAL::Eigen_diagonalize_traits")
 
+/// \cond SKIP_IN_MANUAL
+
 namespace CGAL {
 
 /// \ingroup PkgSolver
@@ -298,5 +300,7 @@ public:
 };
 
 } // namespace CGAL
+
+/// \endcond
 
 #endif // CGAL_DIAGONALIZE_TRAITS_H

--- a/Solver_interface/include/CGAL/Diagonalize_traits.h
+++ b/Solver_interface/include/CGAL/Diagonalize_traits.h
@@ -26,6 +26,14 @@
 #include <CGAL/number_type_config.h>
 #include <CGAL/double.h>
 
+#ifdef CGAL_TEST_SUITE
+#define CGAL_WARNING_DIAGONALIZE_TRAITS
+#else
+#define CGAL_WARNING_DIAGONALIZE_TRAITS \
+  CGAL_DEPRECATED_MSG("CGAL::Diagonalize_traits is an outdated class that can \
+lead to precision issues, using CGAL::Eigen_diagonalize_traits is strongly advised")
+#endif
+
 namespace CGAL {
 
 /// \ingroup PkgSolver
@@ -33,6 +41,10 @@ namespace CGAL {
 /// The class `Diagonalize_traits` provides an internal
 /// implementation for the diagonalization of Variance-Covariance
 /// Matrices.
+///
+/// \warning This class is outdated: it can lead to precision issues
+/// and should only be used if \ref thirdpartyEigen "Eigen" is not
+/// available. Otherwise, `Eigen_diagonalize_traits` should be used.
 ///
 /// \tparam FT Number type
 /// \tparam dim Dimension of the matrices and vectors
@@ -49,6 +61,7 @@ public:
   /// Fill `eigenvalues` with the eigenvalues of the covariance matrix represented by `cov`.
   /// Eigenvalues are sorted by increasing order.
   /// \return `true` if the operation was successful and `false` otherwise.
+  CGAL_WARNING_DIAGONALIZE_TRAITS
   static bool diagonalize_selfadjoint_covariance_matrix(const Covariance_matrix& cov,
                                                         Vector& eigenvalues)
   {
@@ -59,6 +72,7 @@ public:
   /// Extract the eigenvector associated to the largest eigenvalue
   /// of the covariance matrix represented by `cov`.
   /// \return `true` if the operation was successful and `false` otherwise.
+  CGAL_WARNING_DIAGONALIZE_TRAITS
   static bool extract_largest_eigenvector_of_covariance_matrix(const Covariance_matrix& cov,
                                                                Vector& normal)
   {
@@ -77,6 +91,7 @@ public:
   /// the eigenvectors of the covariance matrix represented by `cov`.
   /// Eigenvalues are sorted by increasing order.
   /// \return `true` if the operation was successful and `false` otherwise.
+  CGAL_WARNING_DIAGONALIZE_TRAITS
   static bool diagonalize_selfadjoint_covariance_matrix(const Covariance_matrix& mat,
                                                         Vector& eigen_values,
                                                         Matrix& eigen_vectors)


### PR DESCRIPTION
## Summary of Changes

Approved [small feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Remove_CGAL::Diagonalize_traits) to remove `CGAL::Diagonalize_traits` (deprecating it first).

## Release Management

* Affected package(s): Solver Interface, Bounding Volumes, Jet Fitting, Mesh 3, Classification, PCA, PSP, Scale Space
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/2676
* pre-approved Laurent Rineau 11:04, 30 May 2018 (CEST) 
