### PR TITLE
TDS_23: Doc cleaning

### DIFF
--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_tds_cell.h
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/include/CGAL/_test_cls_periodic_3_tds_cell.h
@@ -88,11 +88,6 @@ _test_cell_tds_3(const Tds &)
    assert(c2->index(v1)==0);
    assert(c2->index(v2)==1);
    assert(c2->index(v3)==2);
-   //   c2->set_vertices();
-   //   assert(c2->vertex(0)==NULL);
-   //   assert(c2->vertex(1)==NULL);
-   //   assert(c2->vertex(2)==NULL);
-   //   assert(c2->vertex(3)==NULL);
    c2->set_vertices(v0, v1, v2, v3);
    assert(c2->index(v0)==0);
    assert(c2->index(v1)==1);
@@ -107,11 +102,6 @@ _test_cell_tds_3(const Tds &)
    assert(c2->index(n1)==0);
    assert(c2->index(n2)==1);
    assert(c2->index(n3)==2);
-   //   c2->set_neighbors();
-   //   assert(c2->neighbor(0)==NULL);
-   //   assert(c2->neighbor(1)==NULL);
-   //   assert(c2->neighbor(2)==NULL);
-   //   assert(c2->neighbor(3)==NULL);
    c2->set_neighbors(n0, n1, n2, n3);
    assert(c2->index(n0)==0);
    assert(c2->index(n1)==1);

--- a/TDS_2/doc/TDS_2/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/doc/TDS_2/CGAL/Triangulation_data_structure_2.h
@@ -48,10 +48,14 @@ public:
 
   typedef Triangulation_data_structure_2<VertexBase,FaceBase>  Tds;
 
-/// The vertex type.
+  /// The vertex type.
+  ///
+  /// \sa Section \ref TDS_2TheRebindMechanism
   typedef  typename VertexBase::template Rebind_TDS<Tds>::Other  Vertex;
 
-/// The face type.
+  /// The face type.
+  ///
+  /// \sa Section \ref TDS_2TheRebindMechanism
   typedef  typename FaceBase::template Rebind_TDS<Tds>::Other  Face;
 
 /// @}

--- a/TDS_2/doc/TDS_2/CGAL/Triangulation_ds_face_base_2.h
+++ b/TDS_2/doc/TDS_2/CGAL/Triangulation_ds_face_base_2.h
@@ -10,11 +10,13 @@ The class `Triangulation_ds_face_base_2` is a model for the concept
 
 \cgalModels `TriangulationDSFaceBase_2`
 
+\tparam TDS should not be specified (see Section \ref TDS_2TheRebindMechanism and examples)
+
 \sa `CGAL::Triangulation_face_base_2<Traits,Fb>` 
 \sa `CGAL::Triangulation_ds_vertex_base_2<Tds>` 
 
 */
