### PR TITLE
 PMP: Fix boundary cycle when non manifold vertices exist in the cycle (4.14)

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -621,7 +621,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
       hedges_to_stitch.push_back(std::make_pair(curr_h, curr_hn));
 
       // check if we have reached the end of the cycle
-      if(curr_h == curr_hn || curr_h == next(curr_hn, pm))
+      if(prev(curr_h, pm) == curr_hn || prev(curr_h, pm) == next(curr_hn, pm))
       {
         bh = null_h;
         break;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -566,7 +566,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
   // not everything is always stitchable
   std::set<halfedge_descriptor> unstitchable_halfedges;
 
-  halfedge_descriptor null_h = boost::graph_traits<PolygonMesh>::null_halfedge();
+  const halfedge_descriptor null_h = boost::graph_traits<PolygonMesh>::null_halfedge();
   halfedge_descriptor bh = h;
   for(;;) // until there is nothing to stitch anymore
   {


### PR DESCRIPTION
## Summary of Changes

See #4174.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -

