### PR TITLE
BGL: Make halfedges(Face_filtered_graph&) return Iterator_range instead of std::pair

### DIFF
--- a/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
+++ b/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
@@ -944,8 +944,7 @@ template<typename Graph,
          typename FIMap,
          typename VIMap,
          typename HIMap>
-std::pair<typename boost::graph_traits<Face_filtered_graph<Graph, FIMap, VIMap, HIMap> >::halfedge_iterator,
-typename boost::graph_traits<Face_filtered_graph<Graph, FIMap, VIMap, HIMap> >::halfedge_iterator>
+Iterator_range<typename boost::graph_traits<Face_filtered_graph<Graph, FIMap, VIMap, HIMap> >::halfedge_iterator>
 halfedges(const Face_filtered_graph<Graph, FIMap, VIMap, HIMap> & w)
 {
   typedef typename boost::graph_traits<Face_filtered_graph<Graph, FIMap, VIMap, HIMap> >::halfedge_iterator halfedge_iterator;


### PR DESCRIPTION
## Summary of Changes

The function `halfedges(..)` is the only one not returning a range. This is important for writing `for( : )` loops.


## Release Management

* Affected package(s): BGL


