### PR TITLE
Move the definition of CGAL_USE_FILE in case of early return()

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -73,6 +73,9 @@ include(${CGAL_MODULES_DIR}/CGAL_CreateSingleSourceCGALProgram.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_Common.cmake)
 
+set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
+
+
 if(CGAL_BUILDING_LIBS)
   foreach(comp ${CGAL_FIND_COMPONENTS})
     if(CGAL_${comp}_FOUND)
@@ -145,8 +148,6 @@ endforeach()
 
 # Temporary? Change the CMAKE module path
 cgal_setup_module_path()
-
-set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
 
 include("${CGAL_MODULES_DIR}/CGAL_parse_version_h.cmake")
 cgal_parse_version_h( "${CGAL_INSTALLATION_PACKAGE_DIR}/include/CGAL/version.h"


### PR DESCRIPTION
## Summary of Changes

In the `CGALConfig.cmake`, move the definition of `CGAL_USE_FILE` in case of early `return()`. That may happen if `find_package(CGAL)` is called in a sub-directory *before* it is called in the current `CMakeLists.txt`.

I know the bug is already in CGAL-4.13, and I know other bugs about other variables set by `CGALConfig.cmake`, after the early `return()`. But I prefer to fix that only in `master`.

## Release Management

* Affected package(s): Installation
