### PR TITLE
Surface mesh approximation: handle degenerate cases

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -225,8 +225,8 @@ public:
 
       EPICK::Vector_3 base1 = plane.base1();
       EPICK::Vector_3 base2 = plane.base2();
-      base1 = base1 / CGAL::approxiamte_sqrt(base1.squared_length());
-      base2 = base2 / CGAL::approxiamte_sqrt(base2.squared_length());
+      base1 = base1 / CGAL::approximate_sqrt(base1.squared_length());
+      base2 = base2 / CGAL::approximate_sqrt(base2.squared_length());
 
       EPICK::Line_3 base_linex(origin, base1);
       EPICK::Line_3 base_liney(origin, base2);
@@ -236,8 +236,8 @@ public:
         const Point_3 point = plane.projection(p);
         EPICK::Vector_3 vecx(origin, base_linex.projection(point));
         EPICK::Vector_3 vecy(origin, base_liney.projection(point));
-        double x = CGAL::approxiamte_sqrt(vecx.squared_length());
-        double y = CGAL::approxiamte_sqrt(vecy.squared_length());
+        double x = CGAL::approximate_sqrt(vecx.squared_length());
+        double y = CGAL::approximate_sqrt(vecy.squared_length());
         x = vecx * base1 < 0 ? -x : x;
         y = vecy * base2 < 0 ? -y : y;
         pts_2d.push_back(EPICK::Point_2(x, y));

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -225,8 +225,8 @@ public:
 
       EPICK::Vector_3 base1 = plane.base1();
       EPICK::Vector_3 base2 = plane.base2();
-      base1 = base1 / CGAL::approximate_sqrt(base1.squared_length());
-      base2 = base2 / CGAL::approximate_sqrt(base2.squared_length());
+      base1 = base1 / CGAL::sqrt(base1.squared_length());
+      base2 = base2 / CGAL::sqrt(base2.squared_length());
 
       EPICK::Line_3 base_linex(origin, base1);
       EPICK::Line_3 base_liney(origin, base2);
@@ -236,8 +236,8 @@ public:
         const Point_3 point = plane.projection(p);
         EPICK::Vector_3 vecx(origin, base_linex.projection(point));
         EPICK::Vector_3 vecy(origin, base_liney.projection(point));
-        double x = CGAL::approximate_sqrt(vecx.squared_length());
-        double y = CGAL::approximate_sqrt(vecy.squared_length());
+        double x = CGAL::sqrt(vecx.squared_length());
+        double y = CGAL::sqrt(vecy.squared_length());
         x = vecx * base1 < 0 ? -x : x;
         y = vecy * base2 < 0 ? -y : y;
         pts_2d.push_back(EPICK::Point_2(x, y));

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -225,8 +225,8 @@ public:
 
       EPICK::Vector_3 base1 = plane.base1();
       EPICK::Vector_3 base2 = plane.base2();
-      base1 = base1 / std::sqrt(base1.squared_length());
-      base2 = base2 / std::sqrt(base2.squared_length());
+      base1 = base1 / CGAL::approxiamte_sqrt(base1.squared_length());
+      base2 = base2 / CGAL::approxiamte_sqrt(base2.squared_length());
 
       EPICK::Line_3 base_linex(origin, base1);
       EPICK::Line_3 base_liney(origin, base2);
@@ -236,8 +236,8 @@ public:
         const Point_3 point = plane.projection(p);
         EPICK::Vector_3 vecx(origin, base_linex.projection(point));
         EPICK::Vector_3 vecy(origin, base_liney.projection(point));
-        double x = std::sqrt(vecx.squared_length());
-        double y = std::sqrt(vecy.squared_length());
+        double x = CGAL::approxiamte_sqrt(vecx.squared_length());
+        double y = CGAL::approxiamte_sqrt(vecy.squared_length());
         x = vecx * base1 < 0 ? -x : x;
         y = vecy * base2 < 0 ? -y : y;
         pts_2d.push_back(EPICK::Point_2(x, y));

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -193,8 +193,20 @@ public:
       EPICK::Plane_3 fit_plane;
       CGAL::linear_least_squares_fitting_3(
         tris.begin(), tris.end(), fit_plane, CGAL::Dimension_tag<2>());
