### PR TITLE
Mesh_3: Fix the warnings about uninitialized variables

### DIFF
--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -1948,7 +1948,7 @@ int unProject(GLdouble winx, GLdouble winy, GLdouble winz, GLdouble *modelview, 
 CGAL_INLINE_FUNCTION
 Vec Camera::projectedCoordinatesOf(const Vec& src, const Frame* frame) const
 {
-        GLdouble x,y,z;
+    GLdouble x = 0.f, y = 0.f, z = 0.f;
     static GLint viewport[4];
     getViewport(viewport);
 
@@ -1990,7 +1990,7 @@ Vec Camera::projectedCoordinatesOf(const Vec& src, const Frame* frame) const
 CGAL_INLINE_FUNCTION
 Vec Camera::unprojectedCoordinatesOf(const Vec& src, const Frame* frame) const
 {
-    GLdouble x,y,z;
+    GLdouble x = 0.f, y = 0.f, z = 0.f;
     static GLint viewport[4];
     getViewport(viewport);
     unProject(src.x,src.y,src.z, modelViewMatrix_,  projectionMatrix_,  viewport,  &x,&y,&z);
@@ -2480,8 +2480,8 @@ void Camera::setFrustum(double frustum[6])
     double B = (r+l)/(r-l);
     double C = 2*n/(t-b);
     double D = (t+b)/(t-b);
-    float E = -(f+n)/(f-n);
-    float F = -2*(f*n)/(f-n);
+    double E = -(f+n)/(f-n);
+    double F = -2*(f*n)/(f-n);
     projectionMatrix_[0] = A; projectionMatrix_[4] = 0; projectionMatrix_[8] = B ; projectionMatrix_[12] = 0;
     projectionMatrix_[1] = 0; projectionMatrix_[5] = C; projectionMatrix_[9] = D ; projectionMatrix_[13] = 0;
     projectionMatrix_[2] = 0; projectionMatrix_[6] = 0; projectionMatrix_[10] = E ; projectionMatrix_[14] = F;
@@ -2493,8 +2493,8 @@ void Camera::setFrustum(double frustum[6])
     double B = -(r+l)/(r-l);
     double C = 2/(t-b);
     double D = -(t+b)/(t-b);
-    float E = -(f+n)/(f-n);
-    float F = -2/(f-n);
+    double E = -(f+n)/(f-n);
+    double F = -2/(f-n);
     projectionMatrix_[0] = A; projectionMatrix_[1] = 0; projectionMatrix_[2] = 0 ; projectionMatrix_[3] = 0;
     projectionMatrix_[4] = 0; projectionMatrix_[5] = C; projectionMatrix_[6] = 0 ; projectionMatrix_[7] = 0;
     projectionMatrix_[8] = 0; projectionMatrix_[9] = 0; projectionMatrix_[10] = F ; projectionMatrix_[11] = 0;

--- a/GraphicsView/include/CGAL/Qt/frame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/frame_impl.h
@@ -1137,7 +1137,7 @@ void Frame::alignWithFrame(const Frame *const frame, bool move,
     rotate(rotation().inverse() * Quaternion(axis, angle) * orientation());
 
     // Try to align an other axis direction
-    unsigned short d = (index[1] + 1) % 3;
+    unsigned short d = (unsigned short)((index[1] + 1) % 3);
     Vec dir((d == 0) ? 1.0 : 0.0, (d == 1) ? 1.0 : 0.0, (d == 2) ? 1.0 : 0.0);
     dir = inverseTransformOf(dir);
 

--- a/GraphicsView/include/CGAL/Qt/image_interface.h
+++ b/GraphicsView/include/CGAL/Qt/image_interface.h
@@ -56,14 +56,14 @@ private Q_SLOTS:
   {
     if(currentlyFocused == imgHeight
        && ratioCheckBox->isChecked())
-    {imgWidth->setValue(i*ratio);}
+    {imgWidth->setValue(int(i*ratio));}
   }
 
   void imgWidthValueChanged(int i)
   {
     if(currentlyFocused == imgWidth
        && ratioCheckBox->isChecked())
-    {imgHeight->setValue(i/ratio);}
+    {imgHeight->setValue(int(i/ratio));}
   }
 
   void onFocusChanged(QWidget*, QWidget* now)

--- a/GraphicsView/include/CGAL/Qt/qglviewer.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer.h
@@ -218,7 +218,10 @@ public Q_SLOTS:
      also setForegroundColor(). */
   void setBackgroundColor(const QColor &color) {
     backgroundColor_ = color;
-    glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    glClearColor(GLclampf(color.redF()),
+                 GLclampf(color.greenF()),
+                 GLclampf(color.blueF()),
+                 GLclampf(color.alphaF()));
   }
   /*! Sets the foregroundColor() of the viewer, used to draw visual hints. See
    * also setBackgroundColor(). */

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -493,10 +493,10 @@ void CGAL::QGLViewer::postDraw() {
   }
 
   // Restore foregroundColor
-  float color[4];
-  color[0] = foregroundColor().red() / 255.0f;
-  color[1] = foregroundColor().green() / 255.0f;
-  color[2] = foregroundColor().blue() / 255.0f;
+  GLfloat color[4];
+  color[0] = GLfloat(foregroundColor().red()) / 255.0f;
+  color[1] = GLfloat(foregroundColor().green()) / 255.0f;
+  color[2] = GLfloat(foregroundColor().blue()) / 255.0f;
   color[3] = 1.0f;
   glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, color);
   glDisable(GL_LIGHTING);
@@ -818,7 +818,7 @@ CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::renderText(double x, double y, double z, const QString &str,
                            const QFont &font) {
   const Vec proj = camera_->projectedCoordinatesOf(Vec(x, y, z));
-  renderText(proj.x, proj.y, str, font);
+  renderText(int(proj.x), int(proj.y), str, font);
 }
 #endif
 
@@ -2817,7 +2817,7 @@ void CGAL::QGLViewer::getWheelActionBinding(MouseHandler handler, MouseAction ac
       return;
     }
 
-  key = ::Qt::Key(-1);
+  key = ::Qt::Key_unknown;
   modifiers = ::Qt::NoModifier;
 }
 
@@ -3094,7 +3094,7 @@ void CGAL::QGLViewer::drawVisualHints() {
   QMatrix4x4 mvMatrix;
   for(int i=0; i < 16; i++)
   {
-    mvMatrix.data()[i] = camera()->orientation().inverse().matrix()[i];
+    mvMatrix.data()[i] = float(camera()->orientation().inverse().matrix()[i]);
   }
   rendering_program.setUniformValue("mvp_matrix", mvpMatrix);
   rendering_program.setUniformValue("color", QColor(::Qt::lightGray));
@@ -3117,7 +3117,7 @@ void CGAL::QGLViewer::drawVisualHints() {
   camera()->setType(CGAL::qglviewer::Camera::ORTHOGRAPHIC);
   for(int i=0; i < 16; i++)
   {
-    mvMatrix.data()[i] = camera()->orientation().inverse().matrix()[i];
+    mvMatrix.data()[i] = float(camera()->orientation().inverse().matrix()[i]);
   }
   mvpMatrix.setToIdentity();
   mvpMatrix.ortho(-1,1,-1,1,-1,1);
@@ -3151,8 +3151,8 @@ void CGAL::QGLViewer::drawVisualHints() {
     std::vector<float> vertices;
     for(int i=0; i< 4; ++i)
     {
-      float x = (pow(-1, i)*(1-i/2));
-      float y = (pow(-1, i)*(i/2));
+      float x = float(std::pow(-1, i)*(1-i/2));
+      float y = float(std::pow(-1, i)*(i/2));
       vertices.push_back(x);
       vertices.push_back(y);
       vertices.push_back(0);
@@ -3167,9 +3167,11 @@ void CGAL::QGLViewer::drawVisualHints() {
     mvpMatrix.setToIdentity();
     mvpMatrix.ortho(-1,1,-1,1,-1,1);
     size=30*devicePixelRatio();
-    rendering_program.setUniformValue("mvp_matrix", mvpMatrix);  
-    glViewport((camera()->projectedCoordinatesOf(camera()->pivotPoint()).x-size/2)*devicePixelRatio(), (height() - camera()->projectedCoordinatesOf(camera()->pivotPoint()).y-size/2)*devicePixelRatio(), size, size);
-    glScissor ((camera()->projectedCoordinatesOf(camera()->pivotPoint()).x-size/2)*devicePixelRatio(), (height() - camera()->projectedCoordinatesOf(camera()->pivotPoint()).y-size/2)*devicePixelRatio(), size, size);
+    rendering_program.setUniformValue("mvp_matrix", mvpMatrix);
+    glViewport(GLint((camera()->projectedCoordinatesOf(camera()->pivotPoint()).x-size/2)*devicePixelRatio()),
+               GLint((height() - camera()->projectedCoordinatesOf(camera()->pivotPoint()).y-size/2)*devicePixelRatio()), size, size);
+    glScissor (GLint((camera()->projectedCoordinatesOf(camera()->pivotPoint()).x-size/2)*devicePixelRatio()),
+               GLint((height() - camera()->projectedCoordinatesOf(camera()->pivotPoint()).y-size/2)*devicePixelRatio()), size, size);
     rendering_program.setUniformValue("color", QColor(::Qt::black));
     glLineWidth(3.0);
     glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(4));
@@ -3214,18 +3216,21 @@ CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Vec from,
                           CGAL::qglviewer::Vec to, CGAL::qglviewer::Vec color, 
                           std::vector<float> &data) {
+  using std::cos;
+  using std::sin;
+  using std::acos;
   CGAL::qglviewer::Vec temp = to-from;
-  QVector3D dir = QVector3D(temp.x, temp.y, temp.z);
+  QVector3D dir = QVector3D(float(temp.x), float(temp.y), float(temp.z));
   QMatrix4x4 mat;
   mat.setToIdentity();
-  mat.translate(from.x, from.y, from.z);
+  mat.translate(float(from.x), float(from.y), float(from.z));
   mat.scale(dir.length());
   dir.normalize();
   float angle = 0.0;
   if(std::sqrt((dir.x()*dir.x()+dir.y()*dir.y())) > 1)
       angle = 90.0f;
   else
-      angle =acos(dir.y()/std::sqrt(dir.x()*dir.x()+dir.y()*dir.y()+dir.z()*dir.z()))*180.0/CGAL_PI;
+      angle = float(acos(dir.y()/std::sqrt(dir.lengthSquared()))*180.0/CGAL_PI);
 
   QVector3D axis;
   axis = QVector3D(dir.z(), 0, -dir.x());
@@ -3268,7 +3273,7 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back((float)color.y);
       data.push_back((float)color.z);
       //point C1
-      D = (d+360/prec)*CGAL_PI/180.0;
+      D = float((d+360/prec)*CGAL_PI/180.0);
       p = QVector4D(Rf* sin(D), 0.66f, Rf* cos(D), 1.f);
       n = QVector4D(sin(D), sin(a), cos(D), 1.0);
       pR = mat*p;
@@ -3292,7 +3297,7 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
   for(int d = 0; d<360; d+= 360/prec)
   {
       //point A1
-      double D = d*CGAL_PI/180.0;
+      float D = float(d*CGAL_PI/180.0);
       QVector4D p(rf*sin(D), 0.66f, rf*cos(D), 1.f);
       QVector4D n(sin(D), 0.f, cos(D), 1.f);
       QVector4D pR = mat*p;
@@ -3304,9 +3309,9 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back(color.x);
-      data.push_back(color.y);
-      data.push_back(color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
       //point B1
       p = QVector4D(rf * sin(D),0,rf*cos(D), 1.0);
       n = QVector4D(sin(D), 0, cos(D), 1.0);
@@ -3320,11 +3325,11 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back(color.x);
-      data.push_back(color.y);
-      data.push_back(color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
         //point C1
-      D = (d+360/prec)*CGAL_PI/180.0;
+      D = float((d+360/prec)*CGAL_PI/180.0);
       p = QVector4D(rf * sin(D),0,rf*cos(D), 1.0);
       n = QVector4D(sin(D), 0, cos(D), 1.0);
       pR = mat*p;
@@ -3335,11 +3340,11 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back(color.x);
-      data.push_back(color.y);
-      data.push_back(color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
       //point A2
-      D = (d+360/prec)*CGAL_PI/180.0;
+      D = float((d+360/prec)*CGAL_PI/180.0);
 
       p = QVector4D(rf * sin(D),0,rf*cos(D), 1.0);
       n = QVector4D(sin(D), 0, cos(D), 1.0);
@@ -3351,9 +3356,9 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back((float)color.x);
-      data.push_back((float)color.y);
-      data.push_back((float)color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
       //point B2
       p = QVector4D(rf * sin(D), 0.66f, rf*cos(D), 1.f);
       n = QVector4D(sin(D), 0, cos(D), 1.0);
@@ -3365,11 +3370,11 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back((float)color.x);
-      data.push_back((float)color.y);
-      data.push_back((float)color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
       //point C2
-      D = d*CGAL_PI/180.0;
+      D = float(d*CGAL_PI/180.0);
       p = QVector4D(rf * sin(D), 0.66f, rf*cos(D), 1.f);
       n = QVector4D(sin(D), 0.f, cos(D), 1.f);
       pR = mat*p;
@@ -3380,9 +3385,9 @@ void CGAL::QGLViewer::drawArrow(double r,double R, int prec, CGAL::qglviewer::Ve
       data.push_back(nR.x());
       data.push_back(nR.y());
       data.push_back(nR.z());
-      data.push_back(color.x);
-      data.push_back(color.y);
-      data.push_back(color.z);
+      data.push_back(float(color.x));
+      data.push_back(float(color.y));
+      data.push_back(float(color.z));
 
   }
 }
@@ -3403,7 +3408,7 @@ void CGAL::QGLViewer::drawAxis(qreal length) {
   rendering_program_light.bind();
   vaos[AXIS].bind();
   vbos[Axis].bind();
-  vbos[Axis].allocate(data.data(), static_cast<int>(data.size()) * sizeof(float));
+  vbos[Axis].allocate(data.data(), static_cast<int>(data.size() * sizeof(float)));
   rendering_program_light.enableAttributeArray("vertex");
   rendering_program_light.setAttributeBuffer("vertex",GL_FLOAT,0,3,
                                              static_cast<int>(9*sizeof(float)));
@@ -3432,22 +3437,22 @@ void CGAL::QGLViewer::drawGrid(qreal size, int nbSubdivisions) {
   std::vector<float> v_Grid;
   for (int i=0; i<=nbSubdivisions; ++i)
   {
-          const float pos = size*(2.0*i/nbSubdivisions-1.0);
+          const float pos = float(size*(2.0*i/nbSubdivisions-1.0));
           v_Grid.push_back(pos);
-          v_Grid.push_back(-size);
-          v_Grid.push_back(0.0);
+          v_Grid.push_back(float(-size));
+          v_Grid.push_back(0.f);
 
           v_Grid.push_back(pos);
-          v_Grid.push_back(+size);
-          v_Grid.push_back(0.0);
+          v_Grid.push_back(float(+size));
+          v_Grid.push_back(0.f);
 
-          v_Grid.push_back(-size);
+          v_Grid.push_back(float(-size));
           v_Grid.push_back(pos);
-          v_Grid.push_back(0.0);
+          v_Grid.push_back(0.f);
 
-          v_Grid.push_back( size);
+          v_Grid.push_back( float(size));
           v_Grid.push_back( pos);
-          v_Grid.push_back( 0.0);
+          v_Grid.push_back( 0.f);
   }
   rendering_program.bind();
   vaos[GRID].bind();
@@ -3471,7 +3476,7 @@ void CGAL::QGLViewer::drawGrid(qreal size, int nbSubdivisions) {
   rendering_program_light.bind();
   vaos[GRID_AXIS].bind();
   vbos[Grid_axis].bind();
-  vbos[Grid_axis].allocate(d_axis.data(), static_cast<int>(d_axis.size()) * sizeof(float));
+  vbos[Grid_axis].allocate(d_axis.data(), static_cast<int>(d_axis.size() * sizeof(float)));
   rendering_program_light.enableAttributeArray("vertex");
   rendering_program_light.setAttributeBuffer("vertex",GL_FLOAT,0,3,
                                              static_cast<int>(9*sizeof(float)));
@@ -4013,7 +4018,10 @@ QImage* CGAL::QGLViewer::takeSnapshot( CGAL::qglviewer::SnapShotBackground  back
     for (int j=0; j<nbY; j++)
     {
       fbo.bind();
-      glClearColor(backgroundColor().redF(), backgroundColor().greenF(), backgroundColor().blueF(), alpha);
+      glClearColor(GLfloat(backgroundColor().redF()),
+                   GLfloat(backgroundColor().greenF()),
+                   GLfloat(backgroundColor().blueF()),
+                   alpha);
       double frustum[6];
       frustum[0]= -xMin + i*deltaX;
       frustum[1]= -xMin + (i+1)*deltaX ;

--- a/Mesh_3/doc/Mesh_3/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Labeled_mesh_domain_3.h
@@ -183,8 +183,7 @@ be a `CGAL::Image_3` object.
 
 <li><b>`parameters::image_values_to_subdom_indices`</b> a function or
   a function object, compatible with the signature
-  `Subdomain_index(word_type)`, where the type `word_type` is the type
-  of words of the 3D image. This function returns the subdomain index
+  `Subdomain_index(double)`. This function returns the subdomain index
   corresponding to a pixel value. If this parameter is used, then the
   parameter `iso_value` is ignored.
 

--- a/Mesh_3/examples/Mesh_3/mesh_3D_gray_image_multiple_values.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_gray_image_multiple_values.cpp
@@ -34,8 +34,9 @@ struct Image_to_multiple_iso_level_sets {
   const Set& set;
   Image_to_multiple_iso_level_sets(const Set& set) : set(set) {}
 
-  int operator()(float v) const {
-       return int(std::distance(set.begin(), set.lower_bound(v)));
+  int operator()(double v) const {
+       return int(std::distance(set.begin(),
+                                set.lower_bound(float(v))));
   }
 };
 

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1252,11 +1252,6 @@ private:
           facet.first->set_facet_surface_center(facet.second,surface_center);
           facet_m.first->set_facet_surface_center(facet_m.second,surface_center);
         }
-        else
-        {
-          facet.first->set_facet_surface_center(facet.second,Bare_point());
-          facet_m.first->set_facet_surface_center(facet_m.second,Bare_point());
-        }
       }
 
       return surface;

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1687,9 +1687,27 @@ private:
   /**
    * Returns the least square plane from v, using adjacent surface points
    */
-  Plane_3 get_least_square_surface_plane(const Vertex_handle& v,
-                                         Bare_point& ref_point,
-                                         Surface_patch_index index = Surface_patch_index()) const;
+  boost::optional<Plane_3>
+  get_least_square_surface_plane(const Vertex_handle& v,
+                                 Bare_point& ref_point,
+                                 Surface_patch_index index = Surface_patch_index()) const;
+
+  /**
+   * @brief Project \c p on surface, using incident facets of \c v
+   * @param p The point to project
+   * @param v The vertex from which p was moved
+   * @param index The index of the surface patch where v lies, if known.
+   * @return a boost::optional with the projected point if the projection
+   * was possible, or boost::none
+   *
+   * \c p is projected as follows using normal of least square fitting plane
+   * on \c v incident surface points. If \c index is specified, only
+   * surface points that are on the same surface patch are used to compute
+   * the fitting plane.
+   */
+  boost::optional<Bare_point>
+  project_on_surface_if_possible(const Bare_point& p, const Vertex_handle& v,
+                                 Surface_patch_index index = Surface_patch_index()) const;
 
   /**
    * @brief Returns the projection of \c p, using direction of
@@ -2667,7 +2685,6 @@ C3T3_helpers<C3T3,MD>::
 rebuild_restricted_delaunay(OutdatedCells& outdated_cells,
                             Moving_vertices_set& moving_vertices)
 {
-  typename Gt::Equal_3 equal = tr_.geom_traits().equal_3_object();
   typename OutdatedCells::iterator first_cell = outdated_cells.begin();
   typename OutdatedCells::iterator last_cell = outdated_cells.end();
   Update_c3t3 updater(domain_,c3t3_);
@@ -2766,15 +2783,16 @@ rebuild_restricted_delaunay(OutdatedCells& outdated_cells,
        it != vertex_to_proj.end() ;
        ++it )
   {
-    Bare_point new_pos = project_on_surface(wp2p_((*it)->point()),*it);
+    boost::optional<Bare_point> opt_new_pos =
+      project_on_surface(wp2p_((*it)->point()),*it);
 
-    if ( ! equal(new_pos, Bare_point()) )
+    if ( opt_new_pos )
     {
       //freezing needs 'erase' to be done before the vertex is actually destroyed
       // Update moving vertices (it becomes new_vertex)
       moving_vertices.erase(*it);
 
-      Vertex_handle new_vertex = update_mesh(p2wp_(new_pos),*it);
+      Vertex_handle new_vertex = update_mesh(p2wp_(*opt_new_pos),*it);
       c3t3_.set_dimension(new_vertex,2);
 
       moving_vertices.insert(new_vertex);
@@ -2873,15 +2891,16 @@ rebuild_restricted_delaunay(ForwardIterator first_cell,
         it != vertex_to_proj.end() ;
         ++it )
   {
-    Bare_point new_pos = project_on_surface(wp2p_((it->first)->point()),it->first,it->second);
+    boost::optional<Bare_point> opt_new_pos =
+      project_on_surface(wp2p_((it->first)->point()),it->first,it->second);
 
-    if ( ! equal(new_pos, Bare_point()) )
+    if ( opt_new_pos )
     {
       //freezing needs 'erase' to be done before the vertex is actually destroyed
       // Update moving vertices (it becomes new_vertex)
       moving_vertices.erase(it->first);
 
-      Vertex_handle new_vertex = update_mesh(p2wp_(new_pos), it->first);
+      Vertex_handle new_vertex = update_mesh(p2wp_(*opt_new_pos), it->first);
       c3t3_.set_dimension(new_vertex,2);
 
       moving_vertices.insert(new_vertex);
@@ -3333,7 +3352,7 @@ project_on_surface_aux(const Bare_point& p,
 
 
 template <typename C3T3, typename MD>
-typename C3T3_helpers<C3T3,MD>::Plane_3
+boost::optional<typename C3T3_helpers<C3T3,MD>::Plane_3>
 C3T3_helpers<C3T3,MD>::
 get_least_square_surface_plane(const Vertex_handle& v,
                                Bare_point& reference_point,
@@ -3373,7 +3392,7 @@ get_least_square_surface_plane(const Vertex_handle& v,
 
   // In some cases point is not a real surface point
   if ( surface_point_vector.empty() )
-    return Plane_3();
+    return boost::none;
 
   // Compute least square fitting plane
   Plane_3 plane;
@@ -3400,24 +3419,38 @@ project_on_surface(const Bare_point& p,
                    const Vertex_handle& v,
                    Surface_patch_index index) const
 {
+  boost::optional<Bare_point> opt_point =
+    project_on_surface_if_possible(p, v, index);
+  if(opt_point) return *opt_point;
+  else return p;
+}
+
+
+template <typename C3T3, typename MD>
+boost::optional<typename C3T3_helpers<C3T3,MD>::Bare_point>
+C3T3_helpers<C3T3,MD>::
+project_on_surface_if_possible(const Bare_point& p,
+                               const Vertex_handle& v,
+                               Surface_patch_index index) const
+{
   typename Gt::Equal_3 equal = tr_.geom_traits().equal_3_object();
   // return domain_.project_on_surface(p);
   // Get plane
-  Bare_point reference_point(CGAL::ORIGIN);
-  Plane_3 plane = get_least_square_surface_plane(v,reference_point, index);
+  Bare_point reference_point;
+  boost::optional<Plane_3> opt_plane =
+    get_least_square_surface_plane(v,reference_point, index);
 
-  if ( equal(reference_point, CGAL::ORIGIN) )
-    return p;
+  if(!opt_plane) return boost::none;
 
   // Project
   if ( ! equal(p, wp2p_(v->point())) )
     return project_on_surface_aux(p,
                                   wp2p_(v->point()),
-                                  plane.orthogonal_vector());
+                                  opt_plane->orthogonal_vector());
   else
     return project_on_surface_aux(p,
                                   reference_point,
-                                  plane.orthogonal_vector());
+                                  opt_plane->orthogonal_vector());
 }
 
 

--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -545,7 +545,7 @@ polylines_to_protect
                {{ { pix10, Point_3(), Domain_type(), 0, false },
                   { pix11, Point_3(), Domain_type(), 0, false } }} }};
 
-          std::map<Image_word_type, int> pixel_values_set;
+          std::map<Domain_type, int> pixel_values_set;
           for(int ii = 0; ii < 2; ++ii) {
             for(int jj = 0; jj < 2; ++jj) {
               const Pixel& pixel = square[ii][jj].pixel;
@@ -902,7 +902,7 @@ case_1_2_1:
             }
             else {
               // case of two colors with one pixel green and three red
-              Image_word_type value_alone;
+              Domain_type value_alone;
               if(pixel_values_set.begin()->second == 1) {
                 value_alone = pixel_values_set.begin()->first;
               } else {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -379,7 +379,7 @@ Meshing_thread* cgal_code_mesh_3(const Image* pImage,
           Linear_interpolator<Kernel, Image_word_type>(),
           0,
           0,
-          iso_value,
+          Image_word_type(iso_value),
           (std::max)(10, int(10 * (std::min)((std::min)(pImage->vx(),
                                                         pImage->vy()),
                                              pImage->vz())

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
@@ -641,7 +641,10 @@ protected:
         if(!poly.empty())
           for(std::size_t j=0; j<poly.size()-1; ++j)
           {
-            painter->drawLine(poly[j].x(), poly[j].y(), poly[j+1].x(), poly[j+1].y());
+            painter->drawLine(int(poly[j].x()),
+                              int(poly[j].y()),
+                              int(poly[j+1].x()),
+                              int(poly[j+1].y()));
           }
       }
       painter->end();

--- a/Polyhedron/demo/Polyhedron/Scene_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item.cpp
@@ -184,16 +184,18 @@ void CGAL::Three::Scene_item::attribBuffers(CGAL::Three::Viewer_interface* viewe
        if(is_selected) c = c.lighter(120);
        viewer->getShaderProgram(program_name)->setAttributeValue
          ("color_facets",
-          c.redF(),
-          c.greenF(),
-          c.blueF());
+          GLfloat(c.redF()),
+          GLfloat(c.greenF()),
+          GLfloat(c.blueF()));
     }
     else if(program_name == PROGRAM_WITH_TEXTURED_EDGES)
     {
         if(is_selected) c = c.lighter(50);
         viewer->getShaderProgram(program_name)->setUniformValue
           ("color_lines",
-           QVector3D(c.redF(), c.greenF(), c.blueF()));
+           QVector3D(float(c.redF()),
+                     float(c.greenF()),
+                     float(c.blueF())));
     }
     viewer->getShaderProgram(program_name)->release();
 }

--- a/Polyhedron/demo/Polyhedron/TextRenderer.cpp
+++ b/Polyhedron/demo/Polyhedron/TextRenderer.cpp
@@ -23,15 +23,15 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
           if(viewer->testDisplayId(src.x, src.y, src.z))
           {
             if(item->is_3D())
-              rect = QRect(camera->projectedCoordinatesOf(src).x-item->width()/2,
-                           camera->projectedCoordinatesOf(src).y-item->height()/2,
-                           item->width(),
-                           item->height());
+              rect = QRect(int(camera->projectedCoordinatesOf(src).x-item->width()/2),
+                           int(camera->projectedCoordinatesOf(src).y-item->height()/2),
+                           int(item->width()),
+                           int(item->height()));
             else
-              rect = QRect(src.x-item->width()/2,
-                           src.y-item->height()/2,
-                           item->width(),
-                           item->height());
+              rect = QRect(int(src.x-item->width()/2),
+                           int(src.y-item->height()/2),
+                           int(item->width()),
+                           int(item->height()));
 
             painter->setFont(item->font());
             painter->setPen(QPen(item->color()));
@@ -48,18 +48,18 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer)
       {
         if(item->is_always_visible() || viewer->testDisplayId(src.x, src.y, src.z))
         {
-            rect = QRect(camera->projectedCoordinatesOf(src).x-item->width()/2,
-                       camera->projectedCoordinatesOf(src).y-item->height()/2,
-                       item->width(),
-                       item->height());
+            rect = QRect(int(camera->projectedCoordinatesOf(src).x-item->width()/2),
+                         int(camera->projectedCoordinatesOf(src).y-item->height()/2),
+                         int(item->width()),
+                         int(item->height()));
         }
       }
       else
       {
-          rect = QRect(src.x-item->width()/2,
-                     src.y-item->height()/2,
-                     item->width(),
-                     item->height());
+          rect = QRect(int(src.x-item->width()/2),
+                       int(src.y-item->height()/2),
+                       int(item->width()),
+                       int(item->height()));
       }
       painter->setFont(item->font());
       painter->setPen(QPen(item->color()));

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -706,7 +706,10 @@ void Viewer::drawVisualHints()
     //Prints the displayMessage
     QFont font = QFont();
     QFontMetrics fm(font);
-    TextItem *message_text = new TextItem(10 + fm.width(d->message)/2, height()-20, 0, d->message, false, QFont(), Qt::gray );
+    TextItem *message_text = new TextItem(float(10 + fm.width(d->message)/2),
+                                          float(height()-20),
+                                          0, d->message, false,
+                                          QFont(), Qt::gray );
     if (d->_displayMessage)
     {
       d->textRenderer->addText(message_text);
@@ -848,7 +851,10 @@ void Viewer::paintGL()
   else
   {
     d->painter->beginNativePainting();
-    glClearColor(backgroundColor().redF(), backgroundColor().greenF(), backgroundColor().blueF(), 1.0);
+    glClearColor(GLfloat(backgroundColor().redF()),
+                 GLfloat(backgroundColor().greenF()),
+                 GLfloat(backgroundColor().blueF()),
+                 1.f);
     glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
     //set the default frustum
@@ -907,8 +913,8 @@ void Viewer_impl::showDistance(QPoint pixel)
         // fills the buffers
         std::vector<float> v;
         v.resize(6);
-        v[0] = APoint.x; v[1] = APoint.y; v[2] = APoint.z;
-        v[3] = BPoint.x; v[4] = BPoint.y; v[5] = BPoint.z;
+        v[0] = float(APoint.x); v[1] = float(APoint.y); v[2] = float(APoint.z);
+        v[3] = float(BPoint.x); v[4] = float(BPoint.y); v[5] = float(BPoint.z);
         rendering_program_dist.bind();
         vao.bind();
         buffer.bind();
@@ -922,12 +928,21 @@ void Viewer_impl::showDistance(QPoint pixel)
         double dist = std::sqrt((BPoint.x-APoint.x)*(BPoint.x-APoint.x) + (BPoint.y-APoint.y)*(BPoint.y-APoint.y) + (BPoint.z-APoint.z)*(BPoint.z-APoint.z));
         QFont font;
         font.setBold(true);
-        TextItem *ACoord = new TextItem(APoint.x, APoint.y, APoint.z,QString("A(%1,%2,%3)").arg(APoint.x-viewer->offset().x).arg(APoint.y-viewer->offset().y).arg(APoint.z-viewer->offset().z), true, font, Qt::red, true);
+        TextItem *ACoord = new TextItem(float(APoint.x),
+                                        float(APoint.y),
+                                        float(APoint.z),
+                                        QString("A(%1,%2,%3)").arg(APoint.x-viewer->offset().x).arg(APoint.y-viewer->offset().y).arg(APoint.z-viewer->offset().z), true, font, Qt::red, true);
         distance_text.append(ACoord);
-        TextItem *BCoord = new TextItem(BPoint.x, BPoint.y, BPoint.z,QString("B(%1,%2,%3)").arg(BPoint.x-viewer->offset().x).arg(BPoint.y-viewer->offset().y).arg(BPoint.z-viewer->offset().z), true, font, Qt::red, true);
+        TextItem *BCoord = new TextItem(float(BPoint.x),
+                                        float(BPoint.y),
+                                        float(BPoint.z),
+                                        QString("B(%1,%2,%3)").arg(BPoint.x-viewer->offset().x).arg(BPoint.y-viewer->offset().y).arg(BPoint.z-viewer->offset().z), true, font, Qt::red, true);
         distance_text.append(BCoord);
         CGAL::qglviewer::Vec centerPoint = 0.5*(BPoint+APoint);
-        TextItem *centerCoord = new TextItem(centerPoint.x, centerPoint.y, centerPoint.z,QString(" distance: %1").arg(dist), true, font, Qt::red, true);
+        TextItem *centerCoord = new TextItem(float(centerPoint.x),
+                                             float(centerPoint.y),
+                                             float(centerPoint.z),
+                                             QString(" distance: %1").arg(dist), true, font, Qt::red, true);
 
         distance_text.append(centerCoord);
         Q_FOREACH(TextItem* ti, distance_text)

--- a/Polyhedron/demo/Polyhedron/include/id_printing.h
+++ b/Polyhedron/demo/Polyhedron/include/id_printing.h
@@ -215,9 +215,9 @@ void compute_displayed_ids(Mesh& mesh,
     }
   }
   QVector3D point(
-      get(ppmap, displayed_vertices[0]).x() + offset.x,
-      get(ppmap, displayed_vertices[0]).y() + offset.y,
-      get(ppmap, displayed_vertices[0]).z() + offset.z);
+      float(get(ppmap, displayed_vertices[0]).x() + offset.x),
+      float(get(ppmap, displayed_vertices[0]).y() + offset.y),
+      float(get(ppmap, displayed_vertices[0]).z() + offset.z));
 
   //test if we want to erase or not
   BOOST_FOREACH(TextItem* text_item, *targeted_ids)
@@ -342,7 +342,10 @@ void compute_displayed_ids(Mesh& mesh,
     Point pos=Point(get(ppmap, vh).x()+offset.x,
                     get(ppmap, vh).y()+offset.y,
                     get(ppmap, vh).z()+offset.z);
-    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(get(vidmap, vh)), true, font, Qt::red);
+    TextItem* text_item = new TextItem(float(pos.x()),
+                                       float(pos.y()),
+                                       float(pos.z()),
+                                       QString("%1").arg(get(vidmap, vh)), true, font, Qt::red);
     vitems->append(text_item);
     targeted_ids->push_back(text_item);
   }
@@ -354,7 +357,10 @@ void compute_displayed_ids(Mesh& mesh,
                 pos.y()+offset.y,
                 pos.z()+offset.z);
 
-    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(get(hidmap, h)/2), true, font, Qt::green);
+    TextItem* text_item = new TextItem(float(pos.x()),
+                                       float(pos.y()),
+                                       float(pos.z()),
+                                       QString("%1").arg(get(hidmap, h)/2), true, font, Qt::green);
     eitems->append(text_item);
   }
 
@@ -373,7 +379,10 @@ void compute_displayed_ids(Mesh& mesh,
     Point pos(x/total+offset.x,
               y/total+offset.y,
               z/total+offset.z);
-    TextItem* text_item = new TextItem(pos.x(), pos.y(), pos.z(), QString("%1").arg(get(fidmap,f)), true, font, Qt::blue);
+    TextItem* text_item = new TextItem(float(pos.x()),
+                                       float(pos.y()),
+                                       float(pos.z()),
+                                       QString("%1").arg(get(fidmap,f)), true, font, Qt::blue);
     fitems->append(text_item);
   }
 }
@@ -398,9 +407,9 @@ bool printVertexIds(const Mesh& mesh,
   BOOST_FOREACH(typename boost::graph_traits<Mesh>::vertex_descriptor vh, vertices(mesh))
   {
     const Point& p = get(ppmap, vh);
-    vitems->append(new TextItem((float)p.x() + offset.x,
-                                (float)p.y() + offset.y,
-                                (float)p.z() + offset.z,
+    vitems->append(new TextItem(float(p.x() + offset.x),
+                                float(p.y() + offset.y),
+                                float(p.z() + offset.z),
                                 QString("%1").arg(get(idmap, vh)), true, font, Qt::red));
 
   }
@@ -433,9 +442,9 @@ bool printEdgeIds(const Mesh& mesh,
   {
     const Point& p1 = get(ppmap, source(e, mesh));
     const Point& p2 = get(ppmap, target(e, mesh));
-    eitems->append(new TextItem((float)(p1.x() + p2.x()) / 2 + offset.x,
-                                (float)(p1.y() + p2.y()) / 2 + offset.y,
-                                (float)(p1.z() + p2.z()) / 2 + offset.z,
+    eitems->append(new TextItem(float((p1.x() + p2.x()) / 2 + offset.x),
+                                float((p1.y() + p2.y()) / 2 + offset.y),
+                                float((p1.z() + p2.z()) / 2 + offset.z),
                                 QString("%1").arg(get(idmap, halfedge(e, mesh)) / 2), true, font, Qt::green));
   }
   //add the QList to the render's pool
@@ -473,9 +482,9 @@ bool printFaceIds(const Mesh& mesh,
       total += 1.f;
     }
 
-    fitems->append(new TextItem((float)x / total + offset.x,
-                                (float)y / total + offset.y,
-                                (float)z / total + offset.z,
+    fitems->append(new TextItem(float(x / total + offset.x),
+                                float(y / total + offset.y),
+                                float(z / total + offset.z),
                                 QString("%1").arg(get(idmap, fh)), true, font, Qt::blue));
   }
   //add the QList to the render's pool


### PR DESCRIPTION
## Summary of Changes

The previous implementation of `get_least_square_surface_plane` and
`project_on_surface`, in `C3T3_helpers`, was using uninitialized
values. Now, it uses `boost::optional`.

## Release Management

* Affected package(s): Mesh_3


