### PR TITLE
Allow to have different SOVERSION for each CGAL libraries

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -366,11 +366,14 @@ endif()
 #   CGAL-4.10  : 13.0.0 (Change the API/ABI in CGAL_ImageIO.)
 #   CGAL-4.11  : 13.0.1 (Nothing different in CGAL compiled libraries.)
 #   CGAL-4.12  : 13.0.2 (Nothing different in CGAL compiled libraries.)
-#   CGAL-4.14  : 14.0.0 (ABI broken in CGAL::Image_3.)
+#   CGAL-4.14  : 14.0.0 , but only for CGAL_ImageIO (ABI broken in CGAL::Image_3.)
+#   CGAL-4.14  :   13.0.3 , for other libraries
 # ¹) According to http://upstream-tracker.org/versions/cgal.html
 
-set( CGAL_SONAME_VERSION "14" )
-set( CGAL_SOVERSION      "14.0.0" )
+set( CGAL_SONAME_VERSION         "13"     )
+set( CGAL_SOVERSION              "13.0.3" )
+set( CGAL_ImageIO_SONAME_VERSION "14"     )
+set( CGAL_ImageIO_SOVERSION      "14.0.0" )
 
 message( STATUS "CGAL_SONAME_VERSION=${CGAL_SONAME_VERSION}" )
 message( STATUS "CGAL_SOVERSION     =${CGAL_SOVERSION}" )

--- a/Installation/src/CMakeLists.txt
+++ b/Installation/src/CMakeLists.txt
@@ -50,7 +50,11 @@ function (collect_cgal_library LIBRARY_NAME ADDITIONAL_FILES)
       ${rc_file}
       ${ADDITIONAL_FILES})
     #  add_library (${LIBRARY_NAME} ${CGAL_LIBRARY_SOURCE_FILES} ${rc_file} ${ADDITIONAL_FILES}) # builing not creating temporary all_files.cpp
-    if(CGAL_SOVERSION AND CGAL_SONAME_VERSION)
+    if(${LIBRARY_NAME}_SOVERSION AND ${LIBRARY_NAME}_SONAME_VERSION)
+      set_target_properties(${LIBRARY_NAME} PROPERTIES
+        VERSION "${${LIBRARY_NAME}_SOVERSION}"
+        SOVERSION "${${LIBRARY_NAME}_SONAME_VERSION}")
+    elseif(CGAL_SOVERSION AND CGAL_SONAME_VERSION)
       set_target_properties(${LIBRARY_NAME} PROPERTIES
         VERSION "${CGAL_SOVERSION}"
         SOVERSION "${CGAL_SONAME_VERSION}")

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -107,7 +107,7 @@ if(EXISTS ${release_dir})
   file(REMOVE_RECURSE ${release_dir})
 endif()
 
-if (PUBLIC)
+if (PUBLIC AND NOT TESTSUITE)
   message(STATUS "Creating a public release ${CGAL_VERSION} in ${release_dir}")
 else()
   message(STATUS "Creating an internal release ${CGAL_VERSION} in ${release_dir}")
@@ -274,7 +274,7 @@ file(REMOVE ${release_dir}/include/CGAL/license/README.md)
 file(REMOVE ${release_dir}/include/CGAL/license/gpl.h.in)
 file(REMOVE ${release_dir}/include/CGAL/license/package_list.txt)
 
-if(PUBLIC) # we are not creating an internal release.
+if(PUBLIC AND NOT TESTSUITE) # we are not creating an internal release.
   # Taken from create_new_release.
   file(REMOVE_RECURSE ${release_dir}/test)
   file(REMOVE_RECURSE ${release_dir}/package_info)


### PR DESCRIPTION
## Summary of Changes

In CGAL-4.14, I would like to have `libCGAL.so.13` (to keep
compatibility), but `libCGAL_Image.so.14` (to break compatibility).

This PR allows to have different `SOVERSION` and `SONAME` for each libraries. And it also change the SOVERSION and SONAME for `liCGAL_ImageIO`, while keeping the versions same as for CGAL-4.13 for all the other CGAL libraries.

@maxGimeno I need this PR before CGAL-4.14-beta1 is published, so that one can have CGAL-4.14 in recent Linux distributions as soon as possible.

## Release Management

* Affected package(s): Installation

