### PR TITLE
CMake>=3.13: opt for for new policies up to 3.15

### DIFF
--- a/AABB_tree/benchmark/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/benchmark/AABB_tree/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( AABB_traits_benchmark)
-
-
-cmake_minimum_required(VERSION 3.1)
-  cmake_policy(VERSION 3.1)
-
-
-if ( COMMAND cmake_policy )
-
-  cmake_policy( SET CMP0003 NEW )  
-
-endif()
 
 # CGAL and its components
 find_package( CGAL QUIET)

--- a/AABB_tree/demo/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/demo/AABB_tree/CMakeLists.txt
@@ -1,12 +1,12 @@
 # This is the CMake script for compiling the AABB tree demo.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( AABB_tree_Demo )
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/AABB_tree/examples/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/examples/AABB_tree/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( AABB_tree_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/AABB_tree/test/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/test/AABB_tree/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( AABB_tree_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Advancing_front_surface_reconstruction_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Advancing_front_surface_reconstruction/test/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/test/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Advancing_front_surface_reconstruction_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Algebraic_foundations/examples/Algebraic_foundations/CMakeLists.txt
+++ b/Algebraic_foundations/examples/Algebraic_foundations/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_foundations_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Algebraic_foundations/test/Algebraic_foundations/CMakeLists.txt
+++ b/Algebraic_foundations/test/Algebraic_foundations/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_foundations_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_kernel_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core)

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_kernel_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # CGAL and its components

--- a/Algebraic_kernel_for_circles/test/Algebraic_kernel_for_circles/CMakeLists.txt
+++ b/Algebraic_kernel_for_circles/test/Algebraic_kernel_for_circles/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_kernel_for_circles_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Algebraic_kernel_for_spheres/test/Algebraic_kernel_for_spheres/CMakeLists.txt
+++ b/Algebraic_kernel_for_spheres/test/Algebraic_kernel_for_spheres/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Algebraic_kernel_for_spheres_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Alpha_shapes_2/examples/Alpha_shapes_2/CMakeLists.txt
+++ b/Alpha_shapes_2/examples/Alpha_shapes_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Alpha_shapes_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Alpha_shapes_2/test/Alpha_shapes_2/CMakeLists.txt
+++ b/Alpha_shapes_2/test/Alpha_shapes_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Alpha_shapes_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Alpha_shapes_3_Demo)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Alpha_shapes_3/examples/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Alpha_shapes_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Alpha_shapes_3/test/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/test/Alpha_shapes_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Alpha_shapes_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/CMakeLists.txt
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Apollonius_graph_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Apollonius_graph_2/test/Apollonius_graph_2/CMakeLists.txt
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Apollonius_graph_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Arithmetic_kernel/test/Arithmetic_kernel/CMakeLists.txt
+++ b/Arithmetic_kernel/test/Arithmetic_kernel/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Arithmetic_kernel_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Arrangement_on_surface_2_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Arrangement_on_surface_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/CMakeLists.txt
@@ -2,11 +2,11 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Arrangement_on_surface_2_Tests )
 
 enable_testing()
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/BGL/examples/BGL_LCC/CMakeLists.txt
+++ b/BGL/examples/BGL_LCC/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_LCC_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/BGL/examples/BGL_OpenMesh/CMakeLists.txt
+++ b/BGL/examples/BGL_OpenMesh/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_OpenMesh_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/BGL/examples/BGL_arrangement_2/CMakeLists.txt
+++ b/BGL/examples/BGL_arrangement_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_arrangement_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/BGL/examples/BGL_polyhedron_3/CMakeLists.txt
+++ b/BGL/examples/BGL_polyhedron_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_polyhedron_3_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/BGL/examples/BGL_surface_mesh/CMakeLists.txt
+++ b/BGL/examples/BGL_surface_mesh/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_surface_mesh_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package( CGAL QUIET )
 

