### PR TITLE
Graphics_view : Fix QTime warnings

### DIFF
--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -195,7 +195,6 @@ void
 DemosMainWindow::setUseAntialiasing(bool checked)
 {
   view->setRenderHint(QPainter::Antialiasing, checked);
-  view->setRenderHint(QPainter::HighQualityAntialiasing, checked);
 
   statusBar()->showMessage(tr("Antialiasing %1activated").arg(checked?"":"de-"),
                            1000);

--- a/GraphicsView/include/CGAL/Qt/manipulatedFrame.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedFrame.h
@@ -21,6 +21,7 @@
 #include <QDateTime>
 #include <QString>
 #include <QTimer>
+#include <QElapsedTimer>
 
 namespace CGAL{
 namespace qglviewer {
@@ -348,7 +349,7 @@ private:
   qreal zoomSensitivity_;
 
   // Mouse speed and spinning
-  QTime last_move_time;
+  QElapsedTimer last_move_time;
   qreal mouseSpeed_;
   int delay_;
   bool isSpinning_;

--- a/GraphicsView/include/CGAL/Qt/qglviewer.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer.h
@@ -28,7 +28,7 @@
 #include <QOpenGLBuffer>
 #include <QMap>
 #include <QVector>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QTimer>
 #include <QGLContext>
 #include <QOpenGLWidget>
@@ -1038,7 +1038,7 @@ protected:
   int animationTimerId_;
 
   // F P S    d i s p l a y
-  QTime fpsTime_;
+  QElapsedTimer fpsTime_;
   unsigned int fpsCounter_;
   QString fpsString_;
   qreal f_p_s_;

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -46,6 +46,7 @@
 #include <QColorDialog>
 #include <QOpenGLFramebufferObject>
 #include <QFileDialog>
+#include <QElapsedTimer>
 
 namespace CGAL{
 // Static private variable
@@ -2244,7 +2245,7 @@ void CGAL::QGLViewer::keyPressEvent(QKeyEvent *e) {
     unsigned int index = pathIndex_[::Qt::Key(key)];
 
     // not safe, but try to double press on two viewers at the same time !
-    static QTime doublePress;
+    static QElapsedTimer doublePress;
 
     if (modifiers == playPathKeyboardModifiers()) {
       int elapsed = doublePress.restart();

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
@@ -116,9 +116,8 @@ public Q_SLOTS:
     Point pt = *rp+Vector(0.5,0.5,0.5);
     rp++;
     insert_point(Point(pt.x(),pt.y(),(in_plane? 0.0:pt.z())));
-    QString str;
-    ui->viewer->displayMessage(str.sprintf("Added point (%f, %f, %f)",
-           pt.x(),pt.y(),(in_plane? 0.0:pt.z())));
+    ui->viewer->displayMessage(QString("Added point (%1, %2, %3)").arg(
+           pt.x()).arg(pt.y()).arg((in_plane? 0.0:pt.z())));
     changed();
   }
   void insert_point(Point p) {

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
@@ -106,9 +106,8 @@ public Q_SLOTS:
 
   void insert_mp() {
     insert_point(moving_point);
-    QString str;
-    ui->viewer->displayMessage(str.sprintf("Added point (%f, %f, %f)",
-           moving_point.x(),moving_point.y(),moving_point.z()));
+    ui->viewer->displayMessage(QString("Added point (%1, %2, %3)").arg(
+           moving_point.x()).arg(moving_point.y()).arg(moving_point.z()));
     changed();
   }
 

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/MainWindow.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/MainWindow.cpp
@@ -16,8 +16,8 @@ MainWindow::MainWindow(QWidget* parent): CGAL::Qt::DemosMainWindow(parent)
   scene.eight_copies=false;
   scene.two_dimensional=false;
 
-  QTimer = new QTimer(this);
-  connect(QTimer, SIGNAL(timeout()), this, SLOT(lloydStep()));
+  qtimer= new QTimer(this);
+  connect(qtimer, SIGNAL(timeout()), this, SLOT(lloydStep()));
 }
 
 void
@@ -65,9 +65,9 @@ MainWindow::togglePause(bool p)
 {
   if (p) {
     int speed = (100-(speedSlider->value()))*100;
-    QTimer->start(speed);
+    qtimer->start(speed);
   }
-  else QTimer->stop();
+  else qtimer->stop();
 }
 
 void
@@ -158,9 +158,9 @@ void
 MainWindow::speedChanged(int i)
 {
   int speed = (100-i)*100;
-  if (QTimer->isActive()) {
-     QTimer->stop();
-     QTimer->start(speed);
+  if (qtimer->isActive()) {
+     qtimer->stop();
+     qtimer->start(speed);
   }
 }
 

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/MainWindow.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/MainWindow.cpp
@@ -16,8 +16,8 @@ MainWindow::MainWindow(QWidget* parent): CGAL::Qt::DemosMainWindow(parent)
   scene.eight_copies=false;
   scene.two_dimensional=false;
 
-  qtimer = new QTimer(this);
-  connect(qtimer, SIGNAL(timeout()), this, SLOT(lloydStep()));
+  QTimer = new QTimer(this);
+  connect(QTimer, SIGNAL(timeout()), this, SLOT(lloydStep()));
 }
 
 void
@@ -65,9 +65,9 @@ MainWindow::togglePause(bool p)
 {
   if (p) {
     int speed = (100-(speedSlider->value()))*100;
-    qtimer->start(speed);
+    QTimer->start(speed);
   }
-  else qtimer->stop();
+  else QTimer->stop();
 }
 
 void
@@ -158,9 +158,9 @@ void
 MainWindow::speedChanged(int i)
 {
   int speed = (100-i)*100;
-  if (qtimer->isActive()) {
-     qtimer->stop();
-     qtimer->start(speed);
+  if (QTimer->isActive()) {
+     QTimer->stop();
+     QTimer->start(speed);
   }
 }
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -38,7 +38,7 @@
 #include <QSpinBox>
 #include <stdexcept>
 #include <fstream>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QWidgetAction>
 #include <QJsonArray>
 #include <QSequentialIterable>

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -1477,11 +1477,11 @@ void MainWindow::showSceneContextMenu(int selectedItemIndex,
                 this, SLOT(reloadItem()));
       }
       QAction* saveas = menu->addAction(tr("&Save as..."));
-      saveas->setData(qVariantFromValue((void*)item));
+      saveas->setData(QVariant::fromValue((void*)item));
       connect(saveas,  SIGNAL(triggered()),
               this, SLOT(on_actionSaveAs_triggered()));
       QAction* showobject = menu->addAction(tr("&Zoom to this Object"));
-      showobject->setData(qVariantFromValue((void*)item));
+      showobject->setData(QVariant::fromValue((void*)item));
       connect(showobject, SIGNAL(triggered()),
               this, SLOT(viewerShowObject()));
 

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -27,7 +27,7 @@
 
 #include <CGAL/bounding_box.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 
 #include <QAction>
 #include <QMainWindow>
@@ -1241,7 +1241,7 @@ void Polyhedron_demo_cut_plugin::computeIntersection()
   Simple_kernel::Plane_3 plane(n[0], n[1],  n[2], - n * pos);
   //std::cerr << plane << std::endl;
   edges_item->edges.clear();
-  QTime time;
+  QElapsedTimer time;
   time.start();
   bool does_intersect = false;
   for(Facet_sm_trees::iterator it = facet_sm_trees.begin(); it != facet_sm_trees.end(); ++it)

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_decomposition/Nef_plugin.cpp
@@ -8,7 +8,7 @@
 #include <QMenu>
 #include <QMainWindow>
 #include <QApplication>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMessageBox>
 using namespace CGAL::Three;
 class Polyhedron_demo_nef_plugin :
@@ -115,7 +115,7 @@ Polyhedron_demo_nef_plugin::on_actionToNef_triggered()
   }
 
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::cerr << "Convert facegraph to nef polyhedron...";
 
@@ -146,7 +146,7 @@ Polyhedron_demo_nef_plugin::on_actionConvexDecomposition_triggered()
            : qobject_cast<Scene_nef_polyhedron_item*>(scene->item(index));
   QApplication::restoreOverrideCursor();
   if(item) {
-    QTime time;
+    QElapsedTimer time;
     time.start();
     std::cerr << "Convex decomposition...";
 
@@ -188,7 +188,7 @@ Polyhedron_demo_nef_plugin::on_actionToPoly_triggered()
   if(item)
   {
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    QTime time;
+    QElapsedTimer time;
     time.start();
     std::cerr << "Convert nef polyhedron to facegraph...";
 
@@ -277,7 +277,7 @@ void Polyhedron_demo_nef_plugin::boolean_operation(const Boolean_operation opera
 
  // perform Boolean operation
   std::cout << "Boolean operation...";
-  QTime time;
+  QElapsedTimer time;
   time.start();
   switch(operation)
   {

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/Convex_hull_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/Convex_hull_plugin.cpp
@@ -1,4 +1,4 @@
-#include <QTime>
+#include <QElapsedTimer>
 #include <QApplication>
 #include <QAction>
 #include <QMainWindow>
@@ -74,7 +74,7 @@ void Polyhedron_demo_convex_hull_plugin::on_actionConvexHull_triggered()
     // wait cursor
     QApplication::setOverrideCursor(Qt::WaitCursor);
     
-    QTime time;
+    QElapsedTimer time;
     time.start();
     std::cout << "Convex hull...";
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_2/Mesh_2_plugin.cpp
@@ -35,7 +35,7 @@
 
 #include <CGAL/boost/graph/Euler_operations.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>
@@ -266,14 +266,14 @@ private:
     typedef CGAL::Delaunay_mesh_size_criteria_2<CDT>               Criteria;
     typedef CGAL::Delaunay_mesher_2<CDT, Criteria>                   Mesher;
 
-    QTime time; // global timer
+    QElapsedTimer time; // global timer
     time.start();
 
     std::cout << " Building Constrained_Delaunay_triangulation_2..."
               << std::flush;
     CDT cdt;
 
-    QTime ltime; //local timer
+    QElapsedTimer ltime; //local timer
     ltime.start();
     double constant_coordinate =
       polylines_items.back()->polylines.back().back()[constant_coordinate_index];

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -708,9 +708,9 @@ private:
     Volume_plane<y_tag> *y_item = new Volume_plane<y_tag>(img->image()->tx,img->image()->ty, img->image()->tz);
     Volume_plane<z_tag> *z_item = new Volume_plane<z_tag>(img->image()->tx,img->image()->ty, img->image()->tz);
 
-    x_item->setProperty("img",qVariantFromValue((void*)seg_img));
-    y_item->setProperty("img",qVariantFromValue((void*)seg_img));
-    z_item->setProperty("img",qVariantFromValue((void*)seg_img));
+    x_item->setProperty("img",QVariant::fromValue((void*)seg_img));
+    y_item->setProperty("img",QVariant::fromValue((void*)seg_img));
+    z_item->setProperty("img",QVariant::fromValue((void*)seg_img));
 
     x_item->setColor(QColor("red"));
     y_item->setColor(QColor("green"));

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_thread.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Meshing_thread.cpp
@@ -16,7 +16,7 @@
 
 #include "config.h"
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QApplication>
 
 #include "Meshing_thread.h"
@@ -52,7 +52,7 @@ void
 Meshing_thread::
 run()
 {
-  QTime timer;
+  QElapsedTimer timer;
   timer.start();
   CGAL::Three::Three::CursorScopeGuard guard(Qt::BusyCursor);
   f_->launch();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimizer_thread.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimizer_thread.cpp
@@ -16,7 +16,7 @@
 
 #include "config_mesh_3.h"
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QTimer>
 #include "Optimizer_thread.h"
 #include "Scene_c3t3_item.h"
@@ -47,7 +47,7 @@ void
 Optimizer_thread::
 run()
 {
-  QTime timer;
+  QElapsedTimer timer;
   timer.start();
   //SEGFAULT
   rc_ = f_->launch();

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Partition_graph_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Partition_graph_plugin.cpp
@@ -14,7 +14,7 @@
 #include <QMenu>
 #include <QMainWindow>
 #include <QApplication>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMessageBox>
 
 typedef Scene_surface_mesh_item Scene_facegraph_item;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Affine_transform_plugin.cpp
@@ -21,7 +21,7 @@
 #include <QDockWidget>
 #include <QDialog>
 #include <QApplication>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMessageBox>
 
 #include "ui_Transformation_widget.h"

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Fairing_plugin.cpp
@@ -14,7 +14,7 @@ typedef Scene_surface_mesh_item Scene_facegraph_item;
 #include <CGAL/Polygon_mesh_processing/fair.h>
 #include <CGAL/Polygon_mesh_processing/refine.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -18,7 +18,7 @@
 #include <CGAL/Timer.h>
 #include <CGAL/iterator.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -23,7 +23,7 @@
 #include <boost/unordered_set.hpp>
 #include <CGAL/property_map.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>
@@ -340,7 +340,7 @@ public Q_SLOTS:
       // wait cursor
       QApplication::setOverrideCursor(Qt::WaitCursor);
 
-      QTime time;
+      QElapsedTimer time;
       time.start();
 
       typedef boost::graph_traits<FaceGraph>::edge_descriptor edge_descriptor;
@@ -698,7 +698,7 @@ public Q_SLOTS:
       detect_and_split_duplicates(selection, edges_to_protect, target_length);
 
 #ifdef CGAL_LINKED_WITH_TBB
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
       tbb::parallel_for(
@@ -714,7 +714,7 @@ public Q_SLOTS:
       target_length, nb_iter, protect, smooth_features);
     for(Scene_facegraph_item* poly_item : selection)
     {
-      QTime time;
+      QElapsedTimer time;
       time.start();
 
       remesher(poly_item, edges_to_protect[poly_item->polyhedron()]);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -14,7 +14,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QInputDialog>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMessageBox>
 
 #include <Eigen/Sparse>
@@ -368,7 +368,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSegment()
   if (num_vertices(item->skeleton_curve)==0 ) { QApplication::restoreOverrideCursor(); return;}
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
 
     // init the polyhedron simplex indices
@@ -461,7 +461,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConvert_to_me
 
     if ( !is_mesh_valid(pMesh) ) return;
 
-    QTime time;
+    QElapsedTimer time;
     time.start();
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
@@ -499,7 +499,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionContract()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::cout << "Contract...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -524,7 +524,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionCollapse()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::cout << "Collapse...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -550,7 +550,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSplit()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::cout << "Split...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -575,7 +575,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionDegeneracy()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::cout << "Detect degeneracy...\n";
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -626,7 +626,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionRun()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
@@ -749,7 +749,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionSkeletonize()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
@@ -810,7 +810,7 @@ void Polyhedron_demo_mean_curvature_flow_skeleton_plugin::on_actionConverge()
     return;
   }
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Polyhedron_slicer_plugin.cpp
@@ -16,7 +16,7 @@
 #include <CGAL/bounding_box.h> 
 #include <CGAL/Polygon_mesh_slicer.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>
@@ -287,7 +287,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
   if(!new_polyline_item_for_polylines) 
   {
     Scene_polylines_item* new_polylines_item = new Scene_polylines_item();
-    QTime time; time.start();
+    QElapsedTimer time; time.start();
     // call algorithm and fill polylines in polylines_item
     intersection_of_plane_Polyhedra_3_using_AABB_wrapper(*smesh, planes, plane_positions, new_polylines_item->polylines);
     // set names etc and print timing
@@ -301,7 +301,7 @@ void Polyhedron_demo_polyhedron_slicer_plugin::on_Generate_button_clicked()
     scene->addItem(new_polylines_item);
   }
   else {
-    QTime time; time.start();
+    QElapsedTimer time; time.start();
     std::list<std::vector<Epic_kernel::Point_3> > polylines;
     // call algorithm and fill polylines in polylines_item
     intersection_of_plane_Polyhedra_3_using_AABB_wrapper(*smesh, planes, plane_positions, polylines);

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Random_perturbation_plugin.cpp
@@ -16,7 +16,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <CGAL/property_map.h>
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>
@@ -94,7 +94,7 @@ public Q_SLOTS:
 
     // wait cursor
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     std::cout << "Perturbation..." << std::endl;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
@@ -17,7 +17,7 @@
 
 #include "ui_Smoothing_plugin.h"
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QMainWindow>
 #include <QApplication>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Surface_intersection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Surface_intersection_plugin.cpp
@@ -15,7 +15,7 @@
 #include <QMenu>
 #include <QMainWindow>
 #include <QApplication>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMessageBox>
 
 typedef Scene_surface_mesh_item Scene_face_graph_item;
@@ -130,7 +130,7 @@ void Polyhedron_demo_intersection_plugin::intersectionSurfaces()
 
       Scene_polylines_item* new_item = new Scene_polylines_item();
      // perform Boolean operation
-      QTime time;
+      QElapsedTimer time;
       time.start();
 
       try{
@@ -193,7 +193,7 @@ void Polyhedron_demo_intersection_plugin::intersectionPolylines()
       Scene_points_with_normal_item* new_point_item = new Scene_points_with_normal_item();
       Scene_polylines_item* new_pol_item = new Scene_polylines_item();
      // perform Boolean operation
-      QTime time;
+      QElapsedTimer time;
       time.start();
       std::vector<Polyline_3> polyA, polyB;
       Q_FOREACH(const Polyline_3& poly, itemA->polylines)
@@ -289,7 +289,7 @@ void Polyhedron_demo_intersection_plugin::intersectionSurfacePolyline()
   Scene_points_with_normal_item* new_point_item = new Scene_points_with_normal_item();
   Scene_polylines_item* new_pol_item = new Scene_polylines_item();
   // perform Boolean operation
-  QTime time;
+  QElapsedTimer time;
   time.start();
   Scene_face_graph_item::Face_graph tm = *itemA->face_graph();
   std::vector<face_descriptor> Afaces;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Surface_reconstruction_plugin.cpp
@@ -1,4 +1,4 @@
-#include <QTime>
+#include <QElapsedTimer>
 #include <QApplication>
 #include <QAction>
 #include <QList>

--- a/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Subdivision_methods/Subdivision_methods_plugin.cpp
@@ -1,4 +1,4 @@
-#include <QTime>
+#include <QElapsedTimer>
 #include <QApplication>
 #include <QMainWindow>
 #include <QAction>
@@ -81,7 +81,7 @@ template<class FaceGraphItem>
 void Polyhedron_demo_subdivision_methods_plugin::apply_loop(FaceGraphItem* item, int nb_steps)
 {
   typename FaceGraphItem::Face_graph* graph = item->face_graph();
-  QTime time;
+  QElapsedTimer time;
   time.start();
   CGAL::Three::Three::information("Loop subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -113,7 +113,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_catmullclark(FaceGraphIte
 {
   typename FaceGraphItem::Face_graph* graph = item->face_graph();
   if(!graph) return;
-  QTime time;
+  QElapsedTimer time;
   time.start();
   CGAL::Three::Three::information("Catmull-Clark subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -143,7 +143,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_sqrt3(FaceGraphItem* item
 {
   typename FaceGraphItem::Face_graph* graph = item->face_graph();
   if(!graph) return;
-  QTime time;
+  QElapsedTimer time;
   time.start();
   CGAL::Three::Three::information("Sqrt-3 subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -175,7 +175,7 @@ void Polyhedron_demo_subdivision_methods_plugin::apply_doosabin(FaceGraphItem* i
 {
   typename FaceGraphItem::Face_graph* graph = item->face_graph();
   if(!graph) return;
-  QTime time;
+  QElapsedTimer time;
   time.start();
   CGAL::Three::Three::information("Doo-Sabin subdivision...");
   QApplication::setOverrideCursor(Qt::WaitCursor);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_plane_detection_plugin.cpp
@@ -9,7 +9,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QInputDialog>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QDebug>
 #include <QObject>
@@ -196,7 +196,7 @@ void Polyhedron_demo_mesh_plane_detection_plugin::on_actionPlaneDetection_trigge
       if(dialog.exec() == QDialog::Rejected)
         return;
 
-      QTime time;
+      QElapsedTimer time;
       time.start();
       std::cerr << "Detecting planes... ";
       QApplication::setOverrideCursor(Qt::WaitCursor);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_segmentation_plugin.cpp
@@ -10,7 +10,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QInputDialog>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QDebug>
 #include <QObject>
@@ -210,7 +210,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::apply_SDF_button_clicked(Facegrap
   typename boost::property_map<Facegraph, CGAL::face_index_t>::type fidmap =
       get(CGAL::face_index, *pair->first->face_graph());
   FaceGraph_with_id_to_vector_property_map<Facegraph, double> sdf_pmap(&pair->second, fidmap);
-  QTime time;
+  QElapsedTimer time;
   time.start();
   std::pair<double, double> min_max_sdf = sdf_values(*(pair->first->face_graph()), sdf_pmap, cone_angle, number_of_rays);
   std::cout << "ok (" << time.elapsed() << " ms)" << std::endl;
@@ -283,7 +283,7 @@ void Polyhedron_demo_mesh_segmentation_plugin::apply_Partition_button_clicked(Fa
     QApplication::setOverrideCursor(Qt::WaitCursor);
   }
   check_and_set_ids(pair->first->face_graph());
-  QTime time;
+  QElapsedTimer time;
   time.start();
   typename boost::property_map<Facegraph, CGAL::face_index_t>::type fidmap =
       get(CGAL::face_index, *pair->first->face_graph());

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -6,7 +6,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QInputDialog>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 
 #include <CGAL/Surface_mesh_simplification/HalfedgeGraph_Polyhedron_3.h>
@@ -137,7 +137,7 @@ void Polyhedron_demo_mesh_simplification_plugin::on_actionSimplify_triggered()
       return;
 
     // simplify
-    QTime time;
+    QElapsedTimer time;
     time.start();
     std::cout << "Simplify...";
     QApplication::setOverrideCursor(Qt::WaitCursor);

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -11,7 +11,7 @@
 #include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
 #include <CGAL/Three/Three.h>
 #include "Scene.h"
-#include <QTime>
+#include <QElapsedTimer>
 #include <QGraphicsScene>
 #include <QGraphicsItem>
 #include <QPen>
@@ -602,7 +602,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
   ////////// PARAMETERIZE ///////////
   ///////////////////////////////////
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   // add textured polyhedon to the scene
   

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Scene_polyhedron_shortest_path_item.cpp
@@ -472,7 +472,7 @@ bool Scene_polyhedron_shortest_path_item_priv::run_point_select(const Ray_3& ray
 
         CGAL::Three::Three::information(QObject::tr("Computing shortest path polyline..."));
 
-        QTime time;
+        QElapsedTimer time;
         time.start();
         //~ m_shortestPaths->m_debugOutput=true;
         m_shortestPaths->shortest_path_points_to_source_points(

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Shortest_path_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Shortest_path_plugin.cpp
@@ -12,7 +12,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QInputDialog>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QDebug>
 #include <QObject>

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Surface_mesh_approximation_plugin.cpp
@@ -1,6 +1,6 @@
 #include <QApplication>
 #include <QMainWindow>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QAction>
 #include <QObject>
 #include <QDockWidget>
@@ -303,7 +303,7 @@ void Polyhedron_demo_surface_mesh_approximation_plugin::on_buttonSeeding_clicked
   approx.set_metric(static_cast<VSA_wrapper::Metric>(
     ui_widget.comboMetric->currentIndex()));
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
   approx.initialize_seeds(CGAL::parameters::seeding_method(
     static_cast<VSA::Seeding_method>(ui_widget.comboMethod->currentIndex()))

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Scene_edit_polyhedron_item.cpp
@@ -10,7 +10,7 @@
 #include <CGAL/Three/Point_container.h>
 #include <CGAL/Qt/constraint.h>
 #include <algorithm>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include <QApplication>
 

--- a/Surface_mesher/demo/Surface_mesher/volume.cpp
+++ b/Surface_mesher/demo/Surface_mesher/volume.cpp
@@ -21,7 +21,7 @@
 #include <QDoubleSpinBox>
 #include <QMessageBox>
 #include <QTreeWidgetItem>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QColor>
 #include <QColorDialog>
 #include <QSettings>
@@ -708,7 +708,7 @@ void Volume::display_marchin_cube()
 #ifdef CGAL_SURFACE_MESH_DEMO_USE_MARCHING_CUBE
   if(m_surface_mc.empty())
   {
-    QTime total_time;
+    QElapsedTimer total_time;
     total_time.start();
 
     values_list->save_values(fileinfo.absoluteFilePath());
@@ -824,7 +824,7 @@ void Volume::display_surface_mesher_result()
      m_view_surface) // Or it is computed and displayed, and one want
                      // to recompute it.
   {
-    QTime total_time;
+    QElapsedTimer total_time;
     total_time.start();
 
     values_list->save_values(fileinfo.absoluteFilePath());


### PR DESCRIPTION
## Summary of Changes

Replace `QTime`s  by `QElapsedTimer`s. It seems the header of QTime has been deprecated but it has not been documented...

## Release Management

* Affected package(s):Graphics_view