### PR TITLE
Polyhedron demo: Accelerate the creation of items.

### DIFF
--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow.h
@@ -35,6 +35,7 @@
 #include <CGAL/auto_link/Qt.h>
 #include <CGAL/export/Qt.h>
 #include <CGAL/Qt/resources.h>
+#include <QSettings>
 
 // forward declaration
 class QLabel;
@@ -125,6 +126,7 @@ protected:
   QAction* recentFilesSeparator;
   unsigned int maxNumRecentFiles;
   QVector<QAction*> recentFileActs;
+  QSettings settings;
 }; // end class DemosMainWindow
 
 } // namespace Qt
@@ -137,3 +139,4 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(CGAL::Qt::DemosMainWindow::Options)
 #endif // CGAL_HEADER_ONLY
 
 #endif // CGAL_QT_DEMOS_MAIN_WINDOW_H
+

--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -379,13 +379,11 @@ CGAL_INLINE_FUNCTION
 void 
 DemosMainWindow::addToRecentFiles(QString fileName)
 {
-  QSettings settings;
   QStringList files = settings.value("recentFileList").toStringList();
   files.removeAll(fileName);
   files.prepend(fileName);
   while (files.size() > (int)maxNumberOfRecentFiles())
     files.removeLast();
-
   settings.setValue("recentFileList", files);
 
   updateRecentFileActions();
@@ -423,7 +421,6 @@ CGAL_INLINE_FUNCTION
 void 
 DemosMainWindow::updateRecentFileActions()
 {
-  QSettings settings;
   QStringList files = settings.value("recentFileList").toStringList();
 
   int numRecentFiles = qMin(files.size(), (int)this->maxNumberOfRecentFiles());
@@ -444,7 +441,7 @@ DemosMainWindow::updateRecentFileActions()
 CGAL_INLINE_FUNCTION
 void DemosMainWindow::writeState(QString groupname)
 {
-  QSettings settings;
+  
 
   settings.beginGroup(groupname);
   settings.setValue("size", size());
@@ -456,7 +453,7 @@ void DemosMainWindow::writeState(QString groupname)
 CGAL_INLINE_FUNCTION
 void DemosMainWindow::readState(QString groupname, Options /*what_to_save*/)
 {
-  QSettings settings;
+  
   
   settings.beginGroup(groupname);
   resize(settings.value("size", this->size()).toSize());

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -39,6 +39,7 @@
 #include <QTreeWidget>
 #include <QDockWidget>
 #include <stdexcept>
+#include <QTime>
 #ifdef QT_SCRIPT_LIB
 #  include <QScriptValue>
 #  ifdef QT_SCRIPTTOOLS_LIB
@@ -1050,7 +1051,6 @@ void MainWindow::open(QString filename)
     default:
       load_pair = File_loader_dialog::getItem(fileinfo.fileName(), selected_items, &ok);
   }
-
   viewer->makeCurrent();
   if(!ok || load_pair.first.isEmpty()) { return; }
 
@@ -1063,14 +1063,13 @@ void MainWindow::open(QString filename)
   }
 
 
-  QSettings settings;
   settings.setValue("OFF open directory",
                     fileinfo.absoluteDir().absolutePath());
   CGAL::Three::Scene_item* scene_item = loadItem(fileinfo, findLoader(load_pair.first));
+ 
   if(!scene_item)
     return;
   this->addToRecentFiles(fileinfo.absoluteFilePath());
-
   selectSceneItem(scene->addItem(scene_item));
 
   CGAL::Three::Scene_group_item* group =
@@ -1465,7 +1464,6 @@ void MainWindow::updateDisplayInfo() {
 
 void MainWindow::readSettings()
 {
-    QSettings settings;
     // enable anti-aliasing
     ui->actionAntiAliasing->setChecked(settings.value("antialiasing", false).toBool());
     // read plugin blacklist
@@ -1478,7 +1476,7 @@ void MainWindow::writeSettings()
 {
   this->writeState("MainWindow");
   {
-    QSettings settings;
+    
     settings.setValue("antialiasing",
                       ui->actionAntiAliasing->isChecked());
     //setting plugin blacklist
@@ -1587,7 +1585,7 @@ void MainWindow::on_actionLoad_triggered()
       filters << filter;
     }
   }
-  QSettings settings;
+  
   QString directory = settings.value("OFF open directory",
                                      QDir::current().dirName()).toString();
 
@@ -1614,7 +1612,9 @@ void MainWindow::on_actionLoad_triggered()
                     static_cast<unsigned>(nb_files),
                     std::back_inserter(colors_));
   std::size_t nb_item = -1;
+  
   Q_FOREACH(const QString& filename, dialog.selectedFiles()) {
+    
     CGAL::Three::Scene_item* item = NULL;
     if(selectedPlugin) {
       QFileInfo info(filename);


### PR DESCRIPTION
## Summary of Changes

Always use the same member QSettings in the mainwindow makes it 200ms faster to build an item. This is really significant when loading hundreds of small items.
## Release Management

* Issue(s) solved (if any): fix #3373
