### PR TITLE
Change ray_23 and line_23's point(int) function to point(FT)

### DIFF
--- a/Cartesian_kernel/TODO
+++ b/Cartesian_kernel/TODO
@@ -83,13 +83,6 @@ Backward
 - Merge Intersection package ?  What about Conic ?
 - Cd must come back to life somehow...  Currently, I've disabled it ~totally
   in Cartesian.h.  Same thing for Conics...
-- line_get_pointC2() could take "i" as "const FT&" directly, not "int", it
-  will avoid several constructions.  Also, propagating that to the higher
-  level will also bring more functionality at the top level...
-  Seems like a stupid design choice at the beginning ?
-  Or did I miss something ?
-  Do we want to allow that for other implementations ?
-  Maybe there are other similar places.
 - Homogeneous' Point_2 has member functions :
     // and for efficiency in the predicates:
     const RT&     hx_ref() const;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h
@@ -33,7 +33,7 @@ namespace CGAL {
 template < class R_ >
 class LineC3
 {
-  typedef typename R_::RT                   RT;
+  typedef typename R_::FT                   FT;
   typedef typename R_::Point_3              Point_3;
   typedef typename R_::Vector_3             Vector_3;
   typedef typename R_::Direction_3          Direction_3;
@@ -95,7 +95,7 @@ public:
       return Direction_3(to_vector());
   }
 
-  Point_3     point(int i) const;
+  Point_3     point(const FT i) const;
 
   bool        has_on(const Point_3 &p) const;
   bool        is_degenerate() const;
@@ -122,8 +122,8 @@ LineC3<R>::operator!=(const LineC3<R> &l) const
 template < class R >
 inline
 typename LineC3<R>::Point_3
-LineC3<R>::point(int i) const
-{ return point() + to_vector()*RT(i); }
+LineC3<R>::point(const FT i) const
+{ return point() + i * to_vector(); }
 
 template < class R >
 inline

--- a/Cartesian_kernel/include/CGAL/Cartesian/Ray_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Ray_3.h
@@ -74,7 +74,7 @@ public:
   {
       return get_pointee_or_identity(base)[1];
   }
-  Point_3     point(int i) const;
+  Point_3     point(const FT i) const;
 
   Direction_3 direction() const;
   Vector_3    to_vector() const;
@@ -107,12 +107,12 @@ RayC3<R>::operator!=(const RayC3<R> &r) const
 template < class R >
 CGAL_KERNEL_INLINE
 typename RayC3<R>::Point_3
-RayC3<R>::point(int i) const
+RayC3<R>::point(const FT i) const
 {
-  CGAL_kernel_precondition( i >= 0 );
-  if (i == 0) return source();
-  if (i == 1) return second_point();
-  return source() + FT(i) * (second_point() - source());
+  CGAL_kernel_precondition( i >= FT(0) );
+  if (i == FT(0)) return source();
+  if (i == FT(1)) return second_point();
+  return source() + i * to_vector();
 }
 
 template < class R >

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -2935,6 +2935,7 @@ namespace CartesianKernelFunctors {
   class Construct_point_2
   {
     typedef typename K::RT         RT;
+    typedef typename K::FT         FT;
     typedef typename K::Point_2    Point_2;
     typedef typename K::Weighted_point_2 Weighted_point_2;
     typedef typename K::Line_2     Line_2;
@@ -2973,12 +2974,12 @@ namespace CartesianKernelFunctors {
     {
       typename K::Construct_point_2 construct_point_2;
       typename K::FT x, y;
-      line_get_pointC2(l.a(), l.b(), l.c(), 0, x, y);
+      line_get_pointC2(l.a(), l.b(), l.c(), FT(0), x, y);
       return construct_point_2(x,y);
     }
 
     Point_2
-    operator()(const Line_2& l, int i) const
+    operator()(const Line_2& l, const FT i) const
     {
       typename K::Construct_point_2 construct_point_2;
       typename K::FT x, y;

--- a/Cartesian_kernel/include/CGAL/Cartesian/point_constructions_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/point_constructions_2.h
@@ -34,7 +34,7 @@ namespace CGAL {
 template < class K >
 inline
 typename K::Point_2
-line_get_point(const LineC2<K> &l, int i)
+line_get_point(const LineC2<K> &l, const typename K::FT &i)
 {
   typename K::FT x, y;
   line_get_pointC2(l.a(), l.b(), l.c(), i, x, y);

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
@@ -279,7 +279,7 @@ line_y_at_xC2(const FT &a, const FT &b, const FT &c, const FT &x)
 template < class FT > 
 inline
 void
-line_get_pointC2(const FT &a, const FT &b, const FT &c, int i,
+line_get_pointC2(const FT &a, const FT &b, const FT &c, const FT &i,
                  FT &x, FT &y)
 {
   if (CGAL_NTS is_zero(b))

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/RayH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/RayH3.h
@@ -36,7 +36,6 @@ namespace CGAL {
 template < class R_ >
 class RayH3
 {
-   typedef typename R_::RT                   RT;
    typedef typename R_::FT                   FT;
    typedef typename R_::Point_3              Point_3;
    typedef typename R_::Line_3               Line_3;
@@ -68,7 +67,7 @@ public:
     const Point_3 & start() const;
     const Point_3 & source() const;
     Point_3 second_point() const;
-    Point_3 point(int i) const;
+    Point_3 point(const FT i) const;
     Direction_3 direction() const;
     const Vector_3 & to_vector() const;
     Line_3  supporting_line() const;
@@ -118,10 +117,11 @@ RayH3<R>::second_point() const
 template < class R >
 CGAL_KERNEL_INLINE
 typename RayH3<R>::Point_3
-RayH3<R>::point(int i) const
+RayH3<R>::point(const FT i) const
 {
-  CGAL_kernel_precondition( i >= 0 );
-  return start() + RT(i)*to_vector();
+  CGAL_kernel_precondition( i >= FT(0) );
+  if (i == FT(0)) return source();
+  return start() + i * to_vector();
 }
 
 template < class R >

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -3098,7 +3098,16 @@ namespace HomogeneousKernelFunctors {
     }
 
     Point_2
-    operator()(const Line_2& l, const FT i) const
+    operator()(const Line_2& l, const RT& i) const
+    {
+      Point_2 p = K().construct_point_2_object()(l);
+      Vector_2 v = K().construct_vector_2_object()(l);
+      return K().construct_translated_point_2_object()
+                 (p, K().construct_scaled_vector_2_object()(v, i));
+    }
+
+    Point_2
+    operator()(const Line_2& l, const FT& i) const
     {
       Point_2 p = K().construct_point_2_object()(l);
       Vector_2 v = K().construct_vector_2_object()(l);

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -3098,12 +3098,12 @@ namespace HomogeneousKernelFunctors {
     }
 
     Point_2
-    operator()(const Line_2& l, int i) const
+    operator()(const Line_2& l, const FT i) const
     {
       Point_2 p = K().construct_point_2_object()(l);
       Vector_2 v = K().construct_vector_2_object()(l);
       return K().construct_translated_point_2_object()
-                 (p, K().construct_scaled_vector_2_object()(v, RT(i)));
+                 (p, K().construct_scaled_vector_2_object()(v, i));
     }
 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Line_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Line_2.h
@@ -117,7 +117,7 @@ returns an arbitrary point on `l`. It holds
 Furthermore, `l` is directed from `point(i)` 
 to `point(j)`, for all `i` \f$ <\f$ `j`. 
 */ 
-Point_2<Kernel> point(int i) const; 
+Point_2<Kernel> point(const Kernel::FT i) const;
 
 /*!
 returns the orthogonal projection of `p` onto `l`. 

--- a/Kernel_23/doc/Kernel_23/CGAL/Line_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Line_3.h
@@ -71,7 +71,7 @@ Point_3<Kernel> projection(const Point_3<Kernel> &p) const;
 returns an arbitrary point on `l`. It holds 
 `point(i) = point(j)`, iff `i=j`. 
 */ 
-Point_3<Kernel> point(int i) const; 
+Point_3<Kernel> point(const Kernel::FT i) const;
 
 /// @} 
 

--- a/Kernel_23/doc/Kernel_23/CGAL/Ray_2.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Ray_2.h
@@ -64,10 +64,10 @@ Point_2<Kernel> source() const;
 
 /*!
 returns a point on `r`. `point(0)` is the source, 
-`point(i)`, with `i>0`, is different from the 
+`point(i)`, with `i>0`, is different from the
 source. \pre \f$ i \geq0\f$. 
 */ 
-Point_2<Kernel> point(int i) const; 
+Point_2<Kernel> point(const Kernel::FT i) const;
 
 /*!
 returns the direction of `r`. 

--- a/Kernel_23/doc/Kernel_23/CGAL/Ray_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Ray_3.h
@@ -67,7 +67,7 @@ returns a point on `r`. `point(0)` is the source.
 `point(i)`, with `i>0`, is different from the 
 source. \pre \f$ i \geq0\f$. 
 */ 
-Point_3<Kernel> point(int i) const; 
+Point_3<Kernel> point(const Kernel::FT i) const;
 
 /*!
 returns the direction of `r`. 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -5776,7 +5776,7 @@ public:
     to `point(j)`, for all `i < j`. 
   */ 
   Kernel::Point_2 operator()(const Kernel::Line_2& l, 
-                             int i); 
+                             const Kernel::FT i);
 
   /*!
     returns a point on `r`. `point(0)` is the source, 
@@ -5784,7 +5784,7 @@ public:
     source. \pre `i>= 0`. 
   */ 
   Kernel::Point_2 operator()(const Kernel::Ray_2& r, 
-                             int i); 
+                             const Kernel::FT i);
 
   /*!
     returns source or target of `s`: `point(0)` returns 
@@ -5826,7 +5826,7 @@ public:
     to `point(j)`, for all `i < j`. 
   */ 
   Kernel::Point_3 operator()(const Kernel::Line_3& l, 
-                             int i); 
+                             const Kernel::FT i);
 
   /*!
     returns an arbitrary point on `h`. 
@@ -5839,7 +5839,7 @@ public:
     source. \pre `i >= 0`. 
   */ 
   Kernel::Point_3 operator()(const Kernel::Ray_3& r, 
-                             int i); 
+                             const Kernel::FT i);
 
   /*!
     returns source or target of `s`: `point(0)` returns 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -2068,6 +2068,7 @@ namespace CommonKernelFunctors {
   template <typename K>
   class Construct_point_on_2
   {
+    typedef typename K::FT         FT;
     typedef typename K::Point_2    Point_2;
     typedef typename K::Segment_2  Segment_2;
     typedef typename K::Line_2     Line_2;
@@ -2076,7 +2077,7 @@ namespace CommonKernelFunctors {
     typedef Point_2          result_type;
 
     Point_2
-    operator()( const Line_2& l, int i) const
+    operator()( const Line_2& l, const FT i) const
     { return l.point(i); }
 
     Point_2
@@ -2084,13 +2085,14 @@ namespace CommonKernelFunctors {
     { return s.point(i); }
 
     Point_2
-    operator()( const Ray_2& r, int i) const
+    operator()( const Ray_2& r, const FT i) const
     { return r.point(i); }
   };
 
   template <typename K>
   class Construct_point_on_3
   {
+    typedef typename K::FT         FT;
     typedef typename K::Point_3    Point_3;
     typedef typename K::Segment_3  Segment_3;
     typedef typename K::Line_3     Line_3;
@@ -2100,7 +2102,7 @@ namespace CommonKernelFunctors {
     typedef Point_3          result_type;
 
     Point_3
-    operator()( const Line_3& l, int i) const
+    operator()( const Line_3& l, const FT i) const
     { return l.rep().point(i); }
 
     Point_3
@@ -2108,7 +2110,7 @@ namespace CommonKernelFunctors {
     { return s.point(i); }
 
     Point_3
-    operator()( const Ray_3& r, int i) const
+    operator()( const Ray_3& r, const FT i) const
     { return r.rep().point(i); }
 
     Point_3

--- a/Kernel_23/include/CGAL/Line_2.h
+++ b/Kernel_23/include/CGAL/Line_2.h
@@ -31,6 +31,7 @@
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Dimension.h>
 #include <CGAL/IO/io.h>
+#include <CGAL/Kernel/mpl.h>
 
 namespace CGAL {
 
@@ -211,7 +212,19 @@ public:
   }
 
   Point_2
-  point(const FT i) const
+  point(const int i) const
+  {
+    return R().construct_point_2_object()(*this, RT(i));
+  }
+
+  Point_2
+  point(const RT& i) const
+  {
+    return R().construct_point_2_object()(*this,i);
+  }
+
+  Point_2
+  point(const typename First_if_different<FT, RT>::Type& i) const
   {
     return R().construct_point_2_object()(*this,i);
   }

--- a/Kernel_23/include/CGAL/Line_2.h
+++ b/Kernel_23/include/CGAL/Line_2.h
@@ -218,13 +218,14 @@ public:
   }
 
   Point_2
-  point(const RT& i) const
+  point(const typename First_if_different<RT, int, 1>::Type& i) const
   {
     return R().construct_point_2_object()(*this,i);
   }
 
   Point_2
-  point(const typename First_if_different<FT, RT>::Type& i) const
+  point(const typename First_if_different<
+                const typename First_if_different<FT, RT, 2>::Type, int>::Type& i) const
   {
     return R().construct_point_2_object()(*this,i);
   }

--- a/Kernel_23/include/CGAL/Line_2.h
+++ b/Kernel_23/include/CGAL/Line_2.h
@@ -211,7 +211,7 @@ public:
   }
 
   Point_2
-  point(int i) const
+  point(const FT i) const
   {
     return R().construct_point_2_object()(*this,i);
   }

--- a/Kernel_23/include/CGAL/Line_3.h
+++ b/Kernel_23/include/CGAL/Line_3.h
@@ -38,7 +38,7 @@ namespace CGAL {
 template <class R_>
 class Line_3 : public R_::Kernel_base::Line_3
 {
-  typedef typename R_::RT                    RT;
+  typedef typename R_::FT                    FT;
   typedef typename R_::Point_3               Point_3;
   typedef typename R_::Ray_3                 Ray_3;
   typedef typename R_::Segment_3             Segment_3;
@@ -116,7 +116,7 @@ public:
     return R().construct_point_on_3_object()(*this, 0);
   }
 
-  Point_3 point(int i) const
+  Point_3 point(const FT i) const
   { 
     return R().construct_point_on_3_object()(*this, i);
   }

--- a/Kernel_23/include/CGAL/Ray_2.h
+++ b/Kernel_23/include/CGAL/Ray_2.h
@@ -102,23 +102,20 @@ public:
     return R().construct_second_point_2_object()(*this);
   }
 
-
-  Point_2
-  point(int i) const
+  Point_2 point(const FT i) const
   {
-    CGAL_kernel_precondition( i >= 0 );
-    
+    CGAL_kernel_precondition(i >= FT(0));
+
     typename R::Construct_vector_2 construct_vector;
     typename R::Construct_scaled_vector_2 construct_scaled_vector;
     typename R::Construct_translated_point_2 construct_translated_point;
-    if (i == 0) return source();
-    if (i == 1) return second_point();
-    return construct_translated_point(source(),
-				      construct_scaled_vector(construct_vector(source(), 
-									       second_point()),
-							      FT(i)));
-  }
 
+    if (i == FT(0)) return source();
+    if (i == FT(1)) return second_point();
+
+    return construct_translated_point(source(),
+             construct_scaled_vector(construct_vector(source(), second_point()), i));
+  }
 
   typename cpp11::result_of<typename R_::Construct_source_2( Ray_2 )>::type
   start() const

--- a/Kernel_23/include/CGAL/Ray_3.h
+++ b/Kernel_23/include/CGAL/Ray_3.h
@@ -39,7 +39,7 @@ namespace CGAL {
 template <class R_>
 class Ray_3 : public R_::Kernel_base::Ray_3
 {
-  typedef typename R_::RT                    RT;
+  typedef typename R_::FT                    FT;
   typedef typename R_::Point_3               Point_3;
   typedef typename R_::Direction_3           Direction_3;
   typedef typename R_::Vector_3              Vector_3;
@@ -108,8 +108,8 @@ public:
   bool        collinear_has_on(const Point_3 &p) const;
 */
 
-  typename cpp11::result_of<typename R::Construct_point_on_3(Ray_3, int)>::type
-  point(int i) const // TODO : use Qrt
+  typename cpp11::result_of<typename R::Construct_point_on_3(Ray_3, FT)>::type
+  point(const FT i) const
   {
     return R().construct_point_on_3_object()(*this, i);
   }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_2.h
@@ -33,7 +33,7 @@ _test_cls_line_2(const R& )
  std::cout << "Testing class Line_2";
 
  typedef typename  R::RT    RT;
- typedef typename  R::FT    gnuFT;
+ typedef typename  R::FT    FT;
 
  RT n0 =  0;
  RT n1 =  1;
@@ -114,6 +114,7 @@ _test_cls_line_2(const R& )
  assert( l43.has_on( l43.point(0) ) );
  assert( lr21.has_on( lr21.point(1) ) );
  assert( ld21.has_on( ld21.point(-2) ) );
+ assert( ld21.has_on( ld21.point(FT(1)/FT(2)) ) );
  assert( lr21.has_on( r21.source() ) );
  assert( labc.has_on( labc.point(0) ) );
 
@@ -123,16 +124,16 @@ _test_cls_line_2(const R& )
  assert( CGAL::Line_2<R>( n0, n2, n3 ).is_horizontal() );
  assert( ! lr21.is_horizontal() );
 
- assert( ld12.y_at_x( gnuFT(3) ) == gnuFT( 4) );
- assert( lr21.y_at_x( gnuFT(3) ) == gnuFT( 4) );
- assert( ld12.y_at_x( gnuFT(1) ) == gnuFT( 2) );
- assert( l12.y_at_x( gnuFT(5) ) == gnuFT( 6) );
- assert( l34.y_at_x( gnuFT(8) ) == gnuFT( 2) );
+ assert( ld12.y_at_x( FT(3) ) == FT( 4) );
+ assert( lr21.y_at_x( FT(3) ) == FT( 4) );
+ assert( ld12.y_at_x( FT(1) ) == FT( 2) );
+ assert( l12.y_at_x( FT(5) ) == FT( 6) );
+ assert( l34.y_at_x( FT(8) ) == FT( 2) );
 
- assert( l12.x_at_y( gnuFT(0) ) == gnuFT( -1 ) );
- assert( ls12.x_at_y( gnuFT(4) ) == gnuFT( 3 ) );
- assert( l21.x_at_y( gnuFT(6) ) == gnuFT( 5 ) );
- assert( ld21.x_at_y( gnuFT(2) ) == gnuFT( 1 ) );
+ assert( l12.x_at_y( FT(0) ) == FT( -1 ) );
+ assert( ls12.x_at_y( FT(4) ) == FT( 3 ) );
+ assert( l21.x_at_y( FT(6) ) == FT( 5 ) );
+ assert( ld21.x_at_y( FT(2) ) == FT( 1 ) );
 
  CGAL::Direction_2<R> up( n0, n1 );
  CGAL::Aff_transformation_2<R> rot90(CGAL::ROTATION, up, n1, RT(100) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_line_3.h
@@ -34,6 +34,8 @@ _test_cls_line_3(const R& )
  std::cout << "Testing class Line_3" ;
 
  typedef typename  R::RT    RT;
+ typedef typename  R::FT    FT;
+
  const bool nonexact = boost::is_same<RT, double>::value;
 
  typename R::Line_3 il;
@@ -102,6 +104,8 @@ _test_cls_line_3(const R& )
  std::cout << '.';
 
  assert( l4.point(2) - l4.point(1) == l4.point(1) - l4.point(0) );
+ assert( (l4.point(FT(1)/FT(3)) - l4.point(0) == l4.point(1+FT(1)/FT(3)) - l4.point(1)) || nonexact );
+
  CGAL::Point_3<R> p1l4proj = l4.projection(p1);
  assert( l4.has_on( p1l4proj ) || nonexact );
  assert( l4.perpendicular_plane( p1l4proj ).has_on( p1l4proj ) || nonexact );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_3.h
@@ -31,6 +31,7 @@ _test_cls_ray_3(const R& )
  std::cout << "Testing class Ray_3" ;
 
  typedef typename  R::RT    RT;
+ typedef typename  R::FT    FT;
 
  typename R::Ray_3 ir;
  CGAL::Ray_3<R>  r1(ir);
@@ -93,7 +94,7 @@ _test_cls_ray_3(const R& )
  assert( r5.source() == p3 );
  assert( r2.source() != r3.source() );
  assert( r7.direction() == dir );
- assert( r2.direction() == CGAL::Direction_3<R>(r2.point(2) - r2.point(1) ));
+ assert( r2.direction() == CGAL::Direction_3<R>(r2.point(FT(1)/FT(2)) - r2.point(0) ));
  assert( r2.direction() == r3.opposite().direction() );
  assert( r2.to_vector().direction() == r3.opposite().to_vector().direction() );
  assert( r1.supporting_line() == r2.supporting_line() );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_new_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_new_2.h
@@ -31,6 +31,7 @@ _test_cls_ray_new_2(const R& )
  std::cout << "Testing class Ray_2";
 
  typedef typename  R::RT    RT;
+ typedef typename  R::FT    FT;
 
  typedef typename  R::Point_2 Point_2;
  typedef typename  R::Vector_2 Vector_2;
@@ -121,6 +122,7 @@ _test_cls_ray_new_2(const R& )
  assert( ! r0.has_on( construct_point( n8, n5, n8 )) );
  assert( r4.has_on( r4.point(7)) );
  assert( r3.collinear_has_on( r3.point(7)) );
+ assert( r3.collinear_has_on( r3.point(FT(42)/FT(13))) );
  assert( r1.collinear_has_on( p3) );
  assert( ! r3.collinear_has_on( p1 ) );
 


### PR DESCRIPTION
## Summary of Changes

There is no real requirement on `i` being an 'int', except for some symmetry with the segment. On the other hand, it restricts heavily what you can do with the function for no reason.

Ideally, segment_23 would also return a point on the segment with `0<=i<=1`, but it would be a strong breaking change (right now it expects an int and applies a %2 before calling source() or target()). There are not enough reasons to break such low level code.

Put as a bug/cleaning fix, but could (should be a small feature ?)

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): fix #4113
* Feature/Small Feature (if any): 

