### PR TITLE
Circular_kernel_{2,3}: Cleanup of examples and tests

### DIFF
--- a/Circular_kernel_2/examples/Circular_kernel_2/functor_has_on_2.cpp
+++ b/Circular_kernel_2/examples/Circular_kernel_2/functor_has_on_2.cpp
@@ -1,5 +1,5 @@
 #include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/point_generators_2.h>
+#include <iostream>
 
 typedef CGAL::Exact_circular_kernel_2             Circular_k;
 

--- a/Circular_kernel_2/examples/Circular_kernel_2/intersecting_arcs.cpp
+++ b/Circular_kernel_2/examples/Circular_kernel_2/intersecting_arcs.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/point_generators_2.h>
+#include <iostream>
 
 typedef CGAL::Exact_circular_kernel_2             Circular_k;
 

--- a/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
@@ -11,7 +11,13 @@ find_package(CGAL QUIET)
 if ( CGAL_FOUND )
 
 include_directories (BEFORE include)
+
+# The following `include_directories` is used in the git layout
 include_directories (BEFORE ../../../Kernel_23/test/Kernel_23/include)
+
+# The following `include_directories` is used in the layout of the
+# internal releases tarballs
+include_directories (BEFORE ../Kernel_23/include)
 
 create_single_source_cgal_program( "test_Circular_kernel.cpp" )
 create_single_source_cgal_program( "test_Lazy_circular_kernel.cpp" )

--- a/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
@@ -12,10 +12,6 @@ if ( CGAL_FOUND )
 
 include_directories (BEFORE include)
 include_directories (BEFORE ../../../Kernel_23/test/Kernel_23/include)
-include_directories (BEFORE ../Kernel_23/include)
-include_directories (BEFORE ../Cartesian_kernel/include)
-include_directories (BEFORE ../Homogeneous_kernel/include)
-include_directories (BEFORE ../Intersections_2/include)
 
 create_single_source_cgal_program( "test_Circular_kernel.cpp" )
 create_single_source_cgal_program( "test_Lazy_circular_kernel.cpp" )

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Exact_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Exact_circular_kernel.cpp
@@ -26,11 +26,7 @@
 
 #include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
-#include <CGAL/basic.h>
 #include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/intersections.h>
-#include <CGAL/Circular_kernel_intersections.h>
-#include <iostream>
 
 typedef CGAL::Exact_circular_kernel_2 CK;
 

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Filtered_bbox_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Filtered_bbox_circular_kernel.cpp
@@ -32,8 +32,6 @@
 #include <CGAL/MP_Float.h>
 #include <CGAL/Quotient.h>
 #include <CGAL/Filtered_bbox_circular_kernel_2.h>
-#include <CGAL/intersections.h>
-#include <iostream>
 
 typedef CGAL::MP_Float RT;
 typedef CGAL::Quotient<RT> NT1;

--- a/Circular_kernel_2/test/Circular_kernel_2/test_Lazy_circular_kernel.cpp
+++ b/Circular_kernel_2/test/Circular_kernel_2/test_Lazy_circular_kernel.cpp
@@ -26,15 +26,12 @@
 
 #include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 
-#include <CGAL/basic.h>
 #include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/intersections.h>
 #include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Algebraic_kernel_for_circles_2_2.h>
 #include <CGAL/Circular_kernel_2.h>
 
-#include <iostream>
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Linear_k1;
 typedef CGAL::Algebraic_kernel_for_circles_2_2<Linear_k1::FT>          Algebraic_k1;

--- a/Circular_kernel_3/examples/Circular_kernel_3/functor_has_on_3.cpp
+++ b/Circular_kernel_3/examples/Circular_kernel_3/functor_has_on_3.cpp
@@ -1,5 +1,4 @@
 #include <CGAL/Exact_spherical_kernel_3.h>
-#include <CGAL/Random.h>
 
 typedef CGAL::Exact_spherical_kernel_3         Spherical_k;
 

--- a/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
@@ -13,7 +13,13 @@ if ( CGAL_FOUND )
 include(${CGAL_USE_FILE})
 
 include_directories (BEFORE include)
+
+# The following `include_directories` is used in the git layout
 include_directories (BEFORE ../../../Kernel_23/test/Kernel_23/include)
+
+# The following `include_directories` is used in the layout of the
+# internal releases tarballs
+include_directories (BEFORE ../Kernel_23/include)
 
 create_single_source_cgal_program( "test_Spherical_kernel.cpp" )
 create_single_source_cgal_program( "test_Spherical_kernel_basics.cpp" )

--- a/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
@@ -14,13 +14,6 @@ include(${CGAL_USE_FILE})
 
 include_directories (BEFORE include)
 include_directories (BEFORE ../../../Kernel_23/test/Kernel_23/include)
-include_directories (BEFORE ../Kernel_23/include)
-include_directories (BEFORE ../Cartesian_kernel/include)
-include_directories (BEFORE ../Homogeneous_kernel/include)
-include_directories (BEFORE ../../../Intersections_3/include)
-include_directories (BEFORE ../../../Algebraic_kernel_for_spheres/include)
-include_directories (BEFORE ../../../Kernel_23/include)
-include_directories (BEFORE ../../../Cartesian_kernel/include)
 
 create_single_source_cgal_program( "test_Spherical_kernel.cpp" )
 create_single_source_cgal_program( "test_Spherical_kernel_basics.cpp" )

--- a/Circular_kernel_3/test/Circular_kernel_3/test_Spherical_kernel.cpp
+++ b/Circular_kernel_3/test/Circular_kernel_3/test_Spherical_kernel.cpp
@@ -26,7 +26,6 @@
 #include <CGAL/Cartesian.h>
 #include <CGAL/Spherical_kernel_3.h>
 #include <CGAL/Algebraic_kernel_for_spheres_2_3.h>
-#include <CGAL/Quotient.h>
 #include <CGAL/Exact_rational.h>
 #include <CGAL/_test_sphere_predicates.h>
 #include <CGAL/_test_sphere_constructions.h>

--- a/Circular_kernel_3/test/Circular_kernel_3/test_Spherical_kernel_with_core.cpp
+++ b/Circular_kernel_3/test/Circular_kernel_3/test_Spherical_kernel_with_core.cpp
@@ -24,20 +24,12 @@
 
 #ifdef CGAL_USE_CORE
 #include <CGAL/Cartesian.h>
+#include <CGAL/CORE_Expr.h>
 #include <CGAL/Spherical_kernel_3.h>
 #include <CGAL/Algebraic_kernel_for_spheres_2_3.h>
-#include <CGAL/MP_Float.h>
-#include <CGAL/Quotient.h>
-#include <CGAL/Gmpq.h>
-#include <CGAL/CORE_BigRat.h>
-#include <CGAL/Root_of_traits.h>
 #include <CGAL/_test_sphere_predicates.h>
 #include <CGAL/_test_sphere_constructions.h>
 #include <CGAL/_test_sphere_compute.h>
-#include <CGAL/Polynomials_1_3.h>
-#include <CGAL/Polynomials_2_3.h>
-#include <CGAL/Polynomials_for_line_3.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/_test_functionalities_on_sphere.h>
 #endif
 


### PR DESCRIPTION
## Summary of Changes

The tests and examples included unnecessary files.  A test should include the absolute minimum, and examples must be exemplary.

## Release Management

* Affected package(s): Circular_kernel  2D and 3D


