### PR TITLE
Enable the use of Lazy objects in Compact_container

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
@@ -6,9 +6,9 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-// 
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+//
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_X_TRAPEZOID_H
@@ -38,24 +38,24 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_X_trapezoid : public Handle
 {
 public:
-  
+
   //type of trapezoid type
-  enum Type 
+  enum Type
   {
       TD_TRAPEZOID,
       TD_EDGE,
@@ -64,7 +64,7 @@ public:
 
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -76,13 +76,13 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Trapezoid (Self)
   typedef typename Traits::X_trapezoid            Self;
-  
+
   //type of Trapezoid parameter space
   // Ninetuple which represents the Trapezoid:
   //  - for regular & edge trapezoids or active point trapezoids:
@@ -92,21 +92,21 @@ public:
   //  type flag + on boundaries flags,
   //  left-bottom neighbor trapezoid, left-top neighbor trapezoid,
   //  right-bottom neighbor trapezoid, right-top neighbor trapezoid
-  typedef Td_ninetuple<boost::variant<Vertex_const_handle,Point>, 
+  typedef Td_ninetuple<boost::variant<Vertex_const_handle,Point>,
                        boost::variant<Vertex_const_handle,unsigned char>,
                        boost::variant<Halfedge_const_handle,
                                       boost::shared_ptr<X_monotone_curve_2> >,
-                       Halfedge_const_handle, 
+                       Halfedge_const_handle,
                        unsigned char,
                        Self*, Self*,
                        Self*, Self*>            Trpz_parameter_space;
-  
+
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of Around point circulator
   typedef typename TD::Around_point_circulator         Around_point_circulator;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -117,7 +117,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::Around_point_circulator;
@@ -131,20 +131,20 @@ public:
   friend class Trapezoidal_decomposition_2<Traits>::Around_point_circulator;
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class Around_point_circulator;
   friend class In_face_iterator;
 #endif
 #endif
-  
-  
-  
+
+
+
  private:
-  
+
   Trpz_parameter_space* ptr() const { return (Trpz_parameter_space*)(PTR.p);  }
-	
-	
+
+
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -154,9 +154,9 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-	
+
   Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-	
+
   /*! Initialize the trapezoid's neighbours. */
   CGAL_TD_INLINE void init_neighbours(Self* lb_ = 0, Self* lt_ = 0,
                                       Self* rb_ = 0, Self* rt_ = 0)
@@ -168,34 +168,34 @@ public:
   }
 
   /*! Set the DAG node. */
-  CGAL_TD_INLINE void set_dag_node(Dag_node* p) 
+  CGAL_TD_INLINE void set_dag_node(Dag_node* p)
   {
     m_dag_node = p;
-  
+
 #ifdef CGAL_TD_DEBUG
-  
+
     CGAL_assertion(!p || **p == *this);
-  
-#endif	
-	
+
+#endif
+
   }
-  
+
   /*! Set the trapezoid's left (Vertex_const_handle). */
-  CGAL_TD_INLINE void set_left(Vertex_const_handle v) 
+  CGAL_TD_INLINE void set_left(Vertex_const_handle v)
   {
     CGAL_precondition(is_active());
     ptr()->e0 = v;
   }
-  
+
   /*! Set the trapezoid's right (Vertex_const_handle). */
-  CGAL_TD_INLINE void set_right(Vertex_const_handle v) 
+  CGAL_TD_INLINE void set_right(Vertex_const_handle v)
   {
     CGAL_precondition(is_active());
     ptr()->e1 = v;
   }
-  
+
   /*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_bottom(Halfedge_const_handle he) 
+  CGAL_TD_INLINE void set_bottom(Halfedge_const_handle he)
   {
     CGAL_precondition(is_active());
     if (!is_on_bottom_boundary() &&
@@ -208,9 +208,9 @@ public:
       ptr()->e2 = he;
     }
   }
-  
+
   /*! Set the trapezoid's top (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_top(Halfedge_const_handle he) 
+  CGAL_TD_INLINE void set_top(Halfedge_const_handle he)
   {
     CGAL_precondition(is_active());
     if (!is_on_top_boundary() &&
@@ -223,7 +223,7 @@ public:
       ptr()->e3 = he;
     }
   }
-  
+
   CGAL_TD_INLINE void update_removed_trpz()
   {
     CGAL_precondition(is_active());
@@ -234,27 +234,27 @@ public:
       set_curve_for_rem_he(top()->curve());
       return;
     }
-  
+
     //else if (type() == TD_VERTEX)
-  
+
     Curve_end v_ce(left()->curve_end());
     ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(v_ce.cv()));
     //CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2>>( &(ptr()->e2)) != nullptr);
-  
+
     ptr()->e1 = (v_ce.ce() == ARR_MIN_END ) ? CGAL_TD_CV_MIN_END : CGAL_TD_CV_MAX_END;
-  
+
     if (!is_on_boundaries())
     { //if the trapezoid respresents an inner vertex
       ptr()->e0 = left()->point();
     }
   }
 
-  
+
   /*! Set the x_monotone_curve_2 for removed edge degenerate trapezoid. */
   CGAL_TD_INLINE void set_curve_for_rem_he(const X_monotone_curve_2& cv)
   {
     CGAL_precondition (type() == TD_EDGE);
-  
+
     ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(cv));
   }
 
@@ -264,57 +264,57 @@ public:
     ptr()->e4 &= ~CGAL_TD_TYPE_MASK;
     ptr()->e4 |= obj_type;
   }
-  
+
   /*! Set is on left boundary flag. */
-  CGAL_TD_INLINE void set_is_on_left_boundary(bool b) 
+  CGAL_TD_INLINE void set_is_on_left_boundary(bool b)
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_LEFT_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_LEFT_BOUNDARY;
   }
-  
+
   /*! Set is on right boundary flag. */
-  CGAL_TD_INLINE void set_is_on_right_boundary(bool b) 
+  CGAL_TD_INLINE void set_is_on_right_boundary(bool b)
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_RIGHT_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_RIGHT_BOUNDARY;
   }
-  
+
   /*! Set is on bottom boundary flag. */
-  CGAL_TD_INLINE void set_is_on_bottom_boundary(bool b) 
+  CGAL_TD_INLINE void set_is_on_bottom_boundary(bool b)
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_BOTTOM_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_BOTTOM_BOUNDARY;
   }
-  
+
   /*! Set is on top boundary flag. */
-  CGAL_TD_INLINE void set_is_on_top_boundary(bool b) 
+  CGAL_TD_INLINE void set_is_on_top_boundary(bool b)
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_TOP_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_TOP_BOUNDARY;
   }
-  
+
   /*! Set left bottom neighbour. */
   CGAL_TD_INLINE void set_lb(Self* lb) { ptr()->e5 = lb; }
-  
+
   /*! Set left top neighbour. */
   CGAL_TD_INLINE void set_lt(Self* lt) { ptr()->e6 = lt; }
-  
+
   /*! Set right bottom neighbour. */
   CGAL_TD_INLINE void set_rb(Self* rb) { ptr()->e7 = rb; }
-  
+
   /*! Set right top neighbour. */
   CGAL_TD_INLINE void set_rt(Self* rt) { ptr()->e8 = rt; }
 
  public:
-  
+
   /// \name Constructors.
   //@{
 
@@ -333,7 +333,7 @@ public:
 
     m_dag_node = 0;
   }
-  
+
   /*! Constructor given Vertex & Halfedge handles. */
   Td_X_trapezoid (Vertex_const_handle l, Vertex_const_handle r,
                   Halfedge_const_handle b, Halfedge_const_handle t,
@@ -343,7 +343,7 @@ public:
                   Self* rb = 0, Self* rt = 0,
                   Dag_node* node = 0)
   {
-    
+
     //build the type flag
     unsigned char type_flag = 0;
     if (tp == TD_TRAPEZOID)
@@ -357,7 +357,7 @@ public:
       (l, r, b, t, type_flag | boundness_flag, lb, lt, rb, rt);
     m_dag_node = node;
   }
-  
+
   /*! Constructor given Pointers to Vertex & Halfedge handles. */
   Td_X_trapezoid (Vertex_const_handle* l, Vertex_const_handle* r ,
                   Halfedge_const_handle* b, Halfedge_const_handle* t,
@@ -376,33 +376,33 @@ public:
        b ? *b : Traits::he_at_bottom_infinity(),
        t ? *t : Traits::he_at_top_infinity(),
        (type_flag |
-        (on_left_bndry   ? CGAL_TD_ON_LEFT_BOUNDARY   : 0) | 
-        (on_right_bndry  ? CGAL_TD_ON_RIGHT_BOUNDARY  : 0) | 
-        (on_bottom_bndry ? CGAL_TD_ON_BOTTOM_BOUNDARY : 0) | 
+        (on_left_bndry   ? CGAL_TD_ON_LEFT_BOUNDARY   : 0) |
+        (on_right_bndry  ? CGAL_TD_ON_RIGHT_BOUNDARY  : 0) |
+        (on_bottom_bndry ? CGAL_TD_ON_BOTTOM_BOUNDARY : 0) |
         (on_top_bndry    ? CGAL_TD_ON_TOP_BOUNDARY    : 0) ),
-	 lb, lt, rb, rt);
+         lb, lt, rb, rt);
     m_dag_node = node;
     }
-  
+
   /*! Copy constructor. */
   Td_X_trapezoid (const Self& tr) : Handle(tr)
     {
     m_dag_node = tr.m_dag_node;
     }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   CGAL_TD_INLINE Self& operator= (const Self& t2)
       {
-	Handle::operator=(t2);
-	return *this;
+        Handle::operator=(t2);
+        return *this;
       }
 
   /*! Operator==. */
@@ -423,12 +423,12 @@ public:
   /// \name Access methods.
   //@{
 
-  CGAL_TD_INLINE Self& self() 
+  CGAL_TD_INLINE Self& self()
     {
       return *this;
     }
-  
-  CGAL_TD_INLINE const Self& self() const 
+
+  CGAL_TD_INLINE const Self& self() const
     {
       return *this;
     }
@@ -442,17 +442,17 @@ public:
   /*! Access trapezoid left. */
   CGAL_TD_INLINE Vertex_const_handle left_unsafe() const
     {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     CGAL_assertion(boost::get<Vertex_const_handle>(&(ptr()->e0)) != nullptr);
     return boost::get<Vertex_const_handle>(ptr()->e0);
     }
 
-  /*! Access trapezoid left. 
+  /*! Access trapezoid left.
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Vertex_const_handle left() const
     {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     if (is_on_left_boundary() && is_on_bottom_boundary()
         && is_on_top_boundary())
     {
@@ -465,17 +465,17 @@ public:
   /*! Access trapezoid right. */
   CGAL_TD_INLINE Vertex_const_handle right_unsafe() const
     {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     CGAL_assertion(boost::get<Vertex_const_handle>(&(ptr()->e1)) != nullptr);
     return boost::get<Vertex_const_handle>(ptr()->e1);
     }
 
-  /*! Access trapezoid right. 
+  /*! Access trapezoid right.
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Vertex_const_handle right () const
   {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     if (is_on_right_boundary() && is_on_bottom_boundary()
         && is_on_top_boundary())
     {
@@ -484,55 +484,55 @@ public:
     //else
     return right_unsafe();
   }
-  
+
   /*! Access trapezoid bottom. */
   CGAL_TD_INLINE Halfedge_const_handle bottom_unsafe () const
   {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     CGAL_assertion(boost::get<Halfedge_const_handle>(&(ptr()->e2)) != nullptr);
     return boost::get<Halfedge_const_handle>(ptr()->e2);
     }
-  
-  /*! Access trapezoid bottom. 
+
+  /*! Access trapezoid bottom.
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Halfedge_const_handle bottom () const
     {
-    CGAL_precondition(is_active()); 
-    return !is_on_bottom_boundary() ?  
+    CGAL_precondition(is_active());
+    return !is_on_bottom_boundary() ?
             bottom_unsafe() : Traits::he_at_bottom_infinity();
     }
 
   /*! Access trapezoid top. */
   CGAL_TD_INLINE Halfedge_const_handle top_unsafe () const
     {
-    CGAL_precondition(is_active()); 
+    CGAL_precondition(is_active());
     return ptr()->e3;
     }
-  
-  /*! Access trapezoid top. 
+
+  /*! Access trapezoid top.
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Halfedge_const_handle top () const
     {
-    CGAL_precondition(is_active()); 
-    return !is_on_top_boundary() ?	
+    CGAL_precondition(is_active());
+    return !is_on_top_boundary() ?
             top_unsafe() : Traits::he_at_top_infinity();
     }
 
-  CGAL_TD_INLINE Point point_for_inner_rem_vtx() const  
+  CGAL_TD_INLINE Point point_for_inner_rem_vtx() const
     {
-    CGAL_precondition(!is_active()); 
+    CGAL_precondition(!is_active());
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(!is_on_boundaries());
 
     CGAL_assertion(boost::get<Point>( &(ptr()->e0)) != nullptr);
     return boost::get<Point>( ptr()->e0 );
     }
-  
-  CGAL_TD_INLINE std::pair<X_monotone_curve_2*,Arr_curve_end> curve_end_pair_for_boundary_rem_vtx() const  
+
+  CGAL_TD_INLINE std::pair<X_monotone_curve_2*,Arr_curve_end> curve_end_pair_for_boundary_rem_vtx() const
     {
-    CGAL_precondition(!is_active()); 
+    CGAL_precondition(!is_active());
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(is_on_boundaries());
 
@@ -540,17 +540,17 @@ public:
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-   
-    Arr_curve_end ce = 
+
+    Arr_curve_end ce =
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-  
+
     return std::make_pair(cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE Curve_end curve_end_for_boundary_rem_vtx() const  
+  CGAL_TD_INLINE Curve_end curve_end_for_boundary_rem_vtx() const
   {
-    CGAL_precondition(!is_active()); 
+    CGAL_precondition(!is_active());
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(is_on_boundaries());
 
@@ -558,35 +558,35 @@ public:
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-   
-    Arr_curve_end ce = 
+
+    Arr_curve_end ce =
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-  
+
     return Curve_end(*cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE Curve_end curve_end_for_rem_vtx() const  
+  CGAL_TD_INLINE Curve_end curve_end_for_rem_vtx() const
   {
-    CGAL_precondition(!is_active()); 
+    CGAL_precondition(!is_active());
     CGAL_precondition(type() == TD_VERTEX);
 
     CGAL_assertion(boost::get<unsigned char>( &(ptr()->e1)) != nullptr);
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-    
-    Arr_curve_end ce = 
+
+    Arr_curve_end ce =
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-  
+
     return Curve_end(*cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE X_monotone_curve_2& curve_for_rem_he() const  
+  CGAL_TD_INLINE X_monotone_curve_2& curve_for_rem_he() const
   {
-    CGAL_precondition(!is_active() && type() == TD_EDGE); 
-    
+    CGAL_precondition(!is_active() && type() == TD_EDGE);
+
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
@@ -594,7 +594,7 @@ public:
   }
 
   /*! Access trapezoid type. */
-  CGAL_TD_INLINE Type type() const 
+  CGAL_TD_INLINE Type type() const
   {
     switch(ptr()->e4 & CGAL_TD_TYPE_MASK)
     {
@@ -607,95 +607,95 @@ public:
     default:
        CGAL_assertion(false);
        return TD_TRAPEZOID;
-    } 
+    }
     }
 
   /*! Access trapezoid type flag. */
-  CGAL_TD_INLINE unsigned char type_flag() const 
+  CGAL_TD_INLINE unsigned char type_flag() const
     {
     return (ptr()->e4 & CGAL_TD_TYPE_MASK);
     }
-  
+
   /*! Access on boundaries flag. */
-  CGAL_TD_INLINE unsigned char on_boundaries_flag() const 
+  CGAL_TD_INLINE unsigned char on_boundaries_flag() const
   {
     return (ptr()->e4 & CGAL_TD_ON_ALL_BOUNDARIES);
   }
-  
+
   /*! Access is on left boundary. */
-  CGAL_TD_INLINE bool is_on_left_boundary() const 
-    {			
+  CGAL_TD_INLINE bool is_on_left_boundary() const
+    {
     return (ptr()->e4 & CGAL_TD_ON_LEFT_BOUNDARY) != 0;
     }
 
   /*! Access is on right boundary. */
-  CGAL_TD_INLINE bool is_on_right_boundary() const 
+  CGAL_TD_INLINE bool is_on_right_boundary() const
   {
     return (ptr()->e4 & CGAL_TD_ON_RIGHT_BOUNDARY) != 0;
     }
 
   /*! Access is on bottom boundary. */
-  CGAL_TD_INLINE bool is_on_bottom_boundary() const 
+  CGAL_TD_INLINE bool is_on_bottom_boundary() const
   {
     return (ptr()->e4 & CGAL_TD_ON_BOTTOM_BOUNDARY) != 0;
     }
 
   /*! Access is on top boundary. */
-  CGAL_TD_INLINE bool is_on_top_boundary() const 
+  CGAL_TD_INLINE bool is_on_top_boundary() const
   {
     return (ptr()->e4 & CGAL_TD_ON_TOP_BOUNDARY) != 0;
   }
-  
+
   /*! Access is on at least one boundary. */
   CGAL_TD_INLINE bool is_on_boundaries() const
-  {			
+  {
     return (ptr()->e4 & CGAL_TD_ON_ALL_BOUNDARIES) != 0;
   }
-  
+
   /*! Access left bottom neighbour. */
   Self* lb() const    { return ptr()->e5; }
-  
+
   /*! Access left top neighbour. */
   Self* lt() const    { return ptr()->e6; }
-  
+
   /*! Access right bottom neighbour. */
   Self* rb() const    { return ptr()->e7; }
-  
+
   /*! Access right top neighbour. */
   Self* rt() const    { return ptr()->e8; }
-  
+
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return m_dag_node;}
-  
-  
+
+
   //@}
-  
+
   /*! is trapezoid active */
-    bool is_active() const 
+    bool is_active() const
     {
     return rb()!=
-	    (Self*)CGAL_TD_DELETE_SIGNATURE;
+            (Self*)CGAL_TD_DELETE_SIGNATURE;
     }
-  
+
   /*! Removing this trapezoid (defining it as in-active) */
   CGAL_TD_INLINE void remove(Dag_node* left=0)
     {
       CGAL_precondition(is_active());
- 
+
     // update vertex/edge trapezoid parameters after remove
     if (type() != TD_TRAPEZOID)
       update_removed_trpz();
-    
+
       // mark trapezoid as deleted,
     set_rb((Self*)CGAL_TD_DELETE_SIGNATURE);
-    
+
     if (type() == TD_VERTEX)
       curve_end_for_rem_vtx();
-    		
+
       // resets left son in data structure depending on input.
       if (left)
       m_dag_node->set_left_child(*left);
-    }								
+    }
 
   /* Merge this trapezoid with the input trapezoid.
      Precondition:
@@ -709,7 +709,7 @@ public:
   CGAL_TD_INLINE void merge_trapezoid( Self& right)
     {
     //precondition: both are of type trapezoid
-    CGAL_precondition((type() == TD_TRAPEZOID) && 
+    CGAL_precondition((type() == TD_TRAPEZOID) &&
                       (right.type() == TD_TRAPEZOID));
     //precondition: both are active
     CGAL_precondition(is_active() && right.is_active());
@@ -719,25 +719,25 @@ public:
     bool on_right_boundary = right.is_on_right_boundary();
 
     *this = Self (!is_on_left_boundary() ? & left() : 0,
-		              !on_right_boundary ? &right.right() : 0,
-		              !is_on_bottom_boundary() ? &bottom() : 0,
-		              !is_on_top_boundary() ? &top() : 0,
+                              !on_right_boundary ? &right.right() : 0,
+                              !is_on_bottom_boundary() ? &bottom() : 0,
+                              !is_on_top_boundary() ? &top() : 0,
                   CGAL_TD_TRAPEZOID,
                   is_on_left_boundary(), on_right_boundary,
                   is_on_bottom_boundary(), is_on_top_boundary(),
-		              lb(),lt(),
-		              right.rb(),
-		              right.rt());
+                              lb(),lt(),
+                              right.rb(),
+                              right.rt());
 
     if (rb())
       rb()->set_lb(this);
 
     if (rt())
       rt()->set_lt(this);
-    
+
     CGAL_assertion(is_on_right_boundary() == right.is_on_right_boundary());
     }
-	
+
 #ifdef CGAL_TD_DEBUG
   //MICHAL: This method should not compile!!
     bool is_valid(const Traits* traits) const
@@ -764,7 +764,7 @@ public:
           CGAL_warning(!CGAL_POINT_IS_LEFT_LOW(right(),left()));
           return false;
         }
-        
+
         if (!is_on_bottom_boundary())
         {
           if (is_on_left_boundary() || is_on_right_boundary())
@@ -774,7 +774,7 @@ public:
             CGAL_warning(!(is_on_left_boundary() ||is_on_right_boundary()));
             return false;
           }
-          
+
           b = CGAL_IS_IN_X_RANGE(bottom(),left());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(left(), bottom());
@@ -788,7 +788,7 @@ public:
             CGAL_warning(t != SMALLER);
             return false;
           }
-          
+
           b=CGAL_IS_IN_X_RANGE(bottom(),right());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(right(), bottom());
@@ -812,7 +812,7 @@ public:
             CGAL_warning(!(is_on_left_boundary() || is_on_right_boundary()));
             return false;
           }
-          
+
           b=CGAL_IS_IN_X_RANGE(top(),left());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(left(), top());
@@ -826,7 +826,7 @@ public:
             CGAL_warning(t != LARGER);
             return false;
           }
-          
+
           b=CGAL_IS_IN_X_RANGE(top(),right());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(right(), top());
@@ -843,9 +843,9 @@ public:
         }
         if (!traits->is_degenerate(*this))
         {
-          if (rt() && 
+          if (rt() &&
               (! is_top_curve_equal(*rt(), traits)) ||
-              lt() && 
+              lt() &&
               (! is_top_curve_equal(*lt(), traits)) ||
               rb() &&
               (! is_bottom_curve_equal(*rb(), traits)) ||
@@ -903,7 +903,7 @@ public:
         {
           /* if the trapezoid is degenerate, the left() and right()
              points should be on the top() and bottom() curves.
-             In any case none of the geometric boundaries should 
+             In any case none of the geometric boundaries should
              be unbounded */
           if (is_on_bottom_boundary()||
               is_on_top_boundary()||
@@ -1048,7 +1048,7 @@ public:
       }
       return true;
     }
-  
+
   CGAL_TD_INLINE void debug() const // instantiate ptr functions.
   {
     ptr();

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
@@ -6,9 +6,9 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+// 
 //
-//
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_X_TRAPEZOID_H
@@ -38,24 +38,24 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_X_trapezoid : public Handle
 {
 public:
-
+  
   //type of trapezoid type
-  enum Type
+  enum Type 
   {
       TD_TRAPEZOID,
       TD_EDGE,
@@ -64,7 +64,7 @@ public:
 
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -76,13 +76,13 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Trapezoid (Self)
   typedef typename Traits::X_trapezoid            Self;
-
+  
   //type of Trapezoid parameter space
   // Ninetuple which represents the Trapezoid:
   //  - for regular & edge trapezoids or active point trapezoids:
@@ -92,21 +92,21 @@ public:
   //  type flag + on boundaries flags,
   //  left-bottom neighbor trapezoid, left-top neighbor trapezoid,
   //  right-bottom neighbor trapezoid, right-top neighbor trapezoid
-  typedef Td_ninetuple<boost::variant<Vertex_const_handle,Point>,
+  typedef Td_ninetuple<boost::variant<Vertex_const_handle,Point>, 
                        boost::variant<Vertex_const_handle,unsigned char>,
                        boost::variant<Halfedge_const_handle,
                                       boost::shared_ptr<X_monotone_curve_2> >,
-                       Halfedge_const_handle,
+                       Halfedge_const_handle, 
                        unsigned char,
                        Self*, Self*,
                        Self*, Self*>            Trpz_parameter_space;
-
+  
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of Around point circulator
   typedef typename TD::Around_point_circulator         Around_point_circulator;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -117,7 +117,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::Around_point_circulator;
@@ -131,20 +131,20 @@ public:
   friend class Trapezoidal_decomposition_2<Traits>::Around_point_circulator;
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class Around_point_circulator;
   friend class In_face_iterator;
 #endif
 #endif
-
-
-
+  
+  
+  
  private:
-
-  Trpz_parameter_space* ptr() const { return (Trpz_parameter_space*)(PTR);  }
-
-
+  
+  Trpz_parameter_space* ptr() const { return (Trpz_parameter_space*)(PTR.p);  }
+	
+	
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -154,9 +154,9 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-
+	
   Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-
+	
   /*! Initialize the trapezoid's neighbours. */
   CGAL_TD_INLINE void init_neighbours(Self* lb_ = 0, Self* lt_ = 0,
                                       Self* rb_ = 0, Self* rt_ = 0)
@@ -168,34 +168,34 @@ public:
   }
 
   /*! Set the DAG node. */
-  CGAL_TD_INLINE void set_dag_node(Dag_node* p)
+  CGAL_TD_INLINE void set_dag_node(Dag_node* p) 
   {
     m_dag_node = p;
-
+  
 #ifdef CGAL_TD_DEBUG
-
+  
     CGAL_assertion(!p || **p == *this);
-
-#endif
-
+  
+#endif	
+	
   }
-
+  
   /*! Set the trapezoid's left (Vertex_const_handle). */
-  CGAL_TD_INLINE void set_left(Vertex_const_handle v)
+  CGAL_TD_INLINE void set_left(Vertex_const_handle v) 
   {
     CGAL_precondition(is_active());
     ptr()->e0 = v;
   }
-
+  
   /*! Set the trapezoid's right (Vertex_const_handle). */
-  CGAL_TD_INLINE void set_right(Vertex_const_handle v)
+  CGAL_TD_INLINE void set_right(Vertex_const_handle v) 
   {
     CGAL_precondition(is_active());
     ptr()->e1 = v;
   }
-
+  
   /*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_bottom(Halfedge_const_handle he)
+  CGAL_TD_INLINE void set_bottom(Halfedge_const_handle he) 
   {
     CGAL_precondition(is_active());
     if (!is_on_bottom_boundary() &&
@@ -208,9 +208,9 @@ public:
       ptr()->e2 = he;
     }
   }
-
+  
   /*! Set the trapezoid's top (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_top(Halfedge_const_handle he)
+  CGAL_TD_INLINE void set_top(Halfedge_const_handle he) 
   {
     CGAL_precondition(is_active());
     if (!is_on_top_boundary() &&
@@ -223,7 +223,7 @@ public:
       ptr()->e3 = he;
     }
   }
-
+  
   CGAL_TD_INLINE void update_removed_trpz()
   {
     CGAL_precondition(is_active());
@@ -234,27 +234,27 @@ public:
       set_curve_for_rem_he(top()->curve());
       return;
     }
-
+  
     //else if (type() == TD_VERTEX)
-
+  
     Curve_end v_ce(left()->curve_end());
     ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(v_ce.cv()));
     //CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2>>( &(ptr()->e2)) != nullptr);
-
+  
     ptr()->e1 = (v_ce.ce() == ARR_MIN_END ) ? CGAL_TD_CV_MIN_END : CGAL_TD_CV_MAX_END;
-
+  
     if (!is_on_boundaries())
     { //if the trapezoid respresents an inner vertex
       ptr()->e0 = left()->point();
     }
   }
 
-
+  
   /*! Set the x_monotone_curve_2 for removed edge degenerate trapezoid. */
   CGAL_TD_INLINE void set_curve_for_rem_he(const X_monotone_curve_2& cv)
   {
     CGAL_precondition (type() == TD_EDGE);
-
+  
     ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(cv));
   }
 
@@ -264,57 +264,57 @@ public:
     ptr()->e4 &= ~CGAL_TD_TYPE_MASK;
     ptr()->e4 |= obj_type;
   }
-
+  
   /*! Set is on left boundary flag. */
-  CGAL_TD_INLINE void set_is_on_left_boundary(bool b)
+  CGAL_TD_INLINE void set_is_on_left_boundary(bool b) 
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_LEFT_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_LEFT_BOUNDARY;
   }
-
+  
   /*! Set is on right boundary flag. */
-  CGAL_TD_INLINE void set_is_on_right_boundary(bool b)
+  CGAL_TD_INLINE void set_is_on_right_boundary(bool b) 
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_RIGHT_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_RIGHT_BOUNDARY;
   }
-
+  
   /*! Set is on bottom boundary flag. */
-  CGAL_TD_INLINE void set_is_on_bottom_boundary(bool b)
+  CGAL_TD_INLINE void set_is_on_bottom_boundary(bool b) 
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_BOTTOM_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_BOTTOM_BOUNDARY;
   }
-
+  
   /*! Set is on top boundary flag. */
-  CGAL_TD_INLINE void set_is_on_top_boundary(bool b)
+  CGAL_TD_INLINE void set_is_on_top_boundary(bool b) 
   {
     if (b)
       ptr()->e4 |= CGAL_TD_ON_TOP_BOUNDARY;
     else
       ptr()->e4 &= ~CGAL_TD_ON_TOP_BOUNDARY;
   }
-
+  
   /*! Set left bottom neighbour. */
   CGAL_TD_INLINE void set_lb(Self* lb) { ptr()->e5 = lb; }
-
+  
   /*! Set left top neighbour. */
   CGAL_TD_INLINE void set_lt(Self* lt) { ptr()->e6 = lt; }
-
+  
   /*! Set right bottom neighbour. */
   CGAL_TD_INLINE void set_rb(Self* rb) { ptr()->e7 = rb; }
-
+  
   /*! Set right top neighbour. */
   CGAL_TD_INLINE void set_rt(Self* rt) { ptr()->e8 = rt; }
 
  public:
-
+  
   /// \name Constructors.
   //@{
 
@@ -323,7 +323,7 @@ public:
   {
     //define the initial trapezoid: left, right, btm, top are at infinity.
     // its type is TD_TRAPEZOID ,it is on all boundaries, and has no neighbours
-    PTR = new Trpz_parameter_space
+    PTR.p = new Trpz_parameter_space
       (Traits::vtx_at_left_infinity(),
        Traits::vtx_at_right_infinity(),
        Traits::he_at_bottom_infinity(),
@@ -333,7 +333,7 @@ public:
 
     m_dag_node = 0;
   }
-
+  
   /*! Constructor given Vertex & Halfedge handles. */
   Td_X_trapezoid (Vertex_const_handle l, Vertex_const_handle r,
                   Halfedge_const_handle b, Halfedge_const_handle t,
@@ -343,7 +343,7 @@ public:
                   Self* rb = 0, Self* rt = 0,
                   Dag_node* node = 0)
   {
-
+    
     //build the type flag
     unsigned char type_flag = 0;
     if (tp == TD_TRAPEZOID)
@@ -353,11 +353,11 @@ public:
     else //tp == TD_VERTEX
       type_flag |= CGAL_TD_VERTEX;
 
-    PTR = new Trpz_parameter_space
+    PTR.p = new Trpz_parameter_space
       (l, r, b, t, type_flag | boundness_flag, lb, lt, rb, rt);
     m_dag_node = node;
   }
-
+  
   /*! Constructor given Pointers to Vertex & Halfedge handles. */
   Td_X_trapezoid (Vertex_const_handle* l, Vertex_const_handle* r ,
                   Halfedge_const_handle* b, Halfedge_const_handle* t,
@@ -370,39 +370,39 @@ public:
                   Self* rb = 0, Self* rt = 0,
                   Dag_node* node = 0)
   {
-    PTR = new Trpz_parameter_space
+    PTR.p = new Trpz_parameter_space
       (l ? *l : Traits::vtx_at_left_infinity(),
        r ? *r : Traits::vtx_at_right_infinity(),
        b ? *b : Traits::he_at_bottom_infinity(),
        t ? *t : Traits::he_at_top_infinity(),
        (type_flag |
-        (on_left_bndry   ? CGAL_TD_ON_LEFT_BOUNDARY   : 0) |
-        (on_right_bndry  ? CGAL_TD_ON_RIGHT_BOUNDARY  : 0) |
-        (on_bottom_bndry ? CGAL_TD_ON_BOTTOM_BOUNDARY : 0) |
+        (on_left_bndry   ? CGAL_TD_ON_LEFT_BOUNDARY   : 0) | 
+        (on_right_bndry  ? CGAL_TD_ON_RIGHT_BOUNDARY  : 0) | 
+        (on_bottom_bndry ? CGAL_TD_ON_BOTTOM_BOUNDARY : 0) | 
         (on_top_bndry    ? CGAL_TD_ON_TOP_BOUNDARY    : 0) ),
-         lb, lt, rb, rt);
+	 lb, lt, rb, rt);
     m_dag_node = node;
     }
-
+  
   /*! Copy constructor. */
   Td_X_trapezoid (const Self& tr) : Handle(tr)
     {
     m_dag_node = tr.m_dag_node;
     }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   CGAL_TD_INLINE Self& operator= (const Self& t2)
       {
-        Handle::operator=(t2);
-        return *this;
+	Handle::operator=(t2);
+	return *this;
       }
 
   /*! Operator==. */
@@ -423,12 +423,12 @@ public:
   /// \name Access methods.
   //@{
 
-  CGAL_TD_INLINE Self& self()
+  CGAL_TD_INLINE Self& self() 
     {
       return *this;
     }
-
-  CGAL_TD_INLINE const Self& self() const
+  
+  CGAL_TD_INLINE const Self& self() const 
     {
       return *this;
     }
@@ -436,23 +436,23 @@ public:
   /*! Access the trapezoid id (PTR). */
   CGAL_TD_INLINE unsigned long id() const
     {
-      return (unsigned long) PTR;
+      return (unsigned long) PTR.p;
     }
 
   /*! Access trapezoid left. */
   CGAL_TD_INLINE Vertex_const_handle left_unsafe() const
     {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     CGAL_assertion(boost::get<Vertex_const_handle>(&(ptr()->e0)) != nullptr);
     return boost::get<Vertex_const_handle>(ptr()->e0);
     }
 
-  /*! Access trapezoid left.
+  /*! Access trapezoid left. 
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Vertex_const_handle left() const
     {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     if (is_on_left_boundary() && is_on_bottom_boundary()
         && is_on_top_boundary())
     {
@@ -465,17 +465,17 @@ public:
   /*! Access trapezoid right. */
   CGAL_TD_INLINE Vertex_const_handle right_unsafe() const
     {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     CGAL_assertion(boost::get<Vertex_const_handle>(&(ptr()->e1)) != nullptr);
     return boost::get<Vertex_const_handle>(ptr()->e1);
     }
 
-  /*! Access trapezoid right.
+  /*! Access trapezoid right. 
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Vertex_const_handle right () const
   {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     if (is_on_right_boundary() && is_on_bottom_boundary()
         && is_on_top_boundary())
     {
@@ -484,55 +484,55 @@ public:
     //else
     return right_unsafe();
   }
-
+  
   /*! Access trapezoid bottom. */
   CGAL_TD_INLINE Halfedge_const_handle bottom_unsafe () const
   {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     CGAL_assertion(boost::get<Halfedge_const_handle>(&(ptr()->e2)) != nullptr);
     return boost::get<Halfedge_const_handle>(ptr()->e2);
     }
-
-  /*! Access trapezoid bottom.
+  
+  /*! Access trapezoid bottom. 
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Halfedge_const_handle bottom () const
     {
-    CGAL_precondition(is_active());
-    return !is_on_bottom_boundary() ?
+    CGAL_precondition(is_active()); 
+    return !is_on_bottom_boundary() ?  
             bottom_unsafe() : Traits::he_at_bottom_infinity();
     }
 
   /*! Access trapezoid top. */
   CGAL_TD_INLINE Halfedge_const_handle top_unsafe () const
     {
-    CGAL_precondition(is_active());
+    CGAL_precondition(is_active()); 
     return ptr()->e3;
     }
-
-  /*! Access trapezoid top.
+  
+  /*! Access trapezoid top. 
   *   filters out the infinite case which returns predefined dummy values
   */
   CGAL_TD_INLINE Halfedge_const_handle top () const
     {
-    CGAL_precondition(is_active());
-    return !is_on_top_boundary() ?
+    CGAL_precondition(is_active()); 
+    return !is_on_top_boundary() ?	
             top_unsafe() : Traits::he_at_top_infinity();
     }
 
-  CGAL_TD_INLINE Point point_for_inner_rem_vtx() const
+  CGAL_TD_INLINE Point point_for_inner_rem_vtx() const  
     {
-    CGAL_precondition(!is_active());
+    CGAL_precondition(!is_active()); 
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(!is_on_boundaries());
 
     CGAL_assertion(boost::get<Point>( &(ptr()->e0)) != nullptr);
     return boost::get<Point>( ptr()->e0 );
     }
