### PR TITLE
Fix issue #4357

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Line_3_intersection.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Line_3_intersection.h
@@ -24,8 +24,7 @@
 #ifndef CGAL_INTERNAL_INTERSECTIONS_3_TRIANGLE_3_LINE_3_INTERSECTION_H
 #define CGAL_INTERNAL_INTERSECTIONS_3_TRIANGLE_3_LINE_3_INTERSECTION_H
 
-#include <CGAL/kernel_basic.h>
-#include <CGAL/intersections.h>
+#include <CGAL/Intersections_3/Line_3_Plane_3.h>
 
 namespace CGAL {
   


### PR DESCRIPTION
## Summary of Changes

Fix issue #4357

Compilation error if `<CGAL/Intersections_3/Triangle_3_Triangle_3.h>` is included first.

## Release Management

* Affected package(s): Intersections_3
* Issue(s) solved (if any): fix #4357 
* License and copyright ownership: maintenance by GF

