### PR TITLE
Polyhedron demo: Fix statistics for facegraph items

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_item.cpp
@@ -1797,8 +1797,8 @@ CGAL::Three::Scene_item::Header_data Scene_polyhedron_item::header() const
 
   data.categories.append(std::pair<QString,int>(QString("Properties"),9));
   data.categories.append(std::pair<QString,int>(QString("Faces"),10));
-  data.categories.append(std::pair<QString,int>(QString("Edges"),6));
-  data.categories.append(std::pair<QString,int>(QString("Angles"),3));
+  data.categories.append(std::pair<QString,int>(QString("Edges"),7));
+  data.categories.append(std::pair<QString,int>(QString("Angles"),2));
 
 
   //titles

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1657,8 +1657,8 @@ CGAL::Three::Scene_item::Header_data Scene_surface_mesh_item::header() const
 
   data.categories.append(std::pair<QString,int>(QString("Properties"),9));
   data.categories.append(std::pair<QString,int>(QString("Faces"),10));
-  data.categories.append(std::pair<QString,int>(QString("Edges"),6));
-  data.categories.append(std::pair<QString,int>(QString("Angles"),3));
+  data.categories.append(std::pair<QString,int>(QString("Edges"),7));
+  data.categories.append(std::pair<QString,int>(QString("Angles"),2));
 
 
   //titles


### PR DESCRIPTION
## Summary of Changes

Fix headers fot statistics in polyhedorn and surface_mesh items so the Null Length is not in the Angles part anymore.
