### PR TITLE
Travis: Add calls to `time` to display timings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,18 +59,18 @@ install:
   - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
-- wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
-- sudo mv doxygen_exe /usr/bin/doxygen
-- sudo chmod +x /usr/bin/doxygen
-- mkdir -p build 
-- cd build 
-- /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- /usr/bin/time -f 'Spend time of %C: %E real' make
-- /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
-- cd ..
+  - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
+  - sudo mv doxygen_exe /usr/bin/doxygen
+  - sudo chmod +x /usr/bin/doxygen
+  - mkdir -p build 
+  - cd build 
+  - /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of %C: %E real' make
+  - /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
+  - cd ..
 script: 
-- cd ./.travis
-- /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
+  - cd ./.travis
+  - /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,78 +1,79 @@
-language: cpp 
-dist: xenial 
-sudo: required 
-git: 
- depth: 3
+language: cpp
+dist: xenial
+sudo: required
+git:
+  depth: 3
 env:
- matrix: 
-    - PACKAGE='CHECK' 
-    - PACKAGE='AABB_tree Advancing_front_surface_reconstruction Algebraic_foundations ' 
-    - PACKAGE='Algebraic_kernel_d Algebraic_kernel_for_circles Algebraic_kernel_for_spheres ' 
-    - PACKAGE='Alpha_shapes_2 Alpha_shapes_3 Apollonius_graph_2 ' 
-    - PACKAGE='Arithmetic_kernel Arrangement_on_surface_2 Barycentric_coordinates_2 ' 
-    - PACKAGE='BGL Boolean_set_operations_2 Bounding_volumes ' 
-    - PACKAGE='Box_intersection_d Cartesian_kernel CGAL_Core ' 
-    - PACKAGE='CGAL_ImageIO CGAL_ipelets Circular_kernel_2 ' 
-    - PACKAGE='Circular_kernel_3 Circulator Classification ' 
-    - PACKAGE='Combinatorial_map Cone_spanners_2 Convex_decomposition_3 ' 
-    - PACKAGE='Convex_hull_2 Convex_hull_3 Convex_hull_d ' 
-    - PACKAGE='Distance_2 Distance_3 Envelope_2 ' 
-    - PACKAGE='Envelope_3 Filtered_kernel Generalized_map ' 
-    - PACKAGE='Generator Geomview GraphicsView ' 
-    - PACKAGE='HalfedgeDS Hash_map Heat_method_3 ' 
-    - PACKAGE='Homogeneous_kernel Hyperbolic_triangulation_2 Inscribed_areas ' 
-    - PACKAGE='Installation Interpolation Intersections_2 ' 
-    - PACKAGE='Intersections_3 Interval_skip_list Interval_support ' 
-    - PACKAGE='Inventor Jet_fitting_3 Kernel_23 ' 
-    - PACKAGE='Kernel_d LEDA Linear_cell_complex ' 
-    - PACKAGE='MacOSX Maintenance Matrix_search ' 
-    - PACKAGE='Mesh_2 Mesh_3 Mesher_level ' 
-    - PACKAGE='Minkowski_sum_2 Minkowski_sum_3 Modifier ' 
-    - PACKAGE='Modular_arithmetic Nef_2 Nef_3 ' 
-    - PACKAGE='Nef_S2 NewKernel_d Number_types ' 
-    - PACKAGE='OpenNL Optimal_transportation_reconstruction_2 Optimisation_basic ' 
-    - PACKAGE='Partition_2 Periodic_2_triangulation_2 Periodic_3_mesh_3 ' 
-    - PACKAGE='Periodic_3_triangulation_3 Periodic_4_hyperbolic_triangulation_2 Point_set_2 ' 
-    - PACKAGE='Point_set_3 Point_set_processing_3 Point_set_shape_detection_3 ' 
-    - PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_mesh_processing ' 
-    - PACKAGE='Polyhedron Polyhedron_IO Polyline_simplification_2 ' 
-    - PACKAGE='Polynomial Polytope_distance_d Principal_component_analysis ' 
-    - PACKAGE='Principal_component_analysis_LGPL Profiling_tools Property_map ' 
-    - PACKAGE='QP_solver Random_numbers Ridges_3 ' 
-    - PACKAGE='Scale_space_reconstruction_3 Scripts SearchStructures ' 
-    - PACKAGE='Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 ' 
-    - PACKAGE='Skin_surface_3 Snap_rounding_2 Solver_interface ' 
-    - PACKAGE='Spatial_searching Spatial_sorting STL_Extension ' 
-    - PACKAGE='Straight_skeleton_2 Stream_lines_2 Stream_support ' 
-    - PACKAGE='Subdivision_method_3 Surface_mesh Surface_mesh_approximation ' 
-    - PACKAGE='Surface_mesh_deformation Surface_mesher Surface_mesh_parameterization ' 
-    - PACKAGE='Surface_mesh_segmentation Surface_mesh_shortest_path Surface_mesh_simplification ' 
-    - PACKAGE='Surface_mesh_skeletonization Surface_sweep_2 TDS_2 ' 
-    - PACKAGE='TDS_3 Testsuite Three ' 
-    - PACKAGE='Triangulation Triangulation_2 Triangulation_3 ' 
-    - PACKAGE='Union_find Visibility_2 Voronoi_diagram_2 ' 
-    - PACKAGE='wininst ' 
+  matrix:
+    - PACKAGE='CHECK'
+    - PACKAGE='AABB_tree Advancing_front_surface_reconstruction Algebraic_foundations '
+    - PACKAGE='Algebraic_kernel_d Algebraic_kernel_for_circles Algebraic_kernel_for_spheres '
+    - PACKAGE='Alpha_shapes_2 Alpha_shapes_3 Apollonius_graph_2 '
+    - PACKAGE='Arithmetic_kernel Arrangement_on_surface_2 Barycentric_coordinates_2 '
+    - PACKAGE='BGL Boolean_set_operations_2 Bounding_volumes '
+    - PACKAGE='Box_intersection_d Cartesian_kernel CGAL_Core '
+    - PACKAGE='CGAL_ImageIO CGAL_ipelets Circular_kernel_2 '
+    - PACKAGE='Circular_kernel_3 Circulator Classification '
+    - PACKAGE='Combinatorial_map Cone_spanners_2 Convex_decomposition_3 '
+    - PACKAGE='Convex_hull_2 Convex_hull_3 Convex_hull_d '
+    - PACKAGE='Distance_2 Distance_3 Envelope_2 '
+    - PACKAGE='Envelope_3 Filtered_kernel Generalized_map '
+    - PACKAGE='Generator Geomview GraphicsView '
+    - PACKAGE='HalfedgeDS Hash_map Heat_method_3 '
+    - PACKAGE='Homogeneous_kernel Hyperbolic_triangulation_2 Inscribed_areas '
+    - PACKAGE='Installation Interpolation Intersections_2 '
+    - PACKAGE='Intersections_3 Interval_skip_list Interval_support '
+    - PACKAGE='Inventor Jet_fitting_3 Kernel_23 '
+    - PACKAGE='Kernel_d LEDA Linear_cell_complex '
+    - PACKAGE='MacOSX Maintenance Matrix_search '
+    - PACKAGE='Mesh_2 Mesh_3 Mesher_level '
+    - PACKAGE='Minkowski_sum_2 Minkowski_sum_3 Modifier '
+    - PACKAGE='Modular_arithmetic Nef_2 Nef_3 '
+    - PACKAGE='Nef_S2 NewKernel_d Number_types '
+    - PACKAGE='OpenNL Optimal_transportation_reconstruction_2 Optimisation_basic '
+    - PACKAGE='Partition_2 Periodic_2_triangulation_2 Periodic_3_mesh_3 '
+    - PACKAGE='Periodic_3_triangulation_3 Periodic_4_hyperbolic_triangulation_2 Point_set_2 '
+    - PACKAGE='Point_set_3 Point_set_processing_3 Point_set_shape_detection_3 '
+    - PACKAGE='Poisson_surface_reconstruction_3 Polygon Polygon_mesh_processing '
+    - PACKAGE='Polyhedron Polyhedron_IO Polyline_simplification_2 '
+    - PACKAGE='Polynomial Polytope_distance_d Principal_component_analysis '
+    - PACKAGE='Principal_component_analysis_LGPL Profiling_tools Property_map '
+    - PACKAGE='QP_solver Random_numbers Ridges_3 '
+    - PACKAGE='Scale_space_reconstruction_3 Scripts SearchStructures '
+    - PACKAGE='Segment_Delaunay_graph_2 Segment_Delaunay_graph_Linf_2 Set_movable_separability_2 '
+    - PACKAGE='Skin_surface_3 Snap_rounding_2 Solver_interface '
+    - PACKAGE='Spatial_searching Spatial_sorting STL_Extension '
+    - PACKAGE='Straight_skeleton_2 Stream_lines_2 Stream_support '
+    - PACKAGE='Subdivision_method_3 Surface_mesh Surface_mesh_approximation '
+    - PACKAGE='Surface_mesh_deformation Surface_mesher Surface_mesh_parameterization '
+    - PACKAGE='Surface_mesh_segmentation Surface_mesh_shortest_path Surface_mesh_simplification '
+    - PACKAGE='Surface_mesh_skeletonization Surface_sweep_2 TDS_2 '
+    - PACKAGE='TDS_3 Testsuite Three '
+    - PACKAGE='Triangulation Triangulation_2 Triangulation_3 '
+    - PACKAGE='Union_find Visibility_2 Voronoi_diagram_2 '
+    - PACKAGE='wininst '
 compiler: clang
