### PR TITLE
Polyhedron demo: degree sphere plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -163,4 +163,4 @@ target_compile_definitions(degenerated_faces_sm_plugin PUBLIC "-DUSE_SURFACE_MES
 
 qt5_wrap_ui( bubblesUI_FILES Color_spheres_widget.ui )
 polyhedron_demo_plugin(colored_spheres_plugin Colored_spheres_plugin ${bubblesUI_FILES})
-target_link_libraries(colored_spheres_plugin PUBLIC  scene_surface_mesh_item scene_basic_objects scene_sm_item_k_ring_selection)
+target_link_libraries(colored_spheres_plugin PUBLIC  scene_surface_mesh_item scene_basic_objects)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -161,3 +161,6 @@ polyhedron_demo_plugin(degenerated_faces_sm_plugin Degenerated_faces_plugin)
 target_link_libraries(degenerated_faces_sm_plugin PUBLIC scene_surface_mesh_item scene_surface_mesh_selection_item)
 target_compile_definitions(degenerated_faces_sm_plugin PUBLIC "-DUSE_SURFACE_MESH" )
 
+qt5_wrap_ui( bubblesUI_FILES Color_spheres_widget.ui )
+polyhedron_demo_plugin(colored_spheres_plugin Colored_spheres_plugin ${bubblesUI_FILES})
+target_link_libraries(colored_spheres_plugin PUBLIC  scene_surface_mesh_item scene_basic_objects)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -163,4 +163,4 @@ target_compile_definitions(degenerated_faces_sm_plugin PUBLIC "-DUSE_SURFACE_MES
 
 qt5_wrap_ui( bubblesUI_FILES Color_spheres_widget.ui )
 polyhedron_demo_plugin(colored_spheres_plugin Colored_spheres_plugin ${bubblesUI_FILES})
-target_link_libraries(colored_spheres_plugin PUBLIC  scene_surface_mesh_item scene_basic_objects)
+target_link_libraries(colored_spheres_plugin PUBLIC  scene_surface_mesh_item scene_basic_objects scene_sm_item_k_ring_selection)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
@@ -14,14 +14,33 @@
    <string>DockWidget</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
     <item>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="title">
-       <string/>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2"/>
-     </widget>
+     <layout class="QGridLayout" name="gridLayout"/>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton">
+        <property name="text">
+         <string>Add Degree</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ColorSpheresWidget</class>
+ <widget class="QDockWidget" name="ColorSpheresWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>DockWidget</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string/>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2"/>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Color_spheres_widget.ui
@@ -14,33 +14,9 @@
    <string>DockWidget</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="1">
     <item>
      <layout class="QGridLayout" name="gridLayout"/>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pushButton">
-        <property name="text">
-         <string>Add Degree</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </item>
    </layout>
   </widget>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
@@ -5,7 +5,6 @@
 #include "SMesh_type.h"
 #include "Scene_surface_mesh_item.h"
 #include "Scene_spheres_item.h"
-#include "Scene_facegraph_item_k_ring_selection.h"
 
 #include <CGAL/compute_average_spacing.h>
 
@@ -47,17 +46,30 @@ public :
   Scene_item* clone() const Q_DECL_OVERRIDE {return 0;}
   QString toolTip() const Q_DECL_OVERRIDE {return QString();}
   QMenu* contextMenu() Q_DECL_OVERRIDE;
-  void select(double orig_x, double orig_y, double orig_z, 
-              double dir_x, double dir_y, double dir_z) Q_DECL_OVERRIDE;
+  Scene_surface_mesh_item* parent() const { return _parent; } 
+  bool eventFilter(QObject *obj, QEvent *event) Q_DECL_OVERRIDE;
   
+  std::size_t sphere_id(const SMesh::Vertex_index& vi) const { return vertex_sphere_map[std::size_t(vi)]; }
+  bool vertex_has_sphere(const SMesh::Vertex_index& vi) const { return vertex_has_sphere_map[std::size_t(vi)]; }
+  std::size_t vertex_degree(const SMesh::Vertex_index& vi) const { return vertex_deg_map[std::size_t(vi)]; }
+  
+  void set_sphere_id(const SMesh::Vertex_index& vi, std::size_t id) { vertex_sphere_map[std::size_t(vi)] = id; }
+  void set_vertex_has_sphere(const SMesh::Vertex_index& vi, bool b) { vertex_has_sphere_map[std::size_t(vi)] = b; }
+  void set_vertex_degree(const SMesh::Vertex_index& vi, std::size_t deg) { vertex_deg_map[std::size_t(vi)] = deg; }
   
 public Q_SLOTS:
   void resize_spheres();
+
+Q_SIGNALS:
+  void selected(const SMesh::Vertex_index &vi);
   
 private:
   QSlider* radius_slider;
-  Scene_surface_mesh_item* parent;
+  Scene_surface_mesh_item* _parent;
   double radius;
+  std::vector<std::size_t> vertex_sphere_map;
+  std::vector<bool> vertex_has_sphere_map;
+  std::vector<std::size_t> vertex_deg_map;
 };
 
 
@@ -95,28 +107,23 @@ public:
       return true;
     return false;
   }
