### PR TITLE
Ship the lib/ sub-directory with the Windows installer

### DIFF
--- a/wininst/developer_scripts/script_cgal.nsi
+++ b/wininst/developer_scripts/script_cgal.nsi
@@ -153,6 +153,8 @@ Section "!Main CGAL" MAIN_Idx
   File /r "${CGAL_SRC}\doc_html\*.*"
   SetOutPath "$INSTDIR\include"
   File /r "${CGAL_SRC}\include\*.*"
+  SetOutPath "$INSTDIR\lib"
+  File /r "${CGAL_SRC}\lib\*.*"
   SetOutPath "$INSTDIR\scripts"
   File /r "${CGAL_SRC}\scripts\*.*"
   SetOutPath "$INSTDIR\src"


### PR DESCRIPTION

## Summary of Changes

Ship the lib/ sub-directory with the Windows installer, because it contains `lib/cmake/CGAL/CGALConfig.cmake`.

## Release Management

* Affected package(s): Windows installer
* Issue(s) solved (if any): fix #3219
