### PR TITLE
Use $TRAVIS_PULL_REQUEST_BRANCH instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
 compiler: clang-3.6
 install: 
   - echo "$PWD"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - bash .travis/install.sh 
   - export CXX=clang++-3.6 CC=clang-3.6;
 before_script: 

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -134,7 +134,7 @@ cd $ROOT
   fi
   IFS=$old_IFS
 
-  if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$ARG" != Polyhedron_demo ]; then
+  if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$ARG" != Polyhedron_demo ]; then
     DO_IGNORE=FALSE
     . $ROOT/.travis/test_package.sh "$ROOT" "$ARG"
     echo "DO_IGNORE is $DO_IGNORE"

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -10,7 +10,7 @@ env:
 compiler: clang-3.6
 install: 
   - echo "$PWD"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - bash .travis/install.sh 
   - export CXX=clang++-3.6 CC=clang-3.6;
 before_script: 


### PR DESCRIPTION
## Summary of Changes

`TRAVIS_PULL_REQUEST` is actually never empty:
> `TRAVIS_PULL_REQUEST`: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

(from the [documentation](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables))

Use `TRAVIS_PULL_REQUEST_BRANCH` instead:
> `TRAVIS_PULL_REQUEST_BRANCH`:
>    - if the current job is a pull request, the name of the branch from which the PR originated.
>    - if the current job is a push build, this variable is empty ("").

## Release Management

* Affected package(s): Travis

