### PR TITLE
Namespaced newell function

### DIFF
--- a/Nef_3/include/CGAL/normal_vector_newell_3.h
+++ b/Nef_3/include/CGAL/normal_vector_newell_3.h
@@ -35,6 +35,8 @@
 
 namespace CGAL {
 
+namespace internal_nef 
+{
 template <class Handle, class Vector>
 CGAL_MEDIUM_INLINE
 void newell_single_step_3( const Handle& p, const Handle& q, Vector& n )
@@ -63,6 +65,7 @@ void newell_single_step_3( const Handle& p, const Handle& q, Vector& n )
         * q.hw() * q.hw()
     );
 }
+}
 
 template <class IC, class Vector>
 void normal_vector_newell_3( IC first, IC last, Vector& n )
@@ -86,11 +89,11 @@ void normal_vector_newell_3( IC first, IC last, Vector& n )
     IC prev = first;
     ++first;
     while( first != last) {
-        newell_single_step_3( *prev, *first, n);
+        internal_nef::newell_single_step_3( *prev, *first, n);
         prev = first;
         ++first;
     }
-    newell_single_step_3( *prev, *start_point, n);
+    internal_nef::newell_single_step_3( *prev, *start_point, n);
     CGAL_NEF_TRACEN("newell normal vector "<<n);
 }
 
@@ -108,11 +111,11 @@ void normal_vector_newell_3( IC first, IC last, VertexPointMap vpm, Vector& n )
     IC prev = first;
     ++first;
     while( first != last) {
-      newell_single_step_3( get(vpm,*prev), get(vpm,*first), n);
+        internal_nef::newell_single_step_3( get(vpm,*prev), get(vpm,*first), n);
         prev = first;
         ++first;
     }
-    newell_single_step_3( get(vpm,*prev), get(vpm,*start_point), n);
+    internal_nef::newell_single_step_3( get(vpm,*prev), get(vpm,*start_point), n);
     CGAL_NEF_TRACEN("newell normal vector "<<n);
 }
 


### PR DESCRIPTION
Hello all,

Thank you for you swift reply the previous time @gdamiand  and @lrineau .  This is related to issue #4291 and its solution proposed #4293.  The minimal example provided in #4291 does indeed compile now succefully. However  if I create a Nef polyhedron and convert it to a Polygon  polyhedron there is another namespacing issue. I made this small fix that successfully compiled for all my usecases. This  a minimal example that illustrates the other namespacing issue. 

```
#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
#include <CGAL/IO/Polyhedron_iostream.h>

#include <CGAL/Polyhedron_3.h>

#include <CGAL/Nef_polyhedron_3.h>

#include <CGAL/draw_polyhedron.h>

#include <fstream>
typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
typedef CGAL::Polyhedron_3<Kernel> Polyhedron;
typedef CGAL::Nef_polyhedron_3<Kernel> Nef_polyhedron;
int main(int argc, char* argv[]) {
    Polyhedron P;
    std::ifstream in1((argc > 1) ? argv[1] : "compl_scene.off");
    in1 >> P;
    auto nP = Nef_polyhedron(P);
    CGAL::draw(P);
    return EXIT_SUCCESS;
}
```
## Summary of Changes
Simple added a namespace for the newell_single_step_3 to be used internally inside. I am not sure though if this  is the recommended  way to fix this problem. 

## Release Management
* Affected package(s):Nef 

