### PR TITLE
Add a kernel that stores objects twice: with Intervals and Gmpq

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_rational_kernel.h
+++ b/Filtered_kernel/include/CGAL/Filtered_rational_kernel.h
@@ -1,0 +1,457 @@
+// Copyright (c) 2020 GeometryFactory (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+// 
+//
+// Author(s)     : Sebastien Loriot
+
+#ifndef CGAL_FILTERED_RATIONAL_KERNEL_H
+#define CGAL_FILTERED_RATIONAL_KERNEL_H
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/intersections.h>
+#include <CGAL/Filtered_rational.h>
+#include <CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h>
+#include <CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h>
+#include <CGAL/Interval_nt.h>
+#include <CGAL/Gmpq.h>
+
+#include <CGAL/Cartesian_converter.h>
+
+namespace CGAL {
+
+  namespace mpl
+{
+
+BOOST_MPL_HAS_XXX_TRAIT_DEF(first_type)
+BOOST_MPL_HAS_XXX_TRAIT_DEF(second_type)
+
+template <class T> struct is_pair_ {
+  enum { value = has_first_type<T>::value && has_second_type<T>::value }; 
+};
+
+} // mpl namespace
+  
+// Small utility to manipulate pairs for kernel objects, and
+// simple things for bool, Sign...  Object is yet another case...
+template < typename T1, typename T2 >
+struct Pairify {
+  typedef std::pair<T1, T2>  result_type;
+  result_type operator()(const T1 &t1, const T2 &t2) const
+  { return std::make_pair(t1, t2); }
+};
+
+template <>
+struct Pairify <bool, bool> {
+  typedef bool   result_type;
+  result_type operator()(const bool &t1, const bool &t2) const
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
+};
+
+template <>
+struct Pairify <Sign, Sign> {
+  typedef Sign   result_type;
+  result_type operator()(const Sign &t1, const Sign &t2) const
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
+};
+
+template <>
+struct Pairify <Bounded_side, Bounded_side> {
+  typedef Bounded_side   result_type;
+  result_type operator()(const Bounded_side &t1, const Bounded_side &t2) const
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
+};
+
+template <>
+struct Pairify <Angle, Angle> {
+  typedef Angle   result_type;
+  result_type operator()(const Angle &t1, const Angle &t2) const
+  { CGAL_kernel_assertion(t1 == t2); CGAL_USE(t2); return t1; }
+};
+
+template <>
+struct Pairify <const Interval_nt<false>&,const Gmpq&> {
+  
+  typedef Filtered_rational<Interval_nt<false>,Gmpq> result_type;
+  
+  result_type operator()(const Interval_nt<false>& a, const Gmpq& e) const
+  {
+    return Filtered_rational<Interval_nt<false>, Gmpq>(a,e);
+  }
+};
+  
+// Class used by Kernel_checker.
+template <class P1, class P2>
+class Predicate_wrapper
+{
+  P1  p1;
+  P2  p2;
+
+public:
+  Predicate_wrapper(const P1 &pp1 = P1(), const P2 &pp2 = P2())
+    : p1(pp1), p2(pp2)
+  { }
+
+  template <class ... A>
+  typename CGAL::cpp11::result_of<P1(const A&...)>::type
+  operator()(const A&... a) const
+  {
+    typedef typename CGAL::cpp11::result_of<P1(const typename A::first_type&...)>::type result_type_1;
+    typedef typename CGAL::cpp11::result_of<P2(const typename A::second_type&...)>::type result_type_2;
+    CGAL::Interval_nt<false>::Protector p;
+    try{
+      result_type_1 res1 = p1(a.first...);
+      if (is_certain(res1))
+        return make_certain(res1);
+    }
+    catch(Uncertain_conversion_exception&)
+    {}
+    result_type_2 res2 = p2(a.second...);
+    return res2;
+  }
+};
+
+
+  template <class A>
+  struct Getter
+  {
+    typedef A first_type;
+    typedef A second_type;
+  };
+
+  template <class A1, class A2>
+  struct Getter<std::pair<A1,A2>>
+  {
+    typedef A1 first_type;
+    typedef A2 second_type;
+  };
+
+  template <class A_FT, class E_FT>
+  struct Getter<Filtered_rational<A_FT,E_FT>>
+  {
+    typedef A_FT first_type;
+    typedef E_FT second_type;
+  };
+
+                                  
+template <class P1, class P2, class K1, class K2>
+class Construction_wrapper
+{
+  P1  p1;
+  P2  p2;
+
+  CGAL::Cartesian_converter<K2, K1> to_k1;
+
+public:
+  Construction_wrapper(const P1 &pp1 = P1(), const P2 &pp2 = P2())
+    : p1(pp1), p2(pp2)
+  { }
+
+  
+  //get_second is used to allow constructions from K2 
+  template <class A>
+  const A&
+  get_second(const A& a, typename boost::disable_if< mpl::is_pair_<A> >::type* = nullptr) const
+  {
+    return a;
+  }
+  
+  template <class A1, class A2>
+  const A2&
+  get_second(const std::pair<A1,A2>& p) const
+  {
+    return p.second;
+  }
+  
+  template <class A1, class A2>
+  const A2&
+  get_second(const Filtered_rational<A1,A2>& p) const
+  {
+    return p.n2();
+  }
+
+  typedef Filtered_rational<Interval_nt<false>,Gmpq> result_type;
+  
+  // TODO: I think the result_of is simply using P1::result_type because arguments are not valid (pairs...)
+  template <class ... A>
+  typename Pairify<typename CGAL::cpp11::result_of<P1(const typename Getter<A>::first_type&...)>::type,
+                   typename CGAL::cpp11::result_of<P2(const typename Getter<A>::second_type&...)>::type>::result_type
+  operator()(const A&... a) const
+  {
+    typedef typename CGAL::cpp11::result_of<P1(const typename Getter<A>::first_type&...)>::type result_type_1;
+    typedef typename CGAL::cpp11::result_of<P2(const typename Getter<A>::second_type&...)>::type result_type_2;
+    result_type_2 res2 = p2(get_second(a)...);
+    return Pairify<result_type_1, result_type_2>()(to_k1(res2), res2);
+  }
+
+
+  // this is the overload for functors such as Construct_vertex_2
+  template <typename AT, typename ET>
+  typename Pairify<typename CGAL::cpp11::result_of<P1(const AT&,int)>::type,
+                   typename CGAL::cpp11::result_of<P2(const ET&,int)>::type>::result_type
+  operator()(const std::pair<AT,ET>& p, int i) const
+  {
+    typedef typename CGAL::cpp11::result_of<P1(const AT&,int)>::result_type_1;
+    typedef typename CGAL::cpp11::result_of<P2(const ET&,int)>::result_type_2;
+    result_type_2 res2 = p2(get_second(a)...);
+    return Pairify<result_type_1, result_type_2>()(to_k1(res2), res2);
+  }
+  
+};
+
+
+  template < class K1, class K2, class Kernel_ >
+class Filtered_rational_kernel_generic_base
+{
+protected:
+  K1 k1;
+  K2 k2;
+
+public:
+
+  typedef bool                      Boolean;
+  typedef CGAL::Sign                Sign;
+  typedef CGAL::Comparison_result   Comparison_result;
+  typedef CGAL::Orientation         Orientation;
+  typedef CGAL::Oriented_side       Oriented_side;
+  typedef CGAL::Bounded_side        Bounded_side;
+  typedef CGAL::Angle               Angle;
+
+  typedef Kernel_ Kernel;
+  typedef K1     Kernel1;
+  typedef K2     Kernel2;
+
+  enum { Has_filtered_predicates = true };
+  enum { Has_static_filters = false };
+  typedef Boolean_tag<Has_filtered_predicates> Has_filtered_predicates_tag;
+  
+  typedef Filtered_rational<typename K1::FT, typename K2::FT> FT;
+  typedef FT RT;
+
+  typedef Cartesian_coordinate_iterator_2<Kernel> Cartesian_const_iterator_2;
+  typedef Cartesian_coordinate_iterator_3<Kernel> Cartesian_const_iterator_3;
+
+  // Kernel objects are defined as pairs, with primitives run in parallel.
+#define CGAL_kc_pair(X) typedef std::pair<typename K1::X, typename K2::X> X;
+
+
+  // TODO : Object_[23] are subtil : should probably be Object(pair<...>).
+  // Or should Assign_[23] be used, and that's it ?
+  // In any case, Assign will have to be treated separately because it
+  // takes its first argument by non-const reference.
+  // Maybe Primitive_checker should provide a variant with non-const ref...
+
+  CGAL_kc_pair(Object_2)
+  CGAL_kc_pair(Object_3)
+
+  CGAL_kc_pair(Point_2)
+  CGAL_kc_pair(Weighted_point_2)
+  CGAL_kc_pair(Vector_2)
+  CGAL_kc_pair(Direction_2)
+  CGAL_kc_pair(Line_2)
+  CGAL_kc_pair(Ray_2)
+  CGAL_kc_pair(Segment_2)
+  CGAL_kc_pair(Triangle_2)
+  CGAL_kc_pair(Iso_rectangle_2)
+  CGAL_kc_pair(Circle_2)
+  CGAL_kc_pair(Conic_2)
+  CGAL_kc_pair(Aff_transformation_2)
+
+  CGAL_kc_pair(Point_3)
+  CGAL_kc_pair(Weighted_point_3)
+  CGAL_kc_pair(Plane_3)
+  CGAL_kc_pair(Vector_3)
+  CGAL_kc_pair(Direction_3)
+  CGAL_kc_pair(Line_3)
+  CGAL_kc_pair(Ray_3)
+  CGAL_kc_pair(Segment_3)
+  CGAL_kc_pair(Triangle_3)
+  CGAL_kc_pair(Tetrahedron_3)
+  CGAL_kc_pair(Iso_cuboid_3)
+  CGAL_kc_pair(Sphere_3)
+  CGAL_kc_pair(Aff_transformation_3)
+
+#undef CGAL_kc_pair
+
+#define CGAL_Kernel_pred(X, Y) \
+  typedef Predicate_wrapper<typename K1::X, typename K2::X> X; \
+  X Y() const { return X(k1.Y(), k2.Y()); }
+
+#define CGAL_Kernel_cons(X, Y) \
+  typedef Construction_wrapper<typename K1::X, typename K2::X, K1, K2> X; \
+  X Y() const { return X(k1.Y(), k2.Y()); }
+
+
+  public:
+
+  #include <CGAL/Kernel/interface_macros.h>
+};
+
+
+  template < class K1, class K2, class Kernel_ >
+class Filtered_rational_kernel_base
+    : public Filtered_rational_kernel_generic_base<K1,K2,Kernel_>
+{
+
+public:
+  typedef Filtered_rational_kernel_base<K1,K2,Kernel_> Self;
+
+  class Construct_bbox_2 {
+  public:
+    typedef Bbox_2 result_type;
+    
+    template <typename T1, typename T2>
+    Bbox_2 operator()(const std::pair<T1,T2>& p) const
+    {
+      // AF: Or do we want to construct the BBox from Gmpq ?
+      return typename K1::Construct_bbox_2()(p.first);
+    }
+    
+  };
+  
+  Construct_bbox_2 construct_bbox_2_object() const
+  {
+    return Construct_bbox_2();
+  }
+  
+  class Construct_bbox_3 {
+  public:
+    typedef Bbox_2 result_type;
+    
+    template <typename T1, typename T2>
+    Bbox_3 operator()(const std::pair<T1,T2>& p) const
+    {
+      // AF: Or do we want to construct the BBox from Gmpq ?
+      return typename K1::Construct_bbox_3()(p.first);
+    }
+  };
+
+  Construct_bbox_3 construct_bbox_3_object() const
+  {
+    return Construct_bbox_3();
+  }
+  
+  template <typename OptionalVariant>
+  class Make_optional_variant
+    : public boost::static_visitor<>
+  {
+    OptionalVariant& ov;
+  public:
+
+    Make_optional_variant(OptionalVariant ov)
+      : ov(ov)
+    {}
+    
+    template <typename ET>
+    void operator()( const ET & et ) const
+    {
+      typedef typename Type_mapper<ET, K2, Self>::type T;
+      Cartesian_converter<K2,K1> to_k1;
+      to_k1(et);
+      ov = OptionalVariant(std::make_pair(to_k1(et),et));
+    }
+
+    template <typename ET>
+    void operator()( const std::vector<ET>& vec) const
+    {
+      typedef typename Type_mapper<ET, K2, Self>::type T;
+      std::vector<T> resvec;
+      Cartesian_converter<K2,K1> to_k1;
+      for(const ET& et : vec){
+        resvec.push_back(std::make_pair(to_k1(et),et));
+      }
+      ov = OptionalVariant(resvec);
+    }
+  };
+  
+  
+  class Intersect_2 {
+  public:
+
+    template<typename>
+    struct result;
+    
+    template<typename F, typename A, typename B>
+    struct result<F(A,B)> {
+      typedef typename Intersection_traits<Self, A, B>::result_type type;
+    };
+    
+    template <typename T1, typename T2>
+    typename Intersection_traits<Self,T1,T2>::result_type
+    operator()(const T1& s1, const T2& s2) const
+    {
+      typedef typename Type_mapper<T1,Self,K2>::type K2T1;
+      typedef typename Type_mapper<T2,Self,K2>::type K2T2;
+      
+      typedef  typename Intersection_traits<K2, K2T1, K2T2>::result_type Exact_optional_variant;
+      typedef typename Exact_optional_variant::value_type Exact_variant;
+      
+      Exact_optional_variant  eres = typename K2::Intersect_2()(s1.second,s2.second);
+
+      if(! eres){
+        return boost::none;
+      }
+      Exact_variant ev = *eres;
+
+      typedef typename Intersection_traits<Self,T1,T2>::result_type result_type;
+      result_type res;
+      boost::apply_visitor( Make_optional_variant<result_type>(res), ev );
+
+      return res;
+    }
+    
+  };
+  
+  class Intersect_3 {
+  public:
+
+    template <typename T1, typename T2>
+    typename Intersection_traits<Self,T1,T2>::result_type
+    operator()(const T1& s1, const T2& s2) const
+    {
+      typedef typename Type_mapper<T1,Self,K2>::type K2T1;
+      typedef typename Type_mapper<T2,Self,K2>::type K2T2;
+      
+      typedef  typename Intersection_traits<K2, K2T1, K2T2>::result_type Exact_optional_variant;
+      typedef typename Exact_optional_variant::value_type Exact_variant;
+      
+      Exact_optional_variant  eres = K2::Intersect_3()(s1.second,s2.second);
+
+      if(! eres){
+        return boost::none;
+      }
+      Exact_variant ev = *eres;
+
+      typedef typename Intersection_traits<Self,T1,T2>::result_type result_type;
+      result_type res;
+      boost::apply_visitor( Make_optional_variant<result_type>(res), ev );
+
+      return res;
+    }
+    
+  };
+
+  
+};
+
+template < class K1, class K2 >
+class Filtered_rational_kernel_without_type_equality
+  : public Filtered_rational_kernel_base<K1,K2,Filtered_rational_kernel_without_type_equality<K1,K2>>
+{};
+  
+template < class K1, class K2 >
+class Filtered_rational_kernel
+  : public Type_equality_wrapper<Filtered_rational_kernel_base<K1,K2, Filtered_rational_kernel<K1,K2>>,
+                                 Filtered_rational_kernel<K1,K2> >
+{
+};
+  
+} //namespace CGAL
+
+#endif // CGAL_FILTERED_RATIONAL_KERNEL_H