-install: 
+install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
-before_script: 
+before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
   - sudo mv doxygen_exe /usr/bin/doxygen
   - sudo chmod +x /usr/bin/doxygen
-  - mkdir -p build 
-  - cd build 
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' make
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' sudo make install &>/dev/null
+  - mkdir -p build
+  - cd build
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' make
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' sudo make install &>/dev/null
   - cd ..
-script: 
+script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
-    on_success: change # default: always
-    on_failure: always # default: always
-
+    on_success: change
+    # default: always
+    on_failure: always
+    # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - bash .travis/install.sh 
+  - time bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- make 
-- sudo make install &>/dev/null
+- time cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- time make
+- time sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- bash ./build_package.sh $PACKAGE
+- time bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f "Spend time of %C: %E real" bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- /usr/bin/time -f "Spend time of %C: %E real" cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- /usr/bin/time -f "Spend time of %C: %E real" make
-- /usr/bin/time -f "Spend time of %C: %E real" sudo make install &>/dev/null
+- /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- /usr/bin/time -f 'Spend time of %C: %E real' make
+- /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- /usr/bin/time -f "Spend time of %C: %E real" bash ./build_package.sh $PACKAGE
+- /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build
   - cd build
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' make
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' make
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' sudo make install &>/dev/null
   - cd ..
 script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - time bash .travis/install.sh
