### PR TITLE
AP2: Remove bad precondition

### DIFF
--- a/Apollonius_graph_2/include/CGAL/Parabola_segment_2.h
+++ b/Apollonius_graph_2/include/CGAL/Parabola_segment_2.h
@@ -81,7 +81,6 @@ public:
                        FT s0, FT s1) const
   {
     CGAL_precondition(STEP > 0);
-    CGAL_precondition(s0 < s1);
 
     p.clear();
 


### PR DESCRIPTION
## Summary of Changes

Might have t(p0) > tp(1) in parabola segmentation.

## Release Management

* Affected package(s): `Apollonius_graph_2`
* Issue(s) solved (if any): -