--- a/Kernel_23/test/Kernel_23/Filtered_rational_kernel.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_rational_kernel.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2001,2002  
+// Utrecht University (The Netherlands),
+// ETH Zurich (Switzerland),
+// INRIA Sophia-Antipolis (France),
+// Max-Planck-Institute Saarbruecken (Germany),
+// and Tel-Aviv University (Israel).  All rights reserved. 
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// 
+//
+// Author(s)     : Andreas Fabri
+ 
+
+#include <CGAL/Filtered_rational_kernel.h>
+#include <cassert>
+
+#define TEST_FILENAME "Test-Simple_cartesian-IO.out"
+#include "CGAL/_test_io.h"
+
+#include "CGAL/_test_2.h"
+#include "CGAL/_test_3.h"
+
+#include "CGAL/_test_new_2.h"
+#include "CGAL/_test_new_3.h"
+
+#include "CGAL/_test_fct_points_implicit_sphere.h"
+#include "CGAL/_test_orientation_and_bounded_side.h"
+#include "CGAL/_test_fct_constructions_2.h"
+#include "CGAL/_test_fct_constructions_3.h"
+#include "CGAL/_test_fct_point_3.h"
+#include "CGAL/_test_fct_coplanar_3.h"
+#include "CGAL/_test_cls_iso_cuboid_3.h"
+#include "CGAL/_test_angle.h"
+
+#include "CGAL/_test_mf_plane_3_to_2d.h"
+
+
+typedef CGAL::Simple_cartesian<CGAL::Interval_nt<false> > K1;
+typedef CGAL::Simple_cartesian<CGAL::Gmpq> K2;
+typedef CGAL::Filtered_rational_kernel<K1,K2>    Cls;
+
+
+int main()
+{
+  std::cout << "Testing 2d with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  _test_2( Cls() );
+
+  std::cout << "Testing 3d with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  _test_3( Cls() );
+
+  std::cout << "Testing new 2d with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  test_new_2( Cls() );
+  std::cout << "Testing new 3d with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  test_new_3( Cls() );
+
+  std::cout << "Testing new parts with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  _test_orientation_and_bounded_side( Cls() );
+  _test_fct_points_implicit_sphere( Cls() );
+  _test_fct_constructions_2( Cls() );
+  _test_fct_constructions_3( Cls() );
+  _test_fct_point_3( Cls() );
+  _test_fct_coplanar_3( Cls() );
+  _test_cls_iso_cuboid_3( Cls() );
+  _test_angle( Cls() );
+
+  std::cout << "Testing 3d-2d with Filtered_rational_kernel :";
+  std::cout << std::endl;
+  _test_mf_plane_3_to_2d( Cls() );
+
+  return 0;
+}