--- a/BGL/examples/BGL_triangulation_2/CMakeLists.txt
+++ b/BGL/examples/BGL_triangulation_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/BGL/test/BGL/CMakeLists.txt
+++ b/BGL/test/BGL/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( BGL_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Barycentric_coordinates_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Barycentric_coordinates_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/CMakeLists.txt
+++ b/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Boolean_set_operations_2_GraphicsView_Demo ) 
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Boolean_set_operations_2/examples/Boolean_set_operations_2/CMakeLists.txt
+++ b/Boolean_set_operations_2/examples/Boolean_set_operations_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Boolean_set_operations_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Boolean_set_operations_2/test/Boolean_set_operations_2/CMakeLists.txt
+++ b/Boolean_set_operations_2/test/Boolean_set_operations_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Boolean_set_operations_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Approximate_min_ellipsoid_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_annulus_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_annulus_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_annulus_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_circle_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_circle_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_circle_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_ellipse_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_ellipse_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_ellipse_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_quadrilateral_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_quadrilateral_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_quadrilateral_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_sphere_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_sphere_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_sphere_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Min_sphere_of_spheres_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_sphere_of_spheres_d/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Min_sphere_of_spheres_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/examples/Rectangular_p_center_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Rectangular_p_center_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Rectangular_p_center_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
+++ b/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Bounding_volumes_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Box_intersection_d/examples/Box_intersection_d/CMakeLists.txt
+++ b/Box_intersection_d/examples/Box_intersection_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Box_intersection_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
+++ b/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Box_intersection_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/CGAL_Core/examples/Core/CMakeLists.txt
+++ b/CGAL_Core/examples/Core/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Core_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/CGAL_ImageIO/archive/demo/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/archive/demo/CGALimageIO/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGALimageIO_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( CGALimageIO_Examples ) 
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( CGAL_ImageIO_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGAL_ipelets_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/CGAL_ipelets/examples/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/examples/CGAL_ipelets/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( CGAL_ipelets_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Top level CMakeLists.txt for CGAL-branchbuild
 message( "== CMake setup ==" )
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGAL CXX C)
 export(PACKAGE CGAL)
 # Minimal version of CMake:
-cmake_minimum_required(VERSION 3.1)
 
 set( CGAL_BRANCH_BUILD ON CACHE INTERNAL "Create CGAL from a Git branch" FORCE)
 

--- a/Circular_kernel_2/examples/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/examples/Circular_kernel_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circular_kernel_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
@@ -2,9 +2,8 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circular_kernel_2_Tests )
-
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Circular_kernel_3_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Circular_kernel_3/examples/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/examples/Circular_kernel_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circular_kernel_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
@@ -2,9 +2,8 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circular_kernel_3_Tests )
-
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Circulator/examples/Circulator/CMakeLists.txt
+++ b/Circulator/examples/Circulator/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circulator_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Circulator/test/Circulator/CMakeLists.txt
+++ b/Circulator/test/Circulator/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Circulator_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Classification/examples/Classification/CMakeLists.txt
+++ b/Classification/examples/Classification/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Classification_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Classification/test/Classification/CMakeLists.txt
+++ b/Classification/test/Classification/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Classification_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Combinatorial_map/examples/Combinatorial_map/CMakeLists.txt
+++ b/Combinatorial_map/examples/Combinatorial_map/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Combinatorial_map_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Combinatorial_map/test/Combinatorial_map/CMakeLists.txt
+++ b/Combinatorial_map/test/Combinatorial_map/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Combinatorial_map_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Cone_spanners_2_Examples )
 
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core)

--- a/Cone_spanners_2/test/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/test/Cone_spanners_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Cone_spanners_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Convex_decomposition_3/examples/Convex_decomposition_3/CMakeLists.txt
+++ b/Convex_decomposition_3/examples/Convex_decomposition_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_decomposition_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Convex_decomposition_3/test/Convex_decomposition_3/CMakeLists.txt
+++ b/Convex_decomposition_3/test/Convex_decomposition_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_decomposition_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Convex_hull_2/examples/Convex_hull_2/CMakeLists.txt
+++ b/Convex_hull_2/examples/Convex_hull_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Convex_hull_2/test/Convex_hull_2/CMakeLists.txt
+++ b/Convex_hull_2/test/Convex_hull_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Convex_hull_3/demo/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/demo/Convex_hull_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_3_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_3_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Convex_hull_d/test/Convex_hull_d/CMakeLists.txt
+++ b/Convex_hull_d/test/Convex_hull_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Convex_hull_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Distance_2/test/Distance_2/CMakeLists.txt
+++ b/Distance_2/test/Distance_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Distance_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Distance_3/test/Distance_3/CMakeLists.txt
+++ b/Distance_3/test/Distance_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Distance_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Documentation NONE)
 
 # Minimal version of CMake:
-cmake_minimum_required(VERSION 3.1)
 
 # Check whether this cmake script is the top level one
 if ( ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Envelope_2/examples/Envelope_2/CMakeLists.txt
+++ b/Envelope_2/examples/Envelope_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Envelope_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Envelope_2/test/Envelope_2/CMakeLists.txt
+++ b/Envelope_2/test/Envelope_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Envelope_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Envelope_3/examples/Envelope_3/CMakeLists.txt
+++ b/Envelope_3/examples/Envelope_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Envelope_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Envelope_3/test/Envelope_3/CMakeLists.txt
+++ b/Envelope_3/test/Envelope_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Envelope_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Filtered_kernel/benchmark/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/benchmark/Filtered_kernel/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Filtered_kernel_test )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 add_executable(bench_simple_comparisons bench_simple_comparisons.cpp)

