### PR TITLE
Shape detection

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/Least_squares_plane_fit_region.h
@@ -392,7 +392,7 @@ namespace Polygon_mesh {
         m_sqrt(m_squared_distance_3(point, m_plane_of_best_fit));
         
         max_face_distance = 
-        CGAL::max(distance, max_face_distance);
+        (CGAL::max)(distance, max_face_distance);
       }
       CGAL_postcondition(max_face_distance != -FT(1));
 


### PR DESCRIPTION
Shape detection

## Summary of Changes

I fixed the `CGAL::max` error for Windows test suite by changing it to `(CGAL::max)`.

## Release Management

* Affected package(s): Point_set_shape_detection_3
