### PR TITLE
PMP : add fallback to non-Delaunay triangulations for hole filling functions

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/NamedParameters.txt
@@ -191,7 +191,9 @@ a more isotropic mesh.\n
 \cgalNPEnd
 
 \cgalNPBegin{use_delaunay_triangulation} \anchor PMP_use_delaunay_triangulation
-enables the use of the Delaunay triangulation facet search space for hole filling functions.\n
+enables the use of the Delaunay triangulation facet search space for hole filling functions.
+If no valid triangulation can be found in this search space, the algorithm falls back to the
+non-Delaunay triangulations search space to find a solution.\n
 <b>Type:</b> `bool` \n
 <b>Default:</b> `true`
 \cgalNPEnd

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1246,7 +1246,7 @@ triangulate_hole_polyline(const PointRange1& points,
 
 #ifndef CGAL_HOLE_FILLING_DO_NOT_USE_DT3
   if (use_delaunay_triangulation
-      && w == typename WeightCalculator::Weight::NOT_VALID())
+      && w == WeightCalculator::Weight::NOT_VALID())
     w = Fill().operator()(P, Q, tracer, WC);
 #endif
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1242,6 +1242,13 @@ triangulate_hole_polyline(const PointRange1& points,
     use_delaunay_triangulation ? Fill_DT().operator()(P,Q,tracer,WC) :
   #endif
     Fill().operator()(P,Q,tracer,WC);
+
+#ifndef CGAL_HOLE_FILLING_DO_NOT_USE_DT3
+  if (use_delaunay_triangulation
+      && w == typename WeightCalculator::Weight::NOT_VALID())
+    w = Fill().operator()(P, Q, tracer, WC);
+#endif
+
   #ifdef CGAL_PMP_HOLE_FILLING_DEBUG
   std::cerr << w << std::endl;
   #endif

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1106,9 +1106,10 @@ private:
     
     if(W.get(0, n-1) == Weight::NOT_VALID()) {
       #ifndef CGAL_TEST_SUITE
-      CGAL_warning(!"Returning no output. Filling hole with extra triangles is not successful!");
+      CGAL_warning(!"Returning no output using Delaunay triangulation.\n Falling back to the general Triangulation framework.");
       #else
-      std::cerr << "W: Returning no output. Filling hole with extra triangles is not successful!\n";
+      std::cerr << "W: Returning no output using Delaunay triangulation.\n"
+                << "Falling back to the general Triangulation framework.\n";
       #endif
       return Weight::NOT_VALID();
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -65,7 +65,9 @@ namespace Polygon_mesh_processing {
      \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
          If this parameter is omitted, an internal property map for
          `CGAL::vertex_point_t` must be available in `PolygonMesh`\cgalParamEnd
-     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
+     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space.
+         If no valid triangulation can be found in this search space, the algorithm falls back to the
+         non-Delaunay triangulations search space to find a solution \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
   \cgalNamedParamsEnd
 
@@ -156,8 +158,11 @@ namespace Polygon_mesh_processing {
      \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of `pmesh`.
          If this parameter is omitted, an internal property map for
          `CGAL::vertex_point_t` should be available in `PolygonMesh`\cgalParamEnd
-     \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values cause denser refinements, as in `refine()` \cgalParamEnd
-     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
+     \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values
+         cause denser refinements, as in `refine()` \cgalParamEnd
+     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space.
+         If no valid triangulation can be found in this search space, the algorithm falls back to the
+         non-Delaunay triangulations search space to find a solution \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
   \cgalNamedParamsEnd
 
@@ -224,8 +229,11 @@ namespace Polygon_mesh_processing {
          If this parameter is omitted, an internal property map for
          `CGAL::vertex_point_t` should be available in `PolygonMesh`
          \cgalParamEnd
-     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
-     \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values cause denser refinements, as in `refine()` \cgalParamEnd
+     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space.
+         If no valid triangulation can be found in this search space, the algorithm falls back to the
+         non-Delaunay triangulations search space to find a solution \cgalParamEnd
+     \cgalParamBegin{density_control_factor} factor to control density of the ouput mesh, where larger values
+         cause denser refinements, as in `refine()` \cgalParamEnd
      \cgalParamBegin{fairing_continuity} tangential continuity of the output surface patch \cgalParamEnd
      \cgalParamBegin{sparse_linear_solver} an instance of the sparse linear solver used for fairing \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
@@ -317,7 +325,9 @@ namespace Polygon_mesh_processing {
   @param np optional sequence of \ref pmp_namedparameters "Named Parameters" among the ones listed below
 
   \cgalNamedParamsBegin
-     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space \cgalParamEnd
+     \cgalParamBegin{use_delaunay_triangulation} if `true`, use the Delaunay triangulation facet search space.
+         If no valid triangulation can be found in this search space, the algorithm falls back to the
+         non-Delaunay triangulations search space to find a solution \cgalParamEnd
      \cgalParamBegin{geom_traits} a geometric traits class instance \cgalParamEnd
   \cgalNamedParamsEnd
 


### PR DESCRIPTION
## Summary of Changes
By default, hole filling functions in PMP use the 3D Delaunay triangulation as a basis to chose the best triangulation to fill the given hole. When it does not succeed to find a solution in the Delaunay triangulations space (extended by some more cases, not exhaustive), the hole filling function fails to fill the hole.

This PR adds a fallback to the non-Delaunay framework and allows to check the whole set of triangulations to find a solution.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #3928 

