### PR TITLE
CGAL_Core: Remove call of setprecision()

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/CoreDefs.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreDefs.h
@@ -322,7 +322,6 @@ inline bool setRationalReduceFlag(bool f) {
 inline void CORE_init(long d) {
   get_static_defAbsPrec() = CORE_posInfty;
   get_static_defOutputDigits() = d;
-  std::setprecision(get_static_defOutputDigits());
 }
 
 /// change to scientific output format


### PR DESCRIPTION
## Summary of Changes

A call to `std::setprecision()` does not affect any stream. In order to do so the returned object would have to be inserted into a stream. So we can just remove the line.  Thank you for pointing this out @ysyrov.

## Release Management

* Affected package(s): Core
* Issue(s) solved (if any): fix #3606


