### PR TITLE
SMP: Various improvements to the ARAP parameterizer

### DIFF
--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -42,6 +42,9 @@
 
 #if defined(CGAL_EIGEN3_ENABLED)
 #include <CGAL/Eigen_solver_traits.h>
+#ifdef CGAL_SMP_USE_SPARSESUITE_SOLVERS
+#include <Eigen/UmfPackSupport>
+#endif
 #endif
 
 #include <CGAL/assertions.h>
@@ -157,7 +160,14 @@ namespace Surface_mesh_parameterization {
 ///         and `CGAL_EIGEN3_ENABLED` is defined, then an overload of `Eigen_solver_traits`
 ///         is provided as default parameter:
 /// \code
-///   CGAL::Eigen_solver_traits<Eigen::BICGSTAB< Eigen::SparseMatrix<double> > >
+///   CGAL::Eigen_solver_traits<
+///           Eigen::SparseLU<Eigen_sparse_matrix<double>::EigenType> >
+/// \endcode
+///         Moreover, if SparseSuite solvers are available, which is greatly preferable for speed,
+///         then the default parameter is:
+/// \code
+///   CGAL::Eigen_solver_traits<
+///           Eigen::UmfPackLU<Eigen_sparse_matrix<double>::EigenType> >
 /// \endcode
 ///
 /// \sa `CGAL::Surface_mesh_parameterization::Fixed_border_parameterizer_3<TriangleMesh, BorderParameterizer, SolverTraits>`
@@ -176,7 +186,13 @@ public:
   typedef typename Default::Get<
     SolverTraits_,
   #if defined(CGAL_EIGEN3_ENABLED)
-    Eigen_solver_traits< > // defaults to Eigen::BICGSTAB with Eigen_sparse_matrix
+    #ifdef CGAL_SMP_USE_SPARSESUITE_SOLVERS
+      CGAL::Eigen_solver_traits<
+        Eigen::UmfPackLU<Eigen_sparse_matrix<double>::EigenType> >
+    #else
+      CGAL::Eigen_solver_traits<
+        Eigen::SparseLU<Eigen_sparse_matrix<double>::EigenType> >
+    #endif
   #else
     #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
     SolverTraits_ // no parameter provided, and Eigen is not enabled: so don't compile!

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -311,14 +311,21 @@ private:
 
   // Copy the data from two vectors to the UVmap.
   template <typename VertexUVMap,
-            typename VertexIndexMap>
+            typename VertexIndexMap,
+            typename VertexParameterizedMap>
   void assign_solution(const Vector& Xu,
                        const Vector& Xv,
                        const Vertex_set& vertices,
                        VertexUVMap uvmap,
-                       const VertexIndexMap vimap)
+                       const VertexIndexMap vimap,
+                       const VertexParameterizedMap vpmap)
   {
     BOOST_FOREACH(vertex_descriptor vd, vertices) {
+      // The solver might not have managed to exactly constrain the vertex that was marked
+      // as constrained; simply don't update its position.
+      if(get(vpmap, vd))
+        continue;
+
       int index = get(vimap, vd);
       NT u = Xu(index);
       NT v = Xv(index);
@@ -1132,13 +1139,13 @@ private:
       BOOST_FOREACH(vertex_descriptor vd, vertices) {
         if(get(vpmap, vd)) {
           int index = get(vimap, vd);
-          CGAL_postcondition(std::abs(Xu[index] - Bu[index] ) < 1e-10);
-          CGAL_postcondition(std::abs(Xv[index] - Bv[index] ) < 1e-10);
+          CGAL_warning(std::abs(Xu[index] - Bu[index] ) < 1e-7);
+          CGAL_warning(std::abs(Xv[index] - Bv[index] ) < 1e-7);
         }
       }
     )
 
-    assign_solution(Xu, Xv, vertices, uvmap, vimap);
+    assign_solution(Xu, Xv, vertices, uvmap, vimap, vpmap);
     return status;
   }
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -306,7 +306,7 @@ private:
     std::ostringstream out_ss;
     out_ss << filename << iter << ".off" << std::ends;
     std::ofstream out(out_ss.str().c_str());
-    output_uvmap_to_off(mesh, vertices, faces, uvmap, vimap, out);
+    IO::output_uvmap_to_off(mesh, vertices, faces, uvmap, vimap, out);
   }
 
   // Copy the data from two vectors to the UVmap.

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -292,7 +292,7 @@ private:
   {
     // Build the constrained triangulation
 
-    // Since the border is closed and we are interest in triangles that are outside
+    // Since the border is closed and we are interested in triangles that are outside
     // of the border, we actually only need to insert points on the border
     BOOST_FOREACH(halfedge_descriptor hd, halfedges_around_face(bhd, mesh)) {
       vertex_descriptor s = source(hd, mesh);


### PR DESCRIPTION
## Summary of Changes

The main change is the choice of default solvers: ARAP now uses Suitesparse (or SparseLU as back-up) instead of BiCGSTAB. This choice is motivated by tests on a bit more data. Cleaned some minor things along the way.

The documentation changed because I updated the default models, but it is not a real change.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any): Fixes #4290

