### PR TITLE
AABB_tree: Add an overload to build() for shared data

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -145,7 +145,7 @@ namespace CGAL {
     template<typename InputIterator, typename T1, typename T2, typename T3, typename T4>
 		AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&);
     template<typename InputIterator, typename T1, typename T2, typename T3, typename T4, typename T5>
-		AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&,T5&);
+                AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&,T5&);
     #endif
 
     /// After one or more calls to `insert()` the internal data
@@ -156,7 +156,31 @@ namespace CGAL {
     /// `build()` explicitly to ensure that the next call to
     /// query functions will not trigger the reconstruction of the
     /// data structure.
+    /// The parameter pack `T` is of any types
+    /// such that `Primitive` has a constructor with the following signature:
+    /// `Primitive(%InputIterator, T...)`. A call to `AABBTraits::set_shared_data(t...)`
+    /// is made using the internally stored traits.
+    /// For compilers that do not support variadic templates,
+    /// overloads up to 5 template arguments are provided.
+    
+#if !defined(CGAL_CFG_NO_CPP0X_VARIADIC_TEMPLATES) && !defined(CGAL_CFG_NO_CPP0X_RVALUE_REFERENCE)
+    template<typename ... T>
+    void build(T&& ...);
     void build();
+#else
+    void build();
+    template
+    template<typename T1>
+    void build(T1& t1);
+    template<typename T1, typename T2>
+    void build(T1& t1, T2& t2);
+    template<typename T1, typename T2,typename T3>
+    void build(T1& t1, T2& t2, T3& t3);
+    template<typename T1, typename T2,typename T3,typename T4>
+    void build(T1& t1, T2& t2, T3& t3, T4& t4);
+    template<typename T1, typename T2,typename T3,typename T4,typename T5>
+    void build(T1& t1, T2& t2, T3& t3, T4& t4, T5& t5);
+#endif
     ///@}
 
 		/// \name Operations
@@ -728,7 +752,7 @@ public:
                              ConstPrimitiveIterator beyond,
                              T&& ... t)
 	{
-    set_shared_data(std::forward<T>(t)...);
+        set_shared_data(std::forward<T>(t)...);
 		while(first != beyond)
 		{
 			m_primitives.push_back(Primitive(first,std::forward<T>(t)...));
@@ -752,6 +776,14 @@ public:
 
     build();
 	}  
+        
+        template<typename Tr>
+	template<typename ... T>
+	void AABB_tree<Tr>::build(T&& ... t)
+	{
+          set_shared_data(std::forward<T>(t)...);
+          build();
+        }
   #else
   //=============constructor======================
 	template<typename Tr>
@@ -1033,6 +1065,42 @@ public:
 
     build();
 	}
+        //overloads calling set_shared_data()
+        template<typename Tr>
+        template<typename T1>
+	void AABB_tree<Tr>::build(T1& t1)
+	{
+          set_shared_data(t1);
+          build();
+        }
+        template<typename Tr>
+        template<typename T1, typename T2>
+	void AABB_tree<Tr>::build(T1& t1, T2& t2)
+	{
+          set_shared_data(t1, t2);
+          build();
+        }
+        template<typename Tr>
+        template<typename T1, typename T2, typename T3>
+	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3)
+	{
+          set_shared_data(t1, t2, t3);
+          build();
+        }
+        template<typename Tr>
+        template<typename T1, typename T2, typename T3, typename T4>
+	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4)
+	{
+          set_shared_data(t1, t2, t3, t4);
+          build();
+        }
+        template<typename Tr>
+        template<typename T1, typename T2, typename T3, typename T4, typename T5>
+	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4, T5& t5)
+	{
+          set_shared_data(t1, t2, t3, t4, t5);
+          build();
+        }
   #endif
 
 	template<typename Tr>
@@ -1062,7 +1130,7 @@ public:
 
 			// constructs the tree
 			m_p_root_node->expand(m_primitives.begin(), m_primitives.end(),
-														m_primitives.size(), m_traits);
+			m_primitives.size(), m_traits);
 		}
 
 

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -167,7 +167,6 @@ namespace CGAL {
     void build();
 #else
     void build();
-    template
     template<typename T1>
     void build(T1& t1);
     template<typename T1, typename T2>

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -145,7 +145,7 @@ namespace CGAL {
     template<typename InputIterator, typename T1, typename T2, typename T3, typename T4>
 		AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&);
     template<typename InputIterator, typename T1, typename T2, typename T3, typename T4, typename T5>
-                AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&,T5&);
+		AABB_tree(InputIterator first, InputIterator beyond,T1&,T2&,T3&,T4&,T5&);
     #endif
 
     /// After one or more calls to `insert()` the internal data
