### PR TITLE
CGAL 3D Demo: Replace QDoubleSpinBoxes

### DIFF
--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -76,5 +76,3 @@ public:
   {
     return this->validator->top();
   }
-  #include "CGAL_double_edit.moc"
-

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -33,5 +33,11 @@
   {
     this->validator->setTop(d);
   }
+
+  void DoubleEdit::setRange(double min, double max)
+  {
+    setMinimum(min);
+    setMaximum(max);
+  }
   #include "CGAL_double_edit.moc"
 

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -61,5 +61,20 @@ public:
   {
     this->validator->setRange(min, max);
   }
+
+  double DoubleEdit::getValue()
+  {
+    return this->value();
+  }
+
+  double DoubleEdit::getMinimum()
+  {
+    return this->validator->bottom();
+  }
+
+  double DoubleEdit::getMaximum()
+  {
+    return this->validator->top();
+  }
   #include "CGAL_double_edit.moc"
 

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -1,0 +1,14 @@
+#include "CGAL_double_edit.h"
+
+#include <QDoubleValidator>
+
+  DoubleEdit::DoubleEdit(QWidget* parent = nullptr)
+    : QLineEdit(parent)
+  {
+    QDoubleValidator* validator = new QDoubleValidator(parent);
+    validator->setLocale(QLocale::C);
+    this->setValidator(validator);
+  }
+
+  #include "CGAL_double_edit.moc"
+

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -2,13 +2,36 @@
 
 #include <QDoubleValidator>
 
-  DoubleEdit::DoubleEdit(QWidget* parent = nullptr)
-    : QLineEdit(parent)
+  DoubleEdit::DoubleEdit(QWidget *parent)
+    : QLineEdit()
   {
-    QDoubleValidator* validator = new QDoubleValidator(parent);
+    validator = new QDoubleValidator(this);
     validator->setLocale(QLocale::C);
     this->setValidator(validator);
   }
 
+  DoubleEdit::~DoubleEdit()
+  {
+    delete validator;
+  }
+  double DoubleEdit::value() const
+  {
+    return this->text().toDouble();
+  }
+
+  void DoubleEdit::setValue(double d)
+  {
+    this->setText(tr("%1").arg(d));
+  }
+
+  void DoubleEdit::setMinimum(double d)
+  {
+    this->validator->setBottom(d);
+  }
+
+  void DoubleEdit::setMaximum(double d)
+  {
+    this->validator->setTop(d);
+  }
   #include "CGAL_double_edit.moc"
 

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -2,11 +2,32 @@
 
 #include <QDoubleValidator>
 
-  DoubleEdit::DoubleEdit(QWidget *parent)
-    : QLineEdit()
+class DoubleValidator : public QDoubleValidator
+{
+public:
+  DoubleValidator(QObject* parent = nullptr)
+    : QDoubleValidator(parent)
   {
-    validator = new QDoubleValidator(this);
-    validator->setLocale(QLocale::C);
+    setLocale(QLocale::C);
+  }
+
+  void fixup ( QString & input ) const
+  {
+    input.replace(".", locale().decimalPoint());
+    input.replace(",", locale().decimalPoint());
+    QDoubleValidator::fixup(input);
+  }
+  QValidator::State validate ( QString & input, int & pos ) const
+  {
+    fixup(input);
+    return QDoubleValidator::validate(input, pos);
+  }
+};
+
+  DoubleEdit::DoubleEdit(QWidget *parent)
+    : QLineEdit(parent)
+  {
+    validator = new DoubleValidator(this);
     this->setValidator(validator);
   }
 
@@ -14,6 +35,8 @@
   {
     delete validator;
   }
+
+
   double DoubleEdit::value() const
   {
     return this->text().toDouble();
@@ -36,8 +59,7 @@
 
   void DoubleEdit::setRange(double min, double max)
   {
-    setMinimum(min);
-    setMaximum(max);
+    this->validator->setRange(min, max);
   }
   #include "CGAL_double_edit.moc"
 

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
@@ -6,14 +6,11 @@
 #include <QObject>
 #include <QtCore/qglobal.h>
 #include <QLineEdit>
-#ifdef cgal_double_edit_EXPORTS
-#  define CGAL_DOUBLE_EDIT_EXPORT Q_DECL_EXPORT
-#else
-#  define CGAL_DOUBLE_EDIT_EXPORT Q_DECL_IMPORT
-#endif
+#include "Scene_config.h"
 
-class QDoubleValidator;
-class CGAL_DOUBLE_EDIT_EXPORT DoubleEdit : public QLineEdit {
+
+class DoubleValidator;
+class SCENE_EXPORT DoubleEdit : public QLineEdit {
 
   Q_OBJECT
 
@@ -26,6 +23,6 @@ public:
   void setMaximum(double d);
   void setRange(double min, double max);
 private:
-  QDoubleValidator* validator;
+  DoubleValidator* validator;
 };
 #endif // CGAL_DOUBLE_EDIT_H

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
@@ -13,7 +13,9 @@ class DoubleValidator;
 class SCENE_EXPORT DoubleEdit : public QLineEdit {
 
   Q_OBJECT
-
+  Q_PROPERTY(double value READ getValue WRITE setValue)
+  Q_PROPERTY(double minimum READ getMinimum WRITE setMinimum)
+  Q_PROPERTY(double maximum READ getMaximum WRITE setMaximum)
 public:
   DoubleEdit(QWidget* parent = nullptr);
   ~DoubleEdit();
@@ -22,6 +24,9 @@ public:
   void setMinimum(double d);
   void setMaximum(double d);
   void setRange(double min, double max);
+  double getValue();
+  double getMinimum();
+  double getMaximum();
 private:
   DoubleValidator* validator;
 };

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
@@ -24,6 +24,7 @@ public:
   void setValue(double d);
   void setMinimum(double d);
   void setMaximum(double d);
+  void setRange(double min, double max);
 private:
   QDoubleValidator* validator;
 };

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
@@ -12,11 +12,19 @@
 #  define CGAL_DOUBLE_EDIT_EXPORT Q_DECL_IMPORT
 #endif
 
+class QDoubleValidator;
 class CGAL_DOUBLE_EDIT_EXPORT DoubleEdit : public QLineEdit {
 
   Q_OBJECT
 
 public:
-  DoubleEdit(QWidget *parent);
+  DoubleEdit(QWidget* parent = nullptr);
+  ~DoubleEdit();
+  double value() const;
+  void setValue(double d);
+  void setMinimum(double d);
+  void setMaximum(double d);
+private:
+  QDoubleValidator* validator;
 };
 #endif // CGAL_DOUBLE_EDIT_H

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.h
@@ -1,0 +1,22 @@
+#ifndef CGAL_DOUBLE_EDIT_H
+#define CGAL_DOUBLE_EDIT_H
+
+
+
+#include <QObject>
+#include <QtCore/qglobal.h>
+#include <QLineEdit>
+#ifdef cgal_double_edit_EXPORTS
+#  define CGAL_DOUBLE_EDIT_EXPORT Q_DECL_EXPORT
+#else
+#  define CGAL_DOUBLE_EDIT_EXPORT Q_DECL_IMPORT
+#endif
+
+class CGAL_DOUBLE_EDIT_EXPORT DoubleEdit : public QLineEdit {
+
+  Q_OBJECT
+
+public:
+  DoubleEdit(QWidget *parent);
+};
+#endif // CGAL_DOUBLE_EDIT_H

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -190,7 +190,8 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
     Scene_item_rendering_helper.cpp
     Scene_item_rendering_helper_moc.cpp
     Primitive_container.cpp
-    Polyhedron_demo_plugin_helper.cpp)
+    Polyhedron_demo_plugin_helper.cpp
+    CGAL_double_edit.cpp)
   target_link_libraries(demo_framework
     PUBLIC Qt5::OpenGL Qt5::Widgets Qt5::Gui Qt5::Script
     )

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
@@ -38,7 +38,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QSpinBox>
-#include <QDoubleSpinBox>
+#include "CGAL_double_edit.h"
 #include <QSlider>
 
 #include <map>
@@ -619,17 +619,14 @@ public Q_SLOTS:
     scales->setRange (1, 99);
     scales->setValue (5);
 
-    QDoubleSpinBox* voxel_size = dialog.add<QDoubleSpinBox> ("Voxel size (0 for automatic):");
-    voxel_size->setRange (0.0, 10000.0);
-    voxel_size->setValue (0.0);
-    voxel_size->setSingleStep (0.01);
+    DoubleEdit* voxel_size = dialog.add<DoubleEdit> ("Voxel size (0 for automatic):");
 
     if (dialog.exec() != QDialog::Accepted)
       return;
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    float vsize = float(voxel_size->value());
+    float vsize = float(voxel_size->text().toDouble());
     if (vsize == 0.f)
       vsize = -1.f; // auto value
     
@@ -921,10 +918,9 @@ public Q_SLOTS:
     subdivisions->setRange (1, 9999);
     subdivisions->setValue (16);
 
-    QDoubleSpinBox* smoothing = dialog.add<QDoubleSpinBox> ("Regularization weight: ");
-    smoothing->setRange (0.0, 100.0);
-    smoothing->setValue (0.5);
-    smoothing->setSingleStep (0.1);
+    DoubleEdit* smoothing = dialog.add<DoubleEdit> ("Regularization weight: ");
+
+    smoothing->setText(tr("%1").arg(0.5));
 
     if (dialog.exec() != QDialog::Accepted)
       return;
