### PR TITLE
Fix a stack-use-after-scope in Arr_polycurve_basic_traits_2

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
@@ -2534,7 +2534,7 @@ protected:
       Polycurve_basic_traits_2;
 
     /*! The polycurve traits (in case it has state). */
-    const Polycurve_basic_traits_2& m_poly_traits;
+    const Polycurve_basic_traits_2 m_poly_traits;
 
     const Point_2& m_point;
 


### PR DESCRIPTION
## Summary of Changes

Before this patch, `Arr_polycurve_basic_traits_2` was holding a const
reference to a temporary object.

Here was the result of ctest, with the address sanitizer:
```shellsession
$ make && ASAN_OPTIONS=detect_leaks=0 ctest -L Arr -j6
[...]
The following tests FAILED:
        144 - execution___of__generic_curve_data (Failed)
        170 - execution___of__polycurve_circular_arc (Failed)
        172 - execution___of__polycurve_conic (Failed)
        176 - execution___of__polycurves_basic (Failed)
        178 - execution___of__polylines (Failed)
        2166 - test_traits_test_polylines__data_polylines_compare_y_at_x__polyline_traits (Failed)
        2168 - test_traits_test_polylines__data_polylines_intersect__polyline_traits (Failed)
        2169 - test_traits_test_polylines__data_polylines_split__polyline_traits (Failed)
        2171 - test_traits_test_polylines__data_polylines_assertions__polyline_traits (Failed)
        2175 - test_traits_conic_polycurve__data_polycurves_conics_compare_y_at_x__polycurve_conic_traits (Failed)
        2176 - test_traits_conic_polycurve__data_polycurves_conics_compare_y_at_x_left__polycurve_conic_traits (Failed)
        2177 - test_traits_conic_polycurve__data_polycurves_conics_compare_y_at_x_right__polycurve_conic_traits (Failed)
        2179 - test_traits_conic_polycurve__data_polycurves_conics_intersect__polycurve_conic_traits (Failed)
        2180 - test_traits_conic_polycurve__data_polycurves_conics_split__polycurve_conic_traits (Failed)
        2193 - test_traits_circular_arc_polycurve__data_Polycurves_circular_arcs_compare_y_at_x__polycurve_circular_arc_traits (Failed)
        2198 - test_traits_circular_arc_polycurve__data_Polycurves_circular_arcs_split__polycurve_circular_arc_traits (Failed)
        2221 - test_traits_non_caching_polylines__data_polylines_compare_y_at_x__non_caching_polyline_traits (Failed)
        2223 - test_traits_non_caching_polylines__data_polylines_intersect__non_caching_polyline_traits (Failed)
        2224 - test_traits_non_caching_polylines__data_polylines_split__non_caching_polyline_traits (Failed)
        2226 - test_traits_non_caching_polylines__data_polylines_assertions__non_caching_polyline_traits (Failed)
        2400 - execution___of__test_construction_polylines (Failed)
        2477 - execution___of__test_io (Failed)
```

This is fixed rather easily, by copying the traits class, instead of
holding a reference to it.

## Release Management

* Affected package(s): Arr_2
* License and copyright ownership: maintenance by GeometryFactory

