### PR TITLE
Mesh_3: Simplify AABB_primitive of Polyhedral_mesh_domain_3

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Get_facet_patch_id.h
@@ -122,9 +122,9 @@ get(const Get_facet_patch_id_sm<MeshDomain>,
        typename MeshDomain::Polyhedron,
        face_patch_id_t<typename MeshDomain::Patch_id> >::type Fpim;
   Fpim fpim = get(face_patch_id_t<typename MeshDomain::Patch_id>(),
-                  *(primitive_id.graph));
+                  *(primitive_id.second));
   typename MeshDomain::Patch_id patch_index = get(fpim,
-                                                  primitive_id.face_descriptor);
+                                                  primitive_id.first);
   return patch_index;
 }
 }} // end namespace CGAL::Mesh_3

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -211,7 +211,7 @@ public:
 
   BOOST_MPL_HAS_XXX_TRAIT_DEF(HalfedgeDS)
 
-  template <typename P, bool is_a_CGAL_Polyhedron_3 = has_HalfedgeDS<P>::value>
+  template <typename P>
   struct Primitive_type {
       //setting OneFaceGraphPerTree to false transforms the id type into 
       //std::pair<FD, const FaceGraph*>.
@@ -230,41 +230,7 @@ public:
     }
   }; // Primitive_type (for non-Polyhedron_3)
 
-  template <typename P> struct Primitive_type<P, true> {
-    typedef AABB_face_graph_triangle_primitive<P > type;
-
-    static
-    typename IGT_::Triangle_3 datum(const typename type::Id face_handle) {
-      typedef typename IGT_::Point_3 Point;
-      const Point& a = face_handle->halfedge()->vertex()->point();
-      const Point& b = face_handle->halfedge()->next()->vertex()->point();
-      const Point& c = face_handle->halfedge()->next()->next()->vertex()->point();
-      return typename IGT_::Triangle_3(a,b,c);
-    }
-
-    static Surface_patch_index get_index(const typename type::Id face_handle,
-                                         Tag_false)
-    {
-      typename boost::property_map<P, face_patch_id_t<Patch_id> >::type pmap;
-      return get(pmap, face_handle);
-    }
-
-    static Surface_patch_index get_index(const typename type::Id,
-                                         Tag_true)
-    {
-      return Surface_patch_index(0,1);
-    }
-
-    static Surface_patch_index get_index(const typename type::Id face_handle)
-    {
-      namespace m = boost::mpl;
-      return get_index(face_handle,
-                       Boolean_tag<m::or_<boost::is_same<Patch_id, void>,
-                                          boost::is_same<Patch_id, Tag_false>
-                       >::value>());
-    }
-  }; // Primitive_type specialized for CGAL::Polyehdron_3
-
+ 
 public:
   typedef typename Primitive_type<Polyhedron>::type       Ins_fctor_primitive;
   typedef CGAL::AABB_traits<IGT, Ins_fctor_primitive>     Ins_fctor_traits;

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -211,59 +211,22 @@ public:
 
   BOOST_MPL_HAS_XXX_TRAIT_DEF(HalfedgeDS)
 
-  template <typename P>
-  struct Primitive {
-    typedef typename boost::graph_traits<P>::face_descriptor face_descriptor_t;
-
-    face_descriptor_t face_descriptor;
-    const P* graph;
-
-    typedef Triangle_from_face_descriptor_map<P>   Triangle_pmap;
-    typedef One_point_from_face_descriptor_map<P>  Point_pmap;
-
-    typedef typename Triangle_pmap::value_type              Datum;
-    typedef typename Point_pmap::value_type                 Point;
-    typedef Primitive                                       Id;
-
-    Primitive() : face_descriptor(), graph() {}
-
-    template <typename IndexIterator>
-    Primitive(IndexIterator it, const P& polyhedron)
-      : face_descriptor(*it), graph(&polyhedron)
-    {}
-
-    bool operator==(const Primitive& other) const {
-      return other.face_descriptor == this->face_descriptor
-        && other.graph == this->graph;
-    }
-
-    Datum datum() const {
-      return get(Triangle_pmap(graph), face_descriptor);
-    }
-
-    Point reference_point() const {
-      return get(Point_pmap(graph), face_descriptor);
-    }
-
-    Id id() const {
-      return *this;
-    }
-  }; // Primitive template, for face graphs
-
   template <typename P, bool is_a_CGAL_Polyhedron_3 = has_HalfedgeDS<P>::value>
   struct Primitive_type {
-    typedef Primitive<P> type;
+      //setting OneFaceGraphPerTree to false transforms the id type into 
+      //std::pair<FD, const FaceGraph*>.
+    typedef AABB_face_graph_triangle_primitive<P, typename boost::property_map<P,vertex_point_t>::type, CGAL::Tag_false> type;
 
     static
     typename IGT_::Triangle_3 datum(const typename type::Id primitive_id) {
-      CGAL::Triangle_from_face_descriptor_map<P> pmap(primitive_id.graph);
-      return get(pmap, primitive_id.face_descriptor);
+      CGAL::Triangle_from_face_descriptor_map<P> pmap(primitive_id.second);
+      return get(pmap, primitive_id.first);
     }
 
     static Surface_patch_index get_index(const typename type::Id primitive_id) {
       return get(get(face_patch_id_t<Patch_id>(),
-                     *primitive_id.graph),
-                 primitive_id.face_descriptor);
+                     *primitive_id.second),
+                 primitive_id.first);
     }
   }; // Primitive_type (for non-Polyhedron_3)
 


### PR DESCRIPTION
## Summary of Changes

Use the new possibilities of the AABB_face_graph_triangle_primitive to unify and simplify the primitive type of the AABB_tree in the Polyhedral_mesh_domain_3.

## Release Management

* Affected package(s):Mesh_3
* Issue(s) solved (if any): fix #3716 
