### PR TITLE
Polyhedron_demo : Add picking on spheres

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -175,7 +175,8 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_actionDeformation_triggered()
 // what they do is simply transmitting required 'action' to selected scene_edit_polyhedron_item object
 void Polyhedron_demo_edit_polyhedron_plugin::on_AddCtrlVertPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -183,7 +184,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_AddCtrlVertPushButton_clicked()
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_PrevCtrlVertPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+ int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -193,7 +194,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_PrevCtrlVertPushButton_clicked()
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_NextCtrlVertPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -203,7 +204,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_NextCtrlVertPushButton_clicked()
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_SelectAllVerticesPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -213,7 +214,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_SelectAllVerticesPushButton_clic
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -224,7 +225,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_DeleteCtrlVertPushButton_clicked
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ClearROIPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -238,7 +239,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ApplyAndClosePushButton_clicked(
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_DiscardChangesPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if (!edit_item) return;                             // the selected item is not of the right type
 
@@ -297,14 +298,14 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_ActivateFixedPlaneCheckBox_state
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_OverwritePushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
   edit_item->overwrite_deform_object();
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_Select_isolated_components_button_clicked() {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -316,7 +317,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_Select_isolated_components_butto
 }
 
 void Polyhedron_demo_edit_polyhedron_plugin::on_Get_minimum_button_clicked() {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;                             // the selected item is not of the right type
 
@@ -328,7 +329,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_Get_minimum_button_clicked() {
 
 void Polyhedron_demo_edit_polyhedron_plugin::on_SaveROIPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;  
 
@@ -340,7 +341,7 @@ void Polyhedron_demo_edit_polyhedron_plugin::on_SaveROIPushButton_clicked()
 }
 void Polyhedron_demo_edit_polyhedron_plugin::on_ReadROIPushButton_clicked()
 {
-  int item_id = scene->mainSelectionIndex();
+  int item_id = scene->selectionIndices().front();
   Scene_edit_polyhedron_item* edit_item = qobject_cast<Scene_edit_polyhedron_item*>(scene->item(item_id));
   if(!edit_item) return;  
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -347,7 +347,6 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
     typedef typename boost::property_map<Mesh, boost::vertex_point_t>::type VertexPointMap;
     VertexPointMap pmap = get(boost::vertex_point, *mesh);
 
-    int s_index = 0;
     for(mesh_vd vd : fs.get_deform_mesh(mesh)->roi_vertices())
     {
         if(!fs.get_deform_mesh(mesh)->is_control_vertex(vd))
@@ -361,7 +360,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
             {
               CGAL::Color c(0,255,0);
               EPICK::Point_3 point(p.x()+offset.x, p.y()+offset.y, p.z()+offset.z);
-              spheres->add_sphere(EPICK::Sphere_3(point, length_of_axis/15.0*length_of_axis/15.0), s_index++, c);
+              spheres->add_sphere(EPICK::Sphere_3(point, length_of_axis/15.0*length_of_axis/15.0), 0, c);
             }
         }
 
@@ -401,7 +400,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
               EPICK::Point_3 center(p.x()+offset.x,
                                      p.y()+offset.y,
                                      p.z()+offset.z);
-              spheres_ctrl->add_sphere(EPICK::Sphere_3(center, length_of_axis/15.0*length_of_axis/15.0), s_index++, c);
+              spheres_ctrl->add_sphere(EPICK::Sphere_3(center, length_of_axis/15.0*length_of_axis/15.0), 0, c);
             }
         }
     }
@@ -1272,7 +1271,7 @@ void Scene_edit_polyhedron_item::ShowAsSphere(bool b)
   {
     if(!d->spheres)
     {
-      d->spheres = new Scene_spheres_item(this, 0, false);
+      d->spheres = new Scene_spheres_item(this, 0, false, false);
       d->spheres->setName("ROI spheres");
       d->spheres->setRenderingMode(Gouraud);
       connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));
@@ -1284,7 +1283,7 @@ void Scene_edit_polyhedron_item::ShowAsSphere(bool b)
     }
     if(!d->spheres_ctrl)
     {
-      d->spheres_ctrl = new Scene_spheres_item(this, false);
+      d->spheres_ctrl = new Scene_spheres_item(this, false, false);
       d->spheres_ctrl->setName("Control spheres");
       d->spheres_ctrl->setRenderingMode(Gouraud);
       connect(d->spheres_ctrl, &QObject::destroyed, this, Reset_spheres_ctrl(d) );
@@ -1777,6 +1776,10 @@ Scene_surface_mesh_item* Scene_edit_polyhedron_item::sm_item()const
 void Scene_edit_polyhedron_item::computeElements() const
 {
   d->compute_normals_and_vertices(sm_item()->face_graph());
+  if(d->spheres)
+    d->spheres->computeElements();
+  if(d->spheres_ctrl)
+    d->spheres_ctrl->computeElements();
   std::vector<GLfloat> vertices;
   std::vector<GLfloat> *vertices_ptr;
   const CGAL::qglviewer::Vec offset = Three::mainViewer()->offset();

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -99,7 +99,6 @@ struct Scene_edit_polyhedron_item_priv
   mutable std::vector<GLfloat> color_lines;
   mutable std::vector<GLfloat> ROI_points;
   mutable std::vector<GLfloat> control_points;
-  mutable std::vector<GLfloat> ROI_color;
   mutable std::vector<GLfloat> control_color;
   mutable std::vector<GLfloat> normals;
   mutable std::vector<GLfloat> pos_bbox;
@@ -365,10 +364,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
         }
 
     }