+      if (!(boost::math::isfinite)(fit_plane.a()) ||
+        !(boost::math::isfinite)(fit_plane.b()) ||
+        !(boost::math::isfinite)(fit_plane.c()) ||
+        !(boost::math::isfinite)(fit_plane.d())) {
+        // PCA may return plane with NaN efficients
+        // we replace it with an inaccurate plane
+        std::cout << "WARNING: Replacing invalide plane." << std::endl;
+        fit_plane = EPICK::Plane_3(
+          tris.front().vertex(0),
+          EPICK::Vector_3(0.0, 0.0, 1.0));
+      }
       patch_planes.push_back(fit_plane);
     }
+
     std::vector<std::vector<Point_3> > patch_points(approx.number_of_proxies());
     BOOST_FOREACH(vertex_descriptor v, vertices(*pmesh)) {
       BOOST_FOREACH(halfedge_descriptor h, CGAL::halfedges_around_target(v, *pmesh)) {

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.cpp
@@ -15,7 +15,7 @@ VSA_wrapper::VSA_wrapper(const SMesh &mesh) :
     const Point_3 &p2 = vpm[target(next(he, mesh), mesh)];
 
     put(m_center_pmap, f, CGAL::centroid(p0, p1, p2));
-    put(m_area_pmap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
+    put(m_area_pmap, f, CGAL::sqrt(CGAL::squared_area(p0, p1, p2)));
   }
 
   m_pl21_metric = new L21_metric(mesh, vpm);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.cpp
@@ -15,7 +15,7 @@ VSA_wrapper::VSA_wrapper(const SMesh &mesh) :
     const Point_3 &p2 = vpm[target(next(he, mesh), mesh)];
 
     put(m_center_pmap, f, CGAL::centroid(p0, p1, p2));
-    put(m_area_pmap, f, std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2))));
+    put(m_area_pmap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
   }
 
   m_pl21_metric = new L21_metric(mesh, vpm);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
@@ -65,8 +65,7 @@ class VSA_WRAPPER_EXPORT VSA_wrapper {
       : center_pmap(center_pmap_), area_pmap(area_pmap_) {}
 
     FT compute_error(const face_descriptor f, const SMesh &, const Proxy &px) const {
-      return CGAL::approximate_sqrt(
-        CGAL::squared_distance(get(center_pmap, f), px));
+      return CGAL::sqrt(CGAL::squared_distance(get(center_pmap, f), px));
     }
 
     template <typename FaceRange>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
@@ -65,8 +65,8 @@ class VSA_WRAPPER_EXPORT VSA_wrapper {
       : center_pmap(center_pmap_), area_pmap(area_pmap_) {}
 
     FT compute_error(const face_descriptor f, const SMesh &, const Proxy &px) const {
-      return FT(std::sqrt(CGAL::to_double(
-        CGAL::squared_distance(get(center_pmap, f), px))));
+      return CGAL::approximate_sqrt(
+        CGAL::squared_distance(get(center_pmap, f), px));
     }
 
     template <typename FaceRange>

--- a/Surface_mesh_approximation/examples/Surface_mesh_approximation/vsa_isotropic_metric_example.cpp
+++ b/Surface_mesh_approximation/examples/Surface_mesh_approximation/vsa_isotropic_metric_example.cpp
@@ -36,7 +36,7 @@ struct Compact_metric_point_proxy
   // defined as the Euclidean distance between
   // the face center of mass and proxy point.
   FT compute_error(const face_descriptor &f, const Mesh &, const Proxy &px) const {
-    return CGAL::approximate_sqrt(CGAL::squared_distance(center_pmap[f], px));
+    return CGAL::sqrt(CGAL::squared_distance(center_pmap[f], px));
   }
 
   // template functor to compute a best-fit
@@ -84,7 +84,7 @@ int main()
     const Point_3 &p0 = vpmap[source(he, mesh)];
     const Point_3 &p1 = vpmap[target(he, mesh)];
     const Point_3 &p2 = vpmap[target(next(he, mesh), mesh)];
-    put(area_pmap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
+    put(area_pmap, f, CGAL::sqrt(CGAL::squared_area(p0, p1, p2)));
     put(center_pmap, f, CGAL::centroid(p0, p1, p2));
   }
 

--- a/Surface_mesh_approximation/examples/Surface_mesh_approximation/vsa_isotropic_metric_example.cpp
+++ b/Surface_mesh_approximation/examples/Surface_mesh_approximation/vsa_isotropic_metric_example.cpp
@@ -36,8 +36,7 @@ struct Compact_metric_point_proxy
   // defined as the Euclidean distance between
   // the face center of mass and proxy point.
   FT compute_error(const face_descriptor &f, const Mesh &, const Proxy &px) const {
-    return FT(std::sqrt(CGAL::to_double(
-      CGAL::squared_distance(center_pmap[f], px))));
+    return CGAL::approximate_sqrt(CGAL::squared_distance(center_pmap[f], px));
   }
 
   // template functor to compute a best-fit
@@ -85,7 +84,7 @@ int main()
     const Point_3 &p0 = vpmap[source(he, mesh)];
     const Point_3 &p1 = vpmap[target(he, mesh)];
     const Point_3 &p2 = vpmap[target(next(he, mesh), mesh)];
-    put(area_pmap, f, FT(std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2)))));
+    put(area_pmap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
     put(center_pmap, f, CGAL::centroid(p0, p1, p2));
   }
 

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
@@ -102,7 +102,7 @@ public:
         put(m_fnmap, f, CGAL::NULL_VECTOR);
       else
         put(m_fnmap, f, CGAL::unit_normal(p0, p1, p2));
