### PR TITLE
IO: Set precision of the ostream when writing a point set or face graph

### DIFF
--- a/BGL/examples/BGL_surface_mesh/surface_mesh_partition.cpp
+++ b/BGL/examples/BGL_surface_mesh/surface_mesh_partition.cpp
@@ -44,10 +44,12 @@ int main(int argc, char** argv)
 
   // Output the mesh extracted from subpart n°0
   std::ofstream out("sm_part_0.off");
+  out.precision(17);
   CGAL::write_off(out, part_sm);
 
   // Output all the vertices that are in the part n°0
   std::ofstream outxyz("out.xyz");
+  outxyz.precision(17);
   boost::graph_traits<SM>::vertex_iterator vit, ve;
   boost::tie(vit, ve) = vertices(sm);
   for(; vit!=ve; ++vit)

--- a/Point_set_3/examples/Point_set_3/point_set_read_ply.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_read_ply.cpp
@@ -42,6 +42,7 @@ int main (int argc, char** argv)
     }
 
   std::ofstream out ("out.ply");
+  out.precision(17);
   CGAL::write_ply_point_set (out, point_set);
   
   return 0;

--- a/Point_set_3/examples/Point_set_3/point_set_read_xyz.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_read_xyz.cpp
@@ -38,6 +38,7 @@ int main (int argc, char** argv)
   
   // Writing result in OFF format
   std::ofstream out("normalized_normals.off");
+  out.precision(17);
   if (!out || !CGAL::write_off_point_set (out, point_set))
     {
       return EXIT_FAILURE;

--- a/Point_set_processing_3/examples/Point_set_processing_3/bilateral_smooth_point_set_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/bilateral_smooth_point_set_example.cpp
@@ -61,7 +61,8 @@ int main(int argc, char*argv[])
   }
   
   //// Save point set.
