### PR TITLE
Take the version number from `public_release_name`

### DIFF
--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -253,10 +253,15 @@ if (NOT CGAL_CREATED_VERSION_NUM)
       set(CGAL_CREATED_VERSION_NUM "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}")
     endif()
   else()
-    #read version.h and get the line with CGAL_VERSION
-    file(STRINGS "${CGAL_ROOT}/include/CGAL/version.h" CGAL_VERSION_LINE REGEX "CGAL_VERSION ")
-    #extract release id
-    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.?[0-9]*" CGAL_CREATED_VERSION_NUM "${CGAL_VERSION_LINE}")
+    if(EXISTS "${CGAL_ROOT}/doc/public_release_name")
+      file(STRINGS "${CGAL_ROOT}/doc/public_release_name" CGAL_VERSION_LINE)
+      string(REGEX REPLACE "CGAL-" "" CGAL_CREATED_VERSION_NUM "${CGAL_VERSION_LINE}")
+    else()
+      #read version.h and get the line with CGAL_VERSION
+      file(STRINGS "${CGAL_ROOT}/include/CGAL/version.h" CGAL_VERSION_LINE REGEX "CGAL_VERSION ")
+      #extract release id
+      string(REGEX MATCH "[0-9]+\\.[0-9]+\\.?[0-9]*" CGAL_CREATED_VERSION_NUM "${CGAL_VERSION_LINE}")
+    endif()
   endif()
 endif()
 
@@ -264,6 +269,7 @@ endif()
 # closely to the convoluted versioning code and can adapt without a
 # huge diff.
 set(CGAL_DOC_VERSION ${CGAL_CREATED_VERSION_NUM})
+message(CGAL_DOC_VERSION: ${CGAL_DOC_VERSION})
 
 ## generate how_to_cite files
 if(PYTHONINTERP_FOUND)

--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -269,7 +269,6 @@ endif()
 # closely to the convoluted versioning code and can adapt without a
 # huge diff.
 set(CGAL_DOC_VERSION ${CGAL_CREATED_VERSION_NUM})
-message(CGAL_DOC_VERSION: ${CGAL_DOC_VERSION})
 
 ## generate how_to_cite files
 if(PYTHONINTERP_FOUND)

--- a/Documentation/doc/Documentation/Usage.txt
+++ b/Documentation/doc/Documentation/Usage.txt
@@ -10,7 +10,7 @@ However, some dependencies of \cgal might still need to be installed.
 
 Assuming that you have obtained \cgal through one of the package managers offering \cgal on your platform
 (see Section \ref secgettingcgal), you can download \cgal examples (
-<a href="https://github.com/CGAL/cgal/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.tar.xz">CGAL-\cgalReleaseNumber-examples.tar.xz</a>)
+<a href="https://github.com/CGAL/cgal/releases/download/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.tar.xz">CGAL-\cgalReleaseNumber-examples.tar.xz</a>)
 and the compilation of an example is as simple as:
 
     cd $HOME/CGAL-\cgalReleaseNumber/examples/Triangulation_2 # go to an example directory
@@ -51,7 +51,7 @@ acquire these dependencies.
 
 The examples and demos of \cgal are not included when you install \cgal with a package manager,
 and must be downloaded
-<a href="https://github.com/CGAL/cgal/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.tar.xz">here</a>.
+<a href="https://github.com/CGAL/cgal/releases/download/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.tar.xz">here</a>.
 
 \subsection secusingpkgman Using a Package Manager
 

--- a/Documentation/doc/Documentation/windows.txt
+++ b/Documentation/doc/Documentation/windows.txt
@@ -60,7 +60,7 @@ Note that \cgal is a header-only library, and there are therefore no `lib` or `d
 In this section we show how to compile a program that uses \cgal.
 The examples you find in these User Manual pages are not downloaded when you install \cgal
 with the Vcpkg library manager. You must download them separately from the following download page:
-<a href="https://github.com/CGAL/cgal/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.zip">CGAL-\cgalReleaseNumber-examples.zip</a>
+<a href="https://github.com/CGAL/cgal/releases/download/releases/CGAL-\cgalReleaseNumber/CGAL-\cgalReleaseNumber-examples.zip">CGAL-\cgalReleaseNumber-examples.zip</a>
 
 Assuming you have unzipped this file in your home directory `C:\Users\Me`,
 we will next compile an example from the 2D Triangulation package.

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -154,6 +154,10 @@ foreach(pkg ${files})
     process_package(${pkg})
   endif()
 endforeach()
+if(EXISTS ${GIT_REPO}/Maintenance/release_building/public_release_name)
+  file(COPY "${GIT_REPO}/Maintenance/release_building/public_release_name"
+    DESTINATION "${release_dir}/doc")
+endif()
 
 #create VERSION
 file(WRITE ${release_dir}/VERSION "${CGAL_VERSION}")


### PR DESCRIPTION
## Summary of Changes

Try to fix that issue: the version number of CGAL in the documentation of CGAL-5.0-beta2 is `5.0`, instead of `5.0-beta2`.

Also fix the download URLs.



