### PR TITLE
generate a truly Delaunay triangulation

### DIFF
--- a/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
+++ b/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
@@ -24,7 +24,7 @@ int main()
     { 100, 100, 100, 100, 100, 100, 100 }
   };
 
-  typedef CGAL::Dalunay_triangulation<CGAL::Epick_d< CGAL::Dimension_tag<7> > >      T;
+  typedef CGAL::Delaunay_triangulation<CGAL::Epick_d< CGAL::Dimension_tag<7> > >      T;
   T dt(7);
 
   std::vector<T::Point> points;

--- a/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
+++ b/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
@@ -24,7 +24,7 @@ int main()
     { 100, 100, 100, 100, 100, 100, 100 }
   };
 
-  typedef CGAL::Triangulation<CGAL::Epick_d< CGAL::Dimension_tag<7> > >      T;
+  typedef CGAL::Dalunay_triangulation<CGAL::Epick_d< CGAL::Dimension_tag<7> > >      T;
   T dt(7);
 
   std::vector<T::Point> points;


### PR DESCRIPTION
## Summary of Changes

It seems that without the use of the Delaunay_triangulation class, the obtained triangulation is not the actual full Delaunay triangulation of the points.

## Release Management

* Affected package(s): dD Triangulations
* Issue(s) solved (if any): fix #3502