-
-  CGAL_TD_INLINE std::pair<X_monotone_curve_2*,Arr_curve_end> curve_end_pair_for_boundary_rem_vtx() const
+  
+  CGAL_TD_INLINE std::pair<X_monotone_curve_2*,Arr_curve_end> curve_end_pair_for_boundary_rem_vtx() const  
     {
-    CGAL_precondition(!is_active());
+    CGAL_precondition(!is_active()); 
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(is_on_boundaries());
 
@@ -540,17 +540,17 @@ public:
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-
-    Arr_curve_end ce =
+   
+    Arr_curve_end ce = 
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-
+  
     return std::make_pair(cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE Curve_end curve_end_for_boundary_rem_vtx() const
+  CGAL_TD_INLINE Curve_end curve_end_for_boundary_rem_vtx() const  
   {
-    CGAL_precondition(!is_active());
+    CGAL_precondition(!is_active()); 
     CGAL_precondition(type() == TD_VERTEX);
     CGAL_precondition(is_on_boundaries());
 
@@ -558,35 +558,35 @@ public:
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-
-    Arr_curve_end ce =
+   
+    Arr_curve_end ce = 
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-
+  
     return Curve_end(*cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE Curve_end curve_end_for_rem_vtx() const
+  CGAL_TD_INLINE Curve_end curve_end_for_rem_vtx() const  
   {
-    CGAL_precondition(!is_active());
+    CGAL_precondition(!is_active()); 
     CGAL_precondition(type() == TD_VERTEX);
 
     CGAL_assertion(boost::get<unsigned char>( &(ptr()->e1)) != nullptr);
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
-
-    Arr_curve_end ce =
+    
+    Arr_curve_end ce = 
       (boost::get<unsigned char>(ptr()->e1) == CGAL_TD_CV_MIN_END) ?
         ARR_MIN_END : ARR_MAX_END;
-
+  
     return Curve_end(*cv_ptr, ce);
   }
 
-  CGAL_TD_INLINE X_monotone_curve_2& curve_for_rem_he() const
+  CGAL_TD_INLINE X_monotone_curve_2& curve_for_rem_he() const  
   {
-    CGAL_precondition(!is_active() && type() == TD_EDGE);
-
+    CGAL_precondition(!is_active() && type() == TD_EDGE); 
+    
     CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
     X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
@@ -594,7 +594,7 @@ public:
   }
 
   /*! Access trapezoid type. */
-  CGAL_TD_INLINE Type type() const
+  CGAL_TD_INLINE Type type() const 
   {
     switch(ptr()->e4 & CGAL_TD_TYPE_MASK)
     {
@@ -607,95 +607,95 @@ public:
     default:
        CGAL_assertion(false);
        return TD_TRAPEZOID;
-    }
+    } 
     }
 
   /*! Access trapezoid type flag. */
-  CGAL_TD_INLINE unsigned char type_flag() const
+  CGAL_TD_INLINE unsigned char type_flag() const 
     {
     return (ptr()->e4 & CGAL_TD_TYPE_MASK);
     }
-
+  
   /*! Access on boundaries flag. */
-  CGAL_TD_INLINE unsigned char on_boundaries_flag() const
+  CGAL_TD_INLINE unsigned char on_boundaries_flag() const 
   {
     return (ptr()->e4 & CGAL_TD_ON_ALL_BOUNDARIES);
   }
-
+  
   /*! Access is on left boundary. */
-  CGAL_TD_INLINE bool is_on_left_boundary() const
-    {
+  CGAL_TD_INLINE bool is_on_left_boundary() const 
+    {			
     return (ptr()->e4 & CGAL_TD_ON_LEFT_BOUNDARY) != 0;
     }
 
   /*! Access is on right boundary. */
-  CGAL_TD_INLINE bool is_on_right_boundary() const
+  CGAL_TD_INLINE bool is_on_right_boundary() const 
   {
     return (ptr()->e4 & CGAL_TD_ON_RIGHT_BOUNDARY) != 0;
     }
 
   /*! Access is on bottom boundary. */
-  CGAL_TD_INLINE bool is_on_bottom_boundary() const
+  CGAL_TD_INLINE bool is_on_bottom_boundary() const 
   {
     return (ptr()->e4 & CGAL_TD_ON_BOTTOM_BOUNDARY) != 0;
     }
 
   /*! Access is on top boundary. */
-  CGAL_TD_INLINE bool is_on_top_boundary() const
+  CGAL_TD_INLINE bool is_on_top_boundary() const 
   {
     return (ptr()->e4 & CGAL_TD_ON_TOP_BOUNDARY) != 0;
   }
-
+  
   /*! Access is on at least one boundary. */
   CGAL_TD_INLINE bool is_on_boundaries() const
-  {
+  {			
     return (ptr()->e4 & CGAL_TD_ON_ALL_BOUNDARIES) != 0;
   }
-
+  
   /*! Access left bottom neighbour. */
   Self* lb() const    { return ptr()->e5; }
-
+  
   /*! Access left top neighbour. */
   Self* lt() const    { return ptr()->e6; }
-
+  
   /*! Access right bottom neighbour. */
   Self* rb() const    { return ptr()->e7; }
-
+  
   /*! Access right top neighbour. */
   Self* rt() const    { return ptr()->e8; }
-
+  
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return m_dag_node;}
-
-
+  
+  
   //@}
-
+  
   /*! is trapezoid active */
-    bool is_active() const
+    bool is_active() const 
     {
     return rb()!=
-            (Self*)CGAL_TD_DELETE_SIGNATURE;
+	    (Self*)CGAL_TD_DELETE_SIGNATURE;
     }
-
+  
   /*! Removing this trapezoid (defining it as in-active) */
   CGAL_TD_INLINE void remove(Dag_node* left=0)
     {
       CGAL_precondition(is_active());
-
+ 
     // update vertex/edge trapezoid parameters after remove
     if (type() != TD_TRAPEZOID)
       update_removed_trpz();
-
+    
       // mark trapezoid as deleted,
     set_rb((Self*)CGAL_TD_DELETE_SIGNATURE);
-
+    
     if (type() == TD_VERTEX)
       curve_end_for_rem_vtx();
-
+    		
       // resets left son in data structure depending on input.
       if (left)
       m_dag_node->set_left_child(*left);
-    }
+    }								
 
   /* Merge this trapezoid with the input trapezoid.
      Precondition:
@@ -709,7 +709,7 @@ public:
   CGAL_TD_INLINE void merge_trapezoid( Self& right)
     {
     //precondition: both are of type trapezoid
-    CGAL_precondition((type() == TD_TRAPEZOID) &&
+    CGAL_precondition((type() == TD_TRAPEZOID) && 
                       (right.type() == TD_TRAPEZOID));
     //precondition: both are active
     CGAL_precondition(is_active() && right.is_active());
@@ -719,25 +719,25 @@ public:
     bool on_right_boundary = right.is_on_right_boundary();
 
     *this = Self (!is_on_left_boundary() ? & left() : 0,
-                              !on_right_boundary ? &right.right() : 0,
-                              !is_on_bottom_boundary() ? &bottom() : 0,
-                              !is_on_top_boundary() ? &top() : 0,
+		              !on_right_boundary ? &right.right() : 0,
+		              !is_on_bottom_boundary() ? &bottom() : 0,
+		              !is_on_top_boundary() ? &top() : 0,
                   CGAL_TD_TRAPEZOID,
                   is_on_left_boundary(), on_right_boundary,
                   is_on_bottom_boundary(), is_on_top_boundary(),
-                              lb(),lt(),
-                              right.rb(),
-                              right.rt());
+		              lb(),lt(),
+		              right.rb(),
+		              right.rt());
 
     if (rb())
       rb()->set_lb(this);
 
     if (rt())
       rt()->set_lt(this);
-
+    
     CGAL_assertion(is_on_right_boundary() == right.is_on_right_boundary());
     }
-
+	
 #ifdef CGAL_TD_DEBUG
   //MICHAL: This method should not compile!!
     bool is_valid(const Traits* traits) const
@@ -764,7 +764,7 @@ public:
           CGAL_warning(!CGAL_POINT_IS_LEFT_LOW(right(),left()));
           return false;
         }
-
+        
         if (!is_on_bottom_boundary())
         {
           if (is_on_left_boundary() || is_on_right_boundary())
@@ -774,7 +774,7 @@ public:
             CGAL_warning(!(is_on_left_boundary() ||is_on_right_boundary()));
             return false;
           }
-
+          
           b = CGAL_IS_IN_X_RANGE(bottom(),left());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(left(), bottom());
@@ -788,7 +788,7 @@ public:
             CGAL_warning(t != SMALLER);
             return false;
           }
-
+          
           b=CGAL_IS_IN_X_RANGE(bottom(),right());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(right(), bottom());
@@ -812,7 +812,7 @@ public:
             CGAL_warning(!(is_on_left_boundary() || is_on_right_boundary()));
             return false;
           }
-
+          
           b=CGAL_IS_IN_X_RANGE(top(),left());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(left(), top());
@@ -826,7 +826,7 @@ public:
             CGAL_warning(t != LARGER);
             return false;
           }
-
+          
           b=CGAL_IS_IN_X_RANGE(top(),right());
           if (b) {
             t = CGAL_CURVE_COMPARE_Y_AT_X(right(), top());
@@ -843,9 +843,9 @@ public:
         }
         if (!traits->is_degenerate(*this))
         {
-          if (rt() &&
+          if (rt() && 
               (! is_top_curve_equal(*rt(), traits)) ||
-              lt() &&
+              lt() && 
               (! is_top_curve_equal(*lt(), traits)) ||
               rb() &&
               (! is_bottom_curve_equal(*rb(), traits)) ||
@@ -903,7 +903,7 @@ public:
         {
           /* if the trapezoid is degenerate, the left() and right()
              points should be on the top() and bottom() curves.
-             In any case none of the geometric boundaries should
+             In any case none of the geometric boundaries should 
              be unbounded */
           if (is_on_bottom_boundary()||
               is_on_top_boundary()||
@@ -1048,7 +1048,7 @@ public:
       }
       return true;
     }
-
+  
   CGAL_TD_INLINE void debug() const // instantiate ptr functions.
   {
     ptr();

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_ACTIVE_EDGE_H
@@ -37,25 +37,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_active_edge : public Handle
 {
 public:
-  
+
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -67,7 +67,7 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
@@ -75,10 +75,10 @@ public:
   typedef typename Traits::Td_active_edge            Self;
 
   typedef typename Traits::Td_map_item            Td_map_item;
-  
+
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -90,7 +90,7 @@ public:
 
   friend class Trapezoidal_decomposition_2<Traits>;
   friend struct internal::Non_recursive_td_map_item_destructor<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -101,7 +101,7 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class In_face_iterator;
 #endif
@@ -124,7 +124,7 @@ public:
           Dag_node* _p_node)
           : he(_he),next(_next),p_node(_p_node)
     { }
-    
+
     ~Data() { }
 
   protected:
@@ -132,12 +132,12 @@ public:
     Td_map_item next;
     Dag_node* p_node;
   };
-  
+
  private:
-  
+
   Data* ptr() const { return (Data*)(PTR.p);  }
-	
-	
+
+
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -147,9 +147,9 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-	
+
   //Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-	
+
   /*! Initialize the trapezoid's neighbours. */
   inline void init_neighbours(boost::optional<Td_map_item&> next)
   {
@@ -157,21 +157,21 @@ public:
   }
 
   /*! Set the DAG node. */
-  CGAL_TD_INLINE void set_dag_node(Dag_node* p) 
+  CGAL_TD_INLINE void set_dag_node(Dag_node* p)
   {
     ptr()->p_node = p;
     //m_dag_node = p;
-  
+
 //#ifdef CGAL_TD_DEBUG
-//  
+//
 //    CGAL_assertion(!p || **p == *this);
-//  
-//#endif	
-	
+//
+//#endif
+
   }
-  
+
   ///*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_halfedge(Halfedge_const_handle he) 
+  CGAL_TD_INLINE void set_halfedge(Halfedge_const_handle he)
   {
     if (halfedge() !=  Traits::empty_he_handle() &&
         halfedge()->direction() != he->direction())
@@ -183,17 +183,17 @@ public:
       ptr()->he = he;
     }
   }
-  
+
   /*! Set next edge fragment. */
   inline void set_next( const Td_map_item& next) { ptr()->next = next; }
  public:
-  
+
   /// \name Constructors.
   //@{
 
   Td_active_edge ()
   {
-    
+
     PTR.p = new Data
       (Traits::empty_he_handle(), Td_map_item(0), nullptr);
     //m_dag_node = nullptr;
@@ -203,31 +203,31 @@ public:
                   Dag_node* node = 0,
                   boost::optional<Td_map_item&> next = boost::none)
   {
-    
+
     PTR.p = new Data(he, (next) ? *next : Td_map_item(0), node);
     //m_dag_node = node;
   }
-  
-  
+
+
   /*! Copy constructor. */
   Td_active_edge(const Self& tr) : Handle(tr)
   {
 //  m_dag_node = tr.m_dag_node;
   }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   CGAL_TD_INLINE Self& operator= (const Self& t2)
       {
-	Handle::operator=(t2);
-	return *this;
+        Handle::operator=(t2);
+        return *this;
       }
 
   /*! Operator==. */
@@ -248,12 +248,12 @@ public:
   /// \name Access methods.
   //@{
 
-  CGAL_TD_INLINE Self& self() 
+  CGAL_TD_INLINE Self& self()
     {
       return *this;
     }
-  
-  CGAL_TD_INLINE const Self& self() const 
+
+  CGAL_TD_INLINE const Self& self() const
     {
       return *this;
     }
@@ -272,20 +272,20 @@ public:
 
   /*! Access next edge fragment. */
   Td_map_item& next() const    { return ptr()->next; }
-  
+
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; } //m_dag_node;}
-  
+
   bool is_last_reference() const
   {
     return this->refs()==1;
   }
-  
+
   //@}
-  
-  
-  
-  
+
+
+
+
 
 
 };

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_ACTIVE_EDGE_H
@@ -37,25 +37,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_active_edge : public Handle
 {
 public:
-
+  
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -67,7 +67,7 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
@@ -75,10 +75,10 @@ public:
   typedef typename Traits::Td_active_edge            Self;
 
   typedef typename Traits::Td_map_item            Td_map_item;
-
+  
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -90,7 +90,7 @@ public:
 
   friend class Trapezoidal_decomposition_2<Traits>;
   friend struct internal::Non_recursive_td_map_item_destructor<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -101,7 +101,7 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class In_face_iterator;
 #endif
@@ -124,7 +124,7 @@ public:
           Dag_node* _p_node)
           : he(_he),next(_next),p_node(_p_node)
     { }
-
+    
     ~Data() { }
 
   protected:
@@ -132,12 +132,12 @@ public:
     Td_map_item next;
     Dag_node* p_node;
   };
-
+  
  private:
-
-  Data* ptr() const { return (Data*)(PTR);  }
-
-
+  
+  Data* ptr() const { return (Data*)(PTR.p);  }
+	
+	
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -147,9 +147,9 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-
+	
   //Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-
+	
   /*! Initialize the trapezoid's neighbours. */
   inline void init_neighbours(boost::optional<Td_map_item&> next)
   {
@@ -157,21 +157,21 @@ public:
   }
 
   /*! Set the DAG node. */
-  CGAL_TD_INLINE void set_dag_node(Dag_node* p)
+  CGAL_TD_INLINE void set_dag_node(Dag_node* p) 
   {
     ptr()->p_node = p;
     //m_dag_node = p;
-
+  
 //#ifdef CGAL_TD_DEBUG
-//
+//  
 //    CGAL_assertion(!p || **p == *this);
-//
-//#endif
-
+//  
+//#endif	
+	
   }
-
+  
   ///*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  CGAL_TD_INLINE void set_halfedge(Halfedge_const_handle he)
+  CGAL_TD_INLINE void set_halfedge(Halfedge_const_handle he) 
   {
     if (halfedge() !=  Traits::empty_he_handle() &&
         halfedge()->direction() != he->direction())
@@ -183,18 +183,18 @@ public:
       ptr()->he = he;
     }
   }
-
+  
   /*! Set next edge fragment. */
   inline void set_next( const Td_map_item& next) { ptr()->next = next; }
  public:
-
+  
   /// \name Constructors.
   //@{
 
   Td_active_edge ()
   {
-
-    PTR = new Data
+    
+    PTR.p = new Data
       (Traits::empty_he_handle(), Td_map_item(0), nullptr);
     //m_dag_node = nullptr;
   }
@@ -203,31 +203,31 @@ public:
                   Dag_node* node = 0,
                   boost::optional<Td_map_item&> next = boost::none)
   {
-
-    PTR = new Data(he, (next) ? *next : Td_map_item(0), node);
+    
+    PTR.p = new Data(he, (next) ? *next : Td_map_item(0), node);
     //m_dag_node = node;
   }
-
-
+  
+  
   /*! Copy constructor. */
   Td_active_edge(const Self& tr) : Handle(tr)
   {
 //  m_dag_node = tr.m_dag_node;
   }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   CGAL_TD_INLINE Self& operator= (const Self& t2)
       {
-        Handle::operator=(t2);
-        return *this;
+	Handle::operator=(t2);
+	return *this;
       }
 
   /*! Operator==. */
@@ -248,12 +248,12 @@ public:
   /// \name Access methods.
   //@{
 
-  CGAL_TD_INLINE Self& self()
+  CGAL_TD_INLINE Self& self() 
     {
       return *this;
     }
-
-  CGAL_TD_INLINE const Self& self() const
+  
+  CGAL_TD_INLINE const Self& self() const 
     {
       return *this;
     }
@@ -261,7 +261,7 @@ public:
   /*! Access the trapezoid id (PTR). */
   CGAL_TD_INLINE unsigned long id() const
     {
-      return (unsigned long) PTR;
+      return (unsigned long) PTR.p;
     }
 
 
@@ -272,20 +272,20 @@ public:
 
   /*! Access next edge fragment. */
   Td_map_item& next() const    { return ptr()->next; }
-
+  
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; } //m_dag_node;}
-
+  
   bool is_last_reference() const
   {
     return this->refs()==1;
   }
-
+  
   //@}
-
-
-
-
+  
+  
+  
+  
 
 
 };

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_fictitious_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_fictitious_vertex.h
@@ -129,7 +129,7 @@ public:
   };
 
 private:
-  Data* ptr() const { return (Data*)(PTR); }
+  Data* ptr() const { return (Data*)(PTR.p); }
 
   Curve_end vtx_to_ce(Vertex_const_handle v) const
   {
@@ -180,14 +180,14 @@ public:
 
   Td_active_fictitious_vertex()
   {
-    PTR = new Data(Traits::empty_vtx_handle(), Traits::empty_he_handle(), nullptr);
+    PTR.p = new Data(Traits::empty_vtx_handle(), Traits::empty_he_handle(), nullptr);
   }
 
   /*! Constructor given Vertex & Halfedge handles. */
   Td_active_fictitious_vertex(Vertex_const_handle v,
                               Halfedge_const_handle cw_he,
                               Dag_node* node = 0)
-  { PTR = new Data(v, cw_he, node); }
+  { PTR.p = new Data(v, cw_he, node); }
 
 
   /*! Copy constructor. */
@@ -224,7 +224,7 @@ public:
   inline const Self& self() const { return *this; }
 
   /*! Access the trapezoid id (PTR). */
-  inline unsigned long id() const { return (unsigned long) PTR; }
+  inline unsigned long id() const { return (unsigned long) PTR.p; }
 
   /*! Access trapezoid left.
    *   filters out the infinite case which returns predefined dummy values

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_trapezoid.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_trapezoid.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_ACTIVE_TRAPEZOID_H
@@ -39,10 +39,10 @@ namespace CGAL {
  * Implementation of an active trapezoid as two halfedges(top,bottom)
  * and two vertices(left,right).
  * Trapezoids are represented as two vertices called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Each trapezoid has at most four neighbouring trapezoids.
  */
@@ -50,10 +50,10 @@ template <class Td_traits_>
 class Td_active_trapezoid : public Handle
 {
 public:
-
+  
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -65,7 +65,7 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
@@ -73,10 +73,10 @@ public:
   typedef typename Traits::Td_active_trapezoid            Self;
 
   typedef typename Traits::Td_map_item            Td_map_item;
-
+  
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -87,7 +87,7 @@ public:
 
   friend class Trapezoidal_decomposition_2<Traits>;
   friend struct internal::Non_recursive_td_map_item_destructor<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -98,12 +98,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class In_face_iterator;
 #endif
 #endif
-
+  
   protected:
 
    /*! \class
@@ -115,7 +115,7 @@ public:
 
   public:
     //c'tors
-    Data (Vertex_const_handle _left_v,
+    Data (Vertex_const_handle _left_v,   
           Vertex_const_handle _right_v,
           Halfedge_const_handle _bottom_he,
           Halfedge_const_handle _top_he,
@@ -127,25 +127,25 @@ public:
           : left_v(_left_v),right_v(_right_v),bottom_he(_bottom_he),top_he(_top_he),
             lb(_lb),lt(_lt),rb(_rb),rt(_rt),p_node(_p_node)
     { }
-
+    
     ~Data() { }
 
   protected:
-    Vertex_const_handle left_v;
+    Vertex_const_handle left_v; 
     Vertex_const_handle right_v;
     Halfedge_const_handle bottom_he;
     Halfedge_const_handle top_he;
     Td_map_item lb;
     Td_map_item lt;
-    Td_map_item rb;
+    Td_map_item rb; 
     Td_map_item rt;
     Dag_node* p_node;
   };
-
+  
  private:
-
-  Data* ptr() const { return (Data*)(PTR); }
-
+  
+  Data* ptr() const { return (Data*)(PTR.p); }
+	
 public:
 
   ~Td_active_trapezoid(){
@@ -154,7 +154,7 @@ public:
   }
 
 private:
-
+  
 
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
@@ -165,9 +165,9 @@ private:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-
+	
   //Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-
+	
   /*! Initialize the trapezoid's neighbours. */
    inline void init_neighbours(boost::optional<Td_map_item&> lb, boost::optional<Td_map_item&> lt,
                                boost::optional<Td_map_item&> rb, boost::optional<Td_map_item&> rt)
@@ -179,74 +179,74 @@ private:
   }
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p)
+  inline void set_dag_node(Dag_node* p) 
   {
     ptr()->p_node = p;
 //    m_dag_node = p;
-//
+//  
 //#ifdef CGAL_TD_DEBUG
-//
+//  
 //    CGAL_assertion(!p || **p == *this);
-//
-//#endif
-
+//  
+//#endif	
+	
   }
-
+  
   /*! Set the trapezoid's left (Vertex_const_handle). */
-  inline void set_left(Vertex_const_handle v)
+  inline void set_left(Vertex_const_handle v) 
   {
-    ptr()->left_v = v;
+    ptr()->left_v = v; 
   }
-
+  
   /*! Set the trapezoid's right (Vertex_const_handle). */
-  inline void set_right(Vertex_const_handle v)
+  inline void set_right(Vertex_const_handle v) 
   {
-    ptr()->right_v = v;
+    ptr()->right_v = v; 
   }
-
+  
   /*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  inline void set_bottom(Halfedge_const_handle he)
+  inline void set_bottom(Halfedge_const_handle he) 
   {
     if (!is_on_bottom_boundary() &&
         bottom()->direction() != he->direction())
     {
-      ptr()->bottom_he = he->twin();
+      ptr()->bottom_he = he->twin(); 
     }
     else
     {
-      ptr()->bottom_he = he;
+      ptr()->bottom_he = he; 
     }
   }
-
+  
   /*! Set the trapezoid's top (Halfedge_const_handle). */
-  inline void set_top(Halfedge_const_handle he)
+  inline void set_top(Halfedge_const_handle he) 
   {
     if (!is_on_top_boundary() &&
         top()->direction() != he->direction())
     {
-      ptr()->top_he = he->twin();
+      ptr()->top_he = he->twin(); 
     }
     else
     {
-      ptr()->top_he = he;
+      ptr()->top_he = he; 
     }
   }
-
-
+ 
+  
   /*! Set left bottom neighbour. */
   inline void set_lb(const Td_map_item& lb) { ptr()->lb = lb; }
-
+  
   /*! Set left top neighbour. */
   inline void set_lt(const Td_map_item& lt) { ptr()->lt = lt; }
-
+  
   /*! Set right bottom neighbour. */
   inline void set_rb(const Td_map_item& rb) { ptr()->rb = rb; }
-
+  
   /*! Set right top neighbour. */
   inline void set_rt(const Td_map_item& rt) { ptr()->rt = rt; }
 
  public:
-
+  
   /// \name Constructors.
   //@{
 
@@ -255,50 +255,50 @@ private:
   {
     //define the initial trapezoid: left, right, btm, top are at infinity.
     // has no neighbours
-    PTR = new Data
+    PTR.p = new Data
       (Traits::empty_vtx_handle(),
        Traits::empty_vtx_handle(),
        Traits::empty_he_handle(),
        Traits::empty_he_handle(),
        Td_map_item(0), Td_map_item(0) , Td_map_item(0) , Td_map_item(0), nullptr);
-
+   
     //m_dag_node = 0;
   }
 
-  /*! Constructor given Vertex & Halfedge handles. */
+  /*! Constructor given Vertex & Halfedge handles. */ 
   Td_active_trapezoid (Vertex_const_handle l, Vertex_const_handle r,
                   Halfedge_const_handle b, Halfedge_const_handle t,
-                  boost::optional<Td_map_item&> lb = boost::none,
+                  boost::optional<Td_map_item&> lb = boost::none, 
                   boost::optional<Td_map_item&> lt = boost::none,
-                  boost::optional<Td_map_item&> rb = boost::none,
+                  boost::optional<Td_map_item&> rb = boost::none, 
                   boost::optional<Td_map_item&> rt = boost::none,
                   Dag_node* node = 0)
   {
-    PTR = new Data (l, r, b, t, (lb) ? *lb : Td_map_item(0), (lt) ? *lt : Td_map_item(0),
+    PTR.p = new Data (l, r, b, t, (lb) ? *lb : Td_map_item(0), (lt) ? *lt : Td_map_item(0),
                    (rb) ? *rb : Td_map_item(0), (rt) ? *rt : Td_map_item(0), node);
     //m_dag_node = node;
   }
-
-
+ 
+  
   /*! Copy constructor. */
   Td_active_trapezoid (const Self& tr) : Handle(tr)
   {
     //m_dag_node = tr.m_dag_node;
   }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-          Handle::operator=(t2);
-          return *this;
+	  Handle::operator=(t2);
+	  return *this;
   }
 
   /*! Operator==. */
@@ -319,12 +319,12 @@ private:
   /// \name Access methods.
   //@{
 
-  inline Self& self()
+  inline Self& self() 
   {
     return *this;
   }
 
-  inline const Self& self() const
+  inline const Self& self() const 
   {
     return *this;
   }
@@ -332,10 +332,10 @@ private:
   /*! Access the trapezoid id (PTR). */
   inline unsigned long id() const
   {
-    return (unsigned long) PTR;
+    return (unsigned long) PTR.p;
   }
 
-  /*! Access trapezoid left.
+  /*! Access trapezoid left. 
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Vertex_const_handle left() const
@@ -343,76 +343,76 @@ private:
     return ptr()->left_v;
   }
 
-  /*! Access trapezoid right.
+  /*! Access trapezoid right. 
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Vertex_const_handle right () const
   {
-    return ptr()->right_v;
+    return ptr()->right_v; 
   }
-
-  /*! Access trapezoid bottom.
+  
+  /*! Access trapezoid bottom. 
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Halfedge_const_handle bottom () const
   {
-    return  ptr()->bottom_he;
+    return  ptr()->bottom_he; 
   }
-
-  /*! Access trapezoid top.
+ 
+  /*! Access trapezoid top. 
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Halfedge_const_handle top () const
   {
-    return ptr()->top_he;
+    return ptr()->top_he; 
   }
 
   /*! Access is on left boundary. */
-  inline bool is_on_left_boundary() const
-  {
+  inline bool is_on_left_boundary() const 
+  {			
     return (left() == Traits::empty_vtx_handle());
   }
 
   /*! Access is on right boundary. */
-  inline bool is_on_right_boundary() const
+  inline bool is_on_right_boundary() const 
   {
     return (right() == Traits::empty_vtx_handle());
   }
 
   /*! Access is on bottom boundary. */
-  inline bool is_on_bottom_boundary() const
+  inline bool is_on_bottom_boundary() const 
   {
     return (bottom() == Traits::empty_he_handle());
   }
 
   /*! Access is on top boundary. */
-  inline bool is_on_top_boundary() const
+  inline bool is_on_top_boundary() const 
   {
     return (top() == Traits::empty_he_handle());
   }
-
+  
   /*! Access is on at least one boundary. */
   inline bool is_on_boundaries() const
-  {
-    return (is_on_left_boundary() || is_on_right_boundary() ||
+  {			
+    return (is_on_left_boundary() || is_on_right_boundary() || 
             is_on_bottom_boundary() || is_on_top_boundary() );
   }
-
+  
   /*! Access left bottom neighbour. */
   Td_map_item& lb() const    { return ptr()->lb; }
-
+  
   /*! Access left top neighbour. */
   Td_map_item& lt() const    { return ptr()->lt; }
-
+  
   /*! Access right bottom neighbour. */
   Td_map_item& rb() const    { return ptr()->rb; }
-
+  
   /*! Access right top neighbour. */
   Td_map_item& rt() const    { return ptr()->rt; }
-
+  
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; }
-
+  
   bool is_last_reference() const
   {
     return this->refs()==1;
@@ -430,10 +430,10 @@ private:
   {
     internal::Non_recursive_td_map_item_destructor<Traits>(*this);
   }
-
+  
   //@}
-
-
+  
+  
   // Merge this trapezoid with the input trapezoid.
   // Precondition:
   //   Both trapezoids are active and have the same bounding edges from
@@ -455,19 +455,19 @@ private:
     ptr()->top_he = top();
     ptr()->lb = lb();
     ptr()->lt = lt();
-    ptr()->rb = right.rb();
+    ptr()->rb = right.rb(); 
     ptr()->rt = right.rt();
-
+    
     Td_map_item item (*this);
 
     if (ptr()->rb.which() != 0)
     {
-      Self tr(boost::get<Self>(rb()));
-      tr.set_lb(item);
+      Self tr(boost::get<Self>(rb()));     
+      tr.set_lb(item); 
     }
     if (ptr()->rt.which() != 0)
     {
-      Self tr(boost::get<Self>(rt()));
+      Self tr(boost::get<Self>(rt()));     
       tr.set_lt(item);
     }
     CGAL_assertion(is_on_right_boundary() == right.is_on_right_boundary());

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_trapezoid.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_trapezoid.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_ACTIVE_TRAPEZOID_H
@@ -39,10 +39,10 @@ namespace CGAL {
  * Implementation of an active trapezoid as two halfedges(top,bottom)
  * and two vertices(left,right).
  * Trapezoids are represented as two vertices called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Each trapezoid has at most four neighbouring trapezoids.
  */
@@ -50,10 +50,10 @@ template <class Td_traits_>
 class Td_active_trapezoid : public Handle
 {
 public:
-  
+
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -65,7 +65,7 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
@@ -73,10 +73,10 @@ public:
   typedef typename Traits::Td_active_trapezoid            Self;
 
   typedef typename Traits::Td_map_item            Td_map_item;
-  
+
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -87,7 +87,7 @@ public:
 
   friend class Trapezoidal_decomposition_2<Traits>;
   friend struct internal::Non_recursive_td_map_item_destructor<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -98,12 +98,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class In_face_iterator;
 #endif
 #endif
-  
+
   protected:
 
    /*! \class
@@ -115,7 +115,7 @@ public:
 
   public:
     //c'tors
-    Data (Vertex_const_handle _left_v,   
+    Data (Vertex_const_handle _left_v,
           Vertex_const_handle _right_v,
           Halfedge_const_handle _bottom_he,
           Halfedge_const_handle _top_he,
@@ -127,25 +127,25 @@ public:
           : left_v(_left_v),right_v(_right_v),bottom_he(_bottom_he),top_he(_top_he),
             lb(_lb),lt(_lt),rb(_rb),rt(_rt),p_node(_p_node)
     { }
-    
+
     ~Data() { }
 
   protected:
-    Vertex_const_handle left_v; 
+    Vertex_const_handle left_v;
     Vertex_const_handle right_v;
     Halfedge_const_handle bottom_he;
     Halfedge_const_handle top_he;
     Td_map_item lb;
     Td_map_item lt;
-    Td_map_item rb; 
+    Td_map_item rb;
     Td_map_item rt;
     Dag_node* p_node;
   };
-  
+
  private:
-  
+
   Data* ptr() const { return (Data*)(PTR.p); }
-	
+
 public:
 
   ~Td_active_trapezoid(){
@@ -154,7 +154,7 @@ public:
   }
 
 private:
-  
+
 
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
@@ -165,9 +165,9 @@ private:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-	
+
   //Dag_node* m_dag_node; //pointer to the search structure (DAG) node
-	
+
   /*! Initialize the trapezoid's neighbours. */
    inline void init_neighbours(boost::optional<Td_map_item&> lb, boost::optional<Td_map_item&> lt,
                                boost::optional<Td_map_item&> rb, boost::optional<Td_map_item&> rt)
@@ -179,74 +179,74 @@ private:
   }
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p) 
+  inline void set_dag_node(Dag_node* p)
   {
     ptr()->p_node = p;
 //    m_dag_node = p;
-//  
+//
 //#ifdef CGAL_TD_DEBUG
-//  
+//
 //    CGAL_assertion(!p || **p == *this);
-//  
-//#endif	
-	
+//
+//#endif
+
   }
-  
+
   /*! Set the trapezoid's left (Vertex_const_handle). */
-  inline void set_left(Vertex_const_handle v) 
+  inline void set_left(Vertex_const_handle v)
   {
-    ptr()->left_v = v; 
+    ptr()->left_v = v;
   }
-  
+
   /*! Set the trapezoid's right (Vertex_const_handle). */
-  inline void set_right(Vertex_const_handle v) 
+  inline void set_right(Vertex_const_handle v)
   {
-    ptr()->right_v = v; 
+    ptr()->right_v = v;
   }
-  
+
   /*! Set the trapezoid's bottom (Halfedge_const_handle). */
-  inline void set_bottom(Halfedge_const_handle he) 
+  inline void set_bottom(Halfedge_const_handle he)
   {
     if (!is_on_bottom_boundary() &&
         bottom()->direction() != he->direction())
     {
-      ptr()->bottom_he = he->twin(); 
+      ptr()->bottom_he = he->twin();
     }
     else
     {
-      ptr()->bottom_he = he; 
+      ptr()->bottom_he = he;
     }
   }
-  
+
   /*! Set the trapezoid's top (Halfedge_const_handle). */
-  inline void set_top(Halfedge_const_handle he) 
+  inline void set_top(Halfedge_const_handle he)
   {
     if (!is_on_top_boundary() &&
         top()->direction() != he->direction())
     {
-      ptr()->top_he = he->twin(); 
+      ptr()->top_he = he->twin();
     }
     else
     {
-      ptr()->top_he = he; 
+      ptr()->top_he = he;
     }
   }
- 
-  
+
+
   /*! Set left bottom neighbour. */
   inline void set_lb(const Td_map_item& lb) { ptr()->lb = lb; }
-  
+
   /*! Set left top neighbour. */
   inline void set_lt(const Td_map_item& lt) { ptr()->lt = lt; }
-  
+
   /*! Set right bottom neighbour. */
   inline void set_rb(const Td_map_item& rb) { ptr()->rb = rb; }
-  
+
   /*! Set right top neighbour. */
   inline void set_rt(const Td_map_item& rt) { ptr()->rt = rt; }
 
  public:
-  
+
   /// \name Constructors.
   //@{
 
@@ -261,16 +261,16 @@ private:
        Traits::empty_he_handle(),
        Traits::empty_he_handle(),
        Td_map_item(0), Td_map_item(0) , Td_map_item(0) , Td_map_item(0), nullptr);
-   
+
     //m_dag_node = 0;
   }
 
-  /*! Constructor given Vertex & Halfedge handles. */ 
+  /*! Constructor given Vertex & Halfedge handles. */
   Td_active_trapezoid (Vertex_const_handle l, Vertex_const_handle r,
                   Halfedge_const_handle b, Halfedge_const_handle t,
-                  boost::optional<Td_map_item&> lb = boost::none, 
+                  boost::optional<Td_map_item&> lb = boost::none,
                   boost::optional<Td_map_item&> lt = boost::none,
-                  boost::optional<Td_map_item&> rb = boost::none, 
+                  boost::optional<Td_map_item&> rb = boost::none,
                   boost::optional<Td_map_item&> rt = boost::none,
                   Dag_node* node = 0)
   {
@@ -278,27 +278,27 @@ private:
                    (rb) ? *rb : Td_map_item(0), (rt) ? *rt : Td_map_item(0), node);
     //m_dag_node = node;
   }
- 
-  
+
+
   /*! Copy constructor. */
   Td_active_trapezoid (const Self& tr) : Handle(tr)
   {
     //m_dag_node = tr.m_dag_node;
   }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-	  Handle::operator=(t2);
-	  return *this;
+          Handle::operator=(t2);
+          return *this;
   }
 
   /*! Operator==. */
@@ -319,12 +319,12 @@ private:
   /// \name Access methods.
   //@{
 
-  inline Self& self() 
+  inline Self& self()
   {
     return *this;
   }
 
-  inline const Self& self() const 
+  inline const Self& self() const
   {
     return *this;
   }
@@ -335,7 +335,7 @@ private:
     return (unsigned long) PTR.p;
   }
 
-  /*! Access trapezoid left. 
+  /*! Access trapezoid left.
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Vertex_const_handle left() const
@@ -343,76 +343,76 @@ private:
     return ptr()->left_v;
   }
 
-  /*! Access trapezoid right. 
+  /*! Access trapezoid right.
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Vertex_const_handle right () const
   {
-    return ptr()->right_v; 
+    return ptr()->right_v;
   }
-  
-  /*! Access trapezoid bottom. 
+
+  /*! Access trapezoid bottom.
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Halfedge_const_handle bottom () const
   {
-    return  ptr()->bottom_he; 
+    return  ptr()->bottom_he;
   }
- 
-  /*! Access trapezoid top. 
+
+  /*! Access trapezoid top.
   *   filters out the infinite case which returns predefined dummy values
   */
   inline Halfedge_const_handle top () const
   {
-    return ptr()->top_he; 
+    return ptr()->top_he;
   }
 
   /*! Access is on left boundary. */
