### PR TITLE
Incorrect lines in bib file

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -146,7 +146,7 @@ Pion and Monique Teillaud and Mariette Yvinec"
 @ARTICLE{cgal:bdt-hdcvd-14,
    AUTHOR       = {Mikhail Bogdanov and Olivier Devillers and Monique Teillaud},
    JOURNAL      = {Journal of Computational Geometry},
-   NOTE         = {https://hal.inria.fr/hal-00961390|,
+   NOTE         = {https://hal.inria.fr/hal-00961390},
    PAGES        = {56--85},
    TITLE        = {Hyperbolic {Delaunay} complexes and {Voronoi} diagrams made practical},
    VOLUME       = {5},
@@ -2251,6 +2251,7 @@ location    = {Salt Lake City, Utah, USA}
                   Geodesy and Photogrammetry)},
   url           = {http://www.prs.igp.ethz.ch/research/Source_code_and_datasets.html},
   year          = 2014
+}
 
 @inproceedings{ cgal:wk-srhvs-05,
   title={Structure recovery via hybrid variational surface approximation},
@@ -2720,6 +2721,7 @@ ADDRESS = "Saarbr{\"u}cken, Germany"
  year={2009},
  pages={1-6},
  url = {https://igl.ethz.ch/projects/ARAP/}
+}
 
 @book{cgal:bc:m-dbc-27,
   Address   = {Leipzig},


### PR DESCRIPTION
- adding missing closing curly bracket (twice)
- correcting typo '|' -> '}'
