### PR TITLE
Polygon_mesh_processing: Change should  to must/shall

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -6,9 +6,9 @@ In this package, all functions optional parameters are implemented as BGL option
 named parameters (see \ref BGLNamedParameters for more information on how to use them).
 Since the parameters of the various polygon mesh processing functions defined
 in this package are redundant, their long descriptions are centralized below.
-The sequence of named parameters should start with `CGAL::parameters::`.
+The sequence of named parameters starts with `CGAL::parameters::`.
 `CGAL::parameters::all_default()` can be used to indicate
-that default values of optional named parameters must be used.
+that default values of optional named parameters  shall be used.
 
 In the following, we assume that the following types are provided as template parameters
 of polygon mesh processing functions and classes. Note that, for some of these functions,
@@ -45,7 +45,7 @@ is the property map containing the index of each face of the input polygon mesh.
 `boost::graph_traits<PolygonMesh>::%face_descriptor` as key type and the value type:
 \code typename boost::property_traits<typename boost::property_map<PolygonMesh, CGAL::face_index_t>::type>::value_type \endcode
 <b>Default:</b> \code boost::get(CGAL::face_index, pmesh)\endcode
-If this internal property map exists, its values should be initialized.
+If this internal property map exists, its values must be initialized.
 \cgalNPEnd
 
 \cgalNPBegin{edge_is_constrained_map} \anchor PMP_edge_is_constrained_map
@@ -54,7 +54,7 @@ being marked or not. In `isotropic_remeshing()` and `connected_components()`,
 the marked edges are constrained.\n
 <b>Type:</b> a class model of `ReadWritePropertyMap` with
 `boost::graph_traits<PolygonMesh>::%edge_descriptor` as key type and
-`bool` as value type. It should be default constructible.\n
+`bool` as value type. It must be default constructible.\n
 <b>Default:</b> a default property map where no edge is constrained
 \cgalNPEnd
 \cgalNPTableEnd
@@ -63,7 +63,7 @@ In addition to these named parameters, this package offers the following named p
 
 \cgalNPTableBegin
 \cgalNPBegin{geom_traits} \anchor PMP_geom_traits
-is the geometric traits instance in which the mesh processing operation should be performed.\n
+is the geometric traits instance used for the mesh processing operation.\n
 <b>Type:</b> a Geometric traits class.\n
 <b>Default</b>:
 \code typename CGAL::Kernel_traits<
