### PR TITLE
Doc: Remove some obsolete links

### DIFF
--- a/Generator/doc/Generator/CGAL/point_generators_2.h
+++ b/Generator/doc/Generator/CGAL/point_generators_2.h
@@ -146,8 +146,6 @@ distributed in an open disc. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_triangle_2<Point_2, Creator>`
@@ -155,8 +153,6 @@ distributed in an open disc. The default `Creator` is
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_in_disc_2 {
@@ -214,16 +210,12 @@ distributed in a half-open square. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_triangle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_in_square_2 {
@@ -283,8 +275,6 @@ distributed inside a triangle. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
@@ -292,8 +282,6 @@ distributed inside a triangle. The default `Creator` is
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_2, Creator>`
 \sa `CGAL::Random_points_in_tetrahedron_3<Point_2, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_in_triangle_2 {
@@ -360,8 +348,6 @@ typedef const Point_2& reference;
  \cgalModels `InputIterator`
  \cgalModels `PointGenerator`
 
- \sa `std::copy_n()`
- \sa `CGAL::Counting_iterator`
  \sa `CGAL::Points_on_segment_2<Point_2>`
  \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
  \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
@@ -374,8 +360,6 @@ typedef const Point_2& reference;
  \sa`CGAL::Random_points_in_tetrahedral_mesh_3<C3T3>`
  \sa `CGAL::Random_points_in_triangles_3<Point_3>`
  \sa `CGAL::Random_points_in_triangles_2<Point_2>`
- \sa `std::random_shuffle`
-
  */
  template< typename Point_2,
            typename Triangulation,
@@ -432,8 +416,6 @@ get_default_random() );
  \cgalModels `InputIterator`
  \cgalModels `PointGenerator`
 
- \sa `std::copy_n()`
- \sa `CGAL::Counting_iterator`
  \sa `CGAL::Points_on_segment_2<Point_2>`
  \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
  \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
@@ -445,8 +427,6 @@ get_default_random() );
  \sa `CGAL::Random_points_in_tetrahedral_mesh_boundary_3<C3T3>`
  \sa `CGAL::Random_points_in_tetrahedral_mesh_3<C3T3>`
  \sa `CGAL::Random_points_in_triangles_3<Point_3>`
- \sa `std::random_shuffle`
-
  */
  template< typename Point_2,
            typename Triangle_2 = typename Kernel_traits<Point_2>::Kernel::Triangle_2,
@@ -506,8 +486,6 @@ rounding errors.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
@@ -515,8 +493,6 @@ rounding errors.
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_on_circle_2 {
@@ -577,16 +553,12 @@ distributed on a segment. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_triangle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_circle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_square_2<Point_2, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_on_segment_2 {
@@ -647,16 +619,12 @@ distributed on the boundary of a square. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Points_on_segment_2<Point_2>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_triangle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_circle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2, typename Creator >
 class Random_points_on_square_2 {
@@ -717,8 +685,6 @@ endpoints are specified upon construction. The points are equally spaced.
 
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::points_on_segment<Point_2>`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
@@ -727,8 +693,6 @@ endpoints are specified upon construction. The points are equally spaced.
 \sa `CGAL::Random_points_on_segment_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_square_2<Point_2, Creator>`
 \sa `CGAL::random_selection()`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_2 >
 class Points_on_segment_2 {

--- a/Generator/doc/Generator/CGAL/point_generators_3.h
+++ b/Generator/doc/Generator/CGAL/point_generators_3.h
@@ -44,15 +44,11 @@ distributed in a half-open cube. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_sphere_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_tetrahedron_3<Point_3, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3, typename Creator >
 class Random_points_in_cube_3 {
@@ -113,15 +109,11 @@ distributed strictly inside a sphere. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_tetrahedron_3<Point_3, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3, typename Creator >
 class Random_points_in_sphere_3 {
@@ -182,14 +174,10 @@ distributed inside a 3D triangle. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_tetrahedron_3<Point_3, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3, typename Creator >
 class Random_points_in_triangle_3 {
@@ -260,10 +248,10 @@ distributed on a segment. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
-\sa `std::random_shuffle`
-
+\sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
+\sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
+\sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
+\sa `CGAL::Random_points_in_tetrahedron_3<Point_3, Creator>`
 */
 template< typename Point_3, typename Creator >
 class Random_points_on_segment_3 {
@@ -326,13 +314,10 @@ distributed inside a tetrahedron. The default `Creator` is
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
+\sa `CGAL::Random_points_on_segment_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3, typename Creator >
 class Random_points_in_tetrahedron_3 {
@@ -405,8 +390,6 @@ The triangle range must be valid and unchanged while the iterator is used.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_tetrahedron_3<Point_3, Creator>`
@@ -414,8 +397,6 @@ The triangle range must be valid and unchanged while the iterator is used.
 \sa `CGAL::Random_points_in_tetrahedral_mesh_boundary_3<C3T3>`
 \sa `CGAL::Random_points_in_tetrahedral_mesh_3<C3T3>`
 \sa `CGAL::Random_points_in_triangles_2<Point_2>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3,
           typename Triangle_3=typename Kernel_traits<Point_3>::Kernel::Triangle_3,
@@ -476,8 +457,6 @@ The triangle mesh must be valid and unchanged while the iterator is used.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
@@ -487,7 +466,6 @@ The triangle mesh must be valid and unchanged while the iterator is used.
 \sa `CGAL::Random_points_in_tetrahedral_mesh_3<C3T3>`
 \sa `CGAL::Random_points_in_triangles_2<Point_2>`
 \sa `CGAL::Random_points_in_triangles_3<Point_3>`
-\sa `std::random_shuffle`
 
 */
 template < class TriangleMesh,
@@ -559,8 +537,6 @@ The tetrahedral mesh must be valid and unchanged while the iterator is used.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
@@ -570,8 +546,6 @@ The tetrahedral mesh must be valid and unchanged while the iterator is used.
 \sa `CGAL::Random_points_in_tetrahedral_mesh_3<C3T3>`
 \sa `CGAL::Random_points_in_triangles_2<Point_2>`
 \sa `CGAL::Random_points_in_triangles_3<Point_3>`
-\sa `std::random_shuffle`
-
 */
 template <class C3T3,
           class Creator = Creator_uniform_3<
@@ -637,8 +611,6 @@ The tetrahedral mesh must be valid and unchanged while the iterator is used.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_triangle_3<Point_3, Creator>`
@@ -648,8 +620,6 @@ The tetrahedral mesh must be valid and unchanged while the iterator is used.
 \sa `CGAL::Random_points_in_tetrahedral_mesh_boundary_3<C3T3>`
 \sa `CGAL::Random_points_in_triangles_2<Point_2>`
 \sa `CGAL::Random_points_in_triangles_3<Point_3>`
-\sa `std::random_shuffle`
-
 */
 template <class C3T3,
           class Creator = Creator_uniform_3<
@@ -715,13 +685,9 @@ rounding errors.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_on_circle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_sphere_3<Point_3, Creator>`
-\sa `std::random_shuffle`
-
 */
 template< typename Point_3, typename Creator >
 class Random_points_on_sphere_3 {

--- a/Generator/doc/Generator/CGAL/point_generators_d.h
+++ b/Generator/doc/Generator/CGAL/point_generators_d.h
@@ -43,13 +43,10 @@ distributed in an open ball in any dimension.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_disc_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_sphere_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_cube_d<Point_d>`
 \sa `CGAL::Random_points_on_sphere_d<Point_d>`
-
 */
 template< typename Point_d >
 class Random_points_in_ball_d {
@@ -112,13 +109,10 @@ distributed in an half-open cube.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_in_square_2<Point_2, Creator>`
 \sa `CGAL::Random_points_in_cube_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_ball_d<Point_d>`
 \sa `CGAL::Random_points_on_sphere_d<Point_d>`
-
 */
 template< typename Point_d >
 class Random_points_in_cube_d {
@@ -187,13 +181,10 @@ rounding errors.
 \cgalModels `InputIterator`
 \cgalModels `PointGenerator`
 
-\sa `std::copy_n()`
-\sa `CGAL::Counting_iterator`
 \sa `CGAL::Random_points_on_circle_2<Point_2, Creator>`
 \sa `CGAL::Random_points_on_sphere_3<Point_3, Creator>`
 \sa `CGAL::Random_points_in_cube_d<Point_d>`
 \sa `CGAL::Random_points_in_ball_d<Point_d>`
-
 */
 template< typename Point_d >
 class Random_points_on_sphere_d {

--- a/STL_Extension/doc/STL_Extension/PackageDescription.txt
+++ b/STL_Extension/doc/STL_Extension/PackageDescription.txt
@@ -41,11 +41,8 @@
 - `CGAL::Multiset<Type,Compare,Allocator>`
 
 \cgalCRPSection{Generic Algorithms}
-- `std::copy_n`
 - `CGAL::copy_n`
 - `CGAL::min_max_element`
-- `std::next`
-- `std::prev`
 - `CGAL::predecessor`
 - `CGAL::successor`
 


### PR DESCRIPTION
This PR removes some links that have become obsolete after conversion from `CGAL::cpp11` into `std`, as well as a bunch of useless \sa links. 

## Release Management

* Affected package(s): `Generator`, `STL_Extension`

