### PR TITLE
Address warning Wself-assign-overloaded

### DIFF
--- a/Mesh_2/test/Mesh_2/test_double_map.cpp
+++ b/Mesh_2/test/Mesh_2/test_double_map.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
   std::cerr << "Assignment f2=f...\n";
   f2 = f; // check the assignment 
   std::cerr << "Auto-assignment f=f...\n";
-  void(f2 = f2); // check the auto-assignment 
+  f2 = (Map&)f2; // check the auto-assignment 
   std::cerr << "Copy-construction...\n";
   Map f3(f); // check the copy constructor
 

--- a/Mesh_2/test/Mesh_2/test_double_map.cpp
+++ b/Mesh_2/test/Mesh_2/test_double_map.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
   std::cerr << "Assignment f2=f...\n";
   f2 = f; // check the assignment 
   std::cerr << "Auto-assignment f=f...\n";
-  f2 = f2; // check the auto-assignment 
+  void(f2 = f2); // check the auto-assignment 
   std::cerr << "Copy-construction...\n";
   Map f3(f); // check the copy constructor
 

--- a/Modular_arithmetic/test/Modular_arithmetic/Residue.cpp
+++ b/Modular_arithmetic/test/Modular_arithmetic/Residue.cpp
@@ -102,7 +102,7 @@ int main()
 
         assert(mod_x == CGAL::modular_image(int_x));
         int_x -= int_x; int_x = CGAL::mod(int_x, prime);
-        mod_x -= mod_x; 
+        mod_x -= (CGAL::Residue&)mod_x; 
     }
     {
         CGAL::Residue::set_current_prime(67111043);

--- a/Number_types/test/Number_types/Interval_nt.cpp
+++ b/Number_types/test/Number_types/Interval_nt.cpp
@@ -211,7 +211,7 @@ bool multiplication_test()
   g = d * e;
   h = d * f;
   i = a * e;
-  j = j;
+  j = (IA_nt&)j;
 
   // When CGAL_IA_DEBUG is defined, it'll test the current rounding mode for
   // these operations.

--- a/STL_Extension/test/STL_Extension/test_dispatch_output.cpp
+++ b/STL_Extension/test/STL_Extension/test_dispatch_output.cpp
@@ -23,7 +23,7 @@ void check_types(output out){
   CGAL_USE_TYPE(typename output::pointer);
   CGAL_USE_TYPE(typename output::reference);
   T1 tmp=out.get_iterator_tuple();
-  tmp=tmp;
+  tmp=(T1&)tmp;
 }
   
 template <class T1,class T2>
@@ -69,8 +69,8 @@ void complete_test(std::vector<T1> data1,std::list<T2> data2){
   check_types(disp);
   check_types(drop);
   
-  disp = disp;
-  drop = drop;
+  disp = (Dispatcher&)disp;
+  drop = (Dropper&)drop;
 
   std::back_insert_iterator<std::vector<T2> > bck_ins(cont_2);
   

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_types.h
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/include/test_types.h
@@ -167,7 +167,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
   start_testing("assignment operator");
   sdg.insert(site_list.begin(), site_list.end());
 
-  sdg = sdg;
+  sdg = (Segment_Delaunay_graph_2&)sdg;
   sdg2 = sdg;
 
   assert( sdg.is_valid() );

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_types.h
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/include/test_types.h
@@ -167,7 +167,7 @@ bool test_sdg(InputStream&, const SDG&, const char* ifname, const char* ofname,
   start_testing("assignment operator");
   sdg.insert(site_list.begin(), site_list.end());
 
-  sdg = sdg;
+  sdg = (Segment_Delaunay_graph_2&)sdg;
   sdg2 = sdg;
 
   assert( sdg.is_valid() );


### PR DESCRIPTION
## Summary of Changes

In the testsuite we assign sometimes variables to themselves: `f = f`. 
This triggers a [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-49/Mesh_2/TestReport_lrineau_ArchLinux-clang-CXX14.gz) and it can be avoided by writing `void(f = f)`.

## Release Management

* Affected package(s): Mesh_2  (more to follow if it works)

