### PR TITLE
Problems with formulas in documentation

### DIFF
--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/Boolean_set_operations_2.txt
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/Boolean_set_operations_2.txt
@@ -74,7 +74,7 @@ polygon vertices is referred to as the polygon <B>(outer) boundary</B>.
 
 <LI>A polygon whose curves are pairwise disjoint in their interior, and whose vertices' degree equals two is defined as a <B>Simple polygon</B>. Such a polygon has a well-defined interior and exterior and is topologically equivalent to a disk. Note that while traversing the edges of the relatively simple polygon illustrated above (B), no curve is crossed over.
 
-<LI>A <B>Relatively simple</B> polygon allows vertices with a degree\f$\gt 2\f$, but all of its edges are disjoint in their interior. Furthermore, it must be an orientable polygon. Namely when it is inserted into an arrangement and its outer boundary is traversed, the same face is adjacent to all of the halfedges (no crossing over any curve during the traversal). 
+<LI>A <B>Relatively simple</B> polygon allows vertices with a degree\f$> 2\f$, but all of its edges are disjoint in their interior. Furthermore, it must be an orientable polygon. Namely when it is inserted into an arrangement and its outer boundary is traversed, the same face is adjacent to all of the halfedges (no crossing over any curve during the traversal).
 Note that while polygon C has the same curves as polygon B, traversal of the curves leads to crossing over a previously traversed curve, and is therefore neither simple nor relatively simple. 
 
 <LI>A polygon in our context must be relatively simple and its outer boundary vertices must be ordered in a counterclockwise direction around the interior of the polygon.

--- a/Generator/doc/Generator/Generator.txt
+++ b/Generator/doc/Generator/Generator.txt
@@ -277,7 +277,7 @@ triangle (2D and 3D) and in tetrahedra (3D). Basically, in order to generate
 a random point in a \f$N\f$-simplex (a triangle for \f$N = 2\f$, and tetrahedron 
 for \f$N = 3\f$), we generate numbers \f$a_1,a_2,\ldots,a_N\f$ identically and independently 
 uniformly distributed in \f$(0,1)\f$, we sort them, we let \f$a_0 = 0\f$ and \f$a_{N+1} = 1\f$, 
-and then \f$a_{i+1}−a_i\f$, for \f$i = 1,\ldots,N\f$ becomes its 
+and then \f$a_{i+1}-a_i\f$, for \f$i = 1,\ldots,N\f$ becomes its
 barycentric coordinates with respect to the simplex.
 
 Maxime Gimemo introduced the random generators on 2D and 3D triangle meshes.

--- a/Jet_fitting_3/doc/Jet_fitting_3/CGAL/Monge_via_jet_fitting.h
+++ b/Jet_fitting_3/doc/Jet_fitting_3/CGAL/Monge_via_jet_fitting.h
@@ -199,7 +199,7 @@ Monge_via_jet_fitting();
 This operator performs all the computations. The \f$ N\f$ input points are 
 given by the `InputIterator` parameters which value-type are 
 `Data_kernel::Point_3`, `d` is the degree of the fitted 
-polynomial, `d'` is the degree of the expected Monge 
+polynomial, \c d' is the degree of the expected Monge
 coefficients. \pre \f$ N \geq N_{d}:=(d+1)(d+2)/2\f$, \f$ 1 \leq d' \leq\min(d,4) \f$. 
 */ 
 template <class InputIterator> Monge_form 

--- a/Jet_fitting_3/doc/Jet_fitting_3/Jet_fitting_3.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/Jet_fitting_3.txt
@@ -77,13 +77,11 @@ the surface can locally be written as the graph of a bivariate
 function. Letting \f$ h.o.t.\f$ stand for <I>higher order terms</I>, one
 has :
 
-\f[
-\begin{equation}
+\f{equation}{
 z(x,y)=J_{B,d}(x,y) + h.o.t. \ ; \quad 
 J_{B,d}(x,y)=\ccSum{k=0}{d}{(\ccSum{i=0}{i}{
 \frac{B_{k-i,i}x^{k-i}y^{i}}{i!(k-i)!}})}.
-\end{equation}
-\f]
+\f}
 
 The degree \f$ d\f$ polynomial \f$ J_{B,d}\f$ is the Taylor expansion of the
 function \f$ z\f$, and is called its <I>\f$ d\f$-jet</I>. Notice that a \f$ d\f$-jet contains