-  void closure()
-  {
-    dock_widget->hide();
-  }
+  void closure(){ dock_widget->hide(); }
+  
 public Q_SLOTS:
   void pop();
   void invalidateDisplay(bool update_spheres = false);
-  void selected(const std::set<fg_vertex_descriptor> &m);
+  void selected(const SMesh::Vertex_index &vi);
   void changeColor();
+  void vertex_has_been_selected(void*);
 private:
-  QColor changeDegree(size_t vid, bool &ok);
+  QColor changeDegree(SMesh::Vertex_index vi, bool &ok);
   DockWidget* dock_widget;
   QAction* actionBubbles;
-  std::vector<std::size_t> vertex_sphere_map;
-  std::vector<bool> vertex_has_sphere_map;
-  fg_vertex_descriptor sel_v;
-  fg_vertex_descriptor last_v;
+  SMesh::Vertex_index sel_v;
+  SMesh::Vertex_index last_v;
   std::vector<QColor> colors;
   QColor selection_color;
   Colored_spheres_item* spheres;
-  Scene_facegraph_item_k_ring_selection k_ring_selector;
-  std::vector<std::size_t> vertex_deg_map;
 }; // end Colored_spheres_plugin
 
 //   P l u g i n - D e f i n i t i o n s
@@ -180,28 +187,28 @@ void Colored_spheres_plugin::invalidateDisplay(bool update_spheres)
   layout->setColumnStretch(1,1);
   if(update_spheres)
   {
-    SMesh& mesh = *k_ring_selector.poly_item->face_graph();
+    SMesh& mesh = *spheres->parent()->face_graph();
     BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
     {
-      if(vertex_has_sphere_map[std::size_t(vi)])
+      if(spheres->vertex_has_sphere(vi))
       {
-        std::size_t deg = vertex_deg_map[std::size_t(vi)];
+        std::size_t deg = spheres->vertex_degree(vi);
         QColor c = colors[deg];
         typedef unsigned char UC;
         spheres->setColor(CGAL::Color(UC(c.red()), 
                                       UC(c.green()), 
                                       UC(c.blue())), 
-                          vertex_sphere_map[std::size_t(vi)]);
+                          spheres->sphere_id(vi));
       }
     }
-    if(std::size_t(sel_v) < vertex_has_sphere_map.size()
-       && vertex_has_sphere_map[std::size_t(sel_v)])
+    if(std::size_t(sel_v) < spheres->parent()->face_graph()->number_of_vertices()
+       && spheres->vertex_has_sphere(sel_v))
     {
       typedef unsigned char UC;
       spheres->setColor(CGAL::Color(UC(selection_color.red()), 
                                     UC(selection_color.green()), 
                                     UC(selection_color.blue())), 
-                        vertex_sphere_map[std::size_t(sel_v)]);
+                        spheres->sphere_id(sel_v));
     }   
     spheres->invalidateOpenGLBuffers();
     spheres->redraw();
@@ -211,7 +218,7 @@ void Colored_spheres_plugin::invalidateDisplay(bool update_spheres)
   QApplication::restoreOverrideCursor();
 }
 
-QColor Colored_spheres_plugin::changeDegree(std::size_t vid, bool& ok)
+QColor Colored_spheres_plugin::changeDegree(SMesh::Vertex_index vi, bool& ok)
 {
   int new_deg = QInputDialog::getInt(mw, "Add a new degree", "Degree:", 3, 1, 100, 1, &ok);
   if(!ok)
@@ -231,7 +238,7 @@ QColor Colored_spheres_plugin::changeDegree(std::size_t vid, bool& ok)
     colors[new_deg] = color;
     color = colors[new_deg];
   }
-  vertex_deg_map[vid]=new_deg;
+  spheres->set_vertex_degree(vi, new_deg);
   invalidateDisplay();
   ok = true;
   return color;
@@ -244,9 +251,6 @@ void Colored_spheres_plugin::pop()
   if(!smitem)
     return;
   SMesh& mesh = *smitem->face_graph();
-  vertex_sphere_map.resize(vertices(mesh).size());
-  vertex_deg_map.resize(vertex_sphere_map.size());
-  vertex_has_sphere_map.resize(vertex_sphere_map.size(), false);
   double radius = 0.3 * CGAL::compute_average_spacing<CGAL::Sequential_tag>(mesh.points(), 3);
   Colored_spheres_item* spheres = new Colored_spheres_item(smitem, radius);
   QColor c;
