### PR TITLE
Aabb_tree: change the id of AABB_face_graph_triangle_primitive and AABB_halfedge_graph_segment_primitive

### DIFF
--- a/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
@@ -32,7 +32,7 @@
 #include <CGAL/Default.h>
 
 namespace CGAL {
-namespace internal{
+namespace internal_primitive_id{
 //helper struct for creating the right Id: just a face_descriptor if OneFaceGraphPerTree
 // is true,else : a pair with the corresponding graph.
 template<class FaceGraph,
@@ -121,9 +121,9 @@ class AABB_face_graph_triangle_primitive
                           OneFaceGraphPerTree,
                           CacheDatum > Base;
 public:
-  typedef typename internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::Id_ Id;
+  typedef typename internal_primitive_id::Primitive_id<FaceGraph, OneFaceGraphPerTree>::Id_ Id;
 protected:
-  Id this_id;
+  const FaceGraph* this_graph;
 public:
   #ifdef DOXYGEN_RUNNING
   /// \name Types
@@ -142,10 +142,6 @@ public:
   - std::pair<boost::graph_traits<FaceGraph>::face_descriptor, FaceGraph> Id if OneFaceGraphPerTree is `CGAL::Tag_false`
   */
   Unspecified_type Id;
-  /*!
-  Id type of the Base:
-  */
-  typedef typename boost::graph_traits<FaceGraph>::face_descriptor Id_;
   
   /// @}
 
@@ -154,7 +150,10 @@ public:
   */
   static unspecified_type construct_shared_data( FaceGraph& graph );
   #endif
-  Id id() const {return this_id;}
+  Id id() const {
+    return internal_primitive_id::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(Base::id(), 
+                                                                           *this_graph);
+  }
   // constructors
   /*!
     \tparam Iterator an input iterator with `Id` as value type.
@@ -166,45 +165,40 @@ public:
   AABB_face_graph_triangle_primitive(Iterator it, const FaceGraph& graph, VertexPointPMap_ vppm)
     : Base( it,
             Triangle_property_map(const_cast<FaceGraph*>(&graph),vppm),
-            Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
-  {
-    this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(*it, graph);
-  }
+            Point_property_map(const_cast<FaceGraph*>(&graph),vppm) ),
+      this_graph(&graph)
+  {}
 
   /*!
     Constructs a primitive.
     If `VertexPointPMap` is the default of the class, an additional constructor
     is available with `vppm` set to `get(vertex_point, graph)`.
   */
-  AABB_face_graph_triangle_primitive(Id_ id, const FaceGraph& graph, VertexPointPMap_ vppm)
+  AABB_face_graph_triangle_primitive(
+      typename boost::graph_traits<FaceGraph>::face_descriptor id, const FaceGraph& graph, 
+      VertexPointPMap_ vppm)
     : Base( Id_(id),
             Triangle_property_map(const_cast<FaceGraph*>(&graph),vppm),
-            Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
-  {
-    this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(id, graph);
-  }
+            Point_property_map(const_cast<FaceGraph*>(&graph),vppm) ),
+      this_graph(&graph)
+  {}
 
 #ifndef DOXYGEN_RUNNING
   template <class Iterator>
   AABB_face_graph_triangle_primitive(Iterator it, const FaceGraph& graph)
     : Base( Id_(*it),
             Triangle_property_map(const_cast<FaceGraph*>(&graph)),
-            Point_property_map(const_cast<FaceGraph*>(&graph)) )
-  {
-    this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(*it, graph);
-  }
+            Point_property_map(const_cast<FaceGraph*>(&graph)) ),
+      this_graph(&graph)
+  {}
 
-  AABB_face_graph_triangle_primitive(Id id, const FaceGraph& graph)
+  AABB_face_graph_triangle_primitive(
+      typename boost::graph_traits<FaceGraph>::face_descriptor id, const FaceGraph& graph)
     : Base( Id_(id),
             Triangle_property_map(const_cast<FaceGraph*>(&graph)),
-            Point_property_map(const_cast<FaceGraph*>(&graph)) )
-  {
-    this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(id, graph);
-  }
+            Point_property_map(const_cast<FaceGraph*>(&graph)) ),
+      this_graph(&graph)
+  {}
 #endif
 
   /// \internal

--- a/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
@@ -43,10 +43,10 @@ template<class FaceGraph>
 struct Primitive_id<FaceGraph, Tag_true>
 {
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor Id_;
-  template<class Iterator>
-  static Id_ from_iterator(Iterator it, const FaceGraph&)
+  template<class T>
+  static Id_ from_id(const T& id, const FaceGraph&)
   {
-    return Id_(*it);
+    return Id_(id);
   }
 };
 
@@ -55,13 +55,14 @@ struct Primitive_id<FaceGraph, Tag_false>
 {
   typedef std::pair<typename boost::graph_traits<FaceGraph>::face_descriptor,
   FaceGraph> Id_;
-  template<class Iterator>
-  static Id_ from_iterator(Iterator it, const FaceGraph& f)
+  template<class T>
+  static Id_ from_id(const T& id, const FaceGraph& f)
   {
-    return std::make_pair(*it, f);
+    return std::make_pair(id, f);
   }
 };
-}
+}//end internal
+
 /*!
  * \ingroup PkgAABB_tree
  * Primitive type for a facet of a polyhedral surface.
@@ -168,7 +169,7 @@ public:
             Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
   {
     this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_iterator(it, graph);
+        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(*it, graph);
   }
 
   /*!
@@ -182,7 +183,7 @@ public:
             Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
   {
     this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_iterator(id, graph);
+        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(id, graph);
   }
 
 #ifndef DOXYGEN_RUNNING
@@ -193,7 +194,8 @@ public:
             Point_property_map(const_cast<FaceGraph*>(&graph)) )
   {
     this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_iterator(it, graph);}
+        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(*it, graph);
+  }
 
   AABB_face_graph_triangle_primitive(Id id, const FaceGraph& graph)
     : Base( Id_(id),
@@ -201,7 +203,8 @@ public:
             Point_property_map(const_cast<FaceGraph*>(&graph)) )
   {
     this_id = 
-        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_iterator(id, graph);}
+        internal::Primitive_id<FaceGraph, OneFaceGraphPerTree>::from_id(id, graph);
+  }
 #endif
 
   /// \internal

--- a/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
@@ -138,7 +138,7 @@ public:
   typedef Kernel_traits<Point>::Kernel::Triangle_3 Datum;
   /*!
   Id type:
-  - boost::graph_traits<FaceGraph>::face_descriptor Id if OneFaceGraphPerTree is `CGAL::Tag_true
+  - boost::graph_traits<FaceGraph>::face_descriptor Id if OneFaceGraphPerTree is `CGAL::Tag_true`
   - std::pair<boost::graph_traits<FaceGraph>::face_descriptor, FaceGraph> Id if OneFaceGraphPerTree is `CGAL::Tag_false`
   */
   Unspecified_type Id;