-  std::ofstream out(output_filename);   
+  std::ofstream out(output_filename);
+  out.precision(17);
   if (!out ||
       !CGAL::write_xyz_points(
       out, points,

--- a/Point_set_processing_3/examples/Point_set_processing_3/edge_aware_upsample_point_set_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/edge_aware_upsample_point_set_example.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
 
   // Saves point set.
   std::ofstream out(output_filename);  
-
+  out.precision(17);
   if (!out ||
      !CGAL::write_xyz_points(
       out, points,

--- a/Point_set_processing_3/examples/Point_set_processing_3/hierarchy_simplification_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/hierarchy_simplification_example.cpp
@@ -41,6 +41,7 @@ int main(int argc, char*argv[])
 	    << (memory>>20) << " Mib allocated." << std::endl;
 
   std::ofstream f ("out.xyz");
+  f.precision(17);
   CGAL::write_xyz_points (f, points);
   
   return EXIT_SUCCESS;

--- a/Point_set_processing_3/examples/Point_set_processing_3/normal_estimation.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/normal_estimation.cpp
@@ -324,6 +324,7 @@ int main(int argc, char * argv[])
         extension == ".pwn" || extension == ".PWN")
     {
       std::ofstream stream(output_filename.c_str());
+      stream.precision(17);
       if (!stream ||
           !CGAL::write_xyz_points(stream,
                                   points,

--- a/Point_set_processing_3/examples/Point_set_processing_3/random_simplification_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/random_simplification_example.cpp
@@ -34,6 +34,7 @@ int main(int argc, char*argv[])
 
   // Saves point set.
   std::ofstream out((argc>2)?argv[2]:"Three_lady_copy.xyz");
+  out.precision(17);
   if (!out ||
 	  !CGAL::write_xyz_points(
             out, points))

--- a/Point_set_processing_3/examples/Point_set_processing_3/read_write_xyz_point_set_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/read_write_xyz_point_set_example.cpp
@@ -39,6 +39,7 @@ int main(int argc, char*argv[])
     // Note: write_xyz_points() requires property maps to access each
     // point position and normal.
     std::ofstream out("oni_copy.xyz");
+    out.precision(17);
     if (!out ||
         !CGAL::write_xyz_points(
           out, points,

--- a/Point_set_processing_3/examples/Point_set_processing_3/structuring_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/structuring_example.cpp
@@ -68,6 +68,7 @@ int main (int argc, char** argv)
             << " structured point(s) generated." << std::endl;
 
   std::ofstream out ("out.pwn");
+  out.precision(17);
   CGAL::write_xyz_points (out, structured_pts,
                           CGAL::parameters::point_map(Point_map()).normal_map(Normal_map()));
   out.close();

--- a/Point_set_processing_3/examples/Point_set_processing_3/wlop_simplify_and_regularize_point_set_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/wlop_simplify_and_regularize_point_set_example.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv)
      neighbor_radius (neighbor_radius));
   
   std::ofstream out(output_filename);
+  out.precision(17);
   if (!out || !CGAL::write_xyz_points(
         out, output))
   {

--- a/Point_set_processing_3/examples/Point_set_processing_3/write_ply_points_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/write_ply_points_example.cpp
@@ -51,7 +51,7 @@ int main(int, char**)
                                                                  (unsigned char)(64 / (i + 1))),
                                                i));
 
-  std::ofstream f("out.ply");
+  std::ofstream f("out.ply", std::ios::binary);
   CGAL::set_binary_mode(f); // The PLY file will be written in the binary format
   
   CGAL::write_ply_points_with_properties

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -41,6 +41,9 @@ namespace CGAL {
    The function writes for each point a line with the x y z position
    followed by the nx ny nz normal (if available).
 
+   \note The <A HREF="https://en.cppreference.com/w/cpp/io/ios_base/precision">`precision()`</A> 
+         of the output stream might not be sufficient depending on the data to be written.
+
    \tparam PointRange is a model of `ConstRange`. The value type of
    its iterator is the key type of the named parameter `point_map`.
 
@@ -57,7 +60,7 @@ namespace CGAL {
      \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `Kernel`\cgalParamEnd
    \cgalNamedParamsEnd
 
-   \return true on success.
+   \return `true` on success.
 */
 template <typename PointRange,
           typename NamedParameters

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2092,6 +2092,9 @@ private: //------------------------------------------------------- private data
   /// If an alternative vertex_point map is given through `np`, 
   /// then it  will be used instead of the default one.
   /// \pre `operator<<(std::ostream&,const P&)` must be defined.
+  /// \note The <A HREF="https://en.cppreference.com/w/cpp/io/ios_base/precision">`precision()`</A> 
+  ///       of the output stream might not be sufficient depending on the data to be written.
+   
   template <typename P, typename NamedParameters>
   bool write_off(std::ostream& os, const Surface_mesh<P>& sm, const NamedParameters& np) {
     typedef Surface_mesh<P> Mesh;

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_all_short_edges.cpp
@@ -48,7 +48,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
-  std::ofstream os( argc > 3 ? argv[3] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 3 ? argv[3] : "out.off" ) ;
+  os.precision(17);
+  os << surface_mesh ;
 
   return EXIT_SUCCESS ;
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_bounded_normal_change.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_bounded_normal_change.cpp
@@ -44,7 +44,9 @@ typedef SMS::Bounded_normal_change_placement<SMS::LindstromTurk_placement<Surfac
                         .get_placement(Placement())
                       );
 
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17);
+  os << surface_mesh ;
 
   return 0 ;      
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_polyhedron.cpp
@@ -107,7 +107,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
 
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17) ;
+  os << surface_mesh ;
 
   // now check!
   for (Surface_mesh::Halfedge_iterator hit=surface_mesh.halfedges_begin(),

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_constrained_border_surface_mesh.cpp
@@ -102,7 +102,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n"
             << surface_mesh.number_of_edges() << " final edges.\n" ;
 
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17);
+  os << surface_mesh ;
 
   // now check!
   BOOST_FOREACH(halfedge_descriptor hd, halfedges(surface_mesh)){

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_enriched_polyhedron.cpp
@@ -180,7 +180,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17) ;
+  os << surface_mesh ;
   
   return EXIT_SUCCESS ;      
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -49,7 +49,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << (surface_mesh.size_of_halfedges()/2) << " final edges.\n" ;
         
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17) ;
+  os << surface_mesh ;
   
   return EXIT_SUCCESS ;      
 }

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_surface_mesh.cpp
@@ -153,7 +153,9 @@ int main( int argc, char** argv )
   std::cout << "\nFinished...\n" << r << " edges removed.\n" 
             << surface_mesh.number_of_edges() << " final edges.\n";
  
-  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ; os << surface_mesh ;
+  std::ofstream os( argc > 2 ? argv[2] : "out.off" ) ;
+  os.precision(17) ;
+  os << surface_mesh ;
   
   return EXIT_SUCCESS ;      
 }


### PR DESCRIPTION
## Summary of Changes

Examples which write a point set or mesh to a stream should set the precision.
Additionally I added a \note in the manual.

## Release Management

* Affected package(s): Point_set_3, Point_set_processing, Surface_mesh_simplification.

