### PR TITLE
Update of headers

### DIFF
--- a/AABB_tree/doc/AABB_tree/PackageDescription.txt
+++ b/AABB_tree/doc/AABB_tree/PackageDescription.txt
@@ -22,17 +22,17 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `AABBPrimitive`
 - `AABBPrimitiveWithSharedData`
 - `AABBTraits`
 - `AABBGeomTraits`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::AABB_traits<GeomTraits,Primitive>`
 - `CGAL::AABB_tree<AT>`
 
-## Primitives ##
+\cgalCRPSection{Primitives}
 - `CGAL::AABB_triangle_primitive<GeomTraits, Iterator, CacheDatum>`
 - `CGAL::AABB_segment_primitive<GeomTraits, Iterator, CacheDatum>`
 - `CGAL::AABB_primitive<Id,ObjectPropertyMap,PointPropertyMapPolyhedron,ExternalPropertyMaps,CacheDatum>`

--- a/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/PackageDescription.txt
+++ b/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/PackageDescription.txt
@@ -25,13 +25,13 @@ of topological singularities. }
 
 \cgalClassifedRefPages
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Advancing_front_surface_reconstruction`
 - `CGAL::Advancing_front_surface_reconstruction_vertex_base_3`
 - `CGAL::Advancing_front_surface_reconstruction_cell_base_3`
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 - `CGAL::advancing_front_surface_reconstruction()`
 

--- a/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
+++ b/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
@@ -25,7 +25,7 @@
 
 ## Algebraic Structures ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 
 - `IntegralDomainWithoutDivision`
 - `IntegralDomain`
@@ -54,7 +54,7 @@
 - `AlgebraicStructureTraits_::KthRoot`
 - `AlgebraicStructureTraits_::RootOf`
 
-### Classes ###
+\cgalCRPSubsection{Classes}
 
 - `CGAL::Algebraic_structure_traits<T>`
 - `CGAL::Integral_domain_without_division_tag`
@@ -64,7 +64,7 @@
 - `CGAL::Unique_factorization_domain_tag`
 - `CGAL::Euclidean_ring_tag`
 
-### Global Functions ###
+\cgalCRPSubsection{Global Functions}
 
 - `CGAL::is_zero()`
 - `CGAL::is_one()`
@@ -84,7 +84,7 @@
 
 ## Real Embeddable ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 
 - `RealEmbeddable`
 
@@ -98,11 +98,11 @@
 - `RealEmbeddableTraits_::ToDouble`
 - `RealEmbeddableTraits_::ToInterval`
 
-### Classes ###
+\cgalCRPSubsection{Classes}
 
 - `CGAL::Real_embeddable_traits<T>`
 
-### Global Functions ###
+\cgalCRPSubsection{Global Functions}
 
 - `CGAL::is_zero()`
 - `CGAL::abs()`
@@ -115,25 +115,25 @@
 
 ## Real Number Types ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 
 - `RingNumberType`
 - `FieldNumberType`
 
 ## Interoperability ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 
 - `ExplicitInteroperable`
 - `ImplicitInteroperable`
 
-### Classes ###
+\cgalCRPSubsection{Classes}
 
 - `CGAL::Coercion_traits<A,B>`
 
 ## Fractions ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 
 - `Fraction`
 - `FractionTraits`
@@ -141,13 +141,13 @@
 - `FractionTraits_::Compose`
 - `FractionTraits_::CommonFactor`
 
-### Classes ###
+\cgalCRPSubsection{Classes}
 
 - `CGAL::Fraction_traits<T>`
 
 ## Miscellaneous ##
 
-### Concepts ###
+\cgalCRPSubsection{Concepts}
 - `FromIntConstructible`
 - `FromDoubleConstructible`
 

--- a/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
+++ b/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
@@ -23,7 +23,7 @@
 
 \cgalClassifedRefPages
 
-## Algebraic Structures ##
+\cgalCRPSection{Algebraic Structures}
 
 \cgalCRPSubsection{Concepts}
 
@@ -82,7 +82,7 @@
 - `CGAL::kth_root()`
 - `CGAL::root_of()`
 
-## Real Embeddable ##
+\cgalCRPSection{Real Embeddable}
 
 \cgalCRPSubsection{Concepts}
 
@@ -113,14 +113,14 @@
 - `CGAL::to_double()`
 - `CGAL::to_interval()`
 
-## Real Number Types ##
+\cgalCRPSection{Real Number Types}
 
 \cgalCRPSubsection{Concepts}
 
 - `RingNumberType`
 - `FieldNumberType`
 
-## Interoperability ##
+\cgalCRPSection{Interoperability}
 
 \cgalCRPSubsection{Concepts}
 
@@ -131,7 +131,7 @@
 
 - `CGAL::Coercion_traits<A,B>`
 
-## Fractions ##
+\cgalCRPSection{Fractions}
 
 \cgalCRPSubsection{Concepts}
 
@@ -145,7 +145,7 @@
 
 - `CGAL::Fraction_traits<T>`
 
-## Miscellaneous ##
+\cgalCRPSection{Miscellaneous}
 
 \cgalCRPSubsection{Concepts}
 - `FromIntConstructible`

--- a/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
+++ b/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
@@ -34,7 +34,7 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 \cgalCRPSubsection{Univariate Algebraic %Kernel}
 
@@ -95,7 +95,7 @@
 - `AlgebraicKernel_d_2::BoundBetweenX_2`
 - `AlgebraicKernel_d_2::BoundBetweenY_2`
 
-## Models ##
+\cgalCRPSection{Models}
 
 - `CGAL::Algebraic_kernel_d_1<Coeff>`
 - `CGAL::Algebraic_kernel_d_2<Coeff>`

--- a/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
+++ b/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
@@ -36,7 +36,7 @@
 
 ## Concepts ##
 
-### Univariate Algebraic %Kernel ###
+\cgalCRPSubsection{Univariate Algebraic %Kernel}
 
 - `AlgebraicKernel_d_1`
 
@@ -58,7 +58,7 @@
 - `AlgebraicKernel_d_1::ApproximateAbsolute_1`
 - `AlgebraicKernel_d_1::ApproximateRelative_1`
 
-### Bivariate Algebraic %Kernel ###
+\cgalCRPSubsection{Bivariate Algebraic %Kernel}
 
 - `AlgebraicKernel_d_2`
 

--- a/Alpha_shapes_2/doc/Alpha_shapes_2/PackageDescription.txt
+++ b/Alpha_shapes_2/doc/Alpha_shapes_2/PackageDescription.txt
@@ -68,12 +68,12 @@ finite number of different \f$ \alpha\f$-shapes and corresponding
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `AlphaShapeTraits_2`
 - `AlphaShapeFace_2`
 - `AlphaShapeVertex_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Alpha_shape_2<Dt>`
 - `CGAL::Weighted_alpha_shape_euclidean_traits_2<K>`
 - `CGAL::Alpha_shape_vertex_base_2<AlphaShapeTraits_2>`

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/PackageDescription.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/PackageDescription.txt
@@ -83,7 +83,7 @@ of the alpha complex where singular faces are removed.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `AlphaShapeTraits_3`
 - `WeightedAlphaShapeTraits_3`
 - `AlphaShapeCell_3`
@@ -93,7 +93,7 @@ of the alpha complex where singular faces are removed.
 - `FixedAlphaShapeCell_3`
 - `FixedAlphaShapeVertex_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Alpha_status<NT>`
 - `CGAL::Alpha_shape_3<Dt,ExactAlphaComparisonTag>`
 - `CGAL::Alpha_shape_vertex_base_3<Traits,Vb>`

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/PackageDescription.txt
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/PackageDescription.txt
@@ -40,7 +40,7 @@ aforementioned concepts.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `ApolloniusSite_2`
 - `ApolloniusGraphDataStructure_2`
@@ -48,7 +48,7 @@ aforementioned concepts.
 - `ApolloniusGraphTraits_2`
 - `ApolloniusGraphHierarchyVertexBase_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Apollonius_graph_2<Gt,Agds>`
 - `CGAL::Apollonius_site_2<K>`

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
@@ -87,18 +87,18 @@ implemented as peripheral classes or as free (global) functions.
 
 \cgalClassifedRefPages
 
-## Enumerations ##
+\cgalCRPSection{Enumerations}
 
 - `CGAL::Arr_parameter_space`
 - `CGAL::Arr_curve_end`
 - `CGAL::Arr_halfedge_direction`
 
-## Tags ##
+\cgalCRPSection{Tags}
 
 - `CGAL::Arr_oblivious_side_tag`
 - `CGAL::Arr_open_side_tag`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `ArrangementDcel`
 - `ArrangementDcelWithRebind`
@@ -119,13 +119,13 @@ implemented as peripheral classes or as free (global) functions.
 - `ArrangementPointLocation_2`
 - `ArrangementVerticalRayShoot_2`
 
-## Geometric Object Concepts ##
+\cgalCRPSection{Geometric Object Concepts}
 
 - `ArrTraits::Point_2`
 - `ArrTraits::XMonotoneCurve_2`
 - `ArrTraits::Curve_2`
 
-## Function Object Concepts ##
+\cgalCRPSection{Function Object Concepts}
 
 - `ArrTraits::CompareX_2`
 - `ArrTraits::CompareXy_2`
@@ -149,7 +149,7 @@ implemented as peripheral classes or as free (global) functions.
 - `ArrTraits::Approximate_2`
 - `ArrTraits::ConstructXMonotoneCurve_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Arrangement_2<Traits,Dcel>`
 - `CGAL::Arr_accessor<Arrangement>`
@@ -188,10 +188,10 @@ implemented as peripheral classes or as free (global) functions.
 - `CGAL::Arr_face_index_map<Arrangement>`
 - `CGAL::Arr_point_location_result<Arrangement>`
 
-## Macros ##
+\cgalCRPSection{Macros}
 - \link CGAL_ARR_POINT_LOCATION_VERSION `CGAL_ARR_POINT_LOCATION_VERSION` \endlink
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 - `CGAL::is_valid()`
 - `CGAL::insert()`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -558,7 +558,7 @@ Methods to read and write graphs.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `VertexListGraph`
 - `EdgeListGraph`
 - `HalfedgeGraph`
@@ -568,14 +568,14 @@ Methods to read and write graphs.
 - `FaceListGraph`
 - `MutableFaceGraph`
 
-## Properties ##
+\cgalCRPSection{Properties}
 - `boost::vertex_index_t`
 - `boost::halfedge_index_t`
 - `boost::edge_index_t`
 - `boost::face_index_t`
 - `boost::vertex_point_t`
 
-## %CGAL Classes Adapted for the Graph API ##
+\cgalCRPSection{%CGAL Classes Adapted for the Graph API}
 
 Different \cgal types have been adapted as graphs for the \sc{Bgl}. All
 adapted types are listed here. The pages document which concepts they
@@ -591,7 +591,7 @@ user might encounter.
 - \link BGLOMPAK `boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >` \endlink
 - \link BGLOMTMAK `boost::graph_traits<OpenMesh::TriMesh_ArrayKernelT<K> >` \endlink
 
-## Helper Classes ##
+\cgalCRPSection{Helper Classes}
 - `CGAL::Triangulation_vertex_base_with_id_2`
 - `CGAL::Arr_vertex_index_map`
 - `CGAL::Arr_face_index_map`
@@ -603,7 +603,7 @@ user might encounter.
 - `CGAL::Linear_cell_complex_bgl_min_items`
 - `CGAL::Linear_cell_complex_for_bgl_combinatorial_map_helper`
 
-## Helper Functions ##
+\cgalCRPSection{Helper Functions}
 - `CGAL::is_border()`
 - `CGAL::is_border_edge()`
 - `CGAL::is_bivalent()`
@@ -636,7 +636,7 @@ user might encounter.
 - `CGAL::clear()`
 - `CGAL::copy_face_graph()`
 
-## Iterators ##
+\cgalCRPSection{Iterators}
 - `CGAL::Halfedge_around_source_iterator`
 - `CGAL::Halfedge_around_target_iterator`
 - `CGAL::Halfedge_around_face_iterator`
@@ -652,7 +652,7 @@ user might encounter.
 - `CGAL::vertices_around_face()`
 - `CGAL::vertices_around_target()`
 
-## Circulators ##
+\cgalCRPSection{Circulators}
 - `CGAL::Halfedge_around_source_circulator`
 - `CGAL::Halfedge_around_target_circulator`
 - `CGAL::Halfedge_around_face_circulator`
@@ -660,7 +660,7 @@ user might encounter.
 - `CGAL::Face_around_target_circulator`
 - `CGAL::Face_around_face_circulator`
 
-## Euler Operations ##
+\cgalCRPSection{Euler Operations}
 - `CGAL::Euler::add_center_vertex()`
 - `CGAL::Euler::add_edge()`
 - `CGAL::Euler::add_face()`
@@ -681,7 +681,7 @@ user might encounter.
 - `CGAL::Euler::split_loop()`
 - `CGAL::Euler::split_vertex()`
 
-## Selection ##
+\cgalCRPSection{Selection}
 - `CGAL::expand_face_selection()`
 - `CGAL::reduce_face_selection()`
 - `CGAL::expand_edge_selection()`
@@ -691,21 +691,21 @@ user might encounter.
 - `CGAL::select_incident_faces()`
 - `CGAL::expand_face_selection_for_removal()`
 
-## Conversion Functions ##
+\cgalCRPSection{Conversion Functions}
 - `CGAL::split_graph_into_polylines()`
 
-## Graph Adaptors ##
+\cgalCRPSection{Graph Adaptors}
 - `CGAL::Dual`
 - `CGAL::Face_filtered_graph`
 - `CGAL::Graph_with_descriptor_with_graph`
 - `CGAL::Graph_with_descriptor_with_graph_property_map`
 - `CGAL::Seam_mesh`
 
-## Partitioning Methods ##
+\cgalCRPSection{Partitioning Methods}
 - `CGAL::METIS::partition_graph()`
 - `CGAL::METIS::partition_dual_graph()`
 
-## I/O Functions ##
+\cgalCRPSection{I/O Functions}
 - \link PkgBGLIOFct CGAL::read_off() \endlink
 - \link PkgBGLIOFct CGAL::write_off() \endlink
 - \link PkgBGLIOFct CGAL::write_wrl() \endlink

--- a/BGL/include/CGAL/boost/graph/Dual.h
+++ b/BGL/include/CGAL/boost/graph/Dual.h
@@ -43,8 +43,7 @@ vertices as a source and target. It is possible to filter border edges
 using `boost::filtered_graph` as shown in example
 \ref BGL_surface_mesh/surface_mesh_dual.cpp
 
-Property forwarding
--------------------
+\cgalHeading{Property Forwarding}
 \cgalAdvancedBegin
 Edge properties of the underlying graph are forwarded directly. For
 faces and vertices only the `face_index` and `vertex_index` properties

--- a/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
+++ b/BGL/include/CGAL/boost/graph/Graph_with_descriptor_with_graph.h
@@ -118,8 +118,7 @@ The class `Graph_with_descriptor_with_graph` wraps a graph into another graph in
 For example, calling `source(edge, graph)` will trigger an assertion if `edge` does not belong to `graph`.
 It is mainly used for debugging purposes.
 
-Property forwarding
--------------------
+\cgalHeading{Property Forwarding}
 All internal properties of the underlying graph are forwarded.
 
 Property maps can be wrapped with `Graph_with_descriptor_with_graph_property_map`.

--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
@@ -29,12 +29,12 @@
 \cgalCRPSection{Namespaces}
 - `CGAL::Barycentric_coordinates`
 
-\cgalCRPSection{Classes}
+\cgalCRPSection{General Classes}
 - `CGAL::Barycentric_coordinates::Segment_coordinates_2<Traits>`
 - `CGAL::Barycentric_coordinates::Triangle_coordinates_2<Traits>`
 - `CGAL::Barycentric_coordinates::Generalized_barycentric_coordinates_2<Coordinate_2, Traits>`
 
-## ##
+\cgalCRPSection{Models of `BarycentricCoordinates_2`}
 - `CGAL::Barycentric_coordinates::Wachspress_2<Traits>`
 - `CGAL::Barycentric_coordinates::Mean_value_2<Traits>`
 - `CGAL::Barycentric_coordinates::Discrete_harmonic_2<Traits>`

--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
@@ -22,14 +22,14 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `BarycentricTraits_2`
 - `BarycentricCoordinates_2`
 