-    ROI_color.assign(ROI_points.size(),0);
-    for(std::size_t i=0; i<ROI_color.size()/3; i++)
-      ROI_color[3*i+1]=1.0;
-
+   
     for(typename std::list<Control_vertices_data<Mesh> >::const_iterator hgb_data = fs.get_ctrl_vertex_frame_map(mesh).begin(); hgb_data != fs.get_ctrl_vertex_frame_map(mesh).end(); ++hgb_data)
     {
         if(hgb_data->frame == Three::mainViewer()->manipulatedFrame())

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -347,6 +347,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
     typedef typename boost::property_map<Mesh, boost::vertex_point_t>::type VertexPointMap;
     VertexPointMap pmap = get(boost::vertex_point, *mesh);
 
+    int s_index = 0;
     for(mesh_vd vd : fs.get_deform_mesh(mesh)->roi_vertices())
     {
         if(!fs.get_deform_mesh(mesh)->is_control_vertex(vd))
@@ -360,7 +361,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
             {
               CGAL::Color c(0,255,0);
               EPICK::Point_3 point(p.x()+offset.x, p.y()+offset.y, p.z()+offset.z);
-              spheres->add_sphere(EPICK::Sphere_3(point, length_of_axis/15.0*length_of_axis/15.0), c);
+              spheres->add_sphere(EPICK::Sphere_3(point, length_of_axis/15.0*length_of_axis/15.0), s_index++, c);
             }
         }
 
@@ -400,7 +401,7 @@ void Scene_edit_polyhedron_item_priv::compute_normals_and_vertices(Mesh* mesh)
               EPICK::Point_3 center(p.x()+offset.x,
                                      p.y()+offset.y,
                                      p.z()+offset.z);
-              spheres_ctrl->add_sphere(EPICK::Sphere_3(center, length_of_axis/15.0*length_of_axis/15.0), c);
+              spheres_ctrl->add_sphere(EPICK::Sphere_3(center, length_of_axis/15.0*length_of_axis/15.0), s_index++, c);
             }
         }
     }
