### PR TITLE
Point_set_3: add missing copy constructor

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -240,6 +240,18 @@ public:
     return *this;
   }
 
+  /// \cond SKIP_IN_MANUAL
+  // copy constructor (same as assignment)
+  Point_set_3 (const Point_set_3& ps)
+  {
+    m_base = ps.m_base;
+    m_indices = this->property_map<Index> ("index").first;
+    m_points = this->property_map<Point> ("point").first;
+    m_normals = this->property_map<Vector> ("normal").first;
+    m_nb_removed = ps.m_nb_removed;
+  }
+  /// \endcond
+
   /// @}
 
   /// \cond SKIP_IN_MANUAL


### PR DESCRIPTION
## Summary of Changes

The copy constructor was missing, leading to the default being used, which resulted in uninitialized references to the internal properties and made the copied point set unusable (seg fault).

## Release Management

* Affected package(s): Point_set_3
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/4365