### PR TITLE
Installation: Add missing cmake labels

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -104,6 +104,8 @@ function(cgal_add_compilation_test exe_name)
   if(NOT TEST check_build_system)
     add_test(NAME "check_build_system"
       COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "cgal_check_build_system")
+    set_property(TEST "check_build_system"
+      APPEND PROPERTY LABELS "Installation")
     if(POLICY CMP0066) # cmake 3.7 or later
       set_property(TEST "check_build_system"
         PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")

--- a/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/implicit_functions/CMakeLists.txt
@@ -1,7 +1,5 @@
 # This is the CMake script for compiling the CGAL Mesh_3 demo implicit functions.
 
-project( Mesh_3_implicit_functions )
-
 include( polyhedron_demo_macros )
 
 cmake_minimum_required(VERSION 3.1)


### PR DESCRIPTION
## Summary of Changes

Put `Mesh_3_implicit_finctions` in `Polyhedron_demo` and `check_build_system` in `Installation` to get rid of the additional lines in the ctest testsuite.
## Release Management

* Affected package(s):Installation, Polyhedron_Demo

