### PR TITLE
Invalid (X)HTML sequence

### DIFF
--- a/Documentation/doc/Documentation/packages.txt
+++ b/Documentation/doc/Documentation/packages.txt
@@ -2,15 +2,6 @@
 
 \page packages Package Overview
 
-\htmlonly
-<style type="text/css">
-h1 {
-	font-size: 150%;
-    background-color: #EEEDF2;
-}
-</style>
-\endhtmlonly
-
 \section PartAlgebraicFoundations Arithmetic and Algebra
 
 \package_listing{Algebraic_foundations}

--- a/Documentation/doc/Documentation/packages.txt
+++ b/Documentation/doc/Documentation/packages.txt
@@ -2,7 +2,7 @@
 
 \page packages Package Overview
 
-\cgalPackagesSection{PartAlgebraicFoundations,Arithmetic and Algebra}
+\cgalPackageSection{PartAlgebraicFoundations,Arithmetic and Algebra}
 
 \package_listing{Algebraic_foundations}
 \package_listing{Number_types}
@@ -10,25 +10,25 @@
 \package_listing{Polynomial}
 \package_listing{Algebraic_kernel_d}
 
-\cgalPackagesSection{PartCombinatorialAlgorithms,Combinatorial Algorithms}
+\cgalPackageSection{PartCombinatorialAlgorithms,Combinatorial Algorithms}
 
 \package_listing{Matrix_search}
 \package_listing{QP_solver}
 
-\cgalPackagesSection{PartKernels,Geometry Kernels}
+\cgalPackageSection{PartKernels,Geometry Kernels}
 
 \package_listing{Kernel_23}
 \package_listing{Kernel_d}
 \package_listing{Circular_kernel_2}
 \package_listing{Circular_kernel_3}
 
-\cgalPackagesSection{PartConvexHullAlgorithms,Convex Hull Algorithms}
+\cgalPackageSection{PartConvexHullAlgorithms,Convex Hull Algorithms}
 
 \package_listing{Convex_hull_2}
 \package_listing{Convex_hull_3}
 \package_listing{Convex_hull_d}
 
-\cgalPackagesSection{PartPolygons,Polygons}
+\cgalPackageSection{PartPolygons,Polygons}
 
 \package_listing{Polygon}
 \package_listing{Boolean_set_operations_2}
@@ -42,7 +42,7 @@
 \package_listing{Set_movable_separability_2}
 
 
-\cgalPackagesSection{PartPolyhedra,Cell Complexes and Polyhedra}
+\cgalPackageSection{PartPolyhedra,Cell Complexes and Polyhedra}
 
 \package_listing{Polyhedron}
 \package_listing{HalfedgeDS}
@@ -55,7 +55,7 @@
 \package_listing{Minkowski_sum_3}
 
 
-\cgalPackagesSection{PartArrangements,Arrangements}
+\cgalPackageSection{PartArrangements,Arrangements}
 
 \package_listing{Arrangement_on_surface_2}
 \package_listing{Surface_sweep_2}
@@ -63,7 +63,7 @@
 \package_listing{Envelope_2}
 \package_listing{Envelope_3}
 
-\cgalPackagesSection{PartTriangulationsAndDelaunayTriangulations,Triangulations and Delaunay Triangulations}
+\cgalPackageSection{PartTriangulationsAndDelaunayTriangulations,Triangulations and Delaunay Triangulations}
 
 \package_listing{Triangulation_2}
 \package_listing{TDS_2}
@@ -77,14 +77,14 @@
 \package_listing{Alpha_shapes_2}
 \package_listing{Alpha_shapes_3}
 
-\cgalPackagesSection{PartVoronoiDiagrams,Voronoi Diagrams}
+\cgalPackageSection{PartVoronoiDiagrams,Voronoi Diagrams}
 
 \package_listing{Segment_Delaunay_graph_2}
 \package_listing{Segment_Delaunay_graph_Linf_2}
 \package_listing{Apollonius_graph_2}
 \package_listing{Voronoi_diagram_2}
 
