### PR TITLE
Make sure identical vertices have identical coordinates in autorefinement

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
@@ -167,7 +167,7 @@ private:
   Exact_kernel        ek;
   Exact_kernel::Intersect_3 exact_intersection;
   std::vector<vertex_descriptor> tm1_vertices, tm2_vertices;
-
+  const bool doing_autorefinement;
 public:
   const TriangleMesh &tm1, &tm2;
   VertexPointMap vpm1, vpm2;
@@ -176,7 +176,8 @@ public:
                      const TriangleMesh& tm2_,
                      const VertexPointMap& vpm1_,
                      const VertexPointMap& vpm2_)
-  : tm1(tm1_)
+  : doing_autorefinement(&tm1_ == &tm2_)
+  , tm1(tm1_)
   , tm2(tm2_)
   , vpm1(vpm1_)
   , vpm2(vpm2_)
@@ -284,7 +285,15 @@ public:
   {
     put(vpm, vd, exact_to_double(enodes[i]));
     if (&tm1==&tm)
-      tm1_vertices[i] = vd;
+    {
+      if (  tm1_vertices[i] == GT::null_vertex() )
+      {
+        tm1_vertices[i] = vd;
+        return;
+      }
+      if (doing_autorefinement)
+        tm2_vertices[i]==vd;
+    }
     else
       tm2_vertices[i] = vd;
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
@@ -292,7 +292,7 @@ public:
         return;
       }
       if (doing_autorefinement)
-        tm2_vertices[i]==vd;
+        tm2_vertices[i] = vd;
     }
     else
       tm2_vertices[i] = vd;


### PR DESCRIPTION
we abuse the tm2 field to store the second copy of the vertex.