### PR TITLE
SDG: Sanitize input of square root in evaluation of nested extensions

### DIFF
--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Basic_predicates_C2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Basic_predicates_C2.h
@@ -146,8 +146,11 @@ public:
   static
   FT to_ft(const Sqrt_3& x)
   {
-    FT sqrt_e = compute_sqrt( to_ft(x.e()), FT_Has_sqrt() );
-    FT sqrt_f = compute_sqrt( to_ft(x.f()), FT_Has_sqrt() );
+    // If the number type does not offer a square root, x.e() and x.f() (which are of type sqrt_1)
+    // might be negative after (approximately) evaluating them. Taking the max sanitize these values
+    // to ensure that we do not take the square root of a negative number.
+    FT sqrt_e = compute_sqrt( (std::max)(FT(0), to_ft(x.e())), FT_Has_sqrt() );
+    FT sqrt_f = compute_sqrt( (std::max)(FT(0), to_ft(x.f())), FT_Has_sqrt() );
     FT sqrt_ef = sqrt_e * sqrt_f;
     return to_ft(x.a()) + to_ft(x.b()) * sqrt_e
       + to_ft(x.c()) * sqrt_f + to_ft(x.d()) * sqrt_ef;


### PR DESCRIPTION
## Summary of Changes

If the base kernel has an exact number type that does not provide a square root, constructions use square roots extensions to do all the intermediary comparisons. However, at the end you still need to compute actual roots, which will be done using a `sqrt` over a double extracted from the exact number type.

To avoid negative numbers popping up under square roots, this patch sanitizes the input of the square root function in the function that evaluates the nested square root extension.

## Release Management

* Affected package(s): `Segment_Delaunay_Graph_2`
* Issue(s) solved (if any): fix #4030

