### PR TITLE
Polyline_constraint_hierarchy_2.h: remove the useless point_ data member

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -37,12 +37,11 @@ namespace CGAL {
 
 // T               is expected to be Vertex_handle
 // Compare         is a comparison operator for type T
-// Data            is intended to store info on a Vertex
-template <class T, class Compare, class Data>
+// Point           the point type of vertices
+template <class T, class Compare, class Point>
 class Polyline_constraint_hierarchy_2
 {
 public:
-  typedef Data                                    Point;
   typedef T                                       Vertex_handle;
   typedef std::pair<T, T>                         Edge;
   typedef std::pair<T, T>                         Constraint;
@@ -157,7 +156,7 @@ public:
   };
 
   class Context {
-    friend class Polyline_constraint_hierarchy_2<T,Compare,Data>;
+    friend class Polyline_constraint_hierarchy_2<T,Compare,Point>;
   private:
     Vertex_list*    enclosing;
     Vertex_it       pos;
@@ -291,8 +290,8 @@ public:
   void   print() const;
 };
 
-template <class T, class Compare, class Data>
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 Polyline_constraint_hierarchy_2(const Polyline_constraint_hierarchy_2& ch)
   : comp(ch.comp)
   , sc_to_c_map(Pair_compare(comp))
@@ -300,17 +299,17 @@ Polyline_constraint_hierarchy_2(const Polyline_constraint_hierarchy_2& ch)
   copy(ch);
 }
 
