### PR TITLE
Mesh 3 fix: add the possibility to stop the algorithm, when Parallel_tag is used (for CGAL-4.12-branch)

### DIFF
--- a/BGL/include/CGAL/boost/parameter.h
+++ b/BGL/include/CGAL/boost/parameter.h
@@ -113,6 +113,7 @@ BOOST_PARAMETER_NAME( (dump_after_exude_prefix, tag ) dump_after_exude_prefix_)
 BOOST_PARAMETER_NAME( (number_of_initial_points, tag) number_of_initial_points_)
 BOOST_PARAMETER_NAME( (maximal_number_of_vertices, tag ) maximal_number_of_vertices_)
 BOOST_PARAMETER_NAME( (pointer_to_error_code, tag ) pointer_to_error_code_)
+BOOST_PARAMETER_NAME( (pointer_to_stop_atomic_boolean, tag ) pointer_to_stop_atomic_boolean_)
 
 CGAL_PRAGMA_DIAG_POP
 } // parameters

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -406,6 +406,7 @@ refine_mesh(std::string dump_after_refine_surface_prefix)
   r_c3t3_.clear_cells_and_facets_from_c3t3();
 
   const Triangulation& r_tr = r_c3t3_.triangulation();
+  CGAL_USE(r_tr);
 
 #ifndef CGAL_MESH_3_VERBOSE
   // Scan surface and refine it

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -86,8 +86,8 @@ protected:
 
   Mesher_3_base(const Bbox_3 &, int) {}
 
-  Lock_data_structure *get_lock_data_structure() { return 0; }
-  WorksharingDataStructureType *get_worksharing_data_structure() { return 0; }
+  Lock_data_structure *get_lock_data_structure() const { return 0; }
+  WorksharingDataStructureType *get_worksharing_data_structure() const { return 0; }
   void set_bbox(const Bbox_3 &) {}
 };
 
@@ -109,6 +109,10 @@ protected:
     return &m_lock_ds;
   }
   WorksharingDataStructureType *get_worksharing_data_structure()
+  {
+    return &m_worksharing_ds;
+  }
+  const WorksharingDataStructureType *get_worksharing_data_structure() const
   {
     return &m_worksharing_ds;
   }
@@ -784,9 +788,21 @@ typename Mesher_3<C3T3,MC,MD>::Mesher_status
 Mesher_3<C3T3,MC,MD>::
 status() const
 {
-  return Mesher_status(r_c3t3_.triangulation().number_of_vertices(),
-                       facets_mesher_.queue_size(),
-                       cells_mesher_.queue_size());
+#ifdef CGAL_LINKED_WITH_TBB
+  if(boost::is_convertible<Concurrency_tag, Parallel_tag>::value) {
+    const WorksharingDataStructureType* ws_ds =
+      this->get_worksharing_data_structure();
+    return Mesher_status(r_c3t3_.triangulation().number_of_vertices(),
+                         0,
+                         ws_ds->approximate_number_of_enqueued_element());
+  }
+  else
+#endif // with TBB
+  {
+    return Mesher_status(r_c3t3_.triangulation().number_of_vertices(),
+                         facets_mesher_.queue_size(),
+                         cells_mesher_.queue_size());
+  }
 }
 #endif
 

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -33,6 +33,7 @@
 #ifdef CGAL_LINKED_WITH_TBB
   #include <tbb/tbb.h>
 #endif
+#include <CGAL/atomic.h>
 
 #include <CGAL/Meshes/Filtered_deque_container.h>
 #include <CGAL/Meshes/Filtered_multimap_container.h>
@@ -352,7 +353,11 @@ public:
                  const MeshDomain& oracle,
                  Previous_& previous,
                  C3T3& c3t3,
-                 std::size_t maximal_number_of_vertices);
+                 std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                );
   // For parallel
   Refine_cells_3(Tr& triangulation,
                  const Criteria& criteria,
@@ -361,7 +366,11 @@ public:
                  C3T3& c3t3,
                  Lock_data_structure *lock_ds,
                  WorksharingDataStructureType *worksharing_ds,
-                 std::size_t maximal_number_of_vertices);
+                 std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+                , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+                );
 
   // Destructor
   virtual ~Refine_cells_3() { }
