### PR TITLE
Allow Mesh_3 to cope with a 2D initial triangulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Top level CMakeLists.txt for CGAL-branchbuild
+
+# Minimal version of CMake:
+cmake_minimum_required(VERSION 3.1)
+
 message( "== CMake setup ==" )
 project(CGAL CXX C)
 export(PACKAGE CGAL)
-# Minimal version of CMake:
-cmake_minimum_required(VERSION 3.1)
 
 set( CGAL_BRANCH_BUILD ON CACHE INTERNAL "Create CGAL from a Git branch" FORCE)
 

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -3,12 +3,13 @@
 # refer to the root source directory of the project as ${CMAKE_SOURCE_DIR} or
 # ${CMAKE_SOURCE_DIR} and to the root binary directory of the project as
 # ${CMAKE_BINARY_DIR} or ${CMAKE_BINARY_DIR}.
-if(NOT PROJECT_NAME)
-  project(CGAL CXX C)
-endif()
 
 # Minimal version of CMake:
 cmake_minimum_required(VERSION 3.1)
+
+if(NOT PROJECT_NAME)
+  project(CGAL CXX C)
+endif()
 
 # Tested version:
 cmake_policy(VERSION 3.1)

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -118,7 +118,8 @@ if ( CGAL_FOUND )
 #    create_single_source_cgal_program( "mesh_polyhedral_surface_tolerance_region.cpp" )
 #    create_single_source_cgal_program( "mesh_polyhedral_edge_tolerance_region.cpp" )
 
-    foreach(target
+    if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TBB_FOUND AND TARGET ${target})
+      foreach(target
         mesh_3D_image_with_features
         mesh_3D_image
         mesh_polyhedral_domain
@@ -134,10 +135,9 @@ if ( CGAL_FOUND )
         mesh_polyhedral_complex
         mesh_polyhedral_domain_with_features
         mesh_3D_image_variable_size)
-      if(TBB_FOUND AND TARGET ${target})
         CGAL_target_use_TBB(${target})
-      endif()
-    endforeach()
+      endforeach()
+    endif()
 
 else()
   message(STATUS "This program requires the CGAL library, and will not be compiled.")

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -537,9 +537,11 @@ public:
         fit != end; ++fit)
     {
       Facet facet = *fit;
-      Facet mirror = tr_.mirror_facet(facet);
       set_surface_patch_index(facet.first, facet.second, Surface_patch_index());
-      set_surface_patch_index(mirror.first, mirror.second, Surface_patch_index());
+      if(this->triangulation().dimension() > 2) {
+        Facet mirror = tr_.mirror_facet(facet);
+        set_surface_patch_index(mirror.first, mirror.second, Surface_patch_index());
+      }
     }
     this->number_of_facets_ = 0;
     clear_manifold_info();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -38,12 +38,13 @@
 
 #include <CGAL/Mesh_3/Dump_c3t3.h>
 
-#include<CGAL/Mesh_3/Refine_facets_3.h>
-#include<CGAL/Mesh_3/Refine_facets_manifold_base.h>
-#include<CGAL/Mesh_3/Refine_cells_3.h>
+#include <CGAL/Mesh_3/Refine_facets_3.h>
+#include <CGAL/Mesh_3/Refine_facets_manifold_base.h>
+#include <CGAL/Mesh_3/Refine_cells_3.h>
 #include <CGAL/Mesh_3/Refine_tets_visitor.h>
 #include <CGAL/Mesher_level_visitors.h>
 #include <CGAL/Kernel_traits.h>
+#include <CGAL/point_generators_3.h>
 #include <CGAL/atomic.h>
 
 #ifdef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -678,9 +678,17 @@ initialize()
   else
 #endif // CGAL_LINKED_WITH_TBB
   {
+    if (r_c3t3_.number_of_far_points() == 0 &&
+        r_c3t3_.number_of_facets() == 0 &&
+        (r_c3t3_.triangulation().dimension() < 3
 #ifdef CGAL_SEQUENTIAL_MESH_3_ADD_OUTSIDE_POINTS_ON_A_FAR_SPHERE
-    if (r_c3t3_.number_of_far_points() == 0 && r_c3t3_.number_of_facets() == 0)
-    {
+         || true // in sequential mode, one wants the far points only
+                 // if the macro
+                 // `CGAL_SEQUENTIAL_MESH_3_ADD_OUTSIDE_POINTS_ON_A_FAR_SPHERE`
+                 // is defined, or if the dimension of the
+                 // triangulation is 2.
+#endif
+         )) {
       const Bbox_3 &bbox = r_oracle_.bbox();
 
       // Compute radius for far sphere
@@ -706,7 +714,6 @@ initialize()
       std::cerr << "done." << std::endl;
 # endif
     }
-#endif // CGAL_SEQUENTIAL_MESH_3_ADD_OUTSIDE_POINTS_ON_A_FAR_SPHERE
 
 #ifdef CGAL_MESH_3_PROFILING
     double init_time = t.elapsed();

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -530,7 +530,7 @@ void make_mesh_3_impl(C3T3& c3t3,
             with_features,
             mesh_options);
 
-  CGAL_assertion( c3t3.triangulation().dimension() == 3 );
+  CGAL_assertion( c3t3.triangulation().dimension() >= 2 );
 
   // Build mesher and launch refinement process
   // Don't reset c3t3 as we just created it

--- a/Periodic_3_mesh_3/package_info/Periodic_3_mesh_3/dependencies
+++ b/Periodic_3_mesh_3/package_info/Periodic_3_mesh_3/dependencies
@@ -7,6 +7,7 @@ Convex_hull_2
 Distance_2
 Distance_3
 Filtered_kernel
+Generator
 Hash_map
 Homogeneous_kernel
 Installation
@@ -26,6 +27,7 @@ Principal_component_analysis
 Principal_component_analysis_LGPL
 Profiling_tools
 Property_map
+Random_numbers
 STL_Extension
 Solver_interface
 Spatial_sorting

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -41,10 +41,7 @@ if(CGAL_FOUND AND CGAL_Core_FOUND AND Qt5_FOUND AND CGAL_Qt5_FOUND)
   #add_executable ( Periodic_4_hyperbolic_billiards_demo
   #Periodic_4_hyperbolic_billiards_demo.cpp ${RESOURCE_FILES} )
 
-  qt5_use_modules( P4HDT2 Widgets )
-  #qt5_use_modules( Periodic_4_hyperbolic_billiards_demo Widgets )
-
-  target_link_libraries( P4HDT2 ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} )
+  target_link_libraries( P4HDT2 ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} Qt5::Widgets)
 
   #target_link_libraries( Periodic_4_hyperbolic_billiards_demo ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES} )
 else()


### PR DESCRIPTION
## Summary of Changes

In Mesh_3, the initial triangulation after the initialization was assumed with `dimension() == 3`. But, if the input domain is completely coplanar then the initial triangulation can only have `dimension() == 2`. This PR:
  - enables the first stage of Mesh_3 to deal with a 2D triangulation,
  - and adds 3D far points unconditionally, to ensure that the triangulation is 3D for the next stages.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: maintenance by GeometryFactory

