### PR TITLE
Polyhedron demo: Fix normal facet computation for triangulation

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -268,7 +268,6 @@ Scene_polygon_soup_item_priv::triangulate_polygon(Polygons_iterator pit, int pol
     if (normal == CGAL::NULL_VECTOR) // No normal could be computed, return
       return;
 
-    normal = normal / std::sqrt(normal * normal);
     typedef FacetTriangulator<Polyhedron, Kernel, std::size_t> FT;
 
     double diagonal;

--- a/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polygon_soup_item.cpp
@@ -249,10 +249,25 @@ void
 Scene_polygon_soup_item_priv::triangulate_polygon(Polygons_iterator pit, int polygon_id) const
 {
     //Computes the normal of the facet
-    const Point_3& pa = soup->points[pit->at(0)];
-    const Point_3& pb = soup->points[pit->at(1)];
-    const Point_3& pc = soup->points[pit->at(2)];
-    Traits::Vector_3 normal = CGAL::cross_product(pb-pa, pc -pa);
+    Traits::Vector_3 normal = CGAL::NULL_VECTOR;
+
+    // The three first vertices may be aligned, we need to test other
+    // combinations
+    for (std::size_t i = 0; i < pit->size() - 2; ++ i)
+    {
+       const Point_3& pa = soup->points[pit->at(i)];
+       const Point_3& pb = soup->points[pit->at(i+1)];
+       const Point_3& pc = soup->points[pit->at(i+2)];
+       if (!CGAL::collinear (pa, pb, pc))
+       {
+          normal = CGAL::cross_product(pb-pa, pc -pa);
+          break;
+       }
+    }
+
+    if (normal == CGAL::NULL_VECTOR) // No normal could be computed, return
+      return;
+
     normal = normal / std::sqrt(normal * normal);
     typedef FacetTriangulator<Polyhedron, Kernel, std::size_t> FT;
 


### PR DESCRIPTION
## Summary of Changes

When loading a polygon soup with non-triangular facets, these facets are triangulated. For triangulation, the points are projected in 2D after computing the normal vector of the facet.

In the code, the normal is computed using the cross product of the 3 first points of the facet. But it can happen that these 3 points are aligned, leading to an infinite normal and to an assertion failed in the triangulation construction.

This PR tests other combinations of vertices to find the first non-collinear triple. Tested locally, it fixes the bug I had with a specific dataset with aligned vertices.

## Release Management

* Affected package(s): Polyhedron demo

