### PR TITLE
Document that Qt 5.9 or later is required

### DIFF
--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -468,7 +468,7 @@ The exhaustive list of \sc{Qt}5 components used in demos is:
 `Core`, `Gui`, `Help`, `OpenGL`, `Script`, `ScriptTools`, `Svg`, `Widgets`,
 `qcollectiongenerator` (with `sqlite` driver plugin) and `Xml`.
 
-Having \sc{Qt}5 version 5.3.0 is recommended.
+The minimal version of \sc{Qt}5 is version 5.9.0.
 
 \section installation_examples CGAL Examples and Demos
 

--- a/Documentation/doc/Documentation/Installation.txt
+++ b/Documentation/doc/Documentation/Installation.txt
@@ -468,7 +468,7 @@ The exhaustive list of \sc{Qt}5 components used in demos is:
 `Core`, `Gui`, `Help`, `OpenGL`, `Script`, `ScriptTools`, `Svg`, `Widgets`,
 `qcollectiongenerator` (with `sqlite` driver plugin) and `Xml`.
 
-The minimal version of \sc{Qt}5 is version 5.9.0.
+\sc{Qt} version 5.9.0 or later is required.
 
 \section installation_examples CGAL Examples and Demos
 

--- a/Installation/INSTALL.md
+++ b/Installation/INSTALL.md
@@ -60,7 +60,7 @@ CGAL packages, some are only needed for demos.
    * Visualization
      Required for most demos
 
-     - Qt5 (>= 5.3)
+     - Qt5 (>= 5.9)
        http://qt-project.org/
 
      - Geomview


### PR DESCRIPTION
## Summary of Changes

The code of CGAL_Qt5 and CGAL Qt5 demos requires Qt-5.9, but we kept documenting that the minimal version was 5.3. Now, document version 5.9 or later.

## Release Management

* Affected package(s): Installation
* License and copyright ownership: maintenance