--- a/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
@@ -39,7 +39,7 @@
 #include <CGAL/Default.h>
 
 namespace CGAL {
-namespace internal{
+namespace internal_primitive_id{
 //helper struct for creating the right Id: just an edge_descriptor if OneHalfedgeGraphPerTree
 // is true,else : a pair with the corresponding graph.
 template<class HalfedgeGraph,
@@ -136,9 +136,9 @@ class AABB_halfedge_graph_segment_primitive
                           CacheDatum > Base;
 
 public:
-  typedef typename internal::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::Id_ Id;
+  typedef typename internal_primitive_id::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::Id_ Id;
 protected:
-  Id this_id;
+  const HalfedgeGraph* this_graph;
 public:
 #ifdef DOXYGEN_RUNNING
  /// \name Types
@@ -157,11 +157,6 @@ public:
   - std::pair<boost::graph_traits<HalfegdeGraph>::edge_descriptor, HalfegdeGraph> Id if OneHalfegdeGraphPerTree is `CGAL::Tag_false`
   */
   Unspecified_type Id;
-  /*!
-  Id type of the Base:
-  */
-  typedef typename boost::graph_traits<HalfegdeGraph>::edge_descriptor Id_;
-  
   /// @}
 
   /*!
@@ -169,7 +164,11 @@ public:
   */
   static unspecified_type construct_shared_data( HalfedgeGraph& graph );
 #endif
-  Id id() const {return this_id;}
+  Id id() const {
+    return internal_primitive_id::EPrimitive_id<HalfedgeGraph, 
+        OneHalfedgeGraphPerTree>::from_id(Base::id(), 
+                                          *this_graph);
+  }
 
   /*!
   Constructs a primitive.
@@ -183,43 +182,39 @@ public:
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(*it),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph), vppm),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
-  {
-    this_id = 
-        internal::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::from_id(*it, graph);
-  }
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) ),
+      this_graph(&graph)
+  {}
 
   /*!
   Constructs a primitive.
   If `VertexPointPMap` is the default of the class, an additional constructor
   is available with `vppm` set to `boost::get(vertex_point, graph)`.
   */
-  AABB_halfedge_graph_segment_primitive(Id_ id, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
+  AABB_halfedge_graph_segment_primitive(
+      typename boost::graph_traits<HalfedgeGraph>::edge_descriptor id, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(id),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph), vppm),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
-  {
-    this_id = 
-        internal::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::from_id(id, graph);
-  }
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) ),
+      this_graph(&graph)
+  {}
 
   #ifndef DOXYGEN_RUNNING
   template <class Iterator>
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph)
     : Base( Id_(*it),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph)),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ){
-    this_id = 
-        internal::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::from_id(*it, graph);
-  }
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ),
+      this_graph(&graph)
+  {}
 
