### PR TITLE
Remove extra S in macro

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -132,7 +132,7 @@
 
 // workaround for the bug https://svn.boost.org/trac10/ticket/12534
 // That bug was introduced in Boost 1.62 and fixed in 1.63.
-#if BOOST_VERSION >= 106200 && BOOSTS_VERSION < 106300
+#if BOOST_VERSION >= 106200 && BOOST_VERSION < 106300
 #  include <boost/container/flat_map.hpp>
 #endif
 


### PR DESCRIPTION
## Summary of Changes

Fix macro in Installation/include/CGAL/config.h
## Release Management

* Affected package(s):Installation
* Issue(s) solved (if any): fix #4220