-      put(m_famap, f, std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2))));
+      put(m_famap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
     }
   }
   /// @}
@@ -138,9 +138,9 @@ public:
       norm = m_sum_functor(norm,
         m_scale_functor(get(m_fnmap, f), get(m_famap, f)));
     }
-    const FT inv_len = FT(1.0 / std::sqrt(CGAL::to_double(norm.squared_length())));
-    if ((boost::math::isnormal)(inv_len))
-      norm = m_scale_functor(norm, inv_len);
+    if (norm.squared_length() > FT(0.0))
+      norm = m_scale_functor(norm,
+        FT(1.0) / CGAL::approximate_sqrt(norm.squared_length()));
 
     return norm;
   }

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
@@ -98,10 +98,8 @@ public:
       const Point_3 &p0 = vpmap[source(he, tm)];
       const Point_3 &p1 = vpmap[target(he, tm)];
       const Point_3 &p2 = vpmap[target(next(he, tm), tm)];
-      if (CGAL::collinear(p0, p1, p2)) {
-        std::cout << CGAL::unit_normal(p0, p1, p2) << std::endl;
+      if (CGAL::collinear(p0, p1, p2))
         put(m_fnmap, f, CGAL::NULL_VECTOR);
-      }
       else
         put(m_fnmap, f, CGAL::unit_normal(p0, p1, p2));
       put(m_famap, f, std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2))));

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
@@ -57,6 +57,7 @@ class L21_metric_plane_proxy {
   typedef typename GeomTraits::Construct_scaled_vector_3 Construct_scaled_vector_3;
   typedef typename GeomTraits::Construct_sum_of_vectors_3 Construct_sum_of_vectors_3;
   typedef typename GeomTraits::Compute_scalar_product_3 Compute_scalar_product_3;
+  typedef typename GeomTraits::Collinear_3 Collinear_3;
 
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
@@ -91,6 +92,7 @@ public:
     m_scalar_product_functor = traits.compute_scalar_product_3_object();
     m_sum_functor = traits.construct_sum_of_vectors_3_object();
     m_scale_functor = traits.construct_scaled_vector_3_object();
+    m_collinear_functor = traits.collinear_3_object();
 
     // construct internal face normal & area map
     BOOST_FOREACH(face_descriptor f, faces(tm)) {
@@ -151,6 +153,7 @@ private:
   Construct_scaled_vector_3 m_scale_functor;
   Compute_scalar_product_3 m_scalar_product_functor;
   Construct_sum_of_vectors_3 m_sum_functor;
+  Collinear_3 m_collinear_functor;
 };
 
 } // namespace Surface_mesh_approximation

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L2_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L2_metric_plane_proxy.h
@@ -88,7 +88,7 @@ public:
       const Point_3 &p0 = m_vpmap[source(he, *m_tm)];
       const Point_3 &p1 = m_vpmap[target(he, *m_tm)];
       const Point_3 &p2 = m_vpmap[target(next(he, *m_tm), *m_tm)];
-      put(m_famap, f, std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2))));
+      put(m_famap, f, CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2)));
     }
   }
   /// @}
@@ -110,9 +110,9 @@ public:
     const FT sq_d0 = CGAL::squared_distance(p0, px);
     const FT sq_d1 = CGAL::squared_distance(p1, px);
     const FT sq_d2 = CGAL::squared_distance(p2, px);
