### PR TITLE
Move store outside the loop.

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Weighted_point.h
@@ -186,11 +186,10 @@ template <class R_> struct Power_center : Store_kernel<R_> {
     for(i=0; ++f!=e; ++i) {
       WPoint const& wp=*f;
       Point const& p=pdw(wp);
-      FT const& np = sdo(p) - pw(wp);
       for(int j=0;j<d;++j) {
 	m(i,j)=2*(c(p,j)-c(p0,j));
-	b[i] = np - n0;
       }
+      b[i] = sdo(p) - pw(wp) - n0;
     }
     CGAL_assertion (i == d);
     Vec res = typename CVec::Dimension()(d);;

--- a/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
@@ -640,8 +640,8 @@ template <class R_> struct Construct_circumcenter : Store_kernel<R_> {
 	Point const& p=*f;
 	for(int j=0;j<d;++j) {
 	  m(i,j)=2*(c(p,j)-c(p0,j));
-	  b[i] = sdo(p) - n0;
 	}
+	b[i] = sdo(p) - n0;
       }
       CGAL_assertion (i == d);
       Vec res = typename CVec::Dimension()(d);;


### PR DESCRIPTION
## Summary of Changes

Looks like a typo kind of mistake: the value was computed and stored repeatedly in the inner loop instead of once in the outer loop... At least it was correct, if wasteful.

## Release Management

* Affected package(s): NewKernel_d