### PR TITLE
Fix Precompiled Demos

### DIFF
--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -8,10 +8,6 @@ set(CMAKE_AUTOMOC ON)
 
 cmake_minimum_required(VERSION 3.1...3.13)
 
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
-
 if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -26,8 +26,8 @@ if(CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND CGAL_Core_FOUND)
   qt5_add_resources ( RESOURCE_FILES resources/Delaunay_triangulation_2.qrc )
   
   # cpp files
-  add_executable ( HDT2_demo HDT2.cpp ${CGAL_Qt5_RESOURCE_FILES} ${RESOURCE_FILES} ${UIS})
-  target_link_libraries ( HDT2_demo CGAL::CGAL CGAL::CGAL_Qt5 CGAL::CGAL_Core Qt5::Widgets)
+  add_executable ( HDT2 HDT2.cpp ${CGAL_Qt5_RESOURCE_FILES} ${RESOURCE_FILES} ${UIS})
+  target_link_libraries ( HDT2 CGAL::CGAL CGAL::CGAL_Qt5 CGAL::CGAL_Core Qt5::Widgets)
 else()
   message(STATUS "NOTICE: This demo requires CGAL, CGAL_Core, and Qt5 and will not be compiled.")
 endif()

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_AUTOMOC ON)
 
 cmake_minimum_required(VERSION 3.1...3.13)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
@@ -412,12 +412,9 @@ int main(int argc, char **argv)
   app.setOrganizationName("GeometryFactory");
   app.setApplicationName("Delaunay_triangulation_2 demo");
 
-  // Import resources from libCGALQt4.
-  // See http://doc.trolltech.com/4.4/qdir.html#Q_INIT_RESOURCE
-  Q_INIT_RESOURCE(File);
-  Q_INIT_RESOURCE(Triangulation_2);
-  Q_INIT_RESOURCE(Input);
-  Q_INIT_RESOURCE(CGAL);
+  // Import resources from libCGALQt5
+  // See http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE
+  CGAL_Qt_init_resources();// that function is in a DLL
 
   MainWindow mainWindow;
   mainWindow.show();

--- a/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -4,11 +4,7 @@
 
 project( Hyperbolic_triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 2.8.10)
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -6,6 +6,10 @@ project( Hyperbolic_triangulation_2_Examples )
 
 cmake_minimum_required(VERSION 2.8.10)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS Core )
 
 if ( CGAL_FOUND )

--- a/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -4,11 +4,7 @@
 
 project( Hyperbolic_triangulation_2_Tests )
 
-cmake_minimum_required(VERSION 2.8.10)
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -6,6 +6,10 @@ project( Hyperbolic_triangulation_2_Tests )
 
 cmake_minimum_required(VERSION 2.8.10)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS Core )
 
 if ( CGAL_FOUND )

--- a/Maintenance/public_release/scripts/precompiled_demos_zips
+++ b/Maintenance/public_release/scripts/precompiled_demos_zips
@@ -61,6 +61,9 @@ pushd Segment_Delaunay_graph_Linf_2_Demo; zip ../segment_voronoi_diagram_2.zip *
 
 # CGAL-4.8
 pushd Optimal_transportation_reconstruction_2_Demo; zip ../otr2.zip *;               popd
+#missing demos
+pushd Polygon_Demo; zip ../polygon.zip *;               popd
+pushd Principal_component_analysis_Demo; zip ../pca.zip *;               popd
 
 # check
 echo CHECK now. The following lines should be empty.

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -35,16 +35,16 @@ if(CGAL_FOUND AND CGAL_Core_FOUND AND Qt5_FOUND AND CGAL_Qt5_FOUND)
 
   # cpp files
 
-  add_executable ( P4HDT2_demo
+  add_executable ( P4HDT2
   P4HDT2.cpp ${RESOURCE_FILES} ${UIS})
 
   #add_executable ( Periodic_4_hyperbolic_billiards_demo
   #Periodic_4_hyperbolic_billiards_demo.cpp ${RESOURCE_FILES} )
 
-  qt5_use_modules( P4HDT2_demo Widgets )
+  qt5_use_modules( P4HDT2 Widgets )
   #qt5_use_modules( Periodic_4_hyperbolic_billiards_demo Widgets )
 
-  target_link_libraries( P4HDT2_demo ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} )
+  target_link_libraries( P4HDT2 ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} )
 
   #target_link_libraries( Periodic_4_hyperbolic_billiards_demo ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} )
 else()

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -16,6 +16,11 @@ if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()
 
+
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS Core Qt5)
 include(${CGAL_USE_FILE})
 

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -10,15 +10,10 @@ include_directories( ${CMAKE_BINARY_DIR} )
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON) 
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.13)
 
 if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
-endif()
-
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
 endif()
 
 find_package(CGAL QUIET COMPONENTS Core Qt5)

--- a/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -4,11 +4,7 @@
 
 project( Periodic_4_hyperbolic_triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 2.8.10)
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -6,6 +6,10 @@ project( Periodic_4_hyperbolic_triangulation_2_Examples )
 
 cmake_minimum_required(VERSION 2.8.10)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS Core )
 
 if ( CGAL_FOUND AND CGAL_Core_FOUND)

--- a/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -6,6 +6,10 @@ project( Periodic_4_hyperbolic_triangulation_2_Tests )
 
 cmake_minimum_required(VERSION 2.8.10)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(CGAL QUIET COMPONENTS Core )
 
 if ( CGAL_FOUND AND CGAL_Core_FOUND )

--- a/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -4,11 +4,7 @@
 
 project( Periodic_4_hyperbolic_triangulation_2_Tests )
 
-cmake_minimum_required(VERSION 2.8.10)
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 


### PR DESCRIPTION
## Summary of Changes

The executables of the hyperbolic demos did not have the same name as their .cpp in the CMakeLists, which made the testsuite ignore them. 
## Release Management

* Affected package(s):Hyperbolic_triangulation_2, Periodic_4_hyperbolic_triangulation_2

