### PR TITLE
Demo: Fix warnings if no solver available

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_polygonal_impl.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_polygonal_impl.cpp
@@ -20,6 +20,12 @@ SMesh* polygonal_reconstruct (const Point_set& points,
                               double model_complexity,
                               const QString& solver_name)
 {
+  // Avoid warnings if no solver is available
+  CGAL_USE (data_fitting);
+  CGAL_USE (data_coverage);
+  CGAL_USE (model_complexity);
+  CGAL_USE (solver_name);
+  
   Point_set::Property_map<int> shape_map
     = points.property_map<int>("shape").first;
 


### PR DESCRIPTION
## Summary of Changes

If no solver is available, some parameters are not used, which can generate warnings (introduced by https://github.com/CGAL/cgal/pull/4108).

## Release Management

* Affected package(s): Demo