### PR TITLE
Polygon_mesh_processing: Initialize a boost::optional

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
@@ -165,10 +165,10 @@ void test_bool_op_no_copy(
   assert( count_constrained_edges(tm2, ecm2)==307 );
 
   typedef boost::optional<Triangle_mesh*> OTM;
-
+  Triangle_mesh *ptr = NULL;
   const CGAL::cpp11::array<OTM,4> output =
-    reverse ? CGAL::make_array(OTM(&tm2), OTM(&tm1), boost::none, boost::none)
-            : CGAL::make_array(OTM(&tm1), OTM(&tm2), boost::none, boost::none);
+    reverse ? CGAL::make_array(OTM(&tm2), OTM(&tm1), boost::make_optional(false,ptr), boost::make_optional(false,ptr))
+            : CGAL::make_array(OTM(&tm1), OTM(&tm2), boost::make_optional(false,ptr), boost::make_optional(false,ptr));
   PMP::corefine_and_compute_boolean_operations(tm1,
                                                tm2,
                                                output,

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
@@ -165,10 +165,10 @@ void test_bool_op_no_copy(
   assert( count_constrained_edges(tm2, ecm2)==307 );
 
   typedef boost::optional<Triangle_mesh*> OTM;
-  OTM none(boost::none);
+
   const CGAL::cpp11::array<OTM,4> output =
-    reverse ? CGAL::make_array(OTM(&tm2), OTM(&tm1), none, none)
-            : CGAL::make_array(OTM(&tm1), OTM(&tm2), none, none);
+    reverse ? CGAL::make_array(OTM(&tm2), OTM(&tm1), boost::none, boost::none)
+            : CGAL::make_array(OTM(&tm1), OTM(&tm2), boost::none, boost::none);
   PMP::corefine_and_compute_boolean_operations(tm1,
                                                tm2,
                                                output,

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
@@ -165,7 +165,7 @@ void test_bool_op_no_copy(
   assert( count_constrained_edges(tm2, ecm2)==307 );
 
   typedef boost::optional<Triangle_mesh*> OTM;
-  OTM none;
+  OTM none(boost::none);
   const CGAL::cpp11::array<OTM,4> output =
     reverse ? CGAL::make_array(OTM(&tm2), OTM(&tm1), none, none)
             : CGAL::make_array(OTM(&tm1), OTM(&tm2), none, none);


### PR DESCRIPTION
## Summary of Changes

Initialize a `boost::optional` to see if [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-110/Polygon_mesh_processing/TestReport_lrineau_Fedora-32-Release.gz) goes away.

## Release Management

* Affected package(s): Polygon_mesh_processing