-  AABB_halfedge_graph_segment_primitive(Id_ id, const HalfedgeGraph& graph)
+  AABB_halfedge_graph_segment_primitive(
+      typename boost::graph_traits<HalfedgeGraph>::edge_descriptor id, const HalfedgeGraph& graph)
     : Base( Id_(id),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph)),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ){
-    this_id = 
-        internal::EPrimitive_id<HalfedgeGraph, OneHalfedgeGraphPerTree>::from_id(id, graph);
-  }
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ),
+      this_graph(&graph)
+  {}
   #endif
 
   /// \internal

--- a/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
@@ -153,7 +153,7 @@ public:
   typedef Kernel_traits<Point>::Kernel::Segment_3 Datum;
   /*!
   Id type:
-  - boost::graph_traits<HalfegdeGraph>::edge_descriptor Id if OneHalfegdeGraphPerTree is `CGAL::Tag_true
+  - boost::graph_traits<HalfegdeGraph>::edge_descriptor Id if OneHalfegdeGraphPerTree is `CGAL::Tag_true`
   - std::pair<boost::graph_traits<HalfegdeGraph>::edge_descriptor, HalfegdeGraph> Id if OneHalfegdeGraphPerTree is `CGAL::Tag_false`
   */
   Unspecified_type Id;

--- a/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
@@ -35,54 +35,11 @@
 #include <CGAL/is_iterator.h>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/utility/enable_if.hpp>
