### PR TITLE
Mesh_3 : add missing parenthesis around min and max for windows

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -138,7 +138,7 @@ protected:
     , m_lock_ds(bbox, num_grid_cells_per_axis)
   {
     big_moves_current_size_ = 0;
-    big_moves_smallest_ = std::numeric_limits<FT>::max();
+    big_moves_smallest_ = (std::numeric_limits<FT>::max)();
   }
 
   void update_big_moves(const FT& new_sq_move)
@@ -177,7 +177,7 @@ protected:
   void clear_big_moves()
   {
     big_moves_current_size_ = 0;
-    big_moves_smallest_ = std::numeric_limits<FT>::max();
+    big_moves_smallest_ = (std::numeric_limits<FT>::max)();
     big_moves_.clear();
   }
 

--- a/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Worksharing_data_structures.h
@@ -160,11 +160,11 @@ public:
   {
     // Compute indices on grid
     int index_x = static_cast<int>( (to_double(point.x()) - m_xmin) * m_resolution_x);
-    index_x = std::max( 0, std::min(index_x, m_num_grid_cells_per_axis - 1) );
+    index_x = (std::max)( 0, (std::min)(index_x, m_num_grid_cells_per_axis - 1) );
     int index_y = static_cast<int>( (to_double(point.y()) - m_ymin) * m_resolution_y);
-    index_y = std::max( 0, std::min(index_y, m_num_grid_cells_per_axis - 1) );
+    index_y = (std::max)( 0, (std::min)(index_y, m_num_grid_cells_per_axis - 1) );
     int index_z = static_cast<int>( (to_double(point.z()) - m_zmin) * m_resolution_z);
-    index_z = std::max( 0, std::min(index_z, m_num_grid_cells_per_axis - 1) );
+    index_z = (std::max)( 0, (std::min)(index_z, m_num_grid_cells_per_axis - 1) );
 
     int index =
       index_z*m_num_grid_cells_per_axis*m_num_grid_cells_per_axis
@@ -646,16 +646,16 @@ protected:
     int index_x = cell_index;
 
     // For each cell inside the square
-    for (int i = std::max(0, index_x-occupation_radius) ;
-          i <= std::min(m_num_cells_per_axis - 1, index_x+occupation_radius) ;
+    for (int i = (std::max)(0, index_x-occupation_radius) ;
+          i <= (std::min)(m_num_cells_per_axis - 1, index_x+occupation_radius) ;
           ++i)
     {
-      for (int j = std::max(0, index_y-occupation_radius) ;
-            j <= std::min(m_num_cells_per_axis - 1, index_y+occupation_radius) ;
+      for (int j = (std::max)(0, index_y-occupation_radius) ;
+            j <= (std::min)(m_num_cells_per_axis - 1, index_y+occupation_radius) ;
             ++j)
       {
-        for (int k = std::max(0, index_z-occupation_radius) ;
-              k <= std::min(m_num_cells_per_axis - 1, index_z+occupation_radius) ;
+        for (int k = (std::max)(0, index_z-occupation_radius) ;
+              k <= (std::min)(m_num_cells_per_axis - 1, index_z+occupation_radius) ;
               ++k)
         {
           int index =


### PR DESCRIPTION
## Summary of Changes

add missing parenthesis around `std::min` and `std::max`, and `std::numeric_limits<FT>::max` to fix compilation on Windows.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

