### PR TITLE
Number_types: Add '=default' so that code gets generated explicitely

### DIFF
--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -107,6 +107,15 @@ public:
   Gmpq(unsigned long n)
   { mpq_set_ui(mpq(), n, 1); }
 
+
+#ifdef CGAL_CXX11
+  // https://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five
+  Gmpq(const Gmpq&) = default;
+  Gmpq(Gmpq&&) = default;
+  Gmpq& operator=(const Gmpq&) = default;
+  Gmpq& operator=(Gmpq&&) = default;
+#endif // CGAL_CXX11
+
 private:
   void init_ull(unsigned long long n){
       CGAL_assertion(sizeof(long)==4 && sizeof(long long)==8);


### PR DESCRIPTION
## Summary of Changes

Fix warning of g++ 9.0.0
<pre>
/mnt/testsuite/include/CGAL/GMP/Gmpq_type.h: In member function 'CGAL::Gmpq CGAL::Gmpq::operator-() const':
/mnt/testsuite/include/CGAL/GMP/Gmpq_type.h:311:12: warning: implicitly-declared 'CGAL::Gmpq::Gmpq(const CGAL::Gmpq&)' is deprecated [-Wdeprecated-copy]
</pre>

See [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-55/Modular_arithmetic/TestReport_lrineau_Ubuntu-latest-GCC6.gz)

@lrineau  We start with `Gmpq` , but more classes will follow as soon as the column is less yellow.

## Release Management

* Affected package(s):  Number_types 


