### PR TITLE
Fix when not using Gmp

### DIFF
--- a/Segment_Delaunay_graph_Linf_2/include/CGAL/Segment_Delaunay_graph_Linf_filtered_traits_2.h
+++ b/Segment_Delaunay_graph_Linf_2/include/CGAL/Segment_Delaunay_graph_Linf_filtered_traits_2.h
@@ -221,7 +221,7 @@ template<class CK,
 #ifdef CGAL_USE_GMP
 	 class EK      = Simple_cartesian< Gmpq >,
 #else
-	 class EK      = Simple_cartesian< MP_Float >,
+	 class EK      = Simple_cartesian< CGAL::Quotient<MP_Float> >,
 #endif
 	 class EK_MTag = Integral_domain_without_division_tag,
 	 class FK      = Simple_cartesian< Interval_nt<false> >,

--- a/Segment_Delaunay_graph_Linf_2/include/CGAL/Side_of_bounded_square_2.h
+++ b/Segment_Delaunay_graph_Linf_2/include/CGAL/Side_of_bounded_square_2.h
@@ -70,7 +70,7 @@ namespace CGAL {
         bool samepq = false;
         bool samepr = false;
         bool sameqr = false;
-        const Comparison_result cmppq = compare(p, q);
+        const Comparison_result cmppq = CGAL::compare(p, q);
         switch(cmppq) {
           case SMALLER:
             min_p = &p;
@@ -86,7 +86,7 @@ namespace CGAL {
             samepq = true;
             break;
         }
-        const Comparison_result cmppr = compare(p, r);
+        const Comparison_result cmppr = CGAL::compare(p, r);
         Comparison_result cmpqr;
         if (samepq) {
           cmpqr = cmppr;
@@ -105,7 +105,7 @@ namespace CGAL {
           if (min_p == &p) {
             switch(cmppr) {
               case SMALLER:
-                cmpqr = compare(q, r);
+                cmpqr = CGAL::compare(q, r);
                 switch(cmpqr) {
                   case SMALLER:
                     max_p = &r;
@@ -135,7 +135,7 @@ namespace CGAL {
                 max_p = &r;
                 break;
               case LARGER:
-                cmpqr = compare(q, r);
+                cmpqr = CGAL::compare(q, r);
                 switch(cmpqr) {
                   case SMALLER:
                     break;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_et.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_et.cpp
@@ -11,10 +11,9 @@
 #include <cassert>
 
 #include <CGAL/Exact_rational.h>
-#include <CGAL/Exact_integer.h>
 
 // choose number type
-typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_ring_t;
 typedef CGAL::Exact_rational exact_field_t;
 
 namespace CGAL {

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_et.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_et.cpp
@@ -10,28 +10,19 @@
 #include <fstream>
 #include <cassert>
 
-// choose number type
-#ifdef CGAL_USE_GMP
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Exact_integer.h>
 
-#  include <CGAL/Gmpq.h>
-typedef CGAL::Gmpq                     exact_ring_t;
-typedef CGAL::Gmpq                     exact_field_t;
+// choose number type
+typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_field_t;
 
 namespace CGAL {
 // needed for the drawing methods
-Gmpq sqrt(const Gmpq& x) {
-  return Gmpq(  CGAL::sqrt( CGAL::to_double(x) )  );
+exact_ring_t sqrt(const exact_ring_t& x) {
+  return exact_ring_t(  sqrt( to_double(x) )  );
 }
-
-} //namespace CGAL
-#else
-
-#  include <CGAL/MP_Float.h>
-#  include <CGAL/Quotient.h>
-typedef CGAL::MP_Float                 exact_ring_t;
-typedef CGAL::Quotient<exact_ring_t>   exact_field_t;
-
-#endif
+}
 
 typedef exact_ring_t   ring_number_t;
 typedef exact_field_t  field_number_t;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_ft.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_ft.cpp
@@ -10,17 +10,12 @@
 #include <fstream>
 #include <cassert>
 
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Exact_integer.h>
+
 // choose number type
-#ifdef CGAL_USE_GMP
-#  include <CGAL/Gmpq.h>
-typedef CGAL::Gmpq                     exact_ring_t;
-typedef CGAL::Gmpq                     exact_field_t;
-#else
-#  include <CGAL/MP_Float.h>
-#  include <CGAL/Quotient.h>
-typedef CGAL::MP_Float                 exact_ring_t;
-typedef CGAL::Quotient<exact_ring_t>   exact_field_t;
-#endif
+typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_field_t;
 
 #include <CGAL/Simple_cartesian.h>
 

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_ft.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_2_ft.cpp
@@ -11,10 +11,9 @@
 #include <cassert>
 
 #include <CGAL/Exact_rational.h>
-#include <CGAL/Exact_integer.h>
 
 // choose number type
-typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_ring_t;
 typedef CGAL::Exact_rational exact_field_t;
 
 #include <CGAL/Simple_cartesian.h>

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_et.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_et.cpp
@@ -10,28 +10,19 @@
 #include <fstream>
 #include <cassert>
 
-// choose number type
-#ifdef CGAL_USE_GMP
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Exact_integer.h>
 
-#  include <CGAL/Gmpq.h>
-typedef CGAL::Gmpq                     exact_ring_t;
-typedef CGAL::Gmpq                     exact_field_t;
+// choose number type
+typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_field_t;
 
 namespace CGAL {
 // needed for the drawing methods
-Gmpq sqrt(const Gmpq& x) {
-  return Gmpq(  sqrt( to_double(x) )  );
+exact_ring_t sqrt(const exact_ring_t& x) {
+  return exact_ring_t(  sqrt( to_double(x) )  );
 }
-
-} //namespace CGAL
-#else
-
-#  include <CGAL/MP_Float.h>
-#  include <CGAL/Quotient.h>
-typedef CGAL::MP_Float                 exact_ring_t;
-typedef CGAL::Quotient<exact_ring_t>   exact_field_t;
-
-#endif
+}
 
 typedef exact_ring_t   ring_number_t;
 typedef exact_field_t  field_number_t;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_et.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_et.cpp
@@ -11,10 +11,9 @@
 #include <cassert>
 
 #include <CGAL/Exact_rational.h>
-#include <CGAL/Exact_integer.h>
 
 // choose number type
-typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_ring_t;
 typedef CGAL::Exact_rational exact_field_t;
 
 namespace CGAL {

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_ft.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_ft.cpp
@@ -10,17 +10,12 @@
 #include <fstream>
 #include <cassert>
 
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Exact_integer.h>
+
 // choose number type
-#ifdef CGAL_USE_GMP
-#  include <CGAL/Gmpq.h>
-typedef CGAL::Gmpq                     exact_ring_t;
-typedef CGAL::Gmpq                     exact_field_t;
-#else
-#  include <CGAL/MP_Float.h>
-#  include <CGAL/Quotient.h>
-typedef CGAL::MP_Float                 exact_ring_t;
-typedef CGAL::Quotient<exact_ring_t>   exact_field_t;
-#endif
+typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_field_t;
 
 #include <CGAL/Simple_cartesian.h>
 

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_ft.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_hierarchy_2_ft.cpp
@@ -11,10 +11,9 @@
 #include <cassert>
 
 #include <CGAL/Exact_rational.h>
-#include <CGAL/Exact_integer.h>
 
 // choose number type
-typedef CGAL::Exact_integer exact_ring_t;
+typedef CGAL::Exact_rational exact_ring_t;
 typedef CGAL::Exact_rational exact_field_t;
 
 #include <CGAL/Simple_cartesian.h>

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_new_range_api.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_new_range_api.cpp
@@ -7,12 +7,14 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Segment_Delaunay_graph_Linf_filtered_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_Linf_2.h>
-#include <CGAL/Gmpq.h>
+#include <CGAL/Exact_rational.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Field_with_sqrt_tag MTag;
 typedef CGAL::Integral_domain_without_division_tag EMTag;
-typedef CGAL::Simple_cartesian<CGAL::Gmpq> EK;
+typedef CGAL::Exact_rational Number_type;
+
+typedef CGAL::Simple_cartesian<Number_type> EK;
 
 typedef CGAL::Segment_Delaunay_graph_Linf_filtered_traits_without_intersections_2<K, MTag, EK, EMTag>  Gt;
 typedef CGAL::Segment_Delaunay_graph_Linf_2<Gt>  SDG;


### PR DESCRIPTION
Should fix [this](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-I-125/Segment_Delaunay_graph_Linf_2/TestReport_cgaltester_x86-64_Darwin-13.0_Apple-clang-5.1_Release-LEDA-without-GMP.gz) and [that](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-I-125/Segment_Delaunay_graph_Linf_2_Examples/TestReport_cgaltester_x86-64_Darwin-13.0_Apple-clang-5.1_Release-LEDA-without-GMP.gz).
