### PR TITLE
Modified output_to_medit() for consistent facet orientation

### DIFF
--- a/Mesh_3/include/CGAL/IO/File_medit.h
+++ b/Mesh_3/include/CGAL/IO/File_medit.h
@@ -815,7 +815,7 @@ output_to_medit(std::ostream& os,
        fit != c3t3.facets_in_complex_end();
        ++fit)
   {
-    C3T3::Facet f = (*fit);
+    typename C3T3::Facet f = (*fit);
     
     // Apply priority among subdomains, to get consistent facet orientation per subdomain-pair interface.
     if (f.first->subdomain_index() < f.first->neighbor(f.second)->subdomain_index())

--- a/Mesh_3/include/CGAL/IO/File_medit.h
+++ b/Mesh_3/include/CGAL/IO/File_medit.h
@@ -815,27 +815,28 @@ output_to_medit(std::ostream& os,
        fit != c3t3.facets_in_complex_end();
        ++fit)
   {
-    for (int i=0; i<4; i++)
-    {
-      if (i != fit->second)
-      {
-        const Vertex_handle& vh = (*fit).first->vertex(i);
-        os << V[vh] << ' ';
-      }
-    }
+    C3T3::Facet f = (*fit);
+    
+    // Apply priority among subdomains, to get consistent facet orientation per subdomain-pair interface.
+    if (f.first->subdomain_index() < f.first->neighbor(f.second)->subdomain_index())
+      f = tr.mirror_facet(f);
+    
+    // Get facet vertices in CCW order.
+    Vertex_handle vh1 = f.first->vertex((f.second + 1) % 4);
+    Vertex_handle vh2 = f.first->vertex((f.second + 2) % 4);
+    Vertex_handle vh3 = f.first->vertex((f.second + 3) % 4);
+    
+    // Facet orientation also depends on parity.
+    if (f.second % 2 != 0)
+      std::swap(vh2, vh3);
+    
+    os << V[vh1] << ' ' << V[vh2] << ' ' << V[vh3] << ' '; 
     os << get(facet_pmap, *fit) << '\n';
     
     // Print triangle again if needed
     if ( print_each_facet_twice )
     {
-      for (int i=0; i<4; i++)
-      {
-        if (i != fit->second)
-        {
-          const Vertex_handle& vh = (*fit).first->vertex(i);
-          os << V[vh] << ' ';
-        }
-      }
+      os << V[vh1] << ' ' << V[vh2] << ' ' << V[vh3] << ' '; 
       os << get(facet_twice_pmap, *fit) << '\n';
     }
   }


### PR DESCRIPTION
## Summary of Changes

Modified facet output code in function CGAL::output_to_medit() in file File_medit.h. The orientation of neighboring facet triangles in the output medit file was random before. Now, a consistent orientation is ensured by taking both the facet subdomain-index-pair and the facet parity (odd/even index of opposite vertex) into account.

We create a temporary clone of each facet. If the (first, second) subdomain-index of the facet fulfills the condition (first < second), then we mirror the facet. Additionally, if the index of the opposite vertex is an odd number, we swap the vertex orientation of the facet.

NOTE: This could perhaps be written in a different way, like replacing the vertex swap with another call to tr.mirror_facet(). However, I'm staying close to the fix suggested in 2010 by Ianic in this old forum post: http://cgal-discuss.949826.n4.nabble.com/CGAL-3d-Mesh-Triangulation-Facets-with-too-many-neighbors-facets-td2332420.html

## Release Management

* Affected package(s): Mesh_3 / IO
* Issue(s) solved (if any): fix #3566