--- a/Filtered_kernel/examples/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/examples/Filtered_kernel/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Filtered_kernel_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Filtered_kernel/test/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/test/Filtered_kernel/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Filtered_kernel_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Generalized_map/examples/Generalized_map/CMakeLists.txt
+++ b/Generalized_map/examples/Generalized_map/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Generalized_map_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Generalized_map/test/Generalized_map/CMakeLists.txt
+++ b/Generalized_map/test/Generalized_map/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Generalized_map_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Generator/benchmark/Generator/CMakeLists.txt
+++ b/Generator/benchmark/Generator/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Generator_example )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Generator/examples/Generator/CMakeLists.txt
+++ b/Generator/examples/Generator/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Generator_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Generator/test/Generator/CMakeLists.txt
+++ b/Generator/test/Generator/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Generator_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Geomview/demo/Geomview/CMakeLists.txt
+++ b/Geomview/demo/Geomview/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Geomview_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Geomview/test/Geomview/CMakeLists.txt
+++ b/Geomview/test/Geomview/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Geomview_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
+++ b/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Alpha_shapes_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Apollonius_graph_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Bounding_volumes_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
+++ b/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Circular_kernel_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Generator/CMakeLists.txt
+++ b/GraphicsView/demo/Generator/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Generator_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/GraphicsView/CMakeLists.txt
+++ b/GraphicsView/demo/GraphicsView/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (GraphicsView_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
+++ b/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (L1_Voronoi_diagram_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
+++ b/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Largest_empty_rect_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Periodic_2_triangulation_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Polygon_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Segment_Delaunay_graph_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Segment_Delaunay_graph_Linf_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Snap_rounding_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Spatial_searching_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Stream_lines_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/GraphicsView/demo/Triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Triangulation_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Triangulation_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/HalfedgeDS/examples/HalfedgeDS/CMakeLists.txt
+++ b/HalfedgeDS/examples/HalfedgeDS/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( HalfedgeDS_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/HalfedgeDS/test/HalfedgeDS/CMakeLists.txt
+++ b/HalfedgeDS/test/HalfedgeDS/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( HalfedgeDS_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Hash_map/benchmark/Hash_map/CMakeLists.txt
+++ b/Hash_map/benchmark/Hash_map/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Hash_map )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Hash_map/test/Hash_map/CMakeLists.txt
+++ b/Hash_map/test/Hash_map/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Hash_map_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Heat_method_3/examples/Heat_method_3/CMakeLists.txt
+++ b/Heat_method_3/examples/Heat_method_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Heat_method_3_Examples )
 
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Heat_method_3/test/Heat_method_3/CMakeLists.txt
+++ b/Heat_method_3/test/Heat_method_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Heat_method_3_Tests )
 
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Hyperbolic_triangulation_2/benchmark/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/benchmark/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Hyperbolic_triangulation_2_benchmark )
 
-cmake_minimum_required(VERSION 2.8.10)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Hyperbolic_triangulation_2_Demo)
 
 # Find includes in corresponding build directories

--- a/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Hyperbolic_triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Hyperbolic_triangulation_2_Tests )
 
-cmake_minimum_required(VERSION 3.1...3.13)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Inscribed_areas/examples/Inscribed_areas/CMakeLists.txt
+++ b/Inscribed_areas/examples/Inscribed_areas/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Inscribed_areas_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Inscribed_areas/test/Inscribed_areas/CMakeLists.txt
+++ b/Inscribed_areas/test/Inscribed_areas/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Inscribed_areas_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -4,14 +4,10 @@
 # ${CMAKE_SOURCE_DIR} and to the root binary directory of the project as
 # ${CMAKE_BINARY_DIR} or ${CMAKE_BINARY_DIR}.
 if(NOT PROJECT_NAME)
+  cmake_minimum_required(VERSION 3.1...3.15)
   project(CGAL CXX C)
 endif()
 
-# Minimal version of CMake:
-cmake_minimum_required(VERSION 3.1)
-
-# Tested version:
-cmake_policy(VERSION 3.1)
 
 if(POLICY CMP0056)
   # https://cmake.org/cmake/help/v3.2/policy/CMP0056.html

--- a/Installation/demo/CMakeLists.txt
+++ b/Installation/demo/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGAL_DEMOS)
 
-cmake_minimum_required(VERSION 3.1)
 
 if (CGAL_BRANCH_BUILD) 
 

--- a/Installation/examples/CMakeLists.txt
+++ b/Installation/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGAL_EXAMPLES)
 
-cmake_minimum_required(VERSION 3.1)
 
 if (CGAL_BRANCH_BUILD) 
 