-## Namespaces ##
+\cgalCRPSection{Namespaces}
 - `CGAL::Barycentric_coordinates`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Barycentric_coordinates::Segment_coordinates_2<Traits>`
 - `CGAL::Barycentric_coordinates::Triangle_coordinates_2<Traits>`
 - `CGAL::Barycentric_coordinates::Generalized_barycentric_coordinates_2<Coordinate_2, Traits>`
@@ -39,7 +39,7 @@
 - `CGAL::Barycentric_coordinates::Mean_value_2<Traits>`
 - `CGAL::Barycentric_coordinates::Discrete_harmonic_2<Traits>`
 
-## Enumerations ##
+\cgalCRPSection{Enumerations}
 - `CGAL::Barycentric_coordinates::Query_point_location`
 - `CGAL::Barycentric_coordinates::Type_of_algorithm`
 

--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
@@ -33,7 +33,7 @@ containment predicates.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `GpsTraitsGeneralPolygon_2`
 - `GpsTraitsGeneralPolygonWithHoles_2`
 - `GeneralPolygon_2`
@@ -43,7 +43,7 @@ containment predicates.
 - `GeneralPolygonSetDcelFace`
 - `GeneralPolygonSetDcelHalfedge`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Polygon_set_2<Kernel,Container,Dcel>`
 - `CGAL::General_polygon_set_2<Traits,Dcel>`
 - `CGAL::General_polygon_2<ArrTraits>`
@@ -53,7 +53,7 @@ containment predicates.
 - `CGAL::Gps_traits_2<ArrTraits,GeneralPolygon>`
 - `CGAL::Gps_default_dcel<Traits>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - \link boolean_complement `CGAL::complement()` \endlink
 - \link boolean_do_intersect `CGAL::do_intersect()` \endlink
 - \link boolean_intersection `CGAL::intersection()` \endlink

--- a/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
+++ b/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
@@ -20,7 +20,7 @@
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The optimization code uses infix `OPTIMISATION` in the assertions,
 e.g. defining the compiler flag
@@ -29,7 +29,7 @@ checking off, cf. Section  \ref secchecks.
 
 \cgalClassifedRefPages
 
-## Bounding Areas and Volumes ##
+\cgalCRPSection{Bounding Areas and Volumes}
 
 - `CGAL::Min_circle_2<Traits>`
 - `CGAL::Min_circle_2_traits_2<K>`

--- a/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
+++ b/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
@@ -39,16 +39,16 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `BoxIntersectionBox_d`
 - `BoxIntersectionTraits_d`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Box_intersection_d::Box_d<NT,int D,IdPolicy>`
 - `CGAL::Box_intersection_d::Box_with_handle_d<NT, int D, Handle, IdPolicy>`
 - `CGAL::Box_intersection_d::Box_traits_d<BoxHandle>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::box_intersection_d`
 - `CGAL::box_self_intersection_d`
 

--- a/CGAL_ipelets/doc/CGAL_ipelets/PackageDescription.txt
+++ b/CGAL_ipelets/doc/CGAL_ipelets/PackageDescription.txt
@@ -17,7 +17,7 @@
 
 \cgalClassifedRefPages
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Ipelet_base<Kernel,int nbf>`
 
 */

--- a/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
+++ b/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
@@ -44,7 +44,7 @@
 
 - `CircularKernel`
 
-### Functors ###
+\cgalCRPSubsection{Functors}
 
 - `CircularKernel::ConstructLine_2`
 - `CircularKernel::ConstructCircle_2`
@@ -82,16 +82,16 @@
 
 ## Geometric Kernels and Classes ##
 
-### Kernels ###
+\cgalCRPSubsection{Kernels}
 
 - `CGAL::Circular_kernel_2<Kernel,AlgebraicKernelForCircles>`
 - `CGAL::Exact_circular_kernel_2`
 
-### Points ###
+\cgalCRPSubsection{Points}
 
 - `CGAL::Circular_arc_point_2<CircularKernel>`
 
-### Arcs ###
+\cgalCRPSubsection{Arcs}
 
 - `CGAL::Circular_arc_2<CircularKernel>`
 - `CGAL::Line_arc_2<CircularKernel>`
@@ -118,7 +118,7 @@
 
 - `AlgebraicKernelForCircles`
 
-### Functors ###
+\cgalCRPSubsection{Functors}
 
 
 - `AlgebraicKernelForCircles::ConstructPolynomial_1_2`
@@ -133,16 +133,16 @@
 
 ## Algebraic %Kernel and Classes ##
 
-### %Kernel  ###
+\cgalCRPSubsection{%Kernel}
 
 - `CGAL::Algebraic_kernel_for_circles_2_2<RT>`
 
-### Polynomials ###
+\cgalCRPSubsection{Polynomials}
 
 - `CGAL::Polynomial_1_2<RT>`
 - `CGAL::Polynomial_for_circles_2_2<FT>`
 
-### Roots of Polynomials ###
+\cgalCRPSubsection{Roots of Polynomials}
 
 - `CGAL::Sqrt_extension<NT,ROOT>`
 - `CGAL::Root_for_circles_2_2<FT>`

--- a/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
+++ b/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
@@ -40,7 +40,7 @@
 
 \cgalClassifedRefPages
 
-## Geometric Concepts ##
+\cgalCRPSection{Geometric Concepts}
 
 - `CircularKernel`
 
@@ -80,7 +80,7 @@
 - `CircularKernel::Split_2`
 - `CircularKernel::GetEquation`
 
-## Geometric Kernels and Classes ##
+\cgalCRPSection{Geometric Kernels and Classes}
 
 \cgalCRPSubsection{Kernels}
 
@@ -96,7 +96,7 @@
 - `CGAL::Circular_arc_2<CircularKernel>`
 - `CGAL::Line_arc_2<CircularKernel>`
 
-## Geometric Global Functions ##
+\cgalCRPSection{Geometric Global Functions}
 
 - \link compare_x_circular_grp `CGAL::compare_x()` \endlink
 - \link compare_y_circular_grp `CGAL::compare_y()` \endlink
@@ -114,7 +114,7 @@
 - `CGAL::make_x_monotone()`
 - `CGAL::make_xy_monotone()`
 
-## Algebraic Concepts ##
+\cgalCRPSection{Algebraic Concepts}
 
 - `AlgebraicKernelForCircles`
 
@@ -131,7 +131,7 @@
 - `AlgebraicKernelForCircles::YCriticalPoints`
 - `AlgebraicKernelForCircles::Solve`
 
-## Algebraic %Kernel and Classes ##
+\cgalCRPSection{Algebraic %Kernel and Classes}
 
 \cgalCRPSubsection{%Kernel}
 

--- a/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
+++ b/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
@@ -103,7 +103,7 @@
 - `CGAL::Line_arc_3<SphericalKernel>`
 - `CGAL::Circular_arc_3<SphericalKernel>`
 
-### Constants and Enumerations ###
+## Constants and Enumerations ##
 
 - `CGAL::Circle_type`
 

--- a/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
+++ b/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
@@ -36,7 +36,7 @@
 
 \cgalClassifedRefPages
 
-## Geometric Concepts ##
+\cgalCRPSection{Geometric Concepts}
 
 - `SphericalKernel`
 
@@ -87,7 +87,7 @@
 - `SphericalKernel::ComputeApproximateAngle_3`
 - `SphericalKernel::GetEquation`
 
-## Geometric Kernels and Classes ##
+\cgalCRPSection{Geometric Kernels and Classes}
 
 \cgalCRPSubsection{Kernels}
 
@@ -103,11 +103,11 @@
 - `CGAL::Line_arc_3<SphericalKernel>`
 - `CGAL::Circular_arc_3<SphericalKernel>`
 
-## Constants and Enumerations ##
+\cgalCRPSection{Constants and Enumerations}
 
 - `CGAL::Circle_type`
 
-## Geometric Global Functions ##
+\cgalCRPSection{Geometric Global Functions}
 
 - \link compare_x_spherical_grp `CGAL::compare_x()` \endlink
 - \link compare_y_spherical_grp `CGAL::compare_y()` \endlink
@@ -129,7 +129,7 @@
 - \link do_intersect_grp `CGAL::do_intersect()` \endlink
 - \link intersection_grp `CGAL::intersection()` \endlink
 
-## Algebraic Concepts ##
+\cgalCRPSection{Algebraic Concepts}
 
 - `AlgebraicKernelForSpheres`
 
@@ -149,7 +149,7 @@
 - `AlgebraicKernelForSpheres::ZCriticalPoints`
 - `AlgebraicKernelForSpheres::Solve`
 
-## Algebraic %Kernel and Classes ##
+\cgalCRPSection{Algebraic %Kernel and Classes}
 
 \cgalCRPSubsection{%Kernel}
 

--- a/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
+++ b/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
@@ -40,13 +40,13 @@
 
 - `SphericalKernel`
 
-### Object types ###
+\cgalCRPSubsection{Object types}
 
 - `SphericalKernel::CircularArc_3`
 - `SphericalKernel::CircularArcPoint_3`
 - `SphericalKernel::LineArc_3`
 
-### Functors ###
+\cgalCRPSubsection{Functors}
 
 - `SphericalKernel::ConstructPlane_3`
 - `SphericalKernel::ConstructSphere_3`
@@ -89,16 +89,16 @@
 
 ## Geometric Kernels and Classes ##
 
-### Kernels ###
+\cgalCRPSubsection{Kernels}
 
 - `CGAL::Spherical_kernel_3<Kernel,AlgebraicKernelForSpheres>`
 - `CGAL::Exact_spherical_kernel_3`
 
-### Points ###
+\cgalCRPSubsection{Points}
 
 - `CGAL::Circular_arc_point_3<SphericalKernel>`
 
-### Arcs ###
+\cgalCRPSubsection{Arcs}
 
 - `CGAL::Line_arc_3<SphericalKernel>`
 - `CGAL::Circular_arc_3<SphericalKernel>`
@@ -133,7 +133,7 @@
 
 - `AlgebraicKernelForSpheres`
 
-### Functors ###
+\cgalCRPSubsection{Functors}
 
 - `AlgebraicKernelForSpheres::ConstructPolynomial_1_3`
 - `AlgebraicKernelForSpheres::ConstructPolynomialForSpheres_2_3`
@@ -151,17 +151,17 @@
 
 ## Algebraic %Kernel and Classes ##
 
-### %Kernel ###
+\cgalCRPSubsection{%Kernel}
 
 - `CGAL::Algebraic_kernel_for_spheres_2_3<RT>`
 
-### Polynomials ###
+\cgalCRPSubsection{Polynomials}
 
 - `CGAL::Polynomial_1_3<RT>`
 - `CGAL::Polynomial_for_spheres_2_3<FT>`
 - `CGAL::Polynomials_for_lines_3<FT>`
 
-### Roots of Polynomials ###
+\cgalCRPSubsection{Roots of Polynomials}
 
 - `CGAL::Sqrt_extension<NT,ROOT>`
 - `CGAL::Root_for_spheres_2_3<RT>`

--- a/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
+++ b/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
@@ -40,7 +40,7 @@
 
 - `SphericalKernel`
 
-\cgalCRPSubsection{Object types}
+\cgalCRPSubsection{Object Types}
 
 - `SphericalKernel::CircularArc_3`
 - `SphericalKernel::CircularArcPoint_3`

--- a/Circulator/doc/Circulator/PackageDescription.txt
+++ b/Circulator/doc/Circulator/PackageDescription.txt
@@ -58,7 +58,7 @@ circulators as well as with iterators.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `Handle`
 - `Range`
 - `ConstRange`
@@ -67,7 +67,7 @@ circulators as well as with iterators.
 - `BidirectionalCirculator`
 - `RandomAccessCirculator`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Container_from_circulator<C>`
 - `CGAL::Circulator_from_iterator<I>`
 - `CGAL::Circulator_from_container<C>`

--- a/Classification/doc/Classification/PackageDescription.txt
+++ b/Classification/doc/Classification/PackageDescription.txt
@@ -88,43 +88,43 @@ Data structures specialized to classify clusters.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `CGAL::Classification::Classifier`
 - `CGAL::Classification::NeighborQuery`
 
-## Main Functions ##
+\cgalCRPSection{Main Functions}
 
 - `CGAL::Classification::classify()`
 - `CGAL::Classification::classify_with_local_smoothing()`
 - `CGAL::Classification::classify_with_graphcut()`
 
-## Classifiers ##
+\cgalCRPSection{Classifiers}
 
 - `CGAL::Classification::ETHZ::Random_forest_classifier`
 - `CGAL::Classification::OpenCV::Random_forest_classifier`
 - `CGAL::Classification::TensorFlow::Neural_network_classifier<ActivationFunction>`
 - `CGAL::Classification::Sum_of_weighted_features_classifier`
 
-## Common Data Structures ##
+\cgalCRPSection{Common Data Structures}
 
 - `CGAL::Classification::Local_eigen_analysis`
 - `CGAL::Classification::Planimetric_grid<GeomTraits, PointRange, PointMap>`
 - `CGAL::Classification::Evaluation`
 
-## Label ##
+\cgalCRPSection{Label}
 
 - `CGAL::Classification::Label`
 - `CGAL::Classification::Label_handle`
 - `CGAL::Classification::Label_set`
 
-## Feature ##
+\cgalCRPSection{Feature}
 
 - `CGAL::Classification::Feature_base`
 - `CGAL::Classification::Feature_handle`
 - `CGAL::Classification::Feature_set`
 
-## Predefined Features ##
+\cgalCRPSection{Predefined Features}
 
 - `CGAL::Classification::Feature::Color_channel<GeomTraits, PointRange, ColorMap>`
 - `CGAL::Classification::Feature::Distance_to_plane<PointRange, PointMap>`
@@ -138,19 +138,19 @@ Data structures specialized to classify clusters.
 - `CGAL::Classification::Feature::Vertical_range<GeomTraits, PointRange, PointMap>`
 - `CGAL::Classification::Feature::Verticality<GeomTraits>`
 
-## Point Set Classification ##
+\cgalCRPSection{Point Set Classification}
 
 - `CGAL::Classification::Point_set_feature_generator<GeomTraits, PointRange, PointMap, ConcurrencyTag, DiagonalizeTraits>`
 - `CGAL::Classification::Point_set_neighborhood<GeomTraits, PointRange, PointMap>`
 
-## Mesh Classification ##
+\cgalCRPSection{Mesh Classification}
 
 - `CGAL::Classification::Mesh_feature_generator<GeomTraits, FaceGraph, PointMap, ConcurrencyTag, DiagonalizeTraits>`
 - `CGAL::Classification::Mesh_neighborhood<FaceListGraph>`
 - `CGAL::Classification::Face_descriptor_to_center_of_mass_map<FaceListGraph, VertexPointMap>`
 - `CGAL::Classification::Face_descriptor_to_face_descriptor_with_bbox_map<FaceListGraph, VertexPointMap>`
 
-## Cluster Classification ##
+\cgalCRPSection{Cluster Classification}
 
 - `CGAL::Classification::Cluster<ItemRange, ItemMap>`
 - `CGAL::Classification::create_clusters_from_indices()`

--- a/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
+++ b/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
@@ -54,13 +54,13 @@
 - `CGAL::Generic_map_min_items`
 
 ## Global Functions ##
-### Constructions for Combinatorial Maps ###
+\cgalCRPSubsection{Constructions for Combinatorial Maps}
 - `CGAL::make_edge<CMap>`
 - `CGAL::make_combinatorial_polygon<CMap>`
 - `CGAL::make_combinatorial_tetrahedron<CMap>`
 - `CGAL::make_combinatorial_hexahedron<CMap>`
 
-### Operations for Combinatorial Maps ###
+\cgalCRPSubsection{Operations for Combinatorial Maps}
 - `CGAL::is_removable<CMap,i>`
 - `CGAL::remove_cell<CMap,i>`
 - `CGAL::is_insertable_cell_1_in_cell_2<CMap>`