+#include <boost/mpl/if.hpp>
 
 #include <CGAL/Default.h>
 
 namespace CGAL {
-namespace internal_primitive_id{
-//helper base class for creating the right Id: just a face_descriptor if OneFaceGraphPerTree
-// is true,else : a pair with the corresponding graph.
-template<class Graph,
-         class OneGraphPerTree>
-class EPrimitive_wrapper;
-
-template<class Graph>
-class EPrimitive_wrapper<Graph, Tag_true>
-{
-  public:
-  typedef typename boost::graph_traits<Graph>::edge_descriptor Id;
-  
-  EPrimitive_wrapper(const Graph*)
-  {}
-  
-  template<class T>
-  Id from_id(const T& id)const
-  {
-    return Id(id);
-  }
-};
-
-template<class Graph>
-class EPrimitive_wrapper<Graph, Tag_false>
-{
-public:
-  typedef std::pair<typename boost::graph_traits<Graph>::edge_descriptor,
-  Graph> Id;
-  
-  EPrimitive_wrapper(const Graph* graph)
-    :this_graph(graph)
-  {}
-  
-  template<class T>
-  Id from_id(const T& id)const
-  {
-    return std::make_pair(id, *this_graph);
-  }
-  
-private:
-  const Graph* this_graph;
-};
-}//end internal
 
 
 /*!
@@ -122,7 +79,9 @@ template < class HalfedgeGraph,
            class CacheDatum = Tag_false >
 class AABB_halfedge_graph_segment_primitive
 #ifndef DOXYGEN_RUNNING
-  : public AABB_primitive<  typename boost::graph_traits<HalfedgeGraph>::edge_descriptor,
+  : public AABB_primitive<  typename boost::mpl::if_<OneHalfedgeGraphPerTree,
+                                                     typename boost::graph_traits<HalfedgeGraph>::edge_descriptor,
+                                                     std::pair<typename boost::graph_traits<HalfedgeGraph>::edge_descriptor, const HalfedgeGraph*> >::type,
                             Segment_from_edge_descriptor_map<
                               HalfedgeGraph,
                               typename Default::Get<VertexPointPMap,
@@ -134,13 +93,13 @@ class AABB_halfedge_graph_segment_primitive
                                                     typename boost::property_map< HalfedgeGraph,
                                                                                   vertex_point_t>::type >::type >,
                             OneHalfedgeGraphPerTree,
-                            CacheDatum >,
-    public internal_primitive_id::EPrimitive_wrapper<HalfedgeGraph, OneHalfedgeGraphPerTree>
+                            CacheDatum >
 #endif
 {
   typedef typename Default::Get<VertexPointPMap,typename boost::property_map< HalfedgeGraph,vertex_point_t>::type >::type  VertexPointPMap_;
+  typedef typename boost::graph_traits<HalfedgeGraph>::edge_descriptor ED;
+  typedef typename boost::mpl::if_<OneHalfedgeGraphPerTree, ED, std::pair<ED, const HalfedgeGraph*> >::type Id_;
 
-  typedef typename boost::graph_traits<HalfedgeGraph>::edge_descriptor Id_;
   typedef Segment_from_edge_descriptor_map<HalfedgeGraph,VertexPointPMap_>  Segment_property_map;
   typedef Source_point_from_edge_descriptor_map<HalfedgeGraph,VertexPointPMap_> Point_property_map;
 
@@ -149,13 +108,19 @@ class AABB_halfedge_graph_segment_primitive
                           Point_property_map,
                           OneHalfedgeGraphPerTree,
                           CacheDatum > Base;
-  
-  typedef internal_primitive_id::EPrimitive_wrapper<HalfedgeGraph, OneHalfedgeGraphPerTree> Base_2;
+
+  ED make_id(ED ed, const HalfedgeGraph&, Tag_true)
+  {
+    return ed;
+  }
+
+  std::pair<ED, const HalfedgeGraph*> make_id(ED ed, const HalfedgeGraph& fg, Tag_false)
+  {
+    return std::make_pair(ed, &fg);
+  }
 
 public:
-  typedef typename Base_2::Id Id;
 
-public:
 #ifdef DOXYGEN_RUNNING
  /// \name Types
   /// @{
@@ -169,20 +134,20 @@ public:
   typedef Kernel_traits<Point>::Kernel::Segment_3 Datum;
   /*!
   Id type:
-  - boost::graph_traits<HalfegdeGraph>::edge_descriptor Id if OneHalfegdeGraphPerTree is `CGAL::Tag_true`
-  - std::pair<boost::graph_traits<HalfegdeGraph>::edge_descriptor, HalfegdeGraph> Id if OneHalfegdeGraphPerTree is `CGAL::Tag_false`
+  - `boost::graph_traits<HalfedgeGraph>::edge_descriptor if `OneHalfedgeGraphPerTree` is `Tag_true`
+  - `std::pair<boost::graph_traits<HalfedgeGraph>::edge_descriptor`, HalfedgeGraph>` if `OneHalfedgeGraphPerTree` is `Tag_false`
   */
-  Unspecified_type Id;
+  unspecified_type Id;
   /// @}
 
   /*!
-  If `OneHalfedgeGraphPerTreeGraphPerTree` is CGAL::Tag_true, constructs a `Shared_data` object from a reference to the halfedge graph.
+  If `OneHalfedgeGraphPerTree` is CGAL::Tag_true, constructs a `Shared_data` object from a reference to the halfedge graph.
   */
   static unspecified_type construct_shared_data( HalfedgeGraph& graph );
+#else
+  typedef typename Base::Id Id;
 #endif
-  Id id() const {
-    return Base_2::from_id(Base::id());
-  }
+  typedef typename boost::graph_traits<HalfedgeGraph>::edge_descriptor edge_descriptor;
 
   /*!
   Constructs a primitive.
@@ -194,10 +159,9 @@ public:
   */
   template <class Iterator>
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
-    : Base( Id_(*it),
+    : Base( Id_(make_id(*it, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph), vppm),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) ),
-      Base_2(&graph)
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
   {}
 
   /*!
@@ -205,30 +169,23 @@ public:
   If `VertexPointPMap` is the default of the class, an additional constructor
   is available with `vppm` set to `boost::get(vertex_point, graph)`.
   */
-  AABB_halfedge_graph_segment_primitive(
-      typename boost::graph_traits<HalfedgeGraph>::edge_descriptor id, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
-    : Base( Id_(id),
+  AABB_halfedge_graph_segment_primitive(edge_descriptor ed, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
+    : Base( Id_(make_id(ed, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph), vppm),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) ),
-      Base_2(&graph)
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
   {}
 
   #ifndef DOXYGEN_RUNNING
   template <class Iterator>
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph)
-    : Base( Id_(*it),
+    : Base( Id_(make_id(*it, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph)),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ),
-      Base_2(&graph)
-  {}
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ){}
 
-  AABB_halfedge_graph_segment_primitive(
-      typename boost::graph_traits<HalfedgeGraph>::edge_descriptor id, const HalfedgeGraph& graph)
-    : Base( Id_(id),
+  AABB_halfedge_graph_segment_primitive(edge_descriptor ed, const HalfedgeGraph& graph)
+    : Base( Id_(make_id(ed, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph)),
-            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ),
-      Base_2(&graph)
-  {}
+            Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ){}
   #endif
 
   /// \internal

--- a/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
@@ -14,6 +14,7 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/AABB_halfedge_graph_segment_primitive.h>
 #include <CGAL/Timer.h>
 
 typedef CGAL::Epick K;
@@ -25,11 +26,17 @@ typedef K::Ray_3 Ray;
 typedef CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> > Mesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
 CGAL::Default, 
-CGAL::Tag_false> Primitive;
-typedef CGAL::AABB_traits<K, Primitive> Traits;
-typedef CGAL::AABB_tree<Traits> Tree;
-typedef Tree::Primitive_id Primitive_id;
-typedef CGAL::Timer Timer;
+CGAL::Tag_false> T_Primitive;
+typedef CGAL::AABB_traits<K, T_Primitive> T_Traits;
+typedef CGAL::AABB_tree<T_Traits> T_Tree;
+typedef T_Tree::Primitive_id T_Primitive_id;
+
+typedef CGAL::AABB_halfedge_graph_segment_primitive<Mesh,
+CGAL::Default, 
+CGAL::Tag_false> E_Primitive;
+typedef CGAL::AABB_traits<K, E_Primitive> E_Traits;
+typedef CGAL::AABB_tree<E_Traits> E_Tree;
+typedef E_Tree::Primitive_id E_Primitive_id;
 
 int main()
 {
@@ -50,18 +57,27 @@ int main()
     return 1;
   }
   in.close();
-  Tree tree(faces(m1).first, faces(m1).second, m1);
+  T_Tree tree(faces(m1).first, faces(m1).second, m1);
   tree.insert(faces(m2).first, faces(m2).second, m2);
-  //tree.insert(faces(m1).first, faces(m1).second, m1);
   tree.build();
-  Tree::Bounding_box bbox = tree.bbox();
+  T_Tree::Bounding_box bbox = tree.bbox();
   Point bbox_center((bbox.xmin() + bbox.xmax()) / 2, 
                      (bbox.ymin() + bbox.ymax()) / 2, 
                      (bbox.zmin() + bbox.zmax()) / 2);
-  std::vector< Primitive_id > intersections;
+  std::vector< T_Primitive_id > intersections;
   Ray ray(bbox_center+Vector(3,-0.25,0),bbox_center+Vector(-3,+0.25,0));
   tree.all_intersected_primitives(ray,
                                   std::back_inserter(intersections));
+  
+  E_Tree e_tree(edges(m1).first, edges(m1).second, m1);
+  e_tree.insert(edges(m2).first, edges(m2).second, m2);
+  e_tree.build();
+  std::vector< E_Primitive_id > e_intersections;
+  Ray e_ray(Point(0,0,0),Point(0,1,1));
+  e_tree.all_intersected_primitives(e_ray,
+                                  std::back_inserter(e_intersections));
+  
+  
   
   return 0;
 }

--- a/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
@@ -1,0 +1,67 @@
+#include <fstream>
+#include <algorithm>
+#include <iterator>
+
+#include <boost/functional/value_factory.hpp>
+#include <boost/array.hpp>
+
+#include <CGAL/assertions.h>
+#include <CGAL/algorithm.h>
+#include <CGAL/point_generators_3.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/Timer.h>
+
+typedef CGAL::Epick K;
+typedef K::FT FT;
+typedef K::Point_3 Point;
+typedef K::Vector_3 Vector;
+typedef K::Segment_3 Segment;
+typedef K::Ray_3 Ray;
+typedef CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> > Mesh;
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+CGAL::Default, 
+CGAL::Tag_false> Primitive;
+typedef CGAL::AABB_traits<K, Primitive> Traits;
+typedef CGAL::AABB_tree<Traits> Tree;
+typedef Tree::Primitive_id Primitive_id;
+typedef CGAL::Timer Timer;
+
+int main()
+{
+  CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> > m1, m2;
+  std::ifstream in("data/cube.off");
+  if(in)
+    in >> m1;
+  else{
+    std::cout << "error reading cube" << std::endl;
+    return 1;
+  }
+  in.close();
+  in.open("data/tetrahedron.off");
+  if(in)
+    in >> m2;
+  else{
+    std::cout << "error reading tetrahedron" << std::endl;
+    return 1;
+  }
+  in.close();
+  Tree tree(faces(m1).first, faces(m1).second, m1);
+  tree.insert(faces(m2).first, faces(m2).second, m2);
+  //tree.insert(faces(m1).first, faces(m1).second, m1);
+  tree.build();
+  Tree::Bounding_box bbox = tree.bbox();
+  Point bbox_center((bbox.xmin() + bbox.xmax()) / 2, 
+                     (bbox.ymin() + bbox.ymax()) / 2, 
+                     (bbox.zmin() + bbox.zmax()) / 2);
+  std::vector< Primitive_id > intersections;
+  Ray ray(bbox_center+Vector(3,-0.25,0),bbox_center+Vector(-3,+0.25,0));
+  tree.all_intersected_primitives(ray,
+                                  std::back_inserter(intersections));
+  
+  return 0;
+}

--- a/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
@@ -68,7 +68,6 @@ int main()
   Ray ray(bbox_center+Vector(3,-0.25,0),bbox_center+Vector(-3,+0.25,0));
   tree.all_intersected_primitives(ray,
                                   std::back_inserter(intersections));
-  
   E_Tree e_tree(edges(m1).first, edges(m1).second, m1);
   e_tree.insert(edges(m2).first, edges(m2).second, m2);
   e_tree.build();

--- a/BGL/include/CGAL/boost/graph/property_maps.h
+++ b/BGL/include/CGAL/boost/graph/property_maps.h
@@ -73,6 +73,19 @@ struct Triangle_from_face_descriptor_map{
                        get(pmap.m_vpm, target(next(halfedge(f,tm),tm),tm)),
                        get(pmap.m_vpm, source(halfedge(f,tm),tm)) );
   }
