### PR TITLE
Do not collapse an edge is the placement cannot be computed

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Detail/Edge_collapse_impl.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Detail/Edge_collapse_impl.h
@@ -260,7 +260,7 @@ namespace Surface_mesh_simplification
         // satisfying its constraints. In that case the remaining vertex is simply left unmoved.
         Placement_type lPlacement = get_placement(lProfile);
         
-        if ( Is_collapse_geometrically_valid(lProfile,lPlacement) )
+        if ( lPlacement!=boost::none && Is_collapse_geometrically_valid(lProfile,lPlacement) )
         {
           #ifdef CGAL_SURF_SIMPL_INTERMEDIATE_STEPS_PRINTING
           std::cout << "step " << i_rm << " " << source(*lEdge,mSurface)->point() << " " << target(*lEdge,mSurface)->point() << "\n";


### PR DESCRIPTION
Simple fix making it obvious that the placement must be valid.

My guess is that it was the job of the cost to return `boost::none` is the placement was invalid (but nothing was documented).