### PR TITLE
Fix issue #4458 (Mesh_2 and Triangulation_2_projection_traits_3)

### DIFF
--- a/Mesh_2/include/CGAL/Delaunay_mesh_size_criteria_2.h
+++ b/Mesh_2/include/CGAL/Delaunay_mesh_size_criteria_2.h
@@ -111,10 +111,8 @@ public:
       typedef typename Geom_traits::Compute_squared_distance_2
 	Compute_squared_distance_2;
 
-      Geom_traits traits; /** @warning traits with data!! */
-
       Compute_squared_distance_2 squared_distance = 
-	traits.compute_squared_distance_2_object();
+	this->traits.compute_squared_distance_2_object();
 
       const Point_2& pa = fh->vertex(0)->point();
       const Point_2& pb = fh->vertex(1)->point();
@@ -165,7 +163,7 @@ public:
 	    }
 	}
 
-      Compute_area_2 area_2 = traits.compute_area_2_object();
+      Compute_area_2 area_2 = this->traits.compute_area_2_object();
 
       double area = 2*CGAL::to_double(area_2(pa, pb, pc));
 

--- a/Mesh_2/test/Mesh_2/test_mesh_projection_traits.cpp
+++ b/Mesh_2/test/Mesh_2/test_mesh_projection_traits.cpp
@@ -1,0 +1,43 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Delaunay_mesher_2.h>
+#include <CGAL/Delaunay_mesh_face_base_2.h>
+#include <CGAL/Delaunay_mesh_size_criteria_2.h>
+#include <CGAL/Triangulation_2_projection_traits_3.h>
+
+#include <iostream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K1;
+typedef CGAL::Triangulation_2_projection_traits_3<K1> K;
+typedef CGAL::Triangulation_vertex_base_2<K> Vb;
+typedef CGAL::Delaunay_mesh_face_base_2<K> Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb> Tds;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K, Tds> CDT;
+typedef CGAL::Delaunay_mesh_size_criteria_2<CDT> Criteria;
+
+typedef CDT::Vertex_handle Vertex_handle;
+typedef CDT::Point Point;
+
+int main()
+{
+  K gt{ { 0, 0, 1} };
+  CDT cdt(gt);
+
+  Vertex_handle va = cdt.insert(Point(-4,0,0));
+  Vertex_handle vb = cdt.insert(Point(0,-1,0));
+  Vertex_handle vc = cdt.insert(Point(4,0,0));
+  Vertex_handle vd = cdt.insert(Point(0,1,0));
+  cdt.insert(Point(2, 0.6, 0));
+
+  cdt.insert_constraint(va, vb);
+  cdt.insert_constraint(vb, vc);
+  cdt.insert_constraint(vc, vd);
+  cdt.insert_constraint(vd, va);
+
+  std::cout << "Number of vertices: " << cdt.number_of_vertices() << std::endl;
+
+  std::cout << "Meshing the triangulation..." << std::endl;
+  CGAL::refine_Delaunay_mesh_2(cdt, Criteria(0.125, 0.5, gt));
+
+  std::cout << "Number of vertices: " << cdt.number_of_vertices() << std::endl;
+}


### PR DESCRIPTION
## Summary of Changes

Fix the issue "Instantiate new geometry traits" (#4458).

Now, Mesh_2 can be used with `<CGAL/Triangulation_2_projection_traits_3.h>`.

## Release Management

* Affected package(s): Mesh_2
* Issue(s) solved (if any): fix #4458
* License and copyright ownership: maintenance by GeometryFactory


