### PR TITLE
Regular_triangulation_3: Add Regular_triangulation_cell_base_3::hidden_points()

### DIFF
--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
@@ -79,13 +79,13 @@ public:
 
       std::size_t hidden_point_count = 0;
       for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-        hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+        hidden_point_count += iter->hidden_points().size();
 
       Vertex_handle vh = p3rt3.insert(p);
 
       std::size_t hidden_point_count_2 = 0;
       for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-        hidden_point_count_2 += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+        hidden_point_count_2 += iter->hidden_points().size();
       assert(hidden_point_count <= hidden_point_count_2);
       assert(hidden_point_count_2 + p3rt3.number_of_vertices() == cnt);
 #ifdef REALLY_VERBOSE
@@ -121,7 +121,7 @@ public:
 #endif
       std::size_t hidden_point_count = 0;
       for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-        hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+        hidden_point_count += iter->hidden_points().size();
 
       assert(hidden_point_count + cnt + p3rt3.number_of_vertices() == insert_set.size());
     }

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
@@ -47,20 +47,20 @@ public:
 
   static void test_insert_rnd_then_remove_all (unsigned pt_count,
                                                unsigned seed,
-                                               const std::string& path)
+                                               const std::string& /* path */)
   {
     std::cout << "--- test_insert_rnd (" << pt_count << ", " << seed << ')' << std::endl;
 
     CGAL::Random random(seed);
-//    typedef CGAL::Creator_uniform_3<double, Point_3>  Creator;
-//    CGAL::Random_points_in_cube_3<Point_3, Creator> in_cube(0.5, random);
+    typedef CGAL::Creator_uniform_3<double, Point_3>  Creator;
+    CGAL::Random_points_in_cube_3<Point_3, Creator> in_cube(0.5, random);
 
     Iso_cuboid iso_cuboid(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5);
     P3RT3 p3rt3(iso_cuboid);
 
-    std::ofstream stream("p3rt3_ir_point_set");
-    assert(stream);
-    std::ifstream input_stream(path.c_str());
+    //std::ofstream stream("p3rt3_ir_point_set");
+    //assert(stream);
+    //std::ifstream input_stream(path.c_str());
 
     std::vector<Weighted_point_3> insert_set;
     insert_set.reserve(pt_count);
@@ -70,12 +70,12 @@ public:
     std::cout << "-- insert" << std::endl;
     for (unsigned cnt = 1; cnt <= pt_count; ++cnt)
     {
-//      Weighted_point_3 p(*in_cube++, random.get_double(0., 0.015625));
+      Weighted_point_3 p(*in_cube++, random.get_double(0., 0.015625));
 //      std::cout << cnt << " : " << p << std::endl;
-      Weighted_point_3 p;
-      input_stream >> p;
-      assert(p.weight() < 0.015625);
-      stream << p << std::endl;
+//      Weighted_point_3 p;
+//      input_stream >> p;
+//      assert(p.weight() < 0.015625);
+//      stream << p << std::endl;
 
       std::size_t hidden_point_count = 0;
       for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
@@ -100,7 +100,7 @@ public:
         insert_set.push_back(p);
     }
 
-    stream.close();
+    //stream.close();
 
     assert(p3rt3.is_valid());
 
@@ -138,7 +138,6 @@ public:
   {
     //////    Iso_cuboid unitaire ->  0 <= weight < 0.015625
     test_insert_rnd_then_remove_all(800, 7, "data/p3rt3_point_set__s7_n800");
-    test_insert_rnd_then_remove_all(800, 12, "data/p3rt3_point_set__s12_n800");
   }
 };
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_insert_remove_point_set.cpp
@@ -45,22 +45,13 @@ public:
   typedef typename Traits::Point_3                              Point_3;
   typedef typename Traits::Iso_cuboid_3                         Iso_cuboid;
 
-  static void test_insert_rnd_then_remove_all (unsigned pt_count,
-                                               unsigned seed,
-                                               const std::string& /* path */)
+  static void test_insert_rnd_then_remove_all (unsigned pt_count)
   {
-    std::cout << "--- test_insert_rnd (" << pt_count << ", " << seed << ')' << std::endl;
-
-    CGAL::Random random(seed);
     typedef CGAL::Creator_uniform_3<double, Point_3>  Creator;
-    CGAL::Random_points_in_cube_3<Point_3, Creator> in_cube(0.5, random);
+    CGAL::Random_points_in_cube_3<Point_3, Creator> in_cube(0.5);
 
     Iso_cuboid iso_cuboid(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5);
     P3RT3 p3rt3(iso_cuboid);
-
-    //std::ofstream stream("p3rt3_ir_point_set");
-    //assert(stream);
-    //std::ifstream input_stream(path.c_str());
 
     std::vector<Weighted_point_3> insert_set;
     insert_set.reserve(pt_count);
@@ -70,12 +61,7 @@ public:
     std::cout << "-- insert" << std::endl;
     for (unsigned cnt = 1; cnt <= pt_count; ++cnt)
     {
-      Weighted_point_3 p(*in_cube++, random.get_double(0., 0.015625));
-//      std::cout << cnt << " : " << p << std::endl;
-//      Weighted_point_3 p;
-//      input_stream >> p;
-//      assert(p.weight() < 0.015625);
-//      stream << p << std::endl;
+      Weighted_point_3 p(*in_cube++, CGAL::get_default_random().get_double(0., 0.015625));
 
       std::size_t hidden_point_count = 0;
       for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
@@ -100,8 +86,6 @@ public:
         insert_set.push_back(p);
     }
 
-    //stream.close();
-
     assert(p3rt3.is_valid());
 
     std::cout << "-- remove" << std::endl;
@@ -109,7 +93,7 @@ public:
     for (; p3rt3.number_of_vertices() != 0; ++cnt)
     {
       Vertex_iterator iter = p3rt3.vertices_begin();
-      for (int j = random.get_int(0, static_cast<int>(p3rt3.number_of_vertices())); j; --j)
+      for (int j = CGAL::get_default_random().get_int(0, static_cast<int>(p3rt3.number_of_vertices())); j; --j)
         ++iter;
 #ifdef REALLY_VERBOSE
       std::cout << cnt << " : " << iter->point() << std::endl;
@@ -136,8 +120,7 @@ public:
 
   static void test ()
   {
-    //////    Iso_cuboid unitaire ->  0 <= weight < 0.015625
-    test_insert_rnd_then_remove_all(800, 7, "data/p3rt3_point_set__s7_n800");
+    test_insert_rnd_then_remove_all(800);
   }
 };
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_periodic_3_regular_triangulation_3.cpp
@@ -188,7 +188,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count +=  iter->hidden_points().size();  
     assert(hidden_point_count == 0);
   }
 
