### PR TITLE
Fix ctest testsuite script 

### DIFF
--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -28,6 +28,7 @@ if(CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND (CGAL_Core_FOUND OR LEDA_FOUN
   
   # cpp files
   add_executable ( HDT2 HDT2.cpp ${CGAL_Qt5_RESOURCE_FILES} ${RESOURCE_FILES} ${UIS})
+  add_to_cached_list( CGAL_EXECUTABLE_TARGETS HDT2 )
   target_link_libraries ( HDT2 CGAL::CGAL CGAL::CGAL_Qt5 CGAL::CGAL_Core Qt5::Widgets)
 else()
   message(STATUS "NOTICE: This demo requires CGAL, CGAL_Core (or LEDA), and Qt5 and will not be compiled.")

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -39,6 +39,7 @@ if(CGAL_FOUND AND (CGAL_Core_FOUND OR LEDA_FOUND) AND Qt5_FOUND AND CGAL_Qt5_FOU
   if(LEDA_FOUND)
     target_link_libraries( P4HDT2 PRIVATE ${LEDA_LIBRARIES} )
   endif()
+  add_to_cached_list( CGAL_EXECUTABLE_TARGETS P4HDT2 )
 else()
   message(STATUS "NOTICE: This demo requires Qt5 and will not be compiled.")
 endif()

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -252,6 +252,9 @@ run_test_on_platform()
   PLATFORM=${1}
 
   NUMBER_OF_PROCESSORS="`value_of PROCESSORS_${HOST}`"
+  if [ -z "${NUMBER_OF_PROCESSORS}" ]; then
+    NUMBER_OF_PROCESSORS=1
+  fi
   CGAL_BINARY_DIR=${CGAL_BINARY_DIR_BASE}/${PLATFORM}
   cd "${CGAL_BINARY_DIR}"
   log "${ACTUAL_LOGFILE}.test.${PLATFORM}" "Testing on host ${HOST} and platform ${PLATFORM}"
@@ -286,7 +289,7 @@ run_test_on_platform()
   #unsets the limit of 1024 bits for the logs through ssh
   echo "SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1000000000)" > CTestCustom.cmake
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
-  CTEST_OPTS="-T Start -T Test -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} --timeout 1200"
+  CTEST_OPTS="-T Start -T Test --timeout 1200 -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} "
   if [ -z "${SHOW_PROGRESS}" ]; then
     ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .}> tmp.txt
   else


### PR DESCRIPTION
## Summary of Changes

Add a test to replace an empty number of processors by 1 and move --timeout sooner in the options to prevent an eventual other parsing error.

## Release Management

* Affected package(s): Scripts
