### PR TITLE
Triangulation_3: Minor doc fixes

### DIFF
--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
@@ -162,7 +162,7 @@ Delaunay_triangulation_3 (InputIterator first, InputIterator last,
 /// @{
 
 /*!
-Inserts point `p` in the triangulation and returns the corresponding 
+Inserts the point `p` in the triangulation and returns the corresponding
 vertex. Similar to the insertion in a triangulation, but ensures in 
 addition the empty sphere property of all the created faces. 
 The optional argument `start` is used as a starting place for the search. 
@@ -185,7 +185,7 @@ Vertex_handle insert(const Point & p, Vertex_handle hint,
                      bool *could_lock_zone = NULL); 
 
 /*!
-Inserts point `p` in the triangulation and returns the corresponding 
+Inserts the point `p` in the triangulation and returns the corresponding
 vertex. Similar to the above `insert()` function, but takes as additional 
 parameter the return values of a previous location query. See description of 
 `Triangulation_3::locate()`. 
@@ -397,17 +397,14 @@ specifying where to start the search.
 \pre `c` is a cell of `dt`. 
 
 */ 
-Vertex_handle nearest_vertex(Point p, 
-Cell_handle c = Cell_handle()); 
+Vertex_handle nearest_vertex(const Point& p,
+                             Cell_handle c = Cell_handle());
 
 /*!
-Returns the vertex of the cell `c` that is 
-nearest to \f$ p\f$. 
-
+Returns the vertex of the cell `c` that is nearest to \f$ p\f$.
 */ 
-Vertex_handle nearest_vertex_in_cell(Point p, 
-Cell_handle c); 
-
+Vertex_handle nearest_vertex_in_cell(const Point& p,
+                                     Cell_handle c);
 
 /// @}
 
@@ -447,9 +444,9 @@ Returns the pair composed of the resulting output iterators.
 template <class OutputIteratorBoundaryFacets, 
 class OutputIteratorCells> 
 std::pair<OutputIteratorBoundaryFacets, OutputIteratorCells> 
-find_conflicts(Point p, Cell_handle c, 
-OutputIteratorBoundaryFacets bfit, 
-OutputIteratorCells cit, bool *could_lock_zone = NULL); 
+find_conflicts(const Point& p, Cell_handle c,
+               OutputIteratorBoundaryFacets bfit,
+               OutputIteratorCells cit, bool *could_lock_zone = NULL);
 
 /*!
 Same as the other `find_conflicts()` function, except that it also 
@@ -479,24 +476,23 @@ Returns the `Triple` composed of the resulting output iterators.
 
 */ 
 template <class OutputIteratorBoundaryFacets, 
-class OutputIteratorCells, 
-class OutputIteratorInternalFacets> 
+          class OutputIteratorCells,
+          class OutputIteratorInternalFacets>
 Triple<OutputIteratorBoundaryFacets, 
-OutputIteratorCells, 
-OutputIteratorInternalFacets> 
-find_conflicts(Point p, Cell_handle c, 
-OutputIteratorBoundaryFacets bfit, 
-OutputIteratorCells cit, 
-OutputIteratorInternalFacets ifit,
-bool *could_lock_zone = NULL); 
+       OutputIteratorCells,
+       OutputIteratorInternalFacets>
+find_conflicts(const Point& p, Cell_handle c,
+               OutputIteratorBoundaryFacets bfit,
+               OutputIteratorCells cit,
+               OutputIteratorInternalFacets ifit,
+               bool *could_lock_zone = NULL);
 
 /*!
 \deprecated This function is renamed `vertices_on_conflict_zone_boundary` since CGAL-3.8. 
 */ 
 template <class OutputIterator> 
 OutputIterator 
-vertices_in_conflict(Point p, Cell_handle c, 
-OutputIterator res); 
+vertices_in_conflict(const Point& p, Cell_handle c, OutputIterator res);
 
 /*!
 Similar to `find_conflicts()`, but reports the vertices which are on the 
@@ -507,9 +503,7 @@ Returns the resulting output iterator.
 */ 
 template <class OutputIterator> 
 OutputIterator 
-vertices_on_conflict_zone_boundary(Point p, Cell_handle c, 
-OutputIterator res); 
-
+vertices_on_conflict_zone_boundary(const Point& p, Cell_handle c, OutputIterator res);
 
 /// @}
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
@@ -64,13 +64,12 @@ public:
 /// @{
 
 /*!
-The type for points 
-`p` of weighted points \f$ {p}^{(w)}=(p,w_p)\f$ 
+The type for points `p` of weighted points \f$ {p}^{(w)}=(p,w_p)\f$
 */ 
 typedef Traits::Point_3 Bare_point;
 
 /*!
-
+The type for weighted points
 */ 
 typedef Traits::Weighted_point_3 Weighted_point;
 
@@ -126,7 +125,7 @@ The following methods, which already exist in `Triangulation_3`, are overloaded 
 /// @{
 
 /*!
-Inserts weighted point `p` in the triangulation. The optional 
+Inserts the weighted point `p` in the triangulation. The optional
 argument `start` is used as a starting place for the search. 
 
 If this insertion creates a vertex, this vertex is returned. 
@@ -160,7 +159,7 @@ Same as above but uses `hint` as a starting place for the search.
 Vertex_handle insert(const Weighted_point & p, Vertex_handle hint, bool *could_lock_zone = NULL); 
 
 /*!
-Inserts weighted point `p` in the triangulation and returns the corresponding 
+Inserts the weighted point `p` in the triangulation and returns the corresponding
 vertex. Similar to the above `insert()` function, but takes as additional 
 parameter the return values of a previous location query. See description of 
 `Triangulation_3::locate()`. 
@@ -229,16 +228,18 @@ of `p` and is stored in the new cell which contains it.
 \pre `rt`.`dimension()` \f$ \geq2\f$, the set of cells (resp. facets in dimension 2) is connected, not empty, its boundary is connected, and `p` lies inside the hole, which is star-shaped wrt `p`. 
 */ 
 template <class CellIt> 
-Vertex_handle insert_in_hole(Weighted_point p, CellIt cell_begin, CellIt cell_end, 
-Cell_handle begin, int i); 
+Vertex_handle insert_in_hole(const Weighted_point& p,
+                             CellIt cell_begin, CellIt cell_end,
+                             Cell_handle begin, int i);
 
 /*!
 Same as above, except that `newv` will be used as the new vertex, which 
 must have been allocated previously with, e.g.\ `create_vertex`. 
 */ 
 template <class CellIt> 
-Vertex_handle insert_in_hole(Weighted_point p, CellIt cell_begin, CellIt cell_end, 
-Cell_handle begin, int i, Vertex_handle newv); 
+Vertex_handle insert_in_hole(const Weighted_point& p,
+                             CellIt cell_begin, CellIt cell_end,
+                             Cell_handle begin, int i, Vertex_handle newv);
 
 /// @} 
 
@@ -406,7 +407,7 @@ with respect to the power distance. This means that the power
 of the query point `p` with respect to the weighted point in 
 the returned vertex is smaller than the power of `p` 
 with respect to the weighted point 
-in any other vertex. Ties are broken arbitrarily. 
+for any other vertex. Ties are broken arbitrarily.
 The default constructed 
 handle is returned if the triangulation is empty. 
 The optional argument `c` is a hint 
@@ -414,8 +415,8 @@ specifying where to start the search.
 \pre `c` is a cell of `rt`. 
 
 */ 
-Vertex_handle nearest_power_vertex(Weighted_point p, 
-Cell_handle c = Cell_handle()); 
+Vertex_handle nearest_power_vertex(const Bare_point& p,
+                                   Cell_handle c = Cell_handle());
 
 /*!
 Returns the vertex of the cell `c` 
@@ -423,8 +424,8 @@ that is nearest to \f$ p\f$
 with respect to the power distance. 
 
 */ 
-Vertex_handle nearest_power_vertex_in_cell(Weighted_point p, 
-Cell_handle c); 
+Vertex_handle nearest_power_vertex_in_cell(const Bare_point& p,
+                                           Cell_handle c);
 
 
 /// @}
@@ -485,8 +486,7 @@ bool *the_facet_is_in_its_cz = NULL);
 */ 
 template <class OutputIterator> 
 OutputIterator 
