### PR TITLE
Re-add examples incorrectly disabled by PR #2835

### DIFF
--- a/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
@@ -33,6 +33,21 @@ if ( CGAL_FOUND )
     target_link_libraries(draw_triangulation_3 PUBLIC CGAL::CGAL_Qt5)
   endif()
 
+  find_package( TBB QUIET )
+
+  if( TBB_FOUND )
+    include( CGAL_target_use_TBB )
+
+    create_single_source_cgal_program( "parallel_insertion_and_removal_in_regular_3.cpp" )
+    create_single_source_cgal_program( "parallel_insertion_in_delaunay_3.cpp" )
+    create_single_source_cgal_program( "sequential_parallel.cpp" )
+    CGAL_target_use_TBB( parallel_insertion_and_removal_in_regular_3 )
+    CGAL_target_use_TBB( parallel_insertion_in_delaunay_3 )
+    CGAL_target_use_TBB( sequential_parallel )
+  else()
+    message(STATUS "NOTICE: a few examples require TBB and will not be compiled.")
+  endif()
+
 else()
   
     message(STATUS "This program requires the CGAL library, and will not be compiled.")

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -56,6 +56,7 @@
 #ifdef CGAL_LINKED_WITH_TBB
 # include <CGAL/point_generators_3.h>
 # include <tbb/parallel_for.h>
+# include <tbb/task_scheduler_init.h>
 # include <tbb/enumerable_thread_specific.h>
 # include <tbb/concurrent_vector.h>
 #endif

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -41,6 +41,7 @@
 #ifdef CGAL_LINKED_WITH_TBB
 # include <CGAL/point_generators_3.h>
 # include <tbb/parallel_for.h>
+# include <tbb/task_scheduler_init.h>
 # include <tbb/enumerable_thread_specific.h>
 # include <tbb/concurrent_vector.h>
 #endif


### PR DESCRIPTION
## Summary of Changes

Re-add examples incorrectly disabled by PR #2835 and then fix them. The bug was introduced in CGAL-4.13.

## Release Management

* Affected package(s): Triangulation_3

Cc: @afabri 
