### PR TITLE
Fixes for Convex_hull_3: use `is_certain` to avoid exceptions throwing

### DIFF
--- a/Convex_hull_3/doc/Convex_hull_3/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/doc/Convex_hull_3/CGAL/Convex_hull_traits_3.h
@@ -13,6 +13,13 @@ function when `R` is a kernel with exact predicates but inexact constructions
 \cgalModels `IsStronglyConvexTraits_3` 
 
 \attention The user must include the header file of the polygon mesh type, even for the default type.
+
+\cgalAdvancedBegin 
+This class has a fourth undocumented template argument. Passing `CGAL::Tag_false`
+switches off a caching of a plane with coordinates with interval arithmetic. 
+Instead an orientation test of four points is performed.
+\cgalAdvancedEnd
+
 */
   template< typename R, typename PolygonMesh = Polyhedron_3<R> >
 class Convex_hull_traits_3 {

--- a/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
@@ -4,7 +4,7 @@ namespace CGAL {
 \ingroup PkgConvexHull3Functions
 
 \brief computes the convex hull of the set of points in the range
-[`first`, `last`). The polyhedron `pm` is cleared, then
+[`first`, `last`). The polygon mesh `pm` is cleared, then
 the convex hull is stored in `pm`. Note that the convex hull will be triangulated,
 that is `pm` will contain only triangular facets.
 if the convex hull is a point or a segment, endpoints will be added in `pm` as isolated vertices.
@@ -39,9 +39,9 @@ void convex_hull_3(InputIterator first, InputIterator last, PolygonMesh& pm, con
 
 \brief computes the convex hull of the set of points in the range
 [`first`, `last`). The result, which may be a point, a segment,
-a triangle, or a polyhedron, is stored in `ch_object`.
-In the case the result is a polyhedron, the convex hull will be triangulated,
-that is the polyhedron will contain only triangular facets.
+a triangle, or a polygon mesh, is stored in `ch_object`.
+In the case the result is a polygon mesh, the convex hull will be triangulated,
+that is the polygon mesh will contain only triangular facets.
 
 \tparam InputIterator must be an input iterator with a value type  equivalent to `Traits::Point_3`.
 \tparam Traits must be model of the concept `ConvexHullTraits_3`.

--- a/Convex_hull_3/doc/Convex_hull_3/Convex_hull_3.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/Convex_hull_3.txt
@@ -49,11 +49,19 @@ computing the hull.
 
 The function `convex_hull_3()` is parameterized by a traits class,
 which specifies the types and geometric primitives to be used in the
-computation. If input points from a kernel with exact predicates 
+computation.   As the function constructs 3D planes from three input
+points, we cannot simply pass a kernel with inexact constructions as
+optional argument for the traits class.
+
+If input points from a kernel with exact predicates 
 and non-exact constructions are used, and a certified result is expected,
 the traits `Convex_hull_traits_3<R>` should be used 
-(`R` being the input kernel). Note that the default traits class takes this into
-account.
+(`R` being the input kernel).
+If the constructions from a kernel are exact this kernel can be used
+directly as a traits class.
+
+Note that the default traits class takes this into account, that is the
+above considerations are only important for custom traits classes.
 
 \subsubsection Convex_hull_3Example Example
 

--- a/Convex_hull_3/doc/Convex_hull_3/Convex_hull_3.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/Convex_hull_3.txt
@@ -55,7 +55,7 @@ optional argument for the traits class.
 
 If input points from a kernel with exact predicates 
 and non-exact constructions are used, and a certified result is expected,
-the traits `Convex_hull_traits_3<R>` should be used 
+the class `Convex_hull_traits_3<R>` should be used 
 (`R` being the input kernel).
 If the constructions from a kernel are exact this kernel can be used
 directly as a traits class.

--- a/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
@@ -159,7 +159,12 @@ struct GT3_for_CH3 {
 
 
 
-  template <class R_, class Polyhedron = Default, class Has_filtered_predicates_tag = Tag_false>
+  template <class R_, class Polyhedron = Default,
+            class Has_filtered_predicates_tag = Boolean_tag
+            <
+              boost::is_floating_point<typename R_::FT>::type::value &&
+              R_::Has_filtered_predicates_tag::value
+            > >
 class Convex_hull_traits_3 
 {
  public:  

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -352,19 +352,22 @@ public:
         ak_plane.vector = cross_product(to_AK(q)-ap, to_AK(r)-ap);
         ak_plane.point = ap;
       }
-      return sign(scalar_product(to_AK(s) - ak_plane.point,
-                                 ak_plane.vector)) == POSITIVE;
-    }
-    catch (Uncertain_conversion_exception&){
-      if (ek_plane_ptr==NULL) {
-        const typename Exact_K::Point_3 ep = to_EK(p);
-        ek_plane_ptr = new Vector_plus_point<Exact_K>;
-        ek_plane_ptr->vector = cross_product(to_EK(q)-ep, to_EK(r)-ep);
-        ek_plane_ptr->point = ep;
+      Uncertain<Sign> res =
+        sign(scalar_product(to_AK(s) - ak_plane.point,
+                            ak_plane.vector));
+      if(is_certain(res)) {
+        return (get_certain(res) == POSITIVE);
       }
-      return sign(scalar_product(to_EK(s) - ek_plane_ptr->point,
-                                 ek_plane_ptr->vector)) == POSITIVE;
     }
+    catch (Uncertain_conversion_exception&){}
+    if (ek_plane_ptr==NULL) {
+      const typename Exact_K::Point_3 ep = to_EK(p);
+      ek_plane_ptr = new Vector_plus_point<Exact_K>;
+      ek_plane_ptr->vector = cross_product(to_EK(q)-ep, to_EK(r)-ep);
+      ek_plane_ptr->point = ep;
+    }
+    return sign(scalar_product(to_EK(s) - ek_plane_ptr->point,
+                               ek_plane_ptr->vector)) == POSITIVE;
   }
 };
 

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -43,6 +43,7 @@
 #include <iostream>
 #include <algorithm>
 #include <utility>
+#include <memory>
 #include <list>
 #include <vector>
 #include <boost/bind.hpp>
@@ -236,17 +237,23 @@ public:
 //and in case of failure, exact arithmetic is used.
 template <class Kernel, class P>
 class Is_on_positive_side_of_plane_3<Convex_hull_traits_3<Kernel, P, Tag_true>, boost::true_type >{
-  typedef Simple_cartesian<CGAL::internal::Exact_field_selector<double>::Type>  PK;
-  typedef Simple_cartesian<Interval_nt_advanced >                               CK;
+  typedef Simple_cartesian<CGAL::internal::Exact_field_selector<double>::Type>  Exact_K;
+  typedef Simple_cartesian<Interval_nt_advanced >                               Approx_K;
   typedef Convex_hull_traits_3<Kernel, P, Tag_true>                             Traits;
   typedef typename Traits::Point_3                                              Point_3;
 
-  Cartesian_converter<Kernel,CK>                        to_CK;
-  Cartesian_converter<Kernel,PK>                        to_PK;
+  Cartesian_converter<Kernel,Approx_K>                  to_AK;
+  Cartesian_converter<Kernel,Exact_K>                   to_EK;
+
+  template <typename K>
+  struct Vector_plus_point {
+    typename K::Vector_3 vector;
+    typename K::Point_3  point;
+  };
 
   const Point_3& p,q,r;
-  mutable typename CK::Plane_3* ck_plane;
-  mutable typename PK::Plane_3* pk_plane;
+  mutable Vector_plus_point<Approx_K> ak_plane;
+  mutable Vector_plus_point<Exact_K>* ek_plane_ptr;
 
   double m10,m20,m21,Maxx,Maxy,Maxz;
 
@@ -292,8 +299,13 @@ public:
   typedef typename Interval_nt_advanced::Protector           Protector;
 
   Is_on_positive_side_of_plane_3(const Traits&,const Point_3& p_,const Point_3& q_,const Point_3& r_)
-  :p(p_),q(q_),r(r_),ck_plane(NULL),pk_plane(NULL)
+    : p(p_),q(q_),r(r_)
+    , ak_plane()
+    , ek_plane_ptr(0)
   {
+    ak_plane.vector =
+      typename Approx_K::Vector_3(Interval_nt_advanced(0., std::numeric_limits<double>::infinity()),
+                                  0., 0.);
     double pqx = q.x() - p.x();
     double pqy = q.y() - p.y();
     double pqz = q.z() - p.z();
@@ -319,8 +331,7 @@ public:
   }
 
   ~Is_on_positive_side_of_plane_3(){
-    if (ck_plane!=NULL) delete ck_plane;
-    if (pk_plane!=NULL) delete pk_plane;
+    if (ek_plane_ptr!=NULL) delete ek_plane_ptr;
   }
 
   bool operator() (const Point_3& s) const
@@ -334,14 +345,25 @@ public:
       return static_res == 1;
 
     try{
-      if (ck_plane==NULL)
-        ck_plane=new typename CK::Plane_3(to_CK(p),to_CK(q),to_CK(r));
-      return ck_plane->has_on_positive_side(to_CK(s));
+      // infinity() is the sentinel for uninitialized `ak_plane`
+      if (ak_plane.vector.x().sup() == std::numeric_limits<double>::infinity())
+      {
+        const typename Approx_K::Point_3 ap = to_AK(p);
+        ak_plane.vector = cross_product(to_AK(q)-ap, to_AK(r)-ap);
+        ak_plane.point = ap;
+      }
+      return sign(scalar_product(to_AK(s) - ak_plane.point,
+                                 ak_plane.vector)) == POSITIVE;
     }
     catch (Uncertain_conversion_exception&){
-      if (pk_plane==NULL)
-        pk_plane=new typename PK::Plane_3(to_PK(p),to_PK(q),to_PK(r));
-      return pk_plane->has_on_positive_side(to_PK(s));
+      if (ek_plane_ptr==NULL) {
+        const typename Exact_K::Point_3 ep = to_EK(p);
+        ek_plane_ptr = new Vector_plus_point<Exact_K>;
+        ek_plane_ptr->vector = cross_product(to_EK(q)-ep, to_EK(r)-ep);
+        ek_plane_ptr->point = ep;
+      }
+      return sign(scalar_product(to_EK(s) - ek_plane_ptr->point,
+                                 ek_plane_ptr->vector)) == POSITIVE;
     }
   }
 };

--- a/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Epick_without_intervals K;
 typedef CGAL::Polyhedron_3<K> Polyhedron_3;
 typedef K::Point_3 Point_3;
 

--- a/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
@@ -81,4 +81,6 @@ int main()
   test<Epec,CGAL::Polyhedron_3<Epec> >();
   test<Epic,CGAL::Surface_mesh<Epic::Point_3> >();
   test<Epec,CGAL::Surface_mesh<Epec::Point_3> >();
+  test<CGAL::Epick_without_intervals,
+       CGAL::Surface_mesh<CGAL::Epick_without_intervals::Point_3> >();
 }

