### PR TITLE
Set the precision when saving a mesh

### DIFF
--- a/BGL/examples/BGL_LCC/copy_lcc.cpp
+++ b/BGL/examples/BGL_LCC/copy_lcc.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
     CGAL::copy_face_graph(T1, S, CGAL::parameters::vertex_to_vertex_output_iterator(std::inserter(v2v, v2v.end()))
                                                   .halfedge_to_halfedge_output_iterator(std::inserter(h2h, h2h.end())));
     std::ofstream out("reverse.off");
+    out.precision(17);
     out << S;
   }
   return 0;

--- a/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
+++ b/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
   {
     CGAL::copy_face_graph(S, T1);
     std::ofstream out("sm.off");
+    out.precision(17);
     out << T1;
   }
 
@@ -81,6 +82,7 @@ int main(int argc, char* argv[])
     boost::unordered_map<source_face_descriptor, tm_face_descriptor> f2f;
     CGAL::copy_face_graph(T1, S, std::inserter(v2v, v2v.end()), std::inserter(h2h, h2h.end()));
     std::ofstream out("reverse.off");
+    out.precision(17);
     out << S;
     CGAL::copy_face_graph(T1, S, CGAL::parameters::vertex_to_vertex_map(boost::make_assoc_property_map(v2v))
                           .halfedge_to_halfedge_output_iterator(std::inserter(h2h, h2h.end()))

--- a/BGL/examples/BGL_surface_mesh/write_inp.cpp
+++ b/BGL/examples/BGL_surface_mesh/write_inp.cpp
@@ -20,6 +20,7 @@ int main()
   CGAL::make_quad(Point(0,0,1), Point(1,0,1),Point(1,1,1),Point(0,1,1), sm);
 
   std::ofstream out("out.inp");
+  out.precision(17);
   CGAL::write_inp(out, sm, "out.inp", "S4R");
   return 0;
 }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_LCC.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_LCC.cpp
@@ -34,6 +34,7 @@ int main(int argc, char* argv[])
             << num_vertices(mesh2) << "\n";
 
   std::ofstream output("mesh1_refined.off");
+  output.precision(17);
   CGAL::write_off(output, mesh1);
   output.close();
   output.open("mesh2_refined.off");

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_SM.cpp
@@ -41,6 +41,7 @@ int main(int argc, char* argv[])
             << num_vertices(mesh2) << "\n";
 
   std::ofstream output("mesh1_refined.off");
+  output.precision(17);
   output << mesh1;
   output.close();
   output.open("mesh2_refined.off");

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
@@ -136,6 +136,7 @@ int main(int argc, char* argv[])
     {
       std::cout << "Intersection and union were successfully computed\n";
       std::ofstream output("inter_union.off");
+      output.precision(17);
       output << mesh2;
       return 0;
     }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_difference_remeshed.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_difference_remeshed.cpp
@@ -67,6 +67,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Difference was successfully computed\n";
     std::ofstream output("difference.off");
+    output.precision(17);
     output << mesh1;
   }
   else{
@@ -111,6 +112,7 @@ int main(int argc, char* argv[])
     params::edge_is_constrained_map(is_constrained_map) );
 
   std::ofstream output("difference_remeshed.off");
+  output.precision(17);
   output << mesh1;
 
   return 0;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Union was successfully computed\n";
     std::ofstream output("union.off");
+    output.precision(17);
     output << out;
     return 0;
   }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_and_intersection.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_and_intersection.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Union was successfully computed\n";
     std::ofstream output("union.off");
+    output.precision(17);
     output << out_union;
   }
   else
@@ -64,6 +65,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Intersection was successfully computed\n";
     std::ofstream output("intersection.off");
+    output.precision(17);
     output << out_intersection;
   }
   else

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_with_attributes.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_with_attributes.cpp
@@ -94,6 +94,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Union was successfully computed\n";
     std::ofstream output("union.off");
+    output.precision(17);
     output << out;
     return 0;
   }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_polyhedron_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_polyhedron_union.cpp
@@ -39,6 +39,7 @@ int main(int argc, char* argv[])
   {
     std::cout << "Union was successfully computed\n";
     std::ofstream output("union.off");
+    output.precision(17);
     output << out;
     return 0;
   }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_of_patch_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_of_patch_example.cpp
@@ -74,6 +74,7 @@ int main(int argc, char* argv[])
                            );
 
   std::ofstream out("out.off");
+  out.precision(17);
   out << mesh;
   std::cout << "Remeshing done." << std::endl;
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_smoothing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/mesh_smoothing_example.cpp
@@ -48,6 +48,7 @@ int main(int argc, char** argv)
                                          .edge_is_constrained_map(eif));
 
   std::ofstream output("mesh_smoothed.off");
+  output.precision(17);
   output << mesh;
 
   std::cout << "Done!" << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/orient_polygon_soup_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/orient_polygon_soup_example.cpp
@@ -44,11 +44,13 @@ int main(int argc, char* argv[])
     CGAL::Polygon_mesh_processing::orient_to_bound_a_volume(mesh);
 
   std::ofstream out("tet-oriented1.off");
+  out.precision(17);
   out << mesh;
   out.close();
 
   CGAL::Polygon_mesh_processing::reverse_face_orientations(mesh);
   std::ofstream out2("tet-oriented2.off");
+  out2.precision(17);
   out2 << mesh;
   out2.close();
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/random_perturbation_SM_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/random_perturbation_SM_example.cpp
@@ -33,6 +33,7 @@ int main(int argc, char* argv[])
     PMP::parameters::vertex_point_map(mesh.points()).geom_traits(K()));
 
   std::ofstream out("data/eight_perturbed.off");
