### PR TITLE
export(PACKAGE CGAL)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Top level CMakeLists.txt for CGAL-branchbuild
 message( "== CMake setup ==" )
 project(CGAL CXX C)
-
+export(PACKAGE CGAL)
 # Minimal version of CMake:
 cmake_minimum_required(VERSION 3.1)
 


### PR DESCRIPTION
## Summary of Changes

Cmake fix: The project now will be added to the local cmake cache (On UNIX located in $HOME/.cmake)
Fix some warnings for new compilers (gcc 9, -std=c++2a)