--- a/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
+++ b/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
@@ -41,19 +41,19 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `GenericMap`
 - `GenericMapItems`
 - `CellAttribute`
 - `CombinatorialMap`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Combinatorial_map<d,Items,Alloc>`
 - `CGAL::Cell_attribute<CMap,Info_,Tag,OnMerge,OnSplit>`
 - `CGAL::Cell_attribute_with_id<CMap,Info_,Tag,OnMerge,OnSplit>`
 - `CGAL::Generic_map_min_items`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 \cgalCRPSubsection{Constructions for Combinatorial Maps}
 - `CGAL::make_edge<CMap>`
 - `CGAL::make_combinatorial_polygon<CMap>`

--- a/Cone_spanners_2/doc/Cone_spanners_2/PackageDescription.txt
+++ b/Cone_spanners_2/doc/Cone_spanners_2/PackageDescription.txt
@@ -32,15 +32,15 @@ This package also provides options for the Half Yao graph and the Half Theta gra
 \cgalClassifedRefPages
 
 
-## Functors ##
+\cgalCRPSection{Functors}
 - `CGAL::Compute_cone_boundaries_2`
 - `CGAL::Construct_yao_graph_2`
 - `CGAL::Construct_theta_graph_2`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::gnuplot_output_2()`
 
-## Enumerations ##
+\cgalCRPSection{Enumerations}
 - `CGAL::Cones_selected`
 
 */

--- a/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
+++ b/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
@@ -19,7 +19,7 @@
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::convex_decomposition_3(Nef_polyhedron_3& N)`
 
 */

--- a/Convex_hull_2/doc/Convex_hull_2/PackageDescription.txt
+++ b/Convex_hull_2/doc/Convex_hull_2/PackageDescription.txt
@@ -51,7 +51,7 @@ upper hull of a set of points.
 
 \cgalClassifedRefPages
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The assertion flags for the convex hull and extreme point algorithms
 use `CH` in their names (<I>e.g.</I>, `CGAL_CH_NO_POSTCONDITIONS`).
@@ -61,16 +61,16 @@ input points in the polygon or polyhedron defined by the output points.
 The latter is considered an expensive checking and can be enabled by
 defining `CGAL_CH_CHECK_EXPENSIVE`.
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `ConvexHullTraits_2`
 
-## Traits Classes ##
+\cgalCRPSection{Traits Classes}
 
 - `CGAL::Convex_hull_constructive_traits_2<R>`
 - `CGAL::Convex_hull_traits_2<R>`
 
-## Convex Hull Functions ##
+\cgalCRPSection{Convex Hull Functions}
 
 - `CGAL::ch_akl_toussaint()`
 - `CGAL::ch_bykat()`
@@ -80,19 +80,19 @@ defining `CGAL_CH_CHECK_EXPENSIVE`.
 - `CGAL::ch_melkman()`
 - `CGAL::convex_hull_2()`
 
-## Convexity Checking Functions ##
+\cgalCRPSection{Convexity Checking Functions}
 
 - `CGAL::is_ccw_strongly_convex_2()`
 - `CGAL::is_cw_strongly_convex_2()`
 
-## Hull Subsequence Functions ##
+\cgalCRPSection{Hull Subsequence Functions}
 
 - `CGAL::ch_graham_andrew_scan()`
 - `CGAL::ch_jarvis_march()`
 - `CGAL::lower_hull_points_2()`
 - `CGAL::upper_hull_points_2()`
 
-## Extreme Point Functions ##
+\cgalCRPSection{Extreme Point Functions}
 
 - `CGAL::ch_e_point()`
 - `CGAL::ch_nswe_point()`

--- a/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
@@ -51,7 +51,7 @@ and arbitrary dimensions as well as functions for testing if a given set of
 points in is strongly convex or not.  This chapter describes the functions
 available for three dimensions.
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 The assertion flags for the convex hull and extreme point algorithms
 use `CH` in their names (<I>e.g.</I>, `CGAL_CH_NO_POSTCONDITIONS`).
 For the convex hull algorithms, the postcondition
@@ -62,27 +62,27 @@ defining `CGAL_CH_CHECK_EXPENSIVE`.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `ConvexHullTraits_3`
 - `IsStronglyConvexTraits_3`
 
-## Traits Classes ##
+\cgalCRPSection{Traits Classes}
 
 - `CGAL::Convex_hull_traits_3<R>`
 - `CGAL::Extreme_points_traits_adapter_3`
 
-## Convex Hull Functions ##
+\cgalCRPSection{Convex Hull Functions}
 
 - `CGAL::convex_hull_3`
 - `CGAL::extreme_points_3`
 - `CGAL::make_extreme_points_traits_adapter`
 
-## Convexity Checking Function ##
+\cgalCRPSection{Convexity Checking Function}
 
 - `CGAL::is_strongly_convex_3`
 
-## Halfspace Intersection Functions ##
+\cgalCRPSection{Halfspace Intersection Functions}
 
 - `CGAL::halfspace_intersection_3`
 - `CGAL::halfspace_intersection_with_constructions_3`

--- a/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
+++ b/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
@@ -37,7 +37,7 @@ computing the nearest and furthest site Delaunay triangulation.
 
 \cgalClassifedRefPages
 
-## Concepts #
+\cgalCRPSection{Concepts}
 - `ConvexHullTraits_d`
 - `DelaunayLiftedTraits_d`
 - `DelaunayTraits_d`

--- a/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
+++ b/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
@@ -42,7 +42,7 @@ computing the nearest and furthest site Delaunay triangulation.
 - `DelaunayLiftedTraits_d`
 - `DelaunayTraits_d`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Convex_hull_d_traits_3<R>`
 - `CGAL::Convex_hull_d<R>`
 - `CGAL::Delaunay_d< R, Lifted_R > `

--- a/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
@@ -291,6 +291,8 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalTagFalse=\link CGAL::Tag_false `CGAL::Tag_false`\endlink" \
                          "cgalHeading{1}= <B>\1</B><BR>" \
                          "cgalClassifedRefPages=\htmlonly  <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly" \
+                         "cgalCRPSection{1}=<h2>\1</h2>" \
+                         "cgalCRPSubsection{1}=<h3>\1</h3>" \
                          "cgalCite{1}=<!-- -->\cite \1"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
@@ -292,6 +292,8 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalTagFalse=\link CGAL::Tag_false `CGAL::Tag_false`\endlink" \
                          "cgalHeading{1}= <B>\1</B><BR>" \
                          "cgalClassifedRefPages=\htmlonly[block] <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly" \
+                         "cgalCRPSection{1}=<h2>\1</h2>" \
+                         "cgalCRPSubsection{1}=<h3>\1</h3>" \
                          "cgalCite{1}=<!-- -->\cite \1"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/Documentation/doc/resources/1.8.4/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.4/BaseDoxyfile.in
@@ -293,6 +293,9 @@ ALIASES+= "cgalHeading{1}= <B>\1</B><BR>"
 
 ALIASES+= "cgalClassifedRefPages=\htmlonly  <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly"
 
+ALIASES+= "cgalCRPSection{1}=<h2>\1</h2>"
+ALIASES+= "cgalCRPSubsection{1}=<h3>\1</h3>"
+
 ALIASES+= "cgalCite{1}=<!-- -->\cite \1"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/Envelope_2/doc/Envelope_2/PackageDescription.txt
+++ b/Envelope_2/doc/Envelope_2/PackageDescription.txt
@@ -27,18 +27,18 @@ induce the envelope over each interval is unique.
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::lower_envelope_2`
 - `CGAL::upper_envelope_2`
 - `CGAL::lower_envelope_x_monotone_2`
 - `CGAL::upper_envelope_x_monotone_2`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `EnvelopeDiagram_1`
 - `EnvelopeDiagramVertex`
 - `EnvelopeDiagramEdge`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Envelope_diagram_1<Traits> `
 
 */

--- a/Envelope_3/doc/Envelope_3/PackageDescription.txt
+++ b/Envelope_3/doc/Envelope_3/PackageDescription.txt
@@ -28,16 +28,16 @@ diagram cell is unique.
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::lower_envelope_3`
 - `CGAL::upper_envelope_3`
 - `CGAL::lower_envelope_xy_monotone_3`
 - `CGAL::upper_envelope_xy_monotone_3`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `EnvelopeTraits_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Envelope_diagram_2<EnvTraits>`
 
 - `CGAL::Env_triangle_traits_3<Kernel>`

--- a/Generalized_map/doc/Generalized_map/PackageDescription.txt
+++ b/Generalized_map/doc/Generalized_map/PackageDescription.txt
@@ -24,13 +24,13 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `GenericMap`
 - `GenericMapItems`
 - `CellAttribute`
 - `GeneralizedMap`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Generalized_map<d,Items,Alloc>`
 - `CGAL::Cell_attribute<GMap,Info_,Tag,OnMerge,OnSplit>`
 - `CGAL::Generic_map_min_items<d>`

