### PR TITLE
Remove undocumented CGAL::Point_with_normal_3 from examples

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_structured.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_structured.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/Shape_detection_3.h>
 #include <CGAL/structure_point_set.h>
 #include <CGAL/Delaunay_triangulation_3.h>

--- a/Point_set_processing_3/examples/Point_set_processing_3/structuring_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/structuring_example.cpp
@@ -1,7 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
 #include <CGAL/IO/write_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_custom_shape.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_custom_shape.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_parameters.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_point_access.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/efficient_RANSAC_point_access.cpp
@@ -1,6 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Timer.h>
 #include <CGAL/number_utils.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/plane_regularization.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/plane_regularization.cpp
@@ -5,7 +5,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/shape_detection_basic.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/shape_detection_basic.cpp
@@ -5,7 +5,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/shape_detection_with_callback.cpp
+++ b/Point_set_shape_detection_3/examples/Point_set_shape_detection_3/shape_detection_with_callback.cpp
@@ -5,7 +5,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_xyz_points.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 
 #include <CGAL/Shape_detection_3.h>

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction.cpp
@@ -21,7 +21,6 @@
 #include <CGAL/Poisson_implicit_surface_3.h>
 #include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
 #include <CGAL/Poisson_reconstruction_function.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/IO/read_xyz_points.h>
 #include <CGAL/compute_average_spacing.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
@@ -43,7 +42,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::FT FT;
 typedef Kernel::Point_3 Point;
 typedef Kernel::Vector_3 Vector;
-typedef CGAL::Point_with_normal_3<Kernel> Point_with_normal;
+typedef std::pair<Point, Vector> Point_with_normal;
 typedef Kernel::Sphere_3 Sphere;
 typedef std::deque<Point_with_normal> PointList;
 
@@ -180,7 +179,7 @@ int main(int argc, char * argv[])
                     vertices(input_mesh)){
         const Point& p = v->point();
         Vector n = CGAL::Polygon_mesh_processing::compute_vertex_normal(v,input_mesh);
-        points.push_back(Point_with_normal(p,n));
+        points.push_back(std::make_pair(p,n));
       }
     }
     // If XYZ file format
@@ -190,14 +189,14 @@ int main(int argc, char * argv[])
       // Reads the point set file in points[].
       // Note: read_xyz_points_and_normals() requires an iterator over points
       // + property maps to access each point's position and normal.
-      // The position property map can be omitted here as we use iterators over Point_3 elements.
       std::ifstream stream(input_filename.c_str());
       if (!stream ||
           !CGAL::read_xyz_points(
                                 stream,
                                 std::back_inserter(points),
-                                CGAL::parameters::normal_map
-                                (CGAL::make_normal_of_point_with_normal_map(PointList::value_type()))))
+                                CGAL::parameters::point_map
+                                (CGAL::make_first_of_pair_property_map(Point_with_normal())).
+                                normal_map (CGAL::make_second_of_pair_property_map(Point_with_normal()))))
       {
         std::cerr << "Error: cannot read file " << input_filename << std::endl;
         return EXIT_FAILURE;
@@ -226,7 +225,7 @@ int main(int argc, char * argv[])
       return EXIT_FAILURE;
     }
 
-    bool points_have_normals = (points.begin()->normal() != CGAL::NULL_VECTOR);
+    bool points_have_normals = (points.begin()->second != CGAL::NULL_VECTOR);
     if ( ! points_have_normals )
     {
       std::cerr << "Input point set not supported: this reconstruction method requires oriented normals" << std::endl;
@@ -249,11 +248,10 @@ int main(int argc, char * argv[])
     // Creates implicit function from the read points.
     // Note: this method requires an iterator over points
     // + property maps to access each point's position and normal.
-    // The position property map can be omitted here as we use iterators over Point_3 elements.
     Poisson_reconstruction_function function(
                               points.begin(), points.end(),
-                              CGAL::make_identity_property_map(PointList::value_type()),
-                              CGAL::make_normal_of_point_with_normal_map(PointList::value_type()),
+                              CGAL::make_first_of_pair_property_map(Point_with_normal()),
+                              CGAL::make_second_of_pair_property_map(Point_with_normal()),
                               visitor);
 
     #ifdef CGAL_EIGEN3_ENABLED
@@ -295,7 +293,9 @@ int main(int argc, char * argv[])
     std::cerr << "Surface meshing...\n";
 
     // Computes average spacing
-    FT average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>(points, 6 /* knn = 1 ring */);
+    FT average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>
+      (points, 6 /* knn = 1 ring */,
+       CGAL::parameters::point_map (CGAL::make_first_of_pair_property_map(Point_with_normal())));
 
     // Gets one point inside the implicit surface
     Point inner_point = function.get_inner_point();
@@ -369,7 +369,7 @@ int main(int argc, char * argv[])
     double avg_distance = 0;
     for (PointList::const_iterator p=points.begin(); p!=points.end(); p++)
     {
-      double distance = std::sqrt(tree.squared_distance(*p));
+      double distance = std::sqrt(tree.squared_distance(p->first));
 
       max_distance = (std::max)(max_distance, distance);
       avg_distance += distance;

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
@@ -6,12 +6,13 @@
 #include <CGAL/Implicit_surface_3.h>
 #include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
 #include <CGAL/Poisson_reconstruction_function.h>
-#include <CGAL/Point_with_normal_3.h>
 #include <CGAL/property_map.h>
 #include <CGAL/IO/read_xyz_points.h>
 #include <CGAL/compute_average_spacing.h>
 
 #include <CGAL/Polygon_mesh_processing/distance.h>
+
+#include <boost/iterator/transform_iterator.hpp>
 
 #include <vector>
 #include <fstream>
@@ -20,7 +21,10 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::FT FT;
 typedef Kernel::Point_3 Point;
-typedef CGAL::Point_with_normal_3<Kernel> Point_with_normal;
+typedef Kernel::Vector_3 Vector;
+typedef std::pair<Point, Vector> Point_with_normal;
+typedef CGAL::First_of_pair_property_map<Point_with_normal> Point_map;
+typedef CGAL::Second_of_pair_property_map<Point_with_normal> Normal_map;
 typedef Kernel::Sphere_3 Sphere;
 typedef std::vector<Point_with_normal> PointList;
 typedef CGAL::Polyhedron_3<Kernel> Polyhedron;
@@ -39,14 +43,14 @@ int main(void)
     // Reads the point set file in points[].
     // Note: read_xyz_points_and_normals() requires an iterator over points
     // + property maps to access each point's position and normal.
-    // The position property map can be omitted here as we use iterators over Point_3 elements.
     PointList points;
     std::ifstream stream("data/kitten.xyz");
     if (!stream ||
         !CGAL::read_xyz_points(
                               stream,
                               std::back_inserter(points),
-                              CGAL::parameters::normal_map(CGAL::make_normal_of_point_with_normal_map(PointList::value_type()))))
+                              CGAL::parameters::point_map (Point_map()).
+                              normal_map (Normal_map())))
     {
       std::cerr << "Error: cannot read file data/kitten.xyz" << std::endl;
       return EXIT_FAILURE;
@@ -56,9 +60,7 @@ int main(void)
 
     // Note: this method requires an iterator over points
     // + property maps to access each point's position and normal.
-    // The position property map can be omitted here as we use iterators over Point_3 elements.
-    Poisson_reconstruction_function function(points.begin(), points.end(),
-                                             CGAL::make_normal_of_point_with_normal_map(PointList::value_type()) );
+    Poisson_reconstruction_function function(points.begin(), points.end(), Point_map(), Normal_map());
 
     // Computes the Poisson indicator function f()
     // at each vertex of the triangulation.
@@ -66,7 +68,9 @@ int main(void)
       return EXIT_FAILURE;
 
     // Computes average spacing
-    FT average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>(points, 6 /* knn = 1 ring */);
+    FT average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>
+      (points, 6 /* knn = 1 ring */,
+       CGAL::parameters::point_map (Point_map()));
 
     // Gets one point inside the implicit surface
     // and computes implicit function bounding sphere radius.
@@ -108,9 +112,13 @@ int main(void)
     /// [PMP_distance_snippet]
     // computes the approximation error of the reconstruction
     double max_dist =
-      CGAL::Polygon_mesh_processing::approximate_max_distance_to_point_set(output_mesh,
-                                                               points,
-                                                               4000);
+      CGAL::Polygon_mesh_processing::approximate_max_distance_to_point_set
+      (output_mesh,
+       CGAL::make_range (boost::make_transform_iterator
+                         (points.begin(), CGAL::Property_map_to_unary_function<Point_map>()),
+                         boost::make_transform_iterator
+                         (points.end(), CGAL::Property_map_to_unary_function<Point_map>())),
+       4000);
     std::cout << "Max distance to point_set: " << max_dist << std::endl;
     /// [PMP_distance_snippet]
 


### PR DESCRIPTION
## Summary of Changes

There is a structure `CGAL::Point_with_normal_3` that is internally used by the bilateral smoothing algorithm (and some tests). Though undocumented, the header was included in several examples (probably as a result of a large copy-paste, as the structure in itself was not used), and the structure was used in 2 examples of Poisson reconstruction.

I cleaned these examples of it as we should not use undocumented classes in public examples.

## Release Management

* Affected package(s): AFSR, PSP, Shape Detection, Poisson

