### PR TITLE
Mesh_3 is now deterministic with TBB when only one thread is used

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -61,12 +61,6 @@ namespace CGAL {
   }
 
 
-  template < class DSC, bool Const >
-  std::size_t tbb_hasher(const CGAL::CCC_internal::CCC_iterator<DSC, Const>& it)
-  {
-    return CGAL::CCC_internal::hash_value(it);
-  }
-
   // As Marc Glisse pointed out the TBB hash of a std::pair is
   // simplistic and leads to the
   // TBB Warning: Performance is not optimal because the hash function
@@ -80,14 +74,6 @@ namespace CGAL {
                                  CGAL::internal::CC_iterator<DSC, Const> > >()(p);
   }
 
-
-  template < class DSC, bool Const >
-  std::size_t tbb_hasher(const std::pair<CGAL::CCC_internal::CCC_iterator<DSC, Const>,
-                                         CGAL::CCC_internal::CCC_iterator<DSC, Const> >& p)
-  {
-    return boost::hash<std::pair<CGAL::CCC_internal::CCC_iterator<DSC, Const>,
-                                 CGAL::CCC_internal::CCC_iterator<DSC, Const> > >()(p);
-  }
 
 }
 #endif

--- a/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
@@ -14,23 +14,15 @@
 #include <sstream>
 #include <cstring>
 
-// Domain
-typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
-typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
-
-// Triangulation
-typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
-typedef CGAL::Mesh_complex_3_in_triangulation_3<
-  Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
-
-// Mesh Criteria
-typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+#ifdef CGAL_LINKED_WITH_TBB
+#  include <tbb/task_scheduler_init.h>
+#endif
 
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main(int, char*[])
+template <typename Concurrency_tag>
+void test()
 {
   // Collect options
   std::size_t nb_runs   = 2;
@@ -38,6 +30,19 @@ int main(int, char*[])
   unsigned int nb_odt   = 2;
   double perturb_bound  = 10.;
   double exude_bound    = 15.;
+
+  // Domain
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+  typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
+  typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
+
+  // Triangulation
+  typedef typename CGAL::Mesh_triangulation_3<Mesh_domain, K, Concurrency_tag>::type Tr;
+  typedef CGAL::Mesh_complex_3_in_triangulation_3<
+    Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
+
+  // Mesh Criteria
+  typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 
   // Domain
   std::cout << "\tSeed is\t 0" << std::endl;
@@ -108,6 +113,13 @@ int main(int, char*[])
       }
     }
   }
+}
 
-  return 0;
+int main(int, char*[])
+{
+  test<CGAL::Sequential_tag>();
+#ifdef CGAL_LINKED_WITH_TBB
+  tbb::task_scheduler_init init(1);
+  test<CGAL::Parallel_tag>();
+#endif
 }

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -1027,6 +1027,10 @@ bool operator>=(const Compact_container<T, Allocator, Increment_policy, TimeStam
   return ! (lhs < rhs);
 }
 
