### PR TITLE
Mesh_3: remove the attempt for `os << std::pair`

### DIFF
--- a/Mesh_3/include/CGAL/internal/Mesh_3/Handle_IO_for_pair_of_int.h
+++ b/Mesh_3/include/CGAL/internal/Mesh_3/Handle_IO_for_pair_of_int.h
@@ -41,13 +41,6 @@ struct Get_io_signature<std::pair<int, int> > {
   }
 }; // end Get_io_signature<std::pair<int, int> >
 
-inline std::ostream& operator<<(std::ostream& out, const std::pair<int, int>& id) {
-  return out << id.first << " " << id.second;
-}
-inline std::istream& operator>>(std::istream& in, std::pair<int, int>& id) {
-  return in >> id.first >> id.second;
-}
-
 template <>
 class Output_rep<std::pair<int, int> > : public IO_rep_is_specialized {
   typedef std::pair<int, int> T;


### PR DESCRIPTION
## Summary of Changes

`std::cout << std::make_pair(0, 1)` does not compile... I have tried in the past to add an `operator<<` for `std::pair`, but that does not work. Let's remove that old attempt, now.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: maintenance by GeometryFactory
