### PR TITLE
P2T2: Fix not using periodic vertex bases in P2T2 examples

### DIFF
--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_pair_iterator_2.cpp
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_pair_iterator_2.cpp
@@ -2,18 +2,21 @@
 
 #include <CGAL/Periodic_2_Delaunay_triangulation_2.h>
 #include <CGAL/Periodic_2_Delaunay_triangulation_traits_2.h>
+#include <CGAL/Periodic_2_triangulation_face_base_2.h>
+#include <CGAL/Periodic_2_triangulation_vertex_base_2.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 
 #include <iostream>
 #include <vector>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
-typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>         Gt;
-typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt>   Vb;
-typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>              Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                Tds;
-typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>          Delaunay;
-typedef Delaunay::Point                                             Point;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel             K;
+typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>             Gt;
+typedef CGAL::Periodic_2_triangulation_vertex_base_2<Gt>                Vbb;
+typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt, Vbb>  Vb;
+typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>                  Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                    Tds;
+typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>              Delaunay;
+typedef Delaunay::Point                                                 Point;
 
 int main()
 {

--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_transform_iterator_2.cpp
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_transform_iterator_2.cpp
@@ -2,18 +2,21 @@
 
 #include <CGAL/Periodic_2_Delaunay_triangulation_2.h>
 #include <CGAL/Periodic_2_Delaunay_triangulation_traits_2.h>
+#include <CGAL/Periodic_2_triangulation_face_base_2.h>
+#include <CGAL/Periodic_2_triangulation_vertex_base_2.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 
 #include <iostream>
 #include <vector>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
-typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>         Gt;
-typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt>   Vb;
-typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>              Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                Tds;
-typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>          Delaunay;
-typedef Delaunay::Point                                             Point;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel             K;
+typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>             Gt;
+typedef CGAL::Periodic_2_triangulation_vertex_base_2<Gt>                Vbb;
+typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt, Vbb>  Vb;
+typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>                  Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                    Tds;
+typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>              Delaunay;
+typedef Delaunay::Point                                                 Point;
 
 //a functor that returns a std::pair<Point,unsigned>.
 //the unsigned integer is incremented at each call to

--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_zip_iterator_2.cpp
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_info_insert_with_zip_iterator_2.cpp
@@ -2,18 +2,21 @@
 
 #include <CGAL/Periodic_2_Delaunay_triangulation_traits_2.h>
 #include <CGAL/Periodic_2_Delaunay_triangulation_2.h>
+#include <CGAL/Periodic_2_triangulation_face_base_2.h>
+#include <CGAL/Periodic_2_triangulation_vertex_base_2.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 
 #include <iostream>
 #include <vector>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
-typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>         Gt;
-typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt>   Vb;
-typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>              Fb;
-typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                 Tds;
-typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>          Delaunay;
-typedef Delaunay::Point                                             Point;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel             K;
+typedef CGAL::Periodic_2_Delaunay_triangulation_traits_2<K>             Gt;
+typedef CGAL::Periodic_2_triangulation_vertex_base_2<Gt>                Vbb;
+typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, Gt, Vbb>  Vb;
+typedef CGAL::Periodic_2_triangulation_face_base_2<Gt>                  Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                    Tds;
+typedef CGAL::Periodic_2_Delaunay_triangulation_2<Gt, Tds>              Delaunay;
+typedef Delaunay::Point                                                 Point;
 
 int main()
 {


### PR DESCRIPTION
## Summary of Changes

Some examples in P2T2 were using insufficient vertex base classes (only T2 vertex classes and not P2T2 vertex classes). 

It was most likely only seen on some Windows platforms (e.g. https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-105/Periodic_2_triangulation_2_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2013-Debug-64bits.gz), because that compiler was over-zealous and compiling functions not used by the examples (whatever the P2T2 vertex base class brings is rarely used).

## Release Management

* Affected package(s): `Periodic_2_triangulation_2`

