### PR TITLE
Small bugfix (User Manual of CK_2)

### DIFF
--- a/Circular_kernel_2/doc/Circular_kernel_2/Circular_kernel_2.txt
+++ b/Circular_kernel_2/doc/Circular_kernel_2/Circular_kernel_2.txt
@@ -73,7 +73,7 @@ The following example shows how to use a functor of the kernel.
 
 The first pieces of prototype code were comparisons of algebraic
 numbers of degree 2, written by Olivier Devillers
-\cgalCite{cgal:dfmt-amafe-00},cgal:dfmt-amafe-02.
+\cgalCite{cgal:dfmt-amafe-00},\cgalCite{cgal:dfmt-amafe-02}.
 
 Some work was then done in the direction of a "kernel" for
 \cgal.\cgalFootnote{Monique Teillaud, First Prototype of a \cgal Geometric Kernel with Circular Arcs, Technical Report ECG-TR-182203-01, 2002


### PR DESCRIPTION
## Summary of Changes

There was a small bug in the User manual of the 2D Circular Kernel: a citation was missing the \cgalCite macro in Section "4 Design and Implementation History", so it was not linking. Since the bug is so small, I am creating a PR directly against <code>master</code>

## Release Management

* Affected package(s): <code>Circular_kernel_2</code> (documentation)
* Issue(s) solved (if any): none
* Feature/Small Feature (if any): none
* Link to compiled documentation: none
* License and copyright ownership: none