--- a/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
+++ b/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
@@ -45,6 +45,12 @@ class Epick
 #endif
 {};
 
+class Epick_without_intervals
+  : public Static_filters_base<
+      Type_equality_wrapper< Simple_cartesian<double>::Base<Epick_without_intervals>::Type,
+                             Epick_without_intervals > >
+{};
+
 typedef Epick Exact_predicates_inexact_constructions_kernel;
 
 template <>

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -75,8 +75,12 @@ main()
   std::cout << "Testing IO with F_k<Cartesian<double>>:" << std::endl;
   _test_io( Clsd() );
 
-  std::cout << "Testing with Epick:\n";
+  std::cout << "Testing with Epeck:\n";
   test<Cls>();
+  std::cout << "Testing with Epick:\n";
+  test<CGAL::Epick>();
+  std::cout << "Testing with Epick_without_intervals:\n";
+  test<CGAL::Epick_without_intervals>();
   return 0;
 }
 

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -27,6 +27,7 @@
 #include <CGAL/MP_Float.h>
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <cassert>
 
@@ -52,9 +53,12 @@
  
 #include "CGAL/_test_mf_plane_3_to_2d.h"
 
+template <typename Cls>
+void test();
 int
 main()
 {
+  CGAL::force_ieee_double_precision();
   typedef CGAL::Cartesian<double>                               Clsdb;
   typedef CGAL::Filtered_kernel<Clsdb>                          Clsd;
 
@@ -71,6 +75,13 @@ main()
   std::cout << "Testing IO with F_k<Cartesian<double>>:" << std::endl;
   _test_io( Clsd() );
 
+  std::cout << "Testing with Epick:\n";
+  test<Cls>();
+  return 0;
+}
+
+template <typename Cls>
+void test() {
   std::cout << "Testing 2d :";
   std::cout << std::endl;
   _test_2( Cls() );
@@ -101,6 +112,4 @@ main()
   std::cout << "Testing 3d-2d :";
   std::cout << std::endl;
   _test_mf_plane_3_to_2d( Cls() );
-  
-  return 0;
 }

--- a/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
@@ -22,7 +22,6 @@
  
 
 #include <CGAL/Simple_cartesian.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Quotient.h>
 #include <cassert>
 
@@ -91,7 +90,5 @@ main()
 
   typedef   CGAL::Simple_cartesian<CGAL::Quotient<Precise_integer> >     Cls;
   test_kernel("Simple_cartesian<Quotient<Precise_integer>>", Cls());
-  typedef   CGAL::Simple_cartesian<CGAL::Quotient<Precise_integer> >     Cls;
-  test_kernel("Epick_without_intervals", CGAL::Epick_without_intervals());
   return 0;
 }

--- a/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Simple_cartesian.cpp
@@ -22,6 +22,7 @@
  
 
 #include <CGAL/Simple_cartesian.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Quotient.h>
 #include <cassert>
 
@@ -46,30 +47,26 @@
 
 #include "CGAL/_test_mf_plane_3_to_2d.h"
 
-int
-main()
-{
-  typedef   CGAL::Simple_cartesian<double>     Clsd;
-  std::cout << "Testing IO with Simple_cartesian<double> :" << std::endl;
-  _test_io( Clsd() );
+#include <string>
 
-  typedef   CGAL::Simple_cartesian<CGAL::Quotient<Precise_integer> >     Cls;
-  std::cout << "Testing 2d with Simple_cartesian<Quotient<Precise_integer>> :";
+template <typename Cls>
+void test_kernel(std::string kernel_name, Cls) {
+  std::cout << "Testing 2d with "+kernel_name+" :";
   std::cout << std::endl;
   _test_2( Cls() );
 
-  std::cout << "Testing 3d with Simple_cartesian<Quotient<Precise_integer>> :";
+  std::cout << "Testing 3d with "+kernel_name+" :";
   std::cout << std::endl;
   _test_3( Cls() );
 
-  std::cout << "Testing new 2d with Simple_cartesian<Quotient<Precise_integer>>:";
+  std::cout << "Testing new 2d with "+kernel_name+" :";
   std::cout << std::endl;
   test_new_2( Cls() );
-  std::cout << "Testing new 3d with Simple_cartesian<Quotient<Precise_integer>>:";
+  std::cout << "Testing new 3d with "+kernel_name+" :";
   std::cout << std::endl;
   test_new_3( Cls() );
 
-  std::cout << "Testing new parts with Simple_cartesian<Quotient<Precise_integer>> :";
+  std::cout << "Testing new parts with "+kernel_name+" :";
   std::cout << std::endl;
   _test_orientation_and_bounded_side( Cls() );
   _test_fct_points_implicit_sphere( Cls() );
@@ -80,9 +77,21 @@ main()
   _test_cls_iso_cuboid_3( Cls() );
   _test_angle( Cls() );
 
-  std::cout << "Testing 3d-2d with Simple_cartesian<Quotient<Precise_integer>>:";
+  std::cout << "Testing 3d-2d with "+kernel_name+" :";
   std::cout << std::endl;
   _test_mf_plane_3_to_2d( Cls() );
+}
 
+int
+main()
+{
+  typedef   CGAL::Simple_cartesian<double>     Clsd;
+  std::cout << "Testing IO with Simple_cartesian<double> :" << std::endl;
+  _test_io( Clsd() );
+
+  typedef   CGAL::Simple_cartesian<CGAL::Quotient<Precise_integer> >     Cls;
+  test_kernel("Simple_cartesian<Quotient<Precise_integer>>", Cls());
+  typedef   CGAL::Simple_cartesian<CGAL::Quotient<Precise_integer> >     Cls;
+  test_kernel("Epick_without_intervals", CGAL::Epick_without_intervals());
   return 0;
 }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_approx_equal.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_approx_equal.h
@@ -1,0 +1,44 @@
+#ifndef CGAL_TESTSUITE_APPROX_EQUAL_H
+#define CGAL_TESTSUITE_APPROX_EQUAL_H
+#include <boost/math/special_functions/next.hpp>
+
+namespace CGAL {
+namespace testsuite {
+
+template <typename FT>
+bool approx_equal(FT a, FT b) { return a == b; }
+
+bool approx_equal(double a, double b) {
+  return std::abs(boost::math::float_distance(a, b)) <= 1;
+}
+
+struct Xyz_tag {};
+struct Xy_tag {};
+
+template <typename Object>
+bool approx_equal(Object a, Object b, CGAL::testsuite::Xyz_tag)
+{
+  return approx_equal(a.x(), b.x()) &&
+    approx_equal(a.y(), b.y()) &&
+    approx_equal(a.z(), b.z());
+}
+
+template <typename Object>
+bool approx_equal(Object a, Object b, CGAL::testsuite::Xy_tag)
+{
+  return approx_equal(a.x(), b.x()) && approx_equal(a.y(), b.y());
+}
+
+struct Direction_2_tag {};
+template <typename Object>
+bool approx_equal(Object a, Object b, CGAL::testsuite::Direction_2_tag)
+{
+  return CGAL_NTS sign(a.dx()) == CGAL_NTS sign(a.dx())
+    && CGAL_NTS sign(a.dy()) == CGAL_NTS sign(b.dy())
+    && approx_equal(a.dx() * b.dy(), a.dy() * b.dx());
+}
+
+} // end namespace testsuite
+} // end namespace CGAL
+
+#endif // CGAL_TESTSUITE_APPROX_EQUAL_H

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
@@ -25,6 +25,7 @@
 #define CGAL__TEST_CLS_AFF_TRANSFORMATION_2_H
 
 #include <CGAL/use.h>
+#include <boost/type_traits/is_same.hpp>
 
 template <class R>
 bool
@@ -34,6 +35,8 @@ _test_cls_aff_transformation_2(const R& )
 
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
+
+ const bool nonexact = boost::is_same<FT, double>::value;
 
  typename R::Aff_transformation_2 ia;
  CGAL::Aff_transformation_2<R> a1(ia);
@@ -170,7 +173,7 @@ _test_cls_aff_transformation_2(const R& )
     tisor= isor.transform( a[i]);
     assert( tseg == CGAL::Segment_2<R>(tp1, tp2) );
     assert( tray == CGAL::Ray_2<R>(tp3, tp2) );
-    assert( tlin == CGAL::Line_2<R>(tp2, tp4) );
+    assert( tlin == CGAL::Line_2<R>(tp2, tp4) || nonexact);
     assert( ttri == CGAL::Triangle_2<R>(tp2, tp3, tp4) );
     assert( tisor== CGAL::Iso_rectangle_2<R>( tp3, tp4 ) );
 
@@ -180,11 +183,11 @@ _test_cls_aff_transformation_2(const R& )
     tray = tray.transform( inv );
     tlin = tlin.transform( inv );
     ttri = ttri.transform( inv );
-    assert( tp4  == p4 );
-    assert( tseg == seg );
-    assert( tray == ray );
-    assert( tlin == lin );
-    assert( ttri == tri );
+    assert( tp4  == p4  || nonexact );
+    assert( tseg == seg || nonexact );
+    assert( tray == ray || nonexact );
+    assert( tlin == lin || nonexact );
+    assert( ttri == tri || nonexact );
  };
 
  std::cout << '.';
