### PR TITLE
PSP: Reduce the size of the data set in an example

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/callback_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/callback_example.cpp
@@ -44,7 +44,7 @@ struct Progress_to_std_cerr_callback
     // Avoid calling time() at every single iteration, which could
     // impact performances very badly
     ++ nb;
-    if (advancement != 1 && nb % 10000 != 0)
+    if (advancement != 1 && nb % 100 != 0)
       return true;
 
     double t = timer.time();
@@ -65,11 +65,11 @@ struct Progress_to_std_cerr_callback
 
 int main ()
 {
-  // Generate 1000000 points on a sphere of radius 100.
+  // Generate 10000 points on a sphere of radius 100.
   std::vector<Point> points;
-  points.reserve (1000000);
+  points.reserve (10000);
   Generator generator(100.);
-  CGAL::cpp11::copy_n (generator, 1000000, std::back_inserter(points));
+  CGAL::cpp11::copy_n (generator, 10000, std::back_inserter(points));
 
   // Compute average spacing
   FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>

--- a/Point_set_processing_3/examples/Point_set_processing_3/callback_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/callback_example.cpp
@@ -6,6 +6,8 @@
 #include <CGAL/grid_simplify_point_set.h>
 #include <CGAL/jet_smooth_point_set.h>
 
+#include <boost/lexical_cast.hpp>
+
 #include <vector>
 #include <fstream>
 
@@ -21,6 +23,7 @@ typedef CGAL::Parallel_tag Concurrency_tag;
 #else
 typedef CGAL::Sequential_tag Concurrency_tag;
 #endif
+
 
 // instance of CGAL::cpp11::function<bool(double)>
 struct Progress_to_std_cerr_callback
@@ -63,13 +66,15 @@ struct Progress_to_std_cerr_callback
 };
 
 
-int main ()
+int main (int argc, char* argv[])
 {
-  // Generate 10000 points on a sphere of radius 100.
+  int N = (argc > 1) ? boost::lexical_cast<int>(argv[1]) : 1000;
+  
+  // Generate N points on a sphere of radius 100.
   std::vector<Point> points;
-  points.reserve (10000);
+  points.reserve (N);
   Generator generator(100.);
-  CGAL::cpp11::copy_n (generator, 10000, std::back_inserter(points));
+  CGAL::cpp11::copy_n (generator, N, std::back_inserter(points));
 
   // Compute average spacing
   FT average_spacing = CGAL::compute_average_spacing<Concurrency_tag>


### PR DESCRIPTION

## Summary of Changes

10K instead of 1M points is enough to illustrate the callback mechanism.    And it avoids a timeout in the [testsuite ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-117/Point_set_processing_3_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2015-Debug-64bits.gz)

## Release Management

* Affected package(s): Point_set_processing


