### PR TITLE
Add test for output_to_vtu

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features.cpp
@@ -6,6 +6,7 @@
 
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/IO/output_to_vtu.h>
 
 // Domain 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -62,8 +63,10 @@ int main(int argc, char*argv[])
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
 
   // Output
-  std::ofstream medit_file("out.mesh");
-  c3t3.output_to_medit(medit_file);
+  std::ofstream file("out.vtu");
+  CGAL::output_to_vtu(file, c3t3);
+  // Could be replaced by:
+  // c3t3.output_to_medit(file);
 
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features_sm.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_polyhedral_domain_with_features_sm.cpp
@@ -7,6 +7,7 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/IO/output_to_vtu.h>
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -63,8 +64,10 @@ int main(int argc, char*argv[])
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
 
   // Output
-  std::ofstream medit_file("out.mesh");
-  c3t3.output_to_medit(medit_file);
+  std::ofstream file("out-sm.vtu");
+  CGAL::output_to_vtu(file, c3t3, CGAL::IO::ASCII);
+  // Could be replaced by:
+  // c3t3.output_to_medit(file);
 
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/include/CGAL/IO/output_to_vtu.h
+++ b/Mesh_3/include/CGAL/IO/output_to_vtu.h
@@ -66,7 +66,7 @@ write_cells_tag(std::ostream& os,
     // 4 indices (size_t) per cell + length of the encoded data (size_t)
   }
   else {
-    os << "\">\n";   
+    os << ">\n";
     for( Cell_iterator cit = c3t3.cells_in_complex_begin() ;
          cit != c3t3.cells_in_complex_end() ;
          ++cit )
@@ -74,7 +74,7 @@ write_cells_tag(std::ostream& os,
       for (int i=0; i<4; i++)
         os << V[cit->vertex(i)] << " ";
     }
-    os << "      </DataArray>\n";
+    os << "\n      </DataArray>\n";
   }
   
   // Write offsets
@@ -87,7 +87,7 @@ write_cells_tag(std::ostream& os,
     // 1 offset (size_t) per cell + length of the encoded data (size_t)
   }
   else {
-    os << "\">\n";  
+    os << ">\n";
     std::size_t cells_offset = 0;
     for( Cell_iterator cit = c3t3.cells_in_complex_begin() ;
 	 cit != c3t3.cells_in_complex_end() ;
@@ -96,7 +96,7 @@ write_cells_tag(std::ostream& os,
 	cells_offset += 4;
 	os << cells_offset << " ";
       }  
-    os << "      </DataArray>\n";
+    os << "\n      </DataArray>\n";
   }
 
   // Write cell type (tetrahedra == 10)
@@ -109,12 +109,12 @@ write_cells_tag(std::ostream& os,
     // 1 unsigned char per cell + length of the encoded data (size_t)
   }
   else {
-    os << "\">\n";  
+    os << ">\n";
     for( Cell_iterator cit = c3t3.cells_in_complex_begin() ;
 	 cit != c3t3.cells_in_complex_end() ;
 	 ++cit )
       os << "10 ";
-    os << "      </DataArray>\n";
+    os << "\n      </DataArray>\n";
   }
   os << "    </Cells>\n";
 }
@@ -188,7 +188,7 @@ write_c3t3_points_tag(std::ostream& os,
       else
         os << 0.0 << " ";
     }
-    os << "      </DataArray>\n";
+    os << "\n      </DataArray>\n";
   }
   os << "    </Points>\n";
 }
@@ -245,7 +245,7 @@ write_attribute_tag(std::ostream& os,
 	 it != attribute.end();
 	 ++it )
       os << *it << " ";
-    os << "      </DataArray>\n";
+    os << "\n      </DataArray>\n";
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

Add a test for `output_to_vtu` and then fix it.

`output_to_vtu` was added by #3297. (CGAL-4.14).

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #3297 
* License and copyright ownership: maintenance by GF of Inria package

