### PR TITLE
Address VC++ deprecation warnings concerning the STL

### DIFF
--- a/AABB_tree/examples/AABB_tree/AABB_custom_indexed_triangle_set_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_custom_indexed_triangle_set_example.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <list>
-#include <boost/iterator.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/AABB_tree.h>

--- a/AABB_tree/examples/AABB_tree/AABB_custom_triangle_soup_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_custom_triangle_soup_example.cpp
@@ -1,10 +1,11 @@
+
 // Author(s) : Camille Wormser, Pierre Alliez
 // Example of an AABB tree used with a simple list of 
 // triangles (a triangle soup) stored into an array of points.
 
 #include <iostream>
 #include <vector>
-#include <boost/iterator.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/AABB_tree.h>


### PR DESCRIPTION
## Summary of Changes

The testsuite _x64_Cygwin-Windows10_MSVC2017-Debug-64bits_  has several warnings concerning iterators, allocators, argument and result types which must be dealt with. 

## Release Management

* Affected package(s): AABB Tree (more to come)