--- a/Installation/test/CMakeLists.txt
+++ b/Installation/test/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(CGAL_TESTS)
 
-cmake_minimum_required(VERSION 3.1)
 
 if (CGAL_BRANCH_BUILD) 
 

--- a/Installation/test/Installation/CMakeLists.txt
+++ b/Installation/test/Installation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Installation_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 macro(create_link_to_program COMPONENT )

--- a/Interpolation/demo/Interpolation/CMakeLists.txt
+++ b/Interpolation/demo/Interpolation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interpolation_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Interpolation/examples/Interpolation/CMakeLists.txt
+++ b/Interpolation/examples/Interpolation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interpolation_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Interpolation/test/Interpolation/CMakeLists.txt
+++ b/Interpolation/test/Interpolation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interpolation_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Intersections_2/test/Intersections_2/CMakeLists.txt
+++ b/Intersections_2/test/Intersections_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Intersections_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Intersections_3/test/Intersections_3/CMakeLists.txt
+++ b/Intersections_3/test/Intersections_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Intersections_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Interval_skip_list/examples/Interval_skip_list/CMakeLists.txt
+++ b/Interval_skip_list/examples/Interval_skip_list/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interval_skip_list_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Interval_skip_list/test/Interval_skip_list/CMakeLists.txt
+++ b/Interval_skip_list/test/Interval_skip_list/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interval_skip_list_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Interval_support/test/Interval_support/CMakeLists.txt
+++ b/Interval_support/test/Interval_support/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Interval_support_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Inventor/test/Inventor/CMakeLists.txt
+++ b/Inventor/test/Inventor/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Inventor_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Jet_fitting_3/examples/Jet_fitting_3/CMakeLists.txt
+++ b/Jet_fitting_3/examples/Jet_fitting_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Jet_fitting_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Jet_fitting_3/test/Jet_fitting_3/CMakeLists.txt
+++ b/Jet_fitting_3/test/Jet_fitting_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Jet_fitting_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Kernel_23/examples/Kernel_23/CMakeLists.txt
+++ b/Kernel_23/examples/Kernel_23/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Kernel_23_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Kernel_23/test/Kernel_23/CMakeLists.txt
+++ b/Kernel_23/test/Kernel_23/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Kernel_23_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Kernel_d/test/Kernel_d/CMakeLists.txt
+++ b/Kernel_d/test/Kernel_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Kernel_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_2/CMakeLists.txt
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(LCC_performance_2)
 
-cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_3/CMakeLists.txt
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_3/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(LCC_performance_3)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 # cmake ../ -DCMAKE_BUILD_TYPE=Debug
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Linear_cell_complex_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Linear_cell_complex_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Linear_cell_complex_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Matrix_search/examples/Matrix_search/CMakeLists.txt
+++ b/Matrix_search/examples/Matrix_search/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Matrix_search_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Matrix_search/test/Matrix_search/CMakeLists.txt
+++ b/Matrix_search/test/Matrix_search/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Matrix_search_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Mesh_2/demo/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/demo/Mesh_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script (and then adapted manually).
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_2_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Mesh_2/examples/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/examples/Mesh_2/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Mesh_2/test/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/test/Mesh_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Mesh_3/archive/applications/CMakeLists.txt
+++ b/Mesh_3/archive/applications/CMakeLists.txt
@@ -2,9 +2,8 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_3_applications )
-
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 include_directories(../include)
 

