### PR TITLE
Properly canonicalize the result of a subtraction in Mpzf

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -672,7 +672,7 @@ struct Mpzf {
 	  rdata=Mpzf_impl::fill_n_ptr(rdata,xexp-absysize,-1);
 	  mpn_sub_1(rdata, xdata, absxsize, 1);
 	  res.size=absxsize+xexp;
-	  if(res.data()[res.size-1]==0) --res.size;
+	  while(/*res.size>0&&*/res.data()[res.size-1]==0) --res.size;
 	  if(xsize<0) res.size=-res.size;
 	  return res;
 	} else {


### PR DESCRIPTION
1000-999=0001, there are multiple leading 0s to remove.

The issue was reported by @lrineau .

## Release Management

* Affected package(s): Number_types
