### PR TITLE
Fix segfault in `PMP::isotropic_remeshing()`

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1638,6 +1638,9 @@ private:
         BOOST_FOREACH(halfedge_descriptor hf,
                       halfedges_around_face(h, mesh_))
         {
+          if(face(opposite(hf, mesh_), mesh_) == boost::graph_traits<PM>::null_face())
+            continue;
+
           vertex_descriptor vc = target(hf, mesh_);
           vertex_descriptor va = target(next(hf, mesh_), mesh_);
           vertex_descriptor vb = target(next(next(hf, mesh_), mesh_), mesh_);


### PR DESCRIPTION
## Summary of Changes

The collapse step of `PMP::isotropic_remeshing()` has a post processing step that removes degenerate faces.
We had forgotten to deal with degenerate faces that are on a boundary, and this lead to a segfault.
It's fixed now.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #4112
