### PR TITLE
Mesh_3 : fix global optimizers protection

### DIFF
--- a/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
@@ -59,7 +59,12 @@ bool has_non_protecting_weights(const Triangulation& tr,
     const Weighted_point& vv_wp = tr.point(vv);
     if (cwsr(vv_wp, FT(0)) != CGAL::EQUAL)
     {
-      if (with_features && vv->in_dimension() > 1)
+      if (with_features)
+      {
+        if (vv->in_dimension() > 1)
+          return true;
+      }
+      else
         return true;
     }
   }

--- a/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/check_weights.h
@@ -42,8 +42,7 @@ template<typename Triangulation, typename MeshDomain>
 bool has_non_protecting_weights(const Triangulation& tr,
                                 const MeshDomain&)
 {
-  bool with_features =
-    boost::is_same<Has_features<MeshDomain>, CGAL::Tag_true>::value;
+  const bool with_features = Has_features<MeshDomain>::value;
 
   typedef typename Triangulation::FT                FT;
   typedef typename Triangulation::Weighted_point    Weighted_point;


### PR DESCRIPTION
## Summary of Changes

If some vertices have a non-zero weights and do not belong to input
features, then global optimizers should not be used.

Before this PR, the case without feature protection was not treated.

It is already documented in [`exude_mesh_3()`](https://doc.cgal.org/latest/Mesh_3/group__PkgMesh3Functions.html#gabf09a95838226da018a742a631824af9) that "it [...] must be the last optimizer to be called"

## Release Management

* Affected package(s): Mesh_3

