### PR TITLE
Triangulation_2: Initialize to avoid warning

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -649,10 +649,9 @@ public:
 	++it){
       if(! is_subconstraint(*it, *succ)){ // this checks whether other constraints pass
 	Face_handle fh;
-	int i = -1; // this will be set by is_edge() below. Without initialization we get a warning
-        CGAL_triangulation_assertion_code(bool b =)
-          Triangulation::is_edge(*it, *succ, fh, i);
-	CGAL_triangulation_assertion(b);
+	int i;
+	bool b = Triangulation::is_edge(*it, *succ, fh, i);
+	CGAL_assume(b);
 	Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
       }
     }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -649,7 +649,7 @@ public:
 	++it){
       if(! is_subconstraint(*it, *succ)){ // this checks whether other constraints pass
 	Face_handle fh;
-	int i;
+	int i = -1; // this will be set by is_edge() below. Without initialization we get a warning
         CGAL_triangulation_assertion_code(bool b =)
           Triangulation::is_edge(*it, *succ, fh, i);
 	CGAL_triangulation_assertion(b);


### PR DESCRIPTION
## Summary of Changes

Avoid [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-Ic-117/Triangulation_2/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz).  
@mglisse can you please have a quick look, as you made good comments on initialization in other PRs. 

## Release Management

* Affected package(s): Triangulation_2


