### PR TITLE
PMP: Generalize `keep_large(st)_CCs`

### DIFF
--- a/BGL/include/CGAL/boost/graph/parameters_interface.h
+++ b/BGL/include/CGAL/boost/graph/parameters_interface.h
@@ -82,6 +82,7 @@ CGAL_add_named_parameter(use_compact_clipper_t, use_compact_clipper, use_compact
 CGAL_add_named_parameter(output_iterator_t, output_iterator, output_iterator)
 CGAL_add_named_parameter(erase_all_duplicates_t, erase_all_duplicates, erase_all_duplicates)
 CGAL_add_named_parameter(require_same_orientation_t, require_same_orientation, require_same_orientation)
+CGAL_add_named_parameter(face_size_map_t, face_size_map, face_size_map)
 
 // List of named parameters that we use in the package 'Surface Mesh Simplification'
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)

--- a/BGL/test/BGL/test_cgal_bgl_named_params.cpp
+++ b/BGL/test/BGL/test_cgal_bgl_named_params.cpp
@@ -51,7 +51,6 @@ void test(const NamedParameters& np)
   assert(get_param(np, CGAL::internal_np::vertex_to_vertex_map).v == 800000007);
   assert(get_param(np, CGAL::internal_np::halfedge_to_halfedge_map).v == 800000008);
   assert(get_param(np, CGAL::internal_np::face_to_face_map).v == 800000009);
- 
 
     // Named parameters that we use in the package 'Mesh_3'
   assert(get_param(np, CGAL::internal_np::vertex_feature_degree).v == 9);
@@ -88,6 +87,7 @@ void test(const NamedParameters& np)
   assert(get_param(np, CGAL::internal_np::erase_all_duplicates).v == 48);
   assert(get_param(np, CGAL::internal_np::require_same_orientation).v == 49);
   assert(get_param(np, CGAL::internal_np::use_bool_op_to_clip_surface).v == 50);
+  assert(get_param(np, CGAL::internal_np::face_size_map).v == 52);
 
     // Named parameters that we use in the package 'Surface Mesh Simplification'
   assert(get_param(np, CGAL::internal_np::get_cost_policy).v == 34);
@@ -106,7 +106,6 @@ void test(const NamedParameters& np)
   assert(get_param(np, CGAL::internal_np::projection_functor).v == 42);
   assert(get_param(np, CGAL::internal_np::apply_per_connected_component).v == 46);
   assert(get_param(np, CGAL::internal_np::output_iterator).v == 47);
-
 
   // Test types
 
@@ -169,6 +168,7 @@ void test(const NamedParameters& np)
   check_same_type<48>(get_param(np, CGAL::internal_np::erase_all_duplicates));
   check_same_type<49>(get_param(np, CGAL::internal_np::require_same_orientation));
   check_same_type<50>(get_param(np, CGAL::internal_np::use_bool_op_to_clip_surface));
+  check_same_type<52>(get_param(np, CGAL::internal_np::face_size_map));
 
     // Named parameters that we use in the package 'Surface Mesh Simplification'
   check_same_type<34>(get_param(np, CGAL::internal_np::get_cost_policy));
@@ -253,6 +253,7 @@ int main()
                          .output_iterator(A<47>(47))
                          .erase_all_duplicates(A<48>(48))
                          .require_same_orientation(A<49>(49))
+                         .face_size_map(A<52>(52))
        );
 
   return EXIT_SUCCESS;

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -45,6 +45,11 @@ Release date: September 2019
      `CGAL::Polygon_mesh_processing::stitch_boundary_cycles()`, which can be used
      to try and merge together geometrically compatible but combinatorially different halfedges
      that belong to the same boundary cycle.
+-    It is now possible to pass a face-size property map to `CGAL::Polygon_mesh_processing::keep_large_connected_components()`
+     and `CGAL::Polygon_mesh_processing::keep_largest_connected_components()`, enabling users to define
+     how the size of a face is computed (the size of the connected component is the sum of the sizes of its faces).
+     If no property map is passed, the behavior is unchanged to previous versions: the size
+     of a connected component is the number of faces it contains.
 
 ### IO Streams
  -   **Breaking change:** The API of `CGAL::Color` has been cleaned up.

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_traits_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_regular_triangulation_traits_3.h
@@ -77,7 +77,7 @@ public:
   typedef Functor_with_offset_weighted_points_adaptor_3<Self, typename Kernel::Compare_power_distance_3>
       Compare_power_distance_3;
 
-  // Undocumented, requried for Is_Gabriel (Alpha shapes)
+  // Undocumented, required for Is_Gabriel (Alpha shapes)
   typedef Functor_with_offset_weighted_points_adaptor_3<Self, typename Kernel::Power_side_of_bounded_power_sphere_3>
       Power_side_of_bounded_power_sphere_3;
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -390,6 +390,18 @@ if orientation should matter when determining whether two faces are duplicates.
 <b>Default:</b> `false`
 \cgalNPEnd
 
+\cgalNPBegin{face_size_map} \anchor PMP_face_size_map
+Parameter used in the functions `keep_large_connected_components()` and
+`keep_largest_connected_components()` to pass a property map that gives the size of a face when
+evaluating the size of a connected component (which is defined as the sum of the sizes of its faces).
+
+\n
+<b>Type:</b> a class model of `ReadablePropertyMap` with
+`boost::graph_traits<PolygonMesh>::%face_descriptor` as key type and
+a value type supporting construction from `0`, `operator+=()`, and comparison operators. \n
+<b>Default:</b> `CGAL::Constant_property_map<face_descriptor, std::size_t>` with value `1`
+\cgalNPEnd
+
 \cgalNPTableEnd
 
 */

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -709,11 +709,17 @@ enable the user to keep and remove only a selection of connected components,
 provided either as a range of faces that belong to the desired connected components
 or as a range of connected component ids (one or more per connected component).
 
-Finally, `CGAL::Polygon_mesh_processing::keep_largest_connected_components()`
-enables the user to keep only the largest connected components. This feature can
-for example be useful for noisy data were small connected components
-should be discarded in favour of major connected components.
-
+Finally, it can be useful to quickly remove some connected components, for example for noisy data
+where small connected components should be discarded in favor of major connected components.
+The function `CGAL::Polygon_mesh_processing::keep_largest_connected_components()`
+enables the user to keep only a given number from the largest connected components. The size
+of a connected component is given by the sum of the sizes of the faces it contains; by default,
+the size of a face is `1` and thus the size of a connected component is equal to the number of faces
+it contains. However, it is also possible to pass a face size map, such that the size of the face
+is its area, for example.
+Similarly to the previous function, the function
+`CGAL::Polygon_mesh_processing::keep_large_connected_components()` can be used to discard all connected
+components whose size is below a user-defined threshold.
 
 \subsection CCExample Connected Components Example
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/dependencies
@@ -13,4 +13,5 @@ AABB_tree
 Triangulation_2
 Spatial_sorting
 Generator
+Property_map
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -55,16 +55,16 @@
 
 
 namespace CGAL {
-
 namespace Polygon_mesh_processing{
+namespace internal {
 
-  namespace internal {
-    struct MoreSecond {
-      typedef std::pair<std::size_t,std::size_t> T;
-      bool operator()(const T& a, const T& b) const {
-        return a.second > b.second;
-      }
-    };
+  struct MoreSecond
+  {
+    template <typename T1, typename T2>
+    bool operator()(const std::pair<T1, T2>& a, const std::pair<T1, T2>& b) const {
+      return a.second > b.second;
+    }
+  };
 
     // A property map 
     template <typename G>
@@ -264,11 +264,15 @@ void keep_connected_components(PolygonMesh& pmesh
 
 /*!
  * \ingroup keep_connected_components_grp
- *  removes the small connected components and all isolated vertices.
- *  Keep `nb_components_to_keep` largest connected components. 
+ *
+ * removes the small connected components and all isolated vertices.
+ * Keep the `nb_components_to_keep` largest connected components, where the size of a connected
+ * component is computed as the sum of the individual sizes of all the faces of the connected component.
+ * By default, the size of a face is `1` (and thus the size of a connected component is the number
+ * of faces it contains), but it is also possible to pass custom sizes, such as the area of the face.
  *
  * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
- * must be either available as internal property maps 
+ * must be either available as internal property maps
  * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
  *
  * \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
@@ -282,32 +286,47 @@ void keep_connected_components(PolygonMesh& pmesh
  *    \cgalParamBegin{edge_is_constrained_map} a property map containing the constrained-or-not status of each edge of `pmesh` \cgalParamEnd
  *    \cgalParamBegin{face_index_map} a property map containing the index of each face of `pmesh` \cgalParamEnd
  *    \cgalParamBegin{vertex_index_map} a property map containing the index of each vertex of `pmesh` \cgalParamEnd
+ *    \cgalParamBegin{face_size_map}
+ *      a property map containing a size for each face of `pmesh`. The value type of this property map
+ *      is chosen by the user, but must be constructible from `0` and support `operator+=()` and
+ *      comparisons.
+ *    \cgalParamEnd
  * \cgalNamedParamsEnd
  *
  *  \return the number of connected components removed (ignoring isolated vertices).
  */
-template <typename PolygonMesh
-        , typename NamedParameters>
-std::size_t keep_largest_connected_components(PolygonMesh& pmesh
-                                            , std::size_t nb_components_to_keep
-                                            , const NamedParameters& np)
+template <typename PolygonMesh,
+          typename NamedParameters>
+std::size_t keep_largest_connected_components(PolygonMesh& pmesh,
+                                              std::size_t nb_components_to_keep,
+                                              const NamedParameters& np)
 {
-  typedef PolygonMesh PM;
-  typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
+  typedef PolygonMesh                                                   PM;
+  typedef typename boost::graph_traits<PM>::face_descriptor             face_descriptor;
 
   using boost::choose_param;
   using boost::get_param;
 
-  //FaceIndexMap
-  typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
+  // FaceIndexMap
+  typedef typename GetFaceIndexMap<PM, NamedParameters>::type            FaceIndexMap;
   FaceIndexMap fimap = choose_param(get_param(np, internal_np::face_index),
                                     get_property_map(boost::face_index, pmesh));
 
-  //vector_property_map
+  // FaceSizeMap
+  typedef typename boost::lookup_named_param_def<internal_np::face_size_map_t,
+                                                 NamedParameters,
+                                                 Constant_property_map<face_descriptor, std::size_t> // default
+                                                >::type                  FaceSizeMap;
+  typedef typename boost::property_traits<FaceSizeMap>::value_type       Face_size;
+
+  FaceSizeMap face_size_pmap = choose_param(get_param(np, internal_np::face_size_map),
+                                                Constant_property_map<face_descriptor, std::size_t>(1));
+
+  // vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fimap);
   std::size_t num = connected_components(pmesh, face_cc, np);
 
-  // Even even we do not want to keep anything we need to first
+  // Even if we do not want to keep anything we need to first
   // calculate the number of existing connected_components to get the
   // correct return value.
   if(nb_components_to_keep == 0) {
@@ -318,13 +337,13 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh
   if((num == 1)|| (nb_components_to_keep > num) )
     return 0;
 
-  std::vector< std::pair<std::size_t, std::size_t> > component_size(num);
+  std::vector<std::pair<std::size_t, Face_size> > component_size(num);
 
   for(std::size_t i=0; i < num; i++)
-    component_size[i] = std::make_pair(i,0);
+    component_size[i] = std::make_pair(i, Face_size(0));
 
   for(face_descriptor f : faces(pmesh))
-    ++component_size[face_cc[f]].second;
+    component_size[face_cc[f]].second += get(face_size_pmap, f);
 
   // we sort the range [0, num) by component size
   std::sort(component_size.begin(), component_size.end(), internal::MoreSecond());
@@ -348,61 +367,87 @@ std::size_t keep_largest_connected_components(PolygonMesh& pmesh,
 
 /*!
  * \ingroup keep_connected_components_grp
- *  removes connected components with less than a given number of faces.
+ * removes connected components whose size is (strictly) smaller than a given threshold value,
+ * where the size of a connected component is computed as the sum of the individual sizes
+ * of all the faces of the connected component. By default, the size of a face is `1` (and thus
+ * the size of a connected component is the number of faces it contains), but it is also possible
+ * to pass custom sizes, such as the area of the face.
  *
  * Property maps for `CGAL::face_index_t` and `CGAL::vertex_index_t`
- * must be either available as internal property maps 
+ * must be either available as internal property maps
  * to `pmesh` or provided as \ref pmp_namedparameters "Named Parameters".
  *
  * \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
+ * \tparam ThresholdValueType the type of the threshold value
  * \tparam NamedParameters a sequence of \ref pmp_namedparameters "Named Parameters"
  *
  * \param pmesh the polygon mesh
- * \param threshold_components_to_keep the number of faces a component must have so that it is kept
+ * \param threshold_value any connected component with a size (strictly) smaller than this value will be discarded
  * \param np optional \ref pmp_namedparameters "Named Parameters", amongst those described below
  *
  * \cgalNamedParamsBegin
  *    \cgalParamBegin{edge_is_constrained_map} a property map containing the constrained-or-not status of each edge of `pmesh` \cgalParamEnd
  *    \cgalParamBegin{face_index_map} a property map containing the index of each face of `pmesh` \cgalParamEnd
  *    \cgalParamBegin{vertex_index_map} a property map containing the index of each vertex of `pmesh` \cgalParamEnd
+ *    \cgalParamBegin{face_size_map}
+ *      a property map containing a size for each face of `pmesh`. The value type of this property map
+ *      is chosen by the user, but must be constructible from `0` and support `operator+=()` and
+ *      comparisons.
+ *    \cgalParamEnd
  * \cgalNamedParamsEnd
+ *
+ * \pre If a face size property map is passed by the user, `ThresholdValueType` must be the same
+ *      type as the value type of the property map. Otherwise, `ThresholdValueType` must be `std::size_t`.
  *
  *  \return the number of connected components removed (ignoring isolated vertices).
  */
-template <typename PolygonMesh
-        , typename NamedParameters>
-std::size_t keep_large_connected_components(PolygonMesh& pmesh
-                                            , std::size_t threshold_components_to_keep
-                                            , const NamedParameters& np)
+template <typename PolygonMesh,
+          typename ThresholdValueType,
+          typename NamedParameters>
+std::size_t keep_large_connected_components(PolygonMesh& pmesh,
+                                            const ThresholdValueType threshold_value,
+                                            const NamedParameters& np)
 {
-  typedef PolygonMesh PM;
-  typedef typename boost::graph_traits<PM>::face_descriptor face_descriptor;
+  typedef PolygonMesh                                                     PM;
+  typedef typename boost::graph_traits<PM>::face_descriptor               face_descriptor;
 
   using boost::choose_param;
   using boost::get_param;
 
-  //FaceIndexMap
-  typedef typename GetFaceIndexMap<PM, NamedParameters>::type FaceIndexMap;
+  // FaceIndexMap
+  typedef typename GetFaceIndexMap<PM, NamedParameters>::type             FaceIndexMap;
   FaceIndexMap fim = choose_param(get_param(np, internal_np::face_index),
                                   get_property_map(boost::face_index, pmesh));
 
-  //vector_property_map
+  typedef typename boost::lookup_named_param_def<internal_np::face_size_map_t,
+                                                 NamedParameters,
+                                                 Constant_property_map<face_descriptor, std::size_t> // default
+                                                >::type                   FaceSizeMap;
+  typedef typename boost::property_traits<FaceSizeMap>::value_type        Face_size;
+
+  CGAL_static_assertion((std::is_convertible<ThresholdValueType, Face_size>::value));
+
+  FaceSizeMap face_size_pmap = choose_param(get_param(np, internal_np::face_size_map),
+                                           Constant_property_map<face_descriptor, std::size_t>(1));
+
+  // vector_property_map
   boost::vector_property_map<std::size_t, FaceIndexMap> face_cc(fim);
   std::size_t num = connected_components(pmesh, face_cc, np);
-  std::vector< std::pair<std::size_t, std::size_t> > component_size(num);
+  std::vector<Face_size> component_size(num);
 
-  for(std::size_t i=0; i < num; i++)
-    component_size[i] = std::make_pair(i,0);
+  for(std::size_t i=0; i<num; ++i)
+    component_size[i] = Face_size(0);
 
   for(face_descriptor f : faces(pmesh))
-    ++component_size[face_cc[f]].second;
+    component_size[face_cc[f]] += get(face_size_pmap, f);
 
+  const Face_size thresh = threshold_value;
 
   std::vector<std::size_t> cc_to_keep;
-  for(std::size_t i=0; i<num; ++i){
-    if(component_size[i].second >= threshold_components_to_keep){
-      cc_to_keep.push_back( component_size[i].first );
-    }
+  for(std::size_t i=0; i<num; ++i)
+  {
+    if(component_size[i] >= thresh)
+      cc_to_keep.push_back(i);
   }
 
   keep_connected_components(pmesh, cc_to_keep, face_cc, np);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/connected_component_polyhedron.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/connected_component_polyhedron.cpp
@@ -10,7 +10,7 @@ namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Simple_cartesian<double>                       Kernel;
 typedef Kernel::Point_3                                      Point;
-typedef CGAL::Polyhedron_3<Kernel> Mesh;
+typedef CGAL::Polyhedron_3<Kernel>                           Mesh;
 typedef CGAL::Polyhedron_3<Kernel,CGAL::Polyhedron_items_with_id_3> Mesh_with_id;
 
 void mesh_with_id(const char* argv1, const bool save_output)
@@ -23,19 +23,16 @@ void mesh_with_id(const char* argv1, const bool save_output)
   in >> sm;
 
   int i=0;
-  for(face_descriptor f : faces(sm)){
+  for(face_descriptor f : faces(sm))
     f->id() = i++;
-  } 
+
   i=0;
-  for(vertex_descriptor v : vertices(sm)){
+  for(vertex_descriptor v : vertices(sm))
     v->id() = i++;
-  }
 
   std::vector<face_descriptor> cc;
   face_descriptor fd = *faces(sm).first;
-  PMP::connected_component(fd,
-                           sm,
-                           std::back_inserter(cc));
+  PMP::connected_component(fd, sm, std::back_inserter(cc));
 
   std::cerr << cc.size() << " faces in the CC of " << &*fd << std::endl;
 
@@ -43,14 +40,15 @@ void mesh_with_id(const char* argv1, const bool save_output)
     boost::property_map<Mesh_with_id, boost::face_index_t>::type>
       fccmap(get(boost::face_index,sm));
 
-  std::size_t num = PMP::connected_components(sm,
-                                              fccmap);
+  std::size_t num = PMP::connected_components(sm, fccmap);
   if (strcmp(argv1, "data/blobby_3cc.off") == 0)
     assert(num == 3);
 
   std::cerr << "The graph has " << num << " connected components (face connectivity)" << std::endl;
 
-  PMP::keep_largest_connected_components(sm,2);
+  PMP::keep_largest_connected_components(sm, 2,
+                                         CGAL::parameters::face_size_map(
+                                           CGAL::Constant_property_map<face_descriptor, std::size_t>(1)));
 
   if (!save_output)
     return;
@@ -68,13 +66,9 @@ void mesh_no_id(const char* argv1, const bool save_output)
   std::ifstream in(argv1);
   in >> sm;
 
-  
   std::vector<face_descriptor> cc;
   face_descriptor fd = *faces(sm).first;
-  PMP::connected_component(fd,
-                           sm,
-                           std::back_inserter(cc));
-
+  PMP::connected_component(fd, sm, std::back_inserter(cc));
 
   std::cerr << cc.size() << " faces in the CC of " << &*fd << std::endl;
   boost::property_map<Mesh,boost::vertex_external_index_t>::type vim 
@@ -87,10 +81,8 @@ void mesh_no_id(const char* argv1, const bool save_output)
     boost::property_map<Mesh, boost::face_external_index_t>::type>
       fccmap(fim);
 
-  std::size_t num = PMP::connected_components(sm,
-    fccmap,
-    PMP::parameters::face_index_map(fim));
-  
+  std::size_t num = PMP::connected_components(sm, fccmap, PMP::parameters::face_index_map(fim));
+
   if (strcmp(argv1, "data/blobby_3cc.off") == 0)
     assert(num == 3);
 
@@ -99,11 +91,8 @@ void mesh_no_id(const char* argv1, const bool save_output)
   //  std::cout  << &*f << " in connected component " << fccmap[f] << std::endl;
   //}
 
-  PMP::keep_largest_connected_components(sm
-    , 2
-    , PMP::parameters::vertex_index_map(vim).
-      face_index_map(fim));
-
+  PMP::keep_largest_connected_components(sm, 2, PMP::parameters::vertex_index_map(vim)
+                                                                .face_index_map(fim));
   if (save_output)
     return;
 
@@ -125,6 +114,7 @@ void test_border_cases()
   std::size_t i=0;
   for(face_descriptor f : faces(sm))
     f->id() = i++;
+
   i=0;
   for(vertex_descriptor v : vertices(sm))
     v->id() = i++;
@@ -170,13 +160,12 @@ void keep_nothing(const char* argv1)
     return;
   }
   int i=0;
-  for(face_descriptor f : faces(sm)){
+  for(face_descriptor f : faces(sm))
     f->id() = i++;
-  }
+
   i=0;
-  for(vertex_descriptor v : vertices(sm)){
+  for(vertex_descriptor v : vertices(sm))
     v->id() = i++;
-  }
 
   PMP::keep_largest_connected_components(sm, 0);
   assert(num_vertices(sm) == 0);
@@ -193,5 +182,6 @@ int main(int argc, char* argv[])
   mesh_no_id(filename, save_output);
   test_border_cases();
   keep_nothing(filename);
-  return 0;
+
+  return EXIT_SUCCESS;
 }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/connected_component_surface_mesh.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/connected_component_surface_mesh.cpp
@@ -1,7 +1,11 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/Polygon_mesh_processing/connected_components.h>
+
 #include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Polygon_mesh_processing/connected_components.h>
+#include <CGAL/property_map.h>
+#include <CGAL/internal/boost/function_property_map.hpp>
+
 #include <iostream>
 #include <fstream>
 #include <cstring>
@@ -13,86 +17,97 @@ typedef Kernel::Point_3                    Point;
 typedef Kernel::Compare_dihedral_angle_3   Compare_dihedral_angle_3;
 typedef CGAL::Surface_mesh<Point>          Mesh;
 
+template <typename G, typename GT>
+struct Constraint
+  : public boost::put_get_helper<bool, Constraint<G, GT> >
+{
+  typedef typename GT::FT                                  FT;
 
-template <typename G>
-struct Constraint : public boost::put_get_helper<bool,Constraint<G> >{
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
-  typedef boost::readable_property_map_tag      category;
-  typedef bool                                  value_type;
-  typedef bool                                  reference;
-  typedef edge_descriptor                       key_type;
+  typedef boost::readable_property_map_tag                 category;
+  typedef bool                                             value_type;
+  typedef bool                                             reference;
+  typedef edge_descriptor                                  key_type;
 
-  Constraint()
-    :g(NULL)
-  {}
+  Constraint() : g(nullptr), gt(nullptr), bound(0) {}
+  Constraint(const G& g, const GT& gt, const FT bound) : g(&g), gt(&gt), bound(bound) {}
 
-  Constraint(G & g, double bound)
-    : g(&g), bound(bound)
-  {}
+  bool operator[](const edge_descriptor e) const
+  {
+    const Mesh& rg = *g;
 
-  bool operator[](edge_descriptor e) const {
-    return compare((*g).point(source(e,*g)),
-                   (*g).point(target(e,*g)),
-                   (*g).point(target(next(halfedge(e,*g),*g),*g)),
-                   (*g).point(target(next(opposite(halfedge(e,*g),*g),*g),*g)),
-                   bound) == CGAL::SMALLER;
+    return gt->compare_dihedral_angle_3_object()(
+             rg.point(source(e, rg)),
+             rg.point(target(e, rg)),
+             rg.point(target(next(halfedge(e, rg), rg), rg)),
+             rg.point(target(next(opposite(halfedge(e, rg), rg), rg), rg)),
+          bound) == CGAL::SMALLER;
   }
 
-  G* g;
-  Compare_dihedral_angle_3 compare;
-  double bound;
+  const G* g;
+  const GT* gt;
+  FT bound;
 };
 
-
-int main(int argc, char* argv[])
+template <typename G, typename GT>
+struct Face_descriptor_area_functor
 {
+  typedef typename boost::graph_traits<G>::face_descriptor     face_descriptor;
 
-  typedef boost::graph_traits<Mesh>::face_descriptor face_descriptor;
-  const double bound = std::cos(0.7* CGAL_PI);
-  const char* filename = (argc > 1) ? argv[1] : "data/blobby_3cc.off";
-  Mesh sm;
-  std::ifstream in(filename);
-  in >> sm;
+  Face_descriptor_area_functor(const G& g, const GT& gt) : g(g), gt(gt) { }
 
-  std::cout << "VEF " << num_vertices(sm) << " " << num_edges(sm) << " " << num_faces(sm) << "\n";
+  typename GT::FT operator()(const face_descriptor f) const
+  {
+    const auto& vpm = get(CGAL::vertex_point, g);
+
+    return gt.compute_area_3_object()(get(vpm, source(halfedge(f, g), g)),
+                                      get(vpm, target(halfedge(f, g), g)),
+                                      get(vpm, target(next(halfedge(f, g), g), g)));
+  }
+
+  const G& g;
+  const GT& gt;
+};
+
+void test_CC_with_default_size_map(Mesh sm,
+                                   const Kernel& k)
+{
+  std::cout << " -- test with default size map -- " << std::endl;
+
+  typedef boost::graph_traits<Mesh>::face_descriptor                      face_descriptor;
+  typedef Kernel::FT                                                      FT;
+
+  const FT bound = std::cos(0.7 * CGAL_PI);
 
   std::vector<face_descriptor> cc;
   face_descriptor fd = *faces(sm).first;
-  CGAL::Polygon_mesh_processing::connected_component(fd,
-                                                     sm,
-                                                     std::back_inserter(cc));
+  CGAL::Polygon_mesh_processing::connected_component(fd, sm, std::back_inserter(cc));
 
   std::cerr << "connected components without edge constraints" << std::endl;
   std::cerr << cc.size() << " faces in the CC of " << fd << std::endl;
-  if (strcmp(filename, "data/blobby_3cc.off") == 0)
-    assert(cc.size() == 1452);
+  assert(cc.size() == 1452);
 
   std::cerr << "\nconnected components with edge constraints (dihedral angle < 3/4 pi)" << std::endl;
   Mesh::Property_map<face_descriptor,std::size_t> fccmap;
-  fccmap = sm.add_property_map<face_descriptor,std::size_t>("f:CC").first;
-  std::size_t num =
-    PMP::connected_components(sm,
-      fccmap
-    );
+  fccmap = sm.add_property_map<face_descriptor, std::size_t>("f:CC").first;
+  std::size_t num = PMP::connected_components(sm, fccmap);
 
- std::cerr << "The graph has " << num << " connected components (face connectivity)" << std::endl;
- if (strcmp(filename, "data/blobby_3cc.off") == 0)
-   assert(num == 3);
+  std::cerr << "The graph has " << num << " connected components (face connectivity)" << std::endl;
+  assert(num == 3);
 
- std::vector<face_descriptor> one_face_per_cc(num);
- std::vector<std::size_t> cc_size(num,0);
+  std::vector<face_descriptor> one_face_per_cc(num);
+  std::vector<std::size_t> cc_size(num,0);
 
-
- for(face_descriptor f : faces(sm)){
- //  std::cout  << f << " in connected component " << fccmap[f] << std::endl;
+  for(face_descriptor f : faces(sm))
+  {
+    //    std::cout  << f << " in connected component " << fccmap[f] << std::endl;
     std::size_t ccid=fccmap[f];
     if (++cc_size[ccid]==1)
       one_face_per_cc[ccid]=f;
- }
+  }
 
-  std::size_t id_of_cc_to_remove =
-    std::distance(cc_size.begin(),
-                  std::min_element(cc_size.begin(), cc_size.end()));
+  std::size_t id_of_cc_to_remove = std::distance(cc_size.begin(),
+                                                 std::min_element(cc_size.begin(), cc_size.end()));
 
   Mesh copy1 = sm;
   Mesh copy2 = sm;
@@ -102,18 +117,21 @@ int main(int argc, char* argv[])
   for (std::size_t i=0;i<num;++i)
     if (i!=id_of_cc_to_remove)
       ff.push_back(one_face_per_cc[i]);
+
+  // default face size map, but explicitely passed
   PMP::keep_connected_components(copy1, ff,
-     PMP::parameters::edge_is_constrained_map(Constraint<Mesh>(copy1, bound)));
+     PMP::parameters::edge_is_constrained_map(Constraint<Mesh, Kernel>(copy1, k, bound))
+                     .face_size_map(CGAL::Constant_property_map<face_descriptor, std::size_t>(1)));
 
   // remove cc from copy2
   ff.clear();
   ff.push_back(one_face_per_cc[id_of_cc_to_remove]);
   PMP::remove_connected_components(copy2, ff,
-     PMP::parameters::edge_is_constrained_map(Constraint<Mesh>(copy2, bound)));
+     PMP::parameters::edge_is_constrained_map(Constraint<Mesh, Kernel>(copy2, k, bound)));
 
   std::cerr << "We keep the " << num-1 << " largest components" << std::endl;
   PMP::keep_largest_connected_components(sm, num-1,
-    PMP::parameters::edge_is_constrained_map(Constraint<Mesh>(sm, bound)));
+    PMP::parameters::edge_is_constrained_map(Constraint<Mesh, Kernel>(sm, k, bound)));
 
   sm.collect_garbage();
   copy1.collect_garbage();
@@ -130,9 +148,58 @@ int main(int argc, char* argv[])
     CGAL::make_triangle(p,q,r,m);
     CGAL::make_tetrahedron(p,q,r,s,m);
     PMP::keep_large_connected_components(m, 4);
-    m.collect_garbage();
-    assert( num_vertices(m) == 8);
-  }
 
-  return 0;
+    assert(vertices(m).size() == 8);
+  }
+}
+
+void test_CC_with_area_size_map(Mesh sm,
+                                const Kernel& k)
+{
+  std::cout << " -- test with area size map -- " << std::endl;
+
+  typedef boost::graph_traits<Mesh>::face_descriptor                      face_descriptor;
+
+  Face_descriptor_area_functor<Mesh, Kernel> f(sm, k);
+
+  std::cout << "We keep the " << 2 << " largest components" << std::endl;
+  PMP::keep_largest_connected_components(sm, 2,
+                                         PMP::parameters::face_size_map(
+                                           CGAL::internal::boost_::make_function_property_map<face_descriptor>(f)));
+  assert(vertices(sm).size() == 1459);
+
+  {
+    Mesh m;
+
+    Point p(0,0,0), q(1,0,0), r(0,1,0), s(0,0,1);
+    CGAL::make_tetrahedron(p,q,r,s,m);
+    CGAL::make_tetrahedron(p,q,r,s,m);
+
+    Point t(100,100,100);
+    CGAL::make_triangle(p,q,t,m);
+
+    Face_descriptor_area_functor<Mesh, Kernel> f(m, k);
+    PMP::keep_large_connected_components(m, 10,
+                                         CGAL::parameters::face_size_map(
+                                           CGAL::internal::boost_::make_function_property_map<face_descriptor>(f)));
+    assert(vertices(m).size() == 3);
+  }
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+  const char* filename = "data/blobby_3cc.off";
+  Mesh sm;
+  std::ifstream in(filename);
+  assert(in.good());
+  in >> sm;
+
+  Kernel k;
+
+  std::cout << "VEF " << num_vertices(sm) << " " << num_edges(sm) << " " << num_faces(sm) << "\n";
+
+  test_CC_with_default_size_map(sm, k);
+  test_CC_with_area_size_map(sm, k);
+
+  return EXIT_SUCCESS;
 }

--- a/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_3.h
+++ b/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_3.h
@@ -1473,6 +1473,11 @@ public:
     Returns the number of connected components erased (ignoring isolated vertices). 
 
     The polyhedron type must support vertices, halfedges, and removal operations.
+
+    Note that a stronger version of this function is offered by the package \ref PkgPolygonMeshProcessing :
+    \link Polygon_mesh_processing::keep_largest_connected_components() `CGAL::Polygon_mesh_processing::keep_largest_connected_components()` \endlink, which can be called
+    since the class `Polyhedron_3` is a model of the required concepts `FaceListGraph` and `MutableFaceGraph`
+    (see \ref BGLPolyhedral for more information).
   */ 
   unsigned int keep_largest_connected_components(unsigned int nb_components_to_keep); 
 

--- a/Polyhedron/doc/Polyhedron/dependencies
+++ b/Polyhedron/doc/Polyhedron/dependencies
@@ -7,3 +7,4 @@ Stream_support
 HalfedgeDS
 Miscellany
 BGL
+Polygon_mesh_processing


### PR DESCRIPTION
## Summary of Changes

The functions [PMP::keep_large_CCs](https://doc.cgal.org/latest/Polygon_mesh_processing/group__keep__connected__components__grp.html#ga6de4710f16947ea7817a0365c2fb72f1) and [PMP::keep_largest_CCs](https://doc.cgal.org/latest/Polygon_mesh_processing/group__keep__connected__components__grp.html#ga68c6c29dfc6a26a6a2f8befe6944f19d) both determine what is the larger (largest) connected components by counting the number of faces in each connected component. This is quite limited and can also be a little counter intuitive as "large" more naturally evocates the size (i.e. the area) of the connected component rather than the number of its elements.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): [Generalize_keep_largest_CC](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Generalize_keep_largest_CC)
* Pre-approved: @janetournois  12:44, 6 May 2019 (CEST)

