### PR TITLE
AABB_tree: add do_intersect() for trees

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -149,6 +149,7 @@ struct AABB_traits_base_2<GeomTraits,true>{
 template< typename AABBTraits>
 class AABB_tree;
 
+
 /// This traits class handles any type of 3D geometric
 /// primitives provided that the proper intersection tests and
 /// constructions are implemented. It handles points, rays, lines and
@@ -325,7 +326,9 @@ public:
 
   Compute_bbox compute_bbox_object() const {return Compute_bbox(*this);}
 
-
+  /// \brief Function object using `GeomTraits::Do_intersect`.
+  /// In the case the query is a `CGAL::AABB_tree`, the `do_intersect()`
+  /// function of this tree is used.
   class Do_intersect {
     const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& m_traits;
   public:
@@ -359,6 +362,7 @@ public:
   };
 
   Do_intersect do_intersect_object() const {return Do_intersect(*this);}
+
 
   class Intersection {
     const AABB_traits<GeomTraits,AABBPrimitive,BboxMap>& m_traits;

--- a/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
@@ -1,0 +1,75 @@
+#include <fstream>
+#include <iterator>
+
+#include <CGAL/assertions.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/AABB_halfedge_graph_segment_primitive.h>
+#include <CGAL/Timer.h>
+
+typedef CGAL::Epick K;
+typedef K::FT FT;
+typedef K::Point_3 Point;
+typedef K::Vector_3 Vector;
+typedef K::Segment_3 Segment;
+typedef K::Ray_3 Ray;
+typedef CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> > Mesh;
+typedef CGAL::AABB_halfedge_graph_segment_primitive<Mesh,
+CGAL::Default,
+CGAL::Tag_false> S_Primitive;
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh,
+CGAL::Default,
+CGAL::Tag_false> T_Primitive;
+typedef CGAL::AABB_traits<K, T_Primitive> T_Traits;
+typedef CGAL::AABB_traits<K, S_Primitive> S_Traits;
+typedef CGAL::AABB_tree<T_Traits> T_Tree;
+typedef CGAL::AABB_tree<S_Traits> S_Tree;
+typedef T_Tree::Primitive_id T_Primitive_id;
+typedef S_Tree::Primitive_id S_Primitive_id;
+
+int main()
+{
+  CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> > m1, m2;
+  std::ifstream in("data/cube.off");
+  if(in)
+    in >> m1;
+  else{
+    std::cout << "error reading cube" << std::endl;
+    return 1;
+  }
+  in.close();
+  in.open("data/tetrahedron.off");
+  if(in)
+    in >> m2;
+  else{
+    std::cout << "error reading tetrahedron" << std::endl;
+    return 1;
+  }
+  in.close();
+  T_Tree cube_tree(faces(m1).first, faces(m1).second, m1);
+  S_Tree tet_tree(edges(m2).first, edges(m2).second, m2);
+  cube_tree.build();
+  tet_tree.build();
+
+  std::list<T_Tree::Primitive::Id> t_primitives;
+  std::list<S_Tree::Primitive::Id> s_primitives;
+  cube_tree.all_intersected_primitives(tet_tree,std::back_inserter(t_primitives));
+  CGAL_assertion(t_primitives.size() == 6);
+  tet_tree.all_intersected_primitives(cube_tree,std::back_inserter(s_primitives));
+  CGAL_assertion(s_primitives.size() == 6);
+  CGAL_assertion(tet_tree.do_intersect(cube_tree));
+  CGAL_assertion(cube_tree.do_intersect(tet_tree));
+  boost::optional<T_Tree::Primitive::Id> optional_primitive;
+  optional_primitive = cube_tree.any_intersected_primitive(tet_tree);
+  T_Tree::Primitive::Id pid = boost::get<T_Tree::Primitive::Id>(optional_primitive);
+  CGAL_assertion((int)pid.first == 5);
+
+
+
+  return 0;
+}

--- a/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
@@ -64,12 +64,16 @@ int main()
   CGAL_assertion(s_primitives.size() == 6);
   CGAL_assertion(tet_tree.do_intersect(cube_tree));
   CGAL_assertion(cube_tree.do_intersect(tet_tree));
-  boost::optional<T_Tree::Primitive::Id> optional_primitive;
-  optional_primitive = cube_tree.any_intersected_primitive(tet_tree);
-  T_Tree::Primitive::Id pid = boost::get<T_Tree::Primitive::Id>(optional_primitive);
-  CGAL_assertion((int)pid.first == 5);
 
-
-
+  std::vector<T_Tree::Primitive::Id> all_primitives;
+  cube_tree.all_intersected_primitives(tet_tree, std::back_inserter(all_primitives));
+  bool found_f5 = false;
+  for(auto prim : all_primitives)
+  {
+    if((int)prim.first == 5)
+      found_f5 = true;
+  }
+  CGAL_assertion(found_f5);
+  CGAL_USE(found);
   return 0;
 }

--- a/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
@@ -74,6 +74,6 @@ int main()
       found_f5 = true;
   }
   CGAL_assertion(found_f5);
-  CGAL_USE(found);
+  CGAL_USE(found_f5);
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

Add do_intersect() overloads for AABB_trees.  The functions
- `do_intersect()`
- `any_intersected_primitive()`
- `all_intersected_primitives()`
of the AABB_traits now work with another `AABB_tree` as query.
## Release Management

* Affected package(s):AABB_tree