@@ -343,12 +341,10 @@ The fitting process consists of finding the coefficients
 \f$ A_{i,j}\f$ of the degree \f$ d\f$ polynomial 
 
 \anchor eqanswer
-\f[
-\begin{equation}
+\f{equation}{
 J_{A,d}= \ccSum{k=0}{d}{(\ccSum{i=0}{k}{
 \frac{A_{k-i,i}x^{k-i}y^{i}}{i!(k-i)!}})}.
-\end{equation}
-\f]
+\f}
 
 Denote \f$ p_i=(x_i,y_i,z_i), \ i=1,\ldots , N\f$ the coordinates of the
 sample points of \f$ P^+\f$.
@@ -362,7 +358,7 @@ given by
  A =  & (A_{0,0}, A_{1,0},A_{0,1}, \ldots , A_{0,d})^T \\ 
  Z=  &(z_1, z_2,\ldots , z_N)^T \\ 
  M=  &(1,x_i,\ y_i,\ \frac{x_i^2}{2},\ldots ,
-\ \frac{x_iy_i^{d-1}}{(d-1)!},\ \frac{y_i^d}{d!})_{i=1,...,N}\\
+\ \frac{x_iy_i^{d-1}}{(d-1)!},\ \frac{y_i^d}{d!})_{i=1,...,N}
 \f}
 
 The equations for interpolation become \f$ MA=Z\f$. For approximation, the
@@ -395,8 +391,7 @@ The number \f$ r\f$, which is the number of non zero singular values, is
 strictly lower than \f$ N_d\f$ if the system is under constrained. In any
 case, the unique solution which minimize \f$ ||A||_2\f$ is given by:
 
-\f[
-\begin{equation}
+\f{equation}{
 A= V
 \left( \begin{array}{cc}
 D_r^{-1} & 0_{N_d-r,\ r}\\
@@ -404,8 +399,7 @@ D_r^{-1} & 0_{N_d-r,\ r}\\
 \end{array} 
 \right)
  U^TZ.
-\end{equation}
-\f]
+\f}
 
 One can provide the condition number of the matrix \f$ M\f$ (after
 preconditioning) which is the ratio of the maximal and the minimal
@@ -491,22 +485,18 @@ We use explicit formula. The implicit equation of the fitted
 polynomial surface in the fitting-basis with origin the point
 \f$ (0,0,A_{0,0})\f$ is \f$ Q=0\f$ with
 
-\f[
-\begin{equation}
+\f{equation}{
 Q=-w-A_{0,0}  +\ccSum{i,j}{}{\frac{A_{i,j}u^iv^j}{i!j!}}.
-\end{equation}
-\f]
+\f}
 
 The equation in the Monge basis is obtained by substituting \f$ (u,v,w)\f$
 by \f$ P^T_{F\rightarrow M}(x,y,z)\f$. Denote \f$ f(x,y,z)=0\f$ this implicit
 equation. By definition of the Monge basis, we have locally (at
 \f$ (0,0,0)\f$)
 
-\f[ 
-\begin{equation}
+\f{equation}{
 f(x,y,z)=0 \Leftrightarrow z=g(x,y)
-\end{equation}
-\f]
+\f}
 
 and the Taylor expansion of \f$ g\f$ at \f$ (0,0)\f$ are the Monge coefficients
 sought.
@@ -526,7 +516,7 @@ f_{0,0,1} ^{2}}}
 \\
 &b_1=g_{2,1}=-{\frac {-  f_{0,1,1}      f_{2,0,0}    +  f_{2,1,0}    f_{0,0,1}  }{  f_{0,0,1}    ^{2}}}
 \\
-& .... \\
+& ....
 \f}
 
 

--- a/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Vector_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Vector_d.h
@@ -96,8 +96,8 @@ InputIterator first, InputIterator last);
 introduces a 
 variable `v` of type `Vector_d<Kernel>` in dimension `d` 
 initialized to the vector with homogeneous coordinates as defined by 
-`H = set [first,last)` and `D`: \f$ (\pmH[0], 
-\pmH[1], \ldots, \pmH[d-1], \pmD)\f$. The sign 
+`H = set [first,last)` and `D`: \f$ (\pm H_0, 
+\pm H_1, \ldots, \pm H_{D-1}, \pm H_D)\f$. The sign 
 chosen is the sign of \f$ D\f$.
 
 \pre `D` is non-zero, the iterator range defines a \f$ d\f$-tuple of `RT`. 

