### PR TITLE
Typos: splitted -> split

### DIFF
--- a/AABB_tree/doc/AABB_tree/Concepts/AABBTraits.h
+++ b/AABB_tree/doc/AABB_tree/Concepts/AABBTraits.h
@@ -75,7 +75,7 @@ using Intersection_and_primitive_id = unspecified_type;
 
 /// \name Splitting
 /// During the construction of the AABB tree, the primitives are
-/// splitted according to some comparison functions related to the longest axis:
+/// split according to some comparison functions related to the longest axis:
 /// @{
 
 /*!

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -3781,7 +3781,7 @@ namespace CGAL {
       return this->template beta<1>(adart);
     }
 
-    /** Insert a vertex in the given 2-cell which is splitted in triangles,
+    /** Insert a vertex in the given 2-cell which is split in triangles,
      *  once for each inital edge of the facet.
      * @param adart a dart of the facet to triangulate.
      * @param update_attributes a boolean to update the enabled attributes

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_insertions.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_insertions.h
@@ -39,7 +39,7 @@ insert_cell_0_in_cell_1( CMap& amap, typename CMap::Dart_handle adart,
   return amap.insert_cell_0_in_cell_1(adart, ah, update_attributes);
 }
 
-/** Insert a vertex in the given 2-cell which is splitted in triangles,
+/** Insert a vertex in the given 2-cell which is split in triangles,
  * once for each inital edge of the facet.
  * @param amap the used combinatorial map.
  * @param adart a dart of the facet to triangulate.

--- a/Generalized_map/include/CGAL/Generalized_map.h
+++ b/Generalized_map/include/CGAL/Generalized_map.h
@@ -3020,7 +3020,7 @@ namespace CGAL {
       return alpha<0, 1>(adart);
     }
 
-    /** Insert a vertex in the given 2-cell which is splitted in triangles,
+    /** Insert a vertex in the given 2-cell which is split in triangles,
      * once for each inital edge of the facet.
      * @param adart a dart of the facet to triangulate.
      * @return A dart incident to the new vertex.

--- a/Mesh_2/include/CGAL/Mesh_2/Clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Clusters.h
@@ -89,7 +89,7 @@ public:
 
     /**
      * The following map tells what vertices are in the cluster and if
-     * the corresponding segment has been splitted once.
+     * the corresponding segment has been split once.
      */
     typedef std::map<Vertex_handle, bool> Vertices_map;
     Vertices_map vertices;

--- a/Mesh_2/include/CGAL/Mesh_2/Refine_edges.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_edges.h
@@ -493,7 +493,7 @@ public:
   /** This version computes the refinement point without handling
       clusters. The refinement point of an edge is just the middle point of
       the segment.
-      Saves the handles of the edge that will be splitted.
+      Saves the handles of the edge that will be split.
       This function is overridden in class Refine_edge_with_clusters.
   */
   Point refinement_point_impl(const Edge& edge) 

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -280,7 +280,7 @@ public:
   /*! Run the sweep-line alogrithm on a range of x-monotone curves, a range
    * of action event points (if a curve passed through an action point, it will
    * be split) and a range of query points (if a curve passed through a
-   * query point,it will not be splitted).
+   * query point,it will not be split).
    * \param curves_begin An iterator for the first x-monotone curve in the
    *                     range.
    * \param curves_end A past-the-end iterator for this range.

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -299,7 +299,7 @@ template <class OutputIterator>
 void
 insert_constraint(Vertex_handle  vaa, Vertex_handle vbb, OutputIterator out)
 // forces the constrained [va,vb]
-// [va,vb] will eventually be splitted into several edges
+// [va,vb] will eventually be split into several edges
 // if a vertex vc of t lies on segment ab
 // of if ab intersect some constrained edges
 {

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -857,7 +857,7 @@ insert_subconstraint(Vertex_handle vaa,
 		     Vertex_handle vbb,
 		     OutputItertator out)
   // insert the subconstraint [vaa vbb] 
-  // it will eventually be splitted into several subconstraints
+  // it will eventually be split into several subconstraints
 {
   std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
   stack.push(std::make_pair(vaa,vbb));


### PR DESCRIPTION
## Summary of Changes

The word _splitted_ is ["non-standard or archaic"](https://www.yourdictionary.com/splitted)
