### PR TITLE
Polyhedron:  read_OFF() must not set the badbit if there are 0 vertices

### DIFF
--- a/Polyhedron/doc/Polyhedron/CGAL/IO/Polyhedron_iostream.h
+++ b/Polyhedron/doc/Polyhedron/CGAL/IO/Polyhedron_iostream.h
@@ -9,10 +9,10 @@ with file extension <TT>.off</TT>, which is also understood by
 Geomview \cgalCite{cgal:p-gmgv16-96}, from the input stream `in` and 
 appends it to the polyhedral surface \f$ P\f$. Only the point coordinates 
 and facets from the input stream are used to build the polyhedral 
-surface. Neither normal vectors nor color attributes are evaluated. If 
-the stream `in` does not contain a permissible polyhedral surface 
-the `ios::badbit` of the input stream `in` is set and \f$ P\f$ remains 
-unchanged. 
+surface. Neither normal vectors nor color attributes are evaluated. 
+
+\note Before \cgal 5.0 this function has set the `ios::badbit` of the input stream `in`
+when the file contained 0 vertices.
 
 For OFF an ASCII and a binary format exist. The stream detects the 
 format automatically and can read both. 

--- a/Polyhedron_IO/test/Polyhedron_IO/test_polyhedron_io.cpp
+++ b/Polyhedron_IO/test/Polyhedron_IO/test_polyhedron_io.cpp
@@ -64,6 +64,8 @@ const char* tetra =    "OFF\n"
                        "3  3 2 0\n"
                        "3  2 3 1\n";
 
+const char* empty=    "OFF\n"
+                       "0 0 0\n";
 
 void test_file_IO_OFF() {
     typedef Simple_cartesian<double> Kernel;
@@ -115,6 +117,14 @@ void test_file_IO_OFF() {
         P = Polyhedron();
         filein >> P;
         assert( P.is_tetrahedron( P.halfedges_begin()));
+    }
+
+    {
+      Polyhedron P;
+      std::istringstream in( ::empty);
+      read_off(in, P);
+      assert(P.empty());
+      assert(in);
     }
 }
 void test_file_IO_wavefront() {}

--- a/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
+++ b/Stream_support/include/CGAL/IO/File_header_OFF_impl.h
@@ -377,13 +377,7 @@ std::istream& operator>>( std::istream& in, File_header_OFF& h) {
     }
     if ( n_h == 0)
         h.set_index_offset( 0);
-    if ( ! in || h.size_of_vertices() <= 0 ) {
-        in.clear( std::ios::badbit);
-        if ( h.verbose()) {
-            std::cerr << " " << std::endl;
-            std::cerr << "error: File_header_OFF(): File contains <= 0 vertices."
-                      << std::endl;
-        }
+    if ( ! in ) {
         return in;
     }
     if ( h.size_of_halfedges() == 0) {


### PR DESCRIPTION
## Summary of Changes

When reading an OFF file with 0 vertices the `std::ios::badbit` was set.  This was documented behavior.
I suggest that we change this with CGAL 5.0.

Is this a Breaking Change?   I didn't modify changes.md yet, as it makes merging painful.

## Release Management

* Affected package(s): Polyhedron
* Issue(s) solved (if any): fix #3108