@@ -254,21 +258,21 @@ void Colored_spheres_plugin::pop()
   BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
   {
     std::size_t deg = smitem->face_graph()->degree(vi);
-    vertex_deg_map[std::size_t(vi)] = deg;
+    spheres->set_vertex_degree(vi, deg);
     if(deg > max_deg)
       max_deg = deg;
   }
   colors.resize(max_deg + 1);
   BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
   {
-    std::size_t deg = vertex_deg_map[std::size_t(vi)];
+    std::size_t deg = spheres->vertex_degree(vi);
     if(deg != 4)
     {
       c = spheres->color();
       c = QColor::fromHsv((c.hue()+ 55*deg)%360, (deg*25)%155+100,c.lightness(), c.alpha());
       colors[deg] = c;
-      vertex_sphere_map[std::size_t(vi)] = spheres->numberOfSpheres();
-      vertex_has_sphere_map[std::size_t(vi)] = true;
+      spheres->set_sphere_id(vi, spheres->numberOfSpheres());
+      spheres->set_vertex_has_sphere(vi, true);
       const CGAL::qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
       const EPICK::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
       EPICK::Point_3 center(mesh.point(vi) + offset);
@@ -287,23 +291,25 @@ void Colored_spheres_plugin::pop()
   scene->addItem(spheres);
   this->spheres = spheres;
   
-  connect(&k_ring_selector, SIGNAL(selected(const std::set<fg_vertex_descriptor>&)), this,
-          SLOT(selected(const std::set<fg_vertex_descriptor>&)));
-  k_ring_selector.init(smitem, mw, Scene_facegraph_item_k_ring_selection::Active_handle::VERTEX, -1);
-  k_ring_selector.k_ring = 0;
+  connect(spheres, SIGNAL(selected(const SMesh::Vertex_index&)), this,
+          SLOT(selected(const SMesh::Vertex_index&)));
+  connect(smitem, SIGNAL(selected_vertex(void*)), this, SLOT(vertex_has_been_selected(void*)));
+  mw->installEventFilter(spheres);
+  CGAL::QGLViewer::QGLViewerPool().first()->installEventFilter(spheres);
+  
 }
 
-void Colored_spheres_plugin::selected(const std::set<fg_vertex_descriptor> &m)
+void Colored_spheres_plugin::selected(const SMesh::Vertex_index &vi)
 {
-  sel_v = *m.begin();
+  sel_v = vi;
   static bool is_one_currently_selected = false;
   static std::size_t id = INVALID_ID;
   if(!is_one_currently_selected)
   {
-    if(!vertex_has_sphere_map[std::size_t(sel_v)])
+    if(!spheres->vertex_has_sphere(sel_v))
       return;
     else
-      id = vertex_sphere_map[std::size_t(sel_v)];
+      id = spheres->sphere_id(sel_v);
     typedef unsigned char UC;
     spheres->setColor(CGAL::Color(UC(selection_color.red()), 
                                   UC(selection_color.green()), 
@@ -315,20 +321,20 @@ void Colored_spheres_plugin::selected(const std::set<fg_vertex_descriptor> &m)
   else
   {
     if(sel_v != last_v 
-       && vertex_has_sphere_map[std::size_t(sel_v)])
+       && spheres->vertex_has_sphere(sel_v))
     {
       QMessageBox::warning(mw, "Warning", "Cannot overwrite an existing sphere.");
       return;
     }
     bool ok;
-    QColor c = changeDegree(std::size_t(sel_v), ok);
+    QColor c = changeDegree(sel_v, ok);
     if(!ok)
       return;
-    spheres->setCenter(k_ring_selector.poly_item->polyhedron()->point(SMesh::Vertex_index(sel_v)), id);
-    vertex_sphere_map[std::size_t(last_v)] = INVALID_ID;
-    vertex_has_sphere_map[std::size_t(last_v)] = false;
-    vertex_sphere_map[std::size_t(sel_v)] = id;
-    vertex_has_sphere_map[std::size_t(sel_v)] = true;
+    spheres->setCenter(spheres->parent()->face_graph()->point(SMesh::Vertex_index(sel_v)), id);
+    spheres->set_sphere_id(last_v, INVALID_ID);
+    spheres->set_vertex_has_sphere(last_v, false);
+    spheres->set_sphere_id(sel_v, id);
+    spheres->set_vertex_has_sphere(sel_v, true);
     typedef unsigned char UC;
     spheres->setColor(CGAL::Color(UC(c.red()),UC(c.green()),UC(c.blue())), id);
     is_one_currently_selected = false;
@@ -337,6 +343,7 @@ void Colored_spheres_plugin::selected(const std::set<fg_vertex_descriptor> &m)
   spheres->invalidateOpenGLBuffers();
   spheres->redraw();
 }
+
 void Colored_spheres_plugin::changeColor()
 {
   QPushButton* sender_button = qobject_cast<QPushButton*>(sender());
@@ -382,16 +389,25 @@ void Colored_spheres_plugin::changeColor()
   invalidateDisplay(true);
 }
 
+void Colored_spheres_plugin::vertex_has_been_selected(void* void_ptr)
+{
+  SMesh::Vertex_index  vi= SMesh::Vertex_index(static_cast<std::size_t>(reinterpret_cast<std::size_t>(void_ptr)));
+  selected(vi);
+}
 //   I t e m - D e f i n i t i o n s
 Colored_spheres_item::Colored_spheres_item(Scene_surface_mesh_item *parent, double radius)
   :Scene_spheres_item(NULL),
-    parent(parent),
+    _parent(parent),
     radius(radius)
 {
   radius_slider = new QSlider(Qt::Horizontal);
   radius_slider->setMinimum(1);
   radius_slider->setValue(100);
   radius_slider->setMaximum(200);  
+  SMesh& mesh = *parent->face_graph();
+  vertex_sphere_map.resize(vertices(mesh).size());
+  vertex_deg_map.resize(vertex_sphere_map.size());
+  vertex_has_sphere_map.resize(vertex_sphere_map.size(), false);
 }
 
 QMenu* Colored_spheres_item::contextMenu()
@@ -431,8 +447,48 @@ void Colored_spheres_item::resize_spheres()
   }
 }
 
-void Colored_spheres_item::select(double orig_x, double orig_y, double orig_z, double dir_x, double dir_y, double dir_z)
+bool Colored_spheres_item::eventFilter(QObject *obj, QEvent *event)
 {
-  parent->select(orig_x, orig_y, orig_z, dir_x, dir_y, dir_z); 
+  if(!visible())
+    return false;
+  CGAL::Three::Viewer_interface* viewer = qobject_cast<CGAL::Three::Viewer_interface*>(obj);
+  if(!viewer)
+    return false;
+  if(event->type() == QEvent::MouseButtonPress)
+  {
+    QMouseEvent* e = static_cast<QMouseEvent*>(event);
+    if(e->modifiers() == Qt::ShiftModifier)
+    {
+      bool found = false;
+      viewer->makeCurrent();
+      Vec p = viewer->camera()->pointUnderPixel(e->pos(), found);
+      const Vec offset = viewer->offset();
+      if(!found)
+        return false;
+      Kernel::Point_3 picked_point(p.x - offset.x, p.y - offset.y , p.z - offset.z);
+      
+      double min_dist = std::numeric_limits<double>::max();
+      SMesh::Vertex_index closest_vertex;
+      BOOST_FOREACH(SMesh::Vertex_index vi, vertices(*_parent->face_graph()))
+      {
+        if(vertex_has_sphere_map[std::size_t(vi)])
+        {
+          double dist = CGAL::squared_distance(_parent->face_graph()->
+                                               point(vi), picked_point);
+          if(dist < min_dist)
+          {
+            min_dist = dist;
+            closest_vertex = vi;
+          }
+        }
+      }
+      if(min_dist > 1.0001 * radius * (radius_slider->value()/100.0)
+         || min_dist < 0.0099 * radius * (radius_slider->value()/100.0))
+        return false;
+      selected(closest_vertex);
+      return true;
+    }
+  }
+  return false;
 }
 #include "Colored_spheres_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
@@ -12,6 +12,7 @@
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>
+#include <QMessageBox>
 #include <QSlider>
 #include <QHBoxLayout>
 #include <QMenu>
@@ -25,6 +26,7 @@
 #include "ui_Color_spheres_widget.h"
 
 using namespace CGAL::Three;
+std::size_t INVALID_ID = static_cast<std::size_t>(-1);
 
 //   I t e m - C l a s s
 class Colored_spheres_item
@@ -99,16 +101,22 @@ public:
   }
 public Q_SLOTS:
   void pop();
-  void addColor();
-  void invalidateDisplay();
+  void invalidateDisplay(bool update_spheres = false);
   void selected(const std::set<fg_vertex_descriptor> &m);
+  void changeColor();
 private:
+  QColor changeDegree(size_t vid, bool &ok);
   DockWidget* dock_widget;
   QAction* actionBubbles;
-  mutable boost::unordered_map<fg_vertex_descriptor, std::size_t> vertex_sphere_map;
+  std::vector<std::size_t> vertex_sphere_map;
+  std::vector<bool> vertex_has_sphere_map;
+  fg_vertex_descriptor sel_v;
+  fg_vertex_descriptor last_v;
   std::vector<QColor> colors;
+  QColor selection_color;
   Colored_spheres_item* spheres;
   Scene_facegraph_item_k_ring_selection k_ring_selector;
+  std::vector<std::size_t> vertex_deg_map;
 }; // end Colored_spheres_plugin
 
 //   P l u g i n - D e f i n i t i o n s
