### PR TITLE
Inconsistent tags for (X)HTML output (Manual)

### DIFF
--- a/Documentation/doc/Documentation/main.txt
+++ b/Documentation/doc/Documentation/main.txt
@@ -47,7 +47,7 @@ For releases X.Y, with 3.1 <= X.Y <= 4.1 visit
 
 
 
-\htmlonly
+\htmlonly[block]
 <div style="display:none">
 \endhtmlonly
 
@@ -56,7 +56,7 @@ For releases X.Y, with 3.1 <= X.Y <= 4.1 visit
 \subpage packages
 \subpage dev_manual
 
-\htmlonly
+\htmlonly[block]
 </div>
 \endhtmlonly
 


### PR DESCRIPTION
The xhtml lint checker gave:
`parser error : Opening and ending tag mismatch: div line 375 and p`

Solved by making the `\htmlonly` into `\htmlonly[block]` to prevent invalid HTML

