### PR TITLE
Periodic_3_triangulation_3 demo: Initialize Point_3

### DIFF
--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
@@ -1413,7 +1413,7 @@ void Scene::gl_draw_location() {
                 Point p = tet_to_draw.vertex((i+1)&3);
                 Point q = tet_to_draw.vertex((i+2)&3);
                 Point r = tet_to_draw.vertex((i+3)&3);
-                Vector c= (Vector(Point(),p)+Vector(Point(),q)+Vector(Point(),r))/3.;
+                Vector c= (Vector(Point(0,0,0),p)+Vector(Point(0,0,0),q)+Vector(Point(0,0,0),r))/3.;
                 Point cp = Point(c.x(),c.y(),c.z());
                 // project facet center
                 double px,py,pz;
@@ -1524,7 +1524,7 @@ void Scene::gl_draw_conflict() {
                 Point p = tri_to_draw.vertex(0);
                 Point q = tri_to_draw.vertex(1);
                 Point r = tri_to_draw.vertex(2);
-                Vector c= (Vector(Point(),p)+Vector(Point(),q)+Vector(Point(),r))/3.;
+                Vector c= (Vector(Point(0,0,0),p)+Vector(Point(0,0,0),q)+Vector(Point(0,0,0),r))/3.;
                 Point cp = Point(c.x(),c.y(),c.z());
                 // project facet center
                 double px,py,pz;

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
@@ -1410,11 +1410,10 @@ void Scene::gl_draw_location() {
                         ch, off0, off1, off2, off3, offs);
 
             for(int i=0; i < 4; i++){
-                Point p = tet_to_draw.vertex((i+1)&3);
-                Point q = tet_to_draw.vertex((i+2)&3);
-                Point r = tet_to_draw.vertex((i+3)&3);
-                Vector c= (Vector(Point(0,0,0),p)+Vector(Point(0,0,0),q)+Vector(Point(0,0,0),r))/3.;
-                Point cp = Point(c.x(),c.y(),c.z());
+                const Point& p = tet_to_draw.vertex((i+1)&3);
+                const Point& q = tet_to_draw.vertex((i+2)&3);
+                const Point& r = tet_to_draw.vertex((i+3)&3);
+                Point cp = CGAL::centroid(p,q,r);
                 // project facet center
                 double px,py,pz;
                 project(cp.x(),cp.y(),cp.z(),
@@ -1521,11 +1520,10 @@ void Scene::gl_draw_conflict() {
             for (int offs=0 ; offs<=diff_off ; offs++) {
                 if ((((~offs)|diff_off)&7)!=7) continue;
                 Triangle tri_to_draw = construct_triangle(ch,j,off0,off1,off2,offs);
-                Point p = tri_to_draw.vertex(0);
-                Point q = tri_to_draw.vertex(1);
-                Point r = tri_to_draw.vertex(2);
-                Vector c= (Vector(Point(0,0,0),p)+Vector(Point(0,0,0),q)+Vector(Point(0,0,0),r))/3.;
-                Point cp = Point(c.x(),c.y(),c.z());
+                const Point& p = tri_to_draw.vertex(0);
+                const Point& q = tri_to_draw.vertex(1);
+                const Point& r = tri_to_draw.vertex(2);
+                Point cp = CGAL::centroid(p,q,r);
                 // project facet center
                 double px,py,pz;
                 project(cp.x(),cp.y(),cp.z(),


### PR DESCRIPTION
## Summary of Changes

A default  constructed point is not necessarily at the origin.   Fix warning in [testsuite ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-114/Periodic_3_triangulation_3_Demo/TestReport_lrineau_ArchLinux-CXX17-Release.gz)

## Release Management

* Affected package(s): Periodic_3_triangulation_3