@@ -124,10 +132,12 @@ void Colored_spheres_plugin::init(QMainWindow *mainWindow,
   dock_widget->setVisible(false); // do not show at the beginning
   addDockWidget(dock_widget);
   spheres = NULL;
+  selection_color = QColor(255,255,255);
 }
 
-void Colored_spheres_plugin::invalidateDisplay()
+void Colored_spheres_plugin::invalidateDisplay(bool update_spheres)
 {
+  QApplication::setOverrideCursor(Qt::WaitCursor);
   QGridLayout* layout = dock_widget->gridLayout;
   //clear existing layout
   if ( layout != NULL )
@@ -140,45 +150,91 @@ void Colored_spheres_plugin::invalidateDisplay()
     }
   }
   //fill it up again
+  QLabel* text = new QLabel(dock_widget);
+  text->setText(QString("selection"));
+  QPushButton* color_button = new QPushButton(dock_widget);
+  connect(color_button, &QPushButton::clicked,
+          this, &Colored_spheres_plugin::changeColor);
+  QPalette palette;
+  palette.setColor(QPalette::Button,selection_color);
+  color_button->setPalette(palette);
+  layout->addWidget(color_button, 0, 0);
+  layout->addWidget(text, 0, 1);
   for(std::size_t i = 0; i < colors.size(); ++i)
   {
     if(colors[i].isValid())
     {
       QLabel* text = new QLabel(dock_widget);
       text->setText(QString("degree: %1").arg(i));
-      QPushButton* color_button = new QPushButton(dock_widget);
+      color_button = new QPushButton(dock_widget);
+      connect(color_button, &QPushButton::clicked,
+              this, &Colored_spheres_plugin::changeColor);
       QPalette palette;
       palette.setColor(QPalette::Button,colors[i]);
       color_button->setPalette(palette);
-      layout->addWidget(color_button, i, 0);
-      layout->addWidget(text, i, 1);
+      layout->addWidget(color_button, i+1, 0);
+      layout->addWidget(text, i+1, 1);
     }
   }
   layout->setColumnStretch(0,0);
   layout->setColumnStretch(1,1);
