### PR TITLE
Prevent infinite loop in Advancing front surface reconstruction. 

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -2005,6 +2005,7 @@ namespace CGAL {
     {
       // initilisation de la variable globale K: qualite d'echantillonnage requise
       K = K_init; // valeur d'initialisation de K pour commencer prudemment...
+      coord_type K_prev = K;
 
       Vertex_handle v1, v2;
       if (_ordered_border.empty()){
@@ -2069,12 +2070,12 @@ namespace CGAL {
             }
           while((!_ordered_border.empty())&&
                 (_ordered_border.begin()->first < STANDBY_CANDIDATE_BIS));
-
+          K_prev = K;
           K += (std::max)(K_step, min_K - K + eps);
           // on augmente progressivement le K mais on a deja rempli sans
           // faire des betises auparavant...
         }
-      while((!_ordered_border.empty())&&(K <= K)&&(min_K != infinity()));
+      while((!_ordered_border.empty())&&(K <= K)&&(min_K != infinity())&&(K!=K_prev));
 
 #ifdef VERBOSE
       if ((min_K < infinity())&&(!_ordered_border.empty())) {


### PR DESCRIPTION
In some cases K can become really large but doesn't get to infinity and instead gets into a situation where K + epsilon == K and the the while loop never exits. 

## Summary of Changes

Check for the case where K stops changing and exit the loop.  This happens when K + step == K for large values of K.

## Release Management

* Affected package(s):  Advancing front surface reconstruction
* Issue(s) solved (if any): 
* Feature/Small Feature (if any): Small bug fix
* Link to compiled documentation (obligatory for small feature) [link](https://doc.cgal.org/latest/Advancing_front_surface_reconstruction/index.html)
* License and copyright ownership: CGAL