--- a/Generator/doc/Generator/PackageDescription.txt
+++ b/Generator/doc/Generator/PackageDescription.txt
@@ -31,14 +31,14 @@ achieve random permutations for otherwise regular generators (
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `PointGenerator`
 - `RandomConvexSetTraits_2`
 - `RandomPolygonTraits_2`
 - `RandomConvexHullTraits_2`
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 - `CGAL::perturb_points_2()` 
 - `CGAL::points_on_segment_2()` 
@@ -52,7 +52,7 @@ achieve random permutations for otherwise regular generators (
 - `CGAL::random_convex_hull_in_disc_2()`
 - `CGAL::get_default_random()` 
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Random` 
 - `CGAL::Points_on_segment_2<Point_2>` 
@@ -75,7 +75,7 @@ achieve random permutations for otherwise regular generators (
 - `CGAL::Random_points_on_sphere_d<Point_d>` 
 - `CGAL::Random_points_on_square_2<Point_2, Creator>` 
 
-## Traits Class ##
+\cgalCRPSection{Traits Class}
 
 - `CGAL::Random_convex_set_traits_2<Kernel>` 
 

--- a/Geomview/doc/Geomview/PackageDescription.txt
+++ b/Geomview/doc/Geomview/PackageDescription.txt
@@ -18,7 +18,7 @@
 
 \cgalClassifedRefPages
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Geomview_stream`
 
 */

--- a/GraphicsView/doc/GraphicsView/PackageDescription.txt
+++ b/GraphicsView/doc/GraphicsView/PackageDescription.txt
@@ -31,21 +31,21 @@ View Framework</A>.
 
 \cgalClassifedRefPages
 
-## GraphicsItem Classes ##
+\cgalCRPSection{GraphicsItem Classes}
 
 - `CGAL::Qt::GraphicsItem`
 - `CGAL::Qt::TriangulationGraphicsItem<T>`
 - `CGAL::Qt::ConstrainedTriangulationGraphicsItem<CT>`
 - `CGAL::Qt::VoronoiGraphicsItem<DT>`
 
-## Input Classes ##
+\cgalCRPSection{Input Classes}
 - `CGAL::Qt::GraphicsViewInput`
 - `CGAL::Qt::GraphicsViewCircleInput<K>`
 - `CGAL::Qt::GraphicsViewCircularArcInput<K>`
 - `CGAL::Qt::GraphicsViewIsoRectangleInput<K>`
 - `CGAL::Qt::GraphicsViewPolylineInput<K>`
 
-## Miscellaneous Classes ##
+\cgalCRPSection{Miscellaneous Classes}
 - `CGAL::Qt::Converter<K>`
 - `CGAL::Qt::PainterOstream<K>`
 - `CGAL::Qt::GraphicsViewNavigation`

--- a/HalfedgeDS/doc/HalfedgeDS/PackageDescription.txt
+++ b/HalfedgeDS/doc/HalfedgeDS/PackageDescription.txt
@@ -60,14 +60,14 @@ found in \cgalCite{k-ugpdd-99}.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `HalfedgeDS<Traits,Items,Alloc>`
 - `HalfedgeDSItems`
 - `HalfedgeDSVertex`
 - `HalfedgeDSHalfedge`
 - `HalfedgeDSFace`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::HalfedgeDS_default<Traits,HalfedgeDSItems,Alloc>`
 - `CGAL::HalfedgeDS_list<Traits,HalfedgeDSItems,Alloc>`
 - `CGAL::HalfedgeDS_vector<Traits,HalfedgeDSItems,Alloc>`

--- a/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
+++ b/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
@@ -32,15 +32,15 @@ source vertices. }
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `HeatMethodTraits_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Heat_method_3::Surface_mesh_geodesic_distances_3`
 - `CGAL::Heat_method_3::Direct`
 - `CGAL::Heat_method_3::Intrinsic_Delaunay`
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 - `CGAL::Heat_method_3::estimate_geodesic_distances()`
 

--- a/Inscribed_areas/doc/Inscribed_areas/PackageDescription.txt
+++ b/Inscribed_areas/doc/Inscribed_areas/PackageDescription.txt
@@ -22,7 +22,7 @@
 \cgalPkgDescriptionEnd
 
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The optimization code uses infix `OPTIMISATION` in the assertions,
 e.g. defining the compiler flag

--- a/Interpolation/doc/Interpolation/PackageDescription.txt
+++ b/Interpolation/doc/Interpolation/PackageDescription.txt
@@ -88,11 +88,11 @@ User Manual \endlink.
 - `CGAL::Interpolation_traits_2<K>`
 - `CGAL::Interpolation_gradient_fitting_traits_2<K>`
 
-\cgalCRPSection{Natural neighbor coordinate computation}
+\cgalCRPSection{Natural Neighbor Coordinate Computation}
 - `CGAL::natural_neighbor_coordinates_2()`
 - `CGAL::regular_neighbor_coordinates_2()`
 
-\cgalCRPSection{Surface neighbor and surface neighbor coordinate computation}
+\cgalCRPSection{Surface Neighbor and Surface Neighbor Coordinate Computation}
 - `CGAL::Voronoi_intersection_2_traits_3<K>`
 - `CGAL::surface_neighbor_coordinates_3()`
 - `CGAL::surface_neighbors_3()`

--- a/Interpolation/doc/Interpolation/PackageDescription.txt
+++ b/Interpolation/doc/Interpolation/PackageDescription.txt
@@ -43,7 +43,7 @@ these interpolation functions depend on the properties of the
 barycentric coordinates. They are provided in this package under the
 names `linear_interpolation()` and `quadratic_interpolation()`.
 
-## Natural Neighbor Interpolation ##
+\cgalCRPSection{Natural Neighbor Interpolation}
 
 Natural neighbor coordinates are defined by Sibson in 1980 and are based on the Voronoi
 diagram of the data points. Interpolation methods based on natural
@@ -74,11 +74,11 @@ User Manual \endlink.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `InterpolationTraits`
 - `GradientFittingTraits`
 
-## Interpolation Functions ##
+\cgalCRPSection{Interpolation Functions}
 - `CGAL::linear_interpolation()`
 - `CGAL::sibson_c1_interpolation()`
 - `CGAL::farin_c1_interpolation()`
@@ -88,11 +88,11 @@ User Manual \endlink.
 - `CGAL::Interpolation_traits_2<K>`
 - `CGAL::Interpolation_gradient_fitting_traits_2<K>`
 
-## Natural neighbor coordinate computation ##
+\cgalCRPSection{Natural neighbor coordinate computation}
 - `CGAL::natural_neighbor_coordinates_2()`
 - `CGAL::regular_neighbor_coordinates_2()`
 
-## Surface neighbor and surface neighbor coordinate computation ##
+\cgalCRPSection{Surface neighbor and surface neighbor coordinate computation}
 - `CGAL::Voronoi_intersection_2_traits_3<K>`
 - `CGAL::surface_neighbor_coordinates_3()`
 - `CGAL::surface_neighbors_3()`

--- a/Interval_skip_list/doc/Interval_skip_list/PackageDescription.txt
+++ b/Interval_skip_list/doc/Interval_skip_list/PackageDescription.txt
@@ -39,10 +39,10 @@ the interval skip list class is parameterized.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `Interval`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Interval_skip_list<Interval>`
 - `CGAL::Interval_skip_list_interval<Value>`
 - `CGAL::Level_interval<FaceHandle>`

--- a/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
@@ -22,17 +22,17 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `DataKernel`
 - `LocalKernel`
 
 
-## Classes ##
+\cgalCRPSection{Classes}
 - \link CGAL::Monge_via_jet_fitting::Monge_form `CGAL::Monge_via_jet_fitting< DataKernel, LocalKernel, SvdTraits>::Monge_form` \endlink
 - `CGAL::Monge_via_jet_fitting<DataKernel, LocalKernel, SvdTraits>`
 
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 The insert operator (operator<< ) is overloaded for the class \link CGAL::Monge_via_jet_fitting::Monge_form `Monge_form` \endlink. 
 
 */

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -497,7 +497,7 @@
 - `Kernel::SideOfOrientedCircle_2`
 - `Kernel::SideOfOrientedSphere_3`
 
-## Dimension handling tools ##
+## Dimension Handling Tools ##
 
 - `CGAL::Ambient_dimension<T, K>`
 - `CGAL::Feature_dimension<T, K>`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -51,11 +51,11 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `Kernel`
 
-## %Kernel Classes and Operations ##
+\cgalCRPSection{%Kernel Classes and Operations}
 
 - `CGAL::Cartesian<FieldNumberType>`
 - `CGAL::Cartesian_converter<K1, K2, NTConverter>`
@@ -72,13 +72,13 @@
 - `CGAL::Simple_homogeneous<RingNumberType>`
 - `CGAL::Projection_traits_xy_3<K>`
 
-## Predefined Kernels ##
+\cgalCRPSection{Predefined Kernels}
 
 - `CGAL::Exact_predicates_exact_constructions_kernel`
 - `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt`
 - `CGAL::Exact_predicates_inexact_constructions_kernel`
 
-## %Kernel Objects ##
+\cgalCRPSection{%Kernel Objects}
 
 \cgalCRPSubsection{Two-dimensional Objects}
 
@@ -114,7 +114,7 @@
 - `CGAL::Weighted_point_3<Kernel>`
 
 
-## Constants and Enumerations ##
+\cgalCRPSection{Constants and Enumerations}
 
 - `CGAL::Angle`
 - `CGAL::Bounded_side`
@@ -139,7 +139,7 @@
 - `CGAL::Scaling`
 - `CGAL::Translation`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 
 - \link angle_grp `CGAL::angle()` \endlink
 - \link are_ordered_along_line_grp `CGAL::are_ordered_along_line()` \endlink
@@ -222,7 +222,7 @@
 - \link y_equal_grp `CGAL::y_equal()` \endlink
 - \link z_equal_grp `CGAL::z_equal()` \endlink
 
-## %Kernel Geometric Object Concepts ##
+\cgalCRPSection{%Kernel Geometric Object Concepts}
 
 - `Kernel::Circle_2`
 - `Kernel::Circle_3`
@@ -250,7 +250,7 @@
 - `Kernel::WeightedPoint_2`
 - `Kernel::WeightedPoint_3`
 
-## %Kernel Function Object Concepts ##
+\cgalCRPSection{%Kernel Function Object Concepts}
 
 - `Kernel::Angle_2`
 - `Kernel::Angle_3`
@@ -497,7 +497,7 @@
 - `Kernel::SideOfOrientedCircle_2`
 - `Kernel::SideOfOrientedSphere_3`
 
-## Dimension Handling Tools ##
+\cgalCRPSection{Dimension Handling Tools}
 
 - `CGAL::Ambient_dimension<T, K>`
 - `CGAL::Feature_dimension<T, K>`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -80,7 +80,7 @@
 
 ## %Kernel Objects ##
 
-### Two-dimensional Objects ###
+\cgalCRPSubsection{Two-dimensional Objects}
 
 - `CGAL::Aff_transformation_2<Kernel>`
 - `CGAL::Bbox_2`
@@ -95,7 +95,7 @@
 - `CGAL::Vector_2<Kernel>`
 - `CGAL::Weighted_point_2<Kernel>`
 
-### Three-dimensional Objects ###
+\cgalCRPSubsection{Three-dimensional Objects}
 
 - `CGAL::Bbox_3`
 - `CGAL::Aff_transformation_3<Kernel>`

--- a/Kernel_d/doc/Kernel_d/PackageDescription.txt
+++ b/Kernel_d/doc/Kernel_d/PackageDescription.txt
@@ -38,19 +38,19 @@
 
 \cgalClassifedRefPages
 
-## Linear Algebra Concepts and Classes ##
+\cgalCRPSection{Linear Algebra Concepts and Classes}
 - `LinearAlgebraTraits_d`
 - `Vector`
 - `Matrix`
 - `CGAL::Linear_algebraCd<FT>`
 - `CGAL::Linear_algebraHd<RT>`
 
-## Kernels ##
+\cgalCRPSection{Kernels}
 - `CGAL::Cartesian_d<FieldNumberType>`
 - `CGAL::Homogeneous_d<RingNumberType>`
 - `CGAL::Epick_d<DimensionTag>`
 
-## %Kernel Objects ##
+\cgalCRPSection{%Kernel Objects}
 - `CGAL::Point_d<Kernel>`
 - `CGAL::Vector_d<Kernel>`
 - `CGAL::Direction_d<Kernel>`
@@ -62,7 +62,7 @@
 - `CGAL::Iso_box_d<Kernel>`
 - `CGAL::Aff_transformation_d<Kernel>`
 
-## Global %Kernel Functions ##
+\cgalCRPSection{Global %Kernel Functions}
 - `CGAL::affinely_independent()`
 - `CGAL::affine_rank()`
 - `CGAL::center_of_sphere()`
@@ -85,7 +85,7 @@
 - `CGAL::side_of_oriented_sphere()`
 - `CGAL::squared_distance`
 
-## %Kernel Concept ##
+\cgalCRPSection{%Kernel Concept}
 - `Kernel_d`
 - `Kernel_d::Affinely_independent_d`
 - `Kernel_d::Affine_rank_d`

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -65,16 +65,16 @@
 - `CGAL::Linear_cell_complex<d,d2,LCCTraits,Items,Alloc>`
 
 ## Global Functions ##
-### Constructions for Linear Cell Complex ###
+\cgalCRPSubsection{Constructions for Linear Cell Complex}
 - `CGAL::import_from_plane_graph<LCC>`
 - `CGAL::import_from_triangulation_3<LCC,Triangulation>`
 - `CGAL::import_from_polyhedron_3<LCC,Polyhedron>`
 
-### Operations for Linear Cell Complex ###
+\cgalCRPSubsection{Operations for Linear Cell Complex}
 - `CGAL::compute_normal_of_cell_0<LCC>`
 - `CGAL::compute_normal_of_cell_2<LCC>`
 
-### Draw a Linear cell complex ###
+\cgalCRPSubsection{Draw a Linear cell complex}
 - `CGAL::draw<LCC>`
 
 */

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -74,7 +74,7 @@
 - `CGAL::compute_normal_of_cell_0<LCC>`
 - `CGAL::compute_normal_of_cell_2<LCC>`
 
-\cgalCRPSubsection{Draw a Linear cell complex}
+\cgalCRPSubsection{Draw a Linear Cell Complex}
 - `CGAL::draw<LCC>`
 
 */

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -49,13 +49,13 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `CellAttributeWithPoint`
 - `LinearCellComplexItems`
 - `LinearCellComplexTraits`
 - `LinearCellComplex`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Linear_cell_complex_for_combinatorial_map<d,d2,LCCTraits,Items,Alloc>`
 - `CGAL::Linear_cell_complex_for_generalized_map<d,d2,LCCTraits,Items,Alloc>`
 - `CGAL::Linear_cell_complex_min_items<d>`
@@ -64,7 +64,7 @@
 - `CGAL::Cell_attribute_with_point_and_id<LCC,Info_,Tag,OnMerge,OnSplit>`
 - `CGAL::Linear_cell_complex<d,d2,LCCTraits,Items,Alloc>`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 \cgalCRPSubsection{Constructions for Linear Cell Complex}
 - `CGAL::import_from_plane_graph<LCC>`
 - `CGAL::import_from_triangulation_3<LCC,Triangulation>`

--- a/Matrix_search/doc/Matrix_search/PackageDescription.txt
+++ b/Matrix_search/doc/Matrix_search/PackageDescription.txt
@@ -23,7 +23,7 @@
 This chapter describes concepts, classes, and functions for 
 monotone and sorted matrix search.
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The optimization code uses infix `OPTIMISATION` in the assertions,
 e.g. defining the compiler flag

--- a/Mesh_2/doc/Mesh_2/PackageDescription.txt
+++ b/Mesh_2/doc/Mesh_2/PackageDescription.txt
@@ -41,14 +41,14 @@ The package can handle intersecting input constraints  and set no restriction on
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `ConformingDelaunayTriangulationTraits_2`
 - `DelaunayMeshTraits_2`
 - `MeshingCriteria_2`
 - `DelaunayMeshFaceBase_2`
 - `DelaunayMeshVertexBase_2`
 
-## Classes##
+\cgalCRPSection{Classes}
 - `CGAL::Triangulation_conformer_2<CDT>`
 - `CGAL::Delaunay_mesher_2<CDT, Criteria>`
 - `CGAL::Delaunay_mesh_face_base_2<Traits, Fb>`
@@ -57,16 +57,16 @@ The package can handle intersecting input constraints  and set no restriction on
 - `CGAL::Delaunay_mesh_size_criteria_2<CDT>`
 - `CGAL::Mesh_2::Face_badness`
 
-## Global functions ##
+\cgalCRPSection{Global functions}
 - `CGAL::make_conforming_Delaunay_2`
 - `CGAL::make_conforming_Gabriel_2`
 - `CGAL::refine_Delaunay_mesh_2`
 - `CGAL::lloyd_optimize_mesh_2`
 
-## I/O Functions ##
+\cgalCRPSection{I/O Functions}
 - `CGAL::write_vtu()`
 
-## Enumerations ##
+\cgalCRPSection{Enumerations}
 - `CGAL::Mesh_optimization_return_code`
 
 */

--- a/Mesh_2/doc/Mesh_2/PackageDescription.txt
+++ b/Mesh_2/doc/Mesh_2/PackageDescription.txt
@@ -57,7 +57,7 @@ The package can handle intersecting input constraints  and set no restriction on
 - `CGAL::Delaunay_mesh_size_criteria_2<CDT>`
 - `CGAL::Mesh_2::Face_badness`
 
-\cgalCRPSection{Global functions}
+\cgalCRPSection{Global Functions}
 - `CGAL::make_conforming_Delaunay_2`
 - `CGAL::make_conforming_Gabriel_2`
 - `CGAL::refine_Delaunay_mesh_2`

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -52,7 +52,7 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 Here are the main concepts of this package:
 
@@ -78,7 +78,7 @@ related to the template parameters of some models of the main concepts:
 - `MeshPolyline_3`
 - `TriangleAccessor_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Mesh_complex_3_in_triangulation_3<Tr,CornerIndex,CurveIndex>`
 - `CGAL::Mesh_triangulation_3<MD,Gt,Concurrency_tag,Vertex_base,Cell_base>`
@@ -106,7 +106,7 @@ and their associated classes:
 - `CGAL::Labeled_image_mesh_domain_3<Image,BGT>` (deprecated)
 - `CGAL::Gray_image_mesh_domain_3<Image,BGT,Image_word_type>` (deprecated)
 
-## Function Templates ##
+\cgalCRPSection{Function Templates}
 
 - `CGAL::make_mesh_3()`
 - `CGAL::refine_mesh_3()`
@@ -116,7 +116,7 @@ and their associated classes:
 - `CGAL::odt_optimize_mesh_3()`
 - `CGAL::facets_in_complex_3_to_triangle_mesh()`
 
-## CGAL::parameters Functions ##
+\cgalCRPSection{CGAL::parameters Functions}
 
 - `CGAL::parameters::features()`
 - `CGAL::parameters::no_features()`
@@ -132,12 +132,12 @@ and their associated classes:
 - `CGAL::parameters::manifold_with_boundary()`
 - `CGAL::parameters::non_manifold()`
 
-## Enumerations ##
+\cgalCRPSection{Enumerations}
 
 - `CGAL::Mesh_optimization_return_code`
 - `CGAL::Mesh_facet_topology`
 
-## Input/Output Functions ##
+\cgalCRPSection{Input/Output Functions}
 - `CGAL::output_to_medit()`
 - `CGAL::output_to_vtu()`
 */

--- a/Minkowski_sum_2/doc/Minkowski_sum_2/PackageDescription.txt
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/PackageDescription.txt
@@ -34,7 +34,7 @@ bounds, in order to speed up the computation time.
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::minkowski_sum_2()`
 - `CGAL::minkowski_sum_by_decomposition_2()`
 - `CGAL::minkowski_sum_by_full_convolution_2()`
@@ -44,11 +44,11 @@ bounds, in order to speed up the computation time.
 - `CGAL::offset_polygon_2()`
 - `CGAL::inset_polygon_2()`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `PolygonConvexDecomposition_2`
 - `PolygonWithHolesConvexDecomposition_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Small_side_angle_bisector_decomposition_2<Kernel,Container>`
 - `CGAL::Optimal_convex_decomposition_2<Kernel,Container>`
 - `CGAL::Hertel_Mehlhorn_convex_decomposition_2<Kernel,Container>`

--- a/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
+++ b/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
@@ -21,7 +21,7 @@
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::minkowski_sum_3()`
 
 */

--- a/Miscellany/doc/Miscellany/PackageDescription.txt
+++ b/Miscellany/doc/Miscellany/PackageDescription.txt
@@ -19,10 +19,10 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `UniqueHashFunction`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Timer`
 - `CGAL::Real_timer`
 - `CGAL::Memory_sizer`

--- a/Modular_arithmetic/doc/Modular_arithmetic/PackageDescription.txt
+++ b/Modular_arithmetic/doc/Modular_arithmetic/PackageDescription.txt
@@ -19,13 +19,13 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `Modularizable`
 - `ModularTraits`
 - `ModularTraits::ModularImage`
 - `ModularTraits::ModularImageRepresentative`
 
-## Types ##
+\cgalCRPSection{Types}
 - `CGAL::Residue`
 - `CGAL::Modular_traits<T>`
 

--- a/Nef_2/doc/Nef_2/PackageDescription.txt
+++ b/Nef_2/doc/Nef_2/PackageDescription.txt
@@ -21,10 +21,10 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `ExtendedKernelTraits_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Extended_cartesian<FT>`
 - `CGAL::Extended_homogeneous<RT>`
 - `CGAL::Filtered_extended_homogeneous<RT>`

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -46,7 +46,7 @@ a simple OpenGL visualization for debugging and illustrations.
 
 \cgalClassifedRefPages
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Nef_polyhedron_3<Traits>`
 - \link CGAL::Nef_polyhedron_3::Vertex `CGAL::Nef_polyhedron_3<Traits>::Vertex` \endlink
 - \link CGAL::Nef_polyhedron_3::Halfedge `CGAL::Nef_polyhedron_3<Traits>::Halfedge` \endlink
@@ -57,7 +57,7 @@ a simple OpenGL visualization for debugging and illustrations.
 - \link CGAL::Nef_polyhedron_3::SFace `CGAL::Nef_polyhedron_3<Traits>::SFace` \endlink
 - \link CGAL::Nef_polyhedron_3::SFace_cycle_iterator `CGAL::Nef_polyhedron_3<Traits>::SFace_cycle_iterator` \endlink
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::OFF_to_nef_3()`
 - `CGAL::convert_nef_polyhedron_to_polygon_mesh()`
 - \link PkgNef3IOFunctions `CGAL::operator<<()` \endlink

--- a/Number_types/doc/Number_types/PackageDescription.txt
+++ b/Number_types/doc/Number_types/PackageDescription.txt
@@ -60,21 +60,21 @@
 - \link double.h `double` \endlink
 - \link long_double.h `long double` \endlink
 
-### %CORE ###
+\cgalCRPSubsection{%CORE}
 
 - `CORE::BigInt`
 - `CORE::BigRat`
 - `CORE::BigFloat`
 - `CORE::Expr`
 
-### LEDA ###
+\cgalCRPSubsection{LEDA}
 
 - `leda_integer`
 - `leda_rational`
 - `leda_bigfloat`
 - `leda_real`
 
-### GMP ###
+\cgalCRPSubsection{GMP}
 
 - `mpz_class`
 - `mpq_class`
@@ -85,7 +85,7 @@
 - `CGAL::Gmpfr`
 - `CGAL::Gmpfi`
 
-### %CGAL ###
+\cgalCRPSubsection{%CGAL}
 
 - `CGAL::MP_Float`
 - `CGAL::Interval_nt<Protected>`

--- a/Number_types/doc/Number_types/PackageDescription.txt
+++ b/Number_types/doc/Number_types/PackageDescription.txt
@@ -50,7 +50,7 @@
 
 \cgalClassifedRefPages
 
-## Number Type Classes and Concepts ##
+\cgalCRPSection{Number Type Classes and Concepts}
 
 - \link int.h `int` \endlink
 - \link int.h `short int` \endlink
@@ -95,13 +95,13 @@
 - `CGAL::Exact_integer`
 - `CGAL::Exact_rational`
 
-## Relates Rational ##
+\cgalCRPSection{Relates Rational}
 
 - `CGAL::Rational_traits<NT>`
 - `CGAL::simplest_rational_in_interval()`
 - `CGAL::to_rational()`
 
-## Relates Algebraic Extensions ##
+\cgalCRPSection{Relates Algebraic Extensions}
 
 - `RootOf_2`
 - `CGAL::Root_of_traits<RT>`
@@ -110,7 +110,7 @@
 - `CGAL::compute_roots_of_2<RT,OutputIterator>`
 - `CGAL::Sqrt_extension<NT,ROOT>`
 
-## Utilities ##
+\cgalCRPSection{Utilities}
 
 - `CGAL::Min<T,Less>`
 - `CGAL::Max<T,Less>`

--- a/Optimal_transportation_reconstruction_2/doc/Optimal_transportation_reconstruction_2/PackageDescription.txt
+++ b/Optimal_transportation_reconstruction_2/doc/Optimal_transportation_reconstruction_2/PackageDescription.txt
@@ -28,10 +28,10 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `OptimalTransportationReconstructionTraits_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Optimal_transportation_reconstruction_2<Traits, PointPMap, MassPMap>`
 
 */

--- a/Partition_2/doc/Partition_2/PackageDescription.txt
+++ b/Partition_2/doc/Partition_2/PackageDescription.txt
@@ -23,7 +23,7 @@
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 
-## Definitions ##
+\cgalCRPSection{Definitions}
 
 A <i>partition</i> of a polygon is a set 
 of polygons such that the interiors of the polygons do not intersect and
@@ -52,7 +52,7 @@ a convex partitioning from a triangulation of a polygon.
 Each of the partitioning functions uses a traits class to supply the
 primitive types and predicates used by the algorithms.
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The assertion flags for this package use `PARTITION` in their names
 (<I>e.g.</I>, `CGAL_PARTITION_NO_POSTCONDITIONS`).
@@ -68,7 +68,7 @@ original polygon).
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `ConvexPartitionIsValidTraits_2`
 - `IsYMonotoneTraits_2`
 - `OptimalConvexPartitionTraits_2`
@@ -77,20 +77,20 @@ original polygon).
 - `YMonotonePartitionIsValidTraits_2`
 - `YMonotonePartitionTraits_2`
 