@@ -397,6 +406,13 @@ public:
   // Tells if the refinement process of cells is currently finished
   bool no_longer_element_to_refine_impl()
   {
+#ifndef CGAL_NO_ATOMIC
+    if(m_stop_ptr != 0 &&
+       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+    {
+      return true;
+    }
+#endif
     if(m_maximal_number_of_vertices_ !=0 &&
        triangulation_ref_impl().number_of_vertices() >=
        m_maximal_number_of_vertices_)
@@ -590,6 +606,10 @@ private:
   /// Maximal allowed number of vertices
   std::size_t m_maximal_number_of_vertices_;
 
+#ifndef CGAL_NO_ATOMIC
+  /// Pointer to the atomic Boolean that can stop the process
+  CGAL::cpp11::atomic<bool>* const m_stop_ptr;
+#endif
 private:
   // Disabled copy constructor
   Refine_cells_3(const Self& src);
@@ -608,7 +628,11 @@ Refine_cells_3(Tr& triangulation,
                const MD& oracle,
                P_& previous,
                C3T3& c3t3,
-               std::size_t maximal_number_of_vertices)
+               std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+               , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+               )
   : Mesher_level<Tr, Self, Cell_handle, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct >(previous)
   , C_()
@@ -620,6 +644,9 @@ Refine_cells_3(Tr& triangulation,
   , r_oracle_(oracle)
   , r_c3t3_(c3t3)
   , m_maximal_number_of_vertices_(maximal_number_of_vertices)
+#ifndef CGAL_NO_ATOMIC
+  , m_stop_ptr(stop_ptr)
+#endif
 {
 }
 
@@ -634,7 +661,11 @@ Refine_cells_3(Tr& triangulation,
                C3T3& c3t3,
                Lock_data_structure *lock_ds,
                WorksharingDataStructureType *worksharing_ds,
-               std::size_t maximal_number_of_vertices)
+               std::size_t maximal_number_of_vertices
+#ifndef CGAL_NO_ATOMIC
+               , CGAL::cpp11::atomic<bool>* stop_ptr
+#endif
+               )
   : Mesher_level<Tr, Self, Cell_handle, P_,
       Triangulation_mesher_level_traits_3<Tr>, Ct >(previous, lock_ds, worksharing_ds)
   , C_()
@@ -646,6 +677,9 @@ Refine_cells_3(Tr& triangulation,
   , r_oracle_(oracle)
   , r_c3t3_(c3t3)
   , m_maximal_number_of_vertices_(maximal_number_of_vertices)
+#ifndef CGAL_NO_ATOMIC
+  , m_stop_ptr(stop_ptr)
+#endif
 {
 }
 

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -723,9 +723,9 @@ public:
   Auto_worksharing_ds(const Bbox_3 &bbox)
     : NUM_WORK_ITEMS_PER_BATCH(
         Concurrent_mesher_config::get().num_work_items_per_batch)
-    , m_cache_number_of_tasks(0)
   {
     set_bbox(bbox);
+    m_cache_number_of_tasks = 0;
   }
 
   /// Destructor

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -37,6 +37,7 @@
 #include <tbb/concurrent_vector.h>
 #include <tbb/scalable_allocator.h>
 
+#include <tbb/atomic.h>
 
 #include <vector>
 
@@ -722,6 +723,7 @@ public:
   Auto_worksharing_ds(const Bbox_3 &bbox)
     : NUM_WORK_ITEMS_PER_BATCH(
         Concurrent_mesher_config::get().num_work_items_per_batch)
+    , m_cache_number_of_tasks(0)
   {
     set_bbox(bbox);
   }
@@ -750,6 +752,7 @@ public:
       add_batch_and_enqueue_task(workbuffer, parent_task);
       workbuffer.clear();
     }
+    m_cache_number_of_tasks = parent_task.ref_count();
   }
 
   template <typename Func, typename Quality>
@@ -766,6 +769,7 @@ public:
       add_batch_and_enqueue_task(workbuffer, parent_task);
       workbuffer.clear();
     }
+    m_cache_number_of_tasks = parent_task.ref_count();
   }
 
   // Returns true if some items were flushed
@@ -793,7 +797,12 @@ public:
       enqueue_task(*it, parent_task);
     }
 
+    m_cache_number_of_tasks = parent_task.ref_count();
     return (num_flushed_items > 0);
+  }
+
+  int approximate_number_of_enqueued_element() const {
+    return int(m_cache_number_of_tasks) * NUM_WORK_ITEMS_PER_BATCH;
   }
 
 protected:
@@ -820,6 +829,7 @@ protected:
   }
 
   const size_t                      NUM_WORK_ITEMS_PER_BATCH;
+  tbb::atomic<int>                  m_cache_number_of_tasks;
   TLS_WorkBuffer                    m_tls_work_buffers;
 };
 

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -802,7 +802,7 @@ public:
   }
 
   int approximate_number_of_enqueued_element() const {
-    return int(m_cache_number_of_tasks) * NUM_WORK_ITEMS_PER_BATCH;
+    return int(m_cache_number_of_tasks) * int(NUM_WORK_ITEMS_PER_BATCH);
   }
 
 protected:

--- a/Mesh_3/include/CGAL/Mesh_error_code.h
+++ b/Mesh_3/include/CGAL/Mesh_error_code.h
@@ -30,7 +30,8 @@ namespace CGAL {
 
 enum Mesh_error_code {
   CGAL_MESH_3_NO_ERROR = 0,
-  CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED
+  CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED,
+  CGAL_MESH_3_STOPPED
 };
 
 inline
@@ -40,6 +41,8 @@ std::string mesh_error_string(const Mesh_error_code& error_code) {
     return "no error";
   case CGAL_MESH_3_MAXIMAL_NUMBER_OF_VERTICES_REACHED:
     return "the maximal number of vertices has been reached";
+  case CGAL_MESH_3_STOPPED:
+    return "the meshing process was stopped";
   default:
     std::stringstream str("");
     str << "unknown error (error_code="

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -37,6 +37,7 @@
 #include <CGAL/Mesh_3/Mesher_3.h>
 #include <CGAL/Mesh_error_code.h>
 #include <CGAL/optimize_mesh_3.h>
+#include <CGAL/atomic.h>
 
 namespace CGAL {
 
@@ -212,6 +213,7 @@ namespace parameters {
         , nonlinear_growth_of_balls(false)
         , maximal_number_of_vertices(0)
         , pointer_to_error_code(0)
+        , pointer_to_stop_atomic_boolean(0)
       {}
 
       std::string dump_after_init_prefix;
@@ -224,7 +226,7 @@ namespace parameters {
       bool nonlinear_growth_of_balls;
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
-
+      CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
     }; // end struct Mesh_3_options
 
   } // end namespace internal
@@ -368,6 +370,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
+                            (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
                             )
                            )
   { 
@@ -382,6 +385,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
     options.number_of_initial_points=number_of_initial_points_;
     options.maximal_number_of_vertices=maximal_number_of_vertices_;
     options.pointer_to_error_code=pointer_to_error_code_;
+    options.pointer_to_stop_atomic_boolean=pointer_to_stop_atomic_boolean_;
 
     return options;
   }
@@ -537,7 +541,8 @@ void refine_mesh_3_impl(C3T3& c3t3,
   // Build mesher and launch refinement process
   Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology,
                  mesh_options.maximal_number_of_vertices,
-                 mesh_options.pointer_to_error_code);
+                 mesh_options.pointer_to_error_code,
+                 mesh_options.pointer_to_stop_atomic_boolean);
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -213,7 +213,9 @@ namespace parameters {
         , nonlinear_growth_of_balls(false)
         , maximal_number_of_vertices(0)
         , pointer_to_error_code(0)
+#ifndef CGAL_NO_ATOMIC
         , pointer_to_stop_atomic_boolean(0)
+#endif
       {}
 
       std::string dump_after_init_prefix;
@@ -226,7 +228,9 @@ namespace parameters {
       bool nonlinear_growth_of_balls;
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
+#ifndef CGAL_NO_ATOMIC
       CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
+#endif
     }; // end struct Mesh_3_options
 
   } // end namespace internal
@@ -370,7 +374,9 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
+#ifndef CGAL_NO_ATOMIC
                             (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
+#endif
                             )
                            )
   { 
@@ -385,7 +391,9 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
     options.number_of_initial_points=number_of_initial_points_;
     options.maximal_number_of_vertices=maximal_number_of_vertices_;
     options.pointer_to_error_code=pointer_to_error_code_;
+#ifndef CGAL_NO_ATOMIC
     options.pointer_to_stop_atomic_boolean=pointer_to_stop_atomic_boolean_;
+#endif
 
     return options;
   }