-template< typename Tds >
+template< typename TDS = void>
 class Triangulation_ds_face_base_2 {
 public:
 

--- a/TDS_2/doc/TDS_2/CGAL/Triangulation_ds_vertex_base_2.h
+++ b/TDS_2/doc/TDS_2/CGAL/Triangulation_ds_vertex_base_2.h
@@ -18,13 +18,15 @@ geometric triangulation, there are additional geometric requirements
 to be fulfilled by the vertex base class, 
 and `Triangulation_ds_vertex_base_2` cannot be plugged in. 
 
+\tparam TDS should not be specified (see Section \ref TDS_2TheRebindMechanism and examples)
+
 \cgalModels `TriangulationDSVertexBase_2`
 
 \sa `CGAL::Triangulation_vertex_base_2<Traits,Vb>` 
-\sa `CGAL::Triangulation_ds_face_base_2<Tds>` 
+\sa `CGAL::Triangulation_ds_face_base_2<TDS>`
 
 */
-template< typename Tds >
+template< typename TDS = void >
 class Triangulation_ds_vertex_base_2 {
 public:
 

--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDSFaceBase_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDSFaceBase_2.h
@@ -3,6 +3,8 @@
 \ingroup PkgTDS2Concepts
 \cgalConcept
 
+\cgalRefines `TriangulationDataStructure_2::Face`
+
 The concept `TriangulationDSFaceBase_2` describes the requirements for 
 the face base class of a `CGAL::Triangulation_data_structure_2<Vb,Fb>`.
 
@@ -46,22 +48,16 @@ that the `CGAL::Triangulation_data_structure_2`
 actually uses as a base class for the class 
 `CGAL::Triangulation_data_structure_2::Face`. 
 
-\cgalRefines `TriangulationDataStructure_2::Face`
-
-\cgalHasModel `CGAL::Triangulation_ds_face_base_2<Tds>`
-\cgalHasModel `CGAL::Triangulation_face_base_2<Traits,Fb>` 
-\cgalHasModel `CGAL::Regular_triangulation_face_base_2<Traits,Fb>` 
-\cgalHasModel `CGAL::Constrained_triangulation_face_base_2<Traits,Fb>` 
-\cgalHasModel `CGAL::Triangulation_face_base_with_info_2<Info,Traits,Fb>` 
+\cgalHasModel `CGAL::Triangulation_ds_face_base_2<TDS>`
 
 \sa `TriangulationDSVertexBase_2` 
-\sa `TriangulationDataStructure_2::Face` 
-\sa `TriangulationFaceBase_2` 
 \sa `CGAL::Triangulation_data_structure_2<Vb,Fb>` 
 
 */
 
-class TriangulationDSFaceBase_2 {
+class TriangulationDSFaceBase_2
+  : public TriangulationDataStructure_2::Face
+{
 public:
 
 /// \name Types 
@@ -76,6 +72,7 @@ This template class has to define a type `Rebind_TDS<TDS_2>::%Other` which is th
 This type `Other` will be the actual base 
 of the class `CGAL::Triangulation_data_structure_2::Face`. 
 \note It can be implemented using a nested template class.
+\sa Section \ref TDS_2TheRebindMechanism
 */ 
 template <typename TDS2> 
 using Rebind_TDS = unspecified_type;
@@ -103,26 +100,26 @@ typedef TriangulationDataStructure_2::Face_handle Face_handle;
 /*!
 default constructor. 
 */ 
-TriangulationDSFaceBase_2(); 
+TriangulationDSFaceBase_2();
 
 /*!
 Initializes the vertices with `v0, v1, v2` and the neighbors 
 with `Face_handle()`. 
 */ 
-TriangulationDSFaceBase_2(Vertex_handle v0, 
-Vertex_handle v1, 
-Vertex_handle v2); 
+TriangulationDSFaceBase_2(Vertex_handle v0,
+                          Vertex_handle v1,
+                          Vertex_handle v2);
 
 /*!
 initializes the vertices with `v0,v1, v2` and the neighbors with 
 `n0, n1, n2`. 
 */ 
-TriangulationDSFaceBase_2(Vertex_handle v0, 
-Vertex_handle v1, 
-Vertex_handle v2, 
-Face_handle n0, 
-Face_handle n1, 
-Face_handle n2); 
+TriangulationDSFaceBase_2(Vertex_handle v0,
+                          Vertex_handle v1,
+                          Vertex_handle v2,
+                          Face_handle n0,
+                          Face_handle n1,
+                          Face_handle n2);
 
 /// @} 
 
@@ -133,89 +130,6 @@ Face_handle n2);
 returns the dimension. 
 */ 
 int dimension(); 
-
-/*!
-returns the vertex `i` of the face. 
-\pre \f$ 0\leq i \leq2\f$. 
-*/ 
-Vertex_handle vertex(int i) const; 
-
-/*!
-returns `true` if `v` is a vertex of the face. 
-*/ 
-bool has_vertex(Vertex_handle v); 
-
-/*!
-as above, and sets `i` to the index of `v` in the face. 
-*/ 
-bool has_vertex(Vertex_handle v, int& i) const; 
-
-/*!
-returns the index of `v` in the face. 
-*/ 
-int index(Vertex_handle v) const; 
-
-/*!
-returns the neighbor `i` of the face. 
-\pre \f$ 0\leq i \leq2\f$. 
-*/ 
-Face_handle neighbor(int i) const; 
-
-/*!
-returns `true` if `n` is a neighbor of the face. 
-*/ 
-bool has_neighbor(Face_handle n); 
-
-/*!
-as above, and sets i to the index of `n` in the face. 
-*/ 
-bool has_neigbor(Face_handle n, int& i) const; 
-
-/*!
-returns the index of neighbor `n` in the face. 
-*/ 
-int index(const Face_handle n) const; 
-
-/// @} 
-
-/// \name Setting 
-/// @{
-
-/*!
-sets vertex `i` to `v`. 
-\pre \f$ 0\leq i \leq2\f$. 
-*/ 
-void set_vertex(int i, Vertex_handle v); 
-
-/*!
-sets the vertices to `Vertex_handle()`. 
-*/ 
-void set_vertices(); 
-
-/*!
-sets the vertices. 
-*/ 
-void set_vertices(Vertex_handle v0, 
-Vertex_handle v1, 
-Vertex_handle v2); 
-
-/*!
-sets neighbor `i` to `n`. 
-\pre \f$ 0\leq i \leq2\f$. 
-*/ 
-void set_neighbor(int i, Face_handle n); 
-
-/*!
-sets the neighbors to `Face_handle()`. 
-*/ 
-void set_neighbors(); 
-
-/*!
-sets the neighbors. 
-*/ 
-void set_neighbors(Face_handle n0, 
-Face_handle n1, 
-Face_handle n2); 
 
 /// @} 
 

--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDSFaceBase_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDSFaceBase_2.h
@@ -56,7 +56,6 @@ actually uses as a base class for the class
 */
 
 class TriangulationDSFaceBase_2
-  : public TriangulationDataStructure_2::Face
 {
 public:
 

--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDSVertexBase_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDSVertexBase_2.h
@@ -3,6 +3,8 @@
 \ingroup PkgTDS2Concepts
 \cgalConcept
 
+\cgalRefines `TriangulationDataStructure_2::Vertex`
+
 The concept `TriangulationDSVertexBase_2` describes the requirements for the 
 vertex base class of a `CGAL::Triangulation_data_structure_2<Vb,Fb>`.
 
@@ -42,23 +44,16 @@ that the `CGAL::Triangulation_data_structure_2`
 actually uses as a base class for the class 
 of `CGAL::Triangulation_data_structure_2::Vertex`. 
 
-\cgalRefines `TriangulationDataStructure_2::Vertex` 
-
 \cgalHasModel `CGAL::Triangulation_ds_vertex_base_2<Tds>`
-\cgalHasModel `CGAL::Triangulation_vertex_base_2<Traits,Vb>`
-\cgalHasModel `CGAL::Regular_triangulation_vertex_base_2<Traits,Vb>`
-\cgalHasModel `CGAL::Triangulation_hierarchy_vertex_base_2<Vb>`
-\cgalHasModel `CGAL::Triangulation_vertex_base_with_info_2<Info,Traits,Vb>`
 
-\sa `TriangulationVertexBase_2` 
 \sa `TriangulationDSFaceBase_2` 
-\sa `TriangulationFaceBase_2` 
-\sa `TriangulationDataStructure_2::Vertex` 
 \sa `CGAL::Triangulation_data_structure_2<Vb,Fb>` 
 
 */
 
-class TriangulationDSVertexBase_2 {
+class TriangulationDSVertexBase_2
+  : public TriangulationDataStructure_2::Vertex
+{
 public:
 
 /// \name Types 
@@ -72,6 +67,7 @@ This template class has to define a type `Rebind_TDS<TDS2>::%Other` which is the
 This type `Other` will be the actual base 
 of the class `CGAL::Triangulation_data_structure_2::Vertex`. 
 \note It can be implemented using a nested template class.
+\sa Section \ref TDS_2TheRebindMechanism
 */ 
 template <typename TDS2> 
 using Rebind_TDS = unspecified_type;

--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDSVertexBase_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDSVertexBase_2.h
@@ -52,7 +52,6 @@ of `CGAL::Triangulation_data_structure_2::Vertex`.
 */
 
 class TriangulationDSVertexBase_2
-  : public TriangulationDataStructure_2::Vertex
 {
 public:
 

--- a/TDS_2/doc/TDS_2/Concepts/TriangulationDataStructure_2.h
+++ b/TDS_2/doc/TDS_2/Concepts/TriangulationDataStructure_2.h
@@ -111,26 +111,6 @@ Handle to a face.
 typedef unspecified_type Face_handle; 
 
 /*!
-This template class allows to get the type of a triangulation 
-data structure that only changes the vertex type. It has to define a type 
-`Rebind_vertex<Vb2>::%Other` which is a <I>rebound</I> triangulation data structure, that is, the 
-one whose `TriangulationDSVertexBase_2` will be `Vb2`.
-\note It can be implemented using a nested template class.
-*/ 
-template <typename Vb2> 
-using Rebind_vertex = unspecified_type;
-
-/*!
-This template class allows to get the type of a triangulation 
-data structure that only changes the face type. It has to define a type 
-`Rebind_face<Fb2>::%Other` which is a <I>rebound</I> triangulation data structure, that is, the 
-one whose `TriangulationDSFaceBase_2` will be `Fb2`.
-\note It can be implemented using a nested template class.
-*/ 
-template <typename Fb2> 
-using Rebind_face = unspecified_type;
-
-/*!
 The edge type. 
 The `Edge(f,i)` is edge common to faces `f` and 
 `f.neighbor(i)`. It is also the edge joining the vertices 
@@ -743,8 +723,9 @@ triangulation data structure.
 
 \cgalHasModel `CGAL::Triangulation_ds_vertex_base_2<Tds>` 
 
-\sa `TriangulationDataStructure_2` 
+\sa `TriangulationDSVertexBase_2`
 \sa `TriangulationDataStructure_2::Face` 
+\sa `TriangulationDataStructure_2`
 
 */
 class TriangulationDataStructure_2::Vertex {
@@ -863,9 +844,9 @@ define new faces and to delete no longer used faces.
 
 \cgalHasModel `CGAL::Triangulation_ds_face_base_2<Tds>`
 
+\sa `TriangulationDSFaceBase_2`
 \sa `TriangulationDataStructure_2`
 \sa `TriangulationDataStructure_2::Vertex`
-\sa `TriangulationFaceBase_2`
 
 */
 class TriangulationDataStructure_2::Face {

--- a/TDS_2/doc/TDS_2/PackageDescription.txt
+++ b/TDS_2/doc/TDS_2/PackageDescription.txt
@@ -58,7 +58,7 @@ These refining concepts and their models are described in Chapter
 - `TriangulationDSVertexBase_2`
 
 \cgalCRPSection{Classes}
-- `CGAL::Triangulation_data_structure_2<VertexBase,FaceBase>`
+- `CGAL::Triangulation_data_structure_2<Vb,Fb>`
 - `CGAL::Triangulation_ds_face_base_2<Tds>`
 - `CGAL::Triangulation_ds_vertex_base_2<Tds>`
 

--- a/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
+++ b/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
@@ -239,14 +239,14 @@ set_neighbor(int i, Face_handle n)
   N[i] = n;
 }
 
-template <class TDS>      
+template <class TDS>
 inline void
-Triangulation_ds_face_base_2<TDS> :: 
+Triangulation_ds_face_base_2<TDS> ::
 set_vertices()
 {
   V[0] = V[1] = V[2] = Vertex_handle();
 }
-    
+
 template <class TDS>      
 inline void
 Triangulation_ds_face_base_2<TDS> ::     

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_data_structure_3.h
@@ -19,7 +19,6 @@ additional template parameters.
 
 \tparam CellBase  must be a model of `TriangulationDSCellBase_3`. The default is `Triangulation_ds_cell_base_3<TDS>`.
 
-
 \tparam ConcurrencyTag enables the use of a concurrent
 container to store vertices and cells. It can be `Sequential_tag` (use of a 
 `Compact_container` to store vertices and cells) or `Parallel_tag` 
@@ -33,22 +32,31 @@ container to store vertices and cells. It can be `Sequential_tag` (use of a
 The base class `Triangulation_utils_3` defines basic computations on
 indices of vertices and neighbors of cells.
 
-\attention All members listed here are additional to the interface
-specified by the concept.
-
 \sa `CGAL::Triangulation_ds_vertex_base_3` 
 \sa `CGAL::Triangulation_ds_cell_base_3` 
-\sa `CGAL::Triangulation_vertex_base_with_info_3` 
-\sa `CGAL::Triangulation_cell_base_with_info_3` 
 */
 template< typename VertexBase, 
           typename CellBase,
           typename ConcurrencyTag >
-class Triangulation_data_structure_3 : public CGAL::Triangulation_utils_3 {
+class Triangulation_data_structure_3
+  : public CGAL::Triangulation_utils_3
+{
 public:
 
 /// \name Types 
 /// @{
+
+typedef Triangulation_data_structure_2<VertexBase,FaceBase>  Tds;
+
+/// The vertex type.
+///
+/// \sa Section \ref tds3cyclic
+typedef  typename VertexBase::template Rebind_TDS<Tds>::Other  Vertex;
+
+/// The face type.
+///
+/// \sa Section \ref tds3cyclic
+typedef  typename CellBase::template Rebind_TDS<Tds>::Other  Cell;
 
 /*!
 Vertex container type. If `ConcurrencyTag` is `Parallel_tag`, a
@@ -64,6 +72,10 @@ typedef Compact_container<Cell, Default> Cell_range;
 /// @} 
 
 /// \name Operations 
+///
+/// In addition to the interface documented in the concept,
+/// the class offers the following functions.
+///
 /// @{
 
 /*!

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_ds_cell_base_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_ds_cell_base_3.h
@@ -10,9 +10,10 @@ The class `Triangulation_ds_cell_base_3<>` is a model for the concept
 
 \cgalModels `TriangulationDSCellBase_3`
 
+\tparam TDS should not be specified (see Section \ref tds3cyclic and examples)
+
 \sa `CGAL::Triangulation_cell_base_3` 
 \sa `CGAL::Triangulation_ds_vertex_base_3` 
-\sa `CGAL::Triangulation_cell_base_with_info_3` 
 
 */
 template< typename TDS = void >

--- a/TDS_3/doc/TDS_3/CGAL/Triangulation_ds_vertex_base_3.h
+++ b/TDS_3/doc/TDS_3/CGAL/Triangulation_ds_vertex_base_3.h
@@ -20,9 +20,10 @@ example) tuned for a specific application.
 
 \cgalModels `TriangulationDSVertexBase_3`
 
+\tparam TDS should not be specified (see Section \ref tds3cyclic and examples)
+
 \sa `CGAL::Triangulation_vertex_base_3` 
 \sa `CGAL::Triangulation_ds_cell_base_3` 
-\sa `CGAL::Triangulation_vertex_base_with_info_3` 
 
 */
 template< typename TDS = void >

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDSCellBase_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDSCellBase_3.h
@@ -41,7 +41,6 @@ More information can be found in Section \ref TDS3secdesign.
 */
 
 class TriangulationDSCellBase_3
-  : public TriangulationDataStructure_3::Cell
 {
 public:
 

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDSCellBase_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDSCellBase_3.h
@@ -3,6 +3,16 @@
 \ingroup PkgTDS3Concepts
 \cgalConcept
 
+\cgalRefines TriangulationDataStructure_3::Cell
+
+The concept `TriangulationDSCellBase_3` describes the requirements for
+the cell base class of a `CGAL::Triangulation_data_structure_3<Vb,Cb>`.
+
+Note that if the `CGAL::Triangulation_data_structure_3`
+is plugged into a triangulation class,
+the face base class may have additional geometric
+requirements depending on the triangulation class.
+
 At the base level 
 (see the Software Design sections of the Chapters \ref Triangulation3secdesign "Triangulation" 
 and  \ref TDS3secdesign "Triangulation Datastructure"), 
@@ -23,18 +33,16 @@ cell classes. The <I>rebound</I> base classes so obtained are the classes
 which are used as base classes for the final vertex and cell classes. 
 More information can be found in Section \ref TDS3secdesign. 
 
-\cgalHasModel CGAL::Triangulation_ds_cell_base_3 
-\cgalHasModel CGAL::Triangulation_cell_base_3 
-\cgalHasModel CGAL::Triangulation_cell_base_with_info_3 
+\cgalHasModel `CGAL::Triangulation_ds_cell_base_3<TDS>`
 
 \sa `TriangulationDSVertexBase_3` 
-\sa `TriangulationVertexBase_3` 
-\sa `TriangulationHierarchyVertexBase_3` 
-\sa `TriangulationCellBase_3` 
+\sa `CGAL::Triangulation_data_structure_3<Vb,Cb>`
 
 */
 
-class TriangulationDSCellBase_3 {
+class TriangulationDSCellBase_3
+  : public TriangulationDataStructure_3::Cell
+{
 public:
 
 /// \name Types 
@@ -42,13 +50,14 @@ public:
 /// @{
 
 /*!
-This template class has to define a type `Rebind_TDS<TDS2>::%Other` which is the 
+This template class has to define a type `Rebind_TDS<TDS3>::%Other` which is the
 <I>rebound</I> cell, that is, the one whose `Triangulation_data_structure` 
-will be the actually used one. `Rebind_TDS<TDS2>::%Other` will be the real base 
+will be the actually used one. `Rebind_TDS<TDS3>::%Other` will be the real base
 class of `Triangulation_data_structure_3::Cell`.
 \note It can be implemented using a nested template class.
-*/ 
-template <typename TDS2> 
+\sa Section \ref tds3cyclic
+*/
+template <typename TDS3>
 using Rebind_TDS = unspecified_type;
 
 /*!
@@ -66,11 +75,6 @@ typedef TriangulationDataStructure_3::Vertex_handle Vertex_handle;
 */ 
 typedef TriangulationDataStructure_3::Cell_handle Cell_handle; 
 
-/*!
-
-*/ 
-typedef TriangulationDataStructure_3::Cell_data TDS_data; 
-
 /// @} 
 
 /// \name Creation 
@@ -79,113 +83,23 @@ typedef TriangulationDataStructure_3::Cell_data TDS_data;
 /*!
 Default constructor 
 */ 
-Cell_base(); 
+TriangulationDSCellBase_3();
 
 /*!
 Initializes the vertices with `v0, v1, v2, v3`. Neighbors are 
 initialized to the default constructed handle. 
 */ 
-Cell_base( Vertex_handle v0, Vertex_handle v1, 
-Vertex_handle v2, Vertex_handle v3); 
+TriangulationDSCellBase_3( Vertex_handle v0, Vertex_handle v1,
+                           Vertex_handle v2, Vertex_handle v3);
 
 /*!
 Initializes the vertices with `v0, v1, v2, v3` and the neighbors with 
 `n0, n1, n2, n3`. 
 */ 
-Cell_base( Vertex_handle v0, Vertex_handle v1, 
-Vertex_handle v2, Vertex_handle v3, 
-Cell_handle n0, Cell_handle n1, 
-Cell_handle n2, Cell_handle n3); 
-
-/// @} 
-
-/// \name Access Functions 
-/// @{
-
-/*!
-Returns the vertex `i` of `c`. 
-\pre \f$ i \in\{0, 1, 2, 3\}\f$. 
-*/ 
-Vertex_handle vertex(int i) const; 
-
-/*!
-Returns the index of `v`. 
-\pre `v` is a vertex of `c` 
-*/ 
-int index(Vertex_handle v) const; 
-
-/*!
-True iff `v` is a vertex of `c`. 
-*/ 
-bool has_vertex(Vertex_handle v); 
-
-/*!
-Returns `true` if `v` is a vertex of `c`, and 
-computes its index `i` in `c`. 
-*/ 
-bool has_vertex(Vertex_handle v, int & i) const; 
-
-/*!
-Returns the neighbor `i` of `c`. 
-\pre \f$ i \in\{0, 1, 2, 3\}\f$. 
-*/ 
-Cell_handle neighbor(int i) const; 
-
-/*!
-Returns the index of cell `n` in `c`. 
-\pre `n` is a neighbor of `c`. 
-*/ 
-int index(Cell_handle n) const; 
-
-/*!
-Returns `true` if `n` is a neighbor of `c`. 
-*/ 
-bool has_neighbor(Cell_handle n); 
-
-/*!
-Returns `true` if `n` is a neighbor of `c`, and 
-computes its index `i` in `c`. 
-*/ 
-bool has_neighbor(Cell_handle n, int & i) const; 
-
-/// @} 
-
-/// \name Setting 
-/// @{
-
-/*!
-Sets vertex `i` to `v`. 
-\pre \f$ i \in\{0, 1, 2, 3\}\f$. 
-*/ 
-void set_vertex(int i, Vertex_handle v); 
-
-/*!
-Sets the vertices to the default constructed handle. 
-*/ 
-void set_vertices(); 
-
-/*!
-Sets the vertices. 
-*/ 
-void set_vertices( Vertex_handle v0, Vertex_handle v1, 
-Vertex_handle v2, Vertex_handle v3); 
-
-/*!
-Sets neighbor `i` to `n`. 
-\pre \f$ i \in\{0, 1, 2, 3\}\f$. 
-*/ 
-void set_neighbor(int i, Cell_handle n); 
-
-/*!
-Sets the neighbors to the default constructed handle. 
-*/ 
-void set_neighbors(); 
-
-/*!
-Sets the neighbors. 
-*/ 
-void set_neighbors(Cell_handle n0, Cell_handle n1, 
-Cell_handle n2, Cell_handle n3); 
+TriangulationDSCellBase_3( Vertex_handle v0, Vertex_handle v1,
+                           Vertex_handle v2, Vertex_handle v3,
+                           Cell_handle n0, Cell_handle n1,
+                           Cell_handle n2, Cell_handle n3);
 
 /// @} 
 
@@ -224,26 +138,6 @@ void * for_compact_container() const;
 
 */ 
 void * & for_compact_container(); 
-
-/// @}
-
-/// \name Internal
-/// \cgalAdvancedBegin
-/// These functions are used internally by the triangulation data
-/// structure. The user is not encouraged to use them directly as they
-/// may change in the future.
-/// \cgalAdvancedEnd
-/// @{
-
-/*!
-
-*/ 
-TDS_data& tds_data(); 
-
-/*!
-
-*/ 
-const TDS_data& tds_data() const; 
 
 /// @}
 

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDSVertexBase_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDSVertexBase_3.h
@@ -36,7 +36,6 @@ More information can be found in Section \ref TDS3secdesign.
 */
 
 class TriangulationDSVertexBase_3
-  : public TriangulationDataStructure_3::Vertex
 {
 public:
 

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDSVertexBase_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDSVertexBase_3.h
@@ -3,13 +3,17 @@
 \ingroup PkgTDS3Concepts
 \cgalConcept
 
+\cgalRefines TriangulationDataStructure_3::Vertex
+
+The concept TriangulationDSVertexBase_3 describes the requirements for the vertex base class
+of a CGAL::Triangulation_data_structure_3<Vb,Cb>.
+
+Note that if the `CGAL::Triangulation_data_structure_3` is plugged into a triangulation class,
+the vertex base class may have additional geometric requirements depending on the triangulation class.
+
 At the bottom level of 3D-triangulations 
 (see Sections \ref Triangulation3secdesign and \ref TDS3secdesign), 
 a vertex provides access to one of its incident cells through a handle. 
-
-Note that when you use the triangulation data structure as parameter of a 
-geometric triangulation, the vertex base class has additional geometric 
-requirements : it has to match the `TriangulationVertexBase_3` concept. 
 
 Since the Triangulation data structure is the class which defines the handle 
 types, the vertex base class has to be somehow parameterized by the 
@@ -24,31 +28,30 @@ cell classes. The <I>rebound</I> base classes so obtained are the classes which
 are used as base classes for the final vertex and cell classes. 
 More information can be found in Section \ref TDS3secdesign. 
 
-\cgalHasModel CGAL::Triangulation_ds_vertex_base_3 
-\cgalHasModel CGAL::Triangulation_vertex_base_3 
-\cgalHasModel CGAL::Triangulation_vertex_base_with_info_3 
+\cgalHasModel `CGAL::Triangulation_ds_vertex_base_3<TDS>`
 
-\sa `TriangulationVertexBase_3` 
-\sa `TriangulationHierarchyVertexBase_3` 
-\sa `TriangulationDSCellBase_3` 
-\sa `TriangulationCellBase_3` 
+\sa `TriangulationDSCellBase_3`
+\sa `CGAL::Triangulation_data_structure_3<Vb,Cb>`
 
 */
 
-class TriangulationDSVertexBase_3 {
+class TriangulationDSVertexBase_3
+  : public TriangulationDataStructure_3::Vertex
+{
 public:
 
 /// \name Types 
 /// @{
 
 /*!
-This template class has to define a type `Rebind_TDS<TDS2>::%Other` which is the 
+This template class has to define a type `Rebind_TDS<TDS3>::%Other` which is the
 <I>rebound</I> vertex, that is, the one whose `Triangulation_data_structure` 
-will be the actually used one. `Rebind_TDS<TDS2>::%Other` will be the real base 
+will be the actually used one. `Rebind_TDS<TDS3>::%Other` will be the real base
 class of `Triangulation_data_structure_3::Vertex`.
 \note It can be implemented using a nested template class.
+\sa Section \ref tds3cyclic
 */ 
-template <typename TDS2> 
+template <typename TDS3>
 using Rebind_TDS = unspecified_type; 
 
 /*!
@@ -74,32 +77,12 @@ typedef TriangulationDataStructure_3::Cell_handle Cell_handle;
 /*!
 Default constructor. 
 */ 
-TriangulationVertexBase_3(); 
+TriangulationDSVertexBase_3();
 
 /*!
 Constructs a vertex pointing to cell `c`. 
 */ 
-TriangulationVertexBase_3(Cell_handle c); 
-
-/// @} 
-
-/// \name Access Functions 
-/// @{
-
-/*!
-Returns the pointer to an incident cell 
-*/ 
-Cell_handle cell() const; 
-
-/// @} 
-
-/// \name Setting 
-/// @{
-
-/*!
-Sets the incident cell. 
-*/ 
-void set_cell(Cell_handle c); 
+TriangulationDSVertexBase_3(Cell_handle c);
 
 /// @} 
 

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
@@ -38,9 +38,7 @@ the dimension of the triangulation is lower than 3
 (see Section \ref TDS3secintro). 
 
 Thus, a 3D-triangulation data structure can store a triangulation of a 
-topological sphere \f$ S^d\f$ of \f$ \mathbb{R}^{d+1}\f$, for any \f$ d \in \{-1,0,1,2,3\}\f$.<BR> 
-
- 
+topological sphere \f$ S^d\f$ of \f$ \mathbb{R}^{d+1}\f$, for any \f$ d \in \{-1,0,1,2,3\}\f$.<BR>
 
 The second template parameter of the basic triangulation class 
 (see Chapter \ref chapterTriangulation3 "3D Triangulations") 
@@ -67,7 +65,7 @@ neighbors of each cell, where the index corresponds to the preceding
 list of cells. When dimension < 3, the same information is stored 
 for faces of maximal dimension instead of cells. 
 
-\cgalHasModel `CGAL::Triangulation_data_structure_3` 
+\cgalHasModel `CGAL::Triangulation_data_structure_3<Vb, Cb>`
 
 \sa `TriangulationDataStructure_3::Vertex` 
 \sa `TriangulationDataStructure_3::Cell` 
@@ -89,6 +87,11 @@ typedef unspecified_type Vertex;
   %Cell type, requirements are described in `TriangulationDataStructure_3::Cell`.
 */
 typedef unspecified_type Cell;
+
+/*!
+  %Cell data type, requirements are described in `TriangulationDataStructure_3::Cell_data`.
+*/
+typedef unspecified_type Cell_data;
 
 /*!
 Size type (unsigned integral type) 
@@ -1161,6 +1164,7 @@ In order to obtain new cells or destruct unused cells, the user must call the
 structure. 
 
 \sa `TriangulationDataStructure_3::Vertex`
+\sa `TriangulationDataStructure_3::Cell_data`
 
 */
 
@@ -1184,6 +1188,11 @@ typedef TriangulationDataStructure_3::Vertex_handle Vertex_handle;
 
 */ 
 typedef TriangulationDataStructure_3::Cell_handle Cell_handle; 
+
+/*!
+
+*/
+typedef TriangulationDataStructure_3::Cell_data TDS_data;
 
 /// @} 
 
@@ -1272,6 +1281,26 @@ Cell_handle n3);
 
 /// @} 
 
+/// \name Internal
+/// \cgalAdvancedBegin
+/// These functions are used internally by the triangulation data
+/// structure. The user is not encouraged to use them directly as they
+/// may change in the future.
+/// \cgalAdvancedEnd
+/// @{
+
+/*!
+
+*/
+TDS_data& tds_data();
+
+/*!
+
+*/
+const TDS_data& tds_data() const;
+
+/// @}
+
 /// \name Checking 
 /// @{
 
@@ -1286,3 +1315,67 @@ bool is_valid(bool verbose = false, int level = 0) const;
 /// @}
 
 }; /* end Cell */
+
+
+/*!
+\ingroup PkgTDS3Concepts
+\cgalConcept
+
+Various algorithms using a triangulation data structure, such as Delaunay triangulations
+or Alpha Shapes, must be able to associate a state to a cell elemental.
+For efficiency, this information must be stored directly within the cell.
+
+This class is only meant to store a state (Boolean). Consequently, the state must be the default
+value (i.e. `false`) unless a setting function (`mark_in_conflict()`, etc.) has been called.
+
+The three states are "in conflict", "on boundary", and "processed".
+By default, a cell is not in conflict, not on boundary, and not processed.
+
+\sa `TriangulationDataStructure_3::Cell`
+
+*/
+
+class TriangulationDataStructure_3::Cell_data
+{
+public:
+  /// \name Setting
+  /// @{
+
+  /// Clears all flags: the cell is neither in conflict, nor on the boundary, nor processed.
+  void clear();
+
+  /// Sets the "in conflict" state to `true`.
+  ///
+  /// \post `is_in_conflict()` returns `true`
+  void mark_in_conflict();
+
+  /// Sets the "on boundary" state to `true`.
+  ///
+  /// \post `is_on_boundary()` returns `true`
+  void mark_on_boundary();
+
+  /// Sets the "processed" state to `true`.
+  ///
+  /// \post `processed()` returns `true`
+  void mark_processed();
+
+  /// @}
+
+  /// \name Access Functions
+  /// @{
+
+  /// Checks whether the cell has default state (not in conflict, not on boundary, not processed).
+  bool is_clear();
+
+  /// Returns whether the cell has been marked as "in conflict".
+  bool is_in_conflict();
+
+  /// Returns whether the cell has been marked as "on boundary".
+  bool is_on_boundary();
+
+  /// Returns whether the cell has been marked as "processed".
+  bool processed();
+
+  /// @}
+
+}; /* end Cell_data */

--- a/TDS_3/doc/TDS_3/PackageDescription.txt
+++ b/TDS_3/doc/TDS_3/PackageDescription.txt
@@ -50,13 +50,14 @@ Section  \ref TDS3secintro.)
 
 - `TriangulationDataStructure_3`
 - `TriangulationDataStructure_3::Cell`
+- `TriangulationDataStructure_3::Cell_data`
 - `TriangulationDataStructure_3::Vertex`
 - `TriangulationDSCellBase_3`
 - `TriangulationDSVertexBase_3`
 
 \cgalCRPSection{Classes}
 
-- `CGAL::Triangulation_data_structure_3<VertexBase,CellBase,ConcurrencyTag>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
+- `CGAL::Triangulation_data_structure_3<Vb,Cb,CT>` is a model for the concept of the 3D-triangulation data structure `TriangulationDataStructure_3`. It is templated by base classes for vertices and cells.
 
 \cgal provides base vertex classes and base cell classes:
 

--- a/TDS_3/test/TDS_3/include/CGAL/_test_cls_tds_cell.h
+++ b/TDS_3/test/TDS_3/include/CGAL/_test_cls_tds_cell.h
@@ -88,11 +88,6 @@ _test_cell_tds_3(const Tds &)
    assert(c2->index(v1)==0);
    assert(c2->index(v2)==1);
    assert(c2->index(v3)==2);
-   //   c2->set_vertices();
-   //   assert(c2->vertex(0)==NULL);
-   //   assert(c2->vertex(1)==NULL);
-   //   assert(c2->vertex(2)==NULL);
-   //   assert(c2->vertex(3)==NULL);
    c2->set_vertices(v0, v1, v2, v3);
    assert(c2->index(v0)==0);
    assert(c2->index(v1)==1);
@@ -107,11 +102,6 @@ _test_cell_tds_3(const Tds &)
    assert(c2->index(n1)==0);
    assert(c2->index(n2)==1);
    assert(c2->index(n3)==2);
-   //   c2->set_neighbors();
-   //   assert(c2->neighbor(0)==NULL);
-   //   assert(c2->neighbor(1)==NULL);
-   //   assert(c2->neighbor(2)==NULL);
-   //   assert(c2->neighbor(3)==NULL);
    c2->set_neighbors(n0, n1, n2, n3);
    assert(c2->index(n0)==0);
    assert(c2->index(n1)==1);


### PR DESCRIPTION
## Summary of Changes

Some cleaning in TDS_23, only doc, no breaking changes:

* Properly document the refinement of concepts (e.g. `TriangulationDSCell_3` refines `TDS3::Cell`)
* Don't duplicate requirements between concepts that refine each other, instead inherit the concept 
* Fix `Cell_data`'s doc that was all broken. `Cell_data` can't be defined at the level of `TriangulationDSCell_3`, but it must be in the concept TDS3::cell. Its API was also not documented.
* Rebind mechanisms are required by `Triangulation_data_structure_23`, not by the vertex and face/cell concepts of `TDS_23`: it's needed to a fix a circular dependency because there is a TDS class templated by a vertex and a cell, and those are template parametered by the vertex and the cell. But on paper you could define a class `My_TDS_3` that defines everything within a single class.
* Remove mentions of deprecated `TriangulationHierarchyVertexBase_3`
* Fix a bunch of typos (TDS2 in TDS3, wrong types in constructors/default values, etc.)

## Release Management

* Affected package(s): `TDS_2` `TDS_3`
* Issue(s) solved (if any): - 

