### PR TITLE
Straight_skeleton_builder_2_impl.h: Get more precision for free.

### DIFF
--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -1421,8 +1421,8 @@ double angle_wrt_X ( Point const& a, Point const& b )
   double dx = to_double(b.x() - a.x() ) ;
   double dy = to_double(b.y() - a.y() ) ;
   double atan = std::atan2(dy,dx);
-  double rad  = atan >= 0.0 ? atan : 2.0 * 3.141592 + atan ;
-  double deg  = rad * 180.0 / 3.141592 ;
+  double rad  = atan >= 0.0 ? atan : 2.0 * 3.141592653589793238462643 + atan ;
+  double deg  = rad * 180.0 / 3.141592653589793238462643;
   return deg ;
 }
 


### PR DESCRIPTION
## Summary of Changes

The compute speed of double precision does not depend on the number of decimals,
so it's free and better to use more than 5 or 6 decimals for PI.

## Release Management

* Affected package(s): `Straight_skeleton_2`
* Issue(s) solved (if any): fix #4445

