### PR TITLE
STL_Extension: move CGAL::iterator and CGAL::unary/binary functions to CGAL::cpp98::

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -2313,7 +2313,7 @@ namespace CGAL {
     }
 
 
-    struct Remove : public CGAL::unary_function<Vertex_handle, bool>
+    struct Remove : public CGAL::cpp98::unary_function<Vertex_handle, bool>
     {
 
       Extract& E;
@@ -2451,7 +2451,7 @@ namespace CGAL {
   namespace AFSR {
 
     template <typename T>
-    struct Auto_count : public CGAL::unary_function<const T&,std::pair<T,std::size_t> >{
+    struct Auto_count : public CGAL::cpp98::unary_function<const T&,std::pair<T,std::size_t> >{
       mutable std::size_t i;
 
       Auto_count()
@@ -2464,7 +2464,7 @@ namespace CGAL {
     };
 
     template <typename T, typename CC>
-    struct Auto_count_cc : public CGAL::unary_function<const T&,std::pair<T,std::size_t> >{
+    struct Auto_count_cc : public CGAL::cpp98::unary_function<const T&,std::pair<T,std::size_t> >{
       mutable std::size_t i;
       CC cc;
 

--- a/Algebraic_foundations/include/CGAL/Algebraic_extension_traits.h
+++ b/Algebraic_foundations/include/CGAL/Algebraic_extension_traits.h
@@ -47,7 +47,7 @@ public:
     //! computes the factor which normalizes a number to be integral after 
     //  multiplication
     class Normalization_factor 
-        : public CGAL::unary_function<Type,Type> {
+        : public CGAL::cpp98::unary_function<Type,Type> {
     private:
         static Type 
         normalization_factor(const Type&,Integral_domain_without_division_tag){
@@ -68,7 +68,7 @@ public:
     };
     
     class Denominator_for_algebraic_integers 
-        : public CGAL::unary_function<Type,Type> {
+        : public CGAL::cpp98::unary_function<Type,Type> {
     public: 
         //! determine normalization factor
         Type operator () (const Type&) {

--- a/Algebraic_foundations/include/CGAL/Algebraic_structure_traits.h
+++ b/Algebraic_foundations/include/CGAL/Algebraic_structure_traits.h
@@ -112,7 +112,7 @@ class Algebraic_structure_traits_base< Type_, Null_tag > {
 
     // does nothing by default
     class Simplify 
-      : public CGAL::unary_function< Type&, void > {
+      : public CGAL::cpp98::unary_function< Type&, void > {
       public:
         void operator()( Type& ) const {}
     };
@@ -151,7 +151,7 @@ class Algebraic_structure_traits_base< Type_,
 
     // returns Type(1) by default
     class Unit_part 
-      : public CGAL::unary_function< Type, Type > { 
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return( x < Type(0)) ? 
@@ -160,7 +160,7 @@ class Algebraic_structure_traits_base< Type_,
     };
     
     class Square 
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:        
         Type operator()( const Type& x ) const {
           return x*x;
@@ -168,7 +168,7 @@ class Algebraic_structure_traits_base< Type_,
     };
     
     class Is_zero 
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:        
         bool operator()( const Type& x ) const {
           return x == Type(0);
@@ -176,7 +176,7 @@ class Algebraic_structure_traits_base< Type_,
     };
 
     class Is_one 
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:        
         bool operator()( const Type& x ) const {
           return x == Type(1);
@@ -221,7 +221,7 @@ class Algebraic_structure_traits_base< Type_,
   // Default implementation of Divides functor for unique factorization domains
   // x divides y if gcd(y,x) equals x up to inverses 
   class Divides 
-    : public CGAL::binary_function<Type,Type,bool>{
+    : public CGAL::cpp98::binary_function<Type,Type,bool>{
   public:
     bool operator()( const Type& x,  const Type& y) const {  
       typedef CGAL::Algebraic_structure_traits<Type> AST;
@@ -257,7 +257,7 @@ class Algebraic_structure_traits_base< Type_,
 
     // maps to \c Div by default.
     class Integral_division 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > { 
       public:
         Type operator()( 
@@ -279,7 +279,7 @@ class Algebraic_structure_traits_base< Type_,
 
     // Algorithm from NiX/euclids_algorithm.h
     class Gcd 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > { 
       public:
         Type operator()( 
@@ -372,7 +372,7 @@ class Algebraic_structure_traits_base< Type_,
     
     // based on \c Div_mod.
     class Div 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x, 
@@ -390,7 +390,7 @@ class Algebraic_structure_traits_base< Type_,
 
     // based on \c Div_mod.
     class Mod 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > { 
       public:
         Type operator()( const Type& x, 
@@ -408,7 +408,7 @@ class Algebraic_structure_traits_base< Type_,
 
   // Divides for Euclidean Ring 
   class Divides 
-    : public CGAL::binary_function<Type, Type, bool>{
+    : public CGAL::cpp98::binary_function<Type, Type, bool>{
   public:
     bool operator()( const Type& x, const Type& y) const {
       typedef Algebraic_structure_traits<Type> AST;
@@ -448,7 +448,7 @@ class Algebraic_structure_traits_base< Type_, Field_tag >
 
     // returns the argument \a a by default
     class Unit_part 
-      : public CGAL::unary_function< Type, Type > { 
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return( x == Type(0)) ? Type(1) : x;
@@ -456,7 +456,7 @@ class Algebraic_structure_traits_base< Type_, Field_tag >
     };
     // maps to \c operator/ by default.
     class Integral_division 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > { 
       public:
         Type operator()( const Type& x, 
@@ -475,7 +475,7 @@ class Algebraic_structure_traits_base< Type_, Field_tag >
   
   // maps to \c 1/x by default.
   class Inverse 
-    : public CGAL::unary_function< Type, Type > { 
+    : public CGAL::cpp98::unary_function< Type, Type > {
   public:
     Type operator()( const Type& x ) const { 
       return Type(1)/x;
@@ -487,7 +487,7 @@ class Algebraic_structure_traits_base< Type_, Field_tag >
   // returns always true
   // \pre: x != 0
   class Divides
-    : public CGAL::binary_function< Type, Type, bool > {
+    : public CGAL::cpp98::binary_function< Type, Type, bool > {
   public:
     bool operator()( const Type& CGAL_precondition_code(x), const Type& /* y */) const {
       CGAL_precondition_code( typedef Algebraic_structure_traits<Type> AST);
@@ -523,7 +523,7 @@ class Algebraic_structure_traits_base< Type_,
     typedef Field_with_sqrt_tag   Algebraic_category;
 
     struct Is_square
-        :public CGAL::binary_function<Type,Type&,bool>
+        :public CGAL::cpp98::binary_function<Type,Type&,bool>
     {
         bool operator()(const Type& ) const {return true;}
         bool operator()(
@@ -580,7 +580,7 @@ class Algebraic_structure_traits_base< Type_,
 namespace INTERN_AST {
   template< class Type >
   class Div_per_operator 
-    : public CGAL::binary_function< Type, Type,
+    : public CGAL::cpp98::binary_function< Type, Type,
                               Type > {
     public:      
       Type operator()( const Type& x, 
@@ -593,7 +593,7 @@ namespace INTERN_AST {
   
   template< class Type >
   class Mod_per_operator 
-    : public CGAL::binary_function< Type, Type,
+    : public CGAL::cpp98::binary_function< Type, Type,
                               Type > {
     public:
       Type operator()( const Type& x, 
@@ -606,7 +606,7 @@ namespace INTERN_AST {
   
   template< class Type >
   class Is_square_per_sqrt
-    : public CGAL::binary_function< Type, Type&,
+    : public CGAL::cpp98::binary_function< Type, Type&,
                               bool > {
     public:      
       bool operator()( const Type& x, 

--- a/Algebraic_foundations/include/CGAL/Real_embeddable_traits.h
+++ b/Algebraic_foundations/include/CGAL/Real_embeddable_traits.h
@@ -37,7 +37,7 @@ struct  Is_zero_selector{ typedef AST_is_zero Type; };
 template< class T >
 struct Is_zero_selector< T, Null_functor >
 {
-  struct Type : public CGAL::unary_function< T, bool >{
+  struct Type : public CGAL::cpp98::unary_function< T, bool >{
     bool operator()( const T& x ) const {
       return x == T(0);
     }
@@ -81,7 +81,7 @@ public:
   Is_zero;
   
   //! The generic \c Is_finite functor returns true
-  class Is_finite : public CGAL::unary_function< Type, Boolean > {
+  class Is_finite : public CGAL::cpp98::unary_function< Type, Boolean > {
   public:
     Boolean operator()( const Type& ) const {
       return true;
@@ -91,7 +91,7 @@ public:
   //! The generic \c Abs functor implementation
   //! uses one comparisons and the unary minus if necessary.
   class Abs
-    : public CGAL::unary_function< Type, Type > {
+    : public CGAL::cpp98::unary_function< Type, Type > {
   public:
     //! the function call.
     Type  operator()( const Type& x ) const {
@@ -101,7 +101,7 @@ public:
     
   //! The generic \c Sgn functor implementation uses two comparisons.
   class Sgn 
-    : public CGAL::unary_function< Type, ::CGAL::Sign > {
+    : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
   public:
     //! the function call.
     ::CGAL::Sign operator()( const Type& x ) const {
@@ -115,7 +115,7 @@ public:
     
   //! The generic \c Is_positive functor implementation uses one comparison.
   class Is_positive 
-    : public CGAL::unary_function< Type, Boolean > {
+    : public CGAL::cpp98::unary_function< Type, Boolean > {
   public:        
     //! the function call.
     Boolean operator()( const Type& x ) const {
@@ -125,7 +125,7 @@ public:
     
   //! The generic \c Is_negative functor implementation uses one comparison.
   class Is_negative 
-    : public CGAL::unary_function< Type, Boolean > {
+    : public CGAL::cpp98::unary_function< Type, Boolean > {
   public:        
     //! the function call.
     Boolean operator()( const Type& x ) const {
@@ -135,7 +135,7 @@ public:
         
   //! The generic \c Compare functor implementation uses two comparisons.
   class Compare 
-    : public CGAL::binary_function< Type, Type,
+    : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
   public:
     //! the function call.
@@ -152,7 +152,7 @@ public:
         Comparison_result )
       };
   
-  class To_double : public CGAL::unary_function< Type, double > {     
+  class To_double : public CGAL::cpp98::unary_function< Type, double > {
   public:
     double operator()( const Type& x ) const {
       return static_cast<double>(x);
@@ -160,7 +160,7 @@ public:
   };
   
   class To_interval 
-    : public CGAL::unary_function< Type, std::pair<double,double> > {     
+    : public CGAL::cpp98::unary_function< Type, std::pair<double,double> > {
   public:
     std::pair<double,double> operator()( const Type& x ) const {
       double dx(static_cast<double>(x));

--- a/Algebraic_foundations/include/CGAL/number_utils_classes.h
+++ b/Algebraic_foundations/include/CGAL/number_utils_classes.h
@@ -102,7 +102,7 @@ struct Is_zero :
 namespace internal {
 template <class NT, class Compare> struct Compare_base: public Compare {};
 template <class NT> struct Compare_base<NT,Null_functor>
-  :public CGAL::binary_function< NT, NT, Comparison_result > {
+  :public CGAL::cpp98::binary_function< NT, NT, Comparison_result > {
   Comparison_result operator()( const NT& x, const NT& y) const
   {
     if (x < y) return SMALLER;

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -194,7 +194,7 @@ protected:
    
     //! polynomial canonicalizer, needed for the cache
     template <class Poly> 
-    struct Poly_canonicalizer : public CGAL::unary_function< Poly, Poly >
+    struct Poly_canonicalizer : public CGAL::cpp98::unary_function< Poly, Poly >
     {
     // use Polynomial_traits_d<>::Canonicalize ?
         Poly operator()(Poly p) 
@@ -356,7 +356,7 @@ public:
     // Composition of two unary functors
     template<typename InnerFunctor,typename OuterFunctor>
       class Unary_compose 
-      : public CGAL::unary_function<typename InnerFunctor::argument_type,
+      : public CGAL::cpp98::unary_function<typename InnerFunctor::argument_type,
                                    typename OuterFunctor::result_type> {
 				     
     public:
@@ -419,7 +419,7 @@ public:
      * when appropriate
      */
     class Construct_curve_2 :
-        public CGAL::unary_function< Polynomial_2, Curve_analysis_2 > {
+        public CGAL::cpp98::unary_function< Polynomial_2, Curve_analysis_2 > {
 
     public:
 
@@ -443,7 +443,7 @@ public:
      * caching is used when appropriate
      */
     class Construct_curve_pair_2 :
-            public CGAL::binary_function<Curve_analysis_2, Curve_analysis_2,
+            public CGAL::cpp98::binary_function<Curve_analysis_2, Curve_analysis_2,
                 Curve_pair_analysis_2> {
 
     public:
@@ -636,7 +636,7 @@ public:
 
     
     class Compute_polynomial_x_2 :
-      public CGAL::unary_function<Algebraic_real_2, Polynomial_1> {
+      public CGAL::cpp98::unary_function<Algebraic_real_2, Polynomial_1> {
 
     public:
 
@@ -656,7 +656,7 @@ public:
 			       compute_polynomial_x_2_object);
 
     class Compute_polynomial_y_2 :
-      public CGAL::unary_function<Algebraic_real_2, Polynomial_1> {
+      public CGAL::cpp98::unary_function<Algebraic_real_2, Polynomial_1> {
 
     public:
 
@@ -676,7 +676,7 @@ public:
 			       compute_polynomial_y_2_object);
 
 
-    class Isolate_x_2 : public CGAL::binary_function<Algebraic_real_2,
+    class Isolate_x_2 : public CGAL::cpp98::binary_function<Algebraic_real_2,
                                                     Polynomial_1,
                                                     std::pair<Bound,Bound> > {
       
@@ -699,7 +699,7 @@ public:
     CGAL_Algebraic_Kernel_cons(Isolate_x_2, 
 			       isolate_x_2_object);
 
-    class Isolate_y_2 : public CGAL::binary_function<Algebraic_real_2,
+    class Isolate_y_2 : public CGAL::cpp98::binary_function<Algebraic_real_2,
                                                     Polynomial_1,
                                                     std::pair<Bound,Bound> > {
       
@@ -887,7 +887,7 @@ public:
             
     //! returns the x-coordinate of an \c Algebraic_real_2 object
     class Compute_x_2 :
-        public CGAL::unary_function<Algebraic_real_2, Algebraic_real_1> {
+        public CGAL::cpp98::unary_function<Algebraic_real_2, Algebraic_real_1> {
 
     public:
 
@@ -922,7 +922,7 @@ public:
      * return approximation of the y-coordinate. 
      */
     class Compute_y_2 :
-        public CGAL::unary_function<Algebraic_real_2, Algebraic_real_1> {
+        public CGAL::cpp98::unary_function<Algebraic_real_2, Algebraic_real_1> {
         
     public:
         
@@ -945,7 +945,7 @@ public:
 #endif
 
     class Approximate_absolute_x_2 
-    : public CGAL::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
+    : public CGAL::cpp98::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
     
     public:
 
@@ -968,7 +968,7 @@ public:
                                approximate_absolute_x_2_object);
 
     class Approximate_relative_x_2 
-    : public CGAL::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
+    : public CGAL::cpp98::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
     
     public:
         
@@ -990,7 +990,7 @@ public:
                                approximate_relative_x_2_object);
 
     class Approximate_absolute_y_2 
-    : public CGAL::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
+    : public CGAL::cpp98::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
 
     public:
 
@@ -1020,7 +1020,7 @@ public:
                                approximate_absolute_y_2_object);
 
     class Approximate_relative_y_2 
-    : public CGAL::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
+    : public CGAL::cpp98::binary_function<Algebraic_real_2,int,std::pair<Bound,Bound> >{
         
     public:
         
@@ -1171,7 +1171,7 @@ public:
     
     //! \brief comparison of x-coordinates 
     class Compare_x_2 :
-         public CGAL::binary_function<Algebraic_real_2, Algebraic_real_2,
+         public CGAL::cpp98::binary_function<Algebraic_real_2, Algebraic_real_2,
                                       Comparison_result > {
 
     public:
@@ -1264,7 +1264,7 @@ public:
      * If possible, it is recommended to avoid this functor for efficiency.}
      */
     class Compare_y_2 :
-        public CGAL::binary_function< Algebraic_real_2, Algebraic_real_2,
+        public CGAL::cpp98::binary_function< Algebraic_real_2, Algebraic_real_2,
                 Comparison_result > {
     
     public:
@@ -1376,7 +1376,7 @@ public:
      * to have equal x-coordinates, thus only the y-coordinates are compared.
      */
     class Compare_xy_2 :
-          public CGAL::binary_function<Algebraic_real_2, Algebraic_real_2,
+          public CGAL::cpp98::binary_function<Algebraic_real_2, Algebraic_real_2,
                 Comparison_result > {
 
     public:
@@ -1507,7 +1507,7 @@ public:
      * the polynomial \c p is square free.
      */
     class Has_finite_number_of_self_intersections_2 :
-            public CGAL::unary_function< Polynomial_2, bool > {
+            public CGAL::cpp98::unary_function< Polynomial_2, bool > {
         
     public:
 
@@ -1536,7 +1536,7 @@ public:
      * the two polynomials \c f and \c g are coprime.
      */ 
     class Has_finite_number_of_intersections_2 :
-        public CGAL::binary_function< Polynomial_2, Polynomial_2, bool > {
+        public CGAL::cpp98::binary_function< Polynomial_2, Polynomial_2, bool > {
          
     public:
 
@@ -1720,7 +1720,7 @@ public:
     //! Non-Algebraic name
     typedef Algebraic_real_2 Coordinate_2;
 
-    class Is_square_free_2 : public CGAL::unary_function<Polynomial_2,bool> {
+    class Is_square_free_2 : public CGAL::cpp98::unary_function<Polynomial_2,bool> {
 
     public:
 
@@ -1742,7 +1742,7 @@ public:
     typedef Has_finite_number_of_intersections_2 Is_coprime_2;
     CGAL_Algebraic_Kernel_cons(Is_coprime_2, is_coprime_2_object);
 
-    class Make_square_free_2 : public CGAL::unary_function<Polynomial_2,
+    class Make_square_free_2 : public CGAL::cpp98::unary_function<Polynomial_2,
                                                           Polynomial_2> {
 
     public:
@@ -1807,7 +1807,7 @@ public:
      * In pariticular, each singular point is x-critical.
      */
     class X_critical_points_2 : 
-        public CGAL::binary_function< Curve_analysis_2,
+        public CGAL::cpp98::binary_function< Curve_analysis_2,
             CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2>,
             CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2> > {
        
@@ -1886,7 +1886,7 @@ public:
      * In pariticular, each singular point is y-critical.
      */
     class Y_critical_points_2 :
-        public CGAL::binary_function< Curve_analysis_2,
+        public CGAL::cpp98::binary_function< Curve_analysis_2,
             CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2>,
             CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2> > {
         
@@ -1981,7 +1981,7 @@ public:
     // Overload the Sign_at_1 functor, to enable filter steps in the
     // Curve analysis in a coherent way
     class Sign_at_1 
-      : public::CGAL::binary_function<Polynomial_1,Algebraic_real_1,Sign> {
+      : public::CGAL::cpp98::binary_function<Polynomial_1,Algebraic_real_1,Sign> {
 
       
     public:
@@ -2058,7 +2058,7 @@ public:
      * curve. Returns a value convertible to \c CGAL::Sign
      */
     class Sign_at_2 :
-        public CGAL::binary_function<Polynomial_2, Algebraic_real_2, Sign > {
+        public CGAL::cpp98::binary_function<Polynomial_2, Algebraic_real_2, Sign > {
 
     public:
         
@@ -2154,7 +2154,7 @@ public:
     CGAL_Algebraic_Kernel_pred(Sign_at_2, sign_at_2_object);
 
     class Is_zero_at_2 
-      : public CGAL::binary_function<Polynomial_2,Algebraic_real_2,bool> {
+      : public CGAL::cpp98::binary_function<Polynomial_2,Algebraic_real_2,bool> {
     
     public:
       
@@ -2498,7 +2498,7 @@ public:
     CGAL_Algebraic_Kernel_cons(Solve_2, solve_2_object);
 
     class Number_of_solutions_2 
-      : public CGAL::binary_function<Polynomial_2,Polynomial_2,size_type> {
+      : public CGAL::cpp98::binary_function<Polynomial_2,Polynomial_2,size_type> {
     
     public:
       
@@ -2524,7 +2524,7 @@ public:
     // Functor used to evaluate a Polynomial_2 in a Bound, up to a
     // constant factor
     class Evaluate_utcf_2 
-      : public CGAL::binary_function<Polynomial_2,Bound,Polynomial_1> {
+      : public CGAL::cpp98::binary_function<Polynomial_2,Bound,Polynomial_1> {
     
     public:
       
@@ -2600,7 +2600,7 @@ public:
 
     //! Refines the x-coordinate of an Algebraic_real_2 object
     class Refine_x_2 :
-        public CGAL::unary_function<Algebraic_real_2, void> {
+        public CGAL::cpp98::unary_function<Algebraic_real_2, void> {
 
     public:
         
@@ -2624,7 +2624,7 @@ public:
     CGAL_Algebraic_Kernel_pred(Refine_x_2, refine_x_2_object);
     
     class Refine_y_2 :
-        public CGAL::unary_function<Algebraic_real_2, void> {
+        public CGAL::cpp98::unary_function<Algebraic_real_2, void> {
 
     public:
 

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -1808,8 +1808,8 @@ public:
      */
     class X_critical_points_2 : 
         public CGAL::binary_function< Curve_analysis_2,
-            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2>,
-            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2> > {
+            CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2>,
+            CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2> > {
        
     public:
         
@@ -1887,8 +1887,8 @@ public:
      */
     class Y_critical_points_2 :
         public CGAL::binary_function< Curve_analysis_2,
-            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2>,
-            CGAL::iterator<std::output_iterator_tag, Algebraic_real_2> > {
+            CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2>,
+            CGAL::cpp98::iterator<std::output_iterator_tag, Algebraic_real_2> > {
         
 
     public:

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_real_d_1.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_real_d_1.h
@@ -385,7 +385,7 @@ public:
   typedef internal::Algebraic_real_d_1< Coefficient, Rational, HandlePolicy, RepClass > Type;
 
   class Compare
-    : public CGAL::binary_function< Type, Type, CGAL::Comparison_result > {
+    : public CGAL::cpp98::binary_function< Type, Type, CGAL::Comparison_result > {
   public:
     CGAL::Comparison_result operator()( const Type& a, const Type& b ) const
     { return a.compare( b ); }
@@ -414,7 +414,7 @@ public:
   };
 
   class Sgn
-    : public CGAL::unary_function< Type, CGAL::Sign > {
+    : public CGAL::cpp98::unary_function< Type, CGAL::Sign > {
   public:
     CGAL::Sign operator()( const Type& a ) const {
       return a.compare( Rational(0) );
@@ -422,7 +422,7 @@ public:
   };
 
   class To_double
-    : public CGAL::unary_function< Type, double > {
+    : public CGAL::cpp98::unary_function< Type, double > {
   public:
     double operator()(const Type& a) const {
       return a.to_double();
@@ -430,7 +430,7 @@ public:
   };
 
   class To_interval
-    : public CGAL::unary_function< Type, std::pair<double, double> > {
+    : public CGAL::cpp98::unary_function< Type, std::pair<double, double> > {
   public:
     typename std::pair<double, double> operator()(const Type& a) const {
       return a.to_interval();

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Bitstream_coefficient_kernel.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Bitstream_coefficient_kernel.h
@@ -50,7 +50,7 @@ template <typename Coefficient_> struct Bitstream_coefficient_kernel {
         return Is_zero();
     }
 
-    struct Convert_to_bfi : public CGAL::unary_function
+    struct Convert_to_bfi : public CGAL::cpp98::unary_function
         <Coefficient,Bigfloat_interval> {
         
         Bigfloat_interval operator() (Coefficient c) const {

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Bitstream_coefficient_kernel_at_alpha.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Bitstream_coefficient_kernel_at_alpha.h
@@ -120,7 +120,7 @@ public:
     //! \name Functors
     //! @{
 
-    struct Is_zero : public CGAL::unary_function<Coefficient,bool> {
+    struct Is_zero : public CGAL::cpp98::unary_function<Coefficient,bool> {
         
         Is_zero(Algebraic_kernel_d_1* kernel,Algebraic_real_1 alpha) 
             : _m_kernel(kernel),_m_alpha(alpha) {}
@@ -140,7 +140,7 @@ public:
     }
 
     struct Convert_to_bfi 
-        : public CGAL::unary_function<Coefficient,Bigfloat_interval> {
+        : public CGAL::cpp98::unary_function<Coefficient,Bigfloat_interval> {
         
         Convert_to_bfi(Algebraic_kernel_d_1* kernel,
 		       Algebraic_real_1 alpha) 

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
@@ -108,7 +108,7 @@ template<typename Comparable>
 };
 
 template<typename Comparable> struct Compare_for_vert_line_map
-  : public CGAL::binary_function<Comparable,Comparable,bool> {
+  : public CGAL::cpp98::binary_function<Comparable,Comparable,bool> {
     
   BOOST_MPL_HAS_XXX_TRAIT_DEF(T)
   BOOST_MPL_HAS_XXX_TRAIT_DEF(Handle_policy)

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Float_traits.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Float_traits.h
@@ -66,7 +66,7 @@ template<>
 class Float_traits< leda_bigfloat > {
 public:
   struct Get_mantissa
-    : public CGAL::unary_function< leda_bigfloat, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, leda_integer > {
     leda_integer operator()( const leda_bigfloat& x ) const {
       //std::cout << x.get_significant() << std::endl;
       return x.get_significant();                
@@ -74,14 +74,14 @@ public:
   };
         
   struct Get_exponent
-    : public CGAL::unary_function< leda_bigfloat, long > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, long > {
     long operator()( const leda_bigfloat& x ) const {
       return x.get_exponent().to_long();                
     }
   };
 
   struct Mul_by_pow_of_2
-    : public CGAL::binary_function< leda_bigfloat, long, leda_bigfloat> {
+    : public CGAL::cpp98::binary_function< leda_bigfloat, long, leda_bigfloat> {
     leda_bigfloat operator()( const leda_bigfloat& a, long e ) const {
       return leda_bigfloat(a.get_significant(), a.get_exponent()+e);
     }
@@ -98,21 +98,21 @@ class Float_traits< CORE::BigFloat > {
 public:
       
   struct Get_mantissa
-    : public CGAL::unary_function< CORE::BigFloat, CORE::BigInt > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, CORE::BigInt > {
     CORE::BigInt operator()( const CORE::BigFloat& x ) const { 
       return x.m();
     }
   };
         
   struct Get_exponent
-    : public CGAL::unary_function< CORE::BigFloat, long > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, long > {
     long operator()( const CORE::BigFloat& x ) const {
       return CORE::CHUNK_BIT*x.exp(); // The basis is 2^CORE::CHUNK_BIT
     }
   };
 
   struct Mul_by_pow_of_2
-    : public CGAL::binary_function
+    : public CGAL::cpp98::binary_function
     < CORE::BigFloat, long , CORE::BigFloat> {
     CORE::BigFloat operator()( const CORE::BigFloat& a, long e ) const {
       return a*CORE::BigFloat::exp2(e);
@@ -127,7 +127,7 @@ public:
 template<> class Float_traits< Gmpfr > {
   
   struct Get_mantissa_exponent
-    : public CGAL::unary_function< Gmpfr, std::pair<Gmpz,long> > {
+    : public CGAL::cpp98::unary_function< Gmpfr, std::pair<Gmpz,long> > {
     
     std::pair<Gmpz,long> operator()( const Gmpfr& x ) const {
       return x.to_integer_exp(); 
@@ -135,21 +135,21 @@ template<> class Float_traits< Gmpfr > {
   };
 public:  
   struct Get_mantissa
-    : public CGAL::unary_function< Gmpfr, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpfr, Gmpz > {
     Gmpz operator()( const Gmpfr& x ) const {
       return Get_mantissa_exponent()(x).first;      
     }
   };
   
   struct Get_exponent
-    : public CGAL::unary_function< Gmpfr, long > {
+    : public CGAL::cpp98::unary_function< Gmpfr, long > {
     long operator()( const Gmpfr& x ) const { 
       return Get_mantissa_exponent()(x).second;      
     }
   };
     
 struct Mul_by_pow_of_2
-  : public CGAL::binary_function< Gmpfr, Gmpz, Gmpfr> {
+  : public CGAL::cpp98::binary_function< Gmpfr, Gmpz, Gmpfr> {
   Gmpfr operator()( const Gmpfr& a, long e ) const {
     Gmpfr result(0,a.get_precision()); // just to get the prec of a 
     if (e >= 0 ){

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Interval_evaluate_1.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Interval_evaluate_1.h
@@ -39,7 +39,7 @@ namespace CGAL {
 namespace internal {
 
 template<typename Polynomial_1, typename Bound>
-struct Interval_evaluate_1 : public CGAL::binary_function
+struct Interval_evaluate_1 : public CGAL::cpp98::binary_function
 <Polynomial_1,std::pair<Bound,Bound>,
   std::pair<typename CGAL::Coercion_traits<typename 
      CGAL::Polynomial_traits_d<Polynomial_1>::Coefficient_type,Bound>::Type,

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Interval_evaluate_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Interval_evaluate_2.h
@@ -40,7 +40,7 @@ namespace CGAL {
 namespace internal {
 
 template<typename Polynomial_2, typename Bound>
-struct Interval_evaluate_2 : public CGAL::binary_function
+struct Interval_evaluate_2 : public CGAL::cpp98::binary_function
 <Polynomial_2,CGAL::cpp11::array<Bound,4>,
       std::pair<typename CGAL::Coercion_traits<typename CGAL::Polynomial_traits_d<Polynomial_2>::Innermost_coefficient_type,Bound>::Type,
                 typename CGAL::Coercion_traits<typename CGAL::Polynomial_traits_d<Polynomial_2>::Innermost_coefficient_type,Bound>::Type> > {

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Real_embeddable_extension.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Real_embeddable_extension.h
@@ -103,7 +103,7 @@ template<>
 class Real_embeddable_extension< long > {            
 public:      
   struct Ceil_log2_abs
-    : public CGAL::unary_function< long, long > {
+    : public CGAL::cpp98::unary_function< long, long > {
     long operator()( long x ) {
       if (x < 0) x = -x;
       CGAL_precondition(x > 0);
@@ -113,7 +113,7 @@ public:
   };
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< long, long > {
+    : public CGAL::cpp98::unary_function< long, long > {
   private:          
     signed char floor_log2_4bit[16];
   public:
@@ -149,11 +149,11 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< long, long > {
+    : public CGAL::cpp98::unary_function< long, long > {
     long operator() (long x) { return x;}
   };
   struct Ceil
-    : public CGAL::unary_function< long, long > {
+    : public CGAL::cpp98::unary_function< long, long > {
     long operator() (long x) { return x;}
   };
 };
@@ -168,7 +168,7 @@ public:
   typedef leda_integer Type;
 
   struct Ceil_log2_abs
-    : public CGAL::unary_function< leda_integer, long > {
+    : public CGAL::cpp98::unary_function< leda_integer, long > {
     long operator()( const leda_integer& x ) const {
       CGAL_precondition(x != leda_integer(0));
       ::leda::digit_sz ldgzeros = ::leda::digLeadingZeros(x.highword());
@@ -188,7 +188,7 @@ public:
   };
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< leda_integer, long > {
+    : public CGAL::cpp98::unary_function< leda_integer, long > {
     long operator()( const leda_integer& x ) const {
       CGAL_precondition(x != leda_integer(0));
       ::leda::digit_sz ldgzeros 
@@ -200,11 +200,11 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< leda_integer, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_integer, leda_integer > {
     leda_integer operator() (const leda_integer& x) const { return x;}
   };
   struct Ceil
-    : public CGAL::unary_function< leda_integer, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_integer, leda_integer > {
     leda_integer operator() (const leda_integer& x) const { return x;}
   };
 };
@@ -216,7 +216,7 @@ public:
   typedef leda_bigfloat Type;
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< leda_bigfloat, long > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, long > {
     long operator()( const leda_bigfloat& x ) const {
       CGAL_precondition(CGAL::sign(x) != CGAL::ZERO);
       ::leda::integer abs_sign = abs(x.get_significant());
@@ -226,7 +226,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< leda_bigfloat, long > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, long > {
     long operator()( const leda_bigfloat& x ) const {
       CGAL_precondition(CGAL::sign(x) != CGAL::ZERO);
       return ::leda::ilog2(x).to_long();                
@@ -234,14 +234,14 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< leda_bigfloat, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, leda_integer > {
     leda_integer operator() ( const leda_bigfloat& x ) const { 
       return leda::to_integer( x, leda::TO_N_INF );
     }
   };
         
   struct Ceil
-    : public CGAL::unary_function< leda_bigfloat, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat, leda_integer > {
     leda_integer operator() ( const leda_bigfloat& x ) const { 
       return leda::to_integer( x, leda::TO_P_INF );
     }
@@ -255,7 +255,7 @@ public:
   typedef leda_bigfloat_interval Type;
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< leda_bigfloat_interval, long > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat_interval, long > {
               
     result_type operator() (const argument_type& x) const {
       CGAL_precondition(! ::boost::numeric::in_zero(x));
@@ -264,7 +264,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< leda_bigfloat_interval, long > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat_interval, long > {
     long operator()( const leda_bigfloat_interval& x ) const {
       CGAL_precondition(!(::boost::numeric::in_zero(x) && 
               ::boost::numeric::singleton(x)));
@@ -273,7 +273,7 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< leda_bigfloat_interval, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat_interval, leda_integer > {
     leda_integer operator() ( const leda_bigfloat_interval& x ) 
       const { 
       return internal::floor( x.lower() );
@@ -281,7 +281,7 @@ public:
   };
         
   struct Ceil
-    : public CGAL::unary_function< leda_bigfloat_interval, leda_integer > {
+    : public CGAL::cpp98::unary_function< leda_bigfloat_interval, leda_integer > {
     leda_integer operator() ( const leda_bigfloat_interval& x ) 
       const { 
       return internal::ceil( x.upper() );
@@ -299,27 +299,27 @@ class Real_embeddable_extension< CORE::BigInt > {
 public:
   typedef CORE::BigInt Type;
   struct Floor_log2_abs
-    : public CGAL::unary_function< CORE::BigInt, long > {
+    : public CGAL::cpp98::unary_function< CORE::BigInt, long > {
     long operator()( const CORE::BigInt& x ) const {
       return CORE::floorLg(x);
     }            
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< CORE::BigInt, long > {
+    : public CGAL::cpp98::unary_function< CORE::BigInt, long > {
     long operator()( const CORE::BigInt& x ) const {
       return CORE::ceilLg(x);
     }
   };
 
   struct Floor
-    : public CGAL::unary_function< CORE::BigInt, CORE::BigInt > {
+    : public CGAL::cpp98::unary_function< CORE::BigInt, CORE::BigInt > {
     CORE::BigInt operator() (const CORE::BigInt& x) const { 
       return x;
     }
   };
   struct Ceil
-    : public CGAL::unary_function< CORE::BigInt, CORE::BigInt > {
+    : public CGAL::cpp98::unary_function< CORE::BigInt, CORE::BigInt > {
     CORE::BigInt operator() (const CORE::BigInt& x) const { 
       return x;
     }
@@ -332,7 +332,7 @@ class Real_embeddable_extension< CORE::BigFloat > {
 public:
   typedef CORE::BigFloat Type;
   struct Floor_log2_abs
-    : public CGAL::unary_function< CORE::BigFloat, long > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, long > {
     long operator()( CORE::BigFloat x ) const {
       CGAL_precondition(!CGAL::zero_in(x));
       x = CGAL::abs(x);
@@ -341,7 +341,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< CORE::BigFloat, long > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, long > {
     long operator()( CORE::BigFloat x ) const {
       // (already commented out in EXACUS)...
       //   NiX_precond(!(NiX::in_zero(x) && NiX::singleton(x)));
@@ -351,7 +351,7 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< CORE::BigFloat, CORE::BigInt > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, CORE::BigInt > {
     CORE::BigInt operator() ( const CORE::BigFloat& x ) const { 
       CORE::BigInt xi = x.BigIntValue();
       if(x.sign() < 0 && x.cmp(xi)!=0) {
@@ -362,7 +362,7 @@ public:
   };
         
   struct Ceil
-    : public CGAL::unary_function< CORE::BigFloat, CORE::BigInt > {
+    : public CGAL::cpp98::unary_function< CORE::BigFloat, CORE::BigInt > {
     CORE::BigInt operator() ( const CORE::BigFloat& x ) const { 
       CORE::BigInt xi = x.BigIntValue();
       if(x.sign() >0 && x.cmp(xi)!=0) {
@@ -385,7 +385,7 @@ public:
   typedef Gmpz Type;
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< Gmpz, long > {
+    : public CGAL::cpp98::unary_function< Gmpz, long > {
     long operator()( const Gmpz& x ) const {
       CGAL_precondition(!CGAL::is_zero(x));
       return static_cast<long>(mpz_sizeinbase(x.mpz(),2)-1);
@@ -393,7 +393,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< Gmpz, long > {
+    : public CGAL::cpp98::unary_function< Gmpz, long > {
     long operator()( const Gmpz& x ) const {
       long pos  = mpz_scan1(x.mpz(),0);
       long size = static_cast<long>(mpz_sizeinbase(x.mpz(),2));
@@ -405,13 +405,13 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< Gmpz, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpz, Gmpz > {
     Gmpz operator() (const Gmpz& x) const { 
       return x;
     }
   };
   struct Ceil
-    : public CGAL::unary_function< Gmpz, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpz, Gmpz > {
     Gmpz operator() (const Gmpz& x) const { 
       return x;
     }
@@ -427,7 +427,7 @@ public:
   typedef Gmpfr Type;
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< Gmpfr, long > {
+    : public CGAL::cpp98::unary_function< Gmpfr, long > {
     long operator()( const Gmpfr& x ) const {
       Float_traits<Gmpfr>::Get_mantissa get_mantissa; 
       Float_traits<Gmpfr>::Get_exponent get_exponent; 
@@ -438,7 +438,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< Gmpfr, long > {
+    : public CGAL::cpp98::unary_function< Gmpfr, long > {
     long operator()( const Gmpfr& x ) const {
       Float_traits<Gmpfr>::Get_mantissa get_mantissa; 
       Float_traits<Gmpfr>::Get_exponent get_exponent; 
@@ -449,7 +449,7 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< Gmpfr, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpfr, Gmpz > {
     Gmpz operator() ( const Gmpfr& x ) const {  
       Gmpz result; 
       mpfr_get_z (result.mpz(),x.fr(),GMP_RNDD);
@@ -458,7 +458,7 @@ public:
   };
         
   struct Ceil
-    : public CGAL::unary_function< Gmpfr, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpfr, Gmpz > {
     Gmpz operator() ( const Gmpfr& x ) const { 
       Gmpz result; 
       mpfr_get_z (result.mpz(),x.fr(),GMP_RNDU);
@@ -476,7 +476,7 @@ public:
   typedef Gmpfi Type;
 
   struct Floor_log2_abs
-    : public CGAL::unary_function< Gmpfi, long > {
+    : public CGAL::cpp98::unary_function< Gmpfi, long > {
     result_type operator() (const argument_type& x) const {
       CGAL_precondition(!x.is_zero());
       return internal::floor_log2_abs(x.abs().inf());
@@ -484,7 +484,7 @@ public:
   };
         
   struct Ceil_log2_abs
-    : public CGAL::unary_function< Gmpfi, long > {
+    : public CGAL::cpp98::unary_function< Gmpfi, long > {
     long operator()( const Gmpfi& x ) const {
       CGAL_precondition(!x.inf().is_zero() || !x.sup().is_zero());
       return internal::ceil_log2_abs(x.abs().sup());                    
@@ -492,7 +492,7 @@ public:
   };
 
   struct Floor
-    : public CGAL::unary_function< Gmpfi, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpfi, Gmpz > {
     Gmpz operator() ( const Gmpfi& x ) 
       const { 
       return internal::floor( x.inf() );
@@ -500,7 +500,7 @@ public:
   };
         
   struct Ceil
-    : public CGAL::unary_function< Gmpfi, Gmpz > {
+    : public CGAL::cpp98::unary_function< Gmpfi, Gmpz > {
     Gmpz operator() ( const Gmpfi& x ) 
       const { 
       return internal::ceil( x.sup() );

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d_1.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d_1.h
@@ -71,12 +71,12 @@ protected:
 
   // Some functors used for STL calls
   template<typename A,typename B>
-    struct Pair_first : public CGAL::unary_function<std::pair<A,B>,A> {
+    struct Pair_first : public CGAL::cpp98::unary_function<std::pair<A,B>,A> {
       A operator() (std::pair<A,B> pair) const { return pair.first; }
   };
 
   template<typename A,typename B>
-    struct Pair_second : public CGAL::unary_function<std::pair<A,B>,B> {
+    struct Pair_second : public CGAL::cpp98::unary_function<std::pair<A,B>,B> {
       B operator() (std::pair<A,B> pair) const { return pair.second; }
   };
   
@@ -86,7 +86,7 @@ public:
     typedef Algebraic_real_1                      Type;
     
     struct Bound_between 
-      : public CGAL::binary_function< Type, Type, Bound > {
+      : public CGAL::cpp98::binary_function< Type, Type, Bound > {
       Bound operator()( const Type& t1, 
           const Type& t2 ) const {
 #if CGAL_AK_DONT_USE_SIMPLE_BOUND_BETWEEN
@@ -99,21 +99,21 @@ public:
     };
                                 
     struct Lower_bound
-      : public CGAL::unary_function< Type, Bound > {
+      : public CGAL::cpp98::unary_function< Type, Bound > {
       Bound operator()( const Type& t ) const {
         return t.low();
       }
     };
                 
     struct Upper_bound
-      : public CGAL::unary_function< Type, Bound > {
+      : public CGAL::cpp98::unary_function< Type, Bound > {
       Bound operator()( const Type& t ) const {
         return t.high();
       }
     };
                 
     struct Refine
-      : public CGAL::unary_function< Type, void > {
+      : public CGAL::cpp98::unary_function< Type, void > {
       void operator()( const Type& t ) const {
         t.refine();
       }
@@ -151,7 +151,7 @@ public:
     };              
     
     struct Approximate_absolute_1:
-      public CGAL::binary_function<Algebraic_real_1,int,std::pair<Bound,Bound> >{
+      public CGAL::cpp98::binary_function<Algebraic_real_1,int,std::pair<Bound,Bound> >{
       std::pair<Bound,Bound> 
       operator()(const Algebraic_real_1& x, int prec) const {
         Lower_bound lower; 
@@ -170,7 +170,7 @@ public:
     }; 
     
     struct Approximate_relative_1:
-      public CGAL::binary_function<Algebraic_real_1,int,std::pair<Bound,Bound> >{
+      public CGAL::cpp98::binary_function<Algebraic_real_1,int,std::pair<Bound,Bound> >{
       std::pair<Bound,Bound> 
       operator()(const Algebraic_real_1& x, int prec) const {
         
@@ -280,7 +280,7 @@ public:
     /*
     // TODO: Can we avoid to use this?
     struct Greater_compare : 
-      public CGAL::binary_function<Algebraic_real_1,Algebraic_real_1,bool> {
+      public CGAL::cpp98::binary_function<Algebraic_real_1,Algebraic_real_1,bool> {
       
       bool operator() (const Algebraic_real_1& a, const Algebraic_real_1& b)
 	const {
@@ -338,7 +338,7 @@ public:
   };
 
   class Number_of_solutions_1 
-      : public CGAL::unary_function<Polynomial_1,size_type> {
+      : public CGAL::cpp98::unary_function<Polynomial_1,size_type> {
     
     public:
 	
@@ -354,7 +354,7 @@ public:
 
             
   struct Sign_at_1 
-    : public CGAL::binary_function< Polynomial_1, Algebraic_real_1, CGAL::Sign > {
+    : public CGAL::cpp98::binary_function< Polynomial_1, Algebraic_real_1, CGAL::Sign > {
     CGAL::Sign operator()( const Polynomial_1& p, const Algebraic_real_1& ar ) const {
       if(CGAL::is_zero(p)) return ZERO; 
       if(CGAL::degree(p)==0) return p.sign_at(0);
@@ -377,7 +377,7 @@ public:
     }
   };                
   struct Is_zero_at_1 
-    : public CGAL::binary_function< Polynomial_1, Algebraic_real_1, bool > {
+    : public CGAL::cpp98::binary_function< Polynomial_1, Algebraic_real_1, bool > {
     bool operator()( const Polynomial_1& p, const Algebraic_real_1& ar ) const {
       if(CGAL::is_zero(p)) return true; 
       if( ar.low() == ar.high() ) return p.sign_at( ar.low() ) == ZERO;
@@ -387,7 +387,7 @@ public:
   };                
                    
   struct Is_square_free_1 
-    : public CGAL::unary_function< Polynomial_1, bool > {
+    : public CGAL::cpp98::unary_function< Polynomial_1, bool > {
     bool operator()( const Polynomial_1& p ) const {
       typename CGAL::Polynomial_traits_d< Polynomial_1 >::Is_square_free isf;
       return isf(p);
@@ -395,7 +395,7 @@ public:
   };
             
   struct Is_coprime_1
-    : public CGAL::binary_function< Polynomial_1, Polynomial_1, bool > {
+    : public CGAL::cpp98::binary_function< Polynomial_1, Polynomial_1, bool > {
     bool operator()( const Polynomial_1& p1, const Polynomial_1& p2 ) const {
       typename CGAL::Polynomial_traits_d< Polynomial_1 >::Total_degree total_degree;
                         
@@ -405,7 +405,7 @@ public:
   }; 
             
   struct Make_square_free_1
-    : public CGAL::unary_function< Polynomial_1, Polynomial_1 > {
+    : public CGAL::cpp98::unary_function< Polynomial_1, Polynomial_1 > {
     Polynomial_1 operator()( const Polynomial_1& p ) const {
       return typename CGAL::Polynomial_traits_d< Polynomial_1 >::Make_square_free()( p );
     }
@@ -440,7 +440,7 @@ public:
     } 
   };
 
-  struct Compute_polynomial_1 : public CGAL::unary_function<Algebraic_real_1,
+  struct Compute_polynomial_1 : public CGAL::cpp98::unary_function<Algebraic_real_1,
                                                            Polynomial_1> {
     Polynomial_1 operator()(const Algebraic_real_1& x) const {
       return x.polynomial();
@@ -490,7 +490,7 @@ public:
   };
 
   struct Compare_1
-    : public CGAL::binary_function<Algebraic_real_1,
+    : public CGAL::cpp98::binary_function<Algebraic_real_1,
 	                          Algebraic_real_1,
                                   CGAL::Comparison_result>{
     
@@ -535,7 +535,7 @@ public:
 
  public:
 
-  struct Isolate_1 : public CGAL::binary_function
+  struct Isolate_1 : public CGAL::cpp98::binary_function
     < Algebraic_real_1,Polynomial_1,std::pair<Bound,Bound> > {
     
     public:

--- a/Algebraic_kernel_d/include/CGAL/RS/algebraic_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/algebraic_1.h
@@ -259,39 +259,39 @@ public INTERN_RET::Real_embeddable_traits_base<
                                                         Base;
         typedef typename Base::Compare                  Compare;
 
-        class Sgn:public CGAL::unary_function<Type,CGAL::Sign>{
+        class Sgn:public CGAL::cpp98::unary_function<Type,CGAL::Sign>{
                 public:
                 CGAL::Sign operator()(const Type &a)const{
                         return Compare()(a,Type(0));
                 }
         };
 
-        class To_double:public CGAL::unary_function<Type,double>{
+        class To_double:public CGAL::cpp98::unary_function<Type,double>{
                 public:
                 double operator()(const Type &a)const{return a.to_double();}
         };
 
         class To_interval:
-        public CGAL::unary_function<Type,std::pair<double,double> >{
+        public CGAL::cpp98::unary_function<Type,std::pair<double,double> >{
                 public:
                 std::pair<double,double> operator()(const Type &a)const{
                         return a.to_interval();
                 }
         };
 
-        class Is_zero:public CGAL::unary_function<Type,Boolean>{
+        class Is_zero:public CGAL::cpp98::unary_function<Type,Boolean>{
                 public:
                 bool operator()(const Type &a)const{
                         return Sgn()(a)==CGAL::ZERO;
                 }
         };
 
-        class Is_finite:public CGAL::unary_function<Type,Boolean>{
+        class Is_finite:public CGAL::cpp98::unary_function<Type,Boolean>{
                 public:
                 bool operator()(const Type&)const{return true;}
         };
 
-        class Abs:public CGAL::unary_function<Type,Type>{
+        class Abs:public CGAL::cpp98::unary_function<Type,Type>{
                 public:
                 Type operator()(const Type &a)const{
                         return Sgn()(a)==CGAL::NEGATIVE?-a:a;

--- a/Algebraic_kernel_d/include/CGAL/RS/algebraic_z_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/algebraic_z_1.h
@@ -250,39 +250,39 @@ public INTERN_RET::Real_embeddable_traits_base<
                                                         Base;
         typedef typename Base::Compare                  Compare;
 
-        class Sgn:public CGAL::unary_function<Type,CGAL::Sign>{
+        class Sgn:public CGAL::cpp98::unary_function<Type,CGAL::Sign>{
                 public:
                 CGAL::Sign operator()(const Type &a)const{
                         return Compare()(a,Type(0));
                 }
         };
 
-        class To_double:public CGAL::unary_function<Type,double>{
+        class To_double:public CGAL::cpp98::unary_function<Type,double>{
                 public:
                 double operator()(const Type &a)const{return a.to_double();}
         };
 
         class To_interval:
-        public CGAL::unary_function<Type,std::pair<double,double> >{
+        public CGAL::cpp98::unary_function<Type,std::pair<double,double> >{
                 public:
                 std::pair<double,double> operator()(const Type &a)const{
                         return a.to_interval();
                 }
         };
 
-        class Is_zero:public CGAL::unary_function<Type,Boolean>{
+        class Is_zero:public CGAL::cpp98::unary_function<Type,Boolean>{
                 public:
                 bool operator()(const Type &a)const{
                         return Sgn()(a)==CGAL::ZERO;
                 }
         };
 
-        class Is_finite:public CGAL::unary_function<Type,Boolean>{
+        class Is_finite:public CGAL::cpp98::unary_function<Type,Boolean>{
                 public:
                 bool operator()(const Type&)const{return true;}
         };
 
-        class Abs:public CGAL::unary_function<Type,Type>{
+        class Abs:public CGAL::cpp98::unary_function<Type,Type>{
                 public:
                 Type operator()(const Type &a)const{
                         return Sgn()(a)==CGAL::NEGATIVE?-a:a;

--- a/Algebraic_kernel_d/include/CGAL/RS/functors_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/functors_1.h
@@ -61,7 +61,7 @@ struct Construct_algebraic_real_1{
 
 template <class Polynomial_,class Algebraic_>
 struct Compute_polynomial_1:
-public CGAL::unary_function<Algebraic_,Polynomial_>{
+public CGAL::cpp98::unary_function<Algebraic_,Polynomial_>{
         typedef Polynomial_                                     Polynomial;
         typedef Algebraic_                                      Algebraic;
         Polynomial operator()(const Algebraic &x)const{
@@ -71,7 +71,7 @@ public CGAL::unary_function<Algebraic_,Polynomial_>{
 
 template <class Polynomial_,class Ptraits_>
 struct Is_coprime_1:
-public CGAL::binary_function<Polynomial_,Polynomial_,bool>{
+public CGAL::cpp98::binary_function<Polynomial_,Polynomial_,bool>{
         typedef Polynomial_                                     Polynomial;
         typedef Ptraits_                                        Ptraits;
         typedef typename Ptraits::Gcd_up_to_constant_factor     Gcd;
@@ -257,7 +257,7 @@ template <class Polynomial_,
           class Signat_,
           class Ptraits_>
 class Sign_at_1:
-public CGAL::binary_function<Polynomial_,Algebraic_,CGAL::Sign>{
+public CGAL::cpp98::binary_function<Polynomial_,Algebraic_,CGAL::Sign>{
         // This implementation will work with any polynomial type whose
         // coefficient type is explicit interoperable with Gmpfi.
         // TODO: Make this function generic.
@@ -363,7 +363,7 @@ template <class Polynomial_,
           class Signat_,
           class Ptraits_>
 class Is_zero_at_1:
-public CGAL::binary_function<Polynomial_,Algebraic_,bool>{
+public CGAL::cpp98::binary_function<Polynomial_,Algebraic_,bool>{
         // This implementation will work with any polynomial type whose
         // coefficient type is explicit interoperable with Gmpfi.
         // TODO: Make this function generic.
@@ -443,7 +443,7 @@ public CGAL::binary_function<Polynomial_,Algebraic_,bool>{
 // programs assume that this is equal to int
 template <class Polynomial_,class Isolator_>
 struct Number_of_solutions_1:
-public CGAL::unary_function<Polynomial_,int>{
+public CGAL::cpp98::unary_function<Polynomial_,int>{
         typedef Polynomial_                                     Polynomial_1;
         typedef Isolator_                                       Isolator;
         size_t operator()(const Polynomial_1 &p)const{
@@ -459,7 +459,7 @@ template <class Algebraic_,
           class Bound_,
           class Comparator_>
 struct Compare_1:
-public CGAL::binary_function<Algebraic_,Algebraic_,CGAL::Comparison_result>{
+public CGAL::cpp98::binary_function<Algebraic_,Algebraic_,CGAL::Comparison_result>{
         typedef Algebraic_                                      Algebraic;
         typedef Bound_                                          Bound;
         typedef Comparator_                                     Comparator;
@@ -511,7 +511,7 @@ template <class Algebraic_,
           class Bound_,
           class Comparator_>
 struct Bound_between_1:
-public CGAL::binary_function<Algebraic_,Algebraic_,Bound_>{
+public CGAL::cpp98::binary_function<Algebraic_,Algebraic_,Bound_>{
         typedef Algebraic_                                      Algebraic;
         typedef Bound_                                          Bound;
         typedef Comparator_                                     Comparator;
@@ -551,7 +551,7 @@ template <class Polynomial_,
           class Signat_,
           class Ptraits_>
 struct Isolate_1:
-public CGAL::binary_function<Algebraic_,Polynomial_,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,Polynomial_,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef Bound_                                          Bound;
         typedef Algebraic_                                      Algebraic;
@@ -589,7 +589,7 @@ template <class Polynomial_,
           class Algebraic_,
           class Refiner_>
 struct Approximate_absolute_1:
-public CGAL::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef Bound_                                          Bound;
         typedef Algebraic_                                      Algebraic;
@@ -621,7 +621,7 @@ template <class Polynomial_,
           class Algebraic_,
           class Refiner_>
 struct Approximate_relative_1:
-public CGAL::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef Bound_                                          Bound;
         typedef Algebraic_                                      Algebraic;

--- a/Algebraic_kernel_d/include/CGAL/RS/functors_z_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/functors_z_1.h
@@ -69,7 +69,7 @@ struct Construct_algebraic_real_z_1{
 
 template <class Polynomial_,class Algebraic_>
 struct Compute_polynomial_z_1:
-public CGAL::unary_function<Algebraic_,Polynomial_>{
+public CGAL::cpp98::unary_function<Algebraic_,Polynomial_>{
         typedef Polynomial_                                     Polynomial;
         typedef Algebraic_                                      Algebraic;
         Polynomial operator()(const Algebraic &x)const{
@@ -79,7 +79,7 @@ public CGAL::unary_function<Algebraic_,Polynomial_>{
 
 template <class Polynomial_,class Ptraits_>
 struct Is_coprime_z_1:
-public CGAL::binary_function<Polynomial_,Polynomial_,bool>{
+public CGAL::cpp98::binary_function<Polynomial_,Polynomial_,bool>{
         typedef Polynomial_                                     Polynomial;
         typedef Ptraits_                                        Ptraits;
         typedef typename Ptraits::Gcd_up_to_constant_factor     Gcd;
@@ -285,7 +285,7 @@ template <class Polynomial_,
           class Ptraits_,
           class ZPtraits_>
 class Sign_at_z_1:
-public CGAL::binary_function<Polynomial_,Algebraic_,CGAL::Sign>{
+public CGAL::cpp98::binary_function<Polynomial_,Algebraic_,CGAL::Sign>{
         // This implementation will work with any polynomial type whose
         // coefficient type is explicit interoperable with Gmpfi.
         // TODO: Make this function generic.
@@ -397,7 +397,7 @@ template <class Polynomial_,
           class Ptraits_,
           class ZPtraits_>
 class Is_zero_at_z_1:
-public CGAL::binary_function<Polynomial_,Algebraic_,bool>{
+public CGAL::cpp98::binary_function<Polynomial_,Algebraic_,bool>{
         // This implementation will work with any polynomial type whose
         // coefficient type is explicit interoperable with Gmpfi.
         // TODO: Make this function generic.
@@ -483,7 +483,7 @@ template <class Polynomial_,
           class PolConverter_,
           class Isolator_>
 struct Number_of_solutions_z_1:
-public CGAL::unary_function<Polynomial_,int>{
+public CGAL::cpp98::unary_function<Polynomial_,int>{
         typedef Polynomial_                                     Polynomial_1;
         typedef ZPolynomial_                                    ZPolynomial_1;
         typedef PolConverter_                                   PolConverter;
@@ -501,7 +501,7 @@ template <class Algebraic_,
           class Bound_,
           class Comparator_>
 struct Compare_z_1:
-public CGAL::binary_function<Algebraic_,Algebraic_,CGAL::Comparison_result>{
+public CGAL::cpp98::binary_function<Algebraic_,Algebraic_,CGAL::Comparison_result>{
         typedef Algebraic_                                      Algebraic;
         typedef Bound_                                          Bound;
         typedef Comparator_                                     Comparator;
@@ -553,7 +553,7 @@ template <class Algebraic_,
           class Bound_,
           class Comparator_>
 struct Bound_between_z_1:
-public CGAL::binary_function<Algebraic_,Algebraic_,Bound_>{
+public CGAL::cpp98::binary_function<Algebraic_,Algebraic_,Bound_>{
         typedef Algebraic_                                      Algebraic;
         typedef Bound_                                          Bound;
         typedef Comparator_                                     Comparator;
@@ -596,7 +596,7 @@ template <class Polynomial_,
           class Ptraits_,
           class ZPtraits_>
 struct Isolate_z_1:
-public CGAL::binary_function<Algebraic_,Polynomial_,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,Polynomial_,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef ZPolynomial_                                    ZPolynomial_1;
         typedef PolConverter_                                   PolConverter;
@@ -640,7 +640,7 @@ template <class Polynomial_,
           class Algebraic_,
           class Refiner_>
 struct Approximate_absolute_z_1:
-public CGAL::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef Bound_                                          Bound;
         typedef Algebraic_                                      Algebraic;
@@ -672,7 +672,7 @@ template <class Polynomial_,
           class Algebraic_,
           class Refiner_>
 struct Approximate_relative_z_1:
-public CGAL::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
+public CGAL::cpp98::binary_function<Algebraic_,int,std::pair<Bound_,Bound_> >{
         typedef Polynomial_                                     Polynomial_1;
         typedef Bound_                                          Bound;
         typedef Algebraic_                                      Algebraic;

--- a/Algebraic_kernel_d/include/CGAL/RS/polynomial_converter_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/polynomial_converter_1.h
@@ -27,7 +27,7 @@ namespace RS_AK1{
 
 template <class InputPolynomial_,class OutputPolynomial_>
 struct Polynomial_converter_1:
-public CGAL::unary_function<InputPolynomial_,OutputPolynomial_>{
+public CGAL::cpp98::unary_function<InputPolynomial_,OutputPolynomial_>{
         typedef InputPolynomial_                        InpPolynomial_1;
         typedef OutputPolynomial_                       OutPolynomial_1;
         OutPolynomial_1 operator()(const InpPolynomial_1&)const;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_predicates.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_predicates.h
@@ -35,7 +35,7 @@ template < class Td_traits> class Trapezoidal_decomposition_2;
 
 ////MICHAL: not in use
 //template <class map_item>
-//struct Td_active_map_item : public CGAL::unary_function<map_item,bool>
+//struct Td_active_map_item : public CGAL::cpp98::unary_function<map_item,bool>
 //{
 //  bool operator()(const map_item& item) const
 //  {
@@ -46,7 +46,7 @@ template < class Td_traits> class Trapezoidal_decomposition_2;
 ////MICHAL: not in use
 //template <class X_trapezoid,class Traits>
 //struct Td_active_non_degenerate_trapezoid : 
-//public CGAL::unary_function<X_trapezoid,bool>
+//public CGAL::cpp98::unary_function<X_trapezoid,bool>
 //{
 //  Td_active_non_degenerate_trapezoid(Traits& t) : traits(t) {}
 //  bool operator()(const X_trapezoid& tr) const
@@ -59,7 +59,7 @@ template < class Td_traits> class Trapezoidal_decomposition_2;
 
 template <class map_item,class Traits>
 struct Td_active_edge_item:
-  public CGAL::unary_function<map_item,bool>
+  public CGAL::cpp98::unary_function<map_item,bool>
 {
   Td_active_edge_item(const Traits& t) : traits(t) {}
   bool operator()(const map_item& item) const
@@ -71,7 +71,7 @@ struct Td_active_edge_item:
 };
 
 template <class _Tp>
-struct Td_map_item_handle_less : public CGAL::binary_function<_Tp, _Tp, bool>
+struct Td_map_item_handle_less : public CGAL::cpp98::binary_function<_Tp, _Tp, bool>
 {
   bool operator()(const _Tp& __x, const _Tp& __y) const { 
     return __x->id() < __y->id(); }

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
@@ -1432,7 +1432,7 @@ public:
     CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
     
     //! the result type
-    typedef CGAL::iterator< std::output_iterator_tag, CGAL::Object > 
+    typedef CGAL::cpp98::iterator< std::output_iterator_tag, CGAL::Object >
     result_type;
     
     //! the arity of the functor
@@ -1888,7 +1888,7 @@ public:
     CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
     
     //! the result type
-    typedef CGAL::iterator< std::output_iterator_tag, CGAL::Object > 
+    typedef CGAL::cpp98::iterator< std::output_iterator_tag, CGAL::Object >
     result_type;
 
     //! the arity of the functor
@@ -2511,7 +2511,7 @@ public:
     typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
     
     //! the result type
-    typedef CGAL::iterator< std::output_iterator_tag, Coordinate_2 >
+    typedef CGAL::cpp98::iterator< std::output_iterator_tag, Coordinate_2 >
          result_type;
 
     //! the arity of the functor
@@ -2576,7 +2576,7 @@ public:
     typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
     
     //! the result type
-    typedef CGAL::iterator< std::output_iterator_tag, Coordinate_2 >
+    typedef CGAL::cpp98::iterator< std::output_iterator_tag, Coordinate_2 >
              result_type;
 
     //! the arity of the functor

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
@@ -57,7 +57,7 @@ template < class CurvedKernelViaAnalysis_2,
            class ConstructArc_2 =
            typename CurvedKernelViaAnalysis_2::Construct_arc_2 >
 struct Make_x_monotone_2 :
-    public CGAL::binary_function< typename CurvedKernelViaAnalysis_2::Curve_2,
+    public CGAL::cpp98::binary_function< typename CurvedKernelViaAnalysis_2::Curve_2,
             CGAL::cpp98::iterator<std::output_iterator_tag, CGAL::Object>,
             CGAL::cpp98::iterator<std::output_iterator_tag, CGAL::Object> > {
 

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h
@@ -58,8 +58,8 @@ template < class CurvedKernelViaAnalysis_2,
            typename CurvedKernelViaAnalysis_2::Construct_arc_2 >
 struct Make_x_monotone_2 :
     public CGAL::binary_function< typename CurvedKernelViaAnalysis_2::Curve_2,
-            CGAL::iterator<std::output_iterator_tag, CGAL::Object>,
-            CGAL::iterator<std::output_iterator_tag, CGAL::Object> > {
+            CGAL::cpp98::iterator<std::output_iterator_tag, CGAL::Object>,
+            CGAL::cpp98::iterator<std::output_iterator_tag, CGAL::Object> > {
 
     //!\name Public types
     //!@{

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Sweep_curves_adapter_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Sweep_curves_adapter_2.h
@@ -693,7 +693,7 @@ class Make_x_monotone_2
     typedef typename SweepCurvesAdapter_2::Generic_arc_2 Generic_arc_2;
    
 public:
-    typedef CGAL::iterator<std::output_iterator_tag, Generic_arc_2> 
+    typedef CGAL::cpp98::iterator<std::output_iterator_tag, Generic_arc_2>
       result_type;
     
     //! standard constructor

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/test/simple_models.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/test/simple_models.h
@@ -1041,7 +1041,7 @@ public:
     
     //! \brief constructs \c Curve_analysis_2 object, uses caching if appropriate
     struct Construct_curve_2 :
-            public CGAL::unary_function< Polynomial_2, Curve_analysis_2 >
+            public CGAL::cpp98::unary_function< Polynomial_2, Curve_analysis_2 >
     {
         //! \brief constructs an object from \c Algebraic_curve_kernel_2 type
         //! no default constructor provided
@@ -1060,7 +1060,7 @@ public:
      * caching is used when appropriate
      */
     struct Construct_curve_pair_2 :
-            public CGAL::binary_function<Curve_analysis_2, Curve_analysis_2,
+            public CGAL::cpp98::binary_function<Curve_analysis_2, Curve_analysis_2,
                 Curve_pair_analysis_2> {
            
         Curve_pair_analysis_2 operator()
@@ -1078,7 +1078,7 @@ public:
     
     //! returns the first coordinate of \c Xy_coordinate_2
     struct Get_x_2 :
-        public CGAL::unary_function<Xy_coordinate_2, Algebraic_real_1> {
+        public CGAL::cpp98::unary_function<Xy_coordinate_2, Algebraic_real_1> {
         
         Algebraic_real_1 operator()(const Xy_coordinate_2& xy) const {
             return xy.x();
@@ -1088,7 +1088,7 @@ public:
     
     //! returns the second coordinate of \c Xy_coordinate_2
     struct Get_y_2 :
-        public CGAL::unary_function<Xy_coordinate_2, Algebraic_real_1> {
+        public CGAL::cpp98::unary_function<Xy_coordinate_2, Algebraic_real_1> {
         
         Algebraic_real_1 operator()(const Xy_coordinate_2& xy) const {
             return xy.y();
@@ -1097,7 +1097,7 @@ public:
     CGAL_Algebraic_Kernel_cons(Get_y_2, Get_y_2_object);
     
     struct Refine_x_2 :
-        public CGAL::unary_function<Xy_coordinate_2, void> {
+        public CGAL::cpp98::unary_function<Xy_coordinate_2, void> {
       
         void operator()(const Xy_coordinate_2& r) const {  }
         
@@ -1106,7 +1106,7 @@ public:
     CGAL_Algebraic_Kernel_pred(Refine_x_2, refine_x_2_object);
     
     struct Refine_y_2 :
-        public CGAL::unary_function<Xy_coordinate_2, void> {
+        public CGAL::cpp98::unary_function<Xy_coordinate_2, void> {
       
         void operator()(const Xy_coordinate_2& r) const {  }
         
@@ -1196,7 +1196,7 @@ public:
     
     //! \brief comparison of x-coordinates 
     struct Compare_x_2 :
-         public CGAL::binary_function<Algebraic_real_1, Algebraic_real_1,
+         public CGAL::cpp98::binary_function<Algebraic_real_1, Algebraic_real_1,
                 Comparison_result > {
 
         Comparison_result operator()(const Algebraic_real_1& x1, 
@@ -1212,7 +1212,7 @@ public:
 
     //! \brief comparison of y-coordinates of two points
     struct Compare_y_2 :
-        public CGAL::binary_function< Xy_coordinate_2, Xy_coordinate_2,
+        public CGAL::cpp98::binary_function< Xy_coordinate_2, Xy_coordinate_2,
                 Comparison_result > {
         
         Comparison_result operator()(const Xy_coordinate_2& xy1, 
@@ -1226,7 +1226,7 @@ public:
     //!
     //! \c equal_x specifies that only y-coordinates need to be compared
     struct Compare_xy_2 :
-          public CGAL::binary_function<Xy_coordinate_2, Xy_coordinate_2,
+          public CGAL::cpp98::binary_function<Xy_coordinate_2, Xy_coordinate_2,
                 Comparison_result > 
     {
         Comparison_result operator()(const Xy_coordinate_2& xy1, 
@@ -1243,7 +1243,7 @@ public:
     //! for algerbaic curves this means that supporting polynomial is 
     //! square-free
     struct Has_finite_number_of_self_intersections_2 :
-            public CGAL::unary_function< Polynomial_2, bool > {
+            public CGAL::cpp98::unary_function< Polynomial_2, bool > {
 
         bool operator()(const Polynomial_2& p) const {
             return true; //is_square_free(p);
@@ -1258,7 +1258,7 @@ public:
     //! in case of algerbaic curves: checks whether supporting polynomials are
     //! coprime
     struct Has_finite_number_of_intersections_2 :
-        public CGAL::binary_function< Curve_analysis_2, Curve_analysis_2, bool > {
+        public CGAL::cpp98::binary_function< Curve_analysis_2, Curve_analysis_2, bool > {
                
         bool operator()(const Curve_analysis_2& c1, 
                         const Curve_analysis_2& c2) const {
@@ -1315,7 +1315,7 @@ public:
     
     //! \brief computes the derivative w.r.t. the first (innermost) variable
     struct Derivative_x_2 : 
-        public CGAL::unary_function< Polynomial_2, Polynomial_2 > {
+        public CGAL::cpp98::unary_function< Polynomial_2, Polynomial_2 > {
         
         Polynomial_2 operator()(const Polynomial_2& p) const {
             return p;
@@ -1325,7 +1325,7 @@ public:
 
     //! \brief computes the derivative w.r.t. the first (outermost) variable
     struct Derivative_y_2 :
-        public CGAL::unary_function< Polynomial_2, Polynomial_2 > {
+        public CGAL::cpp98::unary_function< Polynomial_2, Polynomial_2 > {
         
         Polynomial_2 operator()(const Polynomial_2& p) const  {
             return p;
@@ -1374,7 +1374,7 @@ public:
      * returns a value convertible to \c CGAL::Sign
      */
     struct Sign_at_2 :
-        public CGAL::binary_function< Polynomial_2, Xy_coordinate_2, Sign > {
+        public CGAL::cpp98::binary_function< Polynomial_2, Xy_coordinate_2, Sign > {
 
         Sign operator()(const Polynomial_2& p, const Xy_coordinate_2& r) const
         {

--- a/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
+++ b/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
@@ -153,7 +153,7 @@ struct Graph_with_descriptor_with_graph
 
 
 template <typename Graph, typename Graph_descriptor, typename Descriptor>
-struct Descriptor2Descriptor: public CGAL::unary_function<Graph_descriptor,Descriptor>
+struct Descriptor2Descriptor: public CGAL::cpp98::unary_function<Graph_descriptor,Descriptor>
 {
 
   Descriptor2Descriptor()

--- a/Bounding_volumes/include/CGAL/Min_annulus_d.h
+++ b/Bounding_volumes/include/CGAL/Min_annulus_d.h
@@ -95,7 +95,7 @@ namespace MA_detail {
 
   // functor for a fixed column of A
   template <class NT, class Iterator>
-  class A_column : public CGAL::unary_function <int, NT>
+  class A_column : public CGAL::cpp98::unary_function <int, NT>
   {
   public:
     typedef NT result_type;
@@ -133,7 +133,7 @@ namespace MA_detail {
   // functor for matrix A
   template <class NT, class Access_coordinate_begin_d,
 	    class Point_iterator >
-  class A_matrix : public CGAL::unary_function
+  class A_matrix : public CGAL::cpp98::unary_function
   <int, boost::transform_iterator <A_column
     <NT, typename Access_coordinate_begin_d::Coordinate_iterator>, 
 				   boost::counting_iterator<int> > >
@@ -167,7 +167,7 @@ namespace MA_detail {
 
   // The functor necessary to realize access to b
   template <class NT>
-  class B_vector : public CGAL::unary_function<int, NT>
+  class B_vector : public CGAL::cpp98::unary_function<int, NT>
   {
   public:
     typedef NT result_type;

--- a/Bounding_volumes/include/CGAL/Min_quadrilateral_traits_2.h
+++ b/Bounding_volumes/include/CGAL/Min_quadrilateral_traits_2.h
@@ -129,7 +129,7 @@ public:
 
   // new predicates
   struct Area_less_rectangle_2
-  : public CGAL::binary_function< Rectangle_2, Rectangle_2, bool >
+  : public CGAL::cpp98::binary_function< Rectangle_2, Rectangle_2, bool >
   {
     RT
     area_numerator(const Rectangle_2& r, Cartesian_tag) const
@@ -170,7 +170,7 @@ public:
     }
   };
   struct Area_less_parallelogram_2
-  : public CGAL::binary_function< Parallelogram_2,
+  : public CGAL::cpp98::binary_function< Parallelogram_2,
                                       Parallelogram_2,
                                       bool >
   {
@@ -215,7 +215,7 @@ public:
     }
   };
   struct Width_less_strip_2
-  : public CGAL::binary_function< Strip_2, Strip_2, bool >
+  : public CGAL::cpp98::binary_function< Strip_2, Strip_2, bool >
   {
     RT
     width_numerator(const Strip_2& r, Cartesian_tag) const
@@ -257,7 +257,7 @@ public:
 
   // new constructions
   struct Construct_vector_from_direction_2
-  : public CGAL::unary_function<Direction_2,Vector_2>
+  : public CGAL::cpp98::unary_function<Direction_2,Vector_2>
   {
     Vector_2 operator()(const Direction_2& d) const { return d.vector(); }
   };

--- a/Bounding_volumes/include/CGAL/Rectangular_p_center_traits_2.h
+++ b/Bounding_volumes/include/CGAL/Rectangular_p_center_traits_2.h
@@ -34,7 +34,7 @@
 namespace CGAL {
 
 template < class A, class S >
-struct Select : public CGAL::binary_function< A, A, A > {
+struct Select : public CGAL::cpp98::binary_function< A, A, A > {
   Select() {}
   Select(const S& s) : s_(s) {}
   A operator()(const A& a, const A& b) const
@@ -47,7 +47,7 @@ protected:
 
 template < class R >
 struct I_Signed_x_distance_2
-: public CGAL::binary_function<
+: public CGAL::cpp98::binary_function<
   Point_2< R >, Point_2< R >, typename R::FT >
 {
   typename R::FT
@@ -56,7 +56,7 @@ struct I_Signed_x_distance_2
 };
 template < class R >
 struct I_Signed_y_distance_2
-: public CGAL::binary_function<
+: public CGAL::cpp98::binary_function<
   Point_2< R >, Point_2< R >, typename R::FT >
 {
   typename R::FT
@@ -65,7 +65,7 @@ struct I_Signed_y_distance_2
 };
 template < class R >
 struct I_Infinity_distance_2
-: public CGAL::binary_function<
+: public CGAL::cpp98::binary_function<
   Point_2< R >, Point_2< R >, typename R::FT >
 {
   typename R::FT
@@ -77,7 +77,7 @@ struct I_Infinity_distance_2
 
 template < class R >
 struct I_Signed_infinity_distance_2
-: public CGAL::binary_function<
+: public CGAL::cpp98::binary_function<
   Point_2< R >, Point_2< R >, typename R::FT >
 {
   typename R::FT

--- a/Bounding_volumes/include/CGAL/min_quadrilateral_2.h
+++ b/Bounding_volumes/include/CGAL/min_quadrilateral_2.h
@@ -296,7 +296,7 @@ namespace Optimisation {
     
     template < class Kernel >
     class Rdbmop
-    : public CGAL::binary_function< Direction_2, int, Direction_2 >
+    : public CGAL::cpp98::binary_function< Direction_2, int, Direction_2 >
     {
       typename Kernel::Construct_perpendicular_vector_2   cperpvec;
       typename Kernel::Construct_vector_from_direction_2  cvec;

--- a/Bounding_volumes/test/Bounding_volumes/minimum_enclosing_quadrilateral_2_test_traits.cpp
+++ b/Bounding_volumes/test/Bounding_volumes/minimum_enclosing_quadrilateral_2_test_traits.cpp
@@ -40,19 +40,19 @@ struct MyTraits {
   };
   struct Strip_2      { Point_2 pp1, pp2; Direction_2 dd; };
   struct Equal_2
-  : public CGAL::binary_function<Point_2,Point_2,bool>
+  : public CGAL::cpp98::binary_function<Point_2,Point_2,bool>
   {
     bool operator()(const Point_2& p, const Point_2& q) const
     { return p.xc == q.xc && p.yc == q.yc; }
   };
   struct Less_xy_2
-  : public CGAL::binary_function<Point_2,Point_2,bool>
+  : public CGAL::cpp98::binary_function<Point_2,Point_2,bool>
   {
     bool operator()(const Point_2& p, const Point_2& q) const
     { return p.xc < q.xc || (p.xc == q.xc && p.yc < q.yc); }
   };
   struct Less_yx_2
-  : public CGAL::binary_function<Point_2,Point_2,bool>
+  : public CGAL::cpp98::binary_function<Point_2,Point_2,bool>
   {
     bool operator()(const Point_2& p, const Point_2& q) const
     { return p.yc < q.yc || (p.yc == q.yc && p.xc < q.xc); }
@@ -66,7 +66,7 @@ struct MyTraits {
     }
   };
   struct Has_on_negative_side_2
-  : public CGAL::binary_function<Line_2,Point_2,bool>
+  : public CGAL::cpp98::binary_function<Line_2,Point_2,bool>
   {
     bool operator()(const Line_2& l, const Point_2& p) const {
       return
@@ -76,14 +76,14 @@ struct MyTraits {
     }
   };
   struct Compare_angle_with_x_axis_2
-  : public CGAL::binary_function<Direction_2,Direction_2,CGAL::Comparison_result>
+  : public CGAL::cpp98::binary_function<Direction_2,Direction_2,CGAL::Comparison_result>
   {
     CGAL::Comparison_result
     operator()(const Direction_2& d, const Direction_2& e) const
     { return CGAL::compare_angle_with_x_axisC2(d.xd, d.yd, e.xd, e.yd); }
   };
   struct Area_less_rectangle_2
-  : public CGAL::binary_function<Rectangle_2,Rectangle_2,bool>
+  : public CGAL::cpp98::binary_function<Rectangle_2,Rectangle_2,bool>
   {
     bool operator()(const Rectangle_2& d, const Rectangle_2& e) const
     {
@@ -102,7 +102,7 @@ struct MyTraits {
     }
   };
   struct Area_less_parallelogram_2
-  : public CGAL::binary_function<Parallelogram_2,Parallelogram_2,bool>
+  : public CGAL::cpp98::binary_function<Parallelogram_2,Parallelogram_2,bool>
   {
     bool operator()(const Parallelogram_2& d,
                     const Parallelogram_2& e) const
@@ -121,7 +121,7 @@ struct MyTraits {
     }
   };
   struct Width_less_strip_2
-  : public CGAL::binary_function<Strip_2,Strip_2,bool>
+  : public CGAL::cpp98::binary_function<Strip_2,Strip_2,bool>
   {
     bool operator()(const Strip_2& d, const Strip_2& e) const
     {
@@ -134,7 +134,7 @@ struct MyTraits {
     }
   };
   struct Construct_vector_2
-  : public CGAL::binary_function<Point_2,Point_2,Vector_2>
+  : public CGAL::cpp98::binary_function<Point_2,Point_2,Vector_2>
   {
     Vector_2 operator()(const Point_2& p, const Point_2& q) const
     {
@@ -145,7 +145,7 @@ struct MyTraits {
     }
   };
   struct Construct_vector_from_direction_2
-  : public CGAL::unary_function<Direction_2,Vector_2>
+  : public CGAL::cpp98::unary_function<Direction_2,Vector_2>
   {
     Vector_2 operator()(const Direction_2& d) const
     {
@@ -156,7 +156,7 @@ struct MyTraits {
     }
   };
   struct Construct_perpendicular_vector_2
-  : public CGAL::binary_function<Vector_2,CGAL::Orientation,Vector_2>
+  : public CGAL::cpp98::binary_function<Vector_2,CGAL::Orientation,Vector_2>
   {
     Vector_2 operator()(const Vector_2& v, CGAL::Orientation o) const
     {
@@ -172,7 +172,7 @@ struct MyTraits {
     }
   };
   struct Construct_direction_2
-  : public CGAL::unary_function<Vector_2,Direction_2>
+  : public CGAL::cpp98::unary_function<Vector_2,Direction_2>
   {
     Direction_2 operator()(const Vector_2& v) const
     {
@@ -183,7 +183,7 @@ struct MyTraits {
     }
   };
   struct Construct_opposite_direction_2
-  : public CGAL::unary_function<Direction_2,Direction_2>
+  : public CGAL::cpp98::unary_function<Direction_2,Direction_2>
   {
     Direction_2 operator()(const Direction_2& d) const
     {
@@ -194,7 +194,7 @@ struct MyTraits {
     }
   };
   struct Construct_line_2
-  : public CGAL::binary_function<Point_2,Direction_2,Line_2>
+  : public CGAL::cpp98::binary_function<Point_2,Direction_2,Line_2>
   {
     Line_2 operator()(const Point_2& p, const Direction_2& d) const
     {

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/Box_traits_d.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/Box_traits_d.h
@@ -92,7 +92,7 @@ struct Predicate_traits_d : public BoxTraits {
 
     // compare dim a b = islolesslo a b dim
     class Compare : 
-        public CGAL::binary_function<Box_parameter,Box_parameter,bool>
+        public CGAL::cpp98::binary_function<Box_parameter,Box_parameter,bool>
     {
         int dim;
     public:
@@ -103,7 +103,7 @@ struct Predicate_traits_d : public BoxTraits {
     };
 
     // loless val dim box = getlo box dim < val
-    class Lo_less : public CGAL::unary_function<Box_parameter,bool> {
+    class Lo_less : public CGAL::cpp98::unary_function<Box_parameter,bool> {
         NT value;
         int dim;
     public:
@@ -113,7 +113,7 @@ struct Predicate_traits_d : public BoxTraits {
         }
     };
 
-    class Hi_greater : public CGAL::unary_function<Box_parameter,bool> {
+    class Hi_greater : public CGAL::cpp98::unary_function<Box_parameter,bool> {
         NT value;
         int dim;
     public:
@@ -124,7 +124,7 @@ struct Predicate_traits_d : public BoxTraits {
     };
 
     // spanning lo hi dim box = getlo box dim < lo && gethi box dim > hi
-    class Spanning : public CGAL::unary_function<Box_parameter,bool> {
+    class Spanning : public CGAL::cpp98::unary_function<Box_parameter,bool> {
         NT lo, hi;
         int dim;
     public:

--- a/CGAL_ImageIO/include/CGAL/Image_3.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3.h
@@ -52,7 +52,7 @@ namespace ImageIO {
 template <typename T>
 struct Indicator_factory
 {
-  class Indicator : public CGAL::unary_function<T, double>
+  class Indicator : public CGAL::cpp98::unary_function<T, double>
   {
     const T label;
   public:

--- a/Combinatorial_map/examples/Combinatorial_map/map_3_foreach.cpp
+++ b/Combinatorial_map/examples/Combinatorial_map/map_3_foreach.cpp
@@ -8,7 +8,7 @@ typedef CMap_3::Dart_handle        Dart_handle;
 
 // Functor used to display all the vertices of a given volume
 template<class CMap, unsigned int i>
-struct Display_vertices_of_cell : public CGAL::unary_function<CMap, void>
+struct Display_vertices_of_cell : public CGAL::cpp98::unary_function<CMap, void>
 {
   Display_vertices_of_cell(const CMap& acmap) :
     cmap(acmap),
@@ -40,7 +40,7 @@ private:
 
 // Functor used to remove a face
 template<class CMap>
-struct Remove_face : public CGAL::unary_function<CMap, void>
+struct Remove_face : public CGAL::cpp98::unary_function<CMap, void>
 {
   Remove_face(CMap& acmap) : cmap(acmap)
   {}
@@ -60,7 +60,7 @@ private:
 
 // Functor allowing to transform a variable into its address.
 template<typename T>
-struct Take_adress : public CGAL::unary_function<T, T*>
+struct Take_adress : public CGAL::cpp98::unary_function<T, T*>
 {
   T* operator() (T& t) const
   { return &t; }

--- a/Cone_spanners_2/include/CGAL/Cone_spanners_2/Less_by_direction_2.h
+++ b/Cone_spanners_2/include/CGAL/Cone_spanners_2/Less_by_direction_2.h
@@ -58,9 +58,10 @@ namespace CGAL {
  *
  */
 template <typename Kernel_, typename Graph_>
-class  Less_by_direction_2 : public CGAL::binary_function <typename Graph_::vertex_descriptor,
-        typename Graph_::vertex_descriptor, bool> {
-
+class Less_by_direction_2
+  : public CGAL::cpp98::binary_function <typename Graph_::vertex_descriptor,
+                                         typename Graph_::vertex_descriptor, bool>
+{
 public:
     // typedef for C++11 - doesn't hurt to also have for C++98
     typedef typename Graph_::vertex_descriptor first_argument_type;

--- a/Generator/doc/Generator/CGAL/Random_convex_set_traits_2.h
+++ b/Generator/doc/Generator/CGAL/Random_convex_set_traits_2.h
@@ -26,26 +26,26 @@ typedef Kernel::FT FT;
 
 /*!
 function object class derived from 
-`CGAL::binary_function<Point_2, Point_2, Point_2>`
+`CGAL::cpp98::binary_function<Point_2, Point_2, Point_2>`
 
 */ 
 typedef unspecified_type Sum; 
 
 /*!
 function object class derived from 
-`CGAL::binary_function<Point_2, Point_2, Point_2>`
+`CGAL::cpp98::binary_function<Point_2, Point_2, Point_2>`
 */ 
 typedef unspecified_type Scale; 
 
 /*!
 function object class derived from 
-`CGAL::unary_function<Point_2, FT>` 
+`CGAL::cpp98::unary_function<Point_2, FT>` 
 */ 
 typedef unspecified_type Max_coordinate; 
 
 /*!
 function object class derived from 
-`CGAL::binary_function<Point_2, Point_2, bool>`
+`CGAL::cpp98::binary_function<Point_2, Point_2, bool>`
 */ 
 typedef unspecified_type Angle_less; 
 

--- a/Generator/include/CGAL/Random_convex_set_traits_2.h
+++ b/Generator/include/CGAL/Random_convex_set_traits_2.h
@@ -46,7 +46,7 @@ struct Random_convex_set_traits_2 : public Kernel {
   { return _origin; }
 
   struct Max_coordinate
-  : public CGAL::unary_function< Point_2, FT >
+  : public CGAL::cpp98::unary_function< Point_2, FT >
   {
     FT
     operator()( const Point_2& p) const
@@ -56,7 +56,7 @@ struct Random_convex_set_traits_2 : public Kernel {
   };
 
   struct Sum
-  : public CGAL::binary_function< Point_2, Point_2, Point_2 >
+  : public CGAL::cpp98::binary_function< Point_2, Point_2, Point_2 >
   {
     Point_2
     operator()( const Point_2& p, const Point_2& q) const
@@ -64,7 +64,7 @@ struct Random_convex_set_traits_2 : public Kernel {
   };
 
   struct Scale
-  : public CGAL::binary_function< Point_2, FT, Point_2 >
+  : public CGAL::cpp98::binary_function< Point_2, FT, Point_2 >
   {
     Point_2
     operator()( const Point_2& p, const FT& k) const
@@ -72,7 +72,7 @@ struct Random_convex_set_traits_2 : public Kernel {
   };
 
   struct Angle_less
-  : public CGAL::binary_function< Point_2, Point_2, bool >
+  : public CGAL::cpp98::binary_function< Point_2, Point_2, bool >
   {
     bool
     operator()( const Point_2& p, const Point_2& q) const

--- a/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
@@ -54,7 +54,8 @@ class PointsInKdTreeGraphicsItem : public GraphicsItem
   // Instead of first collecting points into a container, and then draw them
   // we use an output iterator that draws them on the fly
   template <typename K>
-  class Draw : public CGAL::iterator<std::output_iterator_tag, void, void, void, void> {
+  class Draw
+    : public CGAL::cpp98::iterator<std::output_iterator_tag, void, void, void, void> {
     QPainter* painter;
     QMatrix* matrix;
     Converter<K> convert;

--- a/Inscribed_areas/include/CGAL/extremal_polygon_2.h
+++ b/Inscribed_areas/include/CGAL/extremal_polygon_2.h
@@ -41,7 +41,7 @@ namespace CGAL {
 //!!! This will eventually be integrated into function_objects.h
 template < class Array, class Index, class Element >
 struct Index_operator
-: public CGAL::binary_function< Array, Index, Element >
+: public CGAL::cpp98::binary_function< Array, Index, Element >
 {
   Element&
   operator()( Array& a, const Index& i) const

--- a/Interpolation/doc/Interpolation/CGAL/interpolation_functions.h
+++ b/Interpolation/doc/Interpolation/CGAL/interpolation_functions.h
@@ -21,8 +21,8 @@ The class
 */
 template< typename Map >
 struct Data_access
-  : public CGAL::unary_function<typename Map::key_type,
-                                std::pair<typename Map::mapped_type, bool> >
+  : public CGAL::cpp98::unary_function<typename Map::key_type,
+                                       std::pair<typename Map::mapped_type, bool> >
 {
 public:
 

--- a/Interpolation/include/CGAL/interpolation_functions.h
+++ b/Interpolation/include/CGAL/interpolation_functions.h
@@ -36,8 +36,8 @@ namespace CGAL {
 // Functor class for accessing the function values/gradients
 template< class Map >
 struct Data_access
-  : public CGAL::unary_function<typename Map::key_type,
-                                std::pair<typename Map::mapped_type, bool> >
+  : public CGAL::cpp98::unary_function<typename Map::key_type,
+                                       std::pair<typename Map::mapped_type, bool> >
 {
   typedef typename Map::mapped_type   Data_type;
   typedef typename Map::key_type      Key_type;

--- a/Linear_cell_complex/examples/Linear_cell_complex/gmap_linear_cell_complex_3.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/gmap_linear_cell_complex_3.cpp
@@ -9,7 +9,7 @@ typedef LCC_3::FT                         FT;
 
 // Functor used to display all the vertices of a given volume.
 template<class LCC> 
-struct Display_vol_vertices : public CGAL::unary_function<LCC, void>
+struct Display_vol_vertices : public CGAL::cpp98::unary_function<LCC, void>
 {
   Display_vol_vertices(const LCC& alcc) : 
     lcc(alcc), 

--- a/Linear_cell_complex/examples/Linear_cell_complex/linear_cell_complex_3.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/linear_cell_complex_3.cpp
@@ -8,7 +8,7 @@ typedef LCC_3::Point                                       Point;
 
 // Functor used to display all the vertices of a given volume.
 template<class LCC> 
-struct Display_vol_vertices : public CGAL::unary_function<LCC, void>
+struct Display_vol_vertices : public CGAL::cpp98::unary_function<LCC, void>
 {
   Display_vol_vertices(const LCC& alcc) : 
     lcc(alcc), 

--- a/Matrix_search/include/CGAL/sorted_matrix_search.h
+++ b/Matrix_search/include/CGAL/sorted_matrix_search.h
@@ -125,7 +125,7 @@ private:
 };
 template < class Cell >
 struct Cell_min
-: public CGAL::unary_function< Cell, typename Cell::Value >
+: public CGAL::cpp98::unary_function< Cell, typename Cell::Value >
 {
   typename Cell::Value
   operator()( const Cell& c) const
@@ -134,7 +134,7 @@ struct Cell_min
 
 template < class Cell >
 struct Cell_max
-: public CGAL::unary_function< Cell, typename Cell::Value > {
+: public CGAL::cpp98::unary_function< Cell, typename Cell::Value > {
 
   Cell_max( int offset) : ofs( offset) {}
 

--- a/Mesh_2/include/CGAL/Mesh_2/Clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Clusters.h
@@ -118,8 +118,8 @@ private:
   typedef typename Cluster_map::value_type Cluster_map_value_type;
 
   template <class Pair>
-  struct Pair_get_first: public CGAL::unary_function<Pair,
-                                                    typename Pair::first_type>
+  struct Pair_get_first
+    : public CGAL::cpp98::unary_function<Pair, typename Pair::first_type>
   {
     typedef typename Pair::first_type result;
     const result& operator()(const Pair& p) const

--- a/Mesh_2/include/CGAL/Mesh_2/Refine_edges.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_edges.h
@@ -635,7 +635,7 @@ protected:
 
 private: /** \name DEBUGGING TYPES AND DATAS */
   class From_pair_of_vertex_to_edge 
-    : public CGAL::unary_function<Constrained_edge, Edge>
+    : public CGAL::cpp98::unary_function<Constrained_edge, Edge>
   {
     Tr& tr;
   public:

--- a/Mesh_2/include/CGAL/Mesh_2/Refine_faces.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_faces.h
@@ -385,8 +385,8 @@ class Refine_faces :
   typedef typename Tr::Geom_traits Geom_traits;
 
   template <class Pair>
-  struct Pair_get_first: public CGAL::unary_function<Pair,
-                                                    typename Pair::first_type>
+  struct Pair_get_first
+    : public CGAL::cpp98::unary_function<Pair, typename Pair::first_type>
   {
     typedef typename Pair::first_type result;
     const result& operator()(const Pair& p) const

--- a/Mesh_3/examples/Mesh_3/implicit_functions.h
+++ b/Mesh_3/examples/Mesh_3/implicit_functions.h
@@ -25,7 +25,7 @@ double sphere_function (double x, double y, double z) // (c=(0,0,0), r=Sq_radius
 
 
 template <typename FT, typename P>
-class FT_to_point_function_wrapper : public CGAL::unary_function<P, FT>
+class FT_to_point_function_wrapper : public CGAL::cpp98::unary_function<P, FT>
 {
   typedef FT (*Implicit_function)(FT, FT, FT);
   Implicit_function function;

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1030,7 +1030,7 @@ private:
    * A functor which returns true if a given handle is in c3t3
    */
   template <typename Handle>
-  class Is_in_c3t3 : public CGAL::unary_function<Handle, bool>
+  class Is_in_c3t3 : public CGAL::cpp98::unary_function<Handle, bool>
   {
   public:
     Is_in_c3t3(const C3T3& c3t3) : c3t3_(c3t3) { }
@@ -1047,7 +1047,7 @@ private:
    * A functor which answers true if a Cell_handle is a sliver
    */
   template <typename SliverCriterion>
-  struct Is_sliver : public CGAL::unary_function<Cell_handle,bool>
+  struct Is_sliver : public CGAL::cpp98::unary_function<Cell_handle,bool>
   {
     Is_sliver(const C3T3& c3t3,
               const SliverCriterion& criterion,
@@ -1320,7 +1320,7 @@ private:
    */
   template <typename SliverCriterion>
   class Sliver_criterion_value
-    : public CGAL::unary_function<Cell_handle, double>
+    : public CGAL::cpp98::unary_function<Cell_handle, double>
   {
   public:
     Sliver_criterion_value(const Tr& tr,

--- a/Mesh_3/include/CGAL/Mesh_3/Polyline_with_context.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Polyline_with_context.h
@@ -61,9 +61,9 @@ struct Polyline_with_context
  */
 template <typename Pwc_>
 struct Extract_bare_polyline :
-  public CGAL::unary_function<Pwc_, const typename Pwc_::Bare_polyline&>
+  public CGAL::cpp98::unary_function<Pwc_, const typename Pwc_::Bare_polyline&>
 {
-  typedef CGAL::unary_function<Pwc_, const typename Pwc_::Bare_polyline&> Base;
+  typedef CGAL::cpp98::unary_function<Pwc_, const typename Pwc_::Bare_polyline&> Base;
   typedef typename Base::result_type                                     result_type;
   typedef typename Base::argument_type                                   argument_type;
   

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -82,11 +82,11 @@ namespace Mesh_3 {
     // to use them. -- Laurent Rineau, 2007/07/27
     template <typename Map>
     struct Second_of :
-    public CGAL::unary_function<typename Map::value_type,
-    const typename Map::mapped_type&>
+    public CGAL::cpp98::unary_function<typename Map::value_type,
+                                       const typename Map::mapped_type&>
     {
-      typedef CGAL::unary_function<typename Map::value_type,
-        const typename Map::mapped_type&> Base;
+      typedef CGAL::cpp98::unary_function<typename Map::value_type,
+                                          const typename Map::mapped_type&> Base;
       typedef typename Base::result_type result_type;
       typedef typename Base::argument_type argument_type;
 
@@ -103,7 +103,7 @@ namespace Mesh_3 {
     // It is used in Slivers_exuder, to constructor a transform iterator.
     template <typename Gt, typename Vertex_handle>
     class Min_distance_from_v :
-    public CGAL::unary_function<Vertex_handle, void>
+    public CGAL::cpp98::unary_function<Vertex_handle, void>
     {
       const Vertex_handle * v;
       const Gt& gt;

--- a/Mesh_3/include/CGAL/Mesh_3/Triangulation_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Triangulation_sizing_field.h
@@ -117,7 +117,7 @@ private:
    * Used by boost transform iterator
    */
   struct Extract_point :
-  public CGAL::unary_function<typename Tr::Vertex,Weighted_point>
+  public CGAL::cpp98::unary_function<typename Tr::Vertex,Weighted_point>
   {
     Weighted_point operator()(const typename Tr::Vertex& v) const { return v.point(); }
   };

--- a/Mesh_3/include/CGAL/Mesh_3/utilities.h
+++ b/Mesh_3/include/CGAL/Mesh_3/utilities.h
@@ -70,9 +70,9 @@ struct Debug_messages_tools {
  */
 template <typename Pair>
 struct First_of :
-  public CGAL::unary_function<Pair, const typename Pair::first_type&>
+  public CGAL::cpp98::unary_function<Pair, const typename Pair::first_type&>
 {
-  typedef CGAL::unary_function<Pair, const typename Pair::first_type&> Base;
+  typedef CGAL::cpp98::unary_function<Pair, const typename Pair::first_type&> Base;
   typedef typename Base::result_type                                  result_type;
   typedef typename Base::argument_type                                argument_type;
   

--- a/Mesh_3/test/Mesh_3/implicit_functions.h
+++ b/Mesh_3/test/Mesh_3/implicit_functions.h
@@ -25,7 +25,7 @@ double sphere_function (double x, double y, double z) // (c=(0,0,0), r=Sq_radius
 
 
 template <typename FT, typename P>
-class FT_to_point_function_wrapper : public CGAL::unary_function<P, FT>
+class FT_to_point_function_wrapper : public CGAL::cpp98::unary_function<P, FT>
 {
   typedef FT (*Implicit_function)(FT, FT, FT);
   Implicit_function function;

--- a/Mesh_3/test/Mesh_3/test_c3t3_extract_subdomains_boundaries.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3_extract_subdomains_boundaries.cpp
@@ -24,7 +24,7 @@ double sphere_function (double x, double y, double z) // (c=(0,0,0), r=Sq_radius
 }
 
 template <typename FT, typename P>
-class FT_to_point_function_wrapper : public CGAL::unary_function<P, FT>
+class FT_to_point_function_wrapper : public CGAL::cpp98::unary_function<P, FT>
 {
   typedef FT (*Implicit_function)(FT, FT, FT);
   Implicit_function function;

--- a/Nef_2/include/CGAL/Nef_polynomial.h
+++ b/Nef_2/include/CGAL/Nef_polynomial.h
@@ -146,7 +146,7 @@ public:
     typedef typename AST_NT::Is_exact            Is_exact;
     typedef Tag_false                            Is_numerical_sensitive;                                                           
     class Integral_division
-        : public CGAL::binary_function< Type, Type,
+        : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
     public:
         Type operator()( const Type& x,
@@ -158,7 +158,7 @@ public:
     };
 
     class Gcd 
-      : public CGAL::binary_function< Type, Type, Type > {
+      : public CGAL::cpp98::binary_function< Type, Type, Type > {
     public:
         Type operator()( const Type& x, const Type& y ) const {
             // By definition gcd(0,0) == 0
@@ -176,7 +176,7 @@ template <class NT> class Real_embeddable_traits< Nef_polynomial<NT> >
   public:
     typedef Nef_polynomial<NT> Type;
     class Abs 
-        : public CGAL::unary_function< Type, Type> {
+        : public CGAL::cpp98::unary_function< Type, Type> {
     public:
         Type inline operator()( const Type& x ) const {
             return (CGAL::Nef::sign( x ) == CGAL::NEGATIVE)? -x : x;
@@ -184,7 +184,7 @@ template <class NT> class Real_embeddable_traits< Nef_polynomial<NT> >
     };
 
     class Sgn 
-      : public CGAL::unary_function< Type, CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, CGAL::Sign > {
       public:
         CGAL::Sign inline operator()( const Type& x ) const {
             return CGAL::Nef::sign( x );
@@ -192,7 +192,7 @@ template <class NT> class Real_embeddable_traits< Nef_polynomial<NT> >
     };
     
     class Compare 
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 CGAL::Comparison_result > {
       public:
         CGAL::Comparison_result inline operator()( 
@@ -203,7 +203,7 @@ template <class NT> class Real_embeddable_traits< Nef_polynomial<NT> >
     };
     
     class To_double 
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double inline operator()( const Type& p ) const {
             return CGAL::to_double(
@@ -212,7 +212,7 @@ template <class NT> class Real_embeddable_traits< Nef_polynomial<NT> >
     };
     
     class To_interval 
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& p ) const {
             return CGAL::to_interval(p.eval_at(Nef_polynomial<NT>::infi_maximal_value()));

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
@@ -104,7 +104,7 @@ template<class R_> struct Point_of_sphere : private Store_kernel<R_> {
   typedef Point result_type;
   typedef Sphere first_argument_type;
   typedef int second_argument_type;
-  struct Trans : CGAL::binary_function<FT,int,FT> {
+  struct Trans : CGAL::cpp98::binary_function<FT,int,FT> {
     FT const& r_; int idx; bool sgn;
     Trans (int n, FT const& r, bool b) : r_(r), idx(n), sgn(b) {}
     FT operator()(FT const&x, int i)const{

--- a/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
@@ -1033,7 +1033,7 @@ template<class R_> struct Midpoint : private Store_kernel<R_> {
 	typedef Point first_argument_type;
 	typedef Point second_argument_type;
 	// There is a division, but it will be cast to RT afterwards anyway, so maybe we could use RT.
-	struct Average : CGAL::binary_function<FT,RT,FT> {
+	struct Average : CGAL::cpp98::binary_function<FT,RT,FT> {
 		FT operator()(FT const&a, RT const&b)const{
 			return (a+b)/2;
 		}
@@ -1099,7 +1099,7 @@ template<class R_> struct Squared_distance : private Store_kernel<R_> {
 	typedef RT result_type;
 	typedef Point first_argument_type;
 	typedef Point second_argument_type;
-	struct Sq_diff : CGAL::binary_function<RT,RT,RT> {
+	struct Sq_diff : CGAL::cpp98::binary_function<RT,RT,RT> {
 		RT operator()(RT const&a, RT const&b)const{
 			return CGAL::square(a-b);
 		}

--- a/Number_types/include/CGAL/CORE_BigFloat.h
+++ b/Number_types/include/CGAL/CORE_BigFloat.h
@@ -46,7 +46,7 @@ public:
     typedef CGAL::Tag_true Is_bigfloat_interval; 
   
  
-    struct Lower :public CGAL::unary_function<Interval,Bound>{
+    struct Lower :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator() ( Interval x ) const {   
             CORE::BigFloat result = ::CORE::BigFloat(x.m()-x.err(),0,x.exp());
             CGAL_postcondition(result <= x);
@@ -54,7 +54,7 @@ public:
         }
     };
     
-    struct Upper :public CGAL::unary_function<Interval,Bound>{
+    struct Upper :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator() ( Interval x ) const {     
             CORE::BigFloat result = ::CORE::BigFloat(x.m()+x.err(),0,x.exp());
             CGAL_postcondition(result >= x);
@@ -62,7 +62,7 @@ public:
         }
     };
 
-    struct Width :public CGAL::unary_function<Interval,Bound>{
+    struct Width :public CGAL::cpp98::unary_function<Interval,Bound>{
          
         Bound operator() ( Interval x ) const {    
             unsigned long err = 2*x.err();
@@ -70,52 +70,52 @@ public:
         }
     };
 
-    struct Median :public CGAL::unary_function<Interval,Bound>{
+    struct Median :public CGAL::cpp98::unary_function<Interval,Bound>{
          
         Bound operator() ( Interval x ) const {   
             return Bound(x.m(),0,x.exp());
         }
     };
 
-    struct Norm :public CGAL::unary_function<Interval,Bound>{
+    struct Norm :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator() ( Interval x ) const {
           BOOST_USING_STD_MAX();
           return max BOOST_PREVENT_MACRO_SUBSTITUTION (Upper()(x).abs(),Lower()(x).abs());
         }
     };
     
-    struct Zero_in :public CGAL::unary_function<Interval,bool>{
+    struct Zero_in :public CGAL::cpp98::unary_function<Interval,bool>{
         bool operator() ( Interval x ) const {      
             return x.isZeroIn(); 
         }
     };
 
-    struct In :public CGAL::binary_function<Bound,Interval,bool>{
+    struct In :public CGAL::cpp98::binary_function<Bound,Interval,bool>{
         bool operator()( Bound x, const Interval& a ) const {    
             CGAL_precondition(CGAL::singleton(x));
             return (Lower()(a) <= x && x <= Upper()(a));
         }
     };
 
-    struct Equal :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Equal :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const { 
             return (Upper()(a) == Upper()(b) &&  Lower()(a) == Lower()(b));
         }
     };
     
-    struct Subset :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const {   
             return Lower()(b) <= Lower()(a) && Upper()(a) <= Upper()(b);
         }
     };
     
-    struct Proper_subset :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Proper_subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const { 
             return Subset()(a,b) && (!Equal()(a,b));
         }
     };
     
-    struct Intersection :public CGAL::binary_function<Interval,Interval,Interval>{
+    struct Intersection :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
       Interval operator()( const Interval& a, const Interval& b ) const {
             BOOST_USING_STD_MAX();
             BOOST_USING_STD_MIN();
@@ -129,7 +129,7 @@ public:
     };
  
 
-    struct Overlap :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Overlap :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator() ( Interval x, Interval y ) const {       
             Self::Zero_in Zero_in;
             bool result = Zero_in(x-y);
@@ -137,7 +137,7 @@ public:
         }
     };
    
-    struct Hull :public CGAL::binary_function<Interval,Interval,Interval>{
+    struct Hull :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
 
       // for debugging
 /*      void print_bf(CORE::BigFloat bf, std::string s) const {
@@ -229,13 +229,13 @@ public:
         }
     };
 
-    struct Singleton :public CGAL::unary_function<Interval,bool> {
+    struct Singleton :public CGAL::cpp98::unary_function<Interval,bool> {
         bool operator() ( Interval x ) const {       
             return (x.err() == 0); 
         }
     };
 
-    struct Construct :public CGAL::binary_function<Bound,Bound,Interval>{
+    struct Construct :public CGAL::cpp98::binary_function<Bound,Bound,Interval>{
         Interval operator()( const Bound& l,const Bound& r) const {
             CGAL_precondition( l < r ); 
             return Hull()(l,r);
@@ -376,7 +376,7 @@ template <> class Algebraic_structure_traits< CORE::BigFloat >
     typedef Tag_true           Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             // What I want is a sqrt computed with 
@@ -406,7 +406,7 @@ template <> class Algebraic_structure_traits< CORE::BigFloat >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -429,7 +429,7 @@ template <> class Real_embeddable_traits< CORE::BigFloat >
   : public INTERN_RET::Real_embeddable_traits_base< CORE::BigFloat , CGAL::Tag_true  > {
   public:
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             Type result; 
@@ -462,7 +462,7 @@ template <> class Real_embeddable_traits< CORE::BigFloat >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
             ::CGAL::Sign result =  sign( x.sign());
@@ -471,7 +471,7 @@ template <> class Real_embeddable_traits< CORE::BigFloat >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -483,7 +483,7 @@ template <> class Real_embeddable_traits< CORE::BigFloat >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           // this call is required to get reasonable values for the double
@@ -493,7 +493,7 @@ template <> class Real_embeddable_traits< CORE::BigFloat >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
     public:
         std::pair<double, double> operator()( const Type& x ) const {
                         

--- a/Number_types/include/CGAL/CORE_BigInt.h
+++ b/Number_types/include/CGAL/CORE_BigInt.h
@@ -53,7 +53,7 @@ template <> class Algebraic_structure_traits< CORE::BigInt >
     typedef INTERN_AST::Mod_per_operator< Type > Mod;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         //! computes the largest NT not larger than the square root of \a a.
         Type operator()( const Type& x) const {
@@ -65,7 +65,7 @@ template <> class Algebraic_structure_traits< CORE::BigInt >
 
 
     class Gcd
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -88,7 +88,7 @@ template <> class Real_embeddable_traits< CORE::BigInt >
   public:
 
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CORE::abs( x );
@@ -96,7 +96,7 @@ template <> class Real_embeddable_traits< CORE::BigInt >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return (::CGAL::Sign) CORE::sign( x );
@@ -104,7 +104,7 @@ template <> class Real_embeddable_traits< CORE::BigInt >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -114,7 +114,7 @@ template <> class Real_embeddable_traits< CORE::BigInt >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           // this call is required to get reasonable values for the double
@@ -124,7 +124,7 @@ template <> class Real_embeddable_traits< CORE::BigInt >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x_ ) const {
             CORE::Expr x(x_);

--- a/Number_types/include/CGAL/CORE_BigRat.h
+++ b/Number_types/include/CGAL/CORE_BigRat.h
@@ -67,7 +67,7 @@ template <> class Real_embeddable_traits< CORE::BigRat >
   public:
 
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CORE::abs( x );
@@ -75,7 +75,7 @@ template <> class Real_embeddable_traits< CORE::BigRat >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return (::CGAL::Sign) CORE::sign( x );
@@ -83,7 +83,7 @@ template <> class Real_embeddable_traits< CORE::BigRat >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -94,7 +94,7 @@ template <> class Real_embeddable_traits< CORE::BigRat >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           // this call is required to get reasonable values for the double
@@ -104,7 +104,7 @@ template <> class Real_embeddable_traits< CORE::BigRat >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x_ ) const {
             CORE::Expr x(x_);

--- a/Number_types/include/CGAL/CORE_Expr.h
+++ b/Number_types/include/CGAL/CORE_Expr.h
@@ -44,7 +44,7 @@ template <> class Algebraic_structure_traits< CORE::Expr >
     typedef Tag_true            Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CORE::sqrt( x );
@@ -52,7 +52,7 @@ template <> class Algebraic_structure_traits< CORE::Expr >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -131,7 +131,7 @@ template <> class Real_embeddable_traits< CORE::Expr >
   : public INTERN_RET::Real_embeddable_traits_base< CORE::Expr , CGAL::Tag_true > {
   public:
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return CORE::abs( x );
@@ -139,7 +139,7 @@ template <> class Real_embeddable_traits< CORE::Expr >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return (::CGAL::Sign) CORE::sign( x );
@@ -147,7 +147,7 @@ template <> class Real_embeddable_traits< CORE::Expr >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -161,7 +161,7 @@ template <> class Real_embeddable_traits< CORE::Expr >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           x.approx(53,1075);
@@ -170,7 +170,7 @@ template <> class Real_embeddable_traits< CORE::Expr >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
             std::pair<double,double> result;

--- a/Number_types/include/CGAL/Counted_number.h
+++ b/Number_types/include/CGAL/Counted_number.h
@@ -445,7 +445,7 @@ operator>=(Counted_number<NT> const &n1, Counted_number<NT> const &n2)
 
 template <class NT>
 class Is_valid< Counted_number<NT> >
-  : public CGAL::unary_function< Counted_number<NT>, bool > {
+  : public CGAL::cpp98::unary_function< Counted_number<NT>, bool > {
   public:
     bool operator()( const Counted_number<NT>& x ) {
       return is_valid( x.rep() );
@@ -515,7 +515,7 @@ namespace INTERN_COUNTED_NUMBER{
 
 template< class NT, class Functor >
 struct Simplify_selector {
-  struct Simplify : public CGAL::unary_function<NT&, void> {
+  struct Simplify : public CGAL::cpp98::unary_function<NT&, void> {
     void operator()( NT& x ) const {
       x.simplify();
     }
@@ -529,7 +529,7 @@ struct Simplify_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Unit_part_selector {
-  struct Unit_part : public CGAL::unary_function<NT, NT > {
+  struct Unit_part : public CGAL::cpp98::unary_function<NT, NT > {
     NT operator()( const NT& x ) const {
       return x.unit_part();
     }
@@ -543,7 +543,7 @@ struct Unit_part_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_zero_selector {
-  struct Is_zero : public CGAL::unary_function<NT, bool > {
+  struct Is_zero : public CGAL::cpp98::unary_function<NT, bool > {
     bool operator()( const NT& x ) const {
       return x.is_zero();
     }
@@ -557,7 +557,7 @@ struct Is_zero_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_one_selector {
-  struct Is_one : public CGAL::unary_function<NT, bool > {
+  struct Is_one : public CGAL::cpp98::unary_function<NT, bool > {
     bool operator()( const NT& x ) const {
       return x.is_one();
     }
@@ -571,7 +571,7 @@ struct Is_one_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Square_selector {
-  struct Square : public CGAL::unary_function<NT, NT > {
+  struct Square : public CGAL::cpp98::unary_function<NT, NT > {
     NT operator()( const NT& x ) const {
       return x.square();
     }
@@ -585,7 +585,7 @@ struct Square_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Integral_division_selector {
-  struct Integral_division : public CGAL::binary_function<NT, NT, NT > {
+  struct Integral_division : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return x.integral_division( y );
     }
@@ -599,7 +599,7 @@ struct Integral_division_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_square_selector {
-  struct Is_square : public CGAL::binary_function<NT, NT&, bool > {
+  struct Is_square : public CGAL::cpp98::binary_function<NT, NT&, bool > {
       bool operator()( const NT& x, NT& y ) const {
           return x.is_square( y );
       }
@@ -618,7 +618,7 @@ struct Is_square_selector< NT, Null_functor > {
 
 template <class NT, class AlgebraicStructureTag>
 struct Sqrt_selector{
-    struct Sqrt : public CGAL::unary_function<NT,NT> {
+    struct Sqrt : public CGAL::cpp98::unary_function<NT,NT> {
         NT operator ()(const NT& x) const {
             return x.sqrt();
         }
@@ -631,7 +631,7 @@ struct Sqrt_selector<NT,Null_functor> {
 
 template< class NT, class Functor >
 struct Kth_root_selector {
-  struct Kth_root : public CGAL::binary_function<int, NT, NT > {
+  struct Kth_root : public CGAL::cpp98::binary_function<int, NT, NT > {
     NT operator()( int k, const NT& x ) const {
       return x.kth_root( k );
     }
@@ -687,7 +687,7 @@ struct Root_of_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Gcd_selector {
-  struct Gcd : public CGAL::binary_function<NT, NT, NT > {
+  struct Gcd : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return x.gcd( y );
     }
@@ -701,7 +701,7 @@ struct Gcd_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Div_selector {
-  struct Div : public CGAL::binary_function<NT, NT, NT > {
+  struct Div : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return x.div( y );
     }
@@ -715,7 +715,7 @@ struct Div_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Mod_selector {
-  struct Mod : public CGAL::binary_function<NT, NT, NT > {
+  struct Mod : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return x.mod( y );
     }
@@ -818,20 +818,20 @@ public:
     <Counted_number<NT>, typename RET_NT::Is_zero > ::Is_zero Is_zero;
 
     class Is_finite
-      : public CGAL::unary_function< Counted_number<NT>, bool > {
+      : public CGAL::cpp98::unary_function< Counted_number<NT>, bool > {
       public:
         bool operator()( const Counted_number<NT>& x ) const {
           return CGAL_NTS is_finite( x.rep() );
         }
     };
 
-    struct To_double : public CGAL::unary_function< Counted_number<NT>, double > {
+    struct To_double : public CGAL::cpp98::unary_function< Counted_number<NT>, double > {
         double operator()(const Counted_number<NT>& x) const {
             return x.to_double();
         }
     };
 
-    struct To_interval: public CGAL::unary_function< Counted_number<NT>, std::pair<double,double> > {
+    struct To_interval: public CGAL::cpp98::unary_function< Counted_number<NT>, std::pair<double,double> > {
         std::pair<double,double>
         operator()(const Counted_number<NT>& x) const {
             return x.to_interval();

--- a/Number_types/include/CGAL/Gmpfi.h
+++ b/Number_types/include/CGAL/Gmpfi.h
@@ -42,28 +42,28 @@ public:
         typedef Uncertain<bool> Boolean;
 
         struct Is_zero:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 Boolean operator()(const Type &x)const{
                         return x.is_zero();
                 }
         };
 
         struct Is_one:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 Boolean operator()(const Type &x)const{
                         return x.is_one();
                 }
         };
 
         struct Square:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 Type operator()(const Type &x)const{
                         return x.square();
                 };
         };
 
         struct Is_square:
-        public CGAL::binary_function<Type,Type&,Boolean>{
+        public CGAL::cpp98::binary_function<Type,Type&,Boolean>{
                 Boolean operator()(const Type &x)const{
                         return x.is_square();
                 };
@@ -73,21 +73,21 @@ public:
         };
 
         struct Sqrt:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 Type operator()(const Type &x)const{
                         return x.sqrt();
                 };
         };
 
         struct Kth_Root:
-        public CGAL::binary_function<int,Type,Type>{
+        public CGAL::cpp98::binary_function<int,Type,Type>{
                 Type operator()(int k,const Type &x)const{
                         return (k==3?x.cbrt():x.kthroot(k));
                 };
         };
 
         struct Divides:
-        public CGAL::binary_function<Type,Type,Boolean>{
+        public CGAL::cpp98::binary_function<Type,Type,Boolean>{
                 Boolean operator()(const Type &d,const Type &n)const{
                         // Avoid compiler warning
 		        (void)n;
@@ -115,42 +115,42 @@ public INTERN_RET::Real_embeddable_traits_base<Gmpfi,CGAL::Tag_true>{
         typedef AST::Is_zero    Is_zero;
 
         struct Is_finite:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return(x.is_number());
                 };
         };
 
         struct Abs:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 inline Type operator()(const Type &x)const{
                         return x.abs();
                 };
         };
 
         struct Sgn:
-        public CGAL::unary_function<Type,Sign>{
+        public CGAL::cpp98::unary_function<Type,Sign>{
                 inline Sign operator()(const Type &x)const{
                         return x.sign();
                 };
         };
 
         struct Is_positive:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return x.is_positive();
                 };
         };
 
         struct Is_negative:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return x.is_negative();
                 };
         };
 
         struct Compare:
-        public CGAL::binary_function<Type,Type,Comparison_result>{
+        public CGAL::cpp98::binary_function<Type,Type,Comparison_result>{
                 inline Comparison_result operator()
                         (const Type &x,const Type &y)const{
                                 return x.compare(y);
@@ -159,14 +159,14 @@ public INTERN_RET::Real_embeddable_traits_base<Gmpfi,CGAL::Tag_true>{
         };
 
         struct To_double:
-        public CGAL::unary_function<Type,double>{
+        public CGAL::cpp98::unary_function<Type,double>{
                 inline double operator()(const Type &x)const{
                         return x.to_double();
                 };
         };
 
         struct To_interval:
-        public CGAL::unary_function<Type,std::pair<double,double> >{
+        public CGAL::cpp98::unary_function<Type,std::pair<double,double> >{
                 inline std::pair<double,double> operator()(const Type &x)const{
                                 return x.to_interval();
                         };
@@ -185,86 +185,86 @@ public:
   typedef CGAL::Tag_false With_empty_interval; 
   typedef CGAL::Tag_true  Is_interval; 
 
-  struct Construct :public CGAL::binary_function<Bound,Bound,Interval>{
+  struct Construct :public CGAL::cpp98::binary_function<Bound,Bound,Interval>{
     Interval operator()( const Bound& l,const Bound& r) const {
       CGAL_precondition( l < r ); 
       return Interval(std::make_pair(l,r));
     }
   };
 
-  struct Lower :public CGAL::unary_function<Interval,Bound>{
+  struct Lower :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return a.inf();
     }
   };
 
-  struct Upper :public CGAL::unary_function<Interval,Bound>{
+  struct Upper :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return a.sup();
     }
   };
 
-  struct Width :public CGAL::unary_function<Interval,Bound>{
+  struct Width :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return Gmpfr::sub(a.sup(),a.inf(),std::round_toward_infinity);
     }
   };
 
-  struct Median :public CGAL::unary_function<Interval,Bound>{
+  struct Median :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return (a.inf()+a.sup())/2;
     }
   };
     
-  struct Norm :public CGAL::unary_function<Interval,Bound>{
+  struct Norm :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return a.abs().sup();
     }
   };
 
-  struct Singleton :public CGAL::unary_function<Interval,bool>{
+  struct Singleton :public CGAL::cpp98::unary_function<Interval,bool>{
     bool operator()( const Interval& a ) const {
       return a.inf() == a.sup();
     }
   };
 
-  struct Zero_in :public CGAL::unary_function<Interval,bool>{
+  struct Zero_in :public CGAL::cpp98::unary_function<Interval,bool>{
     bool operator()( const Interval& a ) const {
       return a.inf() <= 0  &&  0 <= a.sup();
     }
   };
 
-  struct In :public CGAL::binary_function<Bound,Interval,bool>{
+  struct In :public CGAL::cpp98::binary_function<Bound,Interval,bool>{
     bool operator()( Bound x, const Interval& a ) const {
       return a.inf() <= x && x <= a.sup();
     }
   };
 
-  struct Equal :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Equal :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return a.is_same(b);
     }
   };
     
-  struct Overlap :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Overlap :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return a.do_overlap(b);
     }
   };
     
-  struct Subset :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return b.inf() <= a.inf() && a.sup() <= b.sup() ;  
     }
   };
     
-  struct Proper_subset :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Proper_subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return Subset()(a,b) && ! Equal()(a,b); 
     }
   };
     
-  struct Hull :public CGAL::binary_function<Interval,Interval,Interval>{
+  struct Hull :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
     Interval operator()( const Interval& a, const Interval& b ) const {
       BOOST_USING_STD_MAX();
       BOOST_USING_STD_MIN();
@@ -278,7 +278,7 @@ public:
   
 //  struct Empty is Null_functor 
   
-  struct Intersection :public CGAL::binary_function<Interval,Interval,Interval>{
+  struct Intersection :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
     Interval operator()( const Interval& a, const Interval& b ) const {
       BOOST_USING_STD_MAX();
       BOOST_USING_STD_MIN();
@@ -300,7 +300,7 @@ public:
   typedef Bigfloat_interval_traits<Gmpfi> Self; 
   typedef CGAL::Tag_true                  Is_bigfloat_interval; 
   
-  struct Relative_precision: public CGAL::unary_function<NT,long>{
+  struct Relative_precision: public CGAL::cpp98::unary_function<NT,long>{
 
     long operator()(const NT& x) const {
       CGAL_precondition(!Singleton()(x));

--- a/Number_types/include/CGAL/Gmpfr.h
+++ b/Number_types/include/CGAL/Gmpfr.h
@@ -35,28 +35,28 @@ public:
         typedef bool            Boolean;
 
         struct Is_zero:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 Boolean operator()(const Type &x)const{
                         return x.is_zero();
                 }
         };
 
         struct Is_one:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 Boolean operator()(const Type &x)const{
                         return x.is_one();
                 }
         };
 
         struct Square:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 Type operator()(const Type &x)const{
                         return x.square();
                 };
         };
 
         struct Is_square:
-        public CGAL::binary_function<Type,Type&,Boolean>{
+        public CGAL::cpp98::binary_function<Type,Type&,Boolean>{
                 Boolean operator()(const Type &x,Type &y)const{
                         return x.is_square(y);
                 };
@@ -66,14 +66,14 @@ public:
         };
 
         struct Sqrt:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 Type operator()(const Type &x)const{
                         return x.sqrt();
                 };
         };
 
         struct Kth_Root:
-        public CGAL::binary_function<int,Type,Type>{
+        public CGAL::cpp98::binary_function<int,Type,Type>{
                 Type operator()(int k,const Type &x)const{
                         return (k==3?x.cbrt():x.kthroot(k));
                 };
@@ -96,42 +96,42 @@ public INTERN_RET::Real_embeddable_traits_base<Gmpfr,CGAL::Tag_true>{
         typedef AST::Is_zero    Is_zero;
 
         struct Is_finite:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return(x.is_number());
                 };
         };
 
         struct Abs:
-        public CGAL::unary_function<Type,Type>{
+        public CGAL::cpp98::unary_function<Type,Type>{
                 inline Type operator()(const Type &x)const{
                         return x.abs();
                 };
         };
 
         struct Sgn:
-        public CGAL::unary_function<Type,Sign>{
+        public CGAL::cpp98::unary_function<Type,Sign>{
                 inline Sign operator()(const Type &x)const{
                         return x.sign();
                 };
         };
 
         struct Is_positive:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return(x.sign()==POSITIVE);
                 };
         };
 
         struct Is_negative:
-        public CGAL::unary_function<Type,Boolean>{
+        public CGAL::cpp98::unary_function<Type,Boolean>{
                 inline Boolean operator()(const Type &x)const{
                         return(x.sign()==NEGATIVE);
                 };
         };
 
         struct Compare:
-        public CGAL::binary_function<Type,Type,Comparison_result>{
+        public CGAL::cpp98::binary_function<Type,Type,Comparison_result>{
                 inline Comparison_result operator()
                         (const Type &x,const Type &y)const{
                                 return x.compare(y);
@@ -140,14 +140,14 @@ public INTERN_RET::Real_embeddable_traits_base<Gmpfr,CGAL::Tag_true>{
         };
 
         struct To_double:
-        public CGAL::unary_function<Type,double>{
+        public CGAL::cpp98::unary_function<Type,double>{
                 inline double operator()(const Type &x)const{
                         return x.to_double();
                 };
         };
 
         struct To_interval:
-        public CGAL::unary_function<Type,std::pair<double,double> >{
+        public CGAL::cpp98::unary_function<Type,std::pair<double,double> >{
                 inline std::pair<double,double>operator()(const Type &x)const{
                                 return x.to_interval();
                 };

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -36,7 +36,7 @@ template <> class Algebraic_structure_traits< Gmpq >
     typedef Tag_false            Is_numerical_sensitive;
 
     class Is_square
-      : public CGAL::binary_function< Type, Type&,
+      : public CGAL::cpp98::binary_function< Type, Type&,
                                 bool > {
       public:
         bool operator()( const Type& x_, Type& y ) const {
@@ -54,7 +54,7 @@ template <> class Algebraic_structure_traits< Gmpq >
     };
 
     class Simplify
-      : public CGAL::unary_function< Type&, void > {
+      : public CGAL::cpp98::unary_function< Type&, void > {
       public:
         void operator()( Type& x) const {
           mpq_canonicalize( x.mpq() );
@@ -70,7 +70,7 @@ template <> class Real_embeddable_traits< Gmpq >
   public:
   
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return x.sign();
@@ -78,7 +78,7 @@ template <> class Real_embeddable_traits< Gmpq >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           return x.to_double();
@@ -86,7 +86,7 @@ template <> class Real_embeddable_traits< Gmpq >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 #if MPFR_VERSION_MAJOR >= 3

--- a/Number_types/include/CGAL/Gmpz.h
+++ b/Number_types/include/CGAL/Gmpz.h
@@ -52,7 +52,7 @@ public:
     typedef INTERN_AST::Is_square_per_sqrt< Type >
     Is_square;
     class Integral_division
-        : public CGAL::binary_function< Type, Type,
+        : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
     public:
         Type operator()( const Type& x,
@@ -65,7 +65,7 @@ public:
     };
 
     class Gcd
-        : public CGAL::binary_function< Type, Type,
+        : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
     public:
         Type operator()( const Type& x,
@@ -97,7 +97,7 @@ public:
     typedef INTERN_AST::Mod_per_operator< Type > Mod;
 
     class Sqrt
-        : public CGAL::unary_function< Type, Type > {
+        : public CGAL::cpp98::unary_function< Type, Type > {
     public:
         Type operator()( const Type& x ) const {
             Gmpz result;
@@ -111,7 +111,7 @@ template <> class Real_embeddable_traits< Gmpz >
     : public INTERN_RET::Real_embeddable_traits_base< Gmpz , CGAL::Tag_true > {
 public:
     class Sgn
-        : public CGAL::unary_function< Type, ::CGAL::Sign > {
+        : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
     public:
         ::CGAL::Sign operator()( const Type& x ) const {
             return x.sign();
@@ -119,7 +119,7 @@ public:
     };
 
     class To_double
-        : public CGAL::unary_function< Type, double > {
+        : public CGAL::cpp98::unary_function< Type, double > {
     public:
         double operator()( const Type& x ) const {
             return x.to_double();
@@ -127,7 +127,7 @@ public:
     };
 
     class To_interval
-        : public CGAL::unary_function< Type, std::pair< double, double > > {
+        : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
     public:
         std::pair<double, double> operator()( const Type& x ) const {
 #if MPFR_VERSION_MAJOR >= 3
@@ -164,7 +164,7 @@ template<> class Algebraic_structure_traits< Quotient<Gmpz> >
 public:
     typedef Quotient<Gmpz> Type;
 
-    struct To_double: public CGAL::unary_function<Quotient<Gmpz>, double>{
+    struct To_double: public CGAL::cpp98::unary_function<Quotient<Gmpz>, double>{
         double operator()(const Quotient<Gmpz>& quot){
             mpq_t  mpQ;
             mpq_init(mpQ);

--- a/Number_types/include/CGAL/Gmpzf.h
+++ b/Number_types/include/CGAL/Gmpzf.h
@@ -37,7 +37,7 @@ public:
     typedef Tag_true            Is_exact;
 
     struct Is_zero
-        : public CGAL::unary_function< Type, bool > {
+        : public CGAL::cpp98::unary_function< Type, bool > {
     public:
         bool operator()( const Type& x ) const {
             return x.is_zero();
@@ -45,7 +45,7 @@ public:
     };
 
     struct Integral_division
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                 Type,
                                 Type > {
     public:
@@ -57,7 +57,7 @@ public:
     };
 
     struct Gcd
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                 Type,
                                 Type > {
     public:
@@ -70,7 +70,7 @@ public:
     };
 
     class Div
-        : public CGAL::binary_function< Type, Type, Type > {
+        : public CGAL::cpp98::binary_function< Type, Type, Type > {
     public:
         Type operator()( const Type& x, const Type& y ) const {
             return Type(x).div( y );
@@ -80,7 +80,7 @@ public:
     typedef INTERN_AST::Mod_per_operator< Type > Mod;
   
   class Is_square
-    : public CGAL::binary_function< Type, Type&, bool > {
+    : public CGAL::cpp98::binary_function< Type, Type&, bool > {
   public:      
     bool operator()( const Type& x, Type& y ) const {
       y = CGAL::approximate_sqrt(x);
@@ -104,7 +104,7 @@ public:
   typedef AST::Is_zero Is_zero;
   
     struct Sgn
-        : public CGAL::unary_function< Type, ::CGAL::Sign > {
+        : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
     public:
         ::CGAL::Sign operator()( const Type& x ) const {
             return x.sign();
@@ -112,7 +112,7 @@ public:
     };
 
     struct Compare
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                   Type,
                                   Comparison_result > {
     public:
@@ -124,7 +124,7 @@ public:
     };
 
     struct To_double
-        : public CGAL::unary_function< Type, double > {
+        : public CGAL::cpp98::unary_function< Type, double > {
     public:
         double operator()( const Type& x ) const {
             return x.to_double();
@@ -132,7 +132,7 @@ public:
     };
 
     struct To_interval
-        : public CGAL::unary_function< Type, std::pair< double, double > > {
+        : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
     public:
         std::pair<double, double> operator()( const Type& x ) const {
 	    return x.to_interval();
@@ -147,7 +147,7 @@ class Real_embeddable_traits< Quotient<Gmpzf> >
 INTERN_QUOTIENT::Real_embeddable_traits_quotient_base< Quotient<Gmpzf> >
 {
 public:
-    struct To_double: public CGAL::unary_function<Quotient<Gmpzf>, double>{
+    struct To_double: public CGAL::cpp98::unary_function<Quotient<Gmpzf>, double>{
         inline
         double operator()(const Quotient<Gmpzf>& q) const {
 	  std::pair<double, long> n = q.numerator().to_double_exp();
@@ -158,7 +158,7 @@ public:
 	}
     };
     struct To_interval
-        : public CGAL::unary_function<Quotient<Gmpzf>, std::pair<double,double> >{
+        : public CGAL::cpp98::unary_function<Quotient<Gmpzf>, std::pair<double,double> >{
         inline
         std::pair<double,double> operator()(const Quotient<Gmpzf>& q) const {
 	  // do here as MP_Float does

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -446,7 +446,7 @@ relative_precision(const Interval_nt<Protected> & d)
 
 template< bool Protected >
 class Is_valid< Interval_nt<Protected> >
-  : public CGAL::unary_function< Interval_nt<Protected>, bool > {
+  : public CGAL::cpp98::unary_function< Interval_nt<Protected>, bool > {
   public :
     bool operator()( const Interval_nt<Protected>& x ) const {
       return is_valid(x.inf()) &&
@@ -683,7 +683,7 @@ operator/ (const Interval_nt<Protected> & a, double b)
 // TODO: What about these two guys? Where do they belong to?
 template <bool Protected>
 struct Min <Interval_nt<Protected> >
-    : public CGAL::binary_function<Interval_nt<Protected>,
+    : public CGAL::cpp98::binary_function<Interval_nt<Protected>,
                              Interval_nt<Protected>,
                              Interval_nt<Protected> >
 {
@@ -698,7 +698,7 @@ struct Min <Interval_nt<Protected> >
 
 template <bool Protected>
 struct Max <Interval_nt<Protected> >
-    : public CGAL::binary_function<Interval_nt<Protected>,
+    : public CGAL::cpp98::binary_function<Interval_nt<Protected>,
                              Interval_nt<Protected>,
                              Interval_nt<Protected> >
 {
@@ -745,7 +745,7 @@ ldexp(const Interval_nt<b> &i, int e)
 // TODO: To which concept do these functors belong? Can we remove them??
 template < bool b >
 struct Equal_to < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -754,7 +754,7 @@ struct Equal_to < Interval_nt<b>, Interval_nt<b> >
 
 template < bool b >
 struct Not_equal_to < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -763,7 +763,7 @@ struct Not_equal_to < Interval_nt<b>, Interval_nt<b> >
 
 template < bool b >
 struct Greater < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -772,7 +772,7 @@ struct Greater < Interval_nt<b>, Interval_nt<b> >
 
 template < bool b >
 struct Less < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -781,7 +781,7 @@ struct Less < Interval_nt<b>, Interval_nt<b> >
 
 template < bool b >
 struct Greater_equal < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -790,7 +790,7 @@ struct Greater_equal < Interval_nt<b>, Interval_nt<b> >
 
 template < bool b >
 struct Less_equal < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
+  : public CGAL::cpp98::binary_function< Interval_nt<b>, Interval_nt<b>, Uncertain<bool> >
 {
   Uncertain<bool> operator()( const Interval_nt<b>& x,
                               const Interval_nt<b>& y) const
@@ -943,7 +943,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
   typedef Uncertain<CGAL::Comparison_result> Comparison_result; 
 
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return INTERN_INTERVAL_NT::abs( x );
@@ -951,7 +951,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class Sgn
-        : public CGAL::unary_function< Type, Uncertain< ::CGAL::Sign > > {
+        : public CGAL::cpp98::unary_function< Type, Uncertain< ::CGAL::Sign > > {
       public:
         Uncertain< ::CGAL::Sign > operator()( const Type& x ) const {
             return INTERN_INTERVAL_NT::sign( x );
@@ -959,7 +959,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class Is_positive
-      : public CGAL::unary_function< Type, Uncertain<bool> > {
+      : public CGAL::cpp98::unary_function< Type, Uncertain<bool> > {
       public:
         Uncertain<bool> operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::is_positive( x );
@@ -967,7 +967,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class Is_negative
-      : public CGAL::unary_function< Type, Uncertain<bool> > {
+      : public CGAL::cpp98::unary_function< Type, Uncertain<bool> > {
       public:
         Uncertain<bool> operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::is_negative( x );
@@ -975,7 +975,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type, Comparison_result > {
+      : public CGAL::cpp98::binary_function< Type, Type, Comparison_result > {
       public:
       Comparison_result operator()( const Type& x, const Type& y ) const {
         return INTERN_INTERVAL_NT::compare( x, y );
@@ -985,7 +985,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
             return INTERN_INTERVAL_NT::to_double( x );
@@ -993,7 +993,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
             return INTERN_INTERVAL_NT::to_interval( x );
@@ -1001,7 +1001,7 @@ template< bool B > class Real_embeddable_traits< Interval_nt<B> >
     };
 
     class Is_finite
-      : public CGAL::unary_function< Type, Boolean > {
+      : public CGAL::cpp98::unary_function< Type, Boolean > {
       public :
         Boolean operator()( const Type& x ) const {
           return CGAL_NTS is_finite( x.inf() ) && CGAL_NTS is_finite( x.sup() );
@@ -1022,7 +1022,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     typedef Uncertain<bool>     Boolean; 
 
     class Is_zero
-      : public CGAL::unary_function< Type, Boolean > {
+      : public CGAL::cpp98::unary_function< Type, Boolean > {
       public:
         Boolean operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::is_zero( x );
@@ -1030,7 +1030,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     };
 
     class Is_one
-      : public CGAL::unary_function< Type, Boolean > {
+      : public CGAL::cpp98::unary_function< Type, Boolean > {
       public:
         Boolean operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::is_one( x );
@@ -1038,7 +1038,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     };
 
     class Square
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::square( x );
@@ -1046,7 +1046,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     };
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return INTERN_INTERVAL_NT::sqrt( x );
@@ -1054,7 +1054,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     };
 
     struct Is_square
-        :public CGAL::binary_function<Interval_nt<B>,Interval_nt<B>&,Boolean >
+        :public CGAL::cpp98::binary_function<Interval_nt<B>,Interval_nt<B>&,Boolean >
     {
         Boolean operator()(const Interval_nt<B>& x) const {
             return INTERN_INTERVAL_NT::is_positive( x );
@@ -1077,7 +1077,7 @@ class Algebraic_structure_traits< Interval_nt<B> >
     };
 
   class Divides
-    : public CGAL::binary_function< Type, Type, Boolean > {
+    : public CGAL::cpp98::binary_function< Type, Type, Boolean > {
   public:
     Boolean operator()( const Type& x, const Type&) const {
       return ! Is_zero()(x);
@@ -1138,86 +1138,86 @@ public:
   typedef CGAL::Tag_false With_empty_interval; 
   typedef CGAL::Tag_true  Is_interval; 
 
- struct Construct :public CGAL::binary_function<Bound,Bound,Interval>{
+ struct Construct :public CGAL::cpp98::binary_function<Bound,Bound,Interval>{
     Interval operator()( const Bound& l,const Bound& r) const {
       CGAL_precondition( l < r ); 
       return Interval(l,r);
     }
   };
 
-  struct Lower :public CGAL::unary_function<Interval,Bound>{
+  struct Lower :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return a.inf();
     }
   };
 
-  struct Upper :public CGAL::unary_function<Interval,Bound>{
+  struct Upper :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return a.sup();
     }
   };
 
-  struct Width :public CGAL::unary_function<Interval,Bound>{
+  struct Width :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return width(a); 
     }
   };
 
-  struct Median :public CGAL::unary_function<Interval,Bound>{
+  struct Median :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return (Lower()(a)+Upper()(a))/2.0;
     }
   };
     
-  struct Norm :public CGAL::unary_function<Interval,Bound>{
+  struct Norm :public CGAL::cpp98::unary_function<Interval,Bound>{
     Bound operator()( const Interval& a ) const {
       return magnitude(a);
     }
   };
 
-  struct Singleton :public CGAL::unary_function<Interval,bool>{
+  struct Singleton :public CGAL::cpp98::unary_function<Interval,bool>{
     bool operator()( const Interval& a ) const {
       return Lower()(a) == Upper()(a);
     }
   };
 
-  struct Zero_in :public CGAL::unary_function<Interval,bool>{
+  struct Zero_in :public CGAL::cpp98::unary_function<Interval,bool>{
     bool operator()( const Interval& a ) const {
       return Lower()(a) <= 0  &&  0 <= Upper()(a);
     }
   };
 
-  struct In :public CGAL::binary_function<Bound,Interval,bool>{
+  struct In :public CGAL::cpp98::binary_function<Bound,Interval,bool>{
     bool operator()( Bound x, const Interval& a ) const {
       return Lower()(a) <= x && x <= Upper()(a);
     }
   };
 
-  struct Equal :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Equal :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return a.is_same(b);
     }
   };
     
-  struct Overlap :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Overlap :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return a.do_overlap(b);
     }
   };
     
-  struct Subset :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return Lower()(b) <= Lower()(a) && Upper()(a) <= Upper()(b) ;  
     }
   };
     
-  struct Proper_subset :public CGAL::binary_function<Interval,Interval,bool>{
+  struct Proper_subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
     bool operator()( const Interval& a, const Interval& b ) const {
       return Subset()(a,b) && ! Equal()(a,b); 
     }
   };
     
-  struct Hull :public CGAL::binary_function<Interval,Interval,Interval>{
+  struct Hull :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
     Interval operator()( const Interval& a, const Interval& b ) const {
       BOOST_USING_STD_MAX();
       BOOST_USING_STD_MIN();
@@ -1231,7 +1231,7 @@ public:
   
 //  struct Empty is Null_functor 
   
-  struct Intersection :public CGAL::binary_function<Interval,Interval,Interval>{
+  struct Intersection :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
     Interval operator()( const Interval& a, const Interval& b ) const {
       BOOST_USING_STD_MAX();
       BOOST_USING_STD_MIN();

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -686,7 +686,7 @@ namespace INTERN_LAZY_EXACT_NT {
 
 template< class NT, class Functor >
 struct Simplify_selector {
-  struct Simplify : public CGAL::unary_function<NT&, void> {
+  struct Simplify : public CGAL::cpp98::unary_function<NT&, void> {
     void operator()( NT& ) const {
       // TODO: In the old implementation the Simplify-functor was the default
       //       (which does nothing). But this cannot be the correct way!?
@@ -701,7 +701,7 @@ struct Simplify_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Unit_part_selector {
-  struct Unit_part : public CGAL::unary_function<NT, NT > {
+  struct Unit_part : public CGAL::cpp98::unary_function<NT, NT > {
     NT operator()( const NT& x ) const {
       return NT( CGAL_NTS unit_part( x.exact() ) );
     }
@@ -715,7 +715,7 @@ struct Unit_part_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_zero_selector {
-  struct Is_zero : public CGAL::unary_function<NT, bool > {
+  struct Is_zero : public CGAL::cpp98::unary_function<NT, bool > {
     bool operator()( const NT& x ) const {
       return CGAL_NTS is_zero( x.exact() );
     }
@@ -729,7 +729,7 @@ struct Is_zero_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_one_selector {
-  struct Is_one : public CGAL::unary_function<NT, bool > {
+  struct Is_one : public CGAL::cpp98::unary_function<NT, bool > {
     bool operator()( const NT& x ) const {
       return CGAL_NTS is_one( x.exact() );
     }
@@ -743,7 +743,7 @@ struct Is_one_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Square_selector {
-  struct Square : public CGAL::unary_function<NT, NT > {
+  struct Square : public CGAL::cpp98::unary_function<NT, NT > {
     NT operator()( const NT& x ) const {
       CGAL_PROFILER(std::string("calls to    : ") + std::string(CGAL_PRETTY_FUNCTION));
       return new Lazy_exact_Square<typename NT::ET>(x);
@@ -758,7 +758,7 @@ struct Square_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Integral_division_selector {
-  struct Integral_division : public CGAL::binary_function<NT, NT, NT > {
+  struct Integral_division : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return NT( CGAL_NTS integral_division( x.exact(), y.exact() ) );
     }
@@ -774,7 +774,7 @@ struct Integral_division_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Is_square_selector {
-  struct Is_square : public CGAL::binary_function<NT, NT&, bool > {
+  struct Is_square : public CGAL::cpp98::binary_function<NT, NT&, bool > {
       bool operator()( const NT& x, NT& y ) const {
           typename NT::ET y_et;
           bool result = CGAL_NTS is_square( x.exact(), y_et );
@@ -796,7 +796,7 @@ struct Is_square_selector< NT, Null_functor > {
 
 template <class NT, class AlgebraicStructureTag>
 struct Sqrt_selector{
-    struct Sqrt : public CGAL::unary_function<NT, NT > {
+    struct Sqrt : public CGAL::cpp98::unary_function<NT, NT > {
         NT operator ()(const NT& x) const {
           CGAL_PROFILER(std::string("calls to    : ") + std::string(CGAL_PRETTY_FUNCTION));
           CGAL_precondition(x >= 0);
@@ -811,7 +811,7 @@ struct Sqrt_selector<NT,Null_functor> {
 
 template< class NT, class Functor >
 struct Kth_root_selector {
-  struct Kth_root : public CGAL::binary_function<int, NT, NT > {
+  struct Kth_root : public CGAL::cpp98::binary_function<int, NT, NT > {
     NT operator()( int k, const NT& x ) const {
       return NT( CGAL_NTS kth_root( k, x.exact() ) );
     }
@@ -856,7 +856,7 @@ struct Root_of_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Gcd_selector {
-  struct Gcd : public CGAL::binary_function<NT, NT, NT > {
+  struct Gcd : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
      CGAL_PROFILER(std::string("calls to    : ") + std::string(CGAL_PRETTY_FUNCTION));
      return NT( CGAL_NTS gcd( x.exact(), y.exact() ) );
@@ -873,7 +873,7 @@ struct Gcd_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Div_selector {
-  struct Div : public CGAL::binary_function<NT, NT, NT > {
+  struct Div : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return NT( CGAL_NTS div( x.exact(), y.exact() ) );
     }
@@ -905,7 +905,7 @@ struct Inverse_selector< NT, Null_functor > {
 
 template< class NT, class Functor >
 struct Mod_selector {
-  struct Mod : public CGAL::binary_function<NT, NT, NT > {
+  struct Mod : public CGAL::cpp98::binary_function<NT, NT, NT > {
     NT operator()( const NT& x, const NT& y ) const {
       return NT( CGAL_NTS mod( x.exact(), y.exact() ) );
     }
@@ -1033,7 +1033,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     typedef Lazy_exact_nt<ET> Type;
 
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& a ) const {
             CGAL_PROFILER(std::string("calls to    : ") + std::string(CGAL_PRETTY_FUNCTION));
@@ -1042,7 +1042,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& a ) const {
             CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
@@ -1055,7 +1055,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& a,
@@ -1076,7 +1076,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& a ) const {
             CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
@@ -1101,7 +1101,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& a ) const {
             CGAL_PROFILER(std::string("calls to    : ") + std::string(CGAL_PRETTY_FUNCTION));
@@ -1110,7 +1110,7 @@ template < typename ET > class Real_embeddable_traits< Lazy_exact_nt<ET> >
     };
 
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x ) const {
           return CGAL_NTS is_finite(x.approx()) || CGAL_NTS is_finite(x.exact());
@@ -1216,13 +1216,13 @@ public:
     typedef Lazy_exact_nt<ET_numerator> Numerator_type;
     typedef Lazy_exact_nt<ET_denominator> Denominator_type;
 
-    struct Common_factor : CGAL::binary_function<Denominator_type,Denominator_type,Denominator_type>{
+    struct Common_factor : CGAL::cpp98::binary_function<Denominator_type,Denominator_type,Denominator_type>{
         Denominator_type operator()(const Denominator_type& a, const Denominator_type& b) const {
             typename ETT::Common_factor common_factor;
             return Denominator_type(common_factor(a.exact(),b.exact()));
         }
     };
-    struct Compose : CGAL::binary_function<Type,Numerator_type,Denominator_type>{
+    struct Compose : CGAL::cpp98::binary_function<Type,Numerator_type,Denominator_type>{
         Type operator()(const Numerator_type& n, const Denominator_type& d) const {
             typename ETT::Compose compose;
             return Type(compose(n.exact(),d.exact()));
@@ -1254,7 +1254,7 @@ class Fraction_traits< Lazy_exact_nt< ET > >
 
 template < class ET >
 struct Min <Lazy_exact_nt<ET> >
-    : public CGAL::binary_function<Lazy_exact_nt<ET>,Lazy_exact_nt<ET>,Lazy_exact_nt<ET> > {
+    : public CGAL::cpp98::binary_function<Lazy_exact_nt<ET>,Lazy_exact_nt<ET>,Lazy_exact_nt<ET> > {
 
     Lazy_exact_nt<ET> operator()( const Lazy_exact_nt<ET>& x, const Lazy_exact_nt<ET>& y) const
     {
@@ -1272,7 +1272,7 @@ struct Min <Lazy_exact_nt<ET> >
 
 template < class ET >
 struct Max <Lazy_exact_nt<ET> >
-    : public CGAL::binary_function<Lazy_exact_nt<ET>,Lazy_exact_nt<ET>,Lazy_exact_nt<ET> > {
+    : public CGAL::cpp98::binary_function<Lazy_exact_nt<ET>,Lazy_exact_nt<ET>,Lazy_exact_nt<ET> > {
 
     Lazy_exact_nt<ET> operator()( const Lazy_exact_nt<ET>& x, const Lazy_exact_nt<ET>& y) const
     {
@@ -1319,7 +1319,7 @@ operator>> (std::istream & is, Lazy_exact_nt<ET> & a)
 
 template< class ET >
 class Is_valid< Lazy_exact_nt<ET> >
-  : public CGAL::unary_function< Lazy_exact_nt<ET>, bool > {
+  : public CGAL::cpp98::unary_function< Lazy_exact_nt<ET>, bool > {
   public :
     bool operator()( const Lazy_exact_nt<ET>& x ) const {
       return is_valid(x.approx());

--- a/Number_types/include/CGAL/MP_Float.h
+++ b/Number_types/include/CGAL/MP_Float.h
@@ -418,7 +418,7 @@ template <> class Algebraic_structure_traits< MP_Float >
     typedef Tag_true            Is_numerical_sensitive;
 
     struct Unit_part
-      : public CGAL::unary_function< Type , Type >
+      : public CGAL::cpp98::unary_function< Type , Type >
     {
       Type operator()(const Type &x) const {
         return x.unit_part();
@@ -426,7 +426,7 @@ template <> class Algebraic_structure_traits< MP_Float >
     };
 
     struct Integral_division
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                  Type,
                                  Type > {
     public:
@@ -442,7 +442,7 @@ template <> class Algebraic_structure_traits< MP_Float >
 
 
     class Square
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return INTERN_MP_FLOAT::square(x);
@@ -450,7 +450,7 @@ template <> class Algebraic_structure_traits< MP_Float >
     };
 
     class Gcd
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -460,7 +460,7 @@ template <> class Algebraic_structure_traits< MP_Float >
     };
 
     class Div
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -473,7 +473,7 @@ template <> class Algebraic_structure_traits< MP_Float >
 // Default implementation of Divides functor for unique factorization domains
   // x divides y if gcd(y,x) equals x up to inverses 
   class Divides 
-    : public CGAL::binary_function<Type,Type,bool>{
+    : public CGAL::cpp98::binary_function<Type,Type,bool>{
   public:
     bool operator()( const Type& x,  const Type& y) const {  
       return internal::division(y,x).second == 0 ;
@@ -495,7 +495,7 @@ template <> class Real_embeddable_traits< MP_Float >
   public:
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return x.sign();
@@ -503,7 +503,7 @@ template <> class Real_embeddable_traits< MP_Float >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -513,7 +513,7 @@ template <> class Real_embeddable_traits< MP_Float >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           return INTERN_MP_FLOAT::to_double( x );
@@ -521,7 +521,7 @@ template <> class Real_embeddable_traits< MP_Float >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           return INTERN_MP_FLOAT::to_interval( x );
@@ -853,14 +853,14 @@ class Real_embeddable_traits< Quotient<MP_Float> >
     : public INTERN_QUOTIENT::Real_embeddable_traits_quotient_base<
 Quotient<MP_Float> >{
 public:
-    struct To_double: public CGAL::unary_function<Quotient<MP_Float>, double>{
+    struct To_double: public CGAL::cpp98::unary_function<Quotient<MP_Float>, double>{
          inline
          double operator()(const Quotient<MP_Float>& q) const {
             return INTERN_MP_FLOAT::to_double(q);
         }
     };
     struct To_interval
-        : public CGAL::unary_function<Quotient<MP_Float>, std::pair<double,double> > {
+        : public CGAL::cpp98::unary_function<Quotient<MP_Float>, std::pair<double,double> > {
         inline
         std::pair<double,double> operator()(const Quotient<MP_Float>& q) const {
             return INTERN_MP_FLOAT::to_interval(q);

--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -1024,21 +1024,21 @@ std::istream& operator>> (std::istream& is, Mpzf& a)
       typedef Tag_false            Is_numerical_sensitive;
 
       struct Is_zero
-	: public CGAL::unary_function< Type, bool > {
+	: public CGAL::cpp98::unary_function< Type, bool > {
 	  bool operator()( const Type& x ) const {
 	    return x.is_zero();
 	  }
 	};
 
       struct Is_one
-	: public CGAL::unary_function< Type, bool > {
+	: public CGAL::cpp98::unary_function< Type, bool > {
 	  bool operator()( const Type& x ) const {
 	    return x.is_one();
 	  }
 	};
 
       struct Gcd
-	: public CGAL::binary_function< Type, Type, Type > {
+	: public CGAL::cpp98::binary_function< Type, Type, Type > {
 	  Type operator()(
 	      const Type& x,
 	      const Type& y ) const {
@@ -1047,14 +1047,14 @@ std::istream& operator>> (std::istream& is, Mpzf& a)
 	};
 
       struct Square
-	: public CGAL::unary_function< Type, Type > {
+	: public CGAL::cpp98::unary_function< Type, Type > {
 	  Type operator()( const Type& x ) const {
 	    return Mpzf_square(x);
 	  }
 	};
 
       struct Integral_division
-	: public CGAL::binary_function< Type, Type, Type > {
+	: public CGAL::cpp98::binary_function< Type, Type, Type > {
 	  Type operator()(
 	      const Type& x,
 	      const Type& y ) const {
@@ -1063,14 +1063,14 @@ std::istream& operator>> (std::istream& is, Mpzf& a)
 	};
 
       struct Sqrt
-	: public CGAL::unary_function< Type, Type > {
+	: public CGAL::cpp98::unary_function< Type, Type > {
 	  Type operator()( const Type& x) const {
 	    return Mpzf_sqrt(x);
 	  }
 	};
 
       struct Is_square
-	: public CGAL::binary_function< Type, Type&, bool > {
+	: public CGAL::cpp98::binary_function< Type, Type&, bool > {
 	  bool operator()( const Type& x, Type& y ) const {
 	    // TODO: avoid doing 2 calls.
 	    if (!Mpzf_is_square(x)) return false;
@@ -1086,21 +1086,21 @@ std::istream& operator>> (std::istream& is, Mpzf& a)
   template <> struct Real_embeddable_traits< Mpzf >
     : public INTERN_RET::Real_embeddable_traits_base< Mpzf , CGAL::Tag_true > {
       struct Sgn
-	: public CGAL::unary_function< Type, ::CGAL::Sign > {
+	: public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
 	  ::CGAL::Sign operator()( const Type& x ) const {
 	    return x.sign();
 	  }
 	};
 
       struct To_double
-	: public CGAL::unary_function< Type, double > {
+	: public CGAL::cpp98::unary_function< Type, double > {
 	    double operator()( const Type& x ) const {
 	      return x.to_double();
 	    }
 	};
 
       struct Compare
-	: public CGAL::binary_function< Type, Type, Comparison_result > {
+	: public CGAL::cpp98::binary_function< Type, Type, Comparison_result > {
 	    Comparison_result operator()(
 		const Type& x,
 		const Type& y ) const {
@@ -1109,7 +1109,7 @@ std::istream& operator>> (std::istream& is, Mpzf& a)
 	};
 
       struct To_interval
-	: public CGAL::unary_function< Type, std::pair< double, double > > {
+	: public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
 	    std::pair<double, double> operator()( const Type& x ) const {
 	      return x.to_interval();
 	    }

--- a/Number_types/include/CGAL/NT_converter.h
+++ b/Number_types/include/CGAL/NT_converter.h
@@ -34,7 +34,7 @@ namespace CGAL {
 
 template < class NT1, class NT2 >
 struct NT_converter
-  : public CGAL::unary_function< NT1, NT2 >
+  : public CGAL::cpp98::unary_function< NT1, NT2 >
 {
     NT2
     operator()(const NT1 &a) const
@@ -50,7 +50,7 @@ struct NT_converter
 
 template < class NT1 >
 struct NT_converter < NT1, NT1 >
-  : public CGAL::unary_function< NT1, NT1 >
+  : public CGAL::cpp98::unary_function< NT1, NT1 >
 {
     const NT1 &
     operator()(const NT1 &a) const
@@ -61,7 +61,7 @@ struct NT_converter < NT1, NT1 >
 
 template < class NT1 >
 struct NT_converter < NT1, double >
-  : public CGAL::unary_function< NT1, double >
+  : public CGAL::cpp98::unary_function< NT1, double >
 {
     double
     operator()(const NT1 &a) const
@@ -72,7 +72,7 @@ struct NT_converter < NT1, double >
 
 template <>
 struct NT_converter < double, double >
-  : public CGAL::unary_function< double, double >
+  : public CGAL::cpp98::unary_function< double, double >
 {
     const double &
     operator()(const double &a) const
@@ -83,7 +83,7 @@ struct NT_converter < double, double >
 
 template < class NT1, bool b >
 struct NT_converter < NT1, Interval_nt<b> >
-  : public CGAL::unary_function< NT1, Interval_nt<b> >
+  : public CGAL::cpp98::unary_function< NT1, Interval_nt<b> >
 {
     Interval_nt<b>
     operator()(const NT1 &a) const
@@ -94,7 +94,7 @@ struct NT_converter < NT1, Interval_nt<b> >
 
 template < bool b >
 struct NT_converter < Interval_nt<b>, Interval_nt<b> >
-  : public CGAL::unary_function< Interval_nt<b>, Interval_nt<b> >
+  : public CGAL::cpp98::unary_function< Interval_nt<b>, Interval_nt<b> >
 {
     const Interval_nt<b> &
     operator()(const Interval_nt<b> &a) const

--- a/Number_types/include/CGAL/Number_type_checker.h
+++ b/Number_types/include/CGAL/Number_type_checker.h
@@ -402,7 +402,7 @@ operator>=(int i, const Number_type_checker<NT1, NT2, Cmp> &b)
 
 template < typename NT1, typename NT2, typename Cmp >
 class Is_valid< Number_type_checker<NT1, NT2, Cmp> >
-    : public CGAL::unary_function< Number_type_checker<NT1, NT2, Cmp> , bool > {
+    : public CGAL::cpp98::unary_function< Number_type_checker<NT1, NT2, Cmp> , bool > {
 public :
     bool operator()(const  Number_type_checker<NT1, NT2, Cmp>& a ) const {
         bool b1 = is_valid(a.n1());
@@ -435,7 +435,7 @@ private:
 public:
     //CGAL::Algebraic_structure_traits<>::Simplify
     class Simplify
-        : public CGAL::unary_function< Type& , void > {
+        : public CGAL::cpp98::unary_function< Type& , void > {
     public:
         void operator()( Type& a) const {
             typename AST1::Simplify()(a.n1());
@@ -446,7 +446,7 @@ public:
 
     //CGAL::Algebraic_structure_traits< >::Is_zero
     class Is_zero
-        : public CGAL::unary_function< Type, bool > {
+        : public CGAL::cpp98::unary_function< Type, bool > {
     public:
         bool operator()(const  Type& a ) const {
             bool b1 = typename AST1::Is_zero()(a.n1());
@@ -458,7 +458,7 @@ public:
 
     // CGAL::Algebraic_structure_traits< >::Is_one
     class Is_one
-        : public CGAL::unary_function< Type, bool > {
+        : public CGAL::cpp98::unary_function< Type, bool > {
     public:
         bool operator()(const Type& a) const {
             bool b1 = typename AST1::Is_one()(a.n1());
@@ -469,7 +469,7 @@ public:
     };
     // CGAL::Algebraic_structure_traits<  >::Square
     class Square
-        : public CGAL::unary_function< Type , Type > {
+        : public CGAL::cpp98::unary_function< Type , Type > {
     public:
         Type operator()(const Type& a) const {
             return Type(
@@ -481,7 +481,7 @@ public:
 
     // CGAL::Algebraic_structure_traits<  >::Unit_part
     class Unit_part
-        : public CGAL::unary_function< Type , Type > {
+        : public CGAL::cpp98::unary_function< Type , Type > {
     public:
         Type operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("AST::Unit_part");
@@ -507,7 +507,7 @@ public:
 
 // CGAL::Algebraic_structure_traits< >::Integral_division
     class Integral_division
-        : public CGAL::binary_function< Type, Type, Type > {
+        : public CGAL::cpp98::binary_function< Type, Type, Type > {
     public:
         Type operator()( const Type& a, const Type& b) const {
             CGAL_NT_CHECK_DEBUG("AST::Integral_division");
@@ -518,7 +518,7 @@ public:
     }; 
   
   class Divides
-    : public CGAL::binary_function< Type, Type, bool > {
+    : public CGAL::cpp98::binary_function< Type, Type, bool > {
   public:
     bool operator()( const Type& a, const Type& b) const {
       CGAL_NT_CHECK_DEBUG("AST::Divides");
@@ -555,7 +555,7 @@ private:
 public:
     // CGAL::Algebraic_structure_traits< >::Gcd
     class Gcd
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                   Type,
                                   Type > {
     public:
@@ -583,7 +583,7 @@ private:
 public:
     // CGAL::Algebraic_structure_traits< >::Div
     class Div
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                   Type,
                                   Type > {
     public:
@@ -598,7 +598,7 @@ public:
     };
     // CGAL::Algebraic_structure_traits< >::Mod
     class Mod
-        : public CGAL::binary_function< Type,
+        : public CGAL::cpp98::binary_function< Type,
                                   Type,
                                   Type > {
     public:
@@ -650,7 +650,7 @@ private:
   typedef Number_type_checker<NT1, NT2, Cmp> Type;
 public:  
   class Inverse
-    : public CGAL::unary_function< Type, Type > {
+    : public CGAL::cpp98::unary_function< Type, Type > {
   public:
     Type operator()( const Type& a ) const {
       NT1 r1 = typename AST1::Inverse()(a.n1());
@@ -677,7 +677,7 @@ public:
 
     // CGAL::Algebraic_structure_traits<  >::Sqrt
     class Sqrt
-        : public CGAL::unary_function< Type , Type > {
+        : public CGAL::cpp98::unary_function< Type , Type > {
     public:
         Type operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("AST::Sqrt");
@@ -726,7 +726,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Abs
     class Abs
-        : public CGAL::unary_function< Type , Type > {
+        : public CGAL::cpp98::unary_function< Type , Type > {
     public:
         Type operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Abs");
@@ -738,7 +738,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Sign
     class Sgn
-        : public CGAL::unary_function< Type , ::CGAL::Sign > {
+        : public CGAL::cpp98::unary_function< Type , ::CGAL::Sign > {
     public:
         ::CGAL::Sign operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Sign");
@@ -750,7 +750,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Is_finite
     class Is_finite
-        : public CGAL::unary_function< Type , bool > {
+        : public CGAL::cpp98::unary_function< Type , bool > {
     public:
         bool operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Is_finite");
@@ -762,7 +762,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Is_positive
     class Is_positive
-        : public CGAL::unary_function< Type , bool > {
+        : public CGAL::cpp98::unary_function< Type , bool > {
     public:
         bool operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Is_positive");
@@ -774,7 +774,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Is_negative
     class Is_negative
-        : public CGAL::unary_function< Type , bool > {
+        : public CGAL::cpp98::unary_function< Type , bool > {
     public:
         bool operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Is_negative");
@@ -786,7 +786,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Is_zero
     class Is_zero
-        : public CGAL::unary_function< Type , bool > {
+        : public CGAL::cpp98::unary_function< Type , bool > {
     public:
         bool operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::Is_zero");
@@ -798,7 +798,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::Compare
     class Compare
-        : public CGAL::binary_function< Type , Type, Comparison_result > {
+        : public CGAL::cpp98::binary_function< Type , Type, Comparison_result > {
     public:
         Comparison_result operator()(const Type& a, const Type& b) const {
             CGAL_NT_CHECK_DEBUG("RET::Compare");
@@ -810,7 +810,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::To_double
     class To_double
-        : public CGAL::unary_function< Type , double > {
+        : public CGAL::cpp98::unary_function< Type , double > {
     public:
         double operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::To_double");
@@ -822,7 +822,7 @@ public:
 
     // CGAL::Real_embeddable_traits<  >::To_interval
     class To_interval
-        : public CGAL::unary_function< Type , std::pair<double, double> > {
+        : public CGAL::cpp98::unary_function< Type , std::pair<double, double> > {
     public:
         std::pair<double, double> operator()(const Type& a) const {
             CGAL_NT_CHECK_DEBUG("RET::To_interval");

--- a/Number_types/include/CGAL/Quotient.h
+++ b/Number_types/include/CGAL/Quotient.h
@@ -548,7 +548,7 @@ operator>(const Quotient<NT>& x, const CGAL_double(NT)& y)
 
 template< class NT >
 class Is_valid< Quotient<NT> >
-  : public CGAL::unary_function< Quotient<NT>, bool > {
+  : public CGAL::cpp98::unary_function< Quotient<NT>, bool > {
   public :
     bool operator()( const Quotient<NT>& x ) const {
       return is_valid(x.num) && is_valid(x.den);
@@ -607,7 +607,7 @@ namespace INTERN_QUOTIENT {
   class Sqrt_selector {
     public:
       class Sqrt
-        : public CGAL::unary_function< NT, NT > {
+        : public CGAL::cpp98::unary_function< NT, NT > {
         public:
           NT operator()( const NT& x ) const {
             CGAL_precondition(x > 0);
@@ -639,7 +639,7 @@ public:
 
 
     class Is_square
-        : public CGAL::binary_function< Quotient<NT>, Quotient<NT>&, bool > {
+        : public CGAL::cpp98::binary_function< Quotient<NT>, Quotient<NT>&, bool > {
     public:
         bool operator()( Quotient<NT> x, Quotient<NT>& y ) const {
             NT x_num, x_den, y_num, y_den;
@@ -670,7 +670,7 @@ public:
                             >::type Sqrt;
 
     class Simplify
-      : public CGAL::unary_function< Type&, void > {
+      : public CGAL::cpp98::unary_function< Type&, void > {
       public:
         void operator()( Type& x) const {
             x.normalize();
@@ -688,7 +688,7 @@ template < class NT > class Real_embeddable_traits_quotient_base< Quotient<NT> >
     typedef Quotient<NT> Type;
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -698,7 +698,7 @@ template < class NT > class Real_embeddable_traits_quotient_base< Quotient<NT> >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
         // Original global function was marked with an TODO!!
@@ -730,7 +730,7 @@ template < class NT > class Real_embeddable_traits_quotient_base< Quotient<NT> >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           Interval_nt<> quot =
@@ -741,7 +741,7 @@ template < class NT > class Real_embeddable_traits_quotient_base< Quotient<NT> >
     };
 
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x ) const {
           return CGAL_NTS is_finite(x.num) && CGAL_NTS is_finite(x.den);

--- a/Number_types/include/CGAL/Sqrt_extension/Algebraic_structure_traits.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Algebraic_structure_traits.h
@@ -42,7 +42,7 @@ class Sqrt_extension_algebraic_structure_traits_base< Type,
     typedef CGAL::Integral_domain_without_division_tag Algebraic_category;
 
     class Simplify
-      : public CGAL::unary_function< Type&, void > {
+      : public CGAL::cpp98::unary_function< Type&, void > {
       public:
         typedef void result_type;
         typedef Type& argument_type;
@@ -62,7 +62,7 @@ public:
     typedef CGAL::Integral_domain_tag Algebraic_category;
     
     class Integral_division
-      : public CGAL::binary_function< Type, Type, Type > {
+      : public CGAL::cpp98::binary_function< Type, Type, Type > {
     public:
       Type operator()( const Type& x,const Type& y ) const {
         return x/y;
@@ -78,7 +78,7 @@ private:
   typedef typename AST_COEFF::Divides Divides_coeff;   
 public:
   class Divides 
-    : public CGAL::binary_function<Type,Type,typename Divides_coeff::result_type>{
+    : public CGAL::cpp98::binary_function<Type,Type,typename Divides_coeff::result_type>{
     typedef typename Divides_coeff::result_type BOOL;
   public:
     BOOL operator()( const Type& x, const Type& y) const {  
@@ -160,14 +160,14 @@ class Sqrt_extension_algebraic_structure_traits_base< Type,
     typedef Field_tag Algebraic_category;
 
     class Unit_part
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return( x == Type(0) ? Type(1) : x );
         }
     };
   class Inverse
-    : public CGAL::unary_function< Type, Type > {
+    : public CGAL::cpp98::unary_function< Type, Type > {
   public:
     Type operator()( const Type& x ) const {
       return Type(1)/x ;

--- a/Number_types/include/CGAL/Sqrt_extension/Real_embeddable_traits.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Real_embeddable_traits.h
@@ -36,7 +36,7 @@ class Real_embeddable_traits< Sqrt_extension<COEFF, ROOT, ACDE_TAG,FP_TAG> >
   typedef Sqrt_extension<COEFF, ROOT, ACDE_TAG,FP_TAG> Type;
 
     class Sgn
-        : public CGAL::unary_function< Type, ::CGAL::Sign >{
+        : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign >{
     public:
         ::CGAL::Sign operator()( const Type& x ) const {
             return x.sign();
@@ -44,7 +44,7 @@ class Real_embeddable_traits< Sqrt_extension<COEFF, ROOT, ACDE_TAG,FP_TAG> >
     };
     
     class Compare
-        : public CGAL::binary_function< Type, Type, Comparison_result > {
+        : public CGAL::cpp98::binary_function< Type, Type, Comparison_result > {
     public:
         Comparison_result operator()( const Type& x, const Type& y) const {
             // must be from the same extension 
@@ -64,7 +64,7 @@ class Real_embeddable_traits< Sqrt_extension<COEFF, ROOT, ACDE_TAG,FP_TAG> >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double,double> operator()(const Type& x) const {
             return x.to_interval();
@@ -72,7 +72,7 @@ class Real_embeddable_traits< Sqrt_extension<COEFF, ROOT, ACDE_TAG,FP_TAG> >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         // The main problem here is, that even tough the total
         // expression fits into double, one of the coefficients

--- a/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
@@ -680,7 +680,7 @@ Sqrt_extension<NT,ROOT,ACDE_TAG,FP_TAG> square (const Sqrt_extension<NT,ROOT,ACD
 //NT_converter specializations
 template <class NT1,class ROOT1,class NT2,class ROOT2,class ACDE_TAG,class FP_TAG>
 struct NT_converter < Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG> , Sqrt_extension<NT2,ROOT2,ACDE_TAG,FP_TAG> >
-  : public CGAL::unary_function< NT1, NT2 >
+  : public CGAL::cpp98::unary_function< NT1, NT2 >
 {
     Sqrt_extension<NT2,ROOT2,ACDE_TAG,FP_TAG>
     operator()(const Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG> &a) const
@@ -698,7 +698,7 @@ struct NT_converter < Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG> , Sqrt_extension
 
 template <class NT1,class NT2,class ROOT2,class ACDE_TAG,class FP_TAG>
 struct NT_converter < NT1 , Sqrt_extension<NT2,ROOT2,ACDE_TAG,FP_TAG> >
-  : public CGAL::unary_function< NT1, NT2 >
+  : public CGAL::cpp98::unary_function< NT1, NT2 >
 {
     Sqrt_extension<NT2,ROOT2,ACDE_TAG,FP_TAG>
     operator()(const NT1 &a) const
@@ -710,7 +710,7 @@ struct NT_converter < NT1 , Sqrt_extension<NT2,ROOT2,ACDE_TAG,FP_TAG> >
 //needed because it's a better match than the specialization <NT1,NT1>
 template <class NT1,class ROOT1,class ACDE_TAG,class FP_TAG>
 struct NT_converter < Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG>, Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG> >
-  : public CGAL::unary_function< NT1, NT1 >
+  : public CGAL::cpp98::unary_function< NT1, NT1 >
 {
     const Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG>&
     operator()(const Sqrt_extension<NT1,ROOT1,ACDE_TAG,FP_TAG> &a) const

--- a/Number_types/include/CGAL/Sqrt_extension/convert_to_bfi.h
+++ b/Number_types/include/CGAL/Sqrt_extension/convert_to_bfi.h
@@ -49,7 +49,7 @@ class Sqrt_extension_bfi_cache {
   typedef typename Coercion_traits<ROOT,BFI>::Cast Cast;
   typedef typename Algebraic_structure_traits<BFI>::Sqrt Sqrt; 
 
-  struct Creator : public CGAL::unary_function<BFI,Input> {
+  struct Creator : public CGAL::cpp98::unary_function<BFI,Input> {
     BFI operator()(const Input& pair){
       return Sqrt()(Cast()(pair.second)); 
     }

--- a/Number_types/include/CGAL/double.h
+++ b/Number_types/include/CGAL/double.h
@@ -73,7 +73,7 @@ is_nan_by_mask_double(unsigned int h, unsigned int l)
 
 template<>
 class Is_valid< double >
-  : public CGAL::unary_function< double, bool > {
+  : public CGAL::cpp98::unary_function< double, bool > {
   public :
     bool operator()( const double& x ) const{
       double d = x;
@@ -86,7 +86,7 @@ class Is_valid< double >
 
 template<>
 class Is_valid< double >
-  : public CGAL::unary_function< double, bool > {
+  : public CGAL::cpp98::unary_function< double, bool > {
   public :
     bool operator()( const double& x ) const {
 #ifdef _MSC_VER
@@ -107,7 +107,7 @@ template <> class Algebraic_structure_traits< double >
     typedef Tag_true             Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return std::sqrt( x );
@@ -115,7 +115,7 @@ template <> class Algebraic_structure_traits< double >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -152,7 +152,7 @@ template <> class Real_embeddable_traits< double >
 // GCC is faster with std::fabs().
 #if defined(__GNUG__) || defined(CGAL_MSVC_USE_STD_FABS) || defined(CGAL_USE_SSE2_FABS)
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
 #ifdef CGAL_USE_SSE2_FABS
@@ -166,7 +166,7 @@ template <> class Real_embeddable_traits< double >
 
 // Is_finite depends on platform
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public :
         bool operator()( const Type& x ) const {
 

--- a/Number_types/include/CGAL/float.h
+++ b/Number_types/include/CGAL/float.h
@@ -63,7 +63,7 @@ is_nan_by_mask_float(unsigned int u)
 
 template<>
 class Is_valid< float >
-  : public CGAL::unary_function< float, bool > {
+  : public CGAL::cpp98::unary_function< float, bool > {
   public :
     bool operator()( const float& x ) const {
       float f = x;
@@ -76,7 +76,7 @@ class Is_valid< float >
 
 template<>
 class Is_valid< float >
-  : public CGAL::unary_function< float, bool > {
+  : public CGAL::cpp98::unary_function< float, bool > {
   public :
     bool operator()( const float& x ) const {
       return (x == x);
@@ -93,7 +93,7 @@ template <> class Algebraic_structure_traits< float >
     typedef Tag_true             Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return std::sqrt( x );
@@ -101,7 +101,7 @@ template <> class Algebraic_structure_traits< float >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k, const Type& x) const {
           CGAL_precondition_msg( k > 0, "'k' must be positive for k-th roots");
@@ -116,7 +116,7 @@ template <> class Real_embeddable_traits< float >
 public:
 // Is_finite depends on platform
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x ) const {
 

--- a/Number_types/include/CGAL/int.h
+++ b/Number_types/include/CGAL/int.h
@@ -38,7 +38,7 @@ namespace CGAL {
 namespace INTERN_INT {
     template< class Type >
     class Is_square_per_double_conversion
-      : public CGAL::binary_function< Type, Type&,
+      : public CGAL::cpp98::binary_function< Type, Type&,
                                 bool > {
       public:
         bool operator()( const Type& x,
@@ -122,7 +122,7 @@ template <> class Real_embeddable_traits< long int >
 public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           return Interval_nt<true>(x).pair();
@@ -169,7 +169,7 @@ template<> class Algebraic_structure_traits< short int >
     //  interoperability. This is nescessary because of the implicit conversion
     //  to int for binary operations between short ints.
     class Integral_division
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -183,7 +183,7 @@ template<> class Algebraic_structure_traits< short int >
     };
 
     class Gcd
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -243,7 +243,7 @@ template<> class Algebraic_structure_traits< short int >
 
     // based on \c Div_mod.
     class Div
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -254,7 +254,7 @@ template<> class Algebraic_structure_traits< short int >
 
     // based on \c Div_mod.
     class Mod
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -282,7 +282,7 @@ template <> class Real_embeddable_traits< unsigned long >
 public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           return Interval_nt<true>(x).pair();

--- a/Number_types/include/CGAL/leda_bigfloat.h
+++ b/Number_types/include/CGAL/leda_bigfloat.h
@@ -45,7 +45,7 @@ template <> class Algebraic_structure_traits< leda_bigfloat >
     typedef Tag_true            Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CGAL_LEDA_SCOPE::sqrt( x );
@@ -53,7 +53,7 @@ template <> class Algebraic_structure_traits< leda_bigfloat >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -73,7 +73,7 @@ template <> class Real_embeddable_traits< leda_bigfloat >
 public:
   
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return CGAL_LEDA_SCOPE::abs( x );
@@ -81,7 +81,7 @@ public:
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return (::CGAL::Sign) CGAL_LEDA_SCOPE::sign( x );
@@ -89,7 +89,7 @@ public:
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -102,7 +102,7 @@ public:
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           return x.to_double();
@@ -110,7 +110,7 @@ public:
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 
@@ -124,7 +124,7 @@ public:
     };
 
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x )  const {
           return !( CGAL_LEDA_SCOPE::isInf(x) || CGAL_LEDA_SCOPE::isNaN(x) );
@@ -134,7 +134,7 @@ public:
 
 template<>
 class Is_valid< leda_bigfloat >
-  : public CGAL::unary_function< leda_bigfloat, bool > {
+  : public CGAL::cpp98::unary_function< leda_bigfloat, bool > {
   public :
     bool operator()( const leda_bigfloat& x ) const {
       return !( CGAL_LEDA_SCOPE::isNaN(x) );

--- a/Number_types/include/CGAL/leda_bigfloat_interval.h
+++ b/Number_types/include/CGAL/leda_bigfloat_interval.h
@@ -176,7 +176,7 @@ public:
     typedef Tag_true            Is_numerical_sensitive;
 
     class Sqrt
-        : public CGAL::unary_function< Type, Type > {
+        : public CGAL::cpp98::unary_function< Type, Type > {
     public:
         Type operator()( const Type& x ) const {
             return ::boost::numeric::sqrt(x);
@@ -189,7 +189,7 @@ template <> class Real_embeddable_traits< leda_bigfloat_interval >
 public:
   
     class Abs
-        : public CGAL::unary_function< Type, Type > {
+        : public CGAL::cpp98::unary_function< Type, Type > {
     public:
         Type operator()( const Type& x ) const {
             return ::boost::numeric::abs(x);
@@ -197,7 +197,7 @@ public:
     };
 
     class To_double
-        : public CGAL::unary_function< Type, double > {
+        : public CGAL::cpp98::unary_function< Type, double > {
     public:
         double operator()( const Type& x ) const {
             return CGAL::to_double(::boost::numeric::median(x));
@@ -205,7 +205,7 @@ public:
     };
 
     class To_interval
-        : public CGAL::unary_function< Type, std::pair< double, double > > {
+        : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
     public:
         std::pair<double, double> operator()( const Type& x ) const {            
             std::pair<double, double> lower_I(CGAL::to_interval(x.lower()));
@@ -314,98 +314,98 @@ public:
     typedef CGAL::Tag_true Is_interval; 
     typedef CGAL::Tag_true With_empty_interval; 
 
-    struct Construct :public CGAL::binary_function<Bound,Bound,Interval>{
+    struct Construct :public CGAL::cpp98::binary_function<Bound,Bound,Interval>{
         Interval operator()( const Bound& l,const Bound& r) const {
             CGAL_precondition( l < r ); 
             return Interval(l,r);
         }
     };
 
-    struct Lower :public CGAL::unary_function<Interval,Bound>{
+    struct Lower :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator()( const Interval& a ) const {
             return a.lower();
         }
     };
 
-    struct Upper :public CGAL::unary_function<Interval,Bound>{
+    struct Upper :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator()( const Interval& a ) const {
             return a.upper();
         }
     };
 
-    struct Width :public CGAL::unary_function<Interval,Bound>{
+    struct Width :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator()( const Interval& a ) const {
             return ::boost::numeric::width(a);
         }
     };
 
-    struct Median :public CGAL::unary_function<Interval,Bound>{
+    struct Median :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator()( const Interval& a ) const {
             return ::boost::numeric::median(a);
         }
     };
     
-    struct Norm :public CGAL::unary_function<Interval,Bound>{
+    struct Norm :public CGAL::cpp98::unary_function<Interval,Bound>{
         Bound operator()( const Interval& a ) const {
             return ::boost::numeric::norm(a);
         }
     };
 
-    struct Empty :public CGAL::unary_function<Interval,bool>{
+    struct Empty :public CGAL::cpp98::unary_function<Interval,bool>{
         bool operator()( const Interval& a ) const {
             return ::boost::numeric::empty(a);
         }
     };
 
-    struct Singleton :public CGAL::unary_function<Interval,bool>{
+    struct Singleton :public CGAL::cpp98::unary_function<Interval,bool>{
         bool operator()( const Interval& a ) const {
             return ::boost::numeric::singleton(a);
         }
     };
 
-    struct Zero_in :public CGAL::unary_function<Interval,bool>{
+    struct Zero_in :public CGAL::cpp98::unary_function<Interval,bool>{
         bool operator()( const Interval& a ) const {
             return ::boost::numeric::in_zero(a);
         }
     };
 
-    struct In :public CGAL::binary_function<Bound,Interval,bool>{
+    struct In :public CGAL::cpp98::binary_function<Bound,Interval,bool>{
         bool operator()( Bound x, const Interval& a ) const {
             return ::boost::numeric::in(x,a);
         }
     };
 
-    struct Equal :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Equal :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const {
             return ::boost::numeric::equal(a,b);
         }
     };
     
-    struct Overlap :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Overlap :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const {
             return ::boost::numeric::overlap(a,b);
         }
     };
     
-    struct Subset :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const {
             return ::boost::numeric::subset(a,b);
         }
     };
     
-    struct Proper_subset :public CGAL::binary_function<Interval,Interval,bool>{
+    struct Proper_subset :public CGAL::cpp98::binary_function<Interval,Interval,bool>{
         bool operator()( const Interval& a, const Interval& b ) const {
             return ::boost::numeric::proper_subset(a,b);
         }
     };
     
-    struct Hull :public CGAL::binary_function<Interval,Interval,Interval>{
+    struct Hull :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
         Interval operator()( const Interval& a, const Interval& b ) const {
             return ::boost::numeric::hull(a,b);
         }
     };
     
-    struct Intersection :public CGAL::binary_function<Interval,Interval,Interval>{
+    struct Intersection :public CGAL::cpp98::binary_function<Interval,Interval,Interval>{
         Interval operator()( const Interval& a, const Interval& b ) const {
             Interval r = ::boost::numeric::intersect(a,b);      
             return r;
@@ -424,7 +424,7 @@ public:
   typedef CGAL::Tag_true Is_bigfloat_interval; 
   
 
-//   struct Get_significant_bits : public CGAL::unary_function<NT,long>{
+//   struct Get_significant_bits : public CGAL::cpp98::unary_function<NT,long>{
 //         long operator()( NT x) const {
 //             CGAL_precondition(!Singleton()(x));
 //             leda::bigfloat lower = x.lower();
@@ -444,7 +444,7 @@ public:
 //     };
 
     
-  struct Relative_precision: public CGAL::unary_function<NT,long>{
+  struct Relative_precision: public CGAL::cpp98::unary_function<NT,long>{
     long operator()(const NT& x) const {
       CGAL_precondition(!Singleton()(x));
       CGAL_precondition(!CGAL::zero_in(x));
@@ -455,7 +455,7 @@ public:
     }
   };
   
-  struct Set_precision : public CGAL::unary_function<long,long> {
+  struct Set_precision : public CGAL::cpp98::unary_function<long,long> {
     long operator()( long prec ) const {
       return BF::set_precision(prec); 
     }

--- a/Number_types/include/CGAL/leda_integer.h
+++ b/Number_types/include/CGAL/leda_integer.h
@@ -54,7 +54,7 @@ template <> class Algebraic_structure_traits< leda_integer >
                                                                  Is_square;
 
     class Gcd
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Type > {
       public:
         Type operator()( const Type& x,
@@ -107,7 +107,7 @@ template <> class Algebraic_structure_traits< leda_integer >
 
 //     typedef INTERN_AST::Div_per_operator< Type > Div;
 //     class Mod
-//       : public CGAL::binary_function< Type, Type,
+//       : public CGAL::cpp98::binary_function< Type, Type,
 //                                 Type > {
 //       public:
 //         Type operator()( const Type& x, const Type& y ) const {
@@ -118,7 +118,7 @@ template <> class Algebraic_structure_traits< leda_integer >
 //     };
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CGAL_LEDA_SCOPE::sqrt( x );
@@ -131,7 +131,7 @@ template <> class Real_embeddable_traits< leda_integer >
   public:
   
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return CGAL_LEDA_SCOPE::abs( x );
@@ -139,7 +139,7 @@ template <> class Real_embeddable_traits< leda_integer >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
             return (::CGAL::Sign) CGAL_LEDA_SCOPE::sign( x );
@@ -147,7 +147,7 @@ template <> class Real_embeddable_traits< leda_integer >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -158,7 +158,7 @@ template <> class Real_embeddable_traits< leda_integer >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           return x.to_double();
@@ -166,7 +166,7 @@ template <> class Real_embeddable_traits< leda_integer >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
       std::pair<double, double> operator()( const Type& x ) const {
         leda::bigfloat h(x);

--- a/Number_types/include/CGAL/leda_rational.h
+++ b/Number_types/include/CGAL/leda_rational.h
@@ -64,7 +64,7 @@ template <> class Algebraic_structure_traits< leda_rational >
 //                                                                 Is_square;
 
     class Simplify
-      : public CGAL::unary_function< Type&, void > {
+      : public CGAL::cpp98::unary_function< Type&, void > {
       public:
         void operator()( Type& x) const {
             x.normalize();
@@ -78,7 +78,7 @@ template <> class Real_embeddable_traits< leda_rational >
   public:
   
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return CGAL_LEDA_SCOPE::abs( x );
@@ -86,7 +86,7 @@ template <> class Real_embeddable_traits< leda_rational >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
             return (::CGAL::Sign) CGAL_LEDA_SCOPE::sign( x );
@@ -94,7 +94,7 @@ template <> class Real_embeddable_traits< leda_rational >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -105,7 +105,7 @@ template <> class Real_embeddable_traits< leda_rational >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           return x.to_double();
@@ -113,7 +113,7 @@ template <> class Real_embeddable_traits< leda_rational >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 

--- a/Number_types/include/CGAL/leda_real.h
+++ b/Number_types/include/CGAL/leda_real.h
@@ -51,7 +51,7 @@ template <> class Algebraic_structure_traits< leda_real >
     typedef Tag_true           Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return CGAL_LEDA_SCOPE::sqrt( x );
@@ -59,7 +59,7 @@ template <> class Algebraic_structure_traits< leda_real >
     };
 
     class Kth_root
-      : public CGAL::binary_function<int, Type, Type> {
+      : public CGAL::cpp98::binary_function<int, Type, Type> {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -110,7 +110,7 @@ template <> class Real_embeddable_traits< leda_real >
   : public INTERN_RET::Real_embeddable_traits_base< leda_real , CGAL::Tag_true > {
   public:
     class Abs
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
             return CGAL_LEDA_SCOPE::abs( x );
@@ -118,7 +118,7 @@ template <> class Real_embeddable_traits< leda_real >
     };
 
     class Sgn
-      : public CGAL::unary_function< Type, ::CGAL::Sign > {
+      : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       public:
         ::CGAL::Sign operator()( const Type& x ) const {
           return (::CGAL::Sign) CGAL_LEDA_SCOPE::sign( x );
@@ -126,7 +126,7 @@ template <> class Real_embeddable_traits< leda_real >
     };
 
     class Compare
-      : public CGAL::binary_function< Type, Type,
+      : public CGAL::cpp98::binary_function< Type, Type,
                                 Comparison_result > {
       public:
         Comparison_result operator()( const Type& x,
@@ -140,7 +140,7 @@ template <> class Real_embeddable_traits< leda_real >
     };
 
     class To_double
-      : public CGAL::unary_function< Type, double > {
+      : public CGAL::cpp98::unary_function< Type, double > {
       public:
         double operator()( const Type& x ) const {
           // this call is required to get reasonable values for the double
@@ -151,7 +151,7 @@ template <> class Real_embeddable_traits< leda_real >
     };
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 

--- a/Number_types/include/CGAL/long_double.h
+++ b/Number_types/include/CGAL/long_double.h
@@ -64,7 +64,7 @@ is_nan_by_mask_long_double(unsigned int h, unsigned int l)
 
 template<>
 class Is_valid< long double >
-  : public CGAL::unary_function< long double, bool > {
+  : public CGAL::cpp98::unary_function< long double, bool > {
   public :
     bool operator()( const long double& x ) const {
       double d = x;
@@ -77,7 +77,7 @@ class Is_valid< long double >
 
 template<>
 class Is_valid< long double >
-  : public CGAL::unary_function< long double, bool > {
+  : public CGAL::cpp98::unary_function< long double, bool > {
   public :
     bool operator()( const long double& x ) const {
       return (x == x);
@@ -97,7 +97,7 @@ template <> class Algebraic_structure_traits< long double >
     typedef Tag_true             Is_numerical_sensitive;
 
     class Sqrt
-      : public CGAL::unary_function< Type, Type > {
+      : public CGAL::cpp98::unary_function< Type, Type > {
       public:
         Type operator()( const Type& x ) const {
           return std::sqrt( x );
@@ -105,7 +105,7 @@ template <> class Algebraic_structure_traits< long double >
     };
 
     class Kth_root
-      :public CGAL::binary_function<int, Type, Type > {
+      :public CGAL::cpp98::binary_function<int, Type, Type > {
       public:
         Type operator()( int k,
                                         const Type& x) const {
@@ -122,7 +122,7 @@ template <> class Real_embeddable_traits< long double >
   public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           // The conversion long double to double does not always follow the
@@ -147,7 +147,7 @@ template <> class Real_embeddable_traits< long double >
 
 // Is_finite depends on platform
     class Is_finite
-      : public CGAL::unary_function< Type, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x ) const {
 #ifdef CGAL_CFG_IEEE_754_BUG

--- a/Number_types/include/CGAL/long_long.h
+++ b/Number_types/include/CGAL/long_long.h
@@ -46,7 +46,7 @@ template<> class Algebraic_structure_traits< long long int >
     typedef INTERN_AST::Mod_per_operator< Type >  Mod;
 
     class Is_square
-      : public CGAL::binary_function< Type, Type&,
+      : public CGAL::cpp98::binary_function< Type, Type&,
                                 bool > {
       public:
         bool operator()( const Type& x,
@@ -67,7 +67,7 @@ template <> class Real_embeddable_traits< long long int >
   public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           return Interval_nt<true>(x).pair();
@@ -81,7 +81,7 @@ template <> class Real_embeddable_traits< unsigned long long >
   public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
           return Interval_nt<true>(x).pair();
@@ -109,7 +109,7 @@ template <> class Real_embeddable_traits< boost::int128_type >
   public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 	  return (Interval_nt<>((double)x)+Interval_nt<>::smallest()).pair();
@@ -123,7 +123,7 @@ template <> class Real_embeddable_traits< boost::uint128_type >
   public:
 
     class To_interval
-      : public CGAL::unary_function< Type, std::pair< double, double > > {
+      : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       public:
         std::pair<double, double> operator()( const Type& x ) const {
 	  return (Interval_nt<>((double)x)+Interval_nt<>::smallest()).pair();

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -57,7 +57,7 @@ class Algebraic_structure_traits< mpq_class  >
     typedef Tag_true            Is_exact;
     typedef Tag_false           Is_numerical_sensitive;
 
-    struct Is_zero: public CGAL::unary_function< mpq_class , bool > {
+    struct Is_zero: public CGAL::cpp98::unary_function< mpq_class , bool > {
         template <class T, class U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -65,7 +65,7 @@ class Algebraic_structure_traits< mpq_class  >
         }
     };
 
-    struct Is_one: public CGAL::unary_function< mpq_class , bool > {
+    struct Is_one: public CGAL::cpp98::unary_function< mpq_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -73,27 +73,27 @@ class Algebraic_structure_traits< mpq_class  >
         }
     };
 
-    struct Simplify: public CGAL::unary_function< mpq_class , void > {
+    struct Simplify: public CGAL::cpp98::unary_function< mpq_class , void > {
         void operator()( mpq_class& x) const {
             // do nothing because x is already canonical?
             x.canonicalize();
         }
     };
 
-    struct Square: public CGAL::unary_function< mpq_class , mpq_class > {
+    struct Square: public CGAL::cpp98::unary_function< mpq_class , mpq_class > {
         mpq_class operator()( const mpq_class& x) const {
             return x*x;
         }
     };
 
-    struct Unit_part: public CGAL::unary_function< mpq_class , mpq_class > {
+    struct Unit_part: public CGAL::cpp98::unary_function< mpq_class , mpq_class > {
         mpq_class operator()( const mpq_class& x) const {
             return( x == 0) ? mpq_class(1) : x;
         }
     };
 
     struct Integral_division
-        : public CGAL::binary_function< mpq_class , mpq_class, mpq_class > {
+        : public CGAL::cpp98::binary_function< mpq_class , mpq_class, mpq_class > {
         template <typename T,  typename U1, typename U2>
         mpq_class operator()(
                 const ::__gmp_expr< T , U1 >& x,
@@ -109,7 +109,7 @@ class Algebraic_structure_traits< mpq_class  >
     };
 
     class Is_square
-        : public CGAL::binary_function< mpq_class, mpq_class&, bool > {
+        : public CGAL::cpp98::binary_function< mpq_class, mpq_class&, bool > {
     public:
         bool operator()( const mpq_class& x, mpq_class& y ) const {
             y = mpq_class (::sqrt( x.get_num() ), ::sqrt( x.get_den() )) ;
@@ -131,14 +131,14 @@ class Real_embeddable_traits< mpq_class >
   : public INTERN_RET::Real_embeddable_traits_base< mpq_class , CGAL::Tag_true > {
   public:
 
-    struct Is_zero: public CGAL::unary_function< mpq_class , bool > {
+    struct Is_zero: public CGAL::cpp98::unary_function< mpq_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
             return ::sgn(x) == 0;
         }
     };
-    struct Is_finite: public CGAL::unary_function<mpq_class,bool> {
+    struct Is_finite: public CGAL::cpp98::unary_function<mpq_class,bool> {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >&) const {
             CGAL_CHECK_GMP_EXPR;
@@ -146,7 +146,7 @@ class Real_embeddable_traits< mpq_class >
         }
     };
 
-    struct Is_positive: public CGAL::unary_function< mpq_class , bool > {
+    struct Is_positive: public CGAL::cpp98::unary_function< mpq_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -154,7 +154,7 @@ class Real_embeddable_traits< mpq_class >
         }
     };
 
-    struct Is_negative: public CGAL::unary_function< mpq_class , bool > {
+    struct Is_negative: public CGAL::cpp98::unary_function< mpq_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -162,7 +162,7 @@ class Real_embeddable_traits< mpq_class >
         }
     };
 
-    struct Abs: public CGAL::unary_function< mpq_class , mpq_class > {
+    struct Abs: public CGAL::cpp98::unary_function< mpq_class , mpq_class > {
         template <typename T, typename U>
         mpq_class operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -171,7 +171,7 @@ class Real_embeddable_traits< mpq_class >
     };
 
     struct Sgn
-        : public CGAL::unary_function< mpq_class, ::CGAL::Sign > {
+        : public CGAL::cpp98::unary_function< mpq_class, ::CGAL::Sign > {
     public:
         template <typename T, typename U>
         ::CGAL::Sign
@@ -182,7 +182,7 @@ class Real_embeddable_traits< mpq_class >
     };
 
     struct Compare
-        : public CGAL::binary_function< mpq_class, mpq_class, Comparison_result>
+        : public CGAL::cpp98::binary_function< mpq_class, mpq_class, Comparison_result>
     {
         template <typename T, typename U1, typename U2>
         Comparison_result operator()(
@@ -197,7 +197,7 @@ class Real_embeddable_traits< mpq_class >
     };
 
     struct To_double
-        : public CGAL::unary_function< mpq_class, double > {
+        : public CGAL::cpp98::unary_function< mpq_class, double > {
         double operator()( const mpq_class& x ) const {
             return x.get_d();
         }
@@ -205,7 +205,7 @@ class Real_embeddable_traits< mpq_class >
 
     struct To_interval
 
-        : public CGAL::unary_function< mpq_class, std::pair< double, double > > {
+        : public CGAL::cpp98::unary_function< mpq_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpq_class& x ) const {
 #if MPFR_VERSION_MAJOR >= 3

--- a/Number_types/include/CGAL/mpz_class.h
+++ b/Number_types/include/CGAL/mpz_class.h
@@ -58,7 +58,7 @@ public:
     typedef Tag_true            Is_exact;
     typedef Tag_false           Is_numerical_sensitive;
 
-    struct Is_zero: public CGAL::unary_function< mpz_class , bool > {
+    struct Is_zero: public CGAL::cpp98::unary_function< mpz_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -66,7 +66,7 @@ public:
         }
     };
 
-    struct Is_one: public CGAL::unary_function< mpz_class , bool > {
+    struct Is_one: public CGAL::cpp98::unary_function< mpz_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -74,20 +74,20 @@ public:
         }
     };
 
-    struct Simplify: public CGAL::unary_function< mpz_class , void > {
+    struct Simplify: public CGAL::cpp98::unary_function< mpz_class , void > {
         template <class T, class U>
         void operator()( const ::__gmp_expr< T ,U >&) const {
             CGAL_CHECK_GMP_EXPR;
         }
     };
 
-    struct Square: public CGAL::unary_function< mpz_class , mpz_class > {
+    struct Square: public CGAL::cpp98::unary_function< mpz_class , mpz_class > {
         mpz_class operator()( const mpz_class& x) const {
             return x*x;
         }
     };
 
-    struct Unit_part: public CGAL::unary_function< mpz_class , mpz_class > {
+    struct Unit_part: public CGAL::cpp98::unary_function< mpz_class , mpz_class > {
         mpz_class operator()( const mpz_class& x) const {
             return (x < 0) ? -1 : 1;
         }
@@ -96,7 +96,7 @@ public:
 
 
     struct Integral_division:
-        public CGAL::binary_function< mpz_class , mpz_class, mpz_class > {
+        public CGAL::cpp98::binary_function< mpz_class , mpz_class, mpz_class > {
         template <typename T,  typename U1, typename U2>
         mpz_class operator()(
                 const ::__gmp_expr< T , U1 >& x,
@@ -111,7 +111,7 @@ public:
         CGAL_IMPLICIT_INTEROPERABLE_BINARY_OPERATOR( Type )
     };
 
-    struct Gcd : public CGAL::binary_function< mpz_class, mpz_class, mpz_class > {
+    struct Gcd : public CGAL::cpp98::binary_function< mpz_class, mpz_class, mpz_class > {
         mpz_class operator()(
                 const mpz_class& x,
                 const mpz_class& y) const {
@@ -122,7 +122,7 @@ public:
         CGAL_IMPLICIT_INTEROPERABLE_BINARY_OPERATOR( Type )
     };
 
-    struct Div : public CGAL::binary_function< mpz_class, mpz_class, mpz_class > {
+    struct Div : public CGAL::cpp98::binary_function< mpz_class, mpz_class, mpz_class > {
         template <typename T,  typename U1, typename U2>
         mpz_class operator()(
                 const ::__gmp_expr< T , U1 >& x,
@@ -133,7 +133,7 @@ public:
         CGAL_IMPLICIT_INTEROPERABLE_BINARY_OPERATOR( Type )
     };
 
-    struct Mod : public CGAL::binary_function< mpz_class, mpz_class, mpz_class > {
+    struct Mod : public CGAL::cpp98::binary_function< mpz_class, mpz_class, mpz_class > {
         template <typename T,  typename U1, typename U2>
         mpz_class operator()(
                 const ::__gmp_expr< T , U1 >& x,
@@ -166,7 +166,7 @@ public:
     };
 
 
-    struct Sqrt: public CGAL::unary_function< mpz_class , mpz_class > {
+    struct Sqrt: public CGAL::cpp98::unary_function< mpz_class , mpz_class > {
         template <typename T, typename U>
         mpz_class operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -175,7 +175,7 @@ public:
     };
 
 
-    /*struct Is_square: public CGAL::binary_function< mpz_class , mpz_class& , bool > {
+    /*struct Is_square: public CGAL::cpp98::binary_function< mpz_class , mpz_class& , bool > {
         template <typename T, typename U>
         bool operator()(
                 const ::__gmp_expr< T , U >& x,
@@ -197,14 +197,14 @@ class Real_embeddable_traits< mpz_class  >
     : public INTERN_RET::Real_embeddable_traits_base< mpz_class , CGAL::Tag_true > {
 public:
 
-    struct Is_zero: public CGAL::unary_function< mpz_class , bool > {
+    struct Is_zero: public CGAL::cpp98::unary_function< mpz_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
             return ::sgn(x) == 0;
         }
     };
-    struct Is_finite: public CGAL::unary_function<mpz_class,bool> {
+    struct Is_finite: public CGAL::cpp98::unary_function<mpz_class,bool> {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& ) const {
             CGAL_CHECK_GMP_EXPR;
@@ -212,7 +212,7 @@ public:
         }
     };
 
-    struct Is_positive: public CGAL::unary_function< mpz_class , bool > {
+    struct Is_positive: public CGAL::cpp98::unary_function< mpz_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -220,7 +220,7 @@ public:
         }
     };
 
-    struct Is_negative: public CGAL::unary_function< mpz_class , bool > {
+    struct Is_negative: public CGAL::cpp98::unary_function< mpz_class , bool > {
         template <typename T, typename U>
         bool operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -228,7 +228,7 @@ public:
         }
     };
 
-    struct Abs: public CGAL::unary_function< mpz_class , mpz_class > {
+    struct Abs: public CGAL::cpp98::unary_function< mpz_class , mpz_class > {
         template <typename T, typename U>
         mpz_class operator()( const ::__gmp_expr< T , U >& x) const {
             CGAL_CHECK_GMP_EXPR;
@@ -237,7 +237,7 @@ public:
     };
 
     struct Sgn
-        : public CGAL::unary_function< mpz_class, ::CGAL::Sign > {
+        : public CGAL::cpp98::unary_function< mpz_class, ::CGAL::Sign > {
     public:
         template <typename T, typename U>
         ::CGAL::Sign operator()( const ::__gmp_expr< T , U >& x ) const {
@@ -247,7 +247,7 @@ public:
     };
 
     struct Compare
-        : public CGAL::binary_function< mpz_class, mpz_class, Comparison_result > {
+        : public CGAL::cpp98::binary_function< mpz_class, mpz_class, Comparison_result > {
         template <typename T,  typename U1, typename U2>
         Comparison_result operator()(
                 const ::__gmp_expr< T , U1 >& x,
@@ -261,7 +261,7 @@ public:
     };
 
     struct To_double
-        : public CGAL::unary_function< mpz_class, double > {
+        : public CGAL::cpp98::unary_function< mpz_class, double > {
         double operator()( const mpz_class& x ) const {
             return x.get_d();
         }
@@ -269,7 +269,7 @@ public:
 
     struct To_interval
 
-        : public CGAL::unary_function< mpz_class, std::pair< double, double > > {
+        : public CGAL::cpp98::unary_function< mpz_class, std::pair< double, double > > {
         std::pair<double, double>
         operator()( const mpz_class& x ) const {
 #if MPFR_VERSION_MAJOR >= 3

--- a/Number_types/include/CGAL/utils_classes.h
+++ b/Number_types/include/CGAL/utils_classes.h
@@ -30,43 +30,43 @@
 namespace CGAL {
 
 template < class A, class B = A >
-struct Equal_to : public CGAL::binary_function< A, B, bool > {
+struct Equal_to : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x == y; }
 };
 
 template < class A, class B = A >
-struct Not_equal_to : public CGAL::binary_function< A, B, bool > {
+struct Not_equal_to : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x != y; }
 };
 
 template < class A, class B = A >
-struct Greater : public CGAL::binary_function< A, B, bool > {
+struct Greater : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x > y; }
 };
 
 template < class A, class B = A >
-struct Less : public CGAL::binary_function< A, B, bool > {
+struct Less : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x < y; }
 };
 
 template < class A, class B = A >
-struct Greater_equal : public CGAL::binary_function< A, B, bool > {
+struct Greater_equal : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x >= y; }
 };
 
 template < class A, class B = A >
-struct Less_equal : public CGAL::binary_function< A, B, bool > {
+struct Less_equal : public CGAL::cpp98::binary_function< A, B, bool > {
   bool operator()( const A& x, const B& y) const
   { return x <= y; }
 };
 
 template < class NT, class Less = std::less< NT > >
-struct Min :public CGAL::binary_function< NT, NT, NT > {
+struct Min :public CGAL::cpp98::binary_function< NT, NT, NT > {
  Min() {}
  Min(const Less& c_) : c(c_) {}
  NT operator()( const NT& x, const NT& y) const
@@ -76,7 +76,7 @@ protected:
 };
 
 template < class NT, class Less = std::less< NT > >
-struct Max :public CGAL::binary_function< NT, NT, NT > {
+struct Max :public CGAL::cpp98::binary_function< NT, NT, NT > {
  Max() {}
  Max(const Less& c_) : c(c_) {}
  NT operator()( const NT& x, const NT& y) const
@@ -201,7 +201,7 @@ inline void sse2minmax(double& a, double b, double& c)
 #endif // CGAL_USE_SSE2_MAX
 
 template <>
-struct Max<double> :public CGAL::binary_function< double, double, double > {
+struct Max<double> :public CGAL::cpp98::binary_function< double, double, double > {
  Max() {}
 
  double operator()( const double& x, const double& y) const
@@ -233,7 +233,7 @@ struct Max<double> :public CGAL::binary_function< double, double, double > {
 };
 
 template <>
-struct Min<double> :public CGAL::binary_function< double, double, double > {
+struct Min<double> :public CGAL::cpp98::binary_function< double, double, double > {
  Min() {}
 
  double operator()( const double& x, const double& y) const
@@ -265,7 +265,7 @@ struct Min<double> :public CGAL::binary_function< double, double, double > {
 };
 template< class T >
 class Is_valid
-  : public CGAL::unary_function< T, bool > {
+  : public CGAL::cpp98::unary_function< T, bool > {
   public:
     bool operator()( const T& ) const {
       return true;

--- a/Number_types/test/Number_types/checked_NT.h
+++ b/Number_types/test/Number_types/checked_NT.h
@@ -48,7 +48,7 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
   typedef typename AST1::Is_numerical_sensitive Is_numerical_sensitive;
   typedef checked_NT<NT1,NT2> Type;
   struct Is_zero
-    : public CGAL::unary_function< Type, bool > {
+    : public CGAL::cpp98::unary_function< Type, bool > {
       bool operator()( const Type& x ) const {
 	bool a=CGAL::is_zero(x.x1);
 	bool b=CGAL::is_zero(x.x2);
@@ -57,7 +57,7 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
       }
     };
   struct Is_one
-    : public CGAL::unary_function< Type, bool > {
+    : public CGAL::cpp98::unary_function< Type, bool > {
       bool operator()( const Type& x ) const {
 	bool a=CGAL::is_one(x.x1);
 	bool b=CGAL::is_one(x.x2);
@@ -66,7 +66,7 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
       }
     };
   struct Is_square
-    : public CGAL::unary_function< Type, bool > {
+    : public CGAL::cpp98::unary_function< Type, bool > {
       bool operator()( const Type& x ) const {
 	bool a=CGAL::is_square(x.x1);
 	bool b=CGAL::is_square(x.x2);
@@ -75,13 +75,13 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
       }
     };
   struct Square
-    : public CGAL::unary_function< Type, Type > {
+    : public CGAL::cpp98::unary_function< Type, Type > {
       Type operator()( const Type& x ) const {
 	return Type(typename Type::pieces(),CGAL::square(x.x1),CGAL::square(x.x2));
       }
     };
   struct Div
-    : public CGAL::binary_function< Type, Type, Type > {
+    : public CGAL::cpp98::binary_function< Type, Type, Type > {
       Type operator()( const Type& x, const Type& y ) const {
 	return Type(typename Type::pieces(),
 	    CGAL::div(x.x1,y.x1),
@@ -89,7 +89,7 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
       }
     };
   struct Mod
-    : public CGAL::binary_function< Type, Type, Type > {
+    : public CGAL::cpp98::binary_function< Type, Type, Type > {
       Type operator()( const Type& x, const Type& y ) const {
 	return Type(typename Type::pieces(),
 	    CGAL::mod(x.x1,y.x1),
@@ -97,7 +97,7 @@ template<class NT1,class NT2> struct Algebraic_structure_traits<checked_NT<NT1,N
       }
     };
   struct Integral_division
-    : public CGAL::binary_function< Type, Type, Type > {
+    : public CGAL::cpp98::binary_function< Type, Type, Type > {
       Type operator()( const Type& x, const Type& y ) const {
 	return Type(typename Type::pieces(),
 	    CGAL::integral_division(x.x1,y.x1),
@@ -110,7 +110,7 @@ template<class NT1,class NT2>struct Real_embeddable_traits<checked_NT<NT1,NT2> >
 : INTERN_RET::Real_embeddable_traits_base<checked_NT<NT1,NT2>, typename Real_embeddable_traits<NT1>::Is_real_embeddable> {
   typedef checked_NT<NT1,NT2> Type;
   struct Sgn
-    : public CGAL::unary_function< Type, ::CGAL::Sign > {
+    : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {
       ::CGAL::Sign operator()( const Type& x ) const {
 	::CGAL::Sign a=CGAL::sign(x.x1);
 	::CGAL::Sign b=CGAL::sign(x.x2);
@@ -119,19 +119,19 @@ template<class NT1,class NT2>struct Real_embeddable_traits<checked_NT<NT1,NT2> >
       }
     };
   struct To_double
-    : public CGAL::unary_function< Type, double > {
+    : public CGAL::cpp98::unary_function< Type, double > {
       double operator()( const Type& x ) const {
 	return x.to_double();
       }
     };
   struct To_interval
-    : public CGAL::unary_function< Type, std::pair< double, double > > {
+    : public CGAL::cpp98::unary_function< Type, std::pair< double, double > > {
       std::pair<double, double> operator()( const Type& x ) const {
 	return x.to_interval();
       }
     };
   struct Compare
-    : public CGAL::binary_function< Type, Type, Comparison_result > {
+    : public CGAL::cpp98::binary_function< Type, Type, Comparison_result > {
       Comparison_result operator()(
 	  const Type& x,
 	  const Type& y ) const {

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
@@ -83,7 +83,7 @@ public:
 
 private:
 
-  struct Point_3_from_sample : public CGAL::unary_function<Sample_, K::Point_3>
+  struct Point_3_from_sample : public CGAL::cpp98::unary_function<Sample_, K::Point_3>
   {
     K::Point_3 operator() (const Sample_& sample) const
     {

--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_transform_iterator_2.cpp
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_transform_iterator_2.cpp
@@ -19,7 +19,7 @@ typedef Delaunay::Point                                             Point;
 //the unsigned integer is incremented at each call to
 //operator()
 struct Auto_count
-  : public CGAL::unary_function<const Point&, std::pair<Point, unsigned> >
+  : public CGAL::cpp98::unary_function<const Point&, std::pair<Point, unsigned> >
 {
   mutable unsigned i;
   Auto_count() : i(0) {}

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
@@ -187,7 +187,7 @@ public:
 
 private:
   struct Cell_handle_hash
-    : public CGAL::unary_function<Cell_handle, std::size_t>
+    : public CGAL::cpp98::unary_function<Cell_handle, std::size_t>
   {
     std::size_t operator()(const Cell_handle& ch) const {
       return boost::hash<typename Cell_handle::pointer>()(&*ch);

--- a/Point_set_processing_3/include/CGAL/estimate_scale.h
+++ b/Point_set_processing_3/include/CGAL/estimate_scale.h
@@ -71,7 +71,7 @@ class Quick_multiscale_approximate_knn_distance<Kernel, typename Kernel::Point_3
   typedef typename Neighbor_search::iterator Iterator;
 
   template <typename ValueType, typename PointMap>
-  struct Pmap_unary_function : public CGAL::unary_function<ValueType, typename Kernel::Point_3>
+  struct Pmap_unary_function : public CGAL::cpp98::unary_function<ValueType, typename Kernel::Point_3>
   {
     PointMap point_map;
     Pmap_unary_function (PointMap point_map) : point_map (point_map) { }
@@ -236,7 +236,7 @@ class Quick_multiscale_approximate_knn_distance<Kernel, typename Kernel::Point_2
   typedef typename Point_set::Vertex_handle Vertex_handle;
 
   template <typename ValueType, typename PointMap>
-  struct Pmap_unary_function : public CGAL::unary_function<ValueType, typename Kernel::Point_2>
+  struct Pmap_unary_function : public CGAL::cpp98::unary_function<ValueType, typename Kernel::Point_2>
   {
     PointMap point_map;
     Pmap_unary_function (PointMap point_map) : point_map (point_map) { }

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_implicit_surface_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_implicit_surface_3.h
@@ -129,7 +129,7 @@ namespace CGAL {
 
   // non documented class
   template <typename FT, typename Point>
-  class Poisson_implicit_function_wrapper : public CGAL::unary_function<Point, FT> 
+  class Poisson_implicit_function_wrapper : public CGAL::cpp98::unary_function<Point, FT> 
   {
     typedef FT (*Poisson_implicit_function)(FT, FT, FT);
 

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/polygon_mesh_slicer.cpp
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/polygon_mesh_slicer.cpp
@@ -44,7 +44,7 @@ typedef CGAL::Timer Timer;
 
 template <typename PolygonMesh>
  class Point_projector
-  : public CGAL::unary_function<typename boost::graph_traits<PolygonMesh>::vertex_descriptor,
+  : public CGAL::cpp98::unary_function<typename boost::graph_traits<PolygonMesh>::vertex_descriptor,
                                typename boost::property_traits<typename boost::property_map<PolygonMesh, CGAL::vertex_point_t>::type>::value_type> {
   typedef typename boost::property_map<PolygonMesh, CGAL::vertex_point_t>::type Ppmap;
 public:

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_distance.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_distance.cpp
@@ -210,7 +210,7 @@ struct Real_embeddable_traits< Custom_traits_Hausdorff::FT >
   : public INTERN_RET::Real_embeddable_traits_base< Custom_traits_Hausdorff::FT , CGAL::Tag_true>
 {
   class To_double
-    : public CGAL::unary_function< Custom_traits_Hausdorff::FT, double > {
+    : public CGAL::cpp98::unary_function< Custom_traits_Hausdorff::FT, double > {
     public:
       double operator()( const Custom_traits_Hausdorff::FT&  ) const { return 0; }
   };

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.h
@@ -55,8 +55,8 @@ class Cluster_classification : public Item_classification_base
   };
 
   struct Point_set_with_cluster_info
-    : public CGAL::unary_function<const Point_set::Index&,
-                                  std::pair<Kernel::Point_3, int> >
+    : public CGAL::cpp98::unary_function<const Point_set::Index&,
+                                         std::pair<Kernel::Point_3, int> >
   {
     Point_set* point_set;
     Point_set::Property_map<int>* cluster_id;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -600,7 +600,7 @@ namespace SurfaceReconstruction
   }
 
   struct Point_set_make_pair_point_index
-    : public CGAL::unary_function<const Point_set::Index&, std::pair<Kernel::Point_3, std::size_t> >
+    : public CGAL::cpp98::unary_function<const Point_set::Index&, std::pair<Kernel::Point_3, std::size_t> >
   {
     const Point_set& point_set;
     Point_set_make_pair_point_index (const Point_set& point_set) : point_set (point_set) { }

--- a/Polynomial/include/CGAL/Polynomial/Algebraic_structure_traits.h
+++ b/Polynomial/include/CGAL/Polynomial/Algebraic_structure_traits.h
@@ -88,7 +88,7 @@ class Polynomial_algebraic_structure_traits_base< POLY,
     typedef Integral_domain_without_division_tag Algebraic_category;
     
     class Simplify 
-      : public CGAL::unary_function< POLY&, void > {
+      : public CGAL::cpp98::unary_function< POLY&, void > {
       public:
         void operator()( POLY& p ) const {
           p.simplify_coefficients();
@@ -96,7 +96,7 @@ class Polynomial_algebraic_structure_traits_base< POLY,
     };
     
     class Unit_part 
-      : public CGAL::unary_function< POLY, POLY > {
+      : public CGAL::cpp98::unary_function< POLY, POLY > {
       public:
         POLY operator()( const POLY& x ) const {
           return POLY( x.unit_part() );
@@ -104,7 +104,7 @@ class Polynomial_algebraic_structure_traits_base< POLY,
     };
   
   class Is_zero
-    : public CGAL::unary_function< POLY, bool > {
+    : public CGAL::cpp98::unary_function< POLY, bool > {
   public:
     bool operator()( const POLY& x ) const {
       return x.is_zero();
@@ -122,7 +122,7 @@ class Polynomial_algebraic_structure_traits_base< POLY, Integral_domain_tag >
     typedef Integral_domain_tag Algebraic_category;
     
     class Integral_division 
-      : public CGAL::binary_function< POLY, POLY, POLY > {
+      : public CGAL::cpp98::binary_function< POLY, POLY, POLY > {
       public:
         POLY operator()( const POLY& x, const POLY& y ) const {
           return x / y;
@@ -136,7 +136,7 @@ private:
   typedef typename Divides_coeff::result_type BOOL;
 public:
   class Divides 
-    : public CGAL::binary_function<POLY,POLY,BOOL>{  
+    : public CGAL::cpp98::binary_function<POLY,POLY,BOOL>{  
   public:
      BOOL operator()( const POLY& p1, const POLY& p2) const {
        POLY q; 
@@ -210,7 +210,7 @@ class Polynomial_algebraic_structure_traits_base< POLY, Unique_factorization_dom
     typedef Unique_factorization_domain_tag Algebraic_category;
     
   class Gcd 
-    : public CGAL::binary_function< POLY, POLY, POLY > {
+    : public CGAL::cpp98::binary_function< POLY, POLY, POLY > {
     typedef typename Polynomial_traits_d<POLY>::Multivariate_content Mcontent;
     typedef typename Mcontent::result_type ICoeff; 
     
@@ -293,7 +293,7 @@ class Polynomial_algebraic_structure_traits_base< POLY, Field_tag >
     };
     
     class Div 
-      : public CGAL::binary_function< POLY, POLY, POLY > {
+      : public CGAL::cpp98::binary_function< POLY, POLY, POLY > {
       public:
         POLY operator()(const POLY& a, const POLY& b) const {
           POLY q, r;
@@ -305,7 +305,7 @@ class Polynomial_algebraic_structure_traits_base< POLY, Field_tag >
     };
     
     class Mod 
-      : public CGAL::binary_function< POLY, POLY, POLY > {
+      : public CGAL::cpp98::binary_function< POLY, POLY, POLY > {
       public:
         POLY operator () (const POLY& a, const POLY& b) const {
           POLY q, r;

--- a/Polynomial/include/CGAL/Polynomial/Degree.h
+++ b/Polynomial/include/CGAL/Polynomial/Degree.h
@@ -38,7 +38,7 @@ template <typename Polynomial > struct Degree;
 // Polynomial musst be at least univariate ! 
 template <typename Coeff_ > 
 struct Degree<Polynomial<Coeff_> >
-  : public CGAL::unary_function< Polynomial<Coeff_> , int  >{
+  : public CGAL::cpp98::unary_function< Polynomial<Coeff_> , int  >{
   
 private: 
   typedef Polynomial<Coeff_> Polynomial_d;

--- a/Polynomial/include/CGAL/Polynomial_traits_d.h
+++ b/Polynomial/include/CGAL/Polynomial_traits_d.h
@@ -123,7 +123,7 @@ public:
 
  
  struct Multivariate_content
-    : public CGAL::unary_function< Polynomial_d , Innermost_coefficient_type >{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Innermost_coefficient_type >{
     Innermost_coefficient_type 
     operator()(const Polynomial_d& p) const {
       typedef Innermost_coefficient_const_iterator IT;
@@ -156,7 +156,7 @@ public:
     
   //       Multivariate_content;
   struct Multivariate_content
-    : public CGAL::unary_function< Polynomial_d , Innermost_coefficient_type >{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Innermost_coefficient_type >{
     Innermost_coefficient_type operator()(const Polynomial_d& p) const {
       if( CGAL::is_zero(p) )
         return Innermost_coefficient_type(0);
@@ -217,7 +217,7 @@ public:
     
   //       Univariate_content
   struct Univariate_content
-    : public CGAL::unary_function< Polynomial_d , Coefficient_type>{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Coefficient_type>{
     Coefficient_type operator()(const Polynomial_d& p) const {
       return p.content();
     }
@@ -287,11 +287,11 @@ public:
   typedef ICoeff Innermost_coefficient_type;
     
   struct Degree 
-    : public CGAL::unary_function< ICoeff , int > {
+    : public CGAL::cpp98::unary_function< ICoeff , int > {
     int operator()(const ICoeff&) const { return 0; }
   };
   struct Total_degree 
-    : public CGAL::unary_function< ICoeff , int > {
+    : public CGAL::cpp98::unary_function< ICoeff , int > {
     int operator()(const ICoeff&) const { return 0; }
   };
     
@@ -309,14 +309,14 @@ public:
   typedef Null_functor  Differentiate;
     
   struct Is_square_free
-    : public CGAL::unary_function< ICoeff, bool > {
+    : public CGAL::cpp98::unary_function< ICoeff, bool > {
     bool operator()( const ICoeff& ) const {
       return true;
     }
   };
     
   struct Make_square_free 
-    : public CGAL::unary_function< ICoeff, ICoeff>{
+    : public CGAL::cpp98::unary_function< ICoeff, ICoeff>{
     ICoeff operator()( const ICoeff& x ) const {
       if (CGAL::is_zero(x)) return x ;
       else  return ICoeff(1);
@@ -329,7 +329,7 @@ public:
   typedef Null_functor  Pseudo_division_quotient;
 
   struct Gcd_up_to_constant_factor 
-    : public CGAL::binary_function< ICoeff, ICoeff, ICoeff >{
+    : public CGAL::cpp98::binary_function< ICoeff, ICoeff, ICoeff >{
     ICoeff operator()(const ICoeff& x, const ICoeff& y) const {
       if (CGAL::is_zero(x) && CGAL::is_zero(y)) 
         return ICoeff(0);
@@ -341,7 +341,7 @@ public:
   typedef Null_functor Integral_division_up_to_constant_factor;
 
   struct Univariate_content_up_to_constant_factor
-    : public CGAL::unary_function< ICoeff, ICoeff >{
+    : public CGAL::cpp98::unary_function< ICoeff, ICoeff >{
     ICoeff operator()(const ICoeff& ) const {
       // TODO: Why not return 0 if argument is 0 ? 
       return ICoeff(1);
@@ -354,7 +354,7 @@ public:
   typedef Null_functor  Evaluate_homogeneous;
     
   struct Innermost_leading_coefficient
-    :public CGAL::unary_function <ICoeff, ICoeff>{
+    :public CGAL::cpp98::unary_function <ICoeff, ICoeff>{
     const ICoeff& operator()(const ICoeff& x){return x;}
   };
     
@@ -368,7 +368,7 @@ public:
   };
   
   struct Get_innermost_coefficient 
-    : public CGAL::binary_function< ICoeff, Polynomial_d, Exponent_vector > {
+    : public CGAL::cpp98::binary_function< ICoeff, Polynomial_d, Exponent_vector > {
     const ICoeff& operator()( const Polynomial_d& p, Exponent_vector ) {
       return p;
     }
@@ -475,7 +475,7 @@ private:
   // coeff type has no comparison operators available.
 private:
   struct Compare_exponents_coeff_pair 
-    : public CGAL::binary_function<
+    : public CGAL::cpp98::binary_function<
        std::pair< Exponent_vector, Innermost_coefficient_type >,
        std::pair< Exponent_vector, Innermost_coefficient_type >,
        bool > 
@@ -701,7 +701,7 @@ public:
 
   // Get_coefficient;
   struct Get_coefficient 
-    : public CGAL::binary_function<Polynomial_d, int, Coefficient_type > {
+    : public CGAL::cpp98::binary_function<Polynomial_d, int, Coefficient_type > {
         
     const Coefficient_type& operator()( const Polynomial_d& p, int i) const {
       CGAL_STATIC_THREAD_LOCAL_VARIABLE(Coefficient_type, zero, 0);
@@ -716,7 +716,7 @@ public:
   //     Get_innermost_coefficient;
   struct Get_innermost_coefficient
     : public 
-    CGAL::binary_function< Polynomial_d, Exponent_vector, Innermost_coefficient_type >
+    cgal::cpp98::binary_function< Polynomial_d, Exponent_vector, Innermost_coefficient_type >
   {
         
     const Innermost_coefficient_type& 
@@ -836,7 +836,7 @@ public:
   typedef CGAL::internal::Degree<Polynomial_d> Degree; 
 
   //       Total_degree;
-  struct Total_degree : public CGAL::unary_function< Polynomial_d , int >{
+  struct Total_degree : public CGAL::cpp98::unary_function< Polynomial_d , int >{
     int operator()(const Polynomial_d& p) const {
       typedef Polynomial_traits_d<Coefficient_type> COEFF_POLY_TRAITS;
       typename COEFF_POLY_TRAITS::Total_degree total_degree;
@@ -854,7 +854,7 @@ public:
 
   //       Leading_coefficient;
   struct Leading_coefficient 
-    : public CGAL::unary_function< Polynomial_d , Coefficient_type>{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Coefficient_type>{
     const Coefficient_type& operator()(const Polynomial_d& p) const {
       return p.lcoeff();
     }
@@ -862,7 +862,7 @@ public:
     
   //       Innermost_leading_coefficient;
   struct Innermost_leading_coefficient 
-    : public CGAL::unary_function< Polynomial_d , Innermost_coefficient_type>{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Innermost_coefficient_type>{
     const Innermost_coefficient_type& 
     operator()(const Polynomial_d& p) const {
       typename PTC::Innermost_leading_coefficient ilcoeff;
@@ -874,7 +874,7 @@ public:
   
   //return a canonical representative of all constant multiples. 
   struct Canonicalize
-    : public CGAL::unary_function<Polynomial_d, Polynomial_d>{
+    : public CGAL::cpp98::unary_function<Polynomial_d, Polynomial_d>{
  
   private: 
     inline Polynomial_d canonicalize_(Polynomial_d p, CGAL::Tag_true) const 
@@ -916,7 +916,7 @@ public:
 
   //       Differentiate;
   struct Differentiate 
-    : public CGAL::unary_function<Polynomial_d, Polynomial_d>{
+    : public CGAL::cpp98::unary_function<Polynomial_d, Polynomial_d>{
     Polynomial_d
     operator()(Polynomial_d p, int i = (d-1)) const {
       if (i == (d-1) ){
@@ -933,7 +933,7 @@ public:
 
   // Evaluate;
   struct Evaluate
-    :public CGAL::binary_function<Polynomial_d,Coefficient_type,Coefficient_type>{
+    :public CGAL::cpp98::binary_function<Polynomial_d,Coefficient_type,Coefficient_type>{
     // Evaluate with respect to one variable 
     Coefficient_type
     operator()(const Polynomial_d& p, const Coefficient_type& x) const {
@@ -1050,7 +1050,7 @@ public:
  
 
 struct Construct_coefficient_const_iterator_range                                       
-     : public CGAL::unary_function< Polynomial_d, 
+     : public CGAL::cpp98::unary_function< Polynomial_d, 
                                   Coefficient_const_iterator_range> {
     Coefficient_const_iterator_range      
     operator () (const Polynomial_d& p) const {                                      
@@ -1059,7 +1059,7 @@ struct Construct_coefficient_const_iterator_range
 };        
                                        
 struct Construct_innermost_coefficient_const_iterator_range                                       
-   : public CGAL::unary_function< Polynomial_d, 
+   : public CGAL::cpp98::unary_function< Polynomial_d, 
                                  Innermost_coefficient_const_iterator_range> {
    Innermost_coefficient_const_iterator_range      
    operator () (const Polynomial_d& p) const {                                      
@@ -1070,7 +1070,7 @@ struct Construct_innermost_coefficient_const_iterator_range
 };                           
   
   struct Is_square_free 
-    : public CGAL::unary_function< Polynomial_d, bool >{
+    : public CGAL::cpp98::unary_function< Polynomial_d, bool >{
     bool operator()( const Polynomial_d& p ) const {
       if( !internal::may_have_multiple_factor( p ) )
         return true;
@@ -1095,7 +1095,7 @@ struct Construct_innermost_coefficient_const_iterator_range
 
                    
   struct Make_square_free 
-    : public CGAL::unary_function< Polynomial_d, Polynomial_d >{
+    : public CGAL::cpp98::unary_function< Polynomial_d, Polynomial_d >{
     Polynomial_d
     operator()(const Polynomial_d& p) const {
       if (CGAL::is_zero(p)) return p;
@@ -1130,7 +1130,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
     
   struct Pseudo_division_quotient
-    :public CGAL::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
+    :public CGAL::cpp98::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
         
     Polynomial_d
     operator()(const Polynomial_d& f, const Polynomial_d& g) const {
@@ -1142,7 +1142,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
 
   struct Pseudo_division_remainder
-    :public CGAL::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
+    :public CGAL::cpp98::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
         
     Polynomial_d
     operator()(const Polynomial_d& f, const Polynomial_d& g) const {
@@ -1154,7 +1154,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
     
   struct Gcd_up_to_constant_factor
-    :public CGAL::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
+    :public CGAL::cpp98::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
     Polynomial_d
     operator()(const Polynomial_d& p, const Polynomial_d& q) const {
       if(p==q) return CGAL::canonicalize(p); 
@@ -1171,7 +1171,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
     
   struct Integral_division_up_to_constant_factor
-    :public CGAL::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
+    :public CGAL::cpp98::binary_function<Polynomial_d, Polynomial_d, Polynomial_d> {
    
   
     
@@ -1200,7 +1200,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
     
   struct Univariate_content_up_to_constant_factor
-    :public CGAL::unary_function<Polynomial_d, Coefficient_type> {
+    :public CGAL::cpp98::unary_function<Polynomial_d, Coefficient_type> {
     Coefficient_type
     operator()(const Polynomial_d& p) const {
       typename PTC::Gcd_up_to_constant_factor gcd_utcf;
@@ -1275,7 +1275,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
 
   struct Shift
-    : public CGAL::binary_function< Polynomial_d,int,Polynomial_d >{
+    : public CGAL::cpp98::binary_function< Polynomial_d,int,Polynomial_d >{
     
     Polynomial_d 
     operator()(const Polynomial_d& p, int e, int i = (d-1)) const {
@@ -1293,7 +1293,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
     
   struct Negate
-    : public CGAL::unary_function< Polynomial_d, Polynomial_d >{
+    : public CGAL::cpp98::unary_function< Polynomial_d, Polynomial_d >{
         
     Polynomial_d operator()(const Polynomial_d& p, int i = (d-1)) const {
       Construct_polynomial construct; 
@@ -1311,7 +1311,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
 
   struct Invert
-    : public CGAL::unary_function< Polynomial_d , Polynomial_d >{
+    : public CGAL::cpp98::unary_function< Polynomial_d , Polynomial_d >{
     Polynomial_d operator()(Polynomial_d p, int i = (PT::d-1)) const {
       if (i == (d-1)){
         p.reversal(); 
@@ -1325,7 +1325,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
 
   struct Translate
-    : public CGAL::binary_function< Polynomial_d , Innermost_coefficient_type,
+    : public CGAL::cpp98::binary_function< Polynomial_d , Innermost_coefficient_type,
                                    Polynomial_d >{
     Polynomial_d
     operator()(
@@ -1370,7 +1370,7 @@ struct Construct_innermost_coefficient_const_iterator_range
 
   struct Scale 
     : public 
-    CGAL::binary_function< Polynomial_d, Innermost_coefficient_type, Polynomial_d > {
+    cgal::cpp98::binary_function< Polynomial_d, Innermost_coefficient_type, Polynomial_d > {
         
     Polynomial_d operator()( Polynomial_d p, const Innermost_coefficient_type& c,
         int i = (PT::d-1) ) const  {
@@ -1416,7 +1416,7 @@ struct Construct_innermost_coefficient_const_iterator_range
   };
 
   struct Resultant
-    : public CGAL::binary_function<Polynomial_d, Polynomial_d, Coefficient_type>{
+    : public CGAL::cpp98::binary_function<Polynomial_d, Polynomial_d, Coefficient_type>{
         
     Coefficient_type
     operator()(

--- a/Polynomial/include/CGAL/Polynomial_traits_d.h
+++ b/Polynomial/include/CGAL/Polynomial_traits_d.h
@@ -715,8 +715,9 @@ public:
     
   //     Get_innermost_coefficient;
   struct Get_innermost_coefficient
-    : public 
-    cgal::cpp98::binary_function< Polynomial_d, Exponent_vector, Innermost_coefficient_type >
+    : public CGAL::cpp98::binary_function< Polynomial_d,
+                                           Exponent_vector,
+                                           Innermost_coefficient_type >
   {
         
     const Innermost_coefficient_type& 
@@ -1368,10 +1369,11 @@ struct Construct_innermost_coefficient_const_iterator_range
     }
   };
 
-  struct Scale 
-    : public 
-    cgal::cpp98::binary_function< Polynomial_d, Innermost_coefficient_type, Polynomial_d > {
-        
+  struct Scale
+    : public CGAL::cpp98::binary_function< Polynomial_d,
+                                           Innermost_coefficient_type,
+                                           Polynomial_d >
+  {
     Polynomial_d operator()( Polynomial_d p, const Innermost_coefficient_type& c,
         int i = (PT::d-1) ) const  {
       CGAL_precondition( i <= d-1 );

--- a/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
+++ b/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
@@ -73,7 +73,7 @@ namespace PD_detail {
 
   // functor for a fixed column of A
   template <class NT, class Iterator>
-  class A_column : public CGAL::unary_function <int, NT>
+  class A_column : public CGAL::cpp98::unary_function <int, NT>
   {
   public:
     typedef NT result_type;
@@ -121,7 +121,7 @@ namespace PD_detail {
   // functor for matrix A
   template <class NT, class Access_coordinate_begin_d,
 	    class Point_iterator >
-  class A_matrix : public CGAL::unary_function
+  class A_matrix : public CGAL::cpp98::unary_function
   <int, boost::transform_iterator <A_column
     <NT, typename Access_coordinate_begin_d::Coordinate_iterator>, 
 				   boost::counting_iterator<int> > >
@@ -177,7 +177,7 @@ namespace PD_detail {
   // 1  (row d+1)
 
   template <class NT>
-  class B_vector : public CGAL::unary_function<int, NT>
+  class B_vector : public CGAL::cpp98::unary_function<int, NT>
   {
   public:
     typedef NT result_type;
@@ -214,7 +214,7 @@ namespace PD_detail {
   // functor for a fixed row of D; note that we have to return 2D in
   // order to please the QP_solver
   template <class NT> 
-  class D_row : public CGAL::unary_function <int, NT> 
+  class D_row : public CGAL::cpp98::unary_function <int, NT> 
   {
   public:
     typedef NT result_type;
@@ -256,7 +256,7 @@ namespace PD_detail {
 
   // functor for matrix D
   template <class NT>
-  class D_matrix : public CGAL::unary_function
+  class D_matrix : public CGAL::cpp98::unary_function
   <int, boost::transform_iterator<D_row<NT>,
 				  boost::counting_iterator<int> > >
   { 

--- a/QP_solver/include/CGAL/QP_models.h
+++ b/QP_solver/include/CGAL/QP_models.h
@@ -396,7 +396,7 @@ namespace QP_model_detail {
   // maps a container to its begin-iterator, as specified by HowToBegin
   template<typename Container, typename Iterator, typename HowToBegin>
   struct Begin
-    : public CGAL::unary_function< Container, Iterator >
+    : public CGAL::cpp98::unary_function< Container, Iterator >
   {
     typedef Iterator result_type;
     result_type operator () ( const Container& v) const 

--- a/QP_solver/include/CGAL/QP_solution.h
+++ b/QP_solver/include/CGAL/QP_solution.h
@@ -775,7 +775,7 @@ namespace QP_solution_detail {
   // Value_by_index
   // --------------
   template < typename ET>
-  class Value_by_index : public CGAL::unary_function< std::size_t, ET>
+  class Value_by_index : public CGAL::cpp98::unary_function< std::size_t, ET>
   {
   public:
     typedef QP_solver_base<ET> QP;
@@ -797,7 +797,7 @@ namespace QP_solution_detail {
   // Unbounded_direction_by_index
   // ----------------------------
   template < typename ET>
-  class Unbounded_direction_by_index : public CGAL::unary_function< std::size_t, ET>
+  class Unbounded_direction_by_index : public CGAL::cpp98::unary_function< std::size_t, ET>
   {
   public:
     typedef QP_solver_base<ET> QP;
@@ -818,7 +818,7 @@ namespace QP_solution_detail {
   // Lambda_by_index
   // ---------------
   template < typename ET>
-  class Lambda_by_index : public CGAL::unary_function< std::size_t, ET>
+  class Lambda_by_index : public CGAL::cpp98::unary_function< std::size_t, ET>
   {
   public:
     typedef QP_solver_base<ET> QP;

--- a/QP_solver/include/CGAL/QP_solver/functors.h
+++ b/QP_solver/include/CGAL/QP_solver/functors.h
@@ -184,7 +184,7 @@ class Value_by_basic_index : public CGAL::cpp98::unary_function<
 
   public:
     typedef typename
-    cgal::cpp98::unary_function<
+    CGAL::cpp98::unary_function<
       int, typename std::iterator_traits
          <RndAccIt>::value_type >::result_type
     result_type;

--- a/QP_solver/include/CGAL/QP_solver/functors.h
+++ b/QP_solver/include/CGAL/QP_solver/functors.h
@@ -65,12 +65,12 @@ class Map_with_default;
 // QP_vector_accessor
 // -------------------
 template < class VectorIt, bool check_lower, bool check_upper >
-class QP_vector_accessor : public CGAL::unary_function<
+class QP_vector_accessor : public CGAL::cpp98::unary_function<
     int, typename std::iterator_traits<VectorIt>::value_type > {
 
   public:
     typedef typename 
-        CGAL::unary_function<
+        CGAL::cpp98::unary_function<
            int, 
            typename std::iterator_traits<VectorIt>::value_type >::result_type
     result_type;
@@ -179,12 +179,12 @@ private:
 // Value_by_basic_index
 // --------------------
 template < class RndAccIt >
-class Value_by_basic_index : public CGAL::unary_function<
+class Value_by_basic_index : public CGAL::cpp98::unary_function<
     int, typename std::iterator_traits<RndAccIt>::value_type > {
 
   public:
     typedef typename
-    CGAL::unary_function<
+    cgal::cpp98::unary_function<
       int, typename std::iterator_traits
          <RndAccIt>::value_type >::result_type
     result_type;

--- a/QP_solver/test/QP_solver/master_mps_to_derivatives.cpp
+++ b/QP_solver/test/QP_solver/master_mps_to_derivatives.cpp
@@ -174,7 +174,7 @@ create_output_file(const char *filename, // Note: "Bernd3" and not
 
 template<typename NT>
 struct tuple_add : 
-  public CGAL::unary_function<const boost::tuple<NT, NT>&, NT>
+  public CGAL::cpp98::unary_function<const boost::tuple<NT, NT>&, NT>
 {
   NT operator()(const boost::tuple<NT, NT>& t) const
   {

--- a/STL_Extension/doc/STL_Extension/CGAL/iterator.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/iterator.h
@@ -644,7 +644,7 @@ Join_input_iterator_2(I1 i1,I2 i2,const Op& op=Op());
 /*!
 \ingroup STLIterators
 
-The class `Join_input_iterator_3` joins two iterators. The result is again an iterator (of the same
+The class `Join_input_iterator_3` joins three iterators. The result is again an iterator (of the same
 iterator category type as the original iterator) that reads an object
 from the stream and applies a function object to that object.
 

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -1314,7 +1314,7 @@ namespace std {
 
   template < class DSC, bool Const >
   struct hash<CGAL::internal::CC_iterator<DSC, Const> >
-    : public CGAL::unary_function<CGAL::internal::CC_iterator<DSC, Const>, std::size_t> {
+    : public CGAL::cpp98::unary_function<CGAL::internal::CC_iterator<DSC, Const>, std::size_t> {
 
     std::size_t operator()(const CGAL::internal::CC_iterator<DSC, Const>& i) const
     {

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -1068,7 +1068,7 @@ namespace std {
   
   template < class CCC, bool Const >
   struct hash<CGAL::CCC_internal::CCC_iterator<CCC, Const> >
-    : public CGAL::unary_function<CGAL::CCC_internal::CCC_iterator<CCC, Const>, std::size_t> {
+    : public CGAL::cpp98::unary_function<CGAL::CCC_internal::CCC_iterator<CCC, Const>, std::size_t> {
 
     std::size_t operator()(const CGAL::CCC_internal::CCC_iterator<CCC, Const>& i) const
     {

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -803,7 +803,7 @@ namespace std {
 
   template < class T, class Alloc >
   struct hash<CGAL::internal::In_place_list_iterator<T, Alloc> >
-    : public CGAL::unary_function<CGAL::internal::In_place_list_iterator<T, Alloc>, std::size_t>  {
+    : public CGAL::cpp98::unary_function<CGAL::internal::In_place_list_iterator<T, Alloc>, std::size_t>  {
 
     std::size_t operator()(const CGAL::internal::In_place_list_iterator<T, Alloc>& i) const
     {
@@ -814,7 +814,7 @@ namespace std {
 
   template < class T, class Alloc >
   struct hash<CGAL::internal::In_place_list_const_iterator<T, Alloc> >
-    : public CGAL::unary_function<CGAL::internal::In_place_list_const_iterator<T, Alloc>, std::size_t> {
+    : public CGAL::cpp98::unary_function<CGAL::internal::In_place_list_const_iterator<T, Alloc>, std::size_t> {
 
     std::size_t operator()(const CGAL::internal::In_place_list_const_iterator<T, Alloc>& i) const
     {

--- a/STL_Extension/include/CGAL/function_objects.h
+++ b/STL_Extension/include/CGAL/function_objects.h
@@ -358,8 +358,8 @@ class Creator_uniform_d {
 
 template < class Op1, class Op2 >
 class Unary_compose_1
-  : public CGAL::unary_function< typename Op2::argument_type,
-                                typename Op1::result_type >
+  : public CGAL::cpp98::unary_function< typename Op2::argument_type,
+                                        typename Op1::result_type >
 {
 protected:
   Op1 op1;
@@ -382,8 +382,8 @@ compose1_1(const Op1& op1, const Op2& op2)
 
 template < class Op1, class Op2, class Op3 >
 class Binary_compose_1
-  : public CGAL::unary_function< typename Op2::argument_type,
-                                typename Op1::result_type >
+  : public CGAL::cpp98::unary_function< typename Op2::argument_type,
+                                        typename Op1::result_type >
 {
 protected:
   Op1 op1;
@@ -408,9 +408,9 @@ compose2_1(const Op1& op1, const Op2& op2, const Op3& op3)
 
 template < class Op1, class Op2 >
 class Unary_compose_2
-  : public CGAL::binary_function< typename Op2::first_argument_type,
-                                 typename Op2::second_argument_type,
-                                 typename Op1::result_type >
+  : public CGAL::cpp98::binary_function< typename Op2::first_argument_type,
+                                         typename Op2::second_argument_type,
+                                         typename Op1::result_type >
 {
 protected:
   Op1 op1;
@@ -435,9 +435,9 @@ compose1_2(const Op1& op1, const Op2& op2)
 
 template < class Op1, class Op2, class Op3 >
 class Binary_compose_2
-  : public CGAL::binary_function< typename Op2::argument_type,
-                                 typename Op3::argument_type,
-                                 typename Op1::result_type >
+  : public CGAL::cpp98::binary_function< typename Op2::argument_type,
+                                         typename Op3::argument_type,
+                                         typename Op1::result_type >
 {
 protected:
   Op1 op1;

--- a/STL_Extension/include/CGAL/functional.h
+++ b/STL_Extension/include/CGAL/functional.h
@@ -23,8 +23,8 @@
 //
 // Author(s)     : Andreas Fabri
 
-#ifndef CGAL_UNARY_FUNCTION_H
-#define CGAL_UNARY_FUNCTION_H
+#ifndef CGAL_FUNCTIONAL_H
+#define CGAL_FUNCTIONAL_H
 
 namespace CGAL {
 
@@ -51,4 +51,4 @@ namespace cpp98 {
 
 } // namespace CGAL
 
-#endif // CGAL_UNARY_FUNCTION_H
+#endif // CGAL_FUNCTIONAL_H

--- a/STL_Extension/include/CGAL/functional.h
+++ b/STL_Extension/include/CGAL/functional.h
@@ -28,24 +28,27 @@
 
 namespace CGAL {
 
+namespace cpp98 {
+
   /// Replacement for `std::unary_function` that is deprecated since C++11,
-  /// and removed from C++17
+  /// and removed from C++17.
   template < typename ArgumentType, typename ResultType>
   struct unary_function {
     typedef ArgumentType argument_type;
     typedef ResultType result_type;
   };
 
-
   /// Replacement for `std::binary_function` that is deprecated since C++11,
-  /// and removed from C++17
+  /// and removed from C++17.
   template < typename Arg1, typename Arg2, typename Result>
   struct binary_function {
     typedef Arg1 first_argument_type;
     typedef Arg2 second_argument_type;
     typedef Result result_type;
   };
-  
+
+} // namespace cpp98
+
 } // namespace CGAL
 
 #endif // CGAL_UNARY_FUNCTION_H

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -98,7 +98,7 @@ namespace std {
 
 template <>
 struct hash<OpenMesh::BaseHandle >
-  : public CGAL::unary_function<OpenMesh::BaseHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::BaseHandle, std::size_t>
 {
 
   std::size_t operator()(const OpenMesh::BaseHandle& h) const
@@ -109,7 +109,7 @@ struct hash<OpenMesh::BaseHandle >
 
 template <>
 struct hash<OpenMesh::VertexHandle >
-  : public CGAL::unary_function<OpenMesh::VertexHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::VertexHandle, std::size_t>
 {
 
   std::size_t operator()(const OpenMesh::VertexHandle& h) const
@@ -120,7 +120,7 @@ struct hash<OpenMesh::VertexHandle >
 
 template <>
 struct hash<OpenMesh::HalfedgeHandle >
-  : public CGAL::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
 {
 
   std::size_t operator()(const OpenMesh::HalfedgeHandle& h) const
@@ -131,7 +131,7 @@ struct hash<OpenMesh::HalfedgeHandle >
 
 template <>
 struct hash<OpenMesh::EdgeHandle >
-  : public CGAL::unary_function<OpenMesh::EdgeHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::EdgeHandle, std::size_t>
 {
 
   std::size_t operator()(const OpenMesh::EdgeHandle& h) const
@@ -142,7 +142,7 @@ struct hash<OpenMesh::EdgeHandle >
 
 template <>
 struct hash<CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle> >
-  : public CGAL::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
 {
 
   std::size_t operator()(const CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle>& h) const
@@ -153,7 +153,7 @@ struct hash<CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle> >
 
 template <>
 struct hash<OpenMesh::FaceHandle >
-  : public CGAL::unary_function<OpenMesh::FaceHandle, std::size_t>
+  : public CGAL::cpp98::unary_function<OpenMesh::FaceHandle, std::size_t>
 {
 
   std::size_t operator()(const OpenMesh::FaceHandle& h) const

--- a/STL_Extension/include/CGAL/internal/boost/array_binary_tree.hpp
+++ b/STL_Extension/include/CGAL/internal/boost/array_binary_tree.hpp
@@ -20,9 +20,11 @@
 #ifndef CGAL_INTERNAL_ARRAY_BINARY_TREE_HPP
 #define CGAL_INTERNAL_ARRAY_BINARY_TREE_HPP
 
-#include <iterator>
-#include <functional>
+#include <CGAL/iterator.h>
+
 #include <boost/config.hpp>
+
+#include <functional>
 
 namespace CGAL { namespace internal {
 namespace boost_ {
@@ -52,13 +54,10 @@ public:
 
   struct children_type {
     struct iterator
+      : public CGAL::cpp98::iterator<std::forward_iterator_tag,
+                                     ArrayBinaryTreeNode,
+                                     difference_type>
     { // replace with iterator_adaptor implementation -JGS
-      typedef std::forward_iterator_tag iterator_category;
-      typedef ArrayBinaryTreeNode value_type;
-      typedef size_type difference_type;
-      typedef ArrayBinaryTreeNode* pointer;
-      typedef ArrayBinaryTreeNode& reference;
-
       inline iterator() : i(0), n(0) { }
       inline iterator(const iterator& x) : r(x.r), i(x.i), n(x.n), id(x.id) { }
       inline iterator& operator=(const iterator& x) {

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -880,7 +880,7 @@ public:
   Join_input_iterator_3& operator=(const Join_input_iterator_3& it)
   {
     i1 = it.i1;
-    i2 = it.i1;
+    i2 = it.i2;
     i3 = it.i3;
     op = it.op;
     return *this;

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -30,18 +30,19 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/circulator.h>
 #include <CGAL/assertions.h>
-#include <CGAL/use.h>
-#include <vector>
-#include <map>
+#include <CGAL/circulator.h>
+#include <CGAL/Iterator_range.h>
+#include <CGAL/result_of.h>
 #include <CGAL/tuple.h>
+#include <CGAL/use.h>
+
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 #include <boost/config.hpp>
 
-#include <CGAL/Iterator_range.h>
-
+#include <vector>
+#include <map>
 
 namespace CGAL {
 
@@ -656,20 +657,19 @@ bool operator!=(const Filter_iterator<I,P>& it1,
 { return !(it1 == it2); }
 
 template <class I1,class Op>
-class Join_input_iterator_1 : public 
-CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
-	      typename Op::result_type, 
-	      typename std::iterator_traits<I1>::difference_type, 
-	      typename Op::result_type*,
-	      typename Op::result_type&>
-{ 
-public: 
-  typedef Join_input_iterator_1<I1,Op> Self;
-  typedef typename Op::result_type value_type;
-  typedef typename std::iterator_traits<I1>::difference_type difference_type; 
-  typedef value_type* pointer;
-  typedef value_type& reference; 
-  
+class Join_input_iterator_1
+{
+  typedef Join_input_iterator_1<I1,Op>                          Self;
+
+  typedef typename std::iterator_traits<I1>::value_type         arg_type;
+
+public:
+  typedef typename std::iterator_traits<I1>::iterator_category  iterator_category;
+  typedef typename cpp11::result_of<Op(arg_type)>::type         value_type;
+  typedef typename std::iterator_traits<I1>::difference_type    difference_type;
+  typedef value_type*                                           pointer;
+  typedef value_type&                                           reference;
+
 protected:
   I1 i1;
   Op op;
@@ -742,20 +742,20 @@ public:
 };
 
 template <class I1,class I2,class Op>
-class Join_input_iterator_2 : public 
-CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
-	      typename Op::result_type, 
-	      typename std::iterator_traits<I1>::difference_type, 
-	      typename Op::result_type*,
-	      typename Op::result_type&>
-{ 
-public: 
-  typedef Join_input_iterator_2<I1,I2,Op> Self;
-  typedef typename Op::result_type value_type;
-  typedef typename std::iterator_traits<I1>::difference_type difference_type; 
-  typedef value_type* pointer;
-  typedef value_type& reference; 
-  
+class Join_input_iterator_2
+{
+  typedef Join_input_iterator_2<I1,I2,Op>                             Self;
+
+  typedef typename std::iterator_traits<I1>::value_type               arg_type_1;
+  typedef typename std::iterator_traits<I2>::value_type               arg_type_2;
+
+public:
+  typedef typename std::iterator_traits<I1>::iterator_category        iterator_category;
+  typedef typename cpp11::result_of<Op(arg_type_1, arg_type_2)>::type value_type;
+  typedef typename std::iterator_traits<I1>::difference_type          difference_type;
+  typedef value_type*                                                 pointer;
+  typedef value_type&                                                 reference;
+
 protected:
   I1 i1;
   I2 i2;
@@ -835,19 +835,21 @@ public:
 };
 
 template <class I1,class I2,class I3,class Op>
-class Join_input_iterator_3 : public 
-CGAL::iterator<typename std::iterator_traits<I1>::iterator_category, 
-	      typename Op::result_type, 
-	      typename std::iterator_traits<I1>::difference_type, 
-	      typename Op::result_type*,
-	      typename Op::result_type&>
-{ 
-public: 
-  typedef Join_input_iterator_3<I1,I2,I3,Op> Self;
-  typedef typename Op::result_type value_type;
-  typedef typename std::iterator_traits<I1>::difference_type difference_type; 
-  typedef value_type* pointer;
-  typedef value_type& reference; 
+class Join_input_iterator_3
+{
+  typedef Join_input_iterator_3<I1,I2,I3,Op>                    Self;
+
+  typedef typename std::iterator_traits<I1>::value_type         arg_type_1;
+  typedef typename std::iterator_traits<I2>::value_type         arg_type_2;
+  typedef typename std::iterator_traits<I3>::value_type         arg_type_3;
+
+public:
+  typedef typename std::iterator_traits<I1>::iterator_category  iterator_category;
+  typedef typename cpp11::result_of<Op(arg_type_1, arg_type_2, arg_type_3)>::type
+                                                                value_type;
+  typedef typename std::iterator_traits<I1>::difference_type    difference_type;
+  typedef value_type*                                           pointer;
+  typedef value_type&                                           reference;
   
 protected:
   I1 i1;

--- a/STL_Extension/include/CGAL/iterator.h
+++ b/STL_Extension/include/CGAL/iterator.h
@@ -88,6 +88,8 @@ Iterator_range<Prevent_deref<I> > make_prevent_deref_range(const I& begin, const
   return Iterator_range<Prevent_deref<I> >(make_prevent_deref(begin), make_prevent_deref(end));
 }
 
+namespace cpp98 {
+
 template<typename Category, typename Tp, typename Distance = std::ptrdiff_t,
          typename Pointer = Tp*, typename Reference = Tp&>
 struct iterator
@@ -104,7 +106,8 @@ struct iterator
   typedef Reference reference;
 };
 
-  
+} // end namespace cpp98
+
 // +----------------------------------------------------------------+
 // | Emptyset_iterator
 // +----------------------------------------------------------------+
@@ -112,7 +115,7 @@ struct iterator
 // +----------------------------------------------------------------+
 
 struct Emptyset_iterator
-  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::cpp98::iterator< std::output_iterator_tag, void, void, void, void >
 {
   template< class T >
   Emptyset_iterator& operator=(const T&) { return *this; }
@@ -132,7 +135,7 @@ struct Emptyset_iterator
 
 template < class Container >
 class Insert_iterator
-  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::cpp98::iterator< std::output_iterator_tag, void, void, void, void >
 {
 protected:
   Container *container;
@@ -173,8 +176,8 @@ inserter(Container &x)
 
 template < class T >
 class Oneset_iterator
-  : public CGAL::iterator< std::bidirectional_iterator_tag,
-			  void, void, void, void >
+  : public CGAL::cpp98::iterator< std::bidirectional_iterator_tag,
+                                  void, void, void, void >
 {
   T* t;
   
@@ -280,7 +283,7 @@ private:
 
 // Undocumented, because there is some hope to merge it into Counting_iterator
 class Counting_output_iterator
-  : public CGAL::iterator< std::output_iterator_tag, void, void, void, void >
+  : public CGAL::cpp98::iterator< std::output_iterator_tag, void, void, void, void >
 {
   std::size_t *c;
 public:
@@ -1216,7 +1219,7 @@ public:
 
 template<typename _Iterator, typename Predicate>
     class Filter_output_iterator
-    : public CGAL::iterator<std::output_iterator_tag, void, void, void, void>
+      : public CGAL::cpp98::iterator<std::output_iterator_tag, void, void, void, void>
     {
     protected:
       _Iterator iterator;

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -47,7 +47,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_type_traits.cpp" )
   create_single_source_cgal_program( "test_Uncertain.cpp" )
   create_single_source_cgal_program( "test_vector.cpp" )
-
+  create_single_source_cgal_program( "test_join_iterators.cpp" )
 else()
   
     message(STATUS "This program requires the CGAL library, and will not be compiled.")

--- a/STL_Extension/test/STL_Extension/test_join_iterators.cpp
+++ b/STL_Extension/test/STL_Extension/test_join_iterators.cpp
@@ -135,9 +135,9 @@ void test_join_input_iterator_3()
   assert(join_ter.current_iterator1() == first);
   assert(join_ter.current_iterator2() == second);
   assert(join_ter.current_iterator3() == third);
-  assert(*join_ter); // calls Collinear_3
-  assert(join_ter[0]); // calls Collinear_3
-  assert(!(join_ter[1])); // calls Collinear_3
+  assert(*join_ter); // calls Collinear_2
+  assert(join_ter[0]); // calls Collinear_2
+  assert(!(join_ter[1])); // calls Collinear_2
 
   const Join join_quinquies(second, third, fourth, Collinear_2());
   assert(join_ter != join_quinquies);

--- a/STL_Extension/test/STL_Extension/test_join_iterators.cpp
+++ b/STL_Extension/test/STL_Extension/test_join_iterators.cpp
@@ -1,0 +1,182 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include <CGAL/iterator.h>
+#include <CGAL/Origin.h>
+
+#include <vector>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel    EPECK;
+typedef EPECK::Point_2                                       Point_2;
+typedef EPECK::Compute_x_2                                   Compute_x_2;
+typedef EPECK::Construct_midpoint_2                          Construct_midpoint_2;
+typedef EPECK::Collinear_2                                   Collinear_2;
+
+typedef std::vector<Point_2>                                 Point_vector;
+typedef Point_vector::iterator                               PV_it;
+typedef Point_vector::const_iterator                         PV_cit;
+
+void test_join_input_iterator_1()
+{
+  Point_vector pv;
+  pv.push_back(Point_2(0.1, 0.1));
+
+  typedef CGAL::Join_input_iterator_1<PV_it, Compute_x_2>    Join;
+
+  Join join;
+  Join join_bis(join);
+  join_bis = join;
+
+  Join join_ter(pv.begin());
+  Join join_quater(pv.begin(), Compute_x_2());
+  assert(join_ter == join_quater);
+
+  assert(join_ter.current_iterator1() == pv.begin());
+  assert(*join_ter == 0.1); // calls Compute_x_2
+  assert(join_ter[0] == 0.1); // calls Compute_x_2
+
+  Join join_quinquies(pv.end(), Compute_x_2());
+  assert(join_ter != join_quinquies);
+  assert(join_ter < join_quinquies);
+
+  ++join_ter;
+  assert(join_ter == join_quinquies);
+  --join_ter;
+  assert(join_ter.current_iterator1() == pv.begin());
+
+  assert((join_ter++).current_iterator1() == pv.begin());
+  assert(join_ter == join_quinquies);
+  assert((join_ter--).current_iterator1() == pv.end());
+  assert(join_ter.current_iterator1() == pv.begin());
+
+  join_ter += 1;
+  assert(join_ter == join_quinquies);
+  join_ter -= 1;
+  assert(join_ter.current_iterator1() == pv.begin());
+
+  join_ter = join_ter + 1;
+  assert(join_ter == join_quinquies);
+  join_ter = join_ter - 1;
+  assert(join_ter.current_iterator1() == pv.begin());
+}
+
+void test_join_input_iterator_2()
+{
+  Point_vector pv;
+  pv.push_back(Point_2(-1, -1));
+  pv.push_back(Point_2(1, 1));
+
+  typedef CGAL::Join_input_iterator_2<PV_cit, PV_cit, Construct_midpoint_2>    Join;
+
+  PV_cit first = pv.begin(), second = ++(pv.begin());
+
+  Join join;
+  Join join_bis(join);
+  join_bis = join;
+
+  Join join_ter(first, second);
+  Join join_quater(first, second, Construct_midpoint_2());
+  assert(join_ter == join_quater);
+
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(*join_ter == CGAL::ORIGIN); // calls Construct_midpoint_2
+  assert(join_ter[0] == CGAL::ORIGIN); // calls Construct_midpoint_2
+
+  Join join_quinquies(second, pv.end(), Construct_midpoint_2());
+  assert(join_ter != join_quinquies);
+  assert(join_ter < join_quinquies);
+
+  ++join_ter;
+  assert(join_ter == join_quinquies);
+  --join_ter;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+
+  assert((join_ter++).current_iterator1() == first);
+  assert(join_ter == join_quinquies);
+  assert((join_ter--).current_iterator1() == second);
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+
+  join_ter += 1;
+  assert(join_ter == join_quinquies);
+  join_ter -= 1;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+
+  join_ter = join_ter + 1;
+  assert(join_ter == join_quinquies);
+  join_ter = join_ter - 1;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+}
+
+void test_join_input_iterator_3()
+{
+  Point_vector pv;
+  pv.push_back(Point_2(-0.1, -0.1));
+  pv.push_back(Point_2(CGAL::ORIGIN));
+  pv.push_back(Point_2(0.1, 0.1));
+  pv.push_back(Point_2(0.1, 0));
+
+  typedef CGAL::Join_input_iterator_3<PV_cit, PV_cit, PV_cit, Collinear_2>    Join;
+
+  PV_cit first = pv.begin(), second = ++(pv.begin()),
+         third = ++(++(pv.begin())), fourth = --(pv.end());
+
+  Join join;
+  Join join_bis(join);
+  join_bis = join;
+
+  Join join_ter(first, second, third);
+  Join join_quater(first, second, third, Collinear_2());
+  assert(join_ter == join_quater);
+
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(join_ter.current_iterator3() == third);
+  assert(*join_ter); // calls Collinear_3
+  assert(join_ter[0]); // calls Collinear_3
+  assert(!(join_ter[1])); // calls Collinear_3
+
+  const Join join_quinquies(second, third, fourth, Collinear_2());
+  assert(join_ter != join_quinquies);
+  assert(join_ter < join_quinquies);
+
+  ++join_ter;
+  assert(join_ter == join_quinquies);
+  --join_ter;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(join_ter.current_iterator3() == third);
+
+  assert((join_ter++).current_iterator1() == first);
+  assert(join_ter == join_quinquies);
+  assert((join_ter--).current_iterator1() == second);
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(join_ter.current_iterator3() == third);
+
+  join_ter += 1;
+  assert(join_ter == join_quinquies);
+  join_ter -= 1;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(join_ter.current_iterator3() == third);
+
+  join_ter = join_ter + 1;
+  assert(join_ter == join_quinquies);
+  join_ter = join_ter - 1;
+  assert(join_ter.current_iterator1() == first);
+  assert(join_ter.current_iterator2() == second);
+  assert(join_ter.current_iterator3() == third);
+}
+
+int main()
+{
+  test_join_input_iterator_1();
+  test_join_input_iterator_2();
+  test_join_input_iterator_3();
+
+  return EXIT_SUCCESS;
+}

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/internal/Auto_count.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/internal/Auto_count.h
@@ -43,7 +43,7 @@ namespace internal {
  */
 template < class T, class C = unsigned int >
 class Auto_count
-: public CGAL::unary_function< const T&, std::pair< T, C > > {
+: public CGAL::cpp98::unary_function< const T&, std::pair< T, C > > {
     mutable C i; // Note, not thread-safe.
 public:
 /// \name Constructors

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Sqrt_extension_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Sqrt_extension_2.h
@@ -264,7 +264,7 @@ public:
     typedef Sqrt_extension_2<NT> Real_embeddable;
     
     class Abs 
-        : public CGAL::unary_function< Real_embeddable, Real_embeddable >{
+        : public CGAL::cpp98::unary_function< Real_embeddable, Real_embeddable >{
     public:
         Real_embeddable operator()(const Real_embeddable& x) const {
             return (x>=0)?x:-x;
@@ -272,7 +272,7 @@ public:
     };    
 
     class Sgn 
-        : public CGAL::unary_function< Real_embeddable, CGAL::Sign >{
+        : public CGAL::cpp98::unary_function< Real_embeddable, CGAL::Sign >{
     public:
         CGAL::Sign operator()(const Real_embeddable& x) const {
             return x.sign();
@@ -280,9 +280,10 @@ public:
     };
     
     class Compare 
-        : public CGAL::binary_function< Real_embeddable,
-                                  Real_embeddable, 
-                                  CGAL::Comparison_result >{
+        : public CGAL::cpp98::binary_function< Real_embeddable,
+                                               Real_embeddable,
+                                               CGAL::Comparison_result >
+    {
     public:
         CGAL::Comparison_result operator()(
                 const Real_embeddable& x, 
@@ -294,7 +295,7 @@ public:
     };
     
     class To_double 
-        : public CGAL::unary_function< Real_embeddable, double >{
+        : public CGAL::cpp98::unary_function< Real_embeddable, double >{
     public:
         double operator()(const Real_embeddable& x) const {
             return x.to_double();
@@ -302,7 +303,7 @@ public:
     };
     
     class To_interval 
-        : public CGAL::unary_function< Real_embeddable, std::pair< double, double > >{
+        : public CGAL::cpp98::unary_function< Real_embeddable, std::pair< double, double > >{
     public:
         std::pair<double,double> operator()(const Real_embeddable& x) const {
             return x.to_interval();

--- a/Spatial_searching/include/CGAL/Kd_tree_rectangle.h
+++ b/Spatial_searching/include/CGAL/Kd_tree_rectangle.h
@@ -35,7 +35,7 @@
 namespace CGAL {
 
   template <class Construct_cartesian_const_iterator_d, class P, class T>
-  struct set_bounds_from_pointer : public CGAL::unary_function<P, void> {
+  struct set_bounds_from_pointer : public CGAL::cpp98::unary_function<P, void> {
     int dim;
     T *lower;
     T *upper;

--- a/Spatial_searching/test/Spatial_searching/Point_with_info.h
+++ b/Spatial_searching/test/Spatial_searching/Point_with_info.h
@@ -38,11 +38,11 @@ template <class Point>
 const Point& get_point(const My_point_with_info<Point>& p) {return get(Point_property_map<Point>(),p);}
 
 template <class Point>
-struct Create_point_with_info : public CGAL::unary_function<Point,Point>{
+struct Create_point_with_info : public CGAL::cpp98::unary_function<Point,Point>{
   const Point& operator() (const Point& p) const { return p; }
 };
 
 template <class Point>
-struct Create_point_with_info<My_point_with_info<Point> > : public CGAL::unary_function<Point,My_point_with_info<Point> >{
+struct Create_point_with_info<My_point_with_info<Point> > : public CGAL::cpp98::unary_function<Point,My_point_with_info<Point> >{
   My_point_with_info<Point> operator() (const Point& p) const { return My_point_with_info<Point>(p); }
 };

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_2.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_2.h
@@ -33,8 +33,8 @@ namespace internal {
 
     template <class K, int x>
     struct Hilbert_cmp_2<K,x,true>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;
@@ -47,8 +47,8 @@ namespace internal {
     
     template <class K>
     struct Hilbert_cmp_2<K,0,false>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;
@@ -61,8 +61,8 @@ namespace internal {
     
     template <class K>
     struct Hilbert_cmp_2<K,1,false>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
@@ -33,8 +33,8 @@ namespace internal {
 
     template <class K, int x>
     struct Hilbert_cmp_3<K,x,true>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -47,8 +47,8 @@ namespace internal {
 
     template <class K>
     struct Hilbert_cmp_3<K,0,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -61,8 +61,8 @@ namespace internal {
 
     template <class K>
     struct Hilbert_cmp_3<K,1,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -75,8 +75,8 @@ namespace internal {
 
     template <class K>
     struct Hilbert_cmp_3<K,2,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_d.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_d.h
@@ -34,8 +34,8 @@ namespace internal {
 
     template <class K>
     struct Hilbert_cmp_d
-        : public CGAL::binary_function<typename K::Point_d,
-                                      typename K::Point_d, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_d,
+                                              typename K::Point_d, bool>
     {
         typedef typename K::Point_d Point;
         K k;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_2.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_2.h
@@ -34,8 +34,8 @@ namespace internal {
 
     template <class K, int x>
     struct Fixed_hilbert_cmp_2<K,x,true>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;
@@ -49,8 +49,8 @@ namespace internal {
     
     template <class K>
     struct Fixed_hilbert_cmp_2<K,0,false>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;
@@ -64,8 +64,8 @@ namespace internal {
     
     template <class K>
     struct Fixed_hilbert_cmp_2<K,1,false>
-        : public CGAL::binary_function<typename K::Point_2,
-                                      typename K::Point_2, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_2,
+                                              typename K::Point_2, bool>
     {
         typedef typename K::Point_2 Point;
         K k;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_3.h
@@ -33,8 +33,8 @@ namespace internal {
 
     template <class K, int x>
     struct Fixed_hilbert_cmp_3<K,x,true>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -48,8 +48,8 @@ namespace internal {
 
     template <class K>
     struct Fixed_hilbert_cmp_3<K,0,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -63,8 +63,8 @@ namespace internal {
 
     template <class K>
     struct Fixed_hilbert_cmp_3<K,1,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;
@@ -78,8 +78,8 @@ namespace internal {
 
     template <class K>
     struct Fixed_hilbert_cmp_3<K,2,false>
-        : public CGAL::binary_function<typename K::Point_3,
-                                      typename K::Point_3, bool>
+        : public CGAL::cpp98::binary_function<typename K::Point_3,
+                                              typename K::Point_3, bool>
     {
         typedef typename K::Point_3 Point;
         K k;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_middle_d.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_middle_d.h
@@ -33,7 +33,7 @@ namespace internal {
 
     template <class K>
     struct Fixed_hilbert_cmp_d
-        : public CGAL::binary_function<typename K::Point_d,
+        : public CGAL::cpp98::binary_function<typename K::Point_d,
                                       typename K::Point_d, bool>
     {
         typedef typename K::Point_d Point;

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
@@ -214,7 +214,7 @@ private :
   
   typedef std::vector<MultinodePtr> MultinodeVector ;
 
-  struct Halfedge_ID_compare : CGAL::binary_function<bool,Halfedge_handle,Halfedge_handle>
+  struct Halfedge_ID_compare : CGAL::cpp98::binary_function<bool,Halfedge_handle,Halfedge_handle>
   {
     bool operator() ( Halfedge_handle const& aA, Halfedge_handle const& aB ) const
     {
@@ -231,7 +231,7 @@ public:
 private :
 
   
-  class Event_compare : public CGAL::binary_function<bool,EventPtr,EventPtr>
+  class Event_compare : public CGAL::cpp98::binary_function<bool,EventPtr,EventPtr>
   {
   public:
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2649,7 +2649,7 @@ namespace std {
 
   template <>
   struct hash<CGAL::SM_Halfedge_index >
-    : public CGAL::unary_function<CGAL::SM_Halfedge_index, std::size_t> {
+    : public CGAL::cpp98::unary_function<CGAL::SM_Halfedge_index, std::size_t> {
 
     std::size_t operator()(const CGAL::SM_Halfedge_index& i) const
     {
@@ -2659,7 +2659,7 @@ namespace std {
 
   template <>
   struct hash<CGAL::SM_Vertex_index >
-    : public CGAL::unary_function<CGAL::SM_Vertex_index, std::size_t>  {
+    : public CGAL::cpp98::unary_function<CGAL::SM_Vertex_index, std::size_t>  {
 
     std::size_t operator()(const CGAL::SM_Vertex_index& i) const
     {
@@ -2669,7 +2669,7 @@ namespace std {
 
   template <>
   struct hash<CGAL::SM_Face_index > 
-    : public CGAL::unary_function<CGAL::SM_Face_index, std::size_t> {
+    : public CGAL::cpp98::unary_function<CGAL::SM_Face_index, std::size_t> {
 
     std::size_t operator()(const CGAL::SM_Face_index& i) const
     {
@@ -2679,7 +2679,7 @@ namespace std {
 
   template <>
   struct hash<CGAL::SM_Edge_index >
-    : public CGAL::unary_function<CGAL::SM_Edge_index, std::size_t>  {
+    : public CGAL::cpp98::unary_function<CGAL::SM_Edge_index, std::size_t>  {
 
     std::size_t operator()(const CGAL::SM_Edge_index& i) const
     {

--- a/Surface_mesher/demo/Surface_mesher/volume.cpp
+++ b/Surface_mesher/demo/Surface_mesher/volume.cpp
@@ -36,7 +36,7 @@
 #include <CGAL/make_surface_mesh.h>
 #include <CGAL/Qt/debug.h>
 
-struct Threshold : public CGAL::unary_function<FT, unsigned char> {
+struct Threshold : public CGAL::cpp98::unary_function<FT, unsigned char> {
   double isovalue;
   bool is_identity;
 
@@ -54,14 +54,14 @@ struct Threshold : public CGAL::unary_function<FT, unsigned char> {
 };
 
 class Classify_from_isovalue_list :
-  public CGAL::unary_function<FT, unsigned char> 
+  public CGAL::cpp98::unary_function<FT, unsigned char> 
 {
   typedef std::pair<FT, result_type> Isovalue;
   typedef std::vector<Isovalue> Isovalues;
   boost::shared_ptr<Isovalues> isovalues;
   bool is_identity;
 
-  struct Sort_isovalues : CGAL::binary_function<Isovalue, Isovalue, bool>
+  struct Sort_isovalues : CGAL::cpp98::binary_function<Isovalue, Isovalue, bool>
   {
     bool operator()(const Isovalue& isoval1, const Isovalue& isoval2)
     {
@@ -110,7 +110,7 @@ public:
 };
 
 class Generate_surface_identifiers :
-  public CGAL::binary_function<Classify_from_isovalue_list::result_type,
+  public CGAL::cpp98::binary_function<Classify_from_isovalue_list::result_type,
                               Classify_from_isovalue_list::result_type,
                               const QTreeWidgetItem*>
 {
@@ -137,13 +137,13 @@ public:
 };
 
 // class Classify_from_isovalue_list :
-//   public CGAL::unary_function<FT, const QTreeWidgetItem*> 
+//   public CGAL::cpp98::unary_function<FT, const QTreeWidgetItem*> 
 // {
 //   typedef std::pair<FT, result_type> Isovalue;
 //   typedef std::vector<Isovalue> Isovalues;
 //   boost::shared_ptr<Isovalues> isovalues;
 
-//   struct Sort_isovalues : CGAL::binary_function<Isovalue, Isovalue, bool>
+//   struct Sort_isovalues : CGAL::cpp98::binary_function<Isovalue, Isovalue, bool>
 //   {
 //     bool operator()(const Isovalue& isoval1, const Isovalue& isoval2)
 //     {

--- a/Surface_mesher/include/CGAL/Implicit_surface_3.h
+++ b/Surface_mesher/include/CGAL/Implicit_surface_3.h
@@ -132,7 +132,7 @@ namespace CGAL {
 
   // non documented class
   template <typename FT, typename Point>
-  class Implicit_function_wrapper : public CGAL::unary_function<Point, FT> 
+  class Implicit_function_wrapper : public CGAL::cpp98::unary_function<Point, FT>
   {
     typedef FT (*Implicit_function)(FT, FT, FT);
 

--- a/Surface_mesher/include/CGAL/Surface_mesher/Implicit_surface_oracle_3.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Implicit_surface_oracle_3.h
@@ -106,7 +106,7 @@ namespace CGAL {
   namespace {
     
   template <typename T>
-  struct Return_min : CGAL::binary_function<T, T, T>
+  struct Return_min : CGAL::cpp98::binary_function<T, T, T>
   {
     T operator()(const T& a, const T& b) const
     {

--- a/Surface_mesher/include/CGAL/Surface_mesher/Sphere_oracle_3.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Sphere_oracle_3.h
@@ -203,7 +203,7 @@ namespace CGAL {
         return Object();
       } // end private_intersection
 
-      struct Lambda_between_0_and_1 : public CGAL::unary_function<FT, bool> 
+      struct Lambda_between_0_and_1 : public CGAL::cpp98::unary_function<FT, bool> 
       {
         bool operator()(const FT x) const
         {
@@ -211,7 +211,7 @@ namespace CGAL {
         }
       };
         
-      struct Lambda_positive : public CGAL::unary_function<FT, bool> 
+      struct Lambda_positive : public CGAL::cpp98::unary_function<FT, bool> 
       {
         bool operator()(const FT x) const
         {
@@ -219,7 +219,7 @@ namespace CGAL {
         }
       };
         
-      struct Always_true : public CGAL::unary_function<FT, bool> 
+      struct Always_true : public CGAL::cpp98::unary_function<FT, bool> 
       {
         bool operator()(const FT) const
         {

--- a/Triangulation_2/examples/Triangulation_2/info_insert_with_transform_iterator_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/info_insert_with_transform_iterator_2.cpp
@@ -13,7 +13,7 @@ typedef Delaunay::Point                                             Point;
 //a functor that returns a std::pair<Point,unsigned>.
 //the unsigned integer is incremented at each call to 
 //operator()
-struct Auto_count : public CGAL::unary_function<const Point&,std::pair<Point,unsigned> >{
+struct Auto_count : public CGAL::cpp98::unary_function<const Point&,std::pair<Point,unsigned> >{
   mutable unsigned i;
   Auto_count() : i(0){}
   std::pair<Point,unsigned> operator()(const Point& p) const {

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -417,7 +417,7 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb, OutputIterator out)
   
 
   class Less_edge 
-    :  public CGAL::binary_function<Edge, Edge, bool>
+    :  public CGAL::cpp98::binary_function<Edge, Edge, bool>
   {
   public:
     Less_edge() {}

--- a/Triangulation_3/examples/Triangulation_3/info_insert_with_transform_iterator.cpp
+++ b/Triangulation_3/examples/Triangulation_3/info_insert_with_transform_iterator.cpp
@@ -13,7 +13,7 @@ typedef Delaunay::Point                                             Point;
 //a functor that returns a std::pair<Point,unsigned>.
 //the unsigned integer is incremented at each call to 
 //operator()
-struct Auto_count : public CGAL::unary_function<const Point&,std::pair<Point,unsigned> >{
+struct Auto_count : public CGAL::cpp98::unary_function<const Point&,std::pair<Point,unsigned> >{
   mutable unsigned i;
   Auto_count() : i(0){}
   std::pair<Point,unsigned> operator()(const Point& p) const {

--- a/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_insert_range_with_info.cpp
@@ -140,9 +140,9 @@ struct Tester
   }
 
   struct Auto_count
-    : public CGAL::unary_function<const Weighted_point&,
-                                  std::pair<Weighted_point,
-                                  unsigned> >
+    : public CGAL::cpp98::unary_function<const Weighted_point&,
+                                         std::pair<Weighted_point,
+                                         unsigned> >
   {
     mutable unsigned i;
     Auto_count() : i(0){}

--- a/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
+++ b/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
@@ -73,7 +73,7 @@ private:
   typedef Halfedge_const_handle                         EH;
   typedef std::vector<EH>                               EHs;
 
-  class Less_edge: public CGAL::binary_function<EH, EH, bool> {
+  class Less_edge: public CGAL::cpp98::binary_function<EH, EH, bool> {
     const Geometry_traits_2* geom_traits;
   public:
     Less_edge() {}
@@ -94,7 +94,7 @@ private:
     }
   };
 
-  class Less_vertex: public CGAL::binary_function<VH, VH, bool> {
+  class Less_vertex: public CGAL::cpp98::binary_function<VH, VH, bool> {
     const Geometry_traits_2* geom_traits;
   public:
     Less_vertex() {}
@@ -110,7 +110,7 @@ private:
     }
   };
 
-  class Closer_edge: public CGAL::binary_function<EH, EH, bool> {
+  class Closer_edge: public CGAL::cpp98::binary_function<EH, EH, bool> {
     const Geometry_traits_2* geom_traits;
     Point_2 q;
   public:
@@ -729,7 +729,7 @@ private:
 
   //functor to decide which vertex is swept earlier by the rotational sweeping
   //ray
-  class Is_swept_earlier:public CGAL::binary_function<VH, VH, bool> {
+  class Is_swept_earlier:public CGAL::cpp98::binary_function<VH, VH, bool> {
     const Point_2& q;
     const Geometry_traits_2* geom_traits;
   public:


### PR DESCRIPTION
## Summary of Changes

This PR puts `CGAL::iterator` and `CGAL::unary/binary_function` in the `CGAL::cpp98` namespace. I didn't find anything else that was relevant for `cpp98`.

Some minor bug fixing of join iterators while there.

## Release Management

* Affected package(s): `STL_Extension`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