+
+  inline friend
+  reference
+  get(const Triangle_from_face_descriptor_map<TriangleMesh,VertexPointMap>& pmap,
+      const std::pair<key_type, const TriangleMesh*>& f)
+  {
+    typename boost::remove_const<TriangleMesh>::type & tm = *(pmap.m_tm);
+    CGAL_precondition(halfedge(f.first,tm) == next(next(next(halfedge(f.first,tm),tm),tm),tm));
+
+    return value_type( get(pmap.m_vpm, target(halfedge(f.first,tm),tm)),
+                       get(pmap.m_vpm, target(next(halfedge(f.first,tm),tm),tm)),
+                       get(pmap.m_vpm, source(halfedge(f.first,tm),tm)) );
+  }
 };
 
 template < class PolygonMesh,
@@ -114,6 +127,15 @@ struct Segment_from_edge_descriptor_map{
     return value_type(get(pmap.m_vpm, source(h, *pmap.m_pm) ),
                       get(pmap.m_vpm, target(h, *pmap.m_pm) ) );
   }
+
+  inline friend
+  reference
+  get(const Segment_from_edge_descriptor_map<PolygonMesh,VertexPointMap>& pmap,
+      const std::pair<key_type, const PolygonMesh*>& h)
+  {
+    return value_type(get(pmap.m_vpm, source(h.first, *pmap.m_pm) ),
+                      get(pmap.m_vpm, target(h.first, *pmap.m_pm) ) );
+  }
 };
 
 //property map to access a point from a face_descriptor
