### PR TITLE
Mesh_3 binary I/O: allow to read a binary file with a CRLF EOL at the end of first line

### DIFF
--- a/Mesh_3/include/CGAL/IO/File_binary_mesh_3.h
+++ b/Mesh_3/include/CGAL/IO/File_binary_mesh_3.h
@@ -69,7 +69,10 @@ bool load_binary_file(std::istream& is, C3T3& c3t3)
     return false;
   }
   std::getline(is, s);
-  if(s != "") {
+  if(!s.empty()) {
+    if(s[s.size()-1] == '\r') { // deal with Windows EOL
+      s.resize(s.size() - 1);
+    }
     if(s != std::string(" ") + CGAL::Get_io_signature<C3T3>()()) {
       std::cerr << "load_binary_file:"
                 << "\n  expected format: " << CGAL::Get_io_signature<C3T3>()()


### PR DESCRIPTION
## Summary of Changes

On Windows, `\n` is turned into `\r\n` when writing to a file. This PR allows the binary I/O of Mesh_3 to deal with a first line that ends with `\r\n` instead of `\n`.

Cc: @janetournois 

## Release Management

* Affected package(s): Mesh_3, Polyhedron demo
* License and copyright ownership: maintenance by GeometryFactory
