### PR TITLE
Mesh_3: older versions of gcc does not like that pair of const

### DIFF
--- a/Mesh_3/include/CGAL/IO/output_to_vtu.h
+++ b/Mesh_3/include/CGAL/IO/output_to_vtu.h
@@ -284,7 +284,7 @@ typedef boost::variant<const std::vector<double>*, const std::vector<uint8_t>*, 
 template <class C3T3>
 void output_to_vtu_with_attributes(std::ostream& os,
                                    const C3T3& c3t3,
-                                   std::vector<std::pair<const char*, const Vtu_attributes> >&attributes,
+                                   std::vector<std::pair<const char*, Vtu_attributes> >&attributes,
                                    IO::Mode mode = IO::BINARY)
 {
   //CGAL_assertion(attributes.size() == attribute_types.size());
@@ -373,7 +373,7 @@ void output_to_vtu(std::ostream& os,
     mids.push_back(v);
   }
   
-  std::vector<std::pair<const char*, const Vtu_attributes > > atts;
+  std::vector<std::pair<const char*, Vtu_attributes > > atts;
   Vtu_attributes v = &mids;
   atts.push_back(std::make_pair("MeshDomain", v));
   output_to_vtu_with_attributes(os, c3t3, atts, mode);


### PR DESCRIPTION
## Summary of Changes

https://cgal.geometryfactory.com/CGAL/testsuite/results-4.14.1-I-173.shtml#Mesh_3_Examples

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): related to #4033 
* License and copyright ownership: maintenance by GeometryFactory

