### PR TITLE
Polyhedron_IO: OBJ_reader reads relative indices

### DIFF
--- a/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/OBJ_reader.h
@@ -48,7 +48,13 @@ read_OBJ( std::istream& input,
       faces.push_back( std::vector<std::size_t>() );
       while(iss >> i)
       {
-        faces.back().push_back(i-1);
+        if(i < 1)
+        {
+          faces.back().push_back(points.size()+i);//negative indices are relative references
+        }
+        else {
+          faces.back().push_back(i-1);
+        }
         iss.ignore(256, ' ');
       }
     }


### PR DESCRIPTION

## Summary of Changes

If an index is negative in a face of an OBJ file, reads it relatively to the current state of the points vector instead of brutally crashing.
## Release Management

* Affected package(s):Polyhedron_IO
* Issue(s) solved (if any): fix #4066 
