### PR TITLE
Fix PMP user manual

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -468,7 +468,7 @@ with duplicated border edges.
 \cgalExample{Polygon_mesh_processing/stitch_borders_example.cpp}
 
 *******************
-\cond
+\if READY_TO_PUBLISH
 \subsection DegenerateFaces Removing Degenerate Faces
 
 Some degenerate faces may be part of a given triangle mesh.
@@ -488,8 +488,7 @@ are removed, the connectivity is fixed, and the number of removed faces
 is output.
 
 \cgalExample{Polygon_mesh_processing/remove_degeneracies_example.cpp}
-\endcond
-
+\endif
 *******************
 \subsection PolygonSoups Polygon Soups
 

--- a/Triangulation/doc/Triangulation/Triangulation.txt
+++ b/Triangulation/doc/Triangulation/Triangulation.txt
@@ -181,7 +181,7 @@ corresponding to a face \f$ f \f$ stores a reference to a full cell `c`
 containing \f$ f \f$, and the indices of the vertices of `c` that belong
 to \f$ f \f$.
 
-\cond
+\if READY_TO_PUBLISH
 \cgalAdvanced The index of a full cell \f$ c\f$ in the \f$ i\f$-th
 neighbor of \f$ c\f$ is called the <I>\f$ i\f$-th mirror-index</I> of
 \f$ c\f$ (Figure \cgalFigureRef{triangulationfigfullcell}).  Mirror indices are
@@ -197,7 +197,7 @@ triangulation. Its second template parameter is used to specify wether
 or not the mirror indices should be kept in memory or computed
 on-the-fly, which is the default case.  Please refer to the
 documentation of that class template for specific details.
-\endcond
+\endif
 
 ###Template Parameters###
 


### PR DESCRIPTION
The end of the user manual was clipped due to the usage of `\cond`. Using `\if` fixed it.

Introduced by #3057