### PR TITLE
Add control over hole size in the hole-filling example

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -412,10 +412,13 @@ one incident non-null face) after each hole filling step.
 Holes are filled one after the other, and the process stops when there is no border edge left.
 
 This process is illustrated by the example below, where holes are
-iteratively filled, refined and faired to get a faired mesh with no hole.
+iteratively filled, refined and faired. Optionally, only holes
+not exceeding a certain diameter or number of edges can be filled.
+This example assumes that the mesh is stored in a `Surface_mesh`
+datastructure. Analogous examples when using the `Polyhedron_3`
+class and a few others are part of the code base.
 
-
-\cgalExample{Polygon_mesh_processing/hole_filling_example.cpp}
+\cgalExample{Polygon_mesh_processing/hole_filling_example_SM.cpp}
 
  \cgalFigureBegin{Triangulated_fork, fork.jpg}
  Holes in the fork model are filled with triangle patches.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -2,6 +2,7 @@
 
 \example Polygon_mesh_processing/self_intersections_example.cpp
 \example Polygon_mesh_processing/hole_filling_example.cpp
+\example Polygon_mesh_processing/hole_filling_example_SM.cpp
 \example Polygon_mesh_processing/stitch_borders_example.cpp
 \example Polygon_mesh_processing/compute_normals_example.cpp
 \example Polygon_mesh_processing/point_inside_example.cpp

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
@@ -4,6 +4,8 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 #include <CGAL/Polygon_mesh_processing/border.h>
 
+#include <boost/lexical_cast.hpp>
+
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_SM.cpp
@@ -6,32 +6,77 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <set>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point;
 typedef CGAL::Surface_mesh<Point> Mesh;
 
-typedef boost::graph_traits<Mesh>::halfedge_descriptor    halfedge_descriptor;
+typedef boost::graph_traits<Mesh>::halfedge_descriptor   halfedge_descriptor;
 typedef boost::graph_traits<Mesh>::face_descriptor       face_descriptor;
-typedef boost::graph_traits<Mesh>::vertex_descriptor      vertex_descriptor;
+typedef boost::graph_traits<Mesh>::vertex_descriptor     vertex_descriptor;
+
+bool is_small_hole(halfedge_descriptor h, Mesh & mesh,
+                   std::set<Point> & examined_points,
+                   double max_hole_diam, int max_num_hole_edges)
+{
+  int num_hole_edges = 0;
+  auto cvpm = CGAL::get_const_property_map(CGAL::vertex_point, mesh);
+  CGAL::Halfedge_around_face_circulator<Mesh> circ(h, mesh), done(circ);
+  CGAL::Bbox_3 hole_bbox;
+
+  do {
+    Point p = get(cvpm, target(*circ, mesh));
+
+    if (examined_points.find(p) != examined_points.end())
+      return false;
+    examined_points.insert(p);
+
+    hole_bbox += CGAL::Bbox_3(p.x(), p.y(), p.z(), p.x(), p.y(), p.z());
+    num_hole_edges++;
+
+    // Exit early, to avoid unnecessary traversal of large holes
+    if (num_hole_edges > max_num_hole_edges) return false;
+    if (hole_bbox.xmax() - hole_bbox.xmin() > max_hole_diam) return false;
+    if (hole_bbox.ymax() - hole_bbox.ymin() > max_hole_diam) return false;
+    if (hole_bbox.zmax() - hole_bbox.zmin() > max_hole_diam) return false;
+  } while (++circ != done);
+
+  return true;
+}
+
+// Incrementally fill the holes that are no larger than given diameter
+// and with no more than a given number of edges (if specified).
 
 int main(int argc, char* argv[])
 {
   const char* filename = (argc > 1) ? argv[1] : "data/mech-holes-shark.off";
-  std::ifstream input(filename);
 
+  // Both of these must be positive in order to be considered
+  double max_hole_diam   = (argc > 2) ? boost::lexical_cast<double>(argv[2]): -1.0;
+  int max_num_hole_edges = (argc > 3) ? boost::lexical_cast<int>(argv[3]) : -1;
+
+  std::ifstream input(filename);
   Mesh mesh;
   if ( !input || !(input >> mesh) ) {
     std::cerr << "Not a valid off file." << std::endl;
     return 1;
   }
 
-  // Incrementally fill the holes
+  // Avoid examining a hole we studied before using a different half edge.
+  std::set<Point> examined_points;
+
   unsigned int nb_holes = 0;
   for(halfedge_descriptor h : halfedges(mesh))
   {
     if(is_border(h,mesh))
     {
+
+      if(max_hole_diam > 0 && max_num_hole_edges > 0 &&
+         !is_small_hole(h, mesh, examined_points,
+                        max_hole_diam, max_num_hole_edges))
+        continue;
+
       std::vector<face_descriptor>  patch_facets;
       std::vector<vertex_descriptor> patch_vertices;
       bool success = std::get<0>(
@@ -52,8 +97,10 @@ int main(int argc, char* argv[])
 
   std::cout << std::endl;
   std::cout << nb_holes << " holes have been filled" << std::endl;
-  
-  std::ofstream out("filled_SM.off");
+
+  std::string outfile = "filled_SM.off";
+  std::ofstream out(outfile.c_str());
+  std::cout << "Mesh written to: " << outfile << std::endl;
   out.precision(17);
   out << mesh << std::endl;
   return 0;


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

I found the hole-filling functionality of CGAL to be very powerful, but problematic in practice, since there is no control over the hole size. Many real-world meshes are not closed, or otherwise have huge holes, and the algorithm either hangs on those or can give junk results.

Here I am making a small addition to the hole-filling example by allowing the user to control the diameter and number of edges in a hole to fill.

I added this to the surface mesh example (there are 4 hole-filing examples in the repo), because the Surface_mesh datastructure seems to be more natural when dealing with meshes than the Polyhedron_3 datastructure, and I mention in the doc that examples exist for the other ones as well (but those I did not modify).

I tested this extensively, including with very large and noisy meshes. A simple way of testing the changed example is to invoke it with the  mech-holes-shark.off dataset in the repo, while setting the maximum hole diameter to 10 and the maximum number of edges in a hole to 80. Then the largest of the 4 holes won't be filled, as desired. 

It took me very many hours to develop this simple change. I hope it can be useful to some folks. 

Lastly, I raised this first at: https://github.com/CGAL/cgal/issues/4410 and I followed the suggestions outlined there.

## Release Management

* Affected package(s): `Polygon Mesh Processing`
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/4410
* License and copyright ownership: Same as the CGAL codebase

