### PR TITLE
Polyhedron demo: re-computes normals after mesh edition in selection item

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -843,6 +843,7 @@ public Q_SLOTS:
     remove_erased_handles<fg_vertex_descriptor>();
     remove_erased_handles<fg_edge_descriptor>();
     remove_erased_handles<fg_face_descriptor>();
+    compute_normal_maps();
   }
   void endSelection(){
     Q_EMIT simplicesSelected(this);


### PR DESCRIPTION
## Summary of Changes
Re-computes the normals of the selection_item after the mesh has been changed. 
## Release Management

* Issue(s) solved (if any): fix #3384 
