### PR TITLE
Fix the default of 3rd template parameter of Convex_hull_traits_3

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
@@ -159,7 +159,12 @@ struct GT3_for_CH3 {
 
 
 
-  template <class R_, class Polyhedron = Default, class Has_filtered_predicates_tag = Tag_false>
+  template <class R_, class Polyhedron = Default,
+            class Has_filtered_predicates_tag = Boolean_tag
+            <
+              boost::is_floating_point<typename R_::FT>::type::value &&
+              R_::Has_filtered_predicates_tag::value
+            > >
 class Convex_hull_traits_3 
 {
  public:  


### PR DESCRIPTION
## Summary of Changes

The documentation of `convex_hull_3` says that, if the kernel is "like `Epick`", then the default traits class of `convex_hull_3` is `Convex_hull_traits_3`.

But that is wrong, because `Convex_hull_traits_3` is documented with only two template parameters, and if the kernel is "like `Epick`", the third argument is `CGAL::Tag_true`, whereas the default of that parameter is `CGAL::Tag_false`. If users want to write explicitly the traits in the call to `convex_hull_3`, they cannot know that there is a third parameters, and that it must be `Tag_true`.

This PR fixes the default of that third argument.

## Release Management

* Affected package(s): Convex_hull_3
* License and copyright ownership: maintenance by GF

Cc: @afabri
