### PR TITLE
Set CMP0077 to OLD (new in CMake-3.13)

### DIFF
--- a/Installation/cmake/modules/CGAL_TweakFindBoost.cmake
+++ b/Installation/cmake/modules/CGAL_TweakFindBoost.cmake
@@ -25,6 +25,9 @@
 # Boost versions, even if the file FindBoost.cmake is old.
 
 if( NOT CGAL_TweakFindBoost )
+  if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 OLD)
+  endif()
   if(DEFINED CGAL_Boost_USE_STATIC_LIBS)
     # If the option is loaded from CGALConfig.h, use its value as default
     # value.  But the user will still have the choice to change the


### PR DESCRIPTION
## Summary of Changes

ArchLinux has upgraded CMake to a dev version of CMake-3.13, and we have CMake [warnings]:
```
CMake Warning (dev) at /mnt/testsuite/cmake/modules/CGAL_TweakFindBoost.cmake:44 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'CGAL_Boost_USE_STATIC_LIBS'.
Call Stack (most recent call first):
  /mnt/testsuite/cmake/modules/CGAL_SetupBoost.cmake:18 (include)
  /home/cgal_tester/build/src/cmake/platforms/ArchLinux-CXX14/CGALConfig.cmake:119 (include)
  /home/cgal_tester/build/src/cmake/platforms/ArchLinux-CXX14/CGALConfig.cmake:159 (check_cgal_component)
  CMakeLists.txt:29 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
[warnings]: https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-Ic-62/TDS_2/TestReport_lrineau_ArchLinux-CXX14.gz

## Release Management

* Affected package(s): all (CMake scripts)


