### PR TITLE
Kernel 23: remove epick without intervals

### DIFF
--- a/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 
 
-typedef CGAL::Epick_without_intervals K;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Polyhedron_3<K> Polyhedron_3;
 typedef K::Point_3 Point_3;
 

--- a/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
@@ -81,6 +81,4 @@ int main()
   test<Epec,CGAL::Polyhedron_3<Epec> >();
   test<Epic,CGAL::Surface_mesh<Epic::Point_3> >();
   test<Epec,CGAL::Surface_mesh<Epec::Point_3> >();
-  test<CGAL::Epick_without_intervals,
-       CGAL::Surface_mesh<CGAL::Epick_without_intervals::Point_3> >();
 }

--- a/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
+++ b/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
@@ -45,12 +45,6 @@ class Epick
 #endif
 {};
 
-class Epick_without_intervals
-  : public Static_filters_base<
-      Type_equality_wrapper< Simple_cartesian<double>::Base<Epick_without_intervals>::Type,
-                             Epick_without_intervals > >
-{};
-
 typedef Epick Exact_predicates_inexact_constructions_kernel;
 
 template <>

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -79,8 +79,7 @@ main()
   test<Cls>();
   std::cout << "Testing with Epick:\n";
   test<CGAL::Epick>();
-  std::cout << "Testing with Epick_without_intervals:\n";
-  test<CGAL::Epick_without_intervals>();
+
   return 0;
 }
 


### PR DESCRIPTION
## Summary of Changes

`EPICK_without_intervals` actually inherits intervals, defeating its purpose. It might be useful and can be fixed e.g. by changing the way the static filter wrapper works (see https://github.com/CGAL/cgal/pull/3939); however, the release is nigh, and so this PR removes it.

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): -
* License and copyright ownership: no change

