### PR TITLE
Doxygen: More space for class names

### DIFF
--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -343,5 +343,5 @@ div.fragment {
 /* Make summary smaller to avoid wrapping of classes and concepts */
 div.summary
 {
-  width: 20%;
+  width: auto;
 }

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -339,3 +339,9 @@ div.fragment {
     padding: 4px;
     margin: 1em 4px 1em 4px;
 }
+
+/* Make summary smaller to avoid wrapping of classes and concepts */
+div.summary
+{
+  width: 20%;
+}

--- a/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
@@ -343,5 +343,5 @@ div.fragment {
 /* Make summary smaller to avoid wrapping of classes and concepts */
 div.summary
 {
-  width: 20%;
+  width: auto;
 }

--- a/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.14/cgal_stylesheet.css
@@ -339,3 +339,9 @@ div.fragment {
     padding: 4px;
     margin: 1em 4px 1em 4px;
 }
+
+/* Make summary smaller to avoid wrapping of classes and concepts */
+div.summary
+{
+  width: 20%;
+}

--- a/Documentation/doc/resources/1.8.4/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.4/cgal_stylesheet.css
@@ -334,5 +334,5 @@ div.fragment {
 /* Make summary smaller to avoid wrapping of classes and concepts */
 div.summary
 {
-  width: 20%;
+  width: auto;
 }

--- a/Documentation/doc/resources/1.8.4/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.4/cgal_stylesheet.css
@@ -329,3 +329,10 @@ div.fragment {
     padding: 4px;
     margin: 1em 4px 1em 4px;
 }
+
+
+/* Make summary smaller to avoid wrapping of classes and concepts */
+div.summary
+{
+  width: 20%;
+}


### PR DESCRIPTION
## Summary of Changes

Give the class name more space by modifying the CSS.

Before:
![image](https://user-images.githubusercontent.com/3263539/70633805-6adc0200-1c31-11ea-9bf6-2a9f7c4be080.png)

After:

![image](https://user-images.githubusercontent.com/3263539/70633896-919a3880-1c31-11ea-9524-5c020a18e002.png)

