### PR TITLE
Add missing 'using' for boost's choose_param() / get_param()

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -1784,6 +1784,9 @@ std::size_t make_umbrella_manifold(typename boost::graph_traits<PolygonMesh>::ha
   typedef typename boost::graph_traits<PolygonMesh>::vertex_descriptor    vertex_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor  halfedge_descriptor;
 
+  using boost::get_param;
+  using boost::choose_param;
+
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::type VertexPointMap;
   VertexPointMap vpm = choose_param(get_param(np, internal_np::vertex_point),
                                     get_property_map(vertex_point, pm));


### PR DESCRIPTION
## Summary of Changes

Should fix the compilation error described in [this comment](https://github.com/CGAL/cgal/pull/3857#issuecomment-493866442).

## Release Management

* Affected package(s): `Polygon_mesh_processing`

