### PR TITLE
Subdivision_methods_3: Use deprecation warning

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
@@ -11,7 +11,10 @@
 #include "Scene_surface_mesh_item.h"
 #include "SMesh_type.h"
 #include <CGAL/subdivision_method_3.h>
+
 using namespace CGAL::Three;
+namespace params = CGAL::parameters;
+
 class Polyhedron_demo_subdivision_methods_plugin :
   public QObject,
   public Polyhedron_demo_plugin_helper
@@ -81,7 +84,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_loop(FaceGraphItem* item,
   time.start();
   messages->information("Loop subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  CGAL::Subdivision_method_3::Loop_subdivision(*graph, nb_steps);
+  CGAL::Subdivision_method_3::Loop_subdivision(*graph, params::number_of_iterations(nb_steps));
   messages->information(QString("ok (%1 ms)").arg(time.elapsed()));
   QApplication::restoreOverrideCursor();
   item->invalidateOpenGLBuffers();
@@ -113,7 +116,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_catmullclark(FaceGraphIte
   time.start();
   messages->information("Catmull-Clark subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  CGAL::Subdivision_method_3::CatmullClark_subdivision(*graph, nb_steps);
+  CGAL::Subdivision_method_3::CatmullClark_subdivision(*graph, params::number_of_iterations(nb_steps));
   messages->information(QString("ok (%1 ms)").arg(time.elapsed()));
   QApplication::restoreOverrideCursor();
   item->invalidateOpenGLBuffers();
@@ -143,7 +146,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_sqrt3(FaceGraphItem* item
   time.start();
   messages->information("Sqrt-3 subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  CGAL::Subdivision_method_3::Sqrt3_subdivision(*graph, nb_steps);
+  CGAL::Subdivision_method_3::Sqrt3_subdivision(*graph, params::number_of_iterations(nb_steps));
   messages->information(QString("ok (%1 ms)").arg(time.elapsed()));
   QApplication::restoreOverrideCursor();
   item->invalidateOpenGLBuffers();
@@ -175,7 +178,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_doosabin(FaceGraphItem* i
   time.start();
   messages->information("Doo-Sabin subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  CGAL::Subdivision_method_3::DooSabin_subdivision(*graph, nb_steps);
+  CGAL::Subdivision_method_3::DooSabin_subdivision(*graph, params::number_of_iterations(nb_steps));
   messages->information(QString("ok (%1 ms)").arg(time.elapsed()));
   QApplication::restoreOverrideCursor();
   item->invalidateOpenGLBuffers();

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_methods_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_methods_3.h
@@ -95,10 +95,13 @@ namespace parameters = CGAL::parameters;
 
 #ifndef DOXYGEN_RUNNING
 // Backward compatibility
+#ifndef CGAL_NO_DEPRECATED_CODE
 template <class PolygonMesh>
+CGAL_DEPRECATED_MSG("you are using the deprecated API of CatmullClark_subdivision(), please update your code")
 void CatmullClark_subdivision(PolygonMesh& pmesh, int step = 1) {
   PQQ(pmesh, CatmullClark_mask_3<PolygonMesh>(&pmesh, get(vertex_point,pmesh)), step);
 }
+#endif  
 #endif
 
 /*!
@@ -142,10 +145,13 @@ void CatmullClark_subdivision(PolygonMesh& pmesh, const NamedParameters& np) {
 
 #ifndef DOXYGEN_RUNNING
 // backward compatibility
+#ifndef CGAL_NO_DEPRECATED_CODE
 template <class PolygonMesh>
+CGAL_DEPRECATED_MSG("you are using the deprecated API of Loop_subdivision(), please update your code")
 void Loop_subdivision(PolygonMesh& pmesh, int step = 1) {
   PTQ(pmesh, Loop_mask_3<PolygonMesh>(&pmesh, get(vertex_point,pmesh)) , step);
 }
+#endif  
 #endif
 
 /*!
@@ -187,10 +193,13 @@ void Loop_subdivision(PolygonMesh& pmesh, const NamedParameters& np) {
 
 #ifndef DOXYGEN_RUNNING
 // backward compatibility
+#ifndef CGAL_NO_DEPRECATED_CODE
 template <class PolygonMesh>
+CGAL_DEPRECATED_MSG("you are using the deprecated API of DooSabin_subdivision(), please update your code")
 void DooSabin_subdivision(PolygonMesh& pmesh, int step = 1) {
   DQQ(pmesh, DooSabin_mask_3<PolygonMesh>(&pmesh, get(vertex_point, pmesh)), step);
 }
+#endif
 #endif
 
 /*!
@@ -232,10 +241,13 @@ void DooSabin_subdivision(PolygonMesh& pmesh, const NamedParameters& np) {
 
 #ifndef DOXYGEN_RUNNING
 // backward compatibility
+#ifndef CGAL_NO_DEPRECATED_CODE
 template <class PolygonMesh>
+CGAL_DEPRECATED_MSG("you are using the deprecated API of Sqrt3_subdivision(), please update your code")
 void Sqrt3_subdivision(PolygonMesh& pmesh, int step = 1) {
   Sqrt3(pmesh, Sqrt3_mask_3<PolygonMesh>(&pmesh, get(vertex_point,pmesh)), step);
 }
+#endif
 #endif
 
 /*!


### PR DESCRIPTION
## Summary of Changes

Add deprecation warning and upgrade the plugin.

## Release Management

* Affected package(s): Subdivision_methods,  Polyhedron demo.
* Issue(s) solved (if any): fix #3497 