--- a/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_3_benchmark )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # Creates a new CMake option, turned ON by default

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 add_definitions(-DCGAL_MESH_3_NO_DEPRECATED_SURFACE_INDEX

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/Minkowski_sum_2/examples/Minkowski_sum_2/CMakeLists.txt
+++ b/Minkowski_sum_2/examples/Minkowski_sum_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Minkowski_sum_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Minkowski_sum_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 # Commented out C++11 for now
 # list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_generalized_initializers has_cpp11)

--- a/Minkowski_sum_3/examples/Minkowski_sum_3/CMakeLists.txt
+++ b/Minkowski_sum_3/examples/Minkowski_sum_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Minkowski_sum_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Minkowski_sum_3/test/Minkowski_sum_3/CMakeLists.txt
+++ b/Minkowski_sum_3/test/Minkowski_sum_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Minkowski_sum_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Modifier/test/Modifier/CMakeLists.txt
+++ b/Modifier/test/Modifier/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Modifier_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Modular_arithmetic/examples/Modular_arithmetic/CMakeLists.txt
+++ b/Modular_arithmetic/examples/Modular_arithmetic/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Modular_arithmetic_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Modular_arithmetic/test/Modular_arithmetic/CMakeLists.txt
+++ b/Modular_arithmetic/test/Modular_arithmetic/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Modular_arithmetic_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Nef_2/examples/Nef_2/CMakeLists.txt
+++ b/Nef_2/examples/Nef_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Nef_2/test/Nef_2/CMakeLists.txt
+++ b/Nef_2/test/Nef_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Nef_3/examples/Nef_3/CMakeLists.txt
+++ b/Nef_3/examples/Nef_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Nef_3/test/Nef_3/CMakeLists.txt
+++ b/Nef_3/test/Nef_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Nef_S2/examples/Nef_S2/CMakeLists.txt
+++ b/Nef_S2/examples/Nef_S2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_S2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Nef_S2/test/Nef_S2/CMakeLists.txt
+++ b/Nef_S2/test/Nef_S2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Nef_S2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/NewKernel_d/test/NewKernel_d/CMakeLists.txt
+++ b/NewKernel_d/test/NewKernel_d/CMakeLists.txt
@@ -3,9 +3,9 @@
 # Then modified by hand to add Eigen3.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( NewKernel_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
   message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -3,9 +3,9 @@
 # that dependency so as to test all the number types not depending on CORE
 # when it is not installed
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Number_types_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package( CGAL QUIET COMPONENTS Core )

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling the Optimal_transportation_reconstruction_2 demo.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Optimal_transportation_reconstruction_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,13 +1,5 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Optimal_transportation_reconstruction_2_Examples )
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
 
 find_package(CGAL QUIET)
 

--- a/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,13 +1,5 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Optimal_transportation_reconstruction_2_Tests )
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
 
 find_package(CGAL QUIET)
 

--- a/Partition_2/examples/Partition_2/CMakeLists.txt
+++ b/Partition_2/examples/Partition_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Partition_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Partition_2/test/Partition_2/CMakeLists.txt
+++ b/Partition_2/test/Partition_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Partition_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_2_triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_2_triangulation_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_3_mesh_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_3_mesh_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_3_triangulation_3_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Periodic_Lloyd_3_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_3_triangulation_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_3_triangulation_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Periodic_4_hyperbolic_triangulation_2/benchmark/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/benchmark/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_4_hyperbolic_triangulation_2_Benchmarks )
 
-cmake_minimum_required(VERSION 2.8.10)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Periodic_4_hyperbolic_triangulation_2_Demo)
 
 # Find includes in corresponding build directories

--- a/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_4_hyperbolic_triangulation_2_Examples )
 
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core )

--- a/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Periodic_4_hyperbolic_triangulation_2_Tests )
 
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core )

--- a/Point_set_2/examples/Point_set_2/CMakeLists.txt
+++ b/Point_set_2/examples/Point_set_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Point_set_2/test/Point_set_2/CMakeLists.txt
+++ b/Point_set_2/test/Point_set_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Point_set_3/examples/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/examples/Point_set_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_3_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Point_set_3/test/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/test/Point_set_3/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_3_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling this folder.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_processing_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # Find CGAL

--- a/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling this folder.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Point_set_processing_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # Find CGAL

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling this folder.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Poisson_surface_reconstruction_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 # Find CGAL
 find_package(CGAL QUIET)

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling this folder.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Poisson_surface_reconstruction_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 # Find CGAL
 find_package(CGAL QUIET)

--- a/Polygon/examples/Polygon/CMakeLists.txt
+++ b/Polygon/examples/Polygon/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polygon_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polygon/test/Polygon/CMakeLists.txt
+++ b/Polygon/test/Polygon/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polygon_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polygon_mesh_processing )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polygon_mesh_processing_Examples )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polygon_mesh_processing_Tests )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling the CGAL Polyhedron demo.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
@@ -1,10 +1,10 @@
 # This is the CMake script for compiling the CGAL Mesh_3 demo implicit functions.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mesh_3_implicit_functions )
 
 include( polyhedron_demo_macros )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Polyhedron/examples/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/examples/Polyhedron/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.

--- a/Polyhedron/test/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/test/Polyhedron/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polyhedron_IO/demo/Polyhedron_IO/CMakeLists.txt
+++ b/Polyhedron_IO/demo/Polyhedron_IO/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_IO_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Polyhedron_IO/examples/Polyhedron_IO/CMakeLists.txt
+++ b/Polyhedron_IO/examples/Polyhedron_IO/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_IO_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polyhedron_IO/test/Polyhedron_IO/CMakeLists.txt
+++ b/Polyhedron_IO/test/Polyhedron_IO/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyhedron_IO_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Polyline_simplification_2_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Polyline_simplification_2/examples/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyline_simplification_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polyline_simplification_2_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/Polynomial/examples/Polynomial/CMakeLists.txt
+++ b/Polynomial/examples/Polynomial/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polynomial_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polynomial/test/Polynomial/CMakeLists.txt
+++ b/Polynomial/test/Polynomial/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polynomial_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core)
 