--- a/Number_types/include/CGAL/Filtered_rational.h
+++ b/Number_types/include/CGAL/Filtered_rational.h
@@ -1,0 +1,961 @@
+// Copyright (c) 2005-2007  
+// Utrecht University (The Netherlands),
+// ETH Zurich (Switzerland),
+// INRIA Sophia-Antipolis (France),
+// Max-Planck-Institute Saarbruecken (Germany),
+// and Tel-Aviv University (Israel).  All rights reserved. 
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Sylvain Pion, Michael Hemmer
+
+#ifndef CGAL_FILTERED_RATIONAL_H
+#define CGAL_FILTERED_RATIONAL_H
+
+#include <CGAL/Gmpq.h>
+#include <CGAL/Interval_nt.h>
+#include <CGAL/number_type_basic.h>
+#include <sstream>
+
+// A number type class, parameterized by 2 number types NT1 and NT2.
+// It runs all operations on parallel over NT1 and NT2.
+// It is also parameterized by a comparator which compares the values
+// of NT1 and NT2 after all arithmetic operations.
+
+// #define CGAL_NT_CHECK_DEBUG(s) std::cerr << s << std::endl
+#define CGAL_NT_CHECK_DEBUG(s)
+
+namespace CGAL {
+
+namespace internal {
+
+// std::equal_to<T> sticks things to one type, so I define my own.
+struct Equal_to
+{
+  template < typename NT1, typename NT2 >
+  bool operator()(const NT1& a, const NT2& b) const
+  { return true; }
+};
+
+} // namespace internal
+
+
+  template < typename NT1 = Interval_nt<true>, typename NT2=Gmpq, typename Cmp = internal::Equal_to >
+class Filtered_rational
+{
+  NT1 _n1;
+  NT2 _n2;
+  Cmp cmp;
+public:
+
+  typedef Filtered_rational<NT1, NT2, Cmp> Self;
+
+  Filtered_rational() {}
+  
+  Filtered_rational(int i)
+    : _n1(i), _n2(i)
+  { CGAL_assertion(is_valid()); }
+
+  Filtered_rational(double d)
+    : _n1(d), _n2(d)
+  { CGAL_assertion(is_valid()); }
+  
+  Filtered_rational(const NT1 &n1, const NT2 &n2)
+    : _n1(n1), _n2(n2)
+  { CGAL_assertion(is_valid()); }
+
+  Filtered_rational(const std::pair<NT1,NT2> &np)
+    : _n1(np.first), _n2(np.second)
+  { CGAL_assertion(is_valid()); }
+
+  Filtered_rational(const NT2 &n2)
+    : _n1(to_interval(n1)), _n2(n2)
+  { CGAL_assertion(is_valid()); }
+
+  Self& operator=(const std::pair<NT1,NT2> &np)
+  {
+    _n1 = np.first;
+    _n2 = np.second;
+  }
+  
+  // The following need to be dependant on NT1 != {NT2,int,double} ...
+  //Filtered_rational(const NT1 &n1) : _n1(n1), _n2(n1) {}
+  //Filtered_rational(const NT2 &n2) : _n1(n2), _n2(n2) {}
+
+  Self& operator+=(const Self &a)
+  { n2() += a.n2(); n1() = to_interval(n2()); return *this; }
+
+  Self& operator-=(const Self &a)
+  { n2() -= a.n2(); n1() = to_interval(n2()); return *this; }
+
+  Self& operator*=(const Self &a)
+  { n2() *= a.n2(); n1() = to_interval(n2()); return *this; }
+
+  Self& operator/=(const Self &a)
+  { n2() /= a.n2(); n1() = to_interval(n2()); return *this; }
+
+  // Accessors and setters.
+  const NT1& n1() const { return _n1; }
+  const NT2& n2() const { return _n2; }
+
+  NT1& n1() { return _n1; }
+  NT2& n2() { return _n2; }
+
+  // Validity checking: the exact number must be in the interval
+
+  bool is_valid() const
+  {
+    NT1 n2i = to_interval(n2());
+    return (n2i.inf() >= n1().inf())  && (n2i.sup() <= n1().sup());
+  }
+};
+
+  
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator+(const Filtered_rational<NT1, NT2, Cmp> &a)
+{
+   CGAL_NT_CHECK_DEBUG("operator+");
+   return Filtered_rational<NT1, NT2, Cmp>(+ a.n1(), + a.n2() );
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator+(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator+");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() + b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator+(int a, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator+");
+   return Filtered_rational<NT1, NT2, Cmp>(a + b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator+(const Filtered_rational<NT1, NT2, Cmp> &a, int b)
+{
+   CGAL_NT_CHECK_DEBUG("operator+");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() + b);
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator-(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator-");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() - b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator-(int a, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator-");
+   return Filtered_rational<NT1, NT2, Cmp>(a - b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator-(const Filtered_rational<NT1, NT2, Cmp> &a, int b)
+{
+   CGAL_NT_CHECK_DEBUG("operator-");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() - b);
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator-(const Filtered_rational<NT1, NT2, Cmp> &a)
+{
+   CGAL_NT_CHECK_DEBUG("unary operator-");
+   return Filtered_rational<NT1, NT2, Cmp>(-a.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator*(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator*");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() * b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator*(int a, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator*");
+   return Filtered_rational<NT1, NT2, Cmp>(a * b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator*(const Filtered_rational<NT1, NT2, Cmp> &a, int b)
+{
+   CGAL_NT_CHECK_DEBUG("operator*");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() * b);
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator/(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator/");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() / b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator/(int a, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   CGAL_NT_CHECK_DEBUG("operator/");
+   return Filtered_rational<NT1, NT2, Cmp>(a / b.n2());
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+Filtered_rational<NT1, NT2, Cmp>
+operator/(const Filtered_rational<NT1, NT2, Cmp> &a, int b)
+{
+   CGAL_NT_CHECK_DEBUG("operator/");
+   return Filtered_rational<NT1, NT2, Cmp>(a.n2() / b);
+}
+
+// arithmetic operators end
+// compare operators begin
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator==(const Filtered_rational<NT1, NT2, Cmp> &a,
+           const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  if(a.n1().is_point() && (b.n1().is_point())){
+    return a.n1().inf() == b.n1().inf();
+  }
+  
+  if(a.n1().do_overlap(b.n1())){
+    return a.n2() == b.n2();
+  }
+  return false;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator!=(const Filtered_rational<NT1, NT2, Cmp> &a,
+           const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  
+  return ! (a == b);
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  if(a.n1().sup() < b.n1().inf()){
+    return true;
+  }
+  if(a.n1().inf() > b.n1.sup){
+    return false;
+  }
+  return a.n2() < b.n2();
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>(const Filtered_rational<NT1, NT2, Cmp> &a,
+          const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b < a;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<=(const Filtered_rational<NT1, NT2, Cmp> &a,
+           const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  if(a.n1().sup() <= b.n1().inf()){
+    return true;
+  }
+  if(a.n1().inf() >= b.n1.sup){
+    return false;
+  }
+  return a.n2() <= b.n2();
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>=(const Filtered_rational<NT1, NT2, Cmp> &a,
+           const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   return b <= a;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator==(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+   bool b1 = a.n1() == i;
+   CGAL_assertion(b1 == ( a.n2() == i ) );
+   return b1;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator!=(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+  Uncertain<bool> ub  = a.n1() != i;
+  if(is_certain(ub)){
+    return get_certain(ub);
+  }
+   return a.n2() != i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+  Uncertain<bool> ub  = a.n1() < i;
+  if(is_certain(ub)){
+    return get_certain(ub);
+  }
+   return a.n2() < i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+  Uncertain<bool> ub  = a.n1() > i;
+  if(is_certain(ub)){
+    return get_certain(ub);
+  }
+   return a.n2() > i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<=(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+  Uncertain<bool> ub  = a.n1() <= i;
+  if(is_certain(ub)){
+    return get_certain(ub);
+  }
+   return a.n2() <= i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>=(const Filtered_rational<NT1, NT2, Cmp> &a, int i)
+{
+  Uncertain<bool> ub  = a.n1() >= i;
+  if(is_certain(ub)){
+    return get_certain(ub);
+  }
+   return a.n2() >= i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator==(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b == i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator!=(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b != i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b > i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b < i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator<=(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return b >= i;
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+bool
+operator>=(int i, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+   return b <= i;
+}
+
+// compare operators end
+// Functors Is_valid
+
+template < typename NT1, typename NT2, typename Cmp >
+class Is_valid< Filtered_rational<NT1, NT2, Cmp> >
+    : public CGAL::cpp98::unary_function< Filtered_rational<NT1, NT2, Cmp> , bool > {
+public :
+    bool operator()(const  Filtered_rational<NT1, NT2, Cmp>& a ) const {
+        bool b1 = is_valid(a.n1());
+        CGAL_assertion(b1 == is_valid(a.n2()) );
+        return b1;
+    }
+};
+
+namespace NTC_INTERN{
+// -----------------------------
+
+// fwd
+template < typename Filtered_rational, typename Algebraic_category>
+class NTC_AST_base
+    :public Algebraic_structure_traits_base< Filtered_rational , Null_tag>{
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+< Filtered_rational<NT1, NT2, Cmp> , Integral_domain_without_division_tag>
+:public Algebraic_structure_traits_base<Filtered_rational<NT1, NT2, Cmp>, 
+Integral_domain_without_division_tag>
+{
+private:
+    typedef Algebraic_structure_traits<NT1> AST1;
+    typedef Algebraic_structure_traits<NT2> AST2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+
+public:
+    //CGAL::Algebraic_structure_traits<>::Simplify
+    class Simplify
+        : public CGAL::cpp98::unary_function< Type& , void > {
+    public:
+        void operator()( Type& a) const {
+            typename AST1::Simplify()(a.n1());
+            typename AST2::Simplify()(a.n2());
+            CGAL_assertion(a.is_valid());
+        }
+    };
+
+    //CGAL::Algebraic_structure_traits< >::Is_zero
+    class Is_zero
+        : public CGAL::cpp98::unary_function< Type, bool > {
+    public:
+        bool operator()(const  Type& a ) const {
+          Uncertain<bool> ub = typename AST1::Is_zero()(a.n1());
+          if(is_certain(ub)){
+            return get_certain(ub);
+          }
+          return typename AST2::Is_zero()(a.n2());
+        }
+    };
+
+    // CGAL::Algebraic_structure_traits< >::Is_one
+    class Is_one
+        : public CGAL::cpp98::unary_function< Type, bool > {
+    public:
+        bool operator()(const Type& a) const {
+          Uncertain<bool> ub = typename AST1::Is_one()(a.n1());
+          if(is_certain(ub)){
+            return get_certain(ub);
+          }
+          return typename AST2::Is_one()(a.n2());
+        }
+    };
+    // CGAL::Algebraic_structure_traits<  >::Square
+    class Square
+        : public CGAL::cpp98::unary_function< Type , Type > {
+    public:
+        Type operator()(const Type& a) const {
+            return Type(typename AST2::Square()(a.n2()));
+        }
+    };
+
+
+    // CGAL::Algebraic_structure_traits<  >::Unit_part
+    class Unit_part
+        : public CGAL::cpp98::unary_function< Type , Type > {
+    public:
+        Type operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("AST::Unit_part");
+            return Type(typename AST2::Unit_part()(a.n2()));
+        }
+    };
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Integral_domain_tag >
+      :public  NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Integral_domain_without_division_tag >
+{
+private:
+    typedef Algebraic_structure_traits<NT1> AST1;
+    typedef Algebraic_structure_traits<NT2> AST2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+
+public:
+
+// CGAL::Algebraic_structure_traits< >::Integral_division
+    class Integral_division
+        : public CGAL::cpp98::binary_function< Type, Type, Type > {
+    public:
+        Type operator()( const Type& a, const Type& b) const {
+            CGAL_NT_CHECK_DEBUG("AST::Integral_division");
+            return Type(typename AST2::Integral_division()(a.n2(),b.n2()));
+        }
+    }; 
+  
+  class Divides
+    : public CGAL::cpp98::binary_function< Type, Type, bool > {
+  public:
+    bool operator()( const Type& a, const Type& b) const {
+      CGAL_NT_CHECK_DEBUG("AST::Divides");
+      Uncertain<bool> ub =  typename AST1::Divides()(a.n1(),b.n1());
+      if(is_certain(ub)){
+        return get_certain(ub);
+      }
+      return typename AST2::Divides()(a.n2(),b.n2());
+
+    }
+    bool operator()( const Type& a, const Type& b, Type& q) const {
+      CGAL_NT_CHECK_DEBUG("AST::Divides");
+      NT1 q1; 
+      bool result1 =  typename AST1::Divides()(a.n1(),b.n1(),q1);
+      NT2 q2; 
+      CGAL_assertion_code( bool result2 = ) // needed for CGAL_assert only
+        typename AST2::Divides()(a.n2(),b.n2(),q2);
+      q = Type(q1,q2);
+      CGAL_assertion(result1 == result2);
+      return result1;
+    }
+    CGAL_IMPLICIT_INTEROPERABLE_BINARY_OPERATOR_WITH_RT(Type,bool)
+  };
+};
+
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+< Filtered_rational< NT1, NT2, Cmp> , Unique_factorization_domain_tag >
+    :public  NTC_AST_base
+< Filtered_rational< NT1, NT2, Cmp> , Integral_domain_tag >
+{
+private:
+    typedef Algebraic_structure_traits<NT1> AST1;
+    typedef Algebraic_structure_traits<NT2> AST2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+public:
+    // CGAL::Algebraic_structure_traits< >::Gcd
+    class Gcd
+        : public CGAL::cpp98::binary_function< Type,
+                                  Type,
+                                  Type > {
+    public:
+        Type operator()(
+                const Type& a,
+                const Type& b) const {
+            CGAL_NT_CHECK_DEBUG("AST::Gcd");
+            return Type(
+                    typename AST1::Gcd()(a.n1(),b.n1()),
+                    typename AST2::Gcd()(a.n2(),b.n2()));
+        }
+    };
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+< Filtered_rational< NT1, NT2, Cmp> , Euclidean_ring_tag >
+    :public  NTC_AST_base
+< Filtered_rational< NT1, NT2, Cmp> , Unique_factorization_domain_tag >
+{
+private:
+    typedef Algebraic_structure_traits<NT1> AST1;
+    typedef Algebraic_structure_traits<NT2> AST2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+public:
+    // CGAL::Algebraic_structure_traits< >::Div
+    class Div
+        : public CGAL::cpp98::binary_function< Type,
+                                  Type,
+                                  Type > {
+    public:
+        Type operator()(
+                const Type& a,
+                const Type& b) const {
+            CGAL_NT_CHECK_DEBUG("AST::Div");
+            return Type(
+                    typename AST1::Div()(a.n1(),b.n1()),
+                    typename AST2::Div()(a.n2(),b.n2()));
+        }
+    };
+    // CGAL::Algebraic_structure_traits< >::Mod
+    class Mod
+        : public CGAL::cpp98::binary_function< Type,
+                                  Type,
+                                  Type > {
+    public:
+        Type operator()(
+                const Type& a,
+                const Type& b) const {
+            CGAL_NT_CHECK_DEBUG("AST::Mod");
+            return Type(
+                    typename AST1::Mod()(a.n1(),b.n1()),
+                    typename AST2::Mod()(a.n2(),b.n2()));
+        }
+    };
+
+    // CGAL::Algebraic_structure_traits< >::Div_mod
+    class Div_mod {
+    public:
+        typedef Type    first_argument_type;
+        typedef Type    second_argument_type;
+        typedef Type&   third_argument_type;
+        typedef Type&   fourth_argument_type;
+        typedef void  result_type;
+
+        void operator()(
+                const Type& a,
+                const Type& b,
+                Type& q,
+                Type& r) const {
+            CGAL_NT_CHECK_DEBUG("AST::Div_mod");
+            NT1 q1,r1;
+            NT2 q2,r2;
+            typename AST1::Div_mod()(a.n1(),b.n1(),q1,r1);
+            typename AST2::Div_mod()(a.n2(),b.n2(),q2,r2);
+            q = Type(q1,q2);
+            r = Type(r1,r2);
+        }
+    };
+};
+
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Field_tag >
+      :public  NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Integral_domain_tag >
+{
+private:
+  typedef Algebraic_structure_traits<NT1> AST1;
+  typedef Algebraic_structure_traits<NT2> AST2;
+  typedef Filtered_rational<NT1, NT2, Cmp> Type;
+public:  
+  class Inverse
+    : public CGAL::cpp98::unary_function< Type, Type > {
+  public:
+    Type operator()( const Type& a ) const {
+      NT1 r1 = typename AST1::Inverse()(a.n1());
+      NT2 r2 = typename AST2::Inverse()(a.n2());
+      return Type(r1,r2); 
+    }
+  };
+
+
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Field_with_sqrt_tag >
+      :public  NTC_AST_base
+      < Filtered_rational< NT1, NT2, Cmp> , Field_tag >
+{
+private:
+    typedef Algebraic_structure_traits<NT1> AST1;
+    typedef Algebraic_structure_traits<NT2> AST2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+
+public:
+
+    // CGAL::Algebraic_structure_traits<  >::Sqrt
+    class Sqrt
+        : public CGAL::cpp98::unary_function< Type , Type > {
+    public:
+        Type operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("AST::Sqrt");
+            return Type(
+                    typename AST1::Sqrt()(a.n1()),
+                    typename AST2::Sqrt()(a.n2()));
+        }
+    };
+};
+
+} // namespace NTC_INTERN
+
+
+template < typename NT1, typename NT2, typename Cmp >
+class Algebraic_structure_traits <Filtered_rational<NT1, NT2, Cmp> >
+  :public NTC_INTERN::NTC_AST_base< Filtered_rational< NT1, NT2, Cmp> ,
+                                 typename Algebraic_structure_traits<NT1>::Algebraic_category >
+{
+    typedef Algebraic_structure_traits<NT1> AST1;
+public:
+    typedef Filtered_rational< NT1, NT2, Cmp> Type;
+    typedef typename AST1::Algebraic_category Algebraic_category;
+    typedef typename AST1::Is_exact Is_exact;
+
+};
+
+
+namespace NTC_INTERN{
+template < typename Filtered_rational, typename Is_real_embeddable >
+class NTC_RET_base;
+
+template < typename NT >
+class NTC_RET_base<NT,Tag_false> : public Real_embeddable_traits<NT>
+{};
+
+template < typename NT1, typename NT2, typename Cmp >
+class NTC_RET_base
+< Filtered_rational<NT1, NT2, Cmp> , Tag_true>
+  :public INTERN_RET::Real_embeddable_traits_base< Filtered_rational< NT1, NT2, Cmp > , CGAL::Tag_true >
+{
+private:
+    typedef Real_embeddable_traits<NT1> RET1;
+    typedef Real_embeddable_traits<NT2> RET2;
+    typedef Filtered_rational<NT1, NT2, Cmp> Type;
+public:
+
+    // CGAL::Real_embeddable_traits<  >::Abs
+    class Abs
+        : public CGAL::cpp98::unary_function< Type , Type > {
+    public:
+        Type operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Abs");
+            return Type(
+                    typename RET1::Abs()(a.n1()),
+                    typename RET2::Abs()(a.n2()));
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Sign
+    class Sgn
+        : public CGAL::cpp98::unary_function< Type , ::CGAL::Sign > {
+    public:
+        ::CGAL::Sign operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Sign");
+            Uncertain<Sign> ub =  typename RET1::Sgn()(a.n1());
+            if(is_certain(ub)){
+              return get_certain(ub);
+            }
+            return typename RET2::Sgn()(a.n2() );
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Is_finite
+    class Is_finite
+        : public CGAL::cpp98::unary_function< Type , bool > {
+    public:
+        bool operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Is_finite");
+            bool r1 =  typename RET1::Is_finite()(a.n1());
+            // CGAL_assertion( r1 == typename RET2::Is_finite()(a.n2()) );
+            // AF: what to do??
+            // See what Gmpq does
+            return r1;
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Is_positive
+    class Is_positive
+        : public CGAL::cpp98::unary_function< Type , bool > {
+    public:
+        bool operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Is_positive");
+            Uncertain<bool> ub =  typename RET1::Is_positive()(a.n1());
+            if(is_certain(ub)){
+              return get_certain(ub);
+            }
+            return typename RET2::Is_positive()(a.n2());
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Is_negative
+    class Is_negative
+        : public CGAL::cpp98::unary_function< Type , bool > {
+    public:
+        bool operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Is_negative");
+            bool r1 =  typename RET1::Is_negative()(a.n1());
+            CGAL_assertion( r1 == typename RET2::Is_negative()(a.n2()) );
+            return r1;
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Is_zero
+    class Is_zero
+        : public CGAL::cpp98::unary_function< Type , bool > {
+    public:
+        bool operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::Is_zero");
+            Uncertain<bool> ub =  typename RET1::Is_zero()(a.n1());
+            if(is_certain(ub)){
+              return get_certain(ub);
+            }
+            return typename RET2::Is_zero()(a.n2() );
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::Compare
+    class Compare
+        : public CGAL::cpp98::binary_function< Type , Type, Comparison_result > {
+    public:
+        Comparison_result operator()(const Type& a, const Type& b) const {
+            CGAL_NT_CHECK_DEBUG("RET::Compare");
+            Uncertain<Comparison_result> ucr =  typename RET1::Compare()(a.n1(),b.n1());
+            if(is_certain(ucr)){
+              return get_certain(ucr);
+            }
+            return typename RET2::Compare()(a.n2(),b.n2());
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::To_double
+    class To_double
+        : public CGAL::cpp98::unary_function< Type , double > {
+    public:
+        double operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::To_double");
+            double r1 =  typename RET1::To_double()(a.n1());
+            // AF: Do we have to check something ??
+            // YES See Lazy_exact_nt
+            // r1 == typename RET2::To_double()(a.n2()) );
+            return r1;
+        }
+    };
+
+    // CGAL::Real_embeddable_traits<  >::To_interval
+    class To_interval
+        : public CGAL::cpp98::unary_function< Type , std::pair<double, double> > {
+    public:
+        std::pair<double, double> operator()(const Type& a) const {
+            CGAL_NT_CHECK_DEBUG("RET::To_interval");
+            std::pair<double, double> r1 =  typename RET1::To_interval()(a.n1());
+            return r1;
+        }
+    };
+};
+
+} // namespace NTC_INTERN
+
+template < typename NT1, typename NT2, typename Cmp >
+class Real_embeddable_traits
+< Filtered_rational<NT1, NT2, Cmp> >
+    :public NTC_INTERN::NTC_RET_base< Filtered_rational< NT1, NT2, Cmp > ,
+      typename Real_embeddable_traits<NT1>::Is_real_embeddable >
+{
+    typedef Real_embeddable_traits<NT1> RET1;
+public:
+    typedef Filtered_rational< NT1, NT2, Cmp >  Type;
+    typedef typename RET1::Is_real_embeddable     Is_real_embeddable;
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+struct Coercion_traits< Filtered_rational<NT1,NT2,Cmp>,
+                        Filtered_rational<NT1,NT2,Cmp> >{
+    typedef Tag_true  Are_explicit_interoperable;
+    typedef Tag_true  Are_implicit_interoperable;
+    typedef Filtered_rational<NT1,NT2,Cmp> Type;
+    struct Cast{
+        typedef Type result_type;
+        Type operator()(const Type& x) const { return x;}
+    };
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+struct Coercion_traits< Filtered_rational<NT1,NT2,Cmp>, int >{
+    typedef Tag_true  Are_explicit_interoperable;
+    typedef Tag_true  Are_implicit_interoperable;
+    typedef Filtered_rational<NT1,NT2,Cmp> Type;
+    struct Cast{
+        typedef Type result_type;
+        Type operator()(const Type& x) const { return x;}
+        Type operator()(int x) const { return Type(x);}
+    };
+};
+
+template < typename NT1, typename NT2, typename Cmp >
+struct Coercion_traits< int , Filtered_rational<NT1,NT2,Cmp> >
+    :public Coercion_traits< Filtered_rational<NT1,NT2,Cmp> , int >{};
+
+namespace NTC_INTERN {
+
+
+template < typename NT_checker, typename Tag = Tag_false >
+struct Coercion_traits_double{
+    typedef Tag_false  Are_explicit_interoperable;
+    typedef Tag_false  Are_implicit_interoperable;
+    typedef Null_tag Type;
+};
+
+template < typename NT1, typename NT2, typename Cmp>
+struct Coercion_traits_double< Filtered_rational<NT1,NT2,Cmp> ,
+                               Tag_true >{
+    typedef Tag_true  Are_explicit_interoperable;
+    typedef Tag_true  Are_implicit_interoperable;
+    typedef Filtered_rational<NT1,NT2,Cmp> Type;
+     struct Cast{
+        typedef Type result_type;
+         Type operator()(const Type& x) const { return x;}
+         Type operator()(const double& x) const {
+             return Type(x);
+         }
+    };
+};
+} // namespace NTC_INTERN
+
+template < typename NT1, typename NT2, typename Cmp >
+struct Coercion_traits< Filtered_rational<NT1,NT2,Cmp>, double >
+    :public NTC_INTERN::Coercion_traits_double< Filtered_rational<NT1,NT2,Cmp>,
+            typename Coercion_traits<NT1,double>::Are_implicit_interoperable >
+{};
+
+template < typename NT1, typename NT2, typename Cmp >
+struct Coercion_traits< double , Filtered_rational<NT1,NT2,Cmp> >
+    :public Coercion_traits< Filtered_rational<NT1,NT2,Cmp>, double > {};
+
+
+// What to do with the IO ?
+// - either pick one as the main, and convert to the second.
+// - output/input pairs, and read both (=> problems with FP values).
+
+template < typename NT1, typename NT2, typename Cmp >
+std::ostream &
+operator<< (std::ostream & os, const Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  return os << b.n1();
+}
+
+template < typename NT1, typename NT2, typename Cmp >
+std::istream &
+operator>> (std::istream & is, Filtered_rational<NT1, NT2, Cmp> &b)
+{
+  is >> b.n1();
+  std::stringstream ss;
+  ss << b.n1();
+  ss >> b.n2();
+  return is;
+}
+
+} //namespace CGAL
+
+#endif // CGAL_FILTERED_RATIONAL_H


### PR DESCRIPTION
## Summary of Changes

Add a kernel and a numbertype that stores interval approximations for Gmqs.

## Release Management.

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

