### PR TITLE
[Small Feature] Add angle(Vector_3, Vector_3) to the kernel

### DIFF
--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/function_objects_polynomial_sphere.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/function_objects_polynomial_sphere.h
@@ -1592,6 +1592,7 @@ template < class SK > \
 #endif
   {
     typedef typename SK::Point_3                   Point_3;
+    typedef typename SK::Vector_3                  Vector_3;
     typedef typename SK::Circular_arc_3            Circular_arc_3;
     typedef typename SK::FT                        FT;
 
@@ -1607,6 +1608,11 @@ template < class SK > \
     FT operator()(const Point_3& p, const Point_3& q, const Point_3& r) const
     {
       return LK_Compute_approximate_angle_3()(p,q,r);
+    }
+    
+    FT operator()(const Vector_3& u, const Vector_3& v) const
+    {
+      return LK_Compute_approximate_angle_3()(u,v);
     }
     
 #endif    

--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/function_objects_polynomial_sphere.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/function_objects_polynomial_sphere.h
@@ -1587,13 +1587,29 @@ template < class SK > \
 
   template <class SK>
   class Compute_approximate_angle_3
+#ifndef CGAL_CFG_MATCHING_BUG_6
+    : public SK::Linear_kernel::Compute_approximate_angle_3
+#endif
   {
+    typedef typename SK::Point_3                   Point_3;
     typedef typename SK::Circular_arc_3            Circular_arc_3;
+    typedef typename SK::FT                        FT;
 
   public:
 
     typedef double result_type;
 
+#ifndef CGAL_CFG_MATCHING_BUG_6
+    using SK::Linear_kernel::Compute_approximate_angle_3::operator();
+#else
+    typedef typename SK::Linear_kernel::Compute_approximate_angle_3 LK_Compute_approximate_angle_3;
+    
+    FT operator()(const Point_3& p, const Point_3& q, const Point_3& r) const
+    {
+      return LK_Compute_approximate_angle_3()(p,q,r);
+    }
+    
+#endif    
     result_type operator() (const Circular_arc_3 & c) const
     { return c.rep().approximate_angle(); }
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -78,7 +78,13 @@ Angle angle(const CGAL::Point_3<Kernel>&p,
             const CGAL::Point_3<Kernel>&r,
             const CGAL::Vector_3<Kernel>&v);
 
+/// @}
 
+
+
+/// \defgroup approximate_angle_grp CGAL::approximate_angle()
+/// \ingroup kernel_global_function
+/// @{
 
 /*!
 returns an approximation of the angle between `p-q` and `r-q`.
@@ -98,7 +104,13 @@ The angle is given in degrees.
 template <typename Kernel>
 Kernel::FT approximate_angle(const CGAL::Vector_3<Kernel>& u,
                              const CGAL::Vector_3<Kernel>& v);
-   
+ /// @}
+
+
+
+/// \defgroup approximate_dihedral_angle_grp CGAL::approximate_dihedral_angle()
+/// \ingroup kernel_global_function
+/// @{  
 /*!
 returns an approximation of the signed dihedral angle in the tetrahedron `pqrs` of edge `pq`.
 The sign is negative if `orientation(p,q,r,s)` is `CGAL::NEGATIVE` and positive otherwise.

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -38,7 +38,7 @@ const CGAL::Point_2<Kernel>& r,
 const CGAL::Point_2<Kernel>& s);
 
 /*!
-returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
 on the angle formed by the two vectors `u` and `v`.
 */
 template <typename Kernel>
@@ -57,7 +57,7 @@ const CGAL::Point_3<Kernel>& q,
 const CGAL::Point_3<Kernel>& r);
 
 /*!
-returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
 on the angle formed by the two vectors `pq`, `rs`. The returned value is
 the same as `angle(q - p, s - r)`.
 */
@@ -68,7 +68,7 @@ Angle angle(const CGAL::Point_3<Kernel>&p,
             const CGAL::Point_3<Kernel>&s);
 
 /*!
-returns \ref CGAL::OBTUSE, \ref CGAL::RIGHT or \ref CGAL::ACUTE depending
+returns `CGAL::OBTUSE`, `CGAL::RIGHT` or `CGAL::ACUTE` depending
 on the angle formed by the normal of the triangle `pqr` and the vector `v`.
 */
 
@@ -83,13 +83,22 @@ Angle angle(const CGAL::Point_3<Kernel>&p,
 /*!
 returns an approximation of the angle between `p-q` and `r-q`.
 The angle is given in degrees.
-\pre `p`and `r` are not equal to `q`.
+\pre `p` and `r` are not equal to `q`.
 */
 template <typename Kernel>
 Kernel::FT approximate_angle(const CGAL::Point_3<Kernel>& p,
                              const CGAL::Point_3<Kernel>& q,
                              const CGAL::Point_3<Kernel>& r);
-  
+
+/*!
+returns an approximation of the angle between `u` and `v`.
+The angle is given in degrees.
+\pre `u` and `v` are not equal to the null vector.
+*/
+template <typename Kernel>
+Kernel::FT approximate_angle(const CGAL::Vector_3<Kernel>& u,
+                             const CGAL::Vector_3<Kernel>& v);
+   
 /*!
 returns an approximation of the signed dihedral angle in the tetrahedron `pqrs` of edge `pq`.
 The sign is negative if `orientation(p,q,r,s)` is `CGAL::NEGATIVE` and positive otherwise.

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -81,6 +81,16 @@ Angle angle(const CGAL::Point_3<Kernel>&p,
 
 
 /*!
+returns an approximation of the angle between `p-q` and `r-q`.
+The angle is given in degrees.
+\pre `p`and `r` are not equal to `q`.
+*/
+template <typename Kernel>
+Kernel::FT approximate_angle(const CGAL::Point_3<Kernel>& p,
+                             const CGAL::Point_3<Kernel>& q,
+                             const CGAL::Point_3<Kernel>& r);
+  
+/*!
 returns an approximation of the signed dihedral angle in the tetrahedron `pqrs` of edge `pq`.
 The sign is negative if `orientation(p,q,r,s)` is `CGAL::NEGATIVE` and positive otherwise.
 The angle is given in degrees.

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1783,9 +1783,17 @@ public:
   /// @{
 
   /*!
+    returns an approximation of the angle between `u` and `v`.
+    The angle is given in degrees.
+    \pre `u`and `v` are not equal to the null vector.
+  */
+  Kernel::FT operator()(const Kernel::Vector_3& u,
+                        const Kernel::Vector_3& v) const;
+  
+  /*!
     returns an approximation of the angle between `p-q` and `r-q`.
     The angle is given in degrees.
-    \pre `p`and `r` are not equal to `q`.
+    \pre `p` and `r` are not equal to `q`.
   */
   Kernel::FT operator()(const Kernel::Point_3& p,
                         const Kernel::Point_3& q,
@@ -6920,7 +6928,7 @@ public:
   Kernel::Vector_2 operator()(const Kernel::Line_2 &l); 
 
   /*!
-    introduces a null vector . 
+    introduces a null vector. 
   */ 
   Kernel::Vector_2 operator()(const Null_vector &NULL_VECTOR); 
 
@@ -6979,7 +6987,7 @@ public:
   Kernel::Vector_3 operator()(const Kernel::Line_3 &l); 
 
   /*!
-    introduces a null vector . 
+    introduces a null vector. 
   */ 
   Kernel::Vector_3 operator()(const Null_vector &NULL_VECTOR); 
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1767,6 +1767,34 @@ public:
 
 }; /* end Kernel::ComputeApproximateArea_3 */
 
+  
+/*!
+  \ingroup PkgKernel23ConceptsFunctionObjects
+  \cgalConcept
+
+  \cgalRefines `AdaptableFunctor`
+
+*/
+class ComputeApproximateAngle_3 {
+public:
+
+  /// \name Operations
+  /// A model of this concept must provide:
+  /// @{
+
+  /*!
+    returns an approximation of the angle between `p-q` and `r-q`.
+    The angle is given in degrees.
+    \pre `p`and `r` are not equal to `q`.
+  */
+  Kernel::FT operator()(const Kernel::Point_3& p,
+                        const Kernel::Point_3& q,
+                        const Kernel::Point_3& r) const;
+
+  /// @}
+
+}; /* end Kernel::ComputeApproximateAngle_3 */
+  
 
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1785,7 +1785,7 @@ public:
   /*!
     returns an approximation of the angle between `u` and `v`.
     The angle is given in degrees.
-    \pre `u`and `v` are not equal to the null vector.
+    \pre `u` and `v` are not equal to the null vector.
   */
   Kernel::FT operator()(const Kernel::Vector_3& u,
                         const Kernel::Vector_3& v) const;

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1289,6 +1289,11 @@ public:
   typedef unspecified_type Compute_approximate_area_3;
 
   /*!
+    a model of `Kernel::ComputeApproximateAngle_3`
+  */
+  typedef unspecified_type Compute_approximate_angle_3;
+
+  /*!
     a model of `Kernel::ComputeApproximateDihedralAngle_3`
   */
   typedef unspecified_type Compute_approximate_dihedral_angle_3;

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -142,6 +142,8 @@
 \cgalCRPSection{Global Functions}
 
 - \link angle_grp `CGAL::angle()` \endlink
+- \link angle_grp `CGAL::approximate_angle()` \endlink
+- \link angle_grp `CGAL::approximate_dihedral_angle()` \endlink
 - \link are_ordered_along_line_grp `CGAL::are_ordered_along_line()` \endlink
 - \link are_strictly_ordered_along_line_grp `CGAL::are_strictly_ordered_along_line()` \endlink
 - \link area_grp `CGAL::area()` \endlink

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -298,6 +298,7 @@
 - `Kernel::ComputeB_2`
 - `Kernel::ComputeC_2`
 - `Kernel::ComputeApproximateArea_3`
+- `Kernel::ComputeApproximateAngle_3`
 - `Kernel::ComputeApproximateDihedralAngle_3`
 - `Kernel::ComputeApproximateSquaredLength_3`
 - `Kernel::ComputeArea_2`

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -830,6 +830,58 @@ namespace CommonKernelFunctors {
   };
 
  template <typename K>
+ class Compute_approximate_angle_3
+ {
+    typedef typename K::Point_3 Point_3;  
+ public:
+   typedef typename K::FT       result_type;
+
+    result_type
+    operator()(const Point_3& p, const Point_3& q, const Point_3& r) const
+   {
+     K k;
+     typename K::Construct_vector_3 vector = k.construct_vector_3_object();
+     typename K::Construct_cross_product_vector_3 cross_product =
+       k.construct_cross_product_vector_3_object();
+     typename K::Compute_scalar_product_3 scalar_product =
+       k.compute_scalar_product_3_object();
+     typedef typename K::FT                           FT;
+     typedef typename K::Vector_3                     Vector_3;
+     
+     Vector_3 u = vector(q,p);
+     Vector_3 v = vector(q,r);
+
+     double product = CGAL::sqrt(to_double(scalar_product(u,u))) * CGAL::sqrt(to_double(scalar_product(v,v)));
+     
+     if(product == 0)
+       return 0;
+     
+     // cosine
+     double dot = to_double(scalar_product(u,v));
+     double cosine = dot / product;
+
+     // sine
+     Vector_3 w = cross_product(u, v);
+     double abs_sine = CGAL::sqrt(to_double(scalar_product(w, w) / product));
+
+     if(abs_sine > 1.){
+       abs_sine = 1.;
+     }
+     if(abs_sine < -1.){
+       abs_sine = -1.;
+     }
+
+     double angle =  std::asin(abs_sine);
+     if(cosine < FT(0)){
+       angle = CGAL_PI - angle;
+     }
+     return angle * 180./CGAL_PI;
+
+     return 0;
+   }
+ };
+  
+ template <typename K>
  class Compute_approximate_dihedral_angle_3
  {
     typedef typename K::Point_3 Point_3;  

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -832,21 +832,18 @@ namespace CommonKernelFunctors {
  template <typename K>
  class Compute_approximate_angle_3
  {
-    typedef typename K::Point_3 Point_3;  
+   typedef typename K::Point_3 Point_3;
+   typedef typename K::Vector_3 Vector_3;
+   
  public:
    typedef typename K::FT       result_type;
 
     result_type
-    operator()(const Point_3& p, const Point_3& q, const Point_3& r) const
+    operator()(const Vector_3& u, const Vector_3& v) const
    {
      K k;
-     typename K::Construct_vector_3 vector = k.construct_vector_3_object();
      typename K::Compute_scalar_product_3 scalar_product =
        k.compute_scalar_product_3_object();
-     typedef typename K::Vector_3                     Vector_3;
-     
-     Vector_3 u = vector(q,p);
-     Vector_3 v = vector(q,r);
 
      double product = CGAL::sqrt(to_double(scalar_product(u,u))) * CGAL::sqrt(to_double(scalar_product(v,v)));
      
@@ -865,6 +862,19 @@ namespace CommonKernelFunctors {
      }
 
      return std::acos(cosine) * 180./CGAL_PI;
+   }
+
+   
+   result_type
+   operator()(const Point_3& p, const Point_3& q, const Point_3& r) const
+   {
+     K k;
+     typename K::Construct_vector_3 vector = k.construct_vector_3_object();
+     
+     Vector_3 u = vector(q,p);
+     Vector_3 v = vector(q,r);
+
+     return this->operator()(u,v); 
    }
  };
   

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -845,7 +845,7 @@ namespace CommonKernelFunctors {
      typename K::Compute_scalar_product_3 scalar_product =
        k.compute_scalar_product_3_object();
 
-     double product = CGAL::sqrt(to_double(scalar_product(u,u))) * CGAL::sqrt(to_double(scalar_product(v,v)));
+     double product = CGAL::sqrt(to_double(scalar_product(u,u)) * to_double(scalar_product(v,v)));
      
      if(product == 0)
        return 0;

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -841,11 +841,8 @@ namespace CommonKernelFunctors {
    {
      K k;
      typename K::Construct_vector_3 vector = k.construct_vector_3_object();
-     typename K::Construct_cross_product_vector_3 cross_product =
-       k.construct_cross_product_vector_3_object();
      typename K::Compute_scalar_product_3 scalar_product =
        k.compute_scalar_product_3_object();
-     typedef typename K::FT                           FT;
      typedef typename K::Vector_3                     Vector_3;
      
      Vector_3 u = vector(q,p);
@@ -860,24 +857,14 @@ namespace CommonKernelFunctors {
      double dot = to_double(scalar_product(u,v));
      double cosine = dot / product;
 
-     // sine
-     Vector_3 w = cross_product(u, v);
-     double abs_sine = CGAL::sqrt(to_double(scalar_product(w, w) / product));
-
-     if(abs_sine > 1.){
-       abs_sine = 1.;
+     if(cosine > 1.){
+       cosine = 1.;
      }
-     if(abs_sine < -1.){
-       abs_sine = -1.;
+     if(cosine < -1.){
+       cosine = -1.;
      }
 
-     double angle =  std::asin(abs_sine);
-     if(cosine < FT(0)){
-       angle = CGAL_PI - angle;
-     }
-     return angle * 180./CGAL_PI;
-
-     return 0;
+     return std::acos(cosine) * 180./CGAL_PI;
    }
  };
   

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -72,6 +72,16 @@ angle(const Point_3<K> &p, const Point_3<K> &q,
 template < class K >
 inline
 typename K::FT
+approximate_angle(const Point_3<K> &p,
+                  const Point_3<K> &q,
+                  const Point_3<K> &r)
+{
+  return internal::approximate_angle(p, q, r, K());
+}
+
+template < class K >
+inline
+typename K::FT
 approximate_dihedral_angle(const Point_3<K> &p,
                            const Point_3<K> &q,
                            const Point_3<K> &r,

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -72,6 +72,15 @@ angle(const Point_3<K> &p, const Point_3<K> &q,
 template < class K >
 inline
 typename K::FT
+approximate_angle(const Vector_3<K> &u,
+                  const Vector_3<K> &v)
+{
+  return internal::approximate_angle(u, v, K());
+}
+  
+template < class K >
+inline
+typename K::FT
 approximate_angle(const Point_3<K> &p,
                   const Point_3<K> &q,
                   const Point_3<K> &r)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -86,6 +86,16 @@ angle(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::FT
+approximate_angle(const typename K::Point_3 &p,
+                  const typename K::Point_3 &q,
+                  const typename K::Point_3 &r, const K& k)
+{
+  return k.compute_approximate_angle_3_object()(p, q, r);
+}
+  
+template < class K >
+inline
+typename K::FT
 approximate_dihedral_angle(const typename K::Point_3 &p,
                            const typename K::Point_3 &q,
                            const typename K::Point_3 &r,

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -86,6 +86,15 @@ angle(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::FT
+approximate_angle(const typename K::Vector_3 &u,
+                  const typename K::Vector_3 &v , const K& k)
+{
+  return k.compute_approximate_angle_3_object()(u, v);
+}
+  
+template < class K >
+inline
+typename K::FT
 approximate_angle(const typename K::Point_3 &p,
                   const typename K::Point_3 &q,
                   const typename K::Point_3 &r, const K& k)

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -173,6 +173,8 @@ CGAL_Kernel_cons(Compute_c_3,
 		 compute_c_3_object)
 CGAL_Kernel_cons(Compute_d_3,
 		 compute_d_3_object)
+CGAL_Kernel_cons(Compute_approximate_angle_3,
+		 compute_approximate_angle_3_object)
 CGAL_Kernel_cons(Compute_approximate_dihedral_angle_3,
 		 compute_approximate_dihedral_angle_3_object)
 CGAL_Kernel_cons(Compute_approximate_area_3,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
@@ -77,6 +77,7 @@ _test_angle(const R&)
   assert( CGAL::angle( org3, sx, sy, vcoplanar) ==  CGAL::RIGHT );
   assert( CGAL::angle( org3, sx, sy, vmz) ==  CGAL::OBTUSE );
   assert( CGAL::approximate_angle( sx, org3, sy ) > RT(89.9) );
+  assert( CGAL::approximate_angle( sx-org3, sy-org3 ) > RT(89.9) );
   assert( CGAL::approximate_angle( sx, org3, sy ) < RT(90.1) );
   assert( CGAL::approximate_angle( sx, org3, sx ) == RT(0) );
   assert( CGAL::approximate_angle( sx, org3, msx ) > RT(179.9) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
@@ -76,7 +76,7 @@ _test_angle(const R&)
   assert( CGAL::angle( org3, sx, sy, vz) ==  CGAL::ACUTE );
   assert( CGAL::angle( org3, sx, sy, vcoplanar) ==  CGAL::RIGHT );
   assert( CGAL::angle( org3, sx, sy, vmz) ==  CGAL::OBTUSE );
-  assert( CGAL::approximate_angle( sx, org3, sy ) > RT(89.9) );
+  assert( CGAL::approximate_angle( sx, org3, sy ) > RT(89) );
   assert( CGAL::approximate_angle( sx-org3, sy-org3 ) > RT(89) );
   assert( CGAL::approximate_angle( sx, org3, sy ) < RT(91) );
   assert( CGAL::approximate_angle( sx, org3, sx ) == RT(0) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
@@ -77,11 +77,11 @@ _test_angle(const R&)
   assert( CGAL::angle( org3, sx, sy, vcoplanar) ==  CGAL::RIGHT );
   assert( CGAL::angle( org3, sx, sy, vmz) ==  CGAL::OBTUSE );
   assert( CGAL::approximate_angle( sx, org3, sy ) > RT(89.9) );
-  assert( CGAL::approximate_angle( sx-org3, sy-org3 ) > RT(89.9) );
-  assert( CGAL::approximate_angle( sx, org3, sy ) < RT(90.1) );
+  assert( CGAL::approximate_angle( sx-org3, sy-org3 ) > RT(89) );
+  assert( CGAL::approximate_angle( sx, org3, sy ) < RT(91) );
   assert( CGAL::approximate_angle( sx, org3, sx ) == RT(0) );
-  assert( CGAL::approximate_angle( sx, org3, msx ) > RT(179.9) );
-  assert( CGAL::approximate_angle( sx, org3, msx ) < RT(180.1) );
+  assert( CGAL::approximate_angle( sx, org3, msx ) > RT(179) );
+  assert( CGAL::approximate_angle( sx, org3, msx ) < RT(181) );
   return true;
 }
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_angle.h
@@ -57,6 +57,7 @@ _test_angle(const R&)
   assert( CGAL::angle( e0, org, e1) == CGAL::RIGHT );
 
   Point_3 sx( RT1, RT0, RT0);
+  Point_3 msx( - RT1, RT0, RT0);
   Point_3 sy( RT0, RT1, RT0);
   Point_3 sz( RT0, RT0, RT1);
   Point_3 org3( RT0, RT0, RT0);
@@ -75,6 +76,11 @@ _test_angle(const R&)
   assert( CGAL::angle( org3, sx, sy, vz) ==  CGAL::ACUTE );
   assert( CGAL::angle( org3, sx, sy, vcoplanar) ==  CGAL::RIGHT );
   assert( CGAL::angle( org3, sx, sy, vmz) ==  CGAL::OBTUSE );
+  assert( CGAL::approximate_angle( sx, org3, sy ) > RT(89.9) );
+  assert( CGAL::approximate_angle( sx, org3, sy ) < RT(90.1) );
+  assert( CGAL::approximate_angle( sx, org3, sx ) == RT(0) );
+  assert( CGAL::approximate_angle( sx, org3, msx ) > RT(179.9) );
+  assert( CGAL::approximate_angle( sx, org3, msx ) < RT(180.1) );
   return true;
 }
 


### PR DESCRIPTION
## Summary of Changes

Computing an angle between 3 points is code that is currently in Surface_mesh_parameterization.
I've put it in a global function and a functor of the Kernel as we also need it for measuring mesh quality.

[small feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/approximate_angle) 

## Release Management

* Affected package(s): Kernel_23

* License and copyright ownership:  LGPL. It was added by Mael to Surface_mesh_parameterization, so we can move it.

TODO: Changelog

