### PR TITLE
[Classification] Add missing "algorithm" include

### DIFF
--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
@@ -45,6 +45,8 @@
 #include <cstdio>
 #endif
 
+#include <algorithm>
+
 #include <CGAL/tags.h>
 
 #ifdef CGAL_LINKED_WITH_TBB


### PR DESCRIPTION
## Summary of Changes

Missing `#include <algorithm>`.

The incriminated file moved and changed quite a bit in `CGAL 4.14`, that's why I don't do the fix for `4.13` (to avoid wasting time with conflicts for a minor bug).

## Release Management

* Affected package(s): Classification