### PR TITLE
Point set processing IO: Several bugfixes

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -418,7 +418,9 @@ public:
       {
         -- m_nb_removed;
         iterator out = m_indices.end() - m_nb_removed - 1;
+        Index idx = *out;
         m_base.reset(*out);
+        *out = idx;
         return out;
       }
   }

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -91,25 +91,44 @@ namespace CGAL {
     PLY_property (const char* name) : name (name) { }
   };
 
+  /// \cond SKIP_IN_MANUAL
+  template <typename PointOrVectorMap>
+  struct GetFTFromMap
+  {
+    typedef typename Kernel_traits<typename boost::property_traits<PointOrVectorMap>::value_type>::Kernel::FT type;
+  };
+  /// \endcond
+  
   /**
      \ingroup PkgPointSetProcessingIOPly
      
      Generates a %PLY property handler to read 3D points. Points are
-     constructed from the input using 3 %PLY properties of type
-     `double` and named `x`, `y` and `z`.
+     constructed from the input using 3 %PLY properties of type `FT`
+     and named `x`, `y` and `z`. `FT` is `float` if the points use
+     `CGAL::Simple_cartesian<float>` and `double` otherwise.
 
      \sa `read_ply_points_with_properties()`
 
      \tparam PointMap the property map used to store points.
   */
   template <typename PointMap>
+#ifdef DOXYGEN_RUNNING
   std::tuple<PointMap,
              typename Kernel_traits<typename PointMap::value_type>::Kernel::Construct_point_3,
-             PLY_property<double>, PLY_property<double>, PLY_property<double> >
+             PLY_property<FT>, PLY_property<FT>, PLY_property<FT> >
+#else
+  std::tuple<PointMap,
+             typename Kernel_traits<typename PointMap::value_type>::Kernel::Construct_point_3,
+             PLY_property<typename GetFTFromMap<PointMap>::type>,
+             PLY_property<typename GetFTFromMap<PointMap>::type>,
+             PLY_property<typename GetFTFromMap<PointMap>::type> >
+#endif
    make_ply_point_reader(PointMap point_map)
   {
     return std::make_tuple (point_map, typename Kernel_traits<typename PointMap::value_type>::Kernel::Construct_point_3(),
-                            PLY_property<double>("x"), PLY_property<double>("y"), PLY_property<double>("z"));
+                            PLY_property<typename GetFTFromMap<PointMap>::type>("x"),
+                            PLY_property<typename GetFTFromMap<PointMap>::type>("y"),
+                            PLY_property<typename GetFTFromMap<PointMap>::type>("z"));
   }
 
   /**
@@ -117,20 +136,32 @@ namespace CGAL {
      
      Generates a %PLY property handler to read 3D normal
      vectors. Vectors are constructed from the input using 3 PLY
-     properties of type `double` and named `nx`, `ny` and `nz`.
+     properties of type `FT` and named `nx`, `ny` and `nz`. `FT`
+     is `float` if the points use `CGAL::Simple_cartesian<float>` and
+     `double` otherwise.
 
      \sa `read_ply_points_with_properties()`
 
      \tparam VectorMap the property map used to store vectors.
   */
   template <typename VectorMap>
+#ifdef DOXYGEN_RUNNING
   std::tuple<VectorMap,
              typename Kernel_traits<typename VectorMap::value_type>::Kernel::Construct_vector_3,
-             PLY_property<double>, PLY_property<double>, PLY_property<double> >
+             PLY_property<FT>, PLY_property<FT>, PLY_property<FT> >
+#else
+  std::tuple<VectorMap,
+             typename Kernel_traits<typename VectorMap::value_type>::Kernel::Construct_vector_3,
+             PLY_property<typename GetFTFromMap<VectorMap>::type>,
+             PLY_property<typename GetFTFromMap<VectorMap>::type>,
+             PLY_property<typename GetFTFromMap<VectorMap>::type> >
+#endif
   make_ply_normal_reader(VectorMap normal_map)
   {
     return std::make_tuple (normal_map, typename Kernel_traits<typename VectorMap::value_type>::Kernel::Construct_vector_3(),
-                            PLY_property<double>("nx"), PLY_property<double>("ny"), PLY_property<double>("nz"));
+                            PLY_property<typename GetFTFromMap<VectorMap>::type>("nx"),
+                            PLY_property<typename GetFTFromMap<VectorMap>::type>("ny"),
+                            PLY_property<typename GetFTFromMap<VectorMap>::type>("nz"));
   }
 
   /// \cond SKIP_IN_MANUAL
