### PR TITLE
Polyhedron demo : Change the sizing preferency for DockWidgets

### DIFF
--- a/Polyhedron/demo/Polyhedron/Polyhedron_demo_plugin_helper.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_demo_plugin_helper.cpp
@@ -8,7 +8,7 @@
 void CGAL::Three::Polyhedron_demo_plugin_helper::addDockWidget(QDockWidget* dock_widget)
 {
   mw->addDockWidget(::Qt::LeftDockWidgetArea, dock_widget);
-  dock_widget->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed));
+  dock_widget->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred));
 
   QList<QDockWidget*> dockWidgets = mw->findChildren<QDockWidget*>();
   int counter = 0;


### PR DESCRIPTION
## Summary of Changes

As it is quite hard to reproduce twice the same bug, I cannot be sure, but this seems to improve the dock widgets management.
## Release Management

* Affected package(s):Three

