### PR TITLE
Doc fixes

### DIFF
--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
@@ -234,7 +234,7 @@ is also a model for the concept `TriangulationTraits_2`.
 
 The kernels `Cartesian`, `Homogeneous`,
 `Simple_cartesian`, `Simple_homogeneous` and
-`Filtered_kernel` can all be used as \cgalModels for
+`Filtered_kernel` can all be used as models for
 `Traits`. `Periodic_2_triangulation_traits_2` provides exact
 predicates and exact constructions if `Traits` does. It provides
 exact predicates but not exact constructions if

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -516,18 +516,17 @@ transform(const Transformation& t, const Polygon_2<Traits_P,Container_P>& p);
 /// followed by the output of the coordinates of the vertices.
 /// @{
 
-/// Inserts the polygon `p` into the stream `os`. \pre The insert
-/// operator must be defined for `Point_2`.
+/// Reads a polygon from stream `is` and assigns it to `p`.
+/// \pre The extract operator must be defined for `Point_2`.
 /// \memberof Polygon_2
 template <class Traits_P, class Container_P>
 std::istream &operator>>(std::istream &is, Polygon_2<Traits_P,Container_P>& p);
 
-/// Reads a polygon from stream `is` and assigns it
-/// to `p`. \pre The extract operator must be defined for `Point_2`.
+/// Inserts the polygon `p` into the stream `os`.
+/// \pre The insert operator must be defined for `Point_2`.
 /// \memberof Polygon_2
 template <class Traits_P, class Container_P>
-std::ostream
-&operator<<(std::ostream &os, const Polygon_2<Traits_P,Container_P>& p);
+std::ostream &operator<<(std::ostream &os, const Polygon_2<Traits_P,Container_P>& p);
 
 /// @} // IO
 

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -489,7 +489,7 @@ class Polygon_2 {
 /// Test for equality: two polygons are equal iff there exists a
 /// cyclic permutation of the vertices of `p2` such that they are
 /// equal to the vertices of `p1`. Note that the template argument
-/// `Container` of `p1` and `p2` may be different.
+/// `%Container` of `p1` and `p2` may be different.
 /// \memberof Polygon_2
 template <class Traits_P, class Container1_P, class Container2_P>
 bool operator==( const Polygon_2<Traits_P,Container1_P> &p1,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/extrude.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/extrude.h
@@ -137,19 +137,21 @@ struct Identity_functor
  * @param np_in an optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map}
- *    the property map that contains the points associated to the vertices of `input`.
- * If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
- * should be available for the vertices of `input` \cgalParamEnd
+ * \cgalParamBegin{vertex_point_map}
+ *   the property map that contains the points associated to the vertices of `input`.
+ *   If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
+ *   should be available for the vertices of `input`
+ * \cgalParamEnd
  * \cgalNamedParamsEnd
  *
- * * @param np_out an optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
+ * @param np_out an optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map}
- *    the property map that will contain the points associated to the vertices of `output`.
- * If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
- * should be available for the vertices of `output` \cgalParamEnd
+ * \cgalParamBegin{vertex_point_map}
+ *   the property map that will contain the points associated to the vertices of `output`.
+ *   If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
+ *   should be available for the vertices of `output`
+ * \cgalParamEnd
  * \cgalNamedParamsEnd
  */
 template <class InputMesh,