@@ -541,8 +549,11 @@ void refine_mesh_3_impl(C3T3& c3t3,
   // Build mesher and launch refinement process
   Mesher mesher (c3t3, domain, criteria, manifold_options.mesh_topology,
                  mesh_options.maximal_number_of_vertices,
-                 mesh_options.pointer_to_error_code,
-                 mesh_options.pointer_to_stop_atomic_boolean);
+                 mesh_options.pointer_to_error_code
+#ifndef CGAL_NO_ATOMIC
+                 , mesh_options.pointer_to_stop_atomic_boolean
+#endif
+		 );
   double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
   c3t3.clear_manifold_info();
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -202,6 +202,11 @@ namespace parameters {
 
     // Various Mesh_3 option
     struct Mesh_3_options {
+#ifndef CGAL_NO_ATOMIC
+      typedef CGAL::cpp11::atomic<bool>* Pointer_to_stop_atomic_boolean_t;
+#else
+      typedef bool* Pointer_to_stop_atomic_boolean_t;
+#endif
       Mesh_3_options() 
         : dump_after_init_prefix()
         , dump_after_refine_surface_prefix()
@@ -229,7 +234,7 @@ namespace parameters {
       std::size_t maximal_number_of_vertices;
       Mesh_error_code* pointer_to_error_code;
 #ifndef CGAL_NO_ATOMIC
-      CGAL::cpp11::atomic<bool>* pointer_to_stop_atomic_boolean;
+      Pointer_to_stop_atomic_boolean_t pointer_to_stop_atomic_boolean;
 #endif
     }; // end struct Mesh_3_options
 
@@ -374,9 +379,7 @@ CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
                             (number_of_initial_points_, (int), -1)
                             (maximal_number_of_vertices_, (std::size_t), 0)
                             (pointer_to_error_code_, (Mesh_error_code*), ((Mesh_error_code*)0))
-#ifndef CGAL_NO_ATOMIC
-                            (pointer_to_stop_atomic_boolean_, (CGAL::cpp11::atomic<bool>*), ((CGAL::cpp11::atomic<bool>*)0))
-#endif
+                            (pointer_to_stop_atomic_boolean_, (internal::Mesh_3_options::Pointer_to_stop_atomic_boolean_t), ((internal::Mesh_3_options::Pointer_to_stop_atomic_boolean_t)0))
                             )
                            )
   { 

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -36,6 +36,7 @@
 #include <CGAL/memory.h>
 #include <CGAL/iterator.h>
 #include <CGAL/CC_safe_handle.h>
+#include <CGAL/atomic.h>
 
 #include <tbb/tbb.h>
 
@@ -255,6 +256,11 @@ public:
   {
     std::swap(m_alloc, c.m_alloc);
     std::swap(m_capacity, c.m_capacity);
+    { // non-atomic swap
+      size_type other_size = c.m_size;
+      c.m_size = size_type(m_size);
+      m_size = other_size;
+    }
     std::swap(m_block_size, c.m_block_size);
     std::swap(m_first_item, c.m_first_item);
     std::swap(m_last_item, c.m_last_item);
@@ -445,6 +451,7 @@ private:
 #ifndef CGAL_NO_ASSERTIONS
     std::memset(&*x, 0, sizeof(T));
 #endif*/
+    --m_size;
     put_on_free_list(&*x, fl);
   }
 public:
@@ -465,9 +472,11 @@ public:
   // The complexity is O(size(free list = capacity-size)).
   void merge(Self &d);
 
-  // Do not call this function while others are inserting/erasing elements
+  // If `CGAL_NO_ATOMIC` is defined, do not call this function while others
+  // are inserting/erasing elements
   size_type size() const
   {
+#ifdef CGAL_NO_ATOMIC
     size_type size = m_capacity;
     for( typename Free_lists::iterator it_free_list = m_free_lists.begin() ;
          it_free_list != m_free_lists.end() ;
@@ -476,6 +485,9 @@ public:
       size -= it_free_list->size();
     }
     return size;
+#else // atomic can be used
+    return m_size;
+#endif
   }
 
   size_type max_size() const
@@ -587,6 +599,7 @@ private:
   {
     CGAL_assertion(type(ret) == USED);
     fl->dec_size();
+    ++m_size;
     return iterator(ret, 0);
   }
 
@@ -674,6 +687,7 @@ private:
     m_first_item = NULL;
     m_last_item  = NULL;
     m_all_items  = All_items();
+    m_size = 0;
   }
 
   allocator_type    m_alloc;
@@ -684,6 +698,11 @@ private:
   pointer           m_last_item;
   All_items         m_all_items;
   mutable Mutex     m_mutex;
+#ifdef CGAL_NO_ATOMIC
+  size_type         m_size;
+#else
+  CGAL::cpp11::atomic<size_type> m_size;
+#endif
 };
 
 template < class T, class Allocator >

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -708,6 +708,7 @@ private:
 template < class T, class Allocator >
 void Concurrent_compact_container<T, Allocator>::merge(Self &d)
 {
+  m_size += d.m_size;
   CGAL_precondition(&d != this);
 
   // Allocators must be "compatible" :


### PR DESCRIPTION
## Summary of Changes

A user using the `Sequential_tag` version of Mesh_3 was able to use 
```C++
while(!mesher.algorithm_done())
  mesher.one_step()
```
and then add extra logic to control the loop and allow the stop of the algorithm before its end. With `Parallel_tag` that was not possible. This PR adds the possibility via a (yet) undocumented feature.

## Release Management

* Affected package(s): Mesh_3


