### PR TITLE
Fix AppleClang -Wnull-pointer-arithmetic warning

### DIFF
--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -28,6 +28,7 @@
 #include <CGAL/Default.h>
 
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 #include <algorithm>
 #include <vector>
@@ -815,7 +816,8 @@ private:
 
   static char * clean_pointer(char * p)
   {
-    return reinterpret_cast<char*>((p - (char *) NULL) & ~ (std::ptrdiff_t) START_END);
+    return reinterpret_cast<char*>(reinterpret_cast<std::uintptr_t>(p) &
+                                   ~ (std::uintptr_t) START_END);
   }
 
   // Returns the pointee, cleaned up from the squatted bits.
@@ -828,7 +830,8 @@ private:
   static Type type(const_pointer ptr)
   {
     char * p = (char *) Traits::pointer(*ptr);
-    return (Type) (p - clean_pointer(p));
+    return (Type) (reinterpret_cast<std::uintptr_t>(p) -
+                   reinterpret_cast<std::uintptr_t>(clean_pointer(p)));
   }
 
   // Sets the pointer part and the type of the pointee.
@@ -837,7 +840,8 @@ private:
     // This out of range compare is always true and causes lots of
     // unnecessary warnings.
     // CGAL_precondition(0 <= t && t < 4);
-    Traits::pointer(*ptr) = (void *) ((clean_pointer((char *) p)) + (int) t);
+    Traits::pointer(*ptr) = reinterpret_cast<void *>
+      (reinterpret_cast<std::uintptr_t>(clean_pointer((char *) p)) + (int) t);
   }
 
 public:

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -815,7 +815,7 @@ private:
 
   static char * clean_pointer(char * p)
   {
-    return ((p - (char *) NULL) & ~ (std::ptrdiff_t) START_END) + (char *) NULL;
+    return reinterpret_cast<char*>((p - (char *) NULL) & ~ (std::ptrdiff_t) START_END);
   }
 
   // Returns the pointee, cleaned up from the squatted bits.

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -28,7 +28,7 @@
 #include <CGAL/Default.h>
 
 #include <cmath>
-#include <cstdint>
+#include <cstddef>
 #include <iterator>
 #include <algorithm>
 #include <vector>
@@ -816,8 +816,8 @@ private:
 
   static char * clean_pointer(char * p)
   {
-    return reinterpret_cast<char*>(reinterpret_cast<std::uintptr_t>(p) &
-                                   ~ (std::uintptr_t) START_END);
+    return reinterpret_cast<char*>(reinterpret_cast<std::ptrdiff_t>(p) &
+                                   ~ (std::ptrdiff_t) START_END);
   }
 
   // Returns the pointee, cleaned up from the squatted bits.
@@ -830,8 +830,8 @@ private:
   static Type type(const_pointer ptr)
   {
     char * p = (char *) Traits::pointer(*ptr);
-    return (Type) (reinterpret_cast<std::uintptr_t>(p) -
-                   reinterpret_cast<std::uintptr_t>(clean_pointer(p)));
+    return (Type) (reinterpret_cast<std::ptrdiff_t>(p) -
+                   reinterpret_cast<std::ptrdiff_t>(clean_pointer(p)));
   }
 
   // Sets the pointer part and the type of the pointee.
@@ -841,7 +841,7 @@ private:
     // unnecessary warnings.
     // CGAL_precondition(0 <= t && t < 4);
     Traits::pointer(*ptr) = reinterpret_cast<void *>
-      (reinterpret_cast<std::uintptr_t>(clean_pointer((char *) p)) + (int) t);
+      (reinterpret_cast<std::ptrdiff_t>(clean_pointer((char *) p)) + (int) t);
   }
 
 public:


### PR DESCRIPTION
## Summary of Changes

This pull-request will fix the [-Wnull-pointer-arithmetic] warning of AppleClang, that we can see [here]:
```
In file included from .../CGAL-5.0-Ic-1/cmake/platforms/x86-64_Darwin-18.2_Apple-clang-default_Release/test/Advancing_front_surface_reconstruction/kernels.cpp:7:
In file included from .../CGAL-5.0-Ic-1/include/CGAL/Advancing_front_surface_reconstruction.h:33:
In file included from .../CGAL-5.0-Ic-1/include/CGAL/Triangulation_data_structure_3.h:51:
.../CGAL-5.0-Ic-1/include/CGAL/Compact_container.h:662:65: warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Wnull-pointer-arithmetic]
    return ((p - (char *) NULL) & ~ (std::ptrdiff_t) START_END) + (char *) NULL;
                                                                ^ ~~~~~~~~~~~~~
```
[here]: https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.0-Ic-1/Advancing_front_surface_reconstruction/TestReport_cgaltester_x86-64_Darwin-18.2_Apple-clang-default_Release.gz

## Release Management

* Affected package(s): STL_Extension (Compact_container)

Cc: @sloriot (maintainer of the new MacOS test platform)