--- a/Polytope_distance_d/examples/Polytope_distance_d/CMakeLists.txt
+++ b/Polytope_distance_d/examples/Polytope_distance_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polytope_distance_d_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Polytope_distance_d/test/Polytope_distance_d/CMakeLists.txt
+++ b/Polytope_distance_d/test/Polytope_distance_d/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Polytope_distance_d_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -1,8 +1,8 @@
 # This is the CMake script for compiling the PCA demo.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Principal_component_analysis_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Principal_component_analysis_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Principal_component_analysis_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Profiling_tools/examples/Profiling_tools/CMakeLists.txt
+++ b/Profiling_tools/examples/Profiling_tools/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Profiling_tools_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Profiling_tools/test/Profiling_tools/CMakeLists.txt
+++ b/Profiling_tools/test/Profiling_tools/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Profiling_tools_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Property_map/examples/Property_map/CMakeLists.txt
+++ b/Property_map/examples/Property_map/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Property_map_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Property_map/test/Property_map/CMakeLists.txt
+++ b/Property_map/test/Property_map/CMakeLists.txt
@@ -1,8 +1,8 @@
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Property_map_Tests )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/QP_solver/examples/QP_solver/CMakeLists.txt
+++ b/QP_solver/examples/QP_solver/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( QP_solver_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/QP_solver/test/QP_solver/CMakeLists.txt
+++ b/QP_solver/test/QP_solver/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( QP_solver_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Random_numbers/test/Random_numbers/CMakeLists.txt
+++ b/Random_numbers/test/Random_numbers/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Random_numbers_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Ridges_3/examples/Ridges_3/CMakeLists.txt
+++ b/Ridges_3/examples/Ridges_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # This is the CMake script for compiling a CGAL application.
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Ridges_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET )

--- a/Ridges_3/test/Ridges_3/CMakeLists.txt
+++ b/Ridges_3/test/Ridges_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Ridges_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/STL_Extension/benchmark/compact_container_benchmark/CMakeLists.txt
+++ b/STL_Extension/benchmark/compact_container_benchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Compact_container_benchmark )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/STL_Extension/benchmark/copy_n_benchmark/CMakeLists.txt
+++ b/STL_Extension/benchmark/copy_n_benchmark/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( copy_n_benchmark_example )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/STL_Extension/examples/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/examples/STL_Extension/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( STL_Extension_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( STL_Extension_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/CMakeLists.txt
+++ b/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Scale_space_reconstruction_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package( CGAL QUIET)
 

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -9,7 +9,7 @@
 # TESTSUITE=indicate if the release is meant to be used by the testsuite, default if OFF
 # GPL_PACKAGE_LIST=path to a file containing the list of GPL packages to include in the release. If not provided all of them are.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.15)
 
 function(process_package pkg)
   if(VERBOSE)

--- a/SearchStructures/examples/RangeSegmentTrees/CMakeLists.txt
+++ b/SearchStructures/examples/RangeSegmentTrees/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( RangeSegmentTrees_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/SearchStructures/test/RangeSegmentTrees/CMakeLists.txt
+++ b/SearchStructures/test/RangeSegmentTrees/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( RangeSegmentTrees_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Segment_Delaunay_graph_2/benchmark/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/benchmark/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_2_example )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Segment_Delaunay_graph_Linf_2/benchmark/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/benchmark/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_2_example )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_Linf_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Segment_Delaunay_graph_Linf_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Set_movable_separability_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_generalized_initializers has_cpp11)
 if (has_cpp11 LESS 0)

--- a/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Set_movable_separability_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if (RUNNING_CGAL_AUTO_TEST)
   # Just to avoid a warning from CMake when that variable is set on the command line...

--- a/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Benchmarks)
 
-cmake_minimum_required(VERSION 2.8.10)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(CGAL QUIET COMPONENTS Core)

--- a/Shape_detection/examples/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/examples/Shape_detection/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Examples)
 
-cmake_minimum_required(VERSION 2.8.10)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(CGAL QUIET COMPONENTS Core)

--- a/Shape_detection/test/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/test/Shape_detection/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Tests)
 
-cmake_minimum_required(VERSION 2.8.10)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(CGAL QUIET COMPONENTS Core)

--- a/Skin_surface_3/examples/Skin_surface_3/CMakeLists.txt
+++ b/Skin_surface_3/examples/Skin_surface_3/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Skin_surface_3_Examples ) 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL)

