### PR TITLE
Fix LCC import_from_triangulation_3

### DIFF
--- a/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
+++ b/Linear_cell_complex/include/CGAL/Cell_attribute_with_point.h
@@ -25,11 +25,11 @@ namespace CGAL {
   class Point_for_cell
   {
   public:
-    /// Contructor without parameter.
+    /// Constructor without parameter.
     Point_for_cell()
     {}
 
-    /// Contructor with a point in parameter.
+    /// Constructor with a point in parameter.
     Point_for_cell(const Point& apoint) : mpoint(apoint)
     {}
 
@@ -87,15 +87,15 @@ namespace CGAL {
     { return !operator==(other); }
 
   protected:
-    /// Default contructor.
+    /// Default constructor.
     Cell_attribute_with_point()
     {}
 
-    /// Contructor with a point in parameter.
+    /// Constructor with a point in parameter.
     Cell_attribute_with_point(const Point& apoint) : Base2(apoint)
     {}
 
-    /// Contructor with a point and an attribute in parameters.
+    /// Constructor with a point and an attribute in parameters.
     Cell_attribute_with_point(const Point& apoint, const Info& ainfo) :
       Base1(ainfo),
       Base2(apoint)
@@ -144,11 +144,11 @@ namespace CGAL {
     { return false; }
 
   protected:
-    /// Default contructor.
+    /// Default constructor.
     Cell_attribute_with_point()
     {}
 
-    /// Contructor with a point in parameter.
+    /// Constructor with a point in parameter.
     Cell_attribute_with_point(const Point& apoint) : Base2(apoint)
     {}
   };

--- a/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
@@ -15,9 +15,27 @@
 
 #include <CGAL/assertions.h>
 #include <map>
+#include <CGAL/Weighted_point_3.h>
 
 namespace CGAL {
 
+  namespace internal 
+  {
+    template<typename Point>
+    struct Get_point
+    {
+      static const Point& run(const Point& p)
+      { return p; }
+    };
+
+    template<typename Kernel>
+    struct Get_point<CGAL::Weighted_point_3<Kernel> >
+    {
+      static const typename Kernel::Point_3& run(const CGAL::Weighted_point_3<Kernel>& p)
+      { return p.point(); }
+    };
+  }
+  
   /** Convert a given Triangulation_3 into a 3D linear cell complex.
    * @param alcc the used linear cell complex.
    * @param atr the Triangulation_3.
@@ -52,7 +70,7 @@ namespace CGAL {
     for (TVertex_iterator itv = atr.vertices_begin();
          itv != atr.vertices_end(); ++itv)
     {
-      TV[itv] = alcc.create_vertex_attribute(itv->point());
+      TV[itv] = alcc.create_vertex_attribute(internal::Get_point<typename Triangulation::Point>::run(itv->point()));
     }
 
     // Create the tetrahedron and create a map to link Cell_iterator


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Bug fix in the function import_from_triangulation_3 that transforms a T3 into a LCC.

When the T3 use weighted points, the function does not compile.

## Release Management

* Affected package(s): T3 ? (or LCC)