@@ -157,13 +188,19 @@ namespace internal {
     // The two following functions prevent the stream to only extract
     // ONE character (= what the types char imply) by requiring
     // explicitely an integer object when reading the stream
-    void read_ascii (std::istream& stream, boost::int8_t& c) const
+    void read_ascii (std::istream& stream, char& c) const
     {
       short s;
       stream >> s;
       c = static_cast<char>(s);
     }
-    void read_ascii (std::istream& stream, boost::uint8_t& c) const
+    void read_ascii (std::istream& stream, signed char& c) const
+    {
+      short s;
+      stream >> s;
+      c = static_cast<signed char>(s);
+    }
+    void read_ascii (std::istream& stream, unsigned char& c) const
     {
       unsigned short s;
       stream >> s;

--- a/Point_set_processing_3/include/CGAL/IO/write_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_las_points.h
@@ -92,41 +92,41 @@ namespace internal {
 
   namespace LAS {
 
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::Intensity&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::Intensity&)
   { r.set_intensity(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Return_number&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Return_number&)
   { r.set_return_number(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Number_of_returns&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Number_of_returns&)
   { r.set_number_of_returns(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Scan_direction_flag&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Scan_direction_flag&)
   { r.set_scan_direction_flag(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Edge_of_flight_line&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Edge_of_flight_line&)
   { r.set_edge_of_flight_line(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Classification&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Classification&)
   { r.set_classification(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Synthetic_flag&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Synthetic_flag&)
   { r.set_synthetic_flag(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Keypoint_flag&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Keypoint_flag&)
   { r.set_keypoint_flag(v); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::Withheld_flag&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Withheld_flag&)
   { r.set_withheld_flag(v); }
-  void output_value(LASpoint& r, float& v, LAS_property::Scan_angle&)
+  void output_value(LASpoint& r, const float& v, LAS_property::Scan_angle&)
   { r.set_scan_angle_rank(char(v)); }
-  void output_value(LASpoint& r, unsigned char& v, LAS_property::User_data&)
+  void output_value(LASpoint& r, const unsigned char& v, LAS_property::User_data&)
   { r.set_user_data(v); }
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::Point_source_ID&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::Point_source_ID&)
   { r.set_point_source_ID(v); }
-  void output_value(LASpoint& r, unsigned int& v, LAS_property::Deleted_flag&)
+  void output_value(LASpoint& r, const unsigned int& v, LAS_property::Deleted_flag&)
   { r.set_deleted_flag(v); }
-  void output_value(LASpoint& r, double& v, LAS_property::GPS_time&)
+  void output_value(LASpoint& r, const double& v, LAS_property::GPS_time&)
   { r.set_gps_time(v); }
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::R&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::R&)
   { r.set_R(v); }
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::G&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::G&)
   { r.set_G(v); }
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::B&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::B&)
   { r.set_B(v); }
-  void output_value(LASpoint& r, unsigned short& v, LAS_property::I&)
+  void output_value(LASpoint& r, const unsigned short& v, LAS_property::I&)
   { r.set_I(v); }
   
   template <typename ForwardIterator>


### PR DESCRIPTION
## Summary of Changes

This PR fixes several bugs/badly done things:
 - The constness of LAS output functions (issue https://github.com/CGAL/cgal/issues/3320)
 - The index of a new point in a point set was not correctly setted when reusing existing memory
 - When writing a point set with points using `float`, they were still written as `double` in the PLY output (which is bad because in binary, it doubles the size of the file with no added value)
 - One of the three `char` types (`signed char`, `char` and `unsigned char`) was missing for PLY IO
 - `char` type appeared as characters in the ASCII PLY output (whereas they should just be numbers)

## Release Management

* Affected package(s): Point Set Processing, Point Set 3
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/3320