-\cgalPackagesSection{PartMeshing,Mesh Generation}
+\cgalPackageSection{PartMeshing,Mesh Generation}
 
 \package_listing{Mesh_2}
 \package_listing{Surface_mesher}
@@ -92,14 +92,14 @@
 \package_listing{Mesh_3}
 \package_listing{Periodic_3_mesh_3}
 
-\cgalPackagesSection{PartReconstruction,Shape Reconstruction}
+\cgalPackageSection{PartReconstruction,Shape Reconstruction}
 
 \package_listing{Poisson_surface_reconstruction_3}
 \package_listing{Scale_space_reconstruction_3}
 \package_listing{Advancing_front_surface_reconstruction}
 \package_listing{Optimal_transportation_reconstruction_2}
 
-\cgalPackagesSection{PartGeometryProcessing,Geometry Processing}
+\cgalPackageSection{PartGeometryProcessing,Geometry Processing}
 
 \package_listing{Polygon_mesh_processing}
 \package_listing{Subdivision_method_3}
@@ -119,7 +119,7 @@
 \package_listing{Classification}
 \package_listing{Heat_method_3}
 
-\cgalPackagesSection{PartSearchStructures,Spatial Searching and Sorting}
+\cgalPackageSection{PartSearchStructures,Spatial Searching and Sorting}
 
 \package_listing{Point_set_2}
 \package_listing{Interval_skip_list}
@@ -129,19 +129,19 @@
 \package_listing{AABB_tree}
 \package_listing{Spatial_sorting}
 
-\cgalPackagesSection{PartGeometricOptimization,Geometric Optimization}
+\cgalPackageSection{PartGeometricOptimization,Geometric Optimization}
 
 \package_listing{Bounding_volumes}
 \package_listing{Inscribed_areas}
 \package_listing{Polytope_distance_d}
 \package_listing{Principal_component_analysis}
 
-\cgalPackagesSection{PartInterpolation,Interpolation}
+\cgalPackageSection{PartInterpolation,Interpolation}
 
 \package_listing{Interpolation}
 \package_listing{Barycentric_coordinates_2}
 
-\cgalPackagesSection{PartSupportLibrary,Support Library}
+\cgalPackageSection{PartSupportLibrary,Support Library}
 
 \package_listing{STL_Extension}
 \package_listing{BGL}
@@ -153,7 +153,7 @@
 \package_listing{Miscellany}
 \package_listing{Stream_support}
 
-\cgalPackagesSection{PartVisualization,Visualization}
+\cgalPackageSection{PartVisualization,Visualization}
 
 \package_listing{Geomview}
 \package_listing{GraphicsView}

--- a/Documentation/doc/Documentation/packages.txt
+++ b/Documentation/doc/Documentation/packages.txt
@@ -2,7 +2,7 @@
 
 \page packages Package Overview
 
-\section PartAlgebraicFoundations Arithmetic and Algebra
+\cgalPackagesSection{PartAlgebraicFoundations,Arithmetic and Algebra}
 
 \package_listing{Algebraic_foundations}
 \package_listing{Number_types}
@@ -10,25 +10,25 @@
 \package_listing{Polynomial}
 \package_listing{Algebraic_kernel_d}
 
-\section PartCombinatorialAlgorithms Combinatorial Algorithms
+\cgalPackagesSection{PartCombinatorialAlgorithms,Combinatorial Algorithms}
 
 \package_listing{Matrix_search}
 \package_listing{QP_solver}
 
-\section PartKernels Geometry Kernels
+\cgalPackagesSection{PartKernels,Geometry Kernels}
 
 \package_listing{Kernel_23}
 \package_listing{Kernel_d}
 \package_listing{Circular_kernel_2}
 \package_listing{Circular_kernel_3}
 
-\section PartConvexHullAlgorithms Convex Hull Algorithms
+\cgalPackagesSection{PartConvexHullAlgorithms,Convex Hull Algorithms}
 
 \package_listing{Convex_hull_2}
 \package_listing{Convex_hull_3}
 \package_listing{Convex_hull_d}
 
