### PR TITLE
Fix bug in clipping code

### DIFF
--- a/BGL/include/CGAL/boost/graph/parameters_interface.h
+++ b/BGL/include/CGAL/boost/graph/parameters_interface.h
@@ -93,6 +93,7 @@ CGAL_add_named_parameter(do_project_t, do_project, do_project)
 
 //internal
 CGAL_add_named_parameter(weight_calculator_t, weight_calculator, weight_calculator)
+CGAL_add_named_parameter(use_bool_op_to_clip_surface_t, use_bool_op_to_clip_surface, use_bool_op_to_clip_surface)
 
 // List of named parameters used in the Point Set Processing package
 CGAL_add_named_parameter(point_t, point_map, point_map)

--- a/BGL/test/BGL/test_cgal_bgl_named_params.cpp
+++ b/BGL/test/BGL/test_cgal_bgl_named_params.cpp
@@ -87,6 +87,7 @@ void test(const NamedParameters& np)
   assert(get_param(np, CGAL::internal_np::use_compact_clipper).v == 45);
   assert(get_param(np, CGAL::internal_np::erase_all_duplicates).v == 48);
   assert(get_param(np, CGAL::internal_np::require_same_orientation).v == 49);
+  assert(get_param(np, CGAL::internal_np::use_bool_op_to_clip_surface).v == 50);
 
     // Named parameters that we use in the package 'Surface Mesh Simplification'
   assert(get_param(np, CGAL::internal_np::get_cost_policy).v == 34);
@@ -166,6 +167,7 @@ void test(const NamedParameters& np)
   check_same_type<45>(get_param(np, CGAL::internal_np::use_compact_clipper));
   check_same_type<48>(get_param(np, CGAL::internal_np::erase_all_duplicates));
   check_same_type<49>(get_param(np, CGAL::internal_np::require_same_orientation));
+  check_same_type<50>(get_param(np, CGAL::internal_np::use_bool_op_to_clip_surface));
 
     // Named parameters that we use in the package 'Surface Mesh Simplification'
   check_same_type<34>(get_param(np, CGAL::internal_np::get_cost_policy));
@@ -243,6 +245,7 @@ int main()
                          .throw_on_self_intersection(A<43>(43))
                          .clip_volume(A<44>(44))
                          .use_compact_clipper(A<45>(45))