+// forward-declare Concurrent_compact_container, for CC_iterator
+template < class T, class Allocator_ >
+class Concurrent_compact_container;
+
 namespace internal {
 
   template < class DSC, bool Const >
@@ -1095,12 +1099,13 @@ namespace internal {
       void        *vp;
     } m_ptr;
 
-    // Only Compact_container should access these constructors.
-    friend class Compact_container<value_type,
-                                   typename DSC::Al,
-                                   typename DSC::Ip,
-                                   typename DSC::Ts>;
+    // Only Compact_container and Concurrent_compact_container should
+    // access these constructors.
+    template <typename T, typename Al, typename Ip, typename Ts>
+    friend class CGAL::Compact_container;
 
+    friend class CGAL::Concurrent_compact_container<value_type,
+                                                    typename DSC::Al>;
 
     // For begin()
     CC_iterator(pointer ptr, int, int)

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -33,9 +33,12 @@
 #include <vector>
 #include <cstring>
 
+#include <CGAL/Compact_container.h>
+
 #include <CGAL/memory.h>
 #include <CGAL/iterator.h>
 #include <CGAL/CC_safe_handle.h>
+#include <CGAL/Time_stamper.h>
 #include <CGAL/atomic.h>
 
 #include <tbb/enumerable_thread_specific.h>
@@ -75,9 +78,6 @@ struct Concurrent_compact_container_traits {
 };
 
 namespace CCC_internal {
-  template < class CCC, bool Const >
-  class CCC_iterator;
-  
   CGAL_GENERATE_MEMBER_DETECTOR(increment_erase_counter);
   
   // A basic "no erase counter" strategy
@@ -176,6 +176,8 @@ class Concurrent_compact_container
   typedef Concurrent_compact_container_traits <T>                   Traits;
 
 public:
+  typedef CGAL::Time_stamper_impl<T>                Time_stamper_impl;
+
   typedef T                                         value_type;
   typedef Allocator                                 allocator_type;
 
@@ -194,8 +196,8 @@ public:
   typedef typename Allocator::difference_type       difference_type;
 #endif
 
-  typedef CCC_internal::CCC_iterator<Self, false>   iterator;
-  typedef CCC_internal::CCC_iterator<Self, true>    const_iterator;
+  typedef internal::CC_iterator<Self, false>        iterator;
+  typedef internal::CC_iterator<Self, true>         const_iterator;
   typedef std::reverse_iterator<iterator>           reverse_iterator;
   typedef std::reverse_iterator<const_iterator>     const_reverse_iterator;
 
@@ -207,11 +209,12 @@ private:
   friend class Free_list<pointer, size_type, Self>;
 
 public:
-  friend class CCC_internal::CCC_iterator<Self, false>;
-  friend class CCC_internal::CCC_iterator<Self, true>;
+  friend class internal::CC_iterator<Self, false>;
+  friend class internal::CC_iterator<Self, true>;
 
   explicit Concurrent_compact_container(const Allocator &a = Allocator())
   : m_alloc(a)
+  , m_time_stamper(new Time_stamper_impl())
   {
     init ();
   }
@@ -220,6 +223,7 @@ public:
   Concurrent_compact_container(InputIterator first, InputIterator last,
                     const Allocator & a = Allocator())
   : m_alloc(a)
+  , m_time_stamper(new Time_stamper_impl())
   {
     init();
     std::copy(first, last, CGAL::inserter(*this));
@@ -228,6 +232,7 @@ public:
   // The copy constructor and assignment operator preserve the iterator order
   Concurrent_compact_container(const Concurrent_compact_container &c)
   : m_alloc(c.get_allocator())
+  , m_time_stamper(new Time_stamper_impl())
   {
     init();
     m_block_size = c.m_block_size;
@@ -246,6 +251,7 @@ public:
   ~Concurrent_compact_container()
   {
     clear();
+    delete m_time_stamper;
   }
 
   bool is_used(const_iterator ptr) const
@@ -267,6 +273,7 @@ public:
     std::swap(m_last_item, c.m_last_item);
     std::swap(m_free_lists, c.m_free_lists);
     m_all_items.swap(c.m_all_items);
+    std::swap(m_time_stamper, c.m_time_stamper);
   }
 
   iterator begin() { return iterator(m_first_item, 0, 0); }
@@ -601,6 +608,7 @@ private:
     CGAL_assertion(type(ret) == USED);
     fl->dec_size();
     ++m_size;
+    m_time_stamper->set_time_stamp(ret);
     return iterator(ret, 0);
   }
 
@@ -689,6 +697,7 @@ private:
     m_last_item  = NULL;
     m_all_items  = All_items();
     m_size = 0;
+    m_time_stamper->reset();
   }
 
   allocator_type    m_alloc;
@@ -704,6 +713,10 @@ private:
 #else
   CGAL::cpp11::atomic<size_type> m_size;
 #endif
+
+  // This is a pointer, so that the definition of Compact_container does
+  // not require a complete type `T`.
+  Time_stamper_impl* m_time_stamper;
 };
 
 template < class T, class Allocator >
@@ -812,6 +825,7 @@ void Concurrent_compact_container<T, Allocator>::
   for (size_type i = old_block_size; i >= 1; --i)
   {
     EraseCounterStrategy::set_erase_counter(*(new_block + i), 0);
+    m_time_stamper->initialize_time_stamp(new_block + i);
     put_on_free_list(new_block + i, fl);
   }
 }
@@ -866,243 +880,7 @@ bool operator>=(const Concurrent_compact_container<T, Allocator> &lhs,
   return ! (lhs < rhs);
 }
 
