### PR TITLE
Fix Polyhedral_complex_mesh_domain_3 when detect_features() is not called

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -224,11 +224,28 @@ public:
     , patch_indices(indices_begin, indices_end)
     , borders_detected_(false)
   {
-    stored_polyhedra.reserve(std::distance(begin, end));
+    patch_id_to_polyhedron_id.resize(std::distance(begin, end)+1);
+    stored_polyhedra.reserve(patch_id_to_polyhedron_id.size()-1);
     CGAL_assertion(stored_polyhedra.capacity() ==
                    std::size_t(std::distance(indices_begin, indices_end)));
+
+    Surface_patch_index sp_index = 1;
+
     for (; begin != end; ++begin) {
+      typedef boost::graph_traits<Polyhedron_type> Graph_traits;
+      typedef typename Graph_traits::face_descriptor face_descriptor;
       stored_polyhedra.push_back(*begin);
+      patch_id_to_polyhedron_id[sp_index] = sp_index - 1;
+
+      typedef typename boost::property_map<Polyhedron_type,
+                                           CGAL::face_patch_id_t<Patch_id>
+                                           >::type PIDMap;
+      PIDMap pid_map = get(face_patch_id_t<Patch_id>(), stored_polyhedra.back());
+      BOOST_FOREACH(face_descriptor fd,
+                    faces(stored_polyhedra.back())) {
+        put(pid_map, fd, sp_index);
+      }
+      ++sp_index;
       this->add_primitives(stored_polyhedra.back());
     }
     this->build();


### PR DESCRIPTION
## Summary of Changes

Fix `Polyhedral_complex_mesh_domain_3` when `detect_features()` is not called.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): https://stackoverflow.com/q/52726224/1728537


