### PR TITLE
Build the kd-tree only if the AABB-tree is built

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -230,6 +230,7 @@ namespace CGAL {
       clear_nodes();
 			m_primitives.clear();
 			clear_search_tree();
+			m_default_search_tree_constructed = false;
 		}
 
 		/// Returns the axis-aligned bounding box of the whole tree.
@@ -321,9 +322,9 @@ namespace CGAL {
     }
     #endif
 
+		bool build_kd_tree() const;
 		template<typename ConstPointIterator>
-		bool accelerate_distance_queries_impl(ConstPointIterator first,
-                                          ConstPointIterator beyond) const;
+		bool build_kd_tree(ConstPointIterator first, ConstPointIterator beyond) const;
 public:
 
     /// \name Intersection Tests
@@ -543,21 +544,20 @@ public:
 
     /// Constructs an internal KD-tree containing the specified point
     /// set, to be used as the set of potential hints for accelerating
-    /// the distance queries. 
-		/// \tparam ConstPointIterator is an iterator with
+    /// the distance queries.
+    /// \tparam ConstPointIterator is an iterator with
     /// value type `Point_and_primitive_id`.
 		template<typename ConstPointIterator>
-		bool accelerate_distance_queries(ConstPointIterator first,
-                                     ConstPointIterator beyond) const
-    {
-      #ifdef CGAL_HAS_THREADS
-      //this ensures that this is done once at a time
-      CGAL_SCOPED_LOCK(kd_tree_mutex);
-      #endif
-      clear_search_tree();
-      return accelerate_distance_queries_impl(first,beyond);
-      
-    }
+		bool accelerate_distance_queries(ConstPointIterator first, ConstPointIterator beyond) const
+		{
+			#ifdef CGAL_HAS_THREADS
+			//this ensures that this is done once at a time
+			CGAL_SCOPED_LOCK(kd_tree_mutex);
+			#endif
+			clear_search_tree();
+			m_default_search_tree_constructed = false; // not a default kd-tree
+			return build_kd_tree(first,beyond);
+		}
     
     /// Returns the minimum squared distance between the query point
     /// and all input primitives. The internal KD-tree is not used.
@@ -601,7 +601,6 @@ public:
 				delete m_p_search_tree;
 				m_p_search_tree = NULL;
 				m_search_tree_constructed = false;
-				m_default_search_tree_constructed = false;
                         }
 		}
 
@@ -641,7 +640,9 @@ public:
 		Point_and_primitive_id best_hint(const Point& query) const
 		{
 			if(m_search_tree_constructed)
+                        {
 				return m_p_search_tree->closest_point(query);
+                        }
 			else
 				return this->any_reference_point_and_id();
 		}
@@ -679,7 +680,7 @@ public:
 		// search KD-tree
 		mutable const Search_tree* m_p_search_tree;
 		mutable bool m_search_tree_constructed;
-    mutable bool m_default_search_tree_constructed;
+    mutable bool m_default_search_tree_constructed; // indicates whether the internal kd-tree should be built
     bool m_need_build;
 
 	private:
@@ -1064,24 +1065,44 @@ public:
 														m_primitives.size(), m_traits);
 		}
 
-    // In case the users has switched on the accelerated distance query
-    // data structure with the default arguments, then it has to be
-    // rebuilt.
-    if(m_default_search_tree_constructed)
-      accelerate_distance_queries();
 
-    m_need_build = false;    
+		// In case the users has switched on the accelerated distance query
+		// data structure with the default arguments, then it has to be
+		// /built/rebuilt.
+		if(m_default_search_tree_constructed)
+			build_kd_tree();
+		m_need_build = false;
 	}
+	// constructs the search KD tree from given points
+	// to accelerate the distance queries
+	template<typename Tr>
+	bool AABB_tree<Tr>::build_kd_tree() const
+	{
+		// iterate over primitives to get reference points on them
+		std::vector<Point_and_primitive_id> points;
+		points.reserve(m_primitives.size());
+		typename Primitives::const_iterator it;
+		for(it = m_primitives.begin(); it != m_primitives.end(); ++it)
+			points.push_back( Point_and_primitive_id(
+				internal::Primitive_helper<AABB_traits>::get_reference_point(
+					*it,m_traits), it->id() ) );
 
+		// clears current KD tree
+		clear_search_tree();
+		bool res = build_kd_tree(points.begin(), points.end());
+		m_default_search_tree_constructed = true;
+		return res;
+	}
 
 	// constructs the search KD tree from given points
 	// to accelerate the distance queries
 	template<typename Tr>
 	template<typename ConstPointIterator>
-	bool AABB_tree<Tr>::accelerate_distance_queries_impl(ConstPointIterator first,
+	bool AABB_tree<Tr>::build_kd_tree(ConstPointIterator first,
 		ConstPointIterator beyond) const
 	{
 		m_p_search_tree = new Search_tree(first, beyond);
+                m_default_search_tree_constructed = true;
 		if(m_p_search_tree != NULL)
 		{
 			m_search_tree_constructed = true;
@@ -1099,30 +1120,29 @@ public:
 	bool AABB_tree<Tr>::accelerate_distance_queries() const
 	{
 		if(m_primitives.empty()) return true;
-    #ifdef CGAL_HAS_THREADS
-    //this ensures that this function will be done once
-    CGAL_SCOPED_LOCK(kd_tree_mutex);
-    #endif
+		if (m_default_search_tree_constructed)
+		{
+			if (!m_need_build) return m_search_tree_constructed;
+			return true; // default return type, no tree built
+		}
 
-    //we only redo computation only if needed 
-    if (!m_need_build && m_default_search_tree_constructed)
-      return m_search_tree_constructed;
-    
-		// iterate over primitives to get reference points on them
-		std::vector<Point_and_primitive_id> points;
-		points.reserve(m_primitives.size());
-		typename Primitives::const_iterator it;
-		for(it = m_primitives.begin(); it != m_primitives.end(); ++it)
-			points.push_back(
-        Point_and_primitive_id(
-          internal::Primitive_helper<AABB_traits>::get_reference_point(*it,m_traits), it->id()
-        )
-      );
-
-    // clears current KD tree
-    clear_search_tree();
-    m_default_search_tree_constructed = true;
-		return accelerate_distance_queries_impl(points.begin(), points.end());
+		if(!m_need_build) // the tree was already built, build the kd-tree
+		{
+			#ifdef CGAL_HAS_THREADS
+			//this ensures that this function will be done once
+			CGAL_SCOPED_LOCK(kd_tree_mutex);
+			#endif
+			if (!m_need_build)
+			{
+				// clears current KD tree
+				clear_search_tree();
+				bool res = build_kd_tree();
+				m_default_search_tree_constructed = true;
+				return res;
+			};
+		}
+		m_default_search_tree_constructed = true;
+		return m_search_tree_constructed;
 	}
 
 	template<typename Tr>


### PR DESCRIPTION
This avoid issues when using thread where the kd-tree is used while being reconstructed.

The issue I observed was that when `squared_distance()` was called by several threads but the tree was not already built and `accelerate_distance_computations()` has been called, some threads were looking in the kd-tree built in `best_hint()` while another one was actually rebuilding it.


