### PR TITLE
Further fix for triangle orientation in medit output

### DIFF
--- a/Mesh_3/include/CGAL/IO/File_medit.h
+++ b/Mesh_3/include/CGAL/IO/File_medit.h
@@ -818,8 +818,12 @@ output_to_medit(std::ostream& os,
     typename C3T3::Facet f = (*fit);
     
     // Apply priority among subdomains, to get consistent facet orientation per subdomain-pair interface.
-    if (f.first->subdomain_index() < f.first->neighbor(f.second)->subdomain_index())
-      f = tr.mirror_facet(f);
+    if ( print_each_facet_twice )
+    {
+      // NOTE: We mirror a facet when needed to make it consistent with No_patch_facet_pmap_first/second.
+      if (f.first->subdomain_index() > f.first->neighbor(f.second)->subdomain_index())
+        f = tr.mirror_facet(f);
+    }
     
     // Get facet vertices in CCW order.
     Vertex_handle vh1 = f.first->vertex((f.second + 1) % 4);
@@ -833,10 +837,10 @@ output_to_medit(std::ostream& os,
     os << V[vh1] << ' ' << V[vh2] << ' ' << V[vh3] << ' '; 
     os << get(facet_pmap, *fit) << '\n';
     
-    // Print triangle again if needed
+    // Print triangle again if needed, with opposite orientation
     if ( print_each_facet_twice )
     {
-      os << V[vh1] << ' ' << V[vh2] << ' ' << V[vh3] << ' '; 
+      os << V[vh3] << ' ' << V[vh2] << ' ' << V[vh1] << ' '; 
       os << get(facet_twice_pmap, *fit) << '\n';
     }
   }


### PR DESCRIPTION
## Summary of Changes

Orientations of output triangles in medit files should now be consistent and work fine in rendering with backface-culling.
* Mirroring facets is now only done when print_each_facet_twice is true. 
* The condition for mirroring facets is inverted, to match the subdomain label ordering imposed by No_patch_facet_pmap_first/second and makes inner facets consistent with outer facets.
* When printing the second triangle (if printing twice), its orientation is reversed (as expected).

## Release Management

* Affected package(s): Mesh_3 I/O
* Issue(s) solved (if any): fix #3566 
