### PR TITLE
Kernel_23: Fix some doc issue with weighted points

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Point_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Point_2.h
@@ -196,8 +196,7 @@ returns the dimension (the constant 2).
 int dimension() const;
 
 /*!
-returns a bounding box containing `p`. Note that bounding boxes
-are not parameterized with whatsoever.
+returns a bounding box containing `p`.
 */
 Bbox_2 bbox() const;
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_2.h
@@ -101,16 +101,6 @@ public:
   */
   bool operator!=(const Weighted_point_2<Kernel> &q) const;
 
-  /*!
-  translates the point by the vector `v`.
-  */
-  Weighted_point_2<Kernel>& operator+=(const Vector_2<Kernel> &v);
-
-  /*!
-  translates the point by the vector -`v`.
-  */
-  Weighted_point_2<Kernel>& operator-=(const Vector_2<Kernel> &v);
-
   /// @}
 
   /// \name Coordinate Access

--- a/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_2.h
@@ -180,8 +180,7 @@ public:
   int dimension() const;
 
   /*!
-  returns a bounding box containing `p`. Note that bounding boxes
-  are not parameterized with whatsoever.
+  returns a bounding box containing `p`.
   */
   Bbox_2 bbox() const;
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_3.h
@@ -101,16 +101,6 @@ public:
   */
   bool operator!=(const Weighted_point_3<Kernel> &q) const;
 
-  /*!
-  translates the point by the vector `v`.
-  */
-  Weighted_point_3<Kernel>& operator+=(const Vector_3<Kernel> &v);
-
-  /*!
-  translates the point by the vector -`v`.
-  */
-  Weighted_point_3<Kernel>& operator-=(const Vector_3<Kernel> &v);
-
   /// @}
 
   /// \name Coordinate Access

--- a/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Weighted_point_3.h
@@ -190,8 +190,7 @@ public:
   int dimension() const;
 
   /*!
-  returns a bounding box containing `p`. Note that bounding boxes
-  are not parameterized with whatsoever.
+  returns a bounding box containing `p`.
   */
   Bbox_3 bbox() const;
 

--- a/Kernel_23/include/CGAL/Weighted_point_3.h
+++ b/Kernel_23/include/CGAL/Weighted_point_3.h
@@ -91,62 +91,62 @@ public:
     : Rep(typename R::Construct_weighted_point_3()(Return_base_tag(), x, y, z))
   {}
 
-  typename cpp11::result_of<typename R::Construct_point_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Construct_point_3(Weighted_point_3)>::type
   point() const
   {
     return typename R::Construct_point_3()(*this);
   }
 
-  typename cpp11::result_of<typename R::Compute_weight_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_weight_3(Weighted_point_3)>::type
   weight() const
   {
     return typename R::Compute_weight_3()(*this);
   }
 
 
-  typename cpp11::result_of<typename R::Compute_x_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_x_3(Point_3)>::type
   x() const
   {
     return typename R::Compute_x_3()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_y_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_y_3(Point_3)>::type
   y() const
   {
     return typename R::Compute_y_3()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_z_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_z_3(Point_3)>::type
   z() const
   {
     return typename R::Compute_z_3()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_hx_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_hx_3(Point_3)>::type
   hx() const
   {
     return R().compute_hx_3_object()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_hy_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_hy_3(Point_3)>::type
   hy() const
   {
     return R().compute_hy_3_object()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_hz_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_hz_3(Point_3)>::type
   hz() const
   {
     return R().compute_hz_3_object()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_hw_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_hw_3(Point_3)>::type
   hw() const
   {
     return R().compute_hw_3_object()(point());
   }
 
-  typename cpp11::result_of<typename R::Compute_x_3( Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_x_3(Point_3)>::type
   cartesian(int i) const
   {
     CGAL_kernel_precondition( (i == 0) || (i == 1) || (i == 2) );
@@ -165,7 +165,7 @@ public:
     return hw();
   }
 
-  typename cpp11::result_of<typename R::Compute_x_3(Weighted_point_3)>::type
+  typename cpp11::result_of<typename R::Compute_x_3(Point_3)>::type
   operator[](int i) const
   {
       return cartesian(i);


### PR DESCRIPTION
## Summary of Changes

The documentation says we can translate weighted points using `operator+(Vector_3)`. In practice, we can't. I'm not too sure about adding overloads for weighted points of predicates/constructions meant to act on (bare) points (see [this comment](https://github.com/CGAL/cgal/issues/3167#issuecomment-396617477)), so the doc is changed instead.

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): fix #3167
* Feature/Small Feature (if any):

