### PR TITLE
Polyhedron Demo: Fix View Menu

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -2981,7 +2981,7 @@ QObject* MainWindow::getDirectChild(QObject* widget)
   return getDirectChild(widget->parent());
 }
 
-void MainWindow::on_action_Organize_Viewers_triggered()
+void MainWindow::on_action_Rearrange_Viewers_triggered()
 {
   if(ui->mdiArea->subWindowList().size() == 1)
     ui->mdiArea->subWindowList().first()->showMaximized();
@@ -3032,7 +3032,7 @@ SubViewer::SubViewer(QWidget *parent, MainWindow* mw, Viewer* mainviewer)
   actionCopyCamera->setObjectName("actionCopyCamera");
   QAction* actionPasteCamera = new QAction("&Paste Camera",this);
   actionPasteCamera->setObjectName("actionPasteCamera");
-  QMenu* cameraMenu = new QMenu("Camera", mw);
+  QMenu* cameraMenu = new QMenu("Ca&mera", mw);
   cameraMenu->addAction(actionDumpCamera);
   cameraMenu->addAction(actionCopyCamera);
   cameraMenu->addAction(actionPasteCamera);
@@ -3048,12 +3048,12 @@ SubViewer::SubViewer(QWidget *parent, MainWindow* mw, Viewer* mainviewer)
   actionDrawTwoSide->setCheckable(true);
   actionDrawTwoSide->setChecked(false);
   viewMenu->addAction(actionDrawTwoSide);
-  QAction* actionQuick = new QAction("Quick Camera Mode",this);
+  QAction* actionQuick = new QAction("&Quick Camera Mode",this);
   actionQuick->setObjectName("actionQuick");
   actionQuick->setCheckable(true);
   actionQuick->setChecked(true);
   viewMenu->addAction(actionQuick);
-  QAction* actionOrtho = new QAction("Orthographic Projection",this);
+  QAction* actionOrtho = new QAction("&Orthographic Projection",this);
   actionOrtho->setObjectName("actionOrtho");
   actionOrtho->setCheckable(true);
   actionOrtho->setChecked(false);
@@ -3136,6 +3136,9 @@ void SubViewer::changeEvent(QEvent *event)
               //| Qt::WindowSystemMenuHint
               | Qt::WindowTitleHint
               );
+      QAction* action = mw->findChild<QAction*>("action_Rearrange_Viewers");
+      action->setVisible(false);
+      viewer->update();
     }
     else
     {
@@ -3151,6 +3154,10 @@ void SubViewer::changeEvent(QEvent *event)
               | Qt::WindowSystemMenuHint
               | Qt::WindowTitleHint
               );
+      QAction* action = mw->findChild<QAction*>("action_Rearrange_Viewers");
+      action->setVisible(true);
+      for(auto v : CGAL::QGLViewer::QGLViewerPool())
+        v->update();
     }
   }
 }

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -183,7 +183,15 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
     shortcut = new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_R), this);
     connect(shortcut, &QShortcut::activated,
             this, &MainWindow::recenterScene);
-
+    shortcut = new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_T), this);
+    connect(shortcut, &QShortcut::activated,
+            this,
+            [this](){
+      Viewer* viewer = qobject_cast<Viewer*>(CGAL::Three::Three::activeViewer());
+      bool b = viewer->property("draw_two_sides").toBool();
+      viewer->setTwoSides(!b);
+    }
+            );
   }
 
   proxyModel = new QSortFilterProxyModel(this);

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -180,6 +180,10 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
     shortcut = new QShortcut(QKeySequence(Qt::Key_F11), this);
     connect(shortcut, SIGNAL(activated()),
             this, SLOT(toggleFullScreen()));
+    shortcut = new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_R), this);
+    connect(shortcut, &QShortcut::activated,
+            this, &MainWindow::recenterScene);
+
   }
 
   proxyModel = new QSortFilterProxyModel(this);
