### PR TITLE
Workaround for SWIG parser

### DIFF
--- a/Installation/include/CGAL/version.h
+++ b/Installation/include/CGAL/version.h
@@ -16,10 +16,12 @@
 #ifndef CGAL_VERSION_H
 #define CGAL_VERSION_H
 
+#ifndef SWIG
 #define CGAL_VERSION 5.1
+#define CGAL_GIT_HASH abcdef
+#endif
 #define CGAL_VERSION_NR 1050100000
 #define CGAL_SVN_REVISION 99999
-#define CGAL_GIT_HASH abcdef
 #define CGAL_RELEASE_DATE 20191108
 
 #include <CGAL/version_macros.h>

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -79,7 +79,7 @@ if (NOT EXISTS ${GIT_REPO}/Installation/include/CGAL/version.h)
 endif()
 
 file(READ "${GIT_REPO}/Installation/include/CGAL/version.h" version_file_content)
-string(REGEX MATCH "define CGAL_VERSION (.*)\n#define CGAL_VERSION_NR" CGAL_VERSION_FOUND "${version_file_content}")
+string(REGEX MATCH "define CGAL_VERSION ([^\n]*)\n" CGAL_VERSION_FOUND "${version_file_content}")
 
 if (CGAL_VERSION_FOUND)
   set(CGAL_VERSION_INPUT "${CMAKE_MATCH_1}")
@@ -171,12 +171,12 @@ if(EXISTS ${GIT_REPO}/.git)
     RESULT_VARIABLE RESULT_VAR
     OUTPUT_VARIABLE OUT_VAR
     )
-  string(REPLACE "CGAL_GIT_HASH abcdef\n" "CGAL_GIT_HASH ${OUT_VAR}" file_content "${file_content}")
+  string(REGEX REPLACE "CGAL_GIT_HASH [^\n]*\n" "CGAL_GIT_HASH ${OUT_VAR}" file_content "${file_content}")
 endif()
 #  update CGAL_RELEASE_DATE
 string(TIMESTAMP TODAY "%Y%m%d")
 string(TIMESTAMP TODAY_FOR_MANPAGES "%B %Y")
-string(REPLACE "CGAL_RELEASE_DATE 20170101" "CGAL_RELEASE_DATE ${TODAY}" file_content "${file_content}")
+string(REGEX REPLACE "CGAL_RELEASE_DATE [^\n]*" "CGAL_RELEASE_DATE ${TODAY}" file_content "${file_content}")
 #  update CGAL_VERSION
 string(REPLACE "CGAL_VERSION ${CGAL_VERSION_INPUT}" "CGAL_VERSION ${CGAL_VERSION}" file_content "${file_content}")
 #  update CGAL_VERSION_NR


### PR DESCRIPTION
## Summary of Changes

Replace #4358.

## Release Management

* Affected package(s): Installation, Scripts
* Issue(s) solved (if any): fix #4355 

TODO after merge: backport manually to 4.14 and 5.0.

