### PR TITLE
Triangulation_2: revert small feature DT2_strict_and_weak_conflict_zone

### DIFF
--- a/Interpolation/include/CGAL/natural_neighbor_coordinates_2.h
+++ b/Interpolation/include/CGAL/natural_neighbor_coordinates_2.h
@@ -99,20 +99,27 @@ natural_neighbors_2(const Dt& dt,
     Point_2 p1(v1->point()), p2(v2->point());
 
     Coord_type coef1(0);
-    Coord_type coef2(0);
     Equal_x_2 equal_x_2;
     if(!equal_x_2(p1,p2))
-    {
       coef1 = (p.x() - p2.x()) / (p1.x() - p2.x());
-      coef2 = 1 - coef1;
-      *out++ = std::make_pair(v1,coef1);
-      *out++ = std::make_pair(v2,coef2);
-    } else {
+    else
       coef1 = (p.y() - p2.y()) / (p1.y() - p2.y());
-      coef2 = 1 - coef1;
-      *out++ = std::make_pair(v1,coef1);
-      *out++ = std::make_pair(v2,coef2);
+
+    if(coef1 == 0)
+    {
+      *out++ = std::make_pair(v2, Coord_type(1));
+      return make_triple(out, Coord_type(1), true);
     }
+
+    Coord_type coef2 = 1 - coef1;
+    if(coef2 == 0)
+    {
+      *out++ = std::make_pair(v1, Coord_type(1));
+      return make_triple(out, Coord_type(1), true);
+    }
+
+    *out++ = std::make_pair(v1,coef1);
+    *out++ = std::make_pair(v2,coef2);
 
     return make_triple(out, coef1+coef2, true);
   }
@@ -142,6 +149,7 @@ natural_neighbors_2(const Dt& dt,
                     EdgeIterator hole_begin, EdgeIterator hole_end)
 {
   CGAL_precondition(dt.dimension() == 2);
+
   typedef typename Dt::Geom_traits       Traits;
   typedef typename Traits::FT            Coord_type;
   typedef typename Traits::Point_2       Point_2;
@@ -187,8 +195,12 @@ natural_neighbors_2(const Dt& dt,
                                                                 p);
 
     area += polygon_area_2(vor.begin(), vor.end(), dt.geom_traits());
-    *out++ = std::make_pair(current,area);
-    area_sum += area;
+
+    if(area > 0)
+    {
+      *out++ = std::make_pair(current,area);
+      area_sum += area;
+    }
 
     //update prev and hit:
     prev = current;

--- a/Interpolation/include/CGAL/natural_neighbor_coordinates_2.h
+++ b/Interpolation/include/CGAL/natural_neighbor_coordinates_2.h
@@ -124,7 +124,7 @@ natural_neighbors_2(const Dt& dt,
   }
 
   std::list<Edge> hole;
-  dt.get_boundary_of_conflicts(p, std::back_inserter(hole), fh, false);
+  dt.get_boundary_of_conflicts(p, std::back_inserter(hole), fh);
 
   return natural_neighbors_2(dt, p, out, hole.begin(), hole.end());
 }

--- a/Interpolation/include/CGAL/regular_neighbor_coordinates_2.h
+++ b/Interpolation/include/CGAL/regular_neighbor_coordinates_2.h
@@ -131,9 +131,12 @@ regular_neighbor_coordinates_vertex_2(const Rt& rt,
     *vor_vertices++ = vor[2];
 
     area += polygon_area_2(vor.begin(), vor.end(), rt.geom_traits());
-    *out++= std::make_pair(current, area);
 
-    area_sum += area;
+    if(area > 0)
+    {
+      *out++= std::make_pair(current, area);
+      area_sum += area;
+    }
 
     //update prev and hit:
     prev = current;
@@ -163,8 +166,11 @@ regular_neighbor_coordinates_vertex_2(const Rt& rt,
       ++fc;
     }
 
-    *out++ = std::make_pair((*hidden_vertices_begin), area);
-    area_sum += area;
+    if(area > 0)
+    {
+      *out++ = std::make_pair((*hidden_vertices_begin), area);
+      area_sum += area;
+    }
   }
 
   return make_triple(out, area_sum, true);

--- a/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
@@ -114,7 +114,7 @@ public:
   nearest_vertex(const Point& p, Face_handle f= Face_handle()) const;
 
   bool does_conflict(const Point &p, Face_handle fh) const;// deprecated
-  bool test_conflict(const Point &p, Face_handle fh, bool strict = true) const;
+  bool test_conflict(const Point &p, Face_handle fh) const;
   bool find_conflicts(const Point &p,               //deprecated
                       std::list<Face_handle>& conflicts,
                       Face_handle start= Face_handle()) const;
@@ -411,8 +411,7 @@ public:
   get_conflicts_and_boundary(const Point  &p,
                              OutputItFaces fit,
                              OutputItBoundaryEdges eit,
-                             Face_handle start = Face_handle(),
-                             bool strict = true) const
+                             Face_handle start = Face_handle()) const
   {
     CGAL_triangulation_precondition(this->dimension() == 2);
     int li;
@@ -427,9 +426,9 @@ public:
       case Triangulation::OUTSIDE_CONVEX_HULL:
         *fit++ = fh; //put fh in OutputItFaces
         std::pair<OutputItFaces,OutputItBoundaryEdges> pit = std::make_pair(fit,eit);
-        pit = propagate_conflicts(p,fh,0,pit, strict);
-        pit = propagate_conflicts(p,fh,1,pit, strict);
-        pit = propagate_conflicts(p,fh,2,pit, strict);
+        pit = propagate_conflicts(p,fh,0,pit);
+        pit = propagate_conflicts(p,fh,1,pit);
+        pit = propagate_conflicts(p,fh,2,pit);
         return pit;
     }
     CGAL_triangulation_assertion(false);
