### PR TITLE
Intersections_3: Fix almost collinear segment bug

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/intersection_3_1_impl.h
+++ b/Intersections_3/include/CGAL/Intersections_3/intersection_3_1_impl.h
@@ -29,6 +29,7 @@
 #include <boost/next_prior.hpp>
 #include <CGAL/Intersection_traits_3.h>
 #include <CGAL/number_utils.h>
+#include <CGAL/utils_classes.h>
 
 namespace CGAL {
 
@@ -424,10 +425,13 @@ intersection(const typename K::Line_3 &l1,
   const Point_3 p4 = p2 + v2;
   if(!K().coplanar_3_object()(p1,p2,p3,p4)) return intersection_return<typename K::Intersect_3, typename K::Line_3, typename K::Line_3>();
   const Vector_3 v3 = p3 - p1;
- const Vector_3 v3v2 = cross_product(v3,v2);
+  const Vector_3 v3v2 = cross_product(v3,v2);
   const Vector_3 v1v2 = cross_product(v1,v2);
-  const FT t = ((v3v2.x()*v1v2.x()) + (v3v2.y()*v1v2.y()) + (v3v2.z()*v1v2.z())) /
-               (v1v2.squared_length());
+  const FT sl = v1v2.squared_length();
+  if(certainly(sl == FT(0)))
+    return intersection_return<typename K::Intersect_3, typename K::Line_3, typename K::Line_3>();
+  const FT t = ((v3v2.x()*v1v2.x()) + (v3v2.y()*v1v2.y()) + (v3v2.z()*v1v2.z())) / sl;
+  
   return intersection_return<typename K::Intersect_3, typename K::Line_3, typename K::Line_3>(p1 + (v1 * t));
 }
 


### PR DESCRIPTION
## Summary of Changes

When computing the intersection of 2 almost collinear segments, the intersection of the two supporting lines is first computed by diving 0 by the length of the cross product of the support vector (which is also 0):

```c++
  const Point_3 &p1 = l1.point();
  const Point_3 &p3 = l2.point();
  const Vector_3 &v1 = l1.to_vector();
  const Vector_3 &v2 = l2.to_vector();
  const Point_3 p2 = p1 + v1;
  const Point_3 p4 = p2 + v2;
  if(!K().coplanar_3_object()(p1,p2,p3,p4)) return intersection_return<typename K::Intersect_3, typename K::Line_3, typename K::Line_3>();
  const Vector_3 v3 = p3 - p1;
  const Vector_3 v3v2 = cross_product(v3,v2);
  const Vector_3 v1v2 = cross_product(v1,v2);
  const FT t = ((v3v2.x()*v1v2.x()) + (v3v2.y()*v1v2.y()) + (v3v2.z()*v1v2.z())) /
               (v1v2.squared_length());
```

In that case, the point has `NaN` coordinates, which later leads to floating point exception when trying to order the points along the line.

This PR adds a test to check if the first coordinate of the point is valid before trying to order it with the vertices of the segments. The result remains consistent with `do_intersect` (see below).

## Source code

Consider the following source code:

```c++
#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
typedef CGAL::Exact_predicates_inexact_constructions_kernel Epick;

#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
typedef CGAL::Exact_predicates_exact_constructions_kernel Epeck;

template <typename Kernel>
void test()
{
  typedef typename Kernel::FT FT;
  typedef typename Kernel::Point_3 Point_3;
  typedef typename Kernel::Segment_3 Segment_3;
  typedef typename Kernel::Line_3 Line_3;
  typedef typename Kernel::Intersect_3 Intersect_3;

  Point_3 a (2.14210641815047786, 1.65153372375060248, 0);
  Point_3 b (2.00450848784844382, 1.6946496914439253, 0);
  Point_3 c (2.23341535311192274, 1.62292229710146785, 0);
  Point_3 d (2.09420592484593726, 1.66654322365572027, 0);
  
  Line_3 lab (a, b);
  Line_3 lcd (c, d);

  if (CGAL::do_intersect(lab, lcd))
    std::cerr << " - Lines do intersect" << std::endl;
  else
    std::cerr << " - Lines don't intersect" << std::endl;
  
  typename CGAL::cpp11::result_of<Intersect_3(Line_3, Line_3)>::type
    line_inter = intersection (lab, lcd);
  
  if (line_inter)
    std::cerr << " - Intersection found" << std::endl;
  else
    std::cerr << " - No intersection found" << std::endl;
  
  Segment_3 sab (a, b);
  Segment_3 scd (c, d);

  if (CGAL::do_intersect(sab, scd))
    std::cerr << " - Segments do intersect" << std::endl;
  else
    std::cerr << " - Segments don't intersect" << std::endl;
  
  typename CGAL::cpp11::result_of<Intersect_3(Segment_3, Segment_3)>::type
    segment_inter = intersection (sab, scd);
  
  if (segment_inter)
    std::cerr << " - Intersection found" << std::endl;
  else
    std::cerr << " - No intersection found" << std::endl;
}

int main()
{
  std::cerr << "Test Epeck" << std::endl;
  test<Epeck>();
  
  std::cerr << "Test Epick" << std::endl;
  test<Epick>();

  return 0;
}
```

Currently, it returns:
```
Test Epeck
 - Lines do intersect
 - Intersection found
 - Segments don't intersect
 - No intersection found
Test Epick
 - Lines do intersect
 - Intersection found
 - Segments don't intersect
zsh: floating point exception (core dumped)  ./intersection_crash
```

My first trial was, in the line/line intersection computation, to return no intersection if the cross-product is found with a length of 0, but in that case, results become inconsistent:
```
Test Epeck
 - Lines do intersect
 - Intersection found
 - Segments don't intersect
 - No intersection found
Test Epick
 - Lines do intersect
 - No intersection found
 - Segments don't intersect
 - No intersection found
```

With this PR, there is no crash and the result is consistent in any case:
```
Test Epeck
 - Lines do intersect
 - Intersection found
 - Segments don't intersect
 - No intersection found
Test Epick
 - Lines do intersect
 - Intersection found
 - Segments don't intersect
 - No intersection found
```

## Release Management

* Affected package(s): Intersections_3 (and probably many more…)

