### PR TITLE
Triangulation_2: Fix CDT_plus_2::remove_constraint()

### DIFF
--- a/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Polyline_constraint_hierarchy_2.h
@@ -256,6 +256,7 @@ public:
   void remove_constraint(Vertex_handle va, Vertex_handle vb)
   {
     remove_constraint(constraint_map[make_edge(va,vb)]);
+    constraint_map.erase(make_edge(va,vb));
   }
 
   void split_constraint(T va, T vb, T vc);

--- a/Triangulation_2/test/Triangulation_2/issue_4010.cpp
+++ b/Triangulation_2/test/Triangulation_2/issue_4010.cpp
@@ -1,0 +1,38 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Triangulation_2.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Constrained_triangulation_plus_2.h>
+
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel                 K;
+typedef CGAL::Polygon_2<K>                                                Polygon_2;
+typedef CGAL::Exact_intersections_tag                                     Itag_;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K,CGAL::Default, Itag_> CDT;
+typedef CGAL::Constrained_triangulation_plus_2<CDT>                       CDTP;
+
+typedef CDTP::Point                                                       Point;
+typedef CDTP::Constraint_id                                               Cid;
+typedef CDTP::Vertex_handle                                               Vertex_handle;
+
+
+int main()
+{
+  CDTP cdtp;
+  
+  Vertex_handle handle1=cdtp.insert(Point(0,0));
+  Vertex_handle handle2=cdtp.insert(Point(0,10));
+  Vertex_handle handle3=cdtp.insert(Point(10,10));
+  Vertex_handle handle4=cdtp.insert(Point(10,0));
+  
+  auto id = cdtp.insert_constraint(handle1,handle3);
+  
+  cdtp.remove_constraint(handle1,handle3);
+  
+  auto lastConstraintId=cdtp.insert_constraint(handle1,handle3);
+  
+  if (lastConstraintId == nullptr){
+    std::cout << "problem" << std::endl;
+    assert(false);
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

Fix the bookkeeping of constraints. Forgot to remove it from a `std::map`.

**This must NOT go into master**, as we have removed the function `remove_constraint()` which takes two vertex handles as key.

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #4010 


