### PR TITLE
Periodic and Hyperbolic triangulations: backtick

### DIFF
--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -15,9 +15,9 @@ The hyperbolic plane is represented in the Poincaré disk model.
 \tparam Tds must be a model of `TriangulationDataStructure_2`. By default, this parameter is instantiated with 
 `Triangulation_data_structure_2< Triangulation_vertex_base_2<Gt>, Hyperbolic_triangulation_face_base_2<Gt> >`
 
-\sa HyperbolicDelaunayTriangulationTraits_2
-\sa TriangulationDataStructure_2
-\sa Delaunay_triangulation_2
+\sa `HyperbolicDelaunayTriangulationTraits_2`
+\sa `TriangulationDataStructure_2`
+\sa `Delaunay_triangulation_2`
 
 */
 

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_traits_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_traits_2.h
@@ -18,9 +18,9 @@ provides exact constructions and predicates. The default value for `K` is
 constructions of Delaunay triangulations and dual objects for input points with 
 algebraic coordinates. 
 
-\sa Hyperbolic_Delaunay_triangulation_CK_traits_2
+\sa `Hyperbolic_Delaunay_triangulation_CK_traits_2`
 
-\cgalModels HyperbolicDelaunayTriangulationTraits_2
+\cgalModels `HyperbolicDelaunayTriangulationTraits_2`
 */
 
 template< class K >

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_triangulation_face_base_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_triangulation_face_base_2.h
@@ -14,7 +14,7 @@ offered by %CGAL.
 \tparam Fb must be a model of `TriangulationFaceBase_2`. %Defaults to `Triangulation_face_base_2<Gt>`.
 
 
-\cgalModels HyperbolicTriangulationFaceBase_2
+\cgalModels `HyperbolicTriangulationFaceBase_2`
 */
 
 

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicDelaunayTriangulationTraits_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicDelaunayTriangulationTraits_2.h
@@ -16,8 +16,8 @@ constructions on these objects.
 This concept refines `DelaunayTriangulationTraits_2` because the class `CGAL::Hyperbolic_Delaunay_triangulation_2`
 internally relies on the class `CGAL::Delaunay_triangulation_2`.	
 
-\cgalHasModel CGAL::Hyperbolic_Delaunay_triangulation_traits_2
-\cgalHasModel CGAL::Hyperbolic_Delaunay_triangulation_CK_traits_2
+\cgalHasModel `CGAL::Hyperbolic_Delaunay_triangulation_traits_2`
+\cgalHasModel `CGAL::Hyperbolic_Delaunay_triangulation_CK_traits_2`
 */
 
 

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicTriangulationFaceBase_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicTriangulationFaceBase_2.h
@@ -14,7 +14,7 @@ This concept provides an interface for the functionality needed in faces to comp
 Delaunay triangulations in the hyperbolic plane. The function `tds_data()` is used
 internally by the triangulation class during the insertion of points in the triangulation.
 
-\cgalHasModel CGAL::Hyperbolic_triangulation_face_base_2
+\cgalHasModel `CGAL::Hyperbolic_triangulation_face_base_2`
 
 \sa `TriangulationDataStructure_2`
 
