### PR TITLE
Triangulation_2:  Fix I/O for Constrained_triangulation_plus_2 

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -322,15 +322,17 @@ Writes the triangulation as for `Triangulation_2<Traits,Tds>` and, for each face
 writes "C" or "N" depending whether edge 
 `(f,i)` is constrained or not. 
 \relates Constrained_triangulation_2 
-*/ 
-ostream & operator<<(ostream& os, const Constrained_triangulation_2<Traits,Tds> &Ct); 
+*/
+template <typename  Traits, typename Tds, typename Itag>
+std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_2<Traits,Tds,Itag> &ct); 
 
 /*!
-Reads a triangulation from stream `is` and assigns it to `t`. Data in the stream must have the same format `operator<<` uses. 
-Note that `t` is first cleared. 
+Reads a triangulation from stream `is` and assigns it to c`t`. Data in the stream must have the same format `operator<<` uses. 
+Note that `ct` is first cleared. 
 \relates Constrained_triangulation_2 
-*/ 
-istream& operator>>(istream& is,Constrained_triangulation_2<Traits,Tds> Ct& t); 
+*/
+template <typename  Traits, typename Tds, typename Itag>
+std::istream& operator>>(std::istream& is,Constrained_triangulation_2<Traits,Tds,Itag> Ct& ct); 
 
 /*! Exception used by constrained triangulations configured with
 the tag `No_intersection_tag`. It is thrown upon insertion of a constraint

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -356,22 +356,6 @@ Returns an iterator past the last vertex on the constraint `cid`.
 Vertices_in_constraint_iterator 
 vertices_in_constraint_end(Constraint_id cid) const; 
 
-/*!
-\deprecated Returns an iterator on the first vertex on the constraint `cid`.
-\attention This function only works for constraints that were inserted
-as a pair of points or pair of vertex handles.
-*/
-Vertices_in_constraint_iterator
-vertices_in_constraint_begin(Vertex_handle va, Vertex_handle vb) const; 
-
-/*!
-\deprecated Returns an iterator past the last vertex on the constraint `cid`.
-\attention This function only works for constraints that were inserted
-as a pair of points or pair of vertex handles.
-*/
-Vertices_in_constraint_iterator
-vertices_in_constraint_end(Vertex_handle va, Vertex_handle vb) const; 
-
 /// @}
 
 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -460,11 +460,29 @@ been removed by the `simplify()` function.
 void
 remove_points_without_corresponding_vertex();
 
-
-
-
 /// @}
 
 
 }; /* end Constrained_triangulation_plus_2 */
+
+/*!
+Writes the triangulation as for `Tr`, then writes one constraint per line, starting with the number
+of vertices and the indices of the vertices of the constraint.
+
+\relates Constrained_triangulation_plus_2 
+*/
+  
+template <typename  Tr>
+std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_plus_2<Tr> &ctp);
+
+  
+/*!
+Reads a triangulation from stream `is` and assigns it to the triangulation. 
+
+\relates Constrained_triangulation_plus_2 
+*/
+template <typename  Tr>
+std::istream & operator>>(std::istream& is, Constrained_triangulation_plus_2<Tr> &ctp);
+
+ 
 } /* end namespace CGAL */

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -121,6 +121,7 @@ public:
   using Ctr::update_constraints;
   using Ctr::delete_vertex;
   using Ctr::push_back;
+  using Ctr::mirror_index;
 #endif
 
   typedef typename Geom_traits::Point_2  Point;
@@ -312,7 +313,7 @@ private:
   template <class Tuple_or_pair,class InputIterator>
   std::ptrdiff_t insert_with_info(InputIterator first,InputIterator last)
   {
-    size_type n = this->number_of_vertices();
+    size_type n = number_of_vertices();
     std::vector<std::size_t> indices;
     std::vector<Point> points;
     std::vector<typename Tds::Vertex::Info> infos;
@@ -343,7 +344,7 @@ private:
       }
     }
 
-    return this->number_of_vertices() - n;
+    return number_of_vertices() - n;
   }
 
 public:
@@ -548,7 +549,7 @@ public:
     f=(*itedge).first;
     i=(*itedge).second;
     if (is_flipable(f,i)) {
-      eni=Edge(f->neighbor(i),this->mirror_index(f,i));
+      eni=Edge(f->neighbor(i),mirror_index(f,i));
       if (less_edge(*itedge,eni)) edge_set.insert(*itedge);
       else edge_set.insert(eni);
     }