-namespace CCC_internal {
-
-  template < class CCC, bool Const >
-  class CCC_iterator
-  {
-    typedef typename CCC::iterator                    iterator;
-    typedef CCC_iterator<CCC, Const>                   Self;
-  public:
-    typedef typename CCC::value_type                  value_type;
-    typedef typename CCC::size_type                   size_type;
-    typedef typename CCC::difference_type             difference_type;
-    typedef typename boost::mpl::if_c< Const, const value_type*,
-                                       value_type*>::type pointer;
-    typedef typename boost::mpl::if_c< Const, const value_type&,
-                                       value_type&>::type reference;
-    typedef std::bidirectional_iterator_tag           iterator_category;
-
-    // the initialization with NULL is required by our Handle concept.
-    CCC_iterator()
-    {
-      m_ptr.p = NULL;
-    }
-
-    // Either a harmless copy-ctor,
-    // or a conversion from iterator to const_iterator.
-    CCC_iterator (const iterator &it)
-    {
-      m_ptr.p = &(*it);
-    }
-
-    // Same for assignment operator (otherwise MipsPro warns)
-    CCC_iterator & operator= (const iterator &it)
-    {
-      m_ptr.p = &(*it);
-      return *this;
-    }
-
-    // Construction from NULL
-    CCC_iterator (Nullptr_t CGAL_assertion_code(n))
-    {
-      CGAL_assertion (n == NULL);
-      m_ptr.p = NULL;
-    }
-
-  private:
-
-    union {
-      pointer      p;
-      void        *vp;
-    } m_ptr;
-
-    // Only Concurrent_compact_container should access these constructors.
-    friend class Concurrent_compact_container<value_type, typename CCC::Al>;
-
-    // For begin()
-    CCC_iterator(pointer ptr, int, int)
-    {
-      m_ptr.p = ptr;
-      if (m_ptr.p == NULL) // empty container.
-        return;
-
-      ++(m_ptr.p); // if not empty, p = start
-      if (CCC::type(m_ptr.p) == CCC::FREE)
-        increment();
-    }
-
-    // Construction from raw pointer and for end().
-    CCC_iterator(pointer ptr, int)
-    {
-      m_ptr.p = ptr;
-    }
-
-    // NB : in case empty container, begin == end == NULL.
-    void increment()
-    {
-      // It's either pointing to end(), or valid.
-      CGAL_assertion_msg(m_ptr.p != NULL,
-        "Incrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(CCC::type(m_ptr.p) != CCC::START_END,
-        "Incrementing end() ?");
-
-      // If it's not end(), then it's valid, we can do ++.
-      do {
-        ++(m_ptr.p);
-        if (CCC::type(m_ptr.p) == CCC::USED ||
-            CCC::type(m_ptr.p) == CCC::START_END)
-          return;
-
-        if (CCC::type(m_ptr.p) == CCC::BLOCK_BOUNDARY)
-          m_ptr.p = CCC::clean_pointee(m_ptr.p);
-      } while (true);
-    }
-
-    void decrement()
-    {
-      // It's either pointing to end(), or valid.
-      CGAL_assertion_msg(m_ptr.p != NULL,
-        "Decrementing a singular iterator or an empty container iterator ?");
-      CGAL_assertion_msg(CCC::type(m_ptr.p - 1) != CCC::START_END,
-        "Decrementing begin() ?");
-
-      // If it's not begin(), then it's valid, we can do --.
-      do {
-        --m_ptr.p;
-        if (CCC::type(m_ptr.p) == CCC::USED ||
-            CCC::type(m_ptr.p) == CCC::START_END)
-          return;
-
-        if (CCC::type(m_ptr.p) == CCC::BLOCK_BOUNDARY)
-          m_ptr.p = CCC::clean_pointee(m_ptr.p);
-      } while (true);
-    }
-
-  public:
-
-    Self & operator++()
-    {
-      CGAL_assertion_msg(m_ptr.p != NULL,
-   "Incrementing a singular iterator or an empty container iterator ?");
-      /* CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED,
-         "Incrementing an invalid iterator."); */
-      increment();
-      return *this;
-    }
-
-    Self & operator--()
-    {
-      CGAL_assertion_msg(m_ptr.p != NULL,
-   "Decrementing a singular iterator or an empty container iterator ?");
-      /* CGAL_assertion_msg(CCC::type(m_ptr.p) == CCC::USED
-          || CCC::type(m_ptr.p) == CCC::START_END,
-          "Decrementing an invalid iterator."); */
-      decrement();
-      return *this;
-    }
-
-    Self operator++(int) { Self tmp(*this); ++(*this); return tmp; }
-    Self operator--(int) { Self tmp(*this); --(*this); return tmp; }
-
-    reference operator*() const { return *(m_ptr.p); }
-
-    pointer   operator->() const { return (m_ptr.p); }
-
-    // For std::less...
-    bool operator<(const CCC_iterator& other) const
-    {
-      return (m_ptr.p < other.m_ptr.p);
-    }
-
-    bool operator>(const CCC_iterator& other) const
-    {
-      return (m_ptr.p > other.m_ptr.p);
-    }
-
-    bool operator<=(const CCC_iterator& other) const
-    {
-      return (m_ptr.p <= other.m_ptr.p);
-    }
-
-    bool operator>=(const CCC_iterator& other) const
-    {
-      return (m_ptr.p >= other.m_ptr.p);
-    }
-
-    // Can itself be used for bit-squatting.
-    void *   for_compact_container() const { return (m_ptr.vp); }
-    void * & for_compact_container()       { return (m_ptr.vp); }
-  };
-
-  template < class CCC, bool Const1, bool Const2 >
-  inline
-  bool operator==(const CCC_iterator<CCC, Const1> &rhs,
-                  const CCC_iterator<CCC, Const2> &lhs)
-  {
-    return rhs.operator->() == lhs.operator->();
-  }
-
-  template < class CCC, bool Const1, bool Const2 >
-  inline
-  bool operator!=(const CCC_iterator<CCC, Const1> &rhs,
-                  const CCC_iterator<CCC, Const2> &lhs)
-  {
-    return rhs.operator->() != lhs.operator->();
-  }
-
-  // Comparisons with NULL are part of CGAL's Handle concept...
-  template < class CCC, bool Const >
-  inline
-  bool operator==(const CCC_iterator<CCC, Const> &rhs,
-                  Nullptr_t CGAL_assertion_code(n))
-  {
-    CGAL_assertion( n == NULL);
-    return rhs.operator->() == NULL;
-  }
-
-  template < class CCC, bool Const >
-  inline
-  bool operator!=(const CCC_iterator<CCC, Const> &rhs,
-      Nullptr_t CGAL_assertion_code(n))
-  {
-    CGAL_assertion( n == NULL);
-    return rhs.operator->() != NULL;
-  }
-
-  template <class CCC, bool Const>
-  std::size_t hash_value(const CCC_iterator<CCC, Const>&  i)
-  {
-    return reinterpret_cast<std::size_t>(&*i) / sizeof(typename CCC::value_type);
-  }
-} // namespace CCC_internal
-
 } //namespace CGAL
