### PR TITLE
SMP: Fix bad usage of pragma message

### DIFF
--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -93,6 +93,7 @@
 #include <boost/foreach.hpp>
 #include <boost/function_output_iterator.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/unordered_set.hpp>
 
 #include <iostream>
@@ -183,6 +184,11 @@ public:
     BorderParameterizer_,
     Two_vertices_parameterizer_3<TriangleMesh_> >::type       Border_parameterizer;
 
+  #if !defined(CGAL_EIGEN3_ENABLED)
+  CGAL_static_assertion_msg(!(boost::is_same<SolverTraits_, Default>::value),
+                            "Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library");
+  #endif
+
   typedef typename Default::Get<
     SolverTraits_,
   #if defined(CGAL_EIGEN3_ENABLED)
@@ -194,7 +200,6 @@ public:
         Eigen::SparseLU<Eigen_sparse_matrix<double>::EigenType> >
     #endif
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
     SolverTraits_ // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
   >::type                                                     Solver_traits;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
@@ -97,7 +97,6 @@ class Barycentric_mapping_parameterizer_3
           Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                           Eigen::IncompleteLUT<double> > > >::type >
 #else
-  #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
         SolverTraits_>::type > // no parameter provided, and Eigen is not enabled: so don't compile!
 #endif
 {

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_authalic_parameterizer_3.h
@@ -101,7 +101,6 @@ class Discrete_authalic_parameterizer_3
           Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                           Eigen::IncompleteLUT<double> > > >::type >
 #else
-  #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
        SolverTraits_>::type > // no parameter provided, and Eigen is not enabled: don't compile
 #endif
 {

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_conformal_map_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_conformal_map_parameterizer_3.h
@@ -101,7 +101,6 @@ class Discrete_conformal_map_parameterizer_3
           Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                           Eigen::IncompleteLUT<double> > > >::type >
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
          SolverTraits_>::type > // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
 {

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
@@ -44,6 +44,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/function_output_iterator.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/unordered_set.hpp>
 
 /// \file Fixed_border_parameterizer_3.h
@@ -114,6 +115,11 @@ public:
     BorderParameterizer_,
     Circular_border_arc_length_parameterizer_3<TriangleMesh_> >::type  Border_parameterizer;
 
+  #if !defined(CGAL_EIGEN3_ENABLED)
+  CGAL_static_assertion_msg(!(boost::is_same<SolverTraits_, Default>::value),
+                            "Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library");
+  #endif
+
   typedef typename Default::Get<
     SolverTraits_,
   #if defined(CGAL_EIGEN3_ENABLED)
@@ -121,7 +127,6 @@ public:
       Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                       Eigen::IncompleteLUT<double> > >
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library");
     SolverTraits_ // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
   >::type                                                     Solver_traits;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -99,7 +99,6 @@ public:
       Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                       Eigen::IncompleteLUT<double> > >
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
     SolverTraits_ // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
   >::type                                                     Solver_traits;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Mean_value_coordinates_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Mean_value_coordinates_parameterizer_3.h
@@ -99,7 +99,6 @@ class Mean_value_coordinates_parameterizer_3
             Eigen::BiCGSTAB<Eigen_sparse_matrix<double>::EigenType,
                             Eigen::IncompleteLUT<double> > > >::type >
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library");
          SolverTraits_>::type > // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
 {

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
@@ -52,6 +52,7 @@
 #include <boost/array.hpp>
 #include <boost/foreach.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 
@@ -393,6 +394,11 @@ class Orbifold_Tutte_parameterizer_3
 {
 public:
 #ifndef DOXYGEN_RUNNING
+  #if !defined(CGAL_EIGEN3_ENABLED)
+  CGAL_static_assertion_msg(!(boost::is_same<SolverTraits_, Default>::value),
+                            "Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library");
+  #endif
+
   typedef typename Default::Get<
     SolverTraits_,
   #if defined(CGAL_EIGEN3_ENABLED)
@@ -404,7 +410,6 @@ public:
         Eigen::SparseLU<Eigen_sparse_matrix<double>::EigenType> >
     #endif
   #else
-    #pragma message("Error: You must either provide 'SolverTraits_' or link CGAL with the Eigen library")
     SolverTraits_ // no parameter provided, and Eigen is not enabled: so don't compile!
   #endif
   >::type                                                     Solver_traits;


### PR DESCRIPTION
## Summary of Changes
I added a pragma message in 9eebcfb so that the error is not just something like `CGAL::Default has no type Vector`. However, it was badly done since the pragma message will show up as soon as Eigen is not linked, even if the user has correctly provided a traits class.

Reported in https://github.com/CGAL/cgal/issues/4442#issuecomment-570511774.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any):