### PR TITLE
NewKernel_d: Suppress VC2015 warning

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
@@ -20,7 +20,8 @@
 
 #ifndef CGAL_KERNEL_D_CARTESIAN_LA_BASE_H
 #define CGAL_KERNEL_D_CARTESIAN_LA_BASE_H
-
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
 #include <CGAL/basic.h>
 #include <CGAL/Origin.h>
 #include <boost/type_traits/integral_constant.hpp>
@@ -28,8 +29,10 @@
 #include <CGAL/NewKernel_d/functor_tags.h>
 #include <CGAL/Uncertain.h>
 #include <CGAL/typeset.h>
+
 #include <CGAL/NewKernel_d/Dimension_base.h>
 #include <CGAL/NewKernel_d/Cartesian_LA_functors.h>
+
 #include <CGAL/NewKernel_d/Vector/array.h>
 #include <CGAL/NewKernel_d/Vector/vector.h>
 #include <CGAL/NewKernel_d/Vector/mix.h>
@@ -174,5 +177,5 @@ struct Cartesian_LA_base_d : public Dimension_base<Dim_>
 };
 
 } //namespace CGAL
-
+#  pragma warning(pop)
 #endif // CGAL_KERNEL_D_CARTESIAN_LA_BASE_H

--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
@@ -20,8 +20,6 @@
 
 #ifndef CGAL_KERNEL_D_CARTESIAN_LA_BASE_H
 #define CGAL_KERNEL_D_CARTESIAN_LA_BASE_H
-#  pragma warning(push)
-#  pragma warning(disable: 4309)
 #include <CGAL/basic.h>
 #include <CGAL/Origin.h>
 #include <boost/type_traits/integral_constant.hpp>
@@ -177,5 +175,5 @@ struct Cartesian_LA_base_d : public Dimension_base<Dim_>
 };
 
 } //namespace CGAL
-#  pragma warning(pop)
+
 #endif // CGAL_KERNEL_D_CARTESIAN_LA_BASE_H

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
@@ -62,7 +62,15 @@ template <class R_> struct Construct_hyperplane : Store_kernel<R_> {
   // Not really needed
   result_type operator()()const{
     typename Get_functor<R_, Construct_ttag<Vector_tag> >::type cv(this->kernel());
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif    
     return result_type(cv(),0);
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
   }
 
   template <class Iter>

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Segment.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Segment.h
@@ -77,8 +77,15 @@ template<class R_> struct Construct_segment : Store_kernel<R_> {
 	}
 	// Not really needed, especially since it forces us to store the kernel
 	result_type operator()()const{
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif
 		Point p = typename Get_functor<R_, Construct_ttag<Point_tag> >::type (this->kernel()) ();
 		return result_type (p, p);
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
 	}
 	// T should only be std::piecewise_construct_t, but we shouldn't fail if it doesn't exist.
 	template<class T,class U,class V>

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
@@ -49,7 +49,14 @@ template <class R_> struct Construct_sphere : Store_kernel<R_> {
   // Not really needed
   result_type operator()()const{
     typename Get_functor<R_, Construct_ttag<Point_tag> >::type cp(this->kernel());
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif  
     return result_type(cp(),0);
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
   }
   template <class Iter>
   result_type operator()(Iter f, Iter e)const{

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
@@ -51,7 +51,14 @@ template <class R_> struct Construct_weighted_point : Store_kernel<R_> {
   // Not really needed
   result_type operator()()const{
     typename Get_functor<R_, Construct_ttag<Point_tag> >::type cp(this->kernel());
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif    
     return result_type(cp(),0);
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
   }
 };
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
@@ -20,7 +20,6 @@
 
 #ifndef CGAL_WRAPPER_POINT_D_H
 #define CGAL_WRAPPER_POINT_D_H
-
 #include <ostream>
 #include <istream>
 #include <CGAL/IO/io.h>
@@ -78,9 +77,18 @@ public:
   typedef          R_                       R;
 
 #ifdef CGAL_CXX11
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif
+  
   template<class...U,class=typename std::enable_if<!std::is_same<std::tuple<typename std::decay<U>::type...>,std::tuple<Point_d> >::value>::type> explicit Point_d(U&&...u)
 	  : Rep(CPBase()(std::forward<U>(u)...)){}
 
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
+  
 //  // called from Construct_point_d
 //  template<class...U> explicit Point_d(Eval_functor&&,U&&...u)
 //	  : Rep(Eval_functor(), std::forward<U>(u)...){}
@@ -324,5 +332,4 @@ operator>>(std::istream &is, Point_d<K> & p)
 
 } //namespace Wrap
 } //namespace CGAL
-
 #endif // CGAL_WRAPPER_POINT_D_H

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Vector_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Vector_d.h
@@ -76,9 +76,17 @@ public:
   typedef          R_                       R;
 
 #ifdef CGAL_CXX11
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)  
+#  pragma warning(push)
+#  pragma warning(disable: 4309)
+#endif
   template<class...U,class=typename std::enable_if<!std::is_same<std::tuple<typename std::decay<U>::type...>,std::tuple<Vector_d> >::value>::type> explicit Vector_d(U&&...u)
 	  : Rep(CVBase()(std::forward<U>(u)...)){}
 
+#if defined(BOOST_MSVC) && (BOOST_MSVC == 1900)
+#  pragma warning(pop)
+#endif
+  
 //  // called from Construct_vector_d
 //  template<class...U> explicit Vector_d(Eval_functor&&,U&&...u)
 //	  : Rep(Eval_functor(), std::forward<U>(u)...){}


### PR DESCRIPTION
## Summary of Changes

Suppress the warning

> include\CGAL/NewKernel_d/Wrapper/Point_d.h(82): warning C4309: 'specialization': truncation of constant value

[here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-126/NewKernel_d/TestReport_afabri_x64_Cygwin-Windows10_MSVC2015-Debug-64bits.gz) that seems to be a false positive for VC2015.

## Release Management

* Affected package(s): NewKernel_d


