### PR TITLE
Polyhedron Demo: Fix path to external plugins

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -631,6 +631,11 @@ void MainWindow::loadPlugins()
   #endif
 #endif
   if(!env_path.isEmpty()) {
+#if defined(_WIN32)
+    QString path = qgetenv("PATH");
+    QByteArray new_path = path.append(env_path.prepend(separator)).toUtf8();
+    qputenv("PATH", new_path);
+#endif
     Q_FOREACH (QString pluginsDir,
                env_path.split(separator, QString::SkipEmptyParts)) {
       QDir dir(pluginsDir);

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -621,9 +621,18 @@ void MainWindow::loadPlugins()
       }
   }
   QString env_path = qgetenv("POLYHEDRON_DEMO_PLUGINS_PATH");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+  QChar separator = QDir::listSeparator();
+#else
+  #if defined(_WIN32)
+    QChar separator = ';';
+  #else 
+    QChar separator = ':';
+  #endif
+#endif
   if(!env_path.isEmpty()) {
     Q_FOREACH (QString pluginsDir,
-               env_path.split(":", QString::SkipEmptyParts)) {
+               env_path.split(separator, QString::SkipEmptyParts)) {
       QDir dir(pluginsDir);
       if(dir.isReadable())
         plugins_directories << dir;


### PR DESCRIPTION
Choose etween ':' and ':' as separator in the path to the plugins dir and add it to the global PATH if running on Windows so the potential plugin dependency dlls are found by the linker.
## Release Management

* Issue(s) solved (if any): fix #3204

