### PR TITLE
Speed-up polygon soup orientation

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
@@ -32,6 +32,7 @@
 #include <CGAL/assertions.h>
 #include <boost/foreach.hpp>
 #include <boost/container/flat_set.hpp>
+#include <boost/container/flat_map.hpp>
 
 #include <set>
 #include <map>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
@@ -163,7 +163,6 @@ struct Polygon_soup_orienter
 //filling containers
   static void fill_edge_map(Edge_map& edges, Marked_edges& marked_edges, const Polygons& polygons) {
     // Fill edges
-    edges.clear();
     for (P_ID i = 0; i < polygons.size(); ++i)
     {
       const P_ID size = polygons[i].size();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -180,7 +180,7 @@ public:
     //check manifoldness
     typedef std::vector<V_ID> PointRange;
     typedef internal::Polygon_soup_orienter<PointRange, PolygonRange> Orienter;
-    typename Orienter::Edge_map edges;
+    typename Orienter::Edge_map edges(max_id+1);
     typename Orienter::Marked_edges marked_edges;
     Orienter::fill_edge_map(edges, marked_edges, polygons);
     //returns false if duplication is necessary

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Orient_soup_plugin.cpp
@@ -300,10 +300,10 @@ void Polyhedron_demo_orient_soup_plugin::getNMPoints(
     Scene_polygon_soup_item* item)
 {
   typedef std::pair<std::size_t, std::size_t>                              V_ID_pair;
-  typedef std::map<V_ID_pair, boost::container::flat_set<std::size_t> >    Edge_map;
-  typedef std::set<V_ID_pair>                                              Marked_edges;
   typedef CGAL::Polygon_mesh_processing::internal::Polygon_soup_orienter<Polygon_soup::Points, 
       Polygon_soup::Polygons> PSO;
+  typedef PSO::Edge_map Edge_map;
+  typedef std::set<V_ID_pair>                                              Marked_edges;
       
   Edge_map edges;
   Marked_edges m_edges;

--- a/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/IO/read_surf_trianglemesh.h
@@ -286,7 +286,7 @@ bool read_surf(std::istream& input, std::vector<Mesh>& output,
 
     Mesh& mesh = output[i];
 
-    PMP::internal::Polygon_soup_to_polygon_mesh<Mesh, Point_3, Triangle_ind>
+    PMP::internal::Polygon_soup_to_polygon_mesh<Mesh, std::vector<Point_3>, std::vector<Triangle_ind>>
       converter(points, polygons);
     converter(mesh, false/*insert_isolated_vertices*/);
 


### PR DESCRIPTION
Replace `map< pair<int,int>, flat_set<int> >` by `vector< flat_map<int, flat_set<int> >`  for the edge map.
The speed up is huge because we use a lot the edge map for navigation and the new data set is efficient because in regular cases, there are no isolated vertices.