### PR TITLE
Factorize more code into Polyhedron_demo.cpp

### DIFF
--- a/Polyhedron/demo/Polyhedron/Classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Classification.cpp
@@ -10,20 +10,9 @@
  */
 int main(int argc, char **argv)
 {
-  QSurfaceFormat fmt;
-
-  fmt.setVersion(4, 3);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  QStringList keywords;
-  keywords << "Classification";
-    Polyhedron_demo app(argc, argv,
+  Polyhedron_demo app(argc, argv,
                       "Classification demo",
                       "CGAL Classification Demo",
-                        keywords);
-  //We set the locale to avoid any trouble with VTK
-  std::setlocale(LC_ALL, "C");
+                      QStringList() << "Classification");
   return app.try_exec();
 }

--- a/Polyhedron/demo/Polyhedron/Mesh_3.cpp
+++ b/Polyhedron/demo/Polyhedron/Mesh_3.cpp
@@ -10,20 +10,9 @@
  */
 int main(int argc, char **argv)
 {
-  QSurfaceFormat fmt;
-
-  fmt.setVersion(4, 3);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  QStringList keywords;
-  keywords << "Mesh_3";
-    Polyhedron_demo app(argc, argv,
+  Polyhedron_demo app(argc, argv,
                       "Mesh_3 demo",
                       "CGAL Mesh_3 Demo",
-                        keywords);
-  //We set the locale to avoid any trouble with VTK
-  std::setlocale(LC_ALL, "C");
+                      QStringList() << "Mesh_3");
   return app.try_exec();
 }

--- a/Polyhedron/demo/Polyhedron/Polyhedron_3.cpp
+++ b/Polyhedron/demo/Polyhedron/Polyhedron_3.cpp
@@ -1,8 +1,4 @@
 #include "Polyhedron_demo.h"
-#include <clocale>
-#include <CGAL/Qt/resources.h>
-#include <QSurfaceFormat>
-
 
 /*!
  * \brief Defines the entry point of the demo.
@@ -10,17 +6,8 @@
  */
 int main(int argc, char **argv)
 {
-  QSurfaceFormat fmt;
-
-  fmt.setVersion(4, 3);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-    Polyhedron_demo app(argc, argv,
+  Polyhedron_demo app(argc, argv,
                       "Polyhedron_3 demo",
                       "CGAL Polyhedron Demo");
-  //We set the locale to avoid any trouble with VTK
-  std::setlocale(LC_ALL, "C");
   return app.try_exec();
 }


### PR DESCRIPTION
## Summary of Changes

Factorize more code into Polyhedron_demo.cpp

At the same time, fix that warning from Qt5:
> Attribute Qt::AA_UseDesktopOpenGL must be set before QCoreApplication is created.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: maintenance of the demo

