### PR TITLE
PMP: Fix boundary cycle when non manifold vertices exist in the cycle (5.0)

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -633,7 +633,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
   // not everything is always stitchable
   std::set<halfedge_descriptor> unstitchable_halfedges;
 
-  halfedge_descriptor null_h = boost::graph_traits<PolygonMesh>::null_halfedge();
+  const halfedge_descriptor null_h = boost::graph_traits<PolygonMesh>::null_halfedge();
   halfedge_descriptor bh = h;
   for(;;) // until there is nothing to stitch anymore
   {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -704,7 +704,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
 #endif
 
       // check if we have reached the end of the cycle
-      if(curr_h == curr_hn || curr_h == next(curr_hn, pm))
+      if(prev(curr_h, pm) == curr_hn || prev(curr_h, pm) == next(curr_hn, pm))
       {
         bh = null_h;
         break;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -20,8 +20,8 @@
 // Author(s)     : Sebastien Loriot
 //                 Mael Rouxel-Labbé
 
-#ifndef CGAL_POLYGON_MESH_PROCESSING_STITCH_POLYGON_MESH_H
-#define CGAL_POLYGON_MESH_PROCESSING_STITCH_POLYGON_MESH_H
+#ifndef CGAL_POLYGON_MESH_PROCESSING_STITCH_BORDERS_H
+#define CGAL_POLYGON_MESH_PROCESSING_STITCH_BORDERS_H
 
 #include <CGAL/license/Polygon_mesh_processing/repair.h>
 
@@ -940,4 +940,4 @@ void stitch_borders(PolygonMesh& pmesh)
 
 #include <CGAL/enable_warnings.h>
 
-#endif //CGAL_POLYGON_MESH_PROCESSING_STITCH_POLYGON_MESH_H
+#endif //CGAL_POLYGON_MESH_PROCESSING_STITCH_BORDERS_H

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_stitching.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_stitching.cpp
@@ -21,6 +21,8 @@ typedef CGAL::Exact_predicates_exact_constructions_kernel       EPECK;
 void test_stitch_boundary_cycles(const char* fname,
                                  const std::size_t expected_n)
 {
+  std::cout << "Testing boundary cycles " << fname << "..." << std::flush;
+
   typedef CGAL::Surface_mesh<EPICK::Point_3>                    Mesh;
 
   std::ifstream input(fname);
@@ -135,7 +137,7 @@ void bug_test()
 
 int main()
 {
-  test_stitch_boundary_cycles("data_stitching/boundary_cycle.off", 5);
+  test_stitch_boundary_cycles("data_stitching/boundary_cycle.off", 4);
   test_stitch_boundary_cycles("data_stitching/boundary_cycle_2.off", 2);
 
   test_polyhedron<EPECK>("data_stitching/full_border.off");


### PR DESCRIPTION
## Summary of Changes

Boundary cycle stitching was done by "zipping" the cycle up from all potential starting points (a pair of consecutive & geometrically equal border halfedges). When there are non manifold vertices, this doesn't work because zipping from one side can zip part of another starting pair.

The function is completely rewritten to zip compatible ranges one-by-one instead (theoretically worse complexity, but unnoticeable in practice).

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -

