### PR TITLE
Update warning macro usages

### DIFF
--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_circle_3.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_circle_3.h
@@ -188,7 +188,7 @@ namespace CGAL {
         }
         break;
         case BIPOLAR:
-          CGAL_kernel_precondition(!"This function does not accept bipolar circle as input.");
+          CGAL_kernel_precondition_msg(false, "This function does not accept bipolar circle as input.");
       }
       return out_it;
     }

--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_circular_arc_3.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_circular_arc_3.h
@@ -525,7 +525,7 @@ namespace CGAL {
           break;
         }
         case BIPOLAR:
-          CGAL_kernel_precondition(!"This function does not accept bipolar circle as input.");
+          CGAL_kernel_precondition_msg(false, "This function does not accept bipolar circle as input.");
       }
       
       return out_it;

--- a/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
@@ -238,7 +238,7 @@ public:
       if(!Infi_box::is_standard(hf->plane()))
 	++i;
     }
-    CGAL_warning("altered code");
+    // CGAL_warning("altered code");
     //    CGAL_assertion(i>=6);
     return (i == 6);
   }

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -893,7 +893,7 @@ public:
       else CGAL_error_msg( "wrong handle type");
     }
 
-    CGAL_warning("altered code in SNC_point_locator");
+    //CGAL_warning("altered code in SNC_point_locator");
     /*
       Halffacet_iterator fc;
       CGAL_forall_facets(fc, *this->sncp()) {
@@ -916,7 +916,7 @@ public:
     if( CGAL::assign( v, result)) {
       _CGAL_NEF_TRACEN("vertex hit, obtaining volume..." << v->point());
 
-      CGAL_warning("altered code in SNC_point_locator");
+      //CGAL_warning("altered code in SNC_point_locator");
       SM_point_locator L(&*v);
       //      Object_handle so = L.locate(s.source()-s.target(), true);
       Object_handle so = L.locate(s.source()-s.target());

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -201,7 +201,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   }
 
   bool simplify_redundant_box_vertex(Vertex_handle v, bool snc_computed) {
-    CGAL_warning("altered code");
+    //CGAL_warning("altered code");
     return false;
     if(snc_computed) return false;
     if(!Infi_box::is_redundant_box_vertex(*v)) return false;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
@@ -64,8 +64,8 @@ struct Cotangent_value_Meyer_impl
     if(divider == 0 /*|| divider != divider*/) 
     {
       CGAL::collinear(get(ppmap, v0), get(ppmap, v1), get(ppmap, v2)) ? 
-        CGAL_warning(!"Infinite Cotangent value with degenerate triangle!") :
-        CGAL_warning(!"Infinite Cotangent value due to floating point arithmetic!");
+        CGAL_warning_msg(false, "Infinite Cotangent value with degenerate triangle!") :
+        CGAL_warning_msg(false, "Infinite Cotangent value due to floating point arithmetic!");
       
 
       return dot_ab > 0 ? (std::numeric_limits<double>::max)() :
@@ -357,7 +357,7 @@ public:
         }
       }
     }
-    CGAL_warning(voronoi_area != 0 && "Zero voronoi area!");
+    CGAL_warning_msg(voronoi_area != 0, "Zero voronoi area!");
     return voronoi_area;
   }
 };
