### PR TITLE
PMP:  deterministic corefinement

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -130,7 +130,7 @@ private:
   typedef typename Graph_traits::halfedge_descriptor        halfedge_descriptor;
    typedef std::vector<Node_id>                                        Node_ids;
    typedef boost::unordered_map<face_descriptor,Node_ids>           On_face_map;
-#ifdef CGAL_FORCE_DETERMINISTIC_COREFINEMENT 
+#ifdef CGAL_FORCE_DETERMINISTIC_COREFINEMENT
    typedef std::map<edge_descriptor,Node_ids>           On_edge_map;
 #else
    typedef boost::unordered_map<edge_descriptor,Node_ids>           On_edge_map;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -130,7 +130,11 @@ private:
   typedef typename Graph_traits::halfedge_descriptor        halfedge_descriptor;
    typedef std::vector<Node_id>                                        Node_ids;
    typedef boost::unordered_map<face_descriptor,Node_ids>           On_face_map;
+#ifdef CGAL_FORCE_DETERMINISTIC_COREFINEMENT 
+   typedef std::map<edge_descriptor,Node_ids>           On_edge_map;
+#else
    typedef boost::unordered_map<edge_descriptor,Node_ids>           On_edge_map;
+#endif
    //to keep the correspondance between node_id and vertex_handle in each mesh
    typedef std::vector<vertex_descriptor>                     Node_id_to_vertex;
    typedef std::map<TriangleMesh*, Node_id_to_vertex >         Mesh_to_map_node;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -107,6 +107,10 @@ public:
   void operator()( const Box& face_box, const Box& edge_box) const {
     halfedge_descriptor fh = face_box.info();
     halfedge_descriptor eh = edge_box.info();
+#ifdef CGAL_FORCE_DETERMINISTIC_COREFINEMENT
+    if (tm_edges.opposite(eh) < eh)
+      eh = tm_edges.opposite(eh);
+#endif
     if(is_border(eh,tm_edges)) eh = opposite(eh, tm_edges);
 
     //check if the segment intersects the plane of the facet or if it is included in the plane


### PR DESCRIPTION
## Summary of Changes

This PR adds the maccro CGAL_FORCE_DETERMINISTIC_COREFINEMENT to the code of corefinement, that force it to be deterministic using a flat_set. 

## Release Management

* Affected package(s): Polygon Mesh Processing
