### PR TITLE
Triangulation_{2,3):  Add ranges

### DIFF
--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -98,6 +98,11 @@ public:
   typedef Triangulation_ds_vertex_circulator_2<Tds>  Vertex_circulator;
   typedef Triangulation_ds_edge_circulator_2<Tds>    Edge_circulator;
 
+  typedef Iterator_range<Prevent_deref<Vertex_iterator> > Vertex_handles;
+  typedef Iterator_range<Prevent_deref<Face_iterator> >   Face_handles;
+  typedef Iterator_range<Edge_iterator>                   Edges;
+  typedef Iterator_range<Halfedge_iterator>               Halfedges;
+    
   typedef Vertex_iterator                            Vertex_handle;
   typedef Face_iterator                              Face_handle;
 
@@ -172,12 +177,20 @@ public:
     return faces().end();
   }
 
+  Face_handles face_handles() const {
+    return make_prevent_deref_range(faces_begin(),faces_end());
+  }
+  
   Vertex_iterator vertices_begin() const  {
     return vertices().begin();
   }
 
   Vertex_iterator vertices_end() const {
     return vertices().end();
+  }
+
+  Vertex_handles vertex_handles() const {
+    return make_prevent_deref_range(vertices_begin(),vertices_end());
   }
   
   Edge_iterator edges_begin() const {
@@ -187,6 +200,10 @@ public:
   Edge_iterator edges_end() const {
     return Edge_iterator(this,1);
   }
+
+  Edges edges() const {
+    return Edges(edges_begin(),edges_end());
+  }
   
   Halfedge_iterator halfedges_begin() const {
     return Halfedge_iterator(this);
@@ -194,6 +211,10 @@ public:
 
   Halfedge_iterator halfedges_end() const {
     return Halfedge_iterator(this,1);
+  }
+  
+  Halfedges halfedges() const {
+    return Halfedges(halfedges_begin(),halfedges_end());
   }
   
   Face_circulator incident_faces(Vertex_handle v, 

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -101,7 +101,6 @@ public:
   typedef Iterator_range<Prevent_deref<Vertex_iterator> > Vertex_handles;
   typedef Iterator_range<Prevent_deref<Face_iterator> >   Face_handles;
   typedef Iterator_range<Edge_iterator>                   Edges;
-  typedef Iterator_range<Halfedge_iterator>               Halfedges;
     
   typedef Vertex_iterator                            Vertex_handle;
   typedef Face_iterator                              Face_handle;
@@ -211,10 +210,6 @@ public:
 
   Halfedge_iterator halfedges_end() const {
     return Halfedge_iterator(this,1);
-  }
-  
-  Halfedges halfedges() const {
-    return Halfedges(halfedges_begin(),halfedges_end());
   }
   
   Face_circulator incident_faces(Vertex_handle v, 

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -170,7 +170,7 @@ public:
   typedef Iterator_range<Prevent_deref<Vertex_iterator> >  Vertex_handles;
 
   typedef Iterator_range<Facet_iterator> Facets;
-    typedef Iterator_range<Edge_iterator> Edges;
+  typedef Iterator_range<Edge_iterator> Edges;
   
 //private: // In 2D only :
   typedef internal::Triangulation_ds_face_circulator_3<Tds>  Face_circulator;

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -166,6 +166,12 @@ public:
   typedef internal::Triangulation_ds_cell_circulator_3<Tds>  Cell_circulator;
   typedef internal::Triangulation_ds_facet_circulator_3<Tds> Facet_circulator;
 
+  typedef Iterator_range<Prevent_deref<Cell_iterator> >    Cell_handles;
+  typedef Iterator_range<Prevent_deref<Vertex_iterator> >  Vertex_handles;
+
+  typedef Iterator_range<Facet_iterator> Facets;
+    typedef Iterator_range<Edge_iterator> Edges;
+  
 //private: // In 2D only :
   typedef internal::Triangulation_ds_face_circulator_3<Tds>  Face_circulator;
 
@@ -564,6 +570,11 @@ public:
     return cells().end();
   }
 
+  Cell_handles cell_handles() const
+  {
+    return make_prevent_deref_range(cells_begin(), cells_end()); 
+  }
+  
   Cell_iterator raw_cells_begin() const
   {
     return cells().begin();
@@ -586,6 +597,11 @@ public:
     return Facet_iterator(this, 1);
   }
 
+  Facets facets() const
+  {
+    return Facets(facets_begin(), facets_end());
+  }
+  
   Edge_iterator edges_begin() const
   {
     if ( dimension() < 1 )
@@ -598,6 +614,11 @@ public:
     return Edge_iterator(this,1);
   }
 
+  Edges edges() const
+  {
+    return Edges(edges_begin(), edges_end());
+  }
+  
   Vertex_iterator vertices_begin() const
   {
     return vertices().begin();
@@ -608,6 +629,11 @@ public:
     return vertices().end();
   }
 
+  Vertex_handles vertex_handles() const
+  {
+    return make_prevent_deref_range(vertices_begin(), vertices_end()); 
+  }
+  
   // CIRCULATOR METHODS
 
   // cells around an edge

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -165,6 +165,10 @@ The value type of this iterator is `Edge`.
 */ 
 typedef unspecified_type Constrained_edges_iterator; 
 
+/*!
+A range type to iterate over the constrained edges.
+*/
+typedef Iterator_range<Constrained_edges_iterator> Constrained_edges;
 
 /*!
 The intersection tag which decides how 
@@ -197,18 +201,18 @@ Constrained_triangulation_2& ct1);
 /// @{
 
 /*!
-Returns `true` if edge `e` is a constrained edge. 
+returns `true` if edge `e` is a constrained edge. 
 */ 
 bool is_constrained(Edge e) const; 
 
 /*!
-Returns `true` if at least one of the edges incident to vertex `v` 
+returns `true` if at least one of the edges incident to vertex `v` 
 is constrained. 
 */ 
 bool are_there_incident_constraints(Vertex_handle v) const; 
 
 /*!
-Outputs the constrained edges incident to `v` 
+outputs the constrained edges incident to `v` 
 into the output iterator `out` and returns the resulting 
 output iterator. 
 \tparam OutputItEdges is an `OutputIterator` with `Edge` as value 
@@ -229,6 +233,11 @@ returns the past-the-end iterator.
 */ 
 Constrained_edges_iterator constrained_edges_end() const;
 
+/*!
+returns a range of constrained edges.
+*/
+Constrained_edges constrained_edges() const;
+  
 /// @} 
 
 /// \name Insertion and Removal 
@@ -236,14 +245,14 @@ Constrained_edges_iterator constrained_edges_end() const;
 /// @{
 
 /*!
-Inserts point `p` and restores the status (constrained or not) of all 
+inserts point `p` and restores the status (constrained or not) of all 
 the touched edges. If present, `f` is used as an hint 
 for the location of `p`. 
 */ 
 Vertex_handle insert(Point p, Face_handle f = Face_handle() ); 
 
 /*!
-Inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
+inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
 \sa `Triangulation_2::locate()`
 */ 
 Vertex_handle 
@@ -258,7 +267,7 @@ Vertex_handle push_back(const Point& p);
 
 
 /*!
-Inserts points `a` and `b` in this order, and inserts the line segment `ab` as a 
+inserts points `a` and `b` in this order, and inserts the line segment `ab` as a 
 constraint. Removes the faces crossed by segment `ab` and creates new 
 faces instead. If a vertex `c` lies on segment `ab`, constraint `ab` is 
 replaced by the two constraints `ac` and `cb`. Apart from the insertion of 
@@ -273,7 +282,7 @@ Equivalent to `insert(c.first, c.second)`.
   void push_back(const std::pair<Point,Point>& c); 
 
 /*!
-Inserts the line segment `s` whose endpoints are the vertices 
+inserts the line segment `s` whose endpoints are the vertices 
 `va` and 
 `vb` as a constraint. The triangles intersected by `s` 
 are removed and new ones are created. 
@@ -281,7 +290,7 @@ are removed and new ones are created.
 void insert_constraint(const Vertex_handle & va, const Vertex_handle & vb); 
 
 /*!
-Inserts a polyline defined by the points in the range `[first,last)`.
+inserts a polyline defined by the points in the range `[first,last)`.
 The polyline is considered as a polygon if the first and last point are equal or if  `close = true`. This enables for example passing the vertex range of a `Polygon_2`.
 \tparam PointIterator must be an `InputIterator` with the value type `Point`. 
 */
@@ -291,23 +300,23 @@ void insert_constraint(PointIterator first, PointIterator last, bool close=false
 
 
 /*! 
-Removes a vertex `v`. 
+removes a vertex `v`. 
 \pre Vertex `v` is not incident to a constrained edge. 
 */ 
 void remove(Vertex_handle v); 
 
 /*!
-Make the edges incident to vertex `v` unconstrained edges. 
+makes the edges incident to vertex `v` unconstrained edges. 
 */ 
 void remove_incident_constraints(Vertex_handle v); 
 
 /*!
-Make edge `(f,i)` unconstrained. 
+makes edge `(f,i)` unconstrained. 
 */ 
 void remove_constrained_edge(Face_handle f, int i); 
 
 /*!
-Checks the validity of the triangulation and the consistency
+checks the validity of the triangulation and the consistency
 of the constrained marks in edges.
 */ 
 bool 
@@ -318,7 +327,7 @@ is_valid(bool verbose = false, int level = 0) const;
 }; /* end Constrained_triangulation_2 */
 
 /*!
-Writes the triangulation as for `Triangulation_2<Traits,Tds>` and, for each face `f`, and integers `i=0,1,2`, 
+writes the triangulation as for `Triangulation_2<Traits,Tds>` and, for each face `f`, and integers `i=0,1,2`, 
 writes "C" or "N" depending whether edge 
 `(f,i)` is constrained or not. 
 \relates Constrained_triangulation_2 
@@ -327,7 +336,7 @@ template <typename  Traits, typename Tds, typename Itag>
 std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_2<Traits,Tds,Itag> &ct); 
 
 /*!
-Reads a triangulation from stream `is` and assigns it to c`t`. Data in the stream must have the same format `operator<<` uses. 
+eeads a triangulation from stream `is` and assigns it to c`t`. Data in the stream must have the same format `operator<<` uses. 
 Note that `ct` is first cleared. 
 \relates Constrained_triangulation_2 
 */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_2.h
@@ -336,7 +336,7 @@ template <typename  Traits, typename Tds, typename Itag>
 std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_2<Traits,Tds,Itag> &ct); 
 
 /*!
-eeads a triangulation from stream `is` and assigns it to c`t`. Data in the stream must have the same format `operator<<` uses. 
+reads a triangulation from stream `is` and assigns it to c`t`. Data in the stream must have the same format `operator<<` uses. 
 Note that `ct` is first cleared. 
 \relates Constrained_triangulation_2 
 */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -77,6 +77,12 @@ The value type of this iterator is `Constraint_id`.
 typedef unspecified_type Constraint_iterator; 
 
 /*!
+A range type for iterating over all constraints.
+*/  
+typedef Iterator_range<Constraint_iterator> Constraints;
+
+  
+/*!
 A subconstraint is a pair of vertices that correspond to an `Edge`.
  */
 typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
@@ -201,13 +207,13 @@ void swap(Constrained_triangulation_plus_2 tr);
 /// @{
 
 /*! 
-Inserts point `p` as a vertex of the triangulation. 
+inserts point `p` as a vertex of the triangulation. 
 */ 
 Vertex_handle insert(const Point& p, 
 Face_handle start = Face_handle() ); 
 
 /*! 
-Inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
+inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
 \sa `Triangulation_2::locate()`
 */ 
 Vertex_handle insert(const Point& p, 
@@ -220,7 +226,7 @@ Equivalent to `insert(p)`.
 Vertex_handle push_back(const Point& p); 
 
 /*! 
-Inserts the points in the range `[first,last)`.
+inserts the points in the range `[first,last)`.
 Returns the number of inserted points. 
 \tparam PointIterator must be an `InputIterator` with the value type `Point`. 
 */ 
@@ -229,19 +235,19 @@ size_type
 insert(PointIterator first, PointIterator last); 
 
 /*! 
-Inserts the constraint segment `ab` in the triangulation.
+inserts the constraint segment `ab` in the triangulation.
 If the two points are equal the point is inserted but no constraint,
 and the default constructed `Constraint_id` is returned.
 */ 
 Constraint_id insert_constraint(Point a, Point b);
 
 /*! 
-Inserts the constraint `c`. 
+inserts the constraint `c`. 
 */ 
   void push_back(const std::pair<Point,Point>& c); 
 
 /*! 
-Inserts a constraint whose endpoints are the vertices 
+inserts a constraint whose endpoints are the vertices 
 pointed by `va` and `vb` in the triangulation.
 If the two vertex handles are equal no constraint is inserted,
 and the default constructed `Constraint_id` is returned.
@@ -249,7 +255,7 @@ and the default constructed `Constraint_id` is returned.
 Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb);
 
 /*!
-Inserts a polyline defined by the points in the range `[first,last)`
+inserts a polyline defined by the points in the range `[first,last)`
 and returns the constraint id.
 The polyline is considered as a closed curve if the first and last point are equal or if  `close == true`. This enables for example passing the vertex range of a `Polygon_2`.
 When traversing the vertices of a closed polyline constraint with a  `Vertices_in_constraint_iterator` the first and last vertex are the same.
@@ -288,7 +294,7 @@ std::size_t insert_constraints(PointIterator points_first, PointIterator points_
 
 
 /*! 
-Removes the constraint `cid`, without removing the points from the triangulation.
+removes the constraint `cid`, without removing the points from the triangulation.
 */ 
 void remove_constraint(Constraint_id cid); 
 
@@ -298,29 +304,39 @@ void remove_constraint(Constraint_id cid);
 /// @{
 
 /*! 
-Returns a `Constraint_iterator` that points at the first 
+returns a `Constraint_iterator` that points at the first 
 constraint of the triangulation. 
 */ 
 Constraint_iterator constraints_begin() const; 
 
 /*! 
-Returns the past-the-end iterator of the constraints of the triangulation. 
+returns the past-the-end iterator of the constraints of the triangulation. 
 */ 
 Constraint_iterator constraints_end() const; 
 
+/*!
+returns a range of constraints.
+*/ 
+Subconstraints constraints() const;  
+  
 /*! 
-Returns a `Subconstraint_iterator` pointing at the first 
+returns a `Subconstraint_iterator` pointing at the first 
 subconstraint of the triangulation. 
 */ 
 Subconstraint_iterator subconstraints_begin() const; 
 
 /*! 
-Returns the past-the-end iterator of the subconstraints of the triangulation. 
+returns the past-the-end iterator of the subconstraints of the triangulation. 
 */ 
 Subconstraint_iterator subconstraints_end() const; 
 
+/*!
+returns a range of subconstraints.
+*/ 
+Subconstraints subconstraints() const;  
+
 /*! 
-Returns the number of constraints enclosing the subconstraint 
+returns the number of constraints enclosing the subconstraint 
 `(va,vb)`. 
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
 */ 
@@ -328,14 +344,14 @@ int number_of_enclosing_constraints(Vertex_handle va,
 Vertex_handle vb) const; 
 
 /*! 
-Returns the `Context` relative to one of the constraints 
+returns the `Context` relative to one of the constraints 
 enclosing the subconstraint `(va,vb)`. 
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
 */ 
 Context context(Vertex_handle va, Vertex_handle vb) const; 
 
 /*! 
-Returns an iterator pointing at the first `Context` 
+returns an iterator pointing at the first `Context` 
 of the sequence of contexts
 corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
@@ -344,7 +360,7 @@ Context_iterator contexts_begin(Vertex_handle va,
                                 Vertex_handle vb) const; 
 
 /*!
-Returns an iterator past the end `Context` 
+returns an iterator past the end `Context` 
 of the sequence of contexts
 corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
@@ -353,22 +369,28 @@ Context_iterator contexts_end(Vertex_handle va,
                               Vertex_handle vb) const; 
 
 /*!
-Returns a range of contexts.
+returns a range of contexts.
 */
 Contexts contexts((Vertex_handle va, 
                      Vertex_handle vb) const; 
   
 /*!
-Returns an iterator on the first vertex on the constraint `cid`. 
+returns an iterator on the first vertex on the constraint `cid`. 
 */ 
 Vertices_in_constraint_iterator 
 vertices_in_constraint_begin(Constraint_id cid) const; 
 
 /*!
-Returns an iterator past the last vertex on the constraint `cid`. 
+returns an iterator past the last vertex on the constraint `cid`. 
 */ 
 Vertices_in_constraint_iterator 
 vertices_in_constraint_end(Constraint_id cid) const; 
+
+/*!
+returns an range of vertices on the constraint `cid`. 
+*/ 
+Vertices_in_constraint
+vertices_in_constraint(Constraint_id cid) const; 
 
 /// @}
 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -371,8 +371,8 @@ Context_iterator contexts_end(Vertex_handle va,
 /*!
 returns a range of contexts.
 */
-Contexts contexts((Vertex_handle va, 
-                     Vertex_handle vb) const; 
+Contexts contexts(Vertex_handle va, 
+                  Vertex_handle vb) const; 
   
 /*!
 returns an iterator on the first vertex on the constraint `cid`. 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -387,7 +387,7 @@ Vertices_in_constraint_iterator
 vertices_in_constraint_end(Constraint_id cid) const; 
 
 /*!
-returns an range of vertices on the constraint `cid`. 
+returns a range of the vertices on the constraint `cid`. 
 */ 
 Vertices_in_constraint
 vertices_in_constraint(Constraint_id cid) const; 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -78,7 +78,6 @@ typedef unspecified_type Constraint_iterator;
 
 /*!
 A subconstraint is a pair of vertices that correspond to an `Edge`.
-\todo The documentation does not match the code
  */
 typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
 
@@ -92,6 +91,11 @@ subconstraint.
 */ 
 typedef unspecified_type Subconstraint_iterator; 
 
+/*!
+A range type for iterating over all subconstraints.
+*/  
+typedef Iterator_range<Subconstraint_iterator> Subconstraints;
+  
 /*! 
 An iterator on the 
 vertices of the chain of subconstraints representing a 
@@ -137,6 +141,10 @@ is `Context`.
 */ 
 typedef unspecified_type Context_iterator; 
 
+/*!
+range type for iterating over contexts.
+*/
+typedef Iterator_range<Context_iterator> Contexts;  
 /// @} 
 
 /// \name Creation 
@@ -333,7 +341,7 @@ corresponding to the constraints enclosing the subconstraint `(va,vb)`.
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
 */ 
 Context_iterator contexts_begin(Vertex_handle va, 
-Vertex_handle vb) const; 
+                                Vertex_handle vb) const; 
 
 /*!
 Returns an iterator past the end `Context` 
@@ -342,8 +350,14 @@ corresponding to the constraints enclosing the subconstraint `(va,vb)`.
 \pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
 */ 
 Context_iterator contexts_end(Vertex_handle va, 
-Vertex_handle vb) const; 
+                              Vertex_handle vb) const; 
 
+/*!
+Returns a range of contexts.
+*/
+Contexts contexts((Vertex_handle va, 
+                     Vertex_handle vb) const; 
+  
 /*!
 Returns an iterator on the first vertex on the constraint `cid`. 
 */ 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -252,6 +252,8 @@ typedef Tds::difference_type difference_type;
 /// finite ones. The triangulation class also defines the following
 /// enum type to specify which case occurs when locating a point in
 /// the triangulation.
+///
+/// In order to write \cpp 11 `for`-loops we provide range types.
 
 /*!
 handle to a vertex.
@@ -300,6 +302,50 @@ finite vertices of the triangulation.
 */ 
 typedef unspecified_type Point_iterator; 
 
+
+/*!
+range type for iterating over all faces, with a nested
+type `iterator` that has as value type `Face_handle`
+*/
+typedef Iterator_range<unspecified_type> All_face_handles;
+
+
+/*!
+range type for iterating over edges.
+*/
+typedef Iterator_range<All_edges_iterator> All_edges;
+
+/*!
+range type for iterating over all vertices, with a nested
+type `iterator` that has as value type `Vertex_handle`
+*/
+typedef Iterator_range<unspecified_type> All_vertex_handles;
+
+
+/*!
+range type for iterating over finite faces, with a nested
+type `iterator` that has as value type `Face_handle`
+*/
+typedef Iterator_range<unspecified_type> Finite_face_handles;
+
+
+/*!
+range type for iterating over edges.
+*/
+typedef Iterator_range<Finite_edges_iterator> Finite_edges;
+
+/*!
+range type for iterating over finite vertices, with a nested
+type `iterator` that has as value type `Vertex_handle`
+*/
+typedef Iterator_range<unspecified_type> Finite_vertex_handles;
+
+/*!
+range type for iterating over the points of the finite vertices.
+*/
+typedef Iterator_range<Point_iterator> Points;
+
+  
 /*!
 circulator over all faces intersected by a line. 
 */ 
@@ -858,6 +904,30 @@ Past-the-end iterator
 */ 
 Point_iterator points_end() const; 
 
+/*!
+returns a range of iterators over finite vertices.
+\note While the value type of `Finite_vertices_iterator` is `Vertex`, the value type of 
+      `Finite_vertex_handles::iterator` is `Vertex_handle`
+*/
+Finite_vertex_handles finite_vertex_handles() const;
+  
+/*!
+returns a range of iterators over finite edges.
+*/
+Finite_edges finite_edges() const;
+  
+/*!
+returns a range of iterators over finite faces.
+\note While the value type of `Finite_faces_iterator` is `Face`, the value type of 
+      `Finite_face_handles::iterator` is `Face_handle`
+*/
+Finite_face_handles finite_face_handles() const;
+
+/*!
+returns a range of iterators over the points of finite vertices.
+*/
+Points points() const;
+
 /// @}
 
 /// \name All Face, Edge and Vertex Iterators
@@ -898,6 +968,26 @@ All_faces_iterator all_faces_begin() const;
 Past-the-end iterator 
 */ 
 All_faces_iterator all_faces_end() const; 
+
+  
+/*!
+returns a range of iterators over all vertices.
+\note While the value type of `All_vertices_iterator` is `Vertex`, the value type of 
+      `All_vertex_handles::iterator` is `Vertex_handle`
+*/
+All_vertex_handles all_vertex_handles() const;
+  
+/*!
+returns a range of iterators over all edges.
+*/
+All_edges all_edges() const;
+  
+/*!
+returns a range of iterators over all faces.
+\note While the value type of `All_faces_iterator` is `Face`, the value type of 
+      `All_face_handles::iterator` is `Face_handle`
+*/
+All_face_handles all_face_handles() const;
 
 /// @} 
 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -304,19 +304,19 @@ typedef unspecified_type Point_iterator;
 
 
 /*!
-range type for iterating over all faces, with a nested
+range type for iterating over all faces (including infinite faces),  with a nested
 type `iterator` that has as value type `Face_handle`
 */
 typedef Iterator_range<unspecified_type> All_face_handles;
 
 
 /*!
-range type for iterating over edges.
+range type for iterating over all edges (including infinite ones).
 */
 typedef Iterator_range<All_edges_iterator> All_edges;
 
 /*!
-range type for iterating over all vertices, with a nested
+range type for iterating over all vertices (including the infinite vertex), with a nested
 type `iterator` that has as value type `Vertex_handle`
 */
 typedef Iterator_range<unspecified_type> All_vertex_handles;
@@ -330,7 +330,7 @@ typedef Iterator_range<unspecified_type> Finite_face_handles;
 
 
 /*!
-range type for iterating over edges.
+range type for iterating over finite edges.
 */
 typedef Iterator_range<Finite_edges_iterator> Finite_edges;
 

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -1056,7 +1056,7 @@ The class `Constrained_triangulation_plus_2` additionally provides the means to
 - traverse all the constraints of the triangulation using an iterator of type `Constraint_iterator` the value type of which is `Constraint_id`,
 - obtain all constraints that induce a constrained edge or a subconstraint,
 - traverse the sequence of vertices of a constraint  using an iterator of type `Vertices_in_constraint_iterator`, the value type of which is `Vertex_handle` 
-- traverse the subconstraints in the triangulation  using an iterator of type `Subconstraint_iterator`,the value type of which is `Subconstraint`.
+- traverse the subconstraints in the triangulation  using an iterator of type `Subconstraint_iterator`, the value type of which is `Subconstraint`.
 
 Note that the `Constrained_edges_iterator` and the `Subconstraint_iterator` are quite similar.
 The `Constrained_edges_iterator` traverses all edges and skips those that are \em not constrained,

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -377,6 +377,22 @@ forms a convex quadrilateral (see \cgalFigureRef{Triangulation_2D_fig_flip_bis})
 Flip.
 \cgalFigureEnd
 
+The triangulation defines iterator types such as `Triangulation_3::All_vertices_iterator`. They behave like
+a `Triangulation_3::Vertex_handle`, in the sense that there is no need to dereference the iterator to obtain a handle.
+Wherever the API expects a handle the iterator can be passed as well.
+
+In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
+`Triangulation_3::All_vertex_handles`, which has a nested type `Triangulation_3::All_vertex_handles::iterator`.
+The value type of this iterator is `Triangulation_3::Vertex_handle`.  Note that you only
+need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+It is similar for the various iterators for vertices and cells.
+
+For the range `Triangulation_3::All_facets` it holds that `Triangulation_3::All_facets::iterator` `==`
+`Triangulation_3::All_facets_iterator`. It is similar for the iterators for edges and points.
+
+\cgalExample{Triangulation_3/for_loop_2.cpp}
+
+
 \subsection Triangulation_2Implementation Implementation
 
 Locate is implemented by a stochastic walk \cgalCite{cgal:dpt-wt-02}.

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -382,15 +382,17 @@ a `Triangulation_3::Vertex_handle`, in the sense that there is no need to derefe
 Wherever the API expects a handle the iterator can be passed as well.
 
 In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
-`Triangulation_3::All_vertex_handles`, which has a nested type `Triangulation_3::All_vertex_handles::iterator`.
-The value type of this iterator is `Triangulation_3::Vertex_handle`.  Note that you only
-need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+`Triangulation_2::All_vertex_handles`, which has a nested type `Triangulation_2::All_vertex_handles::iterator`.
+The value type of this iterator is `Triangulation_2::Vertex_handle`.
 It is similar for the various iterators for vertices and cells.
 
-For the range `Triangulation_3::All_facets` it holds that `Triangulation_3::All_facets::iterator` `==`
-`Triangulation_3::All_facets_iterator`. It is similar for the iterators for edges and points.
+For the range `Triangulation_2::All_edges` it holds that `Triangulation_2::All_edges::iterator` `==`
+`Triangulation_2::All_facets_iterator`. It is similar for the various iterators for edges and points.
 
-\cgalExample{Triangulation_3/for_loop_2.cpp}
+Note that you only need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+
+
+\cgalExample{Triangulation_2/for_loop_2.cpp}
 
 
 \subsection Triangulation_2Implementation Implementation

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -378,7 +378,7 @@ Flip.
 \cgalFigureEnd
 
 The triangulation defines iterator types such as `Triangulation_3::All_vertices_iterator`. They behave like
-a `Triangulation_3::Vertex_handle`, in the sense that there is no need to dereference the iterator to obtain a handle.
+a handle, in the sense that there is no need to dereference the iterator to obtain a handle.
 Wherever the API expects a handle the iterator can be passed as well.
 
 In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
@@ -387,9 +387,9 @@ The value type of this iterator is `Triangulation_2::Vertex_handle`.
 It is similar for the various iterators for vertices and cells.
 
 For the range `Triangulation_2::All_edges` it holds that `Triangulation_2::All_edges::iterator` `==`
-`Triangulation_2::All_facets_iterator`. It is similar for the various iterators for edges and points.
+`Triangulation_2::All_edges_iterator`. It is similar for the various iterators for edges and points.
 
-Note that you only need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+Note that you only need the iterator type if you wish to combine pre \cpp 11 `for`-loops with the range class.
 
 
 \cgalExample{Triangulation_2/for_loop_2.cpp}

--- a/Triangulation_2/doc/Triangulation_2/examples.txt
+++ b/Triangulation_2/doc/Triangulation_2/examples.txt
@@ -1,4 +1,5 @@
 /*!
+\example Triangulation_2/for_loop_2.cpp
 \example Triangulation_2/adding_handles.cpp
 \example Triangulation_2/colored_face.cpp
 \example Triangulation_2/constrained.cpp

--- a/Triangulation_2/examples/Triangulation_2/colored_face.cpp
+++ b/Triangulation_2/examples/Triangulation_2/colored_face.cpp
@@ -11,7 +11,6 @@ typedef CGAL::Triangulation_data_structure_2<Vb,Fb> Tds;
 typedef CGAL::Triangulation_2<K,Tds> Triangulation;
 
 typedef Triangulation::Face_handle Face_handle;
-typedef Triangulation::Finite_faces_iterator Finite_faces_iterator;
 typedef Triangulation::Point  Point;
 
 int main() {
@@ -21,8 +20,8 @@ int main() {
   t.insert(Point(2,0));
   t.insert(Point(2,2));
 
-  Finite_faces_iterator fc = t.finite_faces_begin();
-  for( ; fc != t.finite_faces_end(); ++fc)  fc->info() = CGAL::blue();
+  for(Face_handle f : t.finite_face_handles())
+    f->info() = CGAL::blue();
 
   Point p(0.5,0.5);
   Face_handle fh = t.locate(p);

--- a/Triangulation_2/examples/Triangulation_2/constrained.cpp
+++ b/Triangulation_2/examples/Triangulation_2/constrained.cpp
@@ -8,8 +8,8 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
 typedef CGAL::Exact_predicates_tag                               Itag;
 typedef CGAL::Constrained_Delaunay_triangulation_2<K, CGAL::Default, Itag> CDT;
-typedef CDT::Point          Point;
-
+typedef CDT::Point Point;
+typedef CDT::Edge  Edge;
 int
 main( )
 {
@@ -22,10 +22,9 @@ main( )
 
   assert(cdt.is_valid());
   int count = 0;
-  for (CDT::Finite_edges_iterator eit = cdt.finite_edges_begin();
-       eit != cdt.finite_edges_end();
-       ++eit)
-    if (cdt.is_constrained(*eit)) ++count;
+  for (Edge e : cdt.finite_edges())
+    if (cdt.is_constrained(e))
+      ++count;
   std::cout << "The number of resulting constrained edges is  ";
   std::cout <<  count << std::endl;
   return 0;

--- a/Triangulation_2/examples/Triangulation_2/constrained.cpp
+++ b/Triangulation_2/examples/Triangulation_2/constrained.cpp
@@ -22,7 +22,7 @@ main( )
 
   assert(cdt.is_valid());
   int count = 0;
-  for (Edge e : cdt.finite_edges())
+  for (const Edge& e : cdt.finite_edges())
     if (cdt.is_constrained(e))
       ++count;
   std::cout << "The number of resulting constrained edges is  ";

--- a/Triangulation_2/examples/Triangulation_2/for_loop_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/for_loop_2.cpp
@@ -1,0 +1,47 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Triangulation_2.h>
+#include <iostream>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Triangulation_2<K>      Triangulation;
+typedef Triangulation::Vertex_handle  Vertex_handle;
+typedef Triangulation::Point          Point;
+typedef Triangulation::Finite_vertex_handles    Finite_vertex_handles;
+
+// The following types are different
+// Its value type is Triangulation_2::Vertex
+typedef Triangulation::Finite_vertices_iterator Finite_vertices_iterator;
+// Its value type is Triangulation_2::Vertex_handle
+typedef Finite_vertex_handles::iterator         Finite_vertex_handles_iterator;
+
+int main()
+{
+  std::vector<Point> points =  { Point(0,0), Point(1,0), Point(0,1) };
+
+  Triangulation T;
+
+  T.insert(points.begin(), points.end());
+
+  std::cout << "Triangulation_2::Finite_vertices_iterator is like a  Triangulation_2::Vertex_handle\n";
+  for(Finite_vertices_iterator it = T.finite_vertices_begin();
+      it != T.finite_vertices_end();
+      ++it){
+    std::cout << it->point() << std::endl;
+  }
+
+  std::cout << "Triangulation_2::Finite_vertex_handles::iterator dereferences to Triangulation_2::Vertex_handle\n";
+  Finite_vertex_handles::iterator b, e;
+  std::tie(b,e) = T.finite_vertex_handles();
+  for(; b!=e; ++b){
+    Vertex_handle vh = *b; // you must dereference the iterator to get a handle
+    std::cout << vh->point() << std::endl;
+  }
+  
+  std::cout << "and you can use a C++11 for loop\n";
+  for(Vertex_handle vh : T.finite_vertex_handles()){
+    std::cout << vh->point() << std::endl;
+  }
+  
+  return 0;
+}

--- a/Triangulation_2/examples/Triangulation_2/info_insert_with_pair_iterator_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/info_insert_with_pair_iterator_2.cpp
@@ -8,6 +8,7 @@ typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, K>    Vb;
 typedef CGAL::Triangulation_data_structure_2<Vb>                    Tds;
 typedef CGAL::Delaunay_triangulation_2<K, Tds>                      Delaunay;
 typedef Delaunay::Point                                             Point;
+typedef Delaunay::Vertex_handle                                     Vertex_handle;
 
 int main()
 {
@@ -27,8 +28,8 @@ int main()
 
   // check that the info was correctly set.
   Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ].first != vit->point() ){
+  for (Vertex_handle v : T.finite_vertex_handles())
+    if( points[ v->info() ].first != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_2/examples/Triangulation_2/info_insert_with_pair_iterator_regular_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/info_insert_with_pair_iterator_regular_2.cpp
@@ -13,6 +13,7 @@ typedef CGAL::Triangulation_data_structure_2<Vb,Fb>                    Tds;
 typedef CGAL::Regular_triangulation_2<K, Tds>                          Regular;
 typedef K::Point_2                                                     Point;
 typedef K::Weighted_point_2                                            Wpoint;
+typedef Regular::Vertex_handle                                         Vertex_handle;
 
 int main()
 {
@@ -30,9 +31,8 @@ int main()
   CGAL_assertion( rt.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
-  Regular::Finite_vertices_iterator vit;
-  for (vit = rt.finite_vertices_begin(); vit != rt.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ].first != vit->point() ){
+  for (Vertex_handle v : rt.finite_vertex_handles())
+    if( points[ v->info() ].first != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_2/examples/Triangulation_2/info_insert_with_transform_iterator_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/info_insert_with_transform_iterator_2.cpp
@@ -9,6 +9,7 @@ typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, K>    Vb;
 typedef CGAL::Triangulation_data_structure_2<Vb>                    Tds;
 typedef CGAL::Delaunay_triangulation_2<K, Tds>                      Delaunay;
 typedef Delaunay::Point                                             Point;
+typedef Delaunay::Vertex_handle                                     Vertex_handle;
 
 //a functor that returns a std::pair<Point,unsigned>.
 //the unsigned integer is incremented at each call to 
@@ -40,8 +41,8 @@ int main()
   
   // check that the info was correctly set.
   Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ] != vit->point() ){
+  for (Vertex_handle v : T.finite_vertex_handles())
+    if( points[ v->info() ] != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_2/examples/Triangulation_2/info_insert_with_zip_iterator_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/info_insert_with_zip_iterator_2.cpp
@@ -9,6 +9,7 @@ typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, K>    Vb;
 typedef CGAL::Triangulation_data_structure_2<Vb>                    Tds;
 typedef CGAL::Delaunay_triangulation_2<K, Tds>                      Delaunay;
 typedef Delaunay::Point                                             Point;
+typedef Delaunay::Vertex_handle                                     Vertex_handle;
 
 int main()
 {
@@ -39,9 +40,9 @@ int main()
   
   
   // check that the info was correctly set.
-  Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ] != vit->point() ){
+
+  for (Vertex_handle v : T.finite_vertex_handles())
+    if( points[ v->info() ] != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_2/examples/Triangulation_2/polygon_triangulation.cpp
+++ b/Triangulation_2/examples/Triangulation_2/polygon_triangulation.cpp
@@ -24,27 +24,28 @@ typedef CGAL::Exact_predicates_tag                                Itag;
 typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, Itag>  CDT;
 typedef CDT::Point                                                Point;
 typedef CGAL::Polygon_2<K>                                        Polygon_2;
+typedef CDT::Face_handle                                          Face_handle;
 
 void 
 mark_domains(CDT& ct, 
-             CDT::Face_handle start, 
+             Face_handle start, 
              int index, 
              std::list<CDT::Edge>& border )
 {
   if(start->info().nesting_level != -1){
     return;
   }
-  std::list<CDT::Face_handle> queue;
+  std::list<Face_handle> queue;
   queue.push_back(start);
 
   while(! queue.empty()){
-    CDT::Face_handle fh = queue.front();
+    Face_handle fh = queue.front();
     queue.pop_front();
     if(fh->info().nesting_level == -1){
       fh->info().nesting_level = index;
       for(int i = 0; i < 3; i++){
         CDT::Edge e(fh,i);
-        CDT::Face_handle n = fh->neighbor(i);
+        Face_handle n = fh->neighbor(i);
         if(n->info().nesting_level == -1){
           if(ct.is_constrained(e)) border.push_back(e);
           else queue.push_back(n);
@@ -63,8 +64,8 @@ mark_domains(CDT& ct,
 void
 mark_domains(CDT& cdt)
 {
-  for(CDT::All_faces_iterator it = cdt.all_faces_begin(); it != cdt.all_faces_end(); ++it){
-    it->info().nesting_level = -1;
+  for(CDT::Face_handle f : cdt.all_face_handles()){
+    f->info().nesting_level = -1;
   }
 
   std::list<CDT::Edge> border;
@@ -72,7 +73,7 @@ mark_domains(CDT& cdt)
   while(! border.empty()){
     CDT::Edge e = border.front();
     border.pop_front();
-    CDT::Face_handle n = e.first->neighbor(e.second);
+    Face_handle n = e.first->neighbor(e.second);
     if(n->info().nesting_level == -1){
       mark_domains(cdt, n, e.first->info().nesting_level+1, border);
     }
@@ -104,10 +105,9 @@ int main( )
   mark_domains(cdt);
   
   int count=0;
-  for (CDT::Finite_faces_iterator fit=cdt.finite_faces_begin();
-                                  fit!=cdt.finite_faces_end();++fit)
+  for (Face_handle f : cdt.finite_face_handles())
   {
-    if ( fit->info().in_domain() ) ++count;
+    if ( f->info().in_domain() ) ++count;
   }
   
   std::cout << "There are " << count << " facets in the domain." << std::endl;

--- a/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
+++ b/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
@@ -34,7 +34,7 @@ contexts(const CDTP& cdtp)
     if(cdtp.number_of_enclosing_constraints(vp, vq) == 2){
       std::cout << "subconstraint " << vp->point() << " " << vq->point() 
                 << " is on constraints starting at:\n";
-      for(CDTP::Context c : cdtp.contexts(vp,vq)){
+      for(const CDTP::Context& c : cdtp.contexts(vp,vq)){
         std::cout << (*(c.vertices_begin()))->point() << std::endl;
       }
     }

--- a/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
+++ b/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
@@ -21,10 +21,7 @@ print(const CDTP& cdtp, Cid cid)
   typedef CDTP::Vertices_in_constraint Vertices_in_constraint;
 
   std::cout << "Polyline constraint:" << std::endl;
-  for(Vertices_in_constraint it = cdtp.vertices_in_constraint_begin(cid);
-      it !=cdtp.vertices_in_constraint_end(cid);
-      it++){
-    Vertex_handle vh = *it;
+  for(Vertex_handle vh : cdtp.vertices_in_constraint(cid)){
     std::cout << vh->point() << std::endl;
   }
 }
@@ -33,20 +30,13 @@ print(const CDTP& cdtp, Cid cid)
 void 
 contexts(const CDTP& cdtp)
 {
-  CDTP::Subconstraint_iterator
-    beg = cdtp.subconstraints_begin(),
-    end = cdtp.subconstraints_end();
-
-  for(; beg!=end; ++beg){
-    Vertex_handle vp = beg->first.first, vq = beg->first.second;
+  for(auto sc : cdtp.subconstraints()){
+    Vertex_handle vp = sc.first.first, vq = sc.first.second;
 
     if(cdtp.number_of_enclosing_constraints(vp, vq) == 2){
-      CDTP::Context_iterator cbeg = cdtp.contexts_begin(vp,vq),
-        cend = cdtp.contexts_end(vp,vq);
       std::cout << "subconstraint " << vp->point() << " " << vq->point() 
                 << " is on constraints starting at:\n";
-      for(; cbeg !=  cend; ++cbeg){
-        CDTP::Context c = *cbeg;
+      for(CDTP::Context c : cdtp.contexts(vp,vq)){
         std::cout << (*(c.vertices_begin()))->point() << std::endl;
       }
     }

--- a/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
+++ b/Triangulation_2/examples/Triangulation_2/polylines_triangulation.cpp
@@ -18,8 +18,6 @@ typedef CDTP::Vertex_handle                                               Vertex
 void 
 print(const CDTP& cdtp, Cid cid)
 {
-  typedef CDTP::Vertices_in_constraint Vertices_in_constraint;
-
   std::cout << "Polyline constraint:" << std::endl;
   for(Vertex_handle vh : cdtp.vertices_in_constraint(cid)){
     std::cout << vh->point() << std::endl;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -120,6 +120,7 @@ public:
                                  typename Triangulation::All_edges_iterator>
                                                      Constrained_edges_iterator;
 
+  typedef Iterator_range<Constrained_edges_iterator> Constrained_edges;
 
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
   using Triangulation::number_of_vertices;
@@ -218,6 +219,11 @@ public:
                                       all_edges_end());
   }
 
+  Constrained_edges constrained_edges() const
+  {
+    return Constrained_edges(constrained_edges_begin(),constrained_edges_end());
+  }
+  
   // INSERTION
   Vertex_handle insert(const Point& p, 
 			       Face_handle start = Face_handle() );

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -191,7 +191,8 @@ public:
   typedef Iterator_range<Context_iterator>                Contexts;
   
   typedef typename Constraint_hierarchy::C_iterator   Constraint_iterator;
-
+  typedef Iterator_range<Constraint_iterator> Cconstraints;
+  
   typedef typename Constraint_hierarchy::Subconstraint_iterator  Subconstraint_iterator;
   typedef Iterator_range<Subconstraint_iterator> Subconstraints;
   
@@ -772,6 +773,11 @@ public:
   // Query of the constraint hierarchy
   Constraint_iterator constraints_begin() const;
   Constraint_iterator constraints_end()   const;
+  Constraints constraints() const
+  {
+    return Constraints(constraints_begin(),constraints_end());
+  }
+  
   Subconstraint_iterator subconstraints_begin() const;
   Subconstraint_iterator subconstraints_end() const;
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -179,21 +179,26 @@ public:
   // for user interface with the constraint hierarchy
   typedef typename Constraint_hierarchy::Vertex_it 
                                             Vertices_in_constraint_iterator;
+
+  typedef Iterator_range<Vertices_in_constraint_iterator> Vertices_in_constraint;
   
   typedef typename Constraint_hierarchy::Point_it
                                             Points_in_constraint_iterator;
-
-  typedef typename Constraint_hierarchy::Context      Context;
-  typedef typename Constraint_hierarchy::Context_iterator  Context_iterator;
+  typedef Iterator_range<Points_in_constraint_iterator> Points_in_constraint;
+  
+  typedef typename Constraint_hierarchy::Context          Context;
+  typedef typename Constraint_hierarchy::Context_iterator Context_iterator;
+  typedef Iterator_range<Context_iterator>                Contexts;
+  
   typedef typename Constraint_hierarchy::C_iterator   Constraint_iterator;
+
   typedef typename Constraint_hierarchy::Subconstraint_iterator  Subconstraint_iterator;
+  typedef Iterator_range<Subconstraint_iterator> Subconstraints;
+  
   typedef typename Constraint_hierarchy::Constraint_id Constraint_id;   
                                             
   typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
   
-  //for backward compatibility
-  typedef Vertices_in_constraint_iterator     Vertices_in_constraint;
-
   using Triangulation::geom_traits;
   using Triangulation::cw;
   using Triangulation::ccw;
@@ -769,6 +774,12 @@ public:
   Constraint_iterator constraints_end()   const;
   Subconstraint_iterator subconstraints_begin() const;
   Subconstraint_iterator subconstraints_end() const;
+
+  Subconstraints subconstraints() const
+  {
+    return Subconstraints(subconstraints_begin(),subconstraints_end());
+  }
+  
   Context   context(Vertex_handle va, Vertex_handle vb); //AF: const; 
 
   bool is_subconstraint(Vertex_handle va, 
@@ -780,11 +791,26 @@ public:
   Context_iterator   contexts_end(Vertex_handle va, 
 				  Vertex_handle vb) const;
 
+  Contexts contexts(Vertex_handle va, Vertex_handle vb) const
+  {
+    return Contexts(contexts_begin(va,vb),contexts_end(va,vb));
+  }
+  
   Vertices_in_constraint_iterator vertices_in_constraint_begin(Constraint_id cid) const;
-  Vertices_in_constraint_iterator vertices_in_constraint_end(Constraint_id cid) const ;  
+  Vertices_in_constraint_iterator vertices_in_constraint_end(Constraint_id cid) const;
+  
+  Vertices_in_constraint vertices_in_constraint(Constraint_id cid) const
+  {
+    return Vertices_in_constraint(vertices_in_constraint_begin(cid), vertices_in_constraint_end(cid));
+  }
+  
   Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
   Points_in_constraint_iterator points_in_constraint_end(Constraint_id cid) const ;
 
+  Points_in_constraint points_in_constraint(Constraint_id cid) const
+  {
+    return Points_in_constraint(points_in_constraint_begin(cid), points_in_constraint_end(cid));
+  }
 
   size_type number_of_constraints() {
     return static_cast<size_type> (hierarchy.number_of_constraints());}

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -191,7 +191,7 @@ public:
   typedef Iterator_range<Context_iterator>                Contexts;
   
   typedef typename Constraint_hierarchy::C_iterator   Constraint_iterator;
-  typedef Iterator_range<Constraint_iterator> Cconstraints;
+  typedef Iterator_range<Constraint_iterator> Constraints;
   
   typedef typename Constraint_hierarchy::Subconstraint_iterator  Subconstraint_iterator;
   typedef Iterator_range<Subconstraint_iterator> Subconstraints;
@@ -629,10 +629,7 @@ public:
 
     for(Constraint_iterator cit = constraints_begin(); cit != constraints_end(); ++cit){
       os << (*cit).second->all_size();
-       for(Vertices_in_constraint it = vertices_in_constraint_begin(*cit);
-           it != vertices_in_constraint_end(*cit);
-           it++){
-         Vertex_handle vh = *it;
+      for(Vertex_handle vh : vertices_in_constraint(*cit)){
          os << " " << V[vh];
        }
        os << std::endl;

--- a/Triangulation_2/include/CGAL/Regular_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_2.h
@@ -175,6 +175,8 @@ public:
     operator Vertex_handle() const { return Base::base(); }
   };
 
+  typedef Iterator_range<Prevent_deref<All_vertices_iterator> > All_vertex_handles;
+  
   class Finite_vertices_iterator :
     public Filter_iterator<Finite_vib, Hidden_tester>
   {
@@ -190,6 +192,8 @@ public:
     operator Vertex_handle() const { return Base::base(); }
  };
 
+  typedef Iterator_range<Prevent_deref<Finite_vertices_iterator> > Finite_vertex_handles;
+  
   class Hidden_vertices_iterator :
     public Filter_iterator<Finite_vib, Unhidden_tester>
   {
@@ -205,6 +209,8 @@ public:
     operator Vertex_handle() const { return Base::base(); }
  };
 
+  typedef Iterator_range<Prevent_deref<Hidden_vertices_iterator> > Hidden_vertex_handles;
+  
  //for backward compatibility
   typedef Finite_faces_iterator                Face_iterator;
   typedef Finite_edges_iterator                Edge_iterator;
@@ -341,14 +347,18 @@ public:
 
   All_vertices_iterator all_vertices_begin() const;
   All_vertices_iterator all_vertices_end() const;
-
+  All_vertex_handles all_vertex_handles() const;
+  
   Finite_vertices_iterator finite_vertices_begin() const;
   Finite_vertices_iterator finite_vertices_end() const;
+  Finite_vertex_handles finite_vertex_handles() const;
+  
   Vertex_handle finite_vertex() const;
 
   Hidden_vertices_iterator hidden_vertices_begin() const;
   Hidden_vertices_iterator hidden_vertices_end() const;
-
+  Hidden_vertex_handles hidden_vertex_handles() const;
+  
 //  Vertex_handle file_input(std::istream& is);
 //  void file_output(std::ostream& os) const;
 
@@ -2191,7 +2201,15 @@ all_vertices_end() const
   return CGAL::filter_iterator(Base::all_vertices_end(),
                                Hidden_tester());
 }
-
+  
+template < class Gt, class Tds >
+typename Regular_triangulation_2<Gt,Tds>::All_vertex_handles
+Regular_triangulation_2<Gt,Tds>::
+all_vertex_handles() const
+{
+  return make_prevent_deref_range(all_vertices_begin(),all_vertices_end());
+}
+  
 template < class Gt, class Tds >
 typename Regular_triangulation_2<Gt,Tds>::Finite_vertices_iterator
 Regular_triangulation_2<Gt,Tds>::
@@ -2202,6 +2220,7 @@ finite_vertices_begin() const
                                Base::finite_vertices_begin());
 }
 
+  
 template < class Gt, class Tds >
 typename Regular_triangulation_2<Gt,Tds>::Vertex_handle
 Regular_triangulation_2<Gt,Tds>::
@@ -2222,6 +2241,14 @@ finite_vertices_end() const
 }
 
 template < class Gt, class Tds >
+typename Regular_triangulation_2<Gt,Tds>::Finite_vertex_handles
+Regular_triangulation_2<Gt,Tds>::
+finite_vertex_handles() const
+{
+  return make_prevent_deref_range(finite_vertices_begin(),finite_vertices_end());
+}
+ 
+template < class Gt, class Tds >
 typename Regular_triangulation_2<Gt,Tds>::Hidden_vertices_iterator
 Regular_triangulation_2<Gt,Tds>::
 hidden_vertices_begin() const
@@ -2239,7 +2266,15 @@ hidden_vertices_end() const
   return CGAL::filter_iterator(Base::finite_vertices_end(),
                                Unhidden_tester());
 }
-
+  
+template < class Gt, class Tds >
+typename Regular_triangulation_2<Gt,Tds>::Hidden_vertex_handles
+Regular_triangulation_2<Gt,Tds>::
+hidden_vertex_handles() const
+{
+  return make_prevent_deref_range(hidden_vertices_begin(),hidden_vertices_end());
+}
+  
 template < class Gt, class Tds >
 typename Regular_triangulation_2<Gt,Tds>::Vertex_handle
 Regular_triangulation_2<Gt,Tds>::

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -207,6 +207,20 @@ public:
   typedef Project_point<Vertex>                           Proj_point;
 
   typedef boost::transform_iterator<Proj_point,Finite_vertices_iterator> Point_iterator;
+
+
+  // Range types
+
+  
+  typedef typename Tds::Face_handles           All_face_handles;
+  typedef typename Tds::Vertex_handles         All_vertex_handles;
+  typedef typename Tds::Edges                  All_edges;
+  
+  typedef Iterator_range<Prevent_deref<Finite_faces_iterator> >    Finite_face_handles;
+  typedef Iterator_range<Prevent_deref<Finite_vertices_iterator> > Finite_vertex_handles;
+  typedef Iterator_range<Finite_edges_iterator>                    Finite_edges;
+  typedef Iterator_range<Point_iterator>                           Points;
+  
   typedef Point                value_type; // to have a back_inserter
   typedef const value_type&    const_reference;
   typedef value_type&          reference;
@@ -437,19 +451,32 @@ public:
   //TRAVERSING : ITERATORS AND CIRCULATORS
   Finite_faces_iterator finite_faces_begin() const;
   Finite_faces_iterator finite_faces_end() const;
+  Finite_face_handles finite_face_handles() const;
+  
   Finite_vertices_iterator finite_vertices_begin() const;
   Finite_vertices_iterator finite_vertices_end() const;
+  Finite_vertex_handles finite_vertex_handles() const;
+  
   Finite_edges_iterator finite_edges_begin() const;
   Finite_edges_iterator finite_edges_end() const;
+  Finite_edges finite_edges() const;
+  
   Point_iterator points_begin() const;
   Point_iterator points_end() const;
+  Points points() const;
 
   All_faces_iterator all_faces_begin() const;
   All_faces_iterator all_faces_end() const;
+  All_face_handles all_face_handles() const;
+  
   All_vertices_iterator all_vertices_begin() const;
   All_vertices_iterator all_vertices_end() const;
+  All_vertex_handles all_vertex_handles() const;
+  
   All_edges_iterator all_edges_begin() const;
   All_edges_iterator all_edges_end() const;
+  All_edges all_edges() const;
+  
   All_halfedges_iterator all_halfedges_begin() const;
   All_halfedges_iterator all_halfedges_end() const;
 
@@ -3078,6 +3105,14 @@ finite_faces_end() const
 }
 
 template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::Finite_face_handles
+Triangulation_2<Gt, Tds>::
+finite_face_handles() const
+{
+  return make_prevent_deref_range(finite_faces_begin(),finite_faces_end());
+}
+
+template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::Finite_vertices_iterator
 Triangulation_2<Gt, Tds>::
 finite_vertices_begin() const
@@ -3096,6 +3131,14 @@ finite_vertices_end() const
 {
   return CGAL::filter_iterator(all_vertices_end(),
                                Infinite_tester(this));
+}
+
+template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::Finite_vertex_handles
+Triangulation_2<Gt, Tds>::
+finite_vertex_handles() const
+{
+  return make_prevent_deref_range(finite_vertices_begin(),finite_vertices_end());
 }
 
 template <class Gt, class Tds >
@@ -3119,6 +3162,15 @@ finite_edges_end() const
                                infinite_tester() );
 }
 
+
+template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::Finite_edges
+Triangulation_2<Gt, Tds>::
+finite_edges() const
+{
+  return Finite_edges(finite_edges_begin(), finite_edges_end());
+}
+  
 template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::Point_iterator
 Triangulation_2<Gt, Tds>::
@@ -3136,19 +3188,35 @@ points_end() const
 }
 
 template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::Points
+Triangulation_2<Gt, Tds>::
+points() const
+{
+  return Points(points_begin(), points_end());
+}
+  
+template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::All_faces_iterator
 Triangulation_2<Gt, Tds>::
 all_faces_begin() const
 {
   return _tds.faces_begin();
 }
-
+  
 template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::All_faces_iterator
 Triangulation_2<Gt, Tds>::
 all_faces_end() const
 {
-  return _tds.faces_end();;
+  return _tds.faces_end();
+}
+  
+template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::All_face_handles
+Triangulation_2<Gt, Tds>::
+all_face_handles() const
+{
+  return _tds.face_handles();
 }
 
 template <class Gt, class Tds >
@@ -3165,6 +3233,14 @@ Triangulation_2<Gt, Tds>::
 all_vertices_end() const
 {
   return _tds.vertices_end();
+}
+  
+template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::All_vertex_handles
+Triangulation_2<Gt, Tds>::
+all_vertex_handles() const
+{
+  return _tds.vertex_handles();
 }
 
 template <class Gt, class Tds >

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -3202,7 +3202,6 @@ all_faces_begin() const
 {
   return _tds.faces_begin();
 }
-  
 template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::All_faces_iterator
 Triangulation_2<Gt, Tds>::

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -3259,6 +3259,14 @@ all_edges_end() const
 }
 
 template <class Gt, class Tds >
+typename Triangulation_2<Gt, Tds>::All_edges
+Triangulation_2<Gt, Tds>::
+all_edges() const
+{
+  return _tds.edges();
+}
+  
+template <class Gt, class Tds >
 typename Triangulation_2<Gt, Tds>::All_halfedges_iterator
 Triangulation_2<Gt, Tds>::
 all_halfedges_begin() const

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -170,9 +170,9 @@ public:
       : enclosing(hc.enclosing), pos(hc.pos)
     {}
 
-    Vertex_it    vertices_begin() { return enclosing->skip_begin();}
-    Vertex_it    current() {return pos;}
-    Vertex_it    vertices_end() {return enclosing->skip_end();}
+    Vertex_it    vertices_begin()const { return enclosing->skip_begin();}
+    Vertex_it    current()const {return pos;}
+    Vertex_it    vertices_end()const {return enclosing->skip_end();}
     Constraint_id  id() { return enclosing; }
     std::size_t    number_of_vertices() const {return enclosing->skip_size(); }
   };                                           

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_triang_plus_2.h
@@ -5,17 +5,17 @@ void
 _test_cls_const_triang_plus_2( const TrP & )
 {
   //typedef TriangPlus                           TrP;
-  typedef typename TrP::Geom_traits            Gt;
-  typedef typename Gt::Point_2                 Point;
+  typedef typename TrP::Geom_traits                     Gt;
+  typedef typename Gt::Point_2                          Point;
 
-  typedef typename TrP::Vertex_handle          Vertex_handle;
-  typedef typename TrP::Constraint             Constraint;
-  typedef typename TrP::Constraint_iterator    Constraint_iterator;
-  typedef typename TrP::Constraint_hierarchy   Hierarchy;
-  typedef typename TrP::Context                Context;
-  typedef typename TrP::Context_iterator       Context_iterator;
-  typedef typename TrP::Vertices_in_constraint Vertices_in_constraint;
-  typedef typename TrP::Constraint_id          Constraint_id;
+  typedef typename TrP::Vertex_handle                   Vertex_handle;
+  typedef typename TrP::Constraint                      Constraint;
+  typedef typename TrP::Constraint_iterator             Constraint_iterator;
+  typedef typename TrP::Constraint_hierarchy            Hierarchy;
+  typedef typename TrP::Context                         Context;
+  typedef typename TrP::Context_iterator                Context_iterator;
+  typedef typename TrP::Vertices_in_constraint_iterator Vertices_in_constraint_iterator;
+  typedef typename TrP::Constraint_id                   Constraint_id;
 
   CGAL_USE_TYPE(Hierarchy);
   CGAL_USE_TYPE(Context);
@@ -47,7 +47,7 @@ _test_cls_const_triang_plus_2( const TrP & )
 
   // test access to the hierarchy
   std::cout << " test acces to the constraint hierarchy" << std::endl;
-  Vertices_in_constraint vit = trp.vertices_in_constraint_begin(cid);
+  Vertices_in_constraint_iterator vit = trp.vertices_in_constraint_begin(cid);
   assert (*vit == vh[10] || *vit == vh[11] );
   Vertex_handle va = *++vit;
   Vertex_handle vb = *++vit;
@@ -58,12 +58,12 @@ _test_cls_const_triang_plus_2( const TrP & )
   Context_iterator cit2 = cit1++;
   //trp.print_hierarchy();
   assert( cit1->number_of_vertices() == 4  || cit1->number_of_vertices() == 7);
-  Vertices_in_constraint firstin1 = cit1->vertices_begin();
-  Vertices_in_constraint lastin1 = --(cit1->vertices_end());
-  Vertices_in_constraint currentin1 = cit1->current();
-  Vertices_in_constraint firstin2 = cit2->vertices_begin();
-  Vertices_in_constraint lastin2 = --(cit2->vertices_end());
-  Vertices_in_constraint currentin2 = cit2->current();
+  Vertices_in_constraint_iterator firstin1 = cit1->vertices_begin();
+  Vertices_in_constraint_iterator lastin1 = --(cit1->vertices_end());
+  Vertices_in_constraint_iterator currentin1 = cit1->current();
+  Vertices_in_constraint_iterator firstin2 = cit2->vertices_begin();
+  Vertices_in_constraint_iterator lastin2 = --(cit2->vertices_end());
+  Vertices_in_constraint_iterator currentin2 = cit2->current();
   if ( cit1->number_of_vertices() == 4) {
     assert( (*firstin1 == vh[10] &&  *lastin1 == vh[11]) ||
 	    (*firstin1 == vh[11] &&  *lastin1 == vh[10]));

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
@@ -182,7 +182,9 @@ _test_cls_point_iterator( Triangulation &T )
   assert( n == 0 );
 
   Points range = T.points();
-  p = *(range.first);
+  if(! range.empty()){
+    p = *(range.first);
+  }
   return np;  
 }
 

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
@@ -80,6 +80,8 @@ _test_cls_face_iterator( const Triangulation &T )
   typedef typename Triangulation::Face_handle     Face_handle;
   typedef typename Triangulation::size_type       size_type;
 
+  typedef typename Triangulation::Finite_face_handles Finite_face_handles;
+  
   Face f;
   Face_handle fh;
   Vertex_handle vh;
@@ -104,6 +106,9 @@ _test_cls_face_iterator( const Triangulation &T )
     n--;
   assert(n==0);
 
+  Finite_face_handles range = T.finite_face_handles();
+  fh = *(range.first);
+  
   return n_finite;
  }
 
@@ -119,6 +124,8 @@ _test_cls_vertex_iterator( const Triangulation &T )
   typedef typename Triangulation::Face_handle     Face_handle;
   typedef typename Triangulation::size_type       size_type;
   
+  typedef typename Triangulation::Finite_vertex_handles Finite_vertex_handles;
+    
   Vertex v;
   Face_handle fh;
   Vertex_handle vh;
@@ -143,6 +150,8 @@ _test_cls_vertex_iterator( const Triangulation &T )
     n--;
   assert( n == 0 );
 
+  Finite_vertex_handles range = T.finite_vertex_handles();
+  vh = *(range.first);
   return nv;
 }
 
@@ -153,7 +162,7 @@ _test_cls_point_iterator( Triangulation &T )
   typedef typename Triangulation::Point_iterator Point_iterator;
   typedef typename Triangulation::Point          Point;
   typedef typename Triangulation::size_type      size_type;
-
+  typedef typename Triangulation::Points         Points;
   size_type np = 0;
   Point_iterator pit;
   Point p;
@@ -172,6 +181,8 @@ _test_cls_point_iterator( Triangulation &T )
     n--;
   assert( n == 0 );
 
+  Points range = T.points();
+  p = *(range.first);
   return np;  
 }
 
@@ -184,6 +195,8 @@ _test_cls_edge_iterator( const Triangulation &T )
   typedef typename Triangulation::Edge     Edge;
   typedef typename Triangulation::Face_handle     Face_handle;
   typedef typename Triangulation::size_type      size_type;
+
+  typedef typename Triangulation::Finite_edges Finite_edges;
 
   Edge e;
   Face_handle fh;
@@ -205,6 +218,8 @@ _test_cls_edge_iterator( const Triangulation &T )
     n--;
   assert( n == 0 );
 
+  Finite_edges range = T.finite_edges();
+  e = *(range.first);
   return ne;
 }
 

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_triangulation_iterators.h
@@ -199,6 +199,7 @@ _test_cls_edge_iterator( const Triangulation &T )
   typedef typename Triangulation::size_type      size_type;
 
   typedef typename Triangulation::Finite_edges Finite_edges;
+  typedef typename Triangulation::All_edges All_edges;
 
   Edge e;
   Face_handle fh;
@@ -221,7 +222,14 @@ _test_cls_edge_iterator( const Triangulation &T )
   assert( n == 0 );
 
   Finite_edges range = T.finite_edges();
-  e = *(range.first);
+  if(! range.empty()){
+    e = *(range.first);
+  }
+
+  All_edges aerange = T.all_edges();
+  if(! aerange.empty()){
+    e = *(aerange.first);
+  }
   return ne;
 }
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -228,19 +228,57 @@ In order to write \cpp 11 `for`-loops we provide range types.
 
 */
 /// @{
-
+  
+/*!
+range type for iterating over all cell handles, with a nested type `iterator`
+that has as value type `Cell_handle`.
+*/ 
+  typedef Iterator_range<unspecified_type> All_cell_handles;
+  
   
 /*!
 range type for iterating over facets.
 */
-  typedef Iterator_range<Facet_iterator> All_facets;
+  typedef Iterator_range<All_facets_iterator> All_facets;
+  
+/*!
+range type for iterating over edges.
+*/
+  typedef Iterator_range<All_edges_iterator> All_edges;
   
 /*!
 range type for iterating over all vertex handles, with a nested type `iterator`
 that has as value type `Vertex_handle`.
 */ 
   typedef Iterator_range<unspecified_type> All_vertex_handles;
+
+  /*!
+range type for iterating over finite cell handles, with a nested type `iterator`
+that has as value type `Cell_handle`.
+*/ 
+  typedef Iterator_range<unspecified_type> Finite_cell_handles;
   
+  
+/*!
+range type for iterating over finite facets.
+*/
+  typedef Iterator_range<Finite_facets_iterator> Finite_facets;
+  
+/*!
+range type for iterating over finite edges.
+*/
+  typedef Iterator_range<Finite_edges_iterator> Finite_edges;
+  
+/*!
+range type for iterating over finite vertex handles, with a nested type `iterator`
+that has as value type `Vertex_handle`.
+*/ 
+  typedef Iterator_range<unspecified_type> Finite_vertex_handles;
+
+/*!
+  range type for iterating over the points of the finite vertices.
+ */
+  typedef Iterator_range<unspecified_type> Points;
 /// @}
 
 /// \name Creation 
@@ -1159,11 +1197,34 @@ Point_iterator points_end() const;
 /*! \name Ranges
 
 In order to write \cpp 11 `for`-loops we provide a range type and member functions to generate ranges.
-Note that vertex and cell ranges are special.
+Note that vertex and cell ranges are special. See Section \ref Triangulation3secRanges in the User Manual.
 
 */
 
 /// @{
+
+/*!
+  returns a range of iterators over all cells (even the infinite one).
+  Returns an empty range when `t.number_of_cells() == 0`. 
+  \note While the value type of `All_cells_iterator` is `Cell`, the value type of 
+  `All_cell_handles::iterator` is `Cell_handle`.
+ */
+  All_cell_handles all_cell_handles() const;
+
+ 
+  
+/*!
+  returns a range of iterators starting at an arbitrary facet.
+  Returns an empty range when `t.dimension() < 2`. 
+*/
+All_facets all_facets() const;
+ 
+/*!
+  returns a range of iterators starting at an arbitrary edge.
+  Returns an empty range when `t.dimension() < 2`. 
+*/
+All_edges all_edges() const;
+ 
 /*!
   returns a range of iterators over all vertices (even the infinite one).
   Returns an empty range when `t.number_of_vertices() == 0`. 
@@ -1172,13 +1233,43 @@ Note that vertex and cell ranges are special.
  */
   All_vertex_handles all_vertex_handles() const;
 
+  
+/*!
+  returns a range of iterators over finite cells.
+  Returns an empty range when `t.number_of_cells() == 0`. 
+  \note While the value type of `Finite_cells_iterator` is `Cell`, the value type of 
+  `Finite_cell_handles::iterator` is `Cell_handle`.
+ */
+  Finite_cell_handles finite_cell_handles() const;
 
+ 
+  
 /*!
   returns a range of iterators starting at an arbitrary facet.
   Returns an empty range when `t.dimension() < 2`. 
 */
-All_facets all_facets() const;
+Finite_facets finite_facets() const;
+ 
+/*!
+  returns a range of iterators starting at an arbitrary edge.
+  Returns an empty range when `t.dimension() < 2`. 
+*/
+Finite_edges finite_edges() const;
+ 
+/*!
+  returns a range of iterators over finite vertices.
+  Returns an empty range when `t.number_of_vertices() == 0`. 
+  \note While the value type of `Finite_vertices_iterator` is `Vertex`, the value type of 
+  `Finite_vertex_handles::iterator` is `Vertex_handle`.
+ */
+  Finite_vertex_handles finite_vertex_handles() const;
+
+  /*!
+    returns a range of iterators over the points of finite vertices.
+   */
+  Points points() const;
   
+ 
 /// @} 
   
 /*!\name Cell and Facet Circulators 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -224,7 +224,7 @@ typedef Triangulation_data_structure::Facet_circulator Facet_circulator;
 
 /*! \name Ranges
 
-In order to write \cpp 11 `for`-loops we provide range typesxxx.
+In order to write \cpp 11 `for`-loops we provide range types.
 
 */
 /// @{

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -1089,8 +1089,7 @@ The following iterators allow the user to visit cells, facets, edges and vertice
 
 /*!
 Starts at an arbitrary finite vertex. Then `++` and `--` will 
-iterate over finite vertices. Returns `finite_vertices_end()` when 
-`t.number_of_vertices() == 0`. 
+iterate over finite vertices.
 */ 
 Finite_vertices_iterator finite_vertices_begin() const; 
 
@@ -1101,8 +1100,7 @@ Finite_vertices_iterator finite_vertices_end() const;
 
 /*!
 Starts at an arbitrary finite edge. Then `++` and `--` will 
-iterate over finite edges. Returns `finite_edges_end()` when 
-`t.dimension() < 1`. 
+iterate over finite edges.
 */ 
 Finite_edges_iterator finite_edges_begin() const; 
 
@@ -1136,9 +1134,7 @@ Past-the-end iterator
 Finite_cells_iterator finite_cells_end() const; 
 
 /*!
-Starts at an arbitrary vertex. Iterates over all vertices (even the infinite 
-one). Returns `vertices_end()` when 
-`t.number_of_vertices() == 0`. 
+Starts at an arbitrary vertex. Iterates over all vertices (even the infinite one). 
 */ 
 All_vertices_iterator all_vertices_begin() const; 
 
@@ -1227,7 +1223,6 @@ All_edges all_edges() const;
  
 /*!
   returns a range of iterators over all vertices (even the infinite one).
-  Returns an empty range when `t.number_of_vertices() == 0`. 
   \note While the value type of `All_vertices_iterator` is `Vertex`, the value type of 
   `All_vertex_handles::iterator` is `Vertex_handle`.
 */
@@ -1258,7 +1253,6 @@ Finite_edges finite_edges() const;
  
 /*!
   returns a range of iterators over finite vertices.
-  Returns an empty range when `t.number_of_vertices() == 0`. 
   \note While the value type of `Finite_vertices_iterator` is `Vertex`, the value type of 
   `Finite_vertex_handles::iterator` is `Vertex_handle`.
 */

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -222,7 +222,7 @@ typedef Triangulation_data_structure::Facet_circulator Facet_circulator;
 
 /// @}
 
-/*! \name Ranges
+/*! \name
 
 In order to write \cpp 11 `for`-loops we provide range types.
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -1208,8 +1208,8 @@ Note that vertex and cell ranges are special. See Section \ref Triangulation3sec
   Returns an empty range when `t.number_of_cells() == 0`. 
   \note While the value type of `All_cells_iterator` is `Cell`, the value type of 
   `All_cell_handles::iterator` is `Cell_handle`.
- */
-  All_cell_handles all_cell_handles() const;
+*/
+All_cell_handles all_cell_handles() const;
 
  
   
@@ -1230,8 +1230,8 @@ All_edges all_edges() const;
   Returns an empty range when `t.number_of_vertices() == 0`. 
   \note While the value type of `All_vertices_iterator` is `Vertex`, the value type of 
   `All_vertex_handles::iterator` is `Vertex_handle`.
- */
-  All_vertex_handles all_vertex_handles() const;
+*/
+All_vertex_handles all_vertex_handles() const;
 
   
 /*!
@@ -1239,8 +1239,8 @@ All_edges all_edges() const;
   Returns an empty range when `t.number_of_cells() == 0`. 
   \note While the value type of `Finite_cells_iterator` is `Cell`, the value type of 
   `Finite_cell_handles::iterator` is `Cell_handle`.
- */
-  Finite_cell_handles finite_cell_handles() const;
+*/
+Finite_cell_handles finite_cell_handles() const;
 
  
   
@@ -1261,13 +1261,13 @@ Finite_edges finite_edges() const;
   Returns an empty range when `t.number_of_vertices() == 0`. 
   \note While the value type of `Finite_vertices_iterator` is `Vertex`, the value type of 
   `Finite_vertex_handles::iterator` is `Vertex_handle`.
- */
-  Finite_vertex_handles finite_vertex_handles() const;
+*/
+Finite_vertex_handles finite_vertex_handles() const;
 
-  /*!
-    returns a range of iterators over the points of finite vertices.
-   */
-  Points points() const;
+/*!
+  returns a range of iterators over the points of finite vertices.
+*/
+Points points() const;
   
  
 /// @} 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -115,6 +115,10 @@ typedef Triangulation_data_structure::Facet Facet;
 */ 
 typedef Triangulation_data_structure::Edge Edge;
 
+/*! 
+Concurrency tag (from the TDS).
+*/ 
+typedef Triangulation_data_structure::Concurrency_tag Concurrency_tag;
 
 /// @}
 
@@ -216,12 +220,28 @@ circulator over all facets incident to a given edge
 */ 
 typedef Triangulation_data_structure::Facet_circulator Facet_circulator;
 
-/*! 
-Concurrency tag (from the TDS).
-*/ 
-typedef Triangulation_data_structure::Concurrency_tag Concurrency_tag;
+/// @}
 
-/// @} 
+/*! \name Ranges
+
+In order to write \cpp 11 `for`-loops we provide range typesxxx.
+
+*/
+/// @{
+
+  
+/*!
+range type for iterating over facets.
+*/
+  typedef Iterator_range<Facet_iterator> All_facets;
+  
+/*!
+range type for iterating over all vertex handles, with a nested type `iterator`
+that has as value type `Vertex_handle`.
+*/ 
+  typedef Iterator_range<unspecified_type> All_vertex_handles;
+  
+/// @}
 
 /// \name Creation 
 /// @{
@@ -1136,6 +1156,31 @@ Point_iterator points_end() const;
 
 /// @} 
 
+/*! \name Ranges
+
+In order to write \cpp 11 `for`-loops we provide a range type and member functions to generate ranges.
+Note that vertex and cell ranges are special.
+
+*/
+
+/// @{
+/*!
+  returns a range of iterators over all vertices (even the infinite one).
+  Returns an empty range when `t.number_of_vertices() == 0`. 
+  \note While the value type of `All_vertices_iterator` is `Vertex`, the value type of 
+  `All_vertex_handles::iterator` is `Vertex_handle`.
+ */
+  All_vertex_handles all_vertex_handles() const;
+
+
+/*!
+  returns a range of iterators starting at an arbitrary facet.
+  Returns an empty range when `t.dimension() < 2`. 
+*/
+All_facets all_facets() const;
+  
+/// @} 
+  
 /*!\name Cell and Facet Circulators 
 The following circulators respectively visit all cells or all facets incident to a given edge. They are non-mutable and bidirectional. They are invalidated by any modification of one of the cells traversed.  
 */

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -224,13 +224,13 @@ typedef Triangulation_data_structure::Facet_circulator Facet_circulator;
 
 /*! \name
 
-In order to write \cpp 11 `for`-loops we provide range types.
+In order to write \cpp 11 `for`-loops we provide the following range types.
 
 */
 /// @{
   
 /*!
-range type for iterating over all cell handles, with a nested type `iterator`
+range type for iterating over all cell handles (including infinite cells), with a nested type `iterator`
 that has as value type `Cell_handle`.
 */ 
   typedef Iterator_range<unspecified_type> All_cell_handles;
@@ -1204,7 +1204,7 @@ Note that vertex and cell ranges are special. See Section \ref Triangulation3sec
 /// @{
 
 /*!
-  returns a range of iterators over all cells (even the infinite one).
+  returns a range of iterators over all cells (even the infinite cells).
   Returns an empty range when `t.number_of_cells() == 0`. 
   \note While the value type of `All_cells_iterator` is `Cell`, the value type of 
   `All_cell_handles::iterator` is `Cell_handle`.

--- a/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
+++ b/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
@@ -494,12 +494,14 @@ Wherever the API expects a handle the iterator can be passed as well.
 
 In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
 `Triangulation_3::All_vertex_handles`, which has a nested type `Triangulation_3::All_vertex_handles::iterator`.
-The value type of this iterator is `Triangulation_3::Vertex_handle`.  Note that you only
-need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+The value type of this iterator is `Triangulation_3::Vertex_handle`.
 It is similar for the various iterators for vertices and cells.
 
 For the range `Triangulation_3::All_facets` it holds that `Triangulation_3::All_facets::iterator` `==`
-`Triangulation_3::All_facets_iterator`. It is similar for the iterators for edges and points.
+`Triangulation_3::All_facets_iterator`. It is similar for the iterators for facets, edges and points.
+
+
+Note that you only need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
 
 \cgalExample{Triangulation_3/for_loop.cpp}
 

--- a/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
+++ b/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
@@ -486,6 +486,23 @@ in the range. Note that this is correct because the iterator
 is dereferenced only once per point during the insertion.
 \cgalExample{Triangulation_3/info_insert_with_transform_iterator.cpp}
 
+\subsection Triangulation3secRanges Iterators and Ranges
+
+The triangulation defines iterator types such as `Triangulation_3::All_vertices_iterator`. They behave like
+a `Triangulation_3::Vertex_handle`, that is there is no need to dereference the iterator to obtain a handle.
+Wherever the API expects a handle the iterator can be passed as well.
+
+In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
+`Triangulation_3::All_vertex_handles`, which has a nested type `Triangulation_3::All_vertex_handles::iterator`.
+The value type of this iterator is `Triangulation_3::Vertex_handle`.  Note that you only
+need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
+It is similar for the various iterators for vertice and cells.
+
+For the range `Triangulation_3::All_facets` it holds that `Triangulation_3::All_facets::iterator` `==`
+`Triangulation_3::All_facets_iterator`. It is similar for the iterators for edges and points.
+
+\cgalExample{Triangulation_3/for_loop.cpp}
+
 \subsection Triangulation3secsimplex The Simplex Class 
 
 The triangulation defines a `Triangulation_3::Simplex` class that represents a

--- a/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
+++ b/Triangulation_3/doc/Triangulation_3/Triangulation_3.txt
@@ -489,14 +489,14 @@ is dereferenced only once per point during the insertion.
 \subsection Triangulation3secRanges Iterators and Ranges
 
 The triangulation defines iterator types such as `Triangulation_3::All_vertices_iterator`. They behave like
-a `Triangulation_3::Vertex_handle`, that is there is no need to dereference the iterator to obtain a handle.
+a `Triangulation_3::Vertex_handle`, in the sense that there is no need to dereference the iterator to obtain a handle.
 Wherever the API expects a handle the iterator can be passed as well.
 
 In order to write a \cpp 11 `for`-loop the triangulation calls also offers the range type
 `Triangulation_3::All_vertex_handles`, which has a nested type `Triangulation_3::All_vertex_handles::iterator`.
 The value type of this iterator is `Triangulation_3::Vertex_handle`.  Note that you only
 need the iterator type if you combine the pre \cpp 11 `for`-loop with the range class.
-It is similar for the various iterators for vertice and cells.
+It is similar for the various iterators for vertices and cells.
 
 For the range `Triangulation_3::All_facets` it holds that `Triangulation_3::All_facets::iterator` `==`
 `Triangulation_3::All_facets_iterator`. It is similar for the iterators for edges and points.

--- a/Triangulation_3/doc/Triangulation_3/examples.txt
+++ b/Triangulation_3/doc/Triangulation_3/examples.txt
@@ -1,5 +1,6 @@
 /*!
 \example Triangulation_3/simple_triangulation_3.cpp
+\example Triangulation_3/for_loop.cpp
 \example Triangulation_3/color.cpp
 \example Triangulation_3/adding_handles_3.cpp
 \example Triangulation_3/info_insert_with_pair_iterator.cpp

--- a/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CGAL_Qt5_FOUND)
 endif()
 
 if ( CGAL_FOUND )
+  create_single_source_cgal_program( "for_loop.cpp" )
   create_single_source_cgal_program( "adding_handles_3.cpp" )
   create_single_source_cgal_program( "color.cpp" )
   create_single_source_cgal_program( "copy_triangulation_3.cpp" )

--- a/Triangulation_3/examples/Triangulation_3/color.cpp
+++ b/Triangulation_3/examples/Triangulation_3/color.cpp
@@ -28,9 +28,9 @@ int main()
 
   // Set the color of finite vertices of degree 6 to red.
   Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-      if (T.degree(vit) == 6)
-        vit->info() = CGAL::red();
+  for (Delaunay::Vertex_handle v : T.finite_vertex_handles())
+      if (T.degree(v) == 6)
+        v->info() = CGAL::red();
 
   return 0;
 }

--- a/Triangulation_3/examples/Triangulation_3/for_loop.cpp
+++ b/Triangulation_3/examples/Triangulation_3/for_loop.cpp
@@ -1,0 +1,45 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Triangulation_3.h>
+#include <iostream>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Triangulation_3<K>      Triangulation;
+typedef Triangulation::Vertex_handle  Vertex_handle;
+typedef Triangulation::Point          Point;
+typedef Triangulation::All_vertex_handles    All_vertex_handles;
+
+// The following types are different
+// Its value type is Triangulation_3::Vertex
+typedef Triangulation::All_vertices_iterator All_vertices_iterator;
+// Its value type is Triangulation_3::Vertex_handle
+typedef All_vertex_handles::iterator         All_vertex_handles_iterator;
+
+int main()
+{
+  std::vector<Point> points =  { Point(0,0,0), Point(1,0,0), Point(0,1,0), Point(0,1,1) };
+
+  Triangulation T(points.begin(), points.end());
+
+  std::cout << "Triangulation_3::All_vertices_iterator is like a  Triangulation_3::Vertex_handle\n";
+  for(All_vertices_iterator it = T.all_vertices_begin();
+      it != T.all_vertices_end();
+      ++it){
+    std::cout << it->point() << std::endl;
+  }
+
+  std::cout << "Triangulation_3::All_vertex_handles::iterator dereferences to Triangulation_3::Vertex_handle\n";
+  All_vertex_handles::iterator b, e;
+  boost::tie(b,e) = T.all_vertex_handles();
+  for(; b!=e; ++b){
+    Vertex_handle vh = *b; // you must dereference the iterator to get a handle
+    std::cout << vh->point() << std::endl;
+  }
+  
+  std::cout << "and you can use a C++11 for loop\n";
+  for(Vertex_handle vh : T.all_vertex_handles()){
+    std::cout << vh->point() << std::endl;
+  }
+  
+  return 0;
+}

--- a/Triangulation_3/examples/Triangulation_3/for_loop.cpp
+++ b/Triangulation_3/examples/Triangulation_3/for_loop.cpp
@@ -7,13 +7,13 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Triangulation_3<K>      Triangulation;
 typedef Triangulation::Vertex_handle  Vertex_handle;
 typedef Triangulation::Point          Point;
-typedef Triangulation::All_vertex_handles    All_vertex_handles;
+typedef Triangulation::Finite_vertex_handles    Finite_vertex_handles;
 
 // The following types are different
 // Its value type is Triangulation_3::Vertex
-typedef Triangulation::All_vertices_iterator All_vertices_iterator;
+typedef Triangulation::Finite_vertices_iterator Finite_vertices_iterator;
 // Its value type is Triangulation_3::Vertex_handle
-typedef All_vertex_handles::iterator         All_vertex_handles_iterator;
+typedef Finite_vertex_handles::iterator         Finite_vertex_handles_iterator;
 
 int main()
 {
@@ -21,23 +21,23 @@ int main()
 
   Triangulation T(points.begin(), points.end());
 
-  std::cout << "Triangulation_3::All_vertices_iterator is like a  Triangulation_3::Vertex_handle\n";
-  for(All_vertices_iterator it = T.all_vertices_begin();
-      it != T.all_vertices_end();
+  std::cout << "Triangulation_3::Finite_vertices_iterator is like a  Triangulation_3::Vertex_handle\n";
+  for(Finite_vertices_iterator it = T.finite_vertices_begin();
+      it != T.finite_vertices_end();
       ++it){
     std::cout << it->point() << std::endl;
   }
 
-  std::cout << "Triangulation_3::All_vertex_handles::iterator dereferences to Triangulation_3::Vertex_handle\n";
-  All_vertex_handles::iterator b, e;
-  std::tie(b,e) = T.all_vertex_handles();
+  std::cout << "Triangulation_3::Finite_vertex_handles::iterator dereferences to Triangulation_3::Vertex_handle\n";
+  Finite_vertex_handles::iterator b, e;
+  std::tie(b,e) = T.finite_vertex_handles();
   for(; b!=e; ++b){
     Vertex_handle vh = *b; // you must dereference the iterator to get a handle
     std::cout << vh->point() << std::endl;
   }
   
   std::cout << "and you can use a C++11 for loop\n";
-  for(Vertex_handle vh : T.all_vertex_handles()){
+  for(Vertex_handle vh : T.finite_vertex_handles()){
     std::cout << vh->point() << std::endl;
   }
   

--- a/Triangulation_3/examples/Triangulation_3/for_loop.cpp
+++ b/Triangulation_3/examples/Triangulation_3/for_loop.cpp
@@ -30,7 +30,7 @@ int main()
 
   std::cout << "Triangulation_3::All_vertex_handles::iterator dereferences to Triangulation_3::Vertex_handle\n";
   All_vertex_handles::iterator b, e;
-  boost::tie(b,e) = T.all_vertex_handles();
+  std::tie(b,e) = T.all_vertex_handles();
   for(; b!=e; ++b){
     Vertex_handle vh = *b; // you must dereference the iterator to get a handle
     std::cout << vh->point() << std::endl;

--- a/Triangulation_3/examples/Triangulation_3/info_insert_with_pair_iterator.cpp
+++ b/Triangulation_3/examples/Triangulation_3/info_insert_with_pair_iterator.cpp
@@ -29,9 +29,8 @@ int main()
   CGAL_assertion( T.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
-  Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ].first != vit->point() ){
+  for (Delaunay::Vertex_handle v : T.finite_vertex_handles())
+    if( points[ v->info() ].first != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_3/examples/Triangulation_3/info_insert_with_pair_iterator_regular.cpp
+++ b/Triangulation_3/examples/Triangulation_3/info_insert_with_pair_iterator_regular.cpp
@@ -29,9 +29,8 @@ int main()
   CGAL_assertion( rt.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
-  Regular::Finite_vertices_iterator vit;
-  for (vit = rt.finite_vertices_begin(); vit != rt.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ].first != vit->point() ){
+  for (Regular::Vertex_handle v : rt.finite_vertex_handles())
+    if( points[ v->info() ].first != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_3/examples/Triangulation_3/info_insert_with_transform_iterator.cpp
+++ b/Triangulation_3/examples/Triangulation_3/info_insert_with_transform_iterator.cpp
@@ -41,9 +41,8 @@ int main()
   CGAL_assertion( T.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
-  Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ] != vit->point() ){
+  for (Delaunay::Vertex_handle v : T.finite_vertex_handles())
+    if( points[ v->info() ] != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_3/examples/Triangulation_3/info_insert_with_zip_iterator.cpp
+++ b/Triangulation_3/examples/Triangulation_3/info_insert_with_zip_iterator.cpp
@@ -40,9 +40,8 @@ int main()
   CGAL_assertion( T.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
-  Delaunay::Finite_vertices_iterator vit;
-  for (vit = T.finite_vertices_begin(); vit != T.finite_vertices_end(); ++vit)
-    if( points[ vit->info() ] != vit->point() ){
+  for (Delaunay::Vertex_handle v : T.finite_vertex_handles() )
+    if( points[ v->info() ] != v->point() ){
       std::cerr << "Error different info" << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -431,8 +431,8 @@ public:
   typedef Edge_iterator                        All_edges_iterator;
   typedef Vertex_iterator                      All_vertices_iterator;
 
-  typedef Iterator_range<Prevent_deref<All_cells_iterator> > All_cells_range;
-  typedef Iterator_range<Prevent_deref<All_vertices_iterator> > All_vertices_range;
+  typedef Iterator_range<Prevent_deref<All_cells_iterator> > All_cell_handles;
+  typedef Iterator_range<Prevent_deref<All_vertices_iterator> > All_vertex_handles;
   
   typedef typename Tds::Simplex                Simplex;
 
@@ -1686,7 +1686,7 @@ public:
   All_cells_iterator all_cells_begin() const { return _tds.cells_begin(); }
   All_cells_iterator all_cells_end() const { return _tds.cells_end(); }
 
-  All_cells_range all_cells() const
+  All_cell_handles all_cell_handles() const
   {
     return make_prevent_deref_range(all_cells_begin(), all_cells_end()); 
   }
@@ -1710,7 +1710,7 @@ public:
   All_vertices_iterator all_vertices_begin() const { return _tds.vertices_begin(); }
   All_vertices_iterator all_vertices_end() const { return _tds.vertices_end(); }
 
-  All_vertices_range all_vertices() const
+  All_vertex_handles all_vertex_handles() const
   {
     return make_prevent_deref_range(all_vertices_begin(), all_vertices_end()); 
   }

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -431,8 +431,10 @@ public:
   typedef Edge_iterator                        All_edges_iterator;
   typedef Vertex_iterator                      All_vertices_iterator;
 
-  typedef Iterator_range<Prevent_deref<All_cells_iterator> > All_cell_handles;
-  typedef Iterator_range<Prevent_deref<All_vertices_iterator> > All_vertex_handles;
+  typedef typename Tds::Cell_handles           All_cell_handles;
+  typedef typename Tds::Vertex_handles         All_vertex_handles;
+  typedef typename Tds::Facets                 All_facets;
+  typedef typename Tds::Edges                  All_edges;
   
   typedef typename Tds::Simplex                Simplex;
 
@@ -513,13 +515,15 @@ public:
     operator Vertex_handle() const { return Base::base(); }
   };
 
-
-  typedef Iterator_range<Prevent_deref<Finite_cells_iterator> > Finite_cell_handles;
+  typedef Iterator_range<Prevent_deref<Finite_cells_iterator> >    Finite_cell_handles;
   typedef Iterator_range<Prevent_deref<Finite_vertices_iterator> > Finite_vertex_handles;
-  
+
   typedef Filter_iterator<Edge_iterator, Infinite_tester>     Finite_edges_iterator;
   typedef Filter_iterator<Facet_iterator, Infinite_tester>    Finite_facets_iterator;
 
+  typedef Iterator_range<Finite_edges_iterator> Finite_edges;
+  typedef Iterator_range<Finite_facets_iterator> Finite_facets;
+  
 private:
   // Auxiliary iterators for convenience
   // do not use default template argument to please VC++
@@ -533,6 +537,9 @@ public:
   std::ptrdiff_t,
   std::bidirectional_iterator_tag>   Point_iterator;
 
+
+  typedef Iterator_range<Point_iterator> Points;
+  
   // To have a back_inserter
   typedef Point                                               value_type;
   typedef const value_type&                                   const_reference;
@@ -1699,7 +1706,7 @@ public:
 
   All_cell_handles all_cell_handles() const
   {
-    return make_prevent_deref_range(all_cells_begin(), all_cells_end()); 
+    return _tds.cell_handles();
   }
   
   Finite_vertices_iterator finite_vertices_begin() const
@@ -1728,7 +1735,7 @@ public:
 
   All_vertex_handles all_vertex_handles() const
   {
-    return make_prevent_deref_range(all_vertices_begin(), all_vertices_end()); 
+    return _tds.vertex_handles();
   }
   
   Finite_edges_iterator finite_edges_begin() const
@@ -1743,12 +1750,23 @@ public:
     return CGAL::filter_iterator(edges_end(), Infinite_tester(this));
   }
 
+  Finite_edges finite_edges() const
+  {
+    return Finite_edges(finite_edges_begin(),finite_edges_end());
+  }
+  
   Edge_iterator edges_begin() const { return _tds.edges_begin(); }
   Edge_iterator edges_end() const { return _tds.edges_end(); }
 
+  
   All_edges_iterator all_edges_begin() const { return _tds.edges_begin(); }
   All_edges_iterator all_edges_end() const { return _tds.edges_end(); }
 
+  All_edges all_edges() const
+  {
+    return _tds.edges();
+  }
+  
   Finite_facets_iterator finite_facets_begin() const
   {
     if(dimension() < 2)
@@ -1761,19 +1779,37 @@ public:
     return CGAL::filter_iterator(facets_end(), Infinite_tester(this));
   }
 
+  Finite_facets finite_facets() const
+  {
+    return Finite_facets(finite_facets_begin(),finite_facets_end());
+  }
+
   Facet_iterator facets_begin() const { return _tds.facets_begin(); }
   Facet_iterator facets_end() const { return _tds.facets_end(); }
 
+  
   All_facets_iterator all_facets_begin() const { return _tds.facets_begin(); }
   All_facets_iterator all_facets_end() const { return _tds.facets_end(); }
 
-  Point_iterator points_begin() const {
+  All_facets all_facets() const
+  {
+    return _tds.facets();
+  }
+  
+  Point_iterator points_begin() const
+  {
     return Point_iterator(finite_vertices_begin());
   }
-  Point_iterator points_end() const {
+  Point_iterator points_end() const
+  {
     return Point_iterator(finite_vertices_end());
   }
 
+  Points points() const
+  {
+    return Points(points_begin(),points_end());
+  }
+  
   // cells around an edge
   Cell_circulator incident_cells(const Edge& e) const
   {

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -431,6 +431,9 @@ public:
   typedef Edge_iterator                        All_edges_iterator;
   typedef Vertex_iterator                      All_vertices_iterator;
 
+  typedef Iterator_range<Prevent_deref<All_cells_iterator> > All_cells_range;
+  typedef Iterator_range<Prevent_deref<All_vertices_iterator> > All_vertices_range;
+  
   typedef typename Tds::Simplex                Simplex;
 
 private:
@@ -1683,6 +1686,11 @@ public:
   All_cells_iterator all_cells_begin() const { return _tds.cells_begin(); }
   All_cells_iterator all_cells_end() const { return _tds.cells_end(); }
 
+  All_cells_range all_cells() const
+  {
+    return make_prevent_deref_range(all_cells_begin(), all_cells_end()); 
+  }
+  
   Finite_vertices_iterator finite_vertices_begin() const
   {
     if(number_of_vertices() <= 0)
@@ -1702,6 +1710,11 @@ public:
   All_vertices_iterator all_vertices_begin() const { return _tds.vertices_begin(); }
   All_vertices_iterator all_vertices_end() const { return _tds.vertices_end(); }
 
+  All_vertices_range all_vertices() const
+  {
+    return make_prevent_deref_range(all_vertices_begin(), all_vertices_end()); 
+  }
+  
   Finite_edges_iterator finite_edges_begin() const
   {
     if(dimension() < 1)

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -513,6 +513,10 @@ public:
     operator Vertex_handle() const { return Base::base(); }
   };
 
+
+  typedef Iterator_range<Prevent_deref<Finite_cells_iterator> > Finite_cell_handles;
+  typedef Iterator_range<Prevent_deref<Finite_vertices_iterator> > Finite_vertex_handles;
+  
   typedef Filter_iterator<Edge_iterator, Infinite_tester>     Finite_edges_iterator;
   typedef Filter_iterator<Facet_iterator, Infinite_tester>    Finite_facets_iterator;
 
@@ -1680,6 +1684,13 @@ public:
     return CGAL::filter_iterator(cells_end(), Infinite_tester(this));
   }
 
+  
+  Finite_cell_handles finite_cell_handles() const
+  {
+    return make_prevent_deref_range(finite_cells_begin(), finite_cells_end()); 
+  }
+
+  
   Cell_iterator cells_begin() const { return _tds.cells_begin(); }
   Cell_iterator cells_end() const { return _tds.cells_end(); }
 
@@ -1704,6 +1715,11 @@ public:
     return CGAL::filter_iterator(vertices_end(), Infinite_tester(this));
   }
 
+  Finite_vertex_handles finite_vertex_handles() const
+  {
+    return make_prevent_deref_range(finite_vertices_begin(), finite_vertices_end()); 
+  }
+  
   Vertex_iterator vertices_begin() const { return _tds.vertices_begin(); }
   Vertex_iterator vertices_end() const { return _tds.vertices_end(); }
 

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
@@ -79,7 +79,6 @@ _test_vertex_iterator( const Triangulation &T )
     }
     assert( n == T.number_of_vertices() );
 
-    
     return n;
 }
 

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
@@ -79,6 +79,7 @@ _test_vertex_iterator( const Triangulation &T )
     }
     assert( n == T.number_of_vertices() );
 
+    
     return n;
 }
 
@@ -95,6 +96,18 @@ _test_triangulation_iterator( const Triangulation &T )
   typedef typename Triangulation::Facet_iterator  Facet_iterator;
   typedef typename Triangulation::Edge_iterator   Edge_iterator;
   typedef typename Triangulation::Vertex_iterator Vertex_iterator;
+
+  typedef typename Triangulation::Vertex_handle Vertex_handle;
+  
+  typedef typename Triangulation::All_vertex_handles All_vertex_handles;
+  typedef typename Triangulation::All_cell_handles All_cell_handles;
+  typedef typename Triangulation::All_edges All_edges;
+  typedef typename Triangulation::All_facets All_facets;
+  typedef typename Triangulation::Finite_vertex_handles Finite_vertex_handles;
+  typedef typename Triangulation::Finite_cell_handles Finite_cell_handles;
+  typedef typename Triangulation::Finite_edges Finite_edges;
+  typedef typename Triangulation::Finite_facets Finite_facets;
+  typedef typename Triangulation::Points Points;
 
   typedef typename Triangulation::Cell            Cell;
   typedef typename Triangulation::Facet           Facet;
@@ -116,6 +129,62 @@ _test_triangulation_iterator( const Triangulation &T )
     (void) ch;
   }
   if (T.dimension()==3) {
+    {
+      All_vertex_handles range = T.all_vertex_handles();
+      Vertex_handle vh = *(range.first);
+      assert(vh == T.all_vertices_begin());
+      vh = *(range.second);
+      assert(vh == T.all_vertices_end());
+    }
+    {
+      All_cell_handles range = T.all_cell_handles();
+      Cell_handle vh = *(range.first);
+      assert(vh == T.all_cells_begin());
+      vh = *(range.second);
+      assert(vh == T.all_cells_end());
+    }
+    {
+      All_edges range = T.all_edges();
+      assert(range.first == T.all_edges_begin());
+      assert(range.second == T.all_edges_end());
+    }
+    {
+      All_facets range = T.all_facets();
+      assert(range.first == T.all_facets_begin());
+      assert(range.second == T.all_facets_end());
+    }
+    {
+      Finite_vertex_handles range = T.finite_vertex_handles();
+      Vertex_handle vh = *(range.first);
+      assert(vh == Vertex_handle(T.finite_vertices_begin()));
+      vh = *(range.second);
+      
+      assert(vh == Vertex_handle(T.finite_vertices_end()));
+    }
+    {
+      Finite_cell_handles range = T.finite_cell_handles();
+      Cell_handle ch = *(range.first);
+      assert(ch == Cell_handle(T.finite_cells_begin()));
+      ch = *(range.second);
+      assert(ch == Cell_handle(T.finite_cells_end()));
+    }
+    {
+      Finite_edges range = T.finite_edges();
+      assert(range.first == T.finite_edges_begin());
+      assert(range.second == T.finite_edges_end());
+    }
+    {
+      Finite_facets range = T.finite_facets();
+      assert(range.first == T.finite_facets_begin());
+      assert(range.second == T.finite_facets_end());
+    }
+    {
+      Points range = T.points();
+      assert(range.first == T.points_begin());
+      assert(range.second == T.points_end());
+    }
+
+    
   for (FCit = T.finite_cells_begin(); FCit != T.finite_cells_end(); ++FCit)
   {
      Cell_handle ch = FCit; // Test the conversion.

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -116,7 +116,6 @@ _test_cls_triangulation_3(const Triangulation &)
   typedef typename Cls::Finite_edges_iterator       Finite_edges_iterator;
   typedef typename Cls::Finite_facets_iterator      Finite_facets_iterator;
   typedef typename Cls::Finite_cells_iterator       Finite_cells_iterator;
-  
   CGAL_USE_TYPE(Vertex);
   CGAL_USE_TYPE(Cell);
   CGAL_USE_TYPE(difference_type);

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -116,7 +116,7 @@ _test_cls_triangulation_3(const Triangulation &)
   typedef typename Cls::Finite_edges_iterator       Finite_edges_iterator;
   typedef typename Cls::Finite_facets_iterator      Finite_facets_iterator;
   typedef typename Cls::Finite_cells_iterator       Finite_cells_iterator;
-
+  
   CGAL_USE_TYPE(Vertex);
   CGAL_USE_TYPE(Cell);
   CGAL_USE_TYPE(difference_type);


### PR DESCRIPTION
## Summary of Changes

Add ranges so that users can use C++11 for loops.  This is WIP so that we can review wording for one type and function before applying it on the whole package.

## Release Management

* Affected package(s):  Triangulation_3
* Small feature: https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/RangeForForLoop
* pre-approved by @lrineau 2019-06-14