### PR TITLE
Adapt Mesh_criteria_3 to Boost 1.71 (current 'master')

### DIFF
--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -63,7 +63,6 @@ if ( CGAL_FOUND )
       endif()
 
 
-  if ( Boost_FOUND AND Boost_VERSION GREATER 103400 )
     include( CGAL_CreateSingleSourceCGALProgram )
 
     # Compilable examples
@@ -131,10 +130,6 @@ if ( CGAL_FOUND )
         CGAL_target_use_TBB(${target})
       endif()
     endforeach()
-
-  else()
-    message(STATUS "NOTICE: This program requires Boost >= 1.34.1, and will not be compiled.")
-  endif()
 
 else()
   message(STATUS "This program requires the CGAL library, and will not be compiled.")

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_with_custom_initialization.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_with_custom_initialization.cpp
@@ -54,7 +54,7 @@ int main()
                                               image,
                                               criteria,
                                               (unsigned char)0);
-  CGAL::refine_mesh_3<C3t3>(c3t3, domain, criteria);
+  CGAL::refine_mesh_3(c3t3, domain, criteria);
   /// [Meshing]
 
   // Output

--- a/Mesh_3/include/CGAL/Mesh_criteria_3.h
+++ b/Mesh_3/include/CGAL/Mesh_criteria_3.h
@@ -83,17 +83,17 @@ public:
   typedef CellCriteria      Cell_criteria;
   
   // Constructor
-  Mesh_criteria_3_impl(const Facet_criteria& facet_criteria,
-                       const Cell_criteria& cell_criteria)
+  Mesh_criteria_3_impl(Facet_criteria facet_criteria,
+                       Cell_criteria cell_criteria)
     : edge_criteria_(0)
     , facet_criteria_(facet_criteria)
     , cell_criteria_(cell_criteria)
   { }
   
   // Constructor
-  Mesh_criteria_3_impl(const Edge_criteria& edge_criteria,
-                       const Facet_criteria& facet_criteria,
-                       const Cell_criteria& cell_criteria)
+  Mesh_criteria_3_impl(Edge_criteria edge_criteria,
+                       Facet_criteria facet_criteria,
+                       Cell_criteria cell_criteria)
     : edge_criteria_(edge_criteria)
     , facet_criteria_(facet_criteria)
     , cell_criteria_(cell_criteria)
@@ -182,15 +182,15 @@ public:
   typedef typename Base::Cell_criteria    Cell_criteria;
   
   // Constructor
-  Mesh_criteria_3(const Facet_criteria& facet_criteria,
-                  const Cell_criteria& cell_criteria)
+  Mesh_criteria_3(Facet_criteria facet_criteria,
+                  Cell_criteria cell_criteria)
     : Base(facet_criteria,
            cell_criteria) {}
   
   // Constructor
-  Mesh_criteria_3(const Edge_criteria& edge_criteria,
-                  const Facet_criteria& facet_criteria,
-                  const Cell_criteria& cell_criteria)
+  Mesh_criteria_3(Edge_criteria edge_criteria,
+                  Facet_criteria facet_criteria,
+                  Cell_criteria cell_criteria)
     : Base(edge_criteria,
            facet_criteria,
            cell_criteria) {}

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
@@ -106,7 +106,7 @@ struct Polyhedral_complex_tester : public Tester<K>
       true /*nonlinear_growth_of_balls*/);
     domain.add_vertices_to_c3t3_on_patch_without_feature_edges(c3t3);
 
-    CGAL::refine_mesh_3<C3t3>(c3t3, domain, criteria);
+    CGAL::refine_mesh_3(c3t3, domain, criteria);
 
     CGAL::remove_far_points_in_mesh_3(c3t3);
 


### PR DESCRIPTION
## Summary of Changes

This pull-request adapts Mesh_3 so that it compiles with newest Boost version 1.71 (current `master` branch of Boost). It stays compatible with previous Boost versions as well.

## Release Management

* Affected package(s): Mesh_3, Installation
* License and copyright ownership: maintenance by GF
* This is a bug-fix, based on CGAL-4.13.1.
* No conflict with current `integration` branch.

Cc: @afabri @janetournois 