-  inline bool is_on_left_boundary() const 
-  {			
+  inline bool is_on_left_boundary() const
+  {
     return (left() == Traits::empty_vtx_handle());
   }
 
   /*! Access is on right boundary. */
-  inline bool is_on_right_boundary() const 
+  inline bool is_on_right_boundary() const
   {
     return (right() == Traits::empty_vtx_handle());
   }
 
   /*! Access is on bottom boundary. */
-  inline bool is_on_bottom_boundary() const 
+  inline bool is_on_bottom_boundary() const
   {
     return (bottom() == Traits::empty_he_handle());
   }
 
   /*! Access is on top boundary. */
-  inline bool is_on_top_boundary() const 
+  inline bool is_on_top_boundary() const
   {
     return (top() == Traits::empty_he_handle());
   }
-  
+
   /*! Access is on at least one boundary. */
   inline bool is_on_boundaries() const
-  {			
-    return (is_on_left_boundary() || is_on_right_boundary() || 
+  {
+    return (is_on_left_boundary() || is_on_right_boundary() ||
             is_on_bottom_boundary() || is_on_top_boundary() );
   }
-  
+
   /*! Access left bottom neighbour. */
   Td_map_item& lb() const    { return ptr()->lb; }
-  
+
   /*! Access left top neighbour. */
   Td_map_item& lt() const    { return ptr()->lt; }
-  
+
   /*! Access right bottom neighbour. */
   Td_map_item& rb() const    { return ptr()->rb; }
-  
+
   /*! Access right top neighbour. */
   Td_map_item& rt() const    { return ptr()->rt; }
-  
+
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; }
-  
+
   bool is_last_reference() const
   {
     return this->refs()==1;
@@ -430,10 +430,10 @@ private:
   {
     internal::Non_recursive_td_map_item_destructor<Traits>(*this);
   }
-  
+
   //@}
-  
-  
+
+
   // Merge this trapezoid with the input trapezoid.
   // Precondition:
   //   Both trapezoids are active and have the same bounding edges from
@@ -455,19 +455,19 @@ private:
     ptr()->top_he = top();
     ptr()->lb = lb();
     ptr()->lt = lt();
-    ptr()->rb = right.rb(); 
+    ptr()->rb = right.rb();
     ptr()->rt = right.rt();
-    
+
     Td_map_item item (*this);
 
     if (ptr()->rb.which() != 0)
     {
-      Self tr(boost::get<Self>(rb()));     
-      tr.set_lb(item); 
+      Self tr(boost::get<Self>(rb()));
+      tr.set_lb(item);
     }
     if (ptr()->rt.which() != 0)
     {
-      Self tr(boost::get<Self>(rt()));     
+      Self tr(boost::get<Self>(rt()));
       tr.set_lt(item);
     }
     CGAL_assertion(is_on_right_boundary() == right.is_on_right_boundary());

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_vertex.h
@@ -134,7 +134,7 @@ public:
   };
 
 private:
-  Data* ptr() const { return (Data*)(PTR); }
+  Data* ptr() const { return (Data*)(PTR.p); }
 
   Curve_end vtx_to_ce(Vertex_const_handle v) const
   {
@@ -184,14 +184,14 @@ public:
 
   Td_active_vertex()
   {
-    PTR = new Data(Traits::empty_vtx_handle(), Traits::empty_he_handle(), nullptr);
+    PTR.p = new Data(Traits::empty_vtx_handle(), Traits::empty_he_handle(), nullptr);
   }
 
   /*! Constructor given Vertex & Halfedge handles. */
   Td_active_vertex(Vertex_const_handle v, Halfedge_const_handle cw_he,
                    Dag_node* node = 0)
 
-  { PTR = new Data(v, cw_he, node); }
+  { PTR.p = new Data(v, cw_he, node); }
 
 
   /*! Copy constructor. */
@@ -228,7 +228,7 @@ public:
   inline const Self& self() const { return *this; }
 
   /*! Access the trapezoid id (PTR). */
-  inline unsigned long id() const { return (unsigned long) PTR; }
+  inline unsigned long id() const { return (unsigned long) PTR.p; }
 
   inline Vertex_const_handle vertex() const { return ptr()->v; }
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-// 
+//
 //
 // Author(s)     : Iddo Hanniel <hanniel@math.tau.ac.il>
 //                 Oren Nechushtan <theoren@math.tau.ac.il>
@@ -46,7 +46,7 @@ protected:
 public:
   Td_dag_base() {init();}
   Td_dag_base(const Td_dag_base<T> & x) : Handle(x) {}
-  Td_dag_base & operator=(const Td_dag_base<T> & x) 
+  Td_dag_base & operator=(const Td_dag_base<T> & x)
   {Handle::operator=(x); return *this; }
   bool operator!() const { return PTR.p == 0; }
 };
@@ -68,29 +68,29 @@ public:
   using Td_dag_handle::operator!;
 #endif
 
-protected:	
+protected:
   class node : public Rep
   {
     friend class Td_dag<T>;
   public:
-    node(const T& e,unsigned long _depth=0) : 
+    node(const T& e,unsigned long _depth=0) :
       data(e),leftPtr(),rightPtr(),depth_(_depth){}
-    node(const T& e, const Td_dag_handle& left, 
-         const Td_dag_handle& right,unsigned long _depth=0) : 
+    node(const T& e, const Td_dag_handle& left,
+         const Td_dag_handle& right,unsigned long _depth=0) :
       data(e),leftPtr(left),rightPtr(right),depth_(_depth){}
-    //		node(const T& e) : data(e),leftPtr(),rightPtr(){}
-    //		node(const T& e, const Td_dag_handle& left, 
+    //                node(const T& e) : data(e),leftPtr(),rightPtr(){}
+    //                node(const T& e, const Td_dag_handle& left,
     // const Td_dag_handle& right) : data(e),leftPtr(left),rightPtr(right) {}
     ~node(){}
     bool is_inner_node() const {return !!leftPtr && !!rightPtr;}
     bool visited() const {return visited_;}
   protected:
-    T data;			// information stored in node
+    T data;                        // information stored in node
     Td_dag_handle leftPtr,rightPtr;
     mutable unsigned long depth_;
     mutable bool visited_;
   };
-  
+
 public:
   /* -------constructors destructors -----*/
   Td_dag(){}
@@ -106,7 +106,7 @@ public:
   {
     CGAL_precondition(!operator!());
     return *(const Self*)&ptr()->leftPtr;
-    
+
   }
   const Self& right() const
   {
@@ -131,7 +131,7 @@ public:
   {
     return data_ptr();
   }
-  bool is_inner_node() const 
+  bool is_inner_node() const
   {return !operator!() && ptr()->is_inner_node();}
   unsigned long size() const
   {
@@ -152,9 +152,9 @@ public:
     return !operator==(b);
   }
   /* dynamic management ---------*/
-  
+
   /* description:
-     Shallow copy	*/
+     Shallow copy        */
   Self& operator=(const Self& b)
   {
     Handle::operator=(b);
@@ -198,14 +198,14 @@ public:
   {
     if (!operator!())
       {
-				// create dummy Td_dag
+                                // create dummy Td_dag
         T tmp;
         Self dummy(tmp);
-				// detach right son,redirect to dummy
+                                // detach right son,redirect to dummy
         set_right(dummy);
-				// set right son pointer to 0
+                                // set right son pointer to 0
         ptr()->rightPtr.PTR.p=0;
-				// delete dummy Td_dag
+                                // delete dummy Td_dag
         delete dummy.ptr();
       }
   }
@@ -229,7 +229,7 @@ public:
     CGAL_precondition(!operator!());
     ptr()->leftPtr=left;
     if (left.depth()<depth()+1) left.ptr()->depth_=depth()+1;
-    left.rebalance_depth(); 
+    left.rebalance_depth();
     // does nothing if right is a leaf
   }
   void set_right(const Self& right)
@@ -237,7 +237,7 @@ public:
     CGAL_precondition(!operator!());
     ptr()->rightPtr=right;
     if (right.depth()<depth()+1) right.ptr()->depth_=depth()+1;
-    right.rebalance_depth(); 
+    right.rebalance_depth();
     // does nothing if right is a leaf
   }
   void replace(const T& data,const Self& left,const Self& right)
@@ -292,7 +292,7 @@ public:
       }
   }
 #endif
