### PR TITLE
Fix OFF reader

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/OFF_io_plugin.cpp
@@ -100,7 +100,10 @@ Polyhedron_demo_off_plugin::load_off(QFileInfo fileinfo) {
   // Try to read .off in a surface_mesh
   SMesh *surface_mesh = new SMesh();
   try{
-    in >> *surface_mesh;
+    if(!(in >> *surface_mesh))
+    {
+      surface_mesh->clear();
+    }
   } catch(...)
   {
     surface_mesh->clear();

--- a/Polyhedron_IO/include/CGAL/IO/OFF_reader.h
+++ b/Polyhedron_IO/include/CGAL/IO/OFF_reader.h
@@ -85,19 +85,35 @@ namespace CGAL {
     polygons.resize(scanner.size_of_facets());
     if(scanner.has_colors())
       vcolors.resize(scanner.size_of_vertices());
+    bool vcolored = false;
     for (std::size_t i = 0; i < scanner.size_of_vertices(); ++i) {
         double x, y, z, w;
         scanner.scan_vertex( x, y, z, w);
         CGAL_assertion(w!=0);
         IO::internal::fill_point( x/w, y/w, z/w, points[i] );
-        if(scanner.has_colors())
+        if(i == 0)
         {
-            unsigned char r=0, g=0, b=0;
-            scanner.scan_color( r, g, b);
-            vcolors[i] = Color_rgb(r,g,b);
+          std::string col;
+          char ci;
+          std::getline(in, col);
+          std::istringstream iss(col);
+          if(iss >> ci){
+            std::istringstream iss2(col);
+            vcolors[i] = scanner.get_color_from_line(iss2);
+            vcolored = true;
+          }
         }
         else
-            scanner.skip_to_next_vertex(i);
+        {
+          if(vcolored){
+            //stores the RGB value
+            std::string col;
+            std::getline(in, col);
+            std::istringstream iss(col);
+            vcolors[i] = scanner.get_color_from_line(iss);
+          }
+        }
+        
         if(!in)
           return false;
     }

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2222,6 +2222,7 @@ private: //------------------------------------------------------- private data
       is.setstate(std::ios::failbit);
       return false;
     }
+    is >> sm_skip_comments;
     is >> n >> f >> e;
     if(!is){
       return false;
@@ -2239,12 +2240,14 @@ private: //------------------------------------------------------- private data
       boost::tie(vnormal, created) = sm.template add_property_map<Vertex_index,Vector_3>("v:normal",Vector_3(0,0,0));
       v_has_normals = true;
     }
+    std::string line;
     char ci;
-
     for(int i=0; i < n; i++){
       is >> sm_skip_comments;
+      std::getline(is, line);
+      std::istringstream iss(line);
       double x, y, z;
-      is >> iformat(x) >> iformat(y) >> iformat(z);
+      iss >> iformat(x) >> iformat(y) >> iformat(z);
       
       Vertex_index vi = sm.add_vertex();
       put(vpm, vi, P(x, y, z));
@@ -2252,26 +2255,37 @@ private: //------------------------------------------------------- private data
       
       vertexmap[i] = vi;
       if(v_has_normals){
-        is >> v;
+        if(!(iss >> v))
+        {
+          std::cerr<<"This doesn't seem to be a correct NOFF file. Aborting."<<std::endl;
+          is.setstate(std::ios::failbit);          
+          return false;
+        }
         vnormal[vi] = v;
       }
 
 
       if(i == 0 && ((off == "COFF") || (off == "CNOFF"))){
         std::string col;
-        std::getline(is, col);
-        std::istringstream iss(col);
-        if(iss >> ci){
+        std::getline(iss, col);
+        std::istringstream iss2(col);
+        if(iss2 >> ci){
          bool created;
          boost::tie(vcolor, created) = sm.template add_property_map<Vertex_index,CGAL::Color>("v:color",CGAL::Color(0,0,0));
-         std::istringstream iss2(col);
-         vcolor[vi] = File_scanner_OFF::get_color_from_line(iss2);
+         std::istringstream iss3(col);
+         vcolor[vi] = File_scanner_OFF::get_color_from_line(iss3);
          vcolored = true;
+        }
+        else
+        {
+          std::cerr<<"This doesn't seem to be a correct COFF file. Aborting."<<std::endl;
+          is.setstate(std::ios::failbit);
+          return false;
         }
       }else{
          if(vcolored){
            //stores the RGB value
-           vcolor[vi] = File_scanner_OFF::get_color_from_line(is);
+           vcolor[vi] = File_scanner_OFF::get_color_from_line(iss);
          }
        }
     }


### PR DESCRIPTION
## Summary of Changes
OFF reader is not robust enough. If the header says CNOFF but there is no color/no normals, it crashes. This PR fixes that

## Release Management
* Issue(s) solved (if any): fix #4499 
