### PR TITLE
Triangulation_3: Fix std::unary_function leftover

### DIFF
--- a/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
@@ -6,8 +6,9 @@
 #include <CGAL/Regular_triangulation_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
 
+#include <CGAL/functional.h>
+
 #include <iostream>
-#include <functional>
 #include <utility>
 #include <vector>
 
@@ -139,9 +140,9 @@ struct Tester
   }
 
   struct Auto_count
-    : public std::unary_function<const Weighted_point&,
-                                 std::pair<Weighted_point,
-                                 unsigned> >
+    : public CGAL::unary_function<const Weighted_point&,
+                                  std::pair<Weighted_point,
+                                  unsigned> >
   {
     mutable unsigned i;
     Auto_count() : i(0){}


### PR DESCRIPTION
## Summary of Changes

The merge of #3122 caused some `std::unary_function` to sneak through to the 4.12 branch.

## Release Management

* Affected package(s): Triangulation_3
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

