### PR TITLE
Nef_S2: Fix memory corruption

### DIFF
--- a/Nef_S2/examples/Nef_S2/nef_s2_construction.cpp
+++ b/Nef_S2/examples/Nef_S2/nef_s2_construction.cpp
@@ -17,7 +17,6 @@ int main() {
   Nef_polyhedron N2(c, Nef_polyhedron::INCLUDED);
   Nef_polyhedron N3(N2.complement());
   CGAL_assertion(N1 == N2.join(N3));
-
   Sphere_point   p1(1,0,0), p2(0,1,0), p3(0,0,1);
   Sphere_segment s1(p1,p2), s2(p2,p3), s3(p3,p1);
   Sphere_segment triangle[3] = { s1, s2, s3 };

--- a/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
@@ -943,16 +943,17 @@ create_from_circles(Forward_iterator start, Forward_iterator end)
   SM_output O(*this,From_input); 
 
   typedef typename PHS_traits::INPUT Input_range;
+  PH_geometry ph_g;
   Positive_halfsphere_sweep SP(
     Input_range(L_pos.begin(),L_pos.end()),O,
-    PH_geometry());
+    ph_g);
   SP.sweep();
   //CGAL_NEF_TRACEN("POS SWEEP\n"<<(dump(std::cerr),""));
   v=--this->svertices_end(); e=--this->shalfedges_end();
-
+  NH_geometry nh_geom;
   Negative_halfsphere_sweep SM(
     Input_range(L_neg.begin(),L_neg.end()), O,
-    NH_geometry());
+    nh_geom);
   SM.sweep();
   //CGAL_NEF_TRACEN("NEG SWEEP\n"<<(dump(std::cerr),""));
   ++v; ++e;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
@@ -871,16 +871,17 @@ create_from_segments(Forward_iterator start, Forward_iterator end)
   SM_output O(*this,From_input); 
 
   typedef typename PHS_traits::INPUT Input_range;
+  PH_geometry ph_g;
   Positive_halfsphere_sweep SP(
     Input_range(L_pos.begin(),L_pos.end()),O,
-    PH_geometry());
+    ph_g);
   SP.sweep();
   //CGAL_NEF_TRACEN("POS SWEEP\n"<<(dump(std::cerr),""));
   v=--this->svertices_end(); e=--this->shalfedges_end();
-
+  NH_geometry nh_g;
   Negative_halfsphere_sweep SM(
     Input_range(L_neg.begin(),L_neg.end()),O,
-    NH_geometry());
+    nh_g);
   SM.sweep();
   //CGAL_NEF_TRACEN("NEG SWEEP\n"<<(dump(std::cerr),""));
   ++v; ++e;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
@@ -669,6 +669,7 @@ void find_splittable_edge(const std::pair<typename boost::property_traits<VPM>::
                           const VPM& vpmt,
                           const GT& gt)
 {
+  CGAL_USE(vpmt);
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor   halfedge_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::edge_descriptor       edge_descriptor;
 


### PR DESCRIPTION
## Summary of Changes
Fix a memory corruption due to const refs on temporary objects.
## Release Management

* Affected package(s):Nef_S2