### PR TITLE
PMP: Fix repair polygon soup bad swaps

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -927,7 +927,7 @@ std::size_t merge_duplicate_polygons_in_polygon_soup(const PointRange& points,
 
   std::vector<bool> treated(init_polygons_n, false);
 
-  // PID to pos is to go from a polygon ID to its position in the polygons vector, and pos_to_PID
+  // PID_to_pos is to go from a polygon ID to its position in the polygons vector, and pos_to_PID
   // is to move the other way
   std::vector<std::size_t> PID_to_pos(init_polygons_n);
   std::vector<std::size_t> pos_to_PID(init_polygons_n);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -437,7 +437,7 @@ std::size_t remove_isolated_points_in_polygon_soup(PointRange& points,
       std::cout << "  swapping it to pos: " << swap_position << std::endl;
 #endif
       std::swap(points[swap_position], points[i]);
-      std::swap(visited[swap_position], visited[i]);
+      visited.swap(visited[swap_position], visited[i]);
       id_remapping[swap_position] = i;
       --first_unused_pos;
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -422,17 +422,26 @@ std::size_t remove_isolated_points_in_polygon_soup(PointRange& points,
 
   // Move all the unused points to the end
   std::size_t swap_position = ini_points_size - 1;
-  for(std::size_t i=0; i<ini_points_size; ++i)
+  for(std::size_t i=0; i<ini_points_size;)
   {
     if(!visited[i])
     {
 #ifdef CGAL_PMP_REPAIR_POLYGON_SOUP_VERBOSE_PP
       std::cout << "points[" << i << "] = " << points[i] << " is isolated" << std::endl;
+      std::cout << "  swapping it to pos: " << swap_position << std::endl;
 #endif
       std::swap(points[swap_position], points[i]);
+      std::swap(visited[swap_position], visited[i]);
       id_remapping[swap_position] = i;
       --swap_position;
     }
+    else
+    {
+      ++i;
+    }
+
+    if(i >= swap_position)
+      break;
   }
 
   // Actually remove the unused points

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -949,23 +949,23 @@ std::size_t merge_duplicate_polygons_in_polygon_soup(const PointRange& points,
       if(treated[polygon_to_remove_id])
         continue;
 
-      const P_ID polygon_pos = PID_to_pos[polygon_to_remove_id];
+      const P_ID polygon_to_remove_pos = PID_to_pos[polygon_to_remove_id];
       CGAL_assertion(swap_position < init_polygons_n);
-      const P_ID polygon_at_swap_position_ID = pos_to_PID[swap_position];
+      const P_ID polygon_at_swap_position_id = pos_to_PID[swap_position];
 
 #ifdef CGAL_PMP_REPAIR_POLYGON_SOUP_VERBOSE_PP
-      std::cout << "Removing duplicate, PID: " << polygon_to_remove_id << " at position: " << polygon_pos << std::endl;
-      std::cout << "  swap position: " << swap_position << ", position of PID: " << polygon_at_swap_position_ID << std::endl;
+      std::cout << "Removing duplicate, PID: " << polygon_to_remove_id << " at position: " << polygon_to_remove_pos << std::endl;
+      std::cout << "  swap position: " << swap_position << ", position of PID: " << polygon_at_swap_position_id << std::endl;
 #endif
 
       // Need to keep track of who goes where
-      PID_to_pos[polygon_at_swap_position_ID] = polygon_pos;
+      PID_to_pos[polygon_at_swap_position_id] = polygon_to_remove_pos;
       PID_to_pos[polygon_to_remove_id] = swap_position;
-      pos_to_PID[polygon_pos] = polygon_at_swap_position_ID;
+      pos_to_PID[polygon_to_remove_pos] = polygon_at_swap_position_id;
       pos_to_PID[swap_position] = polygon_to_remove_id;
 
-      CGAL_assertion(polygon_pos <= swap_position);
-      std::swap(polygons[swap_position], polygons[polygon_pos]);
+      CGAL_assertion(polygon_to_remove_pos <= swap_position);
+      std::swap(polygons[swap_position], polygons[polygon_to_remove_pos]);
       --swap_position;
 
       treated[polygon_to_remove_id] = true;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -935,8 +935,11 @@ std::size_t merge_duplicate_polygons_in_polygon_soup(const PointRange& points,
     {
       const P_ID polygon_to_remove = duplicate_polygons[i];
       CGAL_assertion(swap_position < init_polygons_n);
-      std::swap(polygons[swap_position], polygons[polygon_to_remove]);
-      --swap_position;
+      if(polygon_to_remove < swap_position)
+      {
+        std::swap(polygons[swap_position], polygons[polygon_to_remove]);
+        --swap_position;
+      }
     }
 
     all_duplicate_polygons.pop_back();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -437,7 +437,13 @@ std::size_t remove_isolated_points_in_polygon_soup(PointRange& points,
       std::cout << "  swapping it to pos: " << swap_position << std::endl;
 #endif
       std::swap(points[swap_position], points[i]);
-      visited.swap(visited[swap_position], visited[i]);
+
+      // Swap manually because MSVC is unhappy with std::swap(v[i], v[j]) and a vector<bool>,
+      // and Apple Clang is unhappy with v.swap(v[i], v[j])...
+      const bool tmp = visited[swap_position];
+      visited[swap_position] = visited[i];
+      visited[i] = tmp;
+
       id_remapping[swap_position] = i;
       --first_unused_pos;
     }


### PR DESCRIPTION
## Summary of Changes

For unused points and duplicate polygons to be discarded, `repair_polygon_soup()` swaps bad element IDs to be the end of a container before resizing the container to discard the bad elements. The algorithms were similarly wrong in both cases.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): --