--- a/Skin_surface_3/test/Skin_surface_3/CMakeLists.txt
+++ b/Skin_surface_3/test/Skin_surface_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Skin_surface_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Snap_rounding_2/examples/Snap_rounding_2/CMakeLists.txt
+++ b/Snap_rounding_2/examples/Snap_rounding_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Snap_rounding_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
+++ b/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Snap_rounding_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Solver_interface/examples/Solver_interface/CMakeLists.txt
+++ b/Solver_interface/examples/Solver_interface/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Solver_interface_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Spatial_searching/benchmark/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/benchmark/Spatial_searching/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_searching_ )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Spatial_searching/benchmark/Spatial_searching/tools/CMakeLists.txt
+++ b/Spatial_searching/benchmark/Spatial_searching/tools/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( tools_ )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_searching_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # CGAL and its components

--- a/Spatial_searching/test/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/test/Spatial_searching/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_searching_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Spatial_sorting/benchmark/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/benchmark/Spatial_sorting/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_sorting_ )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Spatial_sorting/examples/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/examples/Spatial_sorting/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_sorting_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Spatial_sorting/test/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/test/Spatial_sorting/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Spatial_sorting_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Straight_skeleton_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Straight_skeleton_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/Stream_lines_2/examples/Stream_lines_2/CMakeLists.txt
+++ b/Stream_lines_2/examples/Stream_lines_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Stream_lines_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Stream_lines_2/test/Stream_lines_2/CMakeLists.txt
+++ b/Stream_lines_2/test/Stream_lines_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Stream_lines_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Stream_support/benchmark/Stream_support/CMakeLists.txt
+++ b/Stream_support/benchmark/Stream_support/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Stream_support )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # CGAL and its components

--- a/Stream_support/examples/Stream_support/CMakeLists.txt
+++ b/Stream_support/examples/Stream_support/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Stream_support_Examples)
 
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET)

--- a/Stream_support/test/Stream_support/CMakeLists.txt
+++ b/Stream_support/test/Stream_support/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Stream_support_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Subdivision_method_3/examples/Subdivision_method_3/CMakeLists.txt
+++ b/Subdivision_method_3/examples/Subdivision_method_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Subdivision_method_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Subdivision_method_3/test/Subdivision_method_3/CMakeLists.txt
+++ b/Subdivision_method_3/test/Subdivision_method_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Subdivision_method_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Surface_mesh/benchmark/CMakeLists.txt
+++ b/Surface_mesh/benchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project(Surface_mesh_performance)
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL REQUIRED)
 

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.

--- a/Surface_mesh/test/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/test/Surface_mesh/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Surface_mesh_approximation/benchmark/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/benchmark/Surface_mesh_approximation/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_approximation_Benchmarks )
 
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Surface_mesh_approximation/examples/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/examples/Surface_mesh_approximation/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_approximation_Examples )
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET)

--- a/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_approximation_Tests )
 
 
-cmake_minimum_required(VERSION 2.8.11)
 
 # CGAL and its components
 find_package( CGAL QUIET)

--- a/Surface_mesh_deformation/benchmark/Surface_mesh_deformation/optimal_rotation/CMakeLists.txt
+++ b/Surface_mesh_deformation/benchmark/Surface_mesh_deformation/optimal_rotation/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( benchmark_for_closest_rotation )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Surface_mesh_deformation/demo/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/demo/Surface_mesh_deformation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_deformation_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_deformation_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Surface_mesh_deformation/test/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/test/Surface_mesh_deformation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_deformation_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
@@ -1,9 +1,9 @@
 # This is the CMake script for compiling this folder.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_parameterization_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # Find CGAL

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -1,9 +1,9 @@
 # This is the CMake script for compiling this folder.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_parameterization_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # Find CGAL

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/CMakeLists.txt
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_segmentation_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/Surface_mesh_segmentation/test/Surface_mesh_segmentation/CMakeLists.txt
+++ b/Surface_mesh_segmentation/test/Surface_mesh_segmentation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_segmentation_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
@@ -3,9 +3,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_shortest_path_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/CMakeLists.txt
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1...3.13)
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_shortest_path_Tests )
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/CMakeLists.txt
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_simplification_Examples )
 
 
-cmake_minimum_required(VERSION 3.1)
 
 
 

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/CMakeLists.txt
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_simplification_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Mean_curvature_skeleton )
 
 #SET(CMAKE_BUILD_TYPE "Debug")
 #SET(GCC_COVERAGE_COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
 #SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 # CGAL and its components

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_skeletonization_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Surface_mesh_skeletonization/test/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/test/Surface_mesh_skeletonization/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_skeletonization_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/demo/Surface_mesher/CMakeLists.txt
@@ -1,8 +1,8 @@
 set ( prj Surface_mesher )
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project ( Surface_mesher_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
@@ -1,9 +1,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesher_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/Surface_mesher/test/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/test/Surface_mesher/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesher_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Surface_sweep_2/examples/Surface_sweep_2/CMakeLists.txt
+++ b/Surface_sweep_2/examples/Surface_sweep_2/CMakeLists.txt
@@ -1,18 +1,8 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_sweep_2_Examples )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Surface_sweep_2/test/Surface_sweep_2/CMakeLists.txt
+++ b/Surface_sweep_2/test/Surface_sweep_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_sweep_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET COMPONENTS Core )
 