-## Function Object Concepts ##
+\cgalCRPSection{Function Object Concepts}
 - `PolygonIsValid`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Partition_is_valid_traits_2<Traits, PolygonIsValid>`
 - `CGAL::Partition_traits_2<R>`
 
 
-## Function Object Classes ##
+\cgalCRPSection{Function Object Classes}
 - `CGAL::Is_convex_2<Traits>`
 - `CGAL::Is_vacuously_valid<Traits>`
 - `CGAL::Is_y_monotone_2<Traits>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::approx_convex_partition_2()`
 - `CGAL::convex_partition_is_valid_2()`
 - `CGAL::greene_approx_convex_partition_2()`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -72,6 +72,7 @@ both inside and outside the original domain we store additional
 offset information for each vertex of a face. These offsets are models
 of the concept `Periodic_2Offset_2`.
 
+\cgalClassifedRefPages
 
 ## Concepts ##
 

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -74,7 +74,7 @@ of the concept `Periodic_2Offset_2`.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `Periodic_2TriangulationTraits_2`
 - `Periodic_2DelaunayTriangulationTraits_2`
@@ -82,7 +82,7 @@ of the concept `Periodic_2Offset_2`.
 - `Periodic_2TriangulationVertexBase_2`
 - `Periodic_2Offset_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 \cgalCRPSubsection{Main Classes}
 
@@ -98,7 +98,7 @@ of the concept `Periodic_2Offset_2`.
 - `CGAL::Periodic_2_triangulation_traits_2<Traits,Periodic_2Offset_2>`
 - `CGAL::Periodic_2_Delaunay_triangulation_traits_2<Traits,Periodic_2Offset_2>`
 
-## Enums ##
+\cgalCRPSection{Enums}
 
 - `CGAL::Periodic_2_triangulation_2::Iterator_type`
 - `CGAL::Periodic_2_triangulation_2::Locate_type`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -84,7 +84,7 @@ of the concept `Periodic_2Offset_2`.
 
 ## Classes ##
 
-### Main Classes ###
+\cgalCRPSubsection{Main Classes}
 
 - `CGAL::Periodic_2_triangulation_2<PT,TDS>`
 - `CGAL::Periodic_2_Delaunay_triangulation_2<PT,TDS>`
@@ -93,7 +93,7 @@ of the concept `Periodic_2Offset_2`.
 - `CGAL::Periodic_2_triangulation_vertex_base_2<>`
 - `CGAL::Periodic_2_offset_2`
 
-### Traits Classes ###
+\cgalCRPSubsection{Traits Classes}
 
 - `CGAL::Periodic_2_triangulation_traits_2<Traits,Periodic_2Offset_2>`
 - `CGAL::Periodic_2_Delaunay_triangulation_traits_2<Traits,Periodic_2Offset_2>`

--- a/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
+++ b/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
@@ -42,7 +42,7 @@ flexibility that is offered in the \ref PkgMesh3 package.}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 
-### Relation to the 3D Mesh Generation and 3D Periodic Triangulations Packages ###
+\cgalHeading{Relation to the 3D Mesh Generation and 3D Periodic Triangulations Packages}
 
 A periodic mesh extends, by definition, infinitely in space. To avoid storing and
 manipulating duplicate points, well-chosen "dummy" points are inserted

--- a/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
+++ b/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
@@ -94,7 +94,7 @@ The following functions handle the generation of a periodic mesh:
 - `CGAL::lloyd_optimize_periodic_3_mesh_3()`
 - `CGAL::odt_optimize_periodic_3_mesh_3()`
 
-## Classes and Functions of `Mesh_3` ##
+\cgalCRPSection{Classes and Functions of `Mesh_3`}
 
 Many classes and functions used by this package are defined within the package
 \ref PkgMesh3, see \ref PkgMesh3MeshClasses, \ref PkgMesh3Domains,

--- a/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
+++ b/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
@@ -61,7 +61,7 @@ This package offers these interfaces.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 This package relies entirely on the \ref PkgMesh3Concepts
 and the \ref PkgMesh3SecondaryConcepts described in the \ref PkgMesh3 package.
@@ -71,7 +71,7 @@ and `MeshDomainWithFeatures_3` in the package \ref PkgMesh3 :
 - `Periodic_3MeshDomain_3`
 - `Periodic_3MeshDomainWithFeatures_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 The following class provides the interface between %CGAL's periodic triangulation
 and %CGAL's three-dimensional mesh generator:
@@ -84,7 +84,7 @@ The following class allows to split the canonical cube in two subdomains,
 separated by the zero-level of an implicit function:
 - `CGAL::Implicit_to_labeled_subdomains_function_wrapper<Function,BGT>`
 
-## Function Templates ##
+\cgalCRPSection{Function Templates}
 
 The following functions handle the generation of a periodic mesh:
 - `CGAL::make_periodic_3_mesh_3()`
@@ -100,7 +100,7 @@ Many classes and functions used by this package are defined within the package
 \ref PkgMesh3, see \ref PkgMesh3MeshClasses, \ref PkgMesh3Domains,
 and \ref PkgMesh3Parameters.
 
-## Input/Output Functions ##
+\cgalCRPSection{Input/Output Functions}
 - \link PkgPeriodic3Mesh3IOFunctions `CGAL::output_periodic_mesh_to_medit()` \endlink
 
 */

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
@@ -71,7 +71,7 @@ of the concept `Periodic_3Offset_3`.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `Periodic_3TriangulationTraits_3`
 - `Periodic_3DelaunayTriangulationTraits_3`
@@ -87,7 +87,7 @@ of the concept `Periodic_3Offset_3`.
 
 - `Periodic_3Offset_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 \cgalCRPSubsection{Main Classes}
 
@@ -107,7 +107,7 @@ of the concept `Periodic_3Offset_3`.
 - `CGAL::Periodic_3_Delaunay_triangulation_traits_3<Traits,Periodic_3Offset_3>`
 - `CGAL::Periodic_3_regular_triangulation_traits_3<Traits,Periodic_3Offset_3>`
 
-## Enums ##
+\cgalCRPSection{Enums}
 
 - `CGAL::Periodic_3_triangulation_3::Iterator_type`
 - `CGAL::Periodic_3_triangulation_3::Locate_type`

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
@@ -89,7 +89,7 @@ of the concept `Periodic_3Offset_3`.
 
 ## Classes ##
 
-### Main Classes ###
+\cgalCRPSubsection{Main Classes}
 
 - `CGAL::Periodic_3_triangulation_3<PT,TDS>`
 - `CGAL::Periodic_3_Delaunay_triangulation_3<PT,TDS>`
@@ -101,7 +101,7 @@ of the concept `Periodic_3Offset_3`.
 - `CGAL::Periodic_3_triangulation_ds_cell_base_3<>`
 - `CGAL::Periodic_3_offset_3`
 
-### Traits Classes ###
+\cgalCRPSubsection{Traits Classes}
 
 - `CGAL::Periodic_3_triangulation_traits_3<Traits,Periodic_3Offset_3>`
 - `CGAL::Periodic_3_Delaunay_triangulation_traits_3<Traits,Periodic_3Offset_3>`

--- a/Point_set_2/doc/Point_set_2/PackageDescription.txt
+++ b/Point_set_2/doc/Point_set_2/PackageDescription.txt
@@ -40,13 +40,13 @@ point set class.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `PointSetTraits`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Point_set_2`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::nearest_neighbor()`
 - `CGAL::nearest_neighbors()`
 - `CGAL::range_search()`

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -18,7 +18,7 @@
 
 \cgalClassifedRefPages
 
-## Class ##
+\cgalCRPSection{Class}
 - `CGAL::Point_set_3<Point,Vector>`
 
 \defgroup PkgPointSet3IO Input/Output

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -44,7 +44,7 @@ format.
 
 \cgalClassifedRefPages
 
-## Algorithms ##
+\cgalCRPSection{Algorithms}
 
 - `CGAL::compute_average_spacing()`
 - `CGAL::estimate_global_k_neighbor_scale()`

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -67,14 +67,14 @@ format.
 - `CGAL::vcm_is_on_feature_edge()`
 - `CGAL::structure_point_set()`
 
-## IO (XYZ/OFF Formats) ##
+\cgalCRPSection{IO (XYZ/OFF Formats)}
 
 - `CGAL::read_off_points()`
 - `CGAL::read_xyz_points()`
 - `CGAL::write_off_points()`
 - `CGAL::write_xyz_points()`
 
-## IO (PLY Format) ##
+\cgalCRPSection{IO (PLY Format)}
 
 - `CGAL::read_ply_points()`
 - `CGAL::read_ply_points_with_properties()`
@@ -86,7 +86,7 @@ format.
 - `CGAL::make_ply_normal_reader()`
 - `CGAL::make_ply_normal_writer()`
 
-## IO (LAS Format) ##
+\cgalCRPSection{IO (LAS Format)}
 
 - `CGAL::read_las_points()`
 - `CGAL::read_las_points_with_properties()`

--- a/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/PackageDescription.txt
+++ b/Point_set_shape_detection_3/doc/Point_set_shape_detection_3/PackageDescription.txt
@@ -31,28 +31,28 @@
 
 \cgalClassifedRefPages
 
-## Concept ##
+\cgalCRPSection{Concept}
 - `ShapeDetectionTraits`
 
-## Main Classes ##
+\cgalCRPSection{Main Classes}
 - `CGAL::Shape_detection_3::Shape_detection_traits`
 - `CGAL::Shape_detection_3::Efficient_RANSAC<Traits>`
 - `CGAL::Shape_detection_3::Region_growing<Traits>`
 
-## Shape Interface ##
+\cgalCRPSection{Shape Interface}
 - `CGAL::Shape_detection_3::Shape_base<Traits>`
 
-## Shape Classes ##
+\cgalCRPSection{Shape Classes}
 - `CGAL::Shape_detection_3::Plane<Traits>`
 - `CGAL::Shape_detection_3::Sphere<Traits>`
 - `CGAL::Shape_detection_3::Cylinder<Traits>`
 - `CGAL::Shape_detection_3::Cone<Traits>`
 - `CGAL::Shape_detection_3::Torus<Traits>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::regularize_planes()`
 
-## Property Maps ##
+\cgalCRPSection{Property Maps}
 - `CGAL::Shape_detection_3::Plane_map<Traits>`
 - `CGAL::Shape_detection_3::Point_to_shape_index_map<Traits>`
 

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
@@ -18,7 +18,7 @@
 \cgalPkgDescriptionEnd
 
 \cgalClassifedRefPages
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Poisson_reconstruction_function<GeomTraits>`
 
 */

--- a/Polygon/doc/Polygon/PackageDescription.txt
+++ b/Polygon/doc/Polygon/PackageDescription.txt
@@ -24,23 +24,23 @@
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 
 The assertion flags for the polygons and polygon operations use 
 `POLYGON` in their names (<I>e.g.</I>, `CGAL_POLYGON_NO_ASSERTIONS`).
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `PolygonTraits_2`
 - `GeneralPolygonWithHoles_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Polygon_2<PolygonTraits_2, Container>`
 - `CGAL::Polygon_with_holes_2<PolygonTraits_2,Container>`
 - `CGAL::General_polygon_with_holes_2<General_polygon>`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 - `CGAL::area_2()`
 - `CGAL::bottom_vertex_2()`
 - `CGAL::bounded_side_2()`

--- a/Polygon/include/CGAL/Polygon_2_algorithms.h
+++ b/Polygon/include/CGAL/Polygon_2_algorithms.h
@@ -236,7 +236,7 @@ bool is_convex_2(ForwardIterator first,
 ///   - `orientation_2_object()`
 /// \tparam ForwardIterator must have `PolygonTraits::Point_2` as value type.
 /// 
-/// ### Implementation##
+/// \cgalHeading{Implementation}
 /// 
 /// The simplicity test is implemented by means of a plane sweep algorithm.
 /// The algorithm is quite robust when used with inexact number types.
@@ -299,7 +299,7 @@ Oriented_side oriented_side_2(ForwardIterator first,
 ///   - `orientation_2_object()`
 /// \tparam ForwardIterator must have `Traits::Point_2` as value type.
 /// 
-/// ### Implementation ###
+/// \cgalHeading{Implementation}
 /// 
 /// The running time is linear in the number of vertices of the polygon.
 /// A horizontal ray is taken to count the number of intersections.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -186,7 +186,7 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::detect_sharp_edges()`
 - `CGAL::Polygon_mesh_processing::detect_vertex_incident_patches()`
 
-## Collision Detection
+\cgalCRPSection{Collision Detection}
 - `CGAL::Rigid_triangle_mesh_collision_detection`
 
 \cgalCRPSection{Miscellaneous}

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -86,14 +86,14 @@ ranging from basic operations on simplices, to complex geometry processing algor
 
 \cgalClassifedRefPages
 
-## Parameters ##
+\cgalCRPSection{Parameters}
 
 Optional parameters of the functions of this package
 are implemented as \ref BGLNamedParameters.
 The page \ref pmp_namedparameters "Named Parameters" describes their usage
 and provides a list of the parameters that are used in this package.
 
-## Meshing Functions ##
+\cgalCRPSection{Meshing Functions}
 - `CGAL::Polygon_mesh_processing::fair()`
 - `CGAL::Polygon_mesh_processing::refine()`
 - `CGAL::Polygon_mesh_processing::triangulate_face()`
@@ -103,13 +103,13 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::random_perturbation()`
 - `CGAL::Polygon_mesh_processing::extrude_mesh()`
 
-## Hole Filling Functions ##
+\cgalCRPSection{Hole Filling Functions}
 - `CGAL::Polygon_mesh_processing::triangulate_hole()`
 - `CGAL::Polygon_mesh_processing::triangulate_and_refine_hole()`
 - `CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole()`
 - `CGAL::Polygon_mesh_processing::triangulate_hole_polyline()`
 
-## Predicate Functions ##
+\cgalCRPSection{Predicate Functions}
 - `CGAL::Polygon_mesh_processing::does_self_intersect()`
 - `CGAL::Polygon_mesh_processing::self_intersections()`
 - \link PMP_predicates_grp `CGAL::Polygon_mesh_processing::do_intersect()` \endlink
@@ -121,14 +121,14 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::is_needle_triangle_face()`
 - `CGAL::Polygon_mesh_processing::is_cap_triangle_face()`
 
