### PR TITLE
CGAL_Core: remove 'using namespace std' from namespaces

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/Gmp_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Gmp_impl.h
@@ -46,15 +46,14 @@ MA 02110-1301, USA. */
 #include <string>
 #include <cstdio>
 
-using namespace std;
-
 namespace CORE { 
 
 CGAL_INLINE_FUNCTION
 int
-__gmp_istream_set_base (istream &i, char &c, bool &zero, bool &showbase)
+__gmp_istream_set_base (std::istream &i, char &c, bool &zero, bool &showbase)
 {
   int base;
+  using std::ios;
 
   zero = showbase = false;
   switch (i.flags() & ios::basefield)
@@ -96,7 +95,7 @@ __gmp_istream_set_base (istream &i, char &c, bool &zero, bool &showbase)
 
 CGAL_INLINE_FUNCTION
 void
-__gmp_istream_set_digits (string &s, istream &i, char &c, bool &ok, int base)
+__gmp_istream_set_digits (std::string &s, std::istream &i, char &c, bool &ok, int base)
 {
   switch (base)
     {
@@ -131,13 +130,14 @@ __gmp_istream_set_digits (string &s, istream &i, char &c, bool &ok, int base)
 }
 
 CGAL_INLINE_FUNCTION
-istream &
-//operator>> (istream &i, mpz_ptr z)
-io_read (istream &i, mpz_ptr z)
+std::istream &
+//operator>> (std::istream &i, mpz_ptr z)
+io_read (std::istream &i, mpz_ptr z)
 {
+  using namespace std;
   int base;
   char c = 0;
-  string s;
+  std::string s;
   bool ok = false, zero, showbase;
 
   i.get(c); // start reading
@@ -175,13 +175,14 @@ io_read (istream &i, mpz_ptr z)
 }
 
 CGAL_INLINE_FUNCTION
-istream &
-//operator>> (istream &i, mpq_ptr q)
-io_read (istream &i, mpq_ptr q)
+std::istream &
+//operator>> (std::istream &i, mpq_ptr q)
+io_read (std::istream &i, mpq_ptr q)
 {
+  using namespace std;
   int base;
   char c = 0;
-  string s;
+  std::string s;
   bool ok = false, zero, showbase;
 
   i.get(c); // start reading
@@ -253,9 +254,9 @@ io_read (istream &i, mpq_ptr q)
 }
 
 CGAL_INLINE_FUNCTION
-ostream&
-//operator<< (ostream &o, mpz_srcptr z)
-io_write (ostream &o, mpz_srcptr z)
+std::ostream&
+//operator<< (std::ostream &o, mpz_srcptr z)
+io_write (std::ostream &o, mpz_srcptr z)
 { 
   char *str = new char [mpz_sizeinbase(z,10) + 2];
   str = mpz_get_str(str, 10, z);
@@ -265,9 +266,9 @@ io_write (ostream &o, mpz_srcptr z)
 }
 
 CGAL_INLINE_FUNCTION
-ostream&
-//operator<< (ostream &o, mpq_srcptr q)
-io_write (ostream &o, mpq_srcptr q)
+std::ostream&
+//operator<< (std::ostream &o, mpq_srcptr q)
+io_write (std::ostream &o, mpq_srcptr q)
 { 
   // size according to GMP documentation
   char *str = new char [mpz_sizeinbase(mpq_numref(q), 10) +

--- a/CGAL_Core/include/CGAL/CORE/poly/Poly.h
+++ b/CGAL_Core/include/CGAL/CORE/poly/Poly.h
@@ -65,7 +65,6 @@
 #include <CGAL/tss.h>
 
 namespace CORE { 
-using namespace std;
 class Expr;
 // ==================================================
 // Typedefs
@@ -117,25 +116,25 @@ public:
   Polynomial(const Polynomial &);
   Polynomial(const VecNT &);
   Polynomial(int n, const char* s[]);
-  Polynomial(const string & s, char myX='x');
+  Polynomial(const std::string & s, char myX='x');
   Polynomial(const char* s, char myX='x');
   ~Polynomial();
 
   private:
   void constructX(int n, Polynomial<NT>& P);
-  void constructFromString(string & s, char myX='x');
+  void constructFromString(std::string & s, char myX='x');
   int getnumber(const char* c, int i, unsigned int len, Polynomial<NT> & P);
   bool isint(char c);
   int getint(const char* c, int i, unsigned int len, int & n);
   int matchparen(const char* cstr, int start);
-  int getbasicterm(string & s, Polynomial<NT> & P);
-  int getterm(string & s, Polynomial<NT> & P);
+  int getbasicterm(std::string & s, Polynomial<NT> & P);
+  int getterm(std::string & s, Polynomial<NT> & P);
 
 
   public:
   //Returns a Polynomial corresponding to s, which is supposed to
   //contain as place-holders the chars 'x' and 'y'.
-  Polynomial<NT> getpoly(string & s);
+  Polynomial<NT> getpoly(std::string & s);
 
   // Assignment:
   Polynomial & operator=(const Polynomial&);

--- a/CGAL_Core/include/CGAL/CORE/poly/Poly.tcc
+++ b/CGAL_Core/include/CGAL/CORE/poly/Poly.tcc
@@ -131,21 +131,21 @@ Polynomial<NT>::Polynomial(int n, const char * s[]) {
 //  want to generalize this to BigFloat, etc.
 //
 template <class NT>
-Polynomial<NT>::Polynomial(const string & s, char myX) {
-   string ss(s);
+Polynomial<NT>::Polynomial(const std::string & s, char myX) {
+   std::string ss(s);
    constructFromString(ss, myX);
 }
 template <class NT>
 Polynomial<NT>::Polynomial(const char * s, char myX) {
-   string ss(s);
+   std::string ss(s);
    constructFromString(ss, myX);
 }
 template <class NT>
-void Polynomial<NT>::constructFromString(string & s, char myX) {
+void Polynomial<NT>::constructFromString(std::string & s, char myX) {
   if(myX != 'x' || myX != 'X'){
     //Replace myX with 'x'.
-    string::size_type loc = s.find(myX, 0);
-    while(loc != string::npos){
+    std::string::size_type loc = s.find(myX, 0);
+    while(loc != std::string::npos){
       s.replace(loc,1,1,'x');
       loc = s.find(myX, loc+1);
     }
@@ -241,7 +241,7 @@ int Polynomial<NT>::matchparen(const char* cstr, int start){
 
 
 template <class NT>
-int Polynomial<NT>::getbasicterm(string & s, Polynomial<NT> & P){
+int Polynomial<NT>::getbasicterm(std::string & s, Polynomial<NT> & P){
   const char * cstr = s.c_str();
   unsigned int len = s.length();
   int i=0;
@@ -254,7 +254,7 @@ int Polynomial<NT>::getbasicterm(string & s, Polynomial<NT> & P){
   }else if(cstr[i] =='('){
     int oldi = i;
     i = matchparen(cstr, i);
-    string t = s.substr(oldi+1, i -oldi -1);
+    std::string t = s.substr(oldi+1, i -oldi -1);
     P = getpoly(t);
   }else{
 #ifdef CGAL_CORE_TRACE
@@ -272,7 +272,7 @@ int Polynomial<NT>::getbasicterm(string & s, Polynomial<NT> & P){
 
 
 template <class NT>
-int Polynomial<NT>::getterm(string & s, Polynomial<NT> & P){
+int Polynomial<NT>::getterm(std::string & s, Polynomial<NT> & P){
   unsigned int len = s.length();
   if(len == 0){// Zero Polynomial
     P=Polynomial<NT>();
@@ -280,7 +280,7 @@ int Polynomial<NT>::getterm(string & s, Polynomial<NT> & P){
   }
   unsigned int ind, oind;
   const char* cstr =s.c_str();
-  string t;
+  std::string t;
   //P will be used to accumulate the product of basic terms.
   ind = getbasicterm(s, P);
   while(ind != len-1 && cstr[ind + 1]!='+' && cstr[ind + 1]!='-' ){
@@ -304,11 +304,11 @@ int Polynomial<NT>::getterm(string & s, Polynomial<NT> & P){
 }
 
 template <class NT>
-Polynomial<NT> Polynomial<NT>::getpoly(string & s){
+Polynomial<NT> Polynomial<NT>::getpoly(std::string & s){
 
     //Remove white spaces from the string
-    string::size_type cnt=s.find(' ',0);
-    while(cnt != string::npos){
+    std::string::size_type cnt=s.find(' ',0);
+    while(cnt != std::string::npos){
       s.erase(cnt, 1);
       cnt = s.find(' ', cnt);
     }
@@ -321,10 +321,10 @@ Polynomial<NT> Polynomial<NT>::getpoly(string & s){
     //To handle the case when there is one '=' sign
     //Suppose s is of the form s1 = s2. Then we assign s to
     //s1 + (-1)(s2) and reset len
-    string::size_type loc;
-    if((loc=s.find('=',0)) != string::npos){
+    std::string::size_type loc;
+    if((loc=s.find('=',0)) != std::string::npos){
       s.replace(loc,1,1,'+');
-      string s3 = "(-1)(";
+      std::string s3 = "(-1)(";
       s.insert(loc+1, s3);
       len = s.length();
       s.insert(len, 1, ')');
@@ -332,7 +332,7 @@ Polynomial<NT> Polynomial<NT>::getpoly(string & s){
     len = s.length();
 
     const char *cstr = s.c_str();
-    string t;
+    std::string t;
     Polynomial<NT> P;
     // P will be the polynomial in which we accumulate the
     //sum and difference of the different terms.
@@ -966,7 +966,7 @@ BigInt Polynomial<NT>::UpperBound() const {
     lhsNeg.makeCeilExact();
 
     /* compute B^{deg} */
-    if (rhs <= max(lhsPos,lhsNeg)) {
+    if (rhs <= (std::max)(lhsPos,lhsNeg)) {
       B <<= 1;
       rhs *= (BigInt(1)<<deg);
     } else


### PR DESCRIPTION
Summary of Changes

There was `using namespace std;` in the global scope of `CGAL_Core/include/CGAL/CORE/Gmp_impl.h`. That meant that, in header-only, all CGAL programs using CORE were importing that namespace std in the global scope. And thus conflicts between `byte` and `std::byte` (from C++20).

https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14.1-I-173/Hyperbolic_triangulation_2_Demo/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Debug-64bits.gz

## Release Management

* Affected package(s): CGAL_Core
* License and copyright ownership: maintenance by GF