-  
+
   template <class Container,class Predicate>
   Container& filter(Container& c,const Predicate& pr) const
   {
@@ -310,8 +310,8 @@ public:
 protected:
   void rebalance_depth() const
   {
-    if (is_inner_node()) 
-    {  
+    if (is_inner_node())
+    {
       unsigned long depth_=depth();
       if (left().depth()<depth_+1)
       {
@@ -325,7 +325,7 @@ protected:
       }
     }
   }
-  
+
   unsigned long recursive_size() const
   {
     if (!operator!() && !ptr()->visited())
@@ -345,7 +345,7 @@ protected:
   {
     if (!operator!() && !ptr()->visited())
     {
-      if (pr(operator*())) 
+      if (pr(operator*()))
         c.insert(c.end(),operator*());
       visit_one();
       left().recursive_filter(c,pr);
@@ -354,13 +354,13 @@ protected:
     return c;
   }
 #if 0
-  template <class Container, class Predicate> 
-  Container& recursive_hash_filter(Container& c, const Predicate& ptr) const 
+  template <class Container, class Predicate>
+  Container& recursive_hash_filter(Container& c, const Predicate& ptr) const
     /* Generate a copy of the Dag filtered according to the predicate */
   {
     if (!operator!() && !ptr()->visited())
     {
-      if (pr(operator*())) 
+      if (pr(operator*()))
         c.insert(pair<&operator*(), new X_trapezoid(operator*()));
       // The hash links between the old trapezoid to the new one.
       visit_one();
@@ -374,8 +374,8 @@ protected:
   node* ptr() const {return (node*)PTR.p;}
 };
 
-template<class T,class Traits> 
-std::ostream& write(std::ostream&  out, 
+template<class T,class Traits>
+std::ostream& write(std::ostream&  out,
                     const Td_dag<T>& t,
                     const Traits& traits)
 {
@@ -406,7 +406,7 @@ std::ostream& write(std::ostream&  out,
   return out ;
 }
 
-template<class T> std::ostream& operator<<(std::ostream&  out, 
+template<class T> std::ostream& operator<<(std::ostream&  out,
                                            const Td_dag<T>& t)
 {
   CGAL_STATIC_THREAD_LOCAL_VARIABLE(int, depth,0);
@@ -437,10 +437,10 @@ template<class T> std::ostream& operator<<(std::ostream&  out,
 
 #endif
 
-/* 
+/*
    tech notes:
    The code is Handle designed.
-   left(),right() are designed to cope with Handle(Handle& x) 
+   left(),right() are designed to cope with Handle(Handle& x)
      precondition x.PTR.p!=0
    operator=() performs shallow copy
    operator*() returns data type

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-//
+// 
 //
 // Author(s)     : Iddo Hanniel <hanniel@math.tau.ac.il>
 //                 Oren Nechushtan <theoren@math.tau.ac.il>
@@ -41,14 +41,14 @@ public: //iddo (for CC-7.2) maybe protected?
   typedef const T & const_reference;
 
 protected:
-  void init() { PTR = 0; }
+  void init() { PTR.p = 0; }
 
 public:
   Td_dag_base() {init();}
   Td_dag_base(const Td_dag_base<T> & x) : Handle(x) {}
-  Td_dag_base & operator=(const Td_dag_base<T> & x)
+  Td_dag_base & operator=(const Td_dag_base<T> & x) 
   {Handle::operator=(x); return *this; }
-  bool operator!() const { return PTR == 0; }
+  bool operator!() const { return PTR.p == 0; }
 };
 
 template<class T>
@@ -68,37 +68,37 @@ public:
   using Td_dag_handle::operator!;
 #endif
 
-protected:
+protected:	
   class node : public Rep
   {
     friend class Td_dag<T>;
   public:
-    node(const T& e,unsigned long _depth=0) :
+    node(const T& e,unsigned long _depth=0) : 
       data(e),leftPtr(),rightPtr(),depth_(_depth){}
-    node(const T& e, const Td_dag_handle& left,
-         const Td_dag_handle& right,unsigned long _depth=0) :
+    node(const T& e, const Td_dag_handle& left, 
+         const Td_dag_handle& right,unsigned long _depth=0) : 
       data(e),leftPtr(left),rightPtr(right),depth_(_depth){}
-    //                node(const T& e) : data(e),leftPtr(),rightPtr(){}
-    //                node(const T& e, const Td_dag_handle& left,
+    //		node(const T& e) : data(e),leftPtr(),rightPtr(){}
+    //		node(const T& e, const Td_dag_handle& left, 
     // const Td_dag_handle& right) : data(e),leftPtr(left),rightPtr(right) {}
     ~node(){}
     bool is_inner_node() const {return !!leftPtr && !!rightPtr;}
     bool visited() const {return visited_;}
   protected:
-    T data;                        // information stored in node
+    T data;			// information stored in node
     Td_dag_handle leftPtr,rightPtr;
     mutable unsigned long depth_;
     mutable bool visited_;
   };
-
+  
 public:
   /* -------constructors destructors -----*/
   Td_dag(){}
   Td_dag(const Td_dag_handle& dag):Td_dag_handle(dag){}
   Td_dag(const Self& dag):Td_dag_handle(dag){}
-  Td_dag(const T& rootValue){PTR = new node(rootValue);}
+  Td_dag(const T& rootValue){PTR.p = new node(rootValue);}
   Td_dag(const T& rootValue, const Self& left, const Self& right)
-  {PTR = new node(rootValue, left, right); rebalance_depth();}
+  {PTR.p = new node(rootValue, left, right); rebalance_depth();}
   ~Td_dag(){}
 
   /* --------information retrieval -------*/
@@ -106,7 +106,7 @@ public:
   {
     CGAL_precondition(!operator!());
     return *(const Self*)&ptr()->leftPtr;
-
+    
   }
   const Self& right() const
   {
@@ -131,7 +131,7 @@ public:
   {
     return data_ptr();
   }
-  bool is_inner_node() const
+  bool is_inner_node() const 
   {return !operator!() && ptr()->is_inner_node();}
   unsigned long size() const
   {
@@ -145,16 +145,16 @@ public:
   }
   bool operator==(const Self& b) const
   {
-    return PTR==b.PTR;
+    return PTR.p==b.PTR.p;
   }
   bool operator!=(const Self& b) const
   {
     return !operator==(b);
   }
   /* dynamic management ---------*/
-
+  
   /* description:
-     Shallow copy        */
+     Shallow copy	*/
   Self& operator=(const Self& b)
   {
     Handle::operator=(b);
@@ -189,7 +189,7 @@ public:
         // detach left son,redirect to dummy
         set_left(dummy);
         // set left son pointer to 0
-        ptr()->leftPtr.PTR=0;
+        ptr()->leftPtr.PTR.p=0;
         // delete dummy Td_dag
         delete dummy.ptr();
       }
@@ -198,14 +198,14 @@ public:
   {
     if (!operator!())
       {
-                                // create dummy Td_dag
+				// create dummy Td_dag
         T tmp;
         Self dummy(tmp);
-                                // detach right son,redirect to dummy
+				// detach right son,redirect to dummy
         set_right(dummy);
-                                // set right son pointer to 0
-        ptr()->rightPtr.PTR=0;
-                                // delete dummy Td_dag
+				// set right son pointer to 0
+        ptr()->rightPtr.PTR.p=0;
+				// delete dummy Td_dag
         delete dummy.ptr();
       }
   }
@@ -229,7 +229,7 @@ public:
     CGAL_precondition(!operator!());
     ptr()->leftPtr=left;
     if (left.depth()<depth()+1) left.ptr()->depth_=depth()+1;
-    left.rebalance_depth();
+    left.rebalance_depth(); 
     // does nothing if right is a leaf
   }
   void set_right(const Self& right)
@@ -237,7 +237,7 @@ public:
     CGAL_precondition(!operator!());
     ptr()->rightPtr=right;
     if (right.depth()<depth()+1) right.ptr()->depth_=depth()+1;
-    right.rebalance_depth();
+    right.rebalance_depth(); 
     // does nothing if right is a leaf
   }
   void replace(const T& data,const Self& left,const Self& right)
@@ -292,7 +292,7 @@ public:
       }
   }
 #endif
-
+  
   template <class Container,class Predicate>
   Container& filter(Container& c,const Predicate& pr) const
   {
@@ -310,8 +310,8 @@ public:
 protected:
   void rebalance_depth() const
   {
-    if (is_inner_node())
-    {
+    if (is_inner_node()) 
+    {  
       unsigned long depth_=depth();
       if (left().depth()<depth_+1)
       {
@@ -325,7 +325,7 @@ protected:
       }
     }
   }
-
+  
   unsigned long recursive_size() const
   {
     if (!operator!() && !ptr()->visited())
@@ -345,7 +345,7 @@ protected:
   {
     if (!operator!() && !ptr()->visited())
     {
-      if (pr(operator*()))
+      if (pr(operator*())) 
         c.insert(c.end(),operator*());
       visit_one();
       left().recursive_filter(c,pr);
@@ -354,13 +354,13 @@ protected:
     return c;
   }
 #if 0
-  template <class Container, class Predicate>
-  Container& recursive_hash_filter(Container& c, const Predicate& ptr) const
+  template <class Container, class Predicate> 
+  Container& recursive_hash_filter(Container& c, const Predicate& ptr) const 
     /* Generate a copy of the Dag filtered according to the predicate */
   {
     if (!operator!() && !ptr()->visited())
     {
-      if (pr(operator*()))
+      if (pr(operator*())) 
         c.insert(pair<&operator*(), new X_trapezoid(operator*()));
       // The hash links between the old trapezoid to the new one.
       visit_one();
@@ -371,11 +371,11 @@ protected:
   }
 #endif
  private:
-  node* ptr() const {return (node*)PTR;}
+  node* ptr() const {return (node*)PTR.p;}
 };
 
-template<class T,class Traits>
-std::ostream& write(std::ostream&  out,
+template<class T,class Traits> 
+std::ostream& write(std::ostream&  out, 
                     const Td_dag<T>& t,
                     const Traits& traits)
 {
@@ -406,7 +406,7 @@ std::ostream& write(std::ostream&  out,
   return out ;
 }
 
-template<class T> std::ostream& operator<<(std::ostream&  out,
+template<class T> std::ostream& operator<<(std::ostream&  out, 
                                            const Td_dag<T>& t)
 {
   CGAL_STATIC_THREAD_LOCAL_VARIABLE(int, depth,0);
@@ -437,11 +437,11 @@ template<class T> std::ostream& operator<<(std::ostream&  out,
 
 #endif
 
-/*
+/* 
    tech notes:
    The code is Handle designed.
-   left(),right() are designed to cope with Handle(Handle& x)
-     precondition x.PTR!=0
+   left(),right() are designed to cope with Handle(Handle& x) 
+     precondition x.PTR.p!=0
    operator=() performs shallow copy
    operator*() returns data type
    output is done as a binary tree.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag_node.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_dag_node.h
@@ -39,7 +39,7 @@ template<class Traits>
 class Td_dag_node_base : public Handle
 {
 protected:
-  void init() { PTR = 0; } //MICHAL: I think it is not used - so need to be removed
+  void init() { PTR.p = 0; } //MICHAL: I think it is not used - so need to be removed
 
 public:
   //c'tors
@@ -57,12 +57,12 @@ public:
     return *this;
   }
 
-  //bool operator!() const {  return PTR == 0;  } //MICHAL: maybe use ptr(), and also can change to is_null or something similar
-  bool is_null() const { return PTR == 0; }
-  Rep * ptr() const { return (Rep*) PTR; }
+  //bool operator!() const {  return PTR.p == 0;  } //MICHAL: maybe use ptr(), and also can change to is_null or something similar
+  bool is_null() const { return PTR.p == 0; }
+  Rep * ptr() const { return (Rep*) PTR.p; }
 protected:
-  //Rep *& ptr() { return (Rep*) PTR; }
-  void set_ptr(Rep* rep) { PTR = rep; }
+  //Rep *& ptr() { return (Rep*) PTR.p; }
+  void set_ptr(Rep* rep) { PTR.p = rep; }
 
 };
 
@@ -94,7 +94,7 @@ public:
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
 
 public:
-  //using Td_dag_node_handle::PTR;
+  //using Td_dag_node_handle::PTR.p;
   //using Td_dag_node_handle::operator!;
 
 #endif //CGAL_CFG_USING_BASE_MEMBER_BUG_2
@@ -549,7 +549,7 @@ protected:
 
 private:
 
-  Node* node() const {   return (Node*)Base::PTR;  }
+  Node* node() const {   return (Node*)Base::PTR.p;  }
 
 };
 
@@ -629,7 +629,7 @@ std::ostream& operator<< (std::ostream&  out,
    tech notes:
    The code is Handle designed.
    left_child(),right_child() are designed to cope with Handle(Handle& x)
-     precondition x.PTR!=0
+     precondition x.PTR.p!=0
    operator=() performs shallow copy
    operator*() returns data type
    output is done as a binary tree.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_EDGE_H
@@ -37,25 +37,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_edge : public Handle
 {
 public:
-  
+
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -67,18 +67,18 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Td_inactive_edge (Self)
   typedef typename Traits::Td_inactive_edge            Self;
-  
+
   typedef typename Traits::Td_map_item            Td_map_item;
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -89,7 +89,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -100,12 +100,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class In_face_iterator;
 #endif
 #endif
-  
+
  /*! \class
    * Inner class Data derived from Rep class
    */
@@ -118,19 +118,19 @@ public:
     Data (boost::shared_ptr<X_monotone_curve_2>& _cv, Dag_node* _p_node)
        : cv(_cv), p_node(_p_node) //, lb(_lb),lt(_lt),rb(_rb),rt(_rt)
     { }
-    
+
     ~Data() { }
 
   protected:
-    boost::shared_ptr<X_monotone_curve_2> cv; 
+    boost::shared_ptr<X_monotone_curve_2> cv;
     Dag_node* p_node;
-  }; 
-  
+  };
+
  private:
-  
+
   Data* ptr() const { return (Data*)(PTR.p);  }
-	
-	
+
+
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -142,19 +142,19 @@ public:
 #endif //CGAL_TD_DEBUG
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p) 
+  inline void set_dag_node(Dag_node* p)
   {
     ptr()->p_node = p;
   }
-  
+
   /*! Set the x_monotone_curve_2 for removed edge degenerate trapezoid. */
   CGAL_TD_INLINE void set_curve(boost::shared_ptr<X_monotone_curve_2>& cv)
   {
-    ptr()->cv = cv; 
+    ptr()->cv = cv;
   }
-  
+
  public:
-  
+
   /// \name Constructors.
   //@{
 
@@ -163,25 +163,25 @@ public:
   {
     PTR.p = new Data(cv,node);
   }
-  
+
   /*! Copy constructor. */
   Td_inactive_edge (const Self& tr) : Handle(tr)
   {
   }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-	  Handle::operator=(t2);
-	  return *this;
+          Handle::operator=(t2);
+          return *this;
   }
 
   /*! Operator==. */
@@ -202,12 +202,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self() 
+  inline Self& self()
   {
     return *this;
   }
-  
-  inline const Self& self() const 
+
+  inline const Self& self() const
   {
     return *this;
   }
@@ -218,7 +218,7 @@ public:
     return (unsigned long) PTR.p;
   }
 
-  inline X_monotone_curve_2& curve() const  
+  inline X_monotone_curve_2& curve() const
   {
     X_monotone_curve_2* cv_ptr = (ptr()->cv).get();
     CGAL_assertion(cv_ptr != nullptr);
@@ -227,12 +227,12 @@ public:
 
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; }
-  
-  
+
+
   //@}
-  
-  
-	
+
+
+
 
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_EDGE_H
@@ -37,25 +37,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_edge : public Handle
 {
 public:
-
+  
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -67,18 +67,18 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Td_inactive_edge (Self)
   typedef typename Traits::Td_inactive_edge            Self;
-
+  
   typedef typename Traits::Td_map_item            Td_map_item;
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -89,7 +89,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -100,12 +100,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class In_face_iterator;
 #endif
 #endif
-
+  
  /*! \class
    * Inner class Data derived from Rep class
    */
@@ -118,19 +118,19 @@ public:
     Data (boost::shared_ptr<X_monotone_curve_2>& _cv, Dag_node* _p_node)
        : cv(_cv), p_node(_p_node) //, lb(_lb),lt(_lt),rb(_rb),rt(_rt)
     { }
-
+    
     ~Data() { }
 
   protected:
-    boost::shared_ptr<X_monotone_curve_2> cv;
+    boost::shared_ptr<X_monotone_curve_2> cv; 
     Dag_node* p_node;
-  };
-
+  }; 
+  
  private:
-
-  Data* ptr() const { return (Data*)(PTR);  }
-
-
+  
+  Data* ptr() const { return (Data*)(PTR.p);  }
+	
+	
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -142,46 +142,46 @@ public:
 #endif //CGAL_TD_DEBUG
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p)
+  inline void set_dag_node(Dag_node* p) 
   {
     ptr()->p_node = p;
   }
-
+  
   /*! Set the x_monotone_curve_2 for removed edge degenerate trapezoid. */
   CGAL_TD_INLINE void set_curve(boost::shared_ptr<X_monotone_curve_2>& cv)
   {
-    ptr()->cv = cv;
+    ptr()->cv = cv; 
   }
-
+  
  public:
-
+  
   /// \name Constructors.
   //@{
 
   /*! Constructor given Vertex & Halfedge handles. */
   Td_inactive_edge (boost::shared_ptr<X_monotone_curve_2>& cv, Dag_node* node = nullptr)
   {
-    PTR = new Data(cv,node);
+    PTR.p = new Data(cv,node);
   }
-
+  
   /*! Copy constructor. */
   Td_inactive_edge (const Self& tr) : Handle(tr)
   {
   }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-          Handle::operator=(t2);
-          return *this;
+	  Handle::operator=(t2);
+	  return *this;
   }
 
   /*! Operator==. */
@@ -202,12 +202,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self()
+  inline Self& self() 
   {
     return *this;
   }
-
-  inline const Self& self() const
+  
+  inline const Self& self() const 
   {
     return *this;
   }
@@ -215,10 +215,10 @@ public:
   /*! Access the trapezoid id (PTR). */
   inline unsigned long id() const
   {
-    return (unsigned long) PTR;
+    return (unsigned long) PTR.p;
   }
 
-  inline X_monotone_curve_2& curve() const
+  inline X_monotone_curve_2& curve() const  
   {
     X_monotone_curve_2* cv_ptr = (ptr()->cv).get();
     CGAL_assertion(cv_ptr != nullptr);
@@ -227,12 +227,12 @@ public:
 
   /*! Access DAG node. */
   Dag_node* dag_node() const            {return ptr()->p_node; }
-
-
+  
+  
   //@}
-
-
-
+  
+  
+	
 
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_fictitious_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_fictitious_vertex.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_FICTITIOUS_VERTEX_H
@@ -36,25 +36,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_fictitious_vertex : public Handle
 {
 public:
-  
+
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -66,12 +66,12 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Halfedge_around_vertex_const_circulator
-  typedef typename Traits::Halfedge_around_vertex_const_circulator  
+  typedef typename Traits::Halfedge_around_vertex_const_circulator
     Halfedge_around_vertex_const_circulator;
 
   //type of Td_inactive_fictitious_vertex (Self)
@@ -81,7 +81,7 @@ public:
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -92,7 +92,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -103,12 +103,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class In_face_iterator;
 #endif
 #endif
-  
+
      /*! \class
    * Inner class Data derived from Rep class
    */
@@ -118,27 +118,27 @@ public:
 
   public:
     //c'tors
-    Data (const X_monotone_curve_2& _cv,   
-          Arr_curve_end _ce, 
-          Dag_node* _p_node): cv(_cv),ce(_ce),p_node(_p_node)  
+    Data (const X_monotone_curve_2& _cv,
+          Arr_curve_end _ce,
+          Dag_node* _p_node): cv(_cv),ce(_ce),p_node(_p_node)
     { }
-    
+
     ~Data() { }
 
   protected:
-    X_monotone_curve_2 cv; 
+    X_monotone_curve_2 cv;
     Arr_curve_end ce;
     Dag_node* p_node;
   };
-  
+
  private:
-  
+
   Data* ptr() const { return (Data*)(PTR.p);  }
-	
-	Curve_end vtx_to_ce(Vertex_const_handle v) const
+
+        Curve_end vtx_to_ce(Vertex_const_handle v) const
   {
     //the circulator is of incoming halfedges
-    Halfedge_around_vertex_const_circulator he = v->incident_halfedges(); 
+    Halfedge_around_vertex_const_circulator he = v->incident_halfedges();
     //if the vertex is associated with a point on the bounded coords,
     // we can take any incident halfedge. o/w if the vertex lies at infinity,
     //  it has 2 fictitious incident halfedges
@@ -146,7 +146,7 @@ public:
     if (v->is_at_open_boundary() && he->source()->is_at_open_boundary()) ++he;
 
     return Curve_end(he->curve(),
-                     (he->direction() == ARR_RIGHT_TO_LEFT)? 
+                     (he->direction() == ARR_RIGHT_TO_LEFT)?
                       ARR_MIN_END : ARR_MAX_END);
   }
 
@@ -159,24 +159,24 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-	
+
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p) 
+  inline void set_dag_node(Dag_node* p)
   {
     ptr()->p_node = p;
   }
-  
+
   inline void set_curve_end(Vertex_const_handle v_before_rem)
   {
     Curve_end v_ce(vtx_to_ce(v_before_rem));
     ptr()->cv(v_ce.cv());
     ptr()->ce(v_ce.ce());
   }
-  
- 
+
+
 
  public:
-  
+
   /// \name Constructors.
   //@{
 
@@ -184,30 +184,30 @@ public:
   Td_inactive_fictitious_vertex (Vertex_const_handle v_before_rem, Dag_node* node = nullptr)
   {
     Curve_end v_ce(vtx_to_ce(v_before_rem));
-   
+
     PTR.p = new Data( v_ce.cv(), v_ce.ce(), node);
-    
+
   }
-  
+
   /*! Copy constructor. */
   Td_inactive_fictitious_vertex (const Self& tr) : Handle(tr)
   {
-   
+
   }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-	  Handle::operator=(t2);
-	  return *this;
+          Handle::operator=(t2);
+          return *this;
   }
 
   /*! Operator==. */
@@ -228,12 +228,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self() 
+  inline Self& self()
   {
     return *this;
   }
-  
-  inline const Self& self() const 
+
+  inline const Self& self() const
   {
     return *this;
   }
@@ -244,24 +244,24 @@ public:
     return (unsigned long) PTR.p;
   }
 
-  
-  inline Curve_end curve_end() const  
+
+  inline Curve_end curve_end() const
   {
     return Curve_end(ptr()->cv, ptr()->ce);
   }
 
-  
+
   /*! Access DAG node. */
-  Dag_node* dag_node() const  
+  Dag_node* dag_node() const
   {
-    return ptr()->p_node; 
-  } 
-  
-  
+    return ptr()->p_node;
+  }
+
+
   //@}
-  
-  
-	
+
+
+
 
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_fictitious_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_fictitious_vertex.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_FICTITIOUS_VERTEX_H
@@ -36,25 +36,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_fictitious_vertex : public Handle
 {
 public:
-
+  
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -66,12 +66,12 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Halfedge_around_vertex_const_circulator
-  typedef typename Traits::Halfedge_around_vertex_const_circulator
+  typedef typename Traits::Halfedge_around_vertex_const_circulator  
     Halfedge_around_vertex_const_circulator;
 
   //type of Td_inactive_fictitious_vertex (Self)
@@ -81,7 +81,7 @@ public:
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -92,7 +92,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -103,12 +103,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class In_face_iterator;
 #endif
 #endif
-
+  
      /*! \class
    * Inner class Data derived from Rep class
    */
@@ -118,27 +118,27 @@ public:
 
   public:
     //c'tors
-    Data (const X_monotone_curve_2& _cv,
-          Arr_curve_end _ce,
-          Dag_node* _p_node): cv(_cv),ce(_ce),p_node(_p_node)
+    Data (const X_monotone_curve_2& _cv,   
+          Arr_curve_end _ce, 
+          Dag_node* _p_node): cv(_cv),ce(_ce),p_node(_p_node)  
     { }
-
+    
     ~Data() { }
 
   protected:
-    X_monotone_curve_2 cv;
+    X_monotone_curve_2 cv; 
     Arr_curve_end ce;
     Dag_node* p_node;
   };
-
+  
  private:
-
-  Data* ptr() const { return (Data*)(PTR);  }
-
-        Curve_end vtx_to_ce(Vertex_const_handle v) const
+  
+  Data* ptr() const { return (Data*)(PTR.p);  }
+	
+	Curve_end vtx_to_ce(Vertex_const_handle v) const
   {
     //the circulator is of incoming halfedges
-    Halfedge_around_vertex_const_circulator he = v->incident_halfedges();
+    Halfedge_around_vertex_const_circulator he = v->incident_halfedges(); 
     //if the vertex is associated with a point on the bounded coords,
     // we can take any incident halfedge. o/w if the vertex lies at infinity,
     //  it has 2 fictitious incident halfedges
@@ -146,7 +146,7 @@ public:
     if (v->is_at_open_boundary() && he->source()->is_at_open_boundary()) ++he;
 
     return Curve_end(he->curve(),
-                     (he->direction() == ARR_RIGHT_TO_LEFT)?
+                     (he->direction() == ARR_RIGHT_TO_LEFT)? 
                       ARR_MIN_END : ARR_MAX_END);
   }
 
@@ -159,24 +159,24 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-
+	
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p)
+  inline void set_dag_node(Dag_node* p) 
   {
     ptr()->p_node = p;
   }
-
+  
   inline void set_curve_end(Vertex_const_handle v_before_rem)
   {
     Curve_end v_ce(vtx_to_ce(v_before_rem));
     ptr()->cv(v_ce.cv());
     ptr()->ce(v_ce.ce());
   }
-
-
+  
+ 
 
  public:
-
+  
   /// \name Constructors.
   //@{
 
@@ -184,30 +184,30 @@ public:
   Td_inactive_fictitious_vertex (Vertex_const_handle v_before_rem, Dag_node* node = nullptr)
   {
     Curve_end v_ce(vtx_to_ce(v_before_rem));
-
-    PTR = new Data( v_ce.cv(), v_ce.ce(), node);
-
+   
+    PTR.p = new Data( v_ce.cv(), v_ce.ce(), node);
+    
   }
-
+  
   /*! Copy constructor. */
   Td_inactive_fictitious_vertex (const Self& tr) : Handle(tr)
   {
-
+   
   }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-          Handle::operator=(t2);
-          return *this;
+	  Handle::operator=(t2);
+	  return *this;
   }
 
   /*! Operator==. */
@@ -228,12 +228,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self()
+  inline Self& self() 
   {
     return *this;
   }
-
-  inline const Self& self() const
+  
+  inline const Self& self() const 
   {
     return *this;
   }
@@ -241,27 +241,27 @@ public:
   /*! Access the trapezoid id (PTR). */
   inline unsigned long id() const
   {
-    return (unsigned long) PTR;
+    return (unsigned long) PTR.p;
   }
 
-
-  inline Curve_end curve_end() const
+  
+  inline Curve_end curve_end() const  
   {
     return Curve_end(ptr()->cv, ptr()->ce);
   }
 
-
+  
   /*! Access DAG node. */
-  Dag_node* dag_node() const
+  Dag_node* dag_node() const  
   {
-    return ptr()->p_node;
-  }
-
-
+    return ptr()->p_node; 
+  } 
+  
+  
   //@}
-
-
-
+  
+  
+	
 
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_vertex.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_VERTEX_H
@@ -36,25 +36,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the 
- * right and left boundaries of the trapezoid respectively and the halfedges 
+ * two halfedges called top and bottom. The curve-ends (points) lie on the
+ * right and left boundaries of the trapezoid respectively and the halfedges
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens 
+ * There exist degenerate trapezoids called infinite trapezoid; this happens
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_vertex : public Handle
 {
 public:
-  
+
   //type of traits class
   typedef Td_traits_                                   Traits;
-  
+
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -66,18 +66,18 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-  
+
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Td_inactive_vertex (Self)
   typedef typename Traits::Td_inactive_vertex            Self;
-  
+
   typedef typename Traits::Td_map_item            Td_map_item;
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-  
+
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -88,7 +88,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-  
+
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -99,12 +99,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-  
+
 #else
   friend class In_face_iterator;
 #endif
 #endif
-  
+
    /*! \class
    * Inner class Data derived from Rep class
    */
@@ -116,20 +116,20 @@ public:
     //c'tors
     Data (Point _p, Dag_node* _p_node): p(_p),p_node(_p_node)
     { }
-    
+
     ~Data() { }
 
   protected:
-    Point p; 
+    Point p;
     Dag_node* p_node;
   };
-  
-  
+
+
  private:
-  
+
   Data* ptr() const { return (Data*)(PTR.p);  }
-	
-	
+
+
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -139,15 +139,15 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-	
+
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p) 
+  inline void set_dag_node(Dag_node* p)
   {
     ptr()->p_node = p;
   }
-  
-  
+
+
   inline void set_point(Vertex_const_handle v_before_rem)
   {
     ptr()->p = v_before_rem->point();
@@ -155,7 +155,7 @@ public:
 
 
  public:
-  
+
   /// \name Constructors.
   //@{
 
@@ -164,26 +164,26 @@ public:
   {
     PTR.p = new Data(v_before_rem->point(), node);
   }
-  
-  
+
+
   /*! Copy constructor. */
   Td_inactive_vertex (const Self& tr) : Handle(tr)
   {
   }
-  
+
   //@}
-  
+
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator. 
-  *   operator= should not copy m_dag_node (or otherwise update 
+  /*! Assignment operator.
+  *   operator= should not copy m_dag_node (or otherwise update
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-	  Handle::operator=(t2);
-	  return *this;
+          Handle::operator=(t2);
+          return *this;
   }
 
   /*! Operator==. */
@@ -204,12 +204,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self() 
+  inline Self& self()
   {
     return *this;
   }
-  
-  inline const Self& self() const 
+
+  inline const Self& self() const
   {
     return *this;
   }
@@ -220,21 +220,21 @@ public:
     return (unsigned long) PTR.p;
   }
 
-  inline Point& point() const  
+  inline Point& point() const
   {
     return ptr()->p;
   }
-  
+
   /*! Access DAG node. */
-  Dag_node* dag_node() const  
+  Dag_node* dag_node() const
   {
-    return ptr()->p_node; 
+    return ptr()->p_node;
   }
-  
-  
+
+
   //@}
-  
-	
+
+
 
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_vertex.h
@@ -7,7 +7,7 @@
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)         : Oren Nechushtan <theoren@math.tau.ac.il>
+// Author(s)	 : Oren Nechushtan <theoren@math.tau.ac.il>
 //               updated by: Michal Balas <balasmic@post.tau.ac.il>
 
 #ifndef CGAL_TD_INACTIVE_VERTEX_H
@@ -36,25 +36,25 @@ namespace CGAL {
  * Implementation of a pseudo-trapezoid as two halfedges(top,bottom)
  * and two curve-ends(left,right).
  * Trapezoids are represented as two curve-ends called right and left and
- * two halfedges called top and bottom. The curve-ends (points) lie on the
- * right and left boundaries of the trapezoid respectively and the halfedges
+ * two halfedges called top and bottom. The curve-ends (points) lie on the 
+ * right and left boundaries of the trapezoid respectively and the halfedges 
  * bound the trapezoid from above and below.
- * There exist degenerate trapezoids called infinite trapezoid; this happens
+ * There exist degenerate trapezoids called infinite trapezoid; this happens 
  * when one of the four sides is on the parameter space boundary.
  * Trapezoids are created as active and become inactive when Remove() member
  * function called.
  * Each trapezoid has at most four neighbouring trapezoids.
- * X_trapezoid structure can represent a real trapezoid, a Td-edge or an
+ * X_trapezoid structure can represent a real trapezoid, a Td-edge or an 
  * edge-end (end point).
  */
 template <class Td_traits_>
 class Td_inactive_vertex : public Handle
 {
 public:
-
+  
   //type of traits class
   typedef Td_traits_                                   Traits;
-
+  
   //type of point (Point_2)
   typedef typename Traits::Point                       Point;
 
@@ -66,18 +66,18 @@ public:
 
   //type of Halfedge_const_handle (trapezoid edge)
   typedef typename Traits::Halfedge_const_handle  Halfedge_const_handle;
-
+  
   //type of Vertex_const_handle (trapezoid vertex)
   typedef typename Traits::Vertex_const_handle    Vertex_const_handle;
 
   //type of Td_inactive_vertex (Self)
   typedef typename Traits::Td_inactive_vertex            Self;
-
+  
   typedef typename Traits::Td_map_item            Td_map_item;
 
   //type of Trapezoidal decomposition
   typedef Trapezoidal_decomposition_2<Traits>          TD;
-
+  
   //type of In face iterator
   typedef typename TD::In_face_iterator                In_face_iterator;
 
@@ -88,7 +88,7 @@ public:
   //friend class declarations:
 
   friend class Trapezoidal_decomposition_2<Traits>;
-
+  
 #ifdef CGAL_PM_FRIEND_CLASS
 #if defined(__SUNPRO_CC) || defined(__PGI) || defined(__INTEL_COMPILER)
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
@@ -99,12 +99,12 @@ public:
 #else
   friend class Trapezoidal_decomposition_2<Traits>::In_face_iterator;
 #endif
-
+  
 #else
   friend class In_face_iterator;
 #endif
 #endif
-
+  
    /*! \class
    * Inner class Data derived from Rep class
    */
@@ -116,20 +116,20 @@ public:
     //c'tors
     Data (Point _p, Dag_node* _p_node): p(_p),p_node(_p_node)
     { }
-
+    
     ~Data() { }
 
   protected:
-    Point p;
+    Point p; 
     Dag_node* p_node;
   };
-
-
+  
+  
  private:
-
-  Data* ptr() const { return (Data*)(PTR);  }
-
-
+  
+  Data* ptr() const { return (Data*)(PTR.p);  }
+	
+	
 #ifndef CGAL_TD_DEBUG
 #ifdef CGAL_PM_FRIEND_CLASS
  protected:
@@ -139,15 +139,15 @@ public:
 #else //CGAL_TD_DEBUG
  public:
 #endif //CGAL_TD_DEBUG
-
+	
 
   /*! Set the DAG node. */
-  inline void set_dag_node(Dag_node* p)
+  inline void set_dag_node(Dag_node* p) 
   {
     ptr()->p_node = p;
   }
-
-
+  
+  
   inline void set_point(Vertex_const_handle v_before_rem)
   {
     ptr()->p = v_before_rem->point();
@@ -155,35 +155,35 @@ public:
 
 
  public:
-
+  
   /// \name Constructors.
   //@{
 
   /*! Constructor given Vertex & Halfedge handles. */
   Td_inactive_vertex (Vertex_const_handle v_before_rem, Dag_node* node = nullptr)
   {
-    PTR = new Data(v_before_rem->point(), node);
+    PTR.p = new Data(v_before_rem->point(), node);
   }
-
-
+  
+  
   /*! Copy constructor. */
   Td_inactive_vertex (const Self& tr) : Handle(tr)
   {
   }
-
+  
   //@}
-
+  
   /// \name Operator overloading.
   //@{
 
-  /*! Assignment operator.
-  *   operator= should not copy m_dag_node (or otherwise update
+  /*! Assignment operator. 
+  *   operator= should not copy m_dag_node (or otherwise update 
   *     Dag_node::replace)
     */
   inline Self& operator= (const Self& t2)
   {
-          Handle::operator=(t2);
-          return *this;
+	  Handle::operator=(t2);
+	  return *this;
   }
 
   /*! Operator==. */
@@ -204,12 +204,12 @@ public:
   /// \name Access methods.
   //@{
 
-  inline Self& self()
+  inline Self& self() 
   {
     return *this;
   }
-
-  inline const Self& self() const
+  
+  inline const Self& self() const 
   {
     return *this;
   }
@@ -217,24 +217,24 @@ public:
   /*! Access the trapezoid id (PTR). */
   inline unsigned long id() const
   {
-    return (unsigned long) PTR;
+    return (unsigned long) PTR.p;
   }
 
-  inline Point& point() const
+  inline Point& point() const  
   {
     return ptr()->p;
   }
-
+  
   /*! Access DAG node. */
-  Dag_node* dag_node() const
+  Dag_node* dag_node() const  
   {
-    return ptr()->p_node;
+    return ptr()->p_node; 
   }
-
-
+  
+  
   //@}
-
-
+  
+	
 
 };
 

--- a/Convex_hull_2/include/CGAL/IO/Tee_for_output_iterator.h
+++ b/Convex_hull_2/include/CGAL/IO/Tee_for_output_iterator.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-//
+// 
 //
 // Author(s)     : Stefan Schirra
 
@@ -26,7 +26,7 @@ namespace CGAL {
 template <class T> class _Tee_for_output_iterator_rep;
 
 template <class OutputIterator, class T>
-class Tee_for_output_iterator
+class Tee_for_output_iterator 
   : public Handle
 {
   typedef std::vector<T>                             container;
@@ -38,35 +38,35 @@ class Tee_for_output_iterator
   typedef typename iter_traits::reference            reference;
 
 public:
-  Tee_for_output_iterator(const OutputIterator& o) : o_it(o)
-  {  PTR = (Rep*) new _Tee_for_output_iterator_rep<T>(); }
+  Tee_for_output_iterator(const OutputIterator& o) : o_it(o) 
+  {  PTR.p = (Rep*) new _Tee_for_output_iterator_rep<T>(); }
 
-  Tee_for_output_iterator<OutputIterator,T>&
-  operator=(const T& value)
-  {
+  Tee_for_output_iterator<OutputIterator,T>& 
+  operator=(const T& value) 
+  { 
     ptr()->output_so_far.push_back(value);
     *o_it = value;
     return *this;
   }
 
-  Tee_for_output_iterator<OutputIterator,T>&
-  operator*()
+  Tee_for_output_iterator<OutputIterator,T>& 
+  operator*() 
   { return *this; }
 
-  Tee_for_output_iterator<OutputIterator,T>&
-  operator++()
-  {
-    ++o_it;
-    return *this;
-  }
+  Tee_for_output_iterator<OutputIterator,T>& 
+  operator++() 
+  { 
+    ++o_it; 
+    return *this; 
+  } 
 
-  Tee_for_output_iterator<OutputIterator,T>
-  operator++(int)
-  {
+  Tee_for_output_iterator<OutputIterator,T> 
+  operator++(int) 
+  { 
     Tee_for_output_iterator<OutputIterator,T> tmp = *this;
-    o_it++;
-    return tmp;
-  }
+    o_it++; 
+    return tmp; 
+  } 
 
   iterator
   output_so_far_begin()
@@ -82,7 +82,7 @@ public:
 
   _Tee_for_output_iterator_rep<T>*
   ptr()
-  { return (_Tee_for_output_iterator_rep<T>*)PTR; }
+  { return (_Tee_for_output_iterator_rep<T>*)(PTR.p); }
 
 protected:
   OutputIterator o_it;

--- a/Convex_hull_2/include/CGAL/IO/Tee_for_output_iterator.h
+++ b/Convex_hull_2/include/CGAL/IO/Tee_for_output_iterator.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-// 
+//
 //
 // Author(s)     : Stefan Schirra
 
@@ -26,7 +26,7 @@ namespace CGAL {
 template <class T> class _Tee_for_output_iterator_rep;
 
 template <class OutputIterator, class T>
-class Tee_for_output_iterator 
+class Tee_for_output_iterator
   : public Handle
 {
   typedef std::vector<T>                             container;
@@ -38,35 +38,35 @@ class Tee_for_output_iterator
   typedef typename iter_traits::reference            reference;
 
 public:
-  Tee_for_output_iterator(const OutputIterator& o) : o_it(o) 
+  Tee_for_output_iterator(const OutputIterator& o) : o_it(o)
   {  PTR.p = (Rep*) new _Tee_for_output_iterator_rep<T>(); }
 
-  Tee_for_output_iterator<OutputIterator,T>& 
-  operator=(const T& value) 
-  { 
+  Tee_for_output_iterator<OutputIterator,T>&
+  operator=(const T& value)
+  {
     ptr()->output_so_far.push_back(value);
     *o_it = value;
     return *this;
   }
 
-  Tee_for_output_iterator<OutputIterator,T>& 
-  operator*() 
+  Tee_for_output_iterator<OutputIterator,T>&
+  operator*()
   { return *this; }
 
-  Tee_for_output_iterator<OutputIterator,T>& 
-  operator++() 
-  { 
-    ++o_it; 
-    return *this; 
-  } 
+  Tee_for_output_iterator<OutputIterator,T>&
+  operator++()
+  {
+    ++o_it;
+    return *this;
+  }
 
-  Tee_for_output_iterator<OutputIterator,T> 
-  operator++(int) 
-  { 
+  Tee_for_output_iterator<OutputIterator,T>
+  operator++(int)
+  {
     Tee_for_output_iterator<OutputIterator,T> tmp = *this;
-    o_it++; 
-    return tmp; 
-  } 
+    o_it++;
+    return tmp;
+  }
 
   iterator
   output_so_far_begin()

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -54,7 +54,7 @@ template <class E,
           class E2A,
           class K>
 class Lazy_kernel_base;
-
+  
 template <typename AT, typename ET, typename E2A> class Lazy;
 
 template <typename ET_>
@@ -284,14 +284,14 @@ public:
     os << std::endl;
     if(! is_lazy()){
       for(int i = 0; i < level; i++){
-        os << "    ";
+	os << "    ";
       }
       os << "Exact: ";
       print_at(os, *et);
       os << std::endl;
 #ifdef CGAL_LAZY_KERNEL_DEBUG_SHOW_TYPEID
       for(int i = 0; i < level; i++){
-        os << "    ";
+	os << "    ";
       }
       os << "  (type: " << typeid(*et).name() << ")" << std::endl;
 #endif // CGAL_LAZY_KERNEL_DEBUG_SHOW_TYPEID
@@ -420,11 +420,11 @@ struct Approx_converter
   const Null_vector&
   operator()(const Null_vector& n) const
   { return n; }
-
+  
   const Bbox_2&
   operator()(const Bbox_2& b) const
   { return b; }
-
+  
   const Bbox_3&
   operator()(const Bbox_3& b) const
   { return b; }
@@ -445,11 +445,11 @@ struct Exact_converter
   const Null_vector&
   operator()(const Null_vector& n) const
   { return n; }
-
+  
   const Bbox_2&
   operator()(const Bbox_2& b) const
   { return b; }
-
+  
   const Bbox_3&
   operator()(const Bbox_3& b) const
   { return b; }
@@ -475,7 +475,7 @@ class Lazy_rep_with_vector_1
 public:
 
   void
-  update_exact() const
+  update_exact() const 
   {
 // TODO : This looks really unfinished...
     std::vector<Object> vec;
@@ -671,13 +671,13 @@ class Lazy : public Handle
             class Approximate_kernel_,
             class E2A_>
   friend struct Lazy_kernel;
-
+  
   template <class E_,
             class A_,
             class E2A_,
             class K_>
   friend class Lazy_kernel_base;
-
+  
 public :
 
   typedef Lazy<AT_, ET_, E2A>  Self;
@@ -718,17 +718,17 @@ public :
 
   Lazy(Self_rep *r)
   {
-    PTR = r;
+    PTR.p = r;
   }
 
   Lazy(const ET& e)
   {
-    PTR = new Lazy_rep_0<AT,ET,E2A>(e);
+    PTR.p = new Lazy_rep_0<AT,ET,E2A>(e);
   }
 
   Lazy(ET&& e)
   {
-    PTR = new Lazy_rep_0<AT,ET,E2A>(std::move(e));
+    PTR.p = new Lazy_rep_0<AT,ET,E2A>(std::move(e));
   }
 
   friend void swap(Lazy& a, Lazy& b) noexcept
@@ -768,7 +768,7 @@ public :
     return z;
   }
 
-  Self_rep * ptr() const { return (Self_rep*) PTR; }
+  Self_rep * ptr() const { return (Self_rep*) PTR.p; }
 };
 
 // The magic functor for Construct_bbox_[2,3], as there is no Lazy<Bbox>
@@ -881,10 +881,10 @@ make_lazy(const Object& eto)
       }
 
 CGAL_Kernel_obj(Point_2)
-CGAL_Kernel_obj(Point_3)
+CGAL_Kernel_obj(Point_3)  
 #undef CGAL_Kernel_obj
 
-
+  
   std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#2)" << std::endl;
   std::cerr << "dynamic type of the Object : " << eto.type().name() << std::endl;
 
@@ -927,7 +927,7 @@ struct Ith {
     typedef std::pair<T2,std::pair<bool,bool> > Pair_type_2;
 
     if(const Pair_type_1 *p1 = object_cast<Pair_type_1>(&v[i]))
-            return p1->first;
+    	return p1->first;
     else if(const Pair_type_2 *p2 = object_cast<Pair_type_2>(&v[i]))
         return p2->first;
 
@@ -1176,11 +1176,11 @@ public:
       for (unsigned int i = 0; i < lv.approx().size(); i++) {
 // FIXME : I'm not sure how this work...
 #define CGAL_Kernel_obj(X) if (object_cast<typename AK::X>(& (lv.approx()[i]))) { \
-          *it++ = make_object(typename LK::X(new Lazy_rep_n<typename AK::X, typename EK::X, Ith<typename AK::X>, \
+	  *it++ = make_object(typename LK::X(new Lazy_rep_n<typename AK::X, typename EK::X, Ith<typename AK::X>, \
                                                                       Ith<typename EK::X>, E2A, Lazy_vector> \
                                                  (Ith<typename AK::X>(i), Ith<typename EK::X>(i), lv))); \
           continue; \
-        }
+	}
 
 #include <CGAL/Kernel/interface_macros.h>
 
@@ -1194,9 +1194,9 @@ public:
       std::vector<Object> exact_objects;
       ec(CGAL::exact(l1), CGAL::exact(l2), std::back_inserter(exact_objects));
       for (std::vector<Object>::const_iterator oit = exact_objects.begin();
-           oit != exact_objects.end();
-           ++oit){
-        *it++ = make_lazy<LK>(*oit);
+	   oit != exact_objects.end();
+	   ++oit){
+	*it++ = make_lazy<LK>(*oit);
       }
     }
     return it;
@@ -1255,9 +1255,9 @@ public:
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-        typedef Lazy_rep_n< typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-        return make_object(typename LK::X(lcr)); \
+	typedef Lazy_rep_n< typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+	return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
@@ -1288,15 +1288,15 @@ public:
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-        typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-        return make_object(typename LK::X(lcr)); \
+	typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+	return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
 
     // We now check vector<X>
-
+  
 #define CGAL_Kernel_obj(X) \
       {  \
         const std::vector<typename AK::X>* v_ptr;\
@@ -1313,7 +1313,7 @@ public:
       }
 
 CGAL_Kernel_obj(Point_2)
-CGAL_Kernel_obj(Point_3)
+CGAL_Kernel_obj(Point_3)  
 #undef CGAL_Kernel_obj
 
       std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#1)" << std::endl;
@@ -1342,9 +1342,9 @@ CGAL_Kernel_obj(Point_3)
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-        typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-        return make_object(typename LK::X(lcr)); \
+	typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+	return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
@@ -1367,7 +1367,7 @@ CGAL_Kernel_obj(Point_3)
 
 //____________________________________________________________
 // The magic functor that has Lazy<Something> as result type.
-// Two versions are distinguished: one that needs to fiddle
+// Two versions are distinguished: one that needs to fiddle 
 // with result_of and another that can forward the result types.
 
 namespace internal {
@@ -1394,7 +1394,7 @@ struct Variant_cast {
   T&
   operator()(boost::optional< boost::variant< BOOST_VARIANT_ENUM_PARAMS(U) > >& o) const {
     // can throw but should never because we always build it inside
-    // a static visitor with the right type, if it throws bad_get
+    // a static visitor with the right type, if it throws bad_get 
     return boost::get<T>(*o);
   }
 };
@@ -1405,7 +1405,7 @@ struct Fill_lazy_variant_visitor_2 : boost::static_visitor<> {
   Fill_lazy_variant_visitor_2(Result& r, Origin& o) : r(&r), o(&o) {}
   Result* r;
   Origin* o;
-
+    
   template<typename T>
   void operator()(const T&) {
     // the equivalent type we are currently matching in the lazy kernel
@@ -1415,24 +1415,24 @@ struct Fill_lazy_variant_visitor_2 : boost::static_visitor<> {
 
     typedef Lazy_rep_n<AKT, EKT, Variant_cast<AKT>, Variant_cast<EKT>, typename LK::E2A, Origin> Lcr;
     Lcr * lcr = new Lcr(Variant_cast<AKT>(), Variant_cast<EKT>(), *o);
-
+      
     *r = LKT(lcr);
   }
-
+    
   template<typename T>
   void operator()(const std::vector<T>& t) {
     typedef T AKT;
     typedef typename Type_mapper<AKT, AK, EK>::type EKT;
-    typedef typename Type_mapper<AKT, AK, LK>::type LKT;
+    typedef typename Type_mapper<AKT, AK, LK>::type LKT; 
 
     std::vector<LKT> V;
-    V.resize(t.size());
+    V.resize(t.size()); 
     for (unsigned int i = 0; i < t.size(); i++) {
       V[i] = LKT(new Lazy_rep_n<AKT, EKT, Ith_for_intersection<AKT>,
                  Ith_for_intersection<EKT>, typename LK::E2A, Origin>
                  (Ith_for_intersection<AKT>(i), Ith_for_intersection<EKT>(i), *o));
     }
-
+      
     *r = V;
   }
 };
@@ -1441,14 +1441,14 @@ template<typename Result, typename AK, typename LK, typename EK>
 struct Fill_lazy_variant_visitor_0 : boost::static_visitor<> {
   Fill_lazy_variant_visitor_0(Result& r) : r(&r) {}
   Result* r;
-
+    
   template<typename T>
   void operator()(const T& t) {
     // the equivalent type we are currently matching in the lazy kernel
     typedef T EKT;
     typedef typename Type_mapper<EKT, EK, AK>::type AKT;
     typedef typename Type_mapper<EKT, EK, LK>::type LKT;
-
+      
     *r = LKT(new Lazy_rep_0<AKT, EKT, typename LK::E2A>(t));
   }
 
@@ -1459,11 +1459,11 @@ struct Fill_lazy_variant_visitor_0 : boost::static_visitor<> {
     typedef typename Type_mapper<EKT, EK, LK>::type LKT;
 
     std::vector<LKT> V;
-    V.resize(t.size());
+    V.resize(t.size()); 
     for (unsigned int i = 0; i < t.size(); i++) {
       V[i] = LKT(new Lazy_rep_0<AKT, EKT, typename LK::E2A>(t[i]));
     }
-
+      
     *r = V;
   }
 };
@@ -1499,19 +1499,19 @@ struct Lazy_construction_variant {
   typename result<Lazy_construction_variant(L1, L2)>::type
   operator()(const L1& l1, const L2& l2) const {
     typedef typename cpp11::result_of<Lazy_construction_variant(L1, L2)>::type result_type;
-
-    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type,
+    
+    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type, 
                                          typename Type_mapper<L2, LK, AK>::type)>::type AT;
-    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type,
+    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type, 
                                          typename Type_mapper<L2, LK, EK>::type)>::type ET;
-
+    
     CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
     Protect_FPU_rounding<Protection> P;
 
     try {
       Lazy<AT, ET, E2A> lazy(new Lazy_rep_n<AT, ET, AC, EC, E2A, L1, L2>(AC(), EC(), l1, l2));
 
-      // the approximate result requires the trait with types from the AK
+      // the approximate result requires the trait with types from the AK 
       AT approx_v = lazy.approx();
       // the result we build
       result_type res;
@@ -1524,7 +1524,7 @@ struct Lazy_construction_variant {
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
-
+      
       return res;
     } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
@@ -1547,11 +1547,11 @@ struct Lazy_construction_variant {
   typename result<Lazy_construction_variant(L1, L2, L3)>::type
   operator()(const L1& l1, const L2& l2, const L3& l3) const {
     typedef typename result<Lazy_construction_variant(L1, L2, L3)>::type result_type;
-
-    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type,
+    
+    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type, 
                                          typename Type_mapper<L2, LK, AK>::type,
                                          typename Type_mapper<L3, LK, AK>::type)>::type AT;
-    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type,
+    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type, 
                                          typename Type_mapper<L2, LK, EK>::type,
                                          typename Type_mapper<L3, LK, EK>::type)>::type ET;
 
@@ -1560,7 +1560,7 @@ struct Lazy_construction_variant {
     try {
       Lazy<AT, ET, E2A> lazy(new Lazy_rep_n<AT, ET, AC, EC, E2A, L1, L2, L3>(AC(), EC(), l1, l2, l3));
 
-      // the approximate result requires the trait with types from the AK
+      // the approximate result requires the trait with types from the AK 
       AT approx_v = lazy.approx();
       // the result we build
       result_type res;
@@ -1573,7 +1573,7 @@ struct Lazy_construction_variant {
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
-
+      
       return res;
     } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
@@ -1593,7 +1593,7 @@ struct Lazy_construction_variant {
   }
 };
 
-template<typename LK, typename AC, typename EC, typename E2A = Default,
+template<typename LK, typename AC, typename EC, typename E2A = Default, 
          bool has_result_type = internal::has_result_type<AC>::value && internal::has_result_type<EC>::value >
 struct Lazy_construction;
 
@@ -1605,13 +1605,13 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
 
   typedef typename LK::Approximate_kernel AK;
   typedef typename LK::Exact_kernel EK;
-  typedef typename boost::remove_cv<
+  typedef typename boost::remove_cv< 
     typename boost::remove_reference < typename AC::result_type >::type >::type AT;
-  typedef typename boost::remove_cv<
+  typedef typename boost::remove_cv< 
     typename boost::remove_reference < typename EC::result_type >::type >::type  ET;
 
   typedef typename Default::Get<E2A_, typename LK::E2A>::type E2A;
-
+  
   typedef typename Type_mapper<AT, AK, LK>::type result_type;
 
   CGAL_NO_UNIQUE_ADDRESS AC ac;
@@ -1631,9 +1631,9 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \
     }                                                                   \
-  }
+  }        
 
-  // arity 1-8
+  // arity 1-8 
   BOOST_PP_REPEAT_FROM_TO(1, 9, CGAL_CONSTRUCTION_OPERATOR, _)
 
   // nullary
@@ -1645,7 +1645,7 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
   }
 
 #undef CGAL_CONSTRUCTION_OPERATOR
-
+  
 };
 
 
@@ -1698,9 +1698,9 @@ struct result<F( BOOST_PP_ENUM_PARAMS(n, T) )> { \
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \
     }                                                                   \
-  }
+  }        
 
-  // arity 1-8
+  // arity 1-8 
   BOOST_PP_REPEAT_FROM_TO(1, 9, CGAL_CONSTRUCTION_OPERATOR, _)
 
   // nullary

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -54,7 +54,7 @@ template <class E,
           class E2A,
           class K>
 class Lazy_kernel_base;
-  
+
 template <typename AT, typename ET, typename E2A> class Lazy;
 
 template <typename ET_>
@@ -284,14 +284,14 @@ public:
     os << std::endl;
     if(! is_lazy()){
       for(int i = 0; i < level; i++){
-	os << "    ";
+        os << "    ";
       }
       os << "Exact: ";
       print_at(os, *et);
       os << std::endl;
 #ifdef CGAL_LAZY_KERNEL_DEBUG_SHOW_TYPEID
       for(int i = 0; i < level; i++){
-	os << "    ";
+        os << "    ";
       }
       os << "  (type: " << typeid(*et).name() << ")" << std::endl;
 #endif // CGAL_LAZY_KERNEL_DEBUG_SHOW_TYPEID
@@ -420,11 +420,11 @@ struct Approx_converter
   const Null_vector&
   operator()(const Null_vector& n) const
   { return n; }
-  
+
   const Bbox_2&
   operator()(const Bbox_2& b) const
   { return b; }
-  
+
   const Bbox_3&
   operator()(const Bbox_3& b) const
   { return b; }
@@ -445,11 +445,11 @@ struct Exact_converter
   const Null_vector&
   operator()(const Null_vector& n) const
   { return n; }
-  
+
   const Bbox_2&
   operator()(const Bbox_2& b) const
   { return b; }
-  
+
   const Bbox_3&
   operator()(const Bbox_3& b) const
   { return b; }
@@ -475,7 +475,7 @@ class Lazy_rep_with_vector_1
 public:
 
   void
-  update_exact() const 
+  update_exact() const
   {
 // TODO : This looks really unfinished...
     std::vector<Object> vec;
@@ -671,13 +671,13 @@ class Lazy : public Handle
             class Approximate_kernel_,
             class E2A_>
   friend struct Lazy_kernel;
-  
+
   template <class E_,
             class A_,
             class E2A_,
             class K_>
   friend class Lazy_kernel_base;
-  
+
 public :
 
   typedef Lazy<AT_, ET_, E2A>  Self;
@@ -881,10 +881,10 @@ make_lazy(const Object& eto)
       }
 
 CGAL_Kernel_obj(Point_2)
-CGAL_Kernel_obj(Point_3)  
+CGAL_Kernel_obj(Point_3)
 #undef CGAL_Kernel_obj
 
-  
+
   std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#2)" << std::endl;
   std::cerr << "dynamic type of the Object : " << eto.type().name() << std::endl;
 
@@ -927,7 +927,7 @@ struct Ith {
     typedef std::pair<T2,std::pair<bool,bool> > Pair_type_2;
 
     if(const Pair_type_1 *p1 = object_cast<Pair_type_1>(&v[i]))
-    	return p1->first;
+            return p1->first;
     else if(const Pair_type_2 *p2 = object_cast<Pair_type_2>(&v[i]))
         return p2->first;
 
@@ -1176,11 +1176,11 @@ public:
       for (unsigned int i = 0; i < lv.approx().size(); i++) {
 // FIXME : I'm not sure how this work...
 #define CGAL_Kernel_obj(X) if (object_cast<typename AK::X>(& (lv.approx()[i]))) { \
-	  *it++ = make_object(typename LK::X(new Lazy_rep_n<typename AK::X, typename EK::X, Ith<typename AK::X>, \
+          *it++ = make_object(typename LK::X(new Lazy_rep_n<typename AK::X, typename EK::X, Ith<typename AK::X>, \
                                                                       Ith<typename EK::X>, E2A, Lazy_vector> \
                                                  (Ith<typename AK::X>(i), Ith<typename EK::X>(i), lv))); \
           continue; \
-	}
+        }
 
 #include <CGAL/Kernel/interface_macros.h>
 
@@ -1194,9 +1194,9 @@ public:
       std::vector<Object> exact_objects;
       ec(CGAL::exact(l1), CGAL::exact(l2), std::back_inserter(exact_objects));
       for (std::vector<Object>::const_iterator oit = exact_objects.begin();
-	   oit != exact_objects.end();
-	   ++oit){
-	*it++ = make_lazy<LK>(*oit);
+           oit != exact_objects.end();
+           ++oit){
+        *it++ = make_lazy<LK>(*oit);
       }
     }
     return it;
@@ -1255,9 +1255,9 @@ public:
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-	typedef Lazy_rep_n< typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-	return make_object(typename LK::X(lcr)); \
+        typedef Lazy_rep_n< typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+        return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
@@ -1288,15 +1288,15 @@ public:
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-	typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-	return make_object(typename LK::X(lcr)); \
+        typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+        return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
 
     // We now check vector<X>
-  
+
 #define CGAL_Kernel_obj(X) \
       {  \
         const std::vector<typename AK::X>* v_ptr;\
@@ -1313,7 +1313,7 @@ public:
       }
 
 CGAL_Kernel_obj(Point_2)
-CGAL_Kernel_obj(Point_3)  
+CGAL_Kernel_obj(Point_3)
 #undef CGAL_Kernel_obj
 
       std::cerr << "object_cast inside Lazy_construction_rep::operator() failed. It needs more else if's (#1)" << std::endl;
@@ -1342,9 +1342,9 @@ CGAL_Kernel_obj(Point_3)
 
 #define CGAL_Kernel_obj(X) \
       if (object_cast<typename AK::X>(& (lo.approx()))) { \
-	typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
-	Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
-	return make_object(typename LK::X(lcr)); \
+        typedef Lazy_rep_n<typename AK::X, typename EK::X, Object_cast<typename AK::X>, Object_cast<typename EK::X>, E2A, Lazy_object> Lcr; \
+        Lcr * lcr = new Lcr(Object_cast<typename AK::X>(), Object_cast<typename EK::X>(), lo); \
+        return make_object(typename LK::X(lcr)); \
       }
 
 #include <CGAL/Kernel/interface_macros.h>
@@ -1367,7 +1367,7 @@ CGAL_Kernel_obj(Point_3)
 
 //____________________________________________________________
 // The magic functor that has Lazy<Something> as result type.
-// Two versions are distinguished: one that needs to fiddle 
+// Two versions are distinguished: one that needs to fiddle
 // with result_of and another that can forward the result types.
 
 namespace internal {
@@ -1394,7 +1394,7 @@ struct Variant_cast {
   T&
   operator()(boost::optional< boost::variant< BOOST_VARIANT_ENUM_PARAMS(U) > >& o) const {
     // can throw but should never because we always build it inside
-    // a static visitor with the right type, if it throws bad_get 
+    // a static visitor with the right type, if it throws bad_get
     return boost::get<T>(*o);
   }
 };
@@ -1405,7 +1405,7 @@ struct Fill_lazy_variant_visitor_2 : boost::static_visitor<> {
   Fill_lazy_variant_visitor_2(Result& r, Origin& o) : r(&r), o(&o) {}
   Result* r;
   Origin* o;
-    
+
   template<typename T>
   void operator()(const T&) {
     // the equivalent type we are currently matching in the lazy kernel
@@ -1415,24 +1415,24 @@ struct Fill_lazy_variant_visitor_2 : boost::static_visitor<> {
 
     typedef Lazy_rep_n<AKT, EKT, Variant_cast<AKT>, Variant_cast<EKT>, typename LK::E2A, Origin> Lcr;
     Lcr * lcr = new Lcr(Variant_cast<AKT>(), Variant_cast<EKT>(), *o);
-      
+
     *r = LKT(lcr);
   }
-    
+
   template<typename T>
   void operator()(const std::vector<T>& t) {
     typedef T AKT;
     typedef typename Type_mapper<AKT, AK, EK>::type EKT;
-    typedef typename Type_mapper<AKT, AK, LK>::type LKT; 
+    typedef typename Type_mapper<AKT, AK, LK>::type LKT;
 
     std::vector<LKT> V;
-    V.resize(t.size()); 
+    V.resize(t.size());
     for (unsigned int i = 0; i < t.size(); i++) {
       V[i] = LKT(new Lazy_rep_n<AKT, EKT, Ith_for_intersection<AKT>,
                  Ith_for_intersection<EKT>, typename LK::E2A, Origin>
                  (Ith_for_intersection<AKT>(i), Ith_for_intersection<EKT>(i), *o));
     }
-      
+
     *r = V;
   }
 };
@@ -1441,14 +1441,14 @@ template<typename Result, typename AK, typename LK, typename EK>
 struct Fill_lazy_variant_visitor_0 : boost::static_visitor<> {
   Fill_lazy_variant_visitor_0(Result& r) : r(&r) {}
   Result* r;
-    
+
   template<typename T>
   void operator()(const T& t) {
     // the equivalent type we are currently matching in the lazy kernel
     typedef T EKT;
     typedef typename Type_mapper<EKT, EK, AK>::type AKT;
     typedef typename Type_mapper<EKT, EK, LK>::type LKT;
-      
+
     *r = LKT(new Lazy_rep_0<AKT, EKT, typename LK::E2A>(t));
   }
 
@@ -1459,11 +1459,11 @@ struct Fill_lazy_variant_visitor_0 : boost::static_visitor<> {
     typedef typename Type_mapper<EKT, EK, LK>::type LKT;
 
     std::vector<LKT> V;
-    V.resize(t.size()); 
+    V.resize(t.size());
     for (unsigned int i = 0; i < t.size(); i++) {
       V[i] = LKT(new Lazy_rep_0<AKT, EKT, typename LK::E2A>(t[i]));
     }
-      
+
     *r = V;
   }
 };
@@ -1499,19 +1499,19 @@ struct Lazy_construction_variant {
   typename result<Lazy_construction_variant(L1, L2)>::type
   operator()(const L1& l1, const L2& l2) const {
     typedef typename cpp11::result_of<Lazy_construction_variant(L1, L2)>::type result_type;
-    
-    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type, 
+
+    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type,
                                          typename Type_mapper<L2, LK, AK>::type)>::type AT;
-    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type, 
+    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type,
                                          typename Type_mapper<L2, LK, EK>::type)>::type ET;
-    
+
     CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
     Protect_FPU_rounding<Protection> P;
 
     try {
       Lazy<AT, ET, E2A> lazy(new Lazy_rep_n<AT, ET, AC, EC, E2A, L1, L2>(AC(), EC(), l1, l2));
 
-      // the approximate result requires the trait with types from the AK 
+      // the approximate result requires the trait with types from the AK
       AT approx_v = lazy.approx();
       // the result we build
       result_type res;
@@ -1524,7 +1524,7 @@ struct Lazy_construction_variant {
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
-      
+
       return res;
     } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
@@ -1547,11 +1547,11 @@ struct Lazy_construction_variant {
   typename result<Lazy_construction_variant(L1, L2, L3)>::type
   operator()(const L1& l1, const L2& l2, const L3& l3) const {
     typedef typename result<Lazy_construction_variant(L1, L2, L3)>::type result_type;
-    
-    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type, 
+
+    typedef typename cpp11::result_of<AC(typename Type_mapper<L1, LK, AK>::type,
                                          typename Type_mapper<L2, LK, AK>::type,
                                          typename Type_mapper<L3, LK, AK>::type)>::type AT;
-    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type, 
+    typedef typename cpp11::result_of<EC(typename Type_mapper<L1, LK, EK>::type,
                                          typename Type_mapper<L2, LK, EK>::type,
                                          typename Type_mapper<L3, LK, EK>::type)>::type ET;
 
@@ -1560,7 +1560,7 @@ struct Lazy_construction_variant {
     try {
       Lazy<AT, ET, E2A> lazy(new Lazy_rep_n<AT, ET, AC, EC, E2A, L1, L2, L3>(AC(), EC(), l1, l2, l3));
 
-      // the approximate result requires the trait with types from the AK 
+      // the approximate result requires the trait with types from the AK
       AT approx_v = lazy.approx();
       // the result we build
       result_type res;
@@ -1573,7 +1573,7 @@ struct Lazy_construction_variant {
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
-      
+
       return res;
     } catch (Uncertain_conversion_exception&) {
       CGAL_BRANCH_PROFILER_BRANCH(tmp);
@@ -1593,7 +1593,7 @@ struct Lazy_construction_variant {
   }
 };
 
-template<typename LK, typename AC, typename EC, typename E2A = Default, 
+template<typename LK, typename AC, typename EC, typename E2A = Default,
          bool has_result_type = internal::has_result_type<AC>::value && internal::has_result_type<EC>::value >
 struct Lazy_construction;
 
@@ -1605,13 +1605,13 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
 
   typedef typename LK::Approximate_kernel AK;
   typedef typename LK::Exact_kernel EK;
-  typedef typename boost::remove_cv< 
+  typedef typename boost::remove_cv<
     typename boost::remove_reference < typename AC::result_type >::type >::type AT;
-  typedef typename boost::remove_cv< 
+  typedef typename boost::remove_cv<
     typename boost::remove_reference < typename EC::result_type >::type >::type  ET;
 
   typedef typename Default::Get<E2A_, typename LK::E2A>::type E2A;
-  
+
   typedef typename Type_mapper<AT, AK, LK>::type result_type;
 
   CGAL_NO_UNIQUE_ADDRESS AC ac;
@@ -1631,9 +1631,9 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \
     }                                                                   \
-  }        
+  }
 
-  // arity 1-8 
+  // arity 1-8
   BOOST_PP_REPEAT_FROM_TO(1, 9, CGAL_CONSTRUCTION_OPERATOR, _)
 
   // nullary
@@ -1645,7 +1645,7 @@ struct Lazy_construction<LK, AC, EC, E2A_, true> {
   }
 
 #undef CGAL_CONSTRUCTION_OPERATOR
-  
+
 };
 
 
@@ -1698,9 +1698,9 @@ struct result<F( BOOST_PP_ENUM_PARAMS(n, T) )> { \
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);          \
       return result_type( Handle(new Lazy_rep_0<AT,ET,E2A>(ec( BOOST_PP_ENUM(n, CGAL_LEXACT, _) ))) ); \
     }                                                                   \
-  }        
+  }
 
-  // arity 1-8 
+  // arity 1-8
   BOOST_PP_REPEAT_FROM_TO(1, 9, CGAL_CONSTRUCTION_OPERATOR, _)
 
   // nullary

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -1,16 +1,16 @@
-// Copyright (c) 1999
+// Copyright (c) 1999  
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
 // Max-Planck-Institute Saarbruecken (Germany),
-// and Tel-Aviv University (Israel).  All rights reserved.
+// and Tel-Aviv University (Israel).  All rights reserved. 
 //
 // This file is part of CGAL (www.cgal.org)
 //
 // $URL$
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
-//
+// 
 //
 // Author(s)     : Sylvain Pion
 
@@ -36,35 +36,35 @@ class Rep
 class Handle
 {
   public:
-
+    
     typedef std::ptrdiff_t Id_type ;
-
+    
     Handle() noexcept
-        : PTR(static_cast<Rep*>(0)) {}
+	: PTR{static_cast<Rep*>(0)} {}
 
     // FIXME: if the precondition throws in a noexcept function, the program terminates
     Handle(const Handle& x) noexcept
     {
-      CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
-      PTR = x.PTR;
-      CGAL_assume (PTR->count > 0);
-      PTR->count++;
+      CGAL_precondition( x.PTR.p != static_cast<Rep*>(0) );
+      PTR.p = x.PTR.p;
+      CGAL_assume (PTR.p->count > 0);
+      PTR.p->count++;
     }
 
     ~Handle()
     {
-        if ( PTR && (--PTR->count == 0))
-            delete PTR;
+	if ( PTR.p && (--PTR.p->count == 0))
+	    delete PTR.p;
     }
 
     Handle&
     operator=(const Handle& x) noexcept
     {
-      CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
-      x.PTR->count++;
-      if ( PTR && (--PTR->count == 0))
-          delete PTR;
-      PTR = x.PTR;
+      CGAL_precondition( x.PTR.p != static_cast<Rep*>(0) );
+      x.PTR.p->count++;
+      if ( PTR.p && (--PTR.p->count == 0))
+	  delete PTR.p;
+      PTR.p = x.PTR.p;
       return *this;
     }
 
@@ -72,23 +72,29 @@ class Handle
 
     void reset()
     {
-      if (PTR)
+      if (PTR.p)
       {
-        if (--PTR->count==0)
-          delete PTR;
-        PTR=0;
+        if (--PTR.p->count==0)
+          delete PTR.p;
+        PTR.p=0;
       }
     }
 
-    int
-    refs()  const noexcept { return PTR->count; }
+    int refs()  const noexcept { return PTR.p->count; }
 
-    Id_type id() const noexcept { return PTR - static_cast<Rep*>(0); }
+    Id_type id() const noexcept { return PTR.p - static_cast<Rep*>(0); }
 
-    bool identical(const Handle& h) const noexcept { return PTR == h.PTR; }
+    bool identical(const Handle& h) const noexcept { return PTR.p == h.PTR.p; }
+
+    void*  for_compact_container() const { return PTR.vp; }
+    void*& for_compact_container() { return PTR.vp; }
 
   protected:
-    Rep* PTR;
+
+  union {
+    Rep* p;
+    void* vp;
+  } PTR;
 };
 
 //inline Handle::Id_type id(const Handle& x) { return x.id() ; }

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -1,16 +1,16 @@
-// Copyright (c) 1999  
+// Copyright (c) 1999
 // Utrecht University (The Netherlands),
 // ETH Zurich (Switzerland),
 // INRIA Sophia-Antipolis (France),
 // Max-Planck-Institute Saarbruecken (Germany),
-// and Tel-Aviv University (Israel).  All rights reserved. 
+// and Tel-Aviv University (Israel).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org)
 //
 // $URL$
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
-// 
+//
 //
 // Author(s)     : Sylvain Pion
 
@@ -36,11 +36,11 @@ class Rep
 class Handle
 {
   public:
-    
+
     typedef std::ptrdiff_t Id_type ;
-    
+
     Handle() noexcept
-	: PTR{static_cast<Rep*>(0)} {}
+        : PTR{static_cast<Rep*>(0)} {}
 
     // FIXME: if the precondition throws in a noexcept function, the program terminates
     Handle(const Handle& x) noexcept
@@ -53,8 +53,8 @@ class Handle
 
     ~Handle()
     {
-	if ( PTR.p && (--PTR.p->count == 0))
-	    delete PTR.p;
+        if ( PTR.p && (--PTR.p->count == 0))
+            delete PTR.p;
     }
 
     Handle&
@@ -63,7 +63,7 @@ class Handle
       CGAL_precondition( x.PTR.p != static_cast<Rep*>(0) );
       x.PTR.p->count++;
       if ( PTR.p && (--PTR.p->count == 0))
-	  delete PTR.p;
+          delete PTR.p;
       PTR.p = x.PTR.p;
       return *this;
     }


### PR DESCRIPTION
## Summary of Changes

This PR allows to use kernel objects from `CGAL::Epeck` (or `CGAL::Lazy_kernel<...>`) in `CGAL::Compact_container`.

See also discussion on cgal-dev started by @gdamiand, 2020-02-11 15:07 CET.

## Release Management

* Affected package(s): Kernel_23, Filtered_kernel, STL_Extension
* License and copyright ownership: maintenance by GF

