### PR TITLE
SSE version of Interval_nt

### DIFF
--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -341,9 +341,12 @@ inline double IA_bug_sqrt(double d)
 // Use inline functions instead ?
 #define CGAL_IA_ADD(a,b) CGAL_IA_FORCE_TO_DOUBLE((a)+CGAL_IA_STOP_CPROP(b))
 #define CGAL_IA_SUB(a,b) CGAL_IA_FORCE_TO_DOUBLE(CGAL_IA_STOP_CPROP(a)-(b))
-#define CGAL_IA_MUL(a,b) CGAL_IA_FORCE_TO_DOUBLE((a)*CGAL_IA_STOP_CPROP(b))
-#define CGAL_IA_DIV(a,b) CGAL_IA_FORCE_TO_DOUBLE((a)/CGAL_IA_STOP_CPROP(b))
-#define CGAL_IA_SQUARE(a) CGAL_IA_MUL(a,a)
+#define CGAL_IA_MUL(a,b) CGAL_IA_FORCE_TO_DOUBLE(CGAL_IA_STOP_CPROP(a)*CGAL_IA_STOP_CPROP(b))
+#define CGAL_IA_DIV(a,b) CGAL_IA_FORCE_TO_DOUBLE(CGAL_IA_STOP_CPROP(a)/CGAL_IA_STOP_CPROP(b))
+inline double CGAL_IA_SQUARE(double a){
+  double b = CGAL_IA_STOP_CPROP(a); // only once
+  return CGAL_IA_FORCE_TO_DOUBLE(b*b);
+}
 #define CGAL_IA_SQRT(a) \
         CGAL_IA_FORCE_TO_DOUBLE(CGAL_BUG_SQRT(CGAL_IA_STOP_CPROP(a)))
 

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -276,7 +276,8 @@ inline __m128d IA_opacify128_weak(__m128d x)
 inline __m128d swap_m128d(__m128d x){
 # ifdef __llvm__
   return __builtin_shufflevector(x, x, 1, 0);
-# elif defined __GNUC__ && !defined __INTEL_COMPILER
+# elif defined __GNUC__ && !defined __INTEL_COMPILER \
+  && __GNUC__ * 100 + __GNUC_MINOR__ >= 407
   return __builtin_shuffle(x, (__m128i){ 1, 0 });
 # else
   return _mm_shuffle_pd(x, x, 1);

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -107,7 +107,16 @@ extern "C" {
 #if  defined(__SSE2__) \
   || (defined(_M_IX86_FP) && _M_IX86_FP >= 2) \
   || defined(_M_X64)
-#  include <immintrin.h>
+#  include <emmintrin.h>
+#  if defined __SSE3__
+#    include <pmmintrin.h>
+#  endif
+#  if defined __SSE4_1__
+#    include <smmintrin.h>
+#  endif
+#  if defined __AVX__
+#    include <immintrin.h>
+#  endif
 #  define CGAL_HAS_SSE2 1
 #endif
 

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -262,6 +262,17 @@ inline __m128d IA_opacify128_weak(__m128d x)
   return e;
 # endif
 }
+
+// _mm_shuffle_pd would work everywhere, but it is too opaque for some optimizations (yes, this is a thin line)
+inline __m128d swap_m128d(__m128d x){
+# ifdef __llvm__
+  return __builtin_shufflevector(x, x, 1, 0);
+# elif defined __GNUC__ && !defined __INTEL_COMPILER
+  return __builtin_shuffle(x, (__m128i){ 1, 0 });
+# else
+  return _mm_shuffle_pd(x, x, 1);
+# endif
+}
 #endif
 
 // Interval arithmetic needs to protect against double-rounding effects

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -28,6 +28,7 @@
 
 #include <CGAL/assertions.h>
 #include <CGAL/use.h>
+#include <cstring> // std::memcpy
 
 #ifndef __INTEL_COMPILER
 #include <cmath> // for HUGE_VAL
@@ -255,7 +256,8 @@ inline __m128d IA_opacify128(__m128d x)
 #  ifdef _MSC_VER
   // With VS, __m128d is a union, where volatile doesn't disappear automatically
   // However, this version generates wrong code with clang, check before enabling it for more compilers.
-  return _mm_load_pd((double*)&e);
+  std::memcpy(&x, (void*)&e, 16);
+  return x;
 #  else
   return e;
 #  endif

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -252,7 +252,13 @@ inline __m128d IA_opacify128(__m128d x)
   return x;
 # else
   volatile __m128d e = x;
+#  ifdef _MSC_VER
+  // With VS, __m128d is a union, where volatile doesn't disappear automatically
+  // However, this version generates wrong code with clang, check before enabling it for more compilers.
+  return *(__m128d*)&e;
+#  else
   return e;
+#  endif
 # endif
 }
 