@@ -220,7 +220,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
   }
 
@@ -245,7 +245,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
 
     Weighted_point_3 hidden_point(Point_3(0.101, 0.101, 0.101), 0.001);
@@ -259,7 +259,7 @@ public:
     hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
     {
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
       hidden_found_count += static_cast<unsigned>(std::find(iter->hidden_points_begin(), iter->hidden_points_end(), hidden_point) != iter->hidden_points_end());
     }
     assert(hidden_point_count == 1);
@@ -288,7 +288,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
 
     vh = p3rt3.insert(Weighted_point_3(Point_3(0.1,0.1,0.1),0.01));
@@ -301,7 +301,7 @@ public:
     hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
     {
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
       hidden_found_count += static_cast<unsigned>(std::find(iter->hidden_points_begin(), iter->hidden_points_end(), hidden_point) != iter->hidden_points_end());
     }
     assert(hidden_point_count == 1);
@@ -328,7 +328,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
   }
 
@@ -356,7 +356,7 @@ public:
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
     {
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
       hidden_found_count += static_cast<unsigned>(std::find(iter->hidden_points_begin(), iter->hidden_points_end(), hidden_point) != iter->hidden_points_end());
     }
     assert(hidden_point_count == 1);
@@ -396,7 +396,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
 
     unsigned point_found_count = 0;
@@ -433,7 +433,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
   }
 
@@ -509,7 +509,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
 
     assert(hidden_point_count == 0);
   }
@@ -734,7 +734,7 @@ public:
 
     std::size_t hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 0);
     assert(p3rt3.number_of_hidden_points() == 0);
 
@@ -742,7 +742,7 @@ public:
     assert(vh == Vertex_handle());
     hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 1);
     assert(p3rt3.number_of_hidden_points() == 1);
 
@@ -750,7 +750,7 @@ public:
     assert(vh == Vertex_handle());
     hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 2);
     assert(p3rt3.number_of_hidden_points() == 2);
 
@@ -758,7 +758,7 @@ public:
     assert(vh == Vertex_handle());
     hidden_point_count = 0;
     for (Cell_iterator iter = p3rt3.cells_begin(), end_iter = p3rt3.cells_end(); iter != end_iter; ++iter)
-      hidden_point_count += std::distance(iter->hidden_points_begin(), iter->hidden_points_end());
+      hidden_point_count += iter->hidden_points().size();
     assert(hidden_point_count == 3);
     assert(p3rt3.number_of_hidden_points() == 3);
   }

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
@@ -43,7 +43,7 @@ typedef Point_container::iterator Point_iterator;
 
 /// \name Hidden points-related functions
 /// Not every weighted point inserted in a regular triangulation necessarily
-/// appears in the trinagulation. If the weight of a point is too small compared
+/// appears in the triangulation. If the weight of a point is too small compared
 /// to other points, it might be <I>hidden</I>. These hidden vertices are stored
 /// in a unique corresponding cell (defined through v->cell()). The following
 /// functions provide set and get functionalities.

--- a/Triangulation_3/include/CGAL/Regular_triangulation_cell_base_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_cell_base_3.h
@@ -93,6 +93,11 @@ public:
   Point_const_iterator hidden_points_end() const
   { return hidden_points_end_internal<Memory_policy>(); }
 
+  const C& hidden_points() const
+  {
+    return _hidden;
+  }
+  
   void hide_point(const Point& p)
   { hide_point_internal<Memory_policy>(p); }
   void unhide_point(const Point_iterator pit)


### PR DESCRIPTION

## Summary of Changes

The [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-117/Periodic_3_triangulation_3/TestReport_afabri_x64_Cygwin-Windows10_MSVC2013-Debug-64bits.gz) for 3D periodic regular triangulations calls `std::distance(b,e)` where the iterators are from a list. The function that returns a range (something we want later anyways) permits to call `.size()`. 

## Release Management

* Affected package(s): Triangulation_3 and Periodic_3_triangulation_3

