### PR TITLE
Polyhedron Demo: Fix Rendering of Nested Groups

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -214,6 +214,10 @@ void Scene_group_item::renderChildren(Viewer_interface *viewer,
         picked_item_IDs[depth] = id;
       }
     }
+    CGAL::Three::Scene_group_item* group =
+        qobject_cast<CGAL::Three::Scene_group_item*>(getChild(id));
+    if(group)
+      group->renderChildren(viewer, picked_item_IDs, picked_pixel, with_names);
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
A call to renderChildred() was misisng.
