### PR TITLE
BGL:  Seam_mesh::add_seams() requires .selection.txt

### DIFF
--- a/BGL/include/CGAL/boost/graph/Seam_mesh.h
+++ b/BGL/include/CGAL/boost/graph/Seam_mesh.h
@@ -1107,7 +1107,7 @@ public:
   ///
   /// \returns one of the halfedges of the seam mesh that is on a seam.
   ///
-  /// \pre filename should be the name of a \cgal selection filee with file extension "*.selection.txt":
+  /// \pre filename should be the name of a \cgal selection file with file extension "*.selection.txt":
   ///      edges are described by pairs of integers, on the third line of the file.
   TM_halfedge_descriptor add_seams(const char* filename)
   {

--- a/BGL/include/CGAL/boost/graph/Seam_mesh.h
+++ b/BGL/include/CGAL/boost/graph/Seam_mesh.h
@@ -1065,7 +1065,7 @@ public:
   /// \tparam VdContainer must be a model of <a href="http://en.cppreference.com/w/cpp/concept/SequenceContainer"><tt>SequenceContainer</tt></a> (that is, provide
   ///         the functions: `operator[]` and `at()`).
   ///
-  /// \pre filename should be the name of a \cgal selection file with the file extension "*.selection.txt":
+  /// \pre filename should be the name of a \cgal selection file with file extension "*.selection.txt":
   ///      edges are described by pairs of integers, on the third line of the file.
   template<typename VdContainer>
   TM_halfedge_descriptor add_seams(const char* filename,
@@ -1107,7 +1107,7 @@ public:
   ///
   /// \returns one of the halfedges of the seam mesh that is on a seam.
   ///
-  /// \pre filename should be the name of a CGAL selection filee with the file extension "*.selection.txt":
+  /// \pre filename should be the name of a \cgal selection filee with file extension "*.selection.txt":
   ///      edges are described by pairs of integers, on the third line of the file.
   TM_halfedge_descriptor add_seams(const char* filename)
   {

--- a/BGL/include/CGAL/boost/graph/Seam_mesh.h
+++ b/BGL/include/CGAL/boost/graph/Seam_mesh.h
@@ -1065,8 +1065,8 @@ public:
   /// \tparam VdContainer must be a model of <a href="http://en.cppreference.com/w/cpp/concept/SequenceContainer"><tt>SequenceContainer</tt></a> (that is, provide
   ///         the functions: `operator[]` and `at()`).
   ///
-  /// \pre filename should be the name of a CGAL selection file: edges are
-  ///      described by pairs of integers, on the third line of the file.
+  /// \pre filename should be the name of a \cgal selection file with the file extension "*.selection.txt":
+  ///      edges are described by pairs of integers, on the third line of the file.
   template<typename VdContainer>
   TM_halfedge_descriptor add_seams(const char* filename,
                                    const VdContainer& tm_vds)
@@ -1075,7 +1075,7 @@ public:
 
     // Check the file type
     std::string str = filename;
-    if(str.substr(str.length() - 14) != ".selection.txt") {
+    if( (str.length()) < 14 || (str.substr(str.length() - 14) != ".selection.txt") ) {
       std::cerr << "Error: seams must be given by a *.selection.txt file" << std::endl;
       return tmhd;
     }
@@ -1107,8 +1107,8 @@ public:
   ///
   /// \returns one of the halfedges of the seam mesh that is on a seam.
   ///
-  /// \pre filename should be the name of a CGAL selection file: edges are
-  ///      described by pairs of integers, on the third line of the file.
+  /// \pre filename should be the name of a CGAL selection filee with the file extension "*.selection.txt":
+  ///      edges are described by pairs of integers, on the third line of the file.
   TM_halfedge_descriptor add_seams(const char* filename)
   {
     std::vector<TM_vertex_descriptor> tm_vds;

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/square_border_parameterizer.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/square_border_parameterizer.cpp
@@ -41,7 +41,7 @@ bool read_vertices(const PolyMesh& mesh,
                    Vd_array& fixed_vertices)
 {
   std::string str = filename;
-  if(str.substr(str.length() - 14) != ".selection.txt") {
+  if( (str.length()) < 14 || (str.substr(str.length() - 14) != ".selection.txt") ) {
     std::cerr << "Error: vertices must be given by a *.selection.txt file" << std::endl;
     return false;
   }


### PR DESCRIPTION
## Summary of Changes

Clarify that we require that the selection comes from a file with the extension `*.selection.txt`. 

## Release Management

* Affected package(s): BGL
* Issue(s) solved (if any): fix #3782

