### PR TITLE
Fix intersection(Point_2,Point_2)

### DIFF
--- a/Intersections_2/include/CGAL/Intersection_traits_2.h
+++ b/Intersections_2/include/CGAL/Intersection_traits_2.h
@@ -97,6 +97,11 @@ struct Intersection_traits<K, A, typename K::Point_2> {
   typedef boost::optional<variant_type> result_type;
 };
 
+template<typename K>
+struct Intersection_traits<K, typename K::Point_2, typename K::Point_2> {
+  typedef typename boost::variant<typename K::Point_2> variant_type;
+  typedef boost::optional<variant_type> result_type;
+};
 
 template<typename K>
 struct Intersection_traits<K, typename K::Iso_rectangle_2, typename K::Triangle_2>

--- a/Intersections_2/include/CGAL/Intersections_2/Point_2_Point_2.h
+++ b/Intersections_2/include/CGAL/Intersections_2/Point_2_Point_2.h
@@ -39,7 +39,8 @@ namespace internal {
 template <class K>
 inline bool
 do_intersect(const typename K::Point_2 &pt1, 
-	     const typename K::Point_2 &pt2)
+	     const typename K::Point_2 &pt2,
+	     const K&)
 {
     return pt1 == pt2;
 }
@@ -48,7 +49,8 @@ template <class K>
 typename CGAL::Intersection_traits
 <K, typename K::Point_2, typename K::Point_2>::result_type
 intersection(const typename K::Point_2 &pt1, 
-	     const typename K::Point_2 &pt2)
+	     const typename K::Point_2 &pt2,
+	     const K&)
 {
     if (pt1 == pt2) {
       return intersection_return<typename K::Intersect_2, typename K::Point_2, typename K::Point_2>(pt1);

--- a/Intersections_2/test/Intersections_2/test_intersections_2.cpp
+++ b/Intersections_2/test/Intersections_2/test_intersections_2.cpp
@@ -15,7 +15,7 @@
 #include <CGAL/Intersections_2/Bbox_2_Point_2.h>
 #include <CGAL/Intersections_2/Circle_2_Iso_rectangle_2.h>
 #include <CGAL/Intersections_2/Circle_2_Point_2.h>
-
+#include <CGAL/Intersections_2/Point_2_Point_2.h>
 
 #include <vector>
 #include <iostream>
@@ -292,6 +292,13 @@ check_no_intersection  (L(p(0, 0), p(10,10)), L(p(8,7), p(1, 0)));
     check_intersection<S>  (S(p(-10, -10), p(  0,  10)), T(p(   -9,   9), p(  14,   8), p(-2,-16)));
   }
 
+  void P_P()
+  {
+    std::cout << "Point - Point\n";
+    check_no_intersection<P>  (p(  8, 4), p(-4,  8));
+    check_intersection<P>     (p(  8, 4), p( 8,  4));
+  }
+
   void P_T()
   {
     std::cout << "Point - Triangle\n";
@@ -353,6 +360,7 @@ check_no_intersection  (L(p(0, 0), p(10,10)), L(p(8,7), p(1, 0)));
     R_T();
     S_T();
     P_T();
+    P_P();
     L_Rec();
     R_Rec();
     S_Rec();


### PR DESCRIPTION
## Summary of Changes

Fix `intersection(Point_2,Point_2)`. It seems it was never tested, and never worked.

PR #2792 introduced a compilation error in cgal-swig-bindings, by the addition of `do_intersect(Point_2,Circle_2)` and `intersection(Point_2,Circle_2)`:
```
.../CGAL/Kernel/function_objects.h:2954:63: error: call of overloaded ‘do_intersect(const CGAL::Point_2<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >&, const CGAL::Point_2<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >&, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >)’ is ambiguous
    { return Intersections::internal::do_intersect(t1, t2, K()); }
                                                              ^
```
https://travis-ci.org/CGAL/cgal-swig-bindings/jobs/509442278#L4727

## Release Management

* Affected package(s): Intersections_2
* License and copyright ownership: maintenance by GeometryFactory

