### PR TITLE
Point Set Processing:  cleanup 

### DIFF
--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
@@ -18,8 +18,8 @@
 //
 // Author(s) : Simon Giraudot
 
-#ifndef CGAL_INTERNAL_PSP_PARALLEL_CALLBACK_H
-#define CGAL_INTERNAL_PSP_PARALLEL_CALLBACK_H
+#ifndef CGAL_PSP_INTERNAL_PARALLEL_CALLBACK_H
+#define CGAL_PSP_INTERNAL_PARALLEL_CALLBACK_H
 
 #include <CGAL/license/Point_set_processing_3.h>
 
@@ -28,8 +28,8 @@
 #include <CGAL/thread.h>
 
 namespace CGAL {
-namespace internal {
 namespace Point_set_processing_3 {
+namespace internal {
   
 class Parallel_callback
 {
@@ -110,8 +110,8 @@ public:
   }
 };
 
-} // namespace Point_set_processing_3
 } // namespace internal
+} // namespace Point_set_processing_3
 } // namespace CGAL
 
-#endif // CGAL_INTERNAL_PSP_PARALLEL_CALLBACK_H
+#endif // CGAL_PSP_INTERNAL_PARALLEL_CALLBACK_H

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Search_traits_vertex_handle_3.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Search_traits_vertex_handle_3.h
@@ -235,7 +235,7 @@ struct Euclidean_distance_vertex_handle_3
 
   double transformed_distance(double d) const { return d*d; }
 
-  double inverse_of_transformed_distance(double d) { return sqrt(d); }
+  double inverse_of_transformed_distance(double d) { return CGAL::sqrt(d); }
 
 }; // end of struct Euclidean_distance_vertex_handle_3
 

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Search_traits_vertex_handle_3.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Search_traits_vertex_handle_3.h
@@ -32,6 +32,8 @@
 
 namespace CGAL {
 
+  namespace internal {
+
 /// \cond SKIP_IN_MANUAL
 
 /// A Point_vertex_handle_3 objects wraps either
@@ -89,24 +91,25 @@ public:
 
 }; // end of class Point_vertex_handle_3
 
-
+} // namespace internal
 
 /// Kernel traits specialization for Point_vertex_handle_3.
 template <class Vertex_handle>