-vertices_in_conflict(Weighted_point p, Cell_handle c, 
-OutputIterator res); 
+vertices_in_conflict(const Weighted_point& p, Cell_handle c, OutputIterator res);
 
 /*!
 Similar to `find_conflicts()`, but reports the vertices which are on the 
@@ -497,8 +497,7 @@ Returns the resulting output iterator.
 */ 
 template <class OutputIterator> 
 OutputIterator 
-vertices_on_conflict_zone_boundary(Weighted_point p, Cell_handle c, 
-OutputIterator res); 
+vertices_on_conflict_zone_boundary(const Weighted_point& p, Cell_handle c, OutputIterator res);
 
 /*!
 Similar to `find_conflicts()`, but reports the vertices which are in 
@@ -511,7 +510,7 @@ Returns the resulting output iterator.
 */ 
 template <class OutputIterator> 
 OutputIterator 
-vertices_inside_conflict_zone(Weighted_point p, Cell_handle c, 
+vertices_inside_conflict_zone(const Weighted_point& p, Cell_handle c,
 OutputIterator res); 
 
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -862,7 +862,7 @@ void flip_flippable(Cell_handle c, int i);
 /// @{
 
 /*!
-Inserts point `p` in the triangulation and returns the corresponding 
+Inserts the point `p` in the triangulation and returns the corresponding
 vertex. 
 
 If point `p` coincides with an already existing vertex, this 
@@ -896,7 +896,7 @@ Same as above but uses `hint` as the starting place for the search.
 Vertex_handle insert(const Point & p, Vertex_handle hint); 
 
 /*!
-Inserts point `p` in the triangulation and returns the corresponding 
+Inserts the point `p` in the triangulation and returns the corresponding
 vertex. Similar to the above `insert()` function, but takes as additional 
 parameter the return values of a previous location query. See description of 
 <I>locate()</I> above. 
@@ -926,14 +926,14 @@ valid triangulation when they are applied on a valid triangulation.
 
 // @{
 /*!
-Inserts point `p` in cell `c`. Cell `c` is split into 4 
+Inserts the point `p` in the cell `c`. The cell `c` is split into 4
 tetrahedra. 
 \pre `t.dimension() == 3` and `p` lies strictly inside cell `c`. 
 */ 
 Vertex_handle insert_in_cell(const Point & p, Cell_handle c); 
 
 /*!
-Inserts point `p` in facet `f`. In dimension 3, the 2 
+Inserts the point `p` in the facet `f`. In dimension 3, the 2
 neighboring cells are split into 3 tetrahedra; in dimension 2, the facet 
 is split into 3 triangles. 
 \pre `t.dimension()` \f$ \geq2\f$ and `p` lies strictly inside face `f`. 
@@ -941,14 +941,14 @@ is split into 3 triangles.
 Vertex_handle insert_in_facet(const Point & p, const Facet & f); 
 
 /*!
-As above, insertion in facet `(c,i)`. 
+As above, insertion in the facet `(c,i)`.
 \pre As above and \f$ i \in\{0,1,2,3\}\f$ in dimension 3, \f$ i = 3\f$ in dimension 2. 
 */ 
 Vertex_handle insert_in_facet(const Point & p, 
 Cell_handle c, int i); 
 
 /*!
-Inserts `p` in edge `e`. In dimension 3, 
+Inserts `p` in the edge `e`. In dimension 3,
 all the cells having this edge are split into 2 tetrahedra; in 
 dimension 2, the 2 neighboring facets are split into 2 triangles; in 
 dimension 1, the edge is split into 2 edges. 
@@ -957,10 +957,10 @@ dimension 1, the edge is split into 2 edges.
 Vertex_handle insert_in_edge(const Point & p, const Edge & e); 
 
 /*!
-As above, inserts `p` in edge \f$ (i, j)\f$ of `c`. 
+As above, inserts `p` in the edge \f$ (i, j)\f$ of `c`.
 \pre As above and \f$ i\neq j\f$. Moreover \f$ i,j \in\{0,1,2,3\}\f$ in dimension 3, \f$ i,j \in\{0,1,2\}\f$ in dimension 2, \f$ i,j \in\{0,1\}\f$ in dimension 1. 
 */ 
-Vertex_handle insert_in_edge(Point p, Cell_handle c, int i, int j); 
+Vertex_handle insert_in_edge(const Point& p, Cell_handle c, int i, int j);
 
 /*!
 The cell `c` must be an infinite cell containing `p`. 
@@ -1011,16 +1011,16 @@ This operation is equivalent to calling
 \pre `t.dimension()` \f$ \geq2\f$, the set of cells (resp. facets in dimension 2) is connected, its boundary is connected, and `p` lies inside the hole, which is star-shaped wrt `p`. 
 */ 
 template <class CellIt> 
-Vertex_handle insert_in_hole(Point p, CellIt cell_begin, CellIt cell_end, 
-Cell_handle begin, int i); 
+Vertex_handle insert_in_hole(const Point& p, CellIt cell_begin, CellIt cell_end,
+                             Cell_handle begin, int i);
 
 /*!
 Same as above, except that `newv` will be used as the new vertex, which 
 must have been allocated previously with e.g.\ `create_vertex`. 
 */ 
 template <class CellIt> 
-Vertex_handle insert_in_hole(Point p, CellIt cell_begin, CellIt cell_end, 
-Cell_handle begin, int i, Vertex_handle newv); 
+Vertex_handle insert_in_hole(const Point& p, CellIt cell_begin, CellIt cell_end,
+                             Cell_handle begin, int i, Vertex_handle newv);
 
 /// @} 
 


### PR DESCRIPTION
This PR fixes missing `const&` in function signatures and wrong point types in the function `nearest_power_vertex()` (and similar functions).

## Release Management

* Affected package(s): `Triangulation_3`
* Issue(s) solved (if any): fix #3178 
* Feature/Small Feature (if any): --

