### PR TITLE
Kernel_23: Fix documentation of functor `ConstructLiftedPoint_3`

### DIFF
--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -4701,8 +4701,8 @@ public:
 
   \cgalRefines `AdaptableFunctor` (with two arguments) 
 
-  \sa `CGAL::Plane_3<Kernel>` 
-
+  \sa `CGAL::Plane_3<Kernel>`
+  \sa `ConstructProjectedXYPoint_2`
 */
 class ConstructLiftedPoint_3 {
 public:
@@ -4712,8 +4712,10 @@ public:
   /// @{
 
   /*!
-    returns a point `q` on plane `h`, such that the projection of 
-    this point onto the \f$ xy\f$-plane is `p`. 
+    returns the image point of the projection of `p`
+    under an affine transformation which maps the \f$ xy\f$-plane onto `h`.
+    This affine transformation must be the inverse of the affine transformation used
+    in `ConstructProjectedXYPoint_2`.
   */ 
   Kernel::Point_3 operator()(const Kernel::Plane_3& h, 
                              const Kernel::Point_2& p); 
@@ -5999,8 +6001,8 @@ public:
 
   \cgalRefines `AdaptableFunctor` (with two arguments) 
 
-  \sa `CGAL::Plane_3<Kernel>` 
-
+  \sa `CGAL::Plane_3<Kernel>`
+  \sa `ConstructLiftedPoint_3`
 */
 class ConstructProjectedXYPoint_2 {
 public:
@@ -6012,7 +6014,9 @@ public:
   /*!
     returns the image point of the projection of `p` under an affine 
     transformation, which maps `h` onto the \f$ xy\f$-plane, with the 
-    \f$ z\f$-coordinate removed. 
+    \f$ z\f$-coordinate removed.
+    This affine transformation must be the inverse of the affine transformation used
+    in `ConstructLiftedPoint_3`.
   */ 
   Kernel::Point_2 operator()(const Kernel::Plane_3& h, 
                              const Kernel::Point_3& p); 


### PR DESCRIPTION
## Summary of Changes

Documentation of the functor seems to indicate the projection of the lifted point along `Oz` would be the 2D point, but this is not what this functor is about. Rather, it maps the `xOy` plane and the user-provided plane via an affine transformation (in the CGAL implementation, it maps `Ox` and `Oy` to the vectors given by `plane.base1()` and `plane.base2()`.

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): -