@@ -85,7 +85,7 @@ inserted several times.\n
 is the property map containing the number of feature edges being incident to the vertices of the polygon mesh `pmesh`.\n
 <b>Type:</b> a class model of `ReadWritePropertyMap` with
 `boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
-`int` as value type. It should be default constructible.\n
+`int` as value type. It must be default constructible.\n
 <b>Default:</b> \code boost::get(CGAL::vertex_feature_degree_t(), pmesh) \endcode
 \cgalNPEnd
 
@@ -95,7 +95,7 @@ Constrained vertices may be replaced by new vertices, but the number and locatio
 of vertices remain unchanged.\n
 <b>Type:</b> a class model of `ReadWritePropertyMap` with
 `boost::graph_traits<PolygonMesh>::%vertex_descriptor` as key type and
-`bool` as value type. It should be default constructible.\n
+`bool` as value type. It must be default constructible.\n
 <b>Default:</b> a default property map where no vertex is constrained is provided.
 \cgalNPEnd
 
@@ -188,21 +188,21 @@ enables the use of the Delaunay triangulation facet search space for hole fillin
 \cgalNPEnd
 
 \cgalNPBegin{use_random_uniform_sampling} \anchor PMP_use_random_uniform_sampling
-is a parameter used in `sample_triangle_mesh()` to indicate if points should be picked
+is a parameter used in `sample_triangle_mesh()` to indicate that the points are picked
 in a random uniform way.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
 \cgalNPEnd
 
 \cgalNPBegin{use_grid_sampling} \anchor PMP_use_grid_sampling
-is a parameter used in `sample_triangle_mesh()` to indicate if points should be picked
-in on a grid in each face.\n
+is a parameter used in `sample_triangle_mesh()` to indicate that the points are picked
+on a grid in each face.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `false`
 \cgalNPEnd
 
 \cgalNPBegin{use_monte_carlo_sampling} \anchor PMP_use_monte_carlo_sampling
-is a parameter used in `sample_triangle_mesh()` to indicate if points should be picked
+is a parameter used in `sample_triangle_mesh()` to indicate that the points are picked
 using a Monte-Carlo approach.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `false`
@@ -210,21 +210,21 @@ using a Monte-Carlo approach.\n
 
 \cgalNPBegin{sample_edges} \anchor PMP_sample_edges
 is a parameter used in `sample_triangle_mesh()` to indicate if a dedicated sampling
-of edges should be done.\n
+of edges is done.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
 \cgalNPEnd
 
 \cgalNPBegin{sample_vertices} \anchor PMP_sample_vertices
-is a parameter used in `sample_triangle_mesh()` to indicate if triangle vertices should
-be copied in the output iterator.\n
+is a parameter used in `sample_triangle_mesh()` to indicate that triangle vertices are
+copied in the output iterator.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
 \cgalNPEnd
 
 \cgalNPBegin{sample_faces} \anchor PMP_sample_faces
 is a parameter used in `sample_triangle_mesh()` to indicate if the interior of faces
-should be considered for the sampling.\n
+is considered for the sampling.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
 \cgalNPEnd
@@ -281,7 +281,7 @@ Monte-Carlo methods.\n
 \cgalNPEnd
 
 \cgalNPBegin{do_project} \anchor PMP_do_project
-is a parameter used in `random_perturbation()` to set whether vertices should be re-projected
+is a parameter used in `random_perturbation()` to set whether vertices are re-projected
 to the input surface after their geometric perturbation.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
@@ -304,7 +304,7 @@ Parameter used in orientation functions to choose between an outward or inward o
 
 \cgalNPBegin{do_overlap_test_of_bounded_sides} \anchor PMP_do_overlap_test_of_bounded_sides
 Parameter used in intersection test functions to indicate whether overlapping tests of bounded sides
-of close meshes should be done in addition to surface intersection tests.
+of close meshes are done in addition to surface intersection tests.
 \n
 \b Type : `bool` \n
 \b Default value is `false`

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
@@ -12,4 +12,5 @@ Surface_mesh_deformation
 AABB_tree
 Triangulation_2
 Spatial_sorting
-Random_numbers
+Generator
+

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
@@ -12,3 +12,4 @@ Surface_mesh_deformation
 AABB_tree
 Triangulation_2
 Spatial_sorting
+Random_numbers

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -51,7 +51,7 @@ namespace CGAL {
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
     *       If this parameter is omitted, an internal property map for
-    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
     *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
     *       providing the functor `Construct_bbox_3` and the function
     *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
@@ -101,7 +101,7 @@ namespace CGAL {
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
     *       If this parameter is omitted, an internal property map for
-    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
     *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
     *       providing the functor `Construct_bbox_3` and the function
     *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
@@ -144,7 +144,7 @@ namespace CGAL {
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
     *       If this parameter is omitted, an internal property map for
-    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
     *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
     *       providing the functor `Construct_bbox_3` and the function
     *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`
