### PR TITLE
Classification: Fix OpenCV includes

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -18,7 +18,7 @@ do
   DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-3.6 zsh \
 flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  libboost1.55-dev \
 libboost-system1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev libboost-iostreams1.55-dev \
-qt55base qt55script qt55svg qt55tools qt55graphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
+qt55base qt55script qt55svg qt55tools qt55graphicaleffects libopencv-dev libopencv-ml-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
 || DONE=0 && sudo apt-get update
 done
 exit 0

--- a/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
+++ b/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
@@ -27,7 +27,14 @@
 #include <CGAL/Classification/Label_set.h>
 
 #include <opencv2/opencv.hpp>
+
+#if CV_VERSION_MAJOR > 2 \
+||  (CV_VERSION_MINOR == 4 && CV_VERSION_REVISION >= 11)
 #include <opencv2/ml.hpp>
+#else
+#include <opencv2/ml/ml.hpp>
+#endif
+
 
 
 namespace CGAL {

--- a/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
+++ b/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
@@ -25,13 +25,10 @@
 
 #include <CGAL/Classification/Feature_set.h>
 #include <CGAL/Classification/Label_set.h>
-#if (CV_MAJOR_VERSION < 3)
-#include <cv.h>
-#include <ml.h>
-#else
-#include <opencv/cv.h>
-#include <opencv/ml.h>
-#endif
+
+#include <opencv2/opencv.hpp>
+#include <opencv2/ml.hpp>
+
 
 namespace CGAL {
 

--- a/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
+++ b/Classification/include/CGAL/Classification/OpenCV_random_forest_classifier.h
@@ -28,12 +28,18 @@
 
 #include <opencv2/opencv.hpp>
 
-#if CV_VERSION_MAJOR > 2 \
-||  (CV_VERSION_MINOR == 4 && CV_VERSION_REVISION >= 11)
-#include <opencv2/ml.hpp>
+//In opencv version 2.X the first digit is named EPOCH,
+//until version 3.0 where EPOCH disappears and it becomes MAJOR. Hence this
+//weird condition
+#ifdef CV_VERSION_EPOCH
+  #if  CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR>= 11
+    #include <opencv2/ml.hpp>
+  #else
+    #include <opencv2/ml/ml.hpp>
+  #endif
 #else
-#include <opencv2/ml/ml.hpp>
-#endif
+  #include <opencv2/ml.hpp>
+#endif`
 
 
 


### PR DESCRIPTION
## Summary of Changes

OpenCV includes were done wrong, leading to errors with the latest OpenCV 4.1 version.

## Release Management

* Affected package(s): Classification
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/4214