@@ -151,6 +173,14 @@ struct One_point_from_face_descriptor_map{
   {
     return get(m.m_vpm, target(halfedge(f, *m.m_pm), *m.m_pm));
   }
+
+  inline friend
+  reference
+  get(const One_point_from_face_descriptor_map<PolygonMesh,VertexPointMap>& m,
+      const std::pair<key_type, const PolygonMesh*>& f)
+  {
+    return get(m.m_vpm, target(halfedge(f.first, *m.m_pm), *m.m_pm));
+  }
 };
 
 //property map to access a point from an edge
@@ -186,6 +216,14 @@ struct Source_point_from_edge_descriptor_map{
       key_type h)
   {
     return get(pmap.m_vpm,  source(h, *pmap.m_pm) );
+  }
+
+  inline friend
+  reference
+  get(const Source_point_from_edge_descriptor_map<PolygonMesh,VertexPointMap>& pmap,
+      const std::pair<key_type, const PolygonMesh*>& h)
+  {
+    return get(pmap.m_vpm,  source(h.first, *pmap.m_pm) );
   }
 };
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -22,10 +22,10 @@ Release date: March 2019
 
 ### 3D Fast Intersection and Distance Computation
 
--   The primitives AABB_face_graph_triangle_primitive and 
-    AABB_halfedge_graph_segment_primitive now use a pair of id and 
-    graph if they are parameterized to deal with several graphs in
-    per tree (with the template tag.)
+-   The primitives `AABB_face_graph_triangle_primitive` and
+    `AABB_halfedge_graph_segment_primitive` now use as `Id` a pair of descriptor and
+    graph pointer in the case they are configured to deal with a possible different
+    graph per primitive (configuration set using a template tag).
 
 Release 4.13
 ------------

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -20,6 +20,13 @@ Release date: March 2019
     - `CGAL::Polygon_mesh_processing::merge_duplicated_vertices_in_boundary_cycle()`
     - `CGAL::Polygon_mesh_processing::merge_duplicated_vertices_in_boundary_cycles()`
 
+### 3D Fast Intersection and Distance Computation
+
+-   The primitives AABB_face_graph_triangle_primitive and 
+    AABB_halfedge_graph_segment_primitive now use a pair of id and 
+    graph if they are parameterized to deal with several graphs in
+    per tree (with the template tag.)
+
 Release 4.13
 ------------
 


### PR DESCRIPTION
## Summary of Changes
Use a std::pair containing the id and the associated graph if the tag OneGraphPerTree is false, so it is possible to use the primitives returned by the intersections tests.
## Release Management

* Affected package(s):AABB_tree
* Issue(s) solved (if any): fix #3364 
* Feature/Small Feature (if any): [Pairs as ids](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/AABB_tree/Pairs_as_ids)
* Link to compiled documentation (obligatory for small feature) [link](https://cgal.geometryfactory.com/~mgimeno/AABB_tree_primitive_id/AABB_tree/)
* License and copyright ownership:
 Copyright (c) 2012 INRIA Sophia-Antipolis (France).
* **Pre-approved:** 2018/10/09
