### PR TITLE
Spatial Searching: bugfix disable_if

### DIFF
--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -144,14 +144,18 @@ class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> >
   typedef typename Base_traits::FT FT;
 public:
   // constructors
-  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
-  Fuzzy_sphere(const typename Base_traits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) :
-    Base(center,radius,epsilon,traits_) {}
-  Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
-               const SearchTraits& traits_=SearchTraits(),
+  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){};
+
+  // Constructor for any point type that is not `SearchTraits::Point_d`
+  template <typename Point> // boost::disable_if requires a template argument to work
+  Fuzzy_sphere(const Point& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits(),
                typename boost::disable_if<
-                 boost::is_same<typename Base_traits::Point_d,
-                                typename SearchTraits::Point_d> >::type* = 0)
+               boost::is_same<typename SearchTraits::Point_d,
+               Point> >::type* = 0)
+    : Base(center,radius,epsilon,traits_) {}
+
+  Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),
+               const SearchTraits& traits_=SearchTraits())
     : Base(get(traits_.point_property_map(),center),radius,epsilon,traits_) {}
 };
 

--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -144,7 +144,7 @@ class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> >
   typedef typename Base_traits::FT FT;
 public:
   // constructors
-  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){};
+  Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
 
   // Constructor for any point type that is not `SearchTraits::Point_d`
   template <typename Point> // boost::disable_if requires a template argument to work

--- a/Spatial_searching/include/CGAL/Search_traits_adapter.h
+++ b/Spatial_searching/include/CGAL/Search_traits_adapter.h
@@ -109,11 +109,23 @@ public:
     // This is needed because of an undocumented requirement of 
     // Orthogonal_k_neighbor_search and Orthogonal_incremental_neighbor_search: 
     // Traits::Construct_cartesian_const_iterator should be callable 
-    // on the query point type
-    typename Base_traits::Cartesian_const_iterator_d operator()(const typename Base_traits::Point_d& p) const
+    // on the query point type. If the query point type is the same as
+    // Point_with_info, we disable it.
+
+    template <typename Point> // boost::disable_if requires a template argument to work
+    typename Base_traits::Cartesian_const_iterator_d operator()(const Point& p,
+                                                                typename boost::disable_if<
+                                                                boost::is_same<Point_with_info,
+                                                                Point> >::type* = 0
+      ) const
     { return Base::operator() (p); }
 
-    typename Base_traits::Cartesian_const_iterator_d operator()(const typename Base_traits::Point_d& p, int)  const
+    template <typename Point> // boost::disable_if requires a template argument to work
+    typename Base_traits::Cartesian_const_iterator_d operator()(const Point& p, int,
+                                                                typename boost::disable_if<
+                                                                boost::is_same<Point_with_info,
+                                                                Point> >::type* = 0
+      ) const
     { return Base::operator() (p,0); }
   };
   

--- a/Spatial_searching/include/CGAL/Search_traits_adapter.h
+++ b/Spatial_searching/include/CGAL/Search_traits_adapter.h
@@ -31,6 +31,7 @@
 
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace CGAL{
 

--- a/Spatial_searching/test/Spatial_searching/Search_traits_adapter_with_identity_map.cpp
+++ b/Spatial_searching/test/Spatial_searching/Search_traits_adapter_with_identity_map.cpp
@@ -1,0 +1,38 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Kd_tree.h>
+#include <CGAL/point_generators_2.h>
+#include <CGAL/algorithm.h>
+#include <CGAL/Fuzzy_sphere.h>
+#include <CGAL/Search_traits_2.h>
+#include <CGAL/property_map.h>
+
+typedef CGAL::Simple_cartesian<double> Kernel;
+typedef Kernel::Point_2 Point_2;
+typedef CGAL::Random_points_in_disc_2<Point_2> Random_points;
+
+typedef CGAL::Identity_property_map<Point_2> Point_map;
+typedef CGAL::Search_traits_2<Kernel> Search_base;
+typedef CGAL::Search_traits_adapter<Point_2, Point_map, Search_base> Search_traits;
+typedef CGAL::Fuzzy_sphere<Search_traits> Fuzzy_circle;
+typedef CGAL::Kd_tree<Search_traits> Tree;
+
+int main ()
+{
+  Random_points rdpts;
+  std::vector<Point_2> pts;
+  for (std::size_t i = 0; i < 50; ++ i)
+    pts.push_back (*(rdpts ++));
+
+  Tree tree (pts.begin(), pts.end());
+    
+  Point_2 center(0., 0.);
+  Fuzzy_circle circle (center, 0.5);
+  std::vector<Point_2> result;
+  tree.search(std::back_inserter(result), circle);
+  std::cout << "The points in the fuzzy circle centered at (0., 0.) ";
+  std::cout << "with fuzzy radius (0.5) are: " << std::endl;
+  for (std::size_t i = 0; i < result.size(); ++ i)
+    std::cout << " * " << result[i] << std::endl;
+  
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

When using a `Search_traits_adapter` with a `key_type` that is the same as the point type of the `Search_traits` base, there was a compilation error:
```sh
(...)/Spatial_searching/include/CGAL/Fuzzy_sphere.h:161:69: error: no type named
      'type' in 'boost::disable_if<boost::is_same<CGAL::Point_2<CGAL::Simple_cartesian<double> >,
      CGAL::Point_2<CGAL::Simple_cartesian<double> > >, void>'
                                 typename SearchTraits::Point_d> >::type* = 0)
```

The `disable_if` did not work because none of its arguments was template (so it was instantiated anyway). This PR:
- changes the constructor on which `disable_of` is applied: by default, if the adapter and the base have the same type, we enforce passing by the property map (in case this property map does have the same type but is not `CGAL::Identity_property_map`)
- makes this constructor template so that `disable_of` works
- adds the same behavior to the methods of `Search_traits_adapter` that otherwise create invalid overloads

This solves the problem of using `Search_traits_adapter` with the same `key_type` as the point type of `Search_traits` base (for example using `CGAL::Identity_property_map`: in that case it is useless to use the adapter, but the code should compile and work anyway). Tested locally, this does not break any test/example of `Spatial_searching`.

## Release Management

* Affected package(s): Spatial Searching

