### PR TITLE
Mesh_3: Suppress warning concerning boost/preprocessor

### DIFF
--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -379,6 +379,10 @@ public:
 
   /// Named constructors, for domains created from 3D images
   /// @{
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable: 4003)
+#endif  
   BOOST_PARAMETER_MEMBER_FUNCTION(
                                   (Labeled_mesh_domain_3),
                                   static create_gray_image_mesh_domain,
@@ -479,6 +483,10 @@ public:
        p::construct_surface_patch_index =
        create_construct_surface_patch_index(construct_surface_patch_index_));
   }
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
   /// @}
 
   /**

--- a/STL_Extension/include/CGAL/exceptions.h
+++ b/STL_Extension/include/CGAL/exceptions.h
@@ -26,6 +26,10 @@
 #include <CGAL/config.h>
 #include <stdexcept>
 #include <string>
+
+// Address the warning C4003: not enough actual parameters for macro 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'
+// lexical_cast.hpp includes files from boost/preprocessor
+// This concerns boost 1_67_0
 #if defined(BOOST_MSVC)
 #  pragma warning(push)
 #  pragma warning(disable: 4003)

--- a/STL_Extension/include/CGAL/exceptions.h
+++ b/STL_Extension/include/CGAL/exceptions.h
@@ -26,7 +26,15 @@
 #include <CGAL/config.h>
 #include <stdexcept>
 #include <string>
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable: 4003)
+#endif
 #include <boost/lexical_cast.hpp> 
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
 
 namespace CGAL {
 

--- a/STL_Extension/include/CGAL/result_of.h
+++ b/STL_Extension/include/CGAL/result_of.h
@@ -27,9 +27,21 @@
 #ifndef CGAL_RESULT_OF_H
 #define CGAL_RESULT_OF_H
 
+#include <CGAL/config.h>
 #include <CGAL/disable_warnings.h>
 
+// Address the warning C4003: not enough actual parameters for macro 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'
+// result_of.hpp includes files from boost/preprocessor
+// This concerns boost 1_65_1
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable: 4003)
+#endif
 #include <boost/utility/result_of.hpp>
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
 #include <boost/version.hpp>
 
 namespace CGAL{


### PR DESCRIPTION

## Summary of Changes

assertions.h includes exceptions.h includes lexical_cast.hpp includes...... a boost/preprocessor heaeder for which VC++ generates a [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-Ic-27/Mesh_3/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz):

C:\CGAL\test\CGAL-4.13-Ic-27\include\CGAL/Labeled_mesh_domain_3.h(401): warning C4003: not enough actual parameters for macro 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'



## Release Management

* Affected package(s): Mesh_3


