### PR TITLE
Add missing constructor for unsigned int

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/BigFloat.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloat.h
@@ -58,6 +58,8 @@ public:
   BigFloat(float i) : RCBigFloat(new BigFloatRep(i)) {}
   /// constructor for <tt>int</tt>
   BigFloat(int i) : RCBigFloat(new BigFloatRep(i)) {}
+  /// constructor for <tt>unsigned int</tt>
+  BigFloat(unsigned int i) : RCBigFloat(new BigFloatRep(i)) {}
   /// constructor for <tt>long</tt>
   BigFloat(long l) : RCBigFloat(new BigFloatRep(l)) {}
   /// constructor for <tt>double</tt>

--- a/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
@@ -70,6 +70,7 @@ public:
 public:
   //  constructors
   BigFloatRep(int=0);           //inline
+  BigFloatRep(unsigned int);           //inline
   BigFloatRep(short);           //inline
   BigFloatRep(float);           //inline
   BigFloatRep(long);          //inline
@@ -246,6 +247,9 @@ inline BigFloatRep::BigFloatRep(float n)
 
 //  Chee (8/8/04) -- introduced constructor from int
 inline BigFloatRep::BigFloatRep(int n)
+  : m(n), err(0), exp(0) {}
+
+inline BigFloatRep::BigFloatRep(unsigned int n)
   : m(n), err(0), exp(0) {}
 
 //  Chee (8/8/04) -- introduced constructor from long


### PR DESCRIPTION
`BigInt` has a constructor from unsigned int but BigFloat hasn't. 

Pb reported on cgal-discuss