### PR TITLE
Polyhedron demo: Fix orientation of the sphere generator.

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_plugin.cpp
@@ -569,7 +569,7 @@ void Basic_generator_plugin::generateSphere()
   //emplace the points back on the sphere
   BOOST_FOREACH(typename boost::graph_traits<typename Facegraph_item::Face_graph>::vertex_descriptor vd, vertices(sphere))
   {
-    Kernel::Vector_3 vec(get(vpmap, vd), center);
+    Kernel::Vector_3 vec(center, get(vpmap, vd));
     vec = radius*vec/CGAL::sqrt(vec.squared_length());
     put(vpmap, vd, Kernel::Point_3(center.x() + vec.x(),
                                    center.y() + vec.y(),


### PR DESCRIPTION
## Summary of Changes
The vector to compute the position of the points around the center was inverted.
## Release Management
* Issue(s) solved (if any): fix #3396