### PR TITLE
Documentation italic in italics

### DIFF
--- a/Ridges_3/doc/Ridges_3/Ridges_3.txt
+++ b/Ridges_3/doc/Ridges_3/Ridges_3.txt
@@ -57,7 +57,7 @@ induced by the ambient Euclidean space, and \f$ dk_1\f$, \f$ dk_2\f$ the
 gradients of the principal curvatures. Ridges, illustrated in
 \cgalFigureRef{ellipsoidridges} for the standard ellipsoid, are defined by:
 
-<B>Definition.</B> <EM>\anchor defridgeextrema
+<B>Definition.</B> \anchor defridgeextrema
 A non umbilical point is called
 <UL>
 <LI>a max ridge point, if the <I>extremality coefficient</I> \f$ b_0=\langle
@@ -67,7 +67,6 @@ dk_1,d_1 \rangle\f$ vanishes, i.e.\ \f$ b_0=0\f$.
 \f$ b_3=\langle dk_2,d_2 \rangle\f$ vanishes, i.e.\ \f$ b_3=0\f$
 \cgalFootnote{Notations \f$ b_0, b_3\f$ comes from Equation \ref eqmonge }.
 </UL>
-</EM>
 
 The previous characterization of ridges involves third-order
 differential properties. Using fourth-order differential quantities, a


### PR DESCRIPTION
When having italics in italics and (X)HTML warning is given about  Opening and ending tag mismatch.
The `<EM>` as well as `<I>` result in emphasized text and would map in doxygen both to `<i>` but will confuse doxygen. output

The problematic code can be found in `Ridges_3/doc/Ridges_3/Ridges_3.txt`

The original text looks like:
![italics](https://user-images.githubusercontent.com/5223533/53659178-257ab500-3c5b-11e9-8817-d7711c6bb2eb.jpg)

The updated text:
![new_version_italics](https://user-images.githubusercontent.com/5223533/53659192-2f9cb380-3c5b-11e9-9265-0c5fe5e5da88.jpg)

