### PR TITLE
XHTML incorrect tag sequence with figure

### DIFF
--- a/Visibility_2/doc/Visibility_2/visibility_2.txt
+++ b/Visibility_2/doc/Visibility_2/visibility_2.txt
@@ -129,7 +129,6 @@ does not require preprocessing is advantageous.
 The following example shows how to obtain the regularized and non-regularized visibility regions.
 
 \cgalFigureBegin{simple_example, simple_example.png}
-
 The visibility region of \f$ q \f$ in a simple polygon: (1) non-regularized visibility; and (2) regularized visibility.
 \cgalFigureEnd
 \cgalExample{Visibility_2/simple_polygon_visibility_2.cpp}


### PR DESCRIPTION
Due to the extra empty line an wrong sequence of tags appeared in the HTML output.


