### PR TITLE
Improve the instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,6 @@ Here is a recipe for the examples of the 2D Triangulation package:
  git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
  cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
  /path/to/cgal.git/Scripts/scripts/cgal_create_cmake_script
- cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
  mkdir -p build/debug
  cd build/debug
  cmake -DCGAL_DIR:PATH=/path/to/cgal.git ../..

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,41 +1,7 @@
-NOTICE
-======
-
-Since Version 5.0, CGAL is a header-only library it is not needed
-to build and install it. Usage of CGAL should thus simply amount to:
-
-``` {.bash}
-git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
-cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
-mkdir -p build/debug
-cd build/debug
-cmake -DCMAKE_BUILD_TYPE=Debug -DCGAL_DIR=/path/to/cgal.git
-make
-```
-
-in the case of the building of an example in debug mode.
-
-For more information head over to the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).
-Note that this page describes the setting of CGAL as a sources release and, as such,
-files are organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
-
-
 Building a Program Using CGAL
 =============================
 
-To compile a program using CGAL, simply set `CGAL_DIR` to the location
-of the directory containing `CGALConfig.cmake` (for example the root 
-of the extracted source archive or the root of a git checkout).
-
-Here is an example of how to build in debug the examples from the 3D Triangulations package:
-
-``` {.bash}
- cd /path/to/cgal.git/Triangulation_3/examples/Triangulation_3
- mkdir -p build/debug
- cd build/debug
- cmake -DCGAL_DIR:PATH=/path/to/cgal.git ../..
- make
-```
+Since Version 5.0, CGAL is header-only, hence it does not create a library. It needs however to link to the external libraries GMP and MPRF. 
 
 If you are trying to build examples or tests that do not already have a `CMakeLists.txt`,
 you can trigger its creation by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
@@ -52,4 +18,10 @@ Here is an example for the examples of the 2D Triangulation package:
  make
 ```
 
+Note that this page describes the setting of CGAL as a sources release and, as such,
+files are organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
+
 For more information head over to the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).
+
+
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ Building a Program Using CGAL
 =============================
 
 If you wish to build a program that is not provided with CGAL and does not already have a `CMakeLists.txt`,
-you can trigger the creation of a basic `CmakeLists.txt` by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
+you can trigger the creation of a basic `CMakeLists.txt` by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
 found in `/path/to/cgal.git/Scripts/scripts/` at the root of your program directory.
 
 ``` {.bash}
@@ -33,12 +33,12 @@ found in `/path/to/cgal.git/Scripts/scripts/` at the root of your program direct
  make your_program
 ```
 
-Since the basic `CmakeLists.txt` created by the script `cgal_create_cmake_script` cannot
+Since the basic `CMakeLists.txt` created by the script `cgal_create_cmake_script` cannot
 guess which part(s) of CGAL you are using, it does not link with any optional third party 
 dependency of CGAL. You should look at the documentation of the package(s) that you
-are using to learn which dependencies you must add. The `CmakeLists.txt`
+are using to learn which dependencies you must add. The `CMakeLists.txt`
 of the examples and demos provided with the package(s) that you are using can be used
-to complete your basic `CmakeLists.txt`.
+to complete your basic `CMakeLists.txt`.
 
 
 Repository Structure

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,5 @@
-Building an Example Using CGAL
-==============================
+Building an Example or a Demo of CGAL
+=====================================
 
 Since Version 5.0, CGAL is a header-only library, hence it is not needed to build it. Usage of CGAL should simply amount to:
 
@@ -19,7 +19,7 @@ Note that although CGAL is a header-only library, some parts of it must link to 
 Building a Program Using CGAL
 =============================
 
-If you are trying to build a program that is not provided with CGAL and does not already have a `CMakeLists.txt`,
+If you wish to build a program that is not provided with CGAL and does not already have a `CMakeLists.txt`,
 you can trigger the creation of a basic `CmakeLists.txt` by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
 found in `/path/to/cgal.git/Scripts/scripts/` at the root of your program directory.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,23 +1,52 @@
+Building an Example Using CGAL
+==============================
+
+Since Version 5.0, CGAL is a header-only library, hence it is not needed to build it. Usage of CGAL should simply amount to:
+
+``` {.bash}
+git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
+cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
+mkdir -p build/debug
+cd build/debug
+cmake -DCMAKE_BUILD_TYPE=Debug -DCGAL_DIR=/path/to/cgal.git
+make
+```
+
+in the case of building some CGAL-provided examples in debug mode.
+
+Note that although CGAL is a header-only library, some parts of it must link to several external libraries, such as GMP, MPFR, etc.
+
 Building a Program Using CGAL
 =============================
 
-Since Version 5.0, CGAL is header-only, hence it does not create a library. Some parts of it, however, link to several external libraries, such as GMP, MPFR, etc. 
-
-If you are trying to build examples or tests that do not already have a `CMakeLists.txt`,
-you can trigger its creation by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
-found in `/path/to/cgal.git/Scripts/scripts/` at the root of the example/test directory.
-Here is a recipe for the examples of the 2D Triangulation package:
+If you are trying to build a program that is not provided with CGAL and does not already have a `CMakeLists.txt`,
+you can trigger the creation of a basic `CmakeLists.txt` by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
+found in `/path/to/cgal.git/Scripts/scripts/` at the root of your program directory.
 
 ``` {.bash}
  git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
- cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
+ cd /path/to/your/program
  /path/to/cgal.git/Scripts/scripts/cgal_create_cmake_script
  mkdir -p build/debug
  cd build/debug
- cmake -DCGAL_DIR:PATH=/path/to/cgal.git ../..
- make
+ cmake -DCMAKE_BUILD_TYPE=Debug -DCGAL_DIR:PATH=/path/to/cgal.git ../..
+ make your_program
 ```
 
-If, instead of the git repository you downloaded a source release, the files will be organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
+Since the basic `CmakeLists.txt` created by the script `cgal_create_cmake_script` cannot
+guess which part(s) of CGAL you are using, it does not link with any optional third party 
+dependency of CGAL. You should look at the documentation of the package(s) that you
+are using to learn which dependencies you must add. The `CmakeLists.txt`
+of the examples and demos provided with the package(s) that you are using can be used
+to complete your basic `CmakeLists.txt`.
+
+
+Repository Structure
+====================
+
+If you have downloaded a source release instead of cloning the Git repository, the files will be organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
+
+Documentation
+=============
 
 For more information see the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,7 @@ found in `/path/to/cgal.git/Scripts/scripts/` at the root of the example/test di
 Here is a recipe for the examples of the 2D Triangulation package:
 
 ``` {.bash}
+ git clone https://github.com/CGAL/cgal.git /path/to/cgal.git
  cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
  /path/to/cgal.git/Scripts/scripts/cgal_create_cmake_script
  cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
@@ -18,7 +19,6 @@ Here is a recipe for the examples of the 2D Triangulation package:
  make
 ```
 
-Note that this page describes the setting of CGAL as a sources release and, as such,
-files are organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
+If, instead of the git repository you downloaded a source release, the files will be organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
 
-For more information head over to the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).
+For more information see the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,12 @@
 Building a Program Using CGAL
 =============================
 
-Since Version 5.0, CGAL is header-only, hence it does not create a library. It needs however to link to the external libraries GMP and MPRF. 
+Since Version 5.0, CGAL is header-only, hence it does not create a library. Some parts of it, however, link to several external libraries, such as GMP, MPFR, etc. 
 
 If you are trying to build examples or tests that do not already have a `CMakeLists.txt`,
 you can trigger its creation by calling the script [`cgal_create_cmake_script`](Scripts/scripts/cgal_create_cmake_script)
 found in `/path/to/cgal.git/Scripts/scripts/` at the root of the example/test directory.
-Here is an example for the examples of the 2D Triangulation package:
+Here is a recipe for the examples of the 2D Triangulation package:
 
 ``` {.bash}
  cd /path/to/cgal.git/Triangulation_2/examples/Triangulation_2
@@ -22,6 +22,3 @@ Note that this page describes the setting of CGAL as a sources release and, as s
 files are organized in a slightly different way, see the [Layout of the CGAL Git Repository](README.md).
 
 For more information head over to the [CGAL manual](https://doc.cgal.org/latest/Manual/general_intro.html).
-
-
-


### PR DESCRIPTION
The compilation instructions have been very confusing. Its first section suggests that no libraries are needed and no CMakeLists is needed. Also the same block of code is repeated three times.

I removed the redundant and incorrect first section, made it clear early on how to create a CMakeLists.txt, and that linking to external libraries is necessary. 

I did not remove any information.

This is discussed in more detail at https://github.com/CGAL/cgal/issues/4413