### PR TITLE
Add CGALConfig.cmake to the Windows installer

### DIFF
--- a/wininst/developer_scripts/script_cgal.nsi
+++ b/wininst/developer_scripts/script_cgal.nsi
@@ -164,6 +164,7 @@ Section "!Main CGAL" MAIN_Idx
 
   SetOutPath "$INSTDIR"
   File "${CGAL_SRC}\AUTHORS"
+  File "${CGAL_SRC}\CGALConfig.cmake"
   File "${CGAL_SRC}\CHANGES.md"
   File "${CGAL_SRC}\CMakeLists.txt"
   File "${CGAL_SRC}\INSTALL.md"


### PR DESCRIPTION
## Summary of Changes

Add `CGALConfig.cmake` to the Windows installer. The real `CGALConfig.cmake` is in `lib/cmake/CGAL/`, but that is more convenient if the redirection is also installed by the Windows installer.

## Release Management

* Affected package(s): windows installer

