### PR TITLE
Triangulation_2:  Projection_traits::Construct_bbox_2 must return Bbox_2

### DIFF
--- a/Kernel_23/include/CGAL/internal/Projection_traits_3.h
+++ b/Kernel_23/include/CGAL/internal/Projection_traits_3.h
@@ -52,6 +52,7 @@ struct Projector<R,0>
   static typename R::FT y(const typename R::Point_3& p) {return p.z();}
   static typename R::FT x(const typename R::Vector_3& p) {return p.y();}
   static typename R::FT y(const typename R::Vector_3& p) {return p.z();}
+  static Bbox_2 bbox(const Bbox_3& bb) { return Bbox_2(bb.ymin(),bb.zmin(),bb.ymax(),bb.zmax()); }
   static const int x_index=1;
   static const int y_index=2;
 };
@@ -69,6 +70,7 @@ struct Projector<R,1>
   static typename R::FT y(const typename R::Point_3& p) {return p.z();}
   static typename R::FT x(const typename R::Vector_3& p) {return p.x();}
   static typename R::FT y(const typename R::Vector_3& p) {return p.z();}
+  static Bbox_2 bbox(const Bbox_3& bb) { return Bbox_2(bb.xmin(),bb.zmin(),bb.xmax(),bb.zmax()); }
   static const int x_index=0;
   static const int y_index=2;  
 };
@@ -87,11 +89,18 @@ struct Projector<R,2>
   static typename R::FT y(const typename R::Point_3& p) {return p.y();}
   static typename R::FT x(const typename R::Vector_3& p) {return p.x();}
   static typename R::FT y(const typename R::Vector_3& p) {return p.y();}
+  static Bbox_2 bbox(const Bbox_3& bb) { return Bbox_2(bb.xmin(),bb.ymin(),bb.xmax(),bb.ymax()); }
   static const int x_index=0;
   static const int y_index=1;  
 };
-  
 
+template <class R,int dim>
+class Construct_bbox_projected_2 {
+public:
+  typedef typename R::Point_3     Point;
+  
+  Bbox_2 operator()(const Point& p) const { typename R::Construct_bbox_3 bb;  return Projector<R, dim>::bbox(bb(p)); }
+};
 
 template <class R,int dim>
 class Orientation_projected_3 
@@ -804,7 +813,8 @@ public:
   typedef Construct_weighted_circumcenter_projected_3<Rp,dim> Construct_weighted_circumcenter_2;
   typedef Power_side_of_bounded_power_circle_projected_3<Rp,dim> Power_side_of_bounded_power_circle_2;
   typedef Power_side_of_oriented_power_circle_projected_3<Rp, dim> Power_side_of_oriented_power_circle_2;
-
+  typedef Construct_bbox_projected_2<Rp,dim>                  Construct_bbox_2;
+  
   typedef typename Rp::Construct_point_3                      Construct_point_2;
   typedef typename Rp::Construct_weighted_point_3             Construct_weighted_point_2;
   typedef typename Rp::Construct_segment_3                    Construct_segment_2;
@@ -814,7 +824,7 @@ public:
   typedef typename Rp::Construct_scaled_vector_3              Construct_scaled_vector_2;
   typedef typename Rp::Construct_triangle_3                   Construct_triangle_2;
   typedef typename Rp::Construct_line_3                       Construct_line_2;
-  typedef typename Rp::Construct_bbox_3                       Construct_bbox_2;
+
 
   struct Less_xy_2 {
     typedef bool result_type;

--- a/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
@@ -80,8 +80,8 @@ typedef unspecified_type Compute_squared_distance_2;
 A function object whose
 `operator()` computes the bounding box of a point.
 
-`unspecified_type operator()(Point_2 p);` Returns the bounding box of `p`.
-The result type is either `Bbox_2` or `Bbox_3` (for projection traits classes).
+CGAL::Bbox_2 operator()(Point_2 p);` Returns the bounding box of `p`.
+The result type is `CGAL::Bbox_2` (even for projection traits classes).
 */ 
 typedef unspecified_type Compute_bounding_box_2; 
 

--- a/Triangulation_2/test/Triangulation_2/issue_4405.cpp
+++ b/Triangulation_2/test/Triangulation_2/issue_4405.cpp
@@ -1,0 +1,39 @@
+#define CGAL_CDT_2_DEBUG_INTERSECTIONS 1
+#include <CGAL/Constrained_triangulation_plus_2.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Projection_traits_xy_3.h>
+#include <CGAL/Triangulation_face_base_with_info_2.h>
+#include <CGAL/Triangulation_vertex_base_with_id_2.h>
+
+typedef CGAL::Epick Kernel;
+typedef Kernel::FT FieldNumberType;
+typedef Kernel::Point_2 Point2;
+typedef Kernel::Point_3 Point3;
+struct FaceInfo2
+{
+  unsigned long long m_id;
+};
+typedef CGAL::Projection_traits_xy_3<Kernel> TriangulationTraits;
+typedef CGAL::Triangulation_vertex_base_with_id_2<TriangulationTraits> VertexBaseWithId;
+typedef CGAL::Triangulation_vertex_base_2<TriangulationTraits, VertexBaseWithId> VertexBase;
+typedef CGAL::Triangulation_face_base_with_info_2<FaceInfo2, Kernel> FaceBaseWithInfo;
+typedef CGAL::Constrained_triangulation_face_base_2<TriangulationTraits, FaceBaseWithInfo> FaceBase;
+typedef CGAL::Triangulation_data_structure_2<VertexBase, FaceBase> TriangulationData;
+typedef CGAL::Constrained_Delaunay_triangulation_2<TriangulationTraits, TriangulationData, CGAL::Exact_predicates_tag> ConstrainedTriangulation;
+    typedef CGAL::Constrained_triangulation_plus_2<ConstrainedTriangulation> CDT;
+
+int main()
+{
+  CDT cdt;
+  const Point3 A(539.5294108288881, 332.45151278002265, 109.660400390625);
+  const Point3 B(538.779296875, 329.10546875, 109.707275390625);
+  const Point3 C(539.74609375, 332.431640625, 109.660400390625);
+  const Point3 D(539.68266371486789, 333.13513011783971, 109.649658203125);
+  const Point3 E(539.52898179930912, 332.45155212665065, 109.660400390625);
+  
+  cdt.insert_constraint(A, B);
+  cdt.insert_constraint(C, A);
+  cdt.insert_constraint(D, B);
+  cdt.insert_constraint(C, E);
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

The functor must create a 2D bounding box so that snapping can happen correctly.
@lrineau note that this also means a small change in the concept [`ConstrainedTriangulationTraits_2`](https://doc.cgal.org/latest/Triangulation_2/classConstrainedTriangulationTraits__2.html#a8e5e507b08b0cd8b2351303428219ec3).

## Release Management

* Affected package(s):  Triangulation_2 and Kernel_23
* Issue(s) solved (if any): fix #4405
* License and copyright ownership: maintenance for Inria

