### PR TITLE
Skin_surface_3: Fix for VC2017 which has a problem with the conversion to std::pair

### DIFF
--- a/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
+++ b/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
@@ -782,7 +782,7 @@ get_weighted_circumcenter(const Simplex &s, Gt2 &traits)
     }
     case 2:
     {
-      f = s;
+      f = Facet(s);
       result = traits.construct_weighted_circumcenter_3_object()
                (converter(f.first->vertex((f.second+1)&3)->point()),
                 converter(f.first->vertex((f.second+2)&3)->point()),

--- a/Skin_surface_3/include/CGAL/Triangulated_mixed_complex_observer_3.h
+++ b/Skin_surface_3/include/CGAL/Triangulated_mixed_complex_observer_3.h
@@ -128,7 +128,7 @@ public:
           break;
         }
         case 2: {
-          f = s;
+          f = Rt_Facet(s);
           Surface_weighted_point p0 =
             r2s_converter(f.first->vertex((f.second+1)&3)->point());
           Surface_weighted_point p1 =

--- a/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
+++ b/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
@@ -1024,7 +1024,7 @@ get_weighted_circumcenter(Rt_Simplex const &s)
            r2t_converter_object(e.first->vertex(e.third)->point()));
     break;
   case 2:
-    f=s;
+    f= Rt_Facet(s);
     result = weighted_circumcenter_obj(
            r2t_converter_object(f.first->vertex((f.second+1)&3)->point()),
            r2t_converter_object(f.first->vertex((f.second+2)&3)->point()),

--- a/Skin_surface_3/include/CGAL/triangulate_power_diagram_3.h
+++ b/Skin_surface_3/include/CGAL/triangulate_power_diagram_3.h
@@ -558,7 +558,7 @@ get_orthocenter(Rt_Simplex const &s)
            r2t_converter_object(e.first->vertex(e.third)->point()));
     break;
   case 2:
-    f=s;
+    f= Rt_Facet(s);
     result = orthocenter_obj(
            r2t_converter_object(
               f.first->vertex((f.second+1)&3)->point()),


### PR DESCRIPTION
## Summary of Changes

Fix for VC2017.  See [testsuite ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-48/Skin_surface_3/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz)
See [gist](https://gist.github.com/afabri/8a28b1c30cedbc6e9dfc492a419e399a)
Reported to Microsoft.

## Release Management

* Affected package(s): Skin_surface_3

