### PR TITLE
Convex_hull_d: Initialize to avoid warning

### DIFF
--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -85,7 +85,7 @@ class RC_vertex_d
 public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
-  RC_vertex_d(const Point_d& p) : point_(p), index_(-42), pp(NULL) {}
+  RC_vertex_d(const Point_d& p) : index_(-42), point_(p), pp(NULL) {}
   RC_vertex_d() :  s_(), index_(-42), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -85,8 +85,8 @@ class RC_vertex_d
 public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
-  RC_vertex_d(const Point_d& p) : index_(-42), point_(p), pp(NULL) {}
-  RC_vertex_d() :  s_(),  index_(-42), pp(NULL) {}
+  RC_vertex_d(const Point_d& p) : point_(p), pp(NULL) {}
+  RC_vertex_d() :  s_(), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}
 

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -86,7 +86,7 @@ public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
   RC_vertex_d(const Point_d& p) : index_(-42), point_(p), pp(NULL) {}
-  RC_vertex_d() :  s_(), pp(NULL) {}
+  RC_vertex_d() :  s_(),  index_(-42), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}
 
@@ -514,9 +514,7 @@ Vertex_handle  new_vertex()
         is the point |Regular_complex_d::nil_point| which is a static
         member of class |Regular_complex_d.|}*/
 { 
-  Vertex v(nil_point);
-  Vertex_handle h = vertices_.insert(v);
-  return h; 
+  return vertices_.emplace(nil_point); 
 }
 
 Vertex_handle  new_vertex(const Point_d& p) 
@@ -524,7 +522,7 @@ Vertex_handle  new_vertex(const Point_d& p)
         has |p| as the associated point, but is has no associated
         simplex nor index yet.}*/
 { 
-  return vertices_.emplace(p);;
+  return vertices_.emplace(p);
 }
 
 void associate_vertex_with_simplex(Simplex_handle s, int i, Vertex_handle v)

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -85,7 +85,7 @@ class RC_vertex_d
 public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
-  RC_vertex_d(const Point_d& p) : point_(p), index_(0), pp(NULL) {}
+  RC_vertex_d(const Point_d& p) : point_(p), index_(-42), pp(NULL) {}
   RC_vertex_d() :  s_(), index_(-42), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -86,7 +86,7 @@ public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
   RC_vertex_d(const Point_d& p) : index_(-42), point_(p), pp(NULL) {}
-  RC_vertex_d() :  s_(), index_(-42), pp(NULL) {}
+  RC_vertex_d() :  s_(), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}
 
@@ -524,9 +524,7 @@ Vertex_handle  new_vertex(const Point_d& p)
         has |p| as the associated point, but is has no associated
         simplex nor index yet.}*/
 { 
-  Vertex v(p);
-  Vertex_handle h = vertices_.insert(v);
-  return h;
+  return vertices_.emplace(p);;
 }
 
 void associate_vertex_with_simplex(Simplex_handle s, int i, Vertex_handle v)

--- a/Convex_hull_d/include/CGAL/Regular_complex_d.h
+++ b/Convex_hull_d/include/CGAL/Regular_complex_d.h
@@ -85,7 +85,7 @@ class RC_vertex_d
 public:
   RC_vertex_d(Simplex_handle s, int i, const Point_d& p) :
     s_(s), index_(i), point_(p) {}
-  RC_vertex_d(const Point_d& p) : point_(p), pp(NULL) {}
+  RC_vertex_d(const Point_d& p) : point_(p), index_(0), pp(NULL) {}
   RC_vertex_d() :  s_(), index_(-42), pp(NULL) {}
   // beware that ass_point was initialized here by nil_point
   ~RC_vertex_d() {}


### PR DESCRIPTION
## Summary of Changes

Fix warning in the testsuite [4.14-Ic-110](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-110/Convex_hull_d/TestReport_lrineau_ArchLinux-CXX17-Release.gz)
I initialize now an `int` with `0`, but didn't check if the before uninitialized member was ever used.


## Release Management

* Affected package(s): Convex_hull_d

