### PR TITLE
CMakeLists.txt: Remove unnecessary include directories

### DIFF
--- a/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/CMakeLists.txt
+++ b/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/CMakeLists.txt
@@ -15,11 +15,10 @@ set( QT_USE_QTMAIN   TRUE )
 
 find_package(Qt5 QUIET COMPONENTS Widgets Script Svg)
 
-include_directories (BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 include_directories (BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include )
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND CGAL_Core_FOUND )
-
+set(CMAKE_AUTOMOC ON)
   # UI files (Qt Designer files)
   qt5_wrap_ui( CDT_UI_FILES boolean_operations_2.ui )
 
@@ -27,10 +26,10 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND CGAL_Core_FOUND )
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/boolean_operations_2.qrc )
 
   # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( "boolean_operations_2.cpp" "${CMAKE_CURRENT_BINARY_DIR}/boolean_operations_2.moc" )
+  
 
   # The executable itself.
-  add_executable  ( boolean_operations_2 ${CMAKE_CURRENT_SOURCE_DIR}/boolean_operations_2.cpp boolean_operations_2.moc ${CGAL_Qt5_MOC_FILES} ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} )
+  add_executable  ( boolean_operations_2 ${CMAKE_CURRENT_SOURCE_DIR}/boolean_operations_2.cpp ${CGAL_Qt5_MOC_FILES} ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} )
   qt5_use_modules(boolean_operations_2 Widgets Script Svg)
   # Link with Qt libraries
   target_link_libraries( boolean_operations_2 ${QT_LIBRARIES} )

--- a/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
+++ b/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories (BEFORE ./include)
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
+set(CMAKE_AUTOMOC ON)
 #--------------------------------
 # The "Delaunay" demo: Alpha_shapes_2
 #--------------------------------
@@ -31,11 +31,8 @@ qt5_wrap_ui( DT_UI_FILES Alpha_shapes_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Alpha_shapes_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( Alpha_shapes_2.cpp Alpha_shapes_2.moc )
-
 # The executable itself.
-add_executable  ( Alpha_shapes_2 Alpha_shapes_2.cpp Alpha_shapes_2.moc ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Alpha_shapes_2 Alpha_shapes_2.cpp ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Alpha_shapes_2 )
 

--- a/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
+set(CMAKE_AUTOMOC ON)
 #--------------------------------
 # UI files (Qt Designer files)
 qt5_wrap_ui( DT_UI_FILES Apollonius_graph_2.ui )
@@ -29,10 +29,9 @@ qt5_wrap_ui( DT_UI_FILES Apollonius_graph_2.ui )
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Apollonius_graph_2.qrc )
 
 # use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( Apollonius_graph_2.cpp Apollonius_graph_2.moc )
 
 # The executable itself.
-add_executable  ( Apollonius_graph_2 Apollonius_graph_2.cpp Apollonius_graph_2.moc ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Apollonius_graph_2 Apollonius_graph_2.cpp ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Apollonius_graph_2 )
 

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 include_directories (BEFORE ./include)
-include_directories (BEFORE ../../../Matrix_search/include)
 
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -23,6 +23,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQT_NO_KEYWORDS)
+set(CMAKE_AUTOMOC ON)
 
 #----------------------------------------------
 # The "Bounding volumes" demo: Bounding_volumes
@@ -34,10 +35,9 @@ qt5_wrap_ui( DT_UI_FILES Bounding_volumes.ui )
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Bounding_volumes.qrc )
 
 # use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( "Bounding_volumes.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Bounding_volumes.moc" )
 
 # The executable itself.
-add_executable  ( Bounding_volumes Bounding_volumes.cpp Bounding_volumes.moc ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Bounding_volumes Bounding_volumes.cpp ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Bounding_volumes )
 

--- a/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
+++ b/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
@@ -21,7 +21,8 @@ find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   add_definitions(-DQT_NO_KEYWORDS)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
+  set(CMAKE_AUTOMOC ON)
+  
   #--------------------------------
   # The demo: Circular_kernel_2
   #--------------------------------
@@ -32,10 +33,10 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Circular_kernel_2.qrc )
 
   # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( "Circular_kernel_2.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Circular_kernel_2.moc" )
+ 
 
   # The executable itself.
