### PR TITLE
Point Set Processing: Fix PLY FT type detection

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -92,10 +92,19 @@ namespace CGAL {
   };
 
   /// \cond SKIP_IN_MANUAL
+
+  // Use a double property for all kernels...
+  template <typename FT> struct Convert_FT        { typedef double type; };
+  // ...except if kernel uses type float
+  template <>            struct Convert_FT<float> { typedef float type;  };
+    
   template <typename PointOrVectorMap>
   struct GetFTFromMap
   {
-    typedef typename Kernel_traits<typename boost::property_traits<PointOrVectorMap>::value_type>::Kernel::FT type;
+    typedef typename Convert_FT
+    <typename Kernel_traits
+     <typename boost::property_traits
+      <PointOrVectorMap>::value_type>::Kernel::FT>::type type;
   };
   /// \endcond
   


### PR DESCRIPTION
## Summary of Changes

In order to avoid reading/writing point coordinates that are `float` as `double` when using the PLY reader with `CGAL::Simple_cartesian<float>`, I introduced an automatic detection of the FT type based on the value type of the point map. This detection fails if the kernel is exact, see issue https://github.com/CGAL/cgal/issues/3696.

This fixes it by declaring the type to read/write (from a PLY point of view) as double by default, _except_ when using the float kernel.

(I'll also have to fix https://github.com/CGAL/cgal/pull/3636 similarly.)

## Release Management

* Affected package(s): Point Set Processing
* Affected releases: from 4.13 (the automatic FT detection was not in 4.12)
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/3696

