### PR TITLE
Mesh_3, parallel: fix the stop feature

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -381,6 +381,10 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
   facets_mesher_.set_worksharing_ds(this->get_worksharing_data_structure());
   cells_mesher_.set_lock_ds(this->get_lock_data_structure());
   cells_mesher_.set_worksharing_ds(this->get_worksharing_data_structure());
+#ifndef CGAL_NO_ATOMIC
+  cells_mesher_.set_stop_pointer(stop_ptr);
+  facets_mesher_.set_stop_pointer(stop_ptr);
+#endif
 }
 
 
@@ -749,6 +753,10 @@ one_step()
 
     if ( facets_mesher_.is_algorithm_done() )
     {
+      if(forced_stop()) {
+        return;
+      }
+
       switch(refinement_stage) {
       case REFINE_FACETS:
         facets_mesher_.scan_edges();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -754,6 +754,9 @@ public:
     , m_lock_ds(0)
     , m_worksharing_ds(0)
     , m_empty_root_task(0)
+#ifndef CGAL_NO_ATOMIC
+    , m_stop_ptr(0)
+#endif
   {
   }
 
@@ -1145,6 +1148,26 @@ public:
     m_worksharing_ds = p;
   }
 
+#ifndef CGAL_NO_ATOMIC
+  void set_stop_pointer(CGAL::cpp11::atomic<bool>* stop_ptr)
+  {
+    m_stop_ptr = stop_ptr;
+  }
+#endif
+
+  bool forced_stop() const {
+#ifndef CGAL_NO_ATOMIC
+    if(m_stop_ptr != 0 &&
+       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+    {
+      CGAL_assertion(m_empty_root_task != 0);
+      m_empty_root_task->cancel_group_execution();
+      return true;
+    }
+#endif // not defined CGAL_NO_ATOMIC
+    return false;
+  }
+
 protected:
 
   // Member variables
@@ -1155,6 +1178,9 @@ protected:
   WorksharingDataStructureType *m_worksharing_ds;
 
   tbb::task *m_empty_root_task;
+#ifndef CGAL_NO_ATOMIC
+  CGAL::cpp11::atomic<bool>* m_stop_ptr;
+#endif
 
 private:
 
@@ -1189,6 +1215,10 @@ private:
       Mesher_level_conflict_status status;
       do
       {
+        if(m_mesher_level.forced_stop()) {
+          return;
+        }
+
         status = m_mesher_level.try_lock_and_refine_element(m_container_element, 
                                                             m_visitor);
       }

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -32,6 +32,7 @@
   #include <CGAL/Mesh_3/Profiling_tools.h>
 #endif
 
+#include <CGAL/atomic.h>
 #include <CGAL/Mesh_3/Worksharing_data_structures.h>
 
 #ifdef CGAL_CONCURRENT_MESH_3_PROFILING
@@ -684,6 +685,9 @@ public:
   // Useless here
   void set_lock_ds(Lock_data_structure *) {}
   void set_worksharing_ds(WorksharingDataStructureType *) {}
+#ifndef CGAL_NO_ATOMIC
+  void set_stop_pointer(CGAL::cpp11::atomic<bool>*) {}
+#endif
 
 protected:
 };


### PR DESCRIPTION
## Summary of Changes

When the stop variable is flipped, cancel unprocessed tasks, instead of just waiting for them to finish.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix  #3242
