### PR TITLE
Mpzf: Workaround a misscompilation bug with Intel Compiler 2019

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -302,7 +302,13 @@ struct Mpzf {
     data()[-1] = mini;
   }
   void clear(){
-    while(*--data()==0); // in case we skipped final zeroes
+    // while(*--data()==0);
+    // This line gave a misscompilation by Intel Compiler 2019
+    // (19.0.0.117). I replaced it by the following two lines:
+    // -- Laurent Rineau, sept. 2018
+    --data();
+    while(*data()==0) { --data(); } // in case we skipped final zeroes
+
 #ifdef CGAL_MPZF_USE_CACHE
     if (data() == cache) return;
 #endif


### PR DESCRIPTION
## Summary of Changes

With Intel Compiler 2019, in Mesh_3, there was a misscompilation of `Mpzf::clear()`:
https://github.com/CGAL/cgal/blob/bd105ab68d22230eb5419160f48cde76894510aa/Number_types/include/CGAL/Mpzf.h#L304-L311

The line
```c++
while(*--data()==0);
```
was compiled as if:
```c++
while(*(data()-1)==0);
```
that is: the internal pointer `data_` was not decremented, and the loop was never-ending.

I have modified the code slightly to workaround that bug from Intel Compiler. I was not able to find a small test case triggering the bug, unfortunately.

## Release Management
* Affected package(s): Mesh_3, Number_types

Cc: @mglisse 
