### PR TITLE
Nef_3 : Document convert_nef_polyhedron_to_polygon_soup-GF

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -6,7 +6,7 @@ Release 4.15
 Release date: September 2019
 
 ###3D Boolean Operations on Nef Polyhedra
--   Added a function to convert a Nef_polyhedron to a polygon soup:
+-   Added a function to convert a Nef_polyhedron_3 to a polygon soup:
     - `CGAL::convert_nef_to_polygon_soup()`
 
 Release 4.14

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -1,5 +1,13 @@
 Release History
 ===============
+Release 4.15
+------------
+
+Release date: September 2019
+
+###3D Boolean Operations on Nef Polyhedra
+-   Added a function to convert a Nef_polyhedron to a polygon soup:
+    - `CGAL::convert_nef_to_polygon_soup()`
 
 Release 4.14
 ------------

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -10,7 +10,7 @@ namespace CGAL {
 /// 
 /// @param nef the input.
 /// @param pm the output.
-/// @param triangulate_all_faces the bool for triangulating the faces.
+/// @param triangulate_all_faces indicates whether all the faces must be triangulated.
 /// 
 /// \pre `Polygon_mesh` must have an internal point property map with value type being `Nef_polyhedron_3::Point_3`.
 /// \pre `nef.simple()`
@@ -23,14 +23,14 @@ namespace CGAL {
   /// The polygons can be triangulated by setting `triangulate_all_faces` to `true`.
   /// @tparam Output_kernel the Kernel from which the point type of points come from.
   /// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
-  /// @tparam Polygon_mesh a model of `MutableFaceGraph`.
-  /// @tparam PolygonRange a container of collections of indices of the points in their range.
-  /// @tparam PointRange a container of `Output_kernel::Point_3`.
+  /// @tparam PointRange a model of the concepts `RandomAccessContainer` and 
+  /// `BackInsertionSequence` whose `value_type` is the point type
+  /// @tparam PolygonRange a model of the concept `RandomAccessContainer` whose 
+  /// `value_type` is a model of the concept `RandomAccessContainer` whose `value_type` is `std::size_t`.
   /// 
   /// @param nef the input.
   /// @param pm the output.
-  /// @param triangulate_all_faces the bool for triangulating the faces.
-  /// \pre `nef.simple()`
+  /// @param triangulate_all_faces indicates whether all polygons must be triangulated.
   template <class Output_kernel, class Nef_polyhedron, typename PolygonRange, typename PointRange>
   void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
                                                     PointRange& points,

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -6,7 +6,12 @@ namespace CGAL {
 /// (but faces with more than one connected component of the boundary).
 /// The polygon mesh can be triangulated by setting `triangulate_all_faces` to `true` or by calling the function `triangulate_faces()`.
 /// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
-/// @tparam Polygon_mesh a model of `MutableFaceGraph`.
+/// @tparam Polygon_mesh a model of `MutableFaceGraph` with an internal property map for `CGAL::vertex_point_t`.
+///
+/// The points from `nef` to `pm` are converted using
+/// `CGAL::Cartesian_converter<NefKernel, TargetKernel>`.
+/// `NefKernel` and `TargetKernel` are deduced using `CGAL::Kernel_traits`
+/// from the point type of `nef` and the value type of the vertex_point_map of `tm`.
 /// 
 /// @param nef the input.
 /// @param pm the output.
@@ -21,18 +26,25 @@ namespace CGAL {
   /// \ingroup PkgNef3IOFunctions
   /// Converts an objet of type `Nef_polyhedron_3` into a polygon soup.
   /// The polygons can be triangulated by setting `triangulate_all_faces` to `true`.
-  /// @tparam Output_kernel the Kernel from which the point type of points come from.
   /// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
   /// @tparam PointRange a model of the concepts `RandomAccessContainer` and 
   /// `BackInsertionSequence` whose `value_type` is the point type
-  /// @tparam PolygonRange a model of the concept `RandomAccessContainer` whose 
-  /// `value_type` is a model of the concept `RandomAccessContainer` whose `value_type` is `std::size_t`.
+  /// @tparam PolygonRange a model of the concepts `RandomAccessContainer` and 
+  /// `BackInsertionSequence` whose `value_type` is a model of the concepts 
+  /// `RandomAccessContainer` and `BackInsertionSequence` whose 
+  /// `value_type` is `std::size_t`.
+  /// It must 
+  /// 
+  /// The points from `nef` to `points` are converted using
+  /// `CGAL::Cartesian_converter<NefKernel, OutputKernel>`.
+  /// `NefKernel` and `OutputKernel` are deduced using `CGAL::Kernel_traits`
+  /// from the point types.
   /// 
   /// @param nef the input.
   /// @param points the output points of the soup
   /// @param polygons the output polygons of the soup. 
   /// @param triangulate_all_faces indicates whether all polygons must be triangulated.
-  template <class Output_kernel, class Nef_polyhedron, typename PolygonRange, typename PointRange>
+  template <class Nef_polyhedron, typename PolygonRange, typename PointRange>
   void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
                                                     PointRange& points,
                                                     PolygonRange& polygons,

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -27,22 +27,21 @@ namespace CGAL {
   /// Converts an objet of type `Nef_polyhedron_3` into a polygon soup.
   /// The polygons can be triangulated by setting `triangulate_all_faces` to `true`.
   /// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
-  /// @tparam PointRange a model of the concepts `RandomAccessContainer` and 
-  /// `BackInsertionSequence` whose `value_type` is the point type
-  /// @tparam PolygonRange a model of the concepts `RandomAccessContainer` and 
-  /// `BackInsertionSequence` whose `value_type` is a model of the concepts 
-  /// `RandomAccessContainer` and `BackInsertionSequence` whose 
+  /// @tparam PointRange a model of the concept `BackInsertionSequence`
+  /// whose `value_type` is the point type
+  /// @tparam PolygonRange a model of the concept
+  /// `BackInsertionSequence` whose `value_type` is a model of the concept
+  ///  `BackInsertionSequence` whose
   /// `value_type` is `std::size_t`.
-  /// It must 
-  /// 
+  ///
   /// The points from `nef` to `points` are converted using
   /// `CGAL::Cartesian_converter<NefKernel, OutputKernel>`.
   /// `NefKernel` and `OutputKernel` are deduced using `CGAL::Kernel_traits`
   /// from the point types.
-  /// 
+  ///
   /// @param nef the input.
   /// @param points the output points of the soup
-  /// @param polygons the output polygons of the soup. 
+  /// @param polygons the output polygons of the soup.
   /// @param triangulate_all_faces indicates whether all polygons must be triangulated.
   template <class Nef_polyhedron, typename PolygonRange, typename PointRange>
   void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -29,7 +29,8 @@ namespace CGAL {
   /// `value_type` is a model of the concept `RandomAccessContainer` whose `value_type` is `std::size_t`.
   /// 
   /// @param nef the input.
-  /// @param pm the output.
+  /// @param points the output points of the soup
+  /// @param polygons the output polygons of the soup. 
   /// @param triangulate_all_faces indicates whether all polygons must be triangulated.
   template <class Output_kernel, class Nef_polyhedron, typename PolygonRange, typename PointRange>
   void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,

--- a/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/doc/Nef_3/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -5,9 +5,35 @@ namespace CGAL {
 /// Note that contrary to `Nef_polyhedron_3::convert_to_polyhedron()`, the output is not triangulated
 /// (but faces with more than one connected component of the boundary).
 /// The polygon mesh can be triangulated by setting `triangulate_all_faces` to `true` or by calling the function `triangulate_faces()`.
+/// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
+/// @tparam Polygon_mesh a model of `MutableFaceGraph`.
+/// 
+/// @param nef the input.
+/// @param pm the output.
+/// @param triangulate_all_faces the bool for triangulating the faces.
+/// 
 /// \pre `Polygon_mesh` must have an internal point property map with value type being `Nef_polyhedron_3::Point_3`.
 /// \pre `nef.simple()`
   
   template <class Nef_polyhedron, class Polygon_mesh>
   void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_mesh& pm, bool triangulate_all_faces = false);
+  
+  /// \ingroup PkgNef3IOFunctions
+  /// Converts an objet of type `Nef_polyhedron_3` into a polygon soup.
+  /// The polygons can be triangulated by setting `triangulate_all_faces` to `true`.
+  /// @tparam Output_kernel the Kernel from which the point type of points come from.
+  /// @tparam Nef_polyhedron an object of type `Nef_polyhedron_3`.
+  /// @tparam Polygon_mesh a model of `MutableFaceGraph`.
+  /// @tparam PolygonRange a container of collections of indices of the points in their range.
+  /// @tparam PointRange a container of `Output_kernel::Point_3`.
+  /// 
+  /// @param nef the input.
+  /// @param pm the output.
+  /// @param triangulate_all_faces the bool for triangulating the faces.
+  /// \pre `nef.simple()`
+  template <class Output_kernel, class Nef_polyhedron, typename PolygonRange, typename PointRange>
+  void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
+                                                    PointRange& points,
+                                                    PolygonRange& polygons,
+                                                    bool triangulate_all_faces = false);
 }

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -60,6 +60,7 @@ a simple OpenGL visualization for debugging and illustrations.
 ## Functions ##
 - `CGAL::OFF_to_nef_3()`
 - `CGAL::convert_nef_polyhedron_to_polygon_mesh()`
+- `CGAL::convert_nef_polyhedron_to_polygon_soup()`
 - \link PkgNef3IOFunctions `CGAL::operator<<()` \endlink
 - \link PkgNef3IOFunctions `CGAL::operator>>()` \endlink
 

--- a/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -378,7 +378,6 @@ template <class Nef_polyhedron, class Polygon_mesh>
 void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_mesh& pm, bool triangulate_all_faces = false)
 {
   typedef typename boost::property_traits<typename boost::property_map<Polygon_mesh, vertex_point_t>::type>::value_type PM_Point;
-  typedef typename Kernel_traits<PM_Point>::Kernel PM_Kernel;
 
   std::vector<PM_Point> points;
   std::vector<std::vector<std::size_t> > polygons;

--- a/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -291,7 +291,7 @@ struct Shell_polygons_visitor
       queue.pop_back();
       if (e.first->info().visited) continue;
       e.first->info().visited=true;
-      polygons.resize(polygons.size()+1);
+      polygons.push_back(Polygon());
       if (is_marked)
         for (int i=2; i>=0; --i)
           polygons.back().push_back(e.first->vertex(i)->info());
@@ -346,7 +346,7 @@ void collect_polygon_mesh_info(
 
 } //end of namespace nef_to_pm
 
-template <class Output_kernel, class Nef_polyhedron, typename PolygonRange, typename PointRange>
+template < class Nef_polyhedron, typename PolygonRange, typename PointRange>
 void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
                                                   PointRange& points,
                                                   PolygonRange& polygons,
@@ -354,6 +354,9 @@ void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
 {
   typedef typename Nef_polyhedron::Point_3 Point_3;
   typedef typename Kernel_traits<Point_3>::Kernel Nef_Kernel;
+  typedef typename PointRange::value_type Out_Point;
+  typedef typename Kernel_traits<Out_Point>::Kernel Output_kernel;
+  
   typedef Cartesian_converter<Nef_Kernel, Output_kernel> Converter;
   typename Nef_polyhedron::Volume_const_iterator vol_it = nef.volumes_begin(),
                                                  vol_end = nef.volumes_end();
@@ -379,7 +382,7 @@ void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_m
 
   std::vector<PM_Point> points;
   std::vector<std::vector<std::size_t> > polygons;
-  convert_nef_polyhedron_to_polygon_soup<PM_Kernel>(nef, points, polygons, triangulate_all_faces);
+  convert_nef_polyhedron_to_polygon_soup(nef, points, polygons, triangulate_all_faces);
   Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, pm);
 }
 

--- a/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -371,14 +371,14 @@ void convert_nef_polyhedron_to_polygon_soup(const Nef_polyhedron& nef,
                                          triangulate_all_faces);
 }
 
-template <class Nef_polyhedron, class Polygon_mesh, typename PolygonRange, typename PointRange>
+template <class Nef_polyhedron, class Polygon_mesh>
 void convert_nef_polyhedron_to_polygon_mesh(const Nef_polyhedron& nef, Polygon_mesh& pm, bool triangulate_all_faces = false)
 {
   typedef typename boost::property_traits<typename boost::property_map<Polygon_mesh, vertex_point_t>::type>::value_type PM_Point;
   typedef typename Kernel_traits<PM_Point>::Kernel PM_Kernel;
 
-  PointRange points;
-  PolygonRange polygons;
+  std::vector<PM_Point> points;
+  std::vector<std::vector<std::size_t> > polygons;
   convert_nef_polyhedron_to_polygon_soup<PM_Kernel>(nef, points, polygons, triangulate_all_faces);
   Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, pm);
 }

--- a/Nef_3/test/Nef_3/test_nef_to_soup.cpp
+++ b/Nef_3/test/Nef_3/test_nef_to_soup.cpp
@@ -1,0 +1,48 @@
+#include <CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Nef_polyhedron_3.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/IO/Nef_polyhedron_iostream_3.h>
+
+#include <fstream>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel EPEC;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel EPIC;
+
+int main()
+{ 
+  typedef CGAL::Nef_polyhedron_3< EPEC > Nef_polyhedron;
+  typedef CGAL::Polyhedron_3< EPEC >     Polyhedron;
+  typedef typename EPIC::Point_3         Point;
+  typedef std::list<std::list<std::size_t> > PolygonRange;
+  typedef std::list<Point> PointRange;
+  
+  typename EPEC::RT n, d;
+  std::istringstream str_n("6369051672525773");
+  str_n >> n;
+  std::istringstream str_d("4503599627370496");
+  str_d >> d;
+  
+  EPEC::Point_3 p(n, 0, 0, d);
+  EPEC::Point_3 q(0, n, 0, d);
+  EPEC::Point_3 r(0, 0, n, d);
+  EPEC::Point_3 s(0, 0, 0, 1);
+  
+  std::cout << "    build...\n";
+  Polyhedron P;
+  P.make_tetrahedron( p, q, r, s);
+  Nef_polyhedron nef( P );
+  PointRange points;
+  PolygonRange polygons;
+    std::cout << "    convert...\n";
+  CGAL::convert_nef_polyhedron_to_polygon_soup<
+      EPIC, 
+      Nef_polyhedron, 
+      PolygonRange,
+      PointRange>(nef, points, polygons);
+  CGAL_assertion(points.size() == 4);
+  CGAL_assertion(polygons.size() == 4);
+  return 0;
+}

--- a/Nef_3/test/Nef_3/test_nef_to_soup.cpp
+++ b/Nef_3/test/Nef_3/test_nef_to_soup.cpp
@@ -45,9 +45,7 @@ int main()
   PolygonMesh pm;
   CGAL::convert_nef_polyhedron_to_polygon_mesh<
       Nef_polyhedron, 
-      PolygonMesh,
-      std::vector<std::vector<std::size_t> >,
-      std::vector<Point> >(nef, pm);
+      PolygonMesh>(nef, pm);
   
   return 0;
 }