@@ -932,7 +928,7 @@ public Q_SLOTS:
     QApplication::setOverrideCursor(Qt::WaitCursor);
     CGAL::Real_timer t;
     t.start();
-    run (classif, 2, std::size_t(subdivisions->value()), smoothing->value());
+    run (classif, 2, std::size_t(subdivisions->value()), smoothing->text().toDouble());
     t.stop();
     std::cerr << "Graph Cut classification computed in " << t.time() << " second(s)" << std::endl;
     QApplication::restoreOverrideCursor();
@@ -1371,10 +1367,8 @@ public Q_SLOTS:
       QSpinBox* trials = dialog.add<QSpinBox> ("Number of trials: ", "trials");
       trials->setRange (1, 99999);
       trials->setValue (500);
-      QDoubleSpinBox* rate = dialog.add<QDoubleSpinBox> ("Learning rate: ", "learning_rate");
-      rate->setRange (0.00001, 10000.0);
-      rate->setValue (0.001);
-      rate->setDecimals (5);
+      DoubleEdit* rate = dialog.add<DoubleEdit> ("Learning rate: ", "learning_rate");
+      rate->setText(tr("%1").arg(0.001));
       QSpinBox* batch = dialog.add<QSpinBox> ("Batch size: ", "batch_size");
       batch->setRange (1, 2000000000);
       batch->setValue (1000);

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
@@ -626,7 +626,7 @@ public Q_SLOTS:
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    float vsize = float(voxel_size->text().toDouble());
+    float vsize = float(voxel_size->value());
     if (vsize == 0.f)
       vsize = -1.f; // auto value
     
@@ -928,7 +928,7 @@ public Q_SLOTS:
     QApplication::setOverrideCursor(Qt::WaitCursor);
     CGAL::Real_timer t;
     t.start();
-    run (classif, 2, std::size_t(subdivisions->value()), smoothing->text().toDouble());
+    run (classif, 2, std::size_t(subdivisions->value()), smoothing->value());
     t.stop();
     std::cerr << "Graph Cut classification computed in " << t.time() << " second(s)" << std::endl;
     QApplication::restoreOverrideCursor();
@@ -1368,7 +1368,8 @@ public Q_SLOTS:
       trials->setRange (1, 99999);
       trials->setValue (500);
       DoubleEdit* rate = dialog.add<DoubleEdit> ("Learning rate: ", "learning_rate");