@@ -293,7 +296,7 @@ _test_cls_aff_transformation_2(const R& )
  // rotation
  assert( d0.transform( rot90 ) == d1 );
  assert( d1.transform( rot90.inverse() ) == d0 );
- assert( d0.transform( rot3 ) == CGAL::Direction_2<R>( RT(4), RT(3)) );
+ assert( d0.transform( rot3 ) == CGAL::Direction_2<R>( RT(4), RT(3)) || nonexact);
  co1 = rot3 * rot90;
  assert( d1.transform( rot3) == d0.transform( co1 ) );
  co1 = rot2 * rot90;
@@ -326,7 +329,7 @@ _test_cls_aff_transformation_2(const R& )
  tp3 = p3.transform( rot3 );
  tp4 = p4.transform( rot3 );
  tcirc = circ.orthogonal_transform( rot3 );
- assert( tcirc == CGAL::Circle_2<R>( tp2, tp3, tp4 ) );
+ assert( tcirc == CGAL::Circle_2<R>( tp2, tp3, tp4 ) || nonexact );
 
 
  // copy

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_AFF_TRANSFORMATION_2_H
 #define CGAL__TEST_CLS_AFF_TRANSFORMATION_2_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_aff_transformation_2(const R& )
@@ -56,7 +58,7 @@ _test_cls_aff_transformation_2(const R& )
  CGAL::Vector_2<R> tvec;
  CGAL::Point_2<R>  pnt( n8, n1, n10 );      // ( 6,-5)
  CGAL::Point_2<R>  tpnt;
- CGAL::Point_2<R>  pvec = CGAL::ORIGIN + vec;
+ CGAL::Point_2<R>  pvec = CGAL::ORIGIN + vec; CGAL_USE(pvec);
  CGAL::Vector_2<R> vpnt = pnt - CGAL::ORIGIN;
 
  CGAL::Point_2<R>  p1(-n3, n7, n3 );        // (-1, 2)

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
@@ -25,6 +25,7 @@
 #define CGAL__TEST_CLS_AFF_TRANSFORMATION_3_H
 
 #include <CGAL/use.h>
+#include <boost/type_traits/is_same.hpp>
 
 template <class R>
 bool
@@ -34,6 +35,7 @@ _test_cls_aff_transformation_3(const R& )
 
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
+ const bool nonexact = boost::is_same<FT, double>::value;
 
  typename R::Aff_transformation_3 ia;
  CGAL::Aff_transformation_3<R> a1(ia);
@@ -184,7 +186,7 @@ _test_cls_aff_transformation_3(const R& )
     tlin = lin.transform( a[i] );
     ttri = tri.transform( a[i] );
     ttet = tet.transform( a[i] );
-    assert( tpla == CGAL::Plane_3<R>( tp1, tp2, tp3) );
+    assert( tpla == CGAL::Plane_3<R>( tp1, tp2, tp3) || nonexact );
     assert( tseg == CGAL::Segment_3<R>(tp1, tp2) );
     assert( tray == CGAL::Ray_3<R>(tp3, tp2) );
     assert( tlin == CGAL::Line_3<R>(tp2, tp4) );
@@ -198,13 +200,13 @@ _test_cls_aff_transformation_3(const R& )
     tlin = tlin.transform( inv );
     ttri = ttri.transform( inv );
     ttet = ttet.transform( inv );
-    assert( tp4  == p4 );
-    assert( tpla == pla );
-    assert( tseg == seg );
-    assert( tray == ray );
-    assert( tlin == lin );
-    assert( ttri == tri );
-    assert( ttet == tet );
+    assert( tp4  == p4 || nonexact );
+    assert( tpla == pla || nonexact );
+    assert( tseg == seg || nonexact );
+    assert( tray == ray || nonexact );
+    assert( tlin == lin || nonexact );
+    assert( ttri == tri || nonexact );
+    assert( ttet == tet || nonexact );
  };
 
  std::cout << '.';
@@ -213,7 +215,7 @@ _test_cls_aff_transformation_3(const R& )
  assert( vec.transform(ident) == vec );
  assert( dir.transform(ident) == dir );
  assert( pnt.transform(ident) == pnt );
- assert( pla.transform(ident) == pla );
+ assert( pla.transform(ident) == pla || nonexact );
 
  // scale11 and gscale
  tpnt = pnt.transform(scale11);
@@ -236,7 +238,7 @@ _test_cls_aff_transformation_3(const R& )
  assert( vec.transform(scale11) == vec.transform(gscale) );
  assert( dir.transform(scale11) == dir.transform(gscale) );
  assert( pnt.transform(scale11) == pnt.transform(gscale) );
- assert( pla.transform(scale11) == pla.transform(gscale) );
+ assert( pla.transform(scale11) == pla.transform(gscale) || nonexact );
 
  // translate and gtrans
  tvec = vec.transform(translate);
@@ -274,7 +276,7 @@ _test_cls_aff_transformation_3(const R& )
  assert( pnt.transform(xrefl).transform(xrefl) == pnt );
  assert( dir.transform(xrefl).transform(xrefl) == dir );
  assert( vec.transform(xrefl).transform(xrefl) == vec );
- assert( pla.transform(xrefl).transform(xrefl) == pla );
+ assert( pla.transform(xrefl).transform(xrefl) == pla || nonexact );
  CGAL::Aff_transformation_3<R> co1 = xrefl * xrefl;
  assert( pnt.transform(xrefl).transform(xrefl) == pnt.transform(co1) );
  assert( dir.transform(xrefl).transform(xrefl) == dir.transform(co1) );
@@ -284,7 +286,7 @@ _test_cls_aff_transformation_3(const R& )
  assert( pnt.transform(gat3).transform(gat2) == pnt.transform(co1) );
  assert( dir.transform(gat3).transform(gat2) == dir.transform(co1) );
  assert( vec.transform(gat3).transform(gat2) == vec.transform(co1) );
