### PR TITLE
Fix CTest CGAL tests when binary dir is a sub-directory

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -105,7 +105,12 @@ function(cgal_setup_test_properties test_name)
       APPEND PROPERTY DEPENDS "compilation_of__${exe_name}")
   endif()
 
-  if(POLICY CMP0066) # CMake 3.7 or later
+  get_filename_component(_source_dir_abs ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
+  get_filename_component(_binary_dir_abs ${CMAKE_CURRENT_BINARY_DIR} ABSOLUTE)
+  string(FIND "${_binary_dir_abs}" "${_source_dir_abs}" _search_binary_in_source)
+
+  if(_search_binary_in_source EQUAL "-1"
+     AND POLICY CMP0066) # CMake 3.7 or later
     if(NOT TEST ${PROJECT_NAME}_SetupFixture)
       if(ANDROID)
         add_test(NAME ${PROJECT_NAME}_SetupFixture


### PR DESCRIPTION
## Summary of Changes

When the current binary dir is a sub-directory of the current sources
dir, then the recursive copy of the sources dir to `__exec_test_dir/`
cannot be done. In that case, do not setup the fixture
directory. Tests can still be run in the source directory (and pollute
it).

@afabri: That is an old bug that prevented you from using CTest. You reported it more than one year ago. It will be soon fixed in release branches and `master`.

## Release Management

* Affected package(s): CMake
* Issue(s) solved (if any): fix #2865
