### PR TITLE
Kernel_23: Add an equality test to Aff_transfo 2 and 3.

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_2.h
@@ -178,6 +178,21 @@ public:
 
   std::ostream &
   print(std::ostream &os) const;
+  
+  bool operator==(const Aff_transformationC2 &t)const
+  {
+    for(int i=0; i<3; ++i)
+      for(int j = 0; j< 3; ++j)
+        if(cartesian(i,j)!=t.cartesian(i,j))
+          return false;
+    return true;
+  }
+  
+  bool operator!=(const Aff_transformationC2 &t)const
+  {
+    return !(*this == t);
+  }
+  
 };
 
 template < class R >

--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_3.h
@@ -177,7 +177,21 @@ public:
 
   Aff_transformation_3 operator*(const Aff_transformationC3 &t) const
   { return (*this->Ptr()) * (*t.Ptr()); }
-
+  
+  bool operator==(const Aff_transformationC3 &t)const
+  {
+    for(int i=0; i<3; ++i)
+      for(int j = 0; j< 4; ++j)
+        if(cartesian(i,j)!=t.cartesian(i,j))
+          return false;
+    return true;
+  }
+  
+  bool operator!=(const Aff_transformationC3 &t)const
+  {
+    return !(*this == t);
+  }
+  
 protected:
   Aff_transformation_3  transpose() const { return this->Ptr()->transpose(); }
 };

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
@@ -605,6 +605,21 @@ public:
 
     Aff_transformationH2<R>
     operator*(const Aff_transformationH2<R>& right_argument ) const;
+    
+    
+    bool operator==(const Aff_transformationH2 &t)const
+    {
+      for(int i=0; i<3; ++i)
+        for(int j = 0; j< 3; ++j)
+          if(homogeneous(i,j)!=t.homogeneous(i,j))
+            return false;
+      return true;
+    }
+    
+    bool operator!=(const Aff_transformationH2 &t)const
+    {
+      return !(*this == t);
+    }
 
 };
 

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH3.h
@@ -364,6 +364,20 @@ public:
   RT
   hm(int i, int j) const
   { return this->Ptr()->homogeneous(i,j); }
+  
+  bool operator==(const Aff_transformationH3 &t)const
+  {
+    for(int i=0; i<3; ++i)
+      for(int j = 0; j< 4; ++j)
+        if(homogeneous(i,j)!=t.homogeneous(i,j))
+          return false;
+    return true;
+  }
+  
+  bool operator!=(const Aff_transformationH3 &t)const
+  {
+    return !(*this == t);
+  }
 };
 
 template < class R >

--- a/Kernel_23/doc/Kernel_23/CGAL/Aff_transformation_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Aff_transformation_2.h
@@ -248,6 +248,11 @@ gives the inverse transformation.
 Aff_transformation_2<Kernel> inverse() const; 
 
 /*!
+compares two affine transformations. 
+*/ 
+bool operator==(const Aff_transformation_2<Kernel> &s) const; 
+
+/*!
 returns `true`, if the transformation is not reflecting, 
 i.e.\ the determinant of the involved linear transformation is 
 non-negative. 

--- a/Kernel_23/doc/Kernel_23/CGAL/Aff_transformation_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Aff_transformation_3.h
@@ -180,6 +180,12 @@ gives the inverse transformation.
 Aff_transformation_3<Kernel> inverse() const; 
 
 /*!
+compares two affine transformations. 
+*/ 
+bool operator==(const Aff_transformation_3<Kernel> &s) const; 
+
+
+/*!
 returns `true`, if the transformation is not reflecting, 
 i.e.\ the determinant of the involved linear transformation is 
 non-negative. 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
@@ -577,6 +577,13 @@ _test_cls_aff_transformation_2(const R& )
  assert( ident.homogeneous(1,2) == ident.hm(1,2) );
  assert( gscale.homogeneous(1,1) == gscale.hm(1,1) );
 
+ //equality
+ CGAL::Aff_transformation_2<R> a2(0,1,0,1),
+     a3(0,1,0,1), a4(0,0,1,1);
+ assert(a2 == a3);
+ assert(a3 != a4);
+ 
+
  std::cout << "done" << std::endl;
  return true;
 }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
@@ -543,6 +543,12 @@ _test_cls_aff_transformation_3(const R& )
  assert(unit_sphere.orthogonal_transform(ident) == unit_sphere);
  assert(unit_sphere.orthogonal_transform(translate).center() == pnt);
 
+ //equality
+ CGAL::Aff_transformation_3<R> a2(0,1,0,1,0,1,1,0,1,0,0,1),
+     a3(0,1,0,1,0,1,1,0,1,0,0,1), a4(0,0,1,1,0,0,1,1,0,0,1,1);
+ assert(a2 == a3);
+ assert(a3 != a4);
+ 
  std::cout << "done" << std::endl;
  return true;
 }


### PR DESCRIPTION
## Summary of Changes
Add an equality test to Aff_transformation_2 and Aff_transformation_3.

## Release Management

* Affected package(s): Kernle_23, Cartesian_kernel, Homogeneous_kernel
* Issue(s) solved (if any): fix #3055 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [link](https://mydoc/Manual/Pkg)
* License and copyright ownership:

