### PR TITLE
Convex_hull_3: Fix so that static filters are used

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
@@ -147,15 +147,8 @@ public:
       const Point_3& hp = h.p();
       const Point_3& hq = h.q();
       const Point_3& hr = h.r();
-      //typename OldK::Less_signed_distance_to_plane_3 
-      //	less_signed_distance_to_plane_3;
-      // return less_signed_distance_to_plane_3(hp, hq, hr, p, q);
-      return has_smaller_signed_dist_to_planeC3(hp.x(), hp.y(), hp.z(),
-                                                hq.x(), hq.y(), hq.z(),
-                                                hr.x(), hr.y(), hr.z(),
-                                                p.x(), p.y(), p.z(),
-                                                q.x(), q.y(), q.z());
-      
+      typename K::Less_signed_distance_to_plane_3 less_signed_distance_to_plane_3;
+      return less_signed_distance_to_plane_3(hp, hq, hr, p, q);
     }
   };
 
@@ -164,35 +157,10 @@ struct GT3_for_CH3 {
   typedef typename GT::Point_3 Point_2;
 };
 
-template <class R_, class Has_filtered_predicates_tag /* = Tag_false */>
-struct Convex_hull_traits_base_3 {
-  typedef Point_triple_has_on_positive_side_3<R_>     Has_on_positive_side_3;
-
-  typedef  Point_triple_less_signed_distance_to_plane_3<R_>
-                                                  Less_signed_distance_to_plane_3;
-};
-
-template <class R_>
-struct Convex_hull_traits_base_3<R_, Tag_true>{
-  typedef Filtered_predicate<
-      Point_triple_has_on_positive_side_3< typename R_::Exact_kernel_rt >,
-      Point_triple_has_on_positive_side_3< typename R_::Approximate_kernel >,
-      Point_triple_converter<R_,typename R_::Exact_kernel_rt>,
-      Point_triple_converter<R_,typename R_::Approximate_kernel>
-  > Has_on_positive_side_3;
-
-  typedef Filtered_predicate<
-      Point_triple_less_signed_distance_to_plane_3< typename R_::Exact_kernel_rt >,
-      Point_triple_less_signed_distance_to_plane_3< typename R_::Approximate_kernel >,
-      Point_triple_converter<R_,typename R_::Exact_kernel_rt>,
-      Point_triple_converter<R_,typename R_::Approximate_kernel>
-  > Less_signed_distance_to_plane_3;
-};
 
 
   template <class R_, class Polyhedron = Default, class Has_filtered_predicates_tag = Tag_false>
-class Convex_hull_traits_3 :
-  public Convex_hull_traits_base_3<R_, Has_filtered_predicates_tag>
+class Convex_hull_traits_3 
 {
  public:  
   typedef R_                                     R;
@@ -228,11 +196,12 @@ class Convex_hull_traits_3 :
   typedef typename R::Coplanar_3                 Coplanar_3;
   typedef typename R::Less_distance_to_point_3   Less_distance_to_point_3;
 
-  typedef typename Convex_hull_traits_base_3<R_, Has_filtered_predicates_tag>
-    ::Has_on_positive_side_3 Has_on_positive_side_3;
+  typedef Point_triple_has_on_positive_side_3<R> Has_on_positive_side_3;
 
-  typedef typename Convex_hull_traits_base_3<R_, Has_filtered_predicates_tag>
-    ::Less_signed_distance_to_plane_3 Less_signed_distance_to_plane_3;
+  typedef  Point_triple_less_signed_distance_to_plane_3<R>
+                                                 Less_signed_distance_to_plane_3;
+  
+  
 
   // required for degenerate case of all points coplanar
   typedef CGAL::Projection_traits_xy_3<R>         Traits_xy_3;

--- a/Convex_hull_3/include/CGAL/Extreme_points_traits_adapter_3.h
+++ b/Convex_hull_3/include/CGAL/Extreme_points_traits_adapter_3.h
@@ -138,7 +138,7 @@ public:
   public:
     Construct_plane_3(const PointPropertyMap& map, const typename Base_traits::Construct_plane_3& base):
       Base_traits::Construct_plane_3(base),vpm_(map), base(base){}
-    typename Base_traits::Plane_3 operator()(const Point_3& p, const Point_3& q, const Point_3& r)const 
+    typename Base_traits::Plane_3 operator()(const Vertex& p, const Vertex& q, const Vertex& r)const 
     {
       return base(get(vpm_,p),get(vpm_,q),get(vpm_,r));
     }
@@ -159,7 +159,7 @@ public:
     typedef bool          result_type;
     
     result_type
-    operator()( const Plane_3& pl, const Point_3& p) const
+    operator()( const Plane_3& pl, const Vertex& p) const
     { 
       return base(pl, get(vpm_, p));
     }


### PR DESCRIPTION
## Summary of Changes

Replace "hand written" filtering with just calling the functor of the kernel chosen by the user so that static filters are used.

## Release Management

* Affected package(s): Convex_hull_3