-struct Kernel_traits< Point_vertex_handle_3<Vertex_handle> > {
+struct Kernel_traits< internal::Point_vertex_handle_3<Vertex_handle> > {
   struct Kernel {
     typedef double FT;
     typedef double RT;
   };
 };
 
+  namespace internal {  
 
 /// Functor with two function operators, which return the begin and
 /// past the end iterator for the Cartesian coordinates.
 template <class Vertex_handle>
 struct Construct_cartesian_const_iterator_vertex_handle_3
 {
-  typedef CGAL::Point_vertex_handle_3<Vertex_handle> Point_vertex_handle_3;
+  typedef CGAL::internal::Point_vertex_handle_3<Vertex_handle> Point_vertex_handle_3;
   typedef const double* result_type;
   const double* operator()(const Point_vertex_handle_3& p) const
   { return static_cast<const double*>(p.m_coord); }
@@ -123,7 +126,7 @@ struct Construct_cartesian_const_iterator_vertex_handle_3
 template <class Vertex_handle>
 struct Euclidean_distance_vertex_handle_3
 {
-  typedef CGAL::Point_vertex_handle_3<Vertex_handle> Point_vertex_handle_3;
+  typedef CGAL::internal::Point_vertex_handle_3<Vertex_handle> Point_vertex_handle_3;
   typedef Point_vertex_handle_3 Query_item;
 
   double transformed_distance(const Point_vertex_handle_3& p1, const Point_vertex_handle_3& p2) const {
@@ -252,6 +255,7 @@ class Search_traits_vertex_handle_3
                           >
 {};
 
+  } // namespace internal 
 /// \endcond
 
 } //namespace CGAL

--- a/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
@@ -46,7 +46,7 @@
 #include <CGAL/property_map.h>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>  
@@ -543,7 +543,7 @@ bilateral_smooth_point_set(
 #else
    if (boost::is_convertible<ConcurrencyTag,Parallel_tag>::value)
    {
-     internal::Point_set_processing_3::Parallel_callback
+     Point_set_processing_3::internal::Parallel_callback
        parallel_callback (callback, 2 * nb_points);
 
      Compute_pwns_neighbors<Kernel, Tree> f(k, tree, pwns, pwns_neighbors,
@@ -593,7 +593,7 @@ bilateral_smooth_point_set(
 #ifdef CGAL_LINKED_WITH_TBB
    if(boost::is_convertible<ConcurrencyTag, CGAL::Parallel_tag>::value)
    {
-     internal::Point_set_processing_3::Parallel_callback
+     Point_set_processing_3::internal::Parallel_callback
        parallel_callback (callback, 2 * nb_points, nb_points);
      
      //tbb::task_scheduler_init init(4);

--- a/Point_set_processing_3/include/CGAL/compute_average_spacing.h
+++ b/Point_set_processing_3/include/CGAL/compute_average_spacing.h
@@ -40,7 +40,7 @@
 #include <list>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>
@@ -240,7 +240,7 @@ compute_average_spacing(
 #else
    if (boost::is_convertible<ConcurrencyTag,Parallel_tag>::value)
    {
-     internal::Point_set_processing_3::Parallel_callback
+     Point_set_processing_3::internal::Parallel_callback
        parallel_callback (callback, kd_tree_points.size());
      
      std::vector<FT> spacings (kd_tree_points.size (), -1);

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -25,7 +25,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
 #include <CGAL/Monge_via_jet_fitting.h>

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -41,7 +41,7 @@
 #include <list>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>  
@@ -276,7 +276,7 @@ jet_estimate_normals(
 #else
    if (boost::is_convertible<ConcurrencyTag,Parallel_tag>::value)
    {
-     internal::Point_set_processing_3::Parallel_callback
+     Point_set_processing_3::internal::Parallel_callback
        parallel_callback (callback, kd_tree_points.size());
      
      std::vector<Vector> normals (kd_tree_points.size (),

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -25,7 +25,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
 #include <CGAL/Monge_via_jet_fitting.h>

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -40,7 +40,7 @@
 #include <list>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>  
@@ -266,7 +266,7 @@ jet_smooth_point_set(
 #else
    if (boost::is_convertible<ConcurrencyTag,Parallel_tag>::value)
    {
-     internal::Point_set_processing_3::Parallel_callback
+     Point_set_processing_3::internal::Parallel_callback
        parallel_callback (callback, kd_tree_points.size());
      
      std::vector<Point> mutated_points (kd_tree_points.size (), CGAL::ORIGIN);

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -25,7 +25,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
 #include <CGAL/Search_traits_vertex_handle_3.h>

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -28,7 +28,7 @@
 #include <CGAL/IO/trace.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <CGAL/Search_traits_vertex_handle_3.h>
+#include <CGAL/Point_set_processing_3/internal/Search_traits_vertex_handle_3.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Index_property_map.h>
 #include <CGAL/Memory_sizer.h>
@@ -327,7 +327,7 @@ create_riemannian_graph(
 
     // Types for K nearest neighbors search structure
     typedef Point_vertex_handle_3<ForwardIterator> Point_vertex_handle_3;
-    typedef Search_traits_vertex_handle_3<ForwardIterator> Traits;
+    typedef internal::Search_traits_vertex_handle_3<ForwardIterator> Traits;
     typedef Euclidean_distance_vertex_handle_3<ForwardIterator> KDistance;
     typedef Orthogonal_k_neighbor_search<Traits,KDistance> Neighbor_search;
     typedef typename Neighbor_search::Tree Tree;

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -25,7 +25,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Dimension.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Orthogonal_k_neighbor_search.h>

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -42,7 +42,7 @@
 #include <list>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>  
@@ -257,7 +257,7 @@ pca_estimate_normals(
 #else
   if (boost::is_convertible<ConcurrencyTag,Parallel_tag>::value)
     {
-      internal::Point_set_processing_3::Parallel_callback
+      Point_set_processing_3::internal::Parallel_callback
         parallel_callback (callback, kd_tree_points.size());
      
       std::vector<Vector> normals (kd_tree_points.size (),

--- a/Point_set_processing_3/include/CGAL/radial_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/radial_orient_normals.h
@@ -26,7 +26,7 @@
 #include <CGAL/disable_warnings.h>
 
 #include <CGAL/Origin.h>
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/property_map.h>
 #include <CGAL/point_set_processing_assertions.h>
 

--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -42,7 +42,7 @@
 #include <ctime>
 
 #ifdef CGAL_LINKED_WITH_TBB
-#include <CGAL/internal/Parallel_callback.h>
+#include <CGAL/Point_set_processing_3/internal/Parallel_callback.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include <tbb/scalable_allocator.h>  
@@ -606,7 +606,7 @@ wlop_simplify_and_regularize_point_set(
     //parallel
     if (boost::is_convertible<ConcurrencyTag, Parallel_tag>::value)
     {
-      internal::Point_set_processing_3::Parallel_callback
+      Point_set_processing_3::internal::Parallel_callback
         parallel_callback (callback, iter_number * number_of_sample, iter_n * number_of_sample);
      
       tbb::blocked_range<size_t> block(0, number_of_sample);

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
@@ -14,7 +14,6 @@
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Timer.h>
-#include <CGAL/trace.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh_default_triangulation_3.h>
 #include <CGAL/make_surface_mesh.h>
@@ -322,7 +321,7 @@ int main(int argc, char * argv[])
                                                         sm_radius*average_spacing,  // Max triangle size
                                                         sm_distance*average_spacing); // Approximation error
 
-    CGAL_TRACE_STREAM << "  make_surface_mesh(sphere center=("<<inner_point << "),\n"
+    std::cerr         << "  make_surface_mesh(sphere center=("<<inner_point << "),\n"
                       << "                    sphere radius="<<sm_sphere_radius<<",\n"
                       << "                    angle="<<sm_angle << " degrees,\n"
                       << "                    triangle size="<<sm_radius<<" * average spacing="<<sm_radius*average_spacing<<",\n"

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
@@ -1,4 +1,3 @@
-#include <CGAL/trace.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh_default_triangulation_3.h>

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
@@ -37,7 +37,7 @@
 #include <cmath>
 #include <iterator>
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Reconstruction_triangulation_3.h>
 #include <CGAL/spatial_sort.h>
 #ifdef CGAL_EIGEN3_ENABLED

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_refine_triangulation.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_refine_triangulation.h
@@ -25,7 +25,7 @@
 
 
 // CGAL
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Mesher_level.h>
 #include <CGAL/Mesh_3/Poisson_refine_cells_3.h>
 #include <CGAL/Poisson_mesh_cell_criteria_3.h>

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_reconstruction_test.cpp
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_reconstruction_test.cpp
@@ -10,7 +10,6 @@
 // CGAL
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Timer.h>
-#include <CGAL/trace.h>
 #include <CGAL/Memory_sizer.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh_default_triangulation_3.h>
@@ -254,7 +253,7 @@ int main(int argc, char * argv[])
                                                         sm_radius*average_spacing,  // Max triangle size
                                                         sm_distance*average_spacing); // Approximation error
 
-    CGAL_TRACE_STREAM << "  make_surface_mesh(sphere center=("<<inner_point << "),\n"
+    std::cerr         << "  make_surface_mesh(sphere center=("<<inner_point << "),\n"
                       << "                    sphere radius="<<sm_sphere_radius<<",\n"
                       << "                    angle="<<sm_angle << " degrees,\n"
                       << "                    triangle size="<<sm_radius<<" * average spacing="<<sm_radius*average_spacing<<",\n"

--- a/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
@@ -21,6 +21,7 @@
 #define CGAL_IO_OBJ_READER_H
 
 #include <istream>
+#include <sstream>
 #include <vector>
 
 

--- a/Stream_support/include/CGAL/IO/trace.h
+++ b/Stream_support/include/CGAL/IO/trace.h
@@ -1,10 +1,9 @@
 // Copyright (c) 2007-09  INRIA Sophia-Antipolis (France).
 // All rights reserved.
-//
-// This file is part of CGAL (www.cgal.org).
-// You can redistribute it and/or modify it under the terms of the GNU
-// General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
+// This file is part of CGAL (www.cgal.org); you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the License,
+// or (at your option) any later version.
 //
 // Licensees holding a valid commercial license may use this file in
 // accordance with the commercial license agreement provided with the software.
@@ -14,15 +13,12 @@
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: GPL-3.0+
+// SPDX-License-Identifier: LGPL-3.0+
 //
 // Author(s) : Laurent Saboret
 
-#ifndef CGAL_TRACE_H
-#define CGAL_TRACE_H
-
-#include <CGAL/license/Point_set_processing_3.h>
-
+#ifndef CGAL_IO_TRACE_H
+#define CGAL_IO_TRACE_H
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -35,7 +31,7 @@
 // ---------------
 
 // print_stderr() = printf-like function to print to stderr
-inline void print_stderr(const char *fmt, ...)
+inline void CGAL_print_stderr(const char *fmt, ...)
 {
   va_list argp;
   va_start(argp, fmt);
@@ -46,9 +42,9 @@ inline void print_stderr(const char *fmt, ...)
 // CGAL_TRACE() = printf-like function to print to stderr
 // if DEBUG_TRACE is defined (ignored otherwise)
 #ifdef DEBUG_TRACE
-  #define CGAL_TRACE  print_stderr
+#define CGAL_TRACE  CGAL_print_stderr
 #else
-  #define CGAL_TRACE  if (false) print_stderr
+  #define CGAL_TRACE  if (false) CGAL_print_stderr
 #endif
 
 // CGAL_TRACE_STREAM = C++ stream that prints to std::cerr 
@@ -61,4 +57,4 @@ inline void print_stderr(const char *fmt, ...)
 
 /// \endcond
 
-#endif // CGAL_TRACE_H
+#endif // CGAL_IO_TRACE_H

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Alpha_expansion_graph_cut.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Alpha_expansion_graph_cut.h
@@ -45,7 +45,7 @@
 #ifdef CGAL_SEGMENTATION_BENCH_GRAPHCUT
 #include <CGAL/Timer.h>
 #endif
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 
 #include <CGAL/boost/graph/named_function_params.h>
 

--- a/Surface_mesh_segmentation/package_info/Surface_mesh_segmentation/dependencies
+++ b/Surface_mesh_segmentation/package_info/Surface_mesh_segmentation/dependencies
@@ -11,7 +11,6 @@ Interval_support
 Kernel_23
 Modular_arithmetic
 Number_types
-Point_set_processing_3
 Profiling_tools
 Property_map
 Random_numbers

--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -24,7 +24,7 @@
 #include <CGAL/license/Surface_mesh_skeletonization.h>
 
 
-#include <CGAL/trace.h>
+#include <CGAL/IO/trace.h>
 #include <CGAL/Timer.h>
 #include <CGAL/Default.h>
 

--- a/Surface_mesh_skeletonization/package_info/Surface_mesh_skeletonization/dependencies
+++ b/Surface_mesh_skeletonization/package_info/Surface_mesh_skeletonization/dependencies
@@ -20,7 +20,6 @@ Kernel_d
 Modifier
 Modular_arithmetic
 Number_types
-Point_set_processing_3
 Polygon
 Polygon_mesh_processing
 Polyhedron


### PR DESCRIPTION
## Summary of Changes

- Move `<CGAL/trace.h>`  to `Stream_support/include/CGAL/IO/trace.h>
- This file was also called by Poisson, skeletonization, and segmentation.
- Move internal files to `CGAL/Point_set_processing_3/internal/

## Release Management

* Affected package(s): PSP, Poisson, Skeletonization, Segmentation

