### PR TITLE
PMP: Fix doc macro-master

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -33,6 +33,11 @@
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
 
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL {
 
   namespace Polygon_mesh_processing {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/extrude.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/extrude.h
@@ -34,6 +34,11 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <vector>
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL {
 namespace Polygon_mesh_processing {
 namespace extrude_impl{

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -62,6 +62,11 @@
 #include <utility>
 #include <vector>
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL{
 namespace Polygon_mesh_processing {
 namespace debug{

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_mesh.h
@@ -34,6 +34,11 @@
 
 #include <CGAL/property_map.h>
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL {
 namespace Polygon_mesh_processing {
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_shape.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/smooth_shape.h
@@ -39,6 +39,11 @@
 #include <sstream>
 #endif
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL {
 namespace Polygon_mesh_processing {
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -39,6 +39,11 @@
 
 #include <vector>
 
+#ifdef DOXYGEN_RUNNING
+#define CGAL_PMP_NP_TEMPLATE_PARAMETERS NamedParameters
+#define CGAL_PMP_NP_CLASS NamedParameters
+#endif
+
 namespace CGAL {
 
 namespace Polygon_mesh_processing {


### PR DESCRIPTION
## Summary of Changes

master version of #4269  that adds the missing macro definition to more recent files.

## Release Management

* Affected package(s):PMP