### PR TITLE
Triangulation_2:  Fix Polyline_constraint_hierarchy_2

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -271,7 +271,7 @@ public:
       return Constraint_id(NULL);
     }
     // protects against inserting twice the same constraint
-    Constraint_id cid = hierarchy.insert_constraint(va, vb);
+    Constraint_id cid = hierarchy.insert_constraint_old_API(va, vb);
     if (va != vb && (cid != Constraint_id(NULL)) )  insert_subconstraint(va,vb); 
 
     return cid;

--- a/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
@@ -248,7 +248,7 @@ public:
   // insert/remove
   void add_Steiner(T va, T vb, T vx);
   Vertex_list* insert_constraint_old_API(T va, T vb);
-    Vertex_list* insert_constraint(T va, T vb);
+  Vertex_list* insert_constraint(T va, T vb);
   void append_constraint(Constraint_id cid, T va, T vb);
   void swap(Constraint_id first, Constraint_id second);
   void remove_constraint(Constraint_id cid);

--- a/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
@@ -247,7 +247,8 @@ public:
 
   // insert/remove
   void add_Steiner(T va, T vb, T vx);
-  Vertex_list* insert_constraint(T va, T vb);
+  Vertex_list* insert_constraint_old_API(T va, T vb);
+    Vertex_list* insert_constraint(T va, T vb);
   void append_constraint(Constraint_id cid, T va, T vb);
   void swap(Constraint_id first, Constraint_id second);
   void remove_constraint(Constraint_id cid);
@@ -867,6 +868,34 @@ template <class T, class Compare, class Data>
 typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_list*
 Polyline_constraint_hierarchy_2<T,Compare,Data>::
 insert_constraint(T va, T vb){
+  Edge        he = make_edge(va, vb);
+  Vertex_list*  children = new Vertex_list; 
+  Context_list* fathers;
+
+  typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
+  if(scit == sc_to_c_map.end()){
+    fathers = new Context_list;
+    sc_to_c_map.insert(std::make_pair(he,fathers));
+  } else {
+    fathers = scit->second;
+  }
+
+  children->push_front(Node(va, true));  // was he.first
+  children->push_back(Node(vb, true));   // was he.second
+  constraint_set.insert(children);
+  Context ctxt;
+  ctxt.enclosing = children;
+  ctxt.pos     = children->skip_begin();
+  fathers->push_front(ctxt);
+
+  return children;
+}
+
+  
+template <class T, class Compare, class Data>
+typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_list*
+Polyline_constraint_hierarchy_2<T,Compare,Data>::
+insert_constraint_old_API(T va, T vb){
   Edge        he = make_edge(va, vb);
 
   // First, check if the constraint was already inserted.

--- a/Triangulation_2/test/Triangulation_2/issue_3447.cpp
+++ b/Triangulation_2/test/Triangulation_2/issue_3447.cpp
@@ -1,0 +1,34 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Constrained_triangulation_plus_2.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Triangulation_vertex_base_2<K> Vb;
+typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb>           TDS;
+typedef CGAL::Exact_predicates_tag                               Itag;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, Itag> Triangulation;
+typedef CGAL::Constrained_triangulation_plus_2<Triangulation> Delaunay;
+
+typedef K::Point_2 Point_2;
+
+int main()
+{
+  Delaunay dt;
+
+  dt.insert(Point_2(0,0));
+  dt.insert(Point_2(10,0));
+  dt.insert(Point_2(0,10));
+  dt.insert(Point_2(10,10));
+  
+  std::vector<Point_2> vec_constraint;
+  
+  vec_constraint.push_back(Point_2(1, 2));
+  vec_constraint.push_back(Point_2(2, 2));
+  vec_constraint.push_back(Point_2(3, 2));
+
+  dt.insert_constraint(vec_constraint.begin(), vec_constraint.end());
+
+  dt.insert_constraint(vec_constraint.begin(), vec_constraint.end());
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

We need two versions of the insert_constraint() function of the class `Polyline_constraint_hierarchy_2`, namely
- one for the old API where constraints were just 2d segments (it is deprecated), and where one cannot insert the same constraint twice
- and one for polylines where it is possible to insert the same polyline twice.

### Todo
- [x] Rebase on an earlier release

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #3447
