### PR TITLE
PMP: Add function 'non_manifold_vertices'

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -39,8 +39,9 @@ Release date: September 2019
      Parameters.
 
 ### Polygon Mesh Processing
--    Added the function `non_manifold_vertices()`, which can be used to collect all the non-manifold
-     vertices (i.e. pinched vertices, or vertices appearing in multiple umbrellas) of a mesh.
+-    Added the function `CGAL::Polygon_mesh_processing::non_manifold_vertices()`,
+     which can be used to collect all the non-manifold vertices (i.e. pinched vertices,
+     or vertices appearing in multiple umbrellas) of a mesh.
  -   Added the function `CGAL::Polygon_mesh_processing::centroid()`, which computes
      the centroid of a closed triangle mesh.
 -    Added the functions `CGAL::Polygon_mesh_processing::stitch_boundary_cycle()` and

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -39,6 +39,8 @@ Release date: September 2019
      Parameters.
 
 ### Polygon Mesh Processing
+-    Added the function `non_manifold_vertices()`, which can be used to collect all the non-manifold
+     vertices (i.e. pinched vertices, or vertices appearing in multiple umbrellas) of a mesh.
  -   Added the function `CGAL::Polygon_mesh_processing::centroid()`, which computes
      the centroid of a closed triangle mesh.
 -    Added the functions `CGAL::Polygon_mesh_processing::stitch_boundary_cycle()` and

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -2188,7 +2188,7 @@ std::size_t make_umbrella_manifold(typename boost::graph_traits<PolygonMesh>::ha
 /// using `hnext = prev(opposite(h, pm), pm)`, starting from `h`).
 ///
 /// @tparam PolygonMesh a model of `HalfedgeListGraph`
-/// @tparam OutputIterator a model of `OutputIterator` with value type `boost::graph_traits<PolygonMesh>::halfedge_descriptor`
+/// @tparam OutputIterator a model of `OutputIterator` holding objects of type `boost::graph_traits<PolygonMesh>::halfedge_descriptor`
 ///
 /// @param pm a triangle mesh
 /// @param out the output iterator that collects halfedges incident to `v`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -2188,7 +2188,8 @@ std::size_t make_umbrella_manifold(typename boost::graph_traits<PolygonMesh>::ha
 /// using `hnext = prev(opposite(h, pm), pm)`, starting from `h`).
 ///
 /// @tparam PolygonMesh a model of `HalfedgeListGraph`
-/// @tparam OutputIterator a model of `OutputIterator` holding objects of type `boost::graph_traits<PolygonMesh>::halfedge_descriptor`
+/// @tparam OutputIterator a model of `OutputIterator` holding objects of type
+///                         `boost::graph_traits<PolygonMesh>::%halfedge_descriptor`
 ///
 /// @param pm a triangle mesh
 /// @param out the output iterator that collects halfedges incident to `v`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -2300,7 +2300,6 @@ std::size_t duplicate_non_manifold_vertices(PolygonMesh& pm,
   using boost::choose_param;
 
   typedef boost::graph_traits<PolygonMesh>                            GT;
-  typedef typename GT::vertex_descriptor                              vertex_descriptor;
   typedef typename GT::halfedge_descriptor                            halfedge_descriptor;
 
   typedef typename boost::lookup_named_param_def <

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -1959,6 +1959,8 @@ bool remove_degenerate_faces(TriangleMesh& tmesh)
 /// @param v a vertex of `pm`
 /// @param pm a triangle mesh containing `v`
 ///
+/// \warning This function has linear runtime with respect to the size of the mesh.
+///
 /// \sa `duplicate_non_manifold_vertices()`
 ///
 /// \return `true` if the vertex is non-manifold, `false` otherwise.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -2035,8 +2035,6 @@ struct Vertex_collector
   std::map<vertex_descriptor, std::vector<vertex_descriptor> > collections;
 };
 
-} // end namespace internal
-
 template <typename PolygonMesh, typename VPM, typename ConstraintMap>
 typename boost::graph_traits<PolygonMesh>::vertex_descriptor
 create_new_vertex_for_sector(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor sector_begin_h,
@@ -2181,6 +2179,8 @@ std::size_t make_umbrella_manifold(typename boost::graph_traits<PolygonMesh>::ha
   return nb_new_vertices;
 }
 
+} // end namespace internal
+
 /// \ingroup PMP_repairing_grp
 /// collects the non-manifold vertices (if any) present in the mesh. A non-manifold vertex `v` is returned
 /// via one incident halfedge `h` such that `target(h, pm) = v` for all the umbrellas that `v` apppears in
@@ -2319,7 +2319,7 @@ std::size_t duplicate_non_manifold_vertices(PolygonMesh& pm,
   if(!non_manifold_cones.empty())
   {
     for(halfedge_descriptor h : non_manifold_cones)
-      nb_new_vertices += make_umbrella_manifold(h, pm, dmap, np);
+      nb_new_vertices += internal::make_umbrella_manifold(h, pm, dmap, np);
 
     dmap.dump(out);
   }


### PR DESCRIPTION
Add a new function to collect all non manifold vertices at once. Useful because `is_non_manifold_vertex` runs in linear time.

## Release Management

* Affected package(s): `PMP`
* Feature/Small Feature (if any): [here](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_non_manifold_vertices_collector) -- pre-approved date: 2019-07-02 (accepted 2019-07-16)

