### PR TITLE
Polyhedron demo:  fix the menu entry 'Load plugin'

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -362,6 +362,7 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
   connect(&operationSearchBar, &QLineEdit::textChanged,
           this, &MainWindow::filterOperations);
   loadPlugins();
+  accepted_keywords.clear();
 
   // Setup the submenu of the View menu that can toggle the dockwidgets
   Q_FOREACH(QDockWidget* widget, findChildren<QDockWidget*>()) {

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -454,7 +454,7 @@ private:
   bool bbox_need_update;
   QMap<QString, QPair<QStringList, QString> >plugin_metadata_map;
   QMap<QString, bool> ignored_map;
-  const QStringList& accepted_keywords;
+  QStringList accepted_keywords;
 
 private:
   QMap<QAction*, QMenu*> action_menu_map;


### PR DESCRIPTION
## Summary of Changes

Since PR #3412, the 'Load plugin' had two issues, fixed by this PR:

  - a segfault because a dangling reference to a destroyed object,
  - the inability to load manually a plugin with the wrong meta-data.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: maintenance by GF