-## Orientation Functions ##
+\cgalCRPSection{Orientation Functions}
 - `CGAL::Polygon_mesh_processing::orient_polygon_soup()`
 - `CGAL::Polygon_mesh_processing::orient()`
 - `CGAL::Polygon_mesh_processing::orient_to_bound_a_volume()`
 - `CGAL::Polygon_mesh_processing::is_outward_oriented()`
 - `CGAL::Polygon_mesh_processing::reverse_face_orientations()`
 
-## Combinatorial Repairing Functions ##
+\cgalCRPSection{Combinatorial Repairing Functions}
 - `CGAL::Polygon_mesh_processing::merge_duplicate_points_in_polygon_soup()`
 - `CGAL::Polygon_mesh_processing::merge_duplicate_polygons_in_polygon_soup()`
 - `CGAL::Polygon_mesh_processing::remove_isolated_points_in_polygon_soup()`
@@ -142,14 +142,14 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::merge_duplicated_vertices_in_boundary_cycle()`
 - `CGAL::Polygon_mesh_processing::merge_duplicated_vertices_in_boundary_cycles()`
 
-## Normal Computation Functions ##
+\cgalCRPSection{Normal Computation Functions}
 - `CGAL::Polygon_mesh_processing::compute_face_normal()`
 - `CGAL::Polygon_mesh_processing::compute_face_normals()`
 - `CGAL::Polygon_mesh_processing::compute_vertex_normal()`
 - `CGAL::Polygon_mesh_processing::compute_vertex_normals()`
 - `CGAL::Polygon_mesh_processing::compute_normals()`
 
-## Connected Components ##
+\cgalCRPSection{Connected Components}
 - `CGAL::Polygon_mesh_processing::connected_component()`
 - `CGAL::Polygon_mesh_processing::connected_components()`
 - `CGAL::Polygon_mesh_processing::keep_large_connected_components()`
@@ -157,7 +157,7 @@ and provides a list of the parameters that are used in this package.
 - \link keep_connected_components_grp `CGAL::Polygon_mesh_processing::keep_connected_components()` \endlink
 - \link keep_connected_components_grp `CGAL::Polygon_mesh_processing::remove_connected_components()` \endlink
 
-## Corefinement and Boolean Operation Functions ##
+\cgalCRPSection{Corefinement and Boolean Operation Functions}
 - `CGAL::Polygon_mesh_processing::corefine_and_compute_union()`
 - `CGAL::Polygon_mesh_processing::corefine_and_compute_difference()`
 - `CGAL::Polygon_mesh_processing::corefine_and_compute_intersection()`
@@ -167,21 +167,21 @@ and provides a list of the parameters that are used in this package.
 - `CGAL::Polygon_mesh_processing::clip()`
 - `CGAL::Polygon_mesh_processing::does_bound_a_volume()`
 
-## Geometric Measure Functions ##
+\cgalCRPSection{Geometric Measure Functions}
 - \link measure_grp `CGAL::Polygon_mesh_processing::face_area()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::area()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::volume()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::edge_length()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::face_border_length()` \endlink
 
-## Distance Functions ##
+\cgalCRPSection{Distance Functions}
 - `CGAL::Polygon_mesh_processing::approximate_Hausdorff_distance()`
 - `CGAL::Polygon_mesh_processing::approximate_symmetric_Hausdorff_distance()`
 - `CGAL::Polygon_mesh_processing::approximate_max_distance_to_point_set()`
 - `CGAL::Polygon_mesh_processing::max_distance_to_triangle_mesh()`
 - `CGAL::Polygon_mesh_processing::sample_triangle_mesh()`
 
-## Feature Detection Functions ##
+\cgalCRPSection{Feature Detection Functions}
 - `CGAL::Polygon_mesh_processing::sharp_edges_segmentation()`
 - `CGAL::Polygon_mesh_processing::detect_sharp_edges()`
 - `CGAL::Polygon_mesh_processing::detect_vertex_incident_patches()`
@@ -189,7 +189,7 @@ and provides a list of the parameters that are used in this package.
 ## Collision Detection
 - `CGAL::Rigid_triangle_mesh_collision_detection`
 
-## Miscellaneous ##
+\cgalCRPSection{Miscellaneous}
 - `CGAL::Polygon_mesh_slicer`
 - `CGAL::Side_of_triangle_mesh`
 - `CGAL::Polygon_mesh_processing::bbox()`

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -51,11 +51,11 @@ surface can be used without knowing the halfedge data structure.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `PolyhedronTraits_3`
 - `PolyhedronItems_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Polyhedron_3<Traits>`
 - \link CGAL::Polyhedron_3::Vertex `CGAL::Polyhedron_3<Traits>::Vertex` \endlink
 - \link CGAL::Polyhedron_3::Halfedge `CGAL::Polyhedron_3<Traits>::Halfedge` \endlink
@@ -66,13 +66,13 @@ surface can be used without knowing the halfedge data structure.
 - `CGAL::Polyhedron_min_items_3`
 - `CGAL::Polyhedron_incremental_builder_3<HDS>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - \link PkgPolyhedronIOFunc `CGAL::operator<<()` \endlink
 - \link PkgPolyhedronIOFunc `CGAL::operator>>()` \endlink
 - \link PkgPolyhedronIOFunc `write_off()` \endlink   
 - \link PkgPolyhedronIOFunc `read_off()` \endlink
 
-## Draw a Polyhedron 3 ##
+\cgalCRPSection{Draw a Polyhedron 3}
 - `CGAL::draw<POLY>`
 
 */

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -72,7 +72,7 @@ surface can be used without knowing the halfedge data structure.
 - \link PkgPolyhedronIOFunc `write_off()` \endlink   
 - \link PkgPolyhedronIOFunc `read_off()` \endlink
 
-### Draw a Polyhedron 3 ###
+## Draw a Polyhedron 3 ##
 - `CGAL::draw<POLY>`
 
 */

--- a/Polyline_simplification_2/doc/Polyline_simplification_2/Concepts/PolylineSimplificationVertexBase_2.h
+++ b/Polyline_simplification_2/doc/Polyline_simplification_2/Concepts/PolylineSimplificationVertexBase_2.h
@@ -8,10 +8,6 @@ whether a vertex can be removed, and the cost of the removal.
 
 \cgalRefines `TriangulationVertexBase_2` 
 
-### Types ###
-
-Defines the same types as the `TriangulationVertexBase_2` concept 
-
 \cgalHasModel `CGAL::Polyline_simplification_2::Vertex_base_2<Vb>` 
 
 \sa `TriangulationFaceBase_2` 

--- a/Polyline_simplification_2/doc/Polyline_simplification_2/PackageDescription.txt
+++ b/Polyline_simplification_2/doc/Polyline_simplification_2/PackageDescription.txt
@@ -32,13 +32,13 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `PolylineSimplificationCostFunction`
 - `PolylineSimplificationStopPredicate`
 - `PolylineSimplificationVertexBase_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Polyline_simplification_2::Squared_distance_cost`
 - `CGAL::Polyline_simplification_2::Scaled_squared_distance_cost`
 - `CGAL::Polyline_simplification_2::Hybrid_squared_distance_cost`
@@ -47,7 +47,7 @@
 - `CGAL::Polyline_simplification_2::Stop_below_count_ratio_threshold`
 - `CGAL::Polyline_simplification_2::Vertex_base_2`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 - `CGAL::Polyline_simplification_2::simplify()`
 
 */

--- a/Polynomial/doc/Polynomial/PackageDescription.txt
+++ b/Polynomial/doc/Polynomial/PackageDescription.txt
@@ -26,7 +26,7 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `Polynomial_d`
 - `PolynomialTraits_d`
@@ -95,14 +95,14 @@
 - `PolynomialTraits_d::SturmHabichtSequenceWithCofactors`
 - `PolynomialTraits_d::PrincipalSturmHabichtSequence`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Polynomial<Coeff>`
 - `CGAL::Polynomial_traits_d<Polynomial_d>`
 - `CGAL::Exponent_vector`
 - `CGAL::Polynomial_type_generator<T,d>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 - `CGAL::get_coefficient()`
 - `CGAL::get_innermost_coefficient()`

--- a/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
+++ b/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
@@ -27,7 +27,7 @@ checking off, cf. Section  \ref secchecks.
 
 \cgalClassifedRefPages
 
-\cgalCRPSection{All furthest neighbors}
+\cgalCRPSection{All Furthest Neighbors}
 
 - `CGAL::all_furthest_neighbors_2`
 - `AllFurthestNeighborsTraits_2`

--- a/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
+++ b/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
@@ -19,7 +19,7 @@
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 
-## Assertions ##
+\cgalCRPSection{Assertions}
 The optimization code uses infix `OPTIMISATION` in the assertions,
 e.g. defining the compiler flag
 `CGAL_OPTIMISATION_NO_PRECONDITIONS` switches precondition
@@ -27,18 +27,18 @@ checking off, cf. Section  \ref secchecks.
 
 \cgalClassifedRefPages
 
-## All furthest neighbors ##
+\cgalCRPSection{All furthest neighbors}
 
 - `CGAL::all_furthest_neighbors_2`
 - `AllFurthestNeighborsTraits_2`
 
-## Width ##
+\cgalCRPSection{Width}
 
 - `CGAL::Width_3<Traits>`
 - `CGAL::Width_default_traits_3<K>`
 - `WidthTraits_3`
 
-## Polytope Distance ##
+\cgalCRPSection{Polytope Distance}
 
 - `CGAL::Polytope_distance_d<Traits>`
 - `CGAL::Polytope_distance_d_traits_2<K,ET,NT>`

--- a/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
+++ b/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
@@ -36,7 +36,7 @@
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - \link PkgPrincipalComponentAnalysisDbb `CGAL::barycenter()` \endlink
 - `CGAL::bounding_box()`
 - `CGAL::centroid()`

--- a/QP_solver/doc/QP_solver/PackageDescription.txt
+++ b/QP_solver/doc/QP_solver/PackageDescription.txt
@@ -89,7 +89,7 @@ Programs can be written to an output stream in MPSFormat, using one of the follo
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `QuadraticProgram` (for quadratic programs with variable bounds l <= x <= u)
 - `LinearProgram` (for linear programs with variable bounds l <= x <= u)
 - `NonnegativeQuadraticProgram` (for quadratic programs with variable bounds x >= 0)
@@ -97,7 +97,7 @@ Programs can be written to an output stream in MPSFormat, using one of the follo
 
 - `MPSFormat` (the format used for reading and writing linear and quadratic programs)
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 There is a class that represents the solution of a linear or quadratic program.
 An instance of this class is returned by any of the solution functions below.
@@ -124,7 +124,7 @@ no further copying of data.
 - `CGAL::Nonnegative_quadratic_program_from_iterators<A_it, B_it, R_it, D_it, C_it>` (for nonnegative quadratic programs, wrapping given iterators)
 - `CGAL::Nonnegative_linear_program_from_iterators<A_it, B_it, R_it, C_it>` (for nonnegative linear programs, wrapping given iterators)
 
-## Functions ##
+\cgalCRPSection{Functions}
 
 In case you want to construct a program from complicated iterators
 (whose types you don't know, or simply don't want to bother with),

--- a/Ridges_3/doc/Ridges_3/PackageDescription.txt
+++ b/Ridges_3/doc/Ridges_3/PackageDescription.txt
@@ -23,18 +23,18 @@
 
 \cgalClassifedRefPages
 
-## Enums ##
+\cgalCRPSection{Enums}
 - `CGAL::Ridge_type`
 - `CGAL::Ridge_order`
 - `CGAL::Umbilic_type`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Ridge_line<TriangleMesh>`
 - `CGAL::Umbilic<TriangleMesh>`
 - `CGAL::Ridge_approximation<TriangleMesh,VertexFTMap,VertexVectorMap>`
 - `CGAL::Umbilic_approximation<TriangleMesh,VertexFTMap,VertexVectorMap>`
 
-## Global Functions ##
+\cgalCRPSection{Global Functions}
 - `CGAL::compute_max_ridges()`
 - `CGAL::compute_min_ridges()`
 - `CGAL::compute_crest_ridges()`

--- a/STL_Extension/doc/STL_Extension/PackageDescription.txt
+++ b/STL_Extension/doc/STL_Extension/PackageDescription.txt
@@ -28,19 +28,19 @@
 
 \cgalClassifedRefPages
 
-## Doubly-Connected List Managing Items in Place ##
+\cgalCRPSection{Doubly-Connected List Managing Items in Place}
 - `CGAL::In_place_list<T,bool>`
 - `CGAL::In_place_list_base<T>`
 
-## Compact Container ##
+\cgalCRPSection{Compact Container}
 - `CGAL::Compact_container<T, Allocator>`
 - `CGAL::Compact_container_traits<T>`
 - `CGAL::Compact_container_base`
 
-## Multiset with Extended Functionality ##
+\cgalCRPSection{Multiset with Extended Functionality}
 - `CGAL::Multiset<Type,Compare,Allocator>`
 
-## Generic Algorithms ##
+\cgalCRPSection{Generic Algorithms}
 - `CGAL::cpp11::copy_n`
 - `CGAL::copy_n`
 - `CGAL::min_max_element`
@@ -49,7 +49,7 @@
 - `CGAL::predecessor`
 - `CGAL::successor`
 
-## Iterators and Iterator/Circulator Adaptors ##
+\cgalCRPSection{Iterators and Iterator/Circulator Adaptors}
 - `CGAL::Dispatch_output_iterator<V,O>`
 - `CGAL::Dispatch_or_drop_output_iterator<V,O>`
 - `CGAL::Emptyset_iterator`
@@ -63,10 +63,10 @@
 - `CGAL::Random_access_adaptor<IC>`
 - `CGAL::Random_access_value_adaptor<IC,T>`
 
-## Ranges ##
+\cgalCRPSection{Ranges}
 - `CGAL::Iterator_range`
 
-## Projection Function Objects ##
+\cgalCRPSection{Projection Function Objects}
 - `CGAL::Identity<Value>`
 - `CGAL::Dereference<Value>`
 - `CGAL::Get_address<Value>`
@@ -81,7 +81,7 @@
 - `CGAL::Project_next_opposite<Node>`
 - `CGAL::Project_opposite_prev<Node>`
 
-## Creator Function Objects ##
+\cgalCRPSection{Creator Function Objects}
 - `CGAL::Creator_1<Arg, Result>`
 - `CGAL::Creator_2<Arg1, Arg2, Result>`
 - `CGAL::Creator_3<Arg1, Arg2, Arg3, Result>`
@@ -97,7 +97,7 @@
 - `CGAL::Creator_uniform_9<Arg, Result>`
 - `CGAL::Creator_uniform_d<Arg, Result>`
 
-## Utilities ##
+\cgalCRPSection{Utilities}
 - `CGAL::Twotuple<T>`
 - `CGAL::Threetuple<T>`
 - `CGAL::Fourtuple<T>`

--- a/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
+++ b/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
@@ -26,21 +26,21 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `CGAL::Scale_space_reconstruction_3::Smoother`
 - `CGAL::Scale_space_reconstruction_3::Mesher`
 
-## Main Class ##
+\cgalCRPSection{Main Class}
 
 - `CGAL::Scale_space_surface_reconstruction_3<Geom_traits>`
 
-## Smoothers ##
+\cgalCRPSection{Smoothers}
 
 - `CGAL::Scale_space_reconstruction_3::Weighted_PCA_smoother<Geom_traits, DiagonalizeTraits, ConcurrencyTag>`
 - `CGAL::Scale_space_reconstruction_3::Jet_smoother<Geom_traits, ConcurrencyTag>`
 
-## Meshers ##
+\cgalCRPSection{Meshers}
 
 - `CGAL::Scale_space_reconstruction_3::Alpha_shape_mesher<Geom_traits, FixedSurface>`
 - `CGAL::Scale_space_reconstruction_3::Advancing_front_mesher<Geom_traits>`

--- a/SearchStructures/doc/SearchStructures/PackageDescription.txt
+++ b/SearchStructures/doc/SearchStructures/PackageDescription.txt
@@ -35,12 +35,12 @@ and segment trees in the same data structure.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `RangeSegmentTreeTraits_k`
 - `Sublayer`
 
-## Traits Classes ##
+\cgalCRPSection{Traits Classes}
 
 - `CGAL::Range_segment_tree_traits_set_2<R>`
 - `CGAL::Range_segment_tree_traits_set_3<R>`
@@ -51,7 +51,7 @@ and segment trees in the same data structure.
 - `CGAL::tree_interval_traits`
 - `CGAL::tree_point_traits`
 
-## Search Structure Classes ##
+\cgalCRPSection{Search Structure Classes}
 
 - `CGAL::Range_tree_d<Data, Window, Traits>`
 - `CGAL::Range_tree_k<Traits>`

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/PackageDescription.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/PackageDescription.txt
@@ -40,7 +40,7 @@ the class
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `SegmentDelaunayGraphSite_2`
 - `SegmentDelaunayGraphStorageSite_2`
@@ -49,7 +49,7 @@ the class
 - `SegmentDelaunayGraphTraits_2`
 - `SegmentDelaunayGraphHierarchyVertexBase_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Segment_Delaunay_graph_2<Gt,DS>`
 - `CGAL::Segment_Delaunay_graph_site_2<K>`

--- a/Segment_Delaunay_graph_Linf_2/doc/Segment_Delaunay_graph_Linf_2/PackageDescription.txt
+++ b/Segment_Delaunay_graph_Linf_2/doc/Segment_Delaunay_graph_Linf_2/PackageDescription.txt
@@ -44,11 +44,11 @@ are models of the `SegmentDelaunayGraphLinfTraits_2` concept.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `SegmentDelaunayGraphLinfTraits_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Segment_Delaunay_graph_Linf_2<Gt,DS>`
 - `CGAL::Segment_Delaunay_graph_Linf_hierarchy_2<Gt,STag,DS>`

--- a/Set_movable_separability_2/doc/Set_movable_separability_2/PackageDescription.txt
+++ b/Set_movable_separability_2/doc/Set_movable_separability_2/PackageDescription.txt
@@ -51,12 +51,12 @@ At this point this package consists of the implementations of various predicates
 
 \cgalClassifedRefPages
 
-## Casting Functions ##
+\cgalCRPSection{Casting Functions}
 - `CGAL::Set_movable_separability_2::Single_mold_translational_casting::top_edges()`
 - `CGAL::Set_movable_separability_2::Single_mold_translational_casting::pullout_directions()`
 - `CGAL::Set_movable_separability_2::Single_mold_translational_casting::is_pullout_direction()`
 
-## Casting Concepts ##
+\cgalCRPSection{Casting Concepts}
 - `CastingTraits_2`
 
 */

--- a/Skin_surface_3/doc/Skin_surface_3/PackageDescription.txt
+++ b/Skin_surface_3/doc/Skin_surface_3/PackageDescription.txt
@@ -22,17 +22,17 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `SkinSurface_3`
 - `SkinSurfaceTraits_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Skin_surface_3<SkinSurfaceTraits_3>`
 - `CGAL::Union_of_balls_3<SkinSurfaceTraits_3>`
 
 - `CGAL::Skin_surface_traits_3<K>`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::make_skin_surface_mesh_3<Polyhedron_3>()`
 - `CGAL::mesh_skin_surface_3<SkinSurface_3, Polyhedron_3>()`
 - `CGAL::subdivide_skin_surface_mesh_3<SkinSurface_3, Polyhedron_3>()`

