### PR TITLE
Apollonius Graph 2: make sampling distance a parameter of the parabola sampling function

### DIFF
--- a/Apollonius_graph_2/include/CGAL/Parabola_segment_2.h
+++ b/Apollonius_graph_2/include/CGAL/Parabola_segment_2.h
@@ -75,9 +75,9 @@ public:
     return int(CGAL::sqrt(CGAL::to_double(tt) / 2));
   }
 
-  void generate_points(std::vector<Point_2>& p) const
+  void generate_points(std::vector<Point_2>& p,
+                       const FT STEP = FT(2)) const
   {
-    const FT STEP(2);
     FT s0, s1;
 
     s0 = t(p1);


### PR DESCRIPTION
## Summary of Changes

The current API is not so useful because it is is not adapted to other scales.

This is all undocumented code.

## Release Management

* Affected package(s): `Apollonius_graph_2`
* Issue(s) solved (if any): --

