### PR TITLE
Change return type to avoid raising a precondition

### DIFF
--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/arrange_offset_polygons_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/arrange_offset_polygons_2.h
@@ -21,13 +21,13 @@ The set of input polygons are unique and interior disjoint. That is, given disti
 bounded or unbounded side of `Q` (but not both). 
 \tparam OutputPolygonWithHolesPtrIterator must be an output iterator whose `value_type` is a smart pointer 
 (such as `boost::shared_ptr`) whose `element_type` is `Polygon_with_holes_2<K>`.  
-
+\return `true` if no error was encountered, and `false` otherwise.
 \sa `create_exterior_straight_skeleton_2()`
 \sa `Straight_skeleton_builder_2` 
 
 */
 template<class K, class InputPolygonPtrIterator, class OutputPolygonWithHolesPtrIterator>
-void arrange_offset_polygons_2 ( InputPolygonPtrIterator begin
+bool arrange_offset_polygons_2 ( InputPolygonPtrIterator begin
 , InputPolygonPtrIterator end
 , OutputPolygonWithHolesPtrIterator out
 , K const& k 

--- a/Straight_skeleton_2/include/CGAL/arrange_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/arrange_offset_polygons_2.h
@@ -39,7 +39,7 @@ namespace CGAL {
 //  Every hole is contained in one and only one outer polygon
 //
 template<class K, class InputPolygonPtrIterator, class OutputPolygonWithHolesPtrIterator>
-void arrange_offset_polygons_2 ( InputPolygonPtrIterator           aBegin
+bool arrange_offset_polygons_2 ( InputPolygonPtrIterator           aBegin
                                , InputPolygonPtrIterator           aEnd
                                , OutputPolygonWithHolesPtrIterator rOut
                                , K const&
@@ -95,23 +95,34 @@ void arrange_offset_polygons_2 ( InputPolygonPtrIterator           aBegin
               lParent = lOuter ;
       }
       
-      CGAL_assertion(lParent != NULL);
+      if (lParent == NULL)
+        return false;
       
       lParent->add_hole(*lPoly);
     }
   }  
+  return true;
 }
 
 template<class K, class C>
 std::vector< boost::shared_ptr< Polygon_with_holes_2<K,C> > >
 inline
-arrange_offset_polygons_2 ( std::vector< boost::shared_ptr< Polygon_2<K,C> > > const& aPolygons )
+arrange_offset_polygons_2 ( std::vector< boost::shared_ptr< Polygon_2<K,C> > > const& aPolygons, bool& no_error)
 {
   std::vector< boost::shared_ptr< Polygon_with_holes_2<K,C> > > rResult ;
   
-  arrange_offset_polygons_2(aPolygons.begin(), aPolygons.end(), std::back_inserter(rResult), K() ) ;
+  no_error = arrange_offset_polygons_2(aPolygons.begin(), aPolygons.end(), std::back_inserter(rResult), K() ) ;
   
   return rResult ;
+}
+
+template<class K, class C>
+std::vector< boost::shared_ptr< Polygon_with_holes_2<K,C> > >
+inline
+arrange_offset_polygons_2 ( std::vector< boost::shared_ptr< Polygon_2<K,C> > > const& aPolygons)
+{
+  bool no_error;
+  return arrange_offset_polygons_2(aPolygons, no_error);
 }
 
 } // end namespace CGAL


### PR DESCRIPTION
Return `false` instead of raising an exception.