### PR TITLE
CGAL_imageIO: Fix .inr writing without zlib

### DIFF
--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -194,6 +194,12 @@ size_t ImageIO_write(const _image *im, const void *buf, size_t len) {
       fprintf(stderr, "zlib error: %s\n", gzerror(im->fd, &errnum));
     }
     return ( len - to_be_written );
+  case OM_FILE :
+    while ( (to_be_written > 0) && ((l = gzfwrite( b, sizeof(char), ImageIO_limit_len(to_be_written), im->fd )) > 0) ) {
+      to_be_written -= l;
+      b += l;
+    }
+    return ( len - to_be_written );
 #else
   case OM_FILE :
     while ( (to_be_written > 0) && ((l = fwrite( b, 1, ImageIO_limit_len(to_be_written), im->fd )) > 0) ) {
@@ -243,6 +249,7 @@ size_t ImageIO_read(const _image *im, void *buf, size_t len)
     return ( len - to_be_read );
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+  case OM_FILE :
     while ( (to_be_read > 0) && ((l = gzread(im->fd, (void *) b, ImageIO_limit_len(to_be_read))) > 0) ) {
       to_be_read -= l;
       b += l;
@@ -291,8 +298,10 @@ char *ImageIO_gets( const _image *im, char *str, int size )
     break;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+  case OM_FILE :
     ret = (char *) gzgets(im->fd, str, size);
     break;
+    
 #else
   case OM_FILE :
     ret = fgets(str, size, im->fd);
@@ -312,10 +321,12 @@ long ImageIO_seek( const _image *im, long offset, int whence ) {
     return -1;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ:
+  case OM_FILE:
     return gzseek(im->fd, offset, whence );
-#endif
+#else
   case OM_FILE:
     return fseek( (FILE*)im->fd, offset, whence );
+#endif
   }
 }
 
@@ -330,12 +341,14 @@ int ImageIO_error( const _image *im )
     return 0;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+  case OM_FILE :
     static int errnum;
     (void)gzerror(im->fd, &errnum);
     return( (errnum != Z_OK) || gzeof(im->fd) );
-#endif
+#else
   case OM_FILE :
     return( ferror( (FILE*)im->fd ) || feof( (FILE*)im->fd ) );
+#endif
   }
   //return 0;
 }
@@ -359,15 +372,17 @@ int ImageIO_close( _image* im )
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
   case OM_STD :
+  case OM_FILE :
     ret = gzclose( im->fd );
     break;
 #else 
   case OM_STD :
     break;
-#endif
   case OM_FILE :
     ret = fclose( (FILE*)im->fd );
+#endif
   }
+  
   im->fd = NULL;
   im->openMode = OM_CLOSE;
   
@@ -475,12 +490,18 @@ void _openWriteImage(_image* im, const char *name)
 	im->openMode = OM_GZ;
       }
     else 
-#endif
+    {
+      im->fd = (_ImageIO_file) gzopen(name, "wb");
+      im->openMode = OM_FILE;
+    }
+  }
+#else
     {
       im->fd = (_ImageIO_file) fopen(name, "wb");
       im->openMode = OM_FILE;
     }
   }
+#endif
 }
 
 

--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -63,6 +63,12 @@
 #include <CGAL/ImageIO/mincio.h>
 #endif
 
+
+#ifdef CGAL_USE_ZLIB
+#define ZLIB_MAJOR_VERSION ZLIB_VERNUM>>8
+#define ZLIB_MINOR_VERSION (ZLIB_VERNUM-(ZLIB_MAJOR_VERSION <<8))
+#define CGAL_USE_GZFWRITE  ZLIB_MAJOR_VERSION > 0x12 || ((ZLIB_MAJOR_VERSION == 0x12) && (ZLIB_MINOR_VERSION >= 0x90))
+#endif
 struct Remove_supported_file_format {
   ~Remove_supported_file_format()
   {
@@ -194,12 +200,14 @@ size_t ImageIO_write(const _image *im, const void *buf, size_t len) {
       fprintf(stderr, "zlib error: %s\n", gzerror(im->fd, &errnum));
     }
     return ( len - to_be_written );
+#if CGAL_USE_GZFWRITE
   case OM_FILE :
     while ( (to_be_written > 0) && ((l = gzfwrite( b, sizeof(char), ImageIO_limit_len(to_be_written), im->fd )) > 0) ) {
       to_be_written -= l;
       b += l;
     }
     return ( len - to_be_written );
+#endif // CGAL_USE_GZFWRITE
 #else
   case OM_FILE :
     while ( (to_be_written > 0) && ((l = fwrite( b, 1, ImageIO_limit_len(to_be_written), im->fd )) > 0) ) {
@@ -249,7 +257,9 @@ size_t ImageIO_read(const _image *im, void *buf, size_t len)
     return ( len - to_be_read );
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+#if CGAL_USE_GZFWRITE
   case OM_FILE :
+#endif// CGAL_USE_GZFWRITE
     while ( (to_be_read > 0) && ((l = gzread(im->fd, (void *) b, ImageIO_limit_len(to_be_read))) > 0) ) {
       to_be_read -= l;
       b += l;
@@ -298,7 +308,9 @@ char *ImageIO_gets( const _image *im, char *str, int size )
     break;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+#if CGAL_USE_GZFWRITE
   case OM_FILE :
+#endif // CGAL_USE_GZFWRITE
     ret = (char *) gzgets(im->fd, str, size);
     break;
     
@@ -321,7 +333,9 @@ long ImageIO_seek( const _image *im, long offset, int whence ) {
     return -1;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ:
+#if CGAL_USE_GZFWRITE
   case OM_FILE:
+#endif //CGAL_USE_GZFWRITE
     return gzseek(im->fd, offset, whence );
 #else
   case OM_FILE:
@@ -341,7 +355,9 @@ int ImageIO_error( const _image *im )
     return 0;
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
+#if CGAL_USE_GZFWRITE
   case OM_FILE :
+#endif //CGAL_USE_GZFWRITE
     static int errnum;
     (void)gzerror(im->fd, &errnum);
     return( (errnum != Z_OK) || gzeof(im->fd) );
@@ -372,7 +388,9 @@ int ImageIO_close( _image* im )
 #ifdef CGAL_USE_ZLIB
   case OM_GZ :
   case OM_STD :
+#if CGAL_USE_GZFWRITE
   case OM_FILE :
+#endif//CGAL_USE_GZFWRITE
     ret = gzclose( im->fd );
     break;
 #else 
@@ -489,19 +507,20 @@ void _openWriteImage(_image* im, const char *name)
 #endif
 	im->openMode = OM_GZ;
       }
+#if CGAL_USE_GZFWRITE
     else 
     {
       im->fd = (_ImageIO_file) gzopen(name, "wb");
       im->openMode = OM_FILE;
     }
-  }
+#endif// CGAL_USE_GZFWRITE
 #else
     {
       im->fd = (_ImageIO_file) fopen(name, "wb");
       im->openMode = OM_FILE;
     }
-  }
 #endif
+  }
 }
 
 


### PR DESCRIPTION
## Summary of Changes
When linking with zlib, always use the gz API, as gzFiles are not compatible with fopen(), fread(),etc. 
## Release Management

* Affected package(s):CGAL_imageIO
