### PR TITLE
PMP: Fix test_pmp_clip

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -293,7 +293,7 @@ void test()
   assert(vertices(tm1).size()==3);
   CGAL::clear(tm1);
 
-  ss = std::stringstream();
+  ss.str(std::string());
   ss << "OFF\n 7 4 0\n 0 0 0\n2 0 0\n4 0 0\n4 1 0\n0 1 0\n3 1 0\n 1 1 0\n3 0 1 4\n3 1 2 3\n3 1 5 6\n3 1 3 5\n";
   ss >> tm1;
   CGAL::Euler::remove_face(halfedge(*CGAL::cpp11::prev(faces(tm1).end()),tm1),tm1);
@@ -301,7 +301,7 @@ void test()
   assert(vertices(tm1).size()==6);
   CGAL::clear(tm1);
 
-  ss = std::stringstream();
+  ss.str(std::string());
   ss << "OFF\n 9 7 0\n 0 0 0\n2 0 0\n4 0 0\n4 1 0\n0 1 0\n3 1 0\n 1 1 0\n3 -1 0\n1 -1 0\n3 0 1 4\n3 1 2 3\n3 1 5 6\n3 1 8 7\n3 1 3 5\n3 1 6 4\n3 1 0 8\n";
   ss >> tm1;
   for (int i=0;i<3;++i)
@@ -310,7 +310,7 @@ void test()
   assert(vertices(tm1).size()==7);
   CGAL::clear(tm1);
 
-  ss = std::stringstream();
+  ss.str(std::string());
   ss << "OFF\n 9 7 0\n 0 0 0\n2 0 0\n4 0 0\n4 1 0\n0 1 0\n3 1 0\n 1 1 0\n3 -1 0\n1 -1 0\n3 0 1 4\n3 1 2 3\n3 1 5 6\n3 1 8 7\n3 1 3 5\n3 1 6 4\n3 1 0 8\n";
   ss >> tm1;
   for (int i=0;i<3;++i)
@@ -319,7 +319,7 @@ void test()
   assert(vertices(tm1).size()==3);
   CGAL::clear(tm1);
 
-  ss = std::stringstream();
+  ss.str(std::string());
   ss << "OFF\n 9 7 0\n 0 0 0\n2 0 0\n4 0 0\n4 1 0\n0 1 0\n3 1 0\n 1 1 0\n3 -1 0\n1 -1 0\n3 0 1 4\n3 1 2 3\n3 1 5 6\n3 1 8 7\n3 1 3 5\n3 1 6 4\n3 1 0 8\n";
   ss >> tm1;
   for (int i=0;i<3;++i)


### PR DESCRIPTION

## Summary of Changes

Use a correct way to reset the stringstream in test_pmp_clip, the `=` operator being private.

## Release Management

* Affected package(s):PMP
