### PR TITLE
Polyhedron demo: Fix selection plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Scene_facegraph_item_k_ring_selection.h
@@ -375,6 +375,7 @@ public Q_SLOTS:
       break;
     }
     contour_2d.clear();
+    Q_EMIT endSelection();
     qobject_cast<CGAL::Three::Viewer_interface*>(viewer)->set2DSelectionMode(false);
   }
 


### PR DESCRIPTION
## Summary of Changes
Call filter_operations() after a selection using the lasso so the operations on selection are displayed.
