### PR TITLE
Re-add Epick_without_intervals

### DIFF
--- a/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_extreme_points.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Epick_without_intervals K;
 typedef CGAL::Polyhedron_3<K> Polyhedron_3;
 typedef K::Point_3 Point_3;
 

--- a/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/test_halfspace_intersections.cpp
@@ -81,4 +81,6 @@ int main()
   test<Epec,CGAL::Polyhedron_3<Epec> >();
   test<Epic,CGAL::Surface_mesh<Epic::Point_3> >();
   test<Epec,CGAL::Surface_mesh<Epec::Point_3> >();
+  test<CGAL::Epick_without_intervals,
+       CGAL::Surface_mesh<CGAL::Epick_without_intervals::Point_3> >();
 }

--- a/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
+++ b/Kernel_23/include/CGAL/Exact_predicates_inexact_constructions_kernel.h
@@ -45,7 +45,29 @@ class Epick
 #endif
 {};
 
-typedef Epick Exact_predicates_inexact_constructions_kernel;
+template < typename CK >
+struct Static_filters_without_intervals_base
+  : public internal::Static_filters< CK >
+{
+    template < typename Kernel2 >
+    struct Base {
+        typedef typename CK::template Base<Kernel2>::Type  CK2;
+        typedef Static_filters_without_intervals_base<CK2> Type;
+    };
+};
+
+class Epick_without_intervals
+  : public Static_filters_without_intervals_base<
+      Type_equality_wrapper< Simple_cartesian<double>::Base<Epick_without_intervals>::Type,
+                             Epick_without_intervals > >
+{};
+
+template <>
+struct Triangulation_structural_filtering_traits<Epick_without_intervals> {
+  typedef Tag_true Use_structural_filtering_tag;
+};
+
+typedef Epick_without_intervals Exact_predicates_inexact_constructions_kernel;
 
 template <>
 struct Triangulation_structural_filtering_traits<Epick> {

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -79,7 +79,8 @@ main()
   test<Cls>();
   std::cout << "Testing with Epick:\n";
   test<CGAL::Epick>();
-
+  std::cout << "Testing with Epick_without_intervals:\n";
+  test<CGAL::Epick_without_intervals>();
   return 0;
 }
 


### PR DESCRIPTION
## Summary of Changes

New attempt for `Epick_without_intervals`. First attempt was #3939, reverted by commit bb640d2883be715e8e5727333ad54ef6b1fc6808 in #4096.

This time, I made it with the right kernel base, I think.

## Release Management

* Affected package(s): all

