### PR TITLE
Kernel_23: Fix "used but uninitialized" warnings

### DIFF
--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_ray_3.h
@@ -27,9 +27,6 @@ _test_cls_ray_3(const R& )
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
 
- typename R::Ray_3 ir;
- CGAL::Ray_3<R>  r1(ir);
-
  RT  n1 =  8;
  RT  n2 = 20;
  RT  n3 =  4;
@@ -42,10 +39,18 @@ _test_cls_ray_3(const R& )
  CGAL::Point_3<R> p2( n4, n5, n6, n5);
  CGAL::Point_3<R> p3( n7, n2, n4, n7);
 
+ typename R::Ray_3 ir ( p2, p1 );
+
+ CGAL::Ray_3<R> r1( ir );
  CGAL::Ray_3<R> r2( p1, p2 );
  CGAL::Ray_3<R> r3( p2, p1 );
  CGAL::Ray_3<R> r4( r2 );
  r1 = r4;
+
+ typename R::Ray_3 ir2 ( r4 );
+ ir = r1;
+ r4 = ir2;
+
  CGAL::Direction_3<R> dir( p2 - p1 );
  CGAL::Vector_3<R> vec( p2 - p1 );
  CGAL::Line_3<R> l( p1, p2 );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_segment_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_segment_3.h
@@ -27,9 +27,6 @@ _test_cls_segment_3(const R& )
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
 
- typename R::Segment_3 is;
- CGAL::Segment_3<R>  s1(is);
-
  RT  n1 =  7;
  RT  n2 = 21;
  RT  n3 = 14;
@@ -42,10 +39,18 @@ _test_cls_segment_3(const R& )
  CGAL::Point_3<R> p2( n4, n5, n6, n5);
  CGAL::Point_3<R> p3( n2, n8, n2, n8);
 
+ typename R::Segment_3 is ( p2, p1 );
+
+ CGAL::Segment_3<R> s1( is );
  CGAL::Segment_3<R> s2( p1, p2 );
  CGAL::Segment_3<R> s3( p2, p1 );
  CGAL::Segment_3<R> s4( s2 );
+
  s1 = s4;
+
+ typename R::Segment_3 is2 ( s4 );
+ is = s1;
+ s4 = is2;
 
  assert( CGAL::parallel(s2, s3) );
 


### PR DESCRIPTION
## Summary of Changes

These warnings: https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.1-Ic-33/Kernel_23/TestReport_Friedrich_Debian-stable-arm-linux-gnu-32bits.gz

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): --
