### PR TITLE
AABB_tree: make accelerate distance queries default

### DIFF
--- a/AABB_tree/demo/AABB_tree/Scene.cpp
+++ b/AABB_tree/demo/AABB_tree/Scene.cpp
@@ -806,7 +806,6 @@ void Scene::build_facet_tree()
     timer.start();
     std::cout << "Construct Facet AABB tree...";
     m_facet_tree.rebuild(faces(*m_pPolyhedron).first, faces(*m_pPolyhedron).second,*m_pPolyhedron);
-    m_facet_tree.accelerate_distance_queries();
     std::cout << "done (" << timer.time() << " s)" << std::endl;
 }
 
@@ -826,7 +825,6 @@ void Scene::build_edge_tree()
     timer.start();
     std::cout << "Construct Edge AABB tree...";
     m_edge_tree.rebuild(edges(*m_pPolyhedron).first,edges(*m_pPolyhedron).second,*m_pPolyhedron);
-    m_edge_tree.accelerate_distance_queries();
     std::cout << "done (" << timer.time() << " s)" << std::endl;
 }
 

--- a/AABB_tree/demo/AABB_tree/benchmarks.cpp
+++ b/AABB_tree/demo/AABB_tree/benchmarks.cpp
@@ -77,7 +77,6 @@ void Scene::benchmark_distances(const double duration)
     timer.start();
     std::cout << "Construct AABB tree and internal KD tree...";
     Facet_tree tree(faces(*m_pPolyhedron).first, faces(*m_pPolyhedron).second,*m_pPolyhedron);
-    tree.accelerate_distance_queries();
     std::cout << "done (" << timer.time() << " s)" << std::endl;
 
     // benchmark
@@ -123,7 +122,7 @@ void Scene::bench_memory()
         typedef CGAL::Memory_sizer::size_type size_type;
         size_type before = CGAL::Memory_sizer().virtual_size();
         Facet_tree tree(faces(*m_pPolyhedron).first, faces(*m_pPolyhedron).second,*m_pPolyhedron);
-        // tree.accelerate_distance_queries(); // 150 vs 61 bytes per primitive!
+        tree.do_not_accelerate_distance_queries(); // 150 vs 61 bytes per primitive!
 
         size_type after = CGAL::Memory_sizer().virtual_size();
         size_type bytes = after - before; // in Bytes
@@ -165,7 +164,6 @@ void Scene::bench_construction()
         CGAL::Timer time2;
         time2.start();
         Facet_tree tree2(faces(*m_pPolyhedron).first, faces(*m_pPolyhedron).second,*m_pPolyhedron);
-        tree2.accelerate_distance_queries();
         double duration_construction_and_kdtree = time2.time();
 
         std::cout << m_pPolyhedron->size_of_facets() << "\t" 
@@ -248,7 +246,6 @@ void Scene::bench_distances_vs_nbt()
 
         // constructs tree (out of timing)
         Facet_tree tree(faces(*m_pPolyhedron).first, faces(*m_pPolyhedron).second, *m_pPolyhedron);
-        tree.accelerate_distance_queries();
 
         // calls queries
         CGAL::Timer timer;