-    const FT d0(std::sqrt(CGAL::to_double(sq_d0)));
-    const FT d1(std::sqrt(CGAL::to_double(sq_d1)));
-    const FT d2(std::sqrt(CGAL::to_double(sq_d2)));
+    const FT d0 = CGAL::approximate_sqrt(sq_d0);
+    const FT d1 = CGAL::approximate_sqrt(sq_d1);
+    const FT d2 = CGAL::approximate_sqrt(sq_d2);
 
     return (sq_d0 + sq_d1 + sq_d2 +
             d0 * d1 + d1 * d2 + d2 * d0) * get(m_famap, f) / FT(6.0);

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -139,6 +139,8 @@ private:
   typedef typename Geom_traits::Construct_scaled_vector_3 Construct_scaled_vector_3;
   typedef typename Geom_traits::Construct_sum_of_vectors_3 Construct_sum_of_vectors_3;
   typedef typename Geom_traits::Construct_translated_point_3 Construct_translated_point_3;
+  typedef typename Geom_traits::Construct_cross_product_vector_3 Construct_cross_product_vector_3;
+  typedef typename Geom_traits::Collinear_3 Collinear_3;
 
   // graph_traits typedefs
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor vertex_descriptor;
@@ -242,6 +244,8 @@ private:
   Construct_scaled_vector_3 scale_functor;
   Construct_sum_of_vectors_3 sum_functor;
   Construct_translated_point_3 translate_point_functor;
+  Construct_cross_product_vector_3 cross_product_functor;
+  Collinear_3 collinear_functor;
 
   // Proxies.
   std::vector<Proxy_wrapper> m_proxies;
@@ -290,6 +294,8 @@ public:
     scale_functor = traits.construct_scaled_vector_3_object();
     sum_functor = traits.construct_sum_of_vectors_3_object();
     translate_point_functor = traits.construct_translated_point_3_object();
+    cross_product_functor = traits.construct_cross_product_vector_3_object();
+    collinear_functor = traits.collinear_3_object();
   }
   /// @}
 
@@ -1428,7 +1434,7 @@ private:
         const Point_3 &p2 = m_vpoint_map[target(next(he, *m_ptm), *m_ptm)];
         const FT farea = CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2));
         const Vector_3 fnorm =
-          CGAL::collinear(p0, p1, p2) ? CGAL::NULL_VECTOR : CGAL::unit_normal(p0, p1, p2);
+          collinear_functor(p0, p1, p2) ? CGAL::NULL_VECTOR : CGAL::unit_normal(p0, p1, p2);
 
         norm = sum_functor(norm, scale_functor(fnorm, farea));
         area += farea;