-template <class T, class Compare, class Data>
-Polyline_constraint_hierarchy_2<T,Compare,Data>&
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+Polyline_constraint_hierarchy_2<T,Compare,Point>&
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 operator=(const Polyline_constraint_hierarchy_2& ch){
   copy(ch);
   return *this;
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 copy(const Polyline_constraint_hierarchy_2& ch1)
 {
   // create a identity transfer vertex map
@@ -325,9 +324,9 @@ copy(const Polyline_constraint_hierarchy_2& ch1)
   copy(ch1, vmap);
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 copy(const Polyline_constraint_hierarchy_2& ch1, std::map<Vertex_handle,Vertex_handle>& vmap)
   // copy with a transfer vertex map
 {
@@ -372,9 +371,9 @@ copy(const Polyline_constraint_hierarchy_2& ch1, std::map<Vertex_handle,Vertex_h
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 swap(Polyline_constraint_hierarchy_2& ch)
 {
   constraint_set.swap(ch.constraint_set);
@@ -383,16 +382,16 @@ swap(Polyline_constraint_hierarchy_2& ch)
 
 
 /*
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 is_constrained_edge(T va, T vb) const
 {
   return( c_to_sc_map.find(make_edge(va, vb)) != c_to_sc_map.end() );
 }
 */
 
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 is_subconstrained_edge(T va, T vb) const
 {
   return( sc_to_c_map.find(make_edge(va, vb)) != sc_to_c_map.end() );
@@ -400,8 +399,8 @@ is_subconstrained_edge(T va, T vb) const
 
 
 // af: obsolete
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 enclosing_constraint(Edge he, Constraint& hc) const
 {
   Context_iterator hcit, past;
@@ -412,8 +411,8 @@ enclosing_constraint(Edge he, Constraint& hc) const
 
 
 // used by Constrained_triangulation_plus_2::intersect with Exact_intersection_tag
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 enclosing_constraint(T  vaa, T  vbb, T& va, T& vb) const
 {
   Context_iterator hcit, past;
@@ -440,8 +439,8 @@ enclosing_constraint(T  vaa, T  vbb, T& va, T& vb) const
 }
 
 // af: obsolete
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 enclosing_constraints(T vaa, T vbb , Constraint_list& hcl) const
 {
   Context_iterator hcit, past;
@@ -453,9 +452,9 @@ enclosing_constraints(T vaa, T vbb , Constraint_list& hcl) const
   return true;
 }
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Context
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Context
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 context(T va, T vb)
 {
   Context_iterator hcit, past;
@@ -463,9 +462,9 @@ context(T va, T vb)
   return *hcit;
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 std::size_t 
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 number_of_enclosing_constraints(T va, T vb) const
 {
   Context_list* hcl = nullptr;
@@ -474,9 +473,9 @@ number_of_enclosing_constraints(T va, T vb) const
   return hcl->size();
 }
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Context_iterator
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Context_iterator
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 contexts_begin(T va, T vb) const
 {
    Context_iterator first, last;
@@ -484,9 +483,9 @@ contexts_begin(T va, T vb) const
    return first;
 }
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Context_iterator
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Context_iterator
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 contexts_end(T va, T vb) const
 {   
    Context_iterator first, last;
@@ -494,9 +493,9 @@ contexts_end(T va, T vb) const
    return last;
 } 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 swap(Constraint_id first, Constraint_id second){
     // We have to look at all subconstraints
   for(Vertex_it it = first.vl_ptr()->skip_begin(), succ = it, end = first.vl_ptr()->skip_end(); 
@@ -550,9 +549,9 @@ swap(Constraint_id first, Constraint_id second){
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 remove_constraint(Constraint_id cid){
   constraint_set.erase(cid);
   
@@ -587,8 +586,8 @@ remove_constraint(Constraint_id cid){
 // This function removes vertex v from the polyline constraint
 // It only works for one polyline passing through v
 // and for the case that the constrained edge u,w has no intersections
-template <class T, class Compare, class Data>
-void Polyline_constraint_hierarchy_2<T,Compare,Data>::simplify(Vertex_it uc,
+template <class T, class Compare, class Point>
+void Polyline_constraint_hierarchy_2<T,Compare,Point>::simplify(Vertex_it uc,
                                                        Vertex_it vc,
                                                        Vertex_it wc)
 
@@ -635,9 +634,9 @@ void Polyline_constraint_hierarchy_2<T,Compare,Data>::simplify(Vertex_it uc,
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 std::size_t
-Polyline_constraint_hierarchy_2<T,Compare,Data>::remove_points_without_corresponding_vertex(Constraint_id cid)
+Polyline_constraint_hierarchy_2<T,Compare,Point>::remove_points_without_corresponding_vertex(Constraint_id cid)
 {
   std::size_t n = 0;
   for(Point_it it = points_in_constraint_begin(cid); 
@@ -650,9 +649,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::remove_points_without_correspon
   return n;
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 std::size_t
-Polyline_constraint_hierarchy_2<T,Compare,Data>::remove_points_without_corresponding_vertex()
+Polyline_constraint_hierarchy_2<T,Compare,Point>::remove_points_without_corresponding_vertex()
 {
   std::size_t n = 0;
   for(C_iterator it = constraint_set.begin(); it!= constraint_set.end(); ++it){
@@ -662,9 +661,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::remove_points_without_correspon
 }
 
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Constraint_id
-Polyline_constraint_hierarchy_2<T,Compare,Data>::concatenate(Constraint_id first, Constraint_id second)
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Constraint_id
+Polyline_constraint_hierarchy_2<T,Compare,Point>::concatenate(Constraint_id first, Constraint_id second)
 {
   constraint_set.erase(first);
   constraint_set.erase(second);
@@ -715,9 +714,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::concatenate(Constraint_id first
   return first;
 }
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Constraint_id
-Polyline_constraint_hierarchy_2<T,Compare,Data>::concatenate2(Constraint_id first, Constraint_id second)
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Constraint_id
+Polyline_constraint_hierarchy_2<T,Compare,Point>::concatenate2(Constraint_id first, Constraint_id second)
 {  
   constraint_set.erase(first);
   constraint_set.erase(second);
@@ -771,9 +770,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::concatenate2(Constraint_id firs
   // split a constraint in two constraints, so that vcit becomes the first
   // vertex of the new constraint
   // returns the new constraint 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Constraint_id
-Polyline_constraint_hierarchy_2<T,Compare,Data>::split(Constraint_id first, Vertex_it vcit)
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Constraint_id
+Polyline_constraint_hierarchy_2<T,Compare,Point>::split(Constraint_id first, Vertex_it vcit)
 {
   constraint_set.erase(first);
   Vertex_list* second = new Vertex_list;
@@ -805,9 +804,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::split(Constraint_id first, Vert
   return second;
 }
 
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Constraint_id
-Polyline_constraint_hierarchy_2<T,Compare,Data>::split2(Constraint_id first, Vertex_it vcit)
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Constraint_id
+Polyline_constraint_hierarchy_2<T,Compare,Point>::split2(Constraint_id first, Vertex_it vcit)
 {
   constraint_set.erase(first);
   Vertex_list* second = new Vertex_list;
@@ -844,9 +843,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Data>::split2(Constraint_id first, Ver
 when a constraint is inserted,
 it is, at first, both  a constraint and a subconstraint
  */
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_list*
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Vertex_list*
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 insert_constraint(T va, T vb){
   Edge        he = make_edge(va, vb);
   Vertex_list*  children = new Vertex_list; 
@@ -872,9 +871,9 @@ insert_constraint(T va, T vb){
 }
 
   
-template <class T, class Compare, class Data>
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_list*
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Vertex_list*
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 insert_constraint_old_API(T va, T vb){
   Edge        he = make_edge(va, vb);
 
@@ -901,9 +900,9 @@ insert_constraint_old_API(T va, T vb){
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 append_constraint(Constraint_id cid, T va, T vb){
   Edge        he = make_edge(va, vb);
   Context_list* fathers;
@@ -926,8 +925,8 @@ append_constraint(Constraint_id cid, T va, T vb){
 }
 
 
-template <class T, class Compare, class Data>
-void Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+void Polyline_constraint_hierarchy_2<T,Compare,Point>::
 clear()
 {
   C_iterator cit;
@@ -947,8 +946,8 @@ clear()
 }
 
 
-template <class T, class Compare, class Data>
-bool Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+bool Polyline_constraint_hierarchy_2<T,Compare,Point>::
 next_along_sc(T va, T vb, T& w) const
 {
   // find the next vertex after vb along any enclosing constrained
@@ -976,8 +975,8 @@ next_along_sc(T va, T vb, T& w) const
   Attention, le point v DOIT etre un point de Steiner,
   et les segments va,v et v,vb sont des sous contraintes.
 */
-template <class T, class Compare, class Data>
-void Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+void Polyline_constraint_hierarchy_2<T,Compare,Point>::
 remove_Steiner(T v, T va, T vb)
 {
   // remove a Steiner point
@@ -1008,16 +1007,16 @@ remove_Steiner(T v, T va, T vb)
   same as add_Steiner
   precondition : va,vb est une souscontrainte. 
 */
-template <class T, class Compare, class Data>
-void Polyline_constraint_hierarchy_2<T,Compare,Data>::
+template <class T, class Compare, class Point>
+void Polyline_constraint_hierarchy_2<T,Compare,Point>::
 split_constraint(T va, T vb, T vc){
   add_Steiner(va, vb, vc);
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void 
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 add_Steiner(T va, T vb, T vc){
   Context_list* hcl=nullptr;
   if(!get_contexts(va,vb,hcl)) CGAL_triangulation_assertion(false);
@@ -1068,19 +1067,19 @@ add_Steiner(T va, T vb, T vc){
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 inline
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Edge
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Edge
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 make_edge(T va, T vb) const
 {
   return comp(va, vb) ? Edge(va,vb) : Edge(vb,va);
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 inline
 bool
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 get_contexts(T va, T vb, Context_list* & hcl) const
 {
   Sc_iterator sc_iter = sc_to_c_map.find(make_edge(va,vb));
@@ -1089,10 +1088,10 @@ get_contexts(T va, T vb, Context_list* & hcl) const
   return true;
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 inline
 bool
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 get_contexts(T va, T vb, 
 	     Context_iterator& ctxt, 
 	     Context_iterator& past) const
@@ -1106,19 +1105,19 @@ get_contexts(T va, T vb,
 
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 inline
-typename Polyline_constraint_hierarchy_2<T,Compare,Data>::Vertex_it
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+typename Polyline_constraint_hierarchy_2<T,Compare,Point>::Vertex_it
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 get_pos(T va, T vb) const
   //return pos in the first context
 {
     return (*sc_to_c_map.find(make_edge(va,vb))).second->begin().pos;
 }
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 oriented_end(T va, T vb, T& vc) const
 {
   Context_iterator ctxt, past;
@@ -1130,9 +1129,9 @@ oriented_end(T va, T vb, T& vc) const
 }
 
 
-template <class T, class Compare, class Data>
+template <class T, class Compare, class Point>
 void
-Polyline_constraint_hierarchy_2<T,Compare,Data>::
+Polyline_constraint_hierarchy_2<T,Compare,Point>::
 print() const
 { 
   C_iterator hcit;

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -52,14 +52,12 @@ private:
   class Node {
   public:
     explicit Node(Vertex_handle vh, bool input = false)
-      : vertex_(vh), point_(vh->point()), id(-1), input(input)
+      : vertex_(vh), id(-1), input(input)
     {}
-    Point& point() { return point_; }
-    const Point& point() const { return point_; }
+    const Point& point() const { return vertex_->point(); }
     Vertex_handle vertex() const { return vertex_; }
   private:
     Vertex_handle vertex_;
-    Point point_;
   public:
     int id;
     bool input;
@@ -74,7 +72,7 @@ public:
     : public boost::iterator_adaptor<
     Point_it
     , typename Vertex_list::all_iterator 
-    , Point
+    , const Point
     >
   {
   public:
@@ -82,7 +80,7 @@ public:
     Point_it(typename Vertex_list::all_iterator it) : Point_it::iterator_adaptor_(it) {}
   private:
     friend class boost::iterator_core_access;
-    Point& dereference() const { return this->base()->point(); }
+    const Point& dereference() const { return this->base()->point(); }
   };
 
   // only nodes with a vertex_handle that is still in the triangulation


### PR DESCRIPTION
## Summary of Changes

Small cleanup PR : remove the useless `point_` data member from `Polyline_constraint_hierarchy_2.h`. A *const* reference to the point can be retrieved as `vertex_->point()`.

The `id` public data seems also useless, but it is actually used in `Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h`.

## Release Management

* Affected package(s): Triangulation_2, Polyline_simplification_2
* License and copyright ownership: maintenance by GeometryFactory

