### PR TITLE
Demo/classif: Fix unresized ranges

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.h
@@ -332,6 +332,10 @@ class Point_set_item_classification : public Item_classification_base
     std::vector<int> indices (m_points->point_set()->size(), -1);
 
     m_label_probabilities.clear();
+    m_label_probabilities.resize (m_labels.size());
+    for (std::size_t i = 0; i < m_label_probabilities.size(); ++ i)
+      m_label_probabilities[i].resize (m_points->point_set()->size(), -1);
+    
     if (method == 0)
       CGAL::Classification::classify<Concurrency_tag> (*(m_points->point_set()),
                                                        m_labels, classifier,


### PR DESCRIPTION
## Summary of Changes

Some ranges were sent empty to an algorithm that expects allocated ranges.

## Release Management

* Affected package(s): Demo
* Introduced in CGAL 4.14