@@ -267,8 +273,7 @@ inline __m128d IA_opacify128_weak(__m128d x)
 #  endif
   return x;
 # else
-  volatile __m128d e = x;
-  return e;
+  return IA_opacify128(x);
 # endif
 }
 

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -1,4 +1,4 @@
-// Copyright (c) 1998-2008
+// Copyright (c) 1998-2019
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
@@ -21,7 +21,7 @@
 // SPDX-License-Identifier: LGPL-3.0+
 //
 //
-// Author(s)     : Sylvain Pion
+// Author(s)     : Sylvain Pion, Marc Glisse
 
 #ifndef CGAL_FPU_H
 #define CGAL_FPU_H

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -255,7 +255,7 @@ inline __m128d IA_opacify128(__m128d x)
 #  ifdef _MSC_VER
   // With VS, __m128d is a union, where volatile doesn't disappear automatically
   // However, this version generates wrong code with clang, check before enabling it for more compilers.
-  return *(__m128d*)&e;
+  return _mm_load_pd((double*)&e);
 #  else
   return e;
 #  endif

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1292,7 +1292,31 @@ class Algebraic_structure_traits< Interval_nt<B> >
       return Boolean(true);
     }
   };
-  
+#ifdef CGAL_USE_SSE2
+  class Inverse
+    : public CGAL::cpp98::unary_function< Type, Type > {
+  public:
+    Type operator()( const Type& x ) const {
+      int m = _mm_movemask_pd(x.simd());
+      switch(m) {
+	case 0:
+	case 3: // only possible for [ 0., -0. ]
+	  // The 2 bounds have different sign bits, so the interval contains 0
+	  return Type::largest();
+	case 1:
+	case 2:
+	  {
+            __m128d m1 = _mm_set1_pd(-1.);
+            __m128d xx = IA_opacify128((-x).simd());
+            __m128d r = _mm_div_pd(m1, xx);
+            return Type(IA_opacify128(r));
+	  }
+	default: CGAL_assume(false);
+      }
+      std::abort(); // unreachable
+    }
+  };
+#endif
 };
 
 

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1101,10 +1101,12 @@ namespace INTERN_INTERVAL_NT {
     double i = 0;
     if(d.inf() > 0){
       __m128d x = d.simd();
+      __m128d m = _mm_set_sd(-0.);
+      __m128d y = _mm_xor_pd(x, m);
       // We don't opacify because hopefully a rounded operation is explicit
       // enough that compilers won't mess with it, and it does not care about
       // fesetround.
-      __m128d vr = _mm_sqrt_round_sd(x, x, _MM_FROUND_TO_NEG_INF|_MM_FROUND_NO_EXC);
+      __m128d vr = _mm_sqrt_round_sd(y, y, _MM_FROUND_TO_NEG_INF|_MM_FROUND_NO_EXC);
       i = _mm_cvtsd_f64(vr);
       // We could compute the sqrt of d.sup() using _mm_sqrt_pd (same speed as
       // _sd except on broadwell) so it is already in the high part and we can

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -599,7 +599,7 @@ inline
 Interval_nt<Protected>
 operator+ (double a, const Interval_nt<Protected> & b)
 {
-  // MSVC does not define __SSE3__, not sure if /arch:AVX2 defines __AVX__...
+  // MSVC does not define __SSE3__
 #if defined CGAL_USE_SSE2 && (defined __SSE3__ || defined __AVX__)
   typename Interval_nt<Protected>::Internal_protector P;
   __m128d aa = _mm_set1_pd(IA_opacify(a));
@@ -665,10 +665,13 @@ inline
 Interval_nt<Protected>
 operator* (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 {
+#if 0
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88626
   if(CGAL_CST_TRUE(a.is_point()))
     return a.inf() * b;
   else if(CGAL_CST_TRUE(b.is_point()))
     return a * b.inf();
+#endif
   typedef Interval_nt<Protected> IA;
   typename Interval_nt<Protected>::Internal_protector P;
 #ifdef CGAL_USE_SSE2
@@ -833,10 +836,13 @@ inline
 Interval_nt<Protected>
 operator/ (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 {
+#if 0
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88626
   if(CGAL_CST_TRUE(a.is_point()))
     return a.inf() / b;
   else if(CGAL_CST_TRUE(b.is_point()))
     return a / b.inf();
+#endif
   typedef Interval_nt<Protected> IA;
   typename Interval_nt<Protected>::Internal_protector P;
 #if defined CGAL_USE_SSE2 && (defined __SSE4_1__ || defined __AVX__)

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -406,7 +406,9 @@ inline
 Uncertain<bool>
 operator<(const Interval_nt<Protected> &a, double b)
 {
-  return b > a;
+  if (a.sup() <  b) return true;
+  if (a.inf() >= b) return false;
+  return Uncertain<bool>::indeterminate();
 }
 
 template <bool Protected>

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1375,41 +1375,6 @@ class Algebraic_structure_traits< Interval_nt<B> >
       return Boolean(true);
     }
   };
-#ifdef CGAL_USE_SSE2
-  class Inverse
-    : public CGAL::cpp98::unary_function< Type, Type > {
-  public:
-    Type operator()( const Type& x ) const {
-      typename Type::Internal_protector P;
-#if 0
-      int m = _mm_movemask_pd(x.simd());
-      switch(m) {
-	case 0:
-	case 3: // only possible for [ 0., -0. ]
-	  // The 2 bounds have different sign bits, so the interval contains 0
-	  return Type::largest();
-	case 1:
-	case 2:
-	  {
-            __m128d m1 = _mm_set1_pd(-1.);
-            __m128d xx = IA_opacify128((-x).simd());
-            __m128d r = _mm_div_pd(m1, xx);
-            return Type(IA_opacify128(r));
-	  }
-	default: CGAL_assume(false);
-      }
-      std::abort(); // unreachable
-#else
-      int i = _mm_movemask_pd(_mm_cmpge_pd(x.simd(), _mm_set1_pd(0.)));
-      if(i==3) return Type::largest(); // bi<=0 && bs>=0
-      __m128d m1 = _mm_set1_pd(-1.);
-      __m128d xx = IA_opacify128((-x).simd());
-      __m128d r = _mm_div_pd(m1, xx);
-      return Type(IA_opacify128(r));
-#endif
-    }
-  };
-#endif
 };
 
 

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -71,7 +71,7 @@ public:
 
   Interval_nt()
 #ifndef CGAL_NO_ASSERTIONS
-      : _inf(1), _sup(0)
+      : _inf(-1), _sup(0)
              // to early and deterministically detect use of uninitialized
 #endif
     {}
@@ -136,7 +136,7 @@ public:
 #endif
 
   Interval_nt(double i, double s)
-    : _inf(i), _sup(s)
+    : _inf(-i), _sup(s)
   {
     // Previously it was:
     //    CGAL_assertion_msg(!(i>s);
@@ -179,7 +179,7 @@ public:
 
   double inf() const
   {
-    return _inf;
+    return -_inf;
   }
   double sup() const
   {
@@ -211,6 +211,7 @@ public:
 
 private:
   // Pair inf_sup;
+  // The value stored in _inf is the negated lower bound.
   double _inf, _sup;
 
   struct Test_runtime_rounding_modes {

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 1998-2005,2007  
+// Copyright (c) 1998-2019
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
@@ -21,7 +21,7 @@
 // SPDX-License-Identifier: LGPL-3.0+
 //
 //
-// Author(s)     : Sylvain Pion, Michael Hemmer
+// Author(s)     : Sylvain Pion, Michael Hemmer, Marc Glisse
 
 #ifndef CGAL_INTERVAL_NT_H
 #define CGAL_INTERVAL_NT_H

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -934,6 +934,7 @@ inline
 Interval_nt<Protected>
 operator/ (double a, const Interval_nt<Protected> & b)
 {
+#ifdef CGAL_USE_SSE2
   int i = _mm_movemask_pd(_mm_cmpge_pd(b.simd(), _mm_set1_pd(0.)));
   if(i==3) return Interval_nt<Protected>::largest(); // bi<=0 && bs>=0
   __m128d aa, xx;
@@ -947,6 +948,9 @@ operator/ (double a, const Interval_nt<Protected> & b)
   typename Interval_nt<Protected>::Internal_protector P;
   __m128d r = _mm_div_pd(IA_opacify128_weak(aa), IA_opacify128(xx));
   return Interval_nt<Protected>(IA_opacify128(r));
+#else
+  return Interval_nt<Protected>(a) / b;
+#endif
 }
 
 template <bool Protected>
@@ -954,6 +958,7 @@ inline
 Interval_nt<Protected>
 operator/ (Interval_nt<Protected> a, double b)
 {
+#ifdef CGAL_USE_SSE2
   if(b<0){ a = -a; b = -b; }
   else if(b==0) return Interval_nt<Protected>::largest();
   // Now b > 0
@@ -967,6 +972,9 @@ operator/ (Interval_nt<Protected> a, double b)
   __m128d aa = IA_opacify128(a.simd());
   __m128d r = _mm_div_pd(aa, bb);
   return Interval_nt<Protected>(IA_opacify128(r));
+#else
+  return a / Interval_nt<Protected>(b);
+#endif
 }
 
 // TODO: What about these two guys? Where do they belong to?

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1171,13 +1171,14 @@ namespace INTERN_INTERVAL_NT {
   Interval_nt<Protected>
   square (const Interval_nt<Protected> & d)
   {
+    //TODO: SSE version, possibly using abs
     typename Interval_nt<Protected>::Internal_protector P;
     if (d.inf()>=0.0)
-        return Interval_nt<Protected>(-CGAL_IA_MUL(d.inf(), -d.inf()),
-                                 CGAL_IA_MUL(d.sup(), d.sup()));
+        return Interval_nt<Protected>(-CGAL_IA_MUL(-d.inf(), d.inf()),
+                                 CGAL_IA_SQUARE(d.sup()));
     if (d.sup()<=0.0)
         return Interval_nt<Protected>(-CGAL_IA_MUL(d.sup(), -d.sup()),
-                               CGAL_IA_MUL(d.inf(), d.inf()));
+                               CGAL_IA_SQUARE(-d.inf()));
     return Interval_nt<Protected>(0.0, CGAL_IA_SQUARE((std::max)(-d.inf(),
                      d.sup())));
   }

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1065,9 +1065,20 @@ namespace INTERN_INTERVAL_NT {
   Interval_nt<Protected>
   abs (const Interval_nt<Protected> & d)
   {
+#ifdef CGAL_USE_SSE2
+    __m128d a = d.simd();
+    __m128d b = (-d).simd();
+    __m128d x = _mm_min_pd (a, b);
+    __m128d y = _mm_max_pd (a, b);
+    __m128d t = _mm_move_sd (y, x);
+    __m128d z = _mm_set1_pd(-0.); // +0. would be valid, but I'd rather end up with interval [+0, sup]
+    __m128d r = _mm_min_sd(t, z);
+    return Interval_nt<Protected> (r);
+#else
     if (d.inf() >= 0.0) return d;
     if (d.sup() <= 0.0) return -d;
     return Interval_nt<Protected>(0.0, (std::max)(-d.inf(), d.sup()));
+#endif
   }
 
   template <bool Protected>

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -461,7 +461,7 @@ class Is_valid< Interval_nt<Protected> >
   : public CGAL::cpp98::unary_function< Interval_nt<Protected>, bool > {
   public :
     bool operator()( const Interval_nt<Protected>& x ) const {
-      return is_valid(x.inf()) &&
+      return is_valid(-x.inf()) &&
              is_valid(x.sup()) &&
              x.inf() <= x.sup();
     }
@@ -514,7 +514,7 @@ Interval_nt<Protected>
 operator+ (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 {
   typename Interval_nt<Protected>::Internal_protector P;
-  return Interval_nt<Protected> (-CGAL_IA_SUB(-a.inf(), b.inf()),
+  return Interval_nt<Protected> (-CGAL_IA_ADD(-a.inf(), -b.inf()),
                                   CGAL_IA_ADD(a.sup(), b.sup()));
 }
 
@@ -547,8 +547,8 @@ Interval_nt<Protected>
 operator- (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 {
   typename Interval_nt<Protected>::Internal_protector P;
-  return Interval_nt<Protected>(-CGAL_IA_SUB(b.sup(), a.inf()),
-                                 CGAL_IA_SUB(a.sup(), b.inf()));
+  return Interval_nt<Protected>(-CGAL_IA_ADD(b.sup(), -a.inf()),
+                                 CGAL_IA_ADD(a.sup(), -b.inf()));
 }
 
 template <bool Protected>
@@ -600,21 +600,21 @@ operator* (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 	if (b.sup() < 0.0)
 	    bb=a.sup();
     }
-    return IA(-CGAL_IA_MUL(bb, -b.sup()), CGAL_IA_MUL(aa, b.inf()));
+    return IA(-CGAL_IA_MUL(-bb, b.sup()), CGAL_IA_MUL(-aa, -b.inf()));
   }
   else						// 0 \in a
   {
     if (b.inf()>=0.0)				// b>=0
-      return IA(-CGAL_IA_MUL(a.inf(), -b.sup()),
-                 CGAL_IA_MUL(a.sup(), b.sup()));
+      return IA(-CGAL_IA_MUL(-a.inf(), b.sup()),
+                 CGAL_IA_MUL( a.sup(), b.sup()));
     if (b.sup()<=0.0)				// b<=0
-      return IA(-CGAL_IA_MUL(a.sup(), -b.inf()),
-                 CGAL_IA_MUL(a.inf(), b.inf()));
+      return IA(-CGAL_IA_MUL( a.sup(), -b.inf()),
+                 CGAL_IA_MUL(-a.inf(), -b.inf()));
         					// 0 \in b
-    double tmp1 = CGAL_IA_MUL(a.inf(), -b.sup());
-    double tmp2 = CGAL_IA_MUL(a.sup(), -b.inf());
-    double tmp3 = CGAL_IA_MUL(a.inf(),  b.inf());
-    double tmp4 = CGAL_IA_MUL(a.sup(),  b.sup());
+    double tmp1 = CGAL_IA_MUL(-a.inf(),  b.sup());
+    double tmp2 = CGAL_IA_MUL( a.sup(), -b.inf());
+    double tmp3 = CGAL_IA_MUL(-a.inf(), -b.inf());
+    double tmp4 = CGAL_IA_MUL( a.sup(),  b.sup());
     return IA(-(std::max)(tmp1,tmp2), (std::max)(tmp3,tmp4));
   }
 }
@@ -654,7 +654,7 @@ operator/ (const Interval_nt<Protected> &a, const Interval_nt<Protected> & b)
 	if (a.sup() < 0.0)
 	    bb = b.sup();
     }
-    return IA(-CGAL_IA_DIV(a.inf(), -aa), CGAL_IA_DIV(a.sup(), bb));
+    return IA(-CGAL_IA_DIV(-a.inf(), aa), CGAL_IA_DIV(a.sup(), bb));
   }
   else if (b.sup()<0.0)			// b<0
   {
@@ -703,8 +703,8 @@ struct Min <Interval_nt<Protected> >
                                        const Interval_nt<Protected>& e) const
     {
         return Interval_nt<Protected>(
-                (std::min)(d.inf(), e.inf()),
-                (std::min)(d.sup(), e.sup()));
+                -(std::max)(-d.inf(), -e.inf()),
+                 (std::min)( d.sup(),  e.sup()));
     }
 };
 
@@ -718,8 +718,8 @@ struct Max <Interval_nt<Protected> >
                                        const Interval_nt<Protected>& e) const
     {
         return Interval_nt<Protected>(
-                (std::max)(d.inf(), e.inf()),
-                (std::max)(d.sup(), e.sup()));
+                -(std::min)(-d.inf(), -e.inf()),
+                 (std::max)( d.sup(),  e.sup()));
     }
 };
 


### PR DESCRIPTION
## Summary of Changes

Reimplement interval arithmetic using SSE, for x86.
If I compile benchmark/Triangulation_3/simple_2.cpp with `-DCGAL_NO_STATIC_FILTERS -DCGAL_NO_STRUCTURAL_FILTERING` and run it for 100000 points, this patch roughly divides the running time by 2.
This is x86-only, mostly because I don't know of any good multi-platform simd library that would allow to write (mostly) common code for neon and powerpc (there may be something in a future standard, but that's far away). I could instead write the code in a way that works on x86/powerpc/arm/etc, but then it would not work for MSVC, which I assume would make some people unhappy.
The performance is likely to differ for different CPUs. The most crucial operation, `operator*`, has several implementations that you can compare.
There are probably more operations on intervals that could get a faster, SSE implementation, but that can be added incrementally.
There are a couple code paths that will only be used if you pass `/arch:avx` or `-march=...`.
This is only enabled on 64-bit systems, where AFAIK by default malloc returns memory aligned to 16 bytes. Enabling in on 32-bit systems could be done starting with C++17, but that doesn't seem urgent.

## Release Management

* Affected package(s): Number_types