### PR TITLE
Polyhedron demo: Remove conflicting 'Point' typedef

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.h
@@ -162,9 +162,6 @@ typedef CGAL::Surface_mesh_deformation<SMesh, CGAL::Default, CGAL::Default, CGAL
   ,CGAL::Default, CGAL::Default, CGAL::Default,
   Array_based_vertex_point_map<SMesh> > Deform_sm_mesh;
 
-typedef Deform_mesh::Point  Point;
-typedef Deform_sm_mesh::Point  SM_Point;
-
 /// For storing associated data with a group of control vertices
 template<typename Mesh>
 class Control_vertices_data

--- a/Surface_mesher/demo/Surface_mesher/volume.cpp
+++ b/Surface_mesher/demo/Surface_mesher/volume.cpp
@@ -769,9 +769,9 @@ void Volume::display_marchin_cube()
       const unsigned int nbt = facets.size() / 9;
       for(unsigned int i=begin;i<nbt;i++)
       {
-        const Point a(facets[9*i],   facets[9*i+1], facets[9*i+2]);
-        const Point b(facets[9*i+3], facets[9*i+4], facets[9*i+5]);
-        const Point c(facets[9*i+6], facets[9*i+7], facets[9*i+8]);
+        const Point_3 a(facets[9*i],   facets[9*i+1], facets[9*i+2]);
+        const Point_3 b(facets[9*i+3], facets[9*i+4], facets[9*i+5]);
+        const Point_3 c(facets[9*i+6], facets[9*i+7], facets[9*i+8]);
         const Triangle_3 t(a,b,c);
         const Vector u = t[1] - t[0];
         const Vector v = t[2] - t[0];
@@ -876,7 +876,7 @@ void Volume::display_surface_mesher_result()
 
     if(mw->searchSeedsCheckBox->isChecked())
     {
-      typedef std::vector<std::pair<Point, double> > Seeds;
+      typedef std::vector<std::pair<Point_3, double> > Seeds;
       Seeds seeds;
       {
 	std::cerr << "Search seeds...\n";
@@ -905,13 +905,13 @@ void Volume::display_surface_mesher_result()
 	  it != end; ++it)
       {
         seeds_out << it->first << std::endl;
-	CGAL::Random_points_on_sphere_3<Point> random_points_on_sphere_3(it->second);
+	CGAL::Random_points_on_sphere_3<Point_3> random_points_on_sphere_3(it->second);
 	Oracle::Intersect_3 intersect = oracle.intersect_3_object();
 	for(int i = 0; i < 20; ++i)
 	{
-	  const Point test = it->first + (*random_points_on_sphere_3++ - CGAL::ORIGIN);
+	  const Point_3 test = it->first + (*random_points_on_sphere_3++ - CGAL::ORIGIN);
 	  CGAL::Object o = intersect(surface, Segment_3(it->first, test));
-	  if (const Point* intersection = CGAL::object_cast<Point>(&o)) {
+	  if (const Point_3* intersection = CGAL::object_cast<Point_3>(&o)) {
             segments_out << "2 " << it->first << " " << *intersection << std::endl;
 	    del.insert(*intersection);
           }
@@ -1043,8 +1043,8 @@ void Volume::display_surface_mesher_result()
       const int index = fit->second;
 
       // here "left" means nothing
-      const Point left_circumcenter = cell->circumcenter();
-      const Point right_circumcenter = cell->neighbor(index)->circumcenter();
+      const Point_3 left_circumcenter = cell->circumcenter();
+      const Point_3 right_circumcenter = cell->neighbor(index)->circumcenter();
 
       const Triangle_3 t = 
         Triangle_3(cell->vertex(del.vertex_triple_index(index, 0))->point(),
@@ -1253,8 +1253,8 @@ void Volume::draw()
           end = del.finite_edges_end();
         eit != end; ++eit) 
     {
-      const Point p1 = eit->first->vertex(eit->second)->point();
-      const Point p2 = eit->first->vertex(eit->third)->point();
+      const Point_3 p1 = eit->first->vertex(eit->second)->point();
+      const Point_3 p2 = eit->first->vertex(eit->third)->point();
       ::glVertex3d(p1.x(),p1.y(),p1.z());
       ::glVertex3d(p2.x(),p2.y(),p2.z());
     }
@@ -1354,9 +1354,9 @@ void Volume::gl_draw_surface()
 	if(c2t3.face_status(facet_cell, facet_index) == C2t3::NOT_IN_COMPLEX) {
 	  continue;
 	}
-	const Point& a = facet_cell->vertex(del.vertex_triple_index(facet_index, 0))->point();
-	const Point& b = facet_cell->vertex(del.vertex_triple_index(facet_index, 1))->point();
-	const Point& c = facet_cell->vertex(del.vertex_triple_index(facet_index, 2))->point();
+	const Point_3& a = facet_cell->vertex(del.vertex_triple_index(facet_index, 0))->point();
+	const Point_3& b = facet_cell->vertex(del.vertex_triple_index(facet_index, 1))->point();
+	const Point_3& c = facet_cell->vertex(del.vertex_triple_index(facet_index, 2))->point();
 	Vector n = CGAL::cross_product(b-a,c-a);
 	n = n / std::sqrt(n*n); // unit normal
 	if(m_inverse_normals) {
@@ -1443,9 +1443,9 @@ void Volume::gl_draw_surface()
 	    else 
 	      continue; // go to next facet
 	  }
-	  const Point& a = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 0))->point();
-	  const Point& b = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 1))->point();
-	  const Point& c = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 2))->point();
+	  const Point_3& a = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 0))->point();
+	  const Point_3& b = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 1))->point();
+	  const Point_3& c = opposite_cell->vertex(del.vertex_triple_index(opposite_index, 2))->point();
 	  Vector n = CGAL::cross_product(b-a,c-a);
 	  n = n / std::sqrt(n*n); // unit normal
 	  if(m_inverse_normals) {
@@ -1492,9 +1492,9 @@ void Volume::gl_draw_surface(Iterator begin, Iterator end, const QTreeWidgetItem
       ::glNormal3d(n.x(),n.y(),n.z());
 
     const Triangle_3& t = f.get<0>();
-    const Point& a = t[0];
-    const Point& b = t[1];
-    const Point& c = t[2];
+    const Point_3& a = t[0];
+    const Point_3& b = t[1];
+    const Point_3& c = t[2];
 
     ::glVertex3d(a.x(),a.y(),a.z());
     ::glVertex3d(b.x(),b.y(),b.z());

--- a/Surface_mesher/demo/Surface_mesher/volume.h
+++ b/Surface_mesher/demo/Surface_mesher/volume.h
@@ -43,7 +43,7 @@ struct Kernel : public Kernel1 {
 };
 
 typedef Kernel::FT FT;
-typedef Kernel::Point_3 Point;
+typedef Kernel::Point_3 Point_3;
 typedef Kernel::Sphere_3 Sphere;
 typedef Kernel::Vector_3 Vector;
 typedef Kernel::Triangle_3 Triangle_3;
@@ -53,7 +53,7 @@ typedef Kernel::Segment_3 Segment_3;
 
 typedef boost::tuple<Triangle_3,Vector,const QTreeWidgetItem*> Facet;
 
-typedef CBinary_image_3<FT,Point> Binary_image;
+typedef CBinary_image_3<FT,Point_3> Binary_image;
 
 class QTreeWidgetItem;
 

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -104,7 +104,6 @@ public:
   typedef typename Tr_Base::Lock_data_structure Lock_data_structure;
 
   typedef typename Gt::Point_3       Point;
-    typedef typename Gt::Point_3       Point_;
   typedef typename Gt::Segment_3     Segment;
   typedef typename Gt::Triangle_3    Triangle;
   typedef typename Gt::Tetrahedron_3 Tetrahedron;
@@ -183,12 +182,12 @@ public:
 protected:
 
   Oriented_side
-  side_of_oriented_sphere(const Point_ &p0, const Point_ &p1, const Point_ &p2,
-         const Point_ &p3, const Point_ &t, bool perturb = false) const;
+  side_of_oriented_sphere(const Point &p0, const Point &p1, const Point &p2,
+         const Point &p3, const Point &t, bool perturb = false) const;
 
   Bounded_side
-  coplanar_side_of_bounded_circle(const Point_ &p, const Point_ &q,
-                  const Point_ &r, const Point_ &s, bool perturb = false) const;
+  coplanar_side_of_bounded_circle(const Point &p, const Point &q,
+                  const Point &r, const Point &s, bool perturb = false) const;
 
   // for dual:
   Point
@@ -1409,8 +1408,8 @@ move_if_no_collision_and_give_new_cells(Vertex_handle v, const Point &p,
 template < class Gt, class Tds, class Lds >
 Oriented_side
 Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
-side_of_oriented_sphere(const Point_ &p0, const Point_ &p1, const Point_ &p2,
-                        const Point_ &p3, const Point_ &p, bool perturb) const
+side_of_oriented_sphere(const Point &p0, const Point &p1, const Point &p2,
+                        const Point &p3, const Point &p, bool perturb) const
 {
     CGAL_triangulation_precondition( orientation(p0, p1, p2, p3) == POSITIVE );
 
@@ -1451,8 +1450,8 @@ side_of_oriented_sphere(const Point_ &p0, const Point_ &p1, const Point_ &p2,
 template < class Gt, class Tds, class Lds >
 Bounded_side
 Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
-coplanar_side_of_bounded_circle(const Point_ &p0, const Point_ &p1,
-               const Point_ &p2, const Point_ &p, bool perturb) const
+coplanar_side_of_bounded_circle(const Point &p0, const Point &p1,
+               const Point &p2, const Point &p, bool perturb) const
 {
     // In dim==2, we should even be able to assert orient == POSITIVE.
     CGAL_triangulation_precondition( coplanar_orientation(p0, p1, p2)

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -104,6 +104,7 @@ public:
   typedef typename Tr_Base::Lock_data_structure Lock_data_structure;
 
   typedef typename Gt::Point_3       Point;
+    typedef typename Gt::Point_3       Point_;
   typedef typename Gt::Segment_3     Segment;
   typedef typename Gt::Triangle_3    Triangle;
   typedef typename Gt::Tetrahedron_3 Tetrahedron;
@@ -182,12 +183,12 @@ public:
 protected:
 
   Oriented_side
-  side_of_oriented_sphere(const Point &p0, const Point &p1, const Point &p2,
-         const Point &p3, const Point &t, bool perturb = false) const;
+  side_of_oriented_sphere(const Point_ &p0, const Point_ &p1, const Point_ &p2,
+         const Point_ &p3, const Point_ &t, bool perturb = false) const;
 
   Bounded_side
-  coplanar_side_of_bounded_circle(const Point &p, const Point &q,
-                  const Point &r, const Point &s, bool perturb = false) const;
+  coplanar_side_of_bounded_circle(const Point_ &p, const Point_ &q,
+                  const Point_ &r, const Point_ &s, bool perturb = false) const;
 
   // for dual:
   Point
@@ -1408,8 +1409,8 @@ move_if_no_collision_and_give_new_cells(Vertex_handle v, const Point &p,
 template < class Gt, class Tds, class Lds >
 Oriented_side
 Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
-side_of_oriented_sphere(const Point &p0, const Point &p1, const Point &p2,
-                        const Point &p3, const Point &p, bool perturb) const
+side_of_oriented_sphere(const Point_ &p0, const Point_ &p1, const Point_ &p2,
+                        const Point_ &p3, const Point_ &p, bool perturb) const
 {
     CGAL_triangulation_precondition( orientation(p0, p1, p2, p3) == POSITIVE );
 
@@ -1450,8 +1451,8 @@ side_of_oriented_sphere(const Point &p0, const Point &p1, const Point &p2,
 template < class Gt, class Tds, class Lds >
 Bounded_side
 Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
-coplanar_side_of_bounded_circle(const Point &p0, const Point &p1,
-               const Point &p2, const Point &p, bool perturb) const
+coplanar_side_of_bounded_circle(const Point_ &p0, const Point_ &p1,
+               const Point_ &p2, const Point_ &p, bool perturb) const
 {
     // In dim==2, we should even be able to assert orient == POSITIVE.
     CGAL_triangulation_precondition( coplanar_orientation(p0, p1, p2)


### PR DESCRIPTION
## Summary of Changes

As `Point` seems to be a type that is defined by VC++ we get for VS2017 with `-permissive -std:c++latest` an  [error](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-Ic-26/Polyhedron_Demo/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz)

include\CGAL/Delaunay_triangulation_3.h(1413): error C2244: 'CGAL::Delaunay_triangulation_3<Gt,Tds_,CGAL::Default,Lock_data_structure_>::side_of_oriented_sphere': unable to match function definition to an existing declaration

Adding `typedef Point Point_;` and using the latter in the method definition solves the problem.

## Release Management

* Affected package(s): Polyhedron demo.