@@ -1271,7 +1272,7 @@ void Scene_edit_polyhedron_item::ShowAsSphere(bool b)
   {
     if(!d->spheres)
     {
-      d->spheres = new Scene_spheres_item(this, false);
+      d->spheres = new Scene_spheres_item(this, 0, false);
       d->spheres->setName("ROI spheres");
       d->spheres->setRenderingMode(Gouraud);
       connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -1390,7 +1390,7 @@ void Scene_c3t3_item_priv::computeSpheres()
 
   if(!spheres)
     return;
-
+  int s_id = 0;
   for(Tr::Finite_vertices_iterator
       vit = c3t3.triangulation().finite_vertices_begin(),
       end =  c3t3.triangulation().finite_vertices_end();
@@ -1436,7 +1436,7 @@ void Scene_c3t3_item_priv::computeSpheres()
                           wp2p(vit->point()).z() + offset.z);
     float radius = vit->point().weight() ;
     typedef unsigned char UC;
-    spheres->add_sphere(Geom_traits::Sphere_3(center, radius),
+    spheres->add_sphere(Geom_traits::Sphere_3(center, radius),s_id++,
                         CGAL::Color(UC(c.red()), UC(c.green()), UC(c.blue())));
   }
   spheres->invalidateOpenGLBuffers();
@@ -1602,7 +1602,7 @@ void Scene_c3t3_item::show_spheres(bool b)
     contextMenu()->findChild<QAction*>("actionShowSpheres")->setChecked(b);
     if(b && !d->spheres)
     {
-      d->spheres = new Scene_spheres_item(this, true);
+      d->spheres = new Scene_spheres_item(this, d->c3t3.number_of_vertices_in_complex(), true);
       d->spheres->setName("Protecting spheres");
       d->spheres->setRenderingMode(Gouraud);
       connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -218,6 +218,7 @@ Scene_polylines_item_private::computeSpheres()
       // At this point, 'corner_polyline_nb' gives the multiplicity of all
       // corners.
       //Finds the centers of the spheres and their color
+      int s_id = 0;
       for(iterator
           p_it = corner_polyline_nb.begin(),
           end = corner_polyline_nb.end();
@@ -253,7 +254,7 @@ Scene_polylines_item_private::computeSpheres()
           }
 
           CGAL::Color c(colors[0], colors[1], colors[2]);
-          spheres->add_sphere(K::Sphere_3(center+offset, spheres_drawn_square_radius), c);
+          spheres->add_sphere(K::Sphere_3(center+offset, spheres_drawn_square_radius),s_id++, c);
       }
       spheres->setToolTip(
             QString("<p>Legend of endpoints colors: <ul>"
@@ -560,7 +561,7 @@ void Scene_polylines_item::change_corner_radii(double r) {
         d->draw_extremities = (r > 0);
         if(r>0 && !d->spheres)
         {
-          d->spheres = new Scene_spheres_item(this, false);
+          d->spheres = new Scene_spheres_item(this, 0, false);
           d->spheres->setName("Corner spheres");
           d->spheres->setRenderingMode(Gouraud);
           connect(d->spheres, SIGNAL(destroyed()), this, SLOT(reset_spheres()));

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -1,4 +1,5 @@
 #include "Scene_spheres_item.h"
+#include<fstream>
 #include <CGAL/Three/Triangle_container.h>
 #include <CGAL/Three/Edge_container.h>
 #include <QApplication>
@@ -12,11 +13,13 @@ typedef Edge_container Ec;
 struct Scene_spheres_item_priv
 {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+  typedef CGAL::Sphere_3<Kernel> Sphere;
+  typedef std::pair<Sphere, CGAL::Color> Sphere_pair;
+  typedef std::vector<std::vector<Sphere_pair> > Spheres_container;
 
-  Scene_spheres_item_priv(bool planed, Scene_spheres_item* parent)
+  Scene_spheres_item_priv(bool planed, std::size_t max_index, Scene_spheres_item* parent)
     :precision(36)
     ,has_plane(planed)
-
   {
     item = parent;
     create_flat_and_wire_sphere(1.0f,vertices,normals, edges);
@@ -24,6 +27,7 @@ struct Scene_spheres_item_priv
     edges_colors.clear();
     centers.clear();
     radius.clear();
+    spheres.resize(max_index + 1);
     nb_centers = 0;
     nb_edges = 0;
     nb_vertices = 0;
@@ -33,6 +37,9 @@ struct Scene_spheres_item_priv
   ~Scene_spheres_item_priv()
   {
   }
+
+  void pick(int id)const;
+
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer)const;
 
   int precision;
@@ -44,6 +51,7 @@ struct Scene_spheres_item_priv
   mutable std::vector<float> edges;
   mutable std::vector<float> colors;
   mutable std::vector<float> edges_colors;
+  mutable std::vector<float> picking_colors;
   mutable std::vector<float> centers;
   mutable std::vector<float> radius;
   mutable QOpenGLShaderProgram *program;
@@ -53,12 +61,49 @@ struct Scene_spheres_item_priv
   mutable bool model_sphere_is_up;
   Scene_spheres_item* item;
   QString tooltip;
+  mutable Spheres_container spheres;
 
 };
-Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, bool planed)
+
+void Scene_spheres_item_priv::pick(int id) const
+{
+  int offset = 0;
+  float color[4];
+  for(std::size_t i=0; i<spheres.size(); ++i)
+  {
+   for( std::size_t j = 0; j< spheres[i].size(); ++j)
+   {
+     if(id == -1 || i != static_cast<std::size_t>(id))
+     {
+       color[0]=spheres[i][j].second.red()/255.0;
+       color[1]=spheres[i][j].second.green()/255.0;
+       color[2]=spheres[i][j].second.blue()/255.0;
+     }
+     else
+     {
+       color[0]=1.0f;
+       color[1]=1.0f;
+       color[2]=0.0f;
+     }
+     Vbo* color_vbo = item->getTriangleContainer(0)->getVbo(Tc::FColors);
+     color_vbo->bind();
+     color_vbo->vbo.write(offset*3*sizeof(float), color, 3*sizeof(float));
+     color_vbo->release();
+     ++offset;
+   }
+  }
+}
+
+Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, std::size_t max_index, bool planed)
 {
   setParent(parent);
-  d = new Scene_spheres_item_priv(planed, this);
+  d = new Scene_spheres_item_priv(planed, max_index, this);
+  //for picking
+  setTriangleContainer(1,
+                       new Tc(planed ? Vi::PROGRAM_CUTPLANE_SPHERES
+                                     : Vi::PROGRAM_SPHERES
+                                       ,false));
+  //for drawing
   setTriangleContainer(0, 
                        new Tc(planed ? Vi::PROGRAM_CUTPLANE_SPHERES
                                      : Vi::PROGRAM_SPHERES
@@ -79,6 +124,10 @@ void Scene_spheres_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *v
   item->getTriangleContainer(0)->initializeBuffers(viewer);
   item->getTriangleContainer(0)->setFlatDataSize(nb_vertices);
   item->getTriangleContainer(0)->setCenterSize(nb_centers);
+
+  item->getTriangleContainer(1)->initializeBuffers(viewer);
+  item->getTriangleContainer(1)->setFlatDataSize(nb_vertices);
+  item->getTriangleContainer(1)->setCenterSize(nb_centers);
   vertices.clear();
   vertices.shrink_to_fit();
   item->getEdgeContainer(0)->initializeBuffers(viewer);
@@ -91,6 +140,8 @@ void Scene_spheres_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *v
   centers.swap(centers);
   colors.clear();
   colors.swap(colors);
+  picking_colors.clear();
+  picking_colors.shrink_to_fit();
   radius.clear();
   radius.swap(radius);
   edges_colors.clear();
@@ -113,12 +164,40 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
     setBuffersFilled(true);
     setBuffersInit(viewer, true);
   }
-  if(d->has_plane)
-  {
-    QVector4D cp(d->plane.a(),d->plane.b(),d->plane.c(),d->plane.d());
-    getTriangleContainer(0)->setPlane(cp);
-  }
-  getTriangleContainer(0)->draw(viewer, false);
+  int deviceWidth = viewer->camera()->screenWidth();
+  int deviceHeight = viewer->camera()->screenHeight();
+    if(d->has_plane)
+    {
+      QVector4D cp(d->plane.a(),d->plane.b(),d->plane.c(),d->plane.d());
+      getTriangleContainer(0)->setPlane(cp);
+    }
+    if(d->spheres.size() > 1 && viewer->inDrawWithNames())
+    {
+      getTriangleContainer(1)->allocate(Tc::Flat_normals, 0, 0);
+      getTriangleContainer(1)->getVao(viewer)->program->setAttributeValue("normals", QVector3D(0,0,0));
+      getTriangleContainer(1)->draw(viewer, false);
+    }
+    else
+    {
+      getTriangleContainer(0)->draw(viewer, false);
+    }
+    if(d->spheres.size() > 1 && viewer->inDrawWithNames())
+      {
+        int rowLength = deviceWidth * 4; // data asked in RGBA,so 4 bytes.
+        const static int dataLength = rowLength * deviceHeight;
+        GLubyte* buffer = new GLubyte[dataLength];
+        // Qt uses upper corner for its origin while GL uses the lower corner.
+        QPoint picking_target = viewer->mapFromGlobal(QCursor::pos());
+        viewer->glReadPixels(picking_target.x(), deviceHeight-1-picking_target.y(), 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+        int ID = (buffer[0] + buffer[1] * 256 +buffer[2] * 256*256) ;
+        if(buffer[0]*buffer[1]*buffer[2] < 255*255*255)
+        {
+          d->pick(ID);
+          viewer->displayMessage(QString("Picked spheres index : %1 .").arg(ID), 2000);
+        }
+        else
+          d->pick(-1);
+      }
 }
 
 void Scene_spheres_item::drawEdges(Viewer_interface *viewer) const
@@ -146,21 +225,35 @@ void Scene_spheres_item::drawEdges(Viewer_interface *viewer) const
   getEdgeContainer(0)->draw(viewer, false);
   
 }
-void Scene_spheres_item::add_sphere(const CGAL::Sphere_3<Kernel>& sphere, CGAL::Color color)
+void Scene_spheres_item::add_sphere(const Sphere &sphere, std::size_t index,  CGAL::Color color)
 {
-    d->colors.push_back((float)color.red()/255);
-    d->colors.push_back((float)color.green()/255);
-    d->colors.push_back((float)color.blue()/255);
+  if(index > d->spheres.size()-1)
+    d->spheres.resize(index+1);
 
-    d->edges_colors.push_back((float)color.red()/255);
-    d->edges_colors.push_back((float)color.green()/255);
-    d->edges_colors.push_back((float)color.blue()/255);
+  d->spheres[index].push_back(std::make_pair(sphere, color));
 
-    d->centers.push_back(sphere.center().x());
-    d->centers.push_back(sphere.center().y());
-    d->centers.push_back(sphere.center().z());
+  d->colors.push_back((float)color.red()/255);
+  d->colors.push_back((float)color.green()/255);
+  d->colors.push_back((float)color.blue()/255);
+  int R = (index & 0x000000FF) >>  0;
+  int G = (index & 0x0000FF00) >>  8;
+  int B = (index & 0x00FF0000) >> 16;
+  float r = R/255.0;
+  float g = G/255.0;
+  float b = B/255.0;
+  d->picking_colors.push_back(r);
+  d->picking_colors.push_back(g);
+  d->picking_colors.push_back(b); 
 
-    d->radius.push_back(CGAL::sqrt(sphere.squared_radius()));
+  d->edges_colors.push_back((float)color.red()/255);
+  d->edges_colors.push_back((float)color.green()/255);
+  d->edges_colors.push_back((float)color.blue()/255);
+
+  d->centers.push_back(sphere.center().x());
+  d->centers.push_back(sphere.center().y());
+  d->centers.push_back(sphere.center().z());
+
+  d->radius.push_back(CGAL::sqrt(sphere.squared_radius()));
 }
 
 void Scene_spheres_item::clear_spheres()
@@ -176,6 +269,7 @@ void Scene_spheres_item::invalidateOpenGLBuffers()
 {
   setBuffersFilled(false);
   getTriangleContainer(0)->reset_vbos(NOT_INSTANCED);
+  getTriangleContainer(1)->reset_vbos(NOT_INSTANCED);
   getEdgeContainer(0)->reset_vbos(NOT_INSTANCED);
 }
 
@@ -209,6 +303,11 @@ void Scene_spheres_item::computeElements() const
     
     getTriangleContainer(0)->allocate(Tc::Flat_normals, d->normals.data(),
                                       static_cast<int>(d->normals.size()*sizeof(float)));
+
+
+    getTriangleContainer(1)->allocate(Tc::Flat_vertices, d->vertices.data(),
+                                      static_cast<int>(d->vertices.size()*sizeof(float)));
+
     d->nb_vertices = d->vertices.size();
     
   }
@@ -216,9 +315,16 @@ void Scene_spheres_item::computeElements() const
                                     static_cast<int>(d->colors.size()*sizeof(float)));
   getTriangleContainer(0)->allocate(Tc::Radius, d->radius.data(),
                                     static_cast<int>(d->radius.size()*sizeof(float)));
-  
   getTriangleContainer(0)->allocate(Tc::Facet_centers, d->centers.data(),
                                     static_cast<int>(d->centers.size()*sizeof(float)));
+
+  getTriangleContainer(1)->allocate(Tc::FColors, d->picking_colors.data(),
+                                    static_cast<int>(d->picking_colors.size()*sizeof(float)));
+  getTriangleContainer(1)->allocate(Tc::Radius, d->radius.data(),
+                                    static_cast<int>(d->radius.size()*sizeof(float)));
+  getTriangleContainer(1)->allocate(Tc::Facet_centers, d->centers.data(),
+                                    static_cast<int>(d->centers.size()*sizeof(float)));
+
   if(!d->model_sphere_is_up)
   {
     getEdgeContainer(0)->allocate(Ec::Vertices, d->edges.data(),
@@ -237,7 +343,6 @@ void Scene_spheres_item::computeElements() const
   
   getEdgeContainer(0)->allocate(Ec::Centers, d->centers.data(),
                                 static_cast<int>(d->centers.size()*sizeof(float)));
-  
   d->nb_centers = d->centers.size();
   
 }
@@ -253,4 +358,40 @@ void Scene_spheres_item::gl_initialization(Vi* viewer)
     setBuffersInit(viewer, true);
     setBuffersFilled(true);
   }
+}
+
+void Scene_spheres_item::compute_bbox() const
+{
+  Bbox box = Bbox();
+  for(std::size_t id=0; id<d->spheres.size(); ++id)
+  {
+    for(Sphere_pair pair : d->spheres[id])
+    {
+      box += pair.first.bbox();
+    }
+  }
+  _bbox = box;
+}
+
+bool Scene_spheres_item::save(const std::string& file_name)const
+{
+
+  std::ofstream out(file_name.c_str());
+  if(!out) { return false; }
+
+  std::size_t nb_spheres=0;
+  for(std::size_t i = 0; i<d->spheres.size(); ++i)
+    nb_spheres += d->spheres[i].size();
+
+  out<<nb_spheres << " " << d->spheres.size() -1<<"\n";
+
+  for(std::size_t i = 0; i<d->spheres.size(); ++i)
+  {
+    for(const Sphere_pair& pair : d->spheres[i])
+    {
+      out << i << " " << pair.first.center() << " " << CGAL::sqrt(pair.first.squared_radius())<<"\n";
+    }
+  }
+  out << "\n";
+  return true;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -72,7 +72,7 @@ void Scene_spheres_item_priv::pick(int& id) const
   if(!pickable)
     return;
   
-  if(id >= spheres.size())
+  if(id >= static_cast<int>(spheres.size()))
   {
     id = -1;
   }

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -39,7 +39,7 @@ struct Scene_spheres_item_priv
   {
   }
 
-  void pick(int id)const;
+  void pick(int &id)const;
 
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer)const;
 
@@ -67,10 +67,16 @@ struct Scene_spheres_item_priv
 
 };
 
-void Scene_spheres_item_priv::pick(int id) const
+void Scene_spheres_item_priv::pick(int& id) const
 {
   if(!pickable)
     return;
+  
+  if(id >= spheres.size())
+  {
+    id = -1;
+  }
+    
   int offset = 0;
   float color[4];
   for(std::size_t i=0; i<spheres.size(); ++i)
@@ -203,10 +209,8 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
       if(buffer[0]*buffer[1]*buffer[2] < 255*255*255)
       {
         d->pick(ID);
-        viewer->displayMessage(QString("Picked spheres index : %1 .").arg(ID), 2000);
+        picked(ID);
       }
-      else
-        d->pick(-1);
     }
 }
 

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.cpp
@@ -17,9 +17,10 @@ struct Scene_spheres_item_priv
   typedef std::pair<Sphere, CGAL::Color> Sphere_pair;
   typedef std::vector<std::vector<Sphere_pair> > Spheres_container;
 
