### PR TITLE
Mesh 3 fix: add the possibility to stop the algorithm, when Parallel_tag is used

### DIFF
--- a/BGL/include/CGAL/boost/parameter.h
+++ b/BGL/include/CGAL/boost/parameter.h
@@ -112,6 +112,7 @@ BOOST_PARAMETER_NAME( (dump_after_exude_prefix, tag ) dump_after_exude_prefix_)
 BOOST_PARAMETER_NAME( (number_of_initial_points, tag) number_of_initial_points_)
 BOOST_PARAMETER_NAME( (maximal_number_of_vertices, tag ) maximal_number_of_vertices_)
 BOOST_PARAMETER_NAME( (pointer_to_error_code, tag ) pointer_to_error_code_)
+BOOST_PARAMETER_NAME( (pointer_to_stop_atomic_boolean, tag ) pointer_to_stop_atomic_boolean_)
 
 // First used in <CGAL/Labeled_mesh_domain_3.h>
 BOOST_PARAMETER_NAME( (function, tag ) function_)

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -44,6 +44,7 @@
 #include <CGAL/Mesh_3/Refine_tets_visitor.h>
 #include <CGAL/Mesher_level_visitors.h>
 #include <CGAL/Kernel_traits.h>
+#include <CGAL/atomic.h>
 
 #ifdef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE
 #include <CGAL/Surface_mesher/Surface_mesher_visitor.h>
@@ -214,7 +215,11 @@ public:
            const MeshCriteria& criteria,
            int mesh_topology = 0,
            std::size_t maximal_number_of_vertices = 0,
-           Mesh_error_code* error_code = 0);
+           Mesh_error_code* error_code = 0
+#ifndef CGAL_NO_ATOMIC
+           , CGAL::cpp11::atomic<bool>* stop_ptr = 0
+#endif
+           );
 
   /// Destructor
   ~Mesher_3() 
@@ -280,7 +285,33 @@ private:
   std::size_t maximal_number_of_vertices_;
 
   /// Pointer to the error code
-  Mesh_error_code* error_code_;
+  Mesh_error_code* const error_code_;
+
+#ifndef CGAL_NO_ATOMIC
+  /// Pointer to the atomic Boolean that can stop the process
+  CGAL::cpp11::atomic<bool>* const stop_ptr;
+#endif
+
+  bool forced_stop() const {
+#ifndef CGAL_NO_ATOMIC
+    if(stop_ptr != 0 &&
+       stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+    {
+      if(error_code_ != 0) *error_code_ = CGAL_MESH_3_STOPPED;
+      return true;
+    }
+#endif // not defined CGAL_NO_ATOMIC
+    if(maximal_number_of_vertices_ != 0 &&
+       r_c3t3_.triangulation().number_of_vertices() >=
+       maximal_number_of_vertices_)
+    {
+      if(error_code_ != 0) {
+        *error_code_ = CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED;
+      }
+      return true;
+    }
+    return false;
+  }
 
 private:
   // Disabled copy constructor
@@ -298,7 +329,11 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                                const MC& criteria,
                                int mesh_topology,
                                std::size_t maximal_number_of_vertices,
-                               Mesh_error_code* error_code)
+                               Mesh_error_code* error_code
+#ifndef CGAL_NO_ATOMIC
+                               , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                               )
 : Base(c3t3.bbox(),
        Concurrent_mesher_config::get().locking_grid_num_cells_per_axis)
 , r_oracle_(domain)
@@ -309,13 +344,21 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                  null_mesher_,
                  c3t3,
                  mesh_topology,
-                 maximal_number_of_vertices)
+                 maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                 , stop_ptr
+#endif
+                 )
 , cells_mesher_(c3t3.triangulation(),
                 criteria.cell_criteria_object(),
                 domain,
                 facets_mesher_,
                 c3t3,
-                maximal_number_of_vertices)
+                maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , stop_ptr
+#endif
+                )
 , null_visitor_()
 , facets_visitor_(&cells_mesher_, &null_visitor_)
 #ifndef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE
@@ -326,6 +369,9 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
 , r_c3t3_(c3t3)
 , maximal_number_of_vertices_(maximal_number_of_vertices)
 , error_code_(error_code)
