### PR TITLE
Kernel_23: fix warnings

### DIFF
--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -58,7 +58,7 @@ void test();
 int
 main()
 {
-  CGAL::force_ieee_double_precision();
+  CGAL::Set_ieee_double_precision double_precision_guard;
   typedef CGAL::Cartesian<double>                               Clsdb;
   typedef CGAL::Filtered_kernel<Clsdb>                          Clsd;
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_tetrahedron_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_tetrahedron_3.h
@@ -36,9 +36,6 @@ _test_cls_tetrahedron_3(const R& )
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
 
- typename R::Tetrahedron_3 it;
- CGAL::Tetrahedron_3<R>  t0(it);
-
  RT n0 =  0;
  RT n1 = 12;
  RT n2 = 16;
@@ -59,6 +56,10 @@ _test_cls_tetrahedron_3(const R& )
  CGAL::Point_3<R> ps2( n0, n7, n0, n5); // (0, 3, 0)
  CGAL::Point_3<R> ps1( n7, n0, n0, n5); // (3, 0, 0)
  CGAL::Point_3<R> ps0( CGAL::ORIGIN );  // (0, 0, 0)
+
+ typename R::Tetrahedron_3 it0; // check the default-constructor
+ typename R::Tetrahedron_3 it(p1,p2,p3,p4);
+ CGAL::Tetrahedron_3<R>  t0(it);
 
  const CGAL::Tetrahedron_3<R> t1(p1,p2,p3,p4);
  CGAL::Tetrahedron_3<R> t2(p2,p1,p3,p4);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_triangle_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_triangle_3.h
@@ -36,9 +36,6 @@ _test_cls_triangle_3(const R& )
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
 
- typename R::Triangle_3 it;
- CGAL::Triangle_3<R> t0(it);
-
  RT n0 =  0;
  RT n1 = 12;
  RT n2 = 16;
@@ -61,7 +58,10 @@ _test_cls_triangle_3(const R& )
  CGAL::Point_3<R> ps2( n0, n7, n0, n5); // (0, 3, 0)
  CGAL::Point_3<R> ps1( n7, n0, n0, n5); // (3, 0, 0)
 
+ typename R::Triangle_3 it; // test default-constructor
+
  const CGAL::Triangle_3<R> t1(p1,p2,p3);
+ CGAL::Triangle_3<R> t0(t1);
  CGAL::Triangle_3<R> t2(p4,p2,p3);
  CGAL::Triangle_3<R> t3(ps1,ps2,ps3);
  CGAL::Triangle_3<R> t4(ps2,ps1,ps3);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -221,8 +221,8 @@ test_new_3(const R& rep)
 
   typename R::Construct_tetrahedron_3 construct_tetrahedron
         = rep.construct_tetrahedron_3_object();
-  Tetrahedron_3 th1;
-  Tetrahedron_3 th2 = construct_tetrahedron(p2,p3,p4,p5);
+  Tetrahedron_3 th0; // test default-constructor
+  Tetrahedron_3 th2 = construct_tetrahedron(p2,p3,p4,p5), th1 = th2;
 
   typename R::Construct_iso_cuboid_3 construct_iso_cuboid
         = rep.construct_iso_cuboid_3_object();


### PR DESCRIPTION
## Summary of Changes

Fix remaining warnings after #3939.

Fix one error from #4033.

## Release Management

* Affected package(s): Kernel_23
* License and copyright ownership: maintenance by GF

