### PR TITLE
Fix Iterator_range for Apple Clang

### DIFF
--- a/STL_Extension/include/CGAL/Iterator_range.h
+++ b/STL_Extension/include/CGAL/Iterator_range.h
@@ -77,6 +77,7 @@ namespace CGAL {
   {
     return begin()==end();
   }
+#ifndef CGAL_CFG_NO_CPP0X_TUPLE
 
   operator std::tuple<I&, I&>()
   {
@@ -87,6 +88,8 @@ namespace CGAL {
   {
     return std::tuple<const I&, const I&>{this->first, this->second};
   }
+#endif
+
 };
 
   template <typename T>

--- a/STL_Extension/include/CGAL/Iterator_range.h
+++ b/STL_Extension/include/CGAL/Iterator_range.h
@@ -78,6 +78,15 @@ namespace CGAL {
     return begin()==end();
   }
 
+  operator std::tuple<I&, I&>()
+  {
+    return std::tuple<I&, I&>{this->first, this->second};
+  }
+
+  operator std::tuple<const I&, const I&>() const 
+  {
+    return std::tuple<const I&, const I&>{this->first, this->second};
+  }
 };
 
   template <typename T>


### PR DESCRIPTION
## Summary of Changes

Add an conversion operator to tuple into Iterator_range to satisfy clang used with c++11 and libc++

## Release Management

* Affected package(s):STL_Extension