@@ -240,18 +242,20 @@ void extrude_mesh(const InputMesh& input,
  *
  * \cgalNamedParamsBegin
  * \cgalParamBegin{vertex_point_map}
- * the property map that contains the points associated to the vertices of `input`.
- * If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
- * should be available for the vertices of `input` \cgalParamEnd
+ *   the property map that contains the points associated to the vertices of `input`.
+ *   If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
+ *   should be available for the vertices of `input`
+ * \cgalParamEnd
  * \cgalNamedParamsEnd
  *
- * * @param np_out an optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
+ * @param np_out an optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
  *
  * \cgalNamedParamsBegin
  * \cgalParamBegin{vertex_point_map}
- * the property map that will contain the points associated to the vertices of `output`.
- * If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
- * should be available for the vertices of `output` \cgalParamEnd
+ *   the property map that will contain the points associated to the vertices of `output`.
+ *   If this parameter is omitted, an internal property map for `CGAL::vertex_point_t`
+ *   should be available for the vertices of `output`
+ * \cgalParamEnd
  * \cgalNamedParamsEnd
  */
 template <class InputMesh,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
@@ -1216,8 +1216,9 @@ bool do_intersect(const Polyline& polyline1,
  * @param np2 optional sequence of \ref pmp_namedparameters for `tm2`, among the ones listed below
  *
  * \cgalNamedParamsBegin
- *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm1` (tm2`).
+ *    \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `tm1` (`tm2`).
  *   \attention The two property maps must have the same `value_type`.
+ *
  *   If this parameter is omitted, an internal property map for
  *   `CGAL::vertex_point_t` must be available in `TriangleMesh`\cgalParamEnd
  *    \cgalParamBegin{geom_traits} an instance of a geometric traits class, model of `PMPSelfIntersectionTraits` \cgalParamEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
@@ -1108,8 +1108,8 @@ bool is_mesh2_in_mesh1(const TriangleMesh& tm1,
 
 /**
  * \ingroup PMP_predicates_grp
- * returns `true` if any segment of any polyline of `polylines1` intersects
- * any segment of any polyline of `polylines2`, and `false` otherwise.
+ * returns `true` if there exists a segment of a polyline of `polylines1`
+ * and a segment of a polyline of `polylines2` which intersect, and `false` otherwise.
  * This function depends on the package \ref PkgBoxIntersectionD.
  *
  * \tparam PolylineRange a `RandomAccessRange` of `RandomAccessRange` of points.
@@ -1151,7 +1151,8 @@ bool do_intersect(const PolylineRange& polylines1,
 
 /**
  * \ingroup PMP_predicates_grp
- * returns `true` if any segment of `polyline1` intersects any segment of `polyline2`, and `false` otherwise.
+ * returns `true` if there exists a segment of `polyline1` and a segment of `polyline2` which intersect,
+ * and `false` otherwise.
  * This function depends on the package \ref PkgBoxIntersectionD.
  *
  * \tparam Polyline a `RandomAccessRange` of points.
@@ -1196,7 +1197,7 @@ bool do_intersect(const Polyline& polyline1,
 
 /**
  * \ingroup PMP_predicates_grp
- * returns `true` if any face of `tm1` intersects any face of `tm2`, and `false` otherwise.
+ * returns `true` if there exists a face of `tm1` and a face of `tm2` which intersect, and `false` otherwise.
  * If `do_overlap_test_of_bounded_sides` is set to `true`, the overlap of bounded sides are tested as well. In that case, the meshes must be closed.
  * This function depends on the package \ref PkgBoxIntersectionD.
  *
@@ -1284,7 +1285,8 @@ bool do_intersect(const TriangleMesh& tm1,
 
 /**
  * \ingroup PMP_predicates_grp
- * returns `true` if any face of `tm` and any segment of any polyline of `polylines` intersects, and `false` otherwise.
+ * returns `true` if there exists a face of `tm` and a segment of a polyline of `polylines` which intersect,
+ * and `false` otherwise.
  * This function depends on the package \ref PkgBoxIntersectionD.
  * @pre `CGAL::is_triangle_mesh(tm)`
  *
@@ -1339,7 +1341,7 @@ bool do_intersect(const TriangleMesh& tm,
 
 /**
  * \ingroup PMP_predicates_grp
- * returns `true` if any face of `tm` and any segment of `polyline` intersects, and `false` otherwise.
+ * returns `true` if there exists a face of `tm` and a segment of `polyline` which intersect, and `false` otherwise.
  * This function depends on the package \ref PkgBoxIntersectionD.
  * @pre `CGAL::is_triangle_mesh(tm)`
  *

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Regular_triangulation_2.h
@@ -242,7 +242,7 @@ before the insertions (it may be negative due to hidden points).
 Note that this function is not guaranteed to insert the weighted points 
 following the order of `InputIterator`, as `spatial_sort()` 
 is used to improve efficiency. 
-\tparam InputIterator must be an input iterator with the value type `Weighted_point`. 
+\tparam InputIterator must be an input iterator with the value type \link Regular_triangulation_2::Weighted_point `Weighted_point` \endlink.
 */ 
 template < class InputIterator > 
 std::ptrdiff_t 
@@ -260,8 +260,8 @@ Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is
 only one vertex is created, one of the objects of type `Vertex::Info` will be stored in the vertex. 
 \pre `Vertex` must be model of the concept `TriangulationVertexBaseWithInfo_2`. 
 
-\tparam WeightedPointWithInfoInputIterator must be an input iterator with value type `std::pair<Weighted_point,Vertex::Info>`. 
-
+\tparam WeightedPointWithInfoInputIterator must be an input iterator with value type
+`std::pair<%Weighted_point,Vertex::Info>`.
 */ 
 template < class WeightedPointWithInfoInputIterator > 
 std::ptrdiff_t 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
@@ -103,7 +103,7 @@ Regular_triangulation_3(const Regular_triangulation_3 & rt1);
 Equivalent to constructing an empty triangulation with the optional 
 traits class argument and calling `insert(first,last)`. 
 If parallelism is enabled, the points will be inserted in parallel.
-\tparam InputIterator must be an input iterator with value type `Weighted_point`. 
+\tparam InputIterator must be an input iterator with value type \link Regular_triangulation_3::Weighted_point `Weighted_point` \endlink.
 */ 
 template < class InputIterator > 
 Regular_triangulation_3 (InputIterator first, InputIterator last,
@@ -176,7 +176,7 @@ following the order of `InputIterator`, as `spatial_sort()`
 is used to improve efficiency. 
 If parallelism is enabled, the points will be inserted in parallel.
 
-\tparam InputIterator must be an input iterator with value type `Weighted_point`. 
+\tparam InputIterator must be an input iterator with value type \link Regular_triangulation_3::Weighted_point `Weighted_point` \endlink.
 */ 
 template < class InputIterator > 
 std::ptrdiff_t 


### PR DESCRIPTION
## Summary of Changes

@sloriot @albert-github Would you please have any suggestion on how to:
- remove the link to `Vector_3` on https://doc.cgal.org/latest/Polygon_mesh_processing/group__PMP__meshing__grp.html#ga6cf0f4aaf1f304d129d76b9d20a4e909 (`%` does not seem to work: it's just printed next to the linked `Vector_3`).
- have code in a snippet (e.g. via `\code{.sh} ... \endcode`) while still resolving aliases such as `\cgal` within said snippet