### PR TITLE
Mesh_3: fix issue #2870 (do not deactivate all topological criteria)

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
@@ -87,7 +87,6 @@ public:
     Mesh_criteria criteria(facet_angle = 30,
                            facet_size = 6,
                            facet_distance = 2,
-                           facet_topology = CGAL::MANIFOLD,
                            cell_radius_edge_ratio = 3,
                            cell_size = 8);
 


### PR DESCRIPTION
## Summary of Changes

See https://github.com/CGAL/cgal/issues/2870#issuecomment-494355193.

## Release Management

* Affected package(s): Mesh_3 (testsuite only)
* Issue(s) solved (if any): fix #2870

The buggy test was introduced in CGAL-4.12. Will be fixed in CGAL-4.13.2.
