### PR TITLE
CGAL  Suppress VC2017 deprecation warnings concerning boost 

### DIFF
--- a/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
+++ b/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
@@ -31,10 +31,18 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #if BOOST_VERSION >= 105000
-#include <boost/heap/priority_queue.hpp>
+#  if defined(BOOST_MSVC)
+#    pragma warning(push)
+#    pragma warning(disable: 4996)
+#  endif
+#  include <boost/heap/priority_queue.hpp>
+#  if defined(BOOST_MSVC)
+#    pragma warning(pop)
+#  endif
 #else
-#include <queue>
+#  include <queue>
 #endif
+
 #include <CGAL/assertions.h>
 
 namespace CGAL {

--- a/Mesher_level/include/CGAL/Double_map.h
+++ b/Mesher_level/include/CGAL/Double_map.h
@@ -40,8 +40,14 @@
 #endif
 
 #ifdef CGAL_USE_BOOST_BIMAP
+#  if defined(BOOST_MSVC)
+#    pragma warning(push)
+#    pragma warning(disable: 4996)
+#  endif
 #include <CGAL/boost/bimap.hpp>
 #include <boost/bimap/multiset_of.hpp>
+#  if defined(BOOST_MSVC)
+#    pragma warning(pop)
 #endif
 
 namespace CGAL {


### PR DESCRIPTION

## Summary of Changes

We suppress them so that we can focus on warnings concerning CGAL code.

## Release Management

* Affected package(s): AABB Tree,  Mesher_level


