### PR TITLE
Polyhedron Demo: Fix Erase_all

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1963,9 +1963,11 @@ bool MainWindow::on_actionErase_triggered()
 
 void MainWindow::on_actionEraseAll_triggered()
 {
-  scene->setSelectedItem(0);
-  while(on_actionErase_triggered()) {
-  }
+  QList<int> all_ids;
+  for(int i = 0; i < scene->numberOfEntries(); ++i)
+    all_ids.push_back(i);
+  scene->setSelectedItemsList(all_ids);
+  on_actionErase_triggered();
 }
 
 void MainWindow::on_actionDuplicate_triggered()


### PR DESCRIPTION
## Summary of Changes
Remove the while() mechanic in the eraseall() function of the mainwindow. This way, if the first item of the scene (index 0) is a lock child of a group, it won't hang because it cannot be erased and the erase function returns false.

## Release Management
* Issue(s) solved (if any): fix #3626
