### PR TITLE
Add calls to reserve before creating meshes

### DIFF
--- a/BGL/doc/BGL/Concepts/MutableFaceGraph.h
+++ b/BGL/doc/BGL/Concepts/MutableFaceGraph.h
@@ -47,4 +47,4 @@ Indicates the expected size of vertices (`nv`), edges (`ed`) and faces (`nf`).
  */
 template <typename MutableFaceGraph>
 void
-reserve(MutableFaceGraph& g, boost::graph_traits<MutableFaceGraph>::vertices_size_type nv, boost::graph_traits<MutableFaceGraph>::vertices_size_type ne, boost::graph_traits<MutableFaceGraph>::vertices_size_type nf);
+reserve(MutableFaceGraph& g, boost::graph_traits<MutableFaceGraph>::vertices_size_type nv, boost::graph_traits<MutableFaceGraph>::edges_size_type ne, boost::graph_traits<MutableFaceGraph>::faces_size_type nf);

--- a/BGL/include/CGAL/boost/graph/copy_face_graph.h
+++ b/BGL/include/CGAL/boost/graph/copy_face_graph.h
@@ -71,6 +71,10 @@ void copy_face_graph_impl(const SourceMesh& sm, TargetMesh& tm,
 
   tm_face_descriptor tm_null_face = boost::graph_traits<TargetMesh>::null_face();
 
+  reserve(tm, static_cast<typename boost::graph_traits<TargetMesh>::vertices_size_type>(vertices(sm).size()),
+              static_cast<typename boost::graph_traits<TargetMesh>::edges_size_type>(edges(sm).size()),
+              static_cast<typename boost::graph_traits<TargetMesh>::faces_size_type>(faces(sm).size()) );
+
   //insert halfedges and create each vertex when encountering its halfedge
   BOOST_FOREACH(sm_edge_descriptor sm_e, edges(sm))
   {
@@ -373,7 +377,6 @@ void copy_face_graph(const SourceMesh& sm, TargetMesh& tm,
                      V2V v2v, H2H h2h, F2F f2f,
                      Src_vpm sm_vpm, Tgt_vpm tm_vpm )
 {
-  reserve(tm, vertices(sm).size(), edges(sm).size(), faces(sm).size());
   internal::copy_face_graph(sm, tm,
                             CGAL::graph_has_property<SourceMesh,boost::halfedge_index_t>(),
                             v2v, h2h, f2f,

--- a/BGL/include/CGAL/boost/graph/copy_face_graph.h
+++ b/BGL/include/CGAL/boost/graph/copy_face_graph.h
@@ -373,6 +373,7 @@ void copy_face_graph(const SourceMesh& sm, TargetMesh& tm,
                      V2V v2v, H2H h2h, F2F f2f,
                      Src_vpm sm_vpm, Tgt_vpm tm_vpm )
 {
+  reserve(tm, vertices(sm).size(), edges(sm).size(), faces(sm).size());
   internal::copy_face_graph(sm, tm,
                             CGAL::graph_has_property<SourceMesh,boost::halfedge_index_t>(),
                             v2v, h2h, f2f,

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -470,7 +470,16 @@ struct HDS_property_map<vertex_point_t>
       typename T::Point_3, const typename T::Point_3&> const_type;
   };
 };
-  
+
+template<class T, class I, class A>
+void reserve(HalfedgeDS_default<T,I,A>& p,
+             typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertices_size_type nv,
+             typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::edges_size_type ne,
+             typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::faces_size_type nf)
+{
+  p.reserve(nv, 2*ne, nf);
+}
+
 }// namespace CGAL
 namespace boost {
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -72,7 +72,10 @@ public:
 
   void operator()(PM& pmesh, const bool insert_isolated_vertices = true)
   {
-    reserve(pmesh, _points.size(), 2*_polygons.size(), _polygons.size());
+    reserve(pmesh, static_cast<typename boost::graph_traits<PM>::vertices_size_type>(_points.size()),
+                   static_cast<typename boost::graph_traits<PM>::edges_size_type>(2*_polygons.size()),
+                   static_cast<typename boost::graph_traits<PM>::faces_size_type>(_polygons.size()) );
+
     Vpmap vpmap = get(CGAL::vertex_point, pmesh);
 
     boost::dynamic_bitset<> not_isolated;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -72,6 +72,7 @@ public:
 
   void operator()(PM& pmesh, const bool insert_isolated_vertices = true)
   {
+    reserve(pmesh, _points.size(), 2*_polygons.size(), _polygons.size());
     Vpmap vpmap = get(CGAL::vertex_point, pmesh);
 
     boost::dynamic_bitset<> not_isolated;


### PR DESCRIPTION
Add missing calls to reserve in functions creating meshes.
There might be more I did not think about...