### PR TITLE
PMP debug code - use the new API of `PMP::remove_degenerate_faces()`

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -817,9 +817,9 @@ namespace internal {
       CGAL_expensive_assertion(is_triangle_mesh(mesh_));
       debug_status_map();
       debug_self_intersections();
-      CGAL_assertion(0 == PMP::remove_degenerate_faces(mesh_,
-                                                       parameters::vertex_point_map(vpmap_)
-                                                                  .geom_traits(gt_)));
+      CGAL_assertion(PMP::remove_degenerate_faces(mesh_,
+                            parameters::vertex_point_map(vpmap_)
+                           .geom_traits(gt_)));
 #endif
     }
 
@@ -922,9 +922,9 @@ namespace internal {
 
 #ifdef CGAL_PMP_REMESHING_DEBUG
       debug_status_map();
-      CGAL_assertion(0 == PMP::remove_degenerate_faces(mesh_
-                            , PMP::parameters::vertex_point_map(vpmap_)
-                                              .geom_traits(gt_)));
+      CGAL_assertion(PMP::remove_degenerate_faces(mesh_,
+                             PMP::parameters::vertex_point_map(vpmap_)
+                            .geom_traits(gt_)));
       debug_self_intersections();
 #endif
 


### PR DESCRIPTION
If there is no degenerate faces to deal with, i.e. if the function has nothing to do, it now returns `true`, and not `0`
This change was introduced by commit e4ad5d96a7afd1f2cca3fbc7cb2661a1c1be7659

## Summary of Changes

we now use the new API in the debug code of `isotropic_remeshing()`

## Release Management

* Affected package(s): PMP

