### PR TITLE
Header-only: remove -isystem in the testsuite or dev-mode

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -166,4 +166,9 @@ cgal_parse_version_h( "${CGAL_INSTALLATION_PACKAGE_DIR}/include/CGAL/version.h"
   "CGAL_BUILD_VERSION")
 set(CGAL_VERSION "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}.${CGAL_BUGFIX_VERSION}.${CGAL_BUILD_VERSION}")
 
+if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
+  # Do not use -isystem for CGAL include paths
+  set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
+endif()
+
 include("${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake")


### PR DESCRIPTION
## Summary of Changes

Since PR https://github.com/CGAL/cgal/pull/3900 CGAL is header-only by default. As a side effect, that made all test platforms use `-isystem` instead of `-I` , when supported, to specify the include path for CGAL. And thus all CGAL warnings were disabled.

## Release Management

* Affected package(s): Installation, but all packages might show new warnings
* Issue(s) solved (if any): fix #3900
* License and copyright ownership: GeometryFactory

@maxGimeno: you might see new warnings popping up in all CGAL, once this PR is merged in `integration`. There were just hidden, before.