@@ -2366,7 +2370,7 @@ void MainWindow::setAddKeyFrameKeyboardModifiers(::Qt::KeyboardModifiers m)
   viewer->setAddKeyFrameKeyboardModifiers(m);
 }
 
-void MainWindow::on_actionRecenterScene_triggered()
+void MainWindow::recenterScene()
 {
   //force the recomputaion of the bbox
   bbox_need_update = true;

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -186,7 +186,7 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
     shortcut = new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_T), this);
     connect(shortcut, &QShortcut::activated,
             this,
-            [this](){
+            [](){
       Viewer* viewer = qobject_cast<Viewer*>(CGAL::Three::Three::activeViewer());
       bool b = viewer->property("draw_two_sides").toBool();
       viewer->setTwoSides(!b);

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -362,7 +362,7 @@ protected Q_SLOTS:
   //!menus.
   void filterOperations();
   //!Updates the bounding box and moves the camera to fits the scene.
-  void on_actionRecenterScene_triggered();
+  void recenterScene();
   //!Resizes the header of the scene view
   void resetHeader();
   //!apply an action named `name` to all selected items

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -463,7 +463,7 @@ private:
 
 private Q_SLOTS:
   void on_actionAdd_Viewer_triggered();
-  void on_action_Organize_Viewers_triggered();
+  void on_action_Rearrange_Viewers_triggered();
   void recenterViewer();
   
 private:

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -94,7 +94,6 @@
     </widget>
     <addaction name="actionAdd_Viewer"/>
     <addaction name="action_Organize_Viewers"/>
-    <addaction name="actionRecenterScene"/>
     <addaction name="menuDockWindows"/>
     <addaction name="separator"/>
    </widget>
@@ -454,14 +453,6 @@
     <string>&amp;Organize Viewers</string>
    </property>
   </action>
-  <action name="actionRecenterScene">
-   <property name="text">
-    <string>Recenter Scene</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+R</string>
-   </property>
-  </action>
   <action name="actionSa_ve_Scene_as_Script">
    <property name="text">
     <string>Sa&amp;ve the Scene as a Script File...</string>
@@ -474,8 +465,6 @@
   </action>
  </widget>
  <resources>
-  <include location="Polyhedron_3.qrc"/>
-  <include location="Polyhedron_3.qrc"/>
   <include location="Polyhedron_3.qrc"/>
   <include location="Polyhedron_3.qrc"/>
  </resources>

--- a/Polyhedron/demo/Polyhedron/MainWindow.ui
+++ b/Polyhedron/demo/Polyhedron/MainWindow.ui
@@ -93,7 +93,7 @@
      <addaction name="dummyAction"/>
     </widget>
     <addaction name="actionAdd_Viewer"/>
-    <addaction name="action_Organize_Viewers"/>
+    <addaction name="action_Rearrange_Viewers"/>
     <addaction name="menuDockWindows"/>
     <addaction name="separator"/>
    </widget>
@@ -448,9 +448,9 @@
     <string>Add &amp;Viewer</string>
    </property>
   </action>
-  <action name="action_Organize_Viewers">
+  <action name="action_Rearrange_Viewers">
    <property name="text">
-    <string>&amp;Organize Viewers</string>
+    <string>&amp;Rearrange Viewers</string>
    </property>
   </action>
   <action name="actionSa_ve_Scene_as_Script">


### PR DESCRIPTION
## Summary of Changes

- [x] Draw Two Sides has lost its shortcut Ctrl+T
- [x] The mnemonic Alt+M is lost for Camera
- [x] Recenter scene is present twice.
- [x] "Organize viewer" should be renamed "Rearrange viewers", and be hidden when there is only one viewer that is fullscreen.
- [x] Set the mnemonic of Quick Camera Mode on the Q,
- [x] Set the mnemonic of Orthographic Projection on the O.
## Release Management
* Issue(s) solved (if any): fix #4070 