-      rate->setText(tr("%1").arg(0.001));
+      rate->setRange (0.00001, 10000.0);
+      rate->setValue (0.001);
       QSpinBox* batch = dialog.add<QSpinBox> ("Batch size: ", "batch_size");
       batch->setRange (1, 2000000000);
       batch->setValue (1000);

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.cpp
@@ -910,7 +910,7 @@ void Cluster_classification::train(int classifier, const QMultipleInputDialog& d
     m_neural_network->train (training,
                              dialog.get<QCheckBox>("restart")->isChecked(),
                              dialog.get<QSpinBox>("trials")->value(),
-                             dialog.get<QDoubleSpinBox>("learning_rate")->value(),
+                             dialog.get<DoubleEdit>("learning_rate")->value(),
                              dialog.get<QSpinBox>("batch_size")->value(),
                              hidden_layers);
       

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Point_set_item_classification.cpp
@@ -800,7 +800,7 @@ void Point_set_item_classification::train(int classifier, const QMultipleInputDi
     m_neural_network->train (training,
                              dialog.get<QCheckBox>("restart")->isChecked(),
                              dialog.get<QSpinBox>("trials")->value(),
-                             dialog.get<QDoubleSpinBox>("learning_rate")->value(),
+                             dialog.get<DoubleEdit>("learning_rate")->value(),
                              dialog.get<QSpinBox>("batch_size")->value(),
                              hidden_layers);
       

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Surface_mesh_item_classification.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Surface_mesh_item_classification.cpp
@@ -366,7 +366,7 @@ void Surface_mesh_item_classification::train (int classifier, const QMultipleInp
     m_neural_network->train (training,
                              dialog.get<QCheckBox>("restart")->isChecked(),
                              dialog.get<QSpinBox>("trials")->value(),
-                             dialog.get<QDoubleSpinBox>("learning_rate")->value(),
+                             dialog.get<DoubleEdit>("learning_rate")->value(),
                              dialog.get<QSpinBox>("batch_size")->value(),
                              hidden_layers);
       

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -110,44 +110,18 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QDoubleSpinBox" name="minBox"/>
-           </item>
-           <item>
-            <widget class="QDoubleSpinBox" name="maxBox">
-             <property name="value">
-              <double>2.000000000000000</double>
+            <widget class="DoubleEdit" name="minBox">
+             <property name="text">
+              <string>0,00</string>
              </property>
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="resetButton">
-               <property name="toolTip">
-                <string>Compute Ramp Extremas</string>
-               </property>
-               <property name="text">
-                <string>Reset</string>
-               </property>
-               <property name="autoRepeat">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="DoubleEdit" name="maxBox">
+             <property name="text">
+              <string>2,00</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -223,6 +197,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -112,14 +112,14 @@
            <item>
             <widget class="DoubleEdit" name="minBox">
              <property name="text">
-              <string>0,00</string>
+              <string>0.00</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="DoubleEdit" name="maxBox">
              <property name="text">
-              <string>2,00</string>
+              <string>2.00</string>
              </property>
             </widget>
            </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -443,9 +443,6 @@ public:
     connect(dock_widget->deleteButton, &QPushButton::clicked,
             this, &DisplayPropertyPlugin::delete_group);
 
-    connect(dock_widget->resetButton, &QPushButton::pressed,
-            this, &DisplayPropertyPlugin::resetRampExtremas);
-
     dock_widget->zoomToMaxButton->setEnabled(false);
     dock_widget->zoomToMinButton->setEnabled(false);
     Scene* scene_obj =static_cast<Scene*>(scene);
@@ -464,29 +461,6 @@ private Q_SLOTS:
       dock_widget->raise(); }
   }
 
-  void resetRampExtremas()
-  {
-    Scene_surface_mesh_item* item =
-        qobject_cast<Scene_surface_mesh_item*>(scene->item(scene->mainSelectionIndex()));
-    if(!item)
-      return;
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-    item->face_graph()->collect_garbage();
-    bool ok;
-    switch(dock_widget->propertyBox->currentIndex())
-    {
-    case 0:
-      ok = resetAngles(item);
-      break;
-    default:
-      ok = resetScaledJacobian(item);
-      break;
-    }
-    QApplication::restoreOverrideCursor();
-    if(!ok)
-      QMessageBox::warning(mw, "Error", "You must first run colorize once to initialize the values.");
-  }
-  
   void colorize()
   {
     Scene_heat_item* h_item = nullptr;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
@@ -195,8 +195,6 @@ private:
             ui.edgeLength_dspinbox, SLOT(setEnabled(bool)));
 
     //Set default parameter edge length
-    ui.edgeLength_dspinbox->setDecimals(3);
-    ui.edgeLength_dspinbox->setSingleStep(0.001);
     ui.edgeLength_dspinbox->setRange(1e-6 * diag_length, //min
                                      2.   * diag_length);//max
     ui.edgeLength_dspinbox->setValue(0.05 * diag_length);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/mesh_2_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/mesh_2_dialog.ui
@@ -141,7 +141,7 @@
       <item row="1" column="1">
        <widget class="DoubleEdit" name="edgeLength_dspinbox">
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/mesh_2_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/mesh_2_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>424</width>
-    <height>301</height>
+    <height>302</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,9 +38,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>edgeLength_dspinbox</cstring>
-        </property>
        </widget>
       </item>
       <item row="4" column="0">
@@ -53,22 +50,6 @@
         </property>
         <property name="buddy">
          <cstring>nbIterations_spinbox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="edgeLength_dspinbox">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>1000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
         </property>
        </widget>
       </item>
@@ -157,6 +138,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="edgeLength_dspinbox">
+        <property name="text">
+         <string>0,00</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -185,6 +173,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>buttonBox</tabstop>
  </tabstops>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_rib_exporter_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_rib_exporter_plugin.cpp
@@ -305,7 +305,9 @@ get_parameters_from_dialog()
   QDialog dialog(mw);
   Ui::Rib_dialog ui;
   ui.setupUi(&dialog);
-  
+  ui.ambientIntensity->setMaximum(1.0);
+  ui.shadowIntensity->setMaximum(1.0);
+
   connect(ui.buttonBox, SIGNAL(accepted()), &dialog, SLOT(accept()));
   connect(ui.buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
   connect(ui.resWidth, SIGNAL(valueChanged(int)), this, SLOT(width_changed(int)));

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Local_optimizers_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Local_optimizers_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>546</width>
+    <width>556</width>
     <height>317</height>
    </rect>
   </property>
@@ -50,43 +50,11 @@
      <property name="title">
       <string>Parameters</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="timeLabel">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,0">
+      <item row="1" column="3">
+       <widget class="QCheckBox" name="noBound">
         <property name="text">
-         <string>Max CPU running time (s)</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>maxTime</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="maxTime">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <double>9999.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>60.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QCheckBox" name="noTimeLimit">
-        <property name="text">
-         <string>No time limit</string>
+         <string>No angle bound</string>
         </property>
        </widget>
       </item>
@@ -98,37 +66,36 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>sliverBound</cstring>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QCheckBox" name="noTimeLimit">
+        <property name="text">
+         <string>No time limit</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="sliverBound">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
+      <item row="0" column="0">
+       <widget class="QLabel" name="timeLabel">
+        <property name="text">
+         <string>Max CPU running time (s)</string>
         </property>
-        <property name="readOnly">
-         <bool>false</bool>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="decimals">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <double>180.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>8.000000000000000</double>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="DoubleEdit" name="maxTime">
+        <property name="text">
+         <string>60.0</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QCheckBox" name="noBound">
+       <widget class="DoubleEdit" name="sliverBound">
         <property name="text">
-         <string>No angle bound</string>
+         <string>8.0</string>
         </property>
        </widget>
       </item>
@@ -180,6 +147,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -361,8 +361,6 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   double diag = CGAL::sqrt((bbox.xmax()-bbox.xmin())*(bbox.xmax()-bbox.xmin()) + (bbox.ymax()-bbox.ymin())*(bbox.ymax()-bbox.ymin()) + (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
   int decimals = 0;
   double sizing_default = get_approximate(diag * 0.05, 2, decimals);
-  ui.facetSizing->setDecimals(-decimals+2);
-  ui.facetSizing->setSingleStep(std::pow(10.,decimals));
   ui.facetSizing->setRange(diag * 10e-6, // min
                            diag); // max
   ui.facetSizing->setValue(sizing_default); // default value
@@ -375,8 +373,6 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   ui.tetSizing->setValue(sizing_default); // default value
 
   double approx_default = get_approximate(diag * 0.005, 2, decimals);
-  ui.approx->setDecimals(-decimals+2);
-  ui.approx->setSingleStep(std::pow(10.,decimals));
   ui.approx->setRange(diag * 10e-7, // min
                       diag); // max
   ui.approx->setValue(approx_default);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -293,8 +293,12 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   Ui::Meshing_dialog ui;
   ui.setupUi(&dialog);
 
-  ui.facetAngle->setRange(0.0, 20.0);
+  ui.facetAngle->setRange(0.0, 30.0);
   ui.facetAngle->setValue(25.0);
+  ui.edgeSizing->setMinimum(0.0);
+  ui.sharpEdgesAngle->setMaximum(180);
+  ui.iso_value_spinBox->setRange(-65536.0, 65536.0);
+  ui.tetShape->setMinimum(1.0);
 
   ui.advanced->setVisible(false);
   connect(ui.facetTopologyLabel,

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -293,6 +293,9 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   Ui::Meshing_dialog ui;
   ui.setupUi(&dialog);
 
+  ui.facetAngle->setRange(0.0, 20.0);
+  ui.facetAngle->setValue(25.0);
+
   ui.advanced->setVisible(false);
   connect(ui.facetTopologyLabel,
           &QLabel::linkActivated,
@@ -366,8 +369,6 @@ void Mesh_3_plugin::mesh_3(const bool surface_only, const bool use_defaults)
   ui.facetSizing->setValue(sizing_default); // default value
   ui.edgeSizing->setValue(sizing_default);
 
-  ui.tetSizing->setDecimals(-decimals+2);
-  ui.tetSizing->setSingleStep(std::pow(10.,decimals));
   ui.tetSizing->setRange(diag * 10e-6, // min
                          diag); // max
   ui.tetSizing->setValue(sizing_default); // default value

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
@@ -160,14 +160,14 @@
       <item row="3" column="1">
        <widget class="DoubleEdit" name="sharpEdgesAngle">
         <property name="text">
-         <string>60,00</string>
+         <string>60.00</string>
         </property>
        </widget>
       </item>
       <item row="7" column="1">
        <widget class="DoubleEdit" name="edgeSizing">
         <property name="text">
-         <string>0,0</string>
+         <string>0.0</string>
         </property>
        </widget>
       </item>
@@ -320,7 +320,7 @@
       <item row="1" column="1">
        <widget class="DoubleEdit" name="approx">
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>
@@ -372,35 +372,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="tetShape">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="minimum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>3.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="tetSizing">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>4</number>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -408,9 +379,6 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>tetShape</cstring>
         </property>
        </widget>
       </item>
@@ -422,8 +390,19 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>tetSizing</cstring>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="DoubleEdit" name="tetSizing">
+        <property name="text">
+         <string>0.00</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="tetShape">
+        <property name="text">
+         <string>3.00</string>
         </property>
        </widget>
       </item>
@@ -457,22 +436,6 @@
          <bool>true</bool>
         </property>
        </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="iso_value_spinBox">
-        <property name="minimum">
-         <double>-65536.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>65536.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>3.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="value_outside_spinBox"/>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
@@ -510,6 +473,20 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="DoubleEdit" name="value_outside_spinBox">
+        <property name="text">
+         <string>0.00</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="iso_value_spinBox">
+        <property name="text">
+         <string>3.00</string>
         </property>
        </widget>
       </item>
@@ -562,9 +539,7 @@
   <tabstop>noApprox</tabstop>
   <tabstop>noFacetSizing</tabstop>
   <tabstop>noAngle</tabstop>
-  <tabstop>tetSizing</tabstop>
   <tabstop>noTetSizing</tabstop>
-  <tabstop>tetShape</tabstop>
   <tabstop>noTetShape</tabstop>
   <tabstop>checkBox</tabstop>
   <tabstop>manifoldCheckBox</tabstop>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_dialog.ui
@@ -115,9 +115,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>sharpEdgesAngle</cstring>
-        </property>
        </widget>
       </item>
       <item row="7" column="0">
@@ -128,38 +125,12 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>edgeSizing</cstring>
-        </property>
        </widget>
       </item>
       <item row="7" column="2">
        <widget class="QCheckBox" name="noEdgeSizing">
         <property name="text">
          <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QDoubleSpinBox" name="edgeSizing">
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="sharpEdgesAngle">
-        <property name="maximum">
-         <double>180.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>60.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -183,6 +154,20 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="DoubleEdit" name="sharpEdgesAngle">
+        <property name="text">
+         <string>60,00</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="DoubleEdit" name="edgeSizing">
+        <property name="text">
+         <string>0,0</string>
         </property>
        </widget>
       </item>
@@ -216,9 +201,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>approx</cstring>
-        </property>
        </widget>
       </item>
       <item row="1" column="2">
@@ -234,16 +216,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="approx">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="angleLabel">
         <property name="text">
@@ -251,22 +223,6 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>facetAngle</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="facetSizing">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>4</number>
         </property>
        </widget>
       </item>
@@ -359,27 +315,25 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>facetSizing</cstring>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="approx">
+        <property name="text">
+         <string>0,00</string>
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="DoubleEdit" name="facetSizing"/>
+      </item>
       <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="facetAngle">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
+       <widget class="DoubleEdit" name="facetAngle">
+        <property name="inputMask">
+         <string>25,00</string>
         </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>30.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>25.000000000000000</double>
+        <property name="text">
+         <string>25,00</string>
         </property>
        </widget>
       </item>
@@ -597,12 +551,16 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
-  <tabstop>approx</tabstop>
   <tabstop>noApprox</tabstop>
-  <tabstop>facetSizing</tabstop>
   <tabstop>noFacetSizing</tabstop>
-  <tabstop>facetAngle</tabstop>
   <tabstop>noAngle</tabstop>
   <tabstop>tetSizing</tabstop>
   <tabstop>noTetSizing</tabstop>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
@@ -227,6 +227,9 @@ Mesh_3_optimization_plugin::odt()
   QDialog dialog(mw);
   Ui::Smoother_dialog ui;
   ui.setupUi(&dialog);
+  ui.convergenceRatio->setMaximum(1.0);
+  ui.convergenceRatio->setMinimum(0.0001);
+  ui.freezeRatio->setMinimum(0.0);
   dialog.setWindowFlags(Qt::Dialog|Qt::CustomizeWindowHint|Qt::WindowCloseButtonHint);
   dialog.setWindowTitle(tr("ODT-smoothing parameters"));
 
@@ -362,6 +365,7 @@ Mesh_3_optimization_plugin::perturb()
   QDialog dialog(mw);
   Ui::LocalOptim_dialog ui;
   ui.setupUi(&dialog);
+  ui.sliverBound->setRange(0,180);
   dialog.setWindowFlags(Qt::Dialog|Qt::CustomizeWindowHint|Qt::WindowCloseButtonHint);
   dialog.setWindowTitle(tr("Sliver perturbation parameters"));
   

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Rib_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Rib_dialog.ui
@@ -22,20 +22,6 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="sphereRadius">
-          <property name="decimals">
-           <number>4</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="cylinderRadius">
-          <property name="decimals">
-           <number>4</number>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="cylinderRadiusLabel">
           <property name="text">
@@ -47,6 +33,20 @@
          <widget class="QLabel" name="sphereRadiusLabel">
           <property name="text">
            <string>sphere radius (points)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="DoubleEdit" name="sphereRadius">
+          <property name="text">
+           <string>0.00</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="DoubleEdit" name="cylinderRadius">
+          <property name="text">
+           <string>0.00</string>
           </property>
          </widget>
         </item>
@@ -70,13 +70,6 @@
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="1" column="0">
-         <widget class="QLabel" name="ambientLabel">
-          <property name="text">
-           <string>Ambient Light</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="2">
          <widget class="QCheckBox" name="isAmbientOn">
           <property name="text">
@@ -87,29 +80,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="ambientIntensity">
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.150000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="shadowIntensity">
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.850000000000000</double>
+        <item row="2" column="0">
+         <widget class="QLabel" name="shadowLabel">
+          <property name="text">
+           <string>Shadow Light</string>
           </property>
          </widget>
         </item>
@@ -123,10 +97,24 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="shadowLabel">
+        <item row="1" column="0">
+         <widget class="QLabel" name="ambientLabel">
           <property name="text">
-           <string>Shadow Light</string>
+           <string>Ambient Light</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="DoubleEdit" name="ambientIntensity">
+          <property name="text">
+           <string>0.15</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="DoubleEdit" name="shadowIntensity">
+          <property name="text">
+           <string>0.85</string>
           </property>
          </widget>
         </item>
@@ -245,6 +233,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Smoother_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Smoother_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>507</width>
-    <height>328</height>
+    <height>331</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -50,7 +50,7 @@
      <property name="title">
       <string>Parameters</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0" columnstretch="0,1,0">
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0" columnstretch="0,0,0">
       <property name="topMargin">
        <number>8</number>
       </property>
@@ -68,9 +68,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>maxTime</cstring>
-        </property>
        </widget>
       </item>
       <item row="1" column="2">
@@ -84,21 +81,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="maxTime">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <double>9999.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>60.000000000000000</double>
+       <widget class="DoubleEdit" name="maxTime">
+        <property name="text">
+         <string>60.0</string>
         </property>
        </widget>
       </item>
@@ -122,7 +107,7 @@
      <property name="checkable">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1,0">
       <property name="topMargin">
        <number>8</number>
       </property>
@@ -148,19 +133,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="maxIterationNb">
-        <property name="decimals">
-         <number>0</number>
-        </property>
-        <property name="maximum">
-         <double>200.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>100.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="convergenceLabel">
         <property name="font">
@@ -174,22 +146,6 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="convergenceRatio">
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>0.000100000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.010000000000000</double>
         </property>
        </widget>
       </item>
@@ -207,27 +163,29 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>freezeRatio</cstring>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="DoubleEdit" name="convergenceRatio">
+        <property name="text">
+         <string>0.001</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="freezeRatio">
-        <property name="decimals">
-         <number>4</number>
+      <item row="2" column="2">
+       <widget class="DoubleEdit" name="freezeRatio">
+        <property name="text">
+         <string>0.000</string>
         </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="maxIterationNb">
         <property name="maximum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.001000000000000</double>
+         <number>200</number>
         </property>
         <property name="value">
-         <double>0.000000000000000</double>
+         <number>100</number>
         </property>
        </widget>
       </item>
@@ -279,6 +237,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
@@ -18,7 +18,7 @@
     <item>
      <widget class="QTabWidget" name="selector_tabWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="prismTab">
        <attribute name="title">
@@ -138,7 +138,7 @@ QGroupBox::title {
                <item>
                 <widget class="DoubleEdit" name="prismBaseSpinBox">
                  <property name="text">
-                  <string>1,00</string>
+                  <string>1.00</string>
                  </property>
                 </widget>
                </item>
@@ -159,7 +159,7 @@ QGroupBox::title {
                <item>
                 <widget class="DoubleEdit" name="prismHeightSpinBox">
                  <property name="text">
-                  <string>1,00</string>
+                  <string>1.00</string>
                  </property>
                 </widget>
                </item>
@@ -412,18 +412,15 @@ QGroupBox::title {
                 </widget>
                </item>
                <item>
-                <widget class="QDoubleSpinBox" name="pyramidHeightSpinBox">
-                 <property name="decimals">
-                  <number>5</number>
+                <widget class="DoubleEdit" name="pyramidHeightSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
-                 <property name="minimum">
-                  <double>-999999.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>999999.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>1.000000000000000</double>
+                 <property name="text">
+                  <string>1.00</string>
                  </property>
                 </widget>
                </item>
@@ -457,7 +454,7 @@ QGroupBox::title {
               </layout>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="0,0">
+              <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,0">
                <item>
                 <widget class="QLabel" name="label_13">
                  <property name="toolTip">
@@ -469,18 +466,15 @@ QGroupBox::title {
                 </widget>
                </item>
                <item>
-                <widget class="QDoubleSpinBox" name="pyramidBaseSpinBox">
-                 <property name="decimals">
-                  <number>5</number>
+                <widget class="DoubleEdit" name="pyramidBaseSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
-                 <property name="minimum">
-                  <double>-999999.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>999999.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>1.000000000000000</double>
+                 <property name="text">
+                  <string>1.00</string>
                  </property>
                 </widget>
                </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
@@ -31,7 +31,7 @@
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="../../Polyhedron_3.qrc">:/cgal/Polyhedron_3/resources/prism.png</pixmap>
+           <pixmap>:/cgal/Polyhedron_3/resources/prism.png</pixmap>
           </property>
           <property name="scaledContents">
            <bool>false</bool>
@@ -136,15 +136,9 @@ QGroupBox::title {
                 </widget>
                </item>
                <item>
-                <widget class="QDoubleSpinBox" name="prismBaseSpinBox">
-                 <property name="decimals">
-                  <number>5</number>
-                 </property>
-                 <property name="maximum">
-                  <double>1000000000000000000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>1.000000000000000</double>
+                <widget class="DoubleEdit" name="prismBaseSpinBox">
+                 <property name="text">
+                  <string>1,00</string>
                  </property>
                 </widget>
                </item>
@@ -163,15 +157,9 @@ QGroupBox::title {
                 </widget>
                </item>
                <item>
-                <widget class="QDoubleSpinBox" name="prismHeightSpinBox">
-                 <property name="decimals">
-                  <number>5</number>
-                 </property>
-                 <property name="maximum">
-                  <double>1000000000000000000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>1.000000000000000</double>
+                <widget class="DoubleEdit" name="prismHeightSpinBox">
+                 <property name="text">
+                  <string>1,00</string>
                  </property>
                 </widget>
                </item>
@@ -235,7 +223,7 @@ QGroupBox::title {
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="../../Polyhedron_3.qrc">:/cgal/Polyhedron_3/resources/icosphere.png</pixmap>
+           <pixmap>:/cgal/Polyhedron_3/resources/icosphere.png</pixmap>
           </property>
          </widget>
         </item>
@@ -558,7 +546,7 @@ QGroupBox::title {
              <string/>
             </property>
             <property name="pixmap">
-             <pixmap resource="../../Polyhedron_3.qrc">:/cgal/Polyhedron_3/resources/hexahedron.png</pixmap>
+             <pixmap>:/cgal/Polyhedron_3/resources/hexahedron.png</pixmap>
             </property>
             <property name="scaledContents">
              <bool>false</bool>
@@ -768,7 +756,7 @@ QGroupBox::title {
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="../../Polyhedron_3.qrc">:/cgal/Polyhedron_3/resources/tetrahedron.png</pixmap>
+           <pixmap>:/cgal/Polyhedron_3/resources/tetrahedron.png</pixmap>
           </property>
          </widget>
         </item>
@@ -899,7 +887,7 @@ QGroupBox::title {
              <string/>
             </property>
             <property name="pixmap">
-             <pixmap resource="../../Polyhedron_3.qrc">:/cgal/Polyhedron_3/resources/grid.png</pixmap>
+             <pixmap>:/cgal/Polyhedron_3/resources/grid.png</pixmap>
             </property>
            </widget>
           </item>
@@ -1068,7 +1056,7 @@ QGroupBox::title {
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="overwriteMode">
            <bool>false</bool>
@@ -1105,7 +1093,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="overwriteMode">
            <bool>false</bool>
@@ -1183,11 +1171,13 @@ p, li { white-space: pre-wrap; }
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="../../Polyhedron_3.qrc"/>
-  <include location="../../Polyhedron_3.qrc"/>
-  <include location="../../Polyhedron_3.qrc"/>
-  <include location="../../Polyhedron_3.qrc"/>
- </resources>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/MeshOnGrid_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/MeshOnGrid_dialog.ui
@@ -26,13 +26,6 @@
       <string>Along X</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="x_space_doubleSpinBox">
-        <property name="maximum">
-         <double>99999999999999999475366575191804932315794610450682175621941694731908308538307845136842752.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
@@ -57,6 +50,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="x_space_doubleSpinBox">
+        <property name="text">
+         <string>0,00</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -66,13 +66,6 @@
       <string>Along Y</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="y_space_doubleSpinBox">
-        <property name="maximum">
-         <double>99999999999999999475366575191804932315794610450682175621941694731908308538307845136842752.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
@@ -97,6 +90,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="y_space_doubleSpinBox">
+        <property name="text">
+         <string>0,00</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -106,13 +106,6 @@
       <string>Along Z</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="z_space_doubleSpinBox">
-        <property name="maximum">
-         <double>99999999999999999475366575191804932315794610450682175621941694731908308538307845136842752.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
@@ -134,6 +127,13 @@
         </property>
         <property name="value">
          <number>2</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="z_space_doubleSpinBox">
+        <property name="text">
+         <string>0,00</string>
         </property>
        </widget>
       </item>
@@ -165,6 +165,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/MeshOnGrid_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/MeshOnGrid_dialog.ui
@@ -53,7 +53,7 @@
       <item row="1" column="1">
        <widget class="DoubleEdit" name="x_space_doubleSpinBox">
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>
@@ -93,7 +93,7 @@
       <item row="1" column="1">
        <widget class="DoubleEdit" name="y_space_doubleSpinBox">
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>
@@ -133,7 +133,7 @@
       <item row="1" column="1">
        <widget class="DoubleEdit" name="z_space_doubleSpinBox">
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_plugin.cpp
@@ -64,6 +64,7 @@ public:
     dock_widget->setVisible(false);
 
     ui_widget.setupUi(dock_widget);
+    ui_widget.Density_control_factor_spin_box->setMaximum(96.989999999999995);
     addDockWidget(dock_widget);
     dock_widget->setWindowTitle(tr(
                                   "Fairing "

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_widget.ui
@@ -99,15 +99,9 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="Density_control_factor_spin_box">
-           <property name="maximum">
-            <double>96.989999999999995</double>
-           </property>
-           <property name="singleStep">
-            <double>0.200000000000000</double>
-           </property>
-           <property name="value">
-            <double>2.410000000000000</double>
+          <widget class="DoubleEdit" name="Density_control_factor_spin_box">
+           <property name="text">
+            <string>2,41</string>
            </property>
           </widget>
          </item>
@@ -139,6 +133,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_widget.ui
@@ -101,7 +101,7 @@
          <item>
           <widget class="DoubleEdit" name="Density_control_factor_spin_box">
            <property name="text">
-            <string>2,41</string>
+            <string>2.41</string>
            </property>
           </widget>
          </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -443,6 +443,7 @@ void Polyhedron_demo_hole_filling_plugin::init(QMainWindow* mainWindow,
   dock_widget->installEventFilter(this);
 
   ui_widget.setupUi(dock_widget);
+  ui_widget.Density_control_factor_spin_box->setMaximum(96.989999999999995);
   ui_widget.Accept_button->setVisible(false);
   ui_widget.Reject_button->setVisible(false);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
@@ -87,18 +87,9 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="vertices_threshold_spin_box">
-           <property name="decimals">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <double>999999999.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>10.000000000000000</double>
+          <widget class="DoubleEdit" name="vertices_threshold_spin_box">
+           <property name="text">
+            <string>10.0</string>
            </property>
           </widget>
          </item>
@@ -131,7 +122,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>1,41</string>
+            <string>1.41</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_widget.ui
@@ -123,15 +123,18 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="Density_control_factor_spin_box">
-           <property name="maximum">
-            <double>96.989999999999995</double>
+          <widget class="DoubleEdit" name="Density_control_factor_spin_box">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="singleStep">
-            <double>0.200000000000000</double>
+           <property name="text">
+            <string>1,41</string>
            </property>
-           <property name="value">
-            <double>1.410000000000000</double>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -333,6 +336,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>376</width>
-    <height>368</height>
+    <height>369</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -98,9 +98,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>edgeLength_dspinbox</cstring>
-        </property>
        </widget>
       </item>
       <item row="4" column="0">
@@ -176,22 +173,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="edgeLength_dspinbox">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>1000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
@@ -207,6 +188,22 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="0" column="1">
+       <widget class="DoubleEdit" name="edgeLength_dspinbox">
+        <property name="inputMethodHints">
+         <set>Qt::ImhNone</set>
+        </property>
+        <property name="inputMask">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>0.00</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -239,9 +236,15 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>splitEdgesOnly_checkbox</tabstop>
-  <tabstop>edgeLength_dspinbox</tabstop>
   <tabstop>nbIterations_spinbox</tabstop>
   <tabstop>nbSmoothing_spinbox</tabstop>
   <tabstop>protect_checkbox</tabstop>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -51,6 +51,7 @@ typedef Scene_surface_mesh_item Scene_facegraph_item;
 typedef Scene_facegraph_item::Face_graph FaceGraph;
 typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
+
 // give a halfedge and a target edge length, put in `out` points
 // which the edge equally spaced such that splitting the edge
 // using the sequence of points make the edges shorter than
@@ -331,7 +332,7 @@ public Q_SLOTS:
       }
       bool edges_only = ui.splitEdgesOnly_checkbox->isChecked();
       bool preserve_duplicates = ui.preserveDuplicates_checkbox->isChecked();
-      double target_length = ui.edgeLength_dspinbox->value();
+      double target_length = ui.edgeLength_dspinbox->text().toDouble();
       unsigned int nb_iter = ui.nbIterations_spinbox->value();
       unsigned int nb_smooth = ui.nbSmoothing_spinbox->value();
       bool protect = ui.protect_checkbox->isChecked();
@@ -672,7 +673,7 @@ public Q_SLOTS:
 
         edges_only = ui.splitEdgesOnly_checkbox->isChecked();
         preserve_duplicates = ui.preserveDuplicates_checkbox->isChecked();
-        target_length = ui.edgeLength_dspinbox->value();
+        target_length = ui.edgeLength_dspinbox->text().toDouble();
         nb_iter = ui.nbIterations_spinbox->value();
         protect = ui.protect_checkbox->isChecked();
         smooth_features = ui.smooth1D_checkbox->isChecked();
@@ -904,14 +905,9 @@ private:
     double diago_length = CGAL::sqrt((bbox.xmax()-bbox.xmin())*(bbox.xmax()-bbox.xmin())
                                    + (bbox.ymax()-bbox.ymin())*(bbox.ymax()-bbox.ymin())
                                    + (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
-    double log = std::log10(diago_length);
-    unsigned int nb_decimals = (log > 0) ? 5 : (std::ceil(-log)+3);
 
-    ui.edgeLength_dspinbox->setDecimals(nb_decimals);
-    ui.edgeLength_dspinbox->setSingleStep(1e-3);
-    ui.edgeLength_dspinbox->setRange(1e-6 * diago_length, //min
-                                     2.   * diago_length);//max
-    ui.edgeLength_dspinbox->setValue(0.05 * diago_length);
+
+    ui.edgeLength_dspinbox->setText(tr("%1").arg(0.05 * diago_length));
 
     std::ostringstream oss;
     oss << "Diagonal length of the Bbox of the selection to remesh is ";

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -332,7 +332,7 @@ public Q_SLOTS:
       }
       bool edges_only = ui.splitEdgesOnly_checkbox->isChecked();
       bool preserve_duplicates = ui.preserveDuplicates_checkbox->isChecked();
-      double target_length = ui.edgeLength_dspinbox->text().toDouble();
+      double target_length = ui.edgeLength_dspinbox->value();
       unsigned int nb_iter = ui.nbIterations_spinbox->value();
       unsigned int nb_smooth = ui.nbSmoothing_spinbox->value();
       bool protect = ui.protect_checkbox->isChecked();
@@ -673,7 +673,7 @@ public Q_SLOTS:
 
         edges_only = ui.splitEdgesOnly_checkbox->isChecked();
         preserve_duplicates = ui.preserveDuplicates_checkbox->isChecked();
-        target_length = ui.edgeLength_dspinbox->text().toDouble();
+        target_length = ui.edgeLength_dspinbox->value();
         nb_iter = ui.nbIterations_spinbox->value();
         protect = ui.protect_checkbox->isChecked();
         smooth_features = ui.smooth1D_checkbox->isChecked();
@@ -907,7 +907,7 @@ private:
                                    + (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
 
 
-    ui.edgeLength_dspinbox->setText(tr("%1").arg(0.05 * diago_length));
+    ui.edgeLength_dspinbox->setValue(0.05 * diago_length);
 
     std::ostringstream oss;
     oss << "Diagonal length of the Bbox of the selection to remesh is ";

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -189,17 +189,9 @@ public:
                                             "to a surface mesh item. The generated mcf group must be selected in "
                                             "order to continue an on-going set of operations. "));});
     ui->omega_H->setValue(0.1);
-    ui->omega_H->setSingleStep(0.1);
-    ui->omega_H->setDecimals(3);
     ui->omega_P->setValue(0.2);
-    ui->omega_P->setSingleStep(0.1);
-    ui->omega_P->setDecimals(3);
-    ui->min_edge_length->setDecimals(7);
     ui->min_edge_length->setValue(0.002 * diag);
-    ui->min_edge_length->setSingleStep(0.0000001);
-    ui->delta_area->setDecimals(7);
     ui->delta_area->setValue(1e-4);
-    ui->delta_area->setSingleStep(1e-5);
     ui->is_medially_centered->setChecked(false);
 
     ui->label_omega_H->setToolTip(QString("omega_H controls the velocity of movement and approximation quality"));

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>483</width>
+    <width>498</width>
     <height>279</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
           <item>
            <widget class="QLabel" name="label_omega_H">
             <property name="text">
@@ -60,12 +60,22 @@
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="omega_H"/>
+           <widget class="DoubleEdit" name="omega_H">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>0.00</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
           <item>
            <widget class="QLabel" name="label_omega_P">
             <property name="text">
@@ -74,12 +84,22 @@
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="omega_P"/>
+           <widget class="DoubleEdit" name="omega_P">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>0.00</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0">
           <item>
            <widget class="QLabel" name="label_min_edge_length">
             <property name="text">
@@ -88,12 +108,16 @@
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="min_edge_length"/>
+           <widget class="DoubleEdit" name="min_edge_length">
+            <property name="text">
+             <string>0.00</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="1,0">
           <item>
            <widget class="QLabel" name="label_delta_area">
             <property name="text">
@@ -102,7 +126,17 @@
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="delta_area"/>
+           <widget class="DoubleEdit" name="delta_area">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>0.00</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
@@ -203,6 +237,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>377</width>
-    <height>292</height>
+    <height>293</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,9 +55,6 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>moveSize_dspinbox</cstring>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">
@@ -70,22 +67,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="moveSize_dspinbox">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>1000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QCheckBox" name="project_checkbox">
         <property name="text">
@@ -93,6 +74,19 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="DoubleEdit" name="moveSize_dspinbox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>0,00</string>
         </property>
        </widget>
       </item>
@@ -198,8 +192,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
-  <tabstop>moveSize_dspinbox</tabstop>
   <tabstop>project_checkbox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_dialog.ui
@@ -86,7 +86,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>0,00</string>
+         <string>0.00</string>
         </property>
        </widget>
       </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_plugin.cpp
@@ -196,12 +196,8 @@ public Q_SLOTS:
     double diago_length = CGAL::sqrt((bbox.xmax() - bbox.xmin())*(bbox.xmax() - bbox.xmin())
       + (bbox.ymax() - bbox.ymin())*(bbox.ymax() - bbox.ymin())
       + (bbox.zmax() - bbox.zmin())*(bbox.zmax() - bbox.zmin()));
-    double log = std::log10(diago_length);
-    unsigned int nb_decimals = (log > 0) ? 5 : (std::ceil(-log) + 3);
 
     //parameters
-    ui.moveSize_dspinbox->setDecimals(nb_decimals);
-    ui.moveSize_dspinbox->setSingleStep(1e-3);
     ui.moveSize_dspinbox->setRange(0., diago_length);
     ui.moveSize_dspinbox->setValue(0.05 * diago_length);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
@@ -95,7 +95,6 @@ public:
   void init_ui()
   {
     ui_widget.time_step_spinBox->setValue(0.00001);
-    ui_widget.time_step_spinBox->setSingleStep(0.00001);
     ui_widget.time_step_spinBox->setMinimum(1e-6);
 
     ui_widget.smooth_iter_spinBox->setValue(1);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.ui
@@ -57,7 +57,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>0,000001</string>
+          <string>0.000001</string>
          </property>
         </widget>
        </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.ui
@@ -31,13 +31,13 @@
        <string>Shape Smoothing</string>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="2">
-        <widget class="QDoubleSpinBox" name="time_step_spinBox">
-         <property name="decimals">
-          <number>6</number>
+       <item row="1" column="0">
+        <widget class="QLabel" name="time_step_label">
+         <property name="toolTip">
+          <string>The time step should not be too large or the smoothing will be unsatisfactory</string>
          </property>
-         <property name="minimum">
-          <double>0.000001000000000</double>
+         <property name="text">
+          <string>Time Step:</string>
          </property>
         </widget>
        </item>
@@ -48,13 +48,16 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="time_step_label">
-         <property name="toolTip">
-          <string>The time step should not be too large or the smoothing will be unsatisfactory</string>
+       <item row="1" column="2">
+        <widget class="DoubleEdit" name="time_step_spinBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
-          <string>Time Step:</string>
+          <string>0,000001</string>
          </property>
         </widget>
        </item>
@@ -173,6 +176,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Features_detection_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Features_detection_plugin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>254</width>
-    <height>153</height>
+    <width>271</width>
+    <height>141</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
@@ -24,22 +24,22 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="m_inputOffsetRadius">
-       <property name="decimals">
-        <number>3</number>
+      <widget class="DoubleEdit" name="m_inputOffsetRadius">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.100000000000000</double>
+       <property name="text">
+        <string>0.100</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -48,19 +48,22 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="m_inputConvolveRadius">
-       <property name="decimals">
-        <number>3</number>
+      <widget class="DoubleEdit" name="m_inputConvolveRadius">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
+       <property name="text">
+        <string>0.00</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
      <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
@@ -69,15 +72,15 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="m_inputFeaturesThreshold">
-       <property name="decimals">
-        <number>3</number>
+      <widget class="DoubleEdit" name="m_inputFeaturesThreshold">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="singleStep">
-        <double>0.020000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.160000000000000</double>
+       <property name="text">
+        <string>0.160</string>
        </property>
       </widget>
      </item>
@@ -108,6 +111,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -152,6 +152,7 @@ class Point_set_demo_normal_estimation_dialog : public QDialog, private Ui::Norm
     Point_set_demo_normal_estimation_dialog(QWidget* /*parent*/ = 0)
     {
       setupUi(this);
+      m_offset_radius->setMinimum(0.01);
     }
 
   int pca_neighbors() const { return m_pca_neighbors->value(); }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>301</width>
+    <width>330</width>
     <height>372</height>
    </rect>
   </property>
@@ -139,22 +139,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="m_offset_radius">
-        <property name="minimum">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="m_convolution_radius"/>
-      </item>
       <item row="1" column="0">
        <widget class="QRadioButton" name="buttonRadius">
         <property name="text">
@@ -182,6 +166,20 @@
         </property>
         <property name="value">
          <number>40</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="DoubleEdit" name="m_offset_radius">
+        <property name="text">
+         <string>0.10</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="DoubleEdit" name="m_convolution_radius">
+        <property name="text">
+         <string>0.00</string>
         </property>
        </widget>
       </item>
@@ -213,6 +211,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -259,22 +264,6 @@
     </hint>
     <hint type="destinationlabel">
      <x>199</x>
-     <y>245</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonRadius</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_convolution_radius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>90</x>
-     <y>242</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>285</x>
      <y>245</y>
     </hint>
    </hints>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
@@ -92,6 +92,7 @@ class Point_set_demo_outlier_removal_dialog : public QDialog, private Ui::Outlie
     Point_set_demo_outlier_removal_dialog(QWidget * /*parent*/ = 0)
     {
       setupUi(this);
+      m_distanceThreshold->setMinimum(0.0);
     }
 
     double percentage() const { return m_inputPercentage->value(); }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.ui
@@ -91,26 +91,21 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QDoubleSpinBox" name="m_distanceThreshold">
-     <property name="decimals">
-      <number>6</number>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="value">
-      <double>0.500000000000000</double>
+    <widget class="DoubleEdit" name="m_distanceThreshold">
+     <property name="text">
+      <string>0.5</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -30,6 +30,7 @@
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QMessageBox>
+#include <QSpinBox>
 
 #include <QMultipleInputDialog.h>
 #include "CGAL_double_edit.h"

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -824,7 +824,7 @@ protected Q_SLOTS:
     DoubleEdit* epsilon = dialog.add<DoubleEdit> ("Epsilon: ");
     if (rg_epsilon < 0.)
       rg_epsilon = (std::max)(0.00001, 0.005 * scene->len_diagonal());
-    epsilon->setText(tr("%1").arg(rg_epsilon));
+    epsilon->setValue(rg_epsilon);
     
     DoubleEdit* cluster_epsilon = dialog.add<DoubleEdit> ("Cluster epsilon: ");
     if (rg_cluster_epsilon < 0.)
@@ -838,8 +838,8 @@ protected Q_SLOTS:
     
     if (dialog.exec())
     {
-      rg_epsilon = epsilon->text().toDouble();
-      rg_cluster_epsilon = cluster_epsilon->text().toDouble();
+      rg_epsilon = epsilon->value();
+      rg_cluster_epsilon = cluster_epsilon->value();
       rg_normal_threshold = normal_threshold->value();
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -32,7 +32,7 @@
 #include <QMessageBox>
 
 #include <QMultipleInputDialog.h>
-#include <QDoubleSpinBox>
+#include "CGAL_double_edit.h"
 
 #include <map>
 #include <fstream>
@@ -821,19 +821,15 @@ protected Q_SLOTS:
       return;
 
     QMultipleInputDialog dialog ("Region Selection Parameters", mw);
-    QDoubleSpinBox* epsilon = dialog.add<QDoubleSpinBox> ("Epsilon: ");
-    epsilon->setRange (0.00001, 1000000.);
-    epsilon->setDecimals (5);
+    DoubleEdit* epsilon = dialog.add<DoubleEdit> ("Epsilon: ");
     if (rg_epsilon < 0.)
       rg_epsilon = (std::max)(0.00001, 0.005 * scene->len_diagonal());
-    epsilon->setValue (rg_epsilon);
+    epsilon->setText(tr("%1").arg(rg_epsilon));
     
-    QDoubleSpinBox* cluster_epsilon = dialog.add<QDoubleSpinBox> ("Cluster epsilon: ");
-    cluster_epsilon->setRange (0.00001, 1000000.);
-    cluster_epsilon->setDecimals (5);
+    DoubleEdit* cluster_epsilon = dialog.add<DoubleEdit> ("Cluster epsilon: ");
     if (rg_cluster_epsilon < 0.)
       rg_cluster_epsilon = (std::max)(0.00001, 0.03 * scene->len_diagonal());
-    cluster_epsilon->setValue (rg_cluster_epsilon);
+    cluster_epsilon->setText(tr("%1").arg(rg_cluster_epsilon));
 
     QSpinBox* normal_threshold = dialog.add<QSpinBox> ("Normal threshold: ");
     normal_threshold->setRange (0, 90);
@@ -842,8 +838,8 @@ protected Q_SLOTS:
     
     if (dialog.exec())
     {
-      rg_epsilon = epsilon->value();
-      rg_cluster_epsilon = cluster_epsilon->value();
+      rg_epsilon = epsilon->text().toDouble();
+      rg_cluster_epsilon = cluster_epsilon->text().toDouble();
       rg_normal_threshold = normal_threshold->value();
     }
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
@@ -79,6 +79,11 @@ public:
   Point_set_demo_point_set_shape_detection_dialog(QWidget * /*parent*/ = 0)
   {
     setupUi(this);
+    m_normal_tolerance_field->setMaximum(1.0);
+    m_probability_field->setRange(0.00001, 1.0);
+    m_epsilon_field->setMinimum(0.000001);
+    m_normal_tolerance_field->setMinimum(0.01);
+    m_cluster_epsilon_field->setMinimum(0.000001);
   }
 
   bool region_growing() const { return m_region_growing->isChecked(); }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.ui
@@ -124,7 +124,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
         <item>
          <widget class="QLabel" name="label_2">
           <property name="text">
@@ -133,31 +133,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="m_epsilon_field">
-          <property name="toolTip">
-           <string>Fitting tolerance in Euclidean distance</string>
+         <widget class="DoubleEdit" name="m_epsilon_field">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="decimals">
-           <number>8</number>
-          </property>
-          <property name="minimum">
-           <double>0.000001000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1000000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.001000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.002000000000000</double>
+          <property name="text">
+           <string>0.002</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
         <item>
          <widget class="QLabel" name="label">
           <property name="text">
@@ -166,28 +157,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="m_normal_tolerance_field">
-          <property name="toolTip">
-           <string>Normal angle deviation tolerance as cosine of the angle</string>
+         <widget class="DoubleEdit" name="m_normal_tolerance_field">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.900000000000000</double>
+          <property name="text">
+           <string>0.90</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -214,7 +199,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
         <item>
          <widget class="QLabel" name="label_4">
           <property name="text">
@@ -223,31 +208,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="m_cluster_epsilon_field">
-          <property name="toolTip">
-           <string>Maximum world distance between points on a shape to be considered as connected</string>
+         <widget class="DoubleEdit" name="m_cluster_epsilon_field">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="decimals">
-           <number>8</number>
-          </property>
-          <property name="minimum">
-           <double>0.000001000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1000000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.020000000000000</double>
+          <property name="text">
+           <string>0.002</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0">
         <item>
          <widget class="QLabel" name="label_5">
           <property name="enabled">
@@ -259,27 +235,15 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="m_probability_field">
-          <property name="enabled">
-           <bool>false</bool>
+         <widget class="DoubleEdit" name="m_probability_field">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="toolTip">
-           <string>Probability to overlook the largest primitive in one extraction iteration</string>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="minimum">
-           <double>0.000010000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
+          <property name="text">
+           <string>0.05</string>
           </property>
          </widget>
         </item>
@@ -356,6 +320,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -482,22 +453,6 @@
     </hint>
     <hint type="destinationlabel">
      <x>103</x>
-     <y>214</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ransac</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_probability_field</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>70</x>
-     <y>46</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>352</x>
      <y>214</y>
     </hint>
    </hints>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
@@ -134,6 +134,7 @@ class Point_set_demo_point_set_simplification_dialog : public QDialog, private U
     Point_set_demo_point_set_simplification_dialog(QWidget * /*parent*/ = 0)
     {
       setupUi(this);
+      m_maximumSurfaceVariation->setRange(0.000010, 0.33330);
     }
 
   unsigned int simplificationMethod() const

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.ui
@@ -7,24 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>392</width>
-    <height>248</height>
+    <height>249</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Simplification</string>
   </property>
   <layout class="QGridLayout" columnstretch="0,1" columnminimumwidth="0,1">
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="2" column="0">
+    <widget class="QRadioButton" name="Random">
      <property name="text">
-      <string>Maximum Cluster Size</string>
+      <string>Random</string>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QRadioButton" name="Grid">
-     <property name="text">
-      <string>Grid</string>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -44,51 +40,10 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Maximum Surface Variation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QRadioButton" name="Random">
-     <property name="text">
-      <string>Random</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QRadioButton" name="Hierarchy">
-     <property name="text">
-      <string>Hierarchy</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Points to Remove Randomly</string>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Grid Cell Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -114,28 +69,10 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
-    <widget class="QDoubleSpinBox" name="m_maximumSurfaceVariation">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="suffix">
-      <string/>
-     </property>
-     <property name="decimals">
-      <number>5</number>
-     </property>
-     <property name="minimum">
-      <double>0.000010000000000</double>
-     </property>
-     <property name="maximum">
-      <double>0.333330000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.012340000000000</double>
-     </property>
-     <property name="value">
-      <double>0.333330000000000</double>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Maximum Surface Variation</string>
      </property>
     </widget>
    </item>
@@ -177,8 +114,60 @@
      </property>
     </spacer>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Maximum Cluster Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Points to Remove Randomly</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QRadioButton" name="Grid">
+     <property name="text">
+      <string>Grid</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QRadioButton" name="Hierarchy">
+     <property name="text">
+      <string>Hierarchy</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="DoubleEdit" name="m_maximumSurfaceVariation">
+     <property name="text">
+      <string>0.333333</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -140,16 +140,6 @@
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="distance_spinbox">
-             <property name="toolTip">
-              <string>Points further than this distance will be selected.</string>
-             </property>
-             <property name="decimals">
-              <number>6</number>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="1">
             <widget class="QPushButton" name="select_button">
              <property name="toolTip">
@@ -164,6 +154,13 @@
             <widget class="QLabel" name="label_6">
              <property name="text">
               <string>Threshold:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="DoubleEdit" name="distance_spinbox">
+             <property name="text">
+              <string>0,00</string>
              </property>
             </widget>
            </item>
@@ -190,6 +187,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_to_mesh_distance_widget.ui
@@ -160,7 +160,7 @@
            <item row="0" column="1">
             <widget class="DoubleEdit" name="distance_spinbox">
              <property name="text">
-              <string>0,00</string>
+              <string>0.00</string>
              </property>
             </widget>
            </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -67,6 +67,7 @@ public:
   Point_set_demo_point_set_upsampling_dialog(QWidget * /*parent*/ = 0)
   {
     setupUi(this);
+    m_edgeSensitivity->setMaximum(1.0);
   }
 
   unsigned int sharpness_angle () const { return m_sharpnessAngle->value(); }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.cpp
@@ -68,6 +68,9 @@ public:
   {
     setupUi(this);
     m_edgeSensitivity->setMaximum(1.0);
+    m_neighborhoodRadius->setRange(0.1, 10.0);
+
+
   }
 
   unsigned int sharpness_angle () const { return m_sharpnessAngle->value(); }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_upsampling_plugin.ui
@@ -7,17 +7,93 @@
     <x>0</x>
     <y>0</y>
     <width>348</width>
-    <height>167</height>
+    <height>168</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Edge Aware Upsampling</string>
   </property>
   <layout class="QGridLayout" columnstretch="0,1">
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Output Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Neighborhood Radius</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Edge Sensitivity</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="m_sharpnessAngle">
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="maximum">
+      <number>90</number>
+     </property>
+     <property name="value">
+      <number>25</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDoubleSpinBox" name="m_outputSize">
+     <property name="prefix">
+      <string/>
+     </property>
+     <property name="suffix">
+      <string> * input size</string>
+     </property>
+     <property name="minimum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>4.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Sharpness Angle</string>
      </property>
     </widget>
    </item>
@@ -43,94 +119,22 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
-    <widget class="QDoubleSpinBox" name="m_edgeSensitivity">
-     <property name="maximum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.010000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QDoubleSpinBox" name="m_outputSize">
-     <property name="prefix">
-      <string/>
-     </property>
-     <property name="suffix">
-      <string> * input size</string>
-     </property>
-     <property name="minimum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>4.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_5">
+    <widget class="DoubleEdit" name="m_edgeSensitivity">
      <property name="text">
-      <string>Edge Sensitivity</string>
+      <string>0.00</string>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Sharpness Angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Neighborhood Radius</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QSpinBox" name="m_sharpnessAngle">
-     <property name="suffix">
-      <string>°</string>
-     </property>
-     <property name="maximum">
-      <number>90</number>
-     </property>
-     <property name="value">
-      <number>25</number>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>404</width>
+    <width>427</width>
     <height>482</height>
    </rect>
   </property>
@@ -736,7 +736,6 @@
         </widget>
        </item>
       </layout>
-      <zorder>tabWidget_2</zorder>
      </widget>
      <widget class="QWidget" name="tab_6">
       <attribute name="title">

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_dialog.ui
@@ -49,7 +49,7 @@
      <item row="0" column="1">
       <widget class="DoubleEdit" name="minimumAreaDoubleSpinBox">
        <property name="text">
-        <string>0,01</string>
+        <string>0.01</string>
        </property>
       </widget>
      </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_dialog.ui
@@ -23,25 +23,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QDoubleSpinBox" name="minimumAreaDoubleSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="minimum">
-        <double>0.000010000000000</double>
-       </property>
-       <property name="maximum">
-        <double>1000000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.010000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.010000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="maximumDeviationFromNormalLabel">
        <property name="text">
@@ -62,6 +43,13 @@
        </property>
        <property name="value">
         <number>30</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="DoubleEdit" name="minimumAreaDoubleSpinBox">
+       <property name="text">
+        <string>0,01</string>
        </property>
       </widget>
      </item>
@@ -92,6 +80,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
@@ -191,7 +191,7 @@ void Polyhedron_demo_mesh_plane_detection_plugin::on_actionPlaneDetection_trigge
       QDialog dialog(mw);
       Ui::Mesh_plane_detection_dialog ui;
       ui.setupUi(&dialog);
-  
+      ui.minimumAreaDoubleSpinBox->setMinimum(0.00001);
       // check user cancellation
       if(dialog.exec() == QDialog::Rejected)
         return;

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
@@ -92,6 +92,7 @@ public:
         dock_widget = new QDockWidget("Mesh segmentation parameters", mw);
         dock_widget->setVisible(false); // do not show at the beginning
         ui_widget.setupUi(dock_widget);
+        ui_widget.Smoothness_spin_box->setMaximum(10.0);
         mw->addDockWidget(Qt::LeftDockWidgetArea, dock_widget);
 
         connect(ui_widget.Partition_button,  SIGNAL(clicked()), this, SLOT(on_Partition_button_clicked()));

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_widget.ui
@@ -31,13 +31,6 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QSpinBox" name="Number_of_rays_spin_box">
-         <property name="value">
-          <number>25</number>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="Cone_angle_label">
          <property name="text">
@@ -55,6 +48,13 @@
          </property>
          <property name="value">
           <number>120</number>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="Number_of_rays_spin_box">
+         <property name="value">
+          <number>25</number>
          </property>
         </widget>
        </item>
@@ -100,19 +100,6 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="Smoothness_spin_box">
-         <property name="maximum">
-          <double>10.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.010000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.260000000000000</double>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label">
          <property name="layoutDirection">
@@ -133,6 +120,13 @@
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="DoubleEdit" name="Smoothness_spin_box">
+         <property name="text">
+          <string>0,26</string>
          </property>
         </widget>
        </item>
@@ -194,6 +188,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_widget.ui
@@ -126,7 +126,7 @@
        <item row="1" column="1">
         <widget class="DoubleEdit" name="Smoothness_spin_box">
          <property name="text">
-          <string>0,26</string>
+          <string>0.26</string>
          </property>
         </widget>
        </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
@@ -105,15 +105,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="m_edge_length">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>10000.000000000000000</double>
+      <widget class="DoubleEdit" name="m_edge_length">
+       <property name="text">
+        <string>0.000</string>
        </property>
       </widget>
      </item>
@@ -144,6 +138,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
@@ -452,17 +452,16 @@ void Polyhedron_demo_offset_meshing_plugin::offset_meshing()
   QDialog dialog(mw);
   Ui::Remeshing_dialog ui;
   ui.setupUi(&dialog);
+  ui.angle->setRange(1.0, 30.0);
   connect(ui.buttonBox, SIGNAL(accepted()),
           &dialog, SLOT(accept()));
   connect(ui.buttonBox, SIGNAL(rejected()),
           &dialog, SLOT(reject()));
 
-  ui.sizing->setDecimals(4);
   ui.sizing->setRange(diag * 10e-6, // min
                       diag); // max
   ui.sizing->setValue(diag * 0.05); // default value
 
-  ui.approx->setDecimals(6);
   ui.approx->setRange(diag * 10e-7, // min
                       diag); // max
   ui.approx->setValue(diag * 0.005);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Remeshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Remeshing_dialog.ui
@@ -15,68 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-     <item row="0" column="0">
-      <widget class="QLabel" name="angleLabel">
-       <property name="text">
-        <string>&amp;Angle:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>angle</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QDoubleSpinBox" name="angle">
-       <property name="minimum">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>30.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>25.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="sizingLabel">
-       <property name="text">
-        <string>&amp;Size:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>sizing</cstring>
-       </property>
-      </widget>
-     </item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
      <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="sizing">
-       <property name="decimals">
-        <number>4</number>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="approxLabel">
+      <widget class="DoubleEdit" name="sizing">
        <property name="text">
-        <string>Approximation &amp;error:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>approx</cstring>
+        <string>0.00</string>
        </property>
       </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="approx"/>
      </item>
      <item row="3" column="1">
       <widget class="QComboBox" name="tags">
@@ -97,6 +42,36 @@
        </item>
       </widget>
      </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="angleLabel">
+       <property name="text">
+        <string>&amp;Angle:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="sizingLabel">
+       <property name="text">
+        <string>&amp;Size:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="approxLabel">
+       <property name="text">
+        <string>Approximation &amp;error:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
@@ -107,6 +82,20 @@
        </property>
        <property name="buddy">
         <cstring>tags</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="DoubleEdit" name="approx">
+       <property name="text">
+        <string>0.00</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="DoubleEdit" name="angle">
+       <property name="text">
+        <string>25.0</string>
        </property>
       </widget>
      </item>
@@ -137,6 +126,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_dockwidget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_dockwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>667</width>
+    <width>652</width>
     <height>360</height>
    </rect>
   </property>
@@ -64,20 +64,19 @@
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_9">
-           <property name="toolTip">
-            <string/>
+         <item row="4" column="2">
+          <widget class="QSpinBox" name="nb_iterations">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
-           <property name="text">
-            <string>Error drop</string>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
            </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>#Proxies</string>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+           <property name="value">
+            <number>20</number>
            </property>
           </widget>
          </item>
@@ -87,6 +86,26 @@
             <string>#Relaxations</string>
            </property>
           </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="enable_error_drop">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item row="0" column="2">
           <widget class="QSpinBox" name="nb_proxies">
@@ -104,47 +123,20 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="2" column="2">
-          <widget class="QDoubleSpinBox" name="error_drop">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_9">
            <property name="toolTip">
-            <string>Negative value is ignored</string>
+            <string/>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <property name="text">
+            <string>Error drop</string>
            </property>
-           <property name="buttonSymbols">
-            <enum>QAbstractSpinBox::NoButtons</enum>
-           </property>
-           <property name="decimals">
-            <number>4</number>
-           </property>
-           <property name="minimum">
-            <double>0.001000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.010000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.100000000000000</double>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>#Proxies</string>
            </property>
           </widget>
          </item>
@@ -168,26 +160,10 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="QSpinBox" name="nb_iterations">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="buttonSymbols">
-            <enum>QAbstractSpinBox::NoButtons</enum>
-           </property>
-           <property name="maximum">
-            <number>999</number>
-           </property>
-           <property name="value">
-            <number>20</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="enable_error_drop">
+         <item row="2" column="2">
+          <widget class="DoubleEdit" name="error_drop">
            <property name="text">
-            <string/>
+            <string>0.1</string>
            </property>
           </widget>
          </item>
@@ -410,29 +386,23 @@
               </property>
              </spacer>
             </item>
-            <item row="1" column="2">
-             <widget class="QDoubleSpinBox" name="chord_error">
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::NoButtons</enum>
-              </property>
-              <property name="maximum">
-               <double>10.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-              <property name="value">
-               <double>3.000000000000000</double>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
                <string>Chord error:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="DoubleEdit" name="chord_error">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>3.00</string>
               </property>
              </widget>
             </item>
@@ -491,23 +461,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>enable_error_drop</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>error_drop</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>127</x>
-     <y>168</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>153</x>
-     <y>167</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -81,6 +81,8 @@ public:
     dock_widget = new QDockWidget("Mesh approximation parameters", mw);
     dock_widget->setVisible(false);
     ui_widget.setupUi(dock_widget);
+    ui_widget.chord_error->setRange(0.0, 10.0);
+    ui_widget.error_drop->setRange(0.01, 1.0);
     mw->addDockWidget(Qt::LeftDockWidgetArea, dock_widget);
 
     // connect ui actions

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
@@ -18,7 +18,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -199,7 +199,7 @@
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
+             <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,0">
               <item>
                <widget class="QCheckBox" name="remeshingEdgeLengthInput_checkBox">
                 <property name="toolTip">
@@ -214,7 +214,11 @@
                </widget>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="remeshing_edge_length_spinbox"/>
+               <widget class="DoubleEdit" name="remeshing_edge_length_spinbox">
+                <property name="text">
+                 <string>0,00</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>
@@ -435,6 +439,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DoubleEdit</class>
+   <extends>QLineEdit</extends>
+   <header>CGAL_double_edit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Deform_mesh.ui
@@ -18,7 +18,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -216,7 +216,7 @@
               <item>
                <widget class="DoubleEdit" name="remeshing_edge_length_spinbox">
                 <property name="text">
-                 <string>0,00</string>
+                 <string>0.00</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
## Summary of Changes

Replace all `QDoubleSpinBox`es by a custom class deriving from QLineEdit associated with a validator to restaint it to doubles. 
## Release Management

* Issue(s) solved (if any): fix #4251 