+#ifndef CGAL_NO_ATOMIC
+, stop_ptr(stop_ptr)
+#endif
 {
   facets_mesher_.set_lock_ds(this->get_lock_data_structure());
   facets_mesher_.set_worksharing_ds(this->get_worksharing_data_structure());
@@ -397,8 +443,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
 
   dump_c3t3(r_c3t3_, dump_after_refine_surface_prefix);
 
-  if(maximal_number_of_vertices_ == 0 ||
-     r_tr.number_of_vertices() < maximal_number_of_vertices_)
+  if(!forced_stop())
   {
     // Then scan volume and refine it
     cells_mesher_.scan_triangulation();
@@ -447,8 +492,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
             << nbsteps << "," << cells_mesher_.debug_info() << ")";
 
   while ( ! facets_mesher_.is_algorithm_done() &&
-          ( maximal_number_of_vertices_ == 0 ||
-            maximal_number_of_vertices_ >= r_tr.number_of_vertices()) )
+          ! forced_stop() )
   {
     facets_mesher_.one_step(facets_visitor_);
     std::cerr
@@ -457,13 +501,15 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
     % r_tr.number_of_vertices()
     % nbsteps % cells_mesher_.debug_info()
     % (nbsteps / timer.time());
-    if(refinement_stage == REFINE_FACETS &&
+    if(! forced_stop() &&
+       refinement_stage == REFINE_FACETS &&
        facets_mesher_.is_algorithm_done())
     {
       facets_mesher_.scan_edges();
       refinement_stage = REFINE_FACETS_AND_EDGES;
     }
-    if(refinement_stage == REFINE_FACETS_AND_EDGES &&
+    if(! forced_stop() &&
+       refinement_stage == REFINE_FACETS_AND_EDGES &&
        facets_mesher_.is_algorithm_done())
     {
       facets_mesher_.scan_vertices();
@@ -497,8 +543,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
             << nbsteps << "," << cells_mesher_.debug_info() << ")";
 
   while ( ! cells_mesher_.is_algorithm_done()  &&
-          ( maximal_number_of_vertices_ == 0 ||
-            maximal_number_of_vertices_ >= r_tr.number_of_vertices()) )
+          ! forced_stop() )
   {
     cells_mesher_.one_step(cells_visitor_);
     std::cerr
@@ -516,12 +561,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
   std::cerr << std::endl;
 #endif
 
-  if(maximal_number_of_vertices_ != 0 &&
-     r_tr.number_of_vertices() >= maximal_number_of_vertices_ &&
-     error_code_ != 0)
-  {
-    *error_code_ = CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED;
-  }
+  (void)(forced_stop()); // sets *error_code
 
   timer.stop();
   elapsed_time += timer.time();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -402,6 +402,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
   r_c3t3_.clear_cells_and_facets_from_c3t3();
 
   const Triangulation& r_tr = r_c3t3_.triangulation();
+  CGAL_USE(r_tr);
 
 #ifndef CGAL_MESH_3_VERBOSE
   // Scan surface and refine it

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -49,6 +49,7 @@
 #endif
 
 #include <CGAL/Object.h>
+#include <CGAL/atomic.h>
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
@@ -288,12 +289,19 @@ public:
   Refine_facets_3_base(Tr& tr, Complex3InTriangulation3& c3t3,
                        const MeshDomain& oracle,
                        const Criteria& criteria,
-                       std::size_t maximal_number_of_vertices)
+                       std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                       , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                       )
     : r_tr_(tr)
     , r_criteria_(criteria)
     , r_oracle_(oracle)
     , r_c3t3_(c3t3)
     , m_maximal_number_of_vertices_(maximal_number_of_vertices)
+#ifndef CGAL_NO_ATOMIC
+    , m_stop_ptr(stop_ptr)
+#endif
   {}
 
   void scan_triangulation_impl_amendement() const {}
@@ -301,6 +309,13 @@ public:
   // Tells if the refinement process of cells is currently finished
   bool no_longer_element_to_refine_impl()
   {
+#ifndef CGAL_NO_ATOMIC
+    if(m_stop_ptr != 0 &&
+       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+    {
+      return true;
+    }
+#endif // not defined CGAL_NO_ATOMIC
     if(m_maximal_number_of_vertices_ !=0 &&
        r_tr_.number_of_vertices() >=
        m_maximal_number_of_vertices_)
@@ -626,6 +641,10 @@ protected:
   Complex3InTriangulation3& r_c3t3_;
   /// Maximal allowed number of vertices
   std::size_t m_maximal_number_of_vertices_;
+#ifndef CGAL_NO_ATOMIC
+  /// Pointer to the atomic Boolean that can stop the process
+  CGAL::cpp11::atomic<bool>* const m_stop_ptr;
+#endif
 }; // end class template Refine_facets_3_base
 
 /************************************************
@@ -790,7 +809,11 @@ public:
                   Previous_level_& previous,
                   C3T3& c3t3,
                   int mesh_topology,
-                  std::size_t maximal_number_of_vertices);
+                  std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                  , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                  );
   // For parallel
   Refine_facets_3(Tr& triangulation,
                   const Criteria& criteria,
@@ -799,7 +822,11 @@ public:
                   C3T3& c3t3,
                   Lock_data_structure *lock_ds,
                   WorksharingDataStructureType *worksharing_ds,
-                  std::size_t maximal_number_of_vertices);
+                  std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                  , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                  );
 
   /// Destructor
   virtual ~Refine_facets_3() { }
@@ -911,9 +938,17 @@ Refine_facets_3(Tr& triangulation,
                 P_& previous,
                 C3T3& c3t3,
                 int mesh_topology,
-                std::size_t maximal_number_of_vertices)
+                std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                )
   : Rf_base(triangulation, c3t3, oracle, criteria, mesh_topology,
-            maximal_number_of_vertices)
+            maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , stop_ptr
+#endif
+            )
   , Mesher_level<Tr, Self, Facet, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct>(previous)
   , No_after_no_insertion()
@@ -932,8 +967,16 @@ Refine_facets_3(Tr& triangulation,
                 C3T3& c3t3,
                 Lock_data_structure *lock_ds,
                 WorksharingDataStructureType *worksharing_ds,
-                std::size_t maximal_number_of_vertices)
-  : Rf_base(triangulation, c3t3, oracle, criteria, maximal_number_of_vertices)
+                std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                )
+  : Rf_base(triangulation, c3t3, oracle, criteria, maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+            , stop_ptr
+#endif
+            )
   , Mesher_level<Tr, Self, Facet, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct>(previous)
   , No_after_no_insertion()

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -723,9 +723,9 @@ public:
   Auto_worksharing_ds(const Bbox_3 &bbox)
     : NUM_WORK_ITEMS_PER_BATCH(
         Concurrent_mesher_config::get().num_work_items_per_batch)
-    , m_cache_number_of_tasks(0)
   {
     set_bbox(bbox);
+    m_cache_number_of_tasks = 0;
   }
 
   /// Destructor

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -37,6 +37,7 @@
 #include <tbb/concurrent_vector.h>
 #include <tbb/scalable_allocator.h>
 
+#include <tbb/atomic.h>
 
 #include <vector>
 
@@ -722,6 +723,7 @@ public:
   Auto_worksharing_ds(const Bbox_3 &bbox)
     : NUM_WORK_ITEMS_PER_BATCH(
         Concurrent_mesher_config::get().num_work_items_per_batch)
+    , m_cache_number_of_tasks(0)
   {
     set_bbox(bbox);
   }
@@ -750,6 +752,7 @@ public:
       add_batch_and_enqueue_task(workbuffer, parent_task);
       workbuffer.clear();
     }
+    m_cache_number_of_tasks = parent_task.ref_count();
   }
 
   template <typename Func, typename Quality>
@@ -766,6 +769,7 @@ public:
       add_batch_and_enqueue_task(workbuffer, parent_task);
       workbuffer.clear();
     }
+    m_cache_number_of_tasks = parent_task.ref_count();
   }
 
   // Returns true if some items were flushed
@@ -793,7 +797,12 @@ public:
       enqueue_task(*it, parent_task);
     }
 
+    m_cache_number_of_tasks = parent_task.ref_count();
     return (num_flushed_items > 0);
+  }
+
+  int approximate_number_of_enqueued_element() const {
+    return int(m_cache_number_of_tasks) * NUM_WORK_ITEMS_PER_BATCH;
   }
 
 protected:
@@ -820,6 +829,7 @@ protected:
   }
 
   const size_t                      NUM_WORK_ITEMS_PER_BATCH;
+  tbb::atomic<int>                  m_cache_number_of_tasks;
   TLS_WorkBuffer                    m_tls_work_buffers;
 };
 

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -802,7 +802,7 @@ public:
   }
 
   int approximate_number_of_enqueued_element() const {
-    return int(m_cache_number_of_tasks) * NUM_WORK_ITEMS_PER_BATCH;
+    return int(m_cache_number_of_tasks) * int(NUM_WORK_ITEMS_PER_BATCH);
   }
 
 protected:

--- a/Mesh_3/include/CGAL/Mesh_error_code.h
+++ b/Mesh_3/include/CGAL/Mesh_error_code.h
@@ -30,7 +30,8 @@ namespace CGAL {
 
 enum Mesh_error_code {
   CGAL_MESH_3_NO_ERROR = 0,
-  CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED
+  CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED,
+  CGAL_MESH_3_STOPPED
 };
 
 inline
@@ -40,6 +41,8 @@ std::string mesh_error_string(const Mesh_error_code& error_code) {
     return "no error";
   case CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED:
     return "the maximal number of vertices has been reached";
+  case CGAL_MESH_3_STOPPED:
+    return "the meshing process was stopped";
   default:
     std::stringstream str("");
     str << "unknown error (error_code="

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -38,6 +38,7 @@
 #include <CGAL/Mesh_3/Mesher_3.h>
 #include <CGAL/Mesh_error_code.h>
 #include <CGAL/optimize_mesh_3.h>
+#include <CGAL/atomic.h>
 
 namespace CGAL {
 
@@ -213,6 +214,7 @@ namespace parameters {
         , nonlinear_growth_of_balls(false)
         , maximal_number_of_vertices(0)
         , pointer_to_error_code(0)
+        , pointer_to_stop_atomic_boolean(0)
       {}
 
       std::string dump_after_init_prefix;
@@ -225,7 +227,7 @@ namespace parameters {
       bool nonlinear_growth_of_balls;
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
-
+      CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
     }; // end struct Mesh_3_options
 
   } // end namespace internal
@@ -369,6 +371,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
+                            (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
                             )
                            )
   { 
@@ -383,6 +386,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
     options.number_of_initial_points=number_of_initial_points_;
     options.maximal_number_of_vertices=maximal_number_of_vertices_;
     options.pointer_to_error_code=pointer_to_error_code_;
+    options.pointer_to_stop_atomic_boolean=pointer_to_stop_atomic_boolean_;
 
     return options;
   }
@@ -538,7 +542,8 @@ void refine_mesh_3_impl(C3T3& c3t3,
   // Build mesher and launch refinement process
   Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology,
                  mesh_options.maximal_number_of_vertices,
-                 mesh_options.pointer_to_error_code);
+                 mesh_options.pointer_to_error_code,
+                 mesh_options.pointer_to_stop_atomic_boolean);
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -203,6 +203,11 @@ namespace parameters {
 
     // Various Mesh_3 option
     struct Mesh_3_options {
+#ifndef CGAL_NO_ATOMIC
+      typedef CGAL::cpp11::atomic<bool>* Pointer_to_stop_atomic_boolean_t;
+#else
+      typedef bool* Pointer_to_stop_atomic_boolean_t;
+#endif
       Mesh_3_options() 
         : dump_after_init_prefix()
         , dump_after_refine_surface_prefix()
@@ -230,7 +235,7 @@ namespace parameters {
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
 #ifndef CGAL_NO_ATOMIC
-      CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
+      Pointer_to_stop_atomic_boolean_t pointer_to_stop_atomic_boolean;
 #endif
     }; // end struct Mesh_3_options
 
@@ -375,9 +380,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
-#ifndef CGAL_NO_ATOMIC
-                            (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
-#endif
+                            (pointer_to_stop_atomic_boolean_, (internal::Mesh_3_options::Pointer_to_stop_atomic_boolean_t), ((internal::Mesh_3_options::Pointer_to_stop_atomic_boolean_t)0))
                             )
                            )
   { 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -214,7 +214,9 @@ namespace parameters {
         , nonlinear_growth_of_balls(false)
         , maximal_number_of_vertices(0)
         , pointer_to_error_code(0)
+#ifndef CGAL_NO_ATOMIC
         , pointer_to_stop_atomic_boolean(0)
+#endif
       {}
 
       std::string dump_after_init_prefix;
@@ -227,7 +229,9 @@ namespace parameters {
       bool nonlinear_growth_of_balls;
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
+#ifndef CGAL_NO_ATOMIC
       CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
+#endif
     }; // end struct Mesh_3_options
 
   } // end namespace internal
@@ -371,7 +375,9 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
+#ifndef CGAL_NO_ATOMIC
                             (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
+#endif
                             )
                            )
   { 
@@ -386,7 +392,9 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
     options.number_of_initial_points=number_of_initial_points_;
     options.maximal_number_of_vertices=maximal_number_of_vertices_;
     options.pointer_to_error_code=pointer_to_error_code_;
+#ifndef CGAL_NO_ATOMIC
     options.pointer_to_stop_atomic_boolean=pointer_to_stop_atomic_boolean_;
+#endif
 
     return options;
   }
@@ -542,8 +550,11 @@ void refine_mesh_3_impl(C3T3& c3t3,
   // Build mesher and launch refinement process
   Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology,
                  mesh_options.maximal_number_of_vertices,
-                 mesh_options.pointer_to_error_code,
-                 mesh_options.pointer_to_stop_atomic_boolean);
+                 mesh_options.pointer_to_error_code
+#ifndef CGAL_NO_ATOMIC
+                 , mesh_options.pointer_to_stop_atomic_boolean
+#endif
+		 );
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -138,7 +138,7 @@ private:
   C3t3& c3t3_;
   Domain* domain_;
   Mesh_parameters p_;
-  bool continue_;
+  std::atomic<bool> stop_;
   Mesher* mesher_;
 #ifdef CGAL_MESH_3_MESHER_STATUS_ACTIVATED
   mutable typename Mesher::Mesher_status last_report_;
@@ -177,7 +177,7 @@ Mesh_function(C3t3& c3t3, Domain* domain, const Mesh_parameters& p)
 : c3t3_(c3t3)
 , domain_(domain)
 , p_(p)
-, continue_(true)
+, stop_()
 , mesher_(NULL)
 #ifdef CGAL_MESH_3_MESHER_STATUS_ACTIVATED
 , last_report_(0,0,0)
@@ -330,7 +330,10 @@ launch()
 
   // Build mesher and launch refinement process
   mesher_ = new Mesher(c3t3_, *domain_, criteria,
-                       topology(p_.manifold) & CGAL::MANIFOLD);
+                       topology(p_.manifold) & CGAL::MANIFOLD,
+                       0,
+                       0,
+                       &stop_);
 
 #ifdef CGAL_MESH_3_PROFILING
   CGAL::Real_timer t;
@@ -339,7 +342,7 @@ launch()
 
 #if CGAL_MESH_3_MESHER_STATUS_ACTIVATED
   mesher_->initialize();
-  while ( ! mesher_->is_algorithm_done() && continue_ )
+  while ( ! mesher_->is_algorithm_done() && ! stop_ )
   {
     mesher_->one_step();
   }
@@ -376,7 +379,7 @@ void
 Mesh_function<D_,Tag>::
 stop()
 {
-  continue_ = false;
+  stop_.store(true, std::memory_order_release);
 }
 
 

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -709,6 +709,7 @@ private:
 template < class T, class Allocator >
 void Concurrent_compact_container<T, Allocator>::merge(Self &d)
 {
+  m_size += d.m_size;
   CGAL_precondition(&d != this);
 
   // Allocators must be "compatible" :

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -36,6 +36,7 @@
 #include <CGAL/memory.h>
 #include <CGAL/iterator.h>
 #include <CGAL/CC_safe_handle.h>
+#include <CGAL/atomic.h>
 
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/queuing_mutex.h>
@@ -256,6 +257,11 @@ public:
   {
     std::swap(m_alloc, c.m_alloc);
     std::swap(m_capacity, c.m_capacity);
+    { // non-atomic swap
+      size_type other_size = c.m_size;
+      c.m_size = size_type(m_size);
+      m_size = other_size;
+    }
     std::swap(m_block_size, c.m_block_size);
     std::swap(m_first_item, c.m_first_item);
     std::swap(m_last_item, c.m_last_item);
@@ -446,6 +452,7 @@ private:
 #ifndef CGAL_NO_ASSERTIONS
     std::memset(&*x, 0, sizeof(T));
 #endif*/
+    --m_size;
     put_on_free_list(&*x, fl);
   }
 public:
@@ -466,9 +473,11 @@ public:
   // The complexity is O(size(free list = capacity-size)).
   void merge(Self &d);
 
-  // Do not call this function while others are inserting/erasing elements
+  // If `CGAL_NO_ATOMIC` is defined, do not call this function while others
+  // are inserting/erasing elements
   size_type size() const
   {
+#ifdef CGAL_NO_ATOMIC
     size_type size = m_capacity;
     for( typename Free_lists::iterator it_free_list = m_free_lists.begin() ;
          it_free_list != m_free_lists.end() ;
@@ -477,6 +486,9 @@ public:
       size -= it_free_list->size();
     }
     return size;
+#else // atomic can be used
+    return m_size;
+#endif
   }
 
   size_type max_size() const
@@ -588,6 +600,7 @@ private:
   {
     CGAL_assertion(type(ret) == USED);
     fl->dec_size();
+    ++m_size;
     return iterator(ret, 0);
   }
 
@@ -675,6 +688,7 @@ private:
     m_first_item = NULL;
     m_last_item  = NULL;
     m_all_items  = All_items();
+    m_size = 0;
   }
 
   allocator_type    m_alloc;
@@ -685,6 +699,11 @@ private:
   pointer           m_last_item;
   All_items         m_all_items;
   mutable Mutex     m_mutex;
+#ifdef CGAL_NO_ATOMIC
+  size_type         m_size;
+#else
+  CGAL::cpp11::atomic<size_type> m_size;
+#endif
 };
 
 template < class T, class Allocator >

--- a/STL_Extension/include/CGAL/thread.h
+++ b/STL_Extension/include/CGAL/thread.h
@@ -55,9 +55,10 @@
 
 #if !CGAL_USE_TBB_THREADS
 #  include <thread>
-#  include <atomic>
 #  include <chrono>
 #endif
+
+#include <CGAL/atomic.h> // for CGAL::cpp11::atomic
 
 namespace CGAL {
 
@@ -66,7 +67,6 @@ namespace cpp11 {
 #if CGAL_USE_TBB_THREADS
   
   using std::thread; // std::thread is declared by TBB if TBB_IMPLEMENT_CPP0X == 1
-  using tbb::atomic;
 
   inline void sleep_for (double seconds)
   {
@@ -75,10 +75,9 @@ namespace cpp11 {
     std::this_thread::sleep_for(tbb::tick_count::interval_t(seconds));
   }
   
-#else
+#else // C++11 implementation
 
   using std::thread;
-  using std::atomic;
 
   inline void sleep_for (double seconds)
   {
@@ -89,6 +88,12 @@ namespace cpp11 {
     std::this_thread::sleep_for(ns);
   }
 
+#endif
+
+#if defined(CGAL_NO_ATOMIC) && defined(CGAL_LINKED_WITH_TBB)
+  // If <CGAL/atomic.h> did not defined CGAL::cpp11::atomic, then use
+  // tbb::atomic as a fallback.
+  using tbb::atomic;
 #endif
 
 } // cpp11


### PR DESCRIPTION
## Summary of Changes

A user using the `Sequential_tag` version of Mesh_3 was able to use 
```C++
while(!mesher.algorithm_done())
  mesher.one_step()
```
and then add extra logic to control the loop and allow the stop of the algorithm before its end. With `Parallel_tag` that was not possible. This PR adds the possibility via a (yet) undocumented feature.

## Release Management

* Affected package(s): Mesh_3

