### PR TITLE
Surface_mesh_Examples:Fix cmake warning

### DIFF
--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -6,14 +6,16 @@ project( Surface_mesh_Examples )
 
 cmake_minimum_required(VERSION 2.8.11)
 
-if(NOT POLICY CMP0070 AND  POLICY CMP0053)
+if(POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
-  cmake_policy(SET CMP0053 OLD)
-  elseif(POLICY CMP0070 AND  POLICY CMP0053)
+  if(NOT POLICY CMP0070)
+    cmake_policy(SET CMP0053 OLD)
+  else()
     cmake_policy(SET CMP0053 NEW)
+  endif()
 endif()
-if(POLICY CMP0070 AND  POLICY CMP0071)
-    cmake_policy(SET CMP0071 OLD)
+if(POLICY CMP0071)
+    cmake_policy(SET CMP0071 NEW)
 endif()
 
 find_package(CGAL COMPONENTS Qt5)

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -6,9 +6,14 @@ project( Surface_mesh_Examples )
 
 cmake_minimum_required(VERSION 2.8.11)
 
-if(NOT POLICY CMP0070 AND POLICY CMP0053)
+if(NOT POLICY CMP0070 AND  POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)
+  elseif(POLICY CMP0070 AND  POLICY CMP0053)
+    cmake_policy(SET CMP0053 NEW)
+endif()
+if(POLICY CMP0070 AND  POLICY CMP0071)
+    cmake_policy(SET CMP0071 OLD)
 endif()
 
 find_package(CGAL COMPONENTS Qt5)


### PR DESCRIPTION
## Summary of Changes
If CMP0070 exists,
set policy of CMP0053 to new  and CMP0071 to OLD, if they exist.
## Release Management
* Issue(s) solved (if any): fix #3388
