### PR TITLE
More robust first_intersection

### DIFF
--- a/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
+++ b/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
@@ -180,7 +180,14 @@ private:
 
   struct as_ray_param_visitor {
     typedef FT result_type;
-    as_ray_param_visitor(const Ray* ray) : ray(ray) {}
+    as_ray_param_visitor(const Ray* ray)
+     : ray(ray), max_i(0)
+    {
+      typename AABB_traits::Geom_traits::Vector_3 v = ray->to_vector();
+      for (int i=1; i<3; ++i)
+        if( CGAL::abs(v[i]) > CGAL::abs(v[max_i]) )
+          max_i = i;
+    }
 
     template<typename T>
     FT operator()(const T& s)
@@ -196,16 +203,11 @@ private:
       typename AABB_traits::Geom_traits::Vector_3 x(ray->source(), point);
       typename AABB_traits::Geom_traits::Vector_3 v = ray->to_vector();
 
-      for(int i = 0; i < 3; ++i) {
-        if(v[i] != FT(0.)) {
-          return x[i] / v[i];
-        }
-      }
-      CGAL_assertion(false); // should never end-up here
-      return FT(0.);
+      return x[max_i] / v[max_i];
     }
 
     const Ray* ray;
+    int max_i;
   };
 };
 


### PR DESCRIPTION
`AABB_tree::first_intersection()` is relying on constructions thus the result provided is not exact.
The following patches does not fix the non-exactness issue but increase the precision of the computation done.

I have an additional patch that I did not commit.
**Pro**: It remove a division and increase the precision of the result
**Con**: The bounds on the nodes are larger

I don't have time right know to investigate if the extra patch does worth it. If no one else have time to investigate either, let's create an issue with the preliminary patch once this PR is merged.

```
diff --git a/AABB_tree/include/CGAL/AABB_traits.h b/AABB_tree/include/CGAL/AABB_traits.h
index 632f2256d4..51698a8ece 100644
--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -164,7 +164,16 @@ struct AABB_traits_base_2<GeomTraits,true>{
       if(t_near < FT(0.))
         return FT(0.);
       else
-        return t_near;
+      {
+        int max_i(0);
+
+        const Vector_3 v = ray.to_vector();
+        for (int i=1; i<3; ++i)
+          if( CGAL::abs(v[i]) > CGAL::abs(v[max_i]) )
+            max_i = i;
+        int s = sign(v[max_i]) == POSITIVE ? 1 : -1;
+        return (std::min)( ((bbox.min)(max_i) - ray.source()[max_i])*s, ((bbox.max)(max_i) - ray.source()[max_i])*s );
+      }
     }
   };
 
diff --git a/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h b/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
index c05a0a34ef..56aa96499a 100644
--- a/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
+++ b/AABB_tree/include/CGAL/internal/AABB_tree/AABB_ray_intersection.h
@@ -187,6 +187,7 @@ private:
       for (int i=1; i<3; ++i)
         if( CGAL::abs(v[i]) > CGAL::abs(v[max_i]) )
           max_i = i;
+      s = sign( v[max_i] ) == POSITIVE ? 1 : -1;
     }
 
     template<typename T>
@@ -200,14 +201,12 @@ private:
     }
 
     FT operator()(const Point& point) {
-      typename AABB_traits::Geom_traits::Vector_3 x(ray->source(), point);
-      typename AABB_traits::Geom_traits::Vector_3 v = ray->to_vector();
-
-      return x[max_i] / v[max_i];
+      return s * (point[max_i] - ray->source()[max_i]);
     }
 
     const Ray* ray;
     int max_i;
+    int s;
   };
 };
```
