### PR TITLE
P3t3 demo: Fix crash 

### DIFF
--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/MainWindow.ui
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/MainWindow.ui
@@ -432,6 +432,9 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset resource="Periodic_3_triangulation_3.qrc">
      <normaloff>:/cgal/Periodic_3_triangulation_3/icons/ball.png</normaloff>:/cgal/Periodic_3_triangulation_3/icons/ball.png</iconset>

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
@@ -1463,15 +1463,10 @@ void Scene::gl_draw_conflict() {
     std::vector<Cell_handle> cic;
     std::vector<Facet> boundary_facets;
     // Find the conflict region
-    Cell_handle c = p3dt.locate(moving_point);
-    Point _a(c->vertex(0)->point()),
-          _b(c->vertex(1)->point()),
-          _c(c->vertex(2)->point()),
-          _d(c->vertex(3)->point());
-    if(!( moving_point == _a
-       || moving_point == _b
-       || moving_point == _c
-       || moving_point == _d))
+    P3DT::Locate_type t;
+    int li, lj;
+    Cell_handle c = p3dt.locate(moving_point,t,li,lj);
+    if(t != P3DT::VERTEX)
       p3dt.find_conflicts(moving_point,c,std::back_inserter(boundary_facets),std::back_inserter(cic),CGAL::Emptyset_iterator());
 
     std::vector<Projected_triangle> bfm;

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.cpp
@@ -814,9 +814,10 @@ void Scene::draw() {
     glEnable(GL_DEPTH_TEST);
     if(!are_buffers_initialized)
         initialize_buffers();
-    gl_draw_location();
-
-    gl_draw_conflict();
+    if(dlocate)
+      gl_draw_location();
+    if(dconflict)
+      gl_draw_conflict();
 
     //// Draw the triangulation itself that is stored in the list.
 
@@ -1463,7 +1464,15 @@ void Scene::gl_draw_conflict() {
     std::vector<Facet> boundary_facets;
     // Find the conflict region
     Cell_handle c = p3dt.locate(moving_point);
-    p3dt.find_conflicts(moving_point,c,std::back_inserter(boundary_facets),std::back_inserter(cic),CGAL::Emptyset_iterator());
+    Point _a(c->vertex(0)->point()),
+          _b(c->vertex(1)->point()),
+          _c(c->vertex(2)->point()),
+          _d(c->vertex(3)->point());
+    if(!( moving_point == _a
+       || moving_point == _b
+       || moving_point == _c
+       || moving_point == _d))
+      p3dt.find_conflicts(moving_point,c,std::back_inserter(boundary_facets),std::back_inserter(cic),CGAL::Emptyset_iterator());
 
     std::vector<Projected_triangle> bfm;
 


### PR DESCRIPTION
## Summary of Changes
In find_conflict, if the request point is a vertex of the request cell, there is no conflict and that triggers an assertion. I added a test before calling it in the demo to avoid this situation, that was systematic when adding the moving point to the triangulation.
