### PR TITLE
Reset the halfedge pointer of the faces before setting them

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/HDS_items.h
+++ b/Nef_2/include/CGAL/Nef_2/HDS_items.h
@@ -389,7 +389,9 @@ public:
             hit->reset_fcit();
         for (Isolated_vertex_iterator vit = iv_begin(); vit!=iv_end(); ++vit) 
             vit->reset_ivit();
-        FC.clear(); IV.clear(); }
+        FC.clear(); IV.clear();
+        _e=Halfedge_handle();
+          }
 
     /*{\Mtext There are the same iterator ranges defined for the const
       iterators |Hole_const_iterator|, |Isolated_vertex_const_iterator|.

--- a/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
@@ -473,7 +473,7 @@ check_integrity_and_topological_planarity(bool faces) const
   int fc_num(0),iv_num(0);
   Face_const_iterator fit;
   for (fit = faces_begin(); fit != faces_end(); ++fit) {
-    if (!first) {
+    if (!first && halfedge(fit)!=Halfedge_const_handle()) {
       CGAL_assertion( face(halfedge(fit))==fit ); ++fc_num;
     }
     Hole_const_iterator fcit;


### PR DESCRIPTION
Before the patch, when used with `Bounded_kernel` the halfedge pointer of the unbounded face could be a removed halfedge.