### PR TITLE
Polyhedron demo:  mesh_3_plugin  surface_only

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -502,6 +502,7 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
                                  edge_size,
                                  radius_edge,
                                  manifold,
+                                 surface_only,
                                  scene);
   }
 #endif
@@ -527,6 +528,7 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
                                  radius_edge,
                                  protect_features,
                                  manifold,
+                                 surface_only,
                                  scene,
                                  detect_connected_components,
                                  image_item->isGray(),

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -181,6 +181,7 @@ Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
                                  const double edge_size,
                                  const double tet_shape,
                                  const int manifold,
+                                 const bool surface_only,
                                  CGAL::Three::Scene_interface* scene)
 {
   if (pfunction == NULL) { return NULL; }
@@ -198,7 +199,7 @@ Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
                                [](int i, int j) { return (i * 1000 + j); }
                              );
 
-  Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
+  Scene_c3t3_item* p_new_item = new Scene_c3t3_item(surface_only);
   p_new_item->setScene(scene);
 
   Mesh_parameters param;
@@ -236,6 +237,7 @@ Meshing_thread* cgal_code_mesh_3(const Image* pImage,
                                  const double tet_shape,
                                  bool protect_features,
                                  const int manifold,
+                                 const bool surface_only,
                                  CGAL::Three::Scene_interface* scene,
                                  bool detect_connected_components,
                                  bool is_gray,
@@ -259,7 +261,7 @@ Meshing_thread* cgal_code_mesh_3(const Image* pImage,
   param.tet_shape = tet_shape;
   param.manifold = manifold;
   param.image_3_ptr = pImage;
-  Scene_c3t3_item* p_new_item = new Scene_c3t3_item;
+  Scene_c3t3_item* p_new_item = new Scene_c3t3_item(surface_only);
   p_new_item->setScene(scene);
   if(!is_gray)
   {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
@@ -44,6 +44,7 @@ Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
                                  const double edge_size,
                                  const double tet_shape,
                                  const int manifold,
+                                 const bool surface_only,
                                  CGAL::Three::Scene_interface* scene);
 #endif
 
@@ -58,6 +59,7 @@ Meshing_thread* cgal_code_mesh_3(const CGAL::Image_3* pImage,
                                  const double tet_shape,
                                  bool protect_features,
                                  const int manifold,
+                                 const bool surface_only,
                                  CGAL::Three::Scene_interface* scene,
                                  bool detect_connected_components,
                                  bool is_gray = false,


### PR DESCRIPTION
## Summary of Changes

In the Mesh_3 plugin, generalise the creation of surface-only c3t3 items, also for meshes created from images or implicit functions.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: trivial patch 

