### PR TITLE
Hyperbolic_triangulation_2: Fix demo

### DIFF
--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core Qt5)
 find_package(LEDA QUIET)
 
 if(CGAL_FOUND AND CGAL_Qt5_FOUND AND Qt5_FOUND AND (CGAL_Core_FOUND OR LEDA_FOUND))
+  include_directories( BEFORE ./ ./include )
   # ui files, created with Qt Designer
   qt5_wrap_ui( UIS HDT2.ui )
   


### PR DESCRIPTION
## Summary of Changes

A `include_directories()` instruction disappeared from the CMakeLists.txt of HDT_2 demo. It fixes it.