-  add_executable  ( Circular_kernel_2 Circular_kernel_2.cpp Circular_kernel_2.moc ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+  add_executable  ( Circular_kernel_2 Circular_kernel_2.cpp ${DT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Circular_kernel_2 )
 

--- a/GraphicsView/demo/Generator/CMakeLists.txt
+++ b/GraphicsView/demo/Generator/CMakeLists.txt
@@ -20,6 +20,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
   add_definitions(-DQT_NO_KEYWORDS)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
+  set(CMAKE_AUTOMOC ON)
 
   #--------------------------------
   # Demo: Generator_2
@@ -31,10 +32,9 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Generator_2.qrc )
 
   # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( "Generator_2.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Generator_2.moc" )
-
+  
   # The executable itself.
-  add_executable  ( Generator_2 Generator_2.cpp Generator_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+  add_executable  ( Generator_2 Generator_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Generator_2 )
 

--- a/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
+++ b/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
@@ -23,6 +23,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
 
 #--------------------------------
 # The "L1 Voronoi diagram" demo: L1_voronoi_diagram_2
@@ -33,11 +34,8 @@ qt5_wrap_ui( DT_UI_FILES L1_voronoi_diagram_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./L1_voronoi_diagram_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( L1_voronoi_diagram_2.cpp L1_voronoi_diagram_2.moc )
-
 # The executable itself.
-add_executable  ( L1_voronoi_diagram_2 L1_voronoi_diagram_2.cpp L1_voronoi_diagram_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+add_executable  ( L1_voronoi_diagram_2 L1_voronoi_diagram_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS L1_voronoi_diagram_2 )
 

--- a/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
+++ b/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
@@ -21,6 +21,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
   add_definitions(-DQT_NO_KEYWORDS)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)  
+  set(CMAKE_AUTOMOC ON)
 
   #--------------------------------
   # Demo: Largest_empty_rectangle_2
@@ -31,11 +32,8 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   # qrc files (resources files, that contain icons, at least)
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Largest_empty_rectangle_2.qrc )
 
-  # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( Largest_empty_rectangle_2.cpp Largest_empty_rectangle_2.moc )
-
   # The executable itself.
-  add_executable  ( Largest_empty_rectangle_2 Largest_empty_rectangle_2.cpp Largest_empty_rectangle_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+  add_executable  ( Largest_empty_rectangle_2 Largest_empty_rectangle_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Largest_empty_rectangle_2 )
 

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -20,6 +20,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
 
 #--------------------------------
 # The "2D Periodic triangulation" demo: Periodic_2_triangulation_2
@@ -30,8 +31,6 @@ qt5_wrap_ui( DT_UI_FILES Periodic_2_triangulation_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Periodic_2_triangulation_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( Periodic_2_Delaunay_triangulation_2.cpp Periodic_2_triangulation_2.moc )
 
 # find header files for projects that can show them
 file(GLOB headers "*.h")
@@ -42,8 +41,7 @@ SOURCE_GROUP("QT" FILES ${QT_headers})
 
 # The executable itself.
 add_executable  ( Periodic_2_Delaunay_triangulation_2 
-  Periodic_2_Delaunay_triangulation_2.cpp
-  Periodic_2_triangulation_2.moc 
+  Periodic_2_Delaunay_triangulation_2.cpp 
   ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES}
   ${headers} ${QT_headers} ${P2T2_headers})
 

--- a/GraphicsView/demo/Periodic_2_triangulation_2/Periodic_2_Delaunay_triangulation_2.cpp
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/Periodic_2_Delaunay_triangulation_2.cpp
@@ -432,7 +432,7 @@ void MainWindow::on_actionStoredCoverDomainSimplicesEmphasized_triggered(bool)
 }
 
 
-#include "Periodic_2_triangulation_2.moc"
+#include "Periodic_2_Delaunay_triangulation_2.moc"
 #include <CGAL/Qt/resources.h>
 
 int main(int argc, char **argv)

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   include(${CGAL_USE_FILE})
   add_definitions(-DQT_NO_KEYWORDS)
+  set(CMAKE_AUTOMOC ON)
 
   if( CGAL_Core_FOUND)
     add_definitions(-DCGAL_USE_CORE)
@@ -42,14 +43,11 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   # qrc files (resources files, that contain icons, at least)
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Polygon_2.qrc )
 
-  # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( Polygon_2.cpp "${CMAKE_CURRENT_BINARY_DIR}/Polygon_2.moc" )
-
 #  add_library( CGAL SHARED IMPORTED ) 
 #  SET_PROPERTY(TARGET CGAL PROPERTY IMPORTED_LOCATION ${CGAL_LIBRARY} )
 
   # The executable itself.
-  add_executable  ( Polygon_2 Polygon_2.cpp Polygon_2.moc ${DT_UI_FILES} ${DT_RESOURCE_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+  add_executable  ( Polygon_2 Polygon_2.cpp  ${DT_UI_FILES} ${DT_RESOURCE_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Polygon_2 )
 

--- a/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories (BEFORE ./include)
 
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
+set(CMAKE_AUTOMOC ON)
 
 include(${CGAL_USE_FILE})
 add_definitions(-DQT_NO_KEYWORDS)
@@ -39,11 +40,8 @@ qt5_wrap_ui( CDT_UI_FILES Segment_voronoi_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Segment_voronoi_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( "Segment_voronoi_2.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Segment_voronoi_2.moc" )
-
 # The executable itself.
-add_executable  ( Segment_voronoi_2 Segment_voronoi_2.cpp Segment_voronoi_2.moc ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES}  ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Segment_voronoi_2 Segment_voronoi_2.cpp ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES}  ${CGAL_Qt5_MOC_FILES})
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Segment_voronoi_2 )
 

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories (BEFORE ./include)
 
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
-
+set(CMAKE_AUTOMOC ON)
 include(${CGAL_USE_FILE})
 add_definitions(-DQT_NO_KEYWORDS)
 
@@ -39,11 +39,8 @@ qt5_wrap_ui( CDT_UI_FILES Segment_voronoi_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Segment_voronoi_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( "Segment_voronoi_linf_2.cpp" "${CMAKE_CURRENT_BINARY_DIR}/Segment_voronoi_linf_2.moc" )
-
 # The executable itself.
-add_executable  ( Segment_voronoi_linf_2 Segment_voronoi_linf_2.cpp Segment_voronoi_linf_2.moc ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Segment_voronoi_linf_2 Segment_voronoi_linf_2.cpp ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Segment_voronoi_linf_2 )
 

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
-
+set(CMAKE_AUTOMOC ON)
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -30,11 +30,8 @@ qt5_wrap_ui( DT_UI_FILES Snap_rounding_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Snap_rounding_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( Snap_rounding_2.cpp Snap_rounding_2.moc )
-
 # The executable itself.
-add_executable  ( Snap_rounding_2 Snap_rounding_2.cpp Snap_rounding_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+add_executable  ( Snap_rounding_2 Snap_rounding_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Snap_rounding_2 )
 

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
-include_directories (BEFORE ../../../Snap_rounding_2/include)
 
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -22,6 +22,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
   add_definitions(-DQT_NO_KEYWORDS)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
+  set(CMAKE_AUTOMOC ON)
 
   #--------------------------------
   # Demo: Spatial_searching_2
@@ -32,11 +33,8 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
   # qrc files (resources files, that contain icons, at least)
   qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Spatial_searching_2.qrc )
 
-  # use the Qt MOC preprocessor on classes that derives from QObject
-  qt5_generate_moc( Spatial_searching_2.cpp Spatial_searching_2.moc )
-
   # The executable itself.
-  add_executable  ( Spatial_searching_2 Spatial_searching_2.cpp Spatial_searching_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+  add_executable  ( Spatial_searching_2 Spatial_searching_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Spatial_searching_2 )

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(CGAL COMPONENTS Qt5)
 
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Svg)
 
-include_directories (BEFORE ../../../Spatial_searching/include)
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -22,6 +22,7 @@ if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
 
 add_definitions(-DQT_NO_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
 
 #--------------------------------
 # UI files (Qt Designer files)

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -30,11 +30,8 @@ qt5_wrap_ui( DT_UI_FILES Stream_lines_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ./Stream_lines_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( Stream_lines_2.cpp Stream_lines_2.moc )
-
 # The executable itself.
-add_executable  ( Stream_lines_2 Stream_lines_2.cpp Stream_lines_2.moc ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
+add_executable  ( Stream_lines_2 Stream_lines_2.cpp ${DT_UI_FILES}  ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES} )
 
 add_to_cached_list( CGAL_EXECUTABLE_TARGETS Stream_lines_2 )
 

--- a/GraphicsView/demo/Stream_lines_2/Stream_lines_2.cpp
+++ b/GraphicsView/demo/Stream_lines_2/Stream_lines_2.cpp
@@ -229,7 +229,6 @@ MainWindow::on_actionRecenter_triggered()
 }
 
 
-#include "Stream_lines_2.moc"
 #include <CGAL/Qt/resources.h>
 
 int main(int argc, char **argv)
@@ -249,3 +248,5 @@ int main(int argc, char **argv)
   mainWindow.show();
   return app.exec();
 }
+
+#include "Stream_lines_2.moc"

--- a/Mesh_2/demo/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/demo/Mesh_2/CMakeLists.txt
@@ -11,8 +11,6 @@ endif()
 
 find_package(CGAL QUIET)
 
-include_directories(BEFORE ../../../Triangulation_2/include)
-
 
 if ( CGAL_FOUND )
   include(${CGAL_USE_FILE})

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -53,10 +53,6 @@ if (CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET ${CGAL_QCOLLECTIONGEN
                  -o ${CMAKE_CURRENT_BINARY_DIR}/Periodic_3_triangulation_3.qhc
   )
 
-  # Make sure the compiler can find generated .moc files
-  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
-  include_directories( ${QT_INCLUDE_DIR} )
-
   # The executable itself
   add_executable  ( periodic_3_triangulation_3_demo
                     Scene.cpp moc_Scene.cpp

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(Qt5 QUIET COMPONENTS Widgets)
 if(CGAL_FOUND AND CGAL_Core_FOUND AND Qt5_FOUND AND CGAL_Qt5_FOUND)
 
   find_package( Boost REQUIRED )
-  include_directories(${Boost_INCLUDE_DIRS})
 
   include_directories (BEFORE include )
 

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -18,9 +18,8 @@ find_package(CGAL COMPONENTS Qt5)
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Widgets Svg)
 
 include_directories (BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories (BEFORE ${CMAKE_CURRENT_BINARY_DIR})
-
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )
+  set(CMAKE_AUTOMOC ON)
 
 add_definitions(-DQT_NO_KEYWORDS)
 
@@ -31,11 +30,8 @@ qt5_wrap_ui( CDT_UI_FILES Polyline_simplification_2.ui )
 # qrc files (resources files, that contain icons, at least)
 qt5_add_resources ( CGAL_Qt5_RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Polyline_simplification_2.qrc )
 
-# use the Qt MOC preprocessor on classes that derives from QObject
-qt5_generate_moc( ${CMAKE_CURRENT_SOURCE_DIR}/Polyline_simplification_2.cpp Polyline_simplification_2.moc )
-
 # The executable itself.
-add_executable  ( Polyline_simplification_2 ${CMAKE_CURRENT_SOURCE_DIR}/Polyline_simplification_2.cpp Polyline_simplification_2.moc ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
+add_executable  ( Polyline_simplification_2 ${CMAKE_CURRENT_SOURCE_DIR}/Polyline_simplification_2.cpp ${CDT_UI_FILES} ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
 target_link_libraries( Polyline_simplification_2 PRIVATE
   CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui )

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(CGAL COMPONENTS Qt5)
 find_package(Qt5 QUIET COMPONENTS Xml Script OpenGL Widgets Svg)
 
 include_directories (BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories (BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/../../include )
 include_directories (BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 if ( CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND )

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -12,11 +12,6 @@ if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()
 
-foreach(INCDIR ../../../STL_Extension/include ../../../GraphicsView/include ../../../filtered_kernel/include )
-  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${INCDIR}")
-    include_directories (BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/${INCDIR}")
-  endif()
-endforeach()
 
 include_directories( ./ )
 

--- a/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
@@ -29,11 +29,7 @@ set(PACKAGE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
 # Add several CGAL packages to the include and link paths,
 # if they lie in ${PACKAGE_ROOT}/.
-foreach(INC_DIR ${PACKAGE_ROOT}/include ${PACKAGE_ROOT}/../Mesh_2/include ${PACKAGE_ROOT}/../Data_structure_for_queries_3/include ${PACKAGE_ROOT}/../Marching_cube/include ${PACKAGE_ROOT}/../CGAL_ImageIO/include ${PACKAGE_ROOT}/../GraphicsView/include)
-  if (EXISTS ${INC_DIR})
-    include_directories (BEFORE ${INC_DIR})
-  endif()
-endforeach()
+
 foreach(LIB_DIR ${PACKAGE_ROOT}/../CGAL_ImageIO/src/CGAL_ImageIO ${PACKAGE_ROOT}/../GraphicsView/src/CGALQt5)
   if (EXISTS ${LIB_DIR})
     link_directories (${LIB_DIR})


### PR DESCRIPTION
## Summary of Changes

just a cleanup

### Todo:
- [x] I see 

>   Make sure the compiler can find generated .moc files
  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
  include_directories( ${QT_INCLUDE_DIR} )

in a few files. Either this is really needed and then we have to add it in other demos, or we can remove it.

## Release Management

* Affected package(s): demos

