### PR TITLE
Classification: Remove useless full find_package for OpenCV

### DIFF
--- a/Classification/examples/Classification/CMakeLists.txt
+++ b/Classification/examples/Classification/CMakeLists.txt
@@ -111,7 +111,6 @@ if( WIN32 )
   endif()
 endif()
 
-find_package(OpenCV QUIET)
 if (OpenCV_FOUND)
   message(STATUS "Found OpenCV ${OpenCV_VERSION}")
   include_directories(${OpenCV_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary of Changes

In the `CMakeLists.txt` of the classification examples, there was a duplicated `find_package()` for OpenCV, one of them searching for the whole library. It's useless and probably lead to [these runtime library errors](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-112/Classification_Examples/TestReport_lrineau_Fedora-Release.gz) (as parts of the full OpenCV will search for Qt5).

## Release Management

* Affected package(s): Classification
* Introduced in 4.13

