### PR TITLE
P3T3: Minor improvements (random_shuffle + determinism)

### DIFF
--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_Delaunay_triangulation_3.h
@@ -490,21 +490,27 @@ public:
       is_large_point_set = false;
 
     std::vector<Point> points(first, last);
-    CGAL::cpp98::random_shuffle (points.begin(), points.end());
-    Cell_handle hint;
     std::vector<Vertex_handle> dummy_points, double_vertices;
     typename std::vector<Point>::iterator pbegin = points.begin();
     if(is_large_point_set)
+    {
       dummy_points = insert_dummy_points();
-    else while(!is_1_cover()) {
-      insert(*pbegin);
-      ++pbegin;
-      if(pbegin == points.end())
-        return number_of_vertices() - n;
+    } else {
+      CGAL::cpp98::random_shuffle(points.begin(), points.end());
+      pbegin = points.begin();
+      while(!is_1_cover()) {
+        insert(*pbegin);
+        ++pbegin;
+        if(pbegin == points.end())
+          return number_of_vertices() - n;
+      }
     }
+
+    CGAL_postcondition(is_1_cover());
 
     spatial_sort (pbegin, points.end(), this->geom_traits());
 
+    Cell_handle hint;
     Conflict_tester tester(*pbegin,this);
     Point_hider hider;
     Cover_manager cover_manager(*this);

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_3.h
@@ -519,8 +519,6 @@ public:
       is_large_point_set = false;
 
     std::vector<Weighted_point> points(first, last);
-    CGAL::cpp98::random_shuffle(points.begin(), points.end());
-    Cell_handle hint;
     std::vector<Vertex_handle> dummy_points_vhs, double_vertices;
     std::vector<Weighted_point> dummy_points;
     typename std::vector<Weighted_point>::iterator pbegin = points.begin();
@@ -533,6 +531,8 @@ public:
     }
     else
     {
+      CGAL::cpp98::random_shuffle(points.begin(), points.end());
+      pbegin = points.begin();
       while(!is_1_cover())
       {
         insert(*pbegin);
@@ -541,6 +541,8 @@ public:
           return number_of_vertices() - n;
       }
     }
+
+    CGAL_postcondition(is_1_cover());
 
     // Spatial sorting can only be applied to bare points, so we need an adaptor
     typedef typename Geom_traits::Construct_point_3 Construct_point_3;
@@ -553,6 +555,7 @@ public:
                    CGAL::internal::boost_::make_function_property_map<Weighted_point, Ret, Construct_point_3>(
                        geom_traits().construct_point_3_object()), geom_traits()));
 
+    Cell_handle hint;
     Conflict_tester tester(*pbegin, this);
     Point_hider hider(this);
     Cover_manager cover_manager(*this);

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -2052,11 +2052,11 @@ inline void
 Periodic_3_triangulation_3<GT,TDS>::
 make_canonical(Vertex_triple& t) const
 {
-  int i = (&*(t.first) < &*(t.second))? 0 : 1;
+  int i = (t.first < t.second) ? 0 : 1;
   if(i==0) {
-    i = (&*(t.first) < &*(t.third))? 0 : 2;
+    i = (t.first < t.third) ? 0 : 2;
   } else {
-    i = (&*(t.second) < &*(t.third))? 1 : 2;
+    i = (t.second < t.third) ? 1 : 2;
   }
   Vertex_handle tmp;
   switch(i) {


### PR DESCRIPTION
## Summary of Changes

- Call to `random_shuffle` if `is_point_set_large` is `true` is redundant since the next thing done is to call `spatial_sort`, which calls `random_shuffle` itself.
- `make_canonical` was needlessly using addresses to compare `Vertex_handle`s. With that change, P3T3 is deterministic when using time stamped vertex/cell base classes, but for now requires to always be in 1-cover.

## Release Management

* Affected package(s): `Periodic_3_triangulation_3`
* Issue(s) solved (if any): fix #3346 
* Feature/Small Feature (if any): --
* License and copyright ownership: no change

