### PR TITLE
Polyhedron demo: Fix normal estimation parameter

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -235,7 +235,7 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
       std::cerr << "Estimates normal direction by Jet Fitting (k=" << dialog.jet_neighbors() <<")...\n";
 
       // Estimates normals direction.
-      Jet_estimate_normals_functor functor (points, dialog.pca_neighbors());
+      Jet_estimate_normals_functor functor (points, dialog.jet_neighbors());
       run_with_qprogressdialog (functor, "Estimating normals by jet fitting...", mw);
 
       std::size_t memory = CGAL::Memory_sizer().virtual_size();


### PR DESCRIPTION
## Summary of Changes

Copy/paste error, the jet estimation was using the PCA neighbor parameter instead of its own.

## Release Management

* Affected package(s): Polyhedron demo
* Bug introduced in 4.13

