### PR TITLE
Fixed_alpha_shape_3: Replace destroyed with swapped in documentation

### DIFF
--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_3.h
@@ -477,7 +477,7 @@ Defined in `CGAL/IO/io.h`
 \pre The insert operator must be defined for `Point`. 
 \relates Alpha_shape_3 
 */ 
-  ostream& operator<<(std::ostream& os, 
+std::ostream& operator<<(std::ostream& os, 
 const Alpha_shape_3<Dt,ExactAlphaComparisonTag>& A); 
 
 /*!

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_cell_base_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Alpha_shape_cell_base_3.h
@@ -107,28 +107,28 @@ void set_alpha_max(NT alpha);
 /// @{
 
 /*!
-Returns true for Gabriel faces. 
+returns `true`  for Gabriel faces. 
 */ 
 bool is_Gabriel() const ; 
 
 /*!
-Returns true for convex hull faces. 
+returns `true` for convex hull faces. 
 */ 
 bool is_on_chull() const; 
 
 /*!
-Returns the `alpha_min`. 
-\pre `is_Gabriel()` returns false; 
+returns the `alpha_min`. 
+\pre `is_Gabriel()` returns `false`. 
 */ 
 NT alpha_min() const; 
 
 /*!
-Returns the `alpha_mid`.
+returns `alpha_mid`.
 */ 
 NT alpha_mid() const; 
 
 /*!
-Returns `alpha_max`. 
+returns `alpha_max`. 
 \pre `is_on_chull()` returns `false`. 
 */ 
 NT alpha_max() const; 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
@@ -55,11 +55,11 @@ Enum to classify the simplices of the underlying
 triangulation with respect to a given alpha value. 
 
 Each k-dimensional simplex of the triangulation 
-can be classified as EXTERIOR, SINGULAR, REGULAR 
-or INTERIOR. 
-A \f$ k\f$ simplex is REGULAR if it is on the boundary 
+can be classified as `EXTERIOR`, `SINGULAR`, `REGULAR` 
+or `INTERIOR`. 
+A \f$ k\f$ simplex is `REGULAR` if it is on the boundary 
 of the alpha complex and belongs to a \f$ k+1\f$ simplex in this complex 
-and it is SINGULAR if it is a boundary simplex that is not included in a \f$ k+1\f$ simplex of the complex. 
+and it is `SINGULAR` if it is a boundary simplex that is not included in a \f$ k+1\f$ simplex of the complex. 
 
 */ 
 enum Classification_type {EXTERIOR, SINGULAR, REGULAR, INTERIOR}; 
@@ -70,19 +70,19 @@ enum Classification_type {EXTERIOR, SINGULAR, REGULAR, INTERIOR};
 /// @{
 
 /*!
-Introduces an empty fixed alpha shape and sets the alpha value to `alpha`. 
+builds an empty fixed alpha shape and sets the alpha value to `alpha`. 
 */ 
 Fixed_alpha_shape_3(FT alpha = 0); 
 
 /*!
-Builds a fixed alpha shape from the triangulation `dt`, 
+builds a fixed alpha shape from the triangulation `dt`, 
 and sets the alpha value to `alpha`. 
 \attention This operation swaps `*this` and `dt`, that is `dt` is an empty triangulation once the fixed alpha shape is built.
 */ 
 Fixed_alpha_shape_3(Dt& dt,FT alpha = 0); 
 
 /*!
-Builds a fixed alpha shape for the points in the range 
+builds a fixed alpha shape for the points in the range 
 `[first,last)` and sets the alpha value to `alpha`. 
 \tparam InputIterator must be an input iterator with value type `Point` (the type point of the underlying triangulation.) 
 */ 
@@ -99,7 +99,7 @@ const FT& alpha = 0);
 
 /*!
 
-Inserts the point p in the underlying triangulation and returns the corresponding vertex.
+inserts the point `p` in the underlying triangulation and returns the corresponding vertex.
 The optional argument `start` is used as a starting place for the search. 
 The classification types of the new simplices are computed and that of the simplices incident 
 to the new ones are updated. 
@@ -109,14 +109,14 @@ Vertex_handle insert (Point p,Cell_handle start = Cell_handle());
 
 /*!
 
-Removes the vertex v from the underlying triangulation. 
+removes the vertex `v` from the underlying triangulation. 
 The classification types of new simplices and their incident faces are set or reset.
 
 */ 
 void remove (Vertex_handle v); 
 
 /*!
-Clears the structure. 
+clears the structure. 
 */ 
 void 
 clear(); 
