### PR TITLE
Mesh_3: fix protection of 1D features on borders of 3D images

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -186,7 +186,14 @@ private:
                     Vector vy)
   {
 #ifdef CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
-    std::cerr << "New curve:\n";
+    std::cerr << "New curve:\n"
+              << "  base("
+              << p00 << " , "
+              << p00+vx << " , "
+              << p00+vy << ")\n"
+              << "  vectors: "
+              << "( " << vx << " ) "
+              << " ( " << vy << " )\n";
 #endif // CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
     const double step = (end - start)/prec;
     const double stop = end-step/2;
@@ -199,12 +206,15 @@ private:
     {
       const double y = (equation.*f)(x);
 #ifdef CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
-      std::cerr << "  (" << x << ", " << y << ")\n";
+      std::cerr << "  (" << x << ", " << y << ") -> ";
 #endif // CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
       const Point inter_p =
         translate(translate(p00,
                             scale(vx, x)),
                   scale(vy, y));
+#ifdef CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
+      std::cerr << "( " << inter_p << ")\n";
+#endif // CGAL_MESH_3_DEBUG_POLYLINES_TO_PROTECT
       v_int = g_manip.get_vertex(inter_p, false);
       g_manip.try_add_edge(old, v_int);
 

--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -682,6 +682,7 @@ case_4:
               // Diagonal, but the wrong one.
               // Vertical swap
               std::swap(square[0][1], square[0][0]);
+              std::swap(square[1][1], square[1][0]);
             }
             if(square[0][1].domain == square[1][0].domain) {
               // diagonal case 1-2-1


### PR DESCRIPTION
## Summary of Changes

PR #2739 introduced a bug in CGAL-4.13. This PR fixes it.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #2739
* License and copyright ownership: maintenance by GeometryFactory

