### PR TITLE
Fix the use of VTK offset in Labeled_mesh_domain_3

### DIFF
--- a/CGAL_ImageIO/include/CGAL/Image_3.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3.h
@@ -146,6 +146,10 @@ public:
   double vy() const { return image_ptr->vy; }
   double vz() const { return image_ptr->vz; }
 
+  double tx() const { return image_ptr->tx; }
+  double ty() const { return image_ptr->ty; }
+  double tz() const { return image_ptr->tz; }
+
   float value(const std::size_t i,
               const std::size_t j,
               const std::size_t k) const

--- a/Mesh_3/include/CGAL/Labeled_image_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_image_mesh_domain_3.h
@@ -109,12 +109,12 @@ private:
   /// Returns a box enclosing image \c im
   Bbox_3 compute_bounding_box(const Image& im) const
   {
-    return Bbox_3(-im.vx(),
-                  -im.vy(),
-                  -im.vz(),
-                  double(im.xdim()+1)*im.vx(),
-                  double(im.ydim()+1)*im.vy(),
-                  double(im.zdim()+1)*im.vz());
+    return Bbox_3(-im.vx()+im.tx(),
+                  -im.vy()+im.ty(),
+                  -im.vz()+im.tz(),
+                  double(im.xdim()+1)*im.vx()+im.tx(),
+                  double(im.ydim()+1)*im.vy()+im.ty(),
+                  double(im.zdim()+1)*im.vz()+im.tz());
   }
 };  // end class Labeled_image_mesh_domain_3
 

--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -88,10 +88,10 @@ namespace internal {
   /// Returns a box enclosing image \c im
   inline Bbox_3 compute_bounding_box(const Image_3& im)
   {
-    return Bbox_3(-1,-1,-1,
-                  double(im.xdim())*im.vx()+1,
-                  double(im.ydim())*im.vy()+1,
-                  double(im.zdim())*im.vz()+1);
+    return Bbox_3(-1+im.tx(),-1+im.ty(),-1+im.tz(),
+                  double(im.xdim())*im.vx()+im.tx()+1,
+                  double(im.ydim())*im.vy()+im.ty()+1,
+                  double(im.zdim())*im.vz()+im.tz()+1);
   }
 
   template <typename Image_values_to_subdom_indices>


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Fix https://github.com/CGAL/cgal/pull/3539#issuecomment-503078370.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #3539.
* License and copyright ownership: maintenance by GeometryFactory