--- a/QP_solver/doc/QP_solver/CGAL/QP_solution.h
+++ b/QP_solver/doc/QP_solver/CGAL/QP_solution.h
@@ -495,9 +495,9 @@ then \f$\lambda_i\geq 0\f$ (\f$\lambda_i\leq 0\f$, respectively).
 <LI>
 \f[
 \begin{array}{llll}
-&&\geq 0 & \mbox{if \f$u_j=\infty\f$} \\
+&&\geq 0 & \mbox{if $u_j=\infty$} \\
 \qplambda^T A_j &\quad  \\
-&&\leq 0 & \mbox{if \f$l_j=-\infty\f$.}
+&&\leq 0 & \mbox{if $l_j=-\infty$}.
 \end{array}
 \f]
 <LI> \f[\qplambda^T\qpb \quad<\quad \ccSum{j: \qplambda^TA_j <0}{}{ \qplambda^TA_j u_j }
@@ -508,12 +508,12 @@ then \f$\lambda_i\geq 0\f$ (\f$\lambda_i\leq 0\f$, respectively).
 that there is a feasible solution \f$\qpx\f$. Then we get
 \f[
 \begin{array}{lcll}
-0 &\geq& \qplambda^T(A\qpx -\qpb) &  \mbox{(by \f$A\qpx\qprel \qpb\f$ and 1.)} \\
+0 &\geq& \qplambda^T(A\qpx -\qpb) &  \mbox{(by $A\qpx\qprel \qpb$ and 1.)} \\
   &=& \ccSum{j: \qplambda^TA_j <0}{}{ \qplambda^TA_j x_j }
 \quad+\quad  \ccSum{j: \qplambda^TA_j >0}{}{ \qplambda^TA_j x_j} - \qplambda^T \qpb \\
   &\geq& \ccSum{j: \qplambda^TA_j <0}{}{ \qplambda^TA_j u_j }
 \quad+\quad  \ccSum{j: \qplambda^TA_j >0}{}{ \qplambda^TA_j l_j} - \qplambda^T \qpb &
-\mbox{(by \f$\qpl\leq \qpx \leq \qpu\f$ and 2.)} \\
+\mbox{(by $\qpl\leq \qpx \leq \qpu$ and 2.)} \\
   &>& 0 & \mbox{(by 3.)}, 
 \end{array}
 \f]
@@ -547,9 +547,9 @@ solution of (QP). The program (QP) is unbounded if an \f$n\f$-vector
 then \f$(A\qpw)_i\leq 0\f$ (\f$(A\qpw)_i\geq 0, (A\qpw)_i=0\f$, respectively).
 <LI> \f[
 \begin{array}{llll}
-&&\geq 0 & \mbox{if \f$l_j\f$ is finite} \\
+&&\geq 0 & \mbox{if $l_j$ is finite} \\
 w_j &\quad  \\
-&&\leq 0 & \mbox{if \f$u_j\f$ is finite.}
+&&\leq 0 & \mbox{if $u_j$ is finite.}
 \end{array}
 \f]
 <LI> \f$\qpw^TD\qpw=0\f$ and \f$(\qpc^T+2{\qpx^*}^TD)\qpw<0\f$.

--- a/QP_solver/doc/QP_solver/QP_solver.txt
+++ b/QP_solver/doc/QP_solver/QP_solver.txt
@@ -528,12 +528,12 @@ when we use the homogeneous representations of the points: if
 \f$ q_1,\ldots,q_n,q\in\mathbb{R}^{d+1}\f$ are homogeneous coordinates for
 \f$ p_1,\ldots,p_n,p\f$ with positive homogenizing coordinates 
 \f$ h_1,\ldots,h_n,h\f$, we have
-\f[$q_j = h_j \cdot (p_j \mid 1) \mbox{~for all $j$, and~} q = h \cdot
+\f[q_j = h_j \cdot (p_j \mid 1) \mbox{~for all $j$, and~} q = h \cdot
 (p\mid 1).\f] Now, nonnegative \f$\lambda_1,\ldots,\lambda_n\f$ are
 suitable coefficients for a convex combination if and only if
 \f[\ccSum{j=1}{n}{~ \lambda_j(p_j \mid 1)} = (p\mid 1), \f]
 equivalently, if there are \f$\mu_1,\ldots,\mu_n\f$ 
-(with \f$\mu_j = \lambda_j \cdot h/{h_j}\f$ for all \f$j\f$) such that
+(with \f$\mu_j = \lambda_j \cdot h/{h_j}\f$ for all $j$) such that
 \f[\ccSum{j=1}{n}{~\mu_j~q_j} = q, \quad \mu_j \geq 0\mbox{~for all $j$}.\f]
 
 The linear program now tests for the existence of nonnegative \f$ \mu_j\f$

--- a/Ridges_3/doc/Ridges_3/Ridges_3.txt
+++ b/Ridges_3/doc/Ridges_3/Ridges_3.txt
@@ -113,20 +113,16 @@ The Taylor expansion of \f$ k_1\f$ (resp. \f$ k_2\f$) along the max
 by \f$ x\f$ (resp. \f$ y\f$) are:
 
 \anchor eqtaylor_along_line
-\f[
-\begin{equation}
+\f{equation}{
 k_1(x) = k_1 + b_0x + \frac{P_1}{2(k_1-k_2)}x^2 + ... , \quad \quad \quad
 P_1= 3b_1^2+(k_1-k_2)(c_0-3k_1^3).
-\end{equation}
-\f]
+\f}
 
 \anchor eqtaylor_along_red_line
-\f[
-\begin{equation}
+\f{equation}{
 k_2(y) = k_2 + b_3y + \frac{P_2}{2(k_2-k_1)}y^2 + ... , \quad \quad \quad
 P_2= 3b_2^2+(k_2-k_1)(c_4-3k_2^3).
-\end{equation}
-\f]
+\f}
 
 Notice also that switching from one to the other of the two
 afore-mentioned coordinate systems reverts the sign of all the odd

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Splitters.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Splitters.h
@@ -160,7 +160,7 @@ namespace CGAL {
 
 Implements the <I>midpoint of max spread</I> splitting rule. 
 A rectangle is cut through \f$ (\mathrm{Mind}+\mathrm{Maxd})/2\f$ orthogonal 
-to the dimension with the maximum point spread \f$ [\mathrm{Mind},\matrm{Maxd}]\f$. 
+to the dimension with the maximum point spread \f$ [\mathrm{Mind},\mathrm{Maxd}]\f$.
 
 \cgalHeading{Parameters}
 

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
@@ -255,12 +255,10 @@ The <em>Laplacian representation</em> (referred to as <em>Laplace coordinates</e
 of a vertex in a surface mesh is one way to <em>encode</em> the local neighborhood of a vertex in the surface mesh.
 In this representation, a vertex \f$ \mathbf{v}_i \f$ is associated a 3D vector defined as:
 
-\f[
-\begin{equation}
+\f{equation}{
 L(\mathbf{v}_i) = \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij}(\mathbf{v}_i - \mathbf{v}_j),
   \label{eq:lap_open}
-\end{equation}
-\f]
+\f}
 
 where:
 - \f$N(\mathbf{v}_i)\f$ denotes the set of vertices adjacent to \f$\mathbf{v}_i\f$;
@@ -282,12 +280,10 @@ Laplacian representation of \f$ v_i \f$ with uniform weights: the red square ver
 
 Considering a surface mesh with \f$n\f$ vertices, it is possible to define its <i>Laplacian representation</i> \f$\Delta\f$ as a \f$n \times 3\f$ matrix:
 
-\f[
-\begin{equation}
+\f{equation}{
 \mathbf{L}\mathbf{V} = \Delta,
   \label{eq:lap_system}
-\end{equation}
-\f]
+\f}
 
 where:
 - \f$\mathbf{L}\f$ is a \f$n \times n\f$ sparse matrix, referred to as the <em>Laplacian matrix</em>. Its elements \f$ m_{ij} \f$, \f$i,j \in \{1 \dots n\} \f$ are defined as follows:
@@ -313,8 +309,7 @@ This package supports hard constraints, that is, target positions of control ver
 
 Given a surface mesh deformation system with a ROI made of \f$ n \f$ vertices and \f$ k \f$ control vertices, we consider the following linear system:
 
-\f[
-\begin{equation}
+\f{equation}{
 \left[
 \begin{array}{ccc}
 \mathbf{L}_f\\
@@ -329,8 +324,7 @@ Given a surface mesh deformation system with a ROI made of \f$ n \f$ vertices an
 \end{array}
 \right],
 \label{eq:lap_energy_system}
-\end{equation}
-\f]
+\f}
 
 where:
 - \f$\mathbf{V}\f$ is a \f$n \times 3\f$ matrix denoting the unknowns of the system that represent the vertex coordinates after deformation. The system is built so that the \f$ k \f$ last rows correspond to the control vertices.
@@ -348,14 +342,12 @@ preserves the Laplacian representation of the surface mesh restricted to the unc
 Given a surface mesh \f$M\f$ with \f$ n \f$ vertices \f$ \{\mathbf{v}_i\} i \in \{1 \dots n  \} \f$ and some deformation
 constraints, we consider the following energy function:
 
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_i \in M}
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij}
 \left\| (\mathbf{v}'_i - \mathbf{v}'_j) - \mathbf{R}_i(\mathbf{v}_i - \mathbf{v}_j) \right\|^2,
   \label{eq:arap_energy}
-\end{equation}
-\f]
+\f}
 
 where:
 - \f$\mathbf{R}_i\f$ is a \f$ 3 \times 3 \f$ rotation matrix
