### PR TITLE
warning: unbalanced grouping commands

### DIFF
--- a/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
@@ -83,7 +83,7 @@ class TriangulationDataStructure {
 public:
 
 /// \name Types
-// @{
+/// @{
 
 /*!
 The vertex type, requirements for this type are described 
@@ -122,6 +122,7 @@ typedef unspecified_type Face;
 /// Vertices and full cells are manipulated via
 /// <I>handles</I>. Handles support the usual two dereference
 /// operators and `operator->`. 
+/// @{
 
 /*!
 Handle to a `Vertex`.

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -378,8 +378,6 @@ specifies which case occurs when locating a point in the triangulation.
                      OUTSIDE_AFFINE_HULL /*!< when the point is outside the affine hull of the current triangulation. */
 }; 
 
-/// @} 
-
 /// \name Creation 
 /// @{
 


### PR DESCRIPTION
Removing last "warning: unbalanced grouping commands" messages.

Note: maybe useful to add in `Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h` some `\name` parts for handles / iterators / ...



