### PR TITLE
Fix for VC2017 with /arch=AVX

### DIFF
--- a/QP_solver/include/CGAL/QP_solver/functors.h
+++ b/QP_solver/include/CGAL/QP_solver/functors.h
@@ -262,6 +262,15 @@ public:
   Map_with_default (const Map* m, const mapped_type& v = mapped_type())
     : map(m), d(v)
   {}
+
+  // Added as workaround for VC2017 with /arch:AVX to fix
+  // https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-95/QP_solver/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz
+  Map_with_default& operator=(const Map_with_default& other)
+  {
+    map = other.map;
+    d = other.d;
+    return *this;
+  }
   
   // operator()
   const mapped_type& operator() (key_type n) const {

--- a/Spatial_searching/include/CGAL/Plane_separator.h
+++ b/Spatial_searching/include/CGAL/Plane_separator.h
@@ -53,8 +53,20 @@ template < class FT> class Plane_separator {
 
   Plane_separator(const int d, const FT& v) : 
 		cutting_dim(d), cutting_val(v) {}
+
   explicit Plane_separator() : cutting_dim(0), cutting_val(0) {}
+
+  // Added as workaround for VC2017 with /arch:AVX to fix
+  // https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-95/Spatial_searching/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz
+  Plane_separator& operator=(const Plane_separator& ps)
+  {
+    cutting_dim = ps.cutting_dim;
+    cutting_val = ps.cutting_val;
+    return *this;
+  }
+
 };
+
 
  template < class FT> 
  std::ostream& operator<< (std::ostream& s, Plane_separator<FT>& x) {


### PR DESCRIPTION
## Summary of Changes

It seems that VC2017 has a problem with default generated assignment operator when it contains two 64bit data members. Providing the implementation fixes this.

## Release Management

* Affected package(s): QP_solver, Spatial_searching

