### PR TITLE
Add to the user manual example a parameter described in the text

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -60,6 +60,8 @@ int main(int argc, char* argv[])
 {
   std::ifstream in((argc>1)?argv[1]:"data/half.xyz");
   double per = (argc>2)?boost::lexical_cast<double>(argv[2]):0;
+  double radius_ratio_bound = (argc>3)?boost::lexical_cast<double>(argv[3]):5.0;
+
   std::vector<Point_3> points;
   std::vector<Facet> facets;
 
@@ -71,7 +73,8 @@ int main(int argc, char* argv[])
   CGAL::advancing_front_surface_reconstruction(points.begin(),
                                                points.end(),
                                                std::back_inserter(facets),
-                                               perimeter);
+                                               perimeter,
+                                               radius_ratio_bound);
 
   std::cout << "OFF\n" << points.size() << " " << facets.size() << " 0\n";
   std::copy(points.begin(),


### PR DESCRIPTION
The user manual at 

https://doc.cgal.org/latest/Advancing_front_surface_reconstruction/index.html 

goes to great lengths to describe the parameter radius_ratio_bound. Yet, the example right below that is meant to illustrate the code is missing it. One of course visit the reference documentation and dig up what it is and where it should go, but it can make the example more useful to actually use the parameter that is discussed. I am setting it to the value 5 that is used as the default value per the user and reference manuals. 