### PR TITLE
Reduce inclusions of <CGAL/basic.h> and <CGAL/number_type_basic.h>

### DIFF
--- a/Number_types/include/CGAL/int.h
+++ b/Number_types/include/CGAL/int.h
@@ -27,7 +27,7 @@
 #ifndef CGAL_INT_H
 #define CGAL_INT_H
 
-#include <CGAL/number_type_basic.h>
+#include <CGAL/Interval_nt.h>
 #include <CGAL/Modular_traits.h>
 #include <CGAL/Modular_arithmetic/Residue_type.h>
 

--- a/Number_types/include/CGAL/long_double.h
+++ b/Number_types/include/CGAL/long_double.h
@@ -26,8 +26,6 @@
 #ifndef CGAL_LONG_DOUBLE_H
 #define CGAL_LONG_DOUBLE_H
 
-#include <CGAL/number_type_basic.h>
-
 #include <utility>
 #include <cmath>
 #ifdef CGAL_CFG_IEEE_754_BUG
@@ -36,6 +34,8 @@
 
 // #include <CGAL/FPU.h>
 #include <CGAL/Interval_nt.h>
+#include <CGAL/assertions.h>
+#include <CGAL/functional.h>
 
 namespace CGAL {
 

--- a/Number_types/include/CGAL/test_FPU_rounding_mode_impl.h
+++ b/Number_types/include/CGAL/test_FPU_rounding_mode_impl.h
@@ -27,7 +27,6 @@
 
 #ifndef CGAL_NDEBUG
 
-#include <CGAL/basic.h>
 #include <CGAL/assertions.h>
 
 namespace CGAL {

--- a/Stream_support/include/CGAL/IO/io_impl.h
+++ b/Stream_support/include/CGAL/IO/io_impl.h
@@ -29,7 +29,6 @@
 #define CGAL_INLINE_FUNCTION
 #endif
 
-#include <CGAL/basic.h>
 #include <CGAL/assertions.h>
 
 #include <sstream>


### PR DESCRIPTION
## Summary of Changes

@afabri reported that the header `<CGAL/Interval_nt.h>` did not compile. That is due to cyclic dependencies, that all lead to `<CGAL/basic.h>` or `<CGAL/number_type_basic.h>`. This pull-request tries to reduce the graph of dependencies between headers of `Number_types/`. At least now `<CGAL/Interval_nt>` does compile.

I have verified that the whole testsuites of `Number_types`, `Kernel_23`, and `Stream_support` still pass, with CTest.

## Release Management

* Affected package(s): Number_types, all the core of CGAL

