### PR TITLE
Remove (GMP|MPFR)_IN_CGAL_AUXILIARY

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -901,7 +901,7 @@ install(PROGRAMS ${scripts} DESTINATION ${CGAL_INSTALL_BIN_DIR})
 install(DIRECTORY ${CGAL_MODULES_REL_DIR}/                DESTINATION ${CGAL_INSTALL_CMAKE_DIR} )
 install(FILES     ${CGAL_MODULES_REL_DIR}/UseCGAL.cmake   DESTINATION ${CGAL_INSTALL_CMAKE_DIR} )
 
-if ( GMP_IN_CGAL_AUXILIARY OR MPFR_IN_CGAL_AUXILIARY )
+if ( IS_DIRECTORY auxiliary/gmp/include AND IS_DIRECTORY auxiliary/gmp/lib )
   install(DIRECTORY auxiliary/gmp/include/ DESTINATION ${CGAL_INSTALL_INC_DIR} )
   install(DIRECTORY auxiliary/gmp/lib/     DESTINATION ${CGAL_INSTALL_LIB_DIR} )
 endif()

--- a/Installation/cmake/modules/CGAL_SetupGMP.cmake
+++ b/Installation/cmake/modules/CGAL_SetupGMP.cmake
@@ -54,14 +54,14 @@ function(use_CGAL_GMP_support target)
     return()
   endif()
 
-  if(NOT GMP_IN_CGAL_AUXILIARY)
+  if(NOT GMP_INCLUDE_DIR STREQUAL "${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include")
     target_include_directories(${target} SYSTEM ${keyword} ${GMP_INCLUDE_DIR})
   else()
     target_include_directories(${target} SYSTEM ${keyword}
       $<BUILD_INTERFACE:${GMP_INCLUDE_DIR}>
       $<INSTALL_INTERFACE:include>)
   endif()
-  if(NOT MPFR_IN_CGAL_AUXILIARY)
+  if(NOT MPFR_INCLUDE_DIR STREQUAL "${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include")
     target_include_directories(${target} SYSTEM ${keyword} ${MPFR_INCLUDE_DIR})
   else()
     target_include_directories(${target} SYSTEM ${keyword}

--- a/Installation/cmake/modules/FindGMP.cmake
+++ b/Installation/cmake/modules/FindGMP.cmake
@@ -4,7 +4,6 @@
 #  GMP_INCLUDE_DIR       - the GMP include directory
 #  GMP_LIBRARIES_DIR     - directory where the GMP libraries are located
 #  GMP_LIBRARIES         - Link these to use GMP
-#  GMP_IN_CGAL_AUXILIARY - TRUE if the GMP found is the one distributed with CGAL in the auxiliary folder
 
 # TODO: support MacOSX
 
@@ -52,8 +51,3 @@ if( NOT GMP_in_cache )
 endif()
 
 find_package_handle_standard_args(GMP "DEFAULT_MSG" GMP_LIBRARIES GMP_INCLUDE_DIR)
-
-if ( GMP_INCLUDE_DIR STREQUAL "${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include" )
-  cache_set( GMP_IN_CGAL_AUXILIARY TRUE )
-endif()
-

--- a/Installation/cmake/modules/FindMPFR.cmake
+++ b/Installation/cmake/modules/FindMPFR.cmake
@@ -3,7 +3,6 @@
 # MPFR_INCLUDE_DIR - the MPFR include directory
 # MPFR_LIBRARIES_DIR - Directory where the MPFR libraries are located
 # MPFR_LIBRARIES - the MPFR libraries
-# MPFR_IN_CGAL_AUXILIARY - TRUE if the MPFR found is the one distributed with CGAL in the auxiliary folder
 
 # TODO: support MacOSX
 
@@ -51,7 +50,3 @@ if (NOT MPFR_in_cache)
 endif()
 
 find_package_handle_standard_args(MPFR "DEFAULT_MSG" MPFR_LIBRARIES MPFR_INCLUDE_DIR)
-
-if ( MPFR_INCLUDE_DIR STREQUAL "${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include" )
-  cache_set( MPFR_IN_CGAL_AUXILIARY TRUE )
-endif()


### PR DESCRIPTION
## Summary of Changes

There was a bug in `FindGMP.cmake` and `FindMPFR.cmake`: they were using the undefined macro `cache_set`.

I have removed those variables definitions, and wrote the code differently where they were used.

Cc: @sloriot 

## Release Management

* Affected package(s): Installation


