### PR TITLE
Polyhedron Demo: fix colorize each Connected Component

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -228,7 +228,7 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionColorConnectedCom
       PatchIDMap pidmap = get(CGAL::face_patch_id_t<int>(), *item->face_graph());
       int nb_patch_ids = CGAL::Polygon_mesh_processing::connected_components(*item->face_graph(),
                                                                              pidmap);
-
+      item->computeItemColorVectorAutomatically(true);
       item->invalidateOpenGLBuffers();
       item->setProperty("NbPatchIds", nb_patch_ids);
       scene->itemChanged(item);


### PR DESCRIPTION
## Summary of Changes
computeItemColorVectorAutomatically(true) was missing.
## Release Management

* Issue(s) solved (if any): fix #3475
