### PR TITLE
[Surface Mesh / Point Set] Fix capacity handling in properties

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -445,7 +445,7 @@ public:
 
 
     // reserve memory for n entries in all arrays
-    void reserve(size_t n) const
+    void reserve(size_t n)
     {
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->reserve(n);
@@ -461,7 +461,7 @@ public:
     }
 
     // free unused space in all arrays
-    void shrink_to_fit() const
+    void shrink_to_fit()
     {
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->shrink_to_fit();
@@ -500,7 +500,7 @@ public:
 private:
     std::vector<Base_property_array*>  parrays_;
     size_t  size_;
-    mutable size_t  capacity_;
+    size_t  capacity_;
 };
 
   /// @endcond

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -245,7 +245,7 @@ class Property_container
 public:
 
     // default constructor
-    Property_container() : size_(0) {}
+    Property_container() : size_(0), capacity_(0) {}
 
     // destructor (deletes all property arrays)
     virtual ~Property_container() { clear(); }
@@ -261,6 +261,7 @@ public:
             clear();
             parrays_.resize(_rhs.n_properties());
             size_ = _rhs.size();
+            capacity_ = _rhs.capacity();
             for (std::size_t i=0; i<parrays_.size(); ++i)
                 parrays_[i] = _rhs.parrays_[i]->clone();
         }
@@ -296,6 +297,7 @@ public:
           continue;
 
         parrays_.push_back (_rhs.parrays_[i]->empty_clone());
+        parrays_.back()->reserve(capacity_);
         parrays_.back()->resize(size_);
       }
     }
@@ -313,6 +315,9 @@ public:
 
     // returns the current size of the property arrays
     size_t size() const { return size_; }
+
+    // returns the current capacity of the property arrays
+    size_t capacity() const { return capacity_; }
 
     // returns the number of property arrays
     size_t n_properties() const { return parrays_.size(); }
@@ -362,6 +367,7 @@ public:
 
         // otherwise add the property
         Property_array<T>* p = new Property_array<T>(name, t);
+        p->reserve(capacity_);
         p->resize(size_);
         parrays_.push_back(p);
         return std::make_pair(Pmap(p), true);
@@ -443,6 +449,7 @@ public:
     {
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->reserve(n);
+        capacity_ = n;
     }
 
     // resize all arrays to size n
@@ -458,6 +465,7 @@ public:
     {
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->shrink_to_fit();
+        capacity_ = size_;
     }
 
     // add a new element to each vector
@@ -466,6 +474,7 @@ public:
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->push_back();
         ++size_;
+        capacity_ = (std::max(size_, capacity_));
     }
 
     // reset element to its default property values
@@ -491,6 +500,7 @@ public:
 private:
     std::vector<Base_property_array*>  parrays_;
     size_t  size_;
+    mutable size_t  capacity_;
 };
 
   /// @endcond

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -449,7 +449,7 @@ public:
     {
         for (std::size_t i=0; i<parrays_.size(); ++i)
             parrays_[i]->reserve(n);
-        capacity_ = n;
+        capacity_ = std::max(n, capacity_);
     }
 
     // resize all arrays to size n


### PR DESCRIPTION
## Summary of Changes

The properties used in Surface Mesh and Point Set 3 are internally a vector of vectors with dynamic type. Most operations on vectors are available (`resize(), `reserve()`, etc.), but I noticed that the capacity was not handled well.

This is what can typically happen:
1. Add some properties
2. Call `resize(s)` and `reserve(c)`
3. -> all properties have size `s` and capacity `c`
4. Add a new property
5. -> this new property is given size `s` and capacity `s` (not `c`), because only `resize()` is called when adding a new property, not `reserve()`

It seems to me that once the user does `reserve()`, then a property added afterwards should also be given the wanted capacity, similarly to how size is handled. This PR mimics the behavior of `resize()/size` with `reserve()/capacity`.

## Release Management

* Affected package(s): Surface Mesh + Point Set 3