### PR TITLE
Polyhedron Demo: Hide ids when modifying the mesh

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1222,6 +1222,7 @@ void Scene_surface_mesh_item::invalidate(Gl_data_names name)
     processData(name);
   else
     initGL();
+  d->killIds();
 }
 
 


### PR DESCRIPTION
## Summary of Changes

As I don't think it is possible to find which ids are impacted by a modification of the mesh (invalidateOpenGLBuffers() only re-compute everything, it is not possible to track which face(s), edge(s) or vertex(ices) is/are precisely modified), I think the easiest way of not having Ids in the wrong place is to simply hide them all. 