### PR TITLE
Replace include(CTest) by minimal usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,12 @@ message( "== CMake setup (DONE) ==\n" )
 
 # Enable testing with BUILD_TESTING
 option(BUILD_TESTING "Build the testing tree." OFF)
-include(CTest)
 if(BUILD_TESTING AND NOT POLICY CMP0064)
   message(FATAL_ERROR "CGAL support of CTest requires CMake version 3.4 or later.
 The variable BUILD_TESTING must be set of OFF.")
+endif()
+if(BUILD_TESTING)
+  enable_testing()
 endif()
 
 # and finally start actual build

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -108,10 +108,12 @@ else ( CGAL_BRANCH_BUILD )
 
   # Enable testing with BUILD_TESTING
   option(BUILD_TESTING "Build the testing tree." OFF)
-  include(CTest)
   if(BUILD_TESTING AND NOT POLICY CMP0064)
     message(FATAL_ERROR "CGAL support of CTest requires CMake version 3.4 or later.
 The variable BUILD_TESTING must be set of OFF.")
+  endif()
+  if(BUILD_TESTING)
+    enable_testing()
   endif()
 endif (CGAL_BRANCH_BUILD )
 

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -3,6 +3,8 @@ if(CGAL_add_test_included)
 endif(CGAL_add_test_included)
 set(CGAL_add_test_included TRUE)
 
+option(BUILD_TESTING "Build the testing tree." OFF)
+
 if(NOT POLICY CMP0064)
   # CMake <= 3.3
   if(BUILD_TESTING)
@@ -19,7 +21,9 @@ if(NOT POLICY CMP0064)
   return()
 endif()
 
-include(CTest)
+if(BUILD_TESTING)
+  enable_testing()
+endif()
 
 cmake_policy(SET CMP0064 NEW)
 


### PR DESCRIPTION
## Summary of Changes

Fix the troublesome extra targets created by `CTest.cmake` (see [StackOverflow](https://stackoverflow.com/q/54507170/1728537)).

Instead of including `CTest.cmake`:

- Define the option `BUILD_TESTING`
- Call to `enable_testing()` if `BUILD_TESTING` is on.

## Release Management

That is a fix, but for a minor issue. I prefer not to backport the fix to release branches.

* Affected package(s): All CGAL, via CMake scripts
* Issue(s) solved (if any): https://stackoverflow.com/q/54507170/1728537