+  if(update_spheres)
+  {
+    SMesh& mesh = *k_ring_selector.poly_item->face_graph();
+    BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
+    {
+      if(vertex_has_sphere_map[std::size_t(vi)])
+      {
+        std::size_t deg = vertex_deg_map[std::size_t(vi)];
+        QColor c = colors[deg];
+        typedef unsigned char UC;
+        spheres->setColor(CGAL::Color(UC(c.red()), 
+                                      UC(c.green()), 
+                                      UC(c.blue())), 
+                          vertex_sphere_map[std::size_t(vi)]);
+      }
+    }
+    if(std::size_t(sel_v) < vertex_has_sphere_map.size()
+       && vertex_has_sphere_map[std::size_t(sel_v)])
+    {
+      typedef unsigned char UC;
+      spheres->setColor(CGAL::Color(UC(selection_color.red()), 
+                                    UC(selection_color.green()), 
+                                    UC(selection_color.blue())), 
+                        vertex_sphere_map[std::size_t(sel_v)]);
+    }   
+    spheres->invalidateOpenGLBuffers();
+    spheres->redraw();
+  }
   
   dock_widget->update();
+  QApplication::restoreOverrideCursor();
 }
 
-void Colored_spheres_plugin::addColor()
+QColor Colored_spheres_plugin::changeDegree(std::size_t vid, bool& ok)
 {
-  int new_deg = QInputDialog::getInt(mw, "Add a new degree", "Degree:", 3);
-  if(new_deg < static_cast<int>(colors.size()))
-  {
-    if(colors[new_deg].isValid())
-    {
-      QMessageBox::warning(mw, "Warning", "This degree is already there.");
-      return;
-    }
-  }
-  else
+  int new_deg = QInputDialog::getInt(mw, "Add a new degree", "Degree:", 3, 1, 100, 1, &ok);
+  if(!ok)
+    return QColor();
+  if(new_deg >= static_cast<int>(colors.size()))
   {
     colors.resize(new_deg+1, QColor());
   }
   QColor color = spheres->color();
-  color = QColor::fromHsv((color.hue()+55*new_deg)%360, (new_deg*25)%155+100,color.lightness(), color.alpha());
-  colors[new_deg] = color;
+  if(colors[new_deg].isValid())
+  {
+    color = colors[new_deg];
+  }
+  else
+  {
+    color = QColor::fromHsv((color.hue()+55*new_deg)%360, (new_deg*25)%155+100,color.lightness(), color.alpha());
+    colors[new_deg] = color;
+    color = colors[new_deg];
+  }
+  vertex_deg_map[vid]=new_deg;
   invalidateDisplay();
+  ok = true;
+  return color;
 }
 
 void Colored_spheres_plugin::pop()
@@ -188,26 +244,31 @@ void Colored_spheres_plugin::pop()
   if(!smitem)
     return;
   SMesh& mesh = *smitem->face_graph();
