### PR TITLE
Mesh_3 : improve doc of constructor for `Polyhedral_complex_mesh_domain_3`

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -198,7 +198,11 @@ public:
   @param end past the end iterator on the input polyhedral surfaces
   @param indices_begin first iterator on the pairs of subdomain indices
              (two subdomain indices per input polyhedral surface),
-             corresponding to the first input polyhedral surface
+             corresponding to the first input polyhedral surface.
+             Each pair should be ordered as follows : the first (resp. second)
+             element is the index of the subdomain that lies on the
+             positively oriented (resp. negatively oriented) side of the
+             corresponding input polyhedral surface.
   @param indices_end past the end iterator on the pairs of subdomain indices
 
   @tparam InputPolyhedraIterator model of `InputIterator`, holding `Polyhedron`'s


### PR DESCRIPTION
## Summary of Changes

This PR improves the documentation of the constructor of `Polyhedral_complex_mesh_domain_3`.

Pairs of subdomain indices cannot be reversed or the domain would not be consistent.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #3870 .

