### PR TITLE
Fix CTest after #3413

### DIFF
--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/cgal_test.cmake
@@ -197,7 +197,7 @@ function(run_test_alt name datafile)
   set(command ${name} ${datafile} ${ARGN})
   string(MAKE_C_IDENTIFIER "${name}  ${ARGV4}  ${ARGV5}" test_name)
   add_test(NAME ${test_name} COMMAND ${command}
-    WORKING_DIRECTORY ${CGAL_CURRENT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   set_property(TEST "${test_name}"
     APPEND PROPERTY DEPENDS "compilation_of__${name}")
   if(POLICY CMP0066) # CMake 3.7 or later

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -42,7 +42,7 @@ endif()
 
 # Process a list, and replace items contains a file pattern (like
 # `*.off`) by the sublist that corresponds to the globbing of the
-# pattern in the directory `${CGAL_CURRENT_SOURCE_DIR}`.
+# pattern in the directory `${CMAKE_CURRENT_SOURCE_DIR}`.
 #
 #
 # For example: the `file
@@ -71,7 +71,7 @@ function(expand_list_with_globbing list_name)
     list(GET input_list ${n} item_n)
 #    message(STATUS "argument ${n} is ${item_n}")
     if(item_n MATCHES ".*\\*.*")
-      file(GLOB files RELATIVE ${CGAL_CURRENT_SOURCE_DIR} ${item_n})
+      file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${item_n})
       list(APPEND output_list ${files})
     else()
       list(APPEND output_list ${item_n})
@@ -97,7 +97,7 @@ function(cgal_setup_test_properties test_name)
   endif()
   set_property(TEST "${test_name}"
     APPEND PROPERTY LABELS "${PROJECT_NAME}")
-  #      message(STATUS "  working dir: ${CGAL_CURRENT_SOURCE_DIR}")
+  #      message(STATUS "  working dir: ${CMAKE_CURRENT_SOURCE_DIR}")
   set_property(TEST "${test_name}"
     PROPERTY WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(exe_name)
@@ -198,7 +198,7 @@ function(cgal_add_test exe_name)
     return()
   endif()
 #  message("Add test ${test_name}")
-  set(cin_file "${CGAL_CURRENT_SOURCE_DIR}/${exe_name}.cin")
+  set(cin_file "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cin")
   if(NOT ARGS AND EXISTS ${cin_file})
     add_test(NAME ${test_name}
       COMMAND ${TIME_COMMAND} ${CMAKE_COMMAND}
@@ -213,11 +213,11 @@ function(cgal_add_test exe_name)
   else()
     if(NOT ARGS AND NOT cgal_add_test_TEST_NAME)
       if(ARGC GREATER 2 AND ARGV2)
-        set(cmd_file "${CGAL_CURRENT_SOURCE_DIR}/${ARGV2}.cmd")
+        set(cmd_file "${CMAKE_CURRENT_SOURCE_DIR}/${ARGV2}.cmd")
       elseif(ARGC GREATER 1 AND ARGV1 AND NOT EXISTS ${cmd_file})
-        set(cmd_file "${CGAL_CURRENT_SOURCE_DIR}/${ARGV1}.cmd")
+        set(cmd_file "${CMAKE_CURRENT_SOURCE_DIR}/${ARGV1}.cmd")
       elseif(NOT EXISTS ${cmd_file})
-        set(cmd_file "${CGAL_CURRENT_SOURCE_DIR}/${exe_name}.cmd")
+        set(cmd_file "${CMAKE_CURRENT_SOURCE_DIR}/${exe_name}.cmd")
       endif()
       if(EXISTS ${cmd_file})
         file(STRINGS "${cmd_file}" CMD_LINES)

--- a/Installation/cmake/modules/UseCGAL.cmake
+++ b/Installation/cmake/modules/UseCGAL.cmake
@@ -9,11 +9,6 @@ include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 
 cgal_setup_module_path()
 
-# Save the current source directory. That variable can be changed by
-# a `CMakeLists.txt`, for `CMakeLists.txt` files that are created in
-# the binary directory.
-set(CGAL_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-
 if(NOT USE_CGAL_FILE_INCLUDED)
   set(USE_CGAL_FILE_INCLUDED 1)
 

--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -11,11 +11,6 @@ get_filename_component(CGAL_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 set(CGAL_HEADER_ONLY TRUE)
 
-# Save the current source directory. That variable can be changed by
-# a `CMakeLists.txt`, for `CMakeLists.txt` files that are created in
-# the binary directory.
-set(CGAL_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-
 function(cgal_detect_branch_build VAR_NAME)
   if(IS_DIRECTORY ${CGAL_CONFIG_DIR}/../../../../Installation/package_info/Installation/)
     set(${VAR_NAME} TRUE PARENT_SCOPE)

--- a/Scripts/developer_scripts/git-show-content
+++ b/Scripts/developer_scripts/git-show-content
@@ -5,7 +5,8 @@ set -e
 
 git=git
 
-base=${1:-HEAD}
+commit=${1:-HEAD}
+base=${2:-cgal/master}
 
 function reset() {
     git update-ref -d refs/cgal/git-show-content
@@ -14,7 +15,7 @@ function reset() {
 
 trap reset ERR EXIT KILL TERM INT
 
-for c in $(git log --pretty='%h' --first-parent cgal/master..$base); do
+for c in $(git log --pretty='%h' --first-parent ${base}..${commit}); do
     git update-ref refs/cgal/git-show-content $c
     git bundle create bundle ${c}^..refs/cgal/git-show-content > /dev/null 2>&1
     gzip -f bundle


### PR DESCRIPTION
## Summary of Changes

Fix a bug with CTest in non-header-only

The pull-request #3413 has introduced a side-effect: CTest was broken when `CGAL_HEADER_ONLY=OFF`, for all tests using a `.cin` or `.cmd` file. That is due to the variable `CGAL_CURRENT_SOURCE_DIR` that was only filled by `UseCGAL.cmake`.

Now that we forbid CGAL directories without `CMakeLists.txt`, that variable `CGAL_CURRENT_SOURCE_DIR` is now useless, and can be removed: `CMAKE_CURRENT_SOURCE_DIR` is sufficient. That fixes the bug with CTest, and also makes the CMake code a bit simpler.

Cc @gdamiand, @sloriot 

## Release Management

* Affected package(s): Installation, CMake scripts, Arr_2

