### PR TITLE
PMP: Fix in normalize()

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -51,7 +51,10 @@ namespace internal {
         traits.compute_squared_length_3_object()(v));
     //If the vector is small enough, approx_sqrt might return 0, and then we get nan values. 
     //To avoid that, we check the resulted norm. If it is 0, we don't normalize.
-    v = traits.construct_divided_vector_3_object()(v, norm == 0 ? 1 : norm);
+    if(norm != 0)
+    {
+      v = traits.construct_divided_vector_3_object()(v, norm );
+    }
   }
 
   template<typename Point

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -49,7 +49,9 @@ namespace internal {
   {
     typename GT::FT norm = CGAL::approximate_sqrt(
         traits.compute_squared_length_3_object()(v));
-    v = traits.construct_divided_vector_3_object()(v, norm);
+    //If the vector is small enough, approx_sqrt might return 0, and then we get nan values. 
+    //To avoid that, we check the resulted norm. If it is 0, we don't normalize.
+    v = traits.construct_divided_vector_3_object()(v, norm == 0 ? 1 : norm);
   }
 
   template<typename Point


### PR DESCRIPTION
## Summary of Changes

If the normal vector is small enough, it might happen that the vector is considered not null, but the approximate_sqrt of its norm is. Then the returned normalized vector is Nan. To avoid that, i added a check that the norm is not null.

## Release Management

* Affected package(s):PMP