@@ -25,7 +25,7 @@ class HyperbolicTriangulationFaceBase_2 {
 
 public:
 
-  /// \name Internal access functions
+  /// \name Internal Access Functions
   /// \cgalAdvancedBegin
   /// These functions are used internally by the hyperbolic Delaunay triangulation.
   /// The user is not encouraged to use them directly as they may change in the future.

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_Delaunay_triangulation_traits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_Delaunay_triangulation_traits_2.h
@@ -21,7 +21,7 @@ predicates. This holds implicitly for
 `CGAL::Exact_predicates_inexact_constructions_kernel`, as it is an
 instantiation of `CGAL::Filtered_kernel`.
 
-\cgalModels ::Periodic_2DelaunayTriangulationTraits_2
+\cgalModels `::Periodic_2DelaunayTriangulationTraits_2`
 */
 template< typename Traits, typename Periodic_2Offset_2 >
 class Periodic_2_Delaunay_triangulation_traits_2

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
@@ -10,14 +10,11 @@ namespace CGAL
 The class `Periodic_2_triangulation_2` represents a 2-dimensional
 triangulation of a point set in \f$ \mathbb T_c^2\f$.
 
-\cgalHeading{Parameters}
-
-The class `Periodic_2_triangulation_2` has two template
-parameters. The first one \tparam Traits is the geometric traits, it
+\tparam Traits is the geometric traits, it
 is to be instantiated by a model of the concept
 `Periodic_2TriangulationTraits_2`.
 
-The second parameter \tparam TDS is the triangulation data structure,
+\tparam TDS is the triangulation data structure,
 it has to be instantiated by a model of the concept
 `TriangulationDataStructure_2` with some additional
 functionality in faces.

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_face_base_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_face_base_2.h
@@ -29,7 +29,7 @@ the offset corresponding to vertex \f$ i\f$.
 The implementation of `has_zero_offsets()` results in checking
 whether all offsets are zero.
 
-\cgalModels ::Periodic_2TriangulationFaceBase_2
+\cgalModels `::Periodic_2TriangulationFaceBase_2`
 
 \sa `CGAL::Triangulation_face_base_2`
 \sa `CGAL::Triangulation_face_base_with_info_2`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_traits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_traits_2.h
@@ -11,8 +11,7 @@ The class `Periodic_2_triangulation_traits_2` is designed as a default
 traits class for the class
 `Periodic_2_triangulation_2<Periodic_2TriangulationTraits_2,TriangulationDataStructure_2>`.
 
-The argument \tparam Traits must be a model of the
-`TriangulationTraits_2` concept. The argument
+\tparam Traits must be a model of the `TriangulationTraits_2` concept.
 \tparam Periodic_2Offset_2 must be a model of the concept
 `Periodic_2Offset_2` and defaults to `Periodic_2_offset_2`.
 

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2DelaunayTriangulationTraits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2DelaunayTriangulationTraits_2.h
@@ -14,18 +14,18 @@ predicates from `DelaunayTriangulationTraits_2` can be used
 directly. For efficiency reasons we maintain for each functor the
 version without offsets.
 
-\cgalRefines ::DelaunayTriangulationTraits_2 and ::Periodic_2TriangulationTraits_2
+\cgalRefines `DelaunayTriangulationTraits_2` and `Periodic_2TriangulationTraits_2`
 
 In addition to the requirements of the concepts `Periodic_2TriangulationTraits_2`
 and `DelaunayTriangulationTraits_2`,
-the concept ::Periodic_2DelaunayTriangulationTraits_2 provides a predicate to check the empty circle property. The
-corresponding predicate type is called type ::Periodic_2DelaunayTriangulationTraits_2::Side_of_oriented_circle_2.
+the concept `::Periodic_2DelaunayTriangulationTraits_2` provides a predicate to check the empty circle property. The
+corresponding predicate type is called type `::Periodic_2DelaunayTriangulationTraits_2::Side_of_oriented_circle_2`.
 
-The additional constructor object ::Periodic_2DelaunayTriangulationTraits_2::Construct_circumcenter_2 is
+The additional constructor object `::Periodic_2DelaunayTriangulationTraits_2::Construct_circumcenter_2` is
 used to build the dual Voronoi diagram and are required only if the
 dual functions are called. The additional predicate type
-::Periodic_2DelaunayTriangulationTraits_2::Compare_distance_2 is required if calls to
-nearest_vertex(..) are issued.
+`::Periodic_2DelaunayTriangulationTraits_2::Compare_distance_2` is required if calls to
+`nearest_vertex(..)` are issued.
 
 \cgalHasModel `CGAL::Periodic_2_Delaunay_triangulation_traits_2<Traits, Offset>`
 
@@ -99,7 +99,7 @@ public:
 
 /// @}
 
-/// \name Predicate functions
+/// \name Predicate Functions
 /// @{
 
   /*!

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2Offset_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2Offset_2.h
@@ -7,7 +7,7 @@
 
 The concept `Periodic_2Offset_2` describes a two-/dimensional integer vector with some specialized access functions and operations.
 
-\cgalHasModel CGAL::Periodic_2_offset_2
+\cgalHasModel `CGAL::Periodic_2_offset_2`
 
 \sa `Periodic_2TriangulationTraits_2`
 \sa `Periodic_2DelaunayTriangulationTraits_2`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationFaceBase_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationFaceBase_2.h
@@ -11,9 +11,9 @@ its four vertices and to its four neighbor faces. The vertices and
 neighbors are indexed 0, 1 and 2. Neighbor \f$ i\f$ lies opposite to
 vertex \f$ i\f$.
 
-\cgalRefines ::TriangulationFaceBase_2
+\cgalRefines `TriangulationFaceBase_2`
 
-\cgalHasModel CGAL::Periodic_2_triangulation_face_base_2
+\cgalHasModel `CGAL::Periodic_2_triangulation_face_base_2`
 
 \sa `TriangulationDataStructure_2`
 \sa `TriangulationFaceBase_2`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
@@ -18,13 +18,13 @@ predicates from `TriangulationTraits_2` can be used
 directly. For efficiency reasons we maintain for each functor the
 version without offsets.
 
-\cgalRefines ::TriangulationTraits_2
+\cgalRefines `TriangulationTraits_2`
 In addition to the requirements described for the traits class
-::TriangulationTraits_2, the geometric traits class of a
+`TriangulationTraits_2`, the geometric traits class of a
 Periodic triangulation must fulfill the following
 requirements:
 
-\cgalHasModel CGAL::Periodic_2_triangulation_traits_2
+\cgalHasModel `CGAL::Periodic_2_triangulation_traits_2`
 
 \sa `TriangulationTraits_2`
 \sa `CGAL::Periodic_2_triangulation_2<Traits,Tds>`

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationVertexBase_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationVertexBase_2.h
@@ -16,7 +16,7 @@ The storage of the offset is only needed when a triangulation is copied.
 
 \cgalRefines `TriangulationVertexBase_2`
 
-\cgalHasModel CGAL::Periodic_2_triangulation_vertex_base_2
+\cgalHasModel` CGAL::Periodic_2_triangulation_vertex_base_2`
 
 \sa `TriangulationDataStructure_2`
 \sa `TriangulationVertexBase_2`

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_Delaunay_triangulation_traits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_Delaunay_triangulation_traits_3.h
@@ -16,7 +16,7 @@ will be used if the flag `Traits::Has_static_filters` exists and is `true`.
 By default, this holds for `CGAL::Exact_predicates_inexact_constructions_kernel` and
 `CGAL::Exact_predicates_exact_constructions_kernel`.
 
-\cgalModels Periodic_3DelaunayTriangulationTraits_3
+\cgalModels `Periodic_3DelaunayTriangulationTraits_3`
 */
 template< typename Traits, typename Offset >
 class Periodic_3_Delaunay_triangulation_traits_3

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_regular_triangulation_traits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_regular_triangulation_traits_3.h
@@ -15,7 +15,7 @@ and is `true`), this class automatically provides filtered predicates.
 By default, this holds for `CGAL::Exact_predicates_inexact_constructions_kernel` and
 `CGAL::Exact_predicates_exact_constructions_kernel`.
 
