### PR TITLE
Update STL_writer.h

### DIFF
--- a/Polyhedron_IO/include/CGAL/IO/STL_writer.h
+++ b/Polyhedron_IO/include/CGAL/IO/STL_writer.h
@@ -85,11 +85,12 @@ write_STL(const TriangleMesh& tm, std::ostream& out)
 
       Vector_3 n = collinear(p,q,r) ? Vector_3(1,0,0):
                                       unit_normal(p,q,r);
-      out << "facet normal " << n << "\nouter loop\n";
-      out << "vertex " << p << "\n";
-      out << "vertex " << q << "\n";
-      out << "vertex " << r << "\n";
-      out << "endloop\nendfacet\n";
+      out << std::scientific << std::setprecision(6);
+      out << "facet normal " << n << "\n    outer loop\n";
+      out << "        vertex " << p << "\n";
+      out << "        vertex " << q << "\n";
+      out << "        vertex " << r << "\n";
+      out << "    endloop\nendfacet\n";
     }
     out << "endsolid\n";
   }

--- a/Polyhedron_IO/include/CGAL/IO/STL_writer.h
+++ b/Polyhedron_IO/include/CGAL/IO/STL_writer.h
@@ -75,7 +75,8 @@ write_STL(const TriangleMesh& tm, std::ostream& out)
   }
   else
   {
-    out << "solid\n";
+    out << "solid\n";    
+    out << std::scientific << std::setprecision(17);
     BOOST_FOREACH(face_descriptor f, faces(tm))
     {
       halfedge_descriptor h = halfedge(f, tm);
@@ -85,12 +86,13 @@ write_STL(const TriangleMesh& tm, std::ostream& out)
 
       Vector_3 n = collinear(p,q,r) ? Vector_3(1,0,0):
                                       unit_normal(p,q,r);
-      out << std::scientific << std::setprecision(6);
-      out << "facet normal " << n << "\n    outer loop\n";
+      out << "facet normal " << n << "\n;
+      out << "    outer loop\n";
       out << "        vertex " << p << "\n";
       out << "        vertex " << q << "\n";
       out << "        vertex " << r << "\n";
-      out << "    endloop\nendfacet\n";
+      out << "    endloop\n";
+      out << "endfacet\n";
     }
     out << "endsolid\n";
   }


### PR DESCRIPTION
Current implementation produces an unreadable format due to incorrect number formatting for ASCII output.
Included sign-mantissa-"e"-sign-exponent format on line 88 by setting notation and precision.
Additionally added some formatting to output for readability and to match common STL file formats.
Works with most STL readers.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [link](https://mydoc/Manual/Pkg)
* License and copyright ownership:

