### PR TITLE
Implement the check that avoids to insert a constraint twice

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -265,7 +265,7 @@ public:
   {
     // protects against inserting a zero length constraint
     if(va == vb){
-    return Constraint_id(NULL);
+      return Constraint_id(NULL);
     }
     // protects against inserting twice the same constraint
     Constraint_id cid = hierarchy.insert_constraint(va, vb);

--- a/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
@@ -191,9 +191,10 @@ private:
   Compare          comp;
   Constraint_set   constraint_set;
   Sc_to_c_map      sc_to_c_map;
-  std::map<std::pair<Vertex_handle, Vertex_handle>,
-	   Constraint_id,
-	   Pair_compare> constraint_map;
+  typedef std::map<std::pair<Vertex_handle, Vertex_handle>,
+		   Constraint_id,
+		   Pair_compare> Constraint_map;
+  Constraint_map constraint_map;
   
 public:
   Polyline_constraint_hierarchy_2(const Compare& comp)
@@ -866,6 +867,14 @@ typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_list*
 Polyline_constraint_hierarchy_2<T,Compare,Data>::
 insert_constraint(T va, T vb){
   Edge        he = make_edge(va, vb);
+
+  // First, check if the constraint was already inserted.
+  // If it was not, then the iterator to the lower bound will serve as
+  // the hint of the insertion.
+  typename Constraint_map::iterator c_map_it = constraint_map.lower_bound(he);
+  if(c_map_it != constraint_map.end() && he == c_map_it->first)
+    return 0;
+
   Vertex_list*  children = new Vertex_list; 
   Context_list* fathers;
 
@@ -885,7 +894,8 @@ insert_constraint(T va, T vb){
   ctxt.pos     = children->skip_begin();
   fathers->push_front(ctxt);
 
-  constraint_map[he] = children;
+  constraint_map.insert(c_map_it,
+			typename Constraint_map::value_type(he, children));
   return children;
 }
 


### PR DESCRIPTION
## Summary of Changes

Since CGAL-4.6, the check that avoids inserting a constrain twice was no longer effective. This PR reintroduces the implementation of the check.

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #3267 
