### PR TITLE
SMSP: Fix some const correctness

### DIFF
--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -11,16 +11,16 @@
 
 #include <boost/lexical_cast.hpp>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef CGAL::Polyhedron_3<Kernel> Triangle_mesh;
-typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh> Traits;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel               Kernel;
+typedef CGAL::Polyhedron_3<Kernel>                                        Triangle_mesh;
+typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, Triangle_mesh>    Traits;
 // default property maps
 typedef boost::property_map<Triangle_mesh,
-                            boost::vertex_external_index_t>::type  Vertex_index_map;
+                            boost::vertex_external_index_t>::const_type   Vertex_index_map;
 typedef boost::property_map<Triangle_mesh,
-                            CGAL::halfedge_external_index_t>::type Halfedge_index_map;
+                            CGAL::halfedge_external_index_t>::const_type  Halfedge_index_map;
 typedef boost::property_map<Triangle_mesh,
-                            CGAL::face_external_index_t>::type     Face_index_map;
+                            CGAL::face_external_index_t>::const_type      Face_index_map;
 typedef CGAL::Surface_mesh_shortest_path<Traits,
                                          Vertex_index_map,
                                          Halfedge_index_map,

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -73,7 +73,7 @@ Refer to those respective papers for the details of the implementation.
 \tparam VPM a model of `ReadablePropertyMap` with `vertex_descriptor` as key and `Traits::Point_3` as value type.
             The default is `boost::property_map<HG, CGAL::vertex_point_t>::%const_type`.
 
-If no property map is provided through the constructor of the class, the internal property maps must
+If index property maps are not provided through the constructor of the class, internal property maps must
 be available and initialized.
 
 \sa \link PkgBGLHelper `CGAL::set_halfedgeds_items_id()`\endlink

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -65,13 +65,18 @@ Refer to those respective papers for the details of the implementation.
 
 \tparam Traits a model of `SurfaceMeshShortestPathTraits`.
 \tparam VIM a model of `ReadablePropertyMap` with `vertex_descriptor` as key and `unsigned int` as value type.
-            The default is `boost::property_map<HG, boost::%vertex_index_t>::%type`.
+            The default is `boost::property_map<HG, boost::%vertex_index_t>::%const_type`.
 \tparam HIM a model of `ReadablePropertyMap` with `halfedge_descriptor` as key and `unsigned int` as value type.
-            The default is `boost::property_map<HG, boost::%halfedge_index_t>::%type`.
+            The default is `boost::property_map<HG, boost::%halfedge_index_t>::%const_type`.
 \tparam FIM a model of `ReadablePropertyMap` with `face_descriptor` as key and `unsigned int` as value type.
-            The default is `boost::property_map<HG, boost::%face_index_t>::%type`.
+            The default is `boost::property_map<HG, boost::%face_index_t>::%const_type`.
 \tparam VPM a model of `ReadablePropertyMap` with `vertex_descriptor` as key and `Traits::Point_3` as value type.
-            The default is `boost::property_map<HG, CGAL::vertex_point_t>::%type`.
+            The default is `boost::property_map<HG, CGAL::vertex_point_t>::%const_type`.
+
+If no property map is provided through the constructor of the class, the internal property maps must
+be available and initialized.
+
+\sa \link PkgBGLHelper `CGAL::set_halfedgeds_items_id()`\endlink
 */
 
 template<class Traits,
@@ -104,22 +109,22 @@ public:
 
   typedef typename Default::Get<
     VIM,
-    typename boost::property_map<Triangle_mesh, boost::vertex_index_t>::type
+    typename boost::property_map<Triangle_mesh, boost::vertex_index_t>::const_type
       >::type Vertex_index_map;
 
   typedef typename Default::Get<
     HIM,
-    typename boost::property_map<Triangle_mesh, boost::halfedge_index_t>::type
+    typename boost::property_map<Triangle_mesh, boost::halfedge_index_t>::const_type
       >::type Halfedge_index_map;
 
   typedef typename Default::Get<
     FIM,
-    typename boost::property_map<Triangle_mesh, boost::face_index_t>::type
+    typename boost::property_map<Triangle_mesh, boost::face_index_t>::const_type
       >::type Face_index_map;
 
   typedef typename Default::Get<
     VPM,