-  double radius = 0.15 * CGAL::compute_average_spacing<CGAL::Sequential_tag>(mesh.points(), 3);
+  vertex_sphere_map.resize(vertices(mesh).size());
+  vertex_deg_map.resize(vertex_sphere_map.size());
+  vertex_has_sphere_map.resize(vertex_sphere_map.size(), false);
+  double radius = 0.3 * CGAL::compute_average_spacing<CGAL::Sequential_tag>(mesh.points(), 3);
   Colored_spheres_item* spheres = new Colored_spheres_item(smitem, radius);
   QColor c;
   std::size_t max_deg = 0;
   BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
   {
     std::size_t deg = smitem->face_graph()->degree(vi);
+    vertex_deg_map[std::size_t(vi)] = deg;
     if(deg > max_deg)
       max_deg = deg;
   }
   colors.resize(max_deg + 1);
   BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
   {
-    std::size_t deg = smitem->face_graph()->degree(vi);
+    std::size_t deg = vertex_deg_map[std::size_t(vi)];
     if(deg != 4)
     {
       c = spheres->color();
       c = QColor::fromHsv((c.hue()+ 55*deg)%360, (deg*25)%155+100,c.lightness(), c.alpha());
       colors[deg] = c;
-      vertex_sphere_map[fg_vertex_descriptor(vi)] = spheres->numberOfSpheres();
+      vertex_sphere_map[std::size_t(vi)] = spheres->numberOfSpheres();
+      vertex_has_sphere_map[std::size_t(vi)] = true;
       const CGAL::qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
       const EPICK::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
       EPICK::Point_3 center(mesh.point(vi) + offset);
@@ -222,8 +283,6 @@ void Colored_spheres_plugin::pop()
   spheres->setRenderingMode(Gouraud);
   //add colors to dock widget
   invalidateDisplay();
-  connect(dock_widget->pushButton, &QPushButton::clicked,
-          this, &Colored_spheres_plugin::addColor);
   dock_widget->show();
   scene->addItem(spheres);
   this->spheres = spheres;
@@ -236,13 +295,92 @@ void Colored_spheres_plugin::pop()
 
 void Colored_spheres_plugin::selected(const std::set<fg_vertex_descriptor> &m)
 {
-  fg_vertex_descriptor sel_v = *m.begin();
-  std::size_t id = vertex_sphere_map[sel_v];
-  spheres->setColor(CGAL::Color(255,255,255), id);
+  sel_v = *m.begin();
+  static bool is_one_currently_selected = false;
+  static std::size_t id = INVALID_ID;
+  if(!is_one_currently_selected)
+  {
+    if(!vertex_has_sphere_map[std::size_t(sel_v)])
+      return;
+    else
+      id = vertex_sphere_map[std::size_t(sel_v)];
+    typedef unsigned char UC;
+    spheres->setColor(CGAL::Color(UC(selection_color.red()), 
+                                  UC(selection_color.green()), 
+                                  UC(selection_color.blue())), 
+                      id);
+    last_v = sel_v;
+    is_one_currently_selected = true;
+  }
+  else
+  {
+    if(sel_v != last_v 
+       && vertex_has_sphere_map[std::size_t(sel_v)])
+    {
+      QMessageBox::warning(mw, "Warning", "Cannot overwrite an existing sphere.");
+      return;
+    }
+    bool ok;
+    QColor c = changeDegree(std::size_t(sel_v), ok);
+    if(!ok)
+      return;
+    spheres->setCenter(k_ring_selector.poly_item->polyhedron()->point(SMesh::Vertex_index(sel_v)), id);
+    vertex_sphere_map[std::size_t(last_v)] = INVALID_ID;
+    vertex_has_sphere_map[std::size_t(last_v)] = false;
+    vertex_sphere_map[std::size_t(sel_v)] = id;
+    vertex_has_sphere_map[std::size_t(sel_v)] = true;
+    typedef unsigned char UC;
+    spheres->setColor(CGAL::Color(UC(c.red()),UC(c.green()),UC(c.blue())), id);
+    is_one_currently_selected = false;
+    sel_v = SMesh::Vertex_index(INVALID_ID);
+  }
   spheres->invalidateOpenGLBuffers();
   spheres->redraw();
 }
-
+void Colored_spheres_plugin::changeColor()
+{
+  QPushButton* sender_button = qobject_cast<QPushButton*>(sender());
+  QGridLayout* layout = dock_widget->gridLayout;
+  QWidget* button;
+  bool found(false);
+  int r;
+  for(r = 0; r < layout->rowCount(); ++r)
+  {
+    QLayoutItem* litem = layout->itemAtPosition(r,0);
+    if(litem){
+      button = litem->widget();
+      if( button == sender_button)
+      {
+        found = true;
+        break;
+      }
+    }
+  }
+  if(!found)
+    return;
+  //case selection color
+  QColor new_color = QColorDialog::getColor();
+  if(!new_color.isValid())
+    return;
+  if(r == 0)
+  {
+    selection_color = new_color;
+  }
+  else
+  {
+    QString text = qobject_cast<QLabel*>(layout->itemAtPosition(r,1)->widget())->text();
+    QRegExp rx("(\\d+)");
+    QString res;
+    int start = text.indexOf(rx);
+    for(; start<text.length(); ++start)
+    {
+      res.append(text.at(start));
+    }
+    int deg = res.toInt();
+    colors[deg] = new_color;
+  }
+  invalidateDisplay(true);
+}
 
 //   I t e m - D e f i n i t i o n s
 Colored_spheres_item::Colored_spheres_item(Scene_surface_mesh_item *parent, double radius)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_plugin.cpp
@@ -1,0 +1,203 @@
+#include  <CGAL/Three/Scene_item.h>
+#include <CGAL/Three/Scene_interface.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Three/Polyhedron_demo_plugin_helper.h>
+#include "Scene_surface_mesh_item.h"
+#include "Scene_spheres_item.h"
+
+#include <CGAL/compute_average_spacing.h>
+
+#include <QAction>
+#include <QMainWindow>
+#include <QApplication>
+#include <QSlider>
+#include <QHBoxLayout>
+#include <QMenu>
+#include <QWidgetAction>
+#include <QLabel>
+#include <QPushButton>
+#include <QColorDialog>
+
+#include "ui_Color_spheres_widget.h"
+
+using namespace CGAL::Three;
+class Colored_spheres_item
+    :public Scene_spheres_item
+{
+  Q_OBJECT
+public :
+  Colored_spheres_item(Scene_group_item *parent, double radius);
+  ~Colored_spheres_item()
+  {
+    delete radius_slider;
+  }
+  // Indicates if rendering mode is supported
+  bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE {
+    return (m == Wireframe || m == Gouraud);
+  }
+  Scene_item* clone() const Q_DECL_OVERRIDE {return 0;}
+  QString toolTip() const Q_DECL_OVERRIDE {return QString();}
+  QMenu* contextMenu() Q_DECL_OVERRIDE;   
+  
+public Q_SLOTS:
+  void resize_spheres();
+  
+private:
+  QSlider* radius_slider;
+  double radius;
+};
+
+
+class DockWidget :
+    public QDockWidget,
+    public Ui::ColorSpheresWidget
+{
+public:
+  DockWidget(QString name, QWidget *parent)
+    :QDockWidget(name,parent)
+  {
+    setupUi(this);
+  }
+};
+
+
+class Colored_spheres_plugin :
+    public QObject,
+    public Polyhedron_demo_plugin_helper
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+  
+public:
+  void init(QMainWindow* mainWindow, CGAL::Three::Scene_interface* scene_interface, Messages_interface*);
+  QList<QAction*> actions() const {
+    return QList<QAction*>() << actionBubbles;
+  }
+  
+  bool applicable(QAction*) const {
+    Scene_surface_mesh_item* smitem = qobject_cast<Scene_surface_mesh_item*>(
+          scene->item(scene->mainSelectionIndex()));
+    if(smitem)
+      return true;
+    return false;
+  }
+  void closure()
+  {
+    //  dock_widget->hide();
+  }
+public Q_SLOTS:
+  void pop();
+private:
+  DockWidget* dock_widget;
+  QAction* actionBubbles;
+  mutable std::vector<SMesh::Vertex_index> vertices;
+  mutable std::set<QColor> colors;
+  //ColoredSpheresWidget* dock_widget;
+}; // end Colored_spheres_plugin
+
+
+void Colored_spheres_plugin::init(QMainWindow *mainWindow, 
+                                  Scene_interface *scene_interface, Messages_interface *)
+{
+  scene = scene_interface;
+  mw = mainWindow;
+  actionBubbles = new QAction(tr("Put Some Colors Inside Your Eyes"), mainWindow);
+  connect(actionBubbles, SIGNAL(triggered()),
+          this, SLOT(pop()));
+  dock_widget = new ColoredSpheresWidget("Bubbles Party", mw);
+  dock_widget->setVisible(false); // do not show at the beginning
+  addDockWidget(dock_widget);
+}
+
+void Colored_spheres_plugin::pop()
+{
+  Scene_surface_mesh_item* smitem = qobject_cast<Scene_surface_mesh_item*>(
+        scene->item(scene->mainSelectionIndex()));
+  if(!smitem)
+    return;
+  SMesh& mesh = *smitem->face_graph();
+  double radius = 0.15 * CGAL::compute_average_spacing<CGAL::Sequential_tag>(mesh.points(), 3);
+  Colored_spheres_item* spheres = new Colored_spheres_item(NULL, radius);
+  QColor c;
+  
+  BOOST_FOREACH(SMesh::Vertex_index vi, mesh.vertices())
+  {
+    std::size_t deg = smitem->face_graph()->degree(vi);
+    if(deg != 4)
+    {
+      c = spheres->color();
+      c = QColor::fromHsv((c.hue()+75*deg)%360, c.saturation(),c.lightness(), c.alpha());
+      colors.insert(c);
+      const CGAL::qglviewer::Vec v_offset = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
+      const EPICK::Vector_3 offset(v_offset.x, v_offset.y, v_offset.z);
+      EPICK::Point_3 center(mesh.point(vi) + offset);
+      
+      typedef unsigned char UC;
+      spheres->add_sphere(EPICK::Sphere_3(center, radius),
+                          CGAL::Color(UC(c.red()), UC(c.green()), UC(c.blue())));
+      vertices.push_back(vi);
+    }
+  }
+  spheres->invalidateOpenGLBuffers();
+  spheres->setName("Bubbles");
+  spheres->setRenderingMode(Gouraud);
+  //add colors to dock widget
+  BOOST_FOREACH(QColor col, colors)
+  {
+    QLabel * text = new QLabel(QString("degree: "));
+    QPushButton* color_button = new QPushButton();
+    
+  }
+  dock_widget->show();
+  scene->addItem(spheres);
+}
+
+Colored_spheres_item::Colored_spheres_item(Scene_group_item *parent, double radius)
+  :Scene_spheres_item(parent),
+    radius(radius)
+{
+  radius_slider = new QSlider(Qt::Horizontal);
+  radius_slider->setMinimum(1);
+  radius_slider->setValue(100);
+  radius_slider->setMaximum(200);
+}
+
+QMenu* Colored_spheres_item::contextMenu()
+{
+  const char* prop_name = "Menu modified by Scene_points_with_normal_item.";
+  
+  QMenu* menu = Scene_item::contextMenu();
+  
+  //add a slider to modify the normals length
+  // Use dynamic properties:
+  // http://doc.qt.io/qt-5/qobject.html#property
+  bool menuChanged = menu->property(prop_name).toBool();
+  
+  if(!menuChanged) {
+    QMenu *container = new QMenu(tr("Bubbles Size"));
+    QWidgetAction *sliderAction = new QWidgetAction(0);
+    connect(radius_slider, &QSlider::sliderReleased, this, &Colored_spheres_item::resize_spheres);
+    
+    sliderAction->setDefaultWidget(radius_slider);
+    
+    container->addAction(sliderAction);
+    menu->addMenu(container);
+    
+    menu->setProperty(prop_name, true);
+  }
+  
+  return menu;
+}
+
+void Colored_spheres_item::resize_spheres()
+{
+  for(std::size_t i = 0; i< numberOfSpheres(); ++i)
+  {
+    setRadius(radius * (radius_slider->value()/100.0),i);
+    invalidateOpenGLBuffers();
+    redraw();
+  }
+}
+
+#include "Colored_spheres_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Colored_spheres_widget.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BubbleWidget</class>
+ <widget class="QDockWidget" name="BubbleWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>469</width>
+    <height>365</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>469</width>
+    <height>19</height>
+   </size>
+  </property>
+  <property name="acceptDrops">
+   <bool>false</bool>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <property name="floating">
+   <bool>false</bool>
+  </property>
+  <property name="features">
+   <set>QDockWidget::AllDockWidgetFeatures</set>
+  </property>
+  <property name="windowTitle">
+   <string>Bubbles</string>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -287,6 +287,14 @@ void Scene_spheres_item::setColor(const CGAL::Color& color, const std::size_t& s
   
 }
 
+void Scene_spheres_item::setCenter(const Kernel::Point_3 &center, const size_t &sphere_id)
+{
+  CGAL_assertion(sphere_id < d->radius.size());
+  d->centers[3*sphere_id]   = center.x();
+  d->centers[3*sphere_id+1] = center.y();
+  d->centers[3*sphere_id+2] = center.z();
+}
+
 std::size_t Scene_spheres_item::numberOfSpheres()
 {
   return d->radius.size();

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -165,14 +165,6 @@ void Scene_spheres_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *v
   program->release();
 
   nb_centers = static_cast<int>(centers.size());
-  centers.clear();
-  centers.swap(centers);
-  colors.clear();
-  colors.swap(colors);
-  radius.clear();
-  radius.swap(radius);
-  edges_colors.clear();
-  edges_colors.swap(edges_colors);
 
   item->are_buffers_filled = true;
 }
@@ -274,4 +266,28 @@ void Scene_spheres_item::setColor(QColor c)
 {
   CGAL::Three::Scene_item::setColor(c);
   this->on_color_changed();
+}
+
+void Scene_spheres_item::setRadius(const double& radius, const std::size_t& sphere_id)
+{
+  CGAL_assertion(sphere_id < d->radius.size());
+  d->radius[sphere_id] = radius;
+}
+
+void Scene_spheres_item::setColor(const CGAL::Color& color, const std::size_t& sphere_id)
+{
+  CGAL_assertion(sphere_id < d->radius.size());
+  d->colors[3*sphere_id]   = (float)color.red()/255;
+  d->colors[3*sphere_id+1] = (float)color.green()/255;
+  d->colors[3*sphere_id+2] = (float)color.blue()/255;
+
+  d->edges_colors[3*sphere_id]   = (float)color.red()/255;
+  d->edges_colors[3*sphere_id+1] = (float)color.green()/255;
+  d->edges_colors[3*sphere_id+2] = (float)color.blue()/255;
+  
+}
+
+std::size_t Scene_spheres_item::numberOfSpheres()
+{
+  return d->radius.size();
 }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -38,14 +38,16 @@ public:
   void add_sphere(const CGAL::Sphere_3<Kernel> &sphere, CGAL::Color = CGAL::Color(120,120,120));
   void clear_spheres();
   void setPrecision(int prec);
+  void setRadius(const double& radius, const std::size_t& sphere_id);
+  void setColor(const CGAL::Color& color, const std::size_t& sphere_id);
 
   void draw(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
   void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
   void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
-  void computeElements() const;
   void setPlane(Kernel::Plane_3 p_plane);
   void setToolTip(QString s);
   void setColor(QColor c) Q_DECL_OVERRIDE;
+  std::size_t numberOfSpheres();
 Q_SIGNALS:
   void on_color_changed();
 protected:

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -40,7 +40,7 @@ public:
   void setPrecision(int prec);
   void setRadius(const double& radius, const std::size_t& sphere_id);
   void setColor(const CGAL::Color& color, const std::size_t& sphere_id);
-
+  void setCenter(const Kernel::Point_3& center, const std::size_t& sphere_id);
   void draw(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
   void drawEdges(CGAL::Three::Viewer_interface* viewer) const Q_DECL_OVERRIDE;
   void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;

--- a/Three/doc/Three/Three.txt
+++ b/Three/doc/Three/Three.txt
@@ -124,6 +124,9 @@ Add it to the project in the CMakeLists.txt :
     qt5_wrap_ui( dockUI_FILES Basic_dock_widget.ui )
     polyhedron_demo_plugin(dock_widget_plugin Dock_widget_plugin ${dockUI_FILES})
 
+\attention If you are using a version ssuperior to 4.5 of QtCreator, you will need to manually add 
+<widget class="QWidget" name="dockWidgetContents"/> to the .ui file, under the declaration of the QDockWidget, to be able to edit it.
+
 Edit the ui file with the editor, then add the following line to your plugin file:
 ~~~~~~~~~~~~~{.cpp}
     #include "ui_Basic_dock_widget.h"


### PR DESCRIPTION
## Summary of Changes
This adds a plugin that displays spheres with color depending on the degree of the corresponding vertex on the targeted surface_mesh. It is possible to change the color associated with a degree, and to move the spheres.
