### PR TITLE
[Surface Mesh / PLY] Fix uninitialized warning and error on unhandled properties

### DIFF
--- a/Stream_support/include/CGAL/IO/PLY.h
+++ b/Stream_support/include/CGAL/IO/PLY.h
@@ -375,6 +375,7 @@ public:
         t = property->buffer();
         return;
       }
+    t = {};
   }
 
   template <typename Type>
@@ -389,6 +390,7 @@ public:
         t = property->buffer();
         return;
       }
+    t = {};
   }
 
   void assign (double& t, const char* tag)
@@ -410,6 +412,7 @@ public:
           
         return;
       }
+    t = {};
   }
   
 };

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2212,22 +2212,35 @@ private: //------------------------------------------------------- private data
     std::vector<internal::PLY::Abstract_property_printer<FIndex>*> fprinters;
     internal::PLY::fill_header (os, sm, fprinters);
 
+    
     std::vector<internal::PLY::Abstract_property_printer<EIndex>*> eprinters;
     if (sm.template properties<EIndex>().size() > 1)
     {
-      os << "element edge " << sm.number_of_edges() << std::endl;
-      os << "property int v0" << std::endl;
-      os << "property int v1" << std::endl;
-      internal::PLY::fill_header (os, sm, eprinters);
+      std::ostringstream oss;
+      internal::PLY::fill_header (oss, sm, eprinters);
+
+      if (!eprinters.empty())
+      {
+        os << "element edge " << sm.number_of_edges() << std::endl;
+        os << "property int v0" << std::endl;
+        os << "property int v1" << std::endl;
+        os << oss.str();
+      }
     }
 
     std::vector<internal::PLY::Abstract_property_printer<HIndex>*> hprinters;
     if (sm.template properties<HIndex>().size() > 1)
     {
-      os << "element halfedge " << sm.number_of_halfedges() << std::endl;
-      os << "property int source" << std::endl;
-      os << "property int target" << std::endl;
-      internal::PLY::fill_header (os, sm, hprinters);
+      std::ostringstream oss;
+      internal::PLY::fill_header (oss, sm, hprinters);
+
+      if (!hprinters.empty())
+      {
+        os << "element halfedge " << sm.number_of_halfedges() << std::endl;
+        os << "property int source" << std::endl;
+        os << "property int target" << std::endl;
+        os << oss.str();
+      }
     }
 
     os << "end_header" << std::endl;  


### PR DESCRIPTION
## Summary of Changes

* Fix uninitialized warning (see [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.0-I-72/Polyhedron_Demo/TestReport_lrineau_ArchLinux-CXX17-Release.gz)). Code introduced in 5.0.
* Fix error https://github.com/CGAL/cgal/issues/4067 that happens when a property is found on edges and halfedges, but then its type is not handled, which leads to the header being filled _but_ the properties not written (which leads to an error when reading the produced PLY). Now, the header for edges and halfedges are only written if the properties were actually found with an handled type.

## Release Management

* Affected package(s): Surface_mesh