### PR TITLE
Polyhedron Demo: Only Select in the clipped zone

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -85,8 +85,6 @@ void Clipping_box_plugin::init(QMainWindow* mainWindow, CGAL::Three::Scene_inter
   connect(dock_widget->pushButton, SIGNAL(toggled(bool)),
           this, SLOT(clip(bool)));
   
-  CGAL::QGLViewer* viewer = *CGAL::QGLViewer::QGLViewerPool().begin();  
-  
   item = NULL;
   visualizer = NULL;
   shift_pressing = false;
@@ -126,7 +124,6 @@ void Clipping_box_plugin::clipbox()
           this, &Clipping_box_plugin::tab_change);
   item->setName("Clipping box");
   item->setRenderingMode(FlatPlusEdges);
-  CGAL::QGLViewer* viewer = *CGAL::QGLViewer::QGLViewerPool().begin();
   scene->addItem(item);
   actionClipbox->setEnabled(false);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
@@ -101,6 +101,16 @@
            </spacer>
           </item>
           <item>
+           <widget class="QPushButton" name="clipButton">
+            <property name="text">
+             <string>Clip</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="unclipButton">
             <property name="enabled">
              <bool>false</bool>
@@ -141,11 +151,22 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Info: SHIFT+Click to clip.</string>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Info: SHIFT+Click to clip</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>While &quot;Clip&quot; is toggled.</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -568,6 +568,31 @@ protected:
   }
 
 protected Q_SLOTS:
+
+  bool is_inside(QVector4D* box, const Kernel::Point_3& p)
+  {
+    if(!static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->isClipping()){
+      return true;
+    }
+    double x = p.x(),
+        y = p.y(),
+        z = p.z();
+
+      if(box[0][0]*x+box[0][1]*y+box[0][2]*z+box[0][3]>0)
+        return false;
+      if(box[1][0]*x+box[1][1]*y+box[1][2]*z+box[1][3]>0)
+        return false;
+      if(box[2][0]*x+box[2][1]*y+box[2][2]*z+box[2][3]>0)
+        return false;
+      if(box[3][0]*x+box[3][1]*y+box[3][2]*z+box[3][3]>0)
+        return false;
+      if(box[4][0]*x+box[4][1]*y+box[4][2]*z+box[4][3]>0)
+        return false;
+      if(box[5][0]*x+box[5][1]*y+box[5][2]*z+box[5][3]>0)
+        return false;
+      return true;
+  }
+  
   void select_points()
   {
     Scene_points_with_normal_item* point_set_item = getSelectedItem<Scene_points_with_normal_item>();
@@ -604,6 +629,15 @@ protected Q_SLOTS:
                        [&] (const Point_set::Index& idx) -> bool
                        { return !selected_bitmap[idx]; }));
     
+    QVector4D* clipbox = static_cast<CGAL::Three::Viewer_interface*>(viewer)->clipBox();
+       for(Point_set::iterator it = points->first_selected();
+           it != points->end();
+           ++it)
+       {
+         if(!is_inside(clipbox, points->point(*it)))
+           points->unselect(*it);
+       }
+       
     point_set_item->invalidateOpenGLBuffers();
     point_set_item->itemChanged();
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -58,6 +58,7 @@ class Selection_test {
   const CGAL::qglviewer::Vec offset;
   Scene_edit_box_item* edit_box;
   Selection_visualizer* visualizer;
+  QVector4D* clipbox;
   const Ui::PointSetSelection& ui_widget;
 
   
@@ -69,6 +70,7 @@ public:
                  const CGAL::qglviewer::Vec offset,
                  Scene_edit_box_item* edit_box,
                  Selection_visualizer* visualizer,
+                 QVector4D* clipbox,
                  const Ui::PointSetSelection& ui_widget)
     : point_set (point_set)
     , selected (selected)
@@ -76,6 +78,7 @@ public:
     , offset (offset)
     , edit_box (edit_box)
     , visualizer (visualizer)
+    , clipbox (clipbox)
     , ui_widget (ui_widget)
   {
   }
@@ -91,8 +94,15 @@ public:
   void apply (std::size_t i) const
   {
     Point_set::Index idx = *(point_set->begin() + i);
-
     const Kernel::Point_3& p = point_set->point (idx);
+
+    // Points outside clipbox are not affected
+    if (!is_inside_clipbox (p))
+    {
+      selected[idx] = point_set->is_selected (point_set->begin() + i);
+      return;
+    }
+
     CGAL::qglviewer::Vec vp (p.x (), p.y (), p.z ());
     bool now_selected = false;
     if(!ui_widget.box->isChecked())
@@ -127,6 +137,22 @@ public:
         selected[idx] = (already_selected && !now_selected);
     }
   }
