### PR TITLE
Point set shape detection: Fix VC2017 bug

### DIFF
--- a/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
+++ b/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
@@ -781,6 +781,8 @@ void regularize_planes (const PointRange& points,
 
 /// \cond SKIP_IN_MANUAL
 
+// Workaround for bug reported here:
+// https://developercommunity.visualstudio.com/content/problem/340310/unaccepted-typename-that-other-compilers-require.html
 #if _MSC_VER == 1915
 #define CGAL_TYPENAME_FOR_MSC
 #else

--- a/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
+++ b/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
@@ -781,7 +781,7 @@ void regularize_planes (const PointRange& points,
 
 /// \cond SKIP_IN_MANUAL
 
-#ifdef _MSC_VER
+#if _MSC_VER == 1915
 #define CGAL_TYPENAME_FOR_MSC
 #else
 #define CGAL_TYPENAME_FOR_MSC typename
@@ -830,7 +830,9 @@ void regularize_planes (const PointRange& points,
                      tolerance_angle, tolerance_coplanarity, symmetry_direction);
 }
 
+#ifdef CGAL_TYPENAME_FOR_MSC
 #undef CGAL_TYPENAME_FOR_MSC
+#endif
 
 
 /// \endcond

--- a/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
+++ b/Point_set_shape_detection_3/include/CGAL/regularize_planes.h
@@ -781,6 +781,11 @@ void regularize_planes (const PointRange& points,
 
 /// \cond SKIP_IN_MANUAL
 
+#ifdef _MSC_VER
+#define CGAL_TYPENAME_FOR_MSC
+#else
+#define CGAL_TYPENAME_FOR_MSC typename
+#endif
 
 // This variant deduces the kernel from the point property map.
 template <typename PointRange,
@@ -802,16 +807,17 @@ void regularize_planes (const PointRange& points,
                         typename Kernel_traits
                         <typename boost::property_traits
                         <PointMap>::value_type>::Kernel::Vector_3 symmetry_direction
-                        = typename Kernel_traits
+                        = CGAL_TYPENAME_FOR_MSC Kernel_traits
                           <typename boost::property_traits
                           <PointMap>::value_type>::Kernel::Vector_3
-                        (typename Kernel_traits
+                        (
+                         CGAL_TYPENAME_FOR_MSC Kernel_traits
                          <typename boost::property_traits
                          <PointMap>::value_type>::Kernel::FT(0.),
-                         typename Kernel_traits
+                         CGAL_TYPENAME_FOR_MSC Kernel_traits
                          <typename boost::property_traits
                          <PointMap>::value_type>::Kernel::FT(0.),
-                         typename Kernel_traits
+                         CGAL_TYPENAME_FOR_MSC Kernel_traits
                          <typename boost::property_traits
                          <PointMap>::value_type>::Kernel::FT(1.)))
 {
@@ -823,6 +829,8 @@ void regularize_planes (const PointRange& points,
                      regularize_coplanarity, regularize_axis_symmetry,
                      tolerance_angle, tolerance_coplanarity, symmetry_direction);
 }
+
+#undef CGAL_TYPENAME_FOR_MSC
 
 
 /// \endcond


### PR DESCRIPTION
## Summary of Changes

Work around a bug that only happens with `_MSC_VER == 1915`.
See [bug report](https://developercommunity.visualstudio.com/content/problem/340310/unaccepted-typename-that-other-compilers-require.html)

## Release Management

* Affected package(s): Point Set Shape Detection

