### PR TITLE
Polyhedron Demo: Fix c3t3 reload

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -2151,6 +2151,11 @@ void Scene_c3t3_item::setAlpha(int alpha)
   redraw();
 }
 
-QSlider* Scene_c3t3_item::alphaSlider() { return d->alphaSlider; }
+QSlider* Scene_c3t3_item::alphaSlider() {
+  if(!d->alphaSlider)
+    d->computeElements();
+  return d->alphaSlider;
+}
+
 
 #include "Scene_c3t3_item.moc"


### PR DESCRIPTION
## Summary of Changes
Check if the alpha slider exists before calling it to avoid a crash on reload.
## Release Management

* Issue(s) solved (if any): fix #3800 
