### PR TITLE
SMP: mute ARAP and Orbifold output by default

### DIFF
--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -1228,7 +1228,9 @@ private:
     if(status != OK)
       return status;
 
+#ifdef CGAL_SMP_ARAP_DEBUG
     output_uvmap("ARAP_final_post_processing.off", mesh, vertices, faces, uvmap, vimap);
+#endif
 
     return OK;
   }
@@ -1293,7 +1295,11 @@ public:
 
     // Compute the initial parameterization of the mesh
     status = compute_initial_uv_map(mesh, bhd, uvmap, vimap);
+
+#ifdef CGAL_SMP_ARAP_DEBUG
     output_uvmap("ARAP_initial_param.off", mesh, vertices, faces, uvmap, vimap);
+#endif
+
     if(status != OK)
       return status;
 
@@ -1341,7 +1347,9 @@ public:
                                                uvmap, vimap, vpmap, A);
 
       // Output the current situation
-//      output_uvmap("ARAP_iteration_", ite, mesh, vertices, faces, uvmap, vimap);
+#ifdef CGAL_SMP_ARAP_DEBUG
+      output_uvmap("ARAP_iteration_", ite, mesh, vertices, faces, uvmap vimap);
+#endif
       energy_last = energy_this;
       energy_this = compute_current_energy(mesh, faces, ctmap, lp, lpmap,
                                                         ltmap, uvmap);
@@ -1368,7 +1376,9 @@ public:
       }
     }
 
+#ifdef CGAL_SMP_ARAP_DEBUG
     output_uvmap("ARAP_final_pre_processing.off", mesh, vertices, faces, uvmap, vimap);
+#endif
 
     if(!is_one_to_one_mapping(mesh, faces, uvmap)) {
      // Use post processing to handle flipped elements

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -231,11 +231,13 @@ private:
                                         get(uvmap, target(hd_1, mesh))),
                               Segment_2(get(uvmap, source(hd_2, mesh)),
                                         get(uvmap, target(hd_2, mesh))))) {
+#ifdef CGAL_SMP_ARAP_DEBUG
           std::ofstream out("non-simple.txt"); // polygon lines
           out << "2 " << get(uvmap, source(hd_1, mesh)) << " 0 "
                       << get(uvmap, target(hd_1, mesh)) << " 0" << std::endl;
           out << "2 " << get(uvmap, source(hd_2, mesh)) << " 0 "
                       << get(uvmap, target(hd_2, mesh)) << " 0" << std::endl;
+#endif
           return false;
         }
       }
@@ -308,8 +310,10 @@ private:
       ct.insert_constraint(sp, tp);
     }
 
+#ifdef CGAL_SMP_ARAP_DEBUG
     std::ofstream out("constrained_triangulation.cgal");
     out << ct;
+#endif
 
     return OK;
   }
@@ -349,8 +353,10 @@ private:
       }
     } while(++fc != done);
 
+#ifdef CGAL_SMP_ARAP_DEBUG
     // Output the exterior faces of the constrained triangulation
     output_ct_exterior_faces(ct);
+#endif
 
     return OK;
   }

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
@@ -40,6 +40,7 @@
 #include <CGAL/circulator.h>
 #include <CGAL/Default.h>
 #include <CGAL/Timer.h>
+#include <CGAL/use.h>
 
 #if defined(CGAL_EIGEN3_ENABLED)
 #include <CGAL/Eigen_solver_traits.h>
@@ -110,7 +111,7 @@ Error_code read_cones(const TriangleMesh& tm, std::ifstream& in, VertexIndexMap 
   while(in >> cone_index)
     cones.push_back(cone_index);
 
-#ifdef CGAL_PARAMETERIZATION_ORBIFOLD_CONE_VERBOSE
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
   std::cout << "Input cones: ";
   for(std::size_t i=0; i<cones.size(); ++i)
     std::cout << cones[i] << " ";
@@ -878,7 +879,7 @@ private:
       X[i] = Xf[i];
     }
 
-#ifdef CGAL_SMP_OUTPUT_ORBIFOLD_MATRICES
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
     std::ofstream outf("matrices/X.txt");
     for(std::size_t i=0; i<n; ++i) {
       outf << X[i] << " ";
@@ -939,6 +940,8 @@ public:
                           VertexUVMap uvmap,
                           VertexIndexMap vimap) const
   {
+    CGAL_USE(bhd);
+
     Error_code status;
 
     status = check_cones(cmap);
@@ -981,7 +984,7 @@ public:
     else // weight_type == Mean_value
       mean_value_laplacian(mesh, vimap, M);
 
-#ifdef CGAL_SMP_OUTPUT_ORBIFOLD_MATRICES
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
     std::ofstream outM("matrices/M.txt");
     outM.precision(20);
     outM << total_size << " " << total_size << std::endl;
@@ -1003,7 +1006,7 @@ public:
     outB.precision(20);
     outB << total_size << std::endl;
     outB << B << std::endl;
-#endif // CGAL_SMP_OUTPUT_ORBIFOLD_MATRICES
+#endif // CGAL_SMP_ORBIFOLD_DEBUG
 
     // compute the flattening by solving the boundary conditions
     // while satisfying the convex combination property with L
@@ -1011,8 +1014,10 @@ public:
     if(status != OK)
       return status;
 
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
     std::ofstream out("orbifold_result.off");
     IO::output_uvmap_to_off(mesh, bhd, uvmap, out);
+#endif
 
     return OK;
   }

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
@@ -48,7 +48,11 @@ class Dijkstra_end_exception : public std::exception
 {
   const char* what() const throw ()
   {
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
     return "Dijkstra: reached the target vertex";
+#else
+    return "";
+#endif
   }
 };
 
@@ -197,7 +201,9 @@ void compute_shortest_paths_between_cones(const TriangleMesh& mesh,
   }
 
   std::ofstream out("shortest_path.selection.txt");
+#ifdef CGAL_SMP_ORBIFOLD_DEBUG
   internal::output_shortest_paths_to_selection_file(mesh, seams, out);
+#endif
 }
 
 } // namespace Surface_mesh_parameterization


### PR DESCRIPTION
## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any): -- 

