### PR TITLE
AABB_tree: add datum()

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -647,12 +647,16 @@ public:
 				return this->any_reference_point_and_id();
 		}
 		
-		//!
-		//! \brief datum
-		//! \param p
-		//! \return 
-		//!
+		//! Returns the datum (geometric object) represented `p`. 
+		//! The return type is 
+		//! - typename `Primitive::Datum_reference` if `Primitive` defines that type.
+		//! - typename `Primitive::Datum` if it doesn't.
+#ifndef DOXYGEN_RUNNING
 		typename internal::Primitive_helper<AABBTraits>::Datum_type 
+#else
+		unspecified_type
+#endif
+		
 		datum(Primitive& p)const
 		{
 		  return internal::Primitive_helper<AABBTraits>::

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -646,6 +646,18 @@ public:
 			else
 				return this->any_reference_point_and_id();
 		}
+		
+		//!
+		//! \brief datum
+		//! \param p
+		//! \return 
+		//!
+		typename internal::Primitive_helper<AABBTraits>::Datum_type 
+		datum(Primitive& p)const
+		{
+		  return internal::Primitive_helper<AABBTraits>::
+		      get_datum(p, this->traits());
+		}
 
 	private:
     //Traits class

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -648,16 +648,7 @@ public:
 		}
 		
 		//! Returns the datum (geometric object) represented `p`. 
-		//! The return type is 
-		//! - typename `Primitive::Datum_reference` if `Primitive` defines that type.
-		//! - typename `Primitive::Datum` if it doesn't.
-#ifndef DOXYGEN_RUNNING
-		typename internal::Primitive_helper<AABBTraits>::Datum_type 
-#else
-		unspecified_type
-#endif
-		
-		datum(Primitive& p)const
+		typename AABBTraits::Primitive::Datum_reference datum(Primitive& p)const
 		{
 		  return internal::Primitive_helper<AABBTraits>::
 		      get_datum(p, this->traits());

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -648,7 +648,12 @@ public:
 		}
 		
 		//! Returns the datum (geometric object) represented `p`. 
-		typename AABBTraits::Primitive::Datum_reference datum(Primitive& p)const
+#ifndef DOXYGEN_RUNNING
+		typename internal::Primitive_helper<AABBTraits>::Datum_type 
+#else
+		typename AABBTraits::Primitive::Datum_reference 
+#endif
+		datum(Primitive& p)const
 		{
 		  return internal::Primitive_helper<AABBTraits>::
 		      get_datum(p, this->traits());

--- a/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
@@ -16,7 +16,7 @@ typedef K::Triangle_3 Triangle;
 typedef CGAL::Surface_mesh<Point> Mesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
-    CGAL::Default, CGAL::Tag_true, CGAL::Tag_true> Primitive_cached;
+    CGAL::Default, CGAL::Tag_false, CGAL::Tag_true> Primitive_cached;
 
 typedef CGAL::AABB_traits<K, Primitive> Traits;
 typedef CGAL::AABB_traits<K, Primitive_cached> Traits_cached;

--- a/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
@@ -15,15 +15,23 @@ typedef K::Point_3 Point;
 typedef K::Triangle_3 Triangle;
 typedef CGAL::Surface_mesh<Point> Mesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
-typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
-    CGAL::Default, CGAL::Tag_false, CGAL::Tag_true> Primitive_cached;
-
 typedef CGAL::AABB_traits<K, Primitive> Traits;
-typedef CGAL::AABB_traits<K, Primitive_cached> Traits_cached;
 typedef CGAL::AABB_tree<Traits> Tree;
-typedef CGAL::AABB_tree<Traits_cached> Tree_cached;
-typedef Tree::Primitive_id Primitive_id;
-typedef Tree_cached::Primitive_id Primitive_id_cached;
+
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+    CGAL::Default, CGAL::Tag_true, CGAL::Tag_true> Primitive2;
+typedef CGAL::AABB_traits<K, Primitive2> Traits2;
+typedef CGAL::AABB_tree<Traits2> Tree2;
+
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+    CGAL::Default, CGAL::Tag_false, CGAL::Tag_true> Primitive3;
+typedef CGAL::AABB_traits<K, Primitive3> Traits3;
+typedef CGAL::AABB_tree<Traits3> Tree3;
+
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+    CGAL::Default, CGAL::Tag_false, CGAL::Tag_false> Primitive4;
+typedef CGAL::AABB_traits<K, Primitive4> Traits4;
+typedef CGAL::AABB_tree<Traits4> Tree4;
 
 int main(void)
 {
@@ -37,15 +45,29 @@ int main(void)
   }
   
   Tree t1(faces(m).begin(), faces(m).end(), m);
-  Tree_cached t2(faces(m).begin(), faces(m).end(), m);
+  Tree2 t2(faces(m).begin(), faces(m).end(), m);
+  Tree3 t3(faces(m).begin(), faces(m).end(), m);
+  Tree4 t4(faces(m).begin(), faces(m).end(), m);
   
   t1.build();
   t2.build();
+  t3.build();
+  t4.build();
+  
   Primitive p1(faces(m).begin(), m);
-  Primitive_cached p2(faces(m).begin(), m);
+  Primitive2 p2(faces(m).begin(), m);
+  Primitive3 p3(faces(m).begin(), m);
+  Primitive4 p4(faces(m).begin(), m);
   Triangle tr1 = t1.datum(p1);
   Triangle tr2 = t2.datum(p2);
-  if(tr1 != tr2)
+  Triangle tr3 = t3.datum(p3);
+  Triangle tr4 = t4.datum(p4);
+  if(tr1 != tr2
+     || tr1 != tr3
+     || tr1 != tr4
+     || tr2 != tr3
+     || tr2 != tr4
+     || tr3 != tr4)
     return 1;
   return 0;
 }

