### PR TITLE
Support Qt-5.12: qcollectiongenerator merged into qhelpgenerator

### DIFF
--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -22,7 +22,13 @@ if(Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
 endif(Qt5_FOUND)
 
-if (CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET Qt5::qcollectiongenerator)
+if( Qt5Help_VERSION VERSION_LESS 5.12 )
+  set(CGAL_QCOLLECTIONGENERATOR_TARGET Qt5::qcollectiongenerator)
+else()
+  set(CGAL_QCOLLECTIONGENERATOR_TARGET Qt5::qhelpgenerator)
+endif()
+
+if (CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET ${CGAL_QCOLLECTIONGENERATOR_TARGET})
 
   # UI files (Qt Designer files)
   qt5_wrap_ui ( UI_FILES MainWindow.ui )
@@ -35,15 +41,10 @@ if (CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET Qt5::qcollectiongener
   qt5_generate_moc( "MainWindow.h" "${CMAKE_CURRENT_BINARY_DIR}/moc_MainWindow.cpp" )
   qt5_generate_moc( "Viewer.h" "${CMAKE_CURRENT_BINARY_DIR}/moc_Viewer.cpp" )
 
-  if(DEFINED QT_QCOLLECTIONGENERATOR_EXECUTABLE)
-  else()
-    set(QT_QCOLLECTIONGENERATOR_EXECUTABLE qcollectiongenerator)
-  endif()
-
   # generate QtAssistant collection file
   add_custom_command ( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Periodic_3_triangulation_3.qhc
       DEPENDS Periodic_3_triangulation_3.qhp Periodic_3_triangulation_3.qhcp
-      COMMAND Qt5::qcollectiongenerator
+      COMMAND ${CGAL_QCOLLECTIONGENERATOR_TARGET}
                  ${CMAKE_CURRENT_SOURCE_DIR}/Periodic_3_triangulation_3.qhcp
                  -o ${CMAKE_CURRENT_BINARY_DIR}/Periodic_3_triangulation_3.qhc
   )
@@ -80,8 +81,8 @@ else ()
     set(PERIODIC_TRIANGULATION_MISSING_DEPS "Qt5, ${PERIODIC_TRIANGULATION_MISSING_DEPS}")
   endif()
 
-  if (NOT TARGET Qt5::qcollectiongenerator)
-    set(PERIODIC_TRIANGULATION_MISSING_DEPS "qcollectiongenerator, ${PERIODIC_TRIANGULATION_MISSING_DEPS}")
+  if (NOT TARGET ${CGAL_QCOLLECTIONGENERATOR_TARGET})
+    set(PERIODIC_TRIANGULATION_MISSING_DEPS "${CGAL_QCOLLECTIONGENERATOR_TARGET}, ${PERIODIC_TRIANGULATION_MISSING_DEPS}")
   endif()
 
   message(STATUS "NOTICE: This demo requires ${PERIODIC_TRIANGULATION_MISSING_DEPS}and will not be compiled.")

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
@@ -23,8 +23,13 @@ include(${CGAL_USE_FILE})
 
 find_package(Qt5 QUIET COMPONENTS Xml Script Help OpenGL Svg)
 
+if( Qt5Help_VERSION VERSION_LESS 5.12 )
+  set(CGAL_QCOLLECTIONGENERATOR_TARGET Qt5::qcollectiongenerator)
+else()
+  set(CGAL_QCOLLECTIONGENERATOR_TARGET Qt5::qhelpgenerator)
+endif()
 
-if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET Qt5::qcollectiongenerator )
+if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET ${CGAL_QCOLLECTIONGENERATOR_TARGET} )
 
   include_directories (BEFORE ../../include ./ )
 
@@ -43,7 +48,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET Qt5::qcollectiongene
   # generate QtAssistant collection file
   add_custom_command ( OUTPUT Periodic_Lloyd_3.qhc
       DEPENDS Periodic_Lloyd_3.qhp Periodic_Lloyd_3.qhcp
-      COMMAND Qt5::qcollectiongenerator
+      COMMAND ${CGAL_QCOLLECTIONGENERATOR_TARGET}
                 ${CMAKE_CURRENT_SOURCE_DIR}/Periodic_Lloyd_3.qhcp
                 -o ${CMAKE_CURRENT_BINARY_DIR}/Periodic_Lloyd_3.qhc
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -71,7 +76,7 @@ else( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND QT_QCOLLECTIONGENERATOR_EX
   endif()      	   
 
   if(NOT QT_QCOLLECTIONGENERATOR_EXECUTABLE)
-    set(PERIODIC_LLOYD_MISSING_DEPS "qcollectiongenerator, ${PERIODIC_LLOYD_MISSING_DEPS}")
+    set(PERIODIC_LLOYD_MISSING_DEPS "${CGAL_QCOLLECTIONGENERATOR_TARGET}, ${PERIODIC_LLOYD_MISSING_DEPS}")
   endif()
 
 


### PR DESCRIPTION
## Summary of Changes

[Qt 5.12 has changed a lot in QtHelp](http://blog.qt.io/blog/2018/11/02/whats-new-qt-help/), and:

> We have merged the qcollectiongenerator tool into the qhelpgenerator, which now accepts both .qhp and .qhcp files as input and generates .qch and .qhc files, respectively.

Our `CMakeLists.txt` needed extra code to use either `qcollectiongenerator` for Qt<=5.11 and `qhelpgenerator` for Qt>=5.12.

## Release Management

* Affected package(s): Periodic_3 demos
* License and copyright ownership: maintenance by GeometryFactory, Inria keeps the rights
