### PR TITLE
Fix Qt deprecation warnings

### DIFF
--- a/AABB_tree/demo/AABB_tree/MainWindow.cpp
+++ b/AABB_tree/demo/AABB_tree/MainWindow.cpp
@@ -23,7 +23,7 @@ MainWindow::MainWindow(QWidget* parent)
 	m_pViewer = ui->viewer;
 
 	// does not save the state of the viewer 
-	m_pViewer->setStateFileName(QString::null);
+	m_pViewer->setStateFileName(QString());
 
 	// accepts drop events
 	setAcceptDrops(true);

--- a/GraphicsView/demo/Circular_kernel_2/ArcsGraphicsItem.h
+++ b/GraphicsView/demo/Circular_kernel_2/ArcsGraphicsItem.h
@@ -116,10 +116,10 @@ ArcsGraphicsItem<CK>::paint(QPainter *painter,
     Line_arc_2 la;
 
     if(assign(cap_ui, *it)){
-      QMatrix matrix = painter->matrix();
-      painter->resetMatrix();
+      QTransform matrix = painter->worldTransform();
+      painter->resetTransform();
       painter->drawPoint(matrix.map(convert(cap_ui.first)));
-      painter->setMatrix(matrix);
+      painter->setWorldTransform(matrix);
     }if(assign(ca, *it)){
       painterostream << ca;
     } else if(assign(la, *it)){

--- a/GraphicsView/demo/Periodic_2_triangulation_2/include/CGAL/Qt/PeriodicTriangulationGraphicsItem.h
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/include/CGAL/Qt/PeriodicTriangulationGraphicsItem.h
@@ -223,8 +223,8 @@ namespace CGAL {
         
         Converter<Geom_traits> convert;
 
-        QMatrix matrix = painter->matrix();
-        painter->resetMatrix();
+        QTransform matrix = painter->worldTransform();
+        painter->resetTransform();
 
         { // Faces
           painter->setPen(QPen());
@@ -254,7 +254,7 @@ namespace CGAL {
           }
         }
 
-        painter->setMatrix(matrix);
+        painter->setWorldTransform(matrix);
       }      
 
       if(visibleEdges()) {
@@ -272,8 +272,8 @@ namespace CGAL {
       if(visibleVertices()) {
         Converter<Geom_traits> convert;
         
-        QMatrix matrix = painter->matrix();
-        painter->resetMatrix();
+        QTransform matrix = painter->worldTransform();
+        painter->resetTransform();
 
         QPen pen = verticesPen();
         if (t->number_of_vertices() < 8) {
@@ -301,7 +301,7 @@ namespace CGAL {
             }
         }
 
-        painter->setMatrix(matrix);
+        painter->setWorldTransform(matrix);
       }
     }
     
@@ -312,10 +312,10 @@ namespace CGAL {
       Converter<Geom_traits> convert;
       
       m_painter->setPen(this->verticesPen());
-      QMatrix matrix = m_painter->matrix();
-      m_painter->resetMatrix();
+      QTransform matrix = m_painter->worldTransform();
+      m_painter->resetTransform();
       m_painter->drawPoint(matrix.map(convert(point)));
-      m_painter->setMatrix(matrix);
+      m_painter->setWorldTransform(matrix);
     }
     
     template <typename T>
@@ -325,10 +325,10 @@ namespace CGAL {
       Converter<Geom_traits> convert;
       
       m_painter->setPen(this->verticesPen());
-      QMatrix matrix = m_painter->matrix();
-      m_painter->resetMatrix();
+      QTransform matrix = m_painter->worldTransform();
+      m_painter->resetTransform();
       m_painter->drawPoint(matrix.map(convert(vh->point())));
-      m_painter->setMatrix(matrix);
+      m_painter->setWorldTransform(matrix);
     }
     
     template <typename T>

--- a/GraphicsView/include/CGAL/Qt/AlphaShapeGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/AlphaShapeGraphicsItem.h
@@ -242,8 +242,8 @@ AlphaShapeGraphicsItem<T>::paintVertices(QPainter *painter)
     Converter<Geom_traits> convert;
 
     painter->setPen(verticesPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename T::Finite_vertices_iterator it = t->finite_vertices_begin();
         it != t->finite_vertices_end();
         it++){
@@ -260,10 +260,10 @@ AlphaShapeGraphicsItem<T>::paintOneVertex(const typename T::Point& point)
   Converter<Geom_traits> convert;
 
   m_painter->setPen(this->verticesPen());
-  QMatrix matrix = m_painter->matrix();
-  m_painter->resetMatrix();
+  QTransform matrix = m_painter->worldTransform();
+  m_painter->resetTransform();
   m_painter->drawPoint(matrix.map(convert(point)));
-  m_painter->setMatrix(matrix);
+  m_painter->setWorldTransform(matrix);
 }
 
 template <typename T>
@@ -273,10 +273,10 @@ AlphaShapeGraphicsItem<T>::paintVertex(typename T::Vertex_handle vh)
   Converter<Geom_traits> convert;
 
   m_painter->setPen(this->verticesPen());
-  QMatrix matrix = m_painter->matrix();
-  m_painter->resetMatrix();
+  QTransform matrix = m_painter->worldTransform();
+  m_painter->resetTransform();
   m_painter->drawPoint(matrix.map(convert(vh->point())));
-  m_painter->setMatrix(matrix);
+  m_painter->setWorldTransform(matrix);
 }
 
 template <typename T>

--- a/GraphicsView/include/CGAL/Qt/DelaunayMeshTriangulationGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/DelaunayMeshTriangulationGraphicsItem.h
@@ -265,14 +265,14 @@ DelaunayMeshTriangulationGraphicsItem<T>::paintSeeds(QPainter *painter)
   {
     Converter<Geom_traits> convert;
     painter->setPen(this->seedsPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
 
     typename std::list<Point>::iterator sit;
     for(sit = seeds_begin; sit != seeds_end; ++sit)
       painter->drawPoint(matrix.map(convert(*sit)));
 
-    painter->setMatrix(matrix);
+    painter->setWorldTransform(matrix);
   }
 }
 

--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -462,7 +462,13 @@ void DemosMainWindow::readState(QString groupname, Options /*what_to_save*/)
   resize(settings.value("size", this->size()).toSize());
 
   QPoint pos = settings.value("pos", this->pos()).toPoint();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if(QGuiApplication::screenAt(pos)) {
+#else
+   QDesktopWidget* desktop = qApp->desktop();
+     if(desktop->availableGeometry(pos).contains(pos)) {
+#endif
+
     move(pos);
   }
   QByteArray mainWindowState = settings.value("state").toByteArray();

--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -461,9 +461,8 @@ void DemosMainWindow::readState(QString groupname, Options /*what_to_save*/)
   settings.beginGroup(groupname);
   resize(settings.value("size", this->size()).toSize());
 
-  QDesktopWidget* desktop = qApp->desktop();
   QPoint pos = settings.value("pos", this->pos()).toPoint();
-  if(desktop->availableGeometry(pos).contains(pos)) {
+  if(QGuiApplication::screenAt(pos)) {
     move(pos);
   }
   QByteArray mainWindowState = settings.value("state").toByteArray();

--- a/GraphicsView/include/CGAL/Qt/PointsGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PointsGraphicsItem.h
@@ -124,8 +124,8 @@ PointsGraphicsItem<P>::paint(QPainter *painter,
     Converter<Traits> convert;
 
     painter->setPen(verticesPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename P::iterator it = points->begin();
         it != points->end();
         it++){

--- a/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
@@ -160,8 +160,8 @@ PointsInKdTreeGraphicsItem<KdTree>::paint(QPainter *painter,
   Iso_rectangle_2 isor = convert(option->exposedRect);
   Fuzzy_iso_box range(isor.vertex(0), isor.vertex(2));
   painter->setPen(verticesPen());
-  QMatrix matrix = painter->matrix();
-  painter->resetMatrix();
+  QTransform matrix = painter->worldTransform();
+  painter->resetTransform();
   Draw<Traits> draw(painter, &matrix);
   kdtree->search(draw, range);
 }

--- a/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PointsInKdTreeGraphicsItem.h
@@ -57,10 +57,10 @@ class PointsInKdTreeGraphicsItem : public GraphicsItem
   class Draw
     : public CGAL::cpp98::iterator<std::output_iterator_tag, void, void, void, void> {
     QPainter* painter;
-    QMatrix* matrix;
+    QTransform* matrix;
     Converter<K> convert;
   public:
-    Draw(QPainter* painter, QMatrix* matrix)
+    Draw(QPainter* painter, QTransform* matrix)
       : painter(painter), matrix(matrix)
     {}
 

--- a/GraphicsView/include/CGAL/Qt/PolygonGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PolygonGraphicsItem.h
@@ -154,8 +154,8 @@ PolygonGraphicsItem<P>::paint(QPainter *painter,
     Converter<Traits> convert;
 
     painter->setPen(verticesPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename P::Vertex_iterator it = poly->vertices_begin();
         it != poly->vertices_end();
         it++){

--- a/GraphicsView/include/CGAL/Qt/PolygonWithHolesGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/PolygonWithHolesGraphicsItem.h
@@ -181,8 +181,8 @@ PolygonWithHolesGraphicsItem<P>::paint(QPainter *painter,
   if(drawVertices()) {
 
     painter->setPen(verticesPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename P::General_polygon_2::Vertex_iterator it = poly->outer_boundary().vertices_begin();
         it != poly->outer_boundary().vertices_end();
         it++){

--- a/GraphicsView/include/CGAL/Qt/RegularGridGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/RegularGridGraphicsItem.h
@@ -180,8 +180,8 @@ void
 
   /*
   painter->setPen(this->verticesPen());
-  QMatrix matrix = painter->matrix();
-  painter->resetMatrix();
+  QTransform matrix = painter->worldTransform();
+  painter->resetTransform();
   for(int i = 0; i < nw; i++){
     for(int j = 0; j < nh; j++){
       painter->drawPoint(matrix.map(QPointF(i*dw, j*dh)));

--- a/GraphicsView/include/CGAL/Qt/RegularGridVectorFieldGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/RegularGridVectorFieldGraphicsItem.h
@@ -163,8 +163,8 @@ void
     }
   }
   painter->setPen(this->verticesPen());
-  QMatrix matrix = painter->matrix();
-  painter->resetMatrix();
+  QTransform matrix = painter->worldTransform();
+  painter->resetTransform();
   for(int i = 0; i < nw; i++){
     for(int j = 0; j < nh; j++){
       painter->drawPoint(matrix.map(QPointF(i*dw, j*dh)));

--- a/GraphicsView/include/CGAL/Qt/RegularTriangulationGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/RegularTriangulationGraphicsItem.h
@@ -209,8 +209,8 @@ RegularTriangulationGraphicsItem<T>::paintVertices(QPainter *painter)
     }
 
 
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename T::Finite_vertices_iterator it = t->finite_vertices_begin();
         it != t->finite_vertices_end();
         it++){
@@ -228,10 +228,10 @@ RegularTriangulationGraphicsItem<T>::paintOneVertex(const typename T::Point& poi
   typename T::Bare_point p = t->geom_traits().construct_point_2_object()(point);
 
   m_painter->setPen(this->verticesPen());
-  QMatrix matrix = m_painter->matrix();
-  m_painter->resetMatrix();
+  QTransform matrix = m_painter->worldTransform();
+  m_painter->resetTransform();
   m_painter->drawPoint(matrix.map(convert(p)));
-  m_painter->setMatrix(matrix);
+  m_painter->setWorldTransform(matrix);
 }
 
 template <typename T>

--- a/GraphicsView/include/CGAL/Qt/SegmentDelaunayGraphGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/SegmentDelaunayGraphGraphicsItem.h
@@ -165,8 +165,8 @@ SegmentDelaunayGraphGraphicsItem<T>::drawAll(QPainter *painter, const QStyleOpti
     }
     {
     m_painter->setPen(this->verticesPen());
-    QMatrix matrix = m_painter->matrix();
-    m_painter->resetMatrix();
+    QTransform matrix = m_painter->worldTransform();
+    m_painter->resetTransform();
     Converter<Kern> convert;
       typename T::Finite_vertices_iterator vit;
       for (vit = t->finite_vertices_begin();

--- a/GraphicsView/include/CGAL/Qt/SegmentDelaunayGraphLinfGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/SegmentDelaunayGraphLinfGraphicsItem.h
@@ -200,8 +200,8 @@ SegmentDelaunayGraphLinfGraphicsItem<T>::drawAll(QPainter *painter, const QStyle
     }
     {
     m_painter->setPen(this->verticesPen());
-    QMatrix matrix = m_painter->matrix();
-    m_painter->resetMatrix();
+    QTransform matrix = m_painter->worldTransform();
+    m_painter->resetTransform();
     Converter<Kern> convert;
       typename T::Finite_vertices_iterator vit;
       for (vit = t->finite_vertices_begin();

--- a/GraphicsView/include/CGAL/Qt/TriangulationGraphicsItem.h
+++ b/GraphicsView/include/CGAL/Qt/TriangulationGraphicsItem.h
@@ -197,8 +197,8 @@ TriangulationGraphicsItem<T>::paintVertices(QPainter *painter)
     Converter<Geom_traits> convert;
 
     painter->setPen(verticesPen());
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename T::Finite_vertices_iterator it = t->finite_vertices_begin();
         it != t->finite_vertices_end();
         it++){
@@ -215,10 +215,10 @@ TriangulationGraphicsItem<T>::paintOneVertex(const typename T::Point& point)
   Converter<Geom_traits> convert;
 
   m_painter->setPen(this->verticesPen());
-  QMatrix matrix = m_painter->matrix();
-  m_painter->resetMatrix();
+  QTransform matrix = m_painter->worldTransform();
+  m_painter->resetTransform();
   m_painter->drawPoint(matrix.map(convert(point)));
-  m_painter->setMatrix(matrix);
+  m_painter->setWorldTransform(matrix);
 }
 
 template <typename T>
@@ -228,10 +228,10 @@ TriangulationGraphicsItem<T>::paintVertex(typename T::Vertex_handle vh)
   Converter<Geom_traits> convert;
 
   m_painter->setPen(this->verticesPen());
-  QMatrix matrix = m_painter->matrix();
-  m_painter->resetMatrix();
+  QTransform matrix = m_painter->worldTransform();
+  m_painter->resetTransform();
   m_painter->drawPoint(matrix.map(convert(vh->point())));
-  m_painter->setMatrix(matrix);
+  m_painter->setWorldTransform(matrix);
 }
 
 template <typename T>

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -1606,7 +1606,7 @@ CGAL_INLINE_FUNCTION
 QString CGAL::QGLViewer::mouseActionString(qglviewer::MouseAction ma) {
   switch (ma) {
   case CGAL::qglviewer::NO_MOUSE_ACTION:
-    return QString::null;
+    return QString();
   case CGAL::qglviewer::ROTATE:
     return CGAL::QGLViewer::tr("Rotates", "ROTATE mouse action");
   case CGAL::qglviewer::ZOOM:
@@ -1632,14 +1632,14 @@ QString CGAL::QGLViewer::mouseActionString(qglviewer::MouseAction ma) {
   case CGAL::qglviewer::ZOOM_ON_REGION:
     return CGAL::QGLViewer::tr("Zooms on region for", "ZOOM_ON_REGION mouse action");
   }
-  return QString::null;
+  return QString();
 }
 
 CGAL_INLINE_FUNCTION
 QString CGAL::QGLViewer::clickActionString(CGAL::qglviewer::ClickAction ca) {
   switch (ca) {
   case CGAL::qglviewer::NO_CLICK_ACTION:
-    return QString::null;
+    return QString();
   case CGAL::qglviewer::ZOOM_ON_PIXEL:
     return CGAL::QGLViewer::tr("Zooms on pixel", "ZOOM_ON_PIXEL click action");
   case CGAL::qglviewer::ZOOM_TO_FIT:
@@ -1664,7 +1664,7 @@ QString CGAL::QGLViewer::clickActionString(CGAL::qglviewer::ClickAction ca) {
   case CGAL::qglviewer::ALIGN_CAMERA:
     return CGAL::QGLViewer::tr("Aligns camera", "ALIGN_CAMERA click action");
   }
-  return QString::null;
+  return QString();
 }
 
 static QString keyString(unsigned int key) {
@@ -1946,7 +1946,7 @@ void CGAL::QGLViewer::setKeyDescription(unsigned int key, QString description) {
 CGAL_INLINE_FUNCTION
 QString CGAL::QGLViewer::cameraPathKeysString() const {
   if (pathIndex_.isEmpty())
-    return QString::null;
+    return QString();
 
   QVector< ::Qt::Key> keys;
   keys.reserve(pathIndex_.count());
@@ -1954,7 +1954,7 @@ QString CGAL::QGLViewer::cameraPathKeysString() const {
                                                   endi = pathIndex_.end();
        i != endi; ++i)
     keys.push_back(i.key());
-  qSort(keys);
+  std::sort(keys.begin(), keys.end());
 
   QVector< ::Qt::Key>::const_iterator it = keys.begin(), end = keys.end();
   QString res = keyString(*it);
@@ -3544,7 +3544,7 @@ This is the name of the XML file where saveStateToFile() saves the viewer state
 restoreStateFromFile() to restore this state later (usually in your init()
 method).
 
-Setting this value to \c QString::null will disable the automatic state file
+Setting this value to \c QString() will disable the automatic state file
 saving that normally occurs on exit.
 
 If more than one viewer are created by the application, this function will
@@ -3576,7 +3576,7 @@ Use restoreStateFromFile() to restore this viewer state.
 
 This method is automatically called when a viewer is closed (using Escape or
 using the window's upper right \c x close button). setStateFileName() to \c
-QString::null to prevent this. */
+QString() to prevent this. */
 CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::saveStateToFile() {
   QString name = stateFileName();

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -145,7 +145,7 @@ MainWindow::MainWindow(bool verbose, QWidget* parent)
   sceneView = ui->sceneView;
   viewer = ui->viewer;
   // do not save the state of the viewer (anoying)
-  viewer->setStateFileName(QString::null);
+  viewer->setStateFileName(QString());
 
   // setup scene
   scene = new Scene(this);
@@ -677,7 +677,7 @@ void MainWindow::updateMenus()
   }
   // sort the operations menu by name
   as = ui->menuOperations->actions();
-  qSort(as.begin(), as.end(), actionsByName);
+  std::sort(as.begin(), as.end(), actionsByName);
   ui->menuOperations->clear();
   ui->menuOperations->addActions(as);
 }
@@ -1990,9 +1990,9 @@ void MainWindow::on_actionLoadPlugin_triggered()
 void MainWindow::recurseExpand(QModelIndex index)
 {
     int row = index.row();
-    if(index.child(0,0).isValid())
+    if(scene->index(0,0,index).isValid())
     {
-        recurseExpand(index.child(0,0));
+        recurseExpand(scene->index(0,0,index));
     }
         CGAL::Three::Scene_group_item* group =
                 qobject_cast<CGAL::Three::Scene_group_item*>(scene->item(scene->getIdFromModelIndex(index)));
@@ -2171,10 +2171,17 @@ void MainWindow::resetHeader()
   sceneView->header()->setSectionResizeMode(Scene::RenderingModeColumn, QHeaderView::ResizeToContents);
   sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
   sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+           sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().horizontalAdvance("_#_"));
+           sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
+           sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_AB_")));
+           sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_View_")));
+#else
   sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width("_#_"));
   sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
   sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString("_AB_")));
   sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString("_View_")));
+#endif
 }
 
 void MainWindow::reset_default_loaders()

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -2172,10 +2172,10 @@ void MainWindow::resetHeader()
   sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
   sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-           sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().horizontalAdvance("_#_"));
-           sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
-           sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_AB_")));
-           sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_View_")));
+  sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().horizontalAdvance("_#_"));
+  sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
+  sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_AB_")));
+  sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_View_")));
 #else
   sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width("_#_"));
   sceneView->resizeColumnToContents(Scene::RenderingModeColumn);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -577,7 +577,11 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = x_cubeLabel->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+      x_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
+#else
       x_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
+#endif
       x_cubeLabel->setText("0");
       x_cubeLabel->setValidator(validator);
 
@@ -603,7 +607,11 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = y_cubeLabel->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+      y_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
+#else
       y_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
+#endif
       y_cubeLabel->setText("0");
       y_cubeLabel->setValidator(validator);
       y_slider = new QSlider(mw);
@@ -628,7 +636,11 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = z_cubeLabel->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+      z_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
+#else
       z_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
+#endif
       z_cubeLabel->setText("0");
       z_cubeLabel->setValidator(validator);
       z_slider = new QSlider(mw);

--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -817,7 +817,7 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
         QList<float> depths = picked_item_IDs.keys();
         if(!depths.isEmpty())
         {
-            qSort(depths);
+            std::sort(depths.begin(), depths.end());
             int id = picked_item_IDs[depths.first()];
             setSelectedItemIndex(id);
             viewer->setSelectedName(id);

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1491,7 +1491,7 @@ void Scene_c3t3_item_priv::computeIntersection(const Primitive& facet)
   Tr::Cell_handle ch = facet.id().first;
   if(intersected_cells.find(ch) == intersected_cells.end())
   {
-    QColor c = this->colors_subdomains[ch->subdomain_index()].light(50);
+    QColor c = this->colors_subdomains[ch->subdomain_index()].lighter(50);
 
     const Tr::Bare_point& pa = wp2p(ch->vertex(0)->point());
     const Tr::Bare_point& pb = wp2p(ch->vertex(1)->point());
@@ -1516,7 +1516,7 @@ void Scene_c3t3_item_priv::computeIntersection(const Primitive& facet)
         const Tr::Bare_point& pc = wp2p(nh->vertex(2)->point());
         const Tr::Bare_point& pd = wp2p(nh->vertex(3)->point());
 
-        QColor c = this->colors_subdomains[nh->subdomain_index()].light(50);
+        QColor c = this->colors_subdomains[nh->subdomain_index()].lighter(50);
 
         CGAL::Color color(UC(c.red()), UC(c.green()), UC(c.blue()));
 

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -973,7 +973,13 @@ void Viewer::drawVisualHints()
     //Prints the displayMessage
     QFont font = QFont();
     QFontMetrics fm(font);
-    TextItem *message_text = new TextItem(float(10 + fm.width(d->message)/2),
+    TextItem *message_text = new TextItem(float(10 +
+                                            #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                                                   fm.horizontalAdvance(d->message)/2)
+                                            #else
+                                                   fm.width(d->message)/2)
+                                            #endif
+                                          ,
                                           float(height()-20),
                                           0, d->message, false,
                                           QFont(), Qt::gray );

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/include/CGAL/Qt/Polyline_simplification_2_graphics_item.h
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/include/CGAL/Qt/Polyline_simplification_2_graphics_item.h
@@ -175,10 +175,10 @@ PolylineSimplificationGraphicsItem<PCT>::paintVertex( typename PCT::Vertex_handl
   // } else {
     this->m_painter->setPen(this->verticesPen());
     //  }
-  QMatrix matrix = this->m_painter->matrix();
-  this->m_painter->resetMatrix();
+  QTransform matrix = this->m_painter->worldTransform();
+  this->m_painter->resetTransform();
   this->m_painter->drawPoint(matrix.map(convert(vh->point())));
-  this->m_painter->setMatrix(matrix);
+  this->m_painter->setWorldTransform(matrix);
 }
 
 
@@ -190,8 +190,8 @@ PolylineSimplificationGraphicsItem<PCT>::paintVertices(QPainter *painter)
   {
     Converter<Geom_traits> convert;
 
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(Constraint_iterator cit = this->t->constraints_begin();
         cit != this->t->constraints_end();
         ++cit){

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/include/CGAL/Qt/TriangulationArrangementGraphicsItem.h
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/include/CGAL/Qt/TriangulationArrangementGraphicsItem.h
@@ -154,10 +154,10 @@ TriangulationArrangementGraphicsItem<T>::paintVertex(typename T::Vertex_handle v
     } else {
       this->m_painter->setPen(this->verticesPen());
     }
-    QMatrix matrix = this->m_painter->matrix();
-    this->m_painter->resetMatrix();
+    QTransform matrix = this->m_painter->worldTransform();
+    this->m_painter->resetTransform();
     this->m_painter->drawPoint(matrix.map(convert(vh->point())));
-    this->m_painter->setMatrix(matrix);
+    this->m_painter->setWorldTransform(matrix);
   }
 }
 
@@ -170,8 +170,8 @@ TriangulationArrangementGraphicsItem<T>::paintVertices(QPainter *painter)
   {
     Converter<Geom_traits> convert;
 
-    QMatrix matrix = painter->matrix();
-    painter->resetMatrix();
+    QTransform matrix = painter->worldTransform();
+    painter->resetTransform();
     for(typename T::Finite_vertices_iterator it = this->t->finite_vertices_begin();
         it != this->t->finite_vertices_end();
         it++)

--- a/Principal_component_analysis/demo/Principal_component_analysis/MainWindow.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/MainWindow.cpp
@@ -26,7 +26,7 @@ MainWindow::MainWindow(QWidget* parent)
 	m_pViewer = ui->viewer;
 
 	// does not save the state of the viewer 
-	m_pViewer->setStateFileName(QString::null);
+	m_pViewer->setStateFileName(QString());
 
 	// accepts drop events
 	setAcceptDrops(true);

--- a/Three/include/CGAL/Three/TextRenderer.h
+++ b/Three/include/CGAL/Three/TextRenderer.h
@@ -30,6 +30,7 @@
 
 #include <CGAL/Three/Viewer_interface.h>
 #include <CGAL/Three/Scene_interface.h>
+#include <QtGlobal>
 
 class QVector3D;
 namespace CGAL{
@@ -60,7 +61,12 @@ public :
         :x(p_x), y(p_y), z(p_z),_3D(p_3D), _is_always_visible(always_visible), m_text(p_text), m_font(font), m_color(p_color)
     {
        QFontMetrics fm(m_font);
-       _width = float(fm.width(m_text));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+       _width = float(fm.horizontalAdvance(m_text)+2);
+#else
+       _width = float(fm.width(m_text)+2);
+#endif
+
        _height = float(fm.height());
     }
     //!\brief Accessor for the string

--- a/Triangulation_3/demo/Triangulation_3/Viewer.cpp
+++ b/Triangulation_3/demo/Triangulation_3/Viewer.cpp
@@ -1766,7 +1766,7 @@ void Viewer::endSelection(const QPoint& p)
   QList<float> depths = picked_IDs.keys();
   if(!depths.isEmpty())
   {
-      qSort(depths);
+      std::sort(depths.begin(), depths.end());
       id = picked_IDs[depths.first()];
       picked = true;
   }
@@ -2267,7 +2267,7 @@ void Viewer::keyPressEvent(QKeyEvent *event)
     else if( m_curMode == SELECT
              && event->key()==Qt::Key_Delete && modifiers==Qt::NoButton ) {
         // sort selected id's in descending order
-        qSort(m_vidSeled.begin(), m_vidSeled.end(), qGreater<int>());
+        std::sort(m_vidSeled.begin(), m_vidSeled.end(), std::greater<int>());
         for(QList<int>::iterator vit=m_vidSeled.begin(); vit<m_vidSeled.end(); ++vit) {
             // remove the selected point from DT and vertex_handle_array
             // note: QList::takeAt will removes the item at index position i and returns it.


### PR DESCRIPTION
## Summary of Changes
Replace the `matrix` calls with `worldTransform`
## Release Management

* Affected package(s):GraphicsView
* Issue(s) solved (if any): fix #4061 
