### PR TITLE
Derecursification of overlap detectiong on the right of event

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_insertion_ss_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_insertion_ss_visitor.h
@@ -158,7 +158,7 @@ add_subcurve(const X_monotone_curve_2& cv, Subcurve* sc)
   if (Base::add_subcurve_(cv, sc)) return;
 
   // sc is an overlap Subcurve of existing edge and new curve,
-  // which means that the edeg will have to be modified
+  // which means that the edge will have to be modified
   if (sc->originating_subcurve1()) {
     this->m_arr->modify_edge
       (this->current_event()->halfedge_handle()->next()->twin(), cv.base());

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2.h
@@ -168,7 +168,10 @@ protected:
   virtual void _handle_left_curves();
 
   /*! Handle the overlap on the right curves of the current event point. */
-  virtual void _handle_overlaps_in_right_curves();
+  void _handle_overlaps_in_right_curves();
+
+  /*! clip the last curve of a subcurve if it is not in the status line and with a left end not being the current event*/
+  void _clip_non_active_curve_at_current_event(Subcurve*);
 
   /*! Handle the subcurves to the right of the current event point. */
   virtual void _handle_right_curves();
@@ -183,9 +186,6 @@ protected:
    * or updated.
    */
   void _add_curve(Event* e, Subcurve* sc, Attribute type);
-
-  /*! Fix overlapping subcurves before handling the current event. */
-  void _fix_overlap_subcurves();
 
   /*! create an overlap subcurve from overlap_cv between c1 and c2.
    * \param overlap_cv the overlapping curve.
@@ -232,11 +232,6 @@ protected:
                                   unsigned int mult,
                                   Subcurve*& c1,
                                   Subcurve*& c2);
-
-  /*! Fix a subcurve that represents an overlap.
-   * \param sc The subcurve.
-   */
-  void _fix_finished_overlap_subcurve(Subcurve* sc);
 };
 
 } // namespace Surface_sweep_2

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/Default_event_base.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/Default_event_base.h
@@ -187,7 +187,7 @@ public:
     for (Subcurve_iterator iter = this->left_curves_begin();
          iter != this->left_curves_end(); ++iter)
     {
-      if ((curve == *iter)) {
+      if (curve == *iter) {
         this->left_curves_erase(iter);
         return;
       }

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_subcurve.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_subcurve.h
@@ -199,7 +199,7 @@ public:
   /*! Get the last intersecing curve so far (non-const version). */
   X_monotone_curve_2& last_curve() { return m_last_curve; }
 
-  /*! Set the last intersecing curve so far.
+  /*! Set the last intersecting curve so far.
    */
   void set_last_curve(const X_monotone_curve_2& cv) { m_last_curve = cv; }
 


### PR DESCRIPTION
Arrangement testsuite is not yet happy with it.
Test failing are `test_construction_segments` and `test_construction_polylines` with some input in 
`Arrangement_on_surface_2/test/Arrangement_on_surface_2/data`

```
for i in ./data/test_construction/segments/*; do
  echo $i; ./test_construction_segments $i;
done
```
I compile the tests with a CGAL build using:
`cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_examples=ON -DWITH_tests=ON -DWITH_demos=ON -DBUILD_TESTING=ON  ../..` and calling `make test_construction_segments` in the generated directory `test/Arrangement_on_surface_2`