@@ -188,7 +188,7 @@ namespace CGAL {
     * \cgalNamedParamsBegin
     *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
     *       If this parameter is omitted, an internal property map for
-    *       `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+    *       `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
     *    \cgalParamBegin{geom_traits} an instance of a geometric traits class,
     *       providing the functor `Construct_bbox_3` and the function
     *       `Construct_bbox_3 construct_bbox_3_object()`. `Construct_bbox_3`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -155,7 +155,7 @@ namespace Polygon_mesh_processing {
   * @tparam PolygonMesh model of `HalfedgeGraph`. If `PolygonMesh`
   *  has an internal property map
   *  for `CGAL::face_index_t` and no `face_index_map` is given
-  *  as a named parameter, then the internal one should be initialized
+  *  as a named parameter, then the internal one must be initialized
   * @tparam FaceRange range of
        `boost::graph_traits<PolygonMesh>::%face_descriptor`, model of `Range`.
         Its iterator type is `InputIterator`.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -109,7 +109,7 @@ void sum_normals(const PM& pmesh,
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -168,7 +168,7 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -205,7 +205,7 @@ compute_face_normals(const PolygonMesh& pmesh
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -285,7 +285,7 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -331,7 +331,7 @@ compute_vertex_normals(const PolygonMesh& pmesh
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
 * \cgalNamedParamsEnd
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -183,7 +183,7 @@ connected_component(typename boost::graph_traits<PolygonMesh>::face_descriptor s
  * \ingroup keep_connected_components_grp
  *  computes for each face the index of the corresponding connected component.
  *
- *  A property map for `CGAL::face_index_t` should be either available as an internal property map 
+ *  A property map for `CGAL::face_index_t` must be either available as an internal property map 
  *  to `pmesh` or provided as one of the \ref pmp_namedparameters "Named Parameters".
  *
  *  \tparam PolygonMesh a model of `FaceListGraph`
@@ -269,7 +269,7 @@ void keep_connected_components(PolygonMesh& pmesh
  *  Keep `nb_components_to_keep` largest connected components. 
  *
  * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
- * should be either available as internal property maps 
+ * must be either available as internal property maps 
  * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
  *
  * \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
@@ -352,7 +352,7 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh,
  *  removes connected components with less than a given number of faces.
  *
  * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
- * should be either available as internal property maps 
+ * must be either available as internal property maps 
  * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
  *
  * \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
@@ -567,7 +567,7 @@ void keep_or_remove_connected_components(PolygonMesh& pmesh
 * then the behavior of this function is undefined.
 *
 * Property maps for `CGAL::vertex_index_t`
-* should be either available as internal property map
+* must be either available as internal property map
 * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
 *
 * \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
@@ -610,7 +610,7 @@ void keep_connected_components(PolygonMesh& pmesh
 * then the behavior of this function is undefined.
 *
 * Property maps for `CGAL::vertex_index_t`
-* should be either available as internal property map
+* must be either available as internal property map
 * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
 *
 *
@@ -651,7 +651,7 @@ void remove_connected_components(PolygonMesh& pmesh
 *  and removes the other connected components and all isolated vertices.
 *
 * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
-* should be either available as internal property maps
+* must be either available as internal property maps
 * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
 *
 * \note If the removal of the connected components makes `pmesh` a non-manifold surface,
@@ -709,7 +709,7 @@ void remove_connected_components(PolygonMesh& pmesh
 *  and removes the other connected components and all isolated vertices.
 *
 * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
-* should be either available as internal property maps
+* must be either available as internal property maps
 * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
 *
 * \note If the removal of the connected components makes `pmesh` a non-manifold surface,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -144,7 +144,7 @@ bool recursive_does_bound_a_volume(const TriangleMesh& tm,
  *   \cgalParamBegin{vertex_point_map}
  *     the property map with the points associated to the vertices of `tm`.
  *     If this parameter is omitted, an internal property map for
- *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+ *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{face_index_map}
  *     a property map containing the index of each face of `tm`.
@@ -453,7 +453,7 @@ boolean_operation(      TriangleMesh& tm1,
   *   \cgalParamBegin{vertex_point_map}
   *     the property map with the points associated to the vertices of `tm1` (`tm2`).
   *     If this parameter is omitted, an internal property map for
-  *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+  *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
   *   \cgalParamEnd
   *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
   *     constrained-or-not status of each edge of `tm1` (`tm2`).
@@ -470,7 +470,7 @@ boolean_operation(      TriangleMesh& tm1,
   *   \cgalParamBegin{vertex_point_map}
   *     the property map with the points associated to the vertices of `tm_out`.
   *     If this parameter is omitted, an internal property map for
-  *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+  *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
   *   \cgalParamEnd
   *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
   *     constrained-or-not status of each edge of `tm_out`. An edge of `tm_out` is constrained
@@ -597,7 +597,7 @@ corefine_and_compute_difference(      TriangleMesh& tm1,
  *   \cgalParamBegin{vertex_point_map}
  *     the property map with the points associated to the vertices of `tm1` (`tm2`).
  *     If this parameter is omitted, an internal property map for
- *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+ *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
  *     constrained-or-not status of each edge of `tm1` (`tm2`)
@@ -690,7 +690,7 @@ namespace experimental {
  *   \cgalParamBegin{vertex_point_map}
  *     the property map with the points associated to the vertices of `tm`.
  *     If this parameter is omitted, an internal property map for
- *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+ *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
  *     constrained-or-not status of each edge of `tm`
@@ -756,7 +756,7 @@ namespace experimental {
  *   \cgalParamBegin{vertex_point_map}
  *     the property map with the points associated to the vertices of `tm`.
  *     If this parameter is omitted, an internal property map for
- *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+ *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{edge_is_constrained_map} a property map containing the
  *     constrained-or-not status of each edge of `tm`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
@@ -252,7 +252,7 @@ template<typename GT,
  * or from the geometric traits class deduced from the point property map
  * of `PolygonMesh`.
  * \tparam EdgeIsFeatureMap a model of `ReadWritePropertyMap` with `boost::graph_traits<PolygonMesh>::%edge_descriptor`
- *  as key type and `bool` as value type. It should be default constructible.
+ *  as key type and `bool` as value type. It must be default constructible.
  * \tparam NamedParameters a sequence of \ref pmp_namedparameters "Named Parameters"
  *
  * \param pmesh the polygon mesh
@@ -380,7 +380,7 @@ namespace internal
  * computing a
  * surface patch id for each face.
  *
- * A property map for `CGAL::face_index_t`should be either available
+ * A property map for `CGAL::face_index_t` must be either available
  * as an internal property map to `pmesh` or provided as one of the Named Parameters.
  *
  * \tparam PolygonMesh a model of `FaceGraph`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -244,7 +244,7 @@ sample_triangles(const FaceRange& triangles,
  *    \cgalParamBegin{vertex_point_map} the property map with the points
  *      associated to the vertices of `tm`. If this parameter is omitted,
  *      an internal property map for `CGAL::vertex_point_t`
- *      should be available for `TriangleMesh`.
+ *      must be available for `TriangleMesh`.
  *    \cgalParamEnd
  *    \cgalParamBegin{geom_traits} a model of `PMPDistanceTraits`. \cgalParamEnd
  *    \cgalParamBegin{use_random_uniform_sampling}
@@ -611,8 +611,8 @@ double approximate_Hausdorff_distance(
  *
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm2`
- *      If this parameter is omitted, an internal property map for CGAL::vertex_point_t should be available in `TriangleMesh`
- *      and in all places where vertex_point_map is used.
+ *      If this parameter is omitted, an internal property map for `CGAL::vertex_point_t` `must be available in `TriangleMesh`
+ *      and in all places where `vertex_point_map` is used.
  *    \cgalParamEnd
  * \cgalNamedParamsEnd
  * The function `CGAL::parameters::all_default()` can be used to indicate to use the default values for
@@ -671,7 +671,7 @@ double approximate_symmetric_Hausdorff_distance(
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map}
  *    the property map with the points associated to the vertices of `tm`. If this parameter is omitted,
- *    an internal property map for `CGAL::vertex_point_t` should be available for the
+ *    an internal property map for `CGAL::vertex_point_t` must be available for the
       vertices of `tm` \cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPDistanceTraits`\cgalParamEnd
  * \cgalNamedParamsEnd
@@ -708,7 +708,7 @@ double max_distance_to_triangle_mesh(const PointRange& points,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map}
  *    the property map with the points associated to the vertices of `tm`. If this parameter is omitted,
- *    an internal property map for `CGAL::vertex_point_t` should be available for the
+ *    an internal property map for `CGAL::vertex_point_t` must be available for the
       vertices of `tm` \cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPDistanceTraits`. \cgalParamEnd
  * \cgalNamedParamsEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -611,7 +611,7 @@ double approximate_Hausdorff_distance(
  *
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm2`
- *      If this parameter is omitted, an internal property map for `CGAL::vertex_point_t` `must be available in `TriangleMesh`
+ *      If this parameter is omitted, an internal property map for `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *      and in all places where `vertex_point_map` is used.
  *    \cgalParamEnd
  * \cgalNamedParamsEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -96,7 +96,7 @@ namespace internal {
   \cgalNamedParamsBegin
     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`.
         If this parameter is omitted, an internal property map for
-      `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+      `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
     \cgalParamBegin{fairing_continuity} tangential continuity of the output surface patch. The larger `fairing_continuity` gets, the more fixed vertices are required \cgalParamEnd
     \cgalParamBegin{sparse_linear_solver} an instance of the sparse linear solver used for fairing \cgalParamEnd
   \cgalNamedParamsEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
@@ -383,7 +383,7 @@ struct Throw_at_first_output {
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  * \return `out`
@@ -503,7 +503,7 @@ compute_face_face_intersection(const FaceRange& face_range1,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  * \return `out`
@@ -627,7 +627,7 @@ compute_face_polyline_intersection( const FaceRange& face_range,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  * \return `out`
@@ -934,7 +934,7 @@ compute_polylines_polylines_intersection(const PolylineRange& polylines1,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  * \return `out`
@@ -983,7 +983,7 @@ compute_face_face_intersection(const TriangleMesh& tm1,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  * \return `out`
@@ -1189,7 +1189,7 @@ bool do_intersect(const Polyline& polyline1,
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm1` (tm2`).
  *   \attention The two property maps must have the same `value_type`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  *    \cgalParamBegin{do_overlap_test_of_bounded_sides} if set to `true` tests also the overlap of the bounded sides of `tm1` and `tm2`.
  *                                                      If `false` (default), only the intersection of surface triangles are tested.
@@ -1273,7 +1273,7 @@ bool do_intersect(const TriangleMesh& tm1,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -1329,7 +1329,7 @@ bool do_intersect(const TriangleMesh& tm,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tn`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -1550,13 +1550,13 @@ struct Mesh_callback
  *     \cgalParamEnd
  * \cgalNamedParamsEnd
  * \param nps an optional range of `vertex_point_map` named parameters containing the `VertexPointMap` of each mesh in `range`, in the same order.
- * If this parameter is omitted, then an internal property map for `CGAL::vertex_point_t` should be available for every mesh in the range.
+ * If this parameter is omitted, then an internal property map for `CGAL::vertex_point_t` must be available for every mesh in the range.
  * All the vertex point maps must be of the same type.
  *
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of a mesh.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in the triangle mesh type used in the range
+ *   `CGAL::vertex_point_t` must be available in the triangle mesh type used in the range
  *     \cgalParamEnd
  * \cgalNamedParamsEnd
  */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -73,7 +73,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
   *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -154,7 +154,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
   *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -217,7 +217,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
   *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -293,7 +293,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -367,7 +367,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel` \cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -426,7 +426,7 @@ public:
   * \cgalNamedParamsBegin
   *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits}an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *
@@ -479,7 +479,7 @@ public:
   * \cgalNamedParamsBegin
   *  \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
   *   If this parameter is omitted, an internal property map for
-  *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+  *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
   *  \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
   * \cgalNamedParamsEnd
   *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -456,7 +456,7 @@ void recursive_orient_volume_ccs( TriangleMesh& tm,
 *   \cgalParamBegin{vertex_point_map}
 *     the property map with the points associated to the vertices of `tm`.
 *     If this parameter is omitted, an internal property map for
-*     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+*     `CGAL::vertex_point_t` must be available in `TriangleMesh`
 *   \cgalParamEnd
 *   \cgalParamBegin{face_index_map}
 *     a property map containing the index of each face of `tm`.
@@ -561,7 +561,7 @@ void orient(TriangleMesh& tm)
  *   \cgalParamBegin{vertex_point_map}
  *     the property map with the points associated to the vertices of `tm`.
  *     If this parameter is omitted, an internal property map for
- *     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+ *     `CGAL::vertex_point_t` must be available in `TriangleMesh`
  *   \cgalParamEnd
  *   \cgalParamBegin{face_index_map}
  *     a property map containing the index of each face of `tm`.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
@@ -135,7 +135,7 @@ namespace internal {
 *    constrained-or-not status of each vertex of `tmesh`. A constrained vertex
 *    cannot be modified at all during perturbation
 *  \cgalParamEnd
-*  \cgalParamBegin{do_project} a boolean that sets whether vertices should be reprojected
+*  \cgalParamBegin{do_project} a boolean that sets whether vertices are reprojected
 *    on the input surface after their coordinates random perturbation
 *  \cgalParamEnd
 *  \cgalParamBegin{random_seed} a non-negative integer value to seed the random

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine.h
@@ -57,7 +57,7 @@ namespace Polygon_mesh_processing {
     \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`
       Instance of a class model of `ReadWritePropertyMap`.
       If this parameter is omitted, an internal property map for
-     `CGAL::vertex_point_t` should be available in `TriangleMesh`
+     `CGAL::vertex_point_t` must be available in `TriangleMesh`
      \cgalParamEnd
     \cgalParamBegin{density_control_factor} factor to control density of the output mesh,
       where larger values lead to denser refinements.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -63,7 +63,7 @@ namespace Polygon_mesh_processing {
 *        If `0` is passed then only the edge-flip, tangential relaxation, and projection steps will be done.
 * @param np optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
 *
-* @pre if constraints protection is activated, the constrained edges should
+* @pre if constraints protection is activated, the constrained edges must
 * not be longer than 4/3*`target_edge_length`
 *
 * \cgalNamedParamsBegin

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -676,7 +676,7 @@ std::size_t remove_null_edges(
 /// \cgalNamedParamsBegin
 ///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`. The type of this map is model of `ReadWritePropertyMap`.
 /// If this parameter is omitted, an internal property map for
-/// `CGAL::vertex_point_t` should be available in `TriangleMesh`
+/// `CGAL::vertex_point_t` must be available in `TriangleMesh`
 /// \cgalParamEnd
 ///    \cgalParamBegin{geom_traits} a geometric traits class instance.
 ///       The traits class must provide the nested type `Point_3`,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -253,7 +253,7 @@ self_intersections( const FaceRange& face_range,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -312,7 +312,7 @@ self_intersections(const TriangleMesh& tmesh, OutputIterator out)
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
 
@@ -403,7 +403,7 @@ OutputIterator self_intersections(const FaceRange& face_range,
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
@@ -445,11 +445,11 @@ bool does_self_intersect(const TriangleMesh& tmesh
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tmesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `TriangleMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `SelfIntersectionTraits` \cgalParamEnd
  * \cgalNamedParamsEnd
  *
- * @return true if the faces in `face_range` self-intersects
+ * @return true if the faces in `face_range` self-intersect
  */
 template <class FaceRange,
           class TriangleMesh,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -503,7 +503,7 @@ void stitch_borders(PolygonMesh& pmesh,
 /// \cgalNamedParamsBegin
 ///    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 /// If this parameter is omitted, an internal property map for
-/// `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+/// `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 /// \cgalNamedParamsEnd
 ///
 template <typename PolygonMesh, class CGAL_PMP_NP_TEMPLATE_PARAMETERS>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/transform.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/transform.h
@@ -44,7 +44,7 @@ namespace Polygon_mesh_processing{
  * * \cgalNamedParamsBegin
  *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `mesh`.
  *   If this parameter is omitted, an internal property map for
- *   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+ *   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
  * \cgalNamedParamsEnd
  * 
  */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -412,7 +412,7 @@ public:
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -464,7 +464,7 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *
@@ -511,7 +511,7 @@ bool triangulate_faces(FaceRange face_range, PolygonMesh& pmesh)
 * \cgalNamedParamsBegin
 *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
 *   If this parameter is omitted, an internal property map for
-*   `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+*   `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
 *    \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
 * \cgalNamedParamsEnd
 *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -64,7 +64,7 @@ namespace Polygon_mesh_processing {
   \cgalNamedParamsBegin
      \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
          If this parameter is omitted, an internal property map for
-         `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
+         `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
      \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
   \cgalNamedParamsEnd


### PR DESCRIPTION
## Summary of Changes

The word _should_  is too weak for a requirement.

## Release Management

* Affected package(s): Polygon_mesh_processing documentation.

