### PR TITLE
Number_types: Add support for arm and aarch64

### DIFF
--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -383,8 +383,23 @@ typedef unsigned int FPU_CW_t;
 #define CGAL_FE_TOWARDZERO   _RC_CHOP
 #define CGAL_FE_UPWARD       _RC_UP
 #define CGAL_FE_DOWNWARD     _RC_DOWN
-# elif (defined __VFP_FP__ && !defined __SOFTFP__) || defined __aarch64__
-//to do
+# elif defined  __arm__
+#define CGAL_IA_SETFPCW(CW) asm volatile ("VMSR FPSCR, %0" : :"r" (CW))
+#define CGAL_IA_GETFPCW(CW) asm volatile ("VMRS %0, FPSCR" : "=r" (CW)); CW &= CGAL_FE_TOWARDZERO
+typedef unsigned int FPU_CW_t;
+#define CGAL_FE_TONEAREST    (0x0)
+#define CGAL_FE_TOWARDZERO   (0xC00000)
+#define CGAL_FE_UPWARD       (0x400000)
+#define CGAL_FE_DOWNWARD     (0x800000)
+# elif defined  __aarch64__
+#define CGAL_IA_SETFPCW(CW) asm volatile ("MSR FPCR, %0" : :"r" (CW))
+#define CGAL_IA_GETFPCW(CW) asm volatile ("MRS %0, FPCR" : "=r" (CW))
+typedef unsigned int FPU_CW_t;
+#define CGAL_FE_TONEAREST    (0x0)
+#define CGAL_FE_TOWARDZERO   (0xC00000)
+#define CGAL_FE_UPWARD       (0x400000)
+#define CGAL_FE_DOWNWARD     (0x800000)
+
 #else
 // This is a version following the ISO C99 standard, which aims at portability.
 // The drawbacks are speed on one hand, and also, on x86, it doesn't fix the

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -383,7 +383,7 @@ typedef unsigned int FPU_CW_t;
 #define CGAL_FE_TOWARDZERO   _RC_CHOP
 #define CGAL_FE_UPWARD       _RC_UP
 #define CGAL_FE_DOWNWARD     _RC_DOWN
-# elif defined  __arm__
+# elif defined  __VFP_FP__
 #define CGAL_IA_SETFPCW(CW) asm volatile ("VMSR FPSCR, %0" : :"r" (CW))
 #define CGAL_IA_GETFPCW(CW) asm volatile ("VMRS %0, FPSCR" : "=r" (CW)); CW &= CGAL_FE_TOWARDZERO
 typedef unsigned int FPU_CW_t;

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -383,7 +383,8 @@ typedef unsigned int FPU_CW_t;
 #define CGAL_FE_TOWARDZERO   _RC_CHOP
 #define CGAL_FE_UPWARD       _RC_UP
 #define CGAL_FE_DOWNWARD     _RC_DOWN
-
+# elif (defined __VFP_FP__ && !defined __SOFTFP__) || defined __aarch64__
+//to do
 #else
 // This is a version following the ISO C99 standard, which aims at portability.
 // The drawbacks are speed on one hand, and also, on x86, it doesn't fix the

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -383,7 +383,7 @@ typedef unsigned int FPU_CW_t;
 #define CGAL_FE_TOWARDZERO   _RC_CHOP
 #define CGAL_FE_UPWARD       _RC_UP
 #define CGAL_FE_DOWNWARD     _RC_DOWN
-# elif defined  __VFP_FP__
+# elif defined __VFP_FP__ && !defined __SOFTFP__
 #define CGAL_IA_SETFPCW(CW) asm volatile ("VMSR FPSCR, %0" : :"r" (CW))
 #define CGAL_IA_GETFPCW(CW) asm volatile ("VMRS %0, FPSCR" : "=r" (CW)); CW &= CGAL_FE_TOWARDZERO
 typedef unsigned int FPU_CW_t;


### PR DESCRIPTION
## Summary of Changes
Define the floating point control word values for arm architectures (for gcc).
## Release Management

* Affected package(s):Number Types