-\section PartPolygons Polygons
+\cgalPackagesSection{PartPolygons,Polygons}
 
 \package_listing{Polygon}
 \package_listing{Boolean_set_operations_2}
@@ -42,7 +42,7 @@
 \package_listing{Set_movable_separability_2}
 
 
-\section PartPolyhedra Cell Complexes and Polyhedra
+\cgalPackagesSection{PartPolyhedra,Cell Complexes and Polyhedra}
 
 \package_listing{Polyhedron}
 \package_listing{HalfedgeDS}
@@ -55,7 +55,7 @@
 \package_listing{Minkowski_sum_3}
 
 
-\section PartArrangements Arrangements
+\cgalPackagesSection{PartArrangements,Arrangements}
 
 \package_listing{Arrangement_on_surface_2}
 \package_listing{Surface_sweep_2}
@@ -63,7 +63,7 @@
 \package_listing{Envelope_2}
 \package_listing{Envelope_3}
 
-\section PartTriangulationsAndDelaunayTriangulations Triangulations and Delaunay Triangulations
+\cgalPackagesSection{PartTriangulationsAndDelaunayTriangulations,Triangulations and Delaunay Triangulations}
 
 \package_listing{Triangulation_2}
 \package_listing{TDS_2}
@@ -77,14 +77,14 @@
 \package_listing{Alpha_shapes_2}
 \package_listing{Alpha_shapes_3}
 
-\section PartVoronoiDiagrams Voronoi Diagrams
+\cgalPackagesSection{PartVoronoiDiagrams,Voronoi Diagrams}
 
 \package_listing{Segment_Delaunay_graph_2}
 \package_listing{Segment_Delaunay_graph_Linf_2}
 \package_listing{Apollonius_graph_2}
 \package_listing{Voronoi_diagram_2}
 
-\section PartMeshing Mesh Generation
+\cgalPackagesSection{PartMeshing,Mesh Generation}
 
 \package_listing{Mesh_2}
 \package_listing{Surface_mesher}
@@ -92,14 +92,14 @@
 \package_listing{Mesh_3}
 \package_listing{Periodic_3_mesh_3}
 
-\section PartReconstruction Shape Reconstruction
+\cgalPackagesSection{PartReconstruction,Shape Reconstruction}
 
 \package_listing{Poisson_surface_reconstruction_3}
 \package_listing{Scale_space_reconstruction_3}
 \package_listing{Advancing_front_surface_reconstruction}
 \package_listing{Optimal_transportation_reconstruction_2}
 
-\section PartGeometryProcessing Geometry Processing
+\cgalPackagesSection{PartGeometryProcessing,Geometry Processing}
 
 \package_listing{Polygon_mesh_processing}
 \package_listing{Subdivision_method_3}
@@ -119,7 +119,7 @@
 \package_listing{Classification}
 \package_listing{Heat_method_3}
 
-\section PartSearchStructures Spatial Searching and Sorting
+\cgalPackagesSection{PartSearchStructures,Spatial Searching and Sorting}
 
 \package_listing{Point_set_2}
 \package_listing{Interval_skip_list}
@@ -129,19 +129,19 @@
 \package_listing{AABB_tree}
 \package_listing{Spatial_sorting}
 
-\section PartGeometricOptimization Geometric Optimization
+\cgalPackagesSection{PartGeometricOptimization,Geometric Optimization}
 
 \package_listing{Bounding_volumes}
 \package_listing{Inscribed_areas}
 \package_listing{Polytope_distance_d}
 \package_listing{Principal_component_analysis}
 
-\section PartInterpolation Interpolation
+\cgalPackagesSection{PartInterpolation,Interpolation}
 
 \package_listing{Interpolation}
 \package_listing{Barycentric_coordinates_2}
 
-\section PartSupportLibrary Support Library
+\cgalPackagesSection{PartSupportLibrary,Support Library}
 
 \package_listing{STL_Extension}
 \package_listing{BGL}
@@ -153,7 +153,7 @@
 \package_listing{Miscellany}
 \package_listing{Stream_support}
 
