### PR TITLE
Multiple definition of incident_cells

### DIFF
--- a/Surface_mesher/doc/Surface_mesher/Concepts/SurfaceMeshTriangulation_3.h
+++ b/Surface_mesher/doc/Surface_mesher/Concepts/SurfaceMeshTriangulation_3.h
@@ -239,15 +239,6 @@ OutputIterator
 incident_cells(Vertex_handle v, OutputIterator cells) const; 
 
 /*!
-Copies the `Cell_handle`s of all cells incident to `v` to the output 
-iterator `cells`. If `t.dimension() < 3`, then do nothing. 
-Returns the resulting output iterator. 
-*/ 
-template <class OutputIterator> 
-OutputIterator 
-incident_cells(Vertex_handle v, OutputIterator cells) const; 
-
-/*!
 Tests whether `p` is a vertex of `t` by locating `p` in 
 the triangulation. If `p` is found, the associated vertex `v` 
 is given. 


### PR DESCRIPTION
## Summary of Changes
The function `incident_cells` has been defined twice, removed second definition.

## Issue details
The issue was found as the (X)HTML checker gave the warning:
```
doc_output/Surface_mesher/classSurfaceMeshTriangulation__3.html:773: element a: validity error : ID a1a72cc14f3646bfe0f4e1969b4c47609 already defined
<a id="a1a72cc14f3646bfe0f4e1969b4c47609"></a>
                                         ^
ID a1a72cc14f3646bfe0f4e1969b4c47609 already defined
Document doc_output/Surface_mesher/classSurfaceMeshTriangulation__3.html does not validate
```

## Release Management
* Affected package(s): Surface_mesher
