### PR TITLE
2D and 3D Triangulations:  Unify insertion of range of points with info

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -13,7 +13,15 @@ Release date: September 2019
     and `CGAL::Constrained_triangulation_plus_2::remove_constraint((Vertex_handle va, Vertex_handle vb)`,
     that is a pair of vertex handles is no longer a key for a polyline constraint.
     Users must use a version prior to 5.0 if they need this functionality.
--   **Breaking change**: Removed the deprecated classes `CGAL::Regular_triangulation_euclidean_traits_2`, `CGAL::Regular_triangulation_filtered_traits_2`.   Users must use a version prior to 5.0 if they need these classes.   
+-   **Breaking change**: Removed the deprecated classes `CGAL::Regular_triangulation_euclidean_traits_2`, `CGAL::Regular_triangulation_filtered_traits_2`.   Users must use a version prior to 5.0 if they need these classes.
+-   **Breaking change**: The constructor and the `insert()` function of `CGAL::Triangulation_2` which takes
+    a range of points as argument no longer performs a `spatial_sort()` of the points.
+-   Add constructor and `insert()` function to `CGAL::Triangulation_2` that takes a range of points with info.  
+    
+### 3D Triangulations
+-   **Breaking change**: The constructor and the `insert()` function of `CGAL::Triangulation_3` which takes
+    a range of points as argument no longer performs a `spatial_sort()` of the points.
+-   Add constructor and`insert` function to `CGAL::Triangulation_3` that takes a range of points with info.  
     
 ### Surface Mesh
  -   New functions to read and write using the PLY format,

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -21,7 +21,7 @@ Release date: September 2019
 ### 3D Triangulations
 -   **Breaking change**: The constructor and the `insert()` function of `CGAL::Triangulation_3` which takes
     a range of points as argument no longer performs a `spatial_sort()` of the points.
--   Add constructor and`insert` function to `CGAL::Triangulation_3` that takes a range of points with info.  
+-   Add constructor and `insert()` function to `CGAL::Triangulation_3` that takes a range of points with info.  
     
 ### Surface Mesh
  -   New functions to read and write using the PLY format,

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Delaunay_triangulation_2.h
@@ -99,7 +99,7 @@ const Delaunay_triangulation_2<Traits,Tds> &tr);
 Equivalent to constructing an empty triangulation with the optional traits class argument and calling insert(first,last).
 */
 template < class InputIterator >
-Delaunay_triangulation_2<Traits,Tds> dt ( InputIterator first, InputIterator last, Traits gt = Traits());
+Delaunay_triangulation_2( InputIterator first, InputIterator last, Traits gt = Traits());
 
 
 /// @} 
@@ -156,7 +156,6 @@ std::ptrdiff_t
 insert(PointInputIterator first, PointInputIterator last); 
 
 /*!
-
 inserts the points in the iterator range `[first,last)`. Returns the number of inserted points. 
 Note that this function is not guaranteed to insert the points 
 following the order of `PointWithInfoInputIterator`, as `spatial_sort()` 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -353,6 +353,12 @@ if `tr` is modified, `*this` is not.
 Triangulation_2( 
 const Triangulation_2& tr); 
 
+  /*!
+Equivalent to constructing an empty triangulation with the optional traits class argument and calling insert(first,last).
+*/
+template < class InputIterator >
+Triangulation_2( InputIterator first, InputIterator last, const Traits& gt = Traits());
+
 /*!
 Assignment. All the vertices and faces are duplicated. 
 After the assignment, `*this` and `tr` 
@@ -685,14 +691,30 @@ Equivalent to `insert(p)`.
 Vertex_handle push_back(const Point& p); 
 
 /*!
-Inserts the points in the range `[first,last)`.
+Inserts the points in the range `[first,last)` in the given order.
 Returns the number of inserted points. 
 \pre The `value_type` of `InputIterator` is `Point`. 
 */ 
 template < class InputIterator > 
 std::ptrdiff_t 
-insert(InputIterator first, InputIterator last); 
+insert(InputIterator first, InputIterator last);
 
+  
+/*!
+inserts the points in the iterator range `[first,last)`. Returns the number of inserted points. 
+
+Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is 
+`v.point() == p` and `v.info() == i`. If several pairs have the same point, 
+only one vertex is created, and one of the objects of type `Vertex::Info` will be stored in the vertex. 
+\pre `Vertex` must be model of the concept `TriangulationVertexBaseWithInfo_2`. 
+
+\tparam PointWithInfoInputIterator must be an input iterator with the value type `std::pair<Point,Vertex::Info>`. 
+
+*/ 
+template < class PointWithInfoInputIterator > 
+std::ptrdiff_t 
+insert(PointWithInfoInputIterator first, PointWithInfoInputIterator last);
+  
 /*!
 Removes the vertex from the triangulation. The created hole is 
 re-triangulated. 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -701,7 +701,7 @@ insert(InputIterator first, InputIterator last);
 
   
 /*!
-inserts the points in the iterator range `[first,last)`. Returns the number of inserted points. 
+inserts the points in the iterator range `[first,last)` in the given order. Returns the number of inserted points. 
 
 Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is 
 `v.point() == p` and `v.info() == i`. If several pairs have the same point, 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -691,17 +691,19 @@ Equivalent to `insert(p)`.
 Vertex_handle push_back(const Point& p); 
 
 /*!
-Inserts the points in the range `[first,last)` in the given order.
-Returns the number of inserted points. 
-\pre The `value_type` of `InputIterator` is `Point`. 
+Inserts the points in the range `[first,last)` in the given order,
+and returns the number of inserted points. 
+
+\tparam PointInputIterator must be an input iterator with value type `Point`. 
 */ 
-template < class InputIterator > 
+template < class PointInputIterator > 
 std::ptrdiff_t 
-insert(InputIterator first, InputIterator last);
+insert(PointInputIterator first, PointInputIterator last);
 
   
 /*!
-inserts the points in the iterator range `[first,last)` in the given order. Returns the number of inserted points. 
+inserts the points in the iterator range `[first,last)` in the given order,
+and returns the number of inserted points. 
 
 Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is 
 `v.point() == p` and `v.info() == i`. If several pairs have the same point, 

--- a/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
@@ -329,8 +329,12 @@ public:
   }
 
 #ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+
 private:
  
+  using Triangulation::top_get_first;
+  using Triangulation::top_get_second;
+  
   template <class Tuple_or_pair,class InputIterator>
   std::ptrdiff_t insert_with_info(InputIterator first,InputIterator last)
   {

--- a/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Delaunay_triangulation_2.h
@@ -31,9 +31,9 @@
 
 #ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 #include <CGAL/Spatial_sort_traits_adapter_2.h>
-#include <CGAL/internal/info_check.h>
+
 #include <CGAL/tss.h>
-#include <boost/iterator/zip_iterator.hpp>
+
 #include <boost/mpl/and.hpp>
 
 #endif //CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
@@ -330,16 +330,7 @@ public:
 
 #ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
-  //top stands for tuple-or-pair
-  template <class Info>
-  const Point& top_get_first(const std::pair<Point,Info>& pair) const { return pair.first; }
-  template <class Info>
-  const Info& top_get_second(const std::pair<Point,Info>& pair) const { return pair.second; }
-  template <class Info>
-  const Point& top_get_first(const boost::tuple<Point,Info>& tuple) const { return boost::get<0>(tuple); }
-  template <class Info>
-  const Info& top_get_second(const boost::tuple<Point,Info>& tuple) const { return boost::get<1>(tuple); }
-
+ 
   template <class Tuple_or_pair,class InputIterator>
   std::ptrdiff_t insert_with_info(InputIterator first,InputIterator last)
   {

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -241,6 +241,7 @@ public:
   template <class InputIterator>
   Triangulation_2(InputIterator first, InputIterator last,
                   const Geom_traits& geom_traits=Geom_traits())
+    : _gt(geom_traits)
   {
     insert(first,last);
   }
@@ -643,7 +644,6 @@ std::ptrdiff_t insert(InputIterator first, InputIterator last,
 
     std::vector<Point> points;
     std::vector<typename Tds::Vertex::Info> infos;
-    std::size_t index=0;
     for (InputIterator it=first;it!=last;++it) {
       Tuple_or_pair value=*it;
       points.push_back(top_get_first(value));

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -243,6 +243,7 @@ public:
                   const Geom_traits& geom_traits=Geom_traits())
     : _gt(geom_traits)
   {
+    _infinite_vertex = _tds.insert_first();
     insert(first,last);
   }
   

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -53,6 +53,11 @@
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <CGAL/boost/iterator/transform_iterator.hpp>
+#include <boost/iterator/zip_iterator.hpp>
+
+#ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+#include <CGAL/internal/info_check.h>
+#endif
 
 #ifndef CGAL_NO_STRUCTURAL_FILTERING
 #include <CGAL/internal/Static_filters/tools.h>
@@ -233,6 +238,13 @@ public:
   Triangulation_2(const Geom_traits& geom_traits=Geom_traits());
   Triangulation_2(const Triangulation_2<Gt,Tds> &tr);
 
+  template <class InputIterator>
+  Triangulation_2(InputIterator first, InputIterator last,
+                  const Geom_traits& geom_traits=Geom_traits())
+  {
+    insert(first,last);
+  }
+  
   //Assignement
   Triangulation_2 &operator=(const Triangulation_2 &tr);
 
@@ -587,32 +599,101 @@ public:
     }
     return os;
   }
-
+  
+#ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 template < class InputIterator >
-std::ptrdiff_t insert(InputIterator first, InputIterator last)
+std::ptrdiff_t insert(InputIterator first, InputIterator last,
+         typename boost::enable_if<
+         boost::is_convertible<
+         typename std::iterator_traits<InputIterator>::value_type,
+         Point
+         >
+         >::type* = NULL)
+#else
+  template < class InputIterator >
+  std::ptrdiff_t
+  insert(InputIterator first, InputIterator last)
+#endif //CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 {
   size_type n = number_of_vertices();
 
-  std::vector<Point> points (first, last);
-
-  typedef typename Geom_traits::Construct_point_2 Construct_point_2;
-  typedef typename boost::result_of<const Construct_point_2(const Point&)>::type Ret;
-  typedef CGAL::internal::boost_::function_property_map<Construct_point_2, Point, Ret> fpmap;
-  typedef CGAL::Spatial_sort_traits_adapter_2<Geom_traits, fpmap> Search_traits_2;
-
-  spatial_sort(points.begin(), points.end(),
-               Search_traits_2(
-                 CGAL::internal::boost_::make_function_property_map<Point, Ret, Construct_point_2>(
-                   geom_traits().construct_point_2_object()), geom_traits()));
-
   Face_handle f;
-  for (typename std::vector<Point>::const_iterator p = points.begin(), end = points.end();
-          p != end; ++p)
-      f = insert (*p, f)->face();
+  for (; first != last; ++first)
+      f = insert (*first, f)->face();
 
   return number_of_vertices() - n;
 }
 
+  
+#ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+    //top stands for tuple-or-pair
+  template <class Info>
+  const Point& top_get_first(const std::pair<Point,Info>& pair) const { return pair.first; }
+  template <class Info>
+  const Info& top_get_second(const std::pair<Point,Info>& pair) const { return pair.second; }
+  template <class Info>
+  const Point& top_get_first(const boost::tuple<Point,Info>& tuple) const { return boost::get<0>(tuple); }
+  template <class Info>
+  const Info& top_get_second(const boost::tuple<Point,Info>& tuple) const { return boost::get<1>(tuple); }
+
+  template <class Tuple_or_pair,class InputIterator>
+  std::ptrdiff_t insert_with_info(InputIterator first,InputIterator last)
+  {
+    size_type n = this->number_of_vertices();
+
+    std::vector<Point> points;
+    std::vector<typename Tds::Vertex::Info> infos;
+    std::size_t index=0;
+    for (InputIterator it=first;it!=last;++it) {
+      Tuple_or_pair value=*it;
+      points.push_back(top_get_first(value));
+      infos.push_back (top_get_second(value));
+    }
+
+    Vertex_handle v_hint;
+    Face_handle hint;
+    for (std::size_t i = 0; i < points.size(); ++i ) {
+      v_hint = insert(points[i], hint);
+      if(v_hint!=Vertex_handle()) {
+        v_hint->info()=infos[i];
+        hint=v_hint->face();
+      }
+    }
+
+    return this->number_of_vertices() - n;
+  }
+
+public:
+
+  template < class InputIterator >
+  std::ptrdiff_t
+  insert(InputIterator first,
+         InputIterator last,
+         typename boost::enable_if<
+           boost::is_convertible<
+             typename std::iterator_traits<InputIterator>::value_type,
+             std::pair<Point,typename internal::Info_check<typename Tds::Vertex>::type>
+           > >::type* = NULL)
+  {
+    return insert_with_info< std::pair<Point,typename internal::Info_check<typename Tds::Vertex>::type> >(first,last);
+  }
+
+  template <class  InputIterator_1,class InputIterator_2>
+  std::ptrdiff_t
+  insert(boost::zip_iterator< boost::tuple<InputIterator_1,InputIterator_2> > first,
+         boost::zip_iterator< boost::tuple<InputIterator_1,InputIterator_2> > last,
+         typename boost::enable_if<
+           boost::mpl::and_<
+             boost::is_convertible< typename std::iterator_traits<InputIterator_1>::value_type, Point >,
+             boost::is_convertible< typename std::iterator_traits<InputIterator_2>::value_type, typename internal::Info_check<typename Tds::Vertex>::type >
+           >
+         >::type* = NULL)
+  {
+    return insert_with_info< boost::tuple<Point,typename internal::Info_check<typename Tds::Vertex>::type> >(first,last);
+  }
+#endif //CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+
+  
 bool well_oriented(Vertex_handle v) const
 {
   Face_circulator fc = incident_faces(v), done(fc);

--- a/Triangulation_2/test/Triangulation_2/test_triangulation_with_zip_iterator_2.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_triangulation_with_zip_iterator_2.cpp
@@ -1,0 +1,49 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Triangulation_2.h>
+#include <CGAL/Triangulation_vertex_base_with_info_2.h>
+#include <boost/iterator/zip_iterator.hpp>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
+typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, K>    Vb;
+typedef CGAL::Triangulation_data_structure_2<Vb>                    Tds;
+typedef CGAL::Triangulation_2<K, Tds>                               Triangulation;
+typedef Triangulation::Point                                        Point;
+
+int main()
+{
+
+  std::vector<unsigned> indices;
+  indices.push_back(0);
+  indices.push_back(1);
+  indices.push_back(2);
+  indices.push_back(3);
+  indices.push_back(4);
+  indices.push_back(5);  
+  
+  std::vector<Point> points;
+  points.push_back(Point(0,0));
+  points.push_back(Point(1,0));
+  points.push_back(Point(0,1));
+  points.push_back(Point(1,47));
+  points.push_back(Point(2,2));
+  points.push_back(Point(-1,0));
+
+  
+  
+  Triangulation T( boost::make_zip_iterator(boost::make_tuple( points.begin(),indices.begin() )),
+                   boost::make_zip_iterator(boost::make_tuple( points.end(),indices.end() ) )  );
+
+  CGAL_assertion( T.number_of_vertices() == 6 );
+  
+  
+  // check that the info was correctly set.
+  Triangulation::Finite_vertices_iterator vit;
+  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
+    if( points[ vit->info() ] != vit->point() ){
+      std::cerr << "Error different info" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+  return 0;
+}

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
@@ -209,7 +209,6 @@ std::ptrdiff_t
 insert(PointInputIterator first, PointInputIterator last); 
 
 /*!
-
 Inserts the points in the iterator range  `[first,last)`. 
 Returns the number of inserted points. 
 Note that this function is not guaranteed to insert the points 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -908,12 +908,29 @@ Cell_handle loc, int li, int lj);
 Inserts the points in the range `[first,last)`. Returns the number of inserted points. 
 Note that this function is not guaranteed to insert the points 
 following the order of `InputIterator`. 
-\tparam InputIterator must be an input iterator with value type `Point`. 
+\tparam PointInputIterator must be an input iterator with value type `Point`. 
 */ 
-template < class InputIterator > 
+template < class PointInputIterator > 
 std::ptrdiff_t 
-insert(InputIterator first, InputIterator last); 
+insert(PointInputIterator first, PointInputIterator last); 
 
+
+/*!
+Inserts the points in the iterator range  `[first,last)`. 
+Returns the number of inserted points. 
+Inserts the points following the order of `PointWithInfoInputIterator`. 
+
+Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is 
+`v.point() == p` and `v.info() == i`. If several pairs have the same point, 
+only one vertex is created, and one of the objects of type `Vertex::Info` will be stored in the vertex. 
+\pre `Vertex` must be model of the concept `TriangulationVertexBaseWithInfo_3`. 
+
+\tparam PointWithInfoInputIterator must be an input iterator with the value type `std::pair<Point,Vertex::Info>`. 
+
+*/ 
+template < class PointWithInfoInputIterator > 
+std::ptrdiff_t 
+insert(PointWithInfoInputIterator first, PointWithInfoInputIterator last); 
 
 /// @} 
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -905,10 +905,9 @@ Vertex_handle insert(const Point & p, Locate_type lt,
 Cell_handle loc, int li, int lj); 
 
 /*!
-Inserts the points in the range `[first,last)`. Returns the number of inserted points. 
-Note that this function is not guaranteed to insert the points 
-following the order of `InputIterator`. 
-\tparam PointInputIterator must be an input iterator with value type `Point`. 
+Inserts the points in the range `[first,last)` in the given order,
+and returns the number of inserted points. 
+
 */ 
 template < class PointInputIterator > 
 std::ptrdiff_t 
@@ -916,9 +915,8 @@ insert(PointInputIterator first, PointInputIterator last);
 
 
 /*!
-Inserts the points in the iterator range  `[first,last)`. 
-Returns the number of inserted points. 
-Inserts the points following the order of `PointWithInfoInputIterator`. 
+Inserts the points in the iterator range  `[first,last)` in the given order,
+and returns the number of inserted points. 
 
 Given a pair `(p,i)`, the vertex `v` storing `p` also stores `i`, that is 
 `v.point() == p` and `v.info() == i`. If several pairs have the same point, 

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -412,20 +412,9 @@ public:
 
 #ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
-  /*
-  //top stands for tuple-or-pair
-  template <class Info>
-  const Point& top_get_first(const std::pair<Point,Info>& pair) const { return pair.first; }
-
-  template <class Info>
-  const Info& top_get_second(const std::pair<Point,Info>& pair) const { return pair.second; }
-
-  template <class Info>
-  const Point& top_get_first(const boost::tuple<Point,Info>& tuple) const { return boost::get<0>(tuple); }
-
-  template <class Info>
-  const Info& top_get_second(const boost::tuple<Point,Info>& tuple) const { return boost::get<1>(tuple); }
-  */
+  using Tr_Base::top_get_first;
+  using Tr_Base::top_get_second;
+  
   template <class Tuple_or_pair,class InputIterator>
   std::ptrdiff_t insert_with_info(InputIterator first, InputIterator last)
   {

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -46,10 +46,8 @@
 
 #ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 #include <CGAL/Spatial_sort_traits_adapter_3.h>
-#include <CGAL/internal/info_check.h>
 
 #include <boost/tuple/tuple.hpp>
-#include <boost/iterator/zip_iterator.hpp>
 #include <boost/mpl/and.hpp>
 #endif //CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 
@@ -414,6 +412,7 @@ public:
 
 #ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
+  /*
   //top stands for tuple-or-pair
   template <class Info>
   const Point& top_get_first(const std::pair<Point,Info>& pair) const { return pair.first; }
@@ -426,7 +425,7 @@ private:
 
   template <class Info>
   const Info& top_get_second(const boost::tuple<Point,Info>& tuple) const { return boost::get<1>(tuple); }
-
+  */
   template <class Tuple_or_pair,class InputIterator>
   std::ptrdiff_t insert_with_info(InputIterator first, InputIterator last)
   {

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -421,6 +421,7 @@ public:
 
 #ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
+  /*
   //top stands for tuple-or-pair
   template <class Info>
   const Weighted_point& top_get_first(const std::pair<Weighted_point,Info>& pair) const { return pair.first; }
@@ -433,7 +434,7 @@ private:
 
   template <class Info>
   const Info& top_get_second(const boost::tuple<Weighted_point,Info>& tuple) const { return boost::get<1>(tuple); }
-
+  */
   // Functor to go from an index of a container of Weighted_point to
   // the corresponding Bare_point
   template<class Construct_bare_point, class Container>

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -421,7 +421,7 @@ public:
 
 #ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
-  /*
+  
   //top stands for tuple-or-pair
   template <class Info>
   const Weighted_point& top_get_first(const std::pair<Weighted_point,Info>& pair) const { return pair.first; }
@@ -434,7 +434,7 @@ private:
 
   template <class Info>
   const Info& top_get_second(const boost::tuple<Weighted_point,Info>& tuple) const { return boost::get<1>(tuple); }
-  */
+  
   // Functor to go from an index of a container of Weighted_point to
   // the corresponding Bare_point
   template<class Construct_bare_point, class Container>

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -68,6 +68,11 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/result_of.hpp>
 
+#ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+#include <CGAL/internal/info_check.h>
+#include <boost/iterator/zip_iterator.hpp>
+#endif
+
 #ifndef CGAL_NO_STRUCTURAL_FILTERING
 #include <CGAL/internal/Static_filters/tools.h>
 #include <CGAL/Triangulation_structural_filtering_traits.h>
@@ -1115,37 +1120,101 @@ public:
                                           Hidden_points_visitor& hider,
                                           bool *could_lock_zone = NULL);
 
+  
+#ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+  template < class InputIterator >
+  std::ptrdiff_t insert(InputIterator first, InputIterator last,
+                        typename boost::enable_if<
+                          boost::is_convertible<
+                              typename std::iterator_traits<InputIterator>::value_type,
+                              Point
+                          >
+                        >::type* = NULL)
+#else
   template < class InputIterator >
   std::ptrdiff_t insert(InputIterator first, InputIterator last)
+#endif //CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
   {
     size_type n = number_of_vertices();
 
-    std::vector<Point> points (first, last);
-
-    // The function insert(first, last) is overwritten in Regular_triangulation_3.h,
-    // so we know that, here, `Point` is not a type of Weighted point.
-    // Nevertheless, to make it more generic (that is, allowing the user to pass
-    // a `Point` type that is not GT::Point_3), we still use the spatial sort
-    // adapter traits and Construct_point_3 here.
-    typedef typename Geom_traits::Construct_point_3 Construct_point_3;
-    typedef typename boost::result_of<const Construct_point_3(const Point&)>::type Ret;
-    typedef CGAL::internal::boost_::function_property_map<Construct_point_3, Point, Ret> fpmap;
-    typedef CGAL::Spatial_sort_traits_adapter_3<Geom_traits, fpmap> Search_traits_3;
-
-    spatial_sort(points.begin(), points.end(),
-                 Search_traits_3(
-                   CGAL::internal::boost_::make_function_property_map<Point, Ret, Construct_point_3>(
-                     geom_traits().construct_point_3_object()), geom_traits()));
-
     Vertex_handle hint;
-    for(typename std::vector<Point>::const_iterator p = points.begin(),
-                                                    end = points.end();
-        p != end; ++p)
-      hint = insert(*p, hint);
+    for(; first != last; ++first)
+      hint = insert(*first, hint);
 
     return number_of_vertices() - n;
   }
 
+#ifndef CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+protected:
+  //top stands for tuple-or-pair
+  template <class Info>
+  const Point& top_get_first(const std::pair<Point,Info>& pair) const { return pair.first; }
+
+  template <class Info>
+  const Info& top_get_second(const std::pair<Point,Info>& pair) const { return pair.second; }
+
+  template <class Info>
+  const Point& top_get_first(const boost::tuple<Point,Info>& tuple) const { return boost::get<0>(tuple); }
+
+  template <class Info>
+  const Info& top_get_second(const boost::tuple<Point,Info>& tuple) const { return boost::get<1>(tuple); }
+
+  template <class Tuple_or_pair,class InputIterator>
+  std::ptrdiff_t insert_with_info(InputIterator first, InputIterator last)
+  {
+    size_type n = number_of_vertices();
+    std::vector<std::size_t> indices;
+    std::vector<Point> points;
+    std::vector<typename Triangulation_data_structure::Vertex::Info> infos;
+    for(InputIterator it=first;it!=last;++it)
+    {
+      Tuple_or_pair value=*it;
+      points.push_back(top_get_first(value));
+      infos.push_back(top_get_second(value));
+    }
+
+    Vertex_handle hint;
+    for(std::size_t i=0; i < points.size(); ++i)
+      {
+        hint = insert(points[i], hint);
+        if(hint != Vertex_handle())
+          hint->info() = infos[i];
+      }
+
+    return number_of_vertices() - n;
+  }
+
+public:
+  template < class InputIterator >
+  std::ptrdiff_t insert(InputIterator first, InputIterator last,
+                        typename boost::enable_if<
+                          boost::is_convertible<
+                            typename std::iterator_traits<InputIterator>::value_type,
+                            std::pair<Point, typename internal::Info_check<
+                                               typename Triangulation_data_structure::Vertex>::type>
+                          > >::type* =NULL)
+  {
+    return insert_with_info< std::pair<Point,typename internal::Info_check<typename Triangulation_data_structure::Vertex>::type> >(first,last);
+  }
+
+  template <class  InputIterator_1,class InputIterator_2>
+  std::ptrdiff_t
+  insert(boost::zip_iterator< boost::tuple<InputIterator_1,InputIterator_2> > first,
+          boost::zip_iterator< boost::tuple<InputIterator_1,InputIterator_2> > last,
+          typename boost::enable_if<
+            boost::mpl::and_<
+              boost::is_convertible< typename std::iterator_traits<InputIterator_1>::value_type, Point >,
+              boost::is_convertible< typename std::iterator_traits<InputIterator_2>::value_type, typename internal::Info_check<typename Triangulation_data_structure::Vertex>::type >
+            >
+          >::type* =NULL)
+  {
+    return insert_with_info< boost::tuple<Point, typename internal::Info_check<
+        typename Triangulation_data_structure::Vertex>::type> >(first,last);
+  }
+#endif //CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
+
+  
+  
   Vertex_handle insert_in_cell(const Point& p, Cell_handle c);
   Vertex_handle insert_in_facet(const Point& p, Cell_handle c, int i);
   Vertex_handle insert_in_facet(const Point& p, const Facet& f) {

--- a/Triangulation_3/test/Triangulation_3/test_Triangulation_with_transform_iterator.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_Triangulation_with_transform_iterator.cpp
@@ -1,0 +1,52 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Triangulation_3.h>
+#include <CGAL/Triangulation_vertex_base_with_info_3.h>
+#include <CGAL/boost/iterator/transform_iterator.hpp>
+
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
+typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, K>    Vb;
+typedef CGAL::Triangulation_cell_base_3<K>                          Cb;
+typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                Tds;
+typedef CGAL::Triangulation_3<K, Tds>                               Triangulation;
+typedef Triangulation::Point                                        Point;
+
+//a functor that returns a std::pair<Point,unsigned>.
+//the unsigned integer is incremented at each call to 
+//operator()
+struct Auto_count : public CGAL::cpp98::unary_function<const Point&,std::pair<Point,unsigned> >{
+  mutable unsigned i;
+  Auto_count() : i(0){}
+  std::pair<Point,unsigned> operator()(const Point& p) const {
+    return std::make_pair(p,i++);
+  }
+};
+
+int main()
+{
+  std::vector<Point> points;
+  points.push_back(Point(0,0,0));
+  points.push_back(Point(1,0,0));
+  points.push_back(Point(0,1,0));
+  points.push_back(Point(0,0,1));
+  points.push_back(Point(2,2,2));
+  points.push_back(Point(-1,0,1));
+
+  Triangulation T( boost::make_transform_iterator(points.begin(),Auto_count()),
+                   boost::make_transform_iterator(points.end(),  Auto_count() )  );
+
+  CGAL_assertion( T.number_of_vertices() == 6 );
+
+  // check that the info was correctly set.
+  Triangulation::Finite_vertices_iterator vit;
+  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
+    if( points[ vit->info() ] != vit->point() ){
+      std::cerr << "Error different info" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  std::cout << "OK" << std::endl;
+
+  return 0;
+}

--- a/Triangulation_3/test/Triangulation_3/test_Triangulation_with_zip_iterator.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_Triangulation_with_zip_iterator.cpp
@@ -1,0 +1,50 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Triangulation_3.h>
+#include <CGAL/Triangulation_vertex_base_with_info_3.h>
+
+#include <boost/iterator/zip_iterator.hpp>
+
+#include <iostream>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
+typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, K>    Vb;
+typedef CGAL::Triangulation_cell_base_3<K>                          Cb;
+typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                Tds;
+typedef CGAL::Triangulation_3<K, Tds>                               Triangulation;
+typedef Triangulation::Point                                        Point;
+
+int main()
+{
+  std::vector<unsigned> indices;
+  indices.push_back(0);
+  indices.push_back(1);
+  indices.push_back(2);
+  indices.push_back(3);
+  indices.push_back(4);
+  indices.push_back(5);
+
+  std::vector<Point> points;
+  points.push_back(Point(0,0,0));
+  points.push_back(Point(1,0,0));
+  points.push_back(Point(0,1,0));
+  points.push_back(Point(0,0,1));
+  points.push_back(Point(2,2,2));
+  points.push_back(Point(-1,0,1));
+
+  Triangulation T(boost::make_zip_iterator(boost::make_tuple( points.begin(),indices.begin() )),
+                  boost::make_zip_iterator(boost::make_tuple( points.end(),indices.end() ) )  );
+
+  CGAL_assertion( T.number_of_vertices() == 6 );
+
+  // check that the info was correctly set.
+  Triangulation::Finite_vertices_iterator vit;
+  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
+    if( points[ vit->info() ] != vit->point() ){
+      std::cerr << "Error different info" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

Add a constructor and insert function that takes a range of points with info (pair/tuple/transform iterator/zip iterator) to `CGAL::Triangulation_2` and `CGAL::Triangulation_3`.
No longer call `spatial_sort()` when inserting a range of points into a  triangulation, as the form of the triangles depends on the insertion order. 

### Todo
- [x] Add to changes.md  (a breaking change)

## Release Management

* Affected package(s): Triangulation_2, Triangulation_3
* Issue(s) solved (if any):  See cgal-discuss: Add information in Triangulation while inserting a range of points

