### PR TITLE
Classification: use cpp98::random_shuffle to avoid errors in C++17

### DIFF
--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
@@ -45,7 +45,7 @@
 #include <cstdio>
 #endif
 
-#include <algorithm>
+#include <CGAL/algorithm.h>
 
 #include <CGAL/tags.h>
 
@@ -113,7 +113,7 @@ public:
     std::vector<int> in_bag_samples = sample_idxes;
 
     // Bagging: draw random sample indexes used for this tree
-    std::random_shuffle (in_bag_samples.begin(),in_bag_samples.end());
+    CGAL::cpp98::random_shuffle (in_bag_samples.begin(),in_bag_samples.end());
 
     // Train the tree
     trees[i_tree].train(samples, labels, &in_bag_samples[0], n_in_bag_samples, split_generator, gen);


### PR DESCRIPTION
## Summary of Changes

`random_shuffle` is deprecated since C++11 and removed in C++17, to avoid errors, we use the CGAL  alternative `CGAL::cpp98::random_shuffle`.

## Release Management

* Affected package(s): Classification
