### PR TITLE
Snap_rounding_2: Fix test script

### DIFF
--- a/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
+++ b/Snap_rounding_2/test/Snap_rounding_2/cgal_test_base
@@ -25,7 +25,7 @@ configure()
 {
   echo "Configuring... "
     
-  if eval 'cmake --no-warn-unused-cli "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
+  if eval 'cmake --no-warn-unused-cli ${INIT_FILE:+"-C${INIT_FILE}"} "$CMAKE_GENERATOR" -DRUNNING_CGAL_AUTO_TEST=TRUE  \
                                      -DCGAL_DIR="$CGAL_DIR" \
                                      .' ; then
         


### PR DESCRIPTION

## Summary of Changes
Add missing argument in cgal_test, that makes that Blake doesn't find the dependencies.
## Release Management

* Affected package(s):Snap_rounding_2
* Issue(s) solved (if any): red square in testsuite.