+  - /usr/bin/time -f "Spend time of %C: %E real" bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- time cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- time make
-- time sudo make install &>/dev/null
+- /usr/bin/time -f "Spend time of %C: %E real" cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- /usr/bin/time -f "Spend time of %C: %E real" make
+- /usr/bin/time -f "Spend time of %C: %E real" sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- time bash ./build_package.sh $PACKAGE
+- /usr/bin/time -f "Spend time of %C: %E real" bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build 
   - cd build 
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' make
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' make
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' sudo make install &>/dev/null
   - cd ..
 script: 
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build
   - cd build
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' make
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' make
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' sudo make install &>/dev/null
   - cd ..
 script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -64,13 +64,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build 
   - cd build 
-  - /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of %C: %E real' make
-  - /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' make
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' sudo make install &>/dev/null
   - cd ..
 script: 
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -5,7 +5,7 @@ set -e
 CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 
 function time {
-  /usr/bin/time -f "Spend time of %C: %E real" "$@"
+  /usr/bin/time -f "Spend time of %C: %E (real)" "$@"
 }
 
 function build_examples {

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -7,8 +7,8 @@ CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 function build_examples {
   mkdir -p build-travis
   cd build-travis
-  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
-  make -j2
+  time cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
+  time make -j2
 }
 
 function build_tests {
@@ -24,8 +24,8 @@ function build_demo {
       EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
       ;;
   esac
-  cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
-  make -j2
+  time cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
+  time make -j2
 }
 old_IFS=$IFS
 IFS=$' '
@@ -42,20 +42,20 @@ cd $ROOT
      [ "$ARG" = Polygon_mesh_processing ] || [ "$ARG" = Property_map ] ||\
      [ "$ARG" = Surface_mesh_deformation ] || [ "$ARG" = Surface_mesh_shortest_path ] ||\
      [ "$ARG" = Surface_mesh_simplification ]; then
-    sudo bash .travis/install_openmesh.sh
+    time sudo bash .travis/install_openmesh.sh
   fi
 
 
   if [ "$ARG" = "CHECK" ]
   then
     cd .travis
-    ./generate_travis.sh --check
+    time ./generate_travis.sh --check
     cd ..
     IFS=$old_IFS
-    zsh $ROOT/Scripts/developer_scripts/test_merge_of_branch HEAD
+    time zsh $ROOT/Scripts/developer_scripts/test_merge_of_branch HEAD
     #test dependencies 
     cd $ROOT
-    bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
+    time bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
 
     cd .travis
   	#parse current matrix and check that no package has been forgotten
@@ -92,8 +92,8 @@ cd $ROOT
     cd $ROOT
     mkdir build_test
     cd build_test
-    cmake -DCMAKE_INSTALL_PREFIX=install/ ..
-    make install
+    time cmake -DCMAKE_INSTALL_PREFIX=install/ ..
+    time make install
     # test install with minimal downstream example
     mkdir installtest
     cd installtest
@@ -106,7 +106,7 @@ cd $ROOT
     echo 'target_link_libraries(${PROJECT_NAME} CGAL::CGAL)' >> CMakeLists.txt
     echo '#include "CGAL/remove_outliers.h"' >> main.cpp
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=../../install ..
+    time cmake -DCMAKE_INSTALL_PREFIX=../../install ..
     cd ..
     exit 0
   fi

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -4,6 +4,10 @@ set -e
 
 CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 
+function time {
+  /usr/bin/time -f "Spend time of %C: %E real" "$@"
+}
+
 function build_examples {
   mkdir -p build-travis
   cd build-travis

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -4,15 +4,15 @@ set -e
 
 CXX_FLAGS="-DCGAL_NDEBUG -ftemplate-backtrace-limit=0"
 
-function time {
+function mytime {
   /usr/bin/time -f "Spend time of %C: %E (real)" "$@"
 }
 
 function build_examples {
   mkdir -p build-travis
   cd build-travis
-  time cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
-  time make -j2
+  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
+  mytime make -j2
 }
 
 function build_tests {
@@ -28,8 +28,8 @@ function build_demo {
       EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
       ;;
   esac
-  time cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
-  time make -j2
+  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
+  mytime make -j2
 }
 old_IFS=$IFS
 IFS=$' '
@@ -46,20 +46,20 @@ cd $ROOT
      [ "$ARG" = Polygon_mesh_processing ] || [ "$ARG" = Property_map ] ||\
      [ "$ARG" = Surface_mesh_deformation ] || [ "$ARG" = Surface_mesh_shortest_path ] ||\
      [ "$ARG" = Surface_mesh_simplification ]; then
-    time sudo bash .travis/install_openmesh.sh
+    mytime sudo bash .travis/install_openmesh.sh
   fi
 
 
   if [ "$ARG" = "CHECK" ]
   then
     cd .travis
-    time ./generate_travis.sh --check
+    mytime ./generate_travis.sh --check
     cd ..
     IFS=$old_IFS
-    time zsh $ROOT/Scripts/developer_scripts/test_merge_of_branch HEAD
+    mytime zsh $ROOT/Scripts/developer_scripts/test_merge_of_branch HEAD
     #test dependencies 
     cd $ROOT
-    time bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
+    mytime bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
 
     cd .travis
   	#parse current matrix and check that no package has been forgotten
@@ -96,8 +96,8 @@ cd $ROOT
     cd $ROOT
     mkdir build_test
     cd build_test
-    time cmake -DCMAKE_INSTALL_PREFIX=install/ ..
-    time make install
+    mytime cmake -DCMAKE_INSTALL_PREFIX=install/ ..
+    mytime make install
     # test install with minimal downstream example
     mkdir installtest
     cd installtest
@@ -110,7 +110,7 @@ cd $ROOT
     echo 'target_link_libraries(${PROJECT_NAME} CGAL::CGAL)' >> CMakeLists.txt
     echo '#include "CGAL/remove_outliers.h"' >> main.cpp
     cd build
-    time cmake -DCMAKE_INSTALL_PREFIX=../../install ..
+    mytime cmake -DCMAKE_INSTALL_PREFIX=../../install ..
     cd ..
     exit 0
   fi

--- a/.travis/generate_travis.sh
+++ b/.travis/generate_travis.sh
@@ -41,19 +41,19 @@ old_IFS=$IFS
 IFS=$'\n'
 for LINE in $(cat "$PWD/.travis/template.txt")
 do
-	if [ "$LINE" != " matrix:" ]
+	if [ "$LINE" != "  matrix:" ]
 	then
 		echo "$LINE" >> .travis.yml
   else
   	break
 	fi
 done
-echo " matrix: " >> .travis.yml
+echo "  matrix:" >> .travis.yml
 #writes the matrix
-echo "    - PACKAGE='CHECK' " >> .travis.yml
+echo "    - PACKAGE='CHECK'" >> .travis.yml
 for package in ${PACKAGES[@]}
 do
-echo "    - PACKAGE='$package' " >> .travis.yml
+echo "    - PACKAGE='$package'" >> .travis.yml
 done
 
 #writes the end of the file
@@ -69,7 +69,6 @@ do
 		echo "$LINE" >> .travis.yml
 	fi
 done
-echo "" >> .travis.yml
 IFS=$' '
 #check if there are differences between the files
 if ! cmp -s ./.travis.yml ./.travis.old;

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build 
   - cd build 
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' make
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' make
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' sudo make install &>/dev/null
   - cd ..
 script: 
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -14,18 +14,18 @@ install:
   - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
-- wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
-- sudo mv doxygen_exe /usr/bin/doxygen
-- sudo chmod +x /usr/bin/doxygen
-- mkdir -p build 
-- cd build 
-- /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- /usr/bin/time -f 'Spend time of %C: %E real' make
-- /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
-- cd ..
+  - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
+  - sudo mv doxygen_exe /usr/bin/doxygen
+  - sudo chmod +x /usr/bin/doxygen
+  - mkdir -p build 
+  - cd build 
+  - /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of %C: %E real' make
+  - /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
+  - cd ..
 script: 
-- cd ./.travis
-- /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
+  - cd ./.travis
+  - /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -1,33 +1,34 @@
-language: cpp 
-dist: xenial 
-sudo: required 
-git: 
- depth: 3
+language: cpp
+dist: xenial
+sudo: required
+git:
+  depth: 3
 env:
- matrix:
+  matrix:
   PACKAGES_MATRIX
 
 compiler: clang
-install: 
+install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
-before_script: 
+before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
   - sudo mv doxygen_exe /usr/bin/doxygen
   - sudo chmod +x /usr/bin/doxygen
-  - mkdir -p build 
-  - cd build 
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' make
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' sudo make install &>/dev/null
+  - mkdir -p build
+  - cd build
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' make
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' sudo make install &>/dev/null
   - cd ..
-script: 
+script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C: \%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
-    on_success: change # default: always
-    on_failure: always # default: always
-
+    on_success: change
+    # default: always
+    on_failure: always
+    # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f "Spend time of %C: %E real" bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- /usr/bin/time -f "Spend time of %C: %E real" cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- /usr/bin/time -f "Spend time of %C: %E real" make
-- /usr/bin/time -f "Spend time of %C: %E real" sudo make install &>/dev/null
+- /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- /usr/bin/time -f 'Spend time of %C: %E real' make
+- /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- /usr/bin/time -f "Spend time of %C: %E real" bash ./build_package.sh $PACKAGE
+- /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build
   - cd build
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' make
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' make
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' sudo make install &>/dev/null
   - cd ..
 script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C\: \%E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - bash .travis/install.sh 
+  - time bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- make 
-- sudo make install &>/dev/null
+- time cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- time make
+- time sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- bash ./build_package.sh $PACKAGE
+- time bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of %C: %E real' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build 
   - cd build 
-  - /usr/bin/time -f 'Spend time of %C: %E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-  - /usr/bin/time -f 'Spend time of %C: %E real' make
-  - /usr/bin/time -f 'Spend time of %C: %E real' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' make
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' sudo make install &>/dev/null
   - cd ..
 script: 
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of %C: %E real' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of %%C: %%E real' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash .travis/install.sh
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
   - sudo chmod +x /usr/bin/doxygen
   - mkdir -p build
   - cd build
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' make
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' sudo make install &>/dev/null
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON ..
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' make
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' sudo make install &>/dev/null
   - cd ..
 script:
   - cd ./.travis
-  - /usr/bin/time -f 'Spend time of \%C -- \%E (real)' bash ./build_package.sh $PACKAGE
+  - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -11,7 +11,7 @@ compiler: clang
 install: 
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
-  - time bash .travis/install.sh
+  - /usr/bin/time -f "Spend time of %C: %E real" bash .travis/install.sh
   - export CXX=clang++ CC=clang;
 before_script: 
 - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
@@ -19,13 +19,13 @@ before_script:
 - sudo chmod +x /usr/bin/doxygen
 - mkdir -p build 
 - cd build 
-- time cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
-- time make
-- time sudo make install &>/dev/null
+- /usr/bin/time -f "Spend time of %C: %E real" cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCGAL_HEADER_ONLY=ON -DCMAKE_CXX_FLAGS_RELEASE=-DCGAL_NDEBUG -DWITH_examples=ON -DWITH_demos=ON -DWITH_tests=ON .. 
+- /usr/bin/time -f "Spend time of %C: %E real" make
+- /usr/bin/time -f "Spend time of %C: %E real" sudo make install &>/dev/null
 - cd ..
 script: 
 - cd ./.travis
-- time bash ./build_package.sh $PACKAGE
+- /usr/bin/time -f "Spend time of %C: %E real" bash ./build_package.sh $PACKAGE
 notifications:
   email:
     on_success: change # default: always


### PR DESCRIPTION
## Summary of Changes

I would like to know why our Travis testsuite is so slow. I have wrapped a lot of commands with `time`, to see the timing.

## Release Management

* Affected package(s): Installation


**Work in progress:** let's see how Travis deals with it.

