### PR TITLE
BGL: Fix type missmatch in adjacent_vertices

### DIFF
--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -1281,7 +1281,7 @@ template <typename Graph>
 Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
-  typedef Vertex_around_face_iterator<Graph> I;
+  typedef Vertex_around_target_iterator<Graph> I;
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1290,7 +1290,7 @@ template <typename Graph>
 Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
-  typedef Vertex_around_face_iterator<Graph> I;
+  typedef Vertex_around_target_iterator<Graph> I;
   return make_range(I(halfedge(v,g),g), I(halfedge(v,g),g,1));
 }
 


### PR DESCRIPTION
## Summary of Changes

The adjacent_vertices uses the wrong iterator type in it's body. This PR changes it to the same as the function's return type.

## Release Management

* Affected package(s): CGAL and the Boost Graph Library