### PR TITLE
Parameterization: No need to disable warnings in CMakeLists.txt

### DIFF
--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -14,24 +14,7 @@ find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
-  # VisualC++ optimization for applications dealing with large data
-  if (MSVC)
 
-    # Allow Windows applications to use up to 3GB of RAM
-    SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-
-    # Turn off stupid VC++ warnings
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4311 /wd4800 /wd4503 /wd4244 /wd4345 /wd4996 /wd4396 /wd4018")
-    
-    # Print new compilation options
-    message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )
-    message( STATUS "USING DEBUG EXEFLAGS   = '${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_DEBUG}'" )
-    message( STATUS "USING RELEASE CXXFLAGS = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}'" )
-    message( STATUS "USING RELEASE EXEFLAGS = '${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_RELEASE}'" )
-  endif(MSVC)
-
-
-  #find Eigen 
   find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
   if(EIGEN3_FOUND)
     include( ${EIGEN3_USE_FILE} )


### PR DESCRIPTION
## Summary of Changes

The example gives the wrong impression that some warnings must be suppressed.

@MaelRL does the Orbifold really need SuiteSparse??

## Release Management

* Affected package(s): Suerface_mesh_parameterization