--- a/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_datum.cpp
@@ -1,0 +1,52 @@
+
+#include <iostream>
+#include <fstream>
+#include <CGAL/Timer.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/Surface_mesh.h>
+
+typedef CGAL::Epick K;
+typedef K::Point_3 Point;
+typedef K::Triangle_3 Triangle;
+typedef CGAL::Surface_mesh<Point> Mesh;
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+    CGAL::Default, CGAL::Tag_true, CGAL::Tag_true> Primitive_cached;
+
+typedef CGAL::AABB_traits<K, Primitive> Traits;
+typedef CGAL::AABB_traits<K, Primitive_cached> Traits_cached;
+typedef CGAL::AABB_tree<Traits> Tree;
+typedef CGAL::AABB_tree<Traits_cached> Tree_cached;
+typedef Tree::Primitive_id Primitive_id;
+typedef Tree_cached::Primitive_id Primitive_id_cached;
+
+int main(void)
+{
+  Mesh m;
+  std::ifstream in("data/cube.off");
+  if(in)
+    in >> m;
+  else{
+    std::cout << "error reading bunny" << std::endl;
+    return 1;
+  }
+  
+  Tree t1(faces(m).begin(), faces(m).end(), m);
+  Tree_cached t2(faces(m).begin(), faces(m).end(), m);
+  
+  t1.build();
+  t2.build();
+  Primitive p1(faces(m).begin(), m);
+  Primitive_cached p2(faces(m).begin(), m);
+  Triangle tr1 = t1.datum(p1);
+  Triangle tr2 = t2.datum(p2);
+  if(tr1 != tr2)
+    return 1;
+  return 0;
+}
+


### PR DESCRIPTION
## Summary of Changes
To make it easier to access the datum of a primitive, regardless of the presence of shared_data or not, a new function is added to AABB_tree.
## Release Management

* Affected package(s):AABB_tree
* Issue(s) solved (if any): fix #1872
* documentation:
<pre>
//! Returns the datum (geometric object) represented `p`. 
typename AABBTraits::Primitive::Datum_reference datum(Primitive& p)const
</pre>