+  
+  bool is_inside_clipbox (const Kernel::Point_3& p) const
+  {
+    if(!static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->isClipping())
+      return true;
+
+    double x = p.x(), y = p.y(), z = p.z();
+
+    return !(clipbox[0][0]*x+clipbox[0][1]*y+clipbox[0][2]*z+clipbox[0][3]>0 ||
+             clipbox[1][0]*x+clipbox[1][1]*y+clipbox[1][2]*z+clipbox[1][3]>0 ||
+             clipbox[2][0]*x+clipbox[2][1]*y+clipbox[2][2]*z+clipbox[2][3]>0 ||
+             clipbox[3][0]*x+clipbox[3][1]*y+clipbox[3][2]*z+clipbox[3][3]>0 ||
+             clipbox[4][0]*x+clipbox[4][1]*y+clipbox[4][2]*z+clipbox[4][3]>0 ||
+             clipbox[5][0]*x+clipbox[5][1]*y+clipbox[5][2]*z+clipbox[5][3]>0);
+  }
+  
 };
 
 
@@ -569,30 +595,6 @@ protected:
 
 protected Q_SLOTS:
 
-  bool is_inside(QVector4D* box, const Kernel::Point_3& p)
-  {
-    if(!static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->isClipping()){
-      return true;
-    }
-    double x = p.x(),
-        y = p.y(),
-        z = p.z();
-
-      if(box[0][0]*x+box[0][1]*y+box[0][2]*z+box[0][3]>0)
-        return false;
-      if(box[1][0]*x+box[1][1]*y+box[1][2]*z+box[1][3]>0)
-        return false;
-      if(box[2][0]*x+box[2][1]*y+box[2][2]*z+box[2][3]>0)
-        return false;
-      if(box[3][0]*x+box[3][1]*y+box[3][2]*z+box[3][3]>0)
-        return false;
-      if(box[4][0]*x+box[4][1]*y+box[4][2]*z+box[4][3]>0)
-        return false;
-      if(box[5][0]*x+box[5][1]*y+box[5][2]*z+box[5][3]>0)
-        return false;
-      return true;
-  }
-  
   void select_points()
   {
     Scene_points_with_normal_item* point_set_item = getSelectedItem<Scene_points_with_normal_item>();
@@ -615,7 +617,9 @@ protected Q_SLOTS:
     bool* selected_bitmap = new bool[points->size()]; // std::vector<bool> is not thread safe
 
     Selection_test selection_test (points, selected_bitmap,
-                                   camera, offset, edit_box, visualizer, ui_widget);
+                                   camera, offset, edit_box, visualizer,
+                                   static_cast<CGAL::Three::Viewer_interface*>(viewer)->clipBox(),
+                                   ui_widget);
 #ifdef CGAL_LINKED_WITH_TBB
     tbb::parallel_for(tbb::blocked_range<size_t>(0, points->size()),
                       selection_test);
@@ -629,15 +633,6 @@ protected Q_SLOTS:
                        [&] (const Point_set::Index& idx) -> bool
                        { return !selected_bitmap[idx]; }));
     
-    QVector4D* clipbox = static_cast<CGAL::Three::Viewer_interface*>(viewer)->clipBox();
-       for(Point_set::iterator it = points->first_selected();
-           it != points->end();
-           ++it)
-       {
-         if(!is_inside(clipbox, points->point(*it)))
-           points->unselect(*it);
-       }
-       
     point_set_item->invalidateOpenGLBuffers();
     point_set_item->itemChanged();
   }

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1683,5 +1683,15 @@ void Viewer::setGlPointSize(const GLfloat &p) { d->gl_point_size = p; }
 
 const GLfloat& Viewer::getGlPointSize() const { return d->gl_point_size; }
 
+QVector4D* Viewer::clipBox() const
+{
+  return d->clipbox;
+}
+
+bool Viewer::isClipping() const
+{
+  return d->clipping;
+}
+
 #include "Viewer.moc"
 

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -154,6 +154,8 @@ public:
    float total_pass()Q_DECL_OVERRIDE;
    const GLfloat& getGlPointSize()const Q_DECL_OVERRIDE;
    void setGlPointSize(const GLfloat& p) Q_DECL_OVERRIDE;
+   QVector4D* clipBox() const Q_DECL_OVERRIDE;
+   bool isClipping() const Q_DECL_OVERRIDE;
 }; // end class Viewer
 
 

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -276,6 +276,8 @@ public:
   virtual int currentPass()const = 0;
   virtual bool isDepthWriting()const = 0;
   virtual QOpenGLFramebufferObject* depthPeelingFbo() = 0;
+  virtual QVector4D* clipBox() const =0;
+  virtual bool isClipping() const = 0;
 }; // end class Viewer_interface
 }
 }


### PR DESCRIPTION
## Summary of Changes
Don't select clipped points.
Also change the design of the clipping box plugin: 
  added a checkable button to enable clipping in 2D, so that it won't conflict with the 2D selection.

@sgiraudot please stress-test this, as I encountered numerous weird bugs while I developped it. I feel like I got rid of everything but I can't be sure.
I strongly suggest to test it in a clean build directory.
## Release Management

* Issue(s) solved (if any): fix #3792 
