### PR TITLE
Surface Mesh: Fix not reseting edge property when a new element re-uses memory

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -879,6 +879,7 @@ public:
         --removed_edges_;
         eremoved_[Edge_index(Halfedge_index(idx))] = false;
         hprops_.reset(Halfedge_index(idx));
+        hprops_.reset(opposite(Halfedge_index(idx)));
         eprops_.reset(Edge_index(Halfedge_index(idx)));
         return Halfedge_index(idx);
       } else {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -879,6 +879,7 @@ public:
         --removed_edges_;
         eremoved_[Edge_index(Halfedge_index(idx))] = false;
         hprops_.reset(Halfedge_index(idx));
+        eprops_.reset(Edge_index(Halfedge_index(idx)));
         return Halfedge_index(idx);
       } else {
         eprops_.push_back();


### PR DESCRIPTION
## Summary of Changes

https://github.com/CGAL/cgal/pull/2358 made it so new elements of the `Surface_mesh` use default property map values instead of values from the deleted element, but edge properties were forgotten.

## Release Management

* Affected package(s): `Surface_mesh`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --

