### PR TITLE
Aos 2 small fixes efif

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
@@ -1927,8 +1927,13 @@ public:
       const Kernel* kernel = m_traits;
       typename Kernel::Equal_3 equal = kernel->equal_3_object();
 
+      // Down cast to pass to kernel member functions
+      const Direction_3& xc1_left = xc1.left();
+      const Direction_3& xc2_left = xc2.left();
+      const Direction_3& xc1_right = xc1.right();
+      const Direction_3& xc2_right = xc2.right();
       if (xc1.is_degenerate() && xc2.is_degenerate())
-        return equal(xc1.left(), xc2.left());
+        return equal(xc1_left, xc2_left);
       if ((xc1.is_full() || xc1.is_meridian()) && xc2.is_degenerate())
         return xc1.has_on(xc2.left());
       if ((xc2.is_full() || xc2.is_meridian()) && xc1.is_degenerate())
@@ -1941,8 +1946,8 @@ public:
       if (!equal(normal1, normal2) && !equal(opposite_normal1, normal2))
         return false;
 
-      bool eq1 = equal(xc1.right(), xc2.left());
-      bool eq2 = equal(xc1.left(), xc2.right());
+      bool eq1 = equal(xc1_right, xc2_left);
+      bool eq2 = equal(xc1_left, xc2_right);
 
 #if defined(CGAL_FULL_X_MONOTONE_GEODESIC_ARC_ON_SPHERE_IS_SUPPORTED)
       if (eq1 && eq2) return true;
@@ -2001,14 +2006,20 @@ public:
       const Kernel* kernel = m_traits;
       typename Kernel::Equal_3 equal = kernel->equal_3_object();
 
+      // Down cast to pass to kernel member functions
+      const Direction_3& xc1_right = xc1.right();
+      const Direction_3& xc2_right = xc2.right();
+      const Direction_3& xc1_left = xc1.left();
+      const Direction_3& xc2_left = xc2.left();
+
       xc.set_is_degenerate(false);
       xc.set_is_empty(false);
       xc.set_is_vertical(xc1.is_vertical());
 
-      bool eq1 = equal(xc1.right(), xc2.left());
+      bool eq1 = equal(xc1_right, xc2_left);
 
 #if defined(CGAL_FULL_X_MONOTONE_GEODESIC_ARC_ON_SPHERE_IS_SUPPORTED)
-      bool eq2 = equal(xc1.left(), xc2.right());
+      bool eq2 = equal(xc1_left, xc2_right);
       if (eq1 && eq2) {
         const Point_2& p =
           xc1.source().is_mid_boundary() ? xc1.source() : xc1.target();
@@ -2027,7 +2038,7 @@ public:
           xc.set_source(xc1.left());
           xc.set_target(xc2.right());
         } else {
-          CGAL_assertion(equal(xc1.left(), xc2.right()));
+          CGAL_assertion(equal(xc1_left, xc2_right));
           xc.set_source(xc2.left());
           xc.set_target(xc1.right());
         }
@@ -2039,7 +2050,7 @@ public:
           xc.set_source(xc2.right());
           xc.set_target(xc1.left());
         } else {
-          CGAL_assertion(equal(xc1.left(), xc2.right()));
+          CGAL_assertion(equal(xc1_left, xc2_right));
           xc.set_source(xc1.right());
           xc.set_target(xc2.left());
         }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
@@ -2008,8 +2008,6 @@ public:
 
       // Down cast to pass to kernel member functions
       const Direction_3& xc1_right = xc1.right();
-      const Direction_3& xc2_right = xc2.right();
-      const Direction_3& xc1_left = xc1.left();
       const Direction_3& xc2_left = xc2.left();
 
       xc.set_is_degenerate(false);
@@ -2019,6 +2017,8 @@ public:
       bool eq1 = equal(xc1_right, xc2_left);
 
 #if defined(CGAL_FULL_X_MONOTONE_GEODESIC_ARC_ON_SPHERE_IS_SUPPORTED)
+      const Direction_3& xc1_left = xc1.left();
+      const Direction_3& xc2_right = xc2.right();
       bool eq2 = equal(xc1_left, xc2_right);
       if (eq1 && eq2) {
         const Point_2& p =
@@ -2028,8 +2028,10 @@ public:
         xc.set_normal(xc1.normal());
         xc.set_is_full(true);
       }
+#else
+      CGAL_assertion_code(const Direction_3& xc1_left = xc1.left();
+                          const Direction_3& xc2_right = xc2.right());
 #endif
-
       if (xc1.is_directed_right() || xc2.is_directed_right()) {
         xc.set_normal(xc1.is_directed_right() ? xc1.normal() : xc2.normal());
         xc.set_is_directed_right(true);
@@ -2037,19 +2039,22 @@ public:
         if (eq1) {
           xc.set_source(xc1.left());
           xc.set_target(xc2.right());
-        } else {
+        }
+        else {
           CGAL_assertion(equal(xc1_left, xc2_right));
           xc.set_source(xc2.left());
           xc.set_target(xc1.right());
         }
-      } else {
+      }
+      else {
         xc.set_normal(xc1.normal());
         xc.set_is_directed_right(false);
 
         if (eq1) {
           xc.set_source(xc2.right());
           xc.set_target(xc1.left());
-        } else {
+        }
+        else {
           CGAL_assertion(equal(xc1_left, xc2_right));
           xc.set_source(xc1.right());
           xc.set_target(xc2.left());

--- a/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_polycurve_basic_traits_2.h
@@ -2521,11 +2521,8 @@ protected:
   template <typename Comparer>
   class Compare_points {
   private:
-    typedef Arr_polycurve_basic_traits_2<Subcurve_traits_2>
-      Polycurve_basic_traits_2;
-
     /*! The polycurve traits (in case it has state). */
-    const Polycurve_basic_traits_2 m_poly_traits;
+    const Subcurve_traits_2& m_subcurve_traits;
 
     const Point_2& m_point;
 
@@ -2533,9 +2530,9 @@ protected:
 
   public:
     // Constructor
-    Compare_points(const Polycurve_basic_traits_2& traits, Comparer compare,
+    Compare_points(const Subcurve_traits_2& traits, Comparer compare,
                    const Point_2& p) :
-      m_poly_traits(traits),
+      m_subcurve_traits(traits),
       m_point(p),
       m_compare(compare)
     {}
@@ -2544,10 +2541,9 @@ protected:
     Comparison_result operator()(const X_monotone_subcurve_2& xs,
                                  Arr_curve_end ce)
     {
-      const Subcurve_traits_2* geom_traits = m_poly_traits.subcurve_traits_2();
       const Point_2& p = (ce == ARR_MAX_END) ?
-        geom_traits->construct_max_vertex_2_object()(xs) :
-        geom_traits->construct_min_vertex_2_object()(xs);
+        m_subcurve_traits.construct_max_vertex_2_object()(xs) :
+        m_subcurve_traits.construct_min_vertex_2_object()(xs);
       return m_compare(p, m_point);
     }
   };
@@ -2696,12 +2692,12 @@ protected:
       Comparison_result res = compare_x(min_vertex(xcv[0]), q);
       if (res != EQUAL) return INVALID_INDEX;
 
-      Compare_points<Compare_xy_2> compare(geom_traits,
+      Compare_points<Compare_xy_2> compare(*geom_traits,
                                            compare_xy_2_object(), q);
       return locate_gen(xcv, compare);
     }
 
-    Compare_points<Compare_x_2> compare(geom_traits, compare_x_2_object(), q);
+    Compare_points<Compare_x_2> compare(*geom_traits, compare_x_2_object(), q);
     return locate_gen(xcv, compare);
   }
 


### PR DESCRIPTION
## Summary of Changes

1. Fixed discrepancy between traits and subcurve-traits in the polycurve basic traits.
2. Down casted a variable of type Point_2 (extended direction) to the Kernel::Direction_2 type, so that it can be passed to kernel functors.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

