### PR TITLE
Fix CDT_2 errors, using snapping of intersection points 

### DIFF
--- a/Kernel_23/include/CGAL/Bbox_2.h
+++ b/Kernel_23/include/CGAL/Bbox_2.h
@@ -162,10 +162,10 @@ void
 Bbox_2::dilate(int dist)
 {
   using boost::math::float_advance;
-  float_advance(rep[0],-dist);
-  float_advance(rep[1],-dist);
-  float_advance(rep[2],dist);
-  float_advance(rep[3],dist);
+  rep[0] = float_advance(rep[0],-dist);
+  rep[1] = float_advance(rep[1],-dist);
+  rep[2] = float_advance(rep[2],dist);
+  rep[3] = float_advance(rep[3],dist);
 }
   
 inline

--- a/Kernel_23/include/CGAL/Bbox_3.h
+++ b/Kernel_23/include/CGAL/Bbox_3.h
@@ -183,12 +183,12 @@ void
 Bbox_3::dilate(int dist)
 {
   using boost::math::float_advance;
-  float_advance(rep[0],-dist);
-  float_advance(rep[1],-dist);
-  float_advance(rep[2],-dist);
-  float_advance(rep[3],dist);
-  float_advance(rep[4],dist);
-  float_advance(rep[5],dist);
+  rep[0] = float_advance(rep[0],-dist);
+  rep[1] = float_advance(rep[1],-dist);
+  rep[2] = float_advance(rep[2],-dist);
+  rep[3] = float_advance(rep[3],dist);
+  rep[4] = float_advance(rep[4],dist);
+  rep[5] = float_advance(rep[5],dist);
 }
 
 


### PR DESCRIPTION
## Summary of Changes

Fix `Bbox_[23]::dilate()`: `boost::math::float_advance` does not modify its argument, but returns a
value! The previous version of the code was not modifying the bbox at all,
and the point snapping was active.

## Release Management

* Affected package(s): Kernel_23, Triangulation_2
* Issue(s) solved (if any): fix #3098, fix #2999 


