### PR TITLE
Surface_sweep_2 Fix c++11 call

### DIFF
--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/Surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/Surface_sweep_2_impl.h
@@ -918,7 +918,7 @@ _create_overlapping_curve(const X_monotone_curve_2& overlap_cv,
   // Get the left end of overlap_cv.
   Event* left_event;
 
-  if (event_on_overlap!=nullptr)
+  if (event_on_overlap!=NULL)
   {
     CGAL_SS_PRINT_EVENT_INFO(event_on_overlap);
     CGAL_SS_PRINT_EOL();


### PR DESCRIPTION
## Summary of Changes

https://cgal.geometryfactory.com/CGAL/testsuite/results-4.14.2-I-193.shtml  shows a call to nullptr. This PR is only to replace it by NULL.
## Release Management

* Affected package(s):Surface_sweep_2