@@ -1555,7 +1561,7 @@ private:
           FT(1.0) / CGAL::approximate_sqrt(chord_vec.squared_length()));
         BOOST_FOREACH(const halfedge_descriptor he, chord) {
           Vector_3 vec = vector_functor(pt_begin, m_vpoint_map[target(he, *m_ptm)]);
-          vec = CGAL::cross_product(chord_vec, vec);
+          vec = cross_product_functor(chord_vec, vec);
           const FT dist = CGAL::approximate_sqrt(vec.squared_length());
           if (dist > dist_max) {
             dist_max = dist;
@@ -1836,7 +1842,7 @@ private:
         chord_vec = scale_functor(chord_vec, FT(1.0) / chord_len);
         for (Boundary_chord_iterator citr = chord_begin; citr != chord_end; ++citr) {
           Vector_3 vec = vector_functor(pt_begin, m_vpoint_map[target(*citr, *m_ptm)]);
-          vec = CGAL::cross_product(chord_vec, vec);
+          vec = cross_product_functor(chord_vec, vec);
           const FT dist = CGAL::approximate_sqrt(vec.squared_length());
           if (dist > dist_max) {
             chord_max = citr;
@@ -1870,7 +1876,7 @@ private:
           px_right = get(m_fproxy_map, face(opposite(he_first, *m_ptm), *m_ptm));
         FT norm_sin(1.0);
         if (!CGAL::is_border(opposite(he_first, *m_ptm), *m_ptm)) {
-          Vector_3 vec = CGAL::cross_product(
+          Vector_3 vec = cross_product_functor(
             m_px_planes[px_left].normal, m_px_planes[px_right].normal);
           norm_sin = CGAL::approximate_sqrt(vec.squared_length());
         }
@@ -2012,7 +2018,7 @@ private:
       Vector_3 vec = vector_functor(CGAL::ORIGIN, CGAL::centroid(p0, p1, p2));
       const FT farea = CGAL::approximate_sqrt(CGAL::squared_area(p0, p1, p2));
       Vector_3 fnorm =
-        CGAL::collinear(p0, p1, p2) ? CGAL::NULL_VECTOR : CGAL::unit_normal(p0, p1, p2);
+        collinear_functor(p0, p1, p2) ? CGAL::NULL_VECTOR : CGAL::unit_normal(p0, p1, p2);
 
       norm = sum_functor(norm, scale_functor(fnorm, farea));
       cent = sum_functor(cent, scale_functor(vec, farea));

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -1552,7 +1552,8 @@ private:
       }
       std::cout << "#anchors: " << count << std::endl;
 
-      halfedge_descriptor he_max = bcycle.he_head;
+      CGAL_assertion(!chord.empty());
+      halfedge_descriptor he_max = *chord.begin();
       Vector_3 chord_vec = vector_functor(pt_begin, pt_end);
       const FT inv_len = FT(1.0) / CGAL::sqrt(chord_vec.squared_length());
       if ((boost::math::isnormal)(inv_len)) {

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -1441,8 +1441,6 @@ private:
       else
         norm = Vector_3(FT(0.0), FT(0.0), FT(1.0));
 
-      std::cout << inv_len << " # " << norm << " # " << area << std::endl;
-
       m_px_planes.push_back(Proxy_plane(fit_plane, norm, area));
     }
   }
@@ -1550,7 +1548,6 @@ private:
         const_cast<Boundary_cycle &>(bcycle).num_anchors = count;
         continue;
       }
-      std::cout << "#anchors: " << count << std::endl;
 
       CGAL_assertion(!chord.empty());
       halfedge_descriptor he_max = *chord.begin();
@@ -1682,7 +1679,7 @@ private:
 
       const sg_vertex_descriptor source = glocal.global_to_local(vpatch.back());
       VertexVector pred(num_vertices(glocal),
-        boost::graph_traits<TriangleMesh>::null_vertex());
+        boost::graph_traits<SubGraph>::null_vertex());
       boost::dijkstra_shortest_paths(glocal, source,
         boost::predecessor_map(&pred[0]).weight_map(local_eweight_map));
 

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -342,6 +342,8 @@ public:
 
     // initialize proxies and the proxy map to prepare for insertion
     bootstrap_from_connected_components();
+    if (max_nb_proxies <= m_proxies.size())
+      return m_proxies.size();
     switch (method) {
       case Surface_mesh_approximation::RANDOM:
         return init_random(max_nb_proxies, min_error_drop, nb_relaxations);

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -211,7 +211,7 @@ private:
 
   // The anchor attached to a vertex.
   struct Anchor {
-    Anchor(const vertex_descriptor &vtx_, const Point_3 pos_)
+    Anchor(const vertex_descriptor vtx_, const Point_3 pos_)
       : vtx(vtx_), pos(pos_) {}
 
     vertex_descriptor vtx; // The associated vertex.
@@ -221,7 +221,7 @@ private:
   // The boundary cycle of a region.
   // One region may have multiple boundary cycles.
   struct Boundary_cycle {
-    Boundary_cycle(const halfedge_descriptor &h)
+    Boundary_cycle(const halfedge_descriptor h)
       : he_head(h), num_anchors(0) {}
 
     halfedge_descriptor he_head; // Heading halfedge of the boundary cycle.
@@ -1505,7 +1505,7 @@ private:
         std::cerr << "#chord_anchor " << m_bcycles.back().num_anchors << std::endl;
 #endif
 
-        BOOST_FOREACH(const halfedge_descriptor &he, chord)
+        BOOST_FOREACH(const halfedge_descriptor he, chord)
           he_candidates.erase(he);
       } while (he_start != he_mark);
     }
@@ -1553,7 +1553,7 @@ private:
         FT dist_max(0.0);
         chord_vec = scale_functor(chord_vec,
           FT(1.0) / CGAL::approximate_sqrt(chord_vec.squared_length()));
-        BOOST_FOREACH(const halfedge_descriptor &he, chord) {
+        BOOST_FOREACH(const halfedge_descriptor he, chord) {
           Vector_3 vec = vector_functor(pt_begin, m_vpoint_map[target(he, *m_ptm)]);
           vec = CGAL::cross_product(chord_vec, vec);
           const FT dist = CGAL::approximate_sqrt(vec.squared_length());
@@ -1565,7 +1565,7 @@ private:
       }
       else {
         FT dist_max(0.0);
-        BOOST_FOREACH(const halfedge_descriptor &he, chord) {
+        BOOST_FOREACH(const halfedge_descriptor he, chord) {
           const FT dist = CGAL::approximate_sqrt(CGAL::squared_distance(
             pt_begin, m_vpoint_map[target(he, *m_ptm)]));
           if (dist > dist_max) {
@@ -1901,7 +1901,7 @@ private:
    * @param he a halfedge descriptor
    * @return `true` is attached with an anchor, and `false` otherwise.
    */
-  bool is_anchor_attached(const halfedge_descriptor &he) const {
+  bool is_anchor_attached(const halfedge_descriptor he) const {
     return is_anchor_attached(target(he, *m_ptm), m_vanchor_map);
   }
 
@@ -1914,7 +1914,7 @@ private:
    */
   template<typename VertexAnchorIndexMap>
   bool is_anchor_attached(
-    const typename boost::property_traits<VertexAnchorIndexMap>::key_type &vtx,
+    const typename boost::property_traits<VertexAnchorIndexMap>::key_type vtx,
     const VertexAnchorIndexMap &vanchor_map) const {
     return get(vanchor_map, vtx) != CGAL_VSA_INVALID_TAG;
   }
@@ -1923,7 +1923,7 @@ private:
    * @brief attaches an anchor to the vertex.
    * @param vtx vertex
    */
-  void attach_anchor(const vertex_descriptor &vtx) {
+  void attach_anchor(const vertex_descriptor vtx) {
     put(m_vanchor_map, vtx, m_anchors.size());
     // default anchor location is the vertex point
     m_anchors.push_back(Anchor(vtx, m_vpoint_map[vtx]));
@@ -1933,7 +1933,7 @@ private:
    * @brief attaches an anchor to the target vertex of the halfedge.
    * @param he halfedge
    */
-  void attach_anchor(const halfedge_descriptor &he) {
+  void attach_anchor(const halfedge_descriptor he) {
     attach_anchor(target(he, *m_ptm));
   }
 

--- a/Surface_mesh_approximation/test/Surface_mesh_approximation/vsa_metric_test.cpp
+++ b/Surface_mesh_approximation/test/Surface_mesh_approximation/vsa_metric_test.cpp
@@ -36,7 +36,7 @@ struct Compact_metric_point_proxy {
   // defined as the Euclidean distance between
   // the face center of mass and proxy point.
   FT compute_error(const face_descriptor &f, const Mesh &, const Proxy &px) const {
-    return CGAL::approximate_sqrt(CGAL::squared_distance(center_pmap[f], px));
+    return CGAL::sqrt(CGAL::squared_distance(center_pmap[f], px));
   }
 
   // template functor to compute a best-fit
@@ -97,7 +97,7 @@ int main()
     const Point_3 &p0 = vpmap[source(he, mesh)];
     const Point_3 &p1 = vpmap[target(he, mesh)];
     const Point_3 &p2 = vpmap[target(next(he, mesh), mesh)];
-    put(area_pmap, f, FT(std::sqrt(CGAL::to_double(CGAL::squared_area(p0, p1, p2)))));
+    put(area_pmap, f, CGAL::sqrt(CGAL::squared_area(p0, p1, p2)));
     put(center_pmap, f, CGAL::centroid(p0, p1, p2));
   }
 

--- a/Surface_mesh_approximation/test/Surface_mesh_approximation/vsa_metric_test.cpp
+++ b/Surface_mesh_approximation/test/Surface_mesh_approximation/vsa_metric_test.cpp
@@ -36,8 +36,7 @@ struct Compact_metric_point_proxy {
   // defined as the Euclidean distance between
   // the face center of mass and proxy point.
   FT compute_error(const face_descriptor &f, const Mesh &, const Proxy &px) const {
-    return FT(std::sqrt(CGAL::to_double(
-      CGAL::squared_distance(center_pmap[f], px))));
+    return CGAL::approximate_sqrt(CGAL::squared_distance(center_pmap[f], px));
   }
 
   // template functor to compute a best-fit


### PR DESCRIPTION
## Fix crash due to degenerate cases

Handle degenerate faces, degenerate 1-d boundaries and floating ball-components with one proxy.

## Release Management

* Affected package(s): Surface Mesh Approximation
