### PR TITLE
Add missing inlines to PSP IO non-template functions

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_las_points.h
@@ -160,47 +160,47 @@ namespace internal {
 
   namespace LAS {
 
-  void get_value(const LASpoint& r, double& v, LAS_property::X&)
+  inline void get_value(const LASpoint& r, double& v, LAS_property::X&)
   { v = r.get_x(); }
-  void get_value(const LASpoint& r, double& v, LAS_property::Y&)
+  inline void get_value(const LASpoint& r, double& v, LAS_property::Y&)
   { v = r.get_y(); }
-  void get_value(const LASpoint& r, double& v, LAS_property::Z&)
+  inline void get_value(const LASpoint& r, double& v, LAS_property::Z&)
   { v = r.get_z(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::Intensity&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::Intensity&)
   { v = r.get_intensity(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Return_number&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Return_number&)
   { v = r.get_return_number(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Number_of_returns&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Number_of_returns&)
   { v = r.get_number_of_returns(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Scan_direction_flag&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Scan_direction_flag&)
   { v = r.get_scan_direction_flag(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Edge_of_flight_line&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Edge_of_flight_line&)
   { v = r.get_edge_of_flight_line(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Classification&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Classification&)
   { v = r.get_classification(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Synthetic_flag&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Synthetic_flag&)
   { v = r.get_synthetic_flag(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Keypoint_flag&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Keypoint_flag&)
   { v = r.get_keypoint_flag(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::Withheld_flag&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::Withheld_flag&)
   { v = r.get_withheld_flag(); }
-  void get_value(const LASpoint& r, float& v, LAS_property::Scan_angle&)
+  inline void get_value(const LASpoint& r, float& v, LAS_property::Scan_angle&)
   { v = r.get_scan_angle(); }
-  void get_value(const LASpoint& r, unsigned char& v, LAS_property::User_data&)
+  inline void get_value(const LASpoint& r, unsigned char& v, LAS_property::User_data&)
   { v = r.get_user_data(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::Point_source_ID&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::Point_source_ID&)
   { v = r.get_point_source_ID(); }
-  void get_value(const LASpoint& r, unsigned int& v, LAS_property::Deleted_flag&)
+  inline void get_value(const LASpoint& r, unsigned int& v, LAS_property::Deleted_flag&)
   { v = r.get_deleted_flag(); }
-  void get_value(const LASpoint& r, double& v, LAS_property::GPS_time&)
+  inline void get_value(const LASpoint& r, double& v, LAS_property::GPS_time&)
   { v = r.get_gps_time(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::R&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::R&)
   { v = r.get_R(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::G&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::G&)
   { v = r.get_G(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::B&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::B&)
   { v = r.get_B(); }
-  void get_value(const LASpoint& r, unsigned short& v, LAS_property::I&)
+  inline void get_value(const LASpoint& r, unsigned short& v, LAS_property::I&)
   { v = r.get_I(); }
 
   

--- a/Point_set_processing_3/include/CGAL/IO/write_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_las_points.h
@@ -92,41 +92,41 @@ namespace internal {
 
   namespace LAS {
 
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::Intensity&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::Intensity&)
   { r.set_intensity(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Return_number&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Return_number&)
   { r.set_return_number(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Number_of_returns&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Number_of_returns&)
   { r.set_number_of_returns(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Scan_direction_flag&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Scan_direction_flag&)
   { r.set_scan_direction_flag(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Edge_of_flight_line&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Edge_of_flight_line&)
   { r.set_edge_of_flight_line(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Classification&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Classification&)
   { r.set_classification(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Synthetic_flag&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Synthetic_flag&)
   { r.set_synthetic_flag(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Keypoint_flag&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Keypoint_flag&)
   { r.set_keypoint_flag(v); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::Withheld_flag&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::Withheld_flag&)
   { r.set_withheld_flag(v); }
-  void output_value(LASpoint& r, const float& v, LAS_property::Scan_angle&)
+  inline void output_value(LASpoint& r, const float& v, LAS_property::Scan_angle&)
   { r.set_scan_angle_rank(char(v)); }
-  void output_value(LASpoint& r, const unsigned char& v, LAS_property::User_data&)
+  inline void output_value(LASpoint& r, const unsigned char& v, LAS_property::User_data&)
   { r.set_user_data(v); }
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::Point_source_ID&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::Point_source_ID&)
   { r.set_point_source_ID(v); }
-  void output_value(LASpoint& r, const unsigned int& v, LAS_property::Deleted_flag&)
+  inline void output_value(LASpoint& r, const unsigned int& v, LAS_property::Deleted_flag&)
   { r.set_deleted_flag(v); }
-  void output_value(LASpoint& r, const double& v, LAS_property::GPS_time&)
+  inline void output_value(LASpoint& r, const double& v, LAS_property::GPS_time&)
   { r.set_gps_time(v); }
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::R&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::R&)
   { r.set_R(v); }
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::G&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::G&)
   { r.set_G(v); }
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::B&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::B&)
   { r.set_B(v); }
-  void output_value(LASpoint& r, const unsigned short& v, LAS_property::I&)
+  inline void output_value(LASpoint& r, const unsigned short& v, LAS_property::I&)
   { r.set_I(v); }
   
   template <typename ForwardIterator>

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -115,15 +115,15 @@ namespace internal {
     stream << "undefined_type";
   }
 
-  template <> void property_header_type<char> (std::ostream& stream) { stream << "char"; }
-  template <> void property_header_type<signed char> (std::ostream& stream) { stream << "char"; }
-  template <> void property_header_type<unsigned char> (std::ostream& stream) { stream << "uchar"; }
-  template <> void property_header_type<short> (std::ostream& stream) { stream << "short"; }
-  template <> void property_header_type<unsigned short> (std::ostream& stream) { stream << "ushort"; }
-  template <> void property_header_type<int> (std::ostream& stream) { stream << "int"; }
-  template <> void property_header_type<unsigned int> (std::ostream& stream) { stream << "uint"; }
-  template <> void property_header_type<float> (std::ostream& stream) { stream << "float"; }
-  template <> void property_header_type<double> (std::ostream& stream) { stream << "double"; }
+  template <> inline void property_header_type<char> (std::ostream& stream) { stream << "char"; }
+  template <> inline void property_header_type<signed char> (std::ostream& stream) { stream << "char"; }
+  template <> inline void property_header_type<unsigned char> (std::ostream& stream) { stream << "uchar"; }
+  template <> inline void property_header_type<short> (std::ostream& stream) { stream << "short"; }
+  template <> inline void property_header_type<unsigned short> (std::ostream& stream) { stream << "ushort"; }
+  template <> inline void property_header_type<int> (std::ostream& stream) { stream << "int"; }
+  template <> inline void property_header_type<unsigned int> (std::ostream& stream) { stream << "uint"; }
+  template <> inline void property_header_type<float> (std::ostream& stream) { stream << "float"; }
+  template <> inline void property_header_type<double> (std::ostream& stream) { stream << "double"; }
     
   template <typename T>
   void property_header (std::ostream& stream, const PLY_property<T>& prop)
@@ -216,9 +216,9 @@ namespace internal {
 
   template <typename T>
   T no_char_character (const T& t) { return t; }
-  int no_char_character (const char& t) { return int(t); }
-  int no_char_character (const signed char& t) { return int(t); }
-  int no_char_character (const unsigned char& t) { return int(t); }
+  inline int no_char_character (const char& t) { return int(t); }
+  inline int no_char_character (const signed char& t) { return int(t); }
+  inline int no_char_character (const unsigned char& t) { return int(t); }
 
   template <typename ForwardIterator,
             typename PropertyMap,


### PR DESCRIPTION
## Summary of Changes

Some functions in PLY/LAS IO are non-template, which creates multiple definition errors if they are included several times. This fixes it.

## Release Management

* Affected package(s): Point Set Processing
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/4090
