### PR TITLE
Mesh_3: Disable parallel sliver exudation in VC++ debug in the testsuite

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -262,6 +262,7 @@ protected:
   template <typename Func>
   void enqueue_work(Func f, FT value) const
   {
+    std::cout << "enqueue_work" << std::endl;
     CGAL_assertion(m_empty_root_task != 0);
     m_worksharing_ds.enqueue_work(f, value, *m_empty_root_task);
   }
@@ -628,7 +629,7 @@ private:
   template <bool pump_vertices_on_surfaces>
   void add_cell_to_queue(Cell_handle ch, FT criterion_value)
   {
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
     // Parallel
     if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
       enqueue_task<pump_vertices_on_surfaces>(
@@ -694,7 +695,7 @@ private:
   }
 
 
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
   // For parallel version
   template <bool pump_vertices_on_surfaces>
   void
@@ -702,7 +703,7 @@ private:
 #endif
 
 private:
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
   // Functor for enqueue_task function
   template <typename SE, bool pump_vertices_on_surfaces>
   class Pump_vertex
@@ -925,7 +926,7 @@ pump_vertices(FT sliver_criterion_limit,
   t.reset();
 #endif
 
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
   // Parallel
   if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
   {
@@ -1605,7 +1606,7 @@ update_mesh(const Weighted_point& new_point,
 }
 
 
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
 // For parallel version
 template <typename C3T3, typename SC, typename V_>
 template <bool pump_vertices_on_surfaces>

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -197,7 +197,7 @@ private:
 
 
   //  The debug version of the VC++ testsuite gets a timeout when using TBB, so let's disable it
-#if defined( CGAL_LINKED_WITH_TBB ) && ( (! defined (BOOST_MSVC)) || ( defined (BOOST_MSVC)  && defined( _DEBUG ) && (! defined ( CGAL_TEST_SUITE ) ) ) )
+#if defined( CGAL_LINKED_WITH_TBB ) && ( !defined (BOOST_MSVC) || !defined( _DEBUG ) || !defined (CGAL_TEST_SUITE) )
 
 // Parallel
 template <typename Tr>

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -195,7 +195,10 @@ private:
   Tet_priority_queue cells_queue_;
 };
 
-#ifdef CGAL_LINKED_WITH_TBB
+
+  //  The debug version of the VC++ testsuite gets a timeout when using TBB, so let's disable it
+#if defined( CGAL_LINKED_WITH_TBB ) && ( (! defined (BOOST_MSVC)) || ( defined (BOOST_MSVC)  && defined( _DEBUG ) && (! defined ( CGAL_TEST_SUITE ) ) ) )
+
 // Parallel
 template <typename Tr>
 class Slivers_exuder_base<Tr, Parallel_tag>


### PR DESCRIPTION
## Summary of Changes

@maxGimeno please no longer test #3634, but test this PR instead.

## Release Management

* Affected package(s): Mesh_3 