- assert( pla.transform(gat3).transform(gat2) == pla.transform(co1) );
+ assert( pla.transform(gat3).transform(gat2) == pla.transform(co1) || nonexact );
  co1 = ident * gat1;
  assert( vec.transform(gat1) == vec.transform(co1) );
  assert( dir.transform(gat1) == dir.transform(co1) );
@@ -296,10 +298,10 @@ _test_cls_aff_transformation_3(const R& )
  assert( pnt.transform(gat1) == pnt.transform(co1) );
  assert( pla.transform(gat1) == pla.transform(co1) );
  co1 = gat1 * gat1.inverse() ;
- assert( vec == vec.transform(co1) );
- assert( dir == dir.transform(co1) );
- assert( pnt == pnt.transform(co1) );
- assert( pla == pla.transform(co1) );
+ assert( vec == vec.transform(co1) || nonexact );
+ assert( dir == dir.transform(co1) || nonexact );
+ assert( pnt == pnt.transform(co1) || nonexact );
+ assert( pla == pla.transform(co1) || nonexact );
 
  assert( vec.transform( gat5 ) == vec.transform( gat2 ) );
  assert( dir.transform( gat5 ) == dir.transform( gat2 ) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_AFF_TRANSFORMATION_3_H
 #define CGAL__TEST_CLS_AFF_TRANSFORMATION_3_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_aff_transformation_3(const R& )
@@ -56,7 +58,7 @@ _test_cls_aff_transformation_3(const R& )
  CGAL::Vector_3<R> tvec;
  CGAL::Point_3<R>  pnt( n8, n1, n9, n10 );  // ( 6,-5, 3)
  CGAL::Point_3<R>  tpnt;
- CGAL::Point_3<R>  pvec = CGAL::ORIGIN + vec;
+ CGAL::Point_3<R>  pvec = CGAL::ORIGIN + vec; CGAL_USE(pvec);
  CGAL::Vector_3<R> vpnt = pnt - CGAL::ORIGIN;
 
  CGAL::Point_3<R>  p1(-n3, n7, n11, n3 );   // (-1, 2,-3)

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_circle_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_circle_2.h
@@ -27,6 +27,8 @@
 #include <CGAL/Bbox_2.h>
 #include <cassert>
 
+#include <boost/type_traits/is_same.hpp>
+
 template <class K>
 void _test_construct_radical_line(const K &k) {
   typedef typename K::FT                               FT;
@@ -82,6 +84,8 @@ _test_cls_circle_2(const R& )
 
  typename R::Circle_2  ic;
  CGAL::Circle_2<R> c0;
+
+ const bool nonexact = boost::is_same<FT, double>::value;
 
  RT n0 =  0;
  RT n1 = 16;
@@ -194,9 +198,9 @@ _test_cls_circle_2(const R& )
          == CGAL::ON_POSITIVE_SIDE );
  assert( c10.oriented_side(CGAL::ORIGIN + v1 + vx*n2 ) \
          == CGAL::ON_NEGATIVE_SIDE );
- assert( c10.oriented_side(p9 ) == CGAL::ON_ORIENTED_BOUNDARY );
- assert( c10.has_on_boundary(p9) );
- assert( c10.has_on_boundary(p4 + v1) );
+ assert( c10.oriented_side(p9 ) == CGAL::ON_ORIENTED_BOUNDARY || nonexact);
+ assert( c10.has_on_boundary(p9) || nonexact);
+ assert( c10.has_on_boundary(p4 + v1) || nonexact );
  CGAL::Point_2<R> p11( n4, n4, n3) ; // (2.5, 2.5)
  CGAL::Point_2<R> p12( n5, n5, n3) ; // ( 5 ,  5 )
  assert( c10.has_on_bounded_side( p11 ) );
@@ -206,8 +210,8 @@ _test_cls_circle_2(const R& )
  assert( c10.has_on_negative_side( p12 ) );
  assert( c10.opposite().has_on_negative_side( p11 ) );
  assert( c10.opposite().has_on_positive_side( p12 ) );
- assert( c10.has_on_boundary( p6 ) );
- assert( c10.has_on_boundary( p8 ) );
+ assert( c10.has_on_boundary( p6 ) || nonexact);
+ assert( c10.has_on_boundary( p8 ) || nonexact);
 
  std::cout << '.';
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_direction_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_direction_2.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_DIRECTION_2_H
 #define CGAL__TEST_CLS_DIRECTION_2_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_direction_2(const R& )
@@ -34,7 +36,7 @@ _test_cls_direction_2(const R& )
 
  typename R::Direction_2  id;
  CGAL::Direction_2<R> d0;
- CGAL::Direction_2<R> d1(id);
+ CGAL::Direction_2<R> d1(id); CGAL_USE(d1);
 
  std::cout << '.';
  RT  n0 = 10;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_direction_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_direction_3.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_DIRECTION_3_H
 #define CGAL__TEST_CLS_DIRECTION_3_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_direction_3(const R& )
@@ -35,7 +37,7 @@ _test_cls_direction_3(const R& )
  typename R::Direction_3  id;
 
  CGAL::Direction_3<R> d0;
- CGAL::Direction_3<R> d1(id);
+ CGAL::Direction_3<R> d1(id); CGAL_USE(d1);
 
  std::cout << '.';
  RT   n0 = 10;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_iso_cuboid_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_iso_cuboid_3.h
@@ -26,6 +26,7 @@
 
 #include <CGAL/Bbox_3.h>
 #include <cassert>
+#include <CGAL/use.h>
 
 template <class R>
 bool
@@ -35,9 +36,6 @@ _test_cls_iso_cuboid_3(const R& )
 
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
-
- typename R::Iso_cuboid_3 ir;
- CGAL::Iso_cuboid_3<R>  r0(ir);
 
  RT n1 =  1;
  RT n2 =  2;
@@ -64,6 +62,10 @@ _test_cls_iso_cuboid_3(const R& )
  CGAL::Point_3<R> p11(n2, n8, n2, n2);    // ( 1, 4, 1)
  CGAL::Point_3<R> p12(n1, n1, n3 );       // ( 1, 1, 3)
  CGAL::Point_3<R> p13(n4, n1, n3 );       // ( 4, 1, 3)
+
+ typename R::Iso_cuboid_3 ir0; CGAL_USE(ir0); // test default-construction
+ typename R::Iso_cuboid_3 ir( p1, p3);
+ CGAL::Iso_cuboid_3<R>  r0(ir);
 
  const CGAL::Iso_cuboid_3<R> r1( p1, p3);
  CGAL::Iso_cuboid_3<R> r1_( p1, p3, 0);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_iso_rectangle_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_iso_rectangle_2.h
@@ -26,6 +26,7 @@
 
 #include <CGAL/Bbox_2.h>
 #include <cassert>
+#include <CGAL/use.h>
 
 template <class R>
 bool
@@ -35,9 +36,6 @@ _test_cls_iso_rectangle_2(const R& )
 
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
-
- typename R::Iso_rectangle_2 ir;
- CGAL::Iso_rectangle_2<R>  r0(ir);
 
  RT n1 =  1;
  RT n2 =  2;
@@ -58,6 +56,10 @@ _test_cls_iso_rectangle_2(const R& )
  CGAL::Point_2<R> p7( n6, n3, n2);    // ( 3, 1.5)
  CGAL::Point_2<R> p8( n4, n6, n2);    // ( 2, 3)
  CGAL::Point_2<R> p9(-n3, n7);        // (-3, 7)
+
+ typename R::Iso_rectangle_2 ir0; CGAL_USE(ir0); // test default-construction
+ typename R::Iso_rectangle_2 ir(p1, p3);
+ CGAL::Iso_rectangle_2<R>  r0(ir);
 
  const CGAL::Iso_rectangle_2<R> r1( p1, p3);
  CGAL::Iso_rectangle_2<R> r1_( p1, p3, 0);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_2.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_LINE_2_H
 #define CGAL__TEST_CLS_LINE_2_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_line_2(const R& )
@@ -47,7 +49,8 @@ _test_cls_line_2(const R& )
  CGAL::Point_2<R> p3(-n6, n6, n3 );   // (-2, 2 )
  CGAL::Point_2<R> p4( n8, n4, n2 );   // ( 4, 2 )
 
- typename R::Line_2 il;
+ typename R::Line_2 il0; CGAL_USE(il0); // test default-construction
+ typename R::Line_2 il(p1, p2);
  CGAL::Line_2<R>  l0(il);
  CGAL::Line_2<R>  l12( p1, p2 );
  CGAL::Line_2<R>  l21( p2, p1 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_LINE_3_H
 #define CGAL__TEST_CLS_LINE_3_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_line_3(const R& )
@@ -33,8 +35,8 @@ _test_cls_line_3(const R& )
  typedef typename  R::RT    RT;
 
  typename R::Line_3 il;
- CGAL::Line_3<R> l0( il );
- CGAL::Line_3<R> l1;
+ CGAL::Line_3<R> l0( il ); CGAL_USE(l0);
+ CGAL::Line_3<R> l1; CGAL_USE(l1);
 
  RT n1 =  3;
  RT n2 = 53;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
@@ -25,6 +25,7 @@
 #define CGAL__TEST_CLS_LINE_3_H
 
 #include <CGAL/use.h>
+#include <boost/type_traits/is_same.hpp>
 
 template <class R>
 bool
@@ -33,6 +34,7 @@ _test_cls_line_3(const R& )
  std::cout << "Testing class Line_3" ;
 
  typedef typename  R::RT    RT;
+ const bool nonexact = boost::is_same<RT, double>::value;
 
  typename R::Line_3 il;
  CGAL::Line_3<R> l0( il ); CGAL_USE(l0);
@@ -101,20 +103,20 @@ _test_cls_line_3(const R& )
 
  assert( l4.point(2) - l4.point(1) == l4.point(1) - l4.point(0) );
  CGAL::Point_3<R> p1l4proj = l4.projection(p1);
- assert( l4.has_on( p1l4proj ) );
- assert( l4.perpendicular_plane( p1l4proj ).has_on( p1l4proj ) );
- assert( l4.perpendicular_plane( p1l4proj ).has_on( p1 ) );
+ assert( l4.has_on( p1l4proj ) || nonexact );
+ assert( l4.perpendicular_plane( p1l4proj ).has_on( p1l4proj ) || nonexact );
+ assert( l4.perpendicular_plane( p1l4proj ).has_on( p1 ) || nonexact );
  CGAL::Point_3<R> p4 = l4.projection(p2);
  CGAL::Point_3<R> p5 = l4.projection(p3);
  assert(  ( l4.direction() == ( p5 - p4 ).direction() )\
-        ||( l4.direction() == ( p4 - p5 ).direction() )  );
+        ||( l4.direction() == ( p4 - p5 ).direction() )  || nonexact );
  assert( l5.direction() == - l6.direction() );
 
  std::cout <<'.';
 
  assert( l2.has_on(p1) );
  assert( l2.has_on(p2) );
- assert( l4.has_on(p4) );
+ assert( l4.has_on(p4) || nonexact );
  assert( l4.has_on(p5) );
  assert( CGAL::Line_3<R>(p1,p1).is_degenerate() );
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_plane_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_plane_3.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_PLANE_3_H
 #define CGAL__TEST_CLS_PLANE_3_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_plane_3(const R& )
@@ -34,7 +36,7 @@ _test_cls_plane_3(const R& )
  typedef typename  R::FT    FT;
 
  typename R::Plane_3  ip;
- CGAL::Plane_3<R> pl0(ip);
+ CGAL::Plane_3<R> pl0(ip); CGAL_USE(pl0);
 
  RT  x1 = -1;
  RT  x2 =  4;
@@ -45,7 +47,7 @@ _test_cls_plane_3(const R& )
                  py(RT(0),RT(1),RT(0)),
                  pz(RT(0),RT(0),RT(1));
 
- CGAL::Point_3<R> p3(p1);
+ CGAL::Point_3<R> p3(p1); CGAL_USE(p3);
  CGAL::Direction_3<R> d1( RT(5), RT(-5), RT(10) );
  CGAL::Vector_3<R>    v1 = d1.vector();
 
@@ -121,8 +123,8 @@ _test_cls_plane_3(const R& )
  assert( xy_pl.has_on( gnup ) );
 
  CGAL::Vector_3<R> nov = pl1.orthogonal_vector();
- CGAL::Vector_3<R> vb1 = pl1.base1();
- CGAL::Vector_3<R> vb2 = pl1.base2();
+ CGAL::Vector_3<R> vb1 = pl1.base1(); CGAL_USE(vb1);
+ CGAL::Vector_3<R> vb2 = pl1.base2(); CGAL_USE(vb2);
  assert( (nov*pl1.base1()) == FT(0)&&(nov*pl1.base2()) == FT(0) );
  assert( (pl1.base2()*pl1.base1()) == FT(0) );
  assert( pl1.has_on(pl1.point() + pl1.base1()) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_point_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_point_2.h
@@ -30,6 +30,7 @@
 #include <CGAL/Origin.h>
 #include <CGAL/Vector_2.h>
 #include <CGAL/Weighted_point_2.h>
+#include <CGAL/use.h>
 
 #include <boost/type_traits/is_convertible.hpp>
 
@@ -49,7 +50,7 @@ _test_cls_point_2(const R& )
  typedef typename R::Point_2::Cartesian_const_iterator CCI;
 
  CGAL::Point_2<R>  p1;
- CGAL::Point_2<R>  p2(ip);
+ CGAL::Point_2<R>  p2(ip); CGAL_USE(p2);
  CGAL::Point_2<R>  p0(CGAL::ORIGIN);
 
  RT  n1(-35 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_point_3.h
@@ -29,6 +29,7 @@
 #include <CGAL/Origin.h>
 #include <CGAL/Vector_3.h>
 #include <CGAL/Weighted_point_3.h>
+#include <CGAL/use.h>
 
 #include <cassert>
 #include <iostream>
@@ -46,7 +47,7 @@ _test_cls_point_3(const R& )
  typedef typename R::Point_3::Cartesian_const_iterator CCI;
 
  CGAL::Point_3<R>  p1;
- CGAL::Point_3<R>  p2(ip);
+ CGAL::Point_3<R>  p2(ip); CGAL_USE(p2);
  CGAL::Point_3<R>  p0(CGAL::ORIGIN);
 
  RT  n1(-35 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_sphere_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_sphere_3.h
@@ -26,6 +26,7 @@
 
 #include <CGAL/Bbox_3.h>
 #include <cassert>
+#include <boost/type_traits/is_same.hpp>
 
 template <class R>
 bool
@@ -38,6 +39,7 @@ _test_cls_sphere_3(const R& )
  typename R::Sphere_3  ic;
  CGAL::Sphere_3<R> c0;
 
+ const bool nonexact = boost::is_same<FT, double>::value;
  RT n0 =  0;
  RT n1 = 16;
  RT n2 = -4;
@@ -104,8 +106,8 @@ _test_cls_sphere_3(const R& )
  assert( cn3 == cp3.opposite() );
  assert( c7.opposite() == c8 );
  assert( c8.opposite() == c7 );
- assert( c1.opposite() == c3 );
- assert( c3.opposite() == c1 );
+ assert( c1.opposite() == c3 || nonexact );
+ assert( c3.opposite() == c1 || nonexact );
  assert( c7.orientation() == CGAL::POSITIVE );
  assert( c8.orientation() == CGAL::NEGATIVE );
  assert( c5.orientation() == CGAL::POSITIVE );
@@ -181,22 +183,22 @@ _test_cls_sphere_3(const R& )
 
  CGAL::Point_3<R> ori = CGAL::Point_3<R>( RT(0), RT(0), RT(0));
  CGAL::Point_3<R> p6  = p2.transform( rotate1 );
- assert( CGAL::compare_distance_to_point( ori, p2, p6) == CGAL::EQUAL );
+ assert( CGAL::compare_distance_to_point( ori, p2, p6) == CGAL::EQUAL || nonexact );
  CGAL::Point_3<R> p7  = p2.transform( rotate2 );
- assert( CGAL::compare_distance_to_point( ori, p2, p7) == CGAL::EQUAL );
+ assert( CGAL::compare_distance_to_point( ori, p2, p7) == CGAL::EQUAL || nonexact );
  CGAL::Point_3<R> p8  = p2.transform( rotate3 );
- assert( CGAL::compare_distance_to_point( ori, p2, p8) == CGAL::EQUAL );
+ assert( CGAL::compare_distance_to_point( ori, p2, p8) == CGAL::EQUAL || nonexact );
  CGAL::Point_3<R> p9  = p2.transform( rotate4 );
  assert( CGAL::compare_distance_to_point( ori, p2, p9) == CGAL::EQUAL );
  CGAL::Point_3<R> p10 = p2.transform( rotate5 );
- assert( CGAL::compare_distance_to_point( ori, p2, p10) == CGAL::EQUAL );
+ assert( CGAL::compare_distance_to_point( ori, p2, p10) == CGAL::EQUAL || nonexact );
  p6 = p6 + v1;
  p7 = p7 + v1;
  p8 = p8 + v1;
  p9 = p9 + v1;
  p10 = p10 + v1;
  CGAL::Sphere_3<R> c10 (p6, p8, p7, p9);
- assert( c10.center() == ori + v1 );
+ assert( c10.center() == ori + v1 || nonexact );
  assert( c10.orientation() == CGAL::POSITIVE );
  assert( c10.opposite().orientation() == CGAL::NEGATIVE );
 
@@ -205,9 +207,9 @@ _test_cls_sphere_3(const R& )
          == CGAL::ON_POSITIVE_SIDE );
  assert( c10.oriented_side(CGAL::ORIGIN + v1 + vx*n2 ) \
          == CGAL::ON_NEGATIVE_SIDE );
- assert( c10.oriented_side(p9 ) == CGAL::ON_ORIENTED_BOUNDARY );
- assert( c10.has_on_boundary(p9) );
- assert( c10.has_on_boundary(p4 + v1) );
+ assert( c10.oriented_side(p9 ) == CGAL::ON_ORIENTED_BOUNDARY || nonexact );
+ assert( c10.has_on_boundary(p9) || nonexact );
+ assert( c10.has_on_boundary(p4 + v1) || nonexact );
  CGAL::Point_3<R> p11( n4, n4, n4, n3) ; // (2.5, 2.5, 2.5)
  CGAL::Point_3<R> p12( n5, n5, n5, n3) ; // ( 5 ,  5,   5 )
  assert( c10.has_on_bounded_side( p11 ) );
@@ -217,8 +219,8 @@ _test_cls_sphere_3(const R& )
  assert( c10.has_on_negative_side( p12 ) );
  assert( c10.opposite().has_on_negative_side( p11 ) );
  assert( c10.opposite().has_on_positive_side( p12 ) );
- assert( c10.has_on_boundary( p6 ) );
- assert( c10.has_on_boundary( p8 ) );
+ assert( c10.has_on_boundary( p6 ) || nonexact );
+ assert( c10.has_on_boundary( p8 ) || nonexact );
 
 
  std::cout << '.';

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_triangle_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_triangle_2.h
@@ -26,6 +26,7 @@
 
 #include <CGAL/Bbox_2.h>
 #include <cassert>
+#include <CGAL/use.h>
 
 template <class R>
 bool
@@ -35,9 +36,6 @@ _test_cls_triangle_2(const R& )
 
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
-
- typename R::Triangle_2 it;
- CGAL::Triangle_2<R> t0(it);
 
  RT n0 =  0;
  RT n1 =  1;
@@ -61,6 +59,10 @@ _test_cls_triangle_2(const R& )
  CGAL::Point_2<R> p7( n4, n0);        // ( 4, 0)
  CGAL::Point_2<R> p8(-n12,-n8,-n2);   // ( 6, 4)
  CGAL::Point_2<R> p9( n9, n9, n3);    // ( 3, 3)
+
+ typename R::Triangle_2 it0; CGAL_USE(it0); // test default-construction
+ typename R::Triangle_2 it(p1, p2, p3);
+ CGAL::Triangle_2<R> t0(it);
 
  CGAL::Triangle_2<R> t1( p1, p3, p5);
  CGAL::Triangle_2<R> t2( p3, p1, p5);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_vector_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_vector_2.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_VECTOR_2_H
 #define CGAL__TEST_CLS_VECTOR_2_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_vector_2(const R& )
@@ -37,7 +39,7 @@ _test_cls_vector_2(const R& )
  typedef typename R::Vector_2::Cartesian_const_iterator CCI;
 
  CGAL::Vector_2<R>  v1;
- CGAL::Vector_2<R>  v2(iv);
+ CGAL::Vector_2<R>  v2(iv); CGAL_USE(v2);
  CGAL::Vector_2<R>  v0(CGAL::NULL_VECTOR);
 
  RT  n1( 12 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_vector_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_vector_3.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_CLS_VECTOR_3_H
 #define CGAL__TEST_CLS_VECTOR_3_H
 
+#include <CGAL/use.h>
+
 template <class R>
 bool
 _test_cls_vector_3(const R& )
@@ -37,7 +39,7 @@ _test_cls_vector_3(const R& )
  typedef typename R::Vector_3::Cartesian_const_iterator CCI;
 
  CGAL::Vector_3<R>  v1;
- CGAL::Vector_3<R>  v2(iv);
+ CGAL::Vector_3<R>  v2(iv); CGAL_USE(v2);
  CGAL::Vector_3<R>  v0(CGAL::NULL_VECTOR);
 
  RT  n1( 12 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_points_implicit_sphere.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_points_implicit_sphere.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_FCT_POINTS_IMPLICIT_SPHERE_H
 #define CGAL__TEST_FCT_POINTS_IMPLICIT_SPHERE_H
 
+#include <boost/type_traits/is_same.hpp>
+
 template <class R>
 bool
 _test_fct_points_implicit_sphere(const R&)
@@ -31,6 +33,8 @@ _test_fct_points_implicit_sphere(const R&)
   typedef typename R::RT    RT;
   typedef typename R::FT    FT;
   typedef CGAL::Tetrahedron_3<R>  Tetrahedron;
+
+  const bool nonexact = boost::is_same<FT, double>::value;
 
   const RT RT0(0);
   const RT RT4(4);
@@ -70,7 +74,7 @@ _test_fct_points_implicit_sphere(const R&)
   CGAL::Point_3<R> tpt = p.transform(rot_z);
   assert( CGAL::squared_distance( tpt, org ) == FT1 );
   p = tpt.transform(rot_z);
-  assert( CGAL::squared_distance(   p, org ) == FT1 );
+  assert( CGAL::squared_distance(   p, org ) == FT1 || nonexact );
   
   CGAL::rational_rotation_approximation( RT(35), RT(-8),
                                          sin, cos, den,
@@ -82,9 +86,9 @@ _test_fct_points_implicit_sphere(const R&)
   
   assert( CGAL::squared_distance(   q, org ) == FT1 );
   tpt = q.transform(rot_x);
-  assert( CGAL::squared_distance( tpt, org ) == FT1 );
+  assert( CGAL::squared_distance( tpt, org ) == FT1 || nonexact );
   q = tpt.transform(rot_y);
-  assert( CGAL::squared_distance(   q, org ) == FT1 );
+  assert( CGAL::squared_distance(   q, org ) == FT1 || nonexact );
   
   CGAL::rational_rotation_approximation( RT(9), RT(-8),
                                          sin, cos, den,
@@ -98,7 +102,7 @@ _test_fct_points_implicit_sphere(const R&)
   tpt = r.transform(rot_z);
   assert( CGAL::squared_distance( tpt, org ) == FT1 );
   r = tpt.transform(rot_y);
-  assert( CGAL::squared_distance(   r, org ) == FT1 );
+  assert( CGAL::squared_distance(   r, org ) == FT1 || nonexact );
   
   CGAL::rational_rotation_approximation( RT(-19), RT(-1),
                                          sin, cos, den,
@@ -137,11 +141,11 @@ _test_fct_points_implicit_sphere(const R&)
   CGAL::Point_3<R> ez( RT0, RT0, RT1);
   CGAL::Point_3<R> oz( RT0, RT0, -RT1);
   assert( CGAL::circumcenter(ex, ey, ez, oz) == org );
-  assert( CGAL::circumcenter(p,q,r,s) == org );
-  assert( CGAL::circumcenter(p,r,q,s) == org );
+  assert( CGAL::circumcenter(p,q,r,s) == org || nonexact );
+  assert( CGAL::circumcenter(p,r,q,s) == org || nonexact );
   assert( CGAL::circumcenter(Tetrahedron(ex, ey, ez, oz)) == org );
-  assert( CGAL::circumcenter(Tetrahedron(p,q,r,s)) == org );
-  assert( CGAL::circumcenter(Tetrahedron(p,r,q,s)) == org );
+  assert( CGAL::circumcenter(Tetrahedron(p,q,r,s)) == org || nonexact );
+  assert( CGAL::circumcenter(Tetrahedron(p,r,q,s)) == org || nonexact );
   
   CGAL::Vector_3<R>  v( RT(12), RT(4), RT(-4), RT(2) );
   CGAL::Point_3<R>   pt = p + v;
@@ -169,10 +173,10 @@ _test_fct_points_implicit_sphere(const R&)
   assert( CGAL::side_of_bounded_sphere(pt,rt,qt,st,ot) \
           == CGAL::ON_UNBOUNDED_SIDE);
 
-  assert( CGAL::circumcenter(pt,qt,rt,st) == c );
-  assert( CGAL::circumcenter(pt,rt,qt,st) == c );
-  assert( CGAL::circumcenter(Tetrahedron(pt,qt,rt,st)) == c );
-  assert( CGAL::circumcenter(Tetrahedron(pt,rt,qt,st)) == c );
+  assert( CGAL::circumcenter(pt,qt,rt,st) == c || nonexact );
+  assert( CGAL::circumcenter(pt,rt,qt,st) == c || nonexact );
+  assert( CGAL::circumcenter(Tetrahedron(pt,qt,rt,st)) == c || nonexact );
+  assert( CGAL::circumcenter(Tetrahedron(pt,rt,qt,st)) == c || nonexact );
 
   // Now test side_of_bounded_sphere(p, q, t).
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_weighted_point_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_weighted_point_2.h
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <iostream>
 
+#include "_approx_equal.h"
+
 template <class R>
 bool
 _test_fct_weighted_point_2(const R& )
@@ -158,8 +160,9 @@ _test_fct_weighted_point_2(const R& )
 
   std::cout << CGAL::weighted_circumcenter(wp_00, wp_10, wp_01) << std::endl;
 
-  assert( CGAL::squared_radius_smallest_orthogonal_circle(wp1, wp3, wp5)
-            == CGAL::squared_radius(p1, p3, p5));
+  using CGAL::testsuite::approx_equal;
+  assert( approx_equal(CGAL::squared_radius_smallest_orthogonal_circle(wp1, wp3, wp5),
+                       CGAL::squared_radius(p1, p3, p5)) );
   assert( CGAL::squared_radius_smallest_orthogonal_circle(wp_00, wp_10, wp_01) == RT(0));
 
   std::cout << "done" << std::endl;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_weighted_point_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_weighted_point_3.h
@@ -27,6 +27,7 @@
 #include <CGAL/Point_3.h>
 #include <CGAL/Weighted_point_3.h>
 
+#include <boost/type_traits/is_same.hpp>
 #include <cassert>
 #include <iostream>
 
@@ -37,6 +38,7 @@ _test_fct_weighted_point_3(const R& )
   std::cout << "Testing functions Weighted_point_3" ;
 
   typedef typename  R::RT    RT;
+  const bool nonexact = boost::is_same<RT, double>::value;
 
   CGAL::Point_3<R> p1(RT(18), RT(15), RT(-21), RT(3) ); //  6,  5, -7
   CGAL::Point_3<R> p2(RT(18), RT(15), RT( 12), RT(3) ); //  6,  5,  4
@@ -138,7 +140,7 @@ _test_fct_weighted_point_3(const R& )
   assert( CGAL::power_side_of_bounded_power_sphere(wp3_b, wp1_b, wp6b_b) == CGAL::ON_BOUNDED_SIDE );
   assert( CGAL::power_side_of_bounded_power_sphere(wp1_b, wp3_b, wp6b_b) == CGAL::ON_BOUNDED_SIDE );
 
-  assert( CGAL::coplanar(p4, p5, p6, p7) );
+  assert( CGAL::coplanar(p4, p5, p6, p7) || nonexact );
   assert( CGAL::power_side_of_bounded_power_sphere(wp4, wp5, wp6, wp7)
           == CGAL::side_of_bounded_sphere(p4, p5, p6, p7) );
   assert( CGAL::power_side_of_bounded_power_sphere(wp4, wp5, wp6, wp5)
@@ -171,11 +173,11 @@ _test_fct_weighted_point_3(const R& )
   assert( CGAL::squared_radius_smallest_orthogonal_sphere(wp1_b, wp3_b) == RT(164));
 
   assert( CGAL::squared_radius_smallest_orthogonal_sphere(wp1, wp3, wp5)
-            == CGAL::squared_radius(p1, p3, p5));
+            == CGAL::squared_radius(p1, p3, p5) || nonexact);
   assert( CGAL::squared_radius_smallest_orthogonal_sphere(wp000, wp100, wp010) == RT(0));
 
   assert( CGAL::squared_radius_smallest_orthogonal_sphere(wp1, wp3, wp4, wp5)
-            == CGAL::squared_radius(p1, p3, p4, p5));
+            == CGAL::squared_radius(p1, p3, p4, p5) || nonexact);
   assert( CGAL::squared_radius_smallest_orthogonal_sphere(wp000, wp100, wp010, wp001) == RT(0));
 
   std::cout << ".";

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_further_fct_point_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_further_fct_point_2.h
@@ -25,6 +25,7 @@
 #define CGAL__TEST_FURTHER_FCT_POINT_2_H
 
 #include "_approx_equal.h"
+#include <boost/type_traits/is_same.hpp>
 
 template <class R>
 bool
@@ -100,6 +101,8 @@ _test_further_fct_point_2(const R& )
  using CGAL::testsuite::approx_equal;
  using CGAL::testsuite::Direction_2_tag;
 
+ const bool nonexact = boost::is_same<FT, double>::value;
+
  assert( approx_equal((p5 - CGAL::ORIGIN).direction(), dir5, Direction_2_tag()) );
 
  assert( CGAL::side_of_bounded_circle(p1, p2, p3, CGAL::Point_2<R>(CGAL::ORIGIN))\
@@ -107,15 +110,15 @@ _test_further_fct_point_2(const R& )
  assert( CGAL::side_of_bounded_circle(p1+v, p2+v, p3+v, CGAL::ORIGIN + v) \
                                       == CGAL::ON_BOUNDED_SIDE );
  assert( CGAL::side_of_bounded_circle(p1+v, p2+v, p3+v, CGAL::ORIGIN - v) \
-                                      == CGAL::ON_UNBOUNDED_SIDE );
+                                      == CGAL::ON_UNBOUNDED_SIDE || nonexact);
  assert( CGAL::side_of_bounded_circle(p1, p2, p3, p4) \
-                                      == CGAL::ON_BOUNDARY );
+                                      == CGAL::ON_BOUNDARY || nonexact);
  assert( CGAL::side_of_bounded_circle(p1+v, p2+v, p3+v, p4+v) \
-                                      == CGAL::ON_BOUNDARY );
+                                      == CGAL::ON_BOUNDARY || nonexact);
  assert( CGAL::side_of_bounded_circle(p1+v, p3+v, p4+v, p2+v) \
-                                      == CGAL::ON_BOUNDARY );
+                                      == CGAL::ON_BOUNDARY || nonexact);
  assert( CGAL::side_of_bounded_circle(p2+v, p4+v, p1+v, p3+v) \
-                                      == CGAL::ON_BOUNDARY );
+                                      == CGAL::ON_BOUNDARY || nonexact);
 
  assert( CGAL::orientation( p1, p2, p3 ) == CGAL::POSITIVE );
 
@@ -130,11 +133,11 @@ _test_further_fct_point_2(const R& )
  assert( CGAL::side_of_oriented_circle(p2+v, p1+v, p3+v, CGAL::ORIGIN - v) \
                                       == CGAL::ON_POSITIVE_SIDE );
  assert( CGAL::side_of_oriented_circle(p1, p2, p3, p4) \
-                                      == CGAL::ON_ORIENTED_BOUNDARY );
+                                      == CGAL::ON_ORIENTED_BOUNDARY || nonexact);
  assert( CGAL::side_of_oriented_circle(p1+v, p2+v, p3+v, p4+v) \
-                                      == CGAL::ON_ORIENTED_BOUNDARY );
+                                      == CGAL::ON_ORIENTED_BOUNDARY || nonexact);
  assert( CGAL::side_of_oriented_circle(p1+v, p3+v, p4+v, p2+v) \
-                                      == CGAL::ON_ORIENTED_BOUNDARY );
+                                      == CGAL::ON_ORIENTED_BOUNDARY || nonexact);
 
  CGAL::Point_2<R> p10( RT(100), RT(100), RT(10) );
  CGAL::Point_2<R> p11( RT(-100), RT(-100), RT(10) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_further_fct_point_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_further_fct_point_2.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_FURTHER_FCT_POINT_2_H
 #define CGAL__TEST_FURTHER_FCT_POINT_2_H
 
+#include "_approx_equal.h"
+
 template <class R>
 bool
 _test_further_fct_point_2(const R& )
@@ -95,8 +97,10 @@ _test_further_fct_point_2(const R& )
  p4 = p0.transform(rotate4);
  p5 = p0.transform(rotate5);
 
+ using CGAL::testsuite::approx_equal;
+ using CGAL::testsuite::Direction_2_tag;
 
- assert( (p5 - CGAL::ORIGIN).direction() == dir5 );
+ assert( approx_equal((p5 - CGAL::ORIGIN).direction(), dir5, Direction_2_tag()) );
 
  assert( CGAL::side_of_bounded_circle(p1, p2, p3, CGAL::Point_2<R>(CGAL::ORIGIN))\
                                       == CGAL::ON_BOUNDED_SIDE );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_mf_plane_3_to_2d.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_mf_plane_3_to_2d.h
@@ -24,6 +24,8 @@
 #ifndef CGAL__TEST_MF_PLANE_3_TO_2D_H
 #define CGAL__TEST_MF_PLANE_3_TO_2D_H
 
+#include <boost/type_traits/is_same.hpp>
+
 template <class R>
 bool
 _test_mf_plane_3_to_2d(const R& )
@@ -34,6 +36,8 @@ _test_mf_plane_3_to_2d(const R& )
  typedef CGAL::Plane_3< R>   Plane_3;
  typedef CGAL::Point_3< R>   Point_3;
  typedef CGAL::Point_2< R>   Point_2;
+
+ const bool nonexact = boost::is_same<RT, double>::value;
 
  RT  n0 =  0;
  RT  n1 =  7;
@@ -51,33 +55,33 @@ _test_mf_plane_3_to_2d(const R& )
  Point_3 p4 = p3 + (p2 - p1);
 
  Plane_3 pl1( p1, p2, p3);
- assert( pl1.has_on( pl1.to_3d( pl1.to_2d( pl1.point() ))) );
- assert( pl1.has_on( pl1.to_3d( pl1.to_2d( p4 ))) );
- assert( p1 == pl1.to_3d( pl1.to_2d( p1)) );
- assert( p2 == pl1.to_3d( pl1.to_2d( p2)) );
- assert( p3 == pl1.to_3d( pl1.to_2d( p3)) );
- assert( p4 == pl1.to_3d( pl1.to_2d( p4)) );
+ assert( pl1.has_on( pl1.to_3d( pl1.to_2d( pl1.point() ))) || nonexact );
+ assert( pl1.has_on( pl1.to_3d( pl1.to_2d( p4 ))) || nonexact );
+ assert( p1 == pl1.to_3d( pl1.to_2d( p1)) || nonexact );
+ assert( p2 == pl1.to_3d( pl1.to_2d( p2)) || nonexact );
+ assert( p3 == pl1.to_3d( pl1.to_2d( p3)) || nonexact );
+ assert( p4 == pl1.to_3d( pl1.to_2d( p4)) || nonexact );
 
  std::cout << '.';
 
  Plane_3 pl2( p2, p1, p3);
- assert( pl2.has_on( pl2.to_3d( pl2.to_2d( pl2.point() ))) );
- assert( pl2.has_on( pl2.to_3d( pl2.to_2d( p4 ))) );
- assert( p1 == pl2.to_3d( pl2.to_2d( p1)) );
- assert( p2 == pl2.to_3d( pl2.to_2d( p2)) );
- assert( p3 == pl2.to_3d( pl2.to_2d( p3)) );
- assert( p4 == pl2.to_3d( pl2.to_2d( p4)) );
+ assert( pl2.has_on( pl2.to_3d( pl2.to_2d( pl2.point() ))) || nonexact );
+ assert( pl2.has_on( pl2.to_3d( pl2.to_2d( p4 ))) || nonexact );
+ assert( p1 == pl2.to_3d( pl2.to_2d( p1)) || nonexact );
+ assert( p2 == pl2.to_3d( pl2.to_2d( p2)) || nonexact );
+ assert( p3 == pl2.to_3d( pl2.to_2d( p3)) || nonexact );
+ assert( p4 == pl2.to_3d( pl2.to_2d( p4)) || nonexact );
 
  Point_3 p5( n2, n8, n0, n7);
  Point_3 p6( n4, n5, n0, n8);
  Plane_3 pl3( p4, p5, p6);
- assert( p4 == pl3.to_3d( pl3.to_2d( p4)) );
+ assert( p4 == pl3.to_3d( pl3.to_2d( p4)) || nonexact );
  assert( p5 == pl3.to_3d( pl3.to_2d( p5)) );
- assert( p6 == pl3.to_3d( pl3.to_2d( p6)) );
+ assert( p6 == pl3.to_3d( pl3.to_2d( p6)) || nonexact );
  Plane_3 pl4( p4, p6, p5);
- assert( p4 == pl4.to_3d( pl4.to_2d( p4)) );
+ assert( p4 == pl4.to_3d( pl4.to_2d( p4)) || nonexact );
  assert( p5 == pl4.to_3d( pl4.to_2d( p5)) );
- assert( p6 == pl4.to_3d( pl4.to_2d( p6)) );
+ assert( p6 == pl4.to_3d( pl4.to_2d( p6)) || nonexact );
 
  Point_3 p7 = CGAL::midpoint( p1, p2);
  Point_3 p8 = CGAL::midpoint( p3, p3 + (p2-p1) );
@@ -98,14 +102,14 @@ _test_mf_plane_3_to_2d(const R& )
  CGAL::Segment_2<R> sp2( pp9, pp10);
  Point_2 pp;
  assert( CGAL::assign( pp, CGAL::intersection( sp1, sp2)) );
- assert( sp1.has_on( pp) );
- assert( sp2.has_on( pp) );
+ assert( sp1.has_on( pp) || nonexact );
+ assert( sp2.has_on( pp) || nonexact );
  Point_3 p = pl1.to_3d( pp);
- assert( pl1.has_on( p ));
+ assert( pl1.has_on( p ) || nonexact );
  CGAL::Segment_3<R> s1( p7, p8);
  CGAL::Segment_3<R> s2( p9, p10);
- assert( s1.has_on( p) );
- assert( s2.has_on( p) );
+ assert( s1.has_on( p) || nonexact );
+ assert( s2.has_on( p) || nonexact );
 
  std::cout << '.' << std::endl;
  return true;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_2.h
@@ -35,7 +35,7 @@
 #include "_test_cls_iso_rectangle_new_2.h"
 #include "_test_cls_circle_new_2.h"
 
-#include <CGAL/Testsuite/use.h>
+#include <CGAL/use.h>
 
 using CGAL::internal::use;
 
@@ -175,8 +175,8 @@ test_new_2(const R& rep)
 
   typename R::Construct_triangle_2 construct_triangle
         = rep.construct_triangle_2_object();
-  Triangle_2 t1;
-  Triangle_2 t2 = construct_triangle(p2,p3,p4);
+  Triangle_2 t0; CGAL_USE(t0); // test default-construction
+  Triangle_2 t2 = construct_triangle(p2,p3,p4), t1 = t2;
 
   typename R::Construct_iso_rectangle_2 construct_iso_rectangle
         = rep.construct_iso_rectangle_2_object();
@@ -379,6 +379,7 @@ test_new_2(const R& rep)
   typename R::Compute_power_product_2 compute_power_product
         = rep.compute_power_product_2_object();
      tmp22d = compute_power_product(wp6, wp7);
+  CGAL_USE(tmp22d);
 
   typename R::Compute_squared_length_2 Compute_squared_length
         = rep.compute_squared_length_2_object();
@@ -672,7 +673,7 @@ test_new_2(const R& rep)
   use(tmp9); use(tmp10); use(tmp11); use(tmp12); use(tmp12a);
   use(tmp14); use(tmp14a); use(tmp15); use(tmp16);
   use(tmp16); use(tmp17); use(tmp19); use(tmp19a); use(tmp22a);
-  use(tmp22b); use(tmp22c); use(tmp23);
+  use(tmp22b); use(tmp22c); use(tmp22d); use(tmp23);
 
   use(tmp58);
   use(tmp57); use(tmp56); use(tmp55); use(tmp54); use(tmp53b); use(tmp53a);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -29,7 +29,7 @@
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/_test_compare_dihedral_angle_3.h>
 
-#include <CGAL/Testsuite/use.h>
+#include <CGAL/use.h>
 
 using CGAL::internal::use;
 
@@ -157,8 +157,8 @@ test_new_3(const R& rep)
 
   typename R::Construct_segment_3 construct_segment
         = rep.construct_segment_3_object();
-  Segment_3 s1;
-  Segment_3 s2 = construct_segment(p2,p3);
+  Segment_3 s0; CGAL_USE(s0); // test default-construction
+  Segment_3 s2 = construct_segment(p2,p3), s1 = s2;
 
   typename R::Construct_ray_3 construct_ray =
         rep.construct_ray_3_object();

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -214,11 +214,10 @@ test_new_3(const R& rep)
   Sphere_3 sp8 = construct_sphere(p3);
   Sphere_3 sp9 = construct_sphere(p3,CLOCKWISE);
 
-
+  Triangle_3 t0; CGAL_USE(t0); // test the default-construction
   typename R::Construct_triangle_3 construct_triangle
         = rep.construct_triangle_3_object();
-  Triangle_3 t1;
-  Triangle_3 t2 = construct_triangle(p2,p3,p4);
+  Triangle_3 t1 = construct_triangle(p2,p3,p4), t2 = t1;
 
   typename R::Construct_tetrahedron_3 construct_tetrahedron
         = rep.construct_tetrahedron_3_object();


### PR DESCRIPTION
## Summary of Changes

Add an alternative to `Epick` without the dynamic filters: only the static filters are applied before the exact computation.

## Release Management

* Affected package(s): Kernel_23m Convex_hull_3
* License and copyright ownership: maintenance by GF

