### PR TITLE
Basic viewers: bugfix for Epeck

### DIFF
--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -144,11 +144,11 @@ inline CGAL::Color get_random_color(CGAL::Random& random)
 //------------------------------------------------------------------------------
 class Basic_viewer_qt : public CGAL::QGLViewer
 {  
+public:
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Local_kernel;
   typedef Local_kernel::Point_3  Local_point;
   typedef Local_kernel::Vector_3 Local_vector;
 
-public:
   // Constructor/Destructor
   Basic_viewer_qt(QWidget* parent,
                   const char* title="",

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -45,29 +45,30 @@ struct DefaultColorFunctorLCC
   }
 };
 
-template<class LCC, int dim=LCC::ambient_dimension>
-struct Geom_utils;
+template<class LCC, class Kernel, int dim=LCC::ambient_dimension>
+struct LCC_geom_utils;
 
-template<class LCC>
-struct Geom_utils<LCC, 3>
+template<class LCC, class Kernel>
+struct LCC_geom_utils<LCC, Kernel, 3>
 {
-  static typename LCC::Vector get_vertex_normal(const LCC& lcc,
-                                                typename LCC::Dart_const_handle dh)
+  static typename Kernel::Vector_3
+  get_vertex_normal(const LCC& lcc, typename LCC::Dart_const_handle dh)
   {
-    typename LCC::Vector n = CGAL::compute_normal_of_cell_0<LCC>(lcc,dh);
+    typename Kernel::Vector_3 n = internal::Geom_utils<typename LCC::Traits>::
+      get_local_vector(CGAL::compute_normal_of_cell_0<LCC>(lcc,dh));
     n = n/(CGAL::sqrt(n*n));
     return n;
   }
 };
 
-template<class LCC>
-struct Geom_utils<LCC, 2>
+template<class LCC, class Kernel>
+struct LCC_geom_utils<LCC, Kernel, 2>
 {
-  static typename LCC::Vector get_vertex_normal(const LCC&,
-                                                typename LCC::Dart_const_handle)
+  static typename Kernel::Vector_3
+  get_vertex_normal(const LCC&, typename LCC::Dart_const_handle)
   {
-    typename LCC::Vector res=CGAL::NULL_VECTOR;
-    return res;
+    typename Kernel::Vector_3 n=CGAL::NULL_VECTOR;
+    return n;
   }
 };
 
@@ -121,8 +122,8 @@ protected:
     cur=dh;
     do
     {
-      add_point_in_face(lcc.point(cur),
-                        Geom_utils<LCC>::get_vertex_normal(lcc, cur));
+      add_point_in_face(lcc.point(cur), LCC_geom_utils<LCC, Local_kernel>::
+                        get_vertex_normal(lcc, cur));
       cur=lcc.next(cur);
     }
     while(cur!=dh);

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -148,41 +148,42 @@ protected:
   }
 
 protected:
-  typename Kernel::Vector_3 get_face_normal(Halfedge_const_handle he)
+  Local_vector get_face_normal(Halfedge_const_handle he)
   {
-    typename Kernel::Vector_3 normal=CGAL::NULL_VECTOR;
+    Local_vector normal=CGAL::NULL_VECTOR;
     Halfedge_const_handle end=he;
     unsigned int nb=0;
     do
     {
-      internal::newell_single_step_3(he->vertex()->point(),
-                                     he->next()->vertex()->point(),
-                                     normal);
+      internal::newell_single_step_3
+        (internal::Geom_utils<Kernel>::get_local_point(he->vertex()->point()),
+         internal::Geom_utils<Kernel>::get_local_point(he->next()->vertex()->point()),
+         normal);
       ++nb;
       he=he->next();
     }
     while (he!=end);
     assert(nb>0);
-    return (typename Kernel::Construct_scaled_vector_3()(normal, 1.0/nb));
+    return (typename Local_kernel::Construct_scaled_vector_3()(normal, 1.0/nb));
   }
   