-    typename boost::property_map<Triangle_mesh, CGAL::vertex_point_t>::type
+    typename boost::property_map<Triangle_mesh, CGAL::vertex_point_t>::const_type
       >::type Vertex_point_map;
 
 #else
@@ -336,7 +341,7 @@ private:
 
 private:
   const Traits& m_traits;
-  Triangle_mesh& m_graph;
+  const Triangle_mesh& m_graph;
 
   Vertex_index_map m_vertexIndexMap;
   Halfedge_index_map m_halfedgeIndexMap;
@@ -2196,11 +2201,15 @@ public:
 
   Equivalent to `Surface_mesh_shortest_path(tm, get(boost::vertex_index, tm), get(boost::halfedge_index, tm),
                                             get(boost::face_index, tm), get(CGAL::vertex_point, tm), traits)`.
+
+  Internal property maps must be available and initialized.
+
+  \sa \link PkgBGLHelper `CGAL::set_halfedgeds_items_id()`\endlink
   */
-  Surface_mesh_shortest_path(Triangle_mesh& tm,
+  Surface_mesh_shortest_path(const Triangle_mesh& tm,
                              const Traits& traits = Traits())
     : m_traits(traits)
-    , m_graph(const_cast<Triangle_mesh&>(tm))
+    , m_graph(tm)
     , m_vertexIndexMap(get(boost::vertex_index, tm))
     , m_halfedgeIndexMap(get(boost::halfedge_index, tm))
     , m_faceIndexMap(get(boost::face_index, tm))
@@ -2234,7 +2243,7 @@ public:
                              Vertex_point_map vertexPointMap,
                              const Traits& traits = Traits())
     : m_traits(traits)
-    , m_graph(const_cast<Triangle_mesh&>(tm))
+    , m_graph(tm)
     , m_vertexIndexMap(vertexIndexMap)
     , m_halfedgeIndexMap(halfedgeIndexMap)
     , m_faceIndexMap(faceIndexMap)

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
@@ -98,7 +98,7 @@ void test_simple_saddle_vertex_mesh()
   typedef Graph_traits::halfedge_descriptor halfedge_descriptor;
   typedef Graph_traits::face_descriptor face_descriptor;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type VPM;
+  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::const_type VPM;
 
   Traits traits;
 
@@ -197,7 +197,7 @@ void test_simple_saddle_vertex_mesh()
 
   collector.m_sequence.clear();
 
-  typedef boost::property_map<Polyhedron_3, CGAL::halfedge_external_index_t>::type HalfedgeIndexMap;
+  typedef boost::property_map<Polyhedron_3, CGAL::halfedge_external_index_t>::const_type HalfedgeIndexMap;
 
   HalfedgeIndexMap halfedgeIndexMap(CGAL::get(CGAL::halfedge_external_index, P));
 
@@ -329,7 +329,7 @@ void test_boundary_mesh()
   typedef Graph_traits::face_descriptor face_descriptor;
   typedef Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type VPM;
+  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::const_type VPM;
 
   Traits traits;
 
@@ -398,7 +398,7 @@ void test_boundary_mesh()
 
   Barycentric_coordinates startLocation = construct_barycentric_coordinates(FT(0.1), FT(0.8), FT(0.1));
 
-  typedef boost::property_map<Polyhedron_3, CGAL::face_external_index_t>::type FaceIndexMap;
+  typedef boost::property_map<Polyhedron_3, CGAL::face_external_index_t>::const_type FaceIndexMap;
 
   FaceIndexMap faceIndexMap(CGAL::get(CGAL::face_external_index, P));
 
@@ -462,6 +462,6 @@ int main()
   shortest_path_regular_tetrahedron();
   test_simple_saddle_vertex_mesh();
   test_boundary_mesh();
-  
+
    return 0;
 }

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
@@ -37,9 +37,9 @@ int main(int argc, char* argv[])
   typedef Graph_traits::face_descriptor face_descriptor;
   typedef Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-  typedef boost::property_map<Polyhedron_3, boost::vertex_index_t>::type VIM;
-  typedef boost::property_map<Polyhedron_3, boost::halfedge_index_t>::type HIM;
-  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::type FIM;
+  typedef boost::property_map<Polyhedron_3, boost::vertex_index_t>::const_type VIM;
+  typedef boost::property_map<Polyhedron_3, boost::halfedge_index_t>::const_type HIM;
+  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::const_type FIM;
 
 
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
@@ -35,8 +35,8 @@ int main(int argc, char* argv[])
   typedef Graph_traits::face_descriptor face_descriptor;
   typedef Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type VPM;
