### PR TITLE
Triangulation: Fix the tests for GCC<4.4 so it wont match clang.

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGAL_CoreDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGAL_CoreDependencies.cmake
@@ -56,7 +56,7 @@ endif()
 # See the release notes of CGAL-4.10: CGAL_Core now requires
 # Boost.Thread, with all compilers but MSVC.
 if (NOT MSVC)
-  find_package( Boost 1.48 REQUIRED thread system )
+  find_package( Boost 1.48 REQUIRED COMPONENTS thread system )
 endif()
 
 function(CGAL_setup_CGAL_Core_dependencies target)

--- a/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
+++ b/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <CGAL/config.h>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
+++ b/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
+++ b/Triangulation/examples/Triangulation/delaunay_triangulation.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/examples/Triangulation/triangulation.cpp
+++ b/Triangulation/examples/Triangulation/triangulation.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <CGAL/config.h>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {

--- a/Triangulation/examples/Triangulation/triangulation.cpp
+++ b/Triangulation/examples/Triangulation/triangulation.cpp
@@ -1,5 +1,4 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
-
+#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {

--- a/Triangulation/examples/Triangulation/triangulation.cpp
+++ b/Triangulation/examples/Triangulation/triangulation.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {

--- a/Triangulation/test/Triangulation/test_delaunay.cpp
+++ b/Triangulation/test/Triangulation/test_delaunay.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <CGAL/config.h>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_delaunay.cpp
+++ b/Triangulation/test/Triangulation/test_delaunay.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_delaunay.cpp
+++ b/Triangulation/test/Triangulation/test_delaunay.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_torture.cpp
+++ b/Triangulation/test/Triangulation/test_torture.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <CGAL/config.h>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_torture.cpp
+++ b/Triangulation/test/Triangulation/test_torture.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_torture.cpp
+++ b/Triangulation/test/Triangulation/test_torture.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 
 #include <iostream>
 int main()

--- a/Triangulation/test/Triangulation/test_triangulation.cpp
+++ b/Triangulation/test/Triangulation/test_triangulation.cpp
@@ -1,5 +1,4 @@
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
-
+#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {
@@ -7,7 +6,6 @@ int main()
 }
 
 #else
-
 #include <CGAL/Epick_d.h>
 #include <CGAL/point_generators_d.h>
 #include <CGAL/Triangulation.h>

--- a/Triangulation/test/Triangulation/test_triangulation.cpp
+++ b/Triangulation/test/Triangulation/test_triangulation.cpp
@@ -1,4 +1,5 @@
-#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#include <CGAL/config.h>
+#if defined(BOOST_GCC) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {

--- a/Triangulation/test/Triangulation/test_triangulation.cpp
+++ b/Triangulation/test/Triangulation/test_triangulation.cpp
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && not defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
+#if defined(__GNUC__) && ! defined (__clang__) && defined(__GNUC_MINOR__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ < 4)
 #include <iostream>
 int main()
 {


### PR DESCRIPTION
## Summary of Changes
Clang also defines `__GNUC__`, but it defines `__clang__` too, so I also check if `__clang__` is not defined to only match GCC < 4.4.

## Release Management
* Affected package(s):Triangulation
* Issue(s) solved (if any): fix ##3605
