### PR TITLE
Mesh_3: fix verbose mode (when the manifold criterion is used)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -461,6 +461,18 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
     % r_tr.number_of_vertices()
     % nbsteps % cells_mesher_.debug_info()
     % (nbsteps / timer.time());
+    if(refinement_stage == REFINE_FACETS &&
+       facets_mesher_.is_algorithm_done())
+    {
+      facets_mesher_.scan_edges();
+      refinement_stage = REFINE_FACETS_AND_EDGES;
+    }
+    if(refinement_stage == REFINE_FACETS_AND_EDGES &&
+       facets_mesher_.is_algorithm_done())
+    {
+      facets_mesher_.scan_vertices();
+      refinement_stage = REFINE_FACETS_AND_EDGES_AND_VERTICES;
+    }
     ++nbsteps;
   }
   std::cerr << std::endl;

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -45,6 +45,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_meshing_polyhedron.cpp" )
   create_single_source_cgal_program( "test_meshing_polylines_only.cpp" )
   create_single_source_cgal_program( "test_meshing_polyhedron_with_features.cpp" )
+  create_single_source_cgal_program( "test_meshing_verbose.cpp" )
   create_single_source_cgal_program( "test_meshing_unit_tetrahedron.cpp" )
   create_single_source_cgal_program( "test_meshing_with_default_edge_size.cpp" )
   create_single_source_cgal_program( "test_meshing_determinism.cpp" )
@@ -53,6 +54,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_mesh_polyhedral_domain_with_features_deprecated.cpp" )
 
   foreach(target
+      test_meshing_verbose
       test_meshing_polyhedron_with_features
       test_meshing_utilities.h
       test_mesh_implicit_domains

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -52,6 +52,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_c3t3_extract_subdomains_boundaries.cpp" )
   create_single_source_cgal_program( "test_mesh_3_issue_1554.cpp" )
   create_single_source_cgal_program( "test_mesh_polyhedral_domain_with_features_deprecated.cpp" )
+  create_single_source_cgal_program( "test_meshing_with_one_step.cpp" )
 
   foreach(target
       test_meshing_verbose

--- a/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
@@ -1,3 +1,7 @@
+// Mesh_3 bug: The surface of c3t3 has holes
+//
+//   https://github.com/CGAL/cgal/issues/1554
+//
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -72,13 +72,20 @@ struct Polyhedron_with_features_tester : public Tester<K>
     CGAL_USE(polyhedra);
     
     // Set mesh criteria
+#ifndef CGAL_MESH_3_VERBOSE
     Edge_criteria edge_criteria(0.2);
     Facet_criteria facet_criteria(30, 0.2, 0.02);
     Cell_criteria cell_criteria(3, 0.2);
+#else // a different set of criteria, for the test of CGAL_MESH_3_VERBOSE
+    Edge_criteria edge_criteria(0.3);
+    Facet_criteria facet_criteria(30, 0.3, 0.03);
+    Cell_criteria cell_criteria(3, 0.4);
+#endif
     Mesh_criteria criteria(edge_criteria, facet_criteria, cell_criteria);
 
     // Mesh generation
     C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
+                                        CGAL::parameters::manifold(),
                                         CGAL::parameters::no_exude(),
                                         CGAL::parameters::no_perturb());
     

--- a/Mesh_3/test/Mesh_3/test_meshing_verbose.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_verbose.cpp
@@ -1,0 +1,5 @@
+#define CGAL_MESH_3_VERBOSE 1
+#include "test_meshing_polyhedron_with_features.cpp"
+
+// This comment is for the shell script cgal_test
+//   int main() { return 0; }

--- a/Mesh_3/test/Mesh_3/test_meshing_with_one_step.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_with_one_step.cpp
@@ -1,0 +1,78 @@
+#define CGAL_MESH_3_VERBOSE 1
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_criteria_3.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Polyhedral_mesh_domain_3.h>
+#include <CGAL/make_mesh_3.h>
+#include <CGAL/refine_mesh_3.h>
+
+// Domain
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Surface_mesh<K::Point_3> Polyhedron;
+typedef CGAL::Polyhedral_mesh_domain_3<Polyhedron, K> Mesh_domain;
+
+typedef CGAL::Sequential_tag Concurrency_tag;
+
+// Triangulation
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,
+                                   CGAL::Default,
+                                   Concurrency_tag>::type Tr;
+
+typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+
+// Criteria
+typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+
+typedef CGAL::Mesh_3::Mesher_3<C3t3,
+                               Mesh_criteria,
+                               Mesh_domain>   Mesher;
+
+// To avoid verbose function and named parameters call
+using namespace CGAL::parameters;
+
+int main(int argc, char*argv[])
+{
+  const char* fname = (argc>1)?argv[1]:"data/sphere.off";
+  // Create input polyhedron
+  Polyhedron polyhedron;
+  std::ifstream input(fname);
+  input >> polyhedron;
+  if(input.fail()){
+    std::cerr << "Error: Cannot read file " <<  fname << std::endl;
+    return EXIT_FAILURE;
+  }
+  input.close();
+  
+  if (!CGAL::is_triangle_mesh(polyhedron)){
+    std::cerr << "Input geometry is not triangulated." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Create domain
+  Mesh_domain domain(polyhedron);
+  
+  // Mesh criteria (no cell_size set)
+  Mesh_criteria criteria(facet_angle=25, facet_size=0.2, facet_distance=0.01,
+                         cell_size = 0.2, cell_radius_edge_ratio=3);
+  
+  // Mesh generation
+  C3t3 c3t3;
+  CGAL::internal::Mesh_3::C3t3_initializer<C3t3,
+                                           Mesh_domain,
+                                           Mesh_criteria,
+                                           false>()(c3t3, domain, criteria, false);
+  Mesher mesher(c3t3, domain, criteria,CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH);
+  mesher.initialize();
+  while ( ! mesher.is_algorithm_done() ) mesher.one_step();
+  assert(c3t3.triangulation().number_of_vertices() > 200);
+  // Output
+  std::ofstream medit_file("out.mesh");
+  c3t3.output_to_medit(medit_file);
+  medit_file.close();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary of Changes

When `CGAL_MESH_3_VERBOSE` is defined, the code path is different and, before this patch, the manifold criterion was without any effect, resulting in a possible non-manifold output surface mesh.

The fix in itself is https://github.com/CGAL/cgal/commit/335034e3cf49ff0764c0f5d5f20a3e20dbc1f813. This PR also adds two tests for two different code paths:
  - one for `CGAL_MESH_3_VERBOSE`,
  - and one for the use of a loop on `mesher.one_step()`.

## Release Management

* Affected package(s): Mesh_3