-  typedef boost::property_map<Polyhedron_3, CGAL::face_index_t>::type FIM;
+  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::const_type VPM;
+  typedef boost::property_map<Polyhedron_3, CGAL::face_index_t>::const_type FIM;
 
   typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron_3, VPM> AABB_face_graph_primitive;
   typedef CGAL::AABB_traits<Kernel, AABB_face_graph_primitive> AABB_face_graph_traits;

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* argv[])
   typedef Graph_traits::face_descriptor face_descriptor;
   typedef Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
-  typedef boost::property_map<Polyhedron_3, boost::vertex_point_t>::type VPM;
-  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::type FIM;
+  typedef boost::property_map<Polyhedron_3, boost::vertex_point_t>::const_type VPM;
+  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::const_type FIM;
 
   typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron_3, VPM> AABB_face_graph_primitive;
   typedef CGAL::AABB_traits<Kernel, AABB_face_graph_primitive> AABB_face_graph_traits;
@@ -83,8 +83,8 @@ int main(int argc, char* argv[])
 
   size_t numTrials = 30;
 
-  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type VPM ;
-  typedef boost::property_map<Polyhedron_3, CGAL::face_index_t>::type FIM;
+  typedef boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::const_type VPM ;
+  typedef boost::property_map<Polyhedron_3, CGAL::face_index_t>::const_type FIM;
 
   FIM faceIndexMap(get(boost::face_index, polyhedron));
   VPM vertexPointMap(get(CGAL::vertex_point, polyhedron));

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
@@ -35,9 +35,9 @@ int main(int argc, char* argv[])
   typedef Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
   typedef Surface_mesh_shortest_path::Face_location Face_location;
-  typedef boost::property_map<Polyhedron_3, boost::vertex_index_t>::type VIM;
-  typedef boost::property_map<Polyhedron_3, boost::halfedge_index_t>::type HIM;
-  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::type FIM;
+  typedef boost::property_map<Polyhedron_3, boost::vertex_index_t>::const_type VIM;
+  typedef boost::property_map<Polyhedron_3, boost::halfedge_index_t>::const_type HIM;
+  typedef boost::property_map<Polyhedron_3, boost::face_index_t>::const_type FIM;
 
   Traits traits;
 

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -61,11 +61,11 @@ struct TestMeshProgramInstance
   typedef typename Graph_traits::face_iterator face_iterator;
   typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
   typedef typename Surface_mesh_shortest_path::Face_location Face_location;
-  typedef typename boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::type VPM;
-  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::vertex_index_t>::type VIM;
-  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::edge_index_t>::type EIM;
-  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::halfedge_index_t>::type HIM;
-  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::face_index_t>::type FIM;
+  typedef typename boost::property_map<Polyhedron_3, CGAL::vertex_point_t>::const_type VPM;
+  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::vertex_index_t>::const_type VIM;
+  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::edge_index_t>::const_type EIM;
+  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::halfedge_index_t>::const_type HIM;
+  typedef typename boost::property_map<typename Traits::Triangle_mesh, boost::face_index_t>::const_type FIM;
 
   TestMeshProgramInstance()
   {

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/include/CGAL/test_util.h
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/include/CGAL/test_util.h
@@ -41,9 +41,9 @@ struct Sequence_item
 };
 
 template <class Traits, 
-  class VIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::vertex_index_t>::type,
-  class HIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::halfedge_index_t>::type,
-  class FIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::face_index_t>::type>
+  class VIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::vertex_index_t>::const_type,
+  class HIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::halfedge_index_t>::const_type,
+  class FIM = typename boost::property_map<typename Traits::Triangle_mesh, boost::face_index_t>::const_type>
 struct Edge_sequence_collector
 {
   typedef typename Traits::Triangle_mesh Triangle_mesh;


### PR DESCRIPTION
## Summary of Changes

Fix some const correctness issue and make it clear that vertex/halfedge/face ID maps should be initialized priori to constructing the SMSP class.

## Release Management

* Affected package(s): `Surface_mesh_shortest_path`
* Issue(s) solved (if any):

