### PR TITLE
Surface_mesh: Fix Property_container::swap()

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -486,6 +486,7 @@ public:
     void swap (Property_container& other)
     {
       this->parrays_.swap (other.parrays_);
+      std::swap(this->size_, other.size_);
     }
   
 private:


### PR DESCRIPTION
## Summary of Changes

The swap function swapped the content, but not the variable storing the size of the content.
The fix is not worth backporting, as the function  is not documented publicly and only used in a future PR.

## Release Management

* Affected package(s): Surface_mesh


