### PR TITLE
Triangulation: Manage binary mode in Triangulation IO

### DIFF
--- a/Triangulation/include/CGAL/Triangulation.h
+++ b/Triangulation/include/CGAL/Triangulation.h
@@ -1416,12 +1416,22 @@ operator<<(std::ostream & os, const Triangulation<TT, TDS> & tr)
 
     // infinite vertex has index 0 (among all the vertices)
     index_of_vertex[tr.infinite_vertex()] = i++;
-    os << *tr.infinite_vertex();
+    if( is_ascii(os) )
+      os << *tr.infinite_vertex();
+    else
+    {
+        write(os, *tr.infinite_vertex(), io_Read_write());
+    }
     for( Vertex_iterator it = tr.vertices_begin(); it != tr.vertices_end(); ++it )
     {
         if( tr.is_infinite(it) )
             continue;
-        os << *it; // write the vertex
+        if( is_ascii(os) )
+          os << *it; // write the vertex
+        else
+        {
+            write(os, *it, io_Read_write());
+        }
         index_of_vertex[it] = i++;
     }
     CGAL_assertion( i == n+1 );


### PR DESCRIPTION
## Summary of Changes

Only the first line of the operator<< tested for ascii mode. Now everything that is output does.
## Release Management

* Affected package(s):Triangulation