--- a/Nef_3/test/Nef_3/test_nef_to_soup.cpp
+++ b/Nef_3/test/Nef_3/test_nef_to_soup.cpp
@@ -15,6 +15,7 @@ int main()
 { 
   typedef CGAL::Nef_polyhedron_3< EPEC > Nef_polyhedron;
   typedef CGAL::Polyhedron_3< EPEC >     Polyhedron;
+  typedef CGAL::Polyhedron_3< EPIC >     PolygonMesh;
   typedef typename EPIC::Point_3         Point;
   typedef std::list<std::list<std::size_t> > PolygonRange;
   typedef std::list<Point> PointRange;
@@ -38,11 +39,15 @@ int main()
   PolygonRange polygons;
     std::cout << "    convert...\n";
   CGAL::convert_nef_polyhedron_to_polygon_soup<
-      EPIC, 
-      Nef_polyhedron, 
-      PolygonRange,
-      PointRange>(nef, points, polygons);
+      EPIC>(nef, points, polygons);
   CGAL_assertion(points.size() == 4);
   CGAL_assertion(polygons.size() == 4);
+  PolygonMesh pm;
+  CGAL::convert_nef_polyhedron_to_polygon_mesh<
+      Nef_polyhedron, 
+      PolygonMesh,
+      std::vector<std::vector<std::size_t> >,
+      std::vector<Point> >(nef, pm);
+  
   return 0;
 }