@@ -440,11 +439,10 @@ public:
   OutputItFaces
   get_conflicts (const Point  &p,
                  OutputItFaces fit,
-                 Face_handle start= Face_handle(),
-                 bool strict = true) const
+                 Face_handle start= Face_handle()) const
   {
     std::pair<OutputItFaces,Emptyset_iterator> pp =
-      get_conflicts_and_boundary(p, fit, Emptyset_iterator(), start, strict);
+      get_conflicts_and_boundary(p, fit, Emptyset_iterator(), start);
     return pp.first;
   }
 
@@ -452,11 +450,10 @@ public:
   OutputItBoundaryEdges
   get_boundary_of_conflicts(const Point  &p,
                             OutputItBoundaryEdges eit,
-                            Face_handle start= Face_handle(),
-                            bool strict = true) const
+                            Face_handle start= Face_handle()) const
   {
     std::pair<Emptyset_iterator, OutputItBoundaryEdges> pp =
-      get_conflicts_and_boundary(p, Emptyset_iterator(), eit, start, strict);
+      get_conflicts_and_boundary(p, Emptyset_iterator(), eit, start);
     return pp.second;
   }
 
@@ -467,18 +464,16 @@ private:
   propagate_conflicts (const Point &p,
                        const Face_handle fh,
                        const int i,
-                       std::pair<OutputItFaces,OutputItBoundaryEdges>
-                       pit,
-                       bool strict = true) const
+                       std::pair<OutputItFaces,OutputItBoundaryEdges> pit) const
   {
     Face_handle fn = fh->neighbor(i);
-    if(! test_conflict(p,fn,strict)) {
+    if(! test_conflict(p,fn)) {
       *(pit.second)++ = Edge(fn, fn->index(fh));
     } else {
       *(pit.first)++ = fn;
       int j = fn->index(fh);
-      pit = propagate_conflicts(p,fn,ccw(j),pit,strict);
-      pit = propagate_conflicts(p,fn,cw(j), pit,strict);
+      pit = propagate_conflicts(p,fn,ccw(j),pit);
+      pit = propagate_conflicts(p,fn,cw(j), pit);
     }
     return pit;
   }
@@ -488,8 +483,7 @@ private:
   non_recursive_propagate_conflicts(const Point  &p,
                                     const Face_handle fh,
                                     const int i,
-                                    std::pair<OutputItFaces,OutputItBoundaryEdges> pit,
-                                    bool strict = true)  const
+                                    std::pair<OutputItFaces,OutputItBoundaryEdges> pit) const
   {
     std::stack<std::pair<Face_handle, int> > stack;
     stack.push(std::make_pair(fh,i));
@@ -499,7 +493,8 @@ private:
       const int i=stack.top().second;
       stack.pop();
       Face_handle fn = fh->neighbor(i);
-      if(! test_conflict(p,fn,strict)) {
+      if(! test_conflict(p,fn))
+      {
         *(pit.second)++ = Edge(fn, fn->index(fh));
       } else {
         *(pit.first)++ = fn;
@@ -516,22 +511,20 @@ private:
   propagate_conflicts (const Point  &p,
                        const Face_handle fh,
                        const int i,
-                       std::pair<OutputItFaces,OutputItBoundaryEdges>
-                       pit,
-                       bool strict = true,
+                       std::pair<OutputItFaces,OutputItBoundaryEdges> pit,
                        int depth=0) const
   {
     if(depth == 100)
-      return non_recursive_propagate_conflicts(p, fh, i, pit, strict);
+      return non_recursive_propagate_conflicts(p, fh, i, pit);
 
     Face_handle fn = fh->neighbor(i);
-    if(! test_conflict(p,fn,strict)) {
+    if(! test_conflict(p,fn)) {
       *(pit.second)++ = Edge(fn, fn->index(fh));
     } else {
       *(pit.first)++ = fn;
       int j = fn->index(fh);
-      pit = propagate_conflicts(p,fn,ccw(j),pit, strict, depth+1);
-      pit = propagate_conflicts(p,fn,cw(j), pit, strict, depth+1);
+      pit = propagate_conflicts(p,fn,ccw(j),pit, depth+1);
+      pit = propagate_conflicts(p,fn,cw(j), pit, depth+1);
     }
     return pit;
   }
@@ -636,12 +629,8 @@ protected:
 template < class Gt, class Tds >
 inline bool
 Delaunay_triangulation_2<Gt,Tds>::
-test_conflict(const Point  &p, Face_handle fh, bool strict) const
+test_conflict(const Point  &p, Face_handle fh) const
 {
-  if(! strict) {
-    Oriented_side os = side_of_oriented_circle(fh,p,false);
-    return os == ON_POSITIVE_SIDE;
-  }
   // return true  if P is inside the circumcircle of fh
   // if fh is infinite, return true when p is in the positive
   // halfspace or on the boundary and in the  finite edge of fh


### PR DESCRIPTION
## Summary of Changes

https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/DT2_strict_and_weak_conflict_zone is a small feature that was integrated a while ago without approval has some legitimate concerns in it (see discussion in the small feature page). This PR reverts its changes, which are entirely code (no doc).

This small feature was integrated to fix some bug in the Interpolation package, possibly due to the presence of potentially null coordinates in the output when called on degenerate configurations. This PR filters irrelevant (`==0`) or illogical (`<0`) coordinates after the computation rather than modifying the triangulation's conflict zone.

No test failed after I reverted the small feature and before I added the filters, so it is difficult to evaluate whether whatever bug forced the small feature in the first place is still fixed by just filtering the output.

## Release Management

* Affected package(s): `Triangulation_2`, `Interpolation`
* Putting it in master and 4.15 because - in theory - it's a small feature change, but it could be back-ported onto any other release.

