### PR TITLE
Polyhedron Demo: Fix isotropic remeshing plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -274,42 +274,26 @@ public:
                       double target_length)
   {
     std::vector<edge_descriptor> p_edges;
-    if(!selection_item->selected_facets.empty()){
-      BOOST_FOREACH(edge_descriptor e, edges(pmesh))
-      {
-        if(get(selection_item->constrained_edges_pmap(), e))
-        {
-          if (selection_item->selected_facets.find(face(halfedge(e, pmesh), pmesh))
-              != selection_item->selected_facets.end()
-              || selection_item->selected_facets.find(face(opposite(halfedge(e, pmesh), pmesh), pmesh))
-              != selection_item->selected_facets.end())
-            p_edges.push_back(e);
-        }
-      }
-      BOOST_FOREACH(face_descriptor f, selection_item->selected_facets)
-      {
-        BOOST_FOREACH(halfedge_descriptor he, halfedges_around_face(halfedge(f, pmesh), pmesh))
-        {
-          if (selection_item->selected_facets.find(face(opposite(he, pmesh), pmesh))
-              == selection_item->selected_facets.end())
-            p_edges.push_back(edge(he, pmesh));
-        }
-      }
-    }
-    else
+    BOOST_FOREACH(edge_descriptor e, selection_item->selected_edges)
     {
-      BOOST_FOREACH(edge_descriptor e, edges(pmesh))
+      p_edges.push_back(e);
+    }
+    BOOST_FOREACH(face_descriptor f, selection_item->selected_facets)
+    {
+      BOOST_FOREACH(halfedge_descriptor he, halfedges_around_face(halfedge(f, pmesh), pmesh))
       {
-        if(get(selection_item->constrained_edges_pmap(), e))
-          p_edges.push_back(e);
+        if (selection_item->selected_facets.find(face(opposite(he, pmesh), pmesh))
+            == selection_item->selected_facets.end())
+          p_edges.push_back(edge(he, pmesh));
       }
     }
     if (!p_edges.empty())
       CGAL::Polygon_mesh_processing::split_long_edges(
-        p_edges
-        , target_length
-        , *selection_item->polyhedron()
-        , PMP::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap()));
+            p_edges
+            , target_length
+            , *selection_item->polyhedron()
+            , PMP::parameters::geom_traits(EPICK())
+            .edge_is_constrained_map(selection_item->constrained_edges_pmap()));
     else
       std::cout << "No selected or boundary edges to be split" << std::endl;
   }

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
@@ -140,7 +140,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::edge_is_feature_t)
 inline get(CGAL::edge_is_feature_t, const Surface_mesh<P>& smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::edge_descriptor edge_descriptor;
-  return smesh. template property_map<edge_descriptor,bool>("e:is_feature", false).first;
+  return smesh. template property_map<edge_descriptor,bool>("e:is_feature").first;
 }
 
 

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
@@ -131,7 +131,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::edge_is_feature_t)
 inline get(CGAL::edge_is_feature_t, Surface_mesh<P>& smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::edge_descriptor edge_descriptor;
-  return smesh. template add_property_map<edge_descriptor,bool>("e:is_feature").first;
+  return smesh. template add_property_map<edge_descriptor,bool>("e:is_feature", false).first;
 }
 
 
@@ -140,7 +140,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::edge_is_feature_t)
 inline get(CGAL::edge_is_feature_t, const Surface_mesh<P>& smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::edge_descriptor edge_descriptor;
-  return smesh. template property_map<edge_descriptor,bool>("e:is_feature").first;
+  return smesh. template property_map<edge_descriptor,bool>("e:is_feature", false).first;
 }
 
 


### PR DESCRIPTION
## Summary of Changes
For some reason, the results in and out the demo differs. This should unify them.
Also :
- protection can use detected shard edges and not only selected edges
- Split only can be used with only a selection of edges and not a selection of faces
- When trying to remesh with a selection of edges and a protection, if the constrained are too long, a pop up asks if the user wants to split instead of simply aborting. 

## Release Management

* Issue(s) solved (if any): fix #3649
