### PR TITLE
Periodic_3_mesh_3: Link with ImageIO for VC++

### DIFF
--- a/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
@@ -5,10 +5,16 @@ project( Periodic_3_mesh_3_Examples )
 
 cmake_minimum_required(VERSION 3.1)
 
-# CGAL and its components
-find_package( CGAL QUIET )
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 
-if ( NOT CGAL_FOUND )
+# CGAL and its components
+find_package( CGAL QUIET  COMPONENTS ImageIO )
+
+if ( CGAL_FOUND )
+  include( ${CGAL_USE_FILE} )
+else()  
   message(STATUS "This project requires the CGAL library, and will not be compiled.")
   return()
 endif()

--- a/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
@@ -5,9 +5,10 @@ project( Periodic_3_mesh_3_Tests )
 
 cmake_minimum_required(VERSION 3.1)
 
-find_package( CGAL QUIET )
+find_package( CGAL QUIET COMPONENTS ImageIO )
 
 if ( CGAL_FOUND )
+  include( ${CGAL_USE_FILE} )
 
   # Use Eigen
   find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)

--- a/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
@@ -5,6 +5,10 @@ project( Periodic_3_mesh_3_Tests )
 
 cmake_minimum_required(VERSION 3.1)
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package( CGAL QUIET COMPONENTS ImageIO )
 
 if ( CGAL_FOUND )


### PR DESCRIPTION
## Summary of Changes

Fix for  the testuite  [4.14-I-108](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-108/Periodic_3_mesh_3/TestReport_afabri_x64_Cygwin-Windows10_MSVC2013-Debug-64bits.gz)

* Added `ImageIO` to `find_package()`  
* Added `include( ${CGAL_USE_FILE} )` 


## Release Management

* Affected package(s): Periodic_3_mesh_3

Fixes #3559.
