### PR TITLE
OTR: Fix validity of triangulation

### DIFF
--- a/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
@@ -921,7 +921,7 @@ public:
     return true;
   }
 
-  bool check_validity_test (const Edge& edge)
+  bool check_validity_test () const
   {
     for(Finite_faces_iterator it = Base::finite_faces_begin();
         it != Base::finite_faces_end(); it++)

--- a/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/OTR_2/Reconstruction_triangulation_2.h
@@ -921,6 +921,22 @@ public:
     return true;
   }
 
+  bool check_validity_test (const Edge& edge)
+  {
+    for(Finite_faces_iterator it = Base::finite_faces_begin();
+        it != Base::finite_faces_end(); it++)
+    {
+      typename Traits_::Orientation s
+        = orientation(it->vertex(0)->point(),
+                      it->vertex(1)->point(),
+                      it->vertex(2)->point());
+      if (s != LEFT_TURN)
+        return false;
+    }
+
+    return true;  
+  }
+
   // COLLAPSE //
 
   // (s,a,b) + (s,b,c) -> (s,a,c) + (a,b,c)

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -606,19 +606,22 @@ public:
       ok = copy.make_collapsible(copy_edge, copy_hull.begin(),
           copy_hull.end(), m_verbose);
       if (!ok) {
-        // std::cerr << "simulation: failed (make collapsible)" << std::endl;
+        if (m_verbose > 1)
+          std::cerr << "simulation: failed (make collapsible)" << std::endl;
         return false;
       }
       ok = copy.check_validity_test(copy_edge);
       if (!ok) {
-        std::cerr << "simulation: failed (validity test)" << std::endl;
+        if (m_verbose > 1)
+          std::cerr << "simulation: failed (validity test)" << std::endl;
         return false;
       }
     }
 
     ok = copy.check_kernel_test(copy_edge);
     if (!ok) {
-      std::cerr << "simulation: failed (kernel test)" << std::endl;
+      if (m_verbose > 1)
+        std::cerr << "simulation: failed (kernel test)" << std::endl;
       return false;
     }
 
@@ -626,7 +629,8 @@ public:
 
     ok = copy.check_validity_test(copy_edge);
     if (!ok) {
-      std::cerr << "simulation: failed (validity test)" << std::endl;
+      if (m_verbose > 1)
+        std::cerr << "simulation: failed (validity test)" << std::endl;
       return false;
     }
 

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -609,6 +609,11 @@ public:
         // std::cerr << "simulation: failed (make collapsible)" << std::endl;
         return false;
       }
+      ok = copy.check_validity_test(copy_edge);
+      if (!ok) {
+        std::cerr << "simulation: failed (validity test)" << std::endl;
+        return false;
+      }
     }
 
     ok = copy.check_kernel_test(copy_edge);
@@ -618,6 +623,12 @@ public:
     }
 
     copy.collapse(copy_edge, m_verbose);
+
+    ok = copy.check_validity_test(copy_edge);
+    if (!ok) {
+      std::cerr << "simulation: failed (validity test)" << std::endl;
+      return false;
+    }
 
     Sample_vector samples;
     m_dt.collect_samples_from_vertex(s, samples, false);

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -610,7 +610,7 @@ public:
           std::cerr << "simulation: failed (make collapsible)" << std::endl;
         return false;
       }
-      ok = copy.check_validity_test(copy_edge);
+      ok = copy.check_validity_test();
       if (!ok) {
         if (m_verbose > 1)
           std::cerr << "simulation: failed (validity test)" << std::endl;
@@ -627,7 +627,7 @@ public:
 
     copy.collapse(copy_edge, m_verbose);
 
-    ok = copy.check_validity_test(copy_edge);
+    ok = copy.check_validity_test();
     if (!ok) {
       if (m_verbose > 1)
         std::cerr << "simulation: failed (validity test)" << std::endl;

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -926,6 +926,9 @@ public:
 
   // edge must not be pinned or have cyclic target
   Edge copy_star(const Edge& edge, Triangulation& copy) {
+    copy.tds().clear();
+    Vertex_handle vinf = copy.tds().create_vertex();
+    copy.set_infinite_vertex (vinf);
     copy.tds().set_dimension(2);
     copy.infinite_vertex()->pinned() = true;
 
@@ -944,10 +947,9 @@ public:
     {
       Vertex_handle v = vcirc;
       CGAL_assertion(v!=m_dt.infinite_vertex());
-      if (cvmap.find(v) == cvmap.end()) {
-        Vertex_handle cv = copy.tds().create_vertex();
-        cvmap[v] = copy_vertex(v, cv);
-      }
+      CGAL_assertion (cvmap.find(v) == cvmap.end());
+      Vertex_handle cv = copy.tds().create_vertex();
+      cvmap[v] = copy_vertex(v, cv);
     }
 
     // copy faces
@@ -994,7 +996,9 @@ public:
   {
     for (unsigned i = 0; i < 3; ++i) {
       Vertex_handle v0i = f0->vertex(i);
+      CGAL_assertion (vmap.find(v0i) != vmap.end());
       Vertex_handle v1i = vmap[v0i];
+      CGAL_assertion (v1i != Vertex_handle());
       f1->set_vertex(i, v1i);
       v1i->set_face(f1);
     }


### PR DESCRIPTION
## Summary of Changes

The OTR algorithm manipulates triangulation objects using low-level functions. In many cases, the validity of the `Triangulation_2` (and even of the TDS sometimes) was broken. Most of the time, things still went well (by luck) but it was likely to create bugs such as https://github.com/CGAL/cgal/issues/3601.

This PR does the following:
- corrects `copy_star()` so that the copy is a valid triangulation (it was _never_ the case before). Note that because the copy is only a copy of a 1-star around a vertex, it may have concavities (therefore, only the TDS is made valid, not the `Triangulation_2`)
- adds a validity-check after flipping and after collapsing (both can produce invalid triangulations) and discard the candidate edge if the produced triangulation is invalid (we only check the geometric orientation of the faces, which is the validity criterion that can be violated)

@palliez do you think these changes make sense? We are forbidding more operations, but it seems very unsafe to create invalid triangulations, so I'm not sure we have the choice…

Experimentally, it does fix https://github.com/CGAL/cgal/issues/3601. I did not notice impacts on cases that were already working (but we don't have that many use cases). The validity checks are only performed on very small triangulation (the copy of a vertex + its 1-ring), so the impact on performances should be reasonable.

## Release Management

* Affected package(s): Optimal Transportation Reconstruction
* Issue(s) solved (if any): fix #3601 