--- a/AABB_tree/examples/AABB_tree/AABB_face_graph_triangle_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_face_graph_triangle_example.cpp
@@ -25,7 +25,6 @@ void run(const FaceGraph& graph){
   // constructs the AABB tree and the internal search tree for
   // efficient distance queries.
   Tree tree( faces(graph).first, faces(graph).second, graph);
-  tree.accelerate_distance_queries();
 
   // counts #intersections with a triangle query
   Segment segment_query(p,q);

--- a/AABB_tree/examples/AABB_tree/AABB_halfedge_graph_edge_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_halfedge_graph_edge_example.cpp
@@ -27,7 +27,6 @@ void run(const HalfedgeGraph& graph){
   // efficient distance queries.  
   Tree tree( CGAL::edges(graph).first,
              CGAL::edges(graph).second, graph);
-  tree.accelerate_distance_queries();
 
   // counts #intersections with a triangle query
   Triangle triangle_query(p,q,r);

--- a/AABB_tree/examples/AABB_tree/AABB_insertion_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_insertion_example.cpp
@@ -37,8 +37,6 @@ int main()
     // data structure to accelerate distance queries
     Tree tree(faces(polyhedron1).first, faces(polyhedron1).second, polyhedron1);
 
-    tree.accelerate_distance_queries();
-
     tree.insert(faces(polyhedron2).first, faces(polyhedron2).second, polyhedron2);
 
     // query point

--- a/AABB_tree/examples/AABB_tree/AABB_polyhedron_edge_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_polyhedron_edge_example.cpp
@@ -31,7 +31,6 @@ int main()
     Tree tree( CGAL::edges(polyhedron).first,
                CGAL::edges(polyhedron).second,
                polyhedron);
-    tree.accelerate_distance_queries();
 
     // counts #intersections with a triangle query
     Triangle triangle_query(p,q,r);

--- a/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_distance_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_polyhedron_facet_distance_example.cpp
@@ -31,7 +31,6 @@ int main()
     // constructs AABB tree and computes internal KD-tree 
     // data structure to accelerate distance queries
     Tree tree(faces(polyhedron).first, faces(polyhedron).second, polyhedron);
-    tree.accelerate_distance_queries();
 
     // query point
     Point query(0.0, 0.0, 3.0);

--- a/AABB_tree/examples/AABB_tree/AABB_segment_3_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_segment_3_example.cpp
@@ -36,7 +36,6 @@ int main()
     // constructs the AABB tree and the internal search tree for 
     // efficient distance computations.
     Tree tree(segments.begin(),segments.end());
-    tree.accelerate_distance_queries();
 
     // counts #intersections with a plane query
     Plane plane_query(a,b,d);

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -623,7 +623,7 @@ public:
                            T&& ... t)
 		: m_traits()
     , m_primitives()
-                , m_p_root_node(nullptr)
+		, m_p_root_node(nullptr)
 		, m_p_search_tree(nullptr)
 		, m_search_tree_constructed(false)
     , m_default_search_tree_constructed(true)

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -705,7 +705,7 @@ public:
 		// In case the users has switched on the accelerated distance query
 		// data structure with the default arguments, then it has to be
 		// /built/rebuilt.
-		if(m_default_search_tree_constructed){
+		if(m_default_search_tree_constructed && !empty()){
 			build_kd_tree();
 		}
 		m_need_build = false;

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -739,7 +739,7 @@ public:
 		ConstPointIterator beyond) const
 	{
 		m_p_search_tree = new Search_tree(first, beyond);
-		m_default_search_tree_constructed = true;
+                m_default_search_tree_constructed = true;
 		if(m_p_search_tree != nullptr)
 		{
 			m_search_tree_constructed = true;

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -185,7 +185,7 @@ namespace CGAL {
       clear_nodes();
 			m_primitives.clear();
 			clear_search_tree();
-			m_default_search_tree_constructed = m_use_lazy_kd_tree;
+			m_default_search_tree_constructed = true;
 		}
 
 		/// Returns the axis-aligned bounding box of the whole tree.
@@ -440,7 +440,6 @@ public:
 		/// returns `true` iff successful memory allocation
 		bool accelerate_distance_queries() const;
 		///Turns off the lazy construction of the internal search tree.
-		/// Must be called before the first distance query.
 		void do_not_accelerate_distance_queries() const;
 
     /// Constructs an internal KD-tree containing the specified point
@@ -593,7 +592,6 @@ public:
 		// search KD-tree
 		mutable const Search_tree* m_p_search_tree;
 		mutable bool m_search_tree_constructed;
-		mutable bool m_use_lazy_kd_tree;
     mutable bool m_default_search_tree_constructed; // indicates whether the internal kd-tree should be built
     bool m_need_build;
 
@@ -614,7 +612,6 @@ public:
     , m_p_root_node(nullptr)
     , m_p_search_tree(nullptr)
     , m_search_tree_constructed(false)
-    , m_use_lazy_kd_tree(true)
     , m_default_search_tree_constructed(true)
     , m_need_build(false)
   {}
@@ -629,7 +626,6 @@ public:
                 , m_p_root_node(nullptr)
 		, m_p_search_tree(nullptr)
 		, m_search_tree_constructed(false)
-		, m_use_lazy_kd_tree(true)
     , m_default_search_tree_constructed(true)
     , m_need_build(false)
 	{
@@ -760,7 +756,6 @@ public:
 	void AABB_tree<Tr>::do_not_accelerate_distance_queries()const
 	{
 	  clear_search_tree();
-	  m_use_lazy_kd_tree = false;
 	  m_default_search_tree_constructed = false;
 	}
 

--- a/AABB_tree/test/AABB_tree/aabb_test_empty_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_empty_tree.cpp
@@ -34,7 +34,6 @@ int main()
     // Test calls to all functions but those who have `!empty()` as
     // precondition.
     CGAL::Emptyset_iterator devnull;
-    tree.accelerate_distance_queries();
     tree.all_intersections(triangle_query, devnull);
     tree.all_intersected_primitives(triangle_query, devnull);
     assert(!tree.any_intersected_primitive(triangle_query));

--- a/AABB_tree/test/AABB_tree/aabb_test_singleton_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_singleton_tree.cpp
@@ -36,7 +36,6 @@ int main()
 
     // Test calls to all functions
     CGAL::Emptyset_iterator devnull;
-    tree.accelerate_distance_queries();
     tree.all_intersections(triangle_query, devnull);
     tree.all_intersected_primitives(triangle_query, devnull);
     assert(tree.any_intersected_primitive(triangle_query));

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -1,5 +1,13 @@
 Release History
 ===============
+Release 5.1
+-----------
+Release date: March 2020
+
+### 3D Fast Intersection and Distance Computation
+-   **Breaking change**: the internal search tree is now lazily constructed. To disable it, one must call
+    the new function `do_not_accelerate_distance_queries()` before the first distance query.
+
 
 Release 5.0
 -----------

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
@@ -319,7 +319,6 @@ public:
 
     m_own_ptree.reset(new Tree(triangles.begin(), triangles.end()));
     m_own_ptree->build();
-    m_own_ptree->accelerate_distance_queries();
   }
 
 private:

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_polyhedron.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_polyhedron.h
@@ -140,7 +140,6 @@ public:
 
     m_own_ptree.reset(new Tree(triangles.begin(), triangles.end()));
     m_own_ptree->build();
-    m_own_ptree->accelerate_distance_queries();
   }
 
 private:

--- a/Mesh_3/include/CGAL/Mesh_3/polyhedral_to_labeled_function_wrapper.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polyhedral_to_labeled_function_wrapper.h
@@ -99,7 +99,7 @@ public:
     , step_size_(step_size)
     , first_level_(first_level)
   {
-    tree_->accelerate_distance_queries();
+
   }
 
   // Default copy constructor and assignment operator are ok
@@ -216,7 +216,6 @@ public:
     , sq_tolerance_size_(tolerance_size*tolerance_size)
     , hint_(p.facets_begin()->halfedge()->vertex()->point())
   {
-    tree_->accelerate_distance_queries();
   }
 
   // Default copy constructor and assignment operator are ok
@@ -292,7 +291,6 @@ public:
     , sq_tolerance_size_(tolerance_size*tolerance_size)
     , hint_(p.facets_begin()->halfedge()->vertex()->point())
   {
-    tree_->accelerate_distance_queries();
   }
 
   // Default copy constructor and assignment operator are ok

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
@@ -360,7 +360,6 @@ int main(int argc, char * argv[])
     // Constructs AABB tree and computes internal KD-tree
     // data structure to accelerate distance queries
     AABB_tree tree(faces(output_mesh).first, faces(output_mesh).second, output_mesh);
-    tree.accelerate_distance_queries();
 
     // Computes distance from each input point to reconstructed mesh
     double max_distance = DBL_MIN;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -558,7 +558,6 @@ double approximate_Hausdorff_distance(
 
   Tree tree( faces(tm).first, faces(tm).second, tm);
   tree.build();
-  tree.accelerate_distance_queries();
   Point_3 hint = get(vpm, *vertices(tm).first);
 
   return internal::approximate_Hausdorff_distance_impl<Concurrency_tag, Kernel>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -381,7 +381,6 @@ namespace internal {
       }
       for(std::size_t i=0; i < trees.size(); ++i){
         trees[i]->build();
-        trees[i]->accelerate_distance_queries();
       }
     }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
@@ -83,7 +83,6 @@ namespace internal {
     if(do_project)
     {
       tree.rebuild(faces(tmesh).first, faces(tmesh).second, tmesh);
-      tree.accelerate_distance_queries();
     }
     typename GT::Construct_translated_point_3 translate
       = gt.construct_translated_point_3_object();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_mesh.h
@@ -225,7 +225,6 @@ void smooth_mesh(const FaceRange& faces,
   }
 
   Tree aabb_tree(input_triangles.begin(), input_triangles.end());
-  aabb_tree.accelerate_distance_queries();
 
   // Setup the working ranges and check some preconditions
   Angle_smoother angle_smoother(tmesh, vpmap, vcmap, gt);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Distance_plugin.cpp
@@ -133,7 +133,6 @@ private:
     typedef CGAL::AABB_tree< Traits > Tree;
 
     Tree tree( faces(m).first, faces(m).second, m);
-    tree.accelerate_distance_queries();
     tree.build();
     boost::graph_traits<Face_graph>::vertex_descriptor vd = *(vertices(m).first);
     Traits::Point_3 hint = get(CGAL::vertex_point,m, vd);

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -77,7 +77,6 @@ double compute_distances(const Mesh& m,
   typedef CGAL::AABB_tree< Traits > Tree;
 
   Tree tree( faces(m).first, faces(m).second, m);
-  tree.accelerate_distance_queries();
   tree.build();
   typedef typename boost::property_map<Mesh, boost::vertex_point_t>::const_type VPMap;
   VPMap vpmap = get(boost::vertex_point, m);

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_poisson_impl.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_poisson_impl.cpp
@@ -358,7 +358,6 @@ SMesh* poisson_reconstruct(Point_set& points,
   // Constructs AABB tree and computes internal KD-tree
   // data structure to accelerate distance queries
   AABB_tree tree(faces(*mesh).first, faces(*mesh).second, *mesh);
-  tree.accelerate_distance_queries();
 
   // Computes distance from each input point to reconstructed mesh
   double max_distance = DBL_MIN;

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
@@ -58,7 +58,6 @@ public:
     , m_is_closed( is_closed(tm) )
   {
     CGAL_assertion(!m_tree_ptr->empty());
-    m_tree_ptr->accelerate_distance_queries();
   }
 
   double operator()(const typename GeomTraits::Point_3& p) const
@@ -188,7 +187,6 @@ public:
     , m_offset_distance(offset_distance)
   {
     CGAL_assertion(! m_tree_ptr->empty() );
-    m_tree_ptr->accelerate_distance_queries();
   }
 
   double operator()(const EPICK::Point_3& p) const

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
@@ -173,9 +173,6 @@ public:
     }
     tree.build();
 
-    if(build_kd_tree) {
-      tree.accelerate_distance_queries();
-    }
 
     if(use_diagonal) {
       CGAL::Bbox_3 bbox = tree.bbox();

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
@@ -171,8 +171,10 @@ public:
         if(!test)
           tree.insert(Primitive(it, mesh, vertex_point_map));
     }
+    if(!build_kd_tree) {
+      tree.do_not_accelerate_distance_queries();
+    }
     tree.build();
-
 
     if(use_diagonal) {
       CGAL::Bbox_3 bbox = tree.bbox();


### PR DESCRIPTION
## Summary of Changes
Make the `accelerate_distance_queries()` lazy and add a function to disable it.

## Release Management

* Affected package(s):AABB_tree
* Issue(s) solved (if any): fix #4008
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

