### PR TITLE
Polygon: Fix `filter_collinear_points()` early return

### DIFF
--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -67,9 +67,6 @@ OutputForwardIterator filter_collinear_points(InputForwardIterator first,
                                               const typename K::FT tolerance =
                                                 std::numeric_limits<typename K::FT>::epsilon())
 {
-  if(std::distance(first, beyond) < 4)
-    return out;
-
   typedef typename K::FT                              FT;
   typedef typename K::Point_2                         Point;
 

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -60,6 +60,8 @@ namespace Polygon_2 {
 //                  by three consecutive points of the range (more specifically,
 //                  on the value of the determinant).
 //
+// \pre The range `(first, beyond)` is composed of at least three points.
+// \pre Not all points in the range `(first, beyond)` are (almost) collinear.
 template<typename K, typename InputForwardIterator, typename OutputForwardIterator>
 OutputForwardIterator filter_collinear_points(InputForwardIterator first,
                                               InputForwardIterator beyond,
@@ -67,6 +69,8 @@ OutputForwardIterator filter_collinear_points(InputForwardIterator first,
                                               const typename K::FT tolerance =
                                                 std::numeric_limits<typename K::FT>::epsilon())
 {
+  CGAL_precondition(std::distance(first, beyond) >= 3);
+
   typedef typename K::FT                              FT;
   typedef typename K::Point_2                         Point;
 
@@ -80,7 +84,9 @@ OutputForwardIterator filter_collinear_points(InputForwardIterator first,
 
   do
   {
-    CGAL_assertion(vit != vit_next && vit_next != vit_next_2 && vit != vit_next_2);
+    CGAL_assertion(vit != vit_next);
+    CGAL_assertion(vit_next != vit_next_2);
+    CGAL_assertion(vit != vit_next_2);
 
     const Point& o = *vit;
     const Point& p = *vit_next;

--- a/Polygon/test/Polygon/AlgorithmTest.cpp
+++ b/Polygon/test/Polygon/AlgorithmTest.cpp
@@ -20,7 +20,7 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 
   std::ifstream from(FileName);
   if (!from) {
-    std::cerr << "could not open file " << FileName << "!" << endl;
+    std::cerr << "Could not open file " << FileName << "!" << endl;
     std::exit(1);
   }
   CGAL::set_ascii_mode(from);
@@ -35,20 +35,33 @@ void test_collinear_point_filtering(const R&, const char* FileName)
   std::cout << std::endl;
 
   std::vector<Point> simplified_polygon;
+  std::size_t final_size;
+
+  // check for 3 points
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.begin() + 3,
+                                                        std::back_inserter(simplified_polygon),
+                                                        0 /*tolerance*/);
+  final_size = simplified_polygon.size();
+  std::cout << "final size: " << final_size << std::endl;
+  assert(final_size == 3);
+
+  // generic tests
+  simplified_polygon.clear();
   CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.end(),
                                                         std::back_inserter(simplified_polygon),
                                                         0 /*tolerance*/);
-  std::size_t final_size = simplified_polygon.size();
+  final_size = simplified_polygon.size();
   std::cout << "final size (tolerance 0): " << final_size << std::endl;
-  CGAL_assertion(final_size == 7);
+  assert(final_size == 7);
 
+    // --
   simplified_polygon.clear();
   CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.end(),
                                                         std::back_inserter(simplified_polygon),
                                                         1e-10);
   final_size = simplified_polygon.size();
   std::cout << "final size (tolerance 1e-10): " << final_size << std::endl;
-  CGAL_assertion(final_size == 5);
+  assert(final_size == 5);
 
   std::cout << "simplified polygon:" << std::endl;
   std::copy(simplified_polygon.begin(), simplified_polygon.end(), std::ostream_iterator<Point>(std::cout, "\n"));


### PR DESCRIPTION
## Summary of Changes

When the range of points was of size 3, nothing was returned.

Also, because this is meant to be filtering points in a polygon, added some preconditions:
- there must be at least three points.
- there must be at least three non-collinear points.

## Release Management

* Affected package(s): `Polygon`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

