### PR TITLE
Triangulation_3: Fix insertion and removal of ranges of weighted points (for 4.12)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -1042,6 +1042,11 @@ public:
     {
       // Lock the element area on the grid
       Element element = derivd.extract_element_from_container_value(ce);
+
+      // This is safe to do with the concurrent compact container because even if the element `ce`
+      // gets removed from the TDS at this point, it is not actually deleted in the cells container and
+      // `ce->vertex(0-3)` still points to a vertex of the vertices container whose `.point()`
+      // can be safely accessed (even if that vertex has itself also been removed from the TDS).
       bool locked = derivd.try_lock_element(element, FIRST_GRID_LOCK_RADIUS);
 
       if( locked )

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -77,8 +77,12 @@ class Triangulation_data_structure_3
   typedef Triangulation_data_structure_3<Vb, Cb, Concurrency_tag_> Tds;
 
 public:
-
   typedef Concurrency_tag_            Concurrency_tag;
+
+  // This tag is used in the parallel operations of RT_3 to access some functions
+  // of the TDS (tds.vertices().is_used(Vertex_handle)) that are much more efficient
+  // than what is exposed by the TDS concept (tds.is_vertex(Vertex_handle)).
+  typedef CGAL::Tag_true              Is_CGAL_TDS_3;
 
   // Tools to change the Vertex and Cell types of the TDS.
   template < typename Vb2 >

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -2481,7 +2481,7 @@ namespace CGAL {
 
       if(*could_lock_zone && removed)
       {
-        // The vertex has been removed, try to re-insert the points that 'v' was hiding
+        // The vertex has been removed, re-insert the points that 'v' was hiding
 
         // Start by unlocking the area of the removed vertex to avoid deadlocks
         this->unlock_all_elements();

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -763,6 +763,25 @@ namespace CGAL {
       return std::copy(vertices.begin(), vertices.end(), res);
     }
 
+    // In parallel operations, we need to be able to check the health of the 'hint' vertex handle,
+    // which might be invalided by other threads. One way to do that is the 'is_vertex()' function
+    // of the TDS, but it runs in O(sqrt(n)) complexity. When we are using our TDS, we can use
+    // a lower level function from the compact container, which runs in constant time.
+    template <typename TDS_>
+    struct Vertex_validity_checker
+    {
+      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) { return tds_.is_vertex(vh_); }
+    };
+
+    template <typename T1, typename T2, typename T3>
+    struct Vertex_validity_checker<CGAL::Triangulation_data_structure_3<T1, T2, T3> >
+    {
+      typedef CGAL::Triangulation_data_structure_3<T1, T2, T3>   TDS_;
+
+      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) {
+        return tds_.vertices().is_used(vh_); }
+    };
+
     void remove (Vertex_handle v);
     // Concurrency-safe
     // See Triangulation_3::remove for more information
@@ -1289,25 +1308,6 @@ namespace CGAL {
       void hide_point(Cell_handle c, const Weighted_point &p) {
         c->hide_point(p);
       }
-    };
-
-    // In parallel operations, we need to be able to check the health of the 'hint' vertex handle,
-    // which might be invalided by other threads. One way to do that is the 'is_vertex()' function
-    // of the TDS, but it runs in O(sqrt(n)) complexity. When we are using our TDS, we can use
-    // a lower level function from the compact container, which runs in constant time.
-    template <typename TDS_>
-    struct Vertex_validity_checker
-    {
-      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) { return tds_.is_vertex(vh_); }
-    };
-
-    template <typename T1, typename T2, typename T3>
-    struct Vertex_validity_checker<CGAL::Triangulation_data_structure_3<T1, T2, T3> >
-    {
-      typedef CGAL::Triangulation_data_structure_3<T1, T2, T3>   TDS_;
-
-      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) {
-        return tds_.vertices().is_used(vh_); }
     };
 
   // Functor for parallel insert(begin, end) function

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -767,19 +767,32 @@ namespace CGAL {
     // which might be invalided by other threads. One way to do that is the 'is_vertex()' function
     // of the TDS, but it runs in O(sqrt(n)) complexity. When we are using our TDS, we can use
     // a lower level function from the compact container, which runs in constant time.
+    BOOST_MPL_HAS_XXX_TRAIT_DEF(Is_CGAL_TDS_3)
+
+    template <typename TDS_,
+              bool has_TDS_tag = has_Is_CGAL_TDS_3<TDS_>::value>
+    struct Is_CGAL_TDS_3 : public CGAL::Tag_false
+    { };
+
     template <typename TDS_>
+    struct Is_CGAL_TDS_3<TDS_, true> : public CGAL::Boolean_tag<TDS_::Is_CGAL_TDS_3::value>
+    { };
+
+    template <typename TDS_,
+              bool is_CGAL_TDS_3 = Is_CGAL_TDS_3<TDS_>::value>
     struct Vertex_validity_checker
     {
-      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) { return tds_.is_vertex(vh_); }
+      bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) {
+        return tds_.is_vertex(vh_);
+      }
     };
 