--- a/Solver_interface/doc/Solver_interface/PackageDescription.txt
+++ b/Solver_interface/doc/Solver_interface/PackageDescription.txt
@@ -22,14 +22,14 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `DiagonalizeTraits`
 - `SparseLinearAlgebraTraits_d`
 - `SparseLinearAlgebraWithFactorTraits_d`
 - `SvdTraits`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Eigen_solver_traits`
 - `CGAL::Eigen_diagonalize_traits`

--- a/Solver_interface/include/CGAL/Eigen_solver_traits.h
+++ b/Solver_interface/include/CGAL/Eigen_solver_traits.h
@@ -86,8 +86,7 @@ The class `Eigen_solver_traits` provides an interface to the sparse solvers of \
 \sa `CGAL::Eigen_vector<T>`
 \sa http://eigen.tuxfamily.org
 
-Example
--------------- 
+\cgalHeading{Instantiation Example}
 
 The instantiation of this class assumes an \ref thirdpartyEigen "Eigen" sparse solver is provided. Here are few examples:
 

--- a/Spatial_searching/doc/Spatial_searching/PackageDescription.txt
+++ b/Spatial_searching/doc/Spatial_searching/PackageDescription.txt
@@ -56,32 +56,32 @@ classes that are described in the reference pages.
 
 \cgalClassifedRefPages
 
-## Search Classes ##
+\cgalCRPSection{Search Classes}
 - `CGAL::K_neighbor_search<Traits, GeneralDistance, Splitter, SpatialTree>`
 - `CGAL::Incremental_neighbor_search<Traits, GeneralDistance, Splitter, SpatialTree>`
 - `CGAL::Orthogonal_incremental_neighbor_search<Traits, OrthogonalDistance, Splitter, SpatialTree>`
 - `CGAL::Orthogonal_k_neighbor_search<Traits, OrthogonalDistance, Splitter, SpatialTree>`
 - `CGAL::Kd_tree<Traits, Splitter, UseExtendedNode>`
 
-## %Range Query Item Classes ##
+\cgalCRPSection{%Range Query Item Classes}
 - `CGAL::Fuzzy_iso_box<Traits>`
 - `CGAL::Fuzzy_sphere<Traits>`
 
-## Search Traits Classes ##
+\cgalCRPSection{Search Traits Classes}
 - `CGAL::Search_traits_2<Kernel>`
 - `CGAL::Search_traits_3<Kernel>`
 - `CGAL::Search_traits_d<Kernel>`
 - `CGAL::Search_traits<NT,Point,CartesianIterator,ConstructCartesianIterator,ConstructMinVertex,ConstructMaxVertex>`
 - `CGAL::Search_traits_adapter<Key,PointPropertyMap,BaseTraits>`
 
-## Distance Classes ##
+\cgalCRPSection{Distance Classes}
 - `CGAL::Euclidean_distance<Traits>`
 - `CGAL::Euclidean_distance_sphere_point<Traits>`
 - `CGAL::Manhattan_distance_iso_box_point<Traits>`
 - `CGAL::Weighted_Minkowski_distance<Traits>`
 - `CGAL::Distance_adapter<Key,PointPropertyMap,Base_distance>`
 
-## %Splitter Classes ##
+\cgalCRPSection{%Splitter Classes}
 - `CGAL::Sliding_midpoint<Traits, SpatialSeparator>`
 - `CGAL::Sliding_fair<Traits, SpatialSeparator>`
 - `CGAL::Fair<Traits, SpatialSeparator>`
@@ -90,7 +90,7 @@ classes that are described in the reference pages.
 - `CGAL::Midpoint_of_max_spread<Traits, SpatialSeparator>`
 - `CGAL::Midpoint_of_rectangle<Traits, SpatialSeparator>`
 
-## Advanced Classes ##
+\cgalCRPSection{Advanced Classes}
 - `CGAL::Kd_tree_node<Traits, Splitter, UseExtendedNode>`
 - `CGAL::Kd_tree_leaf_node<Traits, Splitter, UseExtendedNode>`
 - `CGAL::Kd_tree_internal_node<Traits, Splitter, UseExtendedNode>`
@@ -98,7 +98,7 @@ classes that are described in the reference pages.
 - `CGAL::Plane_separator<FT>`
 - `CGAL::Point_container<Traits>`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `FuzzyQueryItem`
 - `GeneralDistance`
 - `OrthogonalDistance`

--- a/Spatial_sorting/doc/Spatial_sorting/PackageDescription.txt
+++ b/Spatial_sorting/doc/Spatial_sorting/PackageDescription.txt
@@ -34,30 +34,30 @@
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::spatial_sort()`
 - `CGAL::spatial_sort_on_sphere()`
 - `CGAL::hilbert_sort()`
 - `CGAL::hilbert_sort_on_sphere()`
 
-## Function Objects ##
+\cgalCRPSection{Function Objects}
 - `CGAL::Multiscale_sort<Sort>`
 - `CGAL::Hilbert_sort_2<Traits, PolicyTag>`
 - `CGAL::Hilbert_sort_3<Traits, PolicyTag>`
 - `CGAL::Hilbert_sort_on_sphere_3<Traits, PolicyTag>`
 - `CGAL::Hilbert_sort_d<Traits, PolicyTag>`
 
-## Traits classes ##
+\cgalCRPSection{Traits classes}
 - `CGAL::Spatial_sort_traits_adapter_2<Base_traits,PointPropertyMap>`
 - `CGAL::Spatial_sort_traits_adapter_3<Base_traits,PointPropertyMap>`
 - `CGAL::Spatial_sort_traits_adapter_d<Base_traits,PointPropertyMap>`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `SpatialSortingTraits_2`
 - `SpatialSortingTraits_3`
 - `SpatialSortingTraits_d`
 
-## Utilities ##
+\cgalCRPSection{Utilities}
 - `CGAL::Median`
 - `CGAL::Middle`
 - `CGAL::Hilbert_policy<Tag>`

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/PackageDescription.txt
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/PackageDescription.txt
@@ -31,7 +31,7 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `StraightSkeletonVertex_2`
 - `StraightSkeletonHalfedge_2`
 - `StraightSkeletonFace_2`
@@ -42,7 +42,7 @@
 - `PolygonOffsetBuilderTraits_2`
 - `VertexContainer_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Straight_skeleton_vertex_base_2`
 - `CGAL::Straight_skeleton_halfedge_base_2`
 - `CGAL::Straight_skeleton_face_base_2`
@@ -57,7 +57,7 @@
 - `CGAL::Polygon_offset_builder_2`
 - `CGAL::Dummy_straight_skeleton_builder_2_visitor`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::create_exterior_straight_skeleton_2()`
 - `CGAL::create_interior_straight_skeleton_2()`
 - `CGAL::create_offset_polygons_2()`

--- a/Stream_lines_2/doc/Stream_lines_2/PackageDescription.txt
+++ b/Stream_lines_2/doc/Stream_lines_2/PackageDescription.txt
@@ -52,12 +52,12 @@ construct the streamlines, and should be instantiated by a model of the concept
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `StreamLinesTraits_2`
 - `Integrator_2`
 - `VectorField_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Stream_lines_2<VectorField_2,Integrator_2>`
 - `CGAL::Euler_integrator_2<VectorField_2>`
 - `CGAL::Runge_kutta_integrator_2<VectorField_2>`

--- a/Stream_support/doc/Stream_support/PackageDescription.txt
+++ b/Stream_support/doc/Stream_support/PackageDescription.txt
@@ -25,10 +25,10 @@ the printing mode.
 
 \cgalClassifedRefPages
 
-## Enum ##
+\cgalCRPSection{Enum}
 - `CGAL::IO::Mode`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::get_mode()`
 - `CGAL::is_ascii()`
 - `CGAL::is_binary()`
@@ -42,7 +42,7 @@ the printing mode.
 - `CGAL::iformat()`
 - `CGAL::oformat()`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Color`
 - `CGAL::Istream_iterator<T,Stream>`
 - `CGAL::Ostream_iterator<T,Stream>`

--- a/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
@@ -26,21 +26,21 @@
 
 \cgalClassifedRefPages
 
-## Parameters ##
+\cgalCRPSection{Parameters}
 
 Optional parameters of the functions of this package
 are implemented as \ref BGLNamedParameters.
 The page \ref sm_namedparameters describes their usage
 and provides a list of the parameters that are used in this package.
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `SubdivisionMask_3`
 - `PQQMask_3`
 - `PTQMask_3`
 - `DQQMask_3`
 - `Sqrt3Mask_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Subdivision_method_3`
 - `CGAL::CatmullClark_mask_3<PolygonMesh>`
 - `CGAL::Loop_mask_3<PolygonMesh>`

--- a/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
+++ b/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
@@ -34,11 +34,11 @@ and faces is much simpler and can be used at runtime and not at compile time.}
 
 
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Surface_mesh<P>`
                 
-## Draw a Surface Mesh ##
+\cgalCRPSection{Draw a Surface Mesh}
 - `CGAL::draw<SM>`
 
 */

--- a/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
+++ b/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
@@ -38,7 +38,7 @@ and faces is much simpler and can be used at runtime and not at compile time.}
 
 - `CGAL::Surface_mesh<P>`
                 
-### Draw a Surface Mesh ###
+## Draw a Surface Mesh ##
 - `CGAL::draw<SM>`
 
 */

--- a/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
+++ b/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
@@ -26,19 +26,19 @@ The API is flexible and can be extended to user-defined proxies and error metric
 
 \cgalClassifedRefPages
 
-## Parameters ##
+\cgalCRPSection{Parameters}
 Optional parameters of the functions of this package
 are implemented as BGL named parameters.
 The page \ref vsa_namedparameters describes their usage
 and provides the list of parameters used in this package.
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `ErrorMetricProxy`
 
-## Main Functions ##
+\cgalCRPSection{Main Functions}
 - `CGAL::Surface_mesh_approximation::approximate_triangle_mesh()`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Surface_mesh_approximation::L21_metric_plane_proxy`
 - `CGAL::Surface_mesh_approximation::L2_metric_plane_proxy`
 - `CGAL::Variational_shape_approximation`

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
@@ -25,15 +25,15 @@ under positional constraints of some of its vertices, without requiring any addi
 \cgalClassifedRefPages
 
 
-## Main Class ##
+\cgalCRPSection{Main Class}
 - `#CGAL::Surface_mesh_deformation`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `DeformationClosestRotationTraits_3`
 - `RawPoint_3`
 - `SurfaceMeshDeformationWeights`
 
-## Algebraic Traits ##
+\cgalCRPSection{Algebraic Traits}
 - `#CGAL::Deformation_Eigen_closest_rotation_traits_3`
 - `#CGAL::Deformation_Eigen_polar_closest_rotation_traits_3`
 

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Concepts/Parameterizer_3.h
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Concepts/Parameterizer_3.h
@@ -8,8 +8,7 @@ of mesh, `TriangleMesh`, which must be a model of the `FaceGraph` concept.
 Border parameterizers are also models of this concept but they only parameterize
 the border of a given mesh.
 
-Creation
---------------
+\cgalHeading{Creation}
 
 Construction and destruction are undefined.
 

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
@@ -28,15 +28,15 @@ The code is generic and works with any model of the `FaceGraph` concept.}
 
 \cgalClassifedRefPages
 
-## Main Function ##
+\cgalCRPSection{Main Function}
 
 - `CGAL::Surface_mesh_parameterization::parameterize()`
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `Parameterizer_3`
 
-## Surface Parameterization Methods ##
+\cgalCRPSection{Surface Parameterization Methods}
 
 This \cgal package implements several parameterization methods:
 
@@ -64,7 +64,7 @@ The following classes implement the methods listed above:
 - `CGAL::Surface_mesh_parameterization::Mean_value_coordinates_parameterizer_3<TriangleMesh, BorderParameterizer, SolverTraits>`
 - `CGAL::Surface_mesh_parameterization::Orbifold_Tutte_parameterizer_3<TriangleMesh, SolverTraits>`
 
