### PR TITLE
Mesh_3 tests : deal with precision of `double`'s

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_utilities.h
+++ b/Mesh_3/test/Mesh_3/test_meshing_utilities.h
@@ -247,7 +247,7 @@ struct Tester
     std::cout << "\tQuality before optimization: " << original
               << " - Quality after optimization: " << modified << std::endl;
     
-    assert(original <= modified);
+    assert(original <= modified + 1e-15/*precision of double*/);
   }
   
   template<typename C3t3>

--- a/Mesh_3/test/Mesh_3/test_meshing_utilities.h
+++ b/Mesh_3/test/Mesh_3/test_meshing_utilities.h
@@ -247,7 +247,7 @@ struct Tester
     std::cout << "\tQuality before optimization: " << original
               << " - Quality after optimization: " << modified << std::endl;
     
-    assert(original <= modified + 1e-15/*precision of double*/);
+    assert(original <= modified * (1. + 1e-15) /*precision of double*/ );
   }
   
   template<typename C3t3>


### PR DESCRIPTION
## Summary of Changes

Computing the dihedral angles in `double` is sensitive to the precision of `double`.
Therefore we can release the comparison test by 1e-15.

## Release Management

* Affected package(s): Mesh_3 tests
* Issue(s) solved (if any): assertion failure met in the testsuite
[CGAL-4.13-Ic-31](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.13-Ic-31/Mesh_3/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz)
