### PR TITLE
Update Nef_polyhedron_S2.h

### DIFF
--- a/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
@@ -339,7 +339,7 @@ public:
             f->mark() == false);
   }
 
-  bool is_plane() const
+  bool is_sphere() const
   /*{\Mop returns true if |\Mvar| is the whole plane, false otherwise.}*/
   { Const_decorator D(&sphere_map());
     SFace_const_iterator f = D.sfaces_begin();


### PR DESCRIPTION

## Summary of Changes

 Changed incorrect naming of function is_plane to is_sphere to match documentation

## Release Management

* Affected package(s): cgal
* Issue(s) solved (if any): fix is_plane is named is_sphere in the documentation. #3505  Feature/Small Feature (if any):


