### PR TITLE
PSP: fix documentation of PLY IO

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -722,7 +722,7 @@ namespace internal {
   /// \endcond
   
 
-/*
+/**
   \ingroup PkgPointSetProcessingIOPly
 
   Reads user-selected points properties from a .ply stream (ASCII or

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -355,7 +355,8 @@ namespace internal {
    \cgalRequiresCPP11
 
    \tparam PointRange is a model of `ConstRange`. The value type of
-   its iterator is the key type of the named parameter `point_map`.
+   its iterator is the key type of the `PropertyMap` objects provided
+   within the `PropertyHandler` parameter.
    \tparam PropertyHandler handlers to recover properties.
 
    \return `true` on success.


### PR DESCRIPTION
## Summary of Changes

* The documentation of `read_ply_with_properties()` was not compiled because `/*` was used instead of `/**`
* The documentation of `write_ply_with_properties()` was incorrect, referring to a non-existing `point_map` parameter

## Release Management

* Affected package(s): PSP (doc)