### PR TITLE
Classification Plugin Bugfix: do not compute simple properties in parallel

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.cpp
@@ -568,12 +568,12 @@ void Cluster_classification::compute_features (std::size_t nb_scales)
   if (echo)
     generator.generate_echo_based_features (pointwise_features, echo_map);
   
-  add_remaining_point_set_properties_as_features(pointwise_features);
-
 #ifdef CGAL_LINKED_WITH_TBB
   pointwise_features.end_parallel_additions();
 #endif
   
+  add_remaining_point_set_properties_as_features(pointwise_features);
+
   t.stop();
   std::cerr << pointwise_features.size() << " feature(s) computed in " << t.time() << " second(s)" << std::endl;
   t.reset();

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.cpp
@@ -467,11 +467,11 @@ void Point_set_item_classification::compute_features (std::size_t nb_scales)
   if (echo)
     m_generator->generate_echo_based_features (m_features, echo_map);
   
-  add_remaining_point_set_properties_as_features();
-
 #ifdef CGAL_LINKED_WITH_TBB
   m_features.end_parallel_additions();
 #endif
+
+  add_remaining_point_set_properties_as_features();
 
   delete m_sowf;
   m_sowf = new Sum_of_weighted_features (m_labels, m_features);


### PR DESCRIPTION
## Summary of Changes

Simple features (based on point set properties, without any computation) were computed in parallel. The problem is that it resulted in temporary references being passed to threads, which lead to segfaults later.

As these features do not require any computation, it's anyway useless to include them in the parallel processing, so I just move them out of the parallel part.

(This bug is not in `4.12`.)

## Release Management

* Affected package(s): Polyhedron demo