@@ -387,12 +379,10 @@ Each such term of the energy is minimized by using a two-step optimization appro
 In the first step, the positions of the vertices are considered as fixed so that the rotation matrices are the only unknowns.
 
 For the vertex \f$\mathbf{v}_i\f$, we consider the covariance matrix \f$\mathbf{S}_i\f$:
-\f[
-\begin{equation}
+\f{equation}{
 \mathbf{S}_i = \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij} (\mathbf{v}_i - \mathbf{v}_j)(\mathbf{v}'_i - \mathbf{v}'_j)^T,
 \label{eq:cov_matrix}
-\end{equation}
-\f]
+\f}
 
 It was shown \cgalCite{Sorkine2009LeastSquaresRigid} that minimizing the energy contribution of
 \f$\mathbf{v}_i\f$ in Eq. \f$\eqref{eq:arap_energy}\f$ is equivalent to maximizing the trace of the matrix
@@ -404,13 +394,11 @@ In the second step, the rotation matrices are substituted into the partial deriv
 with respect to \f$\mathbf{v}'_i\f$. Assuming the weights are symmetric, setting the derivative to zero results in the
 following equation:
 
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij}(\mathbf{v}'_i - \mathbf{v}'_j) =
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij} \frac{(\mathbf{R}_i + \mathbf{R}_j)}{2} (\mathbf{v}_i - \mathbf{v}_j).
 \label{eq:lap_ber}