--- a/TDS_2/test/TDS_2/CMakeLists.txt
+++ b/TDS_2/test/TDS_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( TDS_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/TDS_3/examples/TDS_3/CMakeLists.txt
+++ b/TDS_3/examples/TDS_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( TDS_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/TDS_3/test/TDS_3/CMakeLists.txt
+++ b/TDS_3/test/TDS_3/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( TDS_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Three/demo/Three/CMakeLists.txt
+++ b/Three/demo/Three/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Three_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/Three/demo/Three/Example_plugin/CMakeLists.txt
+++ b/Three/demo/Three/Example_plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Example_plugin )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Triangulation/applications/Triangulation/CMakeLists.txt
+++ b/Triangulation/applications/Triangulation/CMakeLists.txt
@@ -1,20 +1,8 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_apps )
-
-
-cmake_minimum_required(VERSION 3.1)
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 2.6)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_GREATER 2.8.3)
-    cmake_policy(VERSION 2.8.4)
-  else()
-    cmake_policy(VERSION 2.6)
-  endif()
-endif()
-
-set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true )
- 
 
 # CGAL and its components
 find_package( CGAL QUIET COMPONENTS  )

--- a/Triangulation/benchmark/Triangulation/CMakeLists.txt
+++ b/Triangulation/benchmark/Triangulation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_benchmark )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET COMPONENTS Core )

--- a/Triangulation/examples/Triangulation/CMakeLists.txt
+++ b/Triangulation/examples/Triangulation/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
   message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")

--- a/Triangulation/test/Triangulation/CMakeLists.txt
+++ b/Triangulation/test/Triangulation/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
   message(STATUS "NOTICE: this directory requires a version of gcc >= 4.4, and will not be compiled.")

--- a/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.

--- a/Triangulation_2/test/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/test/Triangulation_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project (Triangulation_3_Demo)
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Triangulation_3/demo/Triangulation_3_Geomview_demos/CMakeLists.txt
+++ b/Triangulation_3/demo/Triangulation_3_Geomview_demos/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_3_Geomview_demos_Demo )
 
-cmake_minimum_required(VERSION 3.1)
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_3_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.

--- a/Triangulation_3/test/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/test/Triangulation_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Triangulation_3_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 
 find_package(CGAL QUIET)

--- a/Union_find/test/Union_find/CMakeLists.txt
+++ b/Union_find/test/Union_find/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Union_find_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Visibility_2/examples/Visibility_2/CMakeLists.txt
+++ b/Visibility_2/examples/Visibility_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Visibility_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Visibility_2/test/Visibility_2/CMakeLists.txt
+++ b/Visibility_2/test/Visibility_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Visibility_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Voronoi_diagram_2/examples/Voronoi_diagram_2/CMakeLists.txt
+++ b/Voronoi_diagram_2/examples/Voronoi_diagram_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Voronoi_diagram_2_Examples )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/CMakeLists.txt
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/CMakeLists.txt
@@ -2,9 +2,9 @@
 # This is the CMake script for compiling a CGAL application.
 
 
+cmake_minimum_required(VERSION 3.1...3.15)
 project( Voronoi_diagram_2_Tests )
 
-cmake_minimum_required(VERSION 3.1)
 
 find_package(CGAL QUIET)
 


### PR DESCRIPTION
## Summary of Changes

Replace:
```cmake
cmake_minimum_required(VERSION 3.1)
```
by:
```cmake
cmake_minimum_required(VERSION 3.1...3.15)
```

Since CMake 3.13, that syntax sets all policies known by CMake-3.15 to `NEW`, and it is backward-compatible with CMake<=3.12: with those version, the `cmake_policy` is just the one of CMake-3.1.

With recent versions of CMake, that should quiet all new warnings about cmake policies, up to `CMP0095`.

Note that it also sets [`CMP0074`] that make the documentation of CMake easier, since CMake>=3.13 (released November 20, 2018): `<package>_ROOT` becomes a unified way to specify to CMake where 3rd party packages are installed.

[`CMP0074`]: https://cmake.org/cmake/help/v3.12/policy/CMP0074.html

## Release Management

* Affected package(s): all 
* License and copyright ownership: maintenance by GeometryFactory