@@ -752,7 +752,7 @@ public:
                              ConstPrimitiveIterator beyond,
                              T&& ... t)
 	{
-        set_shared_data(std::forward<T>(t)...);
+		set_shared_data(std::forward<T>(t)...);
 		while(first != beyond)
 		{
 			m_primitives.push_back(Primitive(first,std::forward<T>(t)...));
@@ -778,9 +778,9 @@ public:
 	}  
         
         template<typename Tr>
-	template<typename ... T>
-	void AABB_tree<Tr>::build(T&& ... t)
-	{
+        template<typename ... T>
+        void AABB_tree<Tr>::build(T&& ... t)
+        {
           set_shared_data(std::forward<T>(t)...);
           build();
         }
@@ -1068,40 +1068,40 @@ public:
         //overloads calling set_shared_data()
         template<typename Tr>
         template<typename T1>
-	void AABB_tree<Tr>::build(T1& t1)
-	{
+        void AABB_tree<Tr>::build(T1& t1)
+        {
           set_shared_data(t1);
           build();
         }
         template<typename Tr>
         template<typename T1, typename T2>
-	void AABB_tree<Tr>::build(T1& t1, T2& t2)
-	{
+        void AABB_tree<Tr>::build(T1& t1, T2& t2)
+        {
           set_shared_data(t1, t2);
           build();
         }
         template<typename Tr>
         template<typename T1, typename T2, typename T3>
-	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3)
-	{
+        void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3)
+        {
           set_shared_data(t1, t2, t3);
           build();
         }
         template<typename Tr>
         template<typename T1, typename T2, typename T3, typename T4>
-	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4)
-	{
+        void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4)
+        {
           set_shared_data(t1, t2, t3, t4);
           build();
         }
         template<typename Tr>
         template<typename T1, typename T2, typename T3, typename T4, typename T5>
-	void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4, T5& t5)
-	{
+        void AABB_tree<Tr>::build(T1& t1, T2& t2, T3& t3, T4& t4, T5& t5)
+        {
           set_shared_data(t1, t2, t3, t4, t5);
           build();
         }
-  #endif
+#endif
 
 	template<typename Tr>
 	void AABB_tree<Tr>::insert(const Primitive& p)

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -156,9 +156,7 @@ namespace CGAL {
     /// `build()` explicitly to ensure that the next call to
     /// query functions will not trigger the reconstruction of the
     /// data structure.
-    /// The parameter pack `T` is of any types
-    /// such that `Primitive` has a constructor with the following signature:
-    /// `Primitive(%InputIterator, T...)`. A call to `AABBTraits::set_shared_data(t...)`
+    /// A call to `AABBTraits::set_shared_data(t...)`
     /// is made using the internally stored traits.
     /// For compilers that do not support variadic templates,
     /// overloads up to 5 template arguments are provided.
@@ -1130,7 +1128,7 @@ public:
 
 			// constructs the tree
 			m_p_root_node->expand(m_primitives.begin(), m_primitives.end(),
-			m_primitives.size(), m_traits);
+					      m_primitives.size(), m_traits);
 		}
 
 


### PR DESCRIPTION
## Summary of Changes
This adds a parameter pack to the function build() that calls set_shared_data(t...) if specified.
## Release Management

* Affected package(s):AABB_tree
* Issue(s) solved (if any): fix #1166 
* Feature/Small Feature (if any):
* documentation: 
```c++
/// After one or more calls to `insert()` the internal data
/// structure of the tree must be reconstructed. This procedure
/// has a complexity of \f$O(n log(n))\f$, where \f$n\f$ is the number of
/// primitives of the tree.  This procedure is called implicitly
/// at the first call to a query member function. You can call
/// `build()` explicitly to ensure that the next call to
/// query functions will not trigger the reconstruction of the
/// data structure.
/// The parameter pack `T` is of any types
/// such that `Primitive` has a constructor with the following signature:
/// `Primitive(%InputIterator, T...)`. A call to `AABBTraits::set_shared_data(t...)`
/// is made using the internally stored traits.
/// For compilers that do not support variadic templates,
/// overloads up to 5 template arguments are provided.
template<typename ... T>
void build(T&& ...);
```