-\end{equation}
-\f]
+\f}
 
 The left-hand side of this equation corresponds to the one of Eq.\f$\eqref{eq:lap_open}\f$,
 and we can set \f$\Delta\f$ to be the right-hand side.
@@ -428,13 +416,11 @@ The original algorithm \cgalCite{Sorkine2007AsRigidAs} we described assumes that
 
 - the weight between two vertices is symmetric. In order to support asymmetric weights in our implementation,
 we slightly change Eq. \f$\eqref{eq:lap_ber}\f$ to:
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} (w_{ij} + w_{ji})(\mathbf{v}'_i - \mathbf{v}'_j) =
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} (w_{ij}\mathbf{R}_i + w_{ji}\mathbf{R}_j)(\mathbf{v}_i - \mathbf{v}_j).
 \label{eq:lap_ber_asym}
-\end{equation}
-\f]
+\f}
 
 - The energy contribution of each vertex is positive. If the weight between two vertices is always positive, this is always the case.
  However, when using the cotangent weighting scheme (the default in our implementation), if the sum of the angles opposite to an edge is greater than \f$ \pi \f$,
@@ -448,14 +434,12 @@ A method minimizing another energy function is described next to avoid the latte
 The elastic energy function proposed by \cgalCite{Chao2010SimpleGeomModel} additionally takes into account
 all the opposite edges in the facets incident to a vertex. The energy function to minimize becomes:
 
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_i \in M}
 \sum_{(\mathbf{v}_j, \mathbf{v}_k) \in E(\mathbf{v}_i)} w_{jk}
 \left\| (\mathbf{v}'_j - \mathbf{v}'_k) - \mathbf{R}_i(\mathbf{v}_j - \mathbf{v}_k) \right\|^2,
   \label{eq:arap_energy_rims}
-\end{equation}
-\f]
+\f}
 
 where \f$E(\mathbf{v}_i)\f$ consists of the set of edges incident to \f$\mathbf{v}_i\f$ (the <em>spokes</em>) and
 the set of edges in the link (the <em>rims</em>) of \f$\mathbf{v}_i\f$ in the surface mesh \f$M\f$
@@ -470,23 +454,19 @@ The method to get the new positions of the unconstrained vertices is similar to 
 method explained in \ref SMD_Overview_ARAP.
 For the first step, the Eq. \f$\eqref{eq:cov_matrix}\f$ is modified to take into account the edges in \f$E(\mathbf{v}_i)\f$:
 