+                         .use_bool_op_to_clip_surface(A<50>(50))
                          .apply_per_connected_component(A<46>(46))
                          .output_iterator(A<47>(47))
                          .erase_all_duplicates(A<48>(48))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -406,9 +406,9 @@ bool clip(      TriangleMesh& tm,
   CGAL::Bbox_3 bbox = ::CGAL::Polygon_mesh_processing::bbox(tm);
 
   //extend the bbox a bit to avoid border cases
-  double xd=(bbox.xmax()-bbox.xmin())/100;
-  double yd=(bbox.ymax()-bbox.ymin())/100;
-  double zd=(bbox.zmax()-bbox.zmin())/100;
+  double xd=(std::max)(1.,(bbox.xmax()-bbox.xmin())/100);
+  double yd=(std::max)(1.,(bbox.ymax()-bbox.ymin())/100);
+  double zd=(std::max)(1.,(bbox.zmax()-bbox.zmin())/100);
   bbox=CGAL::Bbox_3(bbox.xmin()-xd, bbox.ymin()-yd, bbox.zmin()-zd,
                     bbox.xmax()+xd, bbox.ymax()+yd, bbox.zmax()+zd);
   TriangleMesh clipper;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -38,136 +38,6 @@ namespace Polygon_mesh_processing {
 
 namespace internal
 {
-template <class TriangleMesh,
-          class NamedParameters1,
-          class NamedParameters2>
-bool
-clip_open_impl(      TriangleMesh& tm,
-                     TriangleMesh& clipper,
-               const NamedParameters1& np_tm,
-               const NamedParameters2& np_c)
-{
-  typedef typename GetVertexPointMap<TriangleMesh,
-                                     NamedParameters1>::type Vpm;
-  typedef typename GetGeomTraits<TriangleMesh, NamedParameters2>::type GeomTraits;
-  typedef boost::graph_traits<TriangleMesh> GT;
-  typedef typename GT::halfedge_descriptor halfedge_descriptor;
-  typedef typename GT::face_descriptor face_descriptor;
-
-// First build an AABB-tree of the clipper triangles as it will be modified
-  typedef std::vector<typename GeomTraits::Triangle_3> Clipper_triangles;
-  typedef typename Clipper_triangles::iterator Tr_iterator;
-  typedef CGAL::AABB_triangle_primitive<GeomTraits, Tr_iterator> Primitive;
-  typedef CGAL::AABB_traits<GeomTraits, Primitive> AABB_triangle_traits;
-  typedef CGAL::AABB_tree<AABB_triangle_traits> Clipper_tree;
-
-  // vector of clipper triangles
-  Clipper_triangles clipper_triangles;
-  clipper_triangles.reserve( num_faces(clipper) );
-  Vpm vpm_c = boost::choose_param(boost::get_param(np_c, internal_np::vertex_point),
-                                  get_property_map(vertex_point, clipper));
-  BOOST_FOREACH(face_descriptor f, faces(clipper))
-  {
-    halfedge_descriptor h = halfedge(f, clipper);
-    clipper_triangles.push_back( typename GeomTraits::Triangle_3(
-      get(vpm_c, source(h, clipper)),
-      get(vpm_c, target(h, clipper)),
-      get(vpm_c, target(next(h, clipper), clipper)) ) );
-  }
-  // tree
-  Clipper_tree clipper_tree(clipper_triangles.begin(), clipper_triangles.end());
-  // predicate functor
-  Side_of_triangle_mesh<TriangleMesh, GeomTraits, Vpm, Clipper_tree> side_of(clipper_tree);
-  const bool clipper_outward_oriented =
-    CGAL::Polygon_mesh_processing::is_outward_oriented(clipper, np_c);
-  const CGAL::Bounded_side REGION_TO_REMOVE = clipper_outward_oriented
-                                            ? ON_UNBOUNDED_SIDE:ON_BOUNDED_SIDE;
-
-// Second corefine the meshes
-  typedef CGAL::dynamic_edge_property_t<bool> Ecm_tag;
-  typedef typename boost::property_map<TriangleMesh, Ecm_tag>::type Ecm;
-  Ecm ecm = get(Ecm_tag(), tm);
-
-  corefine(tm, clipper, np_tm.edge_is_constrained_map(ecm), np_c);
-
-// Extract connected components
-  typedef typename GetFaceIndexMap<TriangleMesh,
-                                   NamedParameters1>::type Fid_map;
-
-  Fid_map fid_map = boost::choose_param(boost::get_param(np_tm, internal_np::face_index),
-                                        get_property_map(boost::face_index, tm));
-  Vpm vpm1 = boost::choose_param(boost::get_param(np_tm, internal_np::vertex_point),
-                                 get_property_map(vertex_point, tm));
-
-  typedef CGAL::dynamic_vertex_property_t<std::size_t> Vid_tag;
-  typedef typename boost::property_map<TriangleMesh, Vid_tag>::type Vid_map;
-  Vid_map vid_map = get(Vid_tag(), tm);
-
-  // init indices if needed
-  helpers::init_face_indices(tm, fid_map);
-  helpers::init_vertex_indices(tm, vid_map);
-
-  // set the connected component id of each face
-  std::vector<std::size_t> face_cc(num_faces(tm), std::size_t(-1));
-  std::size_t nb_cc =
-    connected_components(tm,
-                         bind_property_maps(fid_map, make_property_map(face_cc)),
-                         parameters::face_index_map(fid_map).
-                         edge_is_constrained_map(ecm));
-
-
-  boost::dynamic_bitset<> cc_not_handled(nb_cc);
-  cc_not_handled.set();
-  std::vector <std::size_t> ccs_to_remove;
-
-  BOOST_FOREACH(face_descriptor f, faces(tm))
-  {
-    std::size_t cc_id = face_cc[ get(fid_map, f) ];
-    if ( !cc_not_handled.test(cc_id) ) continue;
-
-    halfedge_descriptor h=halfedge(f, tm);
-    for(int i=0;i<3;++i)
-    {
-      // look for a vertex not on a constrained edge
-      bool no_marked_edge=true;
-      BOOST_FOREACH(halfedge_descriptor h2, halfedges_around_target(h, tm))
-        if ( get(ecm, edge(h2, tm)) ){
-          no_marked_edge=false;
-          break;
-        }
-      if (no_marked_edge){
-        if ( side_of( get(vpm1, target(h, tm) ) ) == REGION_TO_REMOVE )
-          ccs_to_remove.push_back(cc_id);
-        cc_not_handled.reset(cc_id);
-        break;
-      }
-      h=next(h, tm);
-    }
-    if (!cc_not_handled.any()) break;
-  }
-
-  if (cc_not_handled.any())
-  {
-    // A patch with no vertex incident to a non-constrained edges
-    //  is a coplanar patch: drop it or keep it!
-    if (!boost::choose_param(boost::get_param(np_tm, internal_np::use_compact_clipper), true))
-    {
-      for (std::size_t cc_id = cc_not_handled.find_first();
-                       cc_id < cc_not_handled.npos;
-                       cc_id = cc_not_handled.find_next(cc_id))
-      {
-        ccs_to_remove.push_back(cc_id);
-      }
-    }
-  }
-// Filter out the cc
-  remove_connected_components(tm,
-    ccs_to_remove,
-    bind_property_maps(fid_map, make_property_map(face_cc)),
-    parameters::vertex_index_map(vid_map));
-
-  return true;
-}
 
 template <class Geom_traits, class Plane_3, class Point_3>
 int
@@ -419,7 +289,7 @@ clip_to_bbox(const Plane_3& plane,
   *   \cgalParamEnd
   *   \cgalParamBegin{face_index_map} a property map containing the index of each face of `tm` (`clipper`).
   *     Note that if the property map is writable, the indices of the faces
-  *     of `tm` and `clipper` will be set after the refining `tm` with the intersection with `plane`.
+  *     of `tm` and `clipper` will be set after refining `tm` with the intersection with `clipper`.
   *   \cgalParamEnd
   *   \cgalParamBegin{visitor} a class model of `PMPCorefinementVisitor`
   *                            that is used to track the creation of new faces.
@@ -450,13 +320,14 @@ clip(      TriangleMesh& tm,
      const NamedParameters1& np_tm,
      const NamedParameters2& np_c)
 {
-  const bool close =
+  const bool clip_volume =
     boost::choose_param(boost::get_param(np_tm, internal_np::clip_volume), false);
 
-  if (close && is_closed(tm))
+  if (clip_volume && is_closed(tm))
     return corefine_and_compute_intersection(tm, clipper, tm, np_tm, np_c);
-
-  return internal::clip_open_impl(tm, clipper, np_tm, np_c);
+  return corefine_and_compute_intersection(tm, clipper, tm,
+                                           np_tm.use_bool_op_to_clip_surface(true),
+                                           np_c);
 }
 
 namespace internal{
@@ -542,7 +413,6 @@ bool clip(      TriangleMesh& tm,
                     bbox.xmax()+xd, bbox.ymax()+yd, bbox.zmax()+zd);
   TriangleMesh clipper;
   Oriented_side os = internal::clip_to_bbox(plane, bbox, clipper, parameters::all_default());
-
   switch(os)
   {
     case ON_NEGATIVE_SIDE:

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -428,7 +428,6 @@ corefine_and_compute_boolean_operations(
                         *(*output[Corefinement::INTERSECTION]),
                         parameters::vertex_point_map(vpm1),
                         parameters::vertex_point_map(*cpp11::get<Corefinement::INTERSECTION>(vpm_out_tuple)));
-                        
 
     if (output[Corefinement::TM1_MINUS_TM2] != boost::none)
       if (&tm1 == *output[Corefinement::TM1_MINUS_TM2])
@@ -511,6 +510,20 @@ corefine_and_compute_boolean_operations(
   Edge_mark_map_tuple ecms_out(ecm_out_0, ecm_out_1, ecm_out_2, ecm_out_3);
   Ob ob(tm1, tm2, vpm1, vpm2, fid_map1, fid_map2, ecm_in,
         vpm_out_tuple, ecms_out, uv, output);
+
+  // special case used for clipping open meshes
+  if (  boost::choose_param( boost::get_param(np1, internal_np::use_bool_op_to_clip_surface),
+                             false) )
+  {
+    CGAL_assertion(output[Corefinement::INTERSECTION] != boost::none);
+    CGAL_assertion(output[Corefinement::UNION] == boost::none);
+    CGAL_assertion(output[Corefinement::TM1_MINUS_TM2] == boost::none);
+    CGAL_assertion(output[Corefinement::TM2_MINUS_TM1] == boost::none);
+    const bool use_compact_clipper =
+      boost::choose_param( boost::get_param(np1, internal_np::use_compact_clipper),
+                           true);
+    ob.setup_for_clipping_a_surface(use_compact_clipper);
+  }
 
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, Vpm, Algo_visitor >
     functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,ecm_in));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -902,8 +902,11 @@ public:
               if ( is_dangling_edge(ids.first, ids.second, h1, tm1, is_node_of_degree_one) ||
                    is_dangling_edge(ids.first, ids.second, h2, tm2, is_node_of_degree_one) )
               {
-                impossible_operation.set();
-                return;
+                if (!used_to_clip_a_surface)
+                {
+                  impossible_operation.set();
+                  return;
+                }
               }
               is_patch_inside_tm2.set(patch_id_p2);
             }
@@ -920,8 +923,11 @@ public:
               if ( is_dangling_edge(ids.first, ids.second, h1, tm1, is_node_of_degree_one) ||
                    is_dangling_edge(ids.first, ids.second, h2, tm2, is_node_of_degree_one) )
               {
-                impossible_operation.set();
-                return;
+                if (!used_to_clip_a_surface)
+                {
+                  impossible_operation.set();
+                  return;
+                }
               }
               is_patch_inside_tm1.set(patch_id_q2);
               is_patch_inside_tm2.set(patch_id_p1);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -206,6 +206,16 @@ void test()
   CGAL::clear(tm1);
   CGAL::clear(tm2);
 
+  // clip meshes with intersection polyline opened
+  make_triangle( K::Point_3(0, 0, 0), K::Point_3(0, 4, 0), K::Point_3(4, 0, 0), tm1 );
+  PMP::clip(tm1, K::Plane_3(1, 0, 0, -2));
+  assert(vertices(tm1).size()==4);
+  CGAL::clear(tm1);
+
+  make_triangle( K::Point_3(0, 0, 0), K::Point_3(0, 4, 0), K::Point_3(4, 0, 0), tm1 );
+  PMP::clip(tm1, K::Plane_3(-1, 0, 0, 2));
+  assert(vertices(tm1).size()==3);
+  CGAL::clear(tm1);
 }
 
 int main()


### PR DESCRIPTION
Fixes a bug when a patch with no input vertex must be classified wrt the clipper
The patch uses existing code with a special switch to disable some part of it.

Fix #3428 