### PR TITLE
BGL: fix doc of graph_has_property

### DIFF
--- a/BGL/doc/BGL/CGAL/boost/graph/properties.h
+++ b/BGL/doc/BGL/CGAL/boost/graph/properties.h
@@ -4,11 +4,6 @@ namespace boost {
 /// \ingroup PkgBGLProperties
 /// @{
 
-/// The constant `edge_index` is a property tag which identifies the <i>index</i> property of an edge of a \sc{Bgl}
-/// <a href="https://www.boost.org/libs/graph/doc/Graph.html"><code>Graph</code></a>.
-/// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
-enum edge_index_t { edge_index};
-
 /// The constant `vertex_index` is a property tag which identifies the <i>index</i> property of a vertex of a \sc{Bgl}
 /// <a href="https://www.boost.org/libs/graph/doc/Graph.html"><code>Graph</code></a>.
 /// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
@@ -20,12 +15,16 @@ enum vertex_index_t { vertex_index };
 /// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
 enum halfedge_index_t { halfedge_index };
 
+/// The constant `edge_index` is a property tag which identifies the <i>index</i> property of an edge of a \sc{Bgl}
+/// <a href="https://www.boost.org/libs/graph/doc/Graph.html"><code>Graph</code></a>.
+/// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
+enum edge_index_t { edge_index };
+
 /// The constant `face_index` is a property tag which identifies the <i>index</i> property of a face of a `FaceGraph`.
 ///
 /// This is a property tag introduced by \cgal.
 /// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
 enum face_index_t { face_index };
-
 
 /// The constant `vertex_point` is a property tag which refers to the  geometric embedding property of
 /// a vertex of a `HalfedgeGraph`.
@@ -34,12 +33,25 @@ enum face_index_t { face_index };
 /// \cgalModels <a href="https://www.boost.org/libs/graph/doc/PropertyTag.html"><code>PropertyTag</code></a>
 enum vertex_point_t { vertex_point };
 
-
 /// @}
 } // namespace boost
 
 namespace CGAL {
 
+/// \ingroup PkgBGLProperties
+///
+/// \brief graph_has_property is used to indicate if a model of `HalfedgeGraph` or `FaceGraph`
+/// has an internal property associated with the given `PropertyTag`.
+///
+/// It inherits from \link Tag_true `CGAL::Tag_true` \endlink if there is a
+/// default internal property map for the corresponding property tag and from
+/// \link Tag_false `CGAL::Tag_false` \endlink otherwise.
+///
+/// \tparam Graph a model of `HalfedgeGraph` or `FaceGraph`
+/// \tparam PropertyTag the type of a property tag referring to the property of interest.
+///
+template<typename Graph, typename PropertyTag>
+struct graph_has_property;
 
 /// @{
 

--- a/BGL/include/CGAL/boost/graph/properties.h
+++ b/BGL/include/CGAL/boost/graph/properties.h
@@ -33,62 +33,34 @@
 #include <CGAL/basic.h>
 #include <string>
 
-namespace CGAL{
-/// \ingroup PkgBGLProperties
-/// \brief graph_has_property is used to indicate if
-/// a model of `HalfedgeGraph` or `FaceGraph`
-/// has an internal property associated with the
-/// given `PropertyTag`.
-///
-/// It inherits from `CGAL::Tag_true` if there is a
-/// default internal property map for the
-/// corresponding property tag and from
-/// `CGAL::Tag_false` otherwise.
-///
-/// \tparam Graph a model of `HalfedgeGraph` or `FaceGraph`
-/// \tparam PropertyTag the type of a property tag
-/// referring to the property of interest.
-///
+namespace CGAL {
+
 template<typename Graph, typename PropertyTag>
-struct graph_has_property
-#ifndef DOXYGEN_RUNNING
-    : CGAL::Tag_false
-#endif
-{};
-}
-/// Boost Namespace
+struct graph_has_property : CGAL::Tag_false { };
+
+} // namespace CGAL
+
 namespace boost {
 
-/// \ingroup PkgBGLProperties
-/// @{
-
-/// A property tag which refers to the geometric embedding property
-/// of a vertex of a \ref HalfedgeGraph.
 enum vertex_point_t          { vertex_point          };
-enum vertex_external_index_t { vertex_external_index } ;
 
-/// A property tag which refers to the property
-/// of a halfedge of being a border halfedge.
-enum edge_external_index_t   { edge_external_index   } ;
+// vertex_index_t is defined in boost
+enum vertex_external_index_t { vertex_external_index };
 
-/// A property tag which identifies the *index* property of
-/// a halfedge of a \ref HalfedgeGraph.
-enum halfedge_index_t        { halfedge_index        };
-enum halfedge_external_index_t   { halfedge_external_index   } ;
+enum halfedge_index_t          { halfedge_index };
+enum halfedge_external_index_t { halfedge_external_index };
 
-/// A property tag which identifies the *index* property of
-/// a face of a \ref FaceGraph.
+// edge_index_t is defined in boost
+enum edge_external_index_t   { edge_external_index   };
+
 enum face_index_t            { face_index            };
-enum face_external_index_t   { face_external_index   } ;
+enum face_external_index_t   { face_external_index   };
 
-  
 struct cgal_no_property
 {
   typedef bool type;
   typedef const bool const_type;
 };
-
-/// @}
 
 // Introduce those two tags so we can use BOOST_INSTALL_PROPERTY
 // macro. This is dangerous because we now rely on implementation

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
@@ -18,11 +18,11 @@ the number of edges effectively removed.
 \cgalNamedParamsBegin
   \cgalParamBegin{vertex_point_map} the property map with the points associated to the vertices of the mesh.
      If this parameter is omitted, an internal property map for
-     `CGAL::vertex_point_t` should be available in `PolygonMesh`
+     `CGAL::vertex_point_t` should be available in `TriangleMesh`.
   \cgalParamEnd
 
   \cgalParamBegin{halfedge_index_map} the property map containing an index for each halfedge,
-    initialized 0 to `num_halfedges(graph)`
+    initialized 0 to `num_halfedges(graph)`.
   \cgalParamEnd
 
   \cgalParamBegin{get_cost}
@@ -34,7 +34,7 @@ the number of edges effectively removed.
   \cgalParamEnd
 
   \cgalParamBegin{edge_is_constrained_map}
-    The property map containing the constrained-or-not status of each edge of `pmesh`
+    The property map containing the constrained-or-not status of each edge of `pmesh`.
   \cgalParamEnd
 
   \cgalParamBegin{visitor}


### PR DESCRIPTION
## Summary of Changes

The package BGL has documentation split between `doc/CGAL` and `include/CGAL`. The doc for `graph_has_property` was erroneously put into `include/CGAL` and thus it didn't show up in the doc.

External indices property tags are also undocumented despite being used in most `Polyhedron_3` examples, but I don't know if we really want to document them (@sloriot ?); sounds to me like it would be better to phase out `Polyhedron_3` from example.

## Release Management

* Affected package(s): `BGL`

