### PR TITLE
PMP: Fix distance range type

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -663,7 +663,7 @@ double approximate_symmetric_Hausdorff_distance(
  * \ingroup PMP_distance_grp
  * returns the distance to `tm` of the point from `points`
  * that is the furthest from `tm`.
- * @tparam PointRange a range of `Point_3`, model of `Range`.
+ * @tparam PointRange a range of `Point_3`, model of `Range`. Its iterator type is `RandomAccessIterator`.
  * @tparam TriangleMesh a model of the concept `FaceListGraph`
  * @tparam NamedParameters a sequence of \ref pmp_namedparameters "Named Parameters"
  * @param points the range of points of interest


### PR DESCRIPTION
## Summary of Changes

The function `approximate_Hausdorff_distance_impl()` has a `PointRange` as parameter but then calls a functor with `std::vector<Point_3>` as parameter, which makes the function unable to handle anything else than a vector of Point_3 (which makes the template useless).

This PR makes the functor us a `PointRange` too.

The range used by `max_distance_to_triangle_mesh()` is now documented as having random access iterators.

## Release Management

* Affected package(s): PMP

