### PR TITLE
Polyhedron demo: raise the tabified widgets when they are set visible.

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -142,7 +142,10 @@ private Q_SLOTS:
   void openDialog()
   {
     if(dock_widget->isVisible()) { dock_widget->hide(); }
-    else                         { replaceRamp(); dock_widget->show(); }
+    else{
+      replaceRamp(); 
+      dock_widget->show();
+      dock_widget->raise(); }
   }
 
   void colorize()

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -552,6 +552,7 @@ private:
     } else {
       layout = controlDockWidget->findChild<QLayout*>("vpSliderLayout");
       controlDockWidget->show();
+      controlDockWidget->raise();
     }
 
     return layout;

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Clip_polyhedron_plugin.cpp
@@ -182,7 +182,7 @@ public Q_SLOTS:
   void pop_widget()
   {
     if(dock_widget->isVisible()) { dock_widget->hide(); }
-    else                         { dock_widget->show(); }
+    else                         { dock_widget->show(); dock_widget->raise();}
 
     //creates a new  cutting_plane;
     if(!plane)

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Partition_graph_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Partition_graph_plugin.cpp
@@ -18,7 +18,6 @@
 #include <QAction>
 #include <QMenu>
 #include <QMainWindow>
-#include <QDockWidget>
 #include <QApplication>
 #include <QTime>
 #include <QMessageBox>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
@@ -493,6 +493,7 @@ void Polyhedron_demo_affine_transform_plugin::go(){
         return;
     }
     dock_widget->show();
+    dock_widget->raise();
     started=true;
     actionTransformPolyhedron->setText("Apply affine transformation");
     if(poly_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_plugin.cpp
@@ -179,42 +179,42 @@ private:
 //show the widget
 void Basic_generator_plugin::on_actionPrism_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(PRISM);
 }
 void Basic_generator_plugin::on_actionSphere_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(SPHERE);
 }
 void Basic_generator_plugin::on_actionPyramid_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(PYRAMID);
 }
 void Basic_generator_plugin::on_actionHexahedron_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(HEXAHEDRON);
 }
 void Basic_generator_plugin::on_actionTetrahedron_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(TETRAHEDRON);
 }
 void Basic_generator_plugin::on_actionGrid_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(GRID);
 }
 void Basic_generator_plugin::on_actionPointSet_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(POINT_SET);
 }
 void Basic_generator_plugin::on_actionPolyline_triggered()
 {
-  dock_widget->show();
+  dock_widget->show(); dock_widget->raise();
   dock_widget->selector_tabWidget->tabBar()->setCurrentIndex(POLYLINE);
 }
 void Basic_generator_plugin::on_tab_changed()

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -83,7 +83,8 @@ void Clipping_box_plugin::clipbox()
       return;
   }
   QApplication::setOverrideCursor(Qt::WaitCursor);
-dock_widget->show();
+  dock_widget->show();
+  dock_widget->raise();
   if(!item)
     item = new Scene_edit_box_item(scene);
   connect(item, SIGNAL(destroyed()),

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Alpha_shape_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Alpha_shape_plugin.cpp
@@ -180,6 +180,7 @@ public Q_SLOTS:
     if(dock_widget->isVisible()) { dock_widget->hide(); }
     else {
       dock_widget->show();
+      dock_widget->raise();
       Scene_points_with_normal_item* sel_item =
           qobject_cast<Scene_points_with_normal_item*>(scene->item(scene->mainSelectionIndex()));
       if(sel_item)

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -279,6 +279,7 @@ private Q_SLOTS:
     if(!dock_widget->isVisible())
     {
       dock_widget->show();
+      dock_widget->raise();
     }
     perform();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
@@ -14,7 +14,6 @@
 #include <QAction>
 #include <QDebug>
 #include <QObject>
-#include <QDockWidget>
 //#include <QtConcurrentRun>
 #include <map>
 #include <algorithm>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
@@ -213,7 +213,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::itemAboutToBeDestroyed(CGAL::Thre
 }
 
 void Polyhedron_demo_mesh_segmentation_plugin::on_actionSegmentation_triggered()
-{ dock_widget->show(); }
+{ dock_widget->show(); dock_widget->raise();}
 
 template<class FacegraphItem>
 void Polyhedron_demo_mesh_segmentation_plugin::apply_SDF_button_clicked(FacegraphItem* item)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -1099,8 +1099,10 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
   current_uv_item = projection;
   qobject_cast<Scene_textured_facegraph_item*>(projections.key(current_uv_item))->add_border_edges(current_uv_item->concatenated_borders(),
                                                                                                    is_ogl_4_3);
-  if(dock_widget->isHidden())
+  if(dock_widget->isHidden()){
     dock_widget->setVisible(true);
+    dock_widget->raise();
+  }
   dock_widget->setWindowTitle(tr("UVMapping for %1").arg(new_item->name()));
   ui_widget.component_numberLabel->setText(QString("Component : %1/%2").arg(current_uv_item->current_component()+1).arg(current_uv_item->number_of_components()));
   ui_widget.graphicsView->fitInView(projection->boundingRect(), Qt::KeepAspectRatio);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -198,7 +198,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_actionDeformation_triggered()
 {  
   // dock widget should be constructed in init()
   if(dock_widget->isVisible()) { dock_widget->hide(); }
-  else                         { dock_widget->show(); }
+  else                         { dock_widget->show(); dock_widget->raise();}
 }
 
 /////// Dock window signal handlers //////


### PR DESCRIPTION
## Summary of Changes
Everytime a dockwidget is shown, it should also raise(), so that it comes on top of the possible tab stask.
## Release Management
* Issue(s) solved (if any): fix #3385