-  typename Kernel::Vector_3 get_vertex_normal(Halfedge_const_handle he)
+  Local_vector get_vertex_normal(Halfedge_const_handle he)
   {
-    typename Kernel::Vector_3 normal=CGAL::NULL_VECTOR;
+    Local_vector normal=CGAL::NULL_VECTOR;
     Halfedge_const_handle end=he;
     do
     {
       if (!he->is_border())
       {
-        typename Kernel::Vector_3 n=get_face_normal(he);
-        normal=typename Kernel::Construct_sum_of_vectors_3()(normal, n);
+        Local_vector n=get_face_normal(he);
+        normal=typename Local_kernel::Construct_sum_of_vectors_3()(normal, n);
       }
       he=he->next()->opposite();
     }
     while (he!=end);
     
-    if (!typename Kernel::Equal_3()(normal, CGAL::NULL_VECTOR))
-    { normal=(typename Kernel::Construct_scaled_vector_3()
+    if (!typename Local_kernel::Equal_3()(normal, CGAL::NULL_VECTOR))
+    { normal=(typename Local_kernel::Construct_scaled_vector_3()
               (normal, 1.0/CGAL::sqrt(normal.squared_length()))); }
     
     return normal;

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -71,7 +71,7 @@ class SimpleSurfaceMeshViewerQt : public Basic_viewer_qt
   typedef typename SM::Face_index face_descriptor;
   typedef typename SM::Edge_index edge_descriptor;
   typedef typename SM::Halfedge_index halfedge_descriptor;
-  
+
 public:
   /// Construct the viewer.
   /// @param amesh the surface mesh to view
@@ -156,40 +156,41 @@ protected:
   }
 
 protected:
-  typename Kernel::Vector_3 get_face_normal(halfedge_descriptor he)
+  Local_vector get_face_normal(halfedge_descriptor he)
   {
-    typename Kernel::Vector_3 normal=CGAL::NULL_VECTOR;
+    Local_vector normal=CGAL::NULL_VECTOR;
     halfedge_descriptor end=he;
     unsigned int nb=0;
     do
     {
-      internal::newell_single_step_3(sm.point(sm.source(he)),
-                                     sm.point(sm.target(he)), normal);
+      internal::newell_single_step_3
+        (internal::Geom_utils<Kernel>::get_local_point(sm.point(sm.source(he))),
+         internal::Geom_utils<Kernel>::get_local_point(sm.point(sm.target(he))), normal);
       ++nb;
       he=sm.next(he);
     }
     while (he!=end);
     assert(nb>0);
-    return (typename Kernel::Construct_scaled_vector_3()(normal, 1.0/nb));
+    return (typename Local_kernel::Construct_scaled_vector_3()(normal, 1.0/nb));
   }
   
-  typename Kernel::Vector_3 get_vertex_normal(halfedge_descriptor he)
+  Local_vector get_vertex_normal(halfedge_descriptor he)
   {
-    typename Kernel::Vector_3 normal=CGAL::NULL_VECTOR;
+    Local_vector normal=CGAL::NULL_VECTOR;
     halfedge_descriptor end=he;
     do
     {
       if (!sm.is_border(he))
       {
-        typename Kernel::Vector_3 n=get_face_normal(he);
-        normal=typename Kernel::Construct_sum_of_vectors_3()(normal, n);
+        Local_vector n=get_face_normal(he);
+        normal=typename Local_kernel::Construct_sum_of_vectors_3()(normal, n);
       }
       he=sm.next(sm.opposite(he));
     }
     while (he!=end);
     
-    if (!typename Kernel::Equal_3()(normal, CGAL::NULL_VECTOR))
-    { normal=(typename Kernel::Construct_scaled_vector_3()
+    if (!typename Local_kernel::Equal_3()(normal, CGAL::NULL_VECTOR))
+    { normal=(typename Local_kernel::Construct_scaled_vector_3()
               (normal, 1.0/CGAL::sqrt(normal.squared_length()))); }
     
     return normal;

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -47,11 +47,11 @@ struct DefaultColorFunctorT2
 template<class T2, class ColorFunctor>
 class SimpleTriangulation2ViewerQt : public Basic_viewer_qt
 {
-  typedef Basic_viewer_qt                     Base;
-  typedef typename T2::Vertex_handle          Vertex_const_handle;
+  typedef Basic_viewer_qt                    Base;
+  typedef typename T2::Vertex_handle         Vertex_const_handle;
   typedef typename T2::Finite_edges_iterator Edge_const_handle;
   typedef typename T2::Finite_faces_iterator Facet_const_handle;
-  typedef typename T2::Point                  Point;
+  typedef typename T2::Point                 Point;
  
 public:
   /// Construct the viewer.

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -51,12 +51,12 @@ struct DefaultColorFunctorT3
 template<class T3, class ColorFunctor>
 class SimpleTriangulation3ViewerQt : public Basic_viewer_qt
 {
-  typedef Basic_viewer_qt                 Base;
-  typedef typename T3::Vertex_handle Vertex_const_handle;
+  typedef Basic_viewer_qt                     Base;
+  typedef typename T3::Vertex_handle          Vertex_const_handle;
   typedef typename T3::Finite_edges_iterator  Edge_const_handle;
   typedef typename T3::Finite_facets_iterator Facet_const_handle;
-  typedef typename T3::Cell_handle         Cell_handle;
-  typedef typename T3::Point               Point;
+  typedef typename T3::Cell_handle            Cell_handle;
+  typedef typename T3::Point                  Point;
  
 public:
   /// Construct the viewer.


### PR DESCRIPTION
## Summary of Changes

Update basic viewers to correct a bug when we want to visualize an object using EPEK.

I tested all the 5 existing viewers with EPEK and EPIK without problem.

## Release Management

* Affected package(s): Surface_mesh, Polyhedron, LCC
* Issue(s) solved (if any): fix #3401