+  out.precision(17);
   out << mesh;
   out.close();
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[])
                   CGAL::Polygon_mesh_processing::parameters::density_control_factor(2.));
 
   std::ofstream refined_off("refined.off");
+  refined_off.precision(17);
   refined_off << poly;
   refined_off.close();
   std::cout << "Refinement added " << new_vertices.size() << " vertices." << std::endl;
@@ -75,6 +76,7 @@ int main(int argc, char* argv[])
   std::cout << "Fairing : " << (success ? "succeeded" : "failed") << std::endl;
 
   std::ofstream faired_off("faired.off");
+  faired_off.precision(17);
   faired_off << poly;
   faired_off.close();
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/shape_smoothing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/shape_smoothing_example.cpp
@@ -41,6 +41,7 @@ int main(int argc, char* argv[])
                                                 .vertex_is_constrained_map(vcmap));
 
   std::ofstream output("mesh_shape_smoothed.off");
+  output.precision(17);
   output << mesh;
 
   std::cout << "Done!" << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
@@ -34,6 +34,7 @@ int main(int argc, char* argv[])
   std::cout << "\t Number of facets    :\t" << mesh.size_of_facets() << std::endl;
 
   std::ofstream output("mesh_stitched.off");
+  output.precision(17);
   output << std::setprecision(17) << mesh;
 
   return 0;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/surface_mesh_intersection.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/surface_mesh_intersection.cpp
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
 
   //dump polylines
   std::ofstream output("intersection_polylines.cgal");
+  output.precision(17);
   for(const std::vector<Point>& polyline : polylines)
   {
     output << polyline.size() << " ";

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
@@ -32,6 +32,7 @@ int main(int argc, char* argv[])
       std::cerr << "Error: non-triangular face left in mesh." << std::endl;
 
   std::ofstream cube_off(outfilename);
+  cube_off.precision(17);
   cube_off << mesh;
 
   return 0;

--- a/Polyhedron/examples/Polyhedron/polyhedron_prog_cut_cube.cpp
+++ b/Polyhedron/examples/Polyhedron/polyhedron_prog_cut_cube.cpp
@@ -66,6 +66,6 @@ int main() {
                       Point( 0.0, 0.0, 1.5),
                       Point( 0.0, 0.5, 0.0));
     CGAL::polyhedron_cut_plane_3( P, h, pl);
-    std::cout << P;
+    std::cout <<std::setprecision(17)<< P;
     return 0;
 }

--- a/Polyhedron/examples/Polyhedron/polyhedron_prog_cut_cube.cpp
+++ b/Polyhedron/examples/Polyhedron/polyhedron_prog_cut_cube.cpp
@@ -66,6 +66,6 @@ int main() {
                       Point( 0.0, 0.0, 1.5),
                       Point( 0.0, 0.5, 0.0));
     CGAL::polyhedron_cut_plane_3( P, h, pl);
-    std::cout <<std::setprecision(17)<< P;
+    std::cout << std::setprecision(17)<< P;
     return 0;
 }

--- a/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv.cpp
+++ b/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv.cpp
@@ -102,6 +102,6 @@ int main(int argc, char* argv[]) {
         std::exit(1);
     }
     subdiv( P);
-    std::cout << std::setprecision(17)<<P;
+    std::cout << std::setprecision(17) << P;
     return 0;
 }

--- a/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv.cpp
+++ b/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv.cpp
@@ -102,6 +102,6 @@ int main(int argc, char* argv[]) {
         std::exit(1);
     }
     subdiv( P);
-    std::cout << P;
+    std::cout << std::setprecision(17)<<P;
     return 0;
 }

--- a/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv_with_boundary.cpp
+++ b/Polyhedron/examples/Polyhedron/polyhedron_prog_subdiv_with_boundary.cpp
@@ -196,6 +196,6 @@ int main( int argc, char* argv[]) {
         if ( i & 1)
             subdiv_border( P);
     }
-    cout << P;
+    cout << std::setprecision(17) << P;
     return 0;
 }

--- a/Surface_mesh/examples/Surface_mesh/sm_join.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_join.cpp
@@ -34,5 +34,5 @@ int main(int argc, char* argv[])
   }
   
   
-  std::cout <<std::setprecision(17)<< sm1 << std::endl;
+  std::cout << std::setprecision(17)<< sm1 << std::endl;
 }

--- a/Surface_mesh/examples/Surface_mesh/sm_join.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_join.cpp
@@ -34,5 +34,5 @@ int main(int argc, char* argv[])
   }
   
   
-  std::cout << sm1 << std::endl;
+  std::cout <<std::setprecision(17)<< sm1 << std::endl;
 }

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -39,7 +39,6 @@ int main()
   CGAL::read_ply (in2, mesh);
 
   std::ofstream out ("out.ply");
-  out.precision(17);
 //  CGAL::set_binary_mode(out);
   CGAL::write_ply (out, mesh);
 

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -39,6 +39,7 @@ int main()
   CGAL::read_ply (in2, mesh);
 
   std::ofstream out ("out.ply");
+  out.precision(17);
 //  CGAL::set_binary_mode(out);
   CGAL::write_ply (out, mesh);
 


### PR DESCRIPTION
## Summary of Changes

I know that this is a trivial thing, yet, CGAL is a very high precision numerical software, and surely the default way of saving a mesh should use full precision, especially that some algorithms, eg., mesh smoothing, can have very subtle effects, which won't be recorded if a mesh is saved simply with 8 digits of precision. 

## Release Management

* Affected package(s): Mesh processing
* Issue(s) solved (if any): Fix for mesh not being saved with sufficient precision. 
* License and copyright ownership: Assigned to CGAL under any desired license