-  Scene_spheres_item_priv(bool planed, std::size_t max_index, Scene_spheres_item* parent)
+  Scene_spheres_item_priv(bool planed, std::size_t max_index, Scene_spheres_item* parent, bool pickable)
     :precision(36)
     ,has_plane(planed)
+    ,pickable(pickable)
   {
     item = parent;
     create_flat_and_wire_sphere(1.0f,vertices,normals, edges);
@@ -62,11 +63,14 @@ struct Scene_spheres_item_priv
   Scene_spheres_item* item;
   QString tooltip;
   mutable Spheres_container spheres;
+  const bool pickable;
 
 };
 
 void Scene_spheres_item_priv::pick(int id) const
 {
+  if(!pickable)
+    return;
   int offset = 0;
   float color[4];
   for(std::size_t i=0; i<spheres.size(); ++i)
@@ -94,15 +98,18 @@ void Scene_spheres_item_priv::pick(int id) const
   }
 }
 
-Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, std::size_t max_index, bool planed)
+Scene_spheres_item::Scene_spheres_item(Scene_group_item* parent, std::size_t max_index, bool planed, bool pickable)
 {
   setParent(parent);
-  d = new Scene_spheres_item_priv(planed, max_index, this);
+  d = new Scene_spheres_item_priv(planed, max_index, this, pickable);
+  if(pickable)
+  {
   //for picking
   setTriangleContainer(1,
                        new Tc(planed ? Vi::PROGRAM_CUTPLANE_SPHERES
                                      : Vi::PROGRAM_SPHERES
                                        ,false));
+  }
   //for drawing
   setTriangleContainer(0, 
                        new Tc(planed ? Vi::PROGRAM_CUTPLANE_SPHERES
@@ -124,10 +131,12 @@ void Scene_spheres_item_priv::initializeBuffers(CGAL::Three::Viewer_interface *v
   item->getTriangleContainer(0)->initializeBuffers(viewer);
   item->getTriangleContainer(0)->setFlatDataSize(nb_vertices);
   item->getTriangleContainer(0)->setCenterSize(nb_centers);
-
-  item->getTriangleContainer(1)->initializeBuffers(viewer);
-  item->getTriangleContainer(1)->setFlatDataSize(nb_vertices);
-  item->getTriangleContainer(1)->setCenterSize(nb_centers);
+  if(pickable)
+  {
+    item->getTriangleContainer(1)->initializeBuffers(viewer);
+    item->getTriangleContainer(1)->setFlatDataSize(nb_vertices);
+    item->getTriangleContainer(1)->setCenterSize(nb_centers);
+  }
   vertices.clear();
   vertices.shrink_to_fit();
   item->getEdgeContainer(0)->initializeBuffers(viewer);
@@ -170,9 +179,10 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
     {
       QVector4D cp(d->plane.a(),d->plane.b(),d->plane.c(),d->plane.d());
       getTriangleContainer(0)->setPlane(cp);
-      getTriangleContainer(1)->setPlane(cp);
+      if(d->pickable)
+        getTriangleContainer(1)->setPlane(cp);
     }
-    if(d->spheres.size() > 1 && viewer->inDrawWithNames())
+    if(d->pickable && (d->spheres.size() > 1 && viewer->inDrawWithNames()))
     {
       getTriangleContainer(1)->getVao(viewer)->program->setAttributeValue("normals", QVector3D(0,0,0));
       getTriangleContainer(1)->draw(viewer, false);
@@ -181,7 +191,7 @@ void Scene_spheres_item::draw(Viewer_interface *viewer) const
     {
       getTriangleContainer(0)->draw(viewer, false);
     }
-    if(d->spheres.size() > 1 && viewer->inDrawWithNames())
+    if(d->pickable && (d->spheres.size() > 1 && viewer->inDrawWithNames()))
     {
       int rowLength = deviceWidth * 4; // data asked in RGBA,so 4 bytes.
       const static int dataLength = rowLength * deviceHeight;
@@ -235,16 +245,18 @@ void Scene_spheres_item::add_sphere(const Sphere &sphere, std::size_t index,  CG
   d->colors.push_back((float)color.red()/255);
   d->colors.push_back((float)color.green()/255);
   d->colors.push_back((float)color.blue()/255);
-  int R = (index & 0x000000FF) >>  0;
-  int G = (index & 0x0000FF00) >>  8;
-  int B = (index & 0x00FF0000) >> 16;
-  float r = R/255.0;
-  float g = G/255.0;
-  float b = B/255.0;
-  d->picking_colors.push_back(r);
-  d->picking_colors.push_back(g);
-  d->picking_colors.push_back(b); 
-
+  if(d->pickable)
+  {
+    int R = (index & 0x000000FF) >>  0;
+    int G = (index & 0x0000FF00) >>  8;
+    int B = (index & 0x00FF0000) >> 16;
+    float r = R/255.0;
+    float g = G/255.0;
+    float b = B/255.0;
+    d->picking_colors.push_back(r);
+    d->picking_colors.push_back(g);
+    d->picking_colors.push_back(b); 
+  }
   d->edges_colors.push_back((float)color.red()/255);
   d->edges_colors.push_back((float)color.green()/255);
   d->edges_colors.push_back((float)color.blue()/255);
@@ -252,16 +264,18 @@ void Scene_spheres_item::add_sphere(const Sphere &sphere, std::size_t index,  CG
   d->centers.push_back(sphere.center().x());
   d->centers.push_back(sphere.center().y());
   d->centers.push_back(sphere.center().z());
-
   d->radius.push_back(CGAL::sqrt(sphere.squared_radius()));
 }
 
 void Scene_spheres_item::clear_spheres()
 {
+  d->spheres.clear();
   d->colors.clear();
   d->edges_colors.clear();
   d->centers.clear();
   d->radius.clear();
+  d->picking_colors.clear();
+  setBuffersFilled(false);
 }
 void Scene_spheres_item::setPrecision(int prec) { d->precision = prec; }
 void Scene_spheres_item::setPlane(Kernel::Plane_3 p_plane) { d->plane = p_plane; }
@@ -269,7 +283,11 @@ void Scene_spheres_item::invalidateOpenGLBuffers()
 {
   setBuffersFilled(false);
   getTriangleContainer(0)->reset_vbos(NOT_INSTANCED);
-  getTriangleContainer(1)->reset_vbos(NOT_INSTANCED);
+  getTriangleContainer(0)->reset_vbos(COLORS);
+  if(d->pickable){
+    getTriangleContainer(1)->reset_vbos(NOT_INSTANCED);
+    getTriangleContainer(1)->reset_vbos(COLORS);
+  }
   getEdgeContainer(0)->reset_vbos(NOT_INSTANCED);
 }
 
@@ -304,10 +322,10 @@ void Scene_spheres_item::computeElements() const
     getTriangleContainer(0)->allocate(Tc::Flat_normals, d->normals.data(),
                                       static_cast<int>(d->normals.size()*sizeof(float)));
 
-
-    getTriangleContainer(1)->allocate(Tc::Flat_vertices, d->vertices.data(),
-                                      static_cast<int>(d->vertices.size()*sizeof(float)));
-
+    if(d->pickable)
+      getTriangleContainer(1)->allocate(Tc::Flat_vertices, d->vertices.data(),
+                                        static_cast<int>(d->vertices.size()*sizeof(float)));
+    
     d->nb_vertices = d->vertices.size();
     
   }
@@ -318,12 +336,15 @@ void Scene_spheres_item::computeElements() const
   getTriangleContainer(0)->allocate(Tc::Facet_centers, d->centers.data(),
                                     static_cast<int>(d->centers.size()*sizeof(float)));
 
-  getTriangleContainer(1)->allocate(Tc::FColors, d->picking_colors.data(),
-                                    static_cast<int>(d->picking_colors.size()*sizeof(float)));
-  getTriangleContainer(1)->allocate(Tc::Radius, d->radius.data(),
-                                    static_cast<int>(d->radius.size()*sizeof(float)));
-  getTriangleContainer(1)->allocate(Tc::Facet_centers, d->centers.data(),
-                                    static_cast<int>(d->centers.size()*sizeof(float)));
+  if(d->pickable)
+  {
+    getTriangleContainer(1)->allocate(Tc::FColors, d->picking_colors.data(),
+                                      static_cast<int>(d->picking_colors.size()*sizeof(float)));
+    getTriangleContainer(1)->allocate(Tc::Radius, d->radius.data(),
+                                      static_cast<int>(d->radius.size()*sizeof(float)));
+    getTriangleContainer(1)->allocate(Tc::Facet_centers, d->centers.data(),
+                                      static_cast<int>(d->centers.size()*sizeof(float)));
+  }
 
   if(!d->model_sphere_is_up)
   {
@@ -395,3 +416,4 @@ bool Scene_spheres_item::save(const std::string& file_name)const
   out << "\n";
   return true;
 }
+

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -62,6 +62,7 @@ public:
   void computeElements() const Q_DECL_OVERRIDE;
 Q_SIGNALS:
   void on_color_changed();
+  void picked(std::size_t id) const;
 protected:
   friend struct Scene_spheres_item_priv;
   Scene_spheres_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -15,27 +15,37 @@
 #include <QList>
 #include <vector>
 struct Scene_spheres_item_priv;
+
+/* This item contains spheres and associated colors. They are kept in a Spheres_container,
+ * sorted by the value of their "index". This item also has an internal picking mechanism that
+ * colorizes all the spheres that has the same index as the one that has been picked.
+ * The picking is only usable if several indices exist.
+ * If all the spheres have the index 0, they can have independant colors (generally used by the items that
+ * have a Scene_spheres_item child).
+*/
 class SCENE_BASIC_OBJECTS_EXPORT Scene_spheres_item
     : public CGAL::Three::Scene_item_rendering_helper
 {
   Q_OBJECT
 public:
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-  typedef std::pair<CGAL::Sphere_3<Kernel>*, CGAL::Color> Sphere_pair ;
+  typedef CGAL::Sphere_3<Kernel> Sphere;
+  typedef std::pair<Sphere, CGAL::Color> Sphere_pair;
+  typedef std::vector<std::vector<Sphere_pair> > Spheres_container;
 
-  Scene_spheres_item(Scene_group_item* parent, bool planed = false);
+  Scene_spheres_item(Scene_group_item* parent, std::size_t max_index = 0, bool planed = false);
 
   ~Scene_spheres_item();
 
-  bool isFinite() const Q_DECL_OVERRIDE{ return false; }
+  bool isFinite() const Q_DECL_OVERRIDE{ return true; }
   bool isEmpty() const Q_DECL_OVERRIDE{ return false; }
   Scene_item* clone() const Q_DECL_OVERRIDE{return 0;}
   QString toolTip() const Q_DECL_OVERRIDE;
   bool supportsRenderingMode(RenderingMode m) const Q_DECL_OVERRIDE{
     return (m == Gouraud || m == Wireframe);
   }
-  void compute_bbox() const Q_DECL_OVERRIDE{ _bbox = Bbox(); }
-  void add_sphere(const CGAL::Sphere_3<Kernel> &sphere, CGAL::Color = CGAL::Color(120,120,120));
+  void compute_bbox() const Q_DECL_OVERRIDE;
+  void add_sphere(const Sphere &sphere, std::size_t index = 0, CGAL::Color = CGAL::Color(120,120,120));
   void clear_spheres();
   void setPrecision(int prec);
   void gl_initialization(CGAL::Three::Viewer_interface* viewer);
@@ -45,6 +55,9 @@ public:
   void setPlane(Kernel::Plane_3 p_plane);
   void setToolTip(QString s);
   void setColor(QColor c) Q_DECL_OVERRIDE;
+  bool save(const std::string &file_name) const;
+
+
   void initializeBuffers(Viewer_interface *) const Q_DECL_OVERRIDE;
   void computeElements() const Q_DECL_OVERRIDE;
 Q_SIGNALS:

--- a/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_spheres_item.h
@@ -33,7 +33,7 @@ public:
   typedef std::pair<Sphere, CGAL::Color> Sphere_pair;
   typedef std::vector<std::vector<Sphere_pair> > Spheres_container;
 
-  Scene_spheres_item(Scene_group_item* parent, std::size_t max_index = 0, bool planed = false);
+  Scene_spheres_item(Scene_group_item* parent, std::size_t max_index = 0, bool planed = false, bool pickable = true);
 
   ~Scene_spheres_item();
 

--- a/Polyhedron/demo/Polyhedron/resources/compatibility_shaders/shader_c3t3.frag
+++ b/Polyhedron/demo/Polyhedron/resources/compatibility_shaders/shader_c3t3.frag
@@ -40,7 +40,10 @@ void main(void) {
       highp vec3 V = -fP.xyz; 
       highp vec3 N; 
       if(fN == vec3(0.0,0.0,0.0))
-          N = vec3(0.0,0.0,0.0);
+      {
+        gl_FragColor = my_color;
+        return;
+      }
       else 
           N = normalize(fN); 
       L = normalize(L); 

--- a/Polyhedron/demo/Polyhedron/resources/compatibility_shaders/shader_with_light.frag
+++ b/Polyhedron/demo/Polyhedron/resources/compatibility_shaders/shader_with_light.frag
@@ -50,16 +50,19 @@ void main(void) {
     highp vec3 L = light_pos.xyz - fP.xyz;
     highp vec3 V = -fP.xyz;
     highp vec3 N;
-    if(fN == vec3(0.0,0.0,0.0))
-      N = vec3(0.0,0.0,0.0);
-    else
-      N = normalize(fN);
+    highp vec4 my_color = highp vec4(color.xyz, 1.0);
+    if(fN ==  vec3(0.0,0.0,0.0))
+    {
+      out_color = my_color;
+      return;
+    }
+    N = normalize(fN);
     L = normalize(L);
     V = normalize(V);
     highp vec3 R = reflect(-L, N);
     highp vec4 diffuse;
     float dot_prod = dot(N,L);
-    highp vec4 my_color;
+    
     if(back_front_shading)
     {
       if (dot_prod > 0)
@@ -67,10 +70,7 @@ void main(void) {
       else
         my_color = back_color;
     }
-    else
-    {
-      my_color = highp vec4(color.xyz, 1.0);
-    }
+    
     if(is_two_side == 1)
       diffuse = abs(dot(N,L)) * light_diff * color;
     else

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.frag
@@ -42,7 +42,10 @@ void main(void) {
       vec3 V = -fP.xyz; 
       vec3 N; 
       if(fN == vec3(0.0,0.0,0.0))
-          N = vec3(0.0,0.0,0.0); 
+      {
+        out_color = my_color;
+        return;
+      }
       else 
           N = normalize(fN); 
       L = normalize(L); 

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.frag
@@ -57,8 +57,6 @@ void main(void) {
       out_color = my_color;
       return;
     }
-    if(fN ==  vec3(0.0,0.0,0.0))
-      N =  vec3(0.0,0.0,0.0);
     else
       N = normalize(fN);
     L = normalize(L);

--- a/Polyhedron/demo/Polyhedron/resources/shader_with_light.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_with_light.frag
@@ -51,6 +51,12 @@ void main(void) {
     vec3 L = light_pos.xyz - fP.xyz;
     vec3 V = -fP.xyz;
     vec3 N;
+    vec4 my_color = vec4(color.xyz, 1.0);
+    if(fN ==  vec3(0.0,0.0,0.0))
+    {
+      out_color = my_color;
+      return;
+    }
     if(fN ==  vec3(0.0,0.0,0.0))
       N =  vec3(0.0,0.0,0.0);
     else
@@ -60,7 +66,7 @@ void main(void) {
     vec3 R = reflect(-L, N);
     vec4 diffuse;
     float dot_prod = dot(N,L);
-    vec4 my_color;
+    
     if(back_front_shading)
     {
       if (dot_prod > 0)


### PR DESCRIPTION
## Summary of Changes
Add a mechanism to perform picking on the spheres. Add a parameter to the constructor to disable it.
## Release Management

* Affected package(s):Polyhedron Demo

TODO:
- [x] add a vector of triangulation vertices in c3t3-item to retrive a vertex from its associated sphere.