### PR TITLE
`&*handle`, if handle is null, is undefined-behavior

### DIFF
--- a/TDS_3/include/CGAL/Triangulation_ds_cell_base_3.h
+++ b/TDS_3/include/CGAL/Triangulation_ds_cell_base_3.h
@@ -164,7 +164,7 @@ public:
   void set_neighbor(int i, Cell_handle n)
   {
     CGAL_triangulation_precondition( i >= 0 && i <= 3);
-    CGAL_triangulation_precondition( this != &*n );
+    CGAL_triangulation_precondition( this != n.operator->() );
     N[i] = n;
   }
 


### PR DESCRIPTION
## Summary of Changes

This patch fixes an undefined behavior: when one want to convert a
handle to a point, we used `&*handle` a lot. But dereferencing the
default-constructed (null) handle, is undefined-behavior.

The patch calls `operator->` of the handle class, instead.

That is similar to c774546e1bc95f79aed9718160d23efc5dc08dc2, from PR #161. This time the undefined-behavior was not detected by the static analyzers of clang, but by [USBAN](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html).

## Release Management

* Affected package(s): TDS_3 (and thus Triangulation_3, Mesh_3, and others)
