### PR TITLE
Polyhedron demo: Fix crash in triangulation of non convex facets.

### DIFF
--- a/Polyhedron/demo/Polyhedron/triangulate_primitive.h
+++ b/Polyhedron/demo/Polyhedron/triangulate_primitive.h
@@ -141,8 +141,8 @@ private:
     }
     if(last_inserted == typename CDT::Vertex_handle())
       return false;
-    
-    cdt->insert_constraint(previous, first);
+    if(previous != first)
+      cdt->insert_constraint(previous, first);
     // sets mark is_external
     for(typename CDT::All_faces_iterator
         fit2 = cdt->all_faces_begin(),

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -186,6 +186,8 @@ Inserts the line segment between the points `c.first` and `c.second` as  a const
 /*!
 Inserts the line segment whose endpoints are the vertices `va` and 
 `vb` as a constraint in the triangulation. 
+\pre `va` != `vb`.
+
 */ 
 void insert_constraint(Vertex_handle va, Vertex_handle vb); 
 


### PR DESCRIPTION
## Summary of Changes
Test if the two constraints vertices are different before inserting to avoid crash.