### PR TITLE
New undocumented AABB primitive: cells of a 3D triangulation

### DIFF
--- a/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
@@ -49,7 +49,8 @@ namespace CGAL
         typename Point_from_cell_iterator_proprety_map<GeomTraits, Iterator>::reference
         get(Point_from_cell_iterator_proprety_map<GeomTraits, Iterator>, Iterator it)
       {
-        return it->vertex(1)->point().point();
+        typename GeomTraits::Construct_point_3 point;
+        return point(it->vertex(1)->point());
       }
     };
 
@@ -66,10 +67,11 @@ namespace CGAL
         reference
         get(Tet_from_cell_iterator_proprety_map<GeomTraits, Iterator>, key_type it)
       {
-        return value_type(it->vertex(0)->point().point(),
-                          it->vertex(1)->point().point(),
-                          it->vertex(2)->point().point(),
-                          it->vertex(3)->point().point());
+        typename GeomTraits::Construct_point_3 point;
+        return value_type(point(it->vertex(0)->point()),
+                          point(it->vertex(1)->point()),
+                          point(it->vertex(2)->point()),
+                          point(it->vertex(3)->point()));
       }
     };
 

--- a/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 GeometryFactory (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+// You can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0+
+//
+//
+// Author        : Jane Tournois
+//
+
+#ifndef CGAL_AABB_TRIANGULATION_3_CELL_PRIMITIVE_H_
+#define CGAL_AABB_TRIANGULATION_3_CELL_PRIMITIVE_H_
+
+#include <CGAL/license/AABB_tree.h>
+
+
+#include <CGAL/AABB_primitive.h>
+#include <CGAL/result_of.h>
+#include <iterator>
+
+namespace CGAL
+{
+  namespace internal
+  {
+    template <class GeomTraits, class Iterator>
+    struct Point_from_cell_iterator_proprety_map
+    {
+      //classical typedefs
+      typedef Iterator key_type;
+      typedef typename GeomTraits::Point_3 value_type;
+      typedef typename cpp11::result_of<
+        typename GeomTraits::Construct_vertex_3(typename GeomTraits::Tetrahedron_3, int)
+      >::type reference;
+      typedef boost::readable_property_map_tag category;
+
+      inline friend
+        typename Point_from_cell_iterator_proprety_map<GeomTraits, Iterator>::reference
+        get(Point_from_cell_iterator_proprety_map<GeomTraits, Iterator>, Iterator it)
+      {
+        return it->vertex(1)->point().point();
+      }
+    };
+
+    template <class GeomTraits, class Iterator>
+    struct Tet_from_cell_iterator_proprety_map
+    {
+      //classical typedefs
+      typedef Iterator                           key_type;
+      typedef typename GeomTraits::Tetrahedron_3 value_type;
+      typedef value_type                         reference;
+      typedef boost::readable_property_map_tag category;
+
+      inline friend
+        reference
+        get(Tet_from_cell_iterator_proprety_map<GeomTraits, Iterator>, key_type it)
+      {
+        return value_type(it->vertex(0)->point().point(),
+                          it->vertex(1)->point().point(),
+                          it->vertex(2)->point().point(),
+                          it->vertex(3)->point().point());
+      }
+    };
+
+  }//namespace internal
+
+
+  template < class GeomTraits,
+             class Tr,
+             class CacheDatum = Tag_false,
+             class Handle = typename Tr::Cell_handle>
+  class AABB_triangulation_3_cell_primitive
+#ifndef DOXYGEN_RUNNING
+    : public AABB_primitive<  Handle,
+          internal::Tet_from_cell_iterator_proprety_map<GeomTraits, Handle>,
+          internal::Point_from_cell_iterator_proprety_map<GeomTraits, Handle>,
+          Tag_false,
+          CacheDatum >
+#endif
+  {
+    typedef AABB_primitive< Handle,
+          internal::Tet_from_cell_iterator_proprety_map<GeomTraits, Handle>,
+          internal::Point_from_cell_iterator_proprety_map<GeomTraits, Handle>,
+          Tag_false,
+          CacheDatum > Base;
+  public:
+    AABB_triangulation_3_cell_primitive(Handle h) : Base(h){}  };
+
+}  // end namespace CGAL
+
+
+#endif // CGAL_AABB_TRIANGULATION_3_CELL_PRIMITIVE_H_

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -55,17 +55,26 @@ do_intersect_tetrahedron_bounded(const Bounded &tr,
                                  const K & k)
 {
     typedef typename K::Triangle_3 Triangle;
+    typedef typename K::Boolean Boolean;
 
     CGAL_kernel_precondition( ! k.is_degenerate_3_object() (tr) );
     CGAL_kernel_precondition( ! k.is_degenerate_3_object() (tet) );
 
-    typedef typename K::Triangle_3 Triangle;
-    if (do_intersect(tr, Triangle(tet[0], tet[1], tet[2]), k)) return true;
-    if (do_intersect(tr, Triangle(tet[0], tet[1], tet[3]), k)) return true;
-    if (do_intersect(tr, Triangle(tet[0], tet[2], tet[3]), k)) return true;
-    if (do_intersect(tr, Triangle(tet[1], tet[2], tet[3]), k)) return true;
-
-    return k.has_on_bounded_side_3_object()(tet, p);
+    Boolean result = false;
+    for (int i = 0; i < 4; ++i)
+    {
+      const Boolean b = do_intersect(tr,
+                                     Triangle(tet[i],
+                                              tet[(i+1)%4],
+                                              tet[(i+2)%4]),
+                                     k);
+      if(certainly(b)) return b;
+      if(is_indeterminate(b)) result = b;
+    }
+    const Boolean b = k.has_on_bounded_side_3_object()(tet, p);
+    if(certainly(b)) return b;
+    if(is_indeterminate(b)) result = b;
+    return result;
 }
 
 

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Unbounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Unbounded_3_do_intersect.h
@@ -33,60 +33,75 @@ namespace Intersections {
 namespace internal {
 
 template<typename K, class Unbounded>
-bool do_intersect_tetrahedron_unbounded(const typename K::Tetrahedron_3& tet,
-                                        const Unbounded& unb,
-                                        const K& k) {
+typename K::Boolean
+do_intersect_tetrahedron_unbounded(const typename K::Tetrahedron_3& tet,
+                                   const Unbounded& unb,
+                                   const K& k) {
   typedef typename K::Triangle_3 Triangle;
-  if (do_intersect(unb,Triangle(tet[0], tet[1], tet[2]), k)) return true;
-  if (do_intersect(unb, Triangle(tet[0], tet[1], tet[3]), k)) return true;
-  if (do_intersect(unb, Triangle(tet[0], tet[2], tet[3]), k)) return true;
-  if (do_intersect(unb, Triangle(tet[1], tet[2], tet[3]), k)) return true;
-  return false;
+  typedef typename K::Boolean Boolean;
+  Boolean result = false;
+  for (int i = 0; i < 4; ++i)
+  {
+    const Boolean b = do_intersect(unb,
+                                   Triangle(tet[i],
+                                            tet[(i+1)%4],
+                                            tet[(i+2)%4]),
+                                   k);
+    if(certainly(b)) return b;
+    if(is_indeterminate(b)) result = b;
+  }
+  return result;
 }
 
 
 
 template<typename K>
-bool do_intersect(const typename K::Plane_3& unb,
-                  const typename K::Tetrahedron_3& tet,
-                  const K& k) {
+typename K::Boolean
+do_intersect(const typename K::Plane_3& unb,
+             const typename K::Tetrahedron_3& tet,
+             const K& k) {
   return do_intersect_tetrahedron_unbounded(tet, unb, k);
 }
 
 template<typename K>
-bool do_intersect(const typename K::Tetrahedron_3& tet,
-                  const typename K::Plane_3& unb,
-                  const K& k) {
-  return do_intersect_tetrahedron_unbounded(tet, unb, k);
-}
-
-
-template<typename K>
-bool do_intersect(const typename K::Line_3& unb,
-                  const typename K::Tetrahedron_3& tet,
-                  const K& k) {
-  return do_intersect_tetrahedron_unbounded(tet, unb, k);
-}
-
-template<typename K>
-bool do_intersect(const typename K::Tetrahedron_3& tet,
-                  const typename K::Line_3& unb,
-                  const K& k) {
+typename K::Boolean
+do_intersect(const typename K::Tetrahedron_3& tet,
+             const typename K::Plane_3& unb,
+             const K& k) {
   return do_intersect_tetrahedron_unbounded(tet, unb, k);
 }
 
 
 template<typename K>
-bool do_intersect(const typename K::Ray_3& unb,
-                  const typename K::Tetrahedron_3& tet,
-                  const K& k) {
+typename K::Boolean
+do_intersect(const typename K::Line_3& unb,
+             const typename K::Tetrahedron_3& tet,
+             const K& k) {
   return do_intersect_tetrahedron_unbounded(tet, unb, k);
 }
 
 template<typename K>
-bool do_intersect(const typename K::Tetrahedron_3& tet,
-                  const typename K::Ray_3& unb,
-                  const K& k) {
+typename K::Boolean
+do_intersect(const typename K::Tetrahedron_3& tet,
+             const typename K::Line_3& unb,
+             const K& k) {
+  return do_intersect_tetrahedron_unbounded(tet, unb, k);
+}
+
+
+template<typename K>
+typename K::Boolean
+do_intersect(const typename K::Ray_3& unb,
+             const typename K::Tetrahedron_3& tet,
+             const K& k) {
+  return do_intersect_tetrahedron_unbounded(tet, unb, k);
+}
+
+template<typename K>
+typename K::Boolean
+do_intersect(const typename K::Tetrahedron_3& tet,
+             const typename K::Ray_3& unb,
+             const K& k) {
   return do_intersect_tetrahedron_unbounded(tet, unb, k);
 }
 


### PR DESCRIPTION
## Summary of Changes

The `Scene_c3t3_item` from our 3D demos now uses an AABB tree of cells, instead of an AABB tree of triangles. That divides the number of primitives by 4, and save times:

Before:
```
C3t3 facets AABB tree built in 22.010006904602051 wall-clock seconds
Scene_c3t3_item_priv::computeIntersections in 0.50893402099609375 wall-clock seconds
```

After:
```
C3t3 cells AABB tree built in 13.072829008102417 wall-clock seconds
Scene_c3t3_item_priv::computeIntersections in 0.41458892822265625 wall-clock seconds
```

The gain seems mostly in the construction of the tree (40% saved), and the gain on the queries seems lower (about 20%).

## Release Management

* Affected package(s): AABB_tree, Polyhedron demo
* License and copyright ownership: maintenance by GeometryFactory, license and copyright remain unchanged

