### PR TITLE
TDS_3: Add an edge iterator that puts marks in Cell_data 

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1334,9 +1334,9 @@ refine_balls()
     ++refine_balls_iteration_nb;
     restart = false;
     boost::unordered_map<Vertex_handle, FT, Hash_fct> new_sizes;
-
-    for(typename Tr::Finite_edges_iterator eit = tr.finite_edges_begin(),
-        end = tr.finite_edges_end(); eit != end; ++eit)
+    
+    for(typename Tr::Finite_marking_edges_iterator eit = tr.finite_marking_edges_begin(),
+        end = tr.finite_marking_edges_end(); eit != end; ++eit)
     {
       if(forced_stop()) break;
       const Vertex_handle& va = eit->first->vertex(eit->second);
@@ -1385,6 +1385,10 @@ refine_balls()
         }
       }
     }
+
+    tr.clear_marked_edges();
+
+    
     if(forced_stop()) new_sizes.clear();
 
     // The std::map with Vertex_handle as the key is not robust, because

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -92,24 +92,76 @@ public:
 
   class Cell_data {
     unsigned char conflict_state;
+
   public:
-    Cell_data() : conflict_state(0) {}
+    Cell_data() : conflict_state(0)
+    {}
 
-    void clear()            { conflict_state = 0; }
-    void mark_in_conflict() { conflict_state = 1; }
-    void mark_on_boundary() { conflict_state = 2; }
-    void mark_processed()   { conflict_state = 1; }
+    void clear()
+    {
+      conflict_state &= 0B11111100 ;
+    }
+    
+    void mark_in_conflict()
+    {
+      conflict_state |= 0B00000001 ;
+      conflict_state &= 0B11111101 ;
+    }
+    
+    void mark_on_boundary()
+    {
+      conflict_state &= 0B11111110 ;
+      conflict_state |= 0B00000010 ;
+      
+    }
+    
+    void mark_processed()
+    {
+      conflict_state |= 0B00000001 ;
+      conflict_state &= 0B11111101 ;
+    }
 
-    bool is_clear()       const { return conflict_state == 0; }
-    bool is_in_conflict() const { return conflict_state == 1; }
-    bool is_on_boundary() const { return conflict_state == 2; }
-    bool processed() const { return conflict_state == 1; }
+    bool is_clear() const
+    {
+      return (conflict_state & 3) == 0;
+    }
+    
+    bool is_in_conflict() const
+    {
+      return (conflict_state & 3) == 1;
+    }
+    
+    bool is_on_boundary() const
+    {
+      return (conflict_state & 3)  == 2;
+    }
+    
+    bool processed() const
+    {
+      return (conflict_state & 3) == 1;
+    }
+
+    void set_edge(int i)
+    {
+      conflict_state |= (1 << (i+2));
+    }
+
+    bool edge(int i)
+    {
+      return (conflict_state >> (i+2)) & 0B00000001;
+    }
+
+    void clear_edges()
+    {
+      conflict_state &= 0B00000011;
+    }
   };
 
 private:
 
   friend class internal::Triangulation_ds_facet_iterator_3<Tds>;
   friend class internal::Triangulation_ds_edge_iterator_3<Tds>;
+  friend class internal::Triangulation_ds_marking_edge_iterator_3<Tds>;
 
   friend class internal::Triangulation_ds_cell_circulator_3<Tds>;
   friend class internal::Triangulation_ds_facet_circulator_3<Tds>;
@@ -153,6 +205,7 @@ public:
 
   typedef internal::Triangulation_ds_facet_iterator_3<Tds>   Facet_iterator;
   typedef internal::Triangulation_ds_edge_iterator_3<Tds>    Edge_iterator;
+  typedef internal::Triangulation_ds_marking_edge_iterator_3<Tds>    Marking_edge_iterator;
 
   typedef internal::Triangulation_ds_cell_circulator_3<Tds>  Cell_circulator;
   typedef internal::Triangulation_ds_facet_circulator_3<Tds> Facet_circulator;
@@ -605,6 +658,25 @@ public:
     return Edge_iterator(this,1);
   }
 
+  Marking_edge_iterator marking_edges_begin() const
+  {
+    if ( dimension() < 1 )
+        return marking_edges_end();
+    return Marking_edge_iterator(this);
+  }
+
+  Marking_edge_iterator marking_edges_end() const
+  {
+    return Marking_edge_iterator(this,1);
+  }
+
+  void clear_marked_edges()
+  {
+    for(Cell_handle ch : cell_handles()){
+      ch->tds_data().clear_edges();
+    }
+  }
+  
   Edges edges() const
   {
     return Edges(edges_begin(), edges_end());
@@ -4006,6 +4078,10 @@ count_edges(size_type & i, bool verbose, int level) const
       if (verbose)
           std::cerr << "invalid edge" << std::endl;
       CGAL_triangulation_assertion(false);
+      
+      for(Cell_iterator aci = cells_begin(); aci != cells_end(); ++aci){
+        aci->tds_data().clear_edges();
+      }
       return false;
     }
     ++i;

--- a/TDS_3/include/CGAL/Triangulation_utils_3.h
+++ b/TDS_3/include/CGAL/Triangulation_utils_3.h
@@ -25,6 +25,7 @@ namespace CGAL {
 template < class T = void >
 struct Triangulation_utils_base_3
 {
+  static const int tab_edge_index[4][4];
   static const char tab_next_around_edge[4][4];
   static const int tab_vertex_triple_index[4][3];
   
@@ -33,6 +34,10 @@ struct Triangulation_utils_base_3
   static const int cw_map[3];
 };
 
+template < class T >
+const int Triangulation_utils_base_3<T>::tab_edge_index[4][4] = {
+  { -1, 0, 2, 3 }, { 0, -1, 1, 4}, {2, 1, -1, 5}, {3, 4, 5, -1} };
+  
 template < class T >
 const char Triangulation_utils_base_3<T>::tab_next_around_edge[4][4] = {
       {5, 2, 3, 1},
@@ -93,6 +98,10 @@ struct Triangulation_utils_3
     return tab_vertex_triple_index[i][j];
   }
 
+  static int edge_index(const int i, const int j)
+  {
+    return tab_edge_index[i][j];
+  }
 };
 
 } //namespace CGAL

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -116,6 +116,7 @@ public:
   typedef typename Tr_Base::Finite_cells_iterator    Finite_cells_iterator;
   typedef typename Tr_Base::Finite_facets_iterator   Finite_facets_iterator;
   typedef typename Tr_Base::Finite_edges_iterator    Finite_edges_iterator;
+  typedef typename Tr_Base::Finite_marking_edges_iterator    Finite_marking_edges_iterator;
   typedef typename Tr_Base::All_cells_iterator       All_cells_iterator;
 
   // Traits are not supposed to define Bare_point, but leaving below

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -420,11 +420,13 @@ public:
   typedef typename Tds::Cell_iterator          Cell_iterator;
   typedef typename Tds::Facet_iterator         Facet_iterator;
   typedef typename Tds::Edge_iterator          Edge_iterator;
+  typedef typename Tds::Marking_edge_iterator  Marking_edge_iterator;
   typedef typename Tds::Vertex_iterator        Vertex_iterator;
 
   typedef Cell_iterator                        All_cells_iterator;
   typedef Facet_iterator                       All_facets_iterator;
   typedef Edge_iterator                        All_edges_iterator;
+  typedef Marking_edge_iterator                All_marking_edges_iterator;
   typedef Vertex_iterator                      All_vertices_iterator;
 
   typedef typename Tds::Cell_handles           All_cell_handles;
@@ -466,6 +468,11 @@ private:
       return t->is_infinite(*e);
     }
 
+    bool operator()(const Marking_edge_iterator& e) const
+    {
+      return t->is_infinite(*e);
+    }
+    
     bool operator()(const Facet_iterator& f) const
     {
       return t->is_infinite(*f);
@@ -515,6 +522,7 @@ public:
   typedef Iterator_range<Prevent_deref<Finite_vertices_iterator> > Finite_vertex_handles;
 
   typedef Filter_iterator<Edge_iterator, Infinite_tester>     Finite_edges_iterator;
+    typedef Filter_iterator<Marking_edge_iterator, Infinite_tester>     Finite_marking_edges_iterator;
   typedef Filter_iterator<Facet_iterator, Infinite_tester>    Finite_facets_iterator;
 
   typedef Iterator_range<Finite_edges_iterator> Finite_edges;
@@ -1810,6 +1818,19 @@ public:
     return CGAL::filter_iterator(edges_end(), Infinite_tester(this));
   }
 
+  Finite_marking_edges_iterator finite_marking_edges_begin() const
+  {
+    if(dimension() < 1)
+      return finite_marking_edges_end();
+
+    return CGAL::filter_iterator(marking_edges_end(), Infinite_tester(this), marking_edges_begin());
+  }
+  
+  Finite_marking_edges_iterator finite_marking_edges_end() const
+  {
+    return CGAL::filter_iterator(marking_edges_end(), Infinite_tester(this));
+  }
+  
   Finite_edges finite_edges() const
   {
     return Finite_edges(finite_edges_begin(),finite_edges_end());
@@ -1818,6 +1839,13 @@ public:
   Edge_iterator edges_begin() const { return _tds.edges_begin(); }
   Edge_iterator edges_end() const { return _tds.edges_end(); }
 
+  Marking_edge_iterator marking_edges_begin() const { return _tds.marking_edges_begin(); }
+  Marking_edge_iterator marking_edges_end() const { return _tds.marking_edges_end(); }
+
+  void clear_marked_edges()
+  {
+    _tds.clear_marked_edges();
+  }
   
   All_edges_iterator all_edges_begin() const { return _tds.edges_begin(); }
   All_edges_iterator all_edges_end() const { return _tds.edges_end(); }


### PR DESCRIPTION
## Summary of Changes

The edge iterator  uses a cell iterator and for each edge of the cell gravitates around the edge. In case it finds a cell with a smaller address it it not the "representative" of the edge. 

This PR proposes as alternative an edge iterator that stores in `TDS_3::Cell_data` if an edge was already seen before. If not seen one gravitates around to find the  cell with smallest address, and marks the edge in all incident cells.  

This is faster (In vtune I saw that on one data set `make_mesh_3()` passed 7% in the `operator++()` of the edge iterator while protecting edges)  and the bits of `Cell_data` were not used so far.
However, after a loop over edges one must loop over all cells to reset the mark.  Also one cannot loop over all edges in two threads.

I added new names for the iterators which are up to discussion, but before that it would be good to see if there is a degradation of performance of large 3D triangulations, as setting the old marks are now bit setting operations and not just an assignment of 0, 1, or 2.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

