### PR TITLE
do_intersect() Ambiguity

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/intersection_3_1_impl.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/intersection_3_1_impl.h
@@ -430,7 +430,7 @@ do_intersect(const typename K::Segment_3  &s1,
              const K & k)
 {
   CGAL_precondition(! s1.is_degenerate () && ! s2.is_degenerate () );
-  bool b=do_intersect(s1.supporting_line(),s2.supporting_line(),k);
+  bool b=internal::do_intersect(s1.supporting_line(),s2.supporting_line(),k);
   if (b)
   {
     //supporting_line intersects: points are coplanar


### PR DESCRIPTION
This call to `do_intersect()` is ambiguous, resulting in a compile time error when compiling with clang on my mac.