### PR TITLE
PMP : fix isotropic remeshing surviving tiny constraints

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1440,8 +1440,25 @@ private:
         typename boost::property_traits<VertexPointMap>::reference
           q = get(vpmap_, target(next(next(hd, mesh_), mesh_), mesh_));
 
+#ifdef CGAL_PMP_REMESHING_DEBUG
+        CGAL_assertion((Triangle_3(t, p, q).is_degenerate())
+                     == GeomTraits().collinear_3_object()(t, p, q));
+#endif
+
         if (GeomTraits().collinear_3_object()(t, p, q))
           continue;
+
+#ifdef CGAL_PMP_REMESHING_DEBUG
+        typename GeomTraits::Construct_normal_3 normal
+          = GeomTraits().construct_normal_3_object();
+        Vector_3 normal_before_collapse = normal(s, p, q);
+        Vector_3 normal_after_collapse  = normal(t, p, q);
+
+        CGAL::Sign s1 = CGAL::sign(normal_before_collapse * normal_after_collapse);
+        CGAL::Sign s2 = CGAL::sign(CGAL::cross_product(Vector_3(s, p), Vector_3(s, q))
+                                 * CGAL::cross_product(Vector_3(t, p), Vector_3(t, q)));
+        CGAL_assertion(s1 == s2);
+#endif
 
         if(CGAL::sign(CGAL::cross_product(Vector_3(s, p), Vector_3(s, q))
                     * CGAL::cross_product(Vector_3(t, p), Vector_3(t, q)))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1445,7 +1445,8 @@ private:
                      == GeomTraits().collinear_3_object()(t, p, q));
 #endif
 
-        if (GeomTraits().collinear_3_object()(t, p, q))
+        if ( GeomTraits().collinear_3_object()(s, p, q)
+          || GeomTraits().collinear_3_object()(t, p, q))
           continue;
 
 #ifdef CGAL_PMP_REMESHING_DEBUG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1419,11 +1419,10 @@ private:
 
     bool collapse_would_invert_face(const halfedge_descriptor& h) const
     {
-      const Point& src = get(vpmap_, source(h, mesh_));
-      const Point& tgt = get(vpmap_, target(h, mesh_));
-
-      typename GeomTraits::Construct_normal_3 normal
-        = GeomTraits().construct_normal_3_object();
+      typename boost::property_traits<VertexPointMap>::reference
+        s = get(vpmap_, source(h, mesh_)); //s for source
+      typename boost::property_traits<VertexPointMap>::reference
+        t = get(vpmap_, target(h, mesh_)); //t for target
 
       //check if collapsing the edge [src; tgt] towards tgt
       //would inverse the normal to the considered face
@@ -1436,16 +1435,17 @@ private:
         if (face(hd, mesh_) == boost::graph_traits<PM>::null_face())
           continue;
 
-        const Point& p = get(vpmap_, target(next(hd, mesh_), mesh_));
-        const Point& q = get(vpmap_, target(next(next(hd, mesh_), mesh_), mesh_));
+        typename boost::property_traits<VertexPointMap>::reference
+          p = get(vpmap_, target(next(hd, mesh_), mesh_));
+        typename boost::property_traits<VertexPointMap>::reference
+          q = get(vpmap_, target(next(next(hd, mesh_), mesh_), mesh_));
 
-        if (Triangle_3(tgt, p, q).is_degenerate())
+        if (GeomTraits().collinear_3_object()(t, p, q))
           continue;
 
-        Vector_3 normal_before_collapse = normal(src, p, q);
-        Vector_3 normal_after_collapse  = normal(tgt, p, q);
-
-        if (normal_before_collapse * normal_after_collapse <= 0)
+        if(CGAL::sign(CGAL::cross_product(Vector_3(s, p), Vector_3(s, q))
+                    * CGAL::cross_product(Vector_3(t, p), Vector_3(t, q)))
+          != CGAL::POSITIVE)
           return true;
       }
       return false;


### PR DESCRIPTION
## Summary of Changes

Before collapsing a short edge, the remesher performs the test : `collapse_does_not_invert_face(halfedge)`, that checks whether the collapse would make the mesh fold on itself.

Testing orientation of normals per patch (identified by their Id) is not a
good solution, because it can happen that we are trying to collapse an edge
that is sharp but which has both of its incident faces on the same surface
patch (wrt ids).

The new test is a lot simpler : for each non-degenerate face of the link of
the edge to be collapsed, simply check if its own normal has changed
orientation or not. The adjacent faces do not need to be taken into account

Edit on March 8 : the function `collapse_does_not_invert_face(halfedge)` has been renamed to `collapse_would_invert_face(halfedge)`, and the meaning reversed

## Release Management

* Affected package(s): PMP