--- a/Nef_3/test/Nef_3/test_nef_to_soup.cpp
+++ b/Nef_3/test/Nef_3/test_nef_to_soup.cpp
@@ -38,8 +38,7 @@ int main()
   PointRange points;
   PolygonRange polygons;
     std::cout << "    convert...\n";
-  CGAL::convert_nef_polyhedron_to_polygon_soup<
-      EPIC>(nef, points, polygons);
+  CGAL::convert_nef_polyhedron_to_polygon_soup(nef, points, polygons);
   CGAL_assertion(points.size() == 4);
   CGAL_assertion(polygons.size() == 4);
   PolygonMesh pm;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -44,12 +44,12 @@ namespace Polygon_mesh_processing
 namespace internal
 {
 template <typename PM
-        , typename Point
-        , typename Polygon>
+        , typename PointRange
+        , typename PolygonRange>
 class Polygon_soup_to_polygon_mesh
 {
-  const std::vector<Point>& _points;
-  const std::vector<Polygon>& _polygons;
+  const PointRange& _points;
+  const PolygonRange& _polygons;
 
   typedef typename boost::property_map<PM, CGAL::vertex_point_t>::type Vpmap;
   typedef typename boost::property_traits<Vpmap>::value_type Point_3;
@@ -57,15 +57,17 @@ class Polygon_soup_to_polygon_mesh
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
+  typedef typename PolygonRange::value_type Polygon;
+  typedef typename PointRange::value_type Point;
 
 public:
   /**
   * The constructor for modifier object.
   * @param points points of the soup of polygons.
-  * @param polygons each element in the vector describes a polygon using the index of the points in the vector.
+  * @param polygons each element in the range describes a polygon using the index of the points in the range.
   */
-  Polygon_soup_to_polygon_mesh(const std::vector<Point>& points,
-                               const std::vector<Polygon>& polygons)
+  Polygon_soup_to_polygon_mesh(const PointRange& points,
+                               const PolygonRange& polygons)
     : _points(points),
       _polygons(polygons)
   { }
@@ -195,9 +197,12 @@ public:
   * @pre the input polygon soup describes a consistently oriented
   * polygon mesh.
   *
-  * @tparam PolygonMesh a model of `MutableFaceGraph` with an internal point property map
-  * @tparam Point a point type that has an operator `[]` to access coordinates
-  * @tparam Polygon a `std::vector<std::size_t>` containing the indices
+  * @tparam PolygonMesh a model of `MutableFaceGraph` with an internal point 
+  * property map
+  * @tparam PointRange a `RandomAccessContainer` with a value_type that has an 
+  * operator `[]` to access coordinates
+  * @tparam PolygonRange a `RandomAccessContainer` of `RandomAccessContainer` 
+  * of `std::size_t` containing the indices
   *         of the points of the face
   *
   * @param points points of the soup of polygons
@@ -211,16 +216,16 @@ public:
   * \sa `CGAL::Polygon_mesh_processing::is_polygon_soup_a_polygon_mesh()`
   *
   */
-  template<class PolygonMesh, class Point, class Polygon>
+  template<class PolygonMesh, class PointRange, class PolygonRange>
   void polygon_soup_to_polygon_mesh(
-    const std::vector<Point>& points,
-    const std::vector<Polygon>& polygons,
+    const PointRange& points,
+    const PolygonRange& polygons,
     PolygonMesh& out)
   {
     CGAL_precondition_msg(is_polygon_soup_a_polygon_mesh(polygons),
                           "Input soup needs to be a polygon mesh!");
 
-    internal::Polygon_soup_to_polygon_mesh<PolygonMesh, Point, Polygon>
+    internal::Polygon_soup_to_polygon_mesh<PolygonMesh, PointRange, PolygonRange>
       converter(points, polygons);
     converter(out);
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -199,11 +199,11 @@ public:
   *
   * @tparam PolygonMesh a model of `MutableFaceGraph` with an internal point 
   * property map
-  * @tparam PointRange a `RandomAccessContainer` with a value_type that has an 
-  * operator `[]` to access coordinates
-  * @tparam PolygonRange a `RandomAccessContainer` of `RandomAccessContainer` 
-  * of `std::size_t` containing the indices
-  *         of the points of the face
+  * @tparam PointRange a model of the concepts `RandomAccessContainer` and 
+  * `BackInsertionSequence` whose value type is the point type
+  * @tparam PolygonRange a model of the concept `RandomAccessContainer` whose 
+  * `value_type` is a model of the concept `RandomAccessContainer` whose `value_type` is `std::size_t`.
+
   *
   * @param points points of the soup of polygons
   * @param polygons each element in the vector describes a polygon using the index of the points in `points`


### PR DESCRIPTION
## Summary of Changes
- Make it possible to use `polygon_soup_to_polygon_mesh()` with something else than a std::vector
- Document `convert_nef_polyhedron_to_polygon_soup()` and make it use template types as point range and polygon range.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #1657
* Feature/Small Feature (if any): after first reviews
* Link to compiled documentation (obligatory for small feature) [link](https://cgal.geometryfactory.com/~mgimeno/Nef_to_soup/1/Nef_3/group__PkgNef3IOFunctions.html#ga2e47f1a21e5b35af36c7ef665c66e848)
* License and copyright ownership:

