### PR TITLE
Segment_Delaunay_graph_2: Improve documentation

### DIFF
--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
@@ -20,13 +20,13 @@ This class has six template parameters.
 \tparam CK is the construction kernel and it is the kernel 
 that will be used for constructions.
 \tparam CM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
+the filtering kernel fails to produce an answer. 
+\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 \tparam FK is the  filtering kernel; this kernel will be used for performing the 
 arithmetic filtering for the predicates involved in the computation of 
 the segment Delaunay graph. 
 \tparam FM must be `Field_with_sqrt_tag` or `Field_tag`
-\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
-the filtering kernel fails to produce an answer. 
-\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 
 The first, third and fifth template parameters must be models of the `Kernel` concept.
 The second, fourth and sixth template parameters correspond to how 
@@ -170,14 +170,14 @@ This class has six template parameters.
 \tparam CK is the construction kernel and it is the kernel 
 that will be used for constructions.
 \tparam CM must be `Field_with_sqrt_tag` or `Field_tag`
+\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
+the filtering kernel fails to produce an answer. 
+\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 \tparam FK is the 
 filtering kernel; this kernel will be used for performing the 
 arithmetic filtering for the predicates involved in the computation of 
 the segment Delaunay graph. 
 \tparam FM must be `Field_with_sqrt_tag` or `Field_tag`
-\tparam EK is the exact kernel; this kernel will be used for computing the predicates if 
-the filtering kernel fails to produce an answer. 
-\tparam EM must be `Field_with_sqrt_tag` or `Field_tag`
 
 The first, third and fifth 
 template parameters must be a models of the `Kernel` concept.

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_filtered_traits_2.h
@@ -191,7 +191,7 @@ whereas the second requires the exact evaluation of signs of ring-type
 expressions, i.e., expressions involving only additions, subtractions 
 and multiplications. Finally, in order to get exact constructions 
 `CM` must be set to `Field_with_sqrt_tag` and the number type 
-in `CK` must support operations involing divisions and square 
+in `CK` must support operations involving divisions and square 
 roots (as well as the other three basic operations of course). 
 The way the predicates are evaluated is discussed in 
 \cgalCite{b-ecvdl-96} and \cgalCite{cgal:k-reisv-04} (the geometric filtering 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
@@ -409,10 +409,8 @@ mechanisms. Presently, there two ways of performing arithmetic
 filtering for the predicates involved in the computation of
 segment Delaunay graphs:
 <OL>
-<LI>The user can define his/her kernel using as number type, a
-number type of the form `Filtered_exact<CT,ET>`. Then this
-kernel can be entered as the first template parameter in the
-`Segment_Delaunay_graph_traits_2<K,MTag>`.
+<LI>The user can use a kernel with a filtered number type
+as the first template parameter in the `Segment_Delaunay_graph_traits_2<K,MTag>`.
 <LI>The user can define up to three different kernels `CK`,
 `FK` and `EK` (default values are provided for most
 parameters). The first kernel `CK` is used only for
@@ -429,6 +427,7 @@ classes, which have been implemented using the
 Our experience so far has shown that for all reasonable and valid
 values of the template parameters, the second method for arithmetic
 filtering is more efficient among the two.
+This approach is also used in the examples.
 
 Let's consider once more the class
 `Segment_Delaunay_graph_traits_2<K,MTag>`.

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
@@ -412,7 +412,7 @@ segment Delaunay graphs:
 <LI>The user can define his/her kernel using as number type, a
 number type of the form `Filtered_exact<CT,ET>`. Then this
 kernel can be entered as the first template parameter in the
-`Segment_Delaunay_graph_2<K,MTag>`.
+`Segment_Delaunay_graph_traits_2<K,MTag>`.
 <LI>The user can define up to three different kernels `CK`,
 `FK` and `EK` (default values are provided for most
 parameters). The first kernel `CK` is used only for
@@ -431,7 +431,7 @@ values of the template parameters, the second method for arithmetic
 filtering is more efficient among the two.
 
 Let's consider once more the class
-`Segment_Delaunay_graph_2<K,MTag>`.
+`Segment_Delaunay_graph_traits_2<K,MTag>`.
 The template parameter `MTag` provides another degree of freedom
 to the user, who can indicate the type of arithmetic operations to
 be used in the evaluation of the predicates. More specifically,

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Segment_Delaunay_graph_2.txt
@@ -518,8 +518,8 @@ site-related quantities.
 
 If you have a rather large input, you better use an insertion function that uses
 the spatial sorting of your input (end) points. Note that the functions
-\link CGAL::Segment_Delaunay_graph_2::insert_points `insert_points` \endlink or
-\link CGAL::Segment_Delaunay_graph_2::insert_segments `insert_segments` \endlink
+\link CGAL::Segment_Delaunay_graph_2::insert_points `insert_points()` \endlink or
+\link CGAL::Segment_Delaunay_graph_2::insert_segments `insert_segments()` \endlink
 can be used if your input is only composed of points or segments.
 
 \cgalExample{Segment_Delaunay_graph_2/sdg-fast-sp.cpp}


### PR DESCRIPTION
## Summary of Changes

- [x] Fix typos
- [x] Fix missing links for example the doc speaks about `Filtered_exact` [here](https://cgal.geometryfactory.com/CGAL/doc/master/Segment_Delaunay_graph_2/index.html#Segment_Delaunay_graph_2ArithmeticFiltering).

## Release Management

* Affected package(s):  Segment_Delaunay_graph_2  **only documentation**


