### PR TITLE
GraphicsView: Remove using namespace std

### DIFF
--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -36,7 +36,6 @@
 #include <CGAL/Qt/domUtils.h>
 #include <CGAL/Qt/keyFrameInterpolator.h>
 
-using namespace std;
 using namespace CGAL::qglviewer;
 
 /*! Default constructor.

--- a/GraphicsView/include/CGAL/Qt/constraint_impl.h
+++ b/GraphicsView/include/CGAL/Qt/constraint_impl.h
@@ -36,7 +36,6 @@
 #include <CGAL/Qt/camera.h>
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                  Constraint                                //

--- a/GraphicsView/include/CGAL/Qt/frame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/frame_impl.h
@@ -37,7 +37,6 @@
 #include <math.h>
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Creates a default Frame.
 

--- a/GraphicsView/include/CGAL/Qt/keyFrameInterpolator_impl.h
+++ b/GraphicsView/include/CGAL/Qt/keyFrameInterpolator_impl.h
@@ -34,7 +34,6 @@
 #include <CGAL/Qt/domUtils.h>
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Creates a KeyFrameInterpolator, with \p frame as associated frame().
 

--- a/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
@@ -39,7 +39,6 @@
 #include <QMouseEvent>
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Default constructor.
 

--- a/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
@@ -41,7 +41,6 @@
 #include <QMouseEvent>
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Default constructor.
 

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -59,7 +59,6 @@
 #include <QOpenGLFramebufferObject>
 #include <QFileDialog>
 
-using namespace std;
 using namespace CGAL::qglviewer;
 
 // Static private variable

--- a/GraphicsView/include/CGAL/Qt/quaternion_impl.h
+++ b/GraphicsView/include/CGAL/Qt/quaternion_impl.h
@@ -37,7 +37,6 @@
 
 // All the methods are declared inline in Quaternion.h
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Constructs a Quaternion that will rotate from the \p from direction to the
 \p to direction.
@@ -533,7 +532,7 @@ Quaternion Quaternion::squadTangent(const Quaternion &before,
 }
 
 CGAL_INLINE_FUNCTION
-ostream &operator<<(ostream &o, const Quaternion &Q) {
+std::ostream &operator<<(std::ostream &o, const Quaternion &Q) {
   return o << Q[0] << '\t' << Q[1] << '\t' << Q[2] << '\t' << Q[3];
 }
 

--- a/GraphicsView/include/CGAL/Qt/vec_impl.h
+++ b/GraphicsView/include/CGAL/Qt/vec_impl.h
@@ -37,7 +37,6 @@
 // Most of the methods are declared inline in vec.h
 
 using namespace CGAL::qglviewer;
-using namespace std;
 
 /*! Projects the Vec on the axis of direction \p direction that passes through
 the origin.
@@ -178,6 +177,6 @@ void Vec::initFromDOMElement(const QDomElement &element) {
 }
 
 CGAL_INLINE_FUNCTION
-ostream &operator<<(ostream &o, const Vec &v) {
+std::ostream &operator<<(std::ostream &o, const Vec &v) {
   return o << v.x << '\t' << v.y << '\t' << v.z;
 }


### PR DESCRIPTION

## Summary of Changes
Remove the using namespace std in the qglviewer files.

## Release Management

* Affected package(s):GraphicsView
* Issue(s) solved (if any): fix #3136
* Feature/Small Feature (if any):