@@ -565,7 +566,7 @@ public:
     // f->neighbor(indf) that are distinct from the edge to be flipped
 
     ni = f->neighbor(indf); 
-    indn=this->mirror_index(f,indf);
+    indn=mirror_index(f,indf);
     ei= Edge(f,indf);
     edge_set.erase(ei);
     e[0]= Edge(f,cw(indf));
@@ -576,7 +577,7 @@ public:
     for(i=0;i<4;i++) { 
       ff=e[i].first;
       ii=e[i].second;
-      eni=Edge(ff->neighbor(ii),this->mirror_index(ff,ii));
+      eni=Edge(ff->neighbor(ii),mirror_index(ff,ii));
       if (less_edge(e[i],eni)) {edge_set.erase(e[i]);}
       else { edge_set.erase(eni);} 
     } 
@@ -598,7 +599,7 @@ public:
       ff=e[i].first;
       ii=e[i].second;
       if (is_flipable(ff,ii)) {
-	eni=Edge(ff->neighbor(ii),this->mirror_index(ff,ii));
+	eni=Edge(ff->neighbor(ii),mirror_index(ff,ii));
 	if (less_edge(e[i],eni)) { 
 	  edge_set.insert(e[i]);}
 	else {
@@ -643,17 +644,17 @@ Constrained_Delaunay_triangulation_2<Gt,Tds,Itag>::
 flip (Face_handle& f, int i)
 {
   Face_handle g = f->neighbor(i);
-  int j = this->mirror_index(f,i);
+  int j = mirror_index(f,i);
 
   // save wings neighbors to be able to restore contraint status
   Face_handle f1 = f->neighbor(cw(i));
-  int i1 = this->mirror_index(f,cw(i));
+  int i1 = mirror_index(f,cw(i));
   Face_handle f2 = f->neighbor(ccw(i));
-  int i2 = this->mirror_index(f,ccw(i));
+  int i2 = mirror_index(f,ccw(i));
   Face_handle f3 = g->neighbor(cw(j));
-  int i3 = this->mirror_index(g,cw(j));
+  int i3 = mirror_index(g,cw(j));
   Face_handle f4 = g->neighbor(ccw(j));
-  int i4 = this->mirror_index(g,ccw(j));
+  int i4 = mirror_index(g,ccw(j));
 
   // The following precondition prevents the test suit 
   // of triangulation to work on constrained Delaunay triangulation
@@ -663,13 +664,13 @@ flip (Face_handle& f, int i)
   // restore constraint status
   f->set_constraint(f->index(g), false);
   g->set_constraint(g->index(f), false);
-  f1->neighbor(i1)->set_constraint(this->mirror_index(f1,i1),
+  f1->neighbor(i1)->set_constraint(mirror_index(f1,i1),
 				   f1->is_constrained(i1));
-  f2->neighbor(i2)->set_constraint(this->mirror_index(f2,i2),
+  f2->neighbor(i2)->set_constraint(mirror_index(f2,i2),
 				   f2->is_constrained(i2));
-  f3->neighbor(i3)->set_constraint(this->mirror_index(f3,i3),
+  f3->neighbor(i3)->set_constraint(mirror_index(f3,i3),
 				   f3->is_constrained(i3));
-  f4->neighbor(i4)->set_constraint(this->mirror_index(f4,i4),
+  f4->neighbor(i4)->set_constraint(mirror_index(f4,i4),
 				   f4->is_constrained(i4));
   return;
 }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -144,6 +144,11 @@ public:
   using Triangulation::includes_edge;
   using Triangulation::remove_first;
   using Triangulation::remove_second;
+  using Triangulation::is_valid;
+  using Triangulation::all_edges_begin;
+  using Triangulation::all_edges_end;
+  using Triangulation::mirror_index;
+  using Triangulation::orientation;
 #endif
 
   typedef Gt                                 Geom_traits;
@@ -178,7 +183,7 @@ public:
     for( ;lcit != lc.end(); lcit++) {
       insert( (*lcit).first, (*lcit).second);
     }
-     CGAL_triangulation_postcondition( this->is_valid() );
+     CGAL_triangulation_postcondition( is_valid() );
   }
 
   template<class InputIterator>
@@ -190,7 +195,7 @@ public:
     for ( ; it != last; it++) {
       	insert_constraint((*it).first, (*it).second);
       }
-      CGAL_triangulation_postcondition( this->is_valid() );
+      CGAL_triangulation_postcondition( is_valid() );
   }
 
   //TODO Is that destructor correct ?
@@ -201,16 +206,16 @@ public:
   {
     Is_constrained pred(*this);
     return Constrained_edges_iterator(pred,
-                                      this->all_edges_begin(),
-                                      this->all_edges_end());
+                                      all_edges_begin(),
+                                      all_edges_end());
   }
 
   Constrained_edges_iterator constrained_edges_end() const
   {
     Is_constrained pred(*this);
     return Constrained_edges_iterator(pred,
-                                      this->all_edges_end(),
-                                      this->all_edges_end());
+                                      all_edges_end(),
+                                      all_edges_end());
   }
 
   // INSERTION
@@ -588,7 +593,7 @@ public:
       fc->set_constraint(cw(vindex), false);
       fc->set_constraint(ccw(vindex), false);
       fh = fc->neighbor(vindex);
-      ih = this->mirror_index(fc,vindex);
+      ih = mirror_index(fc,vindex);
       fc->set_constraint(vindex, fh->is_constrained(ih));
     } while (++fc != done);
     return v;
@@ -806,7 +811,7 @@ find_intersected_faces(Vertex_handle vaa,
   // loop over triangles intersected by ab
   bool done = false;
   while (current_vertex != vbb && !done)  { 
-    orient = this->orientation(aa,bb,current_vertex->point());
+    orient = orientation(aa,bb,current_vertex->point());
     int i1, i2;
     switch (orient) {
     case COLLINEAR :  
@@ -993,7 +998,7 @@ update_constraints_incident(Vertex_handle va,
 {
   if (dimension() == 0) return;
   if (dimension()== 1) {
-    Edge_circulator ec=this->incident_edges(va), done(ec);
+    Edge_circulator ec=incident_edges(va), done(ec);
     do {
       ((*ec).first)->set_constraint(2,true);
     }while (++ec != done);
@@ -1001,7 +1006,7 @@ update_constraints_incident(Vertex_handle va,
   else{
     //dimension() ==2
     int cwi, ccwi, indf;
-    Face_circulator fc=this->incident_faces(va), done(fc);  
+    Face_circulator fc=incident_faces(va), done(fc);  
     CGAL_triangulation_assertion(fc != 0);
     do {
       indf = fc->index(va);
@@ -1026,7 +1031,7 @@ Constrained_triangulation_2<Gt,Tds,Itag>::
 clear_constraints_incident(Vertex_handle va)
 // make the edges incident to a newly created vertex unconstrained
 {
- Edge_circulator ec=this->incident_edges(va), done(ec);
+ Edge_circulator ec=incident_edges(va), done(ec);
  Face_handle f;
  int indf;
   if ( ec != 0){
@@ -1035,7 +1040,7 @@ clear_constraints_incident(Vertex_handle va)
       indf = (*ec).second;
       f->set_constraint(indf,false);
       if (dimension() == 2) {
-	f->neighbor(indf)->set_constraint(this->mirror_index(f,indf),false);
+	f->neighbor(indf)->set_constraint(mirror_index(f,indf),false);
       }
     } while (++ec != done);
   }
@@ -1055,7 +1060,7 @@ update_constraints_opposite(Vertex_handle va)
   int indf;
   do {
     indf = f->index(va);
-    if (f->neighbor(indf)->is_constrained(this->mirror_index(f,indf)) ) {
+    if (f->neighbor(indf)->is_constrained(mirror_index(f,indf)) ) {
       f->set_constraint(indf,true);
     }
     else {
@@ -1078,8 +1083,8 @@ update_constraints( const List_edges &hole)
     f =(*it).first;
     i = (*it).second;
     if ( f->is_constrained(i) ) 
-      (f->neighbor(i))->set_constraint(this->mirror_index(f,i),true);
-    else (f->neighbor(i))->set_constraint(this->mirror_index(f,i),false);
+      (f->neighbor(i))->set_constraint(mirror_index(f,i),true);
+    else (f->neighbor(i))->set_constraint(mirror_index(f,i),false);
   }
 }
 
@@ -1092,7 +1097,7 @@ mark_constraint(Face_handle fr, int i)
   if (dimension()==1) fr->set_constraint(2, true);
   else{
     fr->set_constraint(i,true);
-    fr->neighbor(i)->set_constraint(this->mirror_index(fr,i),true);
+    fr->neighbor(i)->set_constraint(mirror_index(fr,i),true);
   }
   return;
 }
@@ -1206,7 +1211,7 @@ remove_constrained_edge(Face_handle f, int i)
 {
   f->set_constraint(i, false);
   if (dimension() == 2)
-    (f->neighbor(i))->set_constraint(this->mirror_index(f,i), false);
+    (f->neighbor(i))->set_constraint(mirror_index(f,i), false);
   return;
 }
 
@@ -1291,28 +1296,28 @@ triangulate_half_hole(List_edges & list_edges,  List_edges & new_edges)
       // in case n1 is no longer a triangle of the new triangulation
       if ( n1->neighbor(ind1) != Face_handle() ) {
 	n=n1->neighbor(ind1);
-	//ind=this->mirror_index(n1,ind1); 
+	//ind=mirror_index(n1,ind1); 
 	// mirror_index does not work in this case
 	ind = cw(n->index(n1->vertex(cw(ind1))));
 	n1=n->neighbor(ind); 
-	ind1= this->mirror_index(n,ind);
+	ind1= mirror_index(n,ind);
       }
       n2=(*next).first;
       ind2=(*next).second;
       // in case n2 is no longer a triangle of the new triangulation
       if (n2->neighbor(ind2) != Face_handle() ) {
 	n=n2->neighbor(ind2); 
-	// ind=this->mirror_index(n2,ind2);
+	// ind=mirror_index(n2,ind2);
 	// mirror_index does not work in this case
 	ind = cw(n->index(n2->vertex(cw(ind2))));
 	n2=n->neighbor(ind); 
-	ind2= this->mirror_index(n,ind);
+	ind2= mirror_index(n,ind);
       }
 
       Vertex_handle v0=n1->vertex(ccw(ind1));
       Vertex_handle v1=n1->vertex(cw(ind1));
       Vertex_handle v2=n2->vertex(cw(ind2));
-      orient = this->orientation(v0->point(),v1->point(),v2->point());
+      orient = orientation(v0->point(),v1->point(),v2->point());
       switch (orient) {
       case RIGHT_TURN : 	  		
 	// creates the new triangle v0v1v2

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -607,7 +607,7 @@ public:
     os << static_cast<const Tr&>(*this);
     Unique_hash_map<Vertex_handle,int> V;
     int inum = 0;
-    for(Vertex_iterator vit= vertices_begin(); vit != vertices_end() ; ++vit){
+    for(Vertex_iterator vit= this->vertices_begin(); vit != this->vertices_end() ; ++vit){
       if(! is_infinite(vit)){
         V[vit] = inum++;
       }
@@ -633,7 +633,7 @@ public:
     
     std::vector<Vertex_handle> V;
     V.reserve(this->number_of_vertices());
-    for(Vertex_iterator vit= vertices_begin(); vit != vertices_end() ; ++vit){
+    for(Vertex_iterator vit= this->vertices_begin(); vit != this->vertices_end() ; ++vit){
       if(! is_infinite(vit)){
         V.push_back(vit);
       }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -134,6 +134,14 @@ public:
   typedef Constrained_triangulation_plus_2<Tr_> Self;
   typedef Tr                                   Base;
 
+  
+#ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
+  using Triangulation::vertices_begin;
+  using Triangulation::vertices_end;
+  using Triangulation::is_infinite;
+  using Triangulation::number_of_vertices;
+#endif
+
   typedef typename Triangulation::Edge             Edge;
   typedef typename Triangulation::Vertex           Vertex;
   typedef typename Triangulation::Vertex_handle    Vertex_handle;
@@ -607,7 +615,7 @@ public:
     os << static_cast<const Tr&>(*this);
     Unique_hash_map<Vertex_handle,int> V;
     int inum = 0;
-    for(Vertex_iterator vit= this->vertices_begin(); vit != this->vertices_end() ; ++vit){
+    for(Vertex_iterator vit = vertices_begin(); vit != vertices_end() ; ++vit){
       if(! is_infinite(vit)){
         V[vit] = inum++;
       }
@@ -632,8 +640,8 @@ public:
     is >> static_cast<Tr&>(*this);
     
     std::vector<Vertex_handle> V;
-    V.reserve(this->number_of_vertices());
-    for(Vertex_iterator vit= this->vertices_begin(); vit != this->vertices_end() ; ++vit){
+    V.reserve(number_of_vertices());
+    for(Vertex_iterator vit = vertices_begin(); vit != vertices_end() ; ++vit){
       if(! is_infinite(vit)){
         V.push_back(vit);
       }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -722,8 +722,6 @@ public:
 
   Vertices_in_constraint_iterator vertices_in_constraint_begin(Constraint_id cid) const;
   Vertices_in_constraint_iterator vertices_in_constraint_end(Constraint_id cid) const ;  
-  Vertices_in_constraint_iterator vertices_in_constraint_begin(Vertex_handle va, Vertex_handle vb) const;
-  Vertices_in_constraint_iterator vertices_in_constraint_end(Vertex_handle va, Vertex_handle vb) const ;
   Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
   Points_in_constraint_iterator points_in_constraint_end(Constraint_id cid) const ;
 
@@ -1205,23 +1203,6 @@ Constrained_triangulation_plus_2<Tr>::
 vertices_in_constraint_end(Constraint_id cid) const
 {
   return  hierarchy.vertices_in_constraint_end(cid);
-}
-template <class Tr>
-inline
-typename Constrained_triangulation_plus_2<Tr>::Vertices_in_constraint_iterator
-Constrained_triangulation_plus_2<Tr>::
-vertices_in_constraint_begin(Vertex_handle va, Vertex_handle vb) const
-{
-  return  hierarchy.vertices_in_constraint_begin(va,vb);
-}
-
-template <class Tr>
-inline
-typename Constrained_triangulation_plus_2<Tr>::Vertices_in_constraint_iterator
-Constrained_triangulation_plus_2<Tr>::
-vertices_in_constraint_end(Vertex_handle va, Vertex_handle vb) const
-{
-  return  hierarchy.vertices_in_constraint_end(va,vb);
 }
 
 template <class Tr>

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -661,11 +661,7 @@ public:
     remove_constraint(cid, Emptyset_iterator());
   }
 
-  void remove_constraint(Vertex_handle va, Vertex_handle vb)
-  {
-    hierarchy.remove_constraint(va,vb);
-  }
-
+ 
   void simplify(Vertices_in_constraint_iterator v)
   {
     Vertices_in_constraint_iterator u = boost::prior(v);

--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -130,6 +130,7 @@ public:
   using Base::test_dim_down;
   using Base::oriented_side;
   using Base::compare_x;
+  using Base::compare_y;
 #endif
 
 private:

--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -97,6 +97,7 @@ public:
   using Base::dimension;
   using Base::geom_traits;
   using Base::infinite_vertex;
+  using Base::finite_vertex;
   using Base::create_face;
   using Base::number_of_faces;
   using Base::all_faces_begin;
@@ -121,12 +122,14 @@ public:
   using Base::is_infinite;
   using Base::degree;
   using Base::delete_vertex;
+  using Base::delete_face;
   using Base::incident_vertices;
   using Base::make_hole;
   using Base::mirror_index;
   using Base::show_vertex;
   using Base::test_dim_down;
   using Base::oriented_side;
+  using Base::compare_x;
 #endif
 
 private:
@@ -1840,10 +1843,10 @@ update_hidden_points_2_2(const Face_handle& f1, const Face_handle& f2)
     const Weighted_point& a1 = f1->vertex(f1->index(f2))->point();
     const Weighted_point& a  = f1->vertex(1-f1->index(f2))->point();
     while(! p_list.empty()) {
-      if(this->compare_x(a, p_list.front()->point()) ==
-           this->compare_x(a, a1)  &&
-           this->compare_y(a, p_list.front()->point()) ==
-           this->compare_y(a, a1))
+      if(compare_x(a, p_list.front()->point()) ==
+           compare_x(a, a1)  &&
+           compare_y(a, p_list.front()->point()) ==
+           compare_y(a, a1))
       {
         hide_vertex(f1, p_list.front());
       } else {
@@ -2163,7 +2166,7 @@ stack_flip_dim1(Face_handle f, int i, Faces_around_stack &faces_around)
   n->neighbor(1-in)->set_neighbor(n->neighbor(1-in)->index(n), f);
  (f->vertex_list()).splice(f->vertex_list().begin(),n->vertex_list());
   set_face(f->vertex_list(),f);
-  this->delete_face(n);
+  delete_face(n);
   hide_vertex(f,va);
   faces_around.push_front(f);
   return;
@@ -2243,13 +2246,13 @@ nearest_power_vertex(const Bare_point& p) const
 {
   if(dimension() == -1) { return Vertex_handle(); }
 
-  if(dimension() == 0) { return this->finite_vertex(); }
+  if(dimension() == 0) { return finite_vertex(); }
 
   typename Geom_traits::Compare_power_distance_2 cmp_power_distance =
       geom_traits().compare_power_distance_2_object();
 
   Vertex_handle vclosest;
-  Vertex_handle v = this->finite_vertex();
+  Vertex_handle v = finite_vertex();
 
   //  if(dimension() == 1) {
   //  }

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -2141,7 +2141,7 @@ move_if_no_collision(Vertex_handle v, const Point &p)
   fill_hole(v, hole);
 
   // fixing pointer
-  Face_circulator fc = this->incident_faces(inserted), done(fc);
+  Face_circulator fc = incident_faces(inserted), done(fc);
   std::vector<Face_handle> faces_pt;
   faces_pt.reserve(16);
   do { faces_pt.push_back(fc); } while(++fc != done);
@@ -2280,7 +2280,7 @@ move_if_no_collision_and_give_new_faces(Vertex_handle v,
   make_hole(v, hole, faces_set);
   fill_hole(v, hole, oif);
 
-  fc = this->incident_faces(inserted), done(fc);
+  fc = incident_faces(inserted), done(fc);
   std::vector<Face_handle> faces_pt;
   faces_pt.reserve(16);
   do { faces_pt.push_back(fc); } while (++fc != done);

--- a/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
@@ -86,6 +86,8 @@ class Triangulation_hierarchy_2
 
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
   using Tr_Base::geom_traits;
+  using Tr_Base::number_of_vertices;
+  using Tr_Base::is_infinite;
 #endif
 
  private:
@@ -130,7 +132,7 @@ public:
   template < class InputIterator >
   std::ptrdiff_t insert(InputIterator first, InputIterator last)
   {
-    std::ptrdiff_t n = this->number_of_vertices();
+    std::ptrdiff_t n = number_of_vertices();
 
       std::vector<Point> points (first, last);
 
@@ -168,7 +170,7 @@ public:
               prev = v;
           }
       }
-      std::ptrdiff_t m = this->number_of_vertices();
+      std::ptrdiff_t m = number_of_vertices();
       return m - n;
   }
 
@@ -583,7 +585,7 @@ template <class Tr>
 typename Triangulation_hierarchy_2<Tr>::Vertex_handle
 Triangulation_hierarchy_2<Tr>::
 move(Vertex_handle v, const Point &p) {
-  CGAL_triangulation_precondition(!this->is_infinite(v));
+  CGAL_triangulation_precondition(!is_infinite(v));
   Vertex_handle w = move_if_no_collision(v,p);
   if(w != v) {
     remove(v);
@@ -716,10 +718,10 @@ locate_in_all(const Point& p,
   Vertex_handle nearest;
   int level  = Triangulation_hierarchy_2__maxlevel;
   typename Geom_traits::Compare_distance_2
-    closer = this->geom_traits().compare_distance_2_object();
+    closer = geom_traits().compare_distance_2_object();
 
   typename Geom_traits::Construct_point_2
-    construct_point = this->geom_traits().construct_point_2_object();
+    construct_point = geom_traits().construct_point_2_object();
   
   // find the highest level with enough vertices that is at the same time 2D
   while ( (hierarchy[--level]->number_of_vertices() 

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
@@ -100,20 +100,19 @@ _test_cls_const_triang_plus_2( const TrP & )
 
   //test remove_constraint
   std::cout << " test removal of constraint" << std::endl;
-  trp.remove_constraint(vh[10],vh[11]);
-  trp.remove_constraint(vh[6],vh[7]);
+  trp.remove_constraint(cid);
 
   std::cerr << " test a special configuration" << std::endl;
   trp.clear();
   Vertex_handle v1 = trp.insert(Point(0, 0));
   Vertex_handle v2 = trp.insert(Point(-1, 0));
   Vertex_handle v3 = trp.insert(Point(1, 0));
-  trp.insert_constraint(v1, v2);
-  trp.insert_constraint(v2, v3);
-  trp.insert_constraint(v3, v1);
-  trp.remove_constraint(v1, v2);
-  trp.remove_constraint(v2, v3);
-  trp.remove_constraint(v3, v1);
+  Constraint_id cid1 = trp.insert_constraint(v1, v2);
+  Constraint_id cid2 = trp.insert_constraint(v2, v3);
+  Constraint_id cid3 = trp.insert_constraint(v3, v1);
+  trp.remove_constraint(cid1);
+  trp.remove_constraint(cid2);
+  trp.remove_constraint(cid3);
 
   std::cerr << " test the configuration of bug #2999" << std::endl;
   trp.clear();

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
@@ -14,6 +14,7 @@ _test_cls_const_triang_plus_2( const TrP & )
   typedef typename TrP::Context                Context;
   typedef typename TrP::Context_iterator       Context_iterator;
   typedef typename TrP::Vertices_in_constraint Vertices_in_constraint;
+  typedef typename TrP::Constraint_id          Constraint_id;
 
   CGAL_USE_TYPE(Hierarchy);
   CGAL_USE_TYPE(Context);
@@ -34,8 +35,9 @@ _test_cls_const_triang_plus_2( const TrP & )
   for(int i=0; i<12; i++){
     vh[i] = trp.insert(pt[i]);
   }
+  Constraint_id cid;
   for(int j=0; j<11; j+=2){
-     trp.insert_constraint(vh[j],vh[j+1]);
+     cid = trp.insert_constraint(vh[j],vh[j+1]);
   }
 
   trp.insert(Point(4,4), Point(4,5));
@@ -44,12 +46,12 @@ _test_cls_const_triang_plus_2( const TrP & )
 
   // test access to the hierarchy
   std::cout << " test acces to the constraint hierarchy" << std::endl;
-  Vertices_in_constraint vit = trp.vertices_in_constraint_begin(vh[10],vh[11]);
+  Vertices_in_constraint vit = trp.vertices_in_constraint_begin(cid);
   assert (*vit == vh[10] || *vit == vh[11] );
   Vertex_handle va = *++vit;
   Vertex_handle vb = *++vit;
   assert (*++vit == vh[11] || *vit == vh[10]);
-  assert (++vit == trp.vertices_in_constraint_end(vh[10],vh[11]));
+  assert (++vit == trp.vertices_in_constraint_end(cid));
   assert(trp.number_of_enclosing_constraints(va,vb) == 2);
   Context_iterator cit1 = trp.contexts_begin(va,vb);
   Context_iterator cit2 = cit1++;

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
@@ -10,6 +10,7 @@ _test_cls_const_triang_plus_2( const TrP & )
 
   typedef typename TrP::Vertex_handle          Vertex_handle;
   typedef typename TrP::Constraint             Constraint;
+  typedef typename TrP::Constraint_iterator    Constraint_iterator;
   typedef typename TrP::Constraint_hierarchy   Hierarchy;
   typedef typename TrP::Context                Context;
   typedef typename TrP::Context_iterator       Context_iterator;
@@ -129,6 +130,31 @@ _test_cls_const_triang_plus_2( const TrP & )
   }
 
   std::cout << std::endl;
+  std::cout << "test IO" << std::endl;
+
+  trp.clear();
+  {
+    Point c1[2] = { Point(0,0), Point(1,0) };
+    Point c2[3] = { Point(0,1), Point(1,1), Point(2,1) };
+    Point c3[4] = { Point(0,0), Point(1,0), Point(1,1), Point(0,1) };
+
+    trp.insert_constraint(c1, c1 + 2);
+    trp.insert_constraint(c2, c2 + 3);
+    trp.insert_constraint(c3, c3 + 4);
+    std::ofstream out("cdtplus.txt");
+    out << trp;
+    out.close();
+    trp.clear();
+    std::ifstream in("cdtplus.txt");
+    in >> trp;
+    assert(trp.number_of_constraints() == 3);
+    std::size_t n = 0;
+    for(Constraint_iterator cit = trp.constraints_begin(); cit != trp.constraints_end(); ++cit){
+      Constraint_id  cid = *cit;
+      n += cid.second->all_size();
+    }
+    assert( n == 9);
+  }
   return;
 }
 


### PR DESCRIPTION
## Summary of Changes

So far we only write/read the underlying constrained triangulation. The fact that constraints consist of subconstraints was lost.   

I based this PR  on #3890 

## Release Management

* Affected package(s): Triangulation_2