-namespace std {
-
-#if defined(BOOST_MSVC)
-#  pragma warning(push)
-#  pragma warning(disable:4099) // For VC10 it is class hash 
-#endif
-
-#ifndef CGAL_CFG_NO_STD_HASH
-  
-  template < class CCC, bool Const >
-  struct hash<CGAL::CCC_internal::CCC_iterator<CCC, Const> >
-    : public CGAL::cpp98::unary_function<CGAL::CCC_internal::CCC_iterator<CCC, Const>, std::size_t> {
-
-    std::size_t operator()(const CGAL::CCC_internal::CCC_iterator<CCC, Const>& i) const
-    {
-      return reinterpret_cast<std::size_t>(&*i) / sizeof(typename CCC::value_type);
-    }
-  };
-#endif // CGAL_CFG_NO_STD_HASH
-
-#if defined(BOOST_MSVC)
-#  pragma warning(pop)
-#endif
-
-} // namespace std
 
 #include <CGAL/enable_warnings.h>
 


### PR DESCRIPTION
## Summary of Changes

- `Time_stamper` uses an atomic counter, to be usable with threads.
- Changes to `Compact_container` and `Concurrent_compact_container`:
  - Remove `CCC_iterator`, because a slightly modified `CC_iterator` can be used instead
  - `Concurrent_compact_container` now uses also the time stamper.

## Release Management

* Affected package(s): STL_Extension, Triangulation_3, Mesh_3
