### PR TITLE
Rewrite to_interval for boost.multiprecision types

### DIFF
--- a/Number_types/include/CGAL/boost_mp.h
+++ b/Number_types/include/CGAL/boost_mp.h
@@ -210,10 +210,14 @@ struct RET_boost_mp_base
             double s = i;
             double inf = std::numeric_limits<double>::infinity();
             int cmp = x.compare(i);
-            if (cmp > 0)
+            if (cmp > 0) {
               s = nextafter(s, +inf);
-            else if (cmp < 0)
+              CGAL_assertion(x.compare(s) < 0);
+            }
+            else if (cmp < 0) {
               i = nextafter(i, -inf);
+              CGAL_assertion(x.compare(i) > 0);
+            }
             return std::pair<double, double> (i, s);
         }
     };

--- a/Number_types/include/CGAL/boost_mp.h
+++ b/Number_types/include/CGAL/boost_mp.h
@@ -503,7 +503,7 @@ typename boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>::result_type,
 boost::multiprecision::number<B, E> >
 { };
 
-// TODO: coercion with expressions, fix existing coercions
+// TODO: fix existing coercions
 // (double -> rational is implicit only for 1.56+, see ticket #10082)
 // The real solution would be to avoid specializing Coercion_traits for all pairs of number types and let it auto-detect what works, so only broken types need an explicit specialization.
 
@@ -521,7 +521,13 @@ struct Coercion_traits<boost::multiprecision::number<B1, E1>, int> { \
 }; \
 template <class B1, boost::multiprecision::expression_template_option E1> \
 struct Coercion_traits<int, boost::multiprecision::number<B1, E1> > \
-: Coercion_traits<boost::multiprecision::number<B1, E1>, int> {}
+: Coercion_traits<boost::multiprecision::number<B1, E1>, int> {}; \
+template <class T1, class T2, class T3, class T4, class T5> \
+struct Coercion_traits<boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>, int> \
+: Coercion_traits<typename boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>::result_type, int>{}; \
+template <class T1, class T2, class T3, class T4, class T5> \
+struct Coercion_traits<int, boost::multiprecision::detail::expression<T1,T2,T3,T4,T5> > \
+: Coercion_traits<typename boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>::result_type, int>{}
 
 CGAL_COERCE_INT(short);
 CGAL_COERCE_INT(int);
@@ -542,7 +548,13 @@ struct Coercion_traits<boost::multiprecision::number<B1, E1>, float> { \
 }; \
 template <class B1, boost::multiprecision::expression_template_option E1> \
 struct Coercion_traits<float, boost::multiprecision::number<B1, E1> > \
-: Coercion_traits<boost::multiprecision::number<B1, E1>, float> {}
+: Coercion_traits<boost::multiprecision::number<B1, E1>, float> {}; \
+template <class T1, class T2, class T3, class T4, class T5> \
+struct Coercion_traits<boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>, float> \
+: Coercion_traits<typename boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>::result_type, float>{}; \
+template <class T1, class T2, class T3, class T4, class T5> \
+struct Coercion_traits<float, boost::multiprecision::detail::expression<T1,T2,T3,T4,T5> > \
+: Coercion_traits<typename boost::multiprecision::detail::expression<T1,T2,T3,T4,T5>::result_type, float>{}
 
 CGAL_COERCE_FLOAT(float);
 CGAL_COERCE_FLOAT(double);

--- a/Number_types/test/Number_types/utilities.cpp
+++ b/Number_types/test/Number_types/utilities.cpp
@@ -10,6 +10,7 @@
 #include <CGAL/Lazy_exact_nt.h> 
 #include <CGAL/Interval_nt.h> 
 #include <CGAL/Sqrt_extension.h> 
+#include <CGAL/boost_mp.h>
 
 #ifdef CGAL_USE_GMP
 #include <CGAL/Gmpz.h>
@@ -82,6 +83,12 @@ int main()
   TESTIT(CGAL::Lazy_exact_nt<QMPF>, "Lazy_exact_nt<Quotient<MP_Float> >")
   TESTIT(CGAL::Interval_nt<>, "Interval_nt<>")
 
+  // Boost.Multiprecision
+#ifdef CGAL_USE_BOOST_MP
+  TESTIT(boost::multiprecision::cpp_int, "cpp_int")
+  TESTIT(boost::multiprecision::cpp_rational, "cpp_rational")
+#endif
+
   // GMP based NTs
 #ifdef CGAL_USE_GMP
   TESTIT(CGAL::Gmpz, "Gmpz")
@@ -90,6 +97,10 @@ int main()
   TESTIT(CGAL::Mpzf, "Mpzf")
 # endif
   TESTIT(CGAL::Gmpq, "Gmpq")
+# ifdef CGAL_USE_BOOST_MP
+  TESTIT(boost::multiprecision::mpz_int, "mpz_int")
+  TESTIT(boost::multiprecision::mpq_rational, "mpq_rational")
+# endif
 #endif // CGAL_USE_GMP
 #ifdef CGAL_USE_GMPXX
   TESTIT(mpz_class, "mpz_class")


### PR DESCRIPTION
## Summary of Changes

We rely a lot on intervals of length 0, for performance. I had written a simple to_interval for boost types (essentially to_double enlarged, so it never has length 0), but I have to copy the one from Gmpq/mpq_class to avoid regressions. I am also adding the boost types to the utilities.cpp test, which required fixing Coercion_traits.
Note that cpp_int/cpp_rational (as opposed to mpz_int/mpq_rational) will still use the simple to_interval, which may make them slower for some applications. But then we currently only use them if GMP and LEDA are not available, so it doesn't matter.

## Release Management

* Affected package(s): Number_types