-\cgalModels Periodic_3RegularTriangulationTraits_3
+\cgalModels `Periodic_3RegularTriangulationTraits_3`
 */
 template< typename Traits, typename Offset >
 class Periodic_3_regular_triangulation_traits_3 :

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_hierarchy_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_hierarchy_3.h
@@ -8,8 +8,6 @@ The class `Periodic_3_triangulation_hierarchy_3` implements a
 triangulation augmented with a data structure which allows fast point 
 location queries. 
 
-\cgalHeading{Template Parameters}
-
 \tparam PTr must be one of the \cgal periodic triangulation classes. <I>In the current
 implementation, only `Periodic_3_Delaunay_triangulation_3` is supported for.</I>
 

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_traits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_traits_3.h
@@ -16,7 +16,7 @@ will be used if the flag `Traits::Has_static_filters` exists and is `true`.
 By default, this holds for `CGAL::Exact_predicates_inexact_constructions_kernel` and
 `CGAL::Exact_predicates_exact_constructions_kernel`.
 
-\cgalModels Periodic_3TriangulationTraits_3
+\cgalModels `Periodic_3TriangulationTraits_3`
 */
 template< typename Traits, typename Offset >
 class Periodic_3_triangulation_traits_3 : public Traits {

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3DelaunayTriangulationTraits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3DelaunayTriangulationTraits_3.h
@@ -13,10 +13,10 @@ work with point-offset pairs. In most cases the offsets will be
 can be used directly. For efficiency reasons we maintain for each
 functor the version without offsets.
 
-\cgalRefines Periodic_3TriangulationTraits_3
-\cgalRefines DelaunayTriangulationTraits_3
+\cgalRefines `Periodic_3TriangulationTraits_3`
+\cgalRefines `DelaunayTriangulationTraits_3`
 
-\cgalHasModel CGAL::Periodic_3_Delaunay_triangulation_traits_3
+\cgalHasModel `CGAL::Periodic_3_Delaunay_triangulation_traits_3`
 
 In addition to the requirements described by the concepts
 `Periodic_3TriangulationTraits_3` and `DelaunayTriangulationTraits_3`,

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3Offset_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3Offset_3.h
@@ -6,7 +6,7 @@
 The concept `Periodic_3Offset_3` describes a three-dimensional integer vector
 with some specialized access functions and operations.
 
-\cgalHasModel CGAL::Periodic_3_offset_3
+\cgalHasModel `CGAL::Periodic_3_offset_3`
 
 \sa `Periodic_3TriangulationTraits_3`
 \sa `Periodic_3DelaunayTriangulationTraits_3`

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationDSCellBase_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationDSCellBase_3.h
@@ -6,10 +6,10 @@
 \cgalRefines `RegularTriangulationCellBase_3`
 \cgalRefines `Periodic_3TriangulationDSCellBase_3`
 
-\cgalHasModel CGAL::Regular_triangulation_cell_base_3<Periodic_3RegularTriangulationTraits_3,
-                                                      Periodic_3_triangulation_ds_cell_base_3< > >
-\cgalHasModel CGAL::Regular_triangulation_cell_base_with_weighted_circumcenter_3<Periodic_3RegularTriangulationTraits_3,
-                                                                                 Periodic_3_triangulation_ds_cell_base_3< > >
+\cgalHasModel `CGAL::Regular_triangulation_cell_base_3<Periodic_3RegularTriangulationTraits_3,
+                                                      Periodic_3_triangulation_ds_cell_base_3< > >`
+\cgalHasModel `CGAL::Regular_triangulation_cell_base_with_weighted_circumcenter_3<Periodic_3RegularTriangulationTraits_3,
+                                                                                 Periodic_3_triangulation_ds_cell_base_3< > >`
 
 The template parameter `Periodic_3RegularTriangulationTraits_3` is expected to be the same as the
 traits class used in `CGAL::Periodic_3_regular_triangulation_3`.

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationDSVertexBase_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationDSVertexBase_3.h
@@ -6,8 +6,8 @@
 \cgalRefines `RegularTriangulationVertexBase_3`
 \cgalRefines `Periodic_3TriangulationDSVertexBase_3`
 
-\cgalHasModel CGAL::Regular_triangulation_vertex_base_3<Periodic_3RegularTriangulationTraits_3,
-                                                        Periodic_3_triangulation_ds_vertex_base_3< > >
+\cgalHasModel `CGAL::Regular_triangulation_vertex_base_3<Periodic_3RegularTriangulationTraits_3,
+                                                        Periodic_3_triangulation_ds_vertex_base_3< > >`
 
 The template parameter `Periodic_3RegularTriangulationTraits_3` is expected to be the same as the
 traits class used in `CGAL::Periodic_3_regular_triangulation_3`.

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationTraits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationTraits_3.h
@@ -13,10 +13,10 @@ work with point-offset pairs. In most cases the offsets will be
 can be used directly. For efficiency reasons we maintain for each
 functor the version without offsets.
 
-\cgalRefines Periodic_3TriangulationTraits_3
-\cgalRefines RegularTriangulationTraits_3
+\cgalRefines `Periodic_3TriangulationTraits_3`
+\cgalRefines `RegularTriangulationTraits_3`
 
-\cgalHasModel CGAL::Periodic_3_regular_triangulation_traits_3
+\cgalHasModel `CGAL::Periodic_3_regular_triangulation_traits_3`
 
 In addition to the requirements described for the traits class
 RegularTriangulationTraits_3, the geometric traits class of a

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationDSCellBase_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationDSCellBase_3.h
@@ -18,7 +18,7 @@ does not contain any information.
 
 \cgalRefines `TriangulationDSCellBase_3`
 
-\cgalHasModel CGAL::Periodic_3_triangulation_ds_cell_base_3
+\cgalHasModel `CGAL::Periodic_3_triangulation_ds_cell_base_3`
 
 \sa `TriangulationDataStructure_3`
 \sa `TriangulationDSCellBase_3`

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationDSVertexBase_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationDSVertexBase_3.h
@@ -12,7 +12,7 @@ a vertex provides access to one of its incident cells through a handle.
 
 \cgalRefines `TriangulationDSVertexBase_3`
 
-\cgalHasModel CGAL::Periodic_3_triangulation_ds_vertex_base_3
+\cgalHasModel `CGAL::Periodic_3_triangulation_ds_vertex_base_3`
 
 \sa `TriangulationDataStructure_3`
 \sa `TriangulationDSVertexBase_3`

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationTraits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationTraits_3.h
@@ -12,15 +12,15 @@ work with point-offset pairs. In most cases the offsets will be
 can be used directly. For efficiency reasons we maintain for each
 functor the version without offsets.
 
-\cgalRefines TriangulationTraits_3
+\cgalRefines `TriangulationTraits_3`
 
-\cgalHasModel CGAL::Periodic_3_triangulation_traits_3
+\cgalHasModel `CGAL::Periodic_3_triangulation_traits_3`
 
-\sa Periodic_3DelaunayTriangulationTraits_3
-\sa Periodic_3RegularTriangulationTraits_3
+\sa `Periodic_3DelaunayTriangulationTraits_3`
+\sa `Periodic_3RegularTriangulationTraits_3`
 
 In addition to the requirements described for the traits class
-TriangulationTraits_3, the geometric traits class of a
+`TriangulationTraits_3`, the geometric traits class of a
 Periodic triangulation must fulfill the following
 requirements.
 */

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Hyperbolic_octagon_translation.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Hyperbolic_octagon_translation.h
@@ -11,7 +11,7 @@ The class `Hyperbolic_octagon_translation` defines an object to represent a hype
 translation of the fundamental group of the Bolza surface \f$\mathcal M\f$. It accepts 
 one template parameter:
 
-\tparam FT 	%Field number Type. Must provide exact computations with algebraic numbers, 
+\tparam FT 	%Field number type. Must provide exact computations with algebraic numbers, 
 			notably with nested square roots. The default value for this parameter is 
 			`CORE::Expr`.
 

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
@@ -13,10 +13,10 @@ modification of the triangulation (insertion or removal).
 
 The class expects two template parameters.
 
-\tparam GT 	Geometric Traits parameter. Must be a model of the concept 
+\tparam GT 	Geometric traits parameter. Must be a model of the concept 
 			`Periodic_4HyperbolicTriangulationTraits_2`. This parameter has no
 			default value.
-\tparam	TDS %Triangulation Data Structure parameter. Must be a model of the concept
+\tparam	TDS %Triangulation data structure parameter. Must be a model of the concept
 		`TriangulationDataStructure_2` with some additional functionality in the vertices 
 		and faces, following the concepts `Periodic_4HyperbolicTriangulationVertexBase_2` and
 		`Periodic_4HyperbolicTriangulationFaceBase_2`, respectively. The default value for 

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_face_base_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_face_base_2.h
@@ -10,18 +10,18 @@ namespace CGAL {
 The class `Periodic_4_hyperbolic_triangulation_face_base_2` is the default model for the 
 concept `Periodic_4HyperbolicTriangulationFaceBase_2`. It accepts two template parameters:
 
-\tparam GT 	Geometric Traits type. This should be the same model of the concept 
+\tparam GT 	Geometric traits type. This should be the same model of the concept 
 			`Periodic_4HyperbolicDelaunayTriangulationTraits_2` that is used in the class
 			`Periodic_4_hyperbolic_Delaunay_triangulation_2`. This template parameter has 
 			no default value.
-\tparam FB 	Face Base type. Should be a model of the concept `TriangulationFaceBase_2`. 
+\tparam FB 	Face base type. Should be a model of the concept `TriangulationFaceBase_2`. 
 		   	The default value for this template parameter is `Triangulation_face_base_2<GT>`
 
 `Periodic_4_hyperbolic_triangulation_face_base_2` can be simply plugged in the triangulation 
 data structure of a periodic hyperbolic triangulation, or used as a base class to derive other 
 base vertex classes tuned for specific applications.
 
-\cgalModels Periodic_4HyperbolicTriangulationFaceBase_2
+\cgalModels `Periodic_4HyperbolicTriangulationFaceBase_2`
 
 \sa `Periodic_4_hyperbolic_triangulation_vertex_base_2` 
 */

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_vertex_base_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_vertex_base_2.h
@@ -10,18 +10,18 @@ namespace CGAL {
 The class `Periodic_4_hyperbolic_triangulation_vertex_base_2` is the default model for the 
 concept `Periodic_4HyperbolicTriangulationVertexBase_2`. It accepts two template parameters:
 
-\tparam GT 	Geometric Traits type. This should be the same model of the concept 
+\tparam GT 	Geometric traits type. This should be the same model of the concept 
 			`Periodic_4HyperbolicDelaunayTriangulationTraits_2` that is used in the class
 			`Periodic_4_hyperbolic_Delaunay_triangulation_2`. This template parameter has 
 			no default value.
-\tparam Vb 	Vertex Base type. Should be a model of the concept `TriangulationVertexBase_2`. 
+\tparam Vb 	Vertex base type. Should be a model of the concept `TriangulationVertexBase_2`. 
 		   	The default value for this template parameter is `CGAL::Triangulation_vertex_base_2<GT>`
 
 `Periodic_4_hyperbolic_triangulation_vertex_base_2` can be simply plugged in the triangulation 
 data structure of a periodic hyperbolic triangulation, or used as a base class to derive other 
 base vertex classes tuned for specific applications.
 
-\cgalModels Periodic_4HyperbolicTriangulationVertexBase_2
+\cgalModels `Periodic_4HyperbolicTriangulationVertexBase_2`
 
 \sa `Periodic_4_hyperbolic_triangulation_face_base_2` 
 */

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicDelaunayTriangulationTraits_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicDelaunayTriangulationTraits_2.h
@@ -5,14 +5,14 @@
 \ingroup PkgPeriodic4HyperbolicTriangulation2Concepts
 \cgalConcept
 
-\cgalRefines Periodic_4HyperbolicTriangulationTraits_2
+\cgalRefines `Periodic_4HyperbolicTriangulationTraits_2`
 
 The concept `Periodic_4HyperbolicDelaunayTriangulationTraits_2` adds a requirement 
 to `Periodic_4HyperbolicTriangulationTraits_2` that needs to be fulfilled 
 by any class used to instantiate the first template parameter of the class 
 `CGAL::Periodic_4_hyperbolic_Delaunay_triangulation_2`. 
 
-\cgalHasModel CGAL::Periodic_4_hyperbolic_Delaunay_triangulation_traits_2
+\cgalHasModel `CGAL::Periodic_4_hyperbolic_Delaunay_triangulation_traits_2`
 */
 
 

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationFaceBase_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationFaceBase_2.h
@@ -5,7 +5,7 @@
 \ingroup PkgPeriodic4HyperbolicTriangulation2Concepts
 \cgalConcept
 
-\cgalRefines TriangulationFaceBase_2
+\cgalRefines `TriangulationFaceBase_2`
 
 A refinement of the concept `TriangulationFaceBase_2` that adds an interface for hyperbolic translations.
 
@@ -20,7 +20,7 @@ corresponding vertex produces the canonical representative of the face in the hy
 Hyperbolic translations are represented by a nested type which is provided by the concept 
 `Periodic_4HyperbolicDelaunayTriangulationTraits_2`.
 
-\cgalHasModel CGAL::Periodic_4_hyperbolic_triangulation_face_base_2
+\cgalHasModel `CGAL::Periodic_4_hyperbolic_triangulation_face_base_2`
 
 \sa `TriangulationDataStructure_2`
 \sa `Periodic_4HyperbolicTriangulationVertexBase_2`

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationTraits_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationTraits_2.h
@@ -5,7 +5,7 @@
 \ingroup PkgPeriodic4HyperbolicTriangulation2Concepts
 \cgalConcept
 
-\cgalRefines HyperbolicDelaunayTriangulationTraits_2
+\cgalRefines `HyperbolicDelaunayTriangulationTraits_2`
 
 The concept `Periodic_4HyperbolicTriangulationTraits_2` describes the set of requirements 
 to be fulfilled by any class used to instantiate the first template parameter of the class 

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationVertexBase_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/Concepts/Periodic_4HyperbolicTriangulationVertexBase_2.h
@@ -5,7 +5,7 @@
 \ingroup PkgPeriodic4HyperbolicTriangulation2Concepts
 \cgalConcept
 
-\cgalRefines TriangulationVertexBase_2
+\cgalRefines `TriangulationVertexBase_2`
 
 A refinement of the concept `TriangulationVertexBase_2` that adds an interface for hyperbolic translations.
 


### PR DESCRIPTION
## Summary of Changes

When working on Issue #3743  I realized that in the package `Triangulation_3` we didn't systematically back-tick.  As this package is the starting point for other triangulation packages those didn't back-tick either.

This only concerns files in `doc/CGAL` and `doc/Concepts`,  so we have to check the generated doxygen output.

## Release Management

* Affected package(s): Hyperbolic, Periodic_2, Periodic_3, Periodic_4


