### PR TITLE
Mesh_3: Allow `Subdomain_index` to be `short`

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -7,7 +7,7 @@ CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 function build_examples {
   mkdir -p build-travis
   cd build-travis
-  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS_RELEASE="${CXX_FLAGS}" ..
+  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
   make -j2
 }
 
@@ -45,7 +45,7 @@ function build_demo {
     QGLVIEWERROOT=$PWD/qglviewer
     export QGLVIEWERROOT
   fi
-  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DQt5_DIR="/opt/qt55/lib/cmake/Qt5" -DQt5Svg_DIR="/opt/qt55/lib/cmake/Qt5Svg" -DQt5OpenGL_DIR="/opt/qt55/lib/cmake/Qt5OpenGL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS_RELEASE="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
+  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DQt5_DIR="/opt/qt55/lib/cmake/Qt5" -DQt5Svg_DIR="/opt/qt55/lib/cmake/Qt5Svg" -DQt5OpenGL_DIR="/opt/qt55/lib/cmake/Qt5OpenGL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
   make -j2
 }
 old_IFS=$IFS

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -2,7 +2,7 @@
 set -e
 [ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 
-CXX_FLAGS="-DCGAL_NDEBUG"
+CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 
 function build_examples {
   mkdir -p build-travis

--- a/Mesh_3/include/CGAL/Mesh_3/io_signature.h
+++ b/Mesh_3/include/CGAL/Mesh_3/io_signature.h
@@ -110,6 +110,46 @@ struct Get_io_signature<unsigned int>
 };
 
 template <>
+struct Get_io_signature<char>
+{
+  std::string operator()() {
+    return "c";
+  }
+};
+
+template <>
+struct Get_io_signature<unsigned char>
+{
+  std::string operator()() {
+    return "uc";
+  }
+};
+
+template <>
+struct Get_io_signature<signed char>
+{
+  std::string operator()() {
+    return "sc";
+  }
+};
+
+template <>
+struct Get_io_signature<short int>
+{
+  std::string operator()() {
+    return "s";
+  }
+};
+
+template <>
+struct Get_io_signature<unsigned short int>
+{
+  std::string operator()() {
+    return "us";
+  }
+};
+
+template <>
 struct Get_io_signature<double>
 {
   std::string operator()() {

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -38,6 +38,7 @@
 #include <CGAL/is_streamable.h>
 #include <CGAL/Real_timer.h>
 #include <CGAL/property_map.h>
+#include <CGAL/internal/Mesh_3/indices_management.h>
 
 #include <vector>
 #include <set>
@@ -546,15 +547,19 @@ class Mesh_domain_with_polyline_features_3
 public:
 /// \name Types
 /// @{
-  typedef typename MeshDomain_3::Index    Index;
+  typedef typename MeshDomain_3::Surface_patch_index Surface_patch_index;
+  typedef typename MeshDomain_3::Subdomain_index     Subdomain_index;
+  typedef int                                        Curve_index;
+  typedef int                                        Corner_index;
 
-  typedef typename MeshDomain_3::Surface_patch_index
-                                  Surface_patch_index;
+  typedef typename Mesh_3::internal::Index_generator_with_features<
+    typename MeshDomain_3::Subdomain_index,
+    Surface_patch_index,
+    Curve_index,
+    Corner_index>::type                              Index;
 
-  typedef int                     Curve_index;
-  typedef int                     Corner_index;
-  typedef CGAL::Tag_true           Has_features;
-  typedef typename MeshDomain_3::R::FT          FT;
+  typedef CGAL::Tag_true                             Has_features;
+  typedef typename MeshDomain_3::R::FT               FT;
 /// @}
 
 #ifndef DOXYGEN_RUNNING
@@ -777,17 +782,46 @@ public:
                                 const Point_3& c1, const Point_3& c2,
                                 const FT sq_r1, const FT sq_r2) const;
 
+
+  /**
+   * Returns the index to be stored in a vertex lying on the surface identified
+   * by \c index.
+   */
+  Index index_from_surface_patch_index(const Surface_patch_index& index) const
+  { return Index(index); }
+
+  /**
+   * Returns the index to be stored in a vertex lying in the subdomain
+   * identified by \c index.
+   */
+  Index index_from_subdomain_index(const Subdomain_index& index) const
+  { return Index(index); }
+
   /// Returns an `Index` from a `Curve_index`
   Index index_from_curve_index(const Curve_index& index) const
   { return Index(index); }
 
-  /// Returns a `Curve_index` from an `Index`
-  Curve_index curve_index(const Index& index) const
-  { return boost::get<Curve_index>(index); }
-
   /// Returns an `Index` from a `Corner_index`
   Index index_from_corner_index(const Corner_index& index) const
   { return Index(index); }
+
+  /**
+   * Returns the \c Surface_patch_index of the surface patch
+   * where lies a vertex with dimension 2 and index \c index.
+   */
+  Surface_patch_index surface_patch_index(const Index& index) const
+  { return boost::get<Surface_patch_index>(index); }
+
+  /**
+   * Returns the index of the subdomain containing a vertex
+   *  with dimension 3 and index \c index.
+   */
+  Subdomain_index subdomain_index(const Index& index) const
+  { return boost::get<Subdomain_index>(index); }
+
+  /// Returns a `Curve_index` from an `Index`
+  Curve_index curve_index(const Index& index) const
+  { return boost::get<Curve_index>(index); }
 
   /// Returns a `Corner_index` from an `Index`
   Corner_index corner_index(const Index& index) const

--- a/Mesh_3/include/CGAL/internal/Mesh_3/indices_management.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/indices_management.h
@@ -33,6 +33,7 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
+#include <boost/mpl/set/set10.hpp>
 #include <CGAL/Mesh_3/Has_features.h>
 #include <CGAL/IO/io.h>
 
@@ -48,7 +49,7 @@ template < typename Subdomain_index, typename Surface_patch_index >
 struct Index_generator
 {
   typedef boost::variant<Subdomain_index,Surface_patch_index> Index;
-  typedef Index                                         type;
+  typedef Index                                               type;
 };
 
 template < typename T >
@@ -56,6 +57,27 @@ struct Index_generator<T, T>
 {
   typedef T       Index;
   typedef Index   type;
+};
+
+template < typename Subdomain_index,
+           typename Surface_patch_index,
+           typename Curves_index,
+           typename Corner_index>
+struct Index_generator_with_features
+{
+  typedef boost::mpl::set4<Subdomain_index,
+                           Surface_patch_index,
+                           Curves_index,
+                           Corner_index>               Set;
+  typedef typename boost::make_variant_over<Set>::type Index;
+  typedef Index                                        type;
+};
+
+template < typename T>
+struct Index_generator_with_features<T, T, T, T>
+{
+  typedef T Index;
+  typedef Index                                         type;
 };
 
 template <typename T, typename Boost_variant>

--- a/Mesh_3/include/CGAL/internal/Mesh_3/indices_management.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/indices_management.h
@@ -33,7 +33,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <boost/mpl/set/set10.hpp>
 #include <CGAL/Mesh_3/Has_features.h>
 #include <CGAL/IO/io.h>
 
@@ -59,17 +58,66 @@ struct Index_generator<T, T>
   typedef Index   type;
 };
 
+// Nasty meta-programming to get a boost::variant of four types that
+// may not be all different.
+template <typename T0> struct seq1 {
+  typedef T0 type;
+};
+template <typename T0, typename T1> struct seq2 {
+  typedef boost::variant<T0, T1> type;
+};
+template <typename T0, typename T1, typename T2> struct seq3 {
+  typedef boost::variant<T0, T1, T2> type;
+};
+template <typename T0, typename T1, typename T2, typename T3> struct seq4 {
+  typedef boost::variant<T0, T1, T2, T3> type;
+};
+
+template <typename T, typename U> struct insert;
+template <typename T, typename U> struct insert<seq1<T>, U> {
+  typedef seq2<T, U> type;
+};
+template <typename T, typename U, typename V> struct insert<seq2<T, U>, V> {
+  typedef seq3<T, U, V> type;
+};
+template <typename T, typename U, typename V, typename W>
+struct insert<seq3<T, U, V>, W> {
+  typedef seq4<T, U, V, W> type;
+};
+template <typename T> struct insert<seq1<T>, T> {
+  typedef seq1<T> type;
+};
+template <typename T, typename U> struct insert<seq2<T, U>, T> {
+  typedef seq2<T, U> type;
+};
+template <typename T, typename U> struct insert<seq2<T, U>, U> {
+  typedef seq2<T, U> type;
+};
+template <typename T, typename U, typename V> struct insert<seq3<T, U, V>, T> {
+  typedef seq3<T, U, V> type;
+};
+template <typename T, typename U, typename V> struct insert<seq3<T, U, V>, U> {
+  typedef seq3<T, U, V> type;
+};
+template <typename T, typename U, typename V> struct insert<seq3<T, U, V>, V> {
+  typedef seq3<T, U, V> type;
+};
+
 template < typename Subdomain_index,
            typename Surface_patch_index,
            typename Curves_index,
            typename Corner_index>
 struct Index_generator_with_features
 {
-  typedef boost::mpl::set4<Subdomain_index,
-                           Surface_patch_index,
-                           Curves_index,
-                           Corner_index>               Set;
-  typedef typename boost::make_variant_over<Set>::type Index;
+  typedef typename insert<
+    typename insert<
+      typename insert<seq1<Subdomain_index>,
+                      Surface_patch_index
+                      >::type,
+      Curves_index
+      >::type,
+    Corner_index>::type seq;
+  typedef typename seq::type Index;
   typedef Index                                        type;
 };
 

--- a/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
@@ -38,6 +38,7 @@ struct Dummy_domain
   typedef typename K::FT FT;
   typedef int Index;
   typedef int Surface_patch_index;
+  typedef unsigned short Subdomain_index;
 };
 
 typedef Dummy_domain<K_e_i> Smooth_domain;

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -39,8 +39,11 @@ struct Polyhedron_with_features_tester : public Tester<K>
   void operator()() const
   {
     typedef CGAL::Mesh_3::Robust_intersection_traits_3<K> Gt;
-    typedef typename CGAL::Mesh_polyhedron_3<Gt>::type Polyhedron;
-    typedef CGAL::Polyhedral_mesh_domain_with_features_3<Gt> Mesh_domain;
+    typedef typename CGAL::Mesh_polyhedron_3<Gt, short>::type Polyhedron;
+    typedef CGAL::Polyhedral_mesh_domain_with_features_3<Gt,
+                                                         Polyhedron,
+                                                         CGAL::Default,
+                                                         short> Mesh_domain;
     
     typedef typename CGAL::Mesh_triangulation_3<
       Mesh_domain,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
@@ -97,14 +97,16 @@ template <typename PatchIdMap, typename Handle_type, typename Int>
 typename PatchIdMapWrapper<PatchIdMap, Int>::value_type
 get(PatchIdMapWrapper<PatchIdMap, Int>& map, Handle_type h)
 {
-  return get(map.map, h) - map.offset;
+  typedef typename PatchIdMapWrapper<PatchIdMap, Int>::value_type value_type;
+  return value_type(get(map.map, h) - map.offset);
 }
 
 template <typename PatchIdMap, typename Handle_type, typename Int>
 void put(PatchIdMapWrapper<PatchIdMap, Int>& map, Handle_type h,
          typename PatchIdMapWrapper<PatchIdMap, Int>::value_type pid)
 {
-  put(map.map, h, pid + map.offset);
+  typedef typename PatchIdMapWrapper<PatchIdMap, Int>::value_type value_type;
+  put(map.map, h, value_type(pid + map.offset));
 }
 
 
@@ -127,14 +129,14 @@ template <typename PatchIdMap, typename Handle_type, typename Int>
 typename PatchIdMapWrapper<PatchIdMap, std::pair<Int, Int> >::value_type
 get(PatchIdMapWrapper<PatchIdMap, std::pair<Int, Int> >& map, Handle_type h)
 {
-  return get(map.map, h).first - map.offset;
+  return Int(get(map.map, h).first - map.offset);
 }
 
 template <typename PatchIdMap, typename Handle_type, typename Int>
 void put(PatchIdMapWrapper<PatchIdMap, std::pair<Int, Int> >& map, Handle_type h,
          typename PatchIdMapWrapper<PatchIdMap, std::pair<Int, Int> >::value_type pid)
 {
-  put(map.map, h, std::pair<Int, Int>(pid+map.offset, 0));
+  put(map.map, h, std::pair<Int, Int>(Int(pid+map.offset), 0));
 }
 
 template <typename PolygonMesh, typename PatchIdMap,


### PR DESCRIPTION
## Summary of Changes

Mesh_3: Allow `Subdomain_index` to be `short`.

... That forced me to modify the `Index` of domains with features.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: no change (maintenance by GF of an Inria package)