-## Border Parameterization Methods ##
+\cgalCRPSection{Border Parameterization Methods}
 
 Border parameterization methods define a
 set of constraints (a constraint specifies two (u,v) coordinates for
@@ -85,14 +85,14 @@ The following classes implement the methods listed above:
 - `CGAL::Surface_mesh_parameterization::Square_border_arc_length_parameterizer_3<TriangleMesh>`
 - `CGAL::Surface_mesh_parameterization::Two_vertices_parameterizer_3<TriangleMesh>`
 
-## Mesh ##
+\cgalCRPSection{Mesh}
 
 The general definition of input meshes handled directly by
 `CGAL::Surface_mesh_parameterization::parameterize()` is a triangulated surface
 mesh model of `FaceGraph` that is homeomorphic to a disc (may have holes). In
 particular, it means that it must be 2-manifold and oriented.
 
-## Checks and Assertions ##
+\cgalCRPSection{Checks and Assertions}
 
 The package performs the next checks:
 

--- a/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
+++ b/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
@@ -32,10 +32,10 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `#SegmentationGeomTraits`
 
-## Main Functions ##
+\cgalCRPSection{Main Functions}
 - `#CGAL::sdf_values()`
 - `#CGAL::sdf_values_postprocessing()`
 - `#CGAL::segmentation_from_sdf_values()`

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
@@ -30,16 +30,16 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `SurfaceMeshShortestPathTraits`
 - `SurfaceMeshShortestPathVisitor`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Surface_mesh_shortest_path<SurfaceMeshShortestPathTraits,VertexIndexMap, HalfedgeIndexMap, FaceIndexMap, VertexPointMap>`
 - `CGAL::Surface_mesh_shortest_path_traits<Kernel, FaceListGraph>`
 
-## Enums ##
+\cgalCRPSection{Enums}
 
 - `CGAL::Surface_mesh_shortest_paths_3::Barycentric_coordinates_type`
 

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
@@ -21,17 +21,17 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `EdgeProfile`
 - `StopPredicate`
 - `GetCost`
 - `GetPlacement`
 - `EdgeCollapseSimplificationVisitor`
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::Surface_mesh_simplification::edge_collapse()`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Surface_mesh_simplification::Edge_collapse_visitor_base<TriangleMesh>`
 - `CGAL::Surface_mesh_simplification::Edge_profile<TriangleMesh>`
 - `CGAL::Surface_mesh_simplification::Count_stop_predicate<TriangleMesh>`

--- a/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
+++ b/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
@@ -28,12 +28,12 @@
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `MeanCurvatureSkeletonizationTraits`
 - `NormalEquationSparseLinearAlgebraTraits_d`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
  - `CGAL::Mean_curvature_flow_skeletonization`
  

--- a/Surface_mesher/doc/Surface_mesher/PackageDescription.txt
+++ b/Surface_mesher/doc/Surface_mesher/PackageDescription.txt
@@ -78,7 +78,7 @@ of  the output mesh  while avoiding an over-refinement of the mesh.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `SurfaceMeshComplex_2InTriangulation_3`
 - `SurfaceMeshTraits_3`
 - `SurfaceMeshFacetsCriteria_3`
@@ -88,7 +88,7 @@ of  the output mesh  while avoiding an over-refinement of the mesh.
 - `ImplicitFunction`
 - `ImplicitSurfaceTraits_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Surface_mesh_complex_2_in_triangulation_3<Tr, Edge_info = void>`
 - `CGAL::Surface_mesh_vertex_base_3<Gt,Vb>`
 - `CGAL::Surface_mesh_cell_base_3<Gt,Cb>`
@@ -98,12 +98,12 @@ of  the output mesh  while avoiding an over-refinement of the mesh.
 - `CGAL::Implicit_surface_3<Traits, Function>`
 - `CGAL::Gray_level_image_3<FT, Point>`
 
-## Tag Classes ##
+\cgalCRPSection{Tag Classes}
 - `CGAL::Manifold_tag`
 - `CGAL::Manifold_with_boundary_tag`
 - `CGAL::Non_manifold_tag`
 
-## Function Templates ##
+\cgalCRPSection{Function Templates}
 - `CGAL::make_surface_mesh()`
 - `CGAL::output_surface_facets_to_polyhedron()`
 - `CGAL::facets_in_complex_2_to_triangle_mesh()`

--- a/Surface_sweep_2/doc/Surface_sweep_2/PackageDescription.txt
+++ b/Surface_sweep_2/doc/Surface_sweep_2/PackageDescription.txt
@@ -30,7 +30,7 @@ manner.
 
 \cgalClassifedRefPages
 
-## Functions ##
+\cgalCRPSection{Functions}
 - `CGAL::compute_intersection_points`
 - `CGAL::compute_subcurves`
 - `CGAL::do_curves_intersect`

--- a/TDS_2/doc/TDS_2/PackageDescription.txt
+++ b/TDS_2/doc/TDS_2/PackageDescription.txt
@@ -49,7 +49,7 @@ These refining concepts and their models are described in Chapter
 \ref Chapter_2D_Triangulations "2D Triangulations".
 
 \cgalClassifedRefPages
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `TriangulationDataStructure_2`
 - `TriangulationDataStructure_2::Face`
 - `TriangulationDataStructure_2::Vertex`
@@ -57,7 +57,7 @@ These refining concepts and their models are described in Chapter
 - `TriangulationDSFaceBase_2`
 - `TriangulationDSVertexBase_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Triangulation_data_structure_2<Vb,Fb>`
 - `CGAL::Triangulation_ds_face_base_2<Tds>`
 - `CGAL::Triangulation_ds_vertex_base_2<Tds>`

--- a/TDS_3/doc/TDS_3/PackageDescription.txt
+++ b/TDS_3/doc/TDS_3/PackageDescription.txt
@@ -46,7 +46,7 @@ Section  \ref TDS3secintro.)
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `TriangulationDataStructure_3`
 - `TriangulationDataStructure_3::Cell`
@@ -54,7 +54,7 @@ Section  \ref TDS3secintro.)
 - `TriangulationDSCellBase_3`
 - `TriangulationDSVertexBase_3`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Triangulation_data_structure_3<TriangulationDSVertexBase_3,TriangulationDSCellBase_3,Vertex_container_strategy,Cell_container_strategy,Concurrency_tag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
 
@@ -63,7 +63,7 @@ Section  \ref TDS3secintro.)
 - `CGAL::Triangulation_ds_cell_base_3<TDS>`
 - `CGAL::Triangulation_ds_vertex_base_3<TDS>`
 
-## Helper Classes ##
+\cgalCRPSection{Helper Classes}
 
 - `CGAL::Triangulation_utils_3` defines operations on the indices of vertices and neighbors within
 a cell of a triangulation.

--- a/Three/doc/Three/PackageDescription.txt
+++ b/Three/doc/Three/PackageDescription.txt
@@ -18,13 +18,13 @@
 \cgalPkgDescriptionEnd
 
 \cgalClassifedRefPages
-## Interfaces ##
+\cgalCRPSection{Interfaces}
 - `CGAL::Three::Viewer_interface`
 - `CGAL::Three::Scene_interface`
 - `CGAL::Three::Polyhedron_demo_plugin_interface`
 - `CGAL::Three::Polyhedron_demo_io_plugin_interface`
 
-## Classes ##
+\cgalCRPSection{Classes}
 -  `TextRenderer`
 -  `TextItem`
 -  `TextListItem`

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation.h
@@ -37,8 +37,7 @@ The triangulation deduces its maximal dimension from the type
 the dimension returned by
 `TriangulationDataStructure_::maximal_dimension()`.
 
-Input/Output
---------------
+\cgalHeading{Input/Output}
 
 The information in the `iostream` is: the current dimension, the number of
 finite vertices, the non-combinatorial information about vertices (point,

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_full_cell.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_full_cell.h
@@ -43,8 +43,7 @@ See the user manual for how to choose the second option.
 
 \cgalModels `TriangulationDSFullCell`
 
-Rebind mechanism 
--------------- 
+\cgalHeading{Rebind mechanism}
 
 In case of derivation from that class, the nested class 
 `Rebind_TDS` need to be provided in the derived class. 

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_vertex.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_vertex.h
@@ -23,8 +23,7 @@ example).
 
 \cgalModels `TriangulationDSVertex`
 
-Rebind Mechanism 
--------------- 
+\cgalHeading{Rebind mechanism}
 
 In case of derivation from that class, the nested class 
 `Rebind_TDS` need to be provided in the derived class. 

--- a/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
@@ -47,8 +47,7 @@ We call a \f$ 0\f$-simplex a <I>vertex</I>, a \f$ (d-1)\f$-simplex a <I>facet</I
 Two full cells are <I>neighbors</I> if they share a facet. Two faces are
 <I>incident</I> if one is included in the other.
 
-Input/Output
---------------
+\cgalHeading{Input/Output}
 
 The information stored in the `iostream` is:
 

--- a/Triangulation/doc/Triangulation/Concepts/TriangulationVertex.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationVertex.h
@@ -14,8 +14,7 @@ an association of the vertex with a geometric point.
 
 \cgalHasModel `CGAL::Triangulation_vertex<TriangulationTraits_, Data, TriangulationDSVertex_>`
 
-Input/Output 
--------------- 
+\cgalHeading{Input/Output}
 
 These operators can be used directly and are called by the I/O 
 operator of class `Triangulation`. 

--- a/Triangulation/doc/Triangulation/PackageDescription.txt
+++ b/Triangulation/doc/Triangulation/PackageDescription.txt
@@ -71,9 +71,9 @@ is opposite to the vertex with the same index.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
-## Triangulation Data Structure ##
+\cgalCRPSection{Triangulation Data Structure}
 
 - `TriangulationDataStructure`
 - `TriangulationDataStructure::FullCell`
@@ -83,7 +83,7 @@ is opposite to the vertex with the same index.
 - `TriangulationDSFace`
 - `FullCellData`
 
-## Triangulations ##
+\cgalCRPSection{Triangulations}
 
 - `TriangulationTraits`
 - `DelaunayTriangulationTraits`
@@ -93,16 +93,16 @@ is opposite to the vertex with the same index.
 
 The latter two concepts are also abbreviated respectively as `TrVertex` and `TrFullCell`.
 
-## Classes ##
+\cgalCRPSection{Classes}
 
-## Triangulation Data Structure ##
+\cgalCRPSection{Triangulation Data Structure}
 
 - `CGAL::Triangulation_data_structure<Dimensionality, TriangulationDSVertex_, TriangulationDSFullCell_>`
 - `CGAL::Triangulation_ds_vertex<TriangulationDataStructure_>`
 - `CGAL::Triangulation_ds_full_cell<TriangulationDataStructure_, TriangulationDSFullCellStoragePolicy>`
 - `CGAL::Triangulation_face<TriangulationDataStructure_>`
 
-## (Geometric) Triangulations ##
+\cgalCRPSection{(Geometric) Triangulations}
 
 - `CGAL::Triangulation<TriangulationTraits_, TriangulationDataStructure_>`
 - `CGAL::Delaunay_triangulation<DelaunayTriangulationTraits_, TriangulationDataStructure_>`
@@ -110,11 +110,11 @@ The latter two concepts are also abbreviated respectively as `TrVertex` and `TrF
 - `CGAL::Triangulation_vertex<TriangulationTraits_, Data, TriangulationDSVertex_>`
 - `CGAL::Triangulation_full_cell<TriangulationTraits_, Data, TriangulationDSFullCell_>`
 
-## Traits Classes ##
+\cgalCRPSection{Traits Classes}
 
 -  `CGAL::Regular_triangulation_traits_adapter<K>`
 
-## Enums ##
+\cgalCRPSection{Enums}
 
 - `CGAL::Triangulation::Locate_type`
 */

--- a/Triangulation/doc/Triangulation/PackageDescription.txt
+++ b/Triangulation/doc/Triangulation/PackageDescription.txt
@@ -69,7 +69,7 @@ indexed  in such a way that the neighbor indexed by \f$ i\f$
 is opposite to the vertex with the same index.
 --->
 
-# Reference Pages Sorted by Type #
+\cgalClassifedRefPages
 
 ## Concepts ##
 

--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -70,7 +70,7 @@ are described in Chapter \ref PkgTDS2Ref "2D Triangulation Data Structure".
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `TriangulationTraits_2`
 - `DelaunayTriangulationTraits_2`
 - `RegularTriangulationTraits_2`
@@ -85,7 +85,7 @@ are described in Chapter \ref PkgTDS2Ref "2D Triangulation Data Structure".
 - `TriangulationHierarchyVertexBase_2`
 - `TriangulationVertexBaseWithInfo_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Triangulation_2<Traits,Tds>`
 - `CGAL::Delaunay_triangulation_2<Traits,Tds>`
@@ -109,10 +109,10 @@ are described in Chapter \ref PkgTDS2Ref "2D Triangulation Data Structure".
 
 - `CGAL::Triangulation_cw_ccw_2`
 
-## Enum ##
+\cgalCRPSection{Enum}
 - \link CGAL::Triangulation_2::Locate_type `CGAL::Triangulation_2<Traits,Tds>::Locate_type` \endlink
 
-## Draw a Triangulation 2 ##
+\cgalCRPSection{Draw a Triangulation 2}
 - `CGAL::draw<T2>`
 
 */

--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -112,7 +112,7 @@ are described in Chapter \ref PkgTDS2Ref "2D Triangulation Data Structure".
 ## Enum ##
 - \link CGAL::Triangulation_2::Locate_type `CGAL::Triangulation_2<Traits,Tds>::Locate_type` \endlink
 
-### Draw a Triangulation 2 ###
+## Draw a Triangulation 2 ##
 - `CGAL::draw<T2>`
 
 */

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -74,7 +74,7 @@ is opposite to the vertex with the same index. See
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `TriangulationTraits_3`
 - `DelaunayTriangulationTraits_3`
@@ -90,7 +90,7 @@ is opposite to the vertex with the same index. See
 - `TriangulationDataStructure_3`
 - `WeightedPoint`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 \cgalCRPSubsection{Main Classes}
 
@@ -113,11 +113,11 @@ is opposite to the vertex with the same index. See
 - `CGAL::Regular_triangulation_euclidean_traits_3<K,Weight>`
 - `CGAL::Robust_weighted_circumcenter_filtered_traits_3<K>`
 
-## Enums ##
+\cgalCRPSection{Enums}
 
 - `CGAL::Triangulation_3::Locate_type`
 
-## Draw a Triangulation 3 ##
+\cgalCRPSection{Draw a Triangulation 3}
 - `CGAL::draw<T3>`
 
 */

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -92,7 +92,7 @@ is opposite to the vertex with the same index. See
 
 ## Classes ##
 
-### Main Classes ###
+\cgalCRPSubsection{Main Classes}
 
 - `CGAL::Triangulation_3<TriangulationTraits_3,TriangulationDataStructure_3,SurjectiveLockDataStructure>`
 - `CGAL::Delaunay_triangulation_3<DelaunayTriangulationTraits_3,TriangulationDataStructure_3,LocationPolicy,SurjectiveLockDataStructure>`
@@ -108,7 +108,7 @@ is opposite to the vertex with the same index. See
 - `CGAL::Regular_triangulation_cell_base_with_weighted_circumcenter_3<RegularTriangulationTraits_3,Cb>`
 - `CGAL::Triangulation_simplex_3<Triangulation_3>`
 
-### Traits Classes ###
+\cgalCRPSubsection{Traits Classes}
 
 - `CGAL::Regular_triangulation_euclidean_traits_3<K,Weight>`
 - `CGAL::Robust_weighted_circumcenter_filtered_traits_3<K>`

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -117,7 +117,7 @@ is opposite to the vertex with the same index. See
 
 - `CGAL::Triangulation_3::Locate_type`
 
-### Draw a Triangulation 3 ###
+## Draw a Triangulation 3 ##
 - `CGAL::draw<T3>`
 
 */

--- a/Visibility_2/doc/Visibility_2/PackageDescription.txt
+++ b/Visibility_2/doc/Visibility_2/PackageDescription.txt
@@ -27,10 +27,10 @@ the visibility area of a point within polygonal regions in two dimensions.}
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 - `Visibility_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 - `CGAL::Simple_polygon_visibility_2<Arrangement_2, Regularization_tag>`
 - `CGAL::Rotational_sweep_visibility_2<Arrangement_2, Regularization_tag>` 
 - `CGAL::Triangular_expansion_visibility_2<Arrangement_2, Regularization_tag>`

--- a/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
+++ b/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
@@ -55,13 +55,13 @@ performing this adaptation.
 
 \cgalClassifedRefPages
 
-## Concepts ##
+\cgalCRPSection{Concepts}
 
 - `DelaunayGraph_2`
 - `AdaptationTraits_2`
 - `AdaptationPolicy_2`
 
-## Classes ##
+\cgalCRPSection{Classes}
 
 - `CGAL::Voronoi_diagram_2<DG,AT,AP>`
 - \link CGAL::Voronoi_diagram_2::Halfedge `CGAL::Voronoi_diagram_2<DG,AT,AP>::Halfedge` \endlink


### PR DESCRIPTION
With the proposed pull request https://github.com/doxygen/doxygen/pull/6793 CGAL would give a number of warning like "found subsubsection command outside of subsection context!" , these are due to the use of the `##` and `---` heading types where the previous level is not used. These headings were only used to have headers (i.e. larger characters and bold), these type of headers have been translated to the new `ALIASES`: `\cgalLevel2` and `\cgalLevel3`, giving also more flexibility regarding possible layout.

**TODO:**
- [ ] Update doc wiki after the merge