@@ -127,40 +127,40 @@ clear();
 /// @{
 
 /*!
-Returns the \f$ \alpha\f$-value. 
+returns the \f$ \alpha\f$-value. 
 */ 
 const FT& 
 get_alpha(void) const; 
 
 /*!
-Classifies the cell `c` of the underlying triangulation in the alpha complex. 
+classifies the cell `c` of the underlying triangulation in the alpha complex. 
 */ 
 Classification_type 
 classify(Cell_handle c) const; 
 
 /*!
-Classifies the facet `f` of the underlying triangulation in the alpha complex. 
+classifies the facet `f` of the underlying triangulation in the alpha complex. 
 */ 
 Classification_type classify(Facet f) const; 
 
 /*!
-Classifies the facet of the cell `f` opposite to the vertex with index 
+classifies the facet of the cell `f` opposite to the vertex with index 
 `i` of the underlying triangulation in the alpha complex. 
 */ 
 Classification_type classify(Cell_handle f, int i) const; 
 
 /*!
-Classifies the edge `e` of the underlying triangulation in the alpha complex. 
+classifies the edge `e` of the underlying triangulation in the alpha complex. 
 */ 
 Classification_type classify(const Edge& e) const; 
 
 /*!
-Classifies the vertex `v` of the underlying triangulation in the alpha complex. 
+classifies the vertex `v` of the underlying triangulation in the alpha complex. 
 */ 
 Classification_type classify(Vertex_handle v) const; 
 
 /*!
-Writes the cells which are of type `type` in the alpha complex 
+writes the cells which are of type `type` in the alpha complex 
 to the sequence 
 pointed to by the output iterator `it`. Returns past the end 
 of the output sequence. 
@@ -169,7 +169,7 @@ template<class OutputIterator>
 OutputIterator get_alpha_shape_cells(OutputIterator it, Classification_type type); 
 
 /*!
-Writes the facets which are of type `type` in the alpha complex 
+writes the facets which are of type `type` in the alpha complex 
 to the sequence pointed to by the output iterator `it`. Returns past the end 
 of the output sequence. 
 */ 
@@ -177,7 +177,7 @@ template<class OutputIterator>
 OutputIterator get_alpha_shape_facets(OutputIterator it, Classification_type type); 
 
 /*!
-Writes the edges which are of type `type` in the alpha complex 
+writes the edges which are of type `type` in the alpha complex 
 to the sequence 
 pointed to by the output iterator `it`. Returns past the end 
 of the output sequence. 
@@ -186,7 +186,7 @@ template<class OutputIterator>
 OutputIterator get_alpha_shape_edges(OutputIterator it, Classification_type type); 
 
 /*!
-Writes the vertices which are of type `type` in the alpha complex 
+writes the vertices which are of type `type` in the alpha complex 
 to the sequence pointed to by the output iterator `it`. Returns past the end 
 of the output sequence. 
 */ 
@@ -198,7 +198,7 @@ OutputIterator get_alpha_shape_vertices(OutputIterator it, Classification_type t
 }; /* end Fixed_alpha_shape_3 */
 
 /*!
-Inserts the fixed alpha shape `A` into the stream `os`. 
+inserts the fixed alpha shape `A` into the stream `os`. 
 
 
 An overlaoad of `operator<<` must be available for `GT::Point`.

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
@@ -77,7 +77,7 @@ Fixed_alpha_shape_3(FT alpha = 0);
 /*!
 Builds a fixed alpha shape from the triangulation `dt`, 
 and sets the alpha value to `alpha`. 
-\attention This operation destroys the triangulation. 
+\attention This operation swaps `*this` and `dt`, that is `dt` is an empty triangulation once the fixed alpha shape is built.
 */ 
 Fixed_alpha_shape_3(Dt& dt,FT alpha = 0); 
 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/CGAL/Fixed_alpha_shape_3.h
@@ -204,7 +204,7 @@ inserts the fixed alpha shape `A` into the stream `os`.
 An overlaoad of `operator<<` must be available for `GT::Point`.
 \relates Fixed_alpha_shape_3 
 */ 
-ostream& operator<<(ostream& os, const Fixed_alpha_shape_3<Dt>& A); 
+  std::ostream& operator<<(std::ostream& os, const Fixed_alpha_shape_3<Dt>& A); 
 
 
 } /* end namespace CGAL */


### PR DESCRIPTION
## Summary of Changes

Rephrase the documentation of a  constructor.

## Release Management

* Affected package(s): Alpha_shapes_3
* Issue(s) solved (if any):  See [stackoverflow](https://stackoverflow.com/questions/57572583/does-fixed-alpha-shape-3-destroy-or-modify-original-triangulation)

