### PR TITLE
Fix CMake warnings about CMP for Visual 2017

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Core Qt5 )
 
 find_package( Qt5 QUIET COMPONENTS Gui Widgets)

--- a/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
@@ -5,6 +5,10 @@ project( CGALimageIO_Examples )
 
 cmake_minimum_required(VERSION 3.1)
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS ImageIO )
 
 if(CGAL_ImageIO_FOUND)

--- a/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
@@ -6,6 +6,10 @@ project( CGAL_ImageIO_Tests )
 
 cmake_minimum_required(VERSION 3.1)
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS ImageIO )
 
 if ( CGAL_FOUND )

--- a/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL)

--- a/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
+++ b/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
+++ b/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 

--- a/GraphicsView/demo/Generator/CMakeLists.txt
+++ b/GraphicsView/demo/Generator/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/GraphicsView/CMakeLists.txt
+++ b/GraphicsView/demo/GraphicsView/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
+++ b/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
+++ b/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -34,12 +34,6 @@ qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Periodic_2_triangulation_2.qrc )
 qt5_generate_moc( Periodic_2_Delaunay_triangulation_2.cpp Periodic_2_triangulation_2.moc )
 
 # find header files for projects that can show them
-
-cmake_minimum_required(VERSION 3.1)
-if(NOT POLICY CMP0070 AND POLICY CMP0053)
-  # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
-  cmake_policy(SET CMP0053 OLD)
-endif()
 file(GLOB headers "*.h")
 file(GLOB QT_headers "include/CGAL/Qt/*.h")
 file(GLOB P2T2_headers "../../../include/CGAL/*.h")

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5 Core)
 
 find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)

--- a/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5 Core)
 
 set( QT_USE_QTXML    TRUE )

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5 Core)
 
 set( QT_USE_QTXML    TRUE )

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 

--- a/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 if(CGAL_Qt5_FOUND)

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -14,6 +14,10 @@ if ( MESH_3_VERBOSE )
   add_definitions(-DCGAL_MESH_3_VERBOSE)
 endif()
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(CGAL COMPONENTS ImageIO)
 
 if ( CGAL_FOUND )

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -6,6 +6,9 @@ project( Mesh_3_Tests )
 
 cmake_minimum_required(VERSION 3.1)
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 
 find_package(CGAL QUIET COMPONENTS ImageIO)
 

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 # Include this package's headers first
 include_directories( BEFORE ./ ./include )
 

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -10,6 +10,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 # Find CGAL
 find_package(CGAL COMPONENTS Qt5)
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -15,6 +15,11 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -1,5 +1,9 @@
 include( polyhedron_demo_macros )
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 if(EIGEN3_FOUND)
   find_package(CGAL COMPONENTS Core)
   

--- a/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
@@ -10,6 +10,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 # Let plugins be compiled in the same directory as the executable.
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 

--- a/Polyhedron/examples/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/examples/Polyhedron/CMakeLists.txt
@@ -11,6 +11,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 if(CGAL_Qt5_FOUND)

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Widgets Svg)

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 foreach(INCDIR ../../../STL_Extension/include ../../../GraphicsView/include ../../../filtered_kernel/include )
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${INCDIR}")
     include_directories (BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/${INCDIR}")

--- a/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
@@ -21,6 +21,10 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(PACKAGE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
 # Add several CGAL packages to the include and link paths,

--- a/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
@@ -5,6 +5,10 @@ project( Surface_mesher_Examples )
 
 cmake_minimum_required(VERSION 3.1)
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS ImageIO)
 
 if ( CGAL_FOUND AND CGAL_ImageIO_FOUND )

--- a/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
@@ -11,6 +11,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 if(CGAL_Qt5_FOUND)

--- a/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT POLICY CMP0070 AND POLICY CMP0053)
   cmake_policy(SET CMP0053 OLD)
 endif()
 
+if(POLICY CMP0071)
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 find_package(CGAL COMPONENTS Qt5)
 
 if(CGAL_Qt5_FOUND)


### PR DESCRIPTION
## Summary of Changes
Fixes the cmake warnings about cmp0071 and CMP0074 .