### PR TITLE
Point Set Processing: Fix PLY unknown element reading

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3/IO.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO.h
@@ -135,7 +135,7 @@ private:
   struct Abstract_ply_property_to_point_set_property
   {
     virtual ~Abstract_ply_property_to_point_set_property() { }
-    virtual void assign (PLY_reader& reader, typename Point_set::Index index) = 0;
+    virtual void assign (PLY_element& element, typename Point_set::Index index) = 0;
   };
 
   template <typename Type>
@@ -154,10 +154,10 @@ private:
       m_pmap = ps.push_property_map (m_map);
     }
     
-    virtual void assign (PLY_reader& reader, typename Point_set::Index index)
+    virtual void assign (PLY_element& element, typename Point_set::Index index)
     {
       Type t;
-      reader.assign (t, m_name.c_str());
+      element.assign (t, m_name.c_str());
       put(m_pmap, index, t);
     }
   };
@@ -178,123 +178,121 @@ public:
       delete m_properties[i];
   }
 
-  void instantiate_properties  (PLY_reader& reader)
+  void instantiate_properties  (PLY_element& element)
   {
-    const std::vector<PLY_read_number*>& readers
-      = reader.readers();
-
     bool has_normal[3] = { false, false, false };
     
-    for (std::size_t i = 0; i < readers.size(); ++ i)
+    for (std::size_t j = 0; j < element.number_of_properties(); ++ j)
+    {
+      internal::PLY::PLY_read_number* property = element.property(j);
+        
+      const std::string& name = property->name();
+      if (name == "x" ||
+          name == "y" ||
+          name == "z")
       {
-        const std::string& name = readers[i]->name();
-        if (name == "x" ||
-            name == "y" ||
-            name == "z")
-          {
-            if (dynamic_cast<PLY_read_typed_number<float>*>(readers[i]))
-              m_use_floats = true;
-            continue;
-          }
-        if (name == "nx")
-          {
-            has_normal[0] = true;
-            continue;
-          }
-        if (name == "ny")
-          {
-            has_normal[1] = true;
-            continue;
-          }
-        if (name == "nz")
-          {
-            has_normal[2] = true;
-            continue;
-          }
-
-        if (dynamic_cast<PLY_read_typed_number<boost::int8_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::int8_t>(m_point_set,
-                                                                     name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<boost::uint8_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::uint8_t>(m_point_set,
-                                                                      name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<boost::int16_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::int16_t>(m_point_set,
-                                                                      name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<boost::uint16_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::uint16_t>(m_point_set,
-                                                                       name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<boost::int32_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::int32_t>(m_point_set,
-                                                                      name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<boost::uint32_t>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<boost::uint32_t>(m_point_set,
-                                                                       name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<float>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<float>(m_point_set,
-                                                             name));
-          }
-        else if (dynamic_cast<PLY_read_typed_number<double>*>(readers[i]))
-          {
-            m_properties.push_back
-              (new PLY_property_to_point_set_property<double>(m_point_set,
-                                                             name));
-          }
+        if (dynamic_cast<PLY_read_typed_number<float>*>(property))
+          m_use_floats = true;
+        continue;
+      }
+      if (name == "nx")
+      {
+        has_normal[0] = true;
+        continue;
+      }
+      if (name == "ny")
+      {
+        has_normal[1] = true;
+        continue;
+      }
+      if (name == "nz")
+      {
+        has_normal[2] = true;
+        continue;
       }
 
+      if (dynamic_cast<PLY_read_typed_number<boost::int8_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::int8_t>(m_point_set,
+                                                                 name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<boost::uint8_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::uint8_t>(m_point_set,
+                                                                  name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<boost::int16_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::int16_t>(m_point_set,
+                                                                  name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<boost::uint16_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::uint16_t>(m_point_set,
+                                                                   name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<boost::int32_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::int32_t>(m_point_set,
+                                                                  name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<boost::uint32_t>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<boost::uint32_t>(m_point_set,
+                                                                   name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<float>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<float>(m_point_set,
+                                                         name));
+      }
+      else if (dynamic_cast<PLY_read_typed_number<double>*>(property))
+      {
+        m_properties.push_back
+          (new PLY_property_to_point_set_property<double>(m_point_set,
+                                                          name));
+      }
+    }
     if (has_normal[0] && has_normal[1] && has_normal[2])
       m_point_set.add_normal_map();
   }
   
-  void process_line (PLY_reader& reader)
+  void process_line (PLY_element& element)
   {
     m_point_set.insert();
     
     if (m_use_floats)
-      process_line<float>(reader);
+      process_line<float>(element);
     else
-      process_line<double>(reader);
+      process_line<double>(element);
 
     for (std::size_t i = 0; i < m_properties.size(); ++ i)
-      m_properties[i]->assign (reader, *(m_point_set.end() - 1));
+      m_properties[i]->assign (element, *(m_point_set.end() - 1));
   }
 
   template <typename FT>
-  void process_line (PLY_reader& reader)
+  void process_line (PLY_element& element)
   {
     FT x = (FT)0.,y = (FT)0., z = (FT)0.,
       nx = (FT)0., ny = (FT)0., nz = (FT)0.;
-    reader.assign (x, "x");
-    reader.assign (y, "y");
-    reader.assign (z, "z");
+    element.assign (x, "x");
+    element.assign (y, "y");
+    element.assign (z, "z");
     Point point (x, y, z);
     m_point_set.point(*(m_point_set.end() - 1)) = point;
 
     if (m_point_set.has_normal_map())
       {
-        reader.assign (nx, "nx");
-        reader.assign (ny, "ny");
-        reader.assign (nz, "nz");
+        element.assign (nx, "nx");
+        element.assign (ny, "ny");
+        element.assign (nz, "nz");
         Vector normal (nx, ny, nz);
         m_point_set.normal(*(m_point_set.end() - 1)) = normal;
       }
@@ -401,24 +399,33 @@ read_ply_point_set(
   if (comments != NULL)
     *comments = reader.comments();
 
-  filler.instantiate_properties (reader);
+  for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
+  {
+    internal::PLY::PLY_element& element = reader.element(i);
 
-  point_set.reserve (reader.m_nb_points);
-  
-  std::size_t points_read = 0;
-  
-  while (!(stream.eof()) && points_read < reader.m_nb_points)
+    if (element.name() == "vertex" || element.name() == "vertices")
     {
-      for (std::size_t i = 0; i < reader.readers().size (); ++ i)
-        reader.readers()[i]->get (stream);
-
-      filler.process_line (reader);
-      
-      ++ points_read;
+      point_set.reserve (element.number_of_items());
+      filler.instantiate_properties (element);
     }
-  // Skip remaining lines
+  
+    for (std::size_t j = 0; j < element.number_of_items(); ++ j)
+    {
+      for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+      {
+        internal::PLY::PLY_read_number* property = element.property(k);
+        property->get (stream);
 
-  return (points_read == reader.m_nb_points);
+        if (stream.eof())
+          return false;
+      }
+
+      if (element.name() == "vertex" || element.name() == "vertices")
+        filler.process_line (element);
+    }
+  }
+
+  return !stream.bad();
 }
   
 /*!

--- a/Point_set_3/include/CGAL/Point_set_3/IO.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO.h
@@ -394,7 +394,10 @@ read_ply_point_set(
   internal::PLY::Point_set_3_filler<Point, Vector> filler(point_set);
   
   if (!(reader.init (stream)))
+  {
+    stream.setstate(std::ios::failbit);
     return false;
+  }
 
   if (comments != NULL)
     *comments = reader.comments();
@@ -415,8 +418,7 @@ read_ply_point_set(
       {
         internal::PLY::PLY_read_number* property = element.property(k);
         property->get (stream);
-
-        if (stream.eof())
+        if (stream.fail())
           return false;
       }
 
@@ -425,7 +427,7 @@ read_ply_point_set(
     }
   }
 
-  return !stream.bad();
+  return true;
 }
   
 /*!

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -765,7 +765,10 @@ bool read_ply_points_with_properties (std::istream& stream,
   internal::PLY::PLY_reader reader;
   
   if (!(reader.init (stream)))
+  {
+    stream.setstate(std::ios::failbit);
     return false;
+  }
   
   for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
   {
@@ -778,7 +781,7 @@ bool read_ply_points_with_properties (std::istream& stream,
         internal::PLY::PLY_read_number* property = element.property(k);
         property->get (stream);
 
-        if (stream.eof())
+        if (stream.fail())
           return false;
       }
 

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -48,12 +48,12 @@
 
 #define TRY_TO_GENERATE_PROPERTY(STD_TYPE, T_TYPE, TYPE)          \
   if (type == STD_TYPE  || type == T_TYPE)                              \
-    m_properties->push_back (new PLY_read_typed_number< TYPE > (name, format))
+    m_elements.back().add_property (new PLY_read_typed_number< TYPE > (name, format))
 
 #define TRY_TO_GENERATE_SIZED_LIST_PROPERTY(STD_SIZE_TYPE, T_SIZE_TYPE, SIZE_TYPE, STD_INDEX_TYPE, T_INDEX_TYPE, INDEX_TYPE) \
   if ((size_type == STD_SIZE_TYPE  || size_type == T_SIZE_TYPE) &&      \
       (index_type == STD_INDEX_TYPE || index_type == T_INDEX_TYPE))     \
-    m_properties->push_back (new PLY_read_typed_list_with_typed_size< SIZE_TYPE , INDEX_TYPE > (name, format))
+    m_elements.back().add_property (new PLY_read_typed_list_with_typed_size< SIZE_TYPE , INDEX_TYPE > (name, format))
 
 #define TRY_TO_GENERATE_LIST_PROPERTY(STD_INDEX_TYPE, T_INDEX_TYPE, INDEX_TYPE) \
   TRY_TO_GENERATE_SIZED_LIST_PROPERTY("uchar", "uint8", boost::uint8_t, STD_INDEX_TYPE, T_INDEX_TYPE, INDEX_TYPE); \
@@ -317,24 +317,145 @@ namespace internal {
     }
   };
 
+  class PLY_element
+  {
+    std::string m_name;
+    std::size_t m_number;
+    
+    std::vector<PLY_read_number*> m_properties;
+  public:
+
+    PLY_element (const std::string& name, std::size_t number)
+      : m_name (name), m_number (number)
+    { }
+
+    PLY_element (const PLY_element& other)
+      : m_name (other.m_name), m_number (other.m_number), m_properties (other.m_properties)
+    {
+      const_cast<PLY_element&>(other).m_properties.clear();
+    }
+
+    PLY_element& operator= (const PLY_element& other)
+    {
+      m_name = other.m_name;
+      m_number = other.m_number;
+      m_properties = other.m_properties;
+      const_cast<PLY_element&>(other).m_properties.clear();
+      return *this;
+    }
+    
+    ~PLY_element()
+    {
+      for (std::size_t i = 0; i < m_properties.size(); ++ i)
+        delete m_properties[i];
+    }
+
+    const std::string& name() const { return m_name; }
+    std::size_t number_of_items() const { return m_number; }
+    std::size_t number_of_properties() const { return m_properties.size(); }
+
+    PLY_read_number* property (std::size_t idx) { return m_properties[idx]; }
+    
+    void add_property (PLY_read_number* read_number)
+    {
+      m_properties.push_back (read_number);
+    }
+
+    template <typename Type>
+    bool has_property (const char* tag)
+    {
+      return has_property (tag, Type());
+    }
+    template <typename Type>
+    bool has_property (const char* tag, const std::vector<Type>&)
+    {
+      for (std::size_t i = 0; i < number_of_properties(); ++ i)
+        if (m_properties[i]->name () == tag)
+          return (dynamic_cast<PLY_read_typed_list<Type>*>(m_properties[i]) != NULL);
+      return false;
+    }
+    
+    template <typename Type>
+    bool has_property (const char* tag, Type)
+    {
+      for (std::size_t i = 0; i < number_of_properties(); ++ i)
+        if (m_properties[i]->name () == tag)
+          return (dynamic_cast<PLY_read_typed_number<Type>*>(m_properties[i]) != NULL);
+      return false;
+    }
+    bool has_property (const char* tag, double)
+    {
+      for (std::size_t i = 0; i < number_of_properties(); ++ i)
+        if (m_properties[i]->name () == tag)
+          return (dynamic_cast<PLY_read_typed_number<double>*>(m_properties[i]) != NULL
+                  || dynamic_cast<PLY_read_typed_number<float>*>(m_properties[i]) != NULL);
+
+      return false;
+    }
+
+    template <typename Type>
+    void assign (Type& t, const char* tag)
+    {
+      for (std::size_t i = 0; i < number_of_properties (); ++ i)
+        if (m_properties[i]->name () == tag)
+        {
+          PLY_read_typed_number<Type>*
+            property = dynamic_cast<PLY_read_typed_number<Type>*>(m_properties[i]);
+          CGAL_assertion (property != NULL);
+          t = property->buffer();
+          return;
+        }
+    }
+
+    template <typename Type>
+    void assign (std::vector<Type>& t, const char* tag)
+    {
+      for (std::size_t i = 0; i < number_of_properties (); ++ i)
+        if (m_properties[i]->name () == tag)
+        {
+          PLY_read_typed_list<Type>*
+            property = dynamic_cast<PLY_read_typed_list<Type>*>(m_properties[i]);
+          CGAL_assertion (property != NULL);
+          t = property->buffer();
+          return;
+        }
+    }
+
+    void assign (double& t, const char* tag)
+    {
+      for (std::size_t i = 0; i < number_of_properties (); ++ i)
+        if (m_properties[i]->name () == tag)
+        {
+          PLY_read_typed_number<double>*
+            property_double = dynamic_cast<PLY_read_typed_number<double>*>(m_properties[i]);
+          if (property_double == NULL)
+          {
+            PLY_read_typed_number<float>*
+              property_float = dynamic_cast<PLY_read_typed_number<float>*>(m_properties[i]);
+            CGAL_assertion (property_float != NULL);
+            t = property_float->buffer();
+          }
+          else
+            t = property_double->buffer();
+          
+          return;
+        }
+    }
+  
+  };
 
   class PLY_reader
   {
-    std::vector<PLY_read_number*> m_point_properties;
-    std::vector<PLY_read_number*> m_face_properties;
-    std::vector<PLY_read_number*>* m_properties;
+    std::vector<PLY_element> m_elements;
     std::string m_comments;
 
   public:
-    std::size_t m_nb_points;
-    std::size_t m_nb_faces;
+    PLY_reader () { }
 
-    PLY_reader () : m_properties (&m_point_properties), m_nb_points (0), m_nb_faces(0)  { }
-
-    const std::vector<PLY_read_number*>& readers() const { return *m_properties; }
-    void read_faces()
+    std::size_t number_of_elements() const { return m_elements.size(); }
+    PLY_element& element (std::size_t idx)
     {
-      m_properties = &m_face_properties;
+      return m_elements[idx];
     }
 
     const std::string& comments() const { return m_comments; }
@@ -349,9 +470,6 @@ namespace internal {
       std::string line;
       std::istringstream iss;
 
-      // Check the order of the properties of the point set
-      bool reading_vertices = false, reading_faces = false;
-  
       while (getline (stream,line))
         {
           iss.clear();
@@ -401,9 +519,6 @@ namespace internal {
 
               if (keyword == "property")
                 {
-                  if (!reading_vertices && !reading_faces)
-                    continue;
-
                   std::string type, name;
                   if (!(iss >> type >> name))
                     {
@@ -455,9 +570,6 @@ namespace internal {
                       m_comments += "\n";
                     }
                 }
-              // When end_header is reached, stop loop and begin reading points
-              else if (keyword == "end_header")
-                break;
               else if (keyword == "element")
                 {
                   std::string type;
@@ -468,120 +580,18 @@ namespace internal {
                       return false;
                     }
                 
-                  if (type == "vertex")
-                    {
-                      m_nb_points = number;
-                      reading_vertices = true;
-                      reading_faces = false;
-                    }
-                
-                  else if (type == "face")
-                    {
-                      m_nb_faces = number;
-                      reading_faces = true;
-                      reading_vertices = false;
-                      m_properties = &m_face_properties;
-                    }
-                  else
-                    {
-                      reading_faces = false;
-                      reading_vertices = false;
-                      continue;
-                    }
+                  m_elements.push_back (PLY_element(type, number));
                 }
-            
+              // When end_header is reached, stop loop and begin reading points
+              else if (keyword == "end_header")
+                break;
             }
         }
-      m_properties = &m_point_properties;
       return true;
     }
 
     ~PLY_reader ()
     {
-      for (std::size_t i = 0; i < m_point_properties.size (); ++ i)
-        delete m_point_properties[i];
-      m_point_properties.clear();
-    }
-  
-    template <typename Type>
-    bool does_tag_exist (const char* tag)
-    {
-      return does_tag_exist (tag, Type());
-    }
-
-    template <typename Type>
-    void assign (Type& t, const char* tag)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          {
-            PLY_read_typed_number<Type>*
-              reader = dynamic_cast<PLY_read_typed_number<Type>*>((*m_properties)[i]);
-            CGAL_assertion (reader != NULL);
-            t = reader->buffer();
-            return;
-          }
-    }
-
-    template <typename Type>
-    void assign (std::vector<Type>& t, const char* tag)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          {
-            PLY_read_typed_list<Type>*
-              reader = dynamic_cast<PLY_read_typed_list<Type>*>((*m_properties)[i]);
-            CGAL_assertion (reader != NULL);
-            t = reader->buffer();
-            return;
-          }
-    }
-
-    template <typename Type>
-    bool does_tag_exist (const char* tag, const std::vector<Type>&)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          return (dynamic_cast<PLY_read_typed_list<Type>*>((*m_properties)[i]) != NULL);
-      return false;
-    }
-    
-    template <typename Type>
-    bool does_tag_exist (const char* tag, Type)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          return (dynamic_cast<PLY_read_typed_number<Type>*>((*m_properties)[i]) != NULL);
-      return false;
-    }
-    bool does_tag_exist (const char* tag, double)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          return (dynamic_cast<PLY_read_typed_number<double>*>((*m_properties)[i]) != NULL
-                  || dynamic_cast<PLY_read_typed_number<float>*>((*m_properties)[i]) != NULL);
-
-      return false;
-    }
-    void assign (double& t, const char* tag)
-    {
-      for (std::size_t i = 0; i < m_properties->size (); ++ i)
-        if ((*m_properties)[i]->name () == tag)
-          {
-            PLY_read_typed_number<double>*
-              reader_double = dynamic_cast<PLY_read_typed_number<double>*>((*m_properties)[i]);
-            if (reader_double == NULL)
-              {
-                PLY_read_typed_number<float>*
-                  reader_float = dynamic_cast<PLY_read_typed_number<float>*>((*m_properties)[i]);
-                CGAL_assertion (reader_float != NULL);
-                t = reader_float->buffer();
-              }
-            else
-              t = reader_double->buffer();
-          
-            return;
-          }
     }
   
   };
@@ -640,12 +650,12 @@ namespace internal {
             typename PropertyMap,
             typename Constructor,
             typename ... T>
-  void process_properties (PLY_reader& reader, OutputValueType& new_element,
+  void process_properties (PLY_element& element, OutputValueType& new_element,
                            std::tuple<PropertyMap, Constructor, PLY_property<T>...>&& current)
   {
     typedef typename PropertyMap::value_type PmapValueType;
     std::tuple<T...> values;
-    Filler<sizeof...(T)-1>::fill(reader, values, current);
+    Filler<sizeof...(T)-1>::fill(element, values, current);
     PmapValueType new_value = call_functor<PmapValueType>(std::get<1>(current), values);
     put (std::get<0>(current), new_element, new_value);
   }
@@ -656,42 +666,42 @@ namespace internal {
             typename ... T,
             typename NextPropertyBinder,
             typename ... PropertyMapBinders>
-  void process_properties (PLY_reader& reader, OutputValueType& new_element,
+  void process_properties (PLY_element& element, OutputValueType& new_element,
                            std::tuple<PropertyMap, Constructor, PLY_property<T>...>&& current,
                            NextPropertyBinder&& next,
                            PropertyMapBinders&& ... properties)
   {
     typedef typename PropertyMap::value_type PmapValueType;
     std::tuple<T...> values;
-    Filler<sizeof...(T)-1>::fill(reader, values, current);
+    Filler<sizeof...(T)-1>::fill(element, values, current);
     PmapValueType new_value = call_functor<PmapValueType>(std::get<1>(current), values);
     put (std::get<0>(current), new_element, new_value);
   
-    process_properties (reader, new_element, std::forward<NextPropertyBinder>(next),
+    process_properties (element, new_element, std::forward<NextPropertyBinder>(next),
                         std::forward<PropertyMapBinders>(properties)...);
   }
 
 
   template <typename OutputValueType, typename PropertyMap, typename T>
-  void process_properties (PLY_reader& reader, OutputValueType& new_element,
+  void process_properties (PLY_element& element, OutputValueType& new_element,
                            std::pair<PropertyMap, PLY_property<T> >&& current)
   {
     T new_value = T();
-    reader.assign (new_value, current.second.name);
+    element.assign (new_value, current.second.name);
     put (current.first, new_element, new_value);
   }
 
   template <typename OutputValueType, typename PropertyMap, typename T,
             typename NextPropertyBinder, typename ... PropertyMapBinders>
-  void process_properties (PLY_reader& reader, OutputValueType& new_element,
+  void process_properties (PLY_element& element, OutputValueType& new_element,
                            std::pair<PropertyMap, PLY_property<T> >&& current,
                            NextPropertyBinder&& next,
                            PropertyMapBinders&& ... properties)
   {
     T new_value = T();
-    reader.assign (new_value, current.second.name);
+    element.assign (new_value, current.second.name);
     put (current.first, new_element, new_value);
-    process_properties (reader, new_element, std::forward<NextPropertyBinder>(next),
+    process_properties (element, new_element, std::forward<NextPropertyBinder>(next),
                         std::forward<PropertyMapBinders>(properties)...);
   }
 
@@ -757,24 +767,31 @@ bool read_ply_points_with_properties (std::istream& stream,
   if (!(reader.init (stream)))
     return false;
   
-  std::size_t points_read = 0;
-  
-  while (!(stream.eof()) && points_read < reader.m_nb_points)
+  for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
+  {
+    internal::PLY::PLY_element& element = reader.element(i);
+
+    for (std::size_t j = 0; j < element.number_of_items(); ++ j)
     {
-      for (std::size_t i = 0; i < reader.readers().size (); ++ i)
-        reader.readers()[i]->get (stream);
+      for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+      {
+        internal::PLY::PLY_read_number* property = element.property(k);
+        property->get (stream);
 
-      OutputValueType new_element;
+        if (stream.eof())
+          return false;
+      }
 
-      internal::PLY::process_properties (reader, new_element, std::forward<PropertyHandler>(properties)...);
-
-      *(output ++) = new_element;
-      
-      ++ points_read;
+      if (element.name() == "vertex" || element.name() == "vertices")
+      {
+        OutputValueType new_element;
+        internal::PLY::process_properties (element, new_element, std::forward<PropertyHandler>(properties)...);
+        *(output ++) = new_element;
+      }
     }
-  // Skip remaining lines
+  }
 
-  return (points_read == reader.m_nb_points);
+  return true;
 }
 
 /// \cond SKIP_IN_MANUAL

--- a/Polyhedron_IO/include/CGAL/IO/PLY_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/PLY_reader.h
@@ -29,36 +29,40 @@ namespace CGAL{
     template <typename Integer, class Polygon_3, class Color_rgb>
     bool
     read_PLY_faces (std::istream& in,
-                    PLY::PLY_reader& reader,
+                    internal::PLY::PLY_element& element,
                     std::vector< Polygon_3 >& polygons,
                     std::vector< Color_rgb >& fcolors,
                     const char* vertex_indices_tag)
     {
-      std::size_t faces_read = 0;
-
       bool has_colors = false;
       std::string rtag = "r", gtag = "g", btag = "b";
-      if ((reader.does_tag_exist<boost::uint8_t>("red") || reader.does_tag_exist<boost::uint8_t>("r")) &&
-          (reader.does_tag_exist<boost::uint8_t>("green") || reader.does_tag_exist<boost::uint8_t>("g")) &&
-          (reader.does_tag_exist<boost::uint8_t>("blue") || reader.does_tag_exist<boost::uint8_t>("b")))
+      if ((element.has_property<boost::uint8_t>("red") || element.has_property<boost::uint8_t>("r")) &&
+          (element.has_property<boost::uint8_t>("green") || element.has_property<boost::uint8_t>("g")) &&
+          (element.has_property<boost::uint8_t>("blue") || element.has_property<boost::uint8_t>("b")))
       {
         has_colors = true;
-        if (reader.does_tag_exist<boost::uint8_t>("red"))
+        if (element.has_property<boost::uint8_t>("red"))
         {
           rtag = "red"; gtag = "green"; btag = "blue";
         }
       }
       
-      while (!(in.eof()) && faces_read < reader.m_nb_faces)
+      for (std::size_t j = 0; j < element.number_of_items(); ++ j)
       {
-        for (std::size_t i = 0; i < reader.readers().size (); ++ i)
-          reader.readers()[i]->get (in);
+        for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+        {
+          internal::PLY::PLY_read_number* property = element.property(k);
+          property->get (in);
+
+          if (in.eof())
+            return false;
+        }
 
         cpp11::tuple<std::vector<Integer>, boost::uint8_t, boost::uint8_t, boost::uint8_t> new_face; 
 
         if (has_colors)
         {
-          PLY::process_properties (reader, new_face,
+          PLY::process_properties (element, new_face,
                                    std::make_pair (CGAL::make_nth_of_tuple_property_map<0>(new_face),
                                                    PLY_property<std::vector<Integer> >(vertex_indices_tag)),
                                    std::make_pair (CGAL::make_nth_of_tuple_property_map<1>(new_face),
@@ -71,15 +75,13 @@ namespace CGAL{
           fcolors.push_back (Color_rgb (get<1>(new_face), get<2>(new_face), get<3>(new_face)));
         }
         else
-          PLY::process_properties (reader, new_face,
+          PLY::process_properties (element, new_face,
                                    std::make_pair (CGAL::make_nth_of_tuple_property_map<0>(new_face),
                                                    PLY_property<std::vector<Integer> >(vertex_indices_tag)));
 
         polygons.push_back (Polygon_3(get<0>(new_face).size()));
         for (std::size_t i = 0; i < get<0>(new_face).size(); ++ i)
           polygons.back()[i] = std::size_t(get<0>(new_face)[i]);
-
-        ++ faces_read;
       }
 
       return !in.bad();
@@ -106,45 +108,66 @@ namespace CGAL{
     if (!(reader.init (in)))
       return false;
   
-    std::size_t points_read = 0;
-  
-    while (!(in.eof()) && points_read < reader.m_nb_points)
+    for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
     {
-      for (std::size_t i = 0; i < reader.readers().size (); ++ i)
-        reader.readers()[i]->get (in);
+      internal::PLY::PLY_element& element = reader.element(i);
 
-      Point_3 new_vertex;
+      if (element.name() == "vertex" || element.name() == "vertices")
+      {
+        for (std::size_t j = 0; j < element.number_of_items(); ++ j)
+        {
+          for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+          {
+            internal::PLY::PLY_read_number* property = element.property(k);
+            property->get (in);
 
-      internal::PLY::process_properties (reader, new_vertex,
-                                         make_ply_point_reader (CGAL::Identity_property_map<Point_3>()));
-                                         
+            if (in.eof())
+              return false;
+          }
 
-      points.push_back (new_vertex);
+          Point_3 new_vertex;
+
+          internal::PLY::process_properties (element, new_vertex,
+                                             make_ply_point_reader (CGAL::Identity_property_map<Point_3>()));
       
-      ++ points_read;
+          points.push_back (get<0>(new_vertex));
+        }
+      }
+      else if (element.name() == "face" || element.name() == "faces")
+      {
+        std::vector<CGAL::Color> dummy;
+
+        if (element.has_property<std::vector<boost::int32_t> > ("vertex_indices"))
+          internal::read_PLY_faces<boost::int32_t> (in, element, polygons, dummy, "vertex_indices");
+        else if (element.has_property<std::vector<boost::uint32_t> > ("vertex_indices"))
+          internal::read_PLY_faces<boost::uint32_t> (in, element, polygons, dummy, "vertex_indices");
+        else if (element.has_property<std::vector<boost::int32_t> > ("vertex_index"))
+          internal::read_PLY_faces<boost::int32_t> (in, element, polygons, dummy, "vertex_index");
+        else if (element.has_property<std::vector<boost::uint32_t> > ("vertex_index"))
+          internal::read_PLY_faces<boost::uint32_t> (in, element, polygons, dummy, "vertex_index");
+        else
+        {
+          std::cerr << "Error: can't find vertex indices in PLY input" << std::endl;
+          return false;
+        }
+      }
+      else // Read other elements and ignore
+      {
+        for (std::size_t j = 0; j < element.number_of_items(); ++ j)
+        {
+          for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+          {
+            internal::PLY::PLY_read_number* property = element.property(k);
+            property->get (in);
+
+            if (in.eof())
+              return false;
+          }
+        }
+      }
     }
 
-    if (points_read != reader.m_nb_points)
-      return false;
-
-    std::vector<CGAL::Color> dummy;
-
-    reader.read_faces();
-
-    if (reader.does_tag_exist<std::vector<boost::int32_t> > ("vertex_indices"))
-      return internal::read_PLY_faces<boost::int32_t> (in, reader, polygons, dummy, "vertex_indices");
-
-    if (reader.does_tag_exist<std::vector<boost::uint32_t> > ("vertex_indices"))
-      return internal::read_PLY_faces<boost::uint32_t> (in, reader, polygons, dummy, "vertex_indices");
-
-    if (reader.does_tag_exist<std::vector<boost::int32_t> > ("vertex_index"))
-      return internal::read_PLY_faces<boost::int32_t> (in, reader, polygons, dummy, "vertex_index");
-
-    if (reader.does_tag_exist<std::vector<boost::uint32_t> > ("vertex_index"))
-      return internal::read_PLY_faces<boost::uint32_t> (in, reader, polygons, dummy, "vertex_index");
-
-    std::cerr << "Error: can't find vertex indices in PLY input" << std::endl;
-    return false;
+    return !in.bad();
   }
 
   template <class Point_3, class Polygon_3, class Color_rgb>
@@ -161,75 +184,96 @@ namespace CGAL{
       std::cerr << "Error: cannot open file" << std::endl;
       return false;
     }
-
     internal::PLY::PLY_reader reader;
   
     if (!(reader.init (in)))
       return false;
-  
-    std::size_t points_read = 0;
 
-    bool has_colors = false;
-    std::string rtag = "r", gtag = "g", btag = "b";
-    if ((reader.does_tag_exist<boost::uint8_t>("red") || reader.does_tag_exist<boost::uint8_t>("r")) &&
-        (reader.does_tag_exist<boost::uint8_t>("green") || reader.does_tag_exist<boost::uint8_t>("g")) &&
-        (reader.does_tag_exist<boost::uint8_t>("blue") || reader.does_tag_exist<boost::uint8_t>("b")))
+    for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
     {
-      has_colors = true;
-      if (reader.does_tag_exist<boost::uint8_t>("red"))
+      internal::PLY::PLY_element& element = reader.element(i);
+
+      if (element.name() == "vertex" || element.name() == "vertices")
       {
-        rtag = "red"; gtag = "green"; btag = "blue";
+        bool has_colors = false;
+        std::string rtag = "r", gtag = "g", btag = "b";
+        if ((element.has_property<boost::uint8_t>("red") || element.has_property<boost::uint8_t>("r")) &&
+            (element.has_property<boost::uint8_t>("green") || element.has_property<boost::uint8_t>("g")) &&
+            (element.has_property<boost::uint8_t>("blue") || element.has_property<boost::uint8_t>("b")))
+        {
+          has_colors = true;
+          if (element.has_property<boost::uint8_t>("red"))
+          {
+            rtag = "red"; gtag = "green"; btag = "blue";
+          }
+        }
+
+        for (std::size_t j = 0; j < element.number_of_items(); ++ j)
+        {
+          for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+          {
+            internal::PLY::PLY_read_number* property = element.property(k);
+            property->get (in);
+
+            if (in.eof())
+              return false;
+          }
+
+          cpp11::tuple<Point_3, boost::uint8_t, boost::uint8_t, boost::uint8_t> new_vertex;
+
+          if (has_colors)
+          {
+            internal::PLY::process_properties (element, new_vertex,
+                                               make_ply_point_reader (CGAL::make_nth_of_tuple_property_map<0>(new_vertex)),
+                                               std::make_pair (CGAL::make_nth_of_tuple_property_map<1>(new_vertex),
+                                                               PLY_property<boost::uint8_t>(rtag.c_str())),
+                                               std::make_pair (CGAL::make_nth_of_tuple_property_map<2>(new_vertex),
+                                                               PLY_property<boost::uint8_t>(gtag.c_str())),
+                                               std::make_pair (CGAL::make_nth_of_tuple_property_map<3>(new_vertex),
+                                                               PLY_property<boost::uint8_t>(btag.c_str())));
+
+            vcolors.push_back (Color_rgb (get<1>(new_vertex), get<2>(new_vertex), get<3>(new_vertex)));
+          }
+          else
+            internal::PLY::process_properties (element, new_vertex,
+                                               make_ply_point_reader (CGAL::make_nth_of_tuple_property_map<0>(new_vertex)));
+
+          points.push_back (get<0>(new_vertex));
+        }
+      }
+      else if (element.name() == "face" || element.name() == "faces")
+      {
+        if (element.has_property<std::vector<boost::int32_t> > ("vertex_indices"))
+          internal::read_PLY_faces<boost::int32_t> (in, element, polygons, fcolors, "vertex_indices");
+        else if (element.has_property<std::vector<boost::uint32_t> > ("vertex_indices"))
+          internal::read_PLY_faces<boost::uint32_t> (in, element, polygons, fcolors, "vertex_indices");
+        else if (element.has_property<std::vector<boost::int32_t> > ("vertex_index"))
+          internal::read_PLY_faces<boost::int32_t> (in, element, polygons, fcolors, "vertex_index");
+        else if (element.has_property<std::vector<boost::uint32_t> > ("vertex_index"))
+          internal::read_PLY_faces<boost::uint32_t> (in, element, polygons, fcolors, "vertex_index");
+        else
+        {
+          std::cerr << "Error: can't find vertex indices in PLY input" << std::endl;
+          return false;
+        }
+      }
+      else // Read other elements and ignore
+      {
+        for (std::size_t j = 0; j < element.number_of_items(); ++ j)
+        {
+          for (std::size_t k = 0; k < element.number_of_properties(); ++ k)
+          {
+            internal::PLY::PLY_read_number* property = element.property(k);
+            property->get (in);
+
+            if (in.eof())
+              return false;
+          }
+        }
       }
     }
 
-    while (!(in.eof()) && points_read < reader.m_nb_points)
-    {
-      for (std::size_t i = 0; i < reader.readers().size (); ++ i)
-        reader.readers()[i]->get (in);
-
-      cpp11::tuple<Point_3, boost::uint8_t, boost::uint8_t, boost::uint8_t> new_vertex;
-
-      if (has_colors)
-      {
-        internal::PLY::process_properties (reader, new_vertex,
-                                           make_ply_point_reader (CGAL::make_nth_of_tuple_property_map<0>(new_vertex)),
-                                           std::make_pair (CGAL::make_nth_of_tuple_property_map<1>(new_vertex),
-                                                           PLY_property<boost::uint8_t>(rtag.c_str())),
-                                           std::make_pair (CGAL::make_nth_of_tuple_property_map<2>(new_vertex),
-                                                           PLY_property<boost::uint8_t>(gtag.c_str())),
-                                           std::make_pair (CGAL::make_nth_of_tuple_property_map<3>(new_vertex),
-                                                           PLY_property<boost::uint8_t>(btag.c_str())));
-
-        vcolors.push_back (Color_rgb (get<1>(new_vertex), get<2>(new_vertex), get<3>(new_vertex)));
-      }
-      else
-        internal::PLY::process_properties (reader, new_vertex,
-                                           make_ply_point_reader (CGAL::make_nth_of_tuple_property_map<0>(new_vertex)));
-      
-      points.push_back (get<0>(new_vertex));
-      
-      ++ points_read;
-    }
-
-    if (points_read != reader.m_nb_points)
-      return false;
-
-    reader.read_faces();
-    
-    if (reader.does_tag_exist<std::vector<boost::int32_t> > ("vertex_indices"))
-      return internal::read_PLY_faces<boost::int32_t> (in, reader, polygons, fcolors, "vertex_indices");
-
-    if (reader.does_tag_exist<std::vector<boost::uint32_t> > ("vertex_indices"))
-      return internal::read_PLY_faces<boost::uint32_t> (in, reader, polygons, fcolors, "vertex_indices");
-
-    if (reader.does_tag_exist<std::vector<boost::int32_t> > ("vertex_index"))
-      return internal::read_PLY_faces<boost::int32_t> (in, reader, polygons, fcolors, "vertex_index");
-
-    if (reader.does_tag_exist<std::vector<boost::uint32_t> > ("vertex_index"))
-      return internal::read_PLY_faces<boost::uint32_t> (in, reader, polygons, fcolors, "vertex_index");
-
-    std::cerr << "Error: can't find vertex indices in PLY input" << std::endl;
-    return false;
+    return !in.bad();
   }
 
 

--- a/Polyhedron_IO/include/CGAL/IO/PLY_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/PLY_reader.h
@@ -54,7 +54,7 @@ namespace CGAL{
           internal::PLY::PLY_read_number* property = element.property(k);
           property->get (in);
 
-          if (in.eof())
+          if (in.fail())
             return false;
         }
 
@@ -84,7 +84,7 @@ namespace CGAL{
           polygons.back()[i] = std::size_t(get<0>(new_face)[i]);
       }
 
-      return !in.bad();
+      return true;
     }
 
   }
@@ -106,7 +106,10 @@ namespace CGAL{
     internal::PLY::PLY_reader reader;
   
     if (!(reader.init (in)))
+    {
+      in.setstate(std::ios::failbit);
       return false;
+    }
   
     for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
     {
@@ -121,7 +124,7 @@ namespace CGAL{
             internal::PLY::PLY_read_number* property = element.property(k);
             property->get (in);
 
-            if (in.eof())
+            if (in.fail())
               return false;
           }
 
@@ -160,14 +163,14 @@ namespace CGAL{
             internal::PLY::PLY_read_number* property = element.property(k);
             property->get (in);
 
-            if (in.eof())
+            if (in.fail())
               return false;
           }
         }
       }
     }
 
-    return !in.bad();
+    return true;
   }
 
   template <class Point_3, class Polygon_3, class Color_rgb>
@@ -187,7 +190,10 @@ namespace CGAL{
     internal::PLY::PLY_reader reader;
   
     if (!(reader.init (in)))
+    {
+      in.setstate(std::ios::failbit);
       return false;
+    }
 
     for (std::size_t i = 0; i < reader.number_of_elements(); ++ i)
     {
@@ -215,7 +221,7 @@ namespace CGAL{
             internal::PLY::PLY_read_number* property = element.property(k);
             property->get (in);
 
-            if (in.eof())
+            if (in.fail())
               return false;
           }
 
@@ -266,14 +272,14 @@ namespace CGAL{
             internal::PLY::PLY_read_number* property = element.property(k);
             property->get (in);
 
-            if (in.eof())
+            if (in.fail())
               return false;
           }
         }
       }
     }
 
-    return !in.bad();
+    return true;
   }
 
 


### PR DESCRIPTION
## Summary of Changes

Currently, our PLY reader only handles elements of type `vertex` and `face`. Though this is in itself acceptable, a problem occurs if another type of element is used in the PLY input: in that case, our reader might read garbage (as the properties of the elements are not processed at all instead of being processed but ignored, which would be the right behaviour).

This PR fixes it. It also makes the handling of PLY element much better: the internal API (not documented) of our PLY reader now allows to have access to _all_ elements and their respective properties, which can be handy if we want to read other types of PLY elements.

## Release Management

* Affected package(s): Point Set Processing, Point Set 3, Polyhedron IO, Polyhedron demo
