### PR TITLE
Fix PR #3987 with "mesh surface only"

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -462,7 +462,9 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   if (!sm_items.empty())
   {
     QList<const SMesh*> polyhedrons;
-    sm_items.removeAll(bounding_sm_item);
+    if(!surface_only) {
+      sm_items.removeAll(bounding_sm_item);
+    }
     std::transform(sm_items.begin(), sm_items.end(),
                    std::back_inserter(polyhedrons),
                    [](Scene_surface_mesh_item* item) {


### PR DESCRIPTION
## Summary of Changes

Fix PR #3987 with "mesh surface only". That was a bug in #3987 merged in 4.14.1-dev. If one tries "mesh surface" then there is an assertion `!tree.empty()`:
```
terminate called after throwing an instance of 'CGAL::Assertion_exception'
  what():  CGAL ERROR: assertion violation!
Expr: !tree_.empty()
File: [...]/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
Line: 649
```

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: maintenance by GF

