### PR TITLE
Box_intersection_d: (void) result to avoid warning

### DIFF
--- a/Box_intersection_d/test/Box_intersection_d/util.h
+++ b/Box_intersection_d/test/Box_intersection_d/util.h
@@ -27,14 +27,14 @@ struct Util {
       int numBoxes, numDim;
       int boxNum, dim;
     
-      std::fscanf(infile, "%d %d\n", &numBoxes, &numDim);
+      (void)std::fscanf(infile, "%d %d\n", &numBoxes, &numDim);
       std::vector< int > minc( numDim ), maxc( numDim );
       /* Read boxes */
       for(boxNum = 0; boxNum < numBoxes; boxNum++) {
           for(dim = 0; dim < numDim; dim++)
-              std::fscanf( infile, "[%d, %d) ", &minc[dim], &maxc[dim] );
+              (void)std::fscanf( infile, "[%d, %d) ", &minc[dim], &maxc[dim] );
           boxes.push_back( Box( &minc[0], &maxc[0] ) );
-          std::fscanf(infile, "\n");
+          (void)std::fscanf(infile, "\n");
       }
     }
     


### PR DESCRIPTION
## Summary of Changes

This [warning ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-62/Box_intersection_d/TestReport_Friedrich_Ubuntu-clang-64bits.gz) should go away.

## Release Management

* Affected package(s): Box_intersection_d

