### PR TITLE
ImageIO and Polyhedron demo - Add error message when `io_image_plugin` can't save

### DIFF
--- a/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO_impl.h
@@ -497,14 +497,19 @@ void _openWriteImage(_image* im, const char *name)
 #endif
 	im->openMode = OM_GZ;
       }
-#if CGAL_USE_GZFWRITE
-    else 
+    else
     {
+#if CGAL_USE_GZFWRITE
       im->fd = (_ImageIO_file) gzopen(name, "wb");
       im->openMode = OM_FILE;
-    }
-#endif// CGAL_USE_GZFWRITE
 #else
+      fprintf(stderr, "_openWriteImage: error: zlib version 1.2.9 or later\n"
+                      "is required to save in non-compressed files\n");
+      return; 
+#endif// CGAL_USE_GZFWRITE
+    }
+
+#else //CGAL_USE_ZLIB
     {
       im->fd = (_ImageIO_file) fopen(name, "wb");
       im->openMode = OM_FILE;

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -2130,10 +2130,13 @@ void MainWindow::save(QString filename, QList<CGAL::Three::Scene_item*>& to_save
     }
   }
   if(!saved)
+  {
     QMessageBox::warning(this,
                          tr("Cannot save"),
                          tr("The selected object %1 was not saved. (Maybe a wrong extension ?)")
                          .arg(to_save.front()->name()));
+    to_save.pop_front();
+  }
 }
 
 void MainWindow::on_actionSaveSnapshot_triggered()

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -292,7 +292,8 @@ public:
 
     point_image p_im = *im_item->image()->image();
     bool ok = _writeImage(&p_im, fileinfo.filePath().toUtf8()) == 0;
-    items.pop_front();
+    if(ok)
+      items.pop_front();
     return ok;
   }
   QString name() const override{ return "segmented images"; }


### PR DESCRIPTION
## Summary of Changes

The ImageIO saving functions cannot save images as `.inr` when Zlib version is lower than 1.2.9,
even if `CGAL_USE_ZLIB` is true.

This PR introduces an error message to help the user understand what's going wrong.

It also fixes a seg fault in the demo, that happened when saving an image as `.inr` had failed.

This PR follows PR #3256

## Release Management

* Affected package(s): ImageIO, Polyhedron demo