-\section PartVisualization Visualization
+\cgalPackagesSection{PartVisualization,Visualization}
 
 \package_listing{Geomview}
 \package_listing{GraphicsView}

--- a/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
@@ -293,7 +293,8 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalClassifedRefPages=\htmlonly  <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly" \
                          "cgalCRPSection{1}=<h2>\1</h2>" \
                          "cgalCRPSubsection{1}=<h3>\1</h3>" \
-                         "cgalCite{1}=<!-- -->\cite \1"
+                         "cgalCite{1}=<!-- -->\cite \1" \
+                         "cgalPackageSection{2}=\htmlonly[block] <div style=\"background-color: #EEEDF2;\">\endhtmlonly \section \1 \2 \n \htmlonly[block] </div>\endhtmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
@@ -294,7 +294,8 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalClassifedRefPages=\htmlonly[block] <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly" \
                          "cgalCRPSection{1}=<h2>\1</h2>" \
                          "cgalCRPSubsection{1}=<h3>\1</h3>" \
-                         "cgalCite{1}=<!-- -->\cite \1"
+                         "cgalCite{1}=<!-- -->\cite \1" \
+                         "cgalPackagesSection{2}=\htmlonly[block] <div style=\"background-color: #EEEDF2;\">\endhtmlonly \section \1 \2 ^^ \htmlonly[block] </div>\endhtmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
@@ -295,7 +295,7 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalCRPSection{1}=<h2>\1</h2>" \
                          "cgalCRPSubsection{1}=<h3>\1</h3>" \
                          "cgalCite{1}=<!-- -->\cite \1" \
-                         "cgalPackagesSection{2}=\htmlonly[block] <div style=\"background-color: #EEEDF2;\">\endhtmlonly \section \1 \2 ^^ \htmlonly[block] </div>\endhtmlonly"
+                         "cgalPackageSection{2}=\htmlonly[block] <div style=\"background-color: #EEEDF2;\">\endhtmlonly \section \1 \2 ^^ \htmlonly[block] </div>\endhtmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/Documentation/doc/resources/1.8.4/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.4/BaseDoxyfile.in
@@ -298,6 +298,8 @@ ALIASES+= "cgalCRPSubsection{1}=<h3>\1</h3>"
 
 ALIASES+= "cgalCite{1}=<!-- -->\cite \1"
 
+ALIASES+= "cgalPackageSection{2}=\htmlonly <div style=\"background-color: #EEEDF2;\">\endhtmlonly \section \1 \2 \n \htmlonly </div>\endhtmlonly"
+
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding
 # "class=itcl::class" will allow you to use the command class in the

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -328,11 +328,6 @@ removes some unneeded files, and performs minor repair on some glitches.''')
 
     re_replace_in_file('\[external\]', '', os.path.join('Manual','annotated.html'))
 
-    # replace h1 tag with some special style properties
-
-    re_replace_in_file("<h1>", "<h1 style=\"font-size: 150%; background-color: #EEEDF2;\">",
-                       os.path.join('Manual','packages.html') )
-
     # fix class/concept mismatch in generated pages
     relationship_pages=list(package_glob('./*/hasModels.html'))
     relationship_pages.extend(package_glob('./*/generalizes.html'))

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -328,6 +328,11 @@ removes some unneeded files, and performs minor repair on some glitches.''')
 
     re_replace_in_file('\[external\]', '', os.path.join('Manual','annotated.html'))
 
+    # replace h1 tag with some special style properties
+
+    re_replace_in_file("<h1>", "<h1 style=\"font-size: 150%; background-color: #EEEDF2;\">",
+                       os.path.join('Manual','packages.html') )
+
     # fix class/concept mismatch in generated pages
     relationship_pages=list(package_glob('./*/hasModels.html'))
     relationship_pages.extend(package_glob('./*/generalizes.html'))


### PR DESCRIPTION
In packages.html we get:
`Element style is not declared in p list of possible children`
as the `style` tag is only allowed in the `head` part of a file.

The specific changes are only needed for this one file, so it has been implemented using the post processing facility of te CGAL documentation generation.


