### PR TITLE
TDS_2/3: Cleanup in the documentation

### DIFF
--- a/TDS_2/doc/TDS_2/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/doc/TDS_2/CGAL/Triangulation_data_structure_2.h
@@ -14,6 +14,10 @@ implemented using `Compact_container`. The class may offer some
 flexibility for the choice of container in the future, in the form of 
 additional template parameters. 
 
+\tparam VertexBase must be a model of `TriangulationDSVertexBase_2`. The default is `Triangulation_ds_vertex_base_2<TDS>`.
+
+\tparam FaceBase  must be a model of `TriangulationDSFaceBase_2`. The default is `Triangulation_ds_face_base_2<TDS>`.
+
 \cgalModels `TriangulationDataStructure_2`
 
 \cgalHeading{Modifiers}
@@ -33,7 +37,7 @@ guarantee the combinatorial validity of the resulting data structure.
 \image html tds-insert_degree_2.png "Insertion and removal of degree 2 vertices. "
 \image latex tds-insert_degree_2.png "Insertion and removal of degree 2 vertices. "
 */
-template< typename Vb, typename Fb >
+template< typename VertexBase, typename FaceBase >
 class Triangulation_data_structure_2 {
 public:
 
@@ -42,13 +46,13 @@ public:
 
 /// @{
 
-  typedef Triangulation_data_structure_2<Vb,Fb>  Tds;
+  typedef Triangulation_data_structure_2<VertexBase,FaceBase>  Tds;
 
 /// The vertex type.
-  typedef  typename Vb::template Rebind_TDS<Tds>::Other  Vertex;
+  typedef  typename VertexBase::template Rebind_TDS<Tds>::Other  Vertex;
 
 /// The face type.
-  typedef  typename Fb::template Rebind_TDS<Tds>::Other  Face;
+  typedef  typename FaceBase::template Rebind_TDS<Tds>::Other  Face;
 
 /// @}
 

--- a/TDS_2/doc/TDS_2/PackageDescription.txt
+++ b/TDS_2/doc/TDS_2/PackageDescription.txt
@@ -58,7 +58,7 @@ These refining concepts and their models are described in Chapter
 - `TriangulationDSVertexBase_2`
 
 \cgalCRPSection{Classes}
-- `CGAL::Triangulation_data_structure_2<Vb,Fb>`
+- `CGAL::Triangulation_data_structure_2<VertexBase,FaceBase>`
 - `CGAL::Triangulation_ds_face_base_2<Tds>`
 - `CGAL::Triangulation_ds_vertex_base_2<Tds>`
 

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
@@ -15,16 +15,12 @@ see below). The class may offer some
 flexibility for the choice of container in the future, in the form of 
 additional template parameters. 
 
-\cgalHeading{Parameters}
+\tparam TriangulationDSVertexBase_3 must be a model of `TriangulationDSVertexBase_3`. The default is `Triangulation_ds_vertex_base_3<TDS>`.
 
-It is parameterized by base classes for vertices and cells which have to match 
-the requirements for the concepts `TriangulationDSCellBase_3` and 
-`TriangulationDSVertexBase_3` respectively. 
+\tparam TriangulationDSCellBase  must be a model of `TriangulationDSCellBase_3. The default is `Triangulation_ds_cell_base_3<TDS>`.
 
-They have the default values `Triangulation_ds_vertex_base_3<TDS>` and 
-`Triangulation_ds_cell_base_3<TDS>` respectively. 
 
-The `Concurrency_tag` parameter allows to enable the use of a concurrent
+\tparam ConcurrencyTag enables the use of a concurrent
 container to store vertices and cells. It can be `Sequential_tag` (use of a 
 `Compact_container` to store vertices and cells) or `Parallel_tag` 
 (use of a `Concurrent_compact_container`). If it is 
@@ -47,7 +43,7 @@ specified by the concept.
 */
 template< typename TriangulationDSVertexBase_3, 
           typename TriangulationDSCellBase_3,
-          typename Concurrency_tag >
+          typename ConcurrencyTag >
 class Triangulation_data_structure_3 : public CGAL::Triangulation_utils_3 {
 public:
 
@@ -55,13 +51,13 @@ public:
 /// @{
 
 /*!
-Vertex container type. If Concurrency_tag is Parallel_tag, a
+Vertex container type. If `ConcurrencyTag` is `Parallel_tag`, a
 `Concurrent_compact_container` is used instead of a `Compact_container`.
 */ 
 typedef Compact_container<Vertex, Default> Vertex_range; 
 
 /*!
-Cell container type. If Concurrency_tag is Parallel_tag, a
+Cell container type. If `ConcurrencyTag` is `Parallel_tag`, a
 `Concurrent_compact_container` is used instead of a `Compact_container`.
 */ 
 typedef Compact_container<Cell, Default> Cell_range; 

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
@@ -41,8 +41,8 @@ specified by the concept.
 \sa `CGAL::Triangulation_vertex_base_with_info_3` 
 \sa `CGAL::Triangulation_cell_base_with_info_3` 
 */
-template< typename TriangulationDSVertexBase_3, 
-          typename TriangulationDSCellBase_3,
+template< typename VertexBase, 
+          typename CellBase,
           typename ConcurrencyTag >
 class Triangulation_data_structure_3 : public CGAL::Triangulation_utils_3 {
 public:

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
@@ -17,7 +17,7 @@ additional template parameters.
 
 \tparam TriangulationDSVertexBase_3 must be a model of `TriangulationDSVertexBase_3`. The default is `Triangulation_ds_vertex_base_3<TDS>`.
 
-\tparam TriangulationDSCellBase  must be a model of `TriangulationDSCellBase_3. The default is `Triangulation_ds_cell_base_3<TDS>`.
+\tparam TriangulationDSCellBase  must be a model of `TriangulationDSCellBase_3`. The default is `Triangulation_ds_cell_base_3<TDS>`.
 
 
 \tparam ConcurrencyTag enables the use of a concurrent
@@ -25,7 +25,7 @@ container to store vertices and cells. It can be `Sequential_tag` (use of a
 `Compact_container` to store vertices and cells) or `Parallel_tag` 
 (use of a `Concurrent_compact_container`). If it is 
 `Parallel_tag`, the following functions can be called concurrently:
-`create_vertex`, `create_cell`, `delete_vertex`, `delete_cell`.
+`create_vertex()`, `create_cell()`, `delete_vertex()`, and `delete_cell()`.
 `Sequential_tag` is the default value.
 
 \cgalModels `TriangulationDataStructure_3`

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
@@ -15,9 +15,9 @@ see below). The class may offer some
 flexibility for the choice of container in the future, in the form of 
 additional template parameters. 
 
-\tparam TriangulationDSVertexBase_3 must be a model of `TriangulationDSVertexBase_3`. The default is `Triangulation_ds_vertex_base_3<TDS>`.
+\tparam VertexBase must be a model of `TriangulationDSVertexBase_3`. The default is `Triangulation_ds_vertex_base_3<TDS>`.
 
-\tparam TriangulationDSCellBase  must be a model of `TriangulationDSCellBase_3`. The default is `Triangulation_ds_cell_base_3<TDS>`.
+\tparam CellBase  must be a model of `TriangulationDSCellBase_3`. The default is `Triangulation_ds_cell_base_3<TDS>`.
 
 
 \tparam ConcurrencyTag enables the use of a concurrent

--- a/TDS_3/doc/TDS_3/PackageDescription.txt
+++ b/TDS_3/doc/TDS_3/PackageDescription.txt
@@ -56,7 +56,7 @@ Section  \ref TDS3secintro.)
 
 \cgalCRPSection{Classes}
 
-- `CGAL::Triangulation_data_structure_3<TriangulationDSVertexBase_3,TriangulationDSCellBase_3,Vertex_container_strategy,Cell_container_strategy,Concurrency_tag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
+- `CGAL::Triangulation_data_structure_3<TriangulationDSVertexBase_3,TriangulationDSCellBase_3,ConcurrencyTag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
 
 \cgal provides base vertex classes and base cell classes:
 

--- a/TDS_3/doc/TDS_3/PackageDescription.txt
+++ b/TDS_3/doc/TDS_3/PackageDescription.txt
@@ -56,7 +56,7 @@ Section  \ref TDS3secintro.)
 
 \cgalCRPSection{Classes}
 
-- `CGAL::Triangulation_data_structure_3<TriangulationDSVertexBase_3,TriangulationDSCellBase_3,ConcurrencyTag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
+- `CGAL::Triangulation_data_structure_3<VertexBase,CellBase,ConcurrencyTag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
 
 \cgal provides base vertex classes and base cell classes:
 

--- a/TDS_3/doc/TDS_3/TriangulationDS_3.txt
+++ b/TDS_3/doc/TDS_3/TriangulationDS_3.txt
@@ -306,8 +306,8 @@ typedef Triangulation_vertex_base_3<GT, Vb2> Other;
 The third template parameter of `Triangulation_data_structure_3` is 
 `ConcurrencyTag`. It enables the use of a concurrent
 container (`Concurrent_compact_container`) to store vertices and cells. 
-If it is `Parallel_tag`, then `create_vertex`, `create_cell`, `delete_vertex` 
-and `delete_cell` can be called concurrently.
+If it is `Parallel_tag`, then `create_vertex()`, `create_cell()`, `delete_vertex()` 
+and `delete_cell()` can be called concurrently.
 
 \section TDS3secexamples Examples 
 

--- a/TDS_3/doc/TDS_3/TriangulationDS_3.txt
+++ b/TDS_3/doc/TDS_3/TriangulationDS_3.txt
@@ -304,7 +304,7 @@ typedef Triangulation_vertex_base_3<GT, Vb2> Other;
 \subsection tds3parallel Parallel Operations
 
 The third template parameter of `Triangulation_data_structure_3` is 
-`Concurrency_tag`. It enables the use of a concurrent
+`ConcurrencyTag`. It enables the use of a concurrent
 container (`Concurrent_compact_container`) to store vertices and cells. 
 If it is `Parallel_tag`, then `create_vertex`, `create_cell`, `delete_vertex` 
 and `delete_cell` can be called concurrently.


### PR DESCRIPTION
## Summary of Changes

- Use `\tparam ` and CamelCase for template parameters.

- Replace  the template parameter `TriangulationDSVertexBase_3`  with `VertexBase` as it makes no sense to write: `TriangulationDSVertexBase_3` must be a model of `TriangulationDSVertexBase_3`.

- Remove non-existing `Vertex_container_strategy,Cell_container_strategy` in the main page of the  Reference manual where we falsely write:  `CGAL::Triangulation_data_structure_3<TriangulationDSVertexBase_3,TriangulationDSCellBase_3,Vertex_container_strategy,Cell_container_strategy,Concurrency_tag>`.

- For the 2D TDS replace template parameters `Vb` and `Fb` with `VertexBase` and `FaceBase`, in order to unify.

- @MaelRL  plans to unify in the periodic versions later.
- Removing `_3` unifies with Alpha shapes_2/3, Mesh_2/3. I didn't check others.


## Release Management

* Affected package(s): TDS_3, TDS_2
