### PR TITLE
Fix for less

### DIFF
--- a/Generator/include/CGAL/Random_polygon_2_sweep.h
+++ b/Generator/include/CGAL/Random_polygon_2_sweep.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2001  
+// Copyright (c) 2001
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
@@ -19,7 +19,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0+
-// 
+//
 //
 // Author(s)     : Geert-Jan Giezeman <geert@cs.uu.nl>
 //               : Susan Hert <hert@mpi-sb.mpg.de>
@@ -146,7 +146,12 @@ template <class ForwardIterator, class PolygonTraits>
 bool Less_segments<ForwardIterator, PolygonTraits>::
 operator()(Vertex_index i, Vertex_index j) const
 {
-    if (m_vertex_data->edges[j.as_int()].is_in_tree) {
+    if (i.as_int() == j.as_int()) {
+        // Some STL implementations may call comparator(x, x)
+        // to verify irreflexivity.  Don't violate less_than_in_tree's
+        // preconditions in such an environment.
+        return false;
+    } else if (m_vertex_data->edges[j.as_int()].is_in_tree) {
         return less_than_in_tree(i,j);
     } else {
         return !less_than_in_tree(j,i);

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_simplicity.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_simplicity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2001  
+// Copyright (c) 2001
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
@@ -19,7 +19,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0+
-// 
+//
 //
 // Author(s)     : Geert-Jan Giezeman <geert@cs.uu.nl>
 
@@ -211,7 +211,12 @@ template <class VertexData>
 bool Less_segments<VertexData>::
 operator()(Vertex_index i, Vertex_index j) const
 {
-    if (m_vertex_data->edges[j.as_int()].is_in_tree) {
+   if (i.as_int() == j.as_int()) {
+        // Some STL implementations may call comparator(x, x)
+        // to verify irreflexivity.  Don't violate less_than_in_tree's
+        // preconditions in such an environment.
+        return false;
+    } else if (m_vertex_data->edges[j.as_int()].is_in_tree) {
         return less_than_in_tree(i,j);
     } else {
         return !less_than_in_tree(j,i);


### PR DESCRIPTION
From @mhsaar 

Some STL implementations may call comparator(x, x)
to verify irreflexivity.  Don't violate less_than_in_tree's
in such an environment.

