### PR TITLE
CGAL: clean up CMakeLists.txt files in examples and tests

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -10,10 +10,6 @@ find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
-  if (MSVC AND ( CMAKE_SIZEOF_VOID_P EQUAL 4 ) )
-     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
-  endif()
-
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})

--- a/Classification/examples/Classification/CMakeLists.txt
+++ b/Classification/examples/Classification/CMakeLists.txt
@@ -45,11 +45,6 @@ else()
 endif()
 
 
-# include for local directory
-include_directories( BEFORE include )
-
-# include for local package
-
 # Creating entries for all C++ files with "main" routine
 # ##########################################################
 

--- a/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
@@ -10,6 +10,12 @@ find_package(CGAL QUIET COMPONENTS Core)
 
 if ( CGAL_FOUND AND CGAL_Core_FOUND)
   include(${CGAL_USE_FILE})
+  if (MSVC)
+    # Turn off a boost related warning that appears with VC2015
+    # boost_1_65_1\boost\graph\named_function_params.hpp(240) :
+    # warning C4172: returning address of local variable or temporary
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4172")
+  endif()
 
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)

--- a/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
@@ -11,11 +11,6 @@ find_package(CGAL QUIET COMPONENTS Core)
 if ( CGAL_FOUND AND CGAL_Core_FOUND)
   include(${CGAL_USE_FILE})
 
-  if (MSVC)
-    # Turn off a boost related warning that appears with VC2015
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4172")
-  endif()
-
   # create a target per cppfile
   file(GLOB cppfiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
   foreach(cppfile ${cppfiles})

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -17,8 +17,6 @@ if ( CGAL_FOUND )
 
   find_package( TBB QUIET )
 
-  include_directories (BEFORE ../../../AABB_tree/include)
-
   # Use Eigen
   find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)
   if (NOT EIGEN3_FOUND)

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -16,7 +16,6 @@ if ( CGAL_FOUND )
   include( CGAL_VersionUtils )
 
   include_directories( BEFORE include )
-  include_directories( BEFORE ../../../Arithmetic_kernel/include)
 
   create_single_source_cgal_program( "bench_interval.cpp" )
   create_single_source_cgal_program( "constant.cpp" )

--- a/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -13,8 +13,6 @@ find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
-  include_directories (BEFORE "include")
-
   create_single_source_cgal_program( "otr2_simplest_example.cpp" )
   create_single_source_cgal_program( "otr2_simplest_example_with_tolerance.cpp" )
   create_single_source_cgal_program( "otr2_list_output_example.cpp" )

--- a/Point_set_3/examples/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/examples/Point_set_3/CMakeLists.txt
@@ -27,10 +27,6 @@ if ( NOT Boost_FOUND )
 
 endif()
 
-# include for local directory
-include_directories( BEFORE include )
-
-# include for local package
 
 # Creating entries for all C++ files with "main" routine
 # ##########################################################

--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -20,7 +20,6 @@ if ( CGAL_FOUND )
     if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
       # Allow Windows 32bit applications to use up to 3GB of RAM
       SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
     endif()
     # Prints new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )

--- a/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
@@ -15,7 +15,6 @@ if ( CGAL_FOUND )
     if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
       # Allow Windows 32bit applications to use up to 3GB of RAM
       SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
     endif()
     # Prints new compilation options
     message( STATUS "USING DEBUG CXXFLAGS   = '${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}'" )

--- a/Solver_interface/examples/Solver_interface/CMakeLists.txt
+++ b/Solver_interface/examples/Solver_interface/CMakeLists.txt
@@ -10,8 +10,6 @@ find_package(CGAL QUIET)
 
 if ( CGAL_FOUND )
 
-  include_directories (BEFORE "../include")
-  
   # Use Eigen
   find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
 

--- a/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
@@ -36,11 +36,6 @@ else()
   include( ${EIGEN3_USE_FILE} )
 endif()
 
-# include for local directory
-
-# include for local package
-include_directories( BEFORE ../../include )
-
 
 # Creating entries for all C++ files with "main" routine
 # ##########################################################

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
@@ -6,9 +6,6 @@ project( Surface_mesh_parameterization_Examples )
 cmake_minimum_required(VERSION 3.1)
 
 
-# Include this package's headers first
-include_directories (BEFORE . include)
-
 # Find CGAL
 find_package(CGAL QUIET)
 

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -6,9 +6,6 @@ project( Surface_mesh_parameterization_Tests )
 cmake_minimum_required(VERSION 3.1)
 
 
-# Include this package's headers first
-include_directories (BEFORE . include)
-
 # Find CGAL
 find_package(CGAL QUIET)
 


### PR DESCRIPTION
## Summary of Changes

Remove unnecessary `include_directories()`.  
If anybody has more suggestions what should get cleaned up it could go into this PR.

For example removing `SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")`  from [this ](https://github.com/CGAL/cgal/blob/master/Spatial_searching/examples/Spatial_searching/CMakeLists.txt#L27) file, first of all as it does not work as @lrineau told me, and secondly because we shouldn't suppress warnings this way.

## Release Management

* Affected package(s): several