-\f[
-\begin{equation}
+\f{equation}{
 \mathbf{S}_i = \sum_{(\mathbf{v}_j, \mathbf{v}_k) \in E(\mathbf{v}_i)} w_{jk} (\mathbf{v}_j - \mathbf{v}_k)(\mathbf{v}'_j - \mathbf{v}'_k)^T,
 \label{eq:cov_matrix_sr}
-\end{equation}
-\f]
+\f}
 
 For the second step, setting partial derivative of Eq. \f$\eqref{eq:arap_energy_rims}\f$ to zero with
 respect to \f$\mathbf{v}_i\f$ gives the following equation:
 
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} (w_{ij} + w_{ji})(\mathbf{v}'_i - \mathbf{v}'_j) =
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} \frac{w_{ij}(\mathbf{R}_i + \mathbf{R}_j + \mathbf{R}_m) + w_{ji}(\mathbf{R}_i + \mathbf{R}_j + \mathbf{R}_n)}{3} (\mathbf{v}_i - \mathbf{v}_j).
 \label{eq:lap_ber_rims}
-\end{equation}
-\f]
+\f}
 
 where \f$\mathbf{R}_m\f$ and \f$\mathbf{R}_n\f$ are the rotation matrices of the vertices \f$\mathbf{v}_m\f$,
 \f$\mathbf{v}_n\f$ which are the opposite vertices of the edge \f$\mathbf{v}_i \mathbf{v}_j\f$
@@ -504,14 +484,12 @@ The implementation in this package uses the cotangent weights by default (negati
 \subsection SMD_Overview_SRE_ARAP Smoothed Rotation Enhanced As-Rigid-As Possible (SR_ARAP) Deformation
 Using 1-ring elements, SR-ARAP adds a bending element to Eq. \f$\eqref{eq:arap_energy}\f$:
 
-\f[
-\begin{equation}
+\f{equation}{
 \sum_{\mathbf{v}_i \in M}
 \sum_{\mathbf{v}_j \in N(\mathbf{v}_i)} w_{ij}
 \left\| (\mathbf{v}'_i - \mathbf{v}'_j) - \mathbf{R}_i(\mathbf{v}_i - \mathbf{v}_j) \right\|^2 + \alpha A \left\| \mathbf{R}_i - \mathbf{R}_j \right\|^2_F
   \label{eq:sre_arap_energy}
-\end{equation}
-\f]
+\f}
 
 where 
 - \f$\alpha=0.02\f$ is a weighting coefficient.


### PR DESCRIPTION
There were some problems with formulas in the documentation most of them resulting in 'Undefined control sequence ' (MathJax output)

Note problem with the Bounding Volumes has not been resolved, separate issue created #3522

## Summary of Changes

- Boolean_set_operations_2/doc/Boolean_set_operations_2/Boolean_set_operations_2.txt
   - `\gt` not accepted in `$..$`, replaced by `>`
- Generator/doc/Generator/Generator.txt
  - replaced unicode minus (U+2212) with an ASCII `-`
- Jet_fitting_3/doc/Jet_fitting_3/CGAL/Monge_via_jet_fitting.h
  - instead of `begin{equation}` use the doxygen possibility for environment (`\f{...`
  - last line in `eqnarray` shpould not end with `\\` (gives extra fomula number , not in MathJax though)
- Jet_fitting_3/doc/Jet_fitting_3/Jet_fitting_3.txt
  - doxygen does not like the construct ``` `d'` ``` replaced with `\c d'` (a `'` later on was substituted by `&rsquo;`
- Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Vector_d.h
  - command `\pmh[0]` etc. not known, replaced by `\pm H_0`  (analogous to the previous comment block in the file)
- QP_solver/doc/QP_solver/CGAL/QP_solution.h
  - spurious `$` in front of `q_j`
- QP_solver/doc/QP_solver/QP_solver.txt
  - `\f$` is not allowed inside a `\mbox`, `$...$` should be used.
- Ridges_3/doc/Ridges_3/Ridges_3.txt
  - instead of `begin{equation}` use the doxygen possibility for environment (`\f{...`
- Spatial_searching/doc/Spatial_searching/CGAL/Splitters.h
  - unknown comamnd `\matrm` replaced by `\mathrm`
- Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
  - instead of `begin{equation}` use the doxygen possibility for environment (`\f{...`