-    template <typename T1, typename T2, typename T3>
-    struct Vertex_validity_checker<CGAL::Triangulation_data_structure_3<T1, T2, T3> >
+    template <typename TDS_>
+    struct Vertex_validity_checker<TDS_, true /* is_CGAL_TDS_3 */>
     {
-      typedef CGAL::Triangulation_data_structure_3<T1, T2, T3>   TDS_;
-
       bool operator()(const typename TDS_::Vertex_handle vh_, const TDS_& tds_) {
-        return tds_.vertices().is_used(vh_); }
+        return tds_.vertices().is_used(vh_);
+      }
     };
 
     void remove (Vertex_handle v);

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
@@ -27,42 +27,82 @@
 
 #include <boost/mpl/if.hpp>
 
+template <typename Parallel_triangulation,
+          typename WeightedTag = typename Parallel_triangulation::Weighted_tag>
+struct PTR_random_pts_generator
+{
+  typedef typename Parallel_triangulation::Point       Point;
+
+  void operator()(const int num, CGAL::Random& rnd, std::vector<Point>& points) const
+  {
+    CGAL::Random_points_in_cube_3<Point> gen(1., rnd);
+
+    points.reserve(num);
+    for(int i=0; i!=num; ++i)
+      points.push_back(*gen++);
+  }
+};
+
+template <typename Parallel_triangulation>
+struct PTR_random_pts_generator<Parallel_triangulation, CGAL::Tag_true /*weighted triangulation*/>
+{
+  typedef typename Parallel_triangulation::Bare_point      Bare_point;
+  typedef typename Parallel_triangulation::Weighted_point  Weighted_point;
+
+  void operator()(const int num, CGAL::Random& rnd, std::vector<Weighted_point>& points) const
+  {
+    CGAL::Random_points_in_cube_3<Bare_point> gen(1., rnd);
+
+    points.reserve(num);
+    for(int i=0; i!=num; ++i)
+      points.push_back(Weighted_point(*gen++, rnd.get_double(-1., 1.)));
+  }
+};
+
 template <class Parallel_triangulation>
 void
 _test_cls_parallel_triangulation_3(const Parallel_triangulation &)
 {
-  const int NUM_INSERTED_POINTS = 5000;
-
   typedef Parallel_triangulation                                Cls;
 
   typedef typename Cls::Vertex_handle                           Vertex_handle;
   typedef typename Cls::Point                                   Point;
 
-  CGAL::Random_points_in_cube_3<Point> rnd(1.);
+  typedef std::vector<Point>                                    Point_container;
 
-  // Construction from a vector of points
-  std::vector<Point> points;
-  points.reserve(NUM_INSERTED_POINTS);
-  for (int i = 0; i != NUM_INSERTED_POINTS; ++i)
-    points.push_back(*rnd++);
-  
+  CGAL::Random rnd;
+  std::cout << "Seed: " << rnd.get_seed() << std::endl;
+
+  const int num_insert = 5000;
+  Point_container points;
+  PTR_random_pts_generator<Parallel_triangulation> points_gen;
+  points_gen(num_insert, rnd, points);
+
   // Construct the locking data-structure, using the bounding-box of the points
-  typename Cls::Lock_data_structure locking_ds(
-    CGAL::Bbox_3(-1., -1., -1., 1., 1., 1.), 50);
+  typename Cls::Lock_data_structure locking_ds(CGAL::Bbox_3(-1., -1., -1., 1., 1., 1.), 50);
+
   // Contruct the triangulation in parallel
   std::cout << "Construction and parallel insertion" << std::endl;
   Cls tr(points.begin(), points.end(), &locking_ds);
+  std::cout << "Triangulation has " << tr.number_of_vertices() << " vertices" << std::endl;
+  assert(tr.is_valid());
 
   std::cout << "Parallel removal" << std::endl;
-  // Remove the first 100,000 vertices
   std::vector<Vertex_handle> vertices_to_remove;
   typename Cls::Finite_vertices_iterator vit = tr.finite_vertices_begin();
-  for (int i = 0 ; i < NUM_INSERTED_POINTS/10 ; ++i)
+
+  const int num_remove = tr.number_of_vertices() / 10;
+  std::cout << "Removing " << num_remove << " from " << tr.number_of_vertices() << " vertices" << std::endl;
+
+  for(int i=0 ; i<num_remove; ++i) {
     vertices_to_remove.push_back(vit++);
+}
+
   // Parallel remove
   tr.remove(vertices_to_remove.begin(), vertices_to_remove.end());
-  
+  std::cout << "Now, " << tr.number_of_vertices() << " vertices are left" << std::endl;
   assert(tr.is_valid());
+
   tr.clear();
   assert(tr.is_valid());
   assert(tr.dimension()==-1);

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
@@ -91,10 +91,10 @@ _test_cls_parallel_triangulation_3(const Parallel_triangulation &)
   std::vector<Vertex_handle> vertices_to_remove;
   typename Cls::Finite_vertices_iterator vit = tr.finite_vertices_begin();
 
-  const int num_remove = tr.number_of_vertices() / 10;
+  const std::size_t num_remove = tr.number_of_vertices() / 10;
   std::cout << "Removing " << num_remove << " from " << tr.number_of_vertices() << " vertices" << std::endl;
 
-  for(int i=0 ; i<num_remove; ++i) {
+  for(std::size_t i=0 ; i<num_remove; ++i) {
     vertices_to_remove.push_back(vit++);
   }
 

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_parallel_triangulation_3.h
@@ -96,7 +96,7 @@ _test_cls_parallel_triangulation_3(const Parallel_triangulation &)
 
   for(int i=0 ; i<num_remove; ++i) {
     vertices_to_remove.push_back(vit++);
-}
+  }
 
   // Parallel remove
   tr.remove(vertices_to_remove.begin(), vertices_to_remove.end());

--- a/Triangulation_3/test/Triangulation_3/test_regular_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_3.cpp
@@ -448,9 +448,10 @@ int main()
     CGAL::Parallel_tag >	                            Tds_parallel;
   typedef CGAL::Regular_triangulation_3<
     traits, Tds_parallel, Lock_ds>                    RT_parallel;
-  // The following test won't do things in parallel since it doesn't provide
-  // a lock data structure
+
+  // The following test won't do things in parallel since it doesn't provide a lock data structure
   test_RT<RT_parallel>();
+
   // This test performs parallel operations
   _test_cls_parallel_triangulation_3( RT_parallel() );
 #endif


### PR DESCRIPTION
## Summary of Changes

- In a parallel insertion of a range of weighted points, the 'hint' is a vertex handle that is unsafe to use because the insertion of a weighted point by another thread might hide (delete) the hint.
  _Solution_: check the validity of the hint before and after trying to lock it.
- The removal of a range of weighted points while storing hidden points means that we re-insert hidden points after a successful removal. However, since we have only locked what was needed to remove the vertex and not to re-insert the hidden points, deadlocks can appear.
  _Solution_: unlock everything after successful removal and threads can then wrestle normally for control of zones to re-insert hidden points. Same check is needed on the hint.

## Release Management

* Affected package(s): `Triangulation_3`
* Issue(s) solved (if any): fix #3354
* Feature/Small Feature (if any): --