@@ -820,7 +820,7 @@ public:
     Vector v = target(he, pmesh())->point() - source(he, pmesh())->point();
     double divider = CGAL::sqrt(v.squared_length());
     if(divider == 0.0) {
-      CGAL_warning(!"Scale dependent weight - zero length edge.");
+      CGAL_warning_msg(false, "Scale dependent weight - zero length edge.");
       return (std::numeric_limits<double>::max)();
     }
     return 1.0 / divider;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -265,7 +265,7 @@ public:
 
   void update_terminal_nodes(std::vector<bool>&)
   {
-    CGAL_assertion(!"This function should not be called");
+    CGAL_error_msg("This function should not be called");
   }
 
 // The following code was used to split polylines at certains points.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -714,7 +714,7 @@ class Intersection_of_triangle_meshes
         switch(type){
           case COPLANAR_TRIANGLES:
             #ifndef DO_NOT_HANDLE_COPLANAR_FACES
-            assert(!"COPLANAR_TRIANGLES : this point should never be reached!");
+            CGAL_error_msg("COPLANAR_TRIANGLES : this point should never be reached!");
             #else
             //nothing needs to be done, cf. comments at the beginning of the file
             #endif

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
@@ -129,7 +129,7 @@ triangulate_hole_polygon_mesh(PolygonMesh& pmesh,
     P_edges.push_back(*circ);
     if(!vertex_map.insert(std::make_pair(target(*circ,pmesh), id++)).second) {
       #ifndef CGAL_TEST_SUITE
-      CGAL_warning(!"Returning no output. Non-manifold vertex is found on boundary!");
+      CGAL_warning_msg(false, "Returning no output. Non-manifold vertex is found on boundary!");
       #else
       std::cerr << "W: Returning no output. Non-manifold vertex is found on boundary!\n";
       #endif

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -790,7 +790,7 @@ public:
     boost::tuple<boost::optional<Edge>, bool, bool> res = construct_3D_triangulation(P, range, tr, edge_exist);
     if(!res.template get<2>()) {
       #ifndef CGAL_TEST_SUITE
-      CGAL_warning(!"Returning no output. Dimension of 3D Triangulation is below 2!");
+      CGAL_warning_msg(false, "Returning no output. Dimension of 3D Triangulation is below 2!");
       #else
       std::cerr << "W: Returning no output. Dimension of 3D Triangulation is below 2!\n";
       #endif
@@ -814,7 +814,7 @@ public:
 
       if(W.get(0, n-1) == Weight::NOT_VALID()) {
         #ifndef CGAL_TEST_SUITE
-        CGAL_warning(!"Returning no output. No possible triangulation is found!");
+        CGAL_warning_msg(false, "Returning no output. No possible triangulation is found!");
         #else
         std::cerr << "W: Returning no output. No possible triangulation is found!\n";
         #endif
@@ -1009,7 +1009,7 @@ private:
         Triangulate_hole_polyline<Kernel, Tracer, WeightCalculator, LookupTable> all_space;
         all_space.triangulate_all(P, Q, WC, std::make_pair(h.first, h.second), W, lambda);
         if(W.get(h.first, h.second) == Weight::NOT_VALID()) {
-          CGAL_warning(!"Returning no output. Filling hole with incomplete patches is not successful!");
+          CGAL_warning_msg(false, "Returning no output. Filling hole with incomplete patches is not successful!");
           return Weight::NOT_VALID();
         }
       }
@@ -1030,7 +1030,7 @@ private:
           Triangulate_hole_polyline<Kernel, Tracer, WeightCalculator, LookupTable> all_space;
           all_space.triangulate_all(P, Q, WC, std::make_pair(h.first, h.second), W, lambda);
           if(W.get(h.first, h.second) == Weight::NOT_VALID()) {
-            CGAL_warning(!"Returning no output. Filling hole with incomplete patches is not successful!");
+            CGAL_warning_msg(false, "Returning no output. Filling hole with incomplete patches is not successful!");
             return Weight::NOT_VALID();
           }
         }
@@ -1045,7 +1045,7 @@ private:
       tr.clear();
       boost::tuple<boost::optional<Edge>, bool, bool> res = construct_3D_triangulation(P, h, tr, edge_exist);
       if(!boost::get<0>(res)) {
-        CGAL_warning(!"Returning no output. Filling hole with incomplete patches is not successful!");
+        CGAL_warning_msg(false, "Returning no output. Filling hole with incomplete patches is not successful!");
         return Weight::NOT_VALID();
       }
       start_edge = *boost::get<0>(res);
@@ -1106,7 +1106,7 @@ private:
     
     if(W.get(0, n-1) == Weight::NOT_VALID()) {
       #ifndef CGAL_TEST_SUITE
-      CGAL_warning(!"Returning no output. Filling hole with extra triangles is not successful!");
+      CGAL_warning_msg(false, "Returning no output using Delaunay triangulation.\n Falling back to the general Triangulation framework.");
       #else
       std::cerr << "W: Returning no output. Filling hole with extra triangles is not successful!\n";
       #endif
@@ -1151,7 +1151,7 @@ public:
 
     if(W.get(0,n-1) == Weight::NOT_VALID() || n <= 2) {
       #ifndef CGAL_TEST_SUITE
-      CGAL_warning(!"Returning no output. No possible triangulation is found!");
+      CGAL_warning_msg(false, "Returning no output. No possible triangulation is found!");
       #else
       std::cerr << "W: Returning no output. No possible triangulation is found!\n";
       #endif

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/experimental/experimental_code.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/experimental/experimental_code.h
@@ -172,7 +172,7 @@ triangulate_hole_polyline_incomplete(InputIterator pbegin, InputIterator pend,
       if(new_facets.empty()) {
         // if no patch facets created and also we are using brute force approach, then there is nothing to do,
         // leave `out` intact and return
-        CGAL_warning(!"Returning no output. Filling hole with incomplete patches is not successful!");
+        CGAL_warning_msg(false, "Returning no output. Filling hole with incomplete patches is not successful!");
         return out;
       }
     }
@@ -221,7 +221,7 @@ triangulate_hole_Polyhedron_incomplete(Polyhedron& polyhedron,
       if(patch_facets_before == patch_facets.size()) {
         // if no patch facets created and also we are using brute force approach, then there is nothing to do,
         // leave `out` intact and return
-        CGAL_warning(!"Returning no output. Filling hole with incomplete patches is not successful!");
+        CGAL_warning_msg(false, "Returning no output. Filling hole with incomplete patches is not successful!");
         return std::make_pair(out, Weight_min_max_dihedral_and_area::NOT_VALID());
       }
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/fair_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/fair_impl.h
@@ -127,7 +127,7 @@ public:
   {
     int depth = static_cast<int>(fc) + 1;
     if(depth < 0 || depth > 3) {
-      CGAL_warning(!"Continuity should be between 0 and 2 inclusively!");
+      CGAL_warning_msg(false, "Continuity should be between 0 and 2 inclusively!");
       return false; 
     }
 
@@ -148,7 +148,7 @@ public:
     BOOST_FOREACH(vertex_descriptor vd, interior_vertices)
     {
       if( !vertex_id_map.insert(std::make_pair(vd, id)).second ) {
-        CGAL_warning(!"Duplicate vertex is found!");
+        CGAL_warning_msg(false, "Duplicate vertex is found!");
         return false;
       }
       ++id;
@@ -169,7 +169,7 @@ public:
     double D;
     bool prefactor_ok = solver.factor(A, D);
     if(!prefactor_ok) {
-      CGAL_warning(!"pre_factor failed!");
+      CGAL_warning_msg(false, "pre_factor failed!");
       return false;
     }
     #ifdef CGAL_PMP_FAIR_DEBUG
@@ -179,7 +179,7 @@ public:
     // solve
     bool is_all_solved = solver.linear_solver(Bx, X) && solver.linear_solver(By, Y) && solver.linear_solver(Bz, Z);
     if(!is_all_solved) {
-      CGAL_warning(!"linear_solver failed!"); 
+      CGAL_warning_msg(false, "linear_solver failed!"); 
       return false; 
     }
     #ifdef CGAL_PMP_FAIR_DEBUG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -178,8 +178,11 @@ bool is_outward_oriented(const PolygonMesh& pmesh,
   CGAL_warning(CGAL::is_closed(pmesh));
   CGAL_precondition(CGAL::is_valid_polygon_mesh(pmesh));
 
+#ifdef CGAL_PMP_DEBUG_CODE
   //check for empty pmesh
   CGAL_warning(faces(pmesh).first != faces(pmesh).second);
+#endif
+
   if (faces(pmesh).first == faces(pmesh).second)
     return true;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -1593,7 +1593,7 @@ bool remove_degenerate_faces(      TriangleMesh& tmesh,
           if ( target(next(opposite(h_side1, tmesh), tmesh), tmesh) ==
                target(next(opposite(h_side2, tmesh), tmesh), tmesh) )
           {
-            CGAL_assertion(!"Forbidden simplification");
+            CGAL_error_msg("Forbidden simplification");
           }
 
           h_side2 = prev(h_side2, tmesh);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
@@ -26,10 +26,10 @@ int main(int argc, char** argv)
     Surface_mesh sm;
     input >> sm;
     bool res = atoi(argv[2*(i+1)])>0;
-    assert(!"Result is not as expected (input orientation)" ||
-           CGAL::Polygon_mesh_processing::does_bound_a_volume(sm)==res);
+    if (CGAL::Polygon_mesh_processing::does_bound_a_volume(sm)!=res)
+      CGAL_error_msg("Result is not as expected (input orientation)");
     CGAL::Polygon_mesh_processing::reverse_face_orientations(sm);
-    assert(!"Result is not as expected (reversed orientation)" ||
-           CGAL::Polygon_mesh_processing::does_bound_a_volume(sm)==res);
+    if (CGAL::Polygon_mesh_processing::does_bound_a_volume(sm)!=res)
+      CGAL_error_msg("Result is not as expected (reversed orientation)");
   }
 }

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/SDF_calculation.h
@@ -289,7 +289,7 @@ public:
     bool accept_if_acute,
     const Disk_samples_list& disk_samples) const {
     if(cone_angle < 0.0 || cone_angle > CGAL_PI) {
-      CGAL_warning(false && "Cone angle is clamped between [0, CGAL_PI].");
+      CGAL_warning_msg(false, "Cone angle is clamped between [0, CGAL_PI].");
       cone_angle = (std::min)(CGAL_PI, (std::max)(0.0, cone_angle));
     }
 
@@ -328,7 +328,7 @@ public:
         Segment segment(center, target_point);
 
         if(traits.is_degenerate_3_object()(segment)) {
-          CGAL_warning(false &&
+          CGAL_warning_msg(false, 
                        "A degenerate segment is constructed. Most probable reason is using CGAL_PI as cone_angle parameter and also picking center of disk as a sample.");
         }
 
@@ -338,7 +338,7 @@ public:
         Ray ray(center, ray_direction);
 
         if(traits.is_degenerate_3_object()(ray)) {
-          CGAL_warning(false &&
+          CGAL_warning_msg(false,
                        "A degenerate ray is constructed. Most probable reason is using CGAL_PI as cone_angle parameter and also picking center of disk as a sample.");
         }
 

--- a/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Surface_mesh_segmentation.h
+++ b/Surface_mesh_segmentation/include/CGAL/internal/Surface_mesh_segmentation/Surface_mesh_segmentation.h
@@ -155,7 +155,7 @@ public:
     boost::tie(min_sdf, max_sdf) = min_max_value(mesh, sdf_values);
 
     if(min_sdf == max_sdf) {
-      CGAL_warning(min_sdf == max_sdf && !"Linear normalization is not applicable!");
+      CGAL_warning_msg(min_sdf == max_sdf, "Linear normalization is not applicable!");
       return std::make_pair(min_sdf, max_sdf);
     }
 


### PR DESCRIPTION
Fixes #4456 + places where `CGAL_warning_msg` was meant to be used (fixes conversion warnings)