### PR TITLE
[Small Feature] CDT+ Split Subconstraint Graph Into Constraints

### DIFF
--- a/Polyline_simplification_2/package_info/Polyline_simplification_2/dependencies
+++ b/Polyline_simplification_2/package_info/Polyline_simplification_2/dependencies
@@ -1,5 +1,6 @@
 Algebraic_foundations
 Arithmetic_kernel
+BGL
 Cartesian_kernel
 Circulator
 Distance_2

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -12,7 +12,7 @@ in the triangulation.
 The class `Constrained_triangulation_plus_2<Tr>`
 inherits from its template parameter Tr, which has to be instantiated
 by a constrained or constrained Delaunay triangulation.
-The intersection tag of the base class determines whether
+The intersection tag of the base class determines whether 
 intersecting input constraints are supported or not.
 When intersections of input constraints are supported,
 the base class constructs a triangulation of the arrangement
@@ -28,7 +28,7 @@ either vertices of the input constraint or intersection points.
 \todo The following description does not match the code
 Two consecutive vertices of an input constraint form a *subconstraint*.
 A subconstraint is a pair of vertex handles and corresponds to a constrained edge of the
-triangulation, which is a pair of a face handle and an index.
+triangulation, which is a pair of a face handle and an index. 
 
 The triangulation also enables the retrieval of the set
 of subconstraints of the triangulation (not ordered along constraints).
@@ -38,82 +38,82 @@ one can obtain the input constraints which induce `e`.
 
 \tparam Tr must be either a CGAL::Constrained_triangulation_2 or a CGAL::Constrained_Delaunay_triangulation_2
 
-\sa `CGAL::Constrained_triangulation_2<Traits,Tds>`
-\sa `CGAL::Constrained_Delaunay_triangulation_2<Traits,Tds>`
-\sa `ConstrainedTriangulationTraits_2`
-\sa `ConstrainedDelaunayTriangulationTraits_2`
+\sa `CGAL::Constrained_triangulation_2<Traits,Tds>` 
+\sa `CGAL::Constrained_Delaunay_triangulation_2<Traits,Tds>` 
+\sa `ConstrainedTriangulationTraits_2` 
+\sa `ConstrainedDelaunayTriangulationTraits_2` 
 
 */
 template< typename Tr >
 class Constrained_triangulation_plus_2 : public Tr {
 public:
 
-/// \name Types
+/// \name Types 
 /// @{
 
-/*!
-The triangulation base class.
-*/
-typedef Tr Triangulation;
+/*! 
+The triangulation base class. 
+*/ 
+typedef Tr Triangulation; 
 
-/*!
+/*! 
 The intersection tag as defined in `Tr`.
-*/
-  typedef Tr::Intersection_tag Intersection_tag;
-
+*/ 
+  typedef Tr::Intersection_tag Intersection_tag; 
+  
 /*!
-The identifier of a polyline constraint.
-The class is model of `Assignable`, `CopyConstructible`, `DefaultConstructible`, `LessThanComparable` and  `EqualityComparable`.
+The identifier of a polyline constraint. 
+The class is model of `Assignable`, `CopyConstructible`, `DefaultConstructible`, `LessThanComparable` and  `EqualityComparable`.  
 
 A default constructed `Constraint_id` is a singular value that can not be the ID of a constraint.
 */
   typedef unspecified_type Constraint_id;
 
-/*!
-An iterator to visit
-all the input constraints. The order of visit is undefined.
-The value type of this iterator is `Constraint_id`.
-*/
-typedef unspecified_type Constraint_iterator;
+/*! 
+An iterator to visit 
+all the input constraints. The order of visit is undefined. 
+The value type of this iterator is `Constraint_id`. 
+*/ 
+typedef unspecified_type Constraint_iterator; 
 
 /*!
 A range type for iterating over all constraints.
-*/
+*/  
 typedef Iterator_range<Constraint_iterator> Constraints;
 
-
+  
 /*!
 A subconstraint is a pair of vertices that correspond to an `Edge`.
  */
 typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
 
-/*!
-An iterator
-to visit all the subconstraints of the triangulation.
-The order of visit is undefined.
-The value type of this iterator is `std::pair<Subconstraint,std::list<Context>*>`
-corresponding to the vertices of the
-subconstraint.
-*/
-typedef unspecified_type Subconstraint_iterator;
+/*! 
+An iterator 
+to visit all the subconstraints of the triangulation. 
+The order of visit is undefined. 
+The value type of this iterator is `std::pair<Subconstraint,std::list<Context>*>` 
+corresponding to the vertices of the 
+subconstraint. 
+*/ 
+typedef unspecified_type Subconstraint_iterator; 
 
 /*!
 A range type for iterating over all subconstraints.
-*/
+*/  
 typedef Iterator_range<Subconstraint_iterator> Subconstraints;
+  
+/*! 
+An iterator on the 
+vertices of the chain of subconstraints representing a 
+constraint. The value type of this iterator is `Vertex_handle`. 
+*/ 
+typedef unspecified_type Vertices_in_constraint_iterator; 
 
-/*!
-An iterator on the
-vertices of the chain of subconstraints representing a
-constraint. The value type of this iterator is `Vertex_handle`.
-*/
-typedef unspecified_type Vertices_in_constraint_iterator;
-
-/*!
-A context enables the access to the vertices of a constraint that pass
+/*! 
+A context enables the access to the vertices of a constraint that pass 
 through a subconstraint.
 
-*/
+*/ 
   class Context {
   public:
     /*!
@@ -137,121 +137,121 @@ through a subconstraint.
     correspond to the two vertices of the subconstraint.
      */
     Vertices_in_constraint_iterator current() const;
-  };
+  }; 
 
-/*!
-An iterator on
-constraints enclosing a given subconstraint. The value type of this
-iterator
-is `Context`.
-*/
-typedef unspecified_type Context_iterator;
+/*! 
+An iterator on 
+constraints enclosing a given subconstraint. The value type of this 
+iterator 
+is `Context`. 
+*/ 
+typedef unspecified_type Context_iterator; 
 
 /*!
 range type for iterating over contexts.
 */
-typedef Iterator_range<Context_iterator> Contexts;
-/// @}
+typedef Iterator_range<Context_iterator> Contexts;  
+/// @} 
 
-/// \name Creation
+/// \name Creation 
 /// @{
 
-/*!
+/*! 
 Introduces an empty triangulation.
-*/
-Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits());
+*/ 
+Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits()); 
 
-/*!
-Copy constructor.
-*/
-Constrained_triangulation_plus_2(const
-Constrained_triangulation_plus_2& ct);
+/*! 
+Copy constructor. 
+*/ 
+Constrained_triangulation_plus_2(const 
+Constrained_triangulation_plus_2& ct); 
 
 
-/*!
-Introduces a constrained triangulation
+/*! 
+Introduces a constrained triangulation 
 from the constraints in the range `[first,last)`.
-\tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`.
-*/
-template<class ConstraintIterator>
-Constrained_triangulation_plus_2(
-ConstraintIterator first,
+\tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`. 
+*/ 
+template<class ConstraintIterator> 
+Constrained_triangulation_plus_2( 
+ConstraintIterator first, 
 ConstraintIterator last,
-const Geom_traits& gt= Geom_traits());
+const Geom_traits& gt= Geom_traits()); 
 
-/// @}
+/// @} 
 
-/// \name Assignment
+/// \name Assignment 
 /// @{
 
-/*!
-Assignment. All the vertices and faces are duplicated.
+/*! 
+Assignment. All the vertices and faces are duplicated. 
 The bidirectional mapping between constraints and subconstraints is also duplicated.
-*/
-Constrained_triangulation_plus_2 operator=(const
-Constrained_triangulation_plus_2& tr);
+*/ 
+Constrained_triangulation_plus_2 operator=(const 
+Constrained_triangulation_plus_2& tr); 
 
-/*!
-The triangulations `tr` and this triangulation are swapped.
-This operation should be preferred to the assignment or to
-the copy constructor if `tr` is deleted after that.
-*/
-void swap(Constrained_triangulation_plus_2 tr);
+/*! 
+The triangulations `tr` and this triangulation are swapped. 
+This operation should be preferred to the assignment or to 
+the copy constructor if `tr` is deleted after that. 
+*/ 
+void swap(Constrained_triangulation_plus_2 tr); 
 
-/// @}
+/// @} 
 
-/// \name Insertion and Removal
+/// \name Insertion and Removal 
 /// The class `Constrained_triangulation_plus_2` overwrites the
 /// following insertion and removal member functions for points and
 /// constraints.
 /// @{
 
-/*!
-inserts point `p` as a vertex of the triangulation.
-*/
-Vertex_handle insert(const Point& p,
-Face_handle start = Face_handle() );
+/*! 
+inserts point `p` as a vertex of the triangulation. 
+*/ 
+Vertex_handle insert(const Point& p, 
+Face_handle start = Face_handle() ); 
 
-/*!
-inserts point `p` in the triangulation at the location given by `(lt,loc,i)`.
+/*! 
+inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
 \sa `Triangulation_2::locate()`
-*/
-Vertex_handle insert(const Point& p,
-Locate_type lt,
-Face_handle loc, int li );
+*/ 
+Vertex_handle insert(const Point& p, 
+Locate_type lt, 
+Face_handle loc, int li ); 
 
-/*!
-Equivalent to `insert(p)`.
-*/
-Vertex_handle push_back(const Point& p);
+/*! 
+Equivalent to `insert(p)`. 
+*/ 
+Vertex_handle push_back(const Point& p); 
 
-/*!
+/*! 
 inserts the points in the range `[first,last)`.
-Returns the number of inserted points.
-\tparam PointIterator must be an `InputIterator` with the value type `Point`.
-*/
-template < class PointIterator >
-size_type
-insert(PointIterator first, PointIterator last);
+Returns the number of inserted points. 
+\tparam PointIterator must be an `InputIterator` with the value type `Point`. 
+*/ 
+template < class PointIterator > 
+size_type 
+insert(PointIterator first, PointIterator last); 
 
-/*!
+/*! 
 inserts the constraint segment `ab` in the triangulation.
 If the two points are equal the point is inserted but no constraint,
 and the default constructed `Constraint_id` is returned.
-*/
+*/ 
 Constraint_id insert_constraint(Point a, Point b);
 
-/*!
-inserts the constraint `c`.
-*/
-  void push_back(const std::pair<Point,Point>& c);
+/*! 
+inserts the constraint `c`. 
+*/ 
+  void push_back(const std::pair<Point,Point>& c); 
 
-/*!
-inserts a constraint whose endpoints are the vertices
+/*! 
+inserts a constraint whose endpoints are the vertices 
 pointed by `va` and `vb` in the triangulation.
 If the two vertex handles are equal no constraint is inserted,
 and the default constructed `Constraint_id` is returned.
-*/
+*/ 
 Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb);
 
 /*!
@@ -262,7 +262,7 @@ When traversing the vertices of a closed polyline constraint with a  `Vertices_i
 In case the range is empty `Constraint_id()`is returned.
 In case all points are equal the point is inserted but no constraint,
 and `Constraint_id()`is returned.
-\tparam PointIterator must be an `InputIterator` with the value type `Point`.
+\tparam PointIterator must be an `InputIterator` with the value type `Point`. 
 */
 template < class PointIterator>
 Constraint_id insert_constraint(PointIterator first, PointIterator last, bool close=false);
@@ -293,112 +293,136 @@ std::size_t insert_constraints(PointIterator points_first, PointIterator points_
                                IndicesIterator indices_first, IndicesIterator indices_last);
 
 
-/*!
+/*! 
+splits into constraints the graph of subconstraints.
+
+Consider the graph `g={V,E}` where `V` is the set of vertices of the
+triangulation and `E` is the set of all subconstraints of all
+constraints of the triangulation.
+
+This function splits into polylines the graph `g` at vertices of
+degree greater than 2 and at vertices for which
+`is_terminal(v)==true`.
+
+Each computed polyline is stored as a constraint of the triangulation.
+
+\warning all existing constraints will be discarded.
+
+\param is_terminal An optional function returning `true` if the vertex
+`v` of degree 2 is a polyline endpoint and `false` otherwise. If
+omitted, a function always returning `false` will be used, that is no
+degree 2 vertex will be considered as a polyline endpoint.
+
+\sa `split_graph_into_polylines()`
+*/ 
+void split_subconstraint_graph_into_constraints(const std::function<bool(Vertex_handle)>& is_terminal);
+  
+/*! 
 removes the constraint `cid`, without removing the points from the triangulation.
-*/
-void remove_constraint(Constraint_id cid);
+*/ 
+void remove_constraint(Constraint_id cid); 
 
-/// @}
+/// @} 
 
-/// \name Access
+/// \name Access 
 /// @{
 
-/*!
-returns a `Constraint_iterator` that points at the first
-constraint of the triangulation.
-*/
-Constraint_iterator constraints_begin() const;
+/*! 
+returns a `Constraint_iterator` that points at the first 
+constraint of the triangulation. 
+*/ 
+Constraint_iterator constraints_begin() const; 
 
-/*!
-returns the past-the-end iterator of the constraints of the triangulation.
-*/
-Constraint_iterator constraints_end() const;
+/*! 
+returns the past-the-end iterator of the constraints of the triangulation. 
+*/ 
+Constraint_iterator constraints_end() const; 
 
 /*!
 returns a range of constraints.
-*/
-Subconstraints constraints() const;
+*/ 
+Subconstraints constraints() const;  
+  
+/*! 
+returns a `Subconstraint_iterator` pointing at the first 
+subconstraint of the triangulation. 
+*/ 
+Subconstraint_iterator subconstraints_begin() const; 
 
-/*!
-returns a `Subconstraint_iterator` pointing at the first
-subconstraint of the triangulation.
-*/
-Subconstraint_iterator subconstraints_begin() const;
-
-/*!
-returns the past-the-end iterator of the subconstraints of the triangulation.
-*/
-Subconstraint_iterator subconstraints_end() const;
+/*! 
+returns the past-the-end iterator of the subconstraints of the triangulation. 
+*/ 
+Subconstraint_iterator subconstraints_end() const; 
 
 /*!
 returns a range of subconstraints.
-*/
-Subconstraints subconstraints() const;
+*/ 
+Subconstraints subconstraints() const;  
 
-/*!
-returns the number of constraints enclosing the subconstraint
-`(va,vb)`.
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
-*/
-int number_of_enclosing_constraints(Vertex_handle va,
-Vertex_handle vb) const;
+/*! 
+returns the number of constraints enclosing the subconstraint 
+`(va,vb)`. 
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
+*/ 
+int number_of_enclosing_constraints(Vertex_handle va, 
+Vertex_handle vb) const; 
 
-/*!
-returns the `Context` relative to one of the constraints
-enclosing the subconstraint `(va,vb)`.
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
-*/
-Context context(Vertex_handle va, Vertex_handle vb) const;
+/*! 
+returns the `Context` relative to one of the constraints 
+enclosing the subconstraint `(va,vb)`. 
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
+*/ 
+Context context(Vertex_handle va, Vertex_handle vb) const; 
 
-/*!
-returns an iterator pointing at the first `Context`
+/*! 
+returns an iterator pointing at the first `Context` 
 of the sequence of contexts
-corresponding to the constraints enclosing the subconstraint `(va,vb)`.
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
-*/
-Context_iterator contexts_begin(Vertex_handle va,
-                                Vertex_handle vb) const;
+corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
+*/ 
+Context_iterator contexts_begin(Vertex_handle va, 
+                                Vertex_handle vb) const; 
 
 /*!
-returns an iterator past the end `Context`
+returns an iterator past the end `Context` 
 of the sequence of contexts
-corresponding to the constraints enclosing the subconstraint `(va,vb)`.
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
-*/
-Context_iterator contexts_end(Vertex_handle va,
-                              Vertex_handle vb) const;
+corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
+*/ 
+Context_iterator contexts_end(Vertex_handle va, 
+                              Vertex_handle vb) const; 
 
 /*!
 returns a range of contexts.
 */
-Contexts contexts(Vertex_handle va,
-                  Vertex_handle vb) const;
+Contexts contexts(Vertex_handle va, 
+                  Vertex_handle vb) const; 
+  
+/*!
+returns an iterator on the first vertex on the constraint `cid`. 
+*/ 
+Vertices_in_constraint_iterator 
+vertices_in_constraint_begin(Constraint_id cid) const; 
 
 /*!
-returns an iterator on the first vertex on the constraint `cid`.
-*/
-Vertices_in_constraint_iterator
-vertices_in_constraint_begin(Constraint_id cid) const;
+returns an iterator past the last vertex on the constraint `cid`. 
+*/ 
+Vertices_in_constraint_iterator 
+vertices_in_constraint_end(Constraint_id cid) const; 
 
 /*!
-returns an iterator past the last vertex on the constraint `cid`.
-*/
-Vertices_in_constraint_iterator
-vertices_in_constraint_end(Constraint_id cid) const;
-
-/*!
-returns a range of the vertices on the constraint `cid`.
-*/
+returns a range of the vertices on the constraint `cid`. 
+*/ 
 Vertices_in_constraint
-vertices_in_constraint(Constraint_id cid) const;
+vertices_in_constraint(Constraint_id cid) const; 
 
 /// @}
 
 
 /*! \name Polyline Simplification
-\cgalAdvancedBegin
+\cgalAdvancedBegin 
 The polyline simplification algorithm described in Chapter
-\ref Chapter_2D_Polyline_simplification
+\ref Chapter_2D_Polyline_simplification 
 operates on polyline constraints. The algorithm removes
 in each simplification step
 a vertex of a constraint and at the same time from the triangulation.
@@ -406,16 +430,16 @@ The class `Constrained_triangulation_plus_2` stores
 for each constraint not only the sequence of vertices but
 also the original sequence of points at those vertices.
 As the `Vertices_in_constraint_iterator` enables the traversal of
-the current set of vertices, the `Points_in_constraint_iterator`
-enables the traversal of the points that were in the constraint
+the current set of vertices, the `Points_in_constraint_iterator` 
+enables the traversal of the points that were in the constraint 
 before the simplification algorithm started.
 
-It enables the simplification algorithm to compute the error introduced by
+It enables the simplification algorithm to compute the error introduced by 
 each simplification step:
 it is the distance of the current sequence (vertices) to the original
 sequence (points).
 
-Those stored points which do not correspond to a vertex can be removed
+Those stored points which do not correspond to a vertex can be removed 
 afterward either for a single constraint or for all constraints.
 
 The simplification algorithm uses the following types and functions.
@@ -443,7 +467,7 @@ Returns an iterator to the first point on the constraint before any simplificati
 \cgalAdvancedEnd
 */
 Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
-
+  
 /*!
 \cgalAdvancedFunction
 \cgalAdvancedBegin
@@ -461,7 +485,7 @@ of the constraint until `remove_points_without_corresponding_vertex(Constraint_i
 or `remove_points_without_corresponding_vertex()` is called.
 
 The polyline simplification algorithm described in Chapter
-\ref Chapter_2D_Polyline_simplification
+\ref Chapter_2D_Polyline_simplification 
 operates on polyline constraints and applies `simplify()` to vertices in
 constraints based on a cost and stop function.
 
@@ -505,20 +529,20 @@ remove_points_without_corresponding_vertex();
 Writes the triangulation as for `Tr`, then writes one constraint per line, starting with the number
 of vertices and the indices of the vertices of the constraint.
 
-\relates Constrained_triangulation_plus_2
+\relates Constrained_triangulation_plus_2 
 */
-
+  
 template <typename  Tr>
 std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_plus_2<Tr> &ctp);
 
-
+  
 /*!
-Reads a triangulation from stream `is` and assigns it to the triangulation.
+Reads a triangulation from stream `is` and assigns it to the triangulation. 
 
-\relates Constrained_triangulation_plus_2
+\relates Constrained_triangulation_plus_2 
 */
 template <typename  Tr>
 std::istream & operator>>(std::istream& is, Constrained_triangulation_plus_2<Tr> &ctp);
 
-
+ 
 } /* end namespace CGAL */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -12,7 +12,7 @@ in the triangulation.
 The class `Constrained_triangulation_plus_2<Tr>`
 inherits from its template parameter Tr, which has to be instantiated
 by a constrained or constrained Delaunay triangulation.
-The intersection tag of the base class determines whether 
+The intersection tag of the base class determines whether
 intersecting input constraints are supported or not.
 When intersections of input constraints are supported,
 the base class constructs a triangulation of the arrangement
@@ -28,7 +28,7 @@ either vertices of the input constraint or intersection points.
 \todo The following description does not match the code
 Two consecutive vertices of an input constraint form a *subconstraint*.
 A subconstraint is a pair of vertex handles and corresponds to a constrained edge of the
-triangulation, which is a pair of a face handle and an index. 
+triangulation, which is a pair of a face handle and an index.
 
 The triangulation also enables the retrieval of the set
 of subconstraints of the triangulation (not ordered along constraints).
@@ -38,82 +38,82 @@ one can obtain the input constraints which induce `e`.
 
 \tparam Tr must be either a CGAL::Constrained_triangulation_2 or a CGAL::Constrained_Delaunay_triangulation_2
 
-\sa `CGAL::Constrained_triangulation_2<Traits,Tds>` 
-\sa `CGAL::Constrained_Delaunay_triangulation_2<Traits,Tds>` 
-\sa `ConstrainedTriangulationTraits_2` 
-\sa `ConstrainedDelaunayTriangulationTraits_2` 
+\sa `CGAL::Constrained_triangulation_2<Traits,Tds>`
+\sa `CGAL::Constrained_Delaunay_triangulation_2<Traits,Tds>`
+\sa `ConstrainedTriangulationTraits_2`
+\sa `ConstrainedDelaunayTriangulationTraits_2`
 
 */
 template< typename Tr >
 class Constrained_triangulation_plus_2 : public Tr {
 public:
 
-/// \name Types 
+/// \name Types
 /// @{
 
-/*! 
-The triangulation base class. 
-*/ 
-typedef Tr Triangulation; 
-
-/*! 
-The intersection tag as defined in `Tr`.
-*/ 
-  typedef Tr::Intersection_tag Intersection_tag; 
-  
 /*!
-The identifier of a polyline constraint. 
-The class is model of `Assignable`, `CopyConstructible`, `DefaultConstructible`, `LessThanComparable` and  `EqualityComparable`.  
+The triangulation base class.
+*/
+typedef Tr Triangulation;
+
+/*!
+The intersection tag as defined in `Tr`.
+*/
+  typedef Tr::Intersection_tag Intersection_tag;
+
+/*!
+The identifier of a polyline constraint.
+The class is model of `Assignable`, `CopyConstructible`, `DefaultConstructible`, `LessThanComparable` and  `EqualityComparable`.
 
 A default constructed `Constraint_id` is a singular value that can not be the ID of a constraint.
 */
   typedef unspecified_type Constraint_id;
 
-/*! 
-An iterator to visit 
-all the input constraints. The order of visit is undefined. 
-The value type of this iterator is `Constraint_id`. 
-*/ 
-typedef unspecified_type Constraint_iterator; 
+/*!
+An iterator to visit
+all the input constraints. The order of visit is undefined.
+The value type of this iterator is `Constraint_id`.
+*/
+typedef unspecified_type Constraint_iterator;
 
 /*!
 A range type for iterating over all constraints.
-*/  
+*/
 typedef Iterator_range<Constraint_iterator> Constraints;
 
-  
+
 /*!
 A subconstraint is a pair of vertices that correspond to an `Edge`.
  */
 typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
 
-/*! 
-An iterator 
-to visit all the subconstraints of the triangulation. 
-The order of visit is undefined. 
-The value type of this iterator is `std::pair<Subconstraint,std::list<Context>*>` 
-corresponding to the vertices of the 
-subconstraint. 
-*/ 
-typedef unspecified_type Subconstraint_iterator; 
+/*!
+An iterator
+to visit all the subconstraints of the triangulation.
+The order of visit is undefined.
+The value type of this iterator is `std::pair<Subconstraint,std::list<Context>*>`
+corresponding to the vertices of the
+subconstraint.
+*/
+typedef unspecified_type Subconstraint_iterator;
 
 /*!
 A range type for iterating over all subconstraints.
-*/  
+*/
 typedef Iterator_range<Subconstraint_iterator> Subconstraints;
-  
-/*! 
-An iterator on the 
-vertices of the chain of subconstraints representing a 
-constraint. The value type of this iterator is `Vertex_handle`. 
-*/ 
-typedef unspecified_type Vertices_in_constraint_iterator; 
 
-/*! 
-A context enables the access to the vertices of a constraint that pass 
+/*!
+An iterator on the
+vertices of the chain of subconstraints representing a
+constraint. The value type of this iterator is `Vertex_handle`.
+*/
+typedef unspecified_type Vertices_in_constraint_iterator;
+
+/*!
+A context enables the access to the vertices of a constraint that pass
 through a subconstraint.
 
-*/ 
+*/
   class Context {
   public:
     /*!
@@ -137,121 +137,121 @@ through a subconstraint.
     correspond to the two vertices of the subconstraint.
      */
     Vertices_in_constraint_iterator current() const;
-  }; 
+  };
 
-/*! 
-An iterator on 
-constraints enclosing a given subconstraint. The value type of this 
-iterator 
-is `Context`. 
-*/ 
-typedef unspecified_type Context_iterator; 
+/*!
+An iterator on
+constraints enclosing a given subconstraint. The value type of this
+iterator
+is `Context`.
+*/
+typedef unspecified_type Context_iterator;
 
 /*!
 range type for iterating over contexts.
 */
-typedef Iterator_range<Context_iterator> Contexts;  
-/// @} 
+typedef Iterator_range<Context_iterator> Contexts;
+/// @}
 
-/// \name Creation 
+/// \name Creation
 /// @{
 
-/*! 
+/*!
 Introduces an empty triangulation.
-*/ 
-Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits()); 
+*/
+Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits());
 
-/*! 
-Copy constructor. 
-*/ 
-Constrained_triangulation_plus_2(const 
-Constrained_triangulation_plus_2& ct); 
+/*!
+Copy constructor.
+*/
+Constrained_triangulation_plus_2(const
+Constrained_triangulation_plus_2& ct);
 
 
-/*! 
-Introduces a constrained triangulation 
+/*!
+Introduces a constrained triangulation
 from the constraints in the range `[first,last)`.
-\tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`. 
-*/ 
-template<class ConstraintIterator> 
-Constrained_triangulation_plus_2( 
-ConstraintIterator first, 
+\tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`.
+*/
+template<class ConstraintIterator>
+Constrained_triangulation_plus_2(
+ConstraintIterator first,
 ConstraintIterator last,
-const Geom_traits& gt= Geom_traits()); 
+const Geom_traits& gt= Geom_traits());
 
-/// @} 
+/// @}
 
-/// \name Assignment 
+/// \name Assignment
 /// @{
 
-/*! 
-Assignment. All the vertices and faces are duplicated. 
+/*!
+Assignment. All the vertices and faces are duplicated.
 The bidirectional mapping between constraints and subconstraints is also duplicated.
-*/ 
-Constrained_triangulation_plus_2 operator=(const 
-Constrained_triangulation_plus_2& tr); 
+*/
+Constrained_triangulation_plus_2 operator=(const
+Constrained_triangulation_plus_2& tr);
 
-/*! 
-The triangulations `tr` and this triangulation are swapped. 
-This operation should be preferred to the assignment or to 
-the copy constructor if `tr` is deleted after that. 
-*/ 
-void swap(Constrained_triangulation_plus_2 tr); 
+/*!
+The triangulations `tr` and this triangulation are swapped.
+This operation should be preferred to the assignment or to
+the copy constructor if `tr` is deleted after that.
+*/
+void swap(Constrained_triangulation_plus_2 tr);
 
-/// @} 
+/// @}
 
-/// \name Insertion and Removal 
+/// \name Insertion and Removal
 /// The class `Constrained_triangulation_plus_2` overwrites the
 /// following insertion and removal member functions for points and
 /// constraints.
 /// @{
 
-/*! 
-inserts point `p` as a vertex of the triangulation. 
-*/ 
-Vertex_handle insert(const Point& p, 
-Face_handle start = Face_handle() ); 
+/*!
+inserts point `p` as a vertex of the triangulation.
+*/
+Vertex_handle insert(const Point& p,
+Face_handle start = Face_handle() );
 
-/*! 
-inserts point `p` in the triangulation at the location given by `(lt,loc,i)`. 
+/*!
+inserts point `p` in the triangulation at the location given by `(lt,loc,i)`.
 \sa `Triangulation_2::locate()`
-*/ 
-Vertex_handle insert(const Point& p, 
-Locate_type lt, 
-Face_handle loc, int li ); 
+*/
+Vertex_handle insert(const Point& p,
+Locate_type lt,
+Face_handle loc, int li );
 
-/*! 
-Equivalent to `insert(p)`. 
-*/ 
-Vertex_handle push_back(const Point& p); 
+/*!
+Equivalent to `insert(p)`.
+*/
+Vertex_handle push_back(const Point& p);
 
-/*! 
+/*!
 inserts the points in the range `[first,last)`.
-Returns the number of inserted points. 
-\tparam PointIterator must be an `InputIterator` with the value type `Point`. 
-*/ 
-template < class PointIterator > 
-size_type 
-insert(PointIterator first, PointIterator last); 
+Returns the number of inserted points.
+\tparam PointIterator must be an `InputIterator` with the value type `Point`.
+*/
+template < class PointIterator >
+size_type
+insert(PointIterator first, PointIterator last);
 
-/*! 
+/*!
 inserts the constraint segment `ab` in the triangulation.
 If the two points are equal the point is inserted but no constraint,
 and the default constructed `Constraint_id` is returned.
-*/ 
+*/
 Constraint_id insert_constraint(Point a, Point b);
 
-/*! 
-inserts the constraint `c`. 
-*/ 
-  void push_back(const std::pair<Point,Point>& c); 
+/*!
+inserts the constraint `c`.
+*/
+  void push_back(const std::pair<Point,Point>& c);
 
-/*! 
-inserts a constraint whose endpoints are the vertices 
+/*!
+inserts a constraint whose endpoints are the vertices
 pointed by `va` and `vb` in the triangulation.
 If the two vertex handles are equal no constraint is inserted,
 and the default constructed `Constraint_id` is returned.
-*/ 
+*/
 Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb);
 
 /*!
@@ -262,7 +262,7 @@ When traversing the vertices of a closed polyline constraint with a  `Vertices_i
 In case the range is empty `Constraint_id()`is returned.
 In case all points are equal the point is inserted but no constraint,
 and `Constraint_id()`is returned.
-\tparam PointIterator must be an `InputIterator` with the value type `Point`. 
+\tparam PointIterator must be an `InputIterator` with the value type `Point`.
 */
 template < class PointIterator>
 Constraint_id insert_constraint(PointIterator first, PointIterator last, bool close=false);
@@ -293,7 +293,7 @@ std::size_t insert_constraints(PointIterator points_first, PointIterator points_
                                IndicesIterator indices_first, IndicesIterator indices_last);
 
 
-/*! 
+/*!
 splits into constraints the graph of subconstraints.
 
 Consider the graph `g={V,E}` where `V` is the set of vertices of the
@@ -314,115 +314,115 @@ omitted, a function always returning `false` will be used, that is no
 degree 2 vertex will be considered as a polyline endpoint.
 
 \sa `split_graph_into_polylines()`
-*/ 
+*/
 void split_subconstraint_graph_into_constraints(const std::function<bool(Vertex_handle)>& is_terminal);
-  
-/*! 
+
+/*!
 removes the constraint `cid`, without removing the points from the triangulation.
-*/ 
-void remove_constraint(Constraint_id cid); 
+*/
+void remove_constraint(Constraint_id cid);
 
-/// @} 
+/// @}
 
-/// \name Access 
+/// \name Access
 /// @{
 
-/*! 
-returns a `Constraint_iterator` that points at the first 
-constraint of the triangulation. 
-*/ 
-Constraint_iterator constraints_begin() const; 
+/*!
+returns a `Constraint_iterator` that points at the first
+constraint of the triangulation.
+*/
+Constraint_iterator constraints_begin() const;
 
-/*! 
-returns the past-the-end iterator of the constraints of the triangulation. 
-*/ 
-Constraint_iterator constraints_end() const; 
+/*!
+returns the past-the-end iterator of the constraints of the triangulation.
+*/
+Constraint_iterator constraints_end() const;
 
 /*!
 returns a range of constraints.
-*/ 
-Subconstraints constraints() const;  
-  
-/*! 
-returns a `Subconstraint_iterator` pointing at the first 
-subconstraint of the triangulation. 
-*/ 
-Subconstraint_iterator subconstraints_begin() const; 
+*/
+Subconstraints constraints() const;
 
-/*! 
-returns the past-the-end iterator of the subconstraints of the triangulation. 
-*/ 
-Subconstraint_iterator subconstraints_end() const; 
+/*!
+returns a `Subconstraint_iterator` pointing at the first
+subconstraint of the triangulation.
+*/
+Subconstraint_iterator subconstraints_begin() const;
+
+/*!
+returns the past-the-end iterator of the subconstraints of the triangulation.
+*/
+Subconstraint_iterator subconstraints_end() const;
 
 /*!
 returns a range of subconstraints.
-*/ 
-Subconstraints subconstraints() const;  
-
-/*! 
-returns the number of constraints enclosing the subconstraint 
-`(va,vb)`. 
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
-*/ 
-int number_of_enclosing_constraints(Vertex_handle va, 
-Vertex_handle vb) const; 
-
-/*! 
-returns the `Context` relative to one of the constraints 
-enclosing the subconstraint `(va,vb)`. 
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
-*/ 
-Context context(Vertex_handle va, Vertex_handle vb) const; 
-
-/*! 
-returns an iterator pointing at the first `Context` 
-of the sequence of contexts
-corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
-*/ 
-Context_iterator contexts_begin(Vertex_handle va, 
-                                Vertex_handle vb) const; 
+*/
+Subconstraints subconstraints() const;
 
 /*!
-returns an iterator past the end `Context` 
+returns the number of constraints enclosing the subconstraint
+`(va,vb)`.
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
+*/
+int number_of_enclosing_constraints(Vertex_handle va,
+Vertex_handle vb) const;
+
+/*!
+returns the `Context` relative to one of the constraints
+enclosing the subconstraint `(va,vb)`.
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
+*/
+Context context(Vertex_handle va, Vertex_handle vb) const;
+
+/*!
+returns an iterator pointing at the first `Context`
 of the sequence of contexts
-corresponding to the constraints enclosing the subconstraint `(va,vb)`. 
-\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation. 
-*/ 
-Context_iterator contexts_end(Vertex_handle va, 
-                              Vertex_handle vb) const; 
+corresponding to the constraints enclosing the subconstraint `(va,vb)`.
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
+*/
+Context_iterator contexts_begin(Vertex_handle va,
+                                Vertex_handle vb) const;
+
+/*!
+returns an iterator past the end `Context`
+of the sequence of contexts
+corresponding to the constraints enclosing the subconstraint `(va,vb)`.
+\pre `va` and `vb` refer to the vertices of a constrained edge of the triangulation.
+*/
+Context_iterator contexts_end(Vertex_handle va,
+                              Vertex_handle vb) const;
 
 /*!
 returns a range of contexts.
 */
-Contexts contexts(Vertex_handle va, 
-                  Vertex_handle vb) const; 
-  
-/*!
-returns an iterator on the first vertex on the constraint `cid`. 
-*/ 
-Vertices_in_constraint_iterator 
-vertices_in_constraint_begin(Constraint_id cid) const; 
+Contexts contexts(Vertex_handle va,
+                  Vertex_handle vb) const;
 
 /*!
-returns an iterator past the last vertex on the constraint `cid`. 
-*/ 
-Vertices_in_constraint_iterator 
-vertices_in_constraint_end(Constraint_id cid) const; 
+returns an iterator on the first vertex on the constraint `cid`.
+*/
+Vertices_in_constraint_iterator
+vertices_in_constraint_begin(Constraint_id cid) const;
 
 /*!
-returns a range of the vertices on the constraint `cid`. 
-*/ 
+returns an iterator past the last vertex on the constraint `cid`.
+*/
+Vertices_in_constraint_iterator
+vertices_in_constraint_end(Constraint_id cid) const;
+
+/*!
+returns a range of the vertices on the constraint `cid`.
+*/
 Vertices_in_constraint
-vertices_in_constraint(Constraint_id cid) const; 
+vertices_in_constraint(Constraint_id cid) const;
 
 /// @}
 
 
 /*! \name Polyline Simplification
-\cgalAdvancedBegin 
+\cgalAdvancedBegin
 The polyline simplification algorithm described in Chapter
-\ref Chapter_2D_Polyline_simplification 
+\ref Chapter_2D_Polyline_simplification
 operates on polyline constraints. The algorithm removes
 in each simplification step
 a vertex of a constraint and at the same time from the triangulation.
@@ -430,16 +430,16 @@ The class `Constrained_triangulation_plus_2` stores
 for each constraint not only the sequence of vertices but
 also the original sequence of points at those vertices.
 As the `Vertices_in_constraint_iterator` enables the traversal of
-the current set of vertices, the `Points_in_constraint_iterator` 
-enables the traversal of the points that were in the constraint 
+the current set of vertices, the `Points_in_constraint_iterator`
+enables the traversal of the points that were in the constraint
 before the simplification algorithm started.
 
-It enables the simplification algorithm to compute the error introduced by 
+It enables the simplification algorithm to compute the error introduced by
 each simplification step:
 it is the distance of the current sequence (vertices) to the original
 sequence (points).
 
-Those stored points which do not correspond to a vertex can be removed 
+Those stored points which do not correspond to a vertex can be removed
 afterward either for a single constraint or for all constraints.
 
 The simplification algorithm uses the following types and functions.
@@ -467,7 +467,7 @@ Returns an iterator to the first point on the constraint before any simplificati
 \cgalAdvancedEnd
 */
 Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
-  
+
 /*!
 \cgalAdvancedFunction
 \cgalAdvancedBegin
@@ -485,7 +485,7 @@ of the constraint until `remove_points_without_corresponding_vertex(Constraint_i
 or `remove_points_without_corresponding_vertex()` is called.
 
 The polyline simplification algorithm described in Chapter
-\ref Chapter_2D_Polyline_simplification 
+\ref Chapter_2D_Polyline_simplification
 operates on polyline constraints and applies `simplify()` to vertices in
 constraints based on a cost and stop function.
 
@@ -529,20 +529,20 @@ remove_points_without_corresponding_vertex();
 Writes the triangulation as for `Tr`, then writes one constraint per line, starting with the number
 of vertices and the indices of the vertices of the constraint.
 
-\relates Constrained_triangulation_plus_2 
+\relates Constrained_triangulation_plus_2
 */
-  
+
 template <typename  Tr>
 std::ostream & operator<<(std::ostream& os, const Constrained_triangulation_plus_2<Tr> &ctp);
 
-  
-/*!
-Reads a triangulation from stream `is` and assigns it to the triangulation. 
 
-\relates Constrained_triangulation_plus_2 
+/*!
+Reads a triangulation from stream `is` and assigns it to the triangulation.
+
+\relates Constrained_triangulation_plus_2
 */
 template <typename  Tr>
 std::istream & operator>>(std::istream& is, Constrained_triangulation_plus_2<Tr> &ctp);
 
- 
+
 } /* end namespace CGAL */

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -1,7 +1,7 @@
 namespace CGAL {
 /*!
 
-\mainpage User Manual 
+\mainpage User Manual
 \anchor Chapter_2D_Triangulations
 
 \cgalAutoToc
@@ -11,16 +11,16 @@ namespace CGAL {
 \image latex tr1dt1.png
 
 This chapter describes the two dimensional triangulations
-of \cgal. 
+of \cgal.
 Section \ref Section_2D_Triangulations_Definitions recalls the
 main definitions about triangulations.
 Section \ref Section_2D_Triangulations_Representation discusses
 the way two-dimensional triangulations are represented in \cgal.
 Section \ref Section_2D_Triangulations_Software_Design presents
 the overall software
-design of the 2D triangulations package. 
+design of the 2D triangulations package.
 The next sections present the different two dimensional triangulations classes
-available in \cgal: 
+available in \cgal:
 basic triangulations (Section \ref Section_2D_Triangulations_Basic),
 Delaunay triangulations
 (Section \ref Section_2D_Triangulations_Delaunay),
@@ -33,18 +33,18 @@ and constrained Delaunay triangulations
 Section \ref Section_2D_Triangulations_Constrained_Plus
 describes a class which implements a constrained or
 constrained Delaunay triangulation with
-an additional data structure 
-to describe how the constraints are refined 
+an additional data structure
+to describe how the constraints are refined
 by the edges of the triangulations.
 Section \ref Section_2D_Triangulations_Hierarchy
 describes a hierarchical data structure for
 fast point location queries.
-At last, Section \ref Section_2D_Triangulations_Flexibility 
-explains how the user can benefit from the flexibility 
+At last, Section \ref Section_2D_Triangulations_Flexibility
+explains how the user can benefit from the flexibility
 of \cgal triangulations using customized classes for faces
 and vertices.
 
-\section Section_2D_Triangulations_Definitions Definitions 
+\section Section_2D_Triangulations_Definitions Definitions
 
 A two dimensional triangulation can be roughly described as a set \f$ T\f$
 of triangular facets such that:
@@ -52,40 +52,40 @@ of triangular facets such that:
 - two facets either are disjoint or share a lower dimensional
 face (edge or vertex).
 
-- the set of facets in \f$ T\f$ is connected for the adjacency relation. 
+- the set of facets in \f$ T\f$ is connected for the adjacency relation.
 
 - the domain \f$ U_T\f$ which is the union
 of facets in \f$ T\f$ has no singularity.
 
-More precisely, a triangulation can be described 
+More precisely, a triangulation can be described
 as a simplicial complex.
 Let us first record a few definitions.
 
-A simplicial complex is a set \f$ T\f$ of simplices such that 
+A simplicial complex is a set \f$ T\f$ of simplices such that
 
-- any face of a simplex in \f$ T\f$ is a simplex in \f$ T\f$ 
+- any face of a simplex in \f$ T\f$ is a simplex in \f$ T\f$
 
 - two simplices in \f$ T\f$ either are disjoint or share
 a common sub-face.
 
-The dimension \f$ d\f$ of a simplicial complex is the 
-maximal dimension of its simplices. 
+The dimension \f$ d\f$ of a simplicial complex is the
+maximal dimension of its simplices.
 
 A simplicial complex \f$ T\f$ is pure if any simplex of \f$ T\f$
-is included in a simplex of \f$ T\f$ with maximal dimension. 
+is included in a simplex of \f$ T\f$ with maximal dimension.
 
 Two simplexes in \f$ T\f$ with maximal dimension \f$ d\f$ are said to be
 adjacent if they share a \f$ d-1\f$ dimensional sub-face.
 A simplicial complex is connected if the adjacency relation
-defines a connected graph 
-over the set of simplices of \f$ T\f$ with maximal dimension. 
+defines a connected graph
+over the set of simplices of \f$ T\f$ with maximal dimension.
 
 The union \f$ U_T\f$ of all simplices in \f$ T\f$ is called the domain of \f$ T\f$.
-A point \f$ p\f$ in the domain of \f$ T\f$ is said to singular 
+A point \f$ p\f$ in the domain of \f$ T\f$ is said to singular
 if its surrounding in \f$ U_T\f$
 is neither a topological ball nor a topological disc.
 
-Then, a two dimensional triangulation can be described as a 
+Then, a two dimensional triangulation can be described as a
 two dimensional simplicial complex that is pure,
 connected and without singularity.
 
@@ -94,14 +94,14 @@ which in turn induces an orientation
 on the edges incident to that facet. The orientation of two adjacent
 facets are said to be consistent if they induce
 opposite orientations on their common incident edge.
-A triangulation is said to be orientable if 
+A triangulation is said to be orientable if
 the orientation of each facet can be chosen in such a way
 that all pairs of incident facets have consistent orientations.
 
 The data structure underlying \cgal triangulations
-allows the user to represent the combinatorics of 
+allows the user to represent the combinatorics of
 any orientable two dimensional triangulations
-without boundaries. 
+without boundaries.
 On top of this data structure, the 2D triangulations classes
 take care of the geometric embedding of the triangulation
 and are designed to handle planar triangulations.
@@ -114,32 +114,32 @@ convex hull of their vertices.
 Because any planar triangulation
 can be completed, this is not a real restriction.
 For instance, a triangulation of a polygonal region can be
-constructed and represented as a subset of a constrained triangulation 
-in which the region boundary edges have been input as 
+constructed and represented as a subset of a constrained triangulation
+in which the region boundary edges have been input as
 constrained edges (see
 Section \ref Section_2D_Triangulations_Constrained,
-\ref Section_2D_Triangulations_Constrained_Delaunay and 
+\ref Section_2D_Triangulations_Constrained_Delaunay and
 \ref Section_2D_Triangulations_Constrained_Plus).
 
 Strictly speaking, the term <I>face</I> should be used
 to design a face of any dimension,
-and the two-dimensional faces of a triangulation 
+and the two-dimensional faces of a triangulation
 should be properly called <I>facets</I>.
 However, following a common usage, we hereafter often call <I>faces</I>, the facets
 of a two dimensional triangulation.
 
-\section Section_2D_Triangulations_Representation Representation 
+\section Section_2D_Triangulations_Representation Representation
 
 \subsection Triangulation_2TheSetofFaces The Set of Faces
 
-A 2D triangulation of \cgal can be viewed as a planar partition 
+A 2D triangulation of \cgal can be viewed as a planar partition
 whose bounded faces are triangular and cover
-the convex hull of the set of vertices. 
+the convex hull of the set of vertices.
 The single unbounded face of this partition
-is the complementary of the convex hull. 
+is the complementary of the convex hull.
 In many applications, such as Kirkpatrick's hierarchy
 or incremental Delaunay construction, it is convenient to
-deal with only triangular faces. Therefore, 
+deal with only triangular faces. Therefore,
 a fictitious vertex, called the *infinite vertex*
 is added to the triangulation as well as
 *infinite edges* and *infinite faces* incident to it.
@@ -155,7 +155,7 @@ equivalent to a two-dimensional sphere.
 This extends to lower dimensional triangulations
 arising in degenerate cases or when the triangulations
 as less than three vertices.
-Including the infinite faces, 
+Including the infinite faces,
 a one dimensional triangulation
 is a ring of edges and vertices
 topologically equivalent to a \f$ 1\f$-sphere.
@@ -185,16 +185,16 @@ saves storage space and results in faster
 algorithms \cgalCite{bdty-tcgal-00}.
 
 The basic elements of the representation are vertices and faces.
-Each triangular face gives access to its three incident vertices 
-and to its three adjacent faces. 
+Each triangular face gives access to its three incident vertices
+and to its three adjacent faces.
 Each vertex gives access to one of its incident faces
 and through that face to the circular list of its incident faces.
 
 The three vertices of a face are indexed with 0, 1 and 2
-in counterclockwise order. The neighbors of a face are also 
+in counterclockwise order. The neighbors of a face are also
 indexed with 0,1,2 in such a way that the neighbor indexed by `i`
 is opposite to the vertex with the same index.
-See \cgalFigureRef{Triangulation_2D_Fig_neighbors1}, 
+See \cgalFigureRef{Triangulation_2D_Fig_neighbors1},
 the functions `ccw(i)`
 and `cw(i)` shown on this figure
 compute respectively \f$ i+1\f$ and \f$ i-1\f$ modulo 3.
@@ -203,21 +203,21 @@ The edges are not explicitly represented, they are only implicitly
 represented through the adjacency relations of two faces.
 Each edge has two implicit representations: the edge
 of a face `f` which is opposed to the vertex indexed `i`,
-can be represented as well as an edge of the `neighbor(i)` of 
+can be represented as well as an edge of the `neighbor(i)` of
 `f`.
 
 \cgalFigureBegin{Triangulation_2D_Fig_neighbors1,rep_bis.png}
 Vertices and neighbors.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Software_Design Software Design 
+\section Section_2D_Triangulations_Software_Design Software Design
 
-The triangulations classes of \cgal 
+The triangulations classes of \cgal
 provide high-level geometric functionalities
 such as location of a point in the triangulation, insertion, removal, or displacement of a point.
 They are build as a layer on top of a data structure
 called the triangulation data structure.
-The triangulation data structure can be thought 
+The triangulation data structure can be thought
 of as a container for the faces and vertices of the triangulation.
 This data structure also takes care
 of all the combinatorial aspects of the triangulation.
@@ -229,8 +229,8 @@ that the triangulation classes have two template parameters:
 
 <UL>
 <LI> the first parameter stands for a
-<B>geometric traits</B> class providing 
-the geometric primitives (points, segments and triangles) 
+<B>geometric traits</B> class providing
+the geometric primitives (points, segments and triangles)
 of the triangulation and the elementary
 operations (predicate or constructions) on those objects.
 
@@ -249,14 +249,14 @@ as a default model of triangulation data structure.
 The class `Triangulation_data_structure_2<Vb,Fb>`
 has two template parameters standing for
 a vertex class and a face class.
-\cgal defines concepts 
+\cgal defines concepts
 for these template parameters
 and provide default models for these concepts.
 The vertex and base classes are templated by the geometric
 traits class which enables them to obtain some knowledge of the geometric
-primitives of the triangulation. 
+primitives of the triangulation.
 Those default vertex and face base classes
-can be replaced by 
+can be replaced by
 user customized base classes in order, for example, to deal
 with additional properties attached to the vertices or faces
 of a triangulation. See Section \ref Section_2D_Triangulations_Flexibility
@@ -272,58 +272,58 @@ forming this design.
 The triangulations software design.
 \cgalFigureEnd
 
-The top triangulation level, responsible for the geometric 
-embedding of the triangulation comes in different flavors 
+The top triangulation level, responsible for the geometric
+embedding of the triangulation comes in different flavors
 according to the different kind of triangulations:
 basic, Delaunay, regular, constrained or constrained Delaunay.
 Each kind of triangulations correspond to a different
-class. 
+class.
 \cgalFigureRef{Triangulation_2D_Fig_derivation_tree} summarizes the derivation dependencies
 of \cgal 2D triangulations classes.
 Any 2D triangulation class is parametrized by
 a geometric traits class and a triangulation data structure.
 While a unique concept `TriangulationDataStructure_2`
 describes the triangulation data structure requirements
-for any triangulation class, 
+for any triangulation class,
 the requirements on the geometric traits class actually depend
 on the triangulation class.
-In general, the requirements for the vertex and face base classes 
+In general, the requirements for the vertex and face base classes
 are described by the basic concepts `TriangulationVertexBase_2`
 and `TriangulationFaceBase_2`. However, some triangulation
 classes require base classes implementing
-refinements 
+refinements
 of the basic concepts.
 
 \cgalFigureBegin{Triangulation_2D_Fig_derivation_tree,derivation_tree.png}
 The derivation tree of 2D triangulations.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Basic Basic Triangulations 
+\section Section_2D_Triangulations_Basic Basic Triangulations
 
-\subsection Subsection_2D_Triangulations_Basic_Description Description 
+\subsection Subsection_2D_Triangulations_Basic_Description Description
 
 The class `Triangulation_2<Traits,Tds>`
 serves as a base class for the other
 2D triangulations classes
-and 
+and
 implements the user
 interface to a triangulation.
 
-The vertices and faces of the triangulations are accessed through 
+The vertices and faces of the triangulations are accessed through
 `handles`,
 `iterators` and `circulators`.
 A handle is a model of the concept `Handle` which basically
 offers the two dereference operators `*` and `->`.
 A circulator is a type devoted to visit circular sequences.
-Handles are used whenever the accessed element 
+Handles are used whenever the accessed element
 is not part of a sequence.
 Iterators and circulators are used
 to visit all or parts of the triangulation.
 
 The iterators and circulators
 are all bidirectional and non mutable.
-The circulators and iterators are convertible to the 
-handles with the same value type, so that 
+The circulators and iterators are convertible to the
+handles with the same value type, so that
 when calling a member function,
 any handle type argument can be replaced
 by an iterator or a circulator
@@ -332,18 +332,18 @@ with the same value type.
 The triangulation class provides a function to visit the vertices
 and neighbors of a face in clockwise or counterclockwise order.
 
-There are circulators 
-to visit the edges or faces 
-incident to a given vertex or the vertices 
+There are circulators
+to visit the edges or faces
+incident to a given vertex or the vertices
 adjacent to it.
 Another circulator type enables the visit of all the faces
 traversed by a given line.
-Circulators step through infinite features as well as 
+Circulators step through infinite features as well as
 through finite ones.
 
-The triangulation class offers 
-some iterators to visit all the 
-faces, edges or vertices and also iterators to visit 
+The triangulation class offers
+some iterators to visit all the
+faces, edges or vertices and also iterators to visit
 selectively the finite
 faces, edges or vertices.
 
@@ -356,7 +356,7 @@ The triangulation class provides a method to locate
 a given point with respect to a triangulation.
 In particular, this method reports whether the point
 coincides with a vertex of the triangulation, lies on an edge,
-in a face or outside of the convex hull. In case of a degenerate 
+in a face or outside of the convex hull. In case of a degenerate
 lower dimensional triangulation, the query point may also lie
 outside the triangulation affine hull.
 
@@ -364,7 +364,7 @@ The triangulation class also provides
 methods to locate a point with respect to
 a given finite face of the triangulation or with respect to its
 circumcircle.
-The faces of the triangulation and their circumcircles 
+The faces of the triangulation and their circumcircles
 have the counterclockwise orientation.
 
 The triangulation can be modified by several functions:
@@ -405,7 +405,7 @@ if no optional argument is given. It takes
 time \f$ O(n)\f$ in the worst case for Delaunay Triangulations, but only \f$ O(\sqrt{n})\f$
 on average if the vertices are distributed uniformly at random.
 The class `Triangulation_hierarchy_2<Traits,Tds>`,
-described in section \ref Section_2D_Triangulations_Hierarchy, 
+described in section \ref Section_2D_Triangulations_Hierarchy,
 implements a data structure designed to
 offer an alternate more efficient point location algorithm.
 
@@ -423,7 +423,7 @@ re-triangulating the hole. Removal takes a time at most proportional to
 which is \f$ O(1)\f$ for a random vertex.
 
 Displacement of a vertex is done by: first, verifying if the triangulation embedding
-remains planar after the displacement; if yes the vertex is directly placed at the new location; otherwise, a point is inserted at the new location 
+remains planar after the displacement; if yes the vertex is directly placed at the new location; otherwise, a point is inserted at the new location
 and the vertex at the obsolete location is removed.
 
 The face, edge, and vertex iterators on finite features
@@ -431,36 +431,36 @@ are derived from their counterparts visiting all (finite and infinite)
 features which are themselves derived from the corresponding iterators
 of the triangulation data structure.
 
-\subsection Subsubsection_2D_Triangulation_Basic_Geometric_Traits Geometric Traits 
+\subsection Subsubsection_2D_Triangulation_Basic_Geometric_Traits Geometric Traits
 
-The geometric traits class of a triangulation 
+The geometric traits class of a triangulation
 is required to provide
 the geometric objects (points, segments and triangles)
 building up the triangulation
 together with the geometric predicates on those objects.
-The required predicates are: 
+The required predicates are:
 
 - comparison of the `x` or `y` coordinates of two points.
 
-- the orientation test which computes 
+- the orientation test which computes
 the order type of three given point.
 
 The concept
-`TriangulationTraits_2` describes the requirements for the 
+`TriangulationTraits_2` describes the requirements for the
 geometric traits class of a triangulation.
-The \cgal kernel classes 
+The \cgal kernel classes
 are models for this concept.
 The \cgal library also provides dedicated models
-of `TriangulationTraits_2` 
+of `TriangulationTraits_2`
 using the kernel geometric objects and predicates.
 These classes are themselves templated with a \cgal kernel
 and extract the required types and predicates from the kernel.
-The class `Projection_traits_xy_3<R>` 
+The class `Projection_traits_xy_3<R>`
 is a geometric traits class to build the triangulation
 of a terrain. Such a triangulation is a two-dimensional
 triangulation embedded in three dimensional space.
 The data points are three-dimensional points.
-The triangulation is 
+The triangulation is
 build according to the projections of those points
 on the \f$ xy\f$ plane and then lifted up to the original
 three-dimensional data points.
@@ -479,15 +479,15 @@ deal with projections on the
 `yz` plane and `xz`-plane,
 respectively.
 
-\subsection Subsection_2D_Triangulations_Basic_Example Example of a Basic Triangulation 
+\subsection Subsection_2D_Triangulations_Basic_Example Example of a Basic Triangulation
 
 The following program creates a triangulation of 2D points
-using the default kernel 
+using the default kernel
 `Exact_predicate_inexact_constructions_kernel`
 as geometric traits class and the default triangulation data structure.
-The input points are read from a file 
+The input points are read from a file
 and inserted in the triangulation.
-Finally points on the convex hull are written to <TT>cout</TT>. 
+Finally points on the convex hull are written to <TT>cout</TT>.
 \cgalExample{Triangulation_2/triangulation_prog1.cpp}
 
 \subsection Triangulation2Draw Draw a 2D Triangulation
@@ -503,17 +503,17 @@ This function requires CGAL_Qt5, and is only available if the flag CGAL_USE_BASI
 Result of the run of the draw_triangulation_2 program. A window shows the 2D triangulation and allows to navigate through the scene.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Delaunay Delaunay Triangulations 
+\section Section_2D_Triangulations_Delaunay Delaunay Triangulations
 
-\subsection Subsection_2D_Triangulations_Delaunay_Description Description 
+\subsection Subsection_2D_Triangulations_Delaunay_Description Description
 
 The class `Delaunay_triangulation_2<Traits,Tds>` is designed to represent
 the Delaunay triangulation of a set of data points in the plane.
 A Delaunay triangulation
 fulfills
-the following <I>empty circle property</I> 
+the following <I>empty circle property</I>
 (also called <I>Delaunay property</I>): the circumscribing
-circle of any facet of the triangulation 
+circle of any facet of the triangulation
 contains no data point in its interior.
 For a point set with no subset of four co-circular points
 the Delaunay triangulation is unique, it is dual
@@ -523,7 +523,7 @@ The class `Delaunay_triangulation_2<Traits,Tds>` derives
 from the class `Triangulation_2<Traits,Tds>`.
 
 The class `Delaunay_triangulation_2<Traits,Tds>`
-inherits the types defined by the 
+inherits the types defined by the
 basic class `Triangulation_2<Traits,Tds>`.
 Additional types, provided by the traits class,
 are defined to represent the dual Voronoi diagram.
@@ -536,7 +536,7 @@ to answer nearest neighbor queries
 and member functions to construct the elements (vertices and edges)
 of the dual Voronoi diagram.
 
-Geometric Traits 
+Geometric Traits
 --------------
 
 The geometric traits class has to be a model of the concept
@@ -546,43 +546,43 @@ In particular this concept provides
 the `side_of_oriented_circle` predicate
 which, given four points `p,q,r,s`
 decides the position of the point \f$ s\f$ with respect to the circle
-passing through \f$ p\f$, \f$ q\f$ and \f$ r\f$. 
+passing through \f$ p\f$, \f$ q\f$ and \f$ r\f$.
 The `side_of_oriented_circle`
 predicate actually defines the Delaunay triangulation.
-Changing this predicate 
+Changing this predicate
 allows the user to build variant of Delaunay triangulations for different metrics
 such that \f$ L_1\f$ or \f$ L_{\infty}\f$ metric or any metric defined by a
 convex object. However, the user of an exotic metric
-must be careful that the constructed triangulation 
+must be careful that the constructed triangulation
 has to be a triangulation of the convex hull
 which means that convex hull edges have to be Delaunay edges.
 This is granted for any smooth convex metric (like \f$ L_2\f$)
 and can be ensured for other metrics (like \f$ L_{\infty}\f$)
 by the addition to the point set of well chosen sentinel points.
 
-The \cgal kernel classes 
+The \cgal kernel classes
 are models of the concept `DelaunayTriangulationTraits_2`
 for the Euclidean metric.
 The traits class for terrains,
 `Projection_traits_xy_3<R>`,
 `Projection_traits_yz_3<R>`, and
-`Projection_traits_xz_3<R>` 
+`Projection_traits_xz_3<R>`
 are also models of `DelaunayTriangulationTraits_2`
 except that they do not fulfill
 the requirements for the duality functions and nearest vertex
 queries.
 
-Implementation 
+Implementation
 --------------
 
 The insertion of a new point in the Delaunay triangulation
 is performed using first the insertion member function
-of the basic triangulation and second 
-performing a sequence of flips to restore the Delaunay property. 
+of the basic triangulation and second
+performing a sequence of flips to restore the Delaunay property.
 The number of flips that have to be performed is \f$ O(d)\f$
 if the new vertex has degree \f$ d\f$ in the updated
 Delaunay triangulation. For
-points distributed uniformly at random, 
+points distributed uniformly at random,
 each insertion takes time \f$ O(1)\f$ on
 average, once the point has been located in the triangulation.
 
@@ -598,9 +598,9 @@ for random points \cgalCite{d-vrtdd-09}.
 
 The displacement of a vertex \f$ v\f$ at a point \f$ p\f$ to a new location \f$ p'\f$, first checks whether the triangulation embedding remains
 planar or not after moving \f$ v\f$ to \f$ p'\f$. If yes, it moves \f$ v\f$ to \f$ p'\f$ and simply performs a sequence of flips
-to restore the Delaunay property, which is \f$ O(d)\f$ where \f$ d\f$ is the degree of the vertex after the displacement. 
+to restore the Delaunay property, which is \f$ O(d)\f$ where \f$ d\f$ is the degree of the vertex after the displacement.
 Otherwise, the displacement is done by inserting a vertex at the new location,
-and removing the obsolete vertex. 
+and removing the obsolete vertex.
 The complexity is \f$ O(n)\f$ in the worst case, but only \f$ O(1 + \delta \sqrt{n})\f$ for evenly distributed vertices in the unit square, where \f$ \delta\f$ is the Euclidean distance between the new and old locations.
 
 After having performed a point location, the
@@ -608,20 +608,20 @@ nearest neighbor of a point is found in time \f$ O(n)\f$ in the
 worst case, but in time \f$ O(1)\f$
 for vertices distributed uniformly at random and any query point.
 
-\subsection Subsection_2D_Triangulations_Delaunay_Terrain Example: a Delaunay Terrain 
+\subsection Subsection_2D_Triangulations_Delaunay_Terrain Example: a Delaunay Terrain
 
-The following code creates a Delaunay triangulation with 
-the usual Euclidean metric for the vertical projection of a 
+The following code creates a Delaunay triangulation with
+the usual Euclidean metric for the vertical projection of a
 terrain model. The points have elevation, that is they are 3D points,
 but the predicates used to build the Delaunay triangulation
-are computed using only the \f$ x\f$ and \f$ y\f$ coordinates 
+are computed using only the \f$ x\f$ and \f$ y\f$ coordinates
 of these points.
 
 The class `Projection_traits_xy_3<K>` is part of the 2D and 3D Linear Geometric Kernel.
 
 \cgalExample{Triangulation_2/terrain.cpp}
 
-\subsection Subsection_2D_Triangulations_Voronoi Example: Voronoi Diagram 
+\subsection Subsection_2D_Triangulations_Voronoi Example: Voronoi Diagram
 
 The following code computes the edges of Voronoi diagram
 of a set of data points
@@ -629,9 +629,9 @@ and counts the number of finite edges and the number of rays
 of this diagram
 \cgalExample{Triangulation_2/voronoi.cpp}
 
-\subsection Subsection_2D_Triangulations_Cropped_Voronoi Example: Print Voronoi Diagram Edges Restricted to a Rectangle 
+\subsection Subsection_2D_Triangulations_Cropped_Voronoi Example: Print Voronoi Diagram Edges Restricted to a Rectangle
 
-The following code computes the Delaunay triangulation of a set of points and prints the Voronoi edges 
+The following code computes the Delaunay triangulation of a set of points and prints the Voronoi edges
 restricted to a given rectangle.
 
 \cgalFigureBegin{figurecropped_voronoi,cropped_voronoi.png}
@@ -640,11 +640,11 @@ Voronoi diagram (in red) of the black points restricted to the blue rectangle.
 
 \cgalExample{Triangulation_2/print_cropped_voronoi.cpp}
 
-\section Section_2D_Triangulations_Regular Regular Triangulations 
+\section Section_2D_Triangulations_Regular Regular Triangulations
 
-\subsection Subsection_2D_Triangulations_Regular_Description Description 
+\subsection Subsection_2D_Triangulations_Regular_Description Description
 
-Let \f$ { PW} = \{(p_i, w_i) | i = 1, \ldots , n \}\f$ be a set of 
+Let \f$ { PW} = \{(p_i, w_i) | i = 1, \ldots , n \}\f$ be a set of
 weighted points where each \f$ p_i\f$ is a point and each \f$ w_i\f$
 is a scalar called the weight of point \f$ p_i\f$.
 Alternatively, each weighted point \f$ (p_i, w_i)\f$ can be regarded
@@ -654,18 +654,18 @@ of \f$ p_i\f$) with center \f$ p_i\f$ and radius \f$ r_i=\sqrt{w_i}\f$.
 The power diagram of the set \f$ { PW}\f$ is a space partition in which
 each cell corresponds to a sphere \f$ (p_i, w_i)\f$ of \f$ { PW}\f$
 and is the locus of points \f$ p\f$ whose power with respect to \f$ (p_i, w_i)\f$
-is less than its power with respect to any other sphere 
+is less than its power with respect to any other sphere
 in \f$ { PW}\f$. In the two-dimensional space,
-the dual of this diagram is a triangulation 
-whose domain covers the convex hull of the set 
+the dual of this diagram is a triangulation
+whose domain covers the convex hull of the set
 \f$ { P}= \{ p_i | i = 1, \ldots , n \}\f$ of center points
 and whose vertices form a subset of \f$ { P}\f$.
 Such a triangulation is called a regular triangulation.
 Three points \f$ p_i, p_j\f$ and \f$ p_k\f$ of \f$ { P}\f$
 form a triangle in the regular triangulation of \f$ { PW}\f$
-iff there is a point \f$ p\f$ of the plane with equal 
+iff there is a point \f$ p\f$ of the plane with equal
 powers with respect to \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$
-and \f$ (p_k, w_k)\f$ and such that this power 
+and \f$ (p_k, w_k)\f$ and such that this power
 is less than the power of \f$ p\f$
 with respect to any other sphere in \f$ { PW}\f$.
 
@@ -673,7 +673,7 @@ Let us defined the power product of two weighted points
 \f$ (p_i, w_i)\f$ and \f$ (p_j, w_j)\f$ as:
 \f[ \Pi(p_i, w_i, p_j, w_j) = p_ip_j ^2 - w_i - w_j . \f]
 \f$ \Pi(p_i, w_i, p_j, 0)\f$ is simply the power of point \f$ p_j\f$
-with respect to the sphere \f$ (p_i, w_i)\f$, and two weighted points 
+with respect to the sphere \f$ (p_i, w_i)\f$, and two weighted points
 are said to be orthogonal if their power product is null.
 The power circle of three weighted points
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$
@@ -683,7 +683,7 @@ and \f$ (p_k, w_k)\f$ is defined as the unique circle
 and \f$ (p_k, w_k)\f$.
 
 The regular triangulation of the sets \f$ { PW}\f$
-satisfies the following <I>regular property</I> (which just reduces to the 
+satisfies the following <I>regular property</I> (which just reduces to the
 Delaunay property when all the weights are null):
 a triangle \f$ p_ip_jp_k\f$ is a face of the regular triangulation
 of \f$ { PW}\f$ iff the power product of any weighted point
@@ -691,7 +691,7 @@ of \f$ { PW}\f$ iff the power product of any weighted point
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$ and \f$ (p_k, w_k)\f$ is positive or null.
 We call power test of \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$, \f$ (p_k, w_k)\f$,
 and \f$ (p_l, w_l)\f$, the predicates which amount to compute
-the sign of 
+the sign of
 the power product of \f$ (p_l, w_l)\f$ with respect to
 the power circle of
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$ and \f$ (p_k, w_k)\f$.
@@ -722,18 +722,18 @@ Alternatively, the regular triangulation
 of the weighted points set \f$ { PW}\f$
 can be obtained as the projection
 on the two dimensional plane of the convex hull of the set of three
-dimensional points 
+dimensional points
 \f$ { P'}= \{ (p_i,p_i ^2 - w_i ) | i = 1, \ldots , n \}\f$.
 
 The class `Regular_triangulation_2<Traits, Tds>`
 is designed to maintain the
 regular triangulation of a set of \f$ 2d\f$ weighted points.
 It derives from the class `Triangulation_2<Traits, Tds>`.
-The functions `insert` and 
+The functions `insert` and
 `remove` are overwritten to handle weighted points
 and maintain the regular
 property.
-The function `move()` is not 
+The function `move()` is not
 overwritten and thus does not preserve the regular property.
 The vertices of the regular triangulation
 of a set of weighted points \f$ {PW}\f$ correspond only to a subset
@@ -745,14 +745,14 @@ triangulation.
 Such a point is called a hidden point.
 Because hidden points can reappear later on as vertices
 when some other point is removed,
-they have to be stored somewhere. 
+they have to be stored somewhere.
 The regular triangulation store those points in special vertices, called
-hidden vertices. 
+hidden vertices.
 A hidden point can reappear as vertex of the triangulation
 only when the two dimensional face that hides it
 is removed from the triangulation. To deal with this feature,
 each face of a regular triangulation stores a list of hidden vertices.
-The points in those vertices 
+The points in those vertices
 are reinserted in the triangulation when the face
 is removed.
 
@@ -764,7 +764,7 @@ the vertices and edges of the dual power diagrams.
 The geometric traits class of a regular triangulation
 must provide a weighted point type
 and a power test on these weighted points.
-The concept 
+The concept
 `RegularTriangulationTraits_2`,
 is a refinement of the concept
 `TriangulationTraits_2`. All \cgal kernels are a model for the traits concept
@@ -778,31 +778,31 @@ includes a Boolean data member to mark the hidden state of the vertex.
 Therefore \cgal defines the concept
 `RegularTriangulationVertexBase_2` which refine
 the concept `TriangulationVertexBase_2`
-and provides a default model 
+and provides a default model
 for this concept.
 
 The face base type of a regular triangulation
 is required to provide a list of hidden vertices,
 designed to store the points hidden by the face. It has to be a model
 of the concept `RegularTriangulationFaceBase_2`.
-\cgal provides the templated class 
+\cgal provides the templated class
 `Regular_triangulation_face_base_2<Traits>`
 as a default base class for faces of regular triangulations.
 
-\subsection Subsection_2D_Triangulations_Regular_Example Example: a Regular Triangulation 
+\subsection Subsection_2D_Triangulations_Regular_Example Example: a Regular Triangulation
 
-The following code creates a regular triangulation 
+The following code creates a regular triangulation
 of a set of weighted points and output the number
 of vertices and the number of hidden vertices.
 
 \cgalExample{Triangulation_2/regular.cpp}
 
-\section Section_2D_Triangulations_Constrained Constrained Triangulations 
+\section Section_2D_Triangulations_Constrained Constrained Triangulations
 
 A constrained triangulation is a triangulation of a set of points
-that has to include among its edges 
+that has to include among its edges
 a given set of polylines joining the points. The
-polylines are called *constraints*. The corresponding 
+polylines are called *constraints*. The corresponding
 edges are called *constrained edges*.
 
 The endpoints of constrained edges are of course vertices of the
@@ -810,8 +810,8 @@ triangulation. However, the triangulation may
 include other vertices as well.
 There are three versions of constrained triangulations.
 <UL>
-<LI>In the basic version, the constrained triangulation 
-does not handle intersecting constraints, and the set of input 
+<LI>In the basic version, the constrained triangulation
+does not handle intersecting constraints, and the set of input
 constraints is required to be a set of segments that do not intersect,
 except possibly at their endpoints. Any number of constrained edges
 may share the same endpoint. Constrained edges may be vertical or
@@ -820,7 +820,7 @@ have zero length.
 In those versions, input constraints may consist of intersecting,
 overlapping or partially overlapping segments.
 The triangulation introduces additional vertices at each point that
-is the proper intersection point of two 
+is the proper intersection point of two
 constraints. A single constraint intersecting other
 constraints will then appear as several constrained edges in the triangulation.
 There are two ways to deal with intersecting constraints.
@@ -861,10 +861,10 @@ from a list of pairs of points which represent the constraints.
 
 The class `Constrained_triangulation_2<Traits,Tds,Itag>`
 overrides the insertion and removal of a point to take care of the
-information about constrained edges. The class also allows the user 
+information about constrained edges. The class also allows the user
 online insertion of a new constraint, given as sequence of points,
 or the removal of a constraint.
-In the current version, the function `move()` is not 
+In the current version, the function `move()` is not
 overwritten and thus does not handle vertices of constraints.
 
 In order to retrieve the constrained edges of a constraint, or
@@ -880,8 +880,8 @@ as it avoids the cascading of intersection computations.
 The geometric traits class of a constraint triangulation
 has to be a model
 of the concept `TriangulationTraits_2`.
-When intersections of input constraints are supported, 
-the geometric traits class has to be a model 
+When intersections of input constraints are supported,
+the geometric traits class has to be a model
 of the concept `ConstrainedTriangulationTraits_2`,
 which refines the concept `TriangulationTraits_2`
 providing additional function object types
@@ -889,7 +889,7 @@ to compute the intersection of two segments.
 
 \subsection Triangulation_2TheFaceBaseClassofaConstrained The Face Base Class of a Constrained Triangulation
 
-The information about constrained edges is stored in the 
+The information about constrained edges is stored in the
 faces of the triangulation. The face base of a Constrained Triangulation
 has to be a model for the concept `ConstrainedTriangulationFaceBase_2`
 which refines the concept `TriangulationFaceBase_2`.
@@ -909,7 +909,7 @@ Constrained and Constrained Delaunay triangulation: the constraining edges are t
 \cgalFigureEnd
 
 
-\section Section_2D_Triangulations_Constrained_Delaunay Constrained Delaunay Triangulations 
+\section Section_2D_Triangulations_Constrained_Delaunay Constrained Delaunay Triangulations
 
 A constrained Delaunay triangulation is a triangulation with
 constrained edges which try to be as much Delaunay as possible.
@@ -919,16 +919,16 @@ necessarily fulfill the empty circle property
 but they fulfill a weaker *constrained empty circle property*.
 To state this property,
 it is convenient to think of constrained
-edges as blocking the view. Then, a triangulation is 
+edges as blocking the view. Then, a triangulation is
 constrained Delaunay iff
 the circumscribing circle
-of any facet encloses 
+of any facet encloses
 no vertex visible
 from the interior of the facet.
 As in the case of constrained triangulations, three different versions
 of Delaunay constrained triangulations are provided. The first version
 handles a set of constraints which do not intersect except possibly
-at the endpoints. The two other versions 
+at the endpoints. The two other versions
 handle intersecting input constraints. One of them
 is designed to be robust
 when used in conjunction with a geometric traits class
@@ -942,7 +942,7 @@ The \cgal class
 is designed to represent
 constrained Delaunay triangulations.
 
-As in the case of constrained triangulations, the third parameter 
+As in the case of constrained triangulations, the third parameter
 `Itag` is the intersection tag
 and serves to choose how intersecting constraints
 are dealt with. It can be instantiated with one of the following
@@ -958,7 +958,7 @@ derives from
 the class `Constrained_triangulation_2<Traits,Tds,Itag>`.
 
 The constrained Delaunay triangulation
-has member functions to override the 
+has member functions to override the
 insertion and removal of a point or of a constraint.
 Each of those member functions takes care
 to restore
@@ -967,13 +967,13 @@ property.
 
 \subsection Triangulation_2TheGeometricTraits_2 The Geometric Traits
 
-The geometric traits class 
+The geometric traits class
 of a constrained Delaunay triangulation is required
 to provide the `side_of_oriented_circle` predicate as the geometric traits
 class of a Delaunay triangulation, and has to be a model of the concept
 `DelaunayTriangulationTraits_2`. When intersecting input
 constraints
-is supported, the geometric traits class is further required 
+is supported, the geometric traits class is further required
 to provide function objects to compute constraints intersections.
 Then, the geometric traits class has to be at the same time a model
 of the concept `ConstrainedTriangulationTraits_2`.
@@ -987,19 +987,19 @@ and the face base class
 of a constrained Delaunay triangulation has to be a model
 of `ConstrainedTriangulationFaceBase_2`.
 
-\subsection Subsection_2D_Triangulations_Constrained_Delaunay_Example Example: a Constrained Delaunay Triangulation 
+\subsection Subsection_2D_Triangulations_Constrained_Delaunay_Example Example: a Constrained Delaunay Triangulation
 
 The following code inserts a set of intersecting constraint segments
-into a triangulation 
+into a triangulation
 and counts the number of constrained edges of the
 resulting triangulation.
 
 \cgalExample{Triangulation_2/constrained.cpp}
 
-\subsection Subsection_2D_Triangulations_Polygon_triangulation Example: Triangulating a Polygonal Domain 
+\subsection Subsection_2D_Triangulations_Polygon_triangulation Example: Triangulating a Polygonal Domain
 
 The following code inserts two nested polygons into a constrained Delaunay triangulation and counts the number of facets that
-are inside the domain delimited by these polygons. Note that the following code does not work if the 
+are inside the domain delimited by these polygons. Note that the following code does not work if the
 boundaries of the polygons intersect.
 
 \cgalFigureBegin{figuretri_domain,tri_domain.png}
@@ -1012,7 +1012,7 @@ Triangulation (in blue) of the domain delimited by the red polygons.
 
 The class `Constrained_triangulation_plus_2<Tr>`
 provides a constrained triangulation with an additional data
-structure 
+structure
 that keeps track of the input constraints and of their refinement
 in the triangulation.
 The class `Constrained_triangulation_plus_2<Tr>`
@@ -1047,7 +1047,7 @@ For a pair `(fh,i)` it is the edge of the face `*fh`, which is opposite to the `
 A <em>constrained edge</em> `e` is an edge of a constrained triangulation `ct`, for which `ct.is_constrained(e)` returns `true`.
 
 A <em>constraint</em> is a polyline which is given as input (in the simplest case just a segment), and
-which is split into constrained edges in the triangulation. 
+which is split into constrained edges in the triangulation.
 
 The type `Subconstraint` is defined as `typedef std::pair<Vertex_handle,Vertex_handle> Subconstraint`.  The two vertex handles must
 be the vertices of a constrained edge.
@@ -1061,7 +1061,7 @@ and offer a `Constrained_edges_iterator`.
 The class `Constrained_triangulation_plus_2` additionally provides the means to
 - traverse all the constraints of the triangulation using an iterator of type `Constraint_iterator` the value type of which is `Constraint_id`,
 - obtain all constraints that induce a constrained edge or a subconstraint,
-- traverse the sequence of vertices of a constraint  using an iterator of type `Vertices_in_constraint_iterator`, the value type of which is `Vertex_handle` 
+- traverse the sequence of vertices of a constraint  using an iterator of type `Vertices_in_constraint_iterator`, the value type of which is `Vertex_handle`
 - traverse the subconstraints in the triangulation  using an iterator of type `Subconstraint_iterator`, the value type of which is `Subconstraint`.
 
 Note that the `Constrained_edges_iterator` and the `Subconstraint_iterator` are quite similar.
@@ -1108,8 +1108,8 @@ define an input segment that induce `e`.
 The following code inserts two polyline constraints into a triangulation.
 Note that if the triangulation supports intersections we can have
 arbitrary complicated overlapping polylines.  They can share
-any number of edges, and a polyline may pass several times through 
-the same edge.  
+any number of edges, and a polyline may pass several times through
+the same edge.
 
 
 
@@ -1117,7 +1117,7 @@ For an edge we can further find out how many and which polyline
 constraints pass through it. For an edge we can obtain an iterator
 range with value type `Constrained_triangulation_plus_2::Context`.
 From a context we can obtain the `Constrained_triangulation_plus_2::Constraint_id`, and an iterator
-pointing at the vertex in the polyline constraint that passes 
+pointing at the vertex in the polyline constraint that passes
 through the edge.
 
 
@@ -1140,14 +1140,14 @@ constraints in a `Constrained_triangulation_plus_2`:
 
 \cgalExample{Triangulation_2/segment_soup_to_polylines.cpp}
 
-\section Section_2D_Triangulations_Hierarchy The Triangulation Hierarchy 
+\section Section_2D_Triangulations_Hierarchy The Triangulation Hierarchy
 
 The class `Triangulation_hierarchy_2<Tr>`
 implements a triangulation augmented with
 a data structure to efficiently answer point location queries.
-The data structure is a hierarchy 
+The data structure is a hierarchy
 of triangulations. The triangulation at the lowest level is
-the original triangulation where operations and point location are to 
+the original triangulation where operations and point location are to
 be performed.
 Then at each succeeding level, the data structure
 stores a triangulation of a small random sample of the vertices
@@ -1160,7 +1160,7 @@ is found through a linear walk performed from
 the nearest neighbor found at the preceding level.
 Because the number of vertices in each triangulation is only a small
 fraction of the number of vertices of the preceding triangulation,
-the data structure remains small and achieves fast point location 
+the data structure remains small and achieves fast point location
 queries on real
 data. As proved in \cgalCite{d-iirdt-98}, this structure has an optimal behavior
 when it is built for Delaunay triangulations.
@@ -1170,7 +1170,7 @@ which is to be instantiated by one of the \cgal triangulation
 classes.
 
 The class `Triangulation_hierarchy_2<Tr>` inherits from the
-triangulation type passed as template parameter `Tr`. 
+triangulation type passed as template parameter `Tr`.
 The `insert`, `move`, and `remove` member functions
 are overwritten to update the data structure at each operation.
 The locate queries are also overwritten to take advantage of the data
@@ -1178,30 +1178,30 @@ structure for a fast processing.
 
 \subsection Triangulation_2TheVertexofaTriangulation The Vertex of a Triangulation Hierarchy
 
-The base vertex class of a triangulation hierarchy 
+The base vertex class of a triangulation hierarchy
 has to be a model of the
 concept
 `TriangulationHierarchyVertexBase_2` which extends
 the concept `TriangulationVertexBase_2`.
 This extension adds
-access and setting member functions 
-for two pointers to the corresponding vertices in the 
+access and setting member functions
+for two pointers to the corresponding vertices in the
 triangulations of the next and preceding levels.
 
 \cgal provides the class `Triangulation_hierarchy_vertex_base_2<Vb>`
-which is a model for the concept 
+which is a model for the concept
 `TriangulationHierarchyVertexBase_2`.
 This class is templated by a parameter `Vb`
 which is to be instantiated by a model of the concept
 `TriangulationVertexBase_2`.
 The class `Triangulation_hierarchy_vertex_base_2<Vb>` inherits
 from its template parameter `Vb`.
-This design enables the usage of 
+This design enables the usage of
 either the default
 vertex class or a user customized
 vertex class with additional functionalities  for `Vb`.
 
-\subsection Subsection_2D_Triangulations_Hierarchy_Examples Examples For the Use of a Triangulation Hierarchy 
+\subsection Subsection_2D_Triangulations_Hierarchy_Examples Examples For the Use of a Triangulation Hierarchy
 
 The following program is an example
 for the standard use of a triangulation hierarchy
@@ -1218,7 +1218,7 @@ a triangulation hierarchy in conjunction with a constrained triangulation with a
 
 
 
-\section Section_2D_Triangulations_Flexibility Flexibility 
+\section Section_2D_Triangulations_Flexibility Flexibility
 
 \subsection Triangulation_2UsingCustomizedVerticesand Using Customized Vertices and Faces
 
@@ -1232,7 +1232,7 @@ which the user can instantiate with his own customized classes.
 
 The most useful flexibility however comes from the fact
 that the triangulation data structure itself has two template
-parameters to be instantiated by 
+parameters to be instantiated by
 classes for the vertices and faces of the triangulation.
 Using his own customized classes to instantiate these
 parameters, the user can easily build up a triangulation with additional
@@ -1252,23 +1252,23 @@ structure, and there is a cyclic dependency on template parameter.
 The cyclic dependency in triangulations software design.
 \cgalFigureEnd
 
-Previously, this cyclic dependency was avoided by 
+Previously, this cyclic dependency was avoided by
 using only `void*` pointers in the interface of base classes.
 These `void*` were converted to appropriate types at the
 triangulation data structure levels. This solution had some drawbacks
-: mainly the user could not add in the vertices or faces of the 
-triangulation a functionality related to types defined by 
+: mainly the user could not add in the vertices or faces of the
+triangulation a functionality related to types defined by
 the triangulation data structure, for instance a handle to a vertex,
-and he was lead to use himself 
+and he was lead to use himself
 `void*` pointers).
 The new solution to resolve the template dependency
-is based on a rebind mechanism similar to the mechanism used in the 
+is based on a rebind mechanism similar to the mechanism used in the
 standard allocator class std::allocator. The rebind mechanism
-is described in Section \ref TDS_2D_default "The Default Triangulation Data Structure" 
+is described in Section \ref TDS_2D_default "The Default Triangulation Data Structure"
 of Chapter \ref Chapter_2D_Triangulation_Data_Structure "2D Triangulation Data Structure".
 For now, we will just notice that the design
 requires
-the existence in the vertex and face base classes 
+the existence in the vertex and face base classes
 of a nested template class
 `Rebind_TDS` defining a type `Other` used by
 the rebinding mechanism.
@@ -1279,17 +1279,17 @@ base classes parameters.
 
 \subsection Triangulation_2AddingColors Adding Colors
 
-The first example corresponds to a case where the user wishes to add in 
+The first example corresponds to a case where the user wishes to add in
 the vertices or faces of the triangulation an additional information
 that does not depend on types provided
-by the triangulation data structure. 
+by the triangulation data structure.
 In that case, predefined classes
 `Triangulation_vertex_base_with_info_2<Info,Traits,Vb>`
 or `Triangulation_face_base_with_info_2<Info,Traits,Vb>`
 can be used. Those classes have
 a template parameter `Info` devoted to
 handle additional information.
-The following example shows how to add a 
+The following example shows how to add a
 `Color` in the triangulation faces.
 
 \cgalExample{Triangulation_2/colored_face.cpp}
@@ -1303,8 +1303,8 @@ The second example adds a `std::string` in the vertices of a terrain.
 \subsection Triangulation_2AddingHandles Adding Handles
 
 This example shows how the user can still
-derive and plug in his own vertex 
-or face class when he would like to have 
+derive and plug in his own vertex
+or face class when he would like to have
 additional functionalities depending on types provided by the triangulation
 data structure.
 
@@ -1316,10 +1316,10 @@ The most efficient method to insert (weighted) points in a
 Delaunay (or regular) triangulation is to provide an iterator
 range over (weighted) points to the insert function. However, an iterator range of
 (weighted) points does not allow the user to set different information to each vertex.
-To solve this problem, in the case the vertex type of the triangulation 
+To solve this problem, in the case the vertex type of the triangulation
 is a model of the concept `TriangulationVertexBaseWithInfo_2`
-(such as `Triangulation_vertex_base_with_info_2`), we provide three examples 
-doing the same operation: set an unsigned integer as the information 
+(such as `Triangulation_vertex_base_with_info_2`), we provide three examples
+doing the same operation: set an unsigned integer as the information
 of each vertex. The value of this unsigned integer is the initial order
 of the corresponding point given in the range.
 
@@ -1349,10 +1349,10 @@ is dereferenced only once per point during the insertion.
 The code of this package is the result of a long development
 process. Here follows a tentative list of people
 who added their stone to this package:
-Jean-Daniel Boissonnat, Herv&eacute; Br&ouml;nnimann, 
+Jean-Daniel Boissonnat, Herv&eacute; Br&ouml;nnimann,
 Olivier Devillers, Andreas Fabri, Fr&eacute;d&eacute;ric Fichel,
 Julia Fl&ouml;totto, Monique Teillaud and Mariette Yvinec.
 
-*/ 
+*/
 } /* namespace CGAL */
 

--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -1,7 +1,7 @@
 namespace CGAL {
 /*!
 
-\mainpage User Manual
+\mainpage User Manual 
 \anchor Chapter_2D_Triangulations
 
 \cgalAutoToc
@@ -11,16 +11,16 @@ namespace CGAL {
 \image latex tr1dt1.png
 
 This chapter describes the two dimensional triangulations
-of \cgal.
+of \cgal. 
 Section \ref Section_2D_Triangulations_Definitions recalls the
 main definitions about triangulations.
 Section \ref Section_2D_Triangulations_Representation discusses
 the way two-dimensional triangulations are represented in \cgal.
 Section \ref Section_2D_Triangulations_Software_Design presents
 the overall software
-design of the 2D triangulations package.
+design of the 2D triangulations package. 
 The next sections present the different two dimensional triangulations classes
-available in \cgal:
+available in \cgal: 
 basic triangulations (Section \ref Section_2D_Triangulations_Basic),
 Delaunay triangulations
 (Section \ref Section_2D_Triangulations_Delaunay),
@@ -33,18 +33,18 @@ and constrained Delaunay triangulations
 Section \ref Section_2D_Triangulations_Constrained_Plus
 describes a class which implements a constrained or
 constrained Delaunay triangulation with
-an additional data structure
-to describe how the constraints are refined
+an additional data structure 
+to describe how the constraints are refined 
 by the edges of the triangulations.
 Section \ref Section_2D_Triangulations_Hierarchy
 describes a hierarchical data structure for
 fast point location queries.
-At last, Section \ref Section_2D_Triangulations_Flexibility
-explains how the user can benefit from the flexibility
+At last, Section \ref Section_2D_Triangulations_Flexibility 
+explains how the user can benefit from the flexibility 
 of \cgal triangulations using customized classes for faces
 and vertices.
 
-\section Section_2D_Triangulations_Definitions Definitions
+\section Section_2D_Triangulations_Definitions Definitions 
 
 A two dimensional triangulation can be roughly described as a set \f$ T\f$
 of triangular facets such that:
@@ -52,40 +52,40 @@ of triangular facets such that:
 - two facets either are disjoint or share a lower dimensional
 face (edge or vertex).
 
-- the set of facets in \f$ T\f$ is connected for the adjacency relation.
+- the set of facets in \f$ T\f$ is connected for the adjacency relation. 
 
 - the domain \f$ U_T\f$ which is the union
 of facets in \f$ T\f$ has no singularity.
 
-More precisely, a triangulation can be described
+More precisely, a triangulation can be described 
 as a simplicial complex.
 Let us first record a few definitions.
 
-A simplicial complex is a set \f$ T\f$ of simplices such that
+A simplicial complex is a set \f$ T\f$ of simplices such that 
 
-- any face of a simplex in \f$ T\f$ is a simplex in \f$ T\f$
+- any face of a simplex in \f$ T\f$ is a simplex in \f$ T\f$ 
 
 - two simplices in \f$ T\f$ either are disjoint or share
 a common sub-face.
 
-The dimension \f$ d\f$ of a simplicial complex is the
-maximal dimension of its simplices.
+The dimension \f$ d\f$ of a simplicial complex is the 
+maximal dimension of its simplices. 
 
 A simplicial complex \f$ T\f$ is pure if any simplex of \f$ T\f$
-is included in a simplex of \f$ T\f$ with maximal dimension.
+is included in a simplex of \f$ T\f$ with maximal dimension. 
 
 Two simplexes in \f$ T\f$ with maximal dimension \f$ d\f$ are said to be
 adjacent if they share a \f$ d-1\f$ dimensional sub-face.
 A simplicial complex is connected if the adjacency relation
-defines a connected graph
-over the set of simplices of \f$ T\f$ with maximal dimension.
+defines a connected graph 
+over the set of simplices of \f$ T\f$ with maximal dimension. 
 
 The union \f$ U_T\f$ of all simplices in \f$ T\f$ is called the domain of \f$ T\f$.
-A point \f$ p\f$ in the domain of \f$ T\f$ is said to singular
+A point \f$ p\f$ in the domain of \f$ T\f$ is said to singular 
 if its surrounding in \f$ U_T\f$
 is neither a topological ball nor a topological disc.
 
-Then, a two dimensional triangulation can be described as a
+Then, a two dimensional triangulation can be described as a 
 two dimensional simplicial complex that is pure,
 connected and without singularity.
 
@@ -94,14 +94,14 @@ which in turn induces an orientation
 on the edges incident to that facet. The orientation of two adjacent
 facets are said to be consistent if they induce
 opposite orientations on their common incident edge.
-A triangulation is said to be orientable if
+A triangulation is said to be orientable if 
 the orientation of each facet can be chosen in such a way
 that all pairs of incident facets have consistent orientations.
 
 The data structure underlying \cgal triangulations
-allows the user to represent the combinatorics of
+allows the user to represent the combinatorics of 
 any orientable two dimensional triangulations
-without boundaries.
+without boundaries. 
 On top of this data structure, the 2D triangulations classes
 take care of the geometric embedding of the triangulation
 and are designed to handle planar triangulations.
@@ -114,32 +114,32 @@ convex hull of their vertices.
 Because any planar triangulation
 can be completed, this is not a real restriction.
 For instance, a triangulation of a polygonal region can be
-constructed and represented as a subset of a constrained triangulation
-in which the region boundary edges have been input as
+constructed and represented as a subset of a constrained triangulation 
+in which the region boundary edges have been input as 
 constrained edges (see
 Section \ref Section_2D_Triangulations_Constrained,
-\ref Section_2D_Triangulations_Constrained_Delaunay and
+\ref Section_2D_Triangulations_Constrained_Delaunay and 
 \ref Section_2D_Triangulations_Constrained_Plus).
 
 Strictly speaking, the term <I>face</I> should be used
 to design a face of any dimension,
-and the two-dimensional faces of a triangulation
+and the two-dimensional faces of a triangulation 
 should be properly called <I>facets</I>.
 However, following a common usage, we hereafter often call <I>faces</I>, the facets
 of a two dimensional triangulation.
 
-\section Section_2D_Triangulations_Representation Representation
+\section Section_2D_Triangulations_Representation Representation 
 
 \subsection Triangulation_2TheSetofFaces The Set of Faces
 
-A 2D triangulation of \cgal can be viewed as a planar partition
+A 2D triangulation of \cgal can be viewed as a planar partition 
 whose bounded faces are triangular and cover
-the convex hull of the set of vertices.
+the convex hull of the set of vertices. 
 The single unbounded face of this partition
-is the complementary of the convex hull.
+is the complementary of the convex hull. 
 In many applications, such as Kirkpatrick's hierarchy
 or incremental Delaunay construction, it is convenient to
-deal with only triangular faces. Therefore,
+deal with only triangular faces. Therefore, 
 a fictitious vertex, called the *infinite vertex*
 is added to the triangulation as well as
 *infinite edges* and *infinite faces* incident to it.
@@ -155,7 +155,7 @@ equivalent to a two-dimensional sphere.
 This extends to lower dimensional triangulations
 arising in degenerate cases or when the triangulations
 as less than three vertices.
-Including the infinite faces,
+Including the infinite faces, 
 a one dimensional triangulation
 is a ring of edges and vertices
 topologically equivalent to a \f$ 1\f$-sphere.
@@ -185,16 +185,16 @@ saves storage space and results in faster
 algorithms \cgalCite{bdty-tcgal-00}.
 
 The basic elements of the representation are vertices and faces.
-Each triangular face gives access to its three incident vertices
-and to its three adjacent faces.
+Each triangular face gives access to its three incident vertices 
+and to its three adjacent faces. 
 Each vertex gives access to one of its incident faces
 and through that face to the circular list of its incident faces.
 
 The three vertices of a face are indexed with 0, 1 and 2
-in counterclockwise order. The neighbors of a face are also
+in counterclockwise order. The neighbors of a face are also 
 indexed with 0,1,2 in such a way that the neighbor indexed by `i`
 is opposite to the vertex with the same index.
-See \cgalFigureRef{Triangulation_2D_Fig_neighbors1},
+See \cgalFigureRef{Triangulation_2D_Fig_neighbors1}, 
 the functions `ccw(i)`
 and `cw(i)` shown on this figure
 compute respectively \f$ i+1\f$ and \f$ i-1\f$ modulo 3.
@@ -203,21 +203,21 @@ The edges are not explicitly represented, they are only implicitly
 represented through the adjacency relations of two faces.
 Each edge has two implicit representations: the edge
 of a face `f` which is opposed to the vertex indexed `i`,
-can be represented as well as an edge of the `neighbor(i)` of
+can be represented as well as an edge of the `neighbor(i)` of 
 `f`.
 
 \cgalFigureBegin{Triangulation_2D_Fig_neighbors1,rep_bis.png}
 Vertices and neighbors.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Software_Design Software Design
+\section Section_2D_Triangulations_Software_Design Software Design 
 
-The triangulations classes of \cgal
+The triangulations classes of \cgal 
 provide high-level geometric functionalities
 such as location of a point in the triangulation, insertion, removal, or displacement of a point.
 They are build as a layer on top of a data structure
 called the triangulation data structure.
-The triangulation data structure can be thought
+The triangulation data structure can be thought 
 of as a container for the faces and vertices of the triangulation.
 This data structure also takes care
 of all the combinatorial aspects of the triangulation.
@@ -229,8 +229,8 @@ that the triangulation classes have two template parameters:
 
 <UL>
 <LI> the first parameter stands for a
-<B>geometric traits</B> class providing
-the geometric primitives (points, segments and triangles)
+<B>geometric traits</B> class providing 
+the geometric primitives (points, segments and triangles) 
 of the triangulation and the elementary
 operations (predicate or constructions) on those objects.
 
@@ -249,14 +249,14 @@ as a default model of triangulation data structure.
 The class `Triangulation_data_structure_2<Vb,Fb>`
 has two template parameters standing for
 a vertex class and a face class.
-\cgal defines concepts
+\cgal defines concepts 
 for these template parameters
 and provide default models for these concepts.
 The vertex and base classes are templated by the geometric
 traits class which enables them to obtain some knowledge of the geometric
-primitives of the triangulation.
+primitives of the triangulation. 
 Those default vertex and face base classes
-can be replaced by
+can be replaced by 
 user customized base classes in order, for example, to deal
 with additional properties attached to the vertices or faces
 of a triangulation. See Section \ref Section_2D_Triangulations_Flexibility
@@ -272,58 +272,58 @@ forming this design.
 The triangulations software design.
 \cgalFigureEnd
 
-The top triangulation level, responsible for the geometric
-embedding of the triangulation comes in different flavors
+The top triangulation level, responsible for the geometric 
+embedding of the triangulation comes in different flavors 
 according to the different kind of triangulations:
 basic, Delaunay, regular, constrained or constrained Delaunay.
 Each kind of triangulations correspond to a different
-class.
+class. 
 \cgalFigureRef{Triangulation_2D_Fig_derivation_tree} summarizes the derivation dependencies
 of \cgal 2D triangulations classes.
 Any 2D triangulation class is parametrized by
 a geometric traits class and a triangulation data structure.
 While a unique concept `TriangulationDataStructure_2`
 describes the triangulation data structure requirements
-for any triangulation class,
+for any triangulation class, 
 the requirements on the geometric traits class actually depend
 on the triangulation class.
-In general, the requirements for the vertex and face base classes
+In general, the requirements for the vertex and face base classes 
 are described by the basic concepts `TriangulationVertexBase_2`
 and `TriangulationFaceBase_2`. However, some triangulation
 classes require base classes implementing
-refinements
+refinements 
 of the basic concepts.
 
 \cgalFigureBegin{Triangulation_2D_Fig_derivation_tree,derivation_tree.png}
 The derivation tree of 2D triangulations.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Basic Basic Triangulations
+\section Section_2D_Triangulations_Basic Basic Triangulations 
 
-\subsection Subsection_2D_Triangulations_Basic_Description Description
+\subsection Subsection_2D_Triangulations_Basic_Description Description 
 
 The class `Triangulation_2<Traits,Tds>`
 serves as a base class for the other
 2D triangulations classes
-and
+and 
 implements the user
 interface to a triangulation.
 
-The vertices and faces of the triangulations are accessed through
+The vertices and faces of the triangulations are accessed through 
 `handles`,
 `iterators` and `circulators`.
 A handle is a model of the concept `Handle` which basically
 offers the two dereference operators `*` and `->`.
 A circulator is a type devoted to visit circular sequences.
-Handles are used whenever the accessed element
+Handles are used whenever the accessed element 
 is not part of a sequence.
 Iterators and circulators are used
 to visit all or parts of the triangulation.
 
 The iterators and circulators
 are all bidirectional and non mutable.
-The circulators and iterators are convertible to the
-handles with the same value type, so that
+The circulators and iterators are convertible to the 
+handles with the same value type, so that 
 when calling a member function,
 any handle type argument can be replaced
 by an iterator or a circulator
@@ -332,18 +332,18 @@ with the same value type.
 The triangulation class provides a function to visit the vertices
 and neighbors of a face in clockwise or counterclockwise order.
 
-There are circulators
-to visit the edges or faces
-incident to a given vertex or the vertices
+There are circulators 
+to visit the edges or faces 
+incident to a given vertex or the vertices 
 adjacent to it.
 Another circulator type enables the visit of all the faces
 traversed by a given line.
-Circulators step through infinite features as well as
+Circulators step through infinite features as well as 
 through finite ones.
 
-The triangulation class offers
-some iterators to visit all the
-faces, edges or vertices and also iterators to visit
+The triangulation class offers 
+some iterators to visit all the 
+faces, edges or vertices and also iterators to visit 
 selectively the finite
 faces, edges or vertices.
 
@@ -356,7 +356,7 @@ The triangulation class provides a method to locate
 a given point with respect to a triangulation.
 In particular, this method reports whether the point
 coincides with a vertex of the triangulation, lies on an edge,
-in a face or outside of the convex hull. In case of a degenerate
+in a face or outside of the convex hull. In case of a degenerate 
 lower dimensional triangulation, the query point may also lie
 outside the triangulation affine hull.
 
@@ -364,7 +364,7 @@ The triangulation class also provides
 methods to locate a point with respect to
 a given finite face of the triangulation or with respect to its
 circumcircle.
-The faces of the triangulation and their circumcircles
+The faces of the triangulation and their circumcircles 
 have the counterclockwise orientation.
 
 The triangulation can be modified by several functions:
@@ -405,7 +405,7 @@ if no optional argument is given. It takes
 time \f$ O(n)\f$ in the worst case for Delaunay Triangulations, but only \f$ O(\sqrt{n})\f$
 on average if the vertices are distributed uniformly at random.
 The class `Triangulation_hierarchy_2<Traits,Tds>`,
-described in section \ref Section_2D_Triangulations_Hierarchy,
+described in section \ref Section_2D_Triangulations_Hierarchy, 
 implements a data structure designed to
 offer an alternate more efficient point location algorithm.
 
@@ -423,7 +423,7 @@ re-triangulating the hole. Removal takes a time at most proportional to
 which is \f$ O(1)\f$ for a random vertex.
 
 Displacement of a vertex is done by: first, verifying if the triangulation embedding
-remains planar after the displacement; if yes the vertex is directly placed at the new location; otherwise, a point is inserted at the new location
+remains planar after the displacement; if yes the vertex is directly placed at the new location; otherwise, a point is inserted at the new location 
 and the vertex at the obsolete location is removed.
 
 The face, edge, and vertex iterators on finite features
@@ -431,36 +431,36 @@ are derived from their counterparts visiting all (finite and infinite)
 features which are themselves derived from the corresponding iterators
 of the triangulation data structure.
 
-\subsection Subsubsection_2D_Triangulation_Basic_Geometric_Traits Geometric Traits
+\subsection Subsubsection_2D_Triangulation_Basic_Geometric_Traits Geometric Traits 
 
-The geometric traits class of a triangulation
+The geometric traits class of a triangulation 
 is required to provide
 the geometric objects (points, segments and triangles)
 building up the triangulation
 together with the geometric predicates on those objects.
-The required predicates are:
+The required predicates are: 
 
 - comparison of the `x` or `y` coordinates of two points.
 
-- the orientation test which computes
+- the orientation test which computes 
 the order type of three given point.
 
 The concept
-`TriangulationTraits_2` describes the requirements for the
+`TriangulationTraits_2` describes the requirements for the 
 geometric traits class of a triangulation.
-The \cgal kernel classes
+The \cgal kernel classes 
 are models for this concept.
 The \cgal library also provides dedicated models
-of `TriangulationTraits_2`
+of `TriangulationTraits_2` 
 using the kernel geometric objects and predicates.
 These classes are themselves templated with a \cgal kernel
 and extract the required types and predicates from the kernel.
-The class `Projection_traits_xy_3<R>`
+The class `Projection_traits_xy_3<R>` 
 is a geometric traits class to build the triangulation
 of a terrain. Such a triangulation is a two-dimensional
 triangulation embedded in three dimensional space.
 The data points are three-dimensional points.
-The triangulation is
+The triangulation is 
 build according to the projections of those points
 on the \f$ xy\f$ plane and then lifted up to the original
 three-dimensional data points.
@@ -479,15 +479,15 @@ deal with projections on the
 `yz` plane and `xz`-plane,
 respectively.
 
-\subsection Subsection_2D_Triangulations_Basic_Example Example of a Basic Triangulation
+\subsection Subsection_2D_Triangulations_Basic_Example Example of a Basic Triangulation 
 
 The following program creates a triangulation of 2D points
-using the default kernel
+using the default kernel 
 `Exact_predicate_inexact_constructions_kernel`
 as geometric traits class and the default triangulation data structure.
-The input points are read from a file
+The input points are read from a file 
 and inserted in the triangulation.
-Finally points on the convex hull are written to <TT>cout</TT>.
+Finally points on the convex hull are written to <TT>cout</TT>. 
 \cgalExample{Triangulation_2/triangulation_prog1.cpp}
 
 \subsection Triangulation2Draw Draw a 2D Triangulation
@@ -503,17 +503,17 @@ This function requires CGAL_Qt5, and is only available if the flag CGAL_USE_BASI
 Result of the run of the draw_triangulation_2 program. A window shows the 2D triangulation and allows to navigate through the scene.
 \cgalFigureEnd
 
-\section Section_2D_Triangulations_Delaunay Delaunay Triangulations
+\section Section_2D_Triangulations_Delaunay Delaunay Triangulations 
 
-\subsection Subsection_2D_Triangulations_Delaunay_Description Description
+\subsection Subsection_2D_Triangulations_Delaunay_Description Description 
 
 The class `Delaunay_triangulation_2<Traits,Tds>` is designed to represent
 the Delaunay triangulation of a set of data points in the plane.
 A Delaunay triangulation
 fulfills
-the following <I>empty circle property</I>
+the following <I>empty circle property</I> 
 (also called <I>Delaunay property</I>): the circumscribing
-circle of any facet of the triangulation
+circle of any facet of the triangulation 
 contains no data point in its interior.
 For a point set with no subset of four co-circular points
 the Delaunay triangulation is unique, it is dual
@@ -523,7 +523,7 @@ The class `Delaunay_triangulation_2<Traits,Tds>` derives
 from the class `Triangulation_2<Traits,Tds>`.
 
 The class `Delaunay_triangulation_2<Traits,Tds>`
-inherits the types defined by the
+inherits the types defined by the 
 basic class `Triangulation_2<Traits,Tds>`.
 Additional types, provided by the traits class,
 are defined to represent the dual Voronoi diagram.
@@ -536,7 +536,7 @@ to answer nearest neighbor queries
 and member functions to construct the elements (vertices and edges)
 of the dual Voronoi diagram.
 
-Geometric Traits
+Geometric Traits 
 --------------
 
 The geometric traits class has to be a model of the concept
@@ -546,43 +546,43 @@ In particular this concept provides
 the `side_of_oriented_circle` predicate
 which, given four points `p,q,r,s`
 decides the position of the point \f$ s\f$ with respect to the circle
-passing through \f$ p\f$, \f$ q\f$ and \f$ r\f$.
+passing through \f$ p\f$, \f$ q\f$ and \f$ r\f$. 
 The `side_of_oriented_circle`
 predicate actually defines the Delaunay triangulation.
-Changing this predicate
+Changing this predicate 
 allows the user to build variant of Delaunay triangulations for different metrics
 such that \f$ L_1\f$ or \f$ L_{\infty}\f$ metric or any metric defined by a
 convex object. However, the user of an exotic metric
-must be careful that the constructed triangulation
+must be careful that the constructed triangulation 
 has to be a triangulation of the convex hull
 which means that convex hull edges have to be Delaunay edges.
 This is granted for any smooth convex metric (like \f$ L_2\f$)
 and can be ensured for other metrics (like \f$ L_{\infty}\f$)
 by the addition to the point set of well chosen sentinel points.
 
-The \cgal kernel classes
+The \cgal kernel classes 
 are models of the concept `DelaunayTriangulationTraits_2`
 for the Euclidean metric.
 The traits class for terrains,
 `Projection_traits_xy_3<R>`,
 `Projection_traits_yz_3<R>`, and
-`Projection_traits_xz_3<R>`
+`Projection_traits_xz_3<R>` 
 are also models of `DelaunayTriangulationTraits_2`
 except that they do not fulfill
 the requirements for the duality functions and nearest vertex
 queries.
 
-Implementation
+Implementation 
 --------------
 
 The insertion of a new point in the Delaunay triangulation
 is performed using first the insertion member function
-of the basic triangulation and second
-performing a sequence of flips to restore the Delaunay property.
+of the basic triangulation and second 
+performing a sequence of flips to restore the Delaunay property. 
 The number of flips that have to be performed is \f$ O(d)\f$
 if the new vertex has degree \f$ d\f$ in the updated
 Delaunay triangulation. For
-points distributed uniformly at random,
+points distributed uniformly at random, 
 each insertion takes time \f$ O(1)\f$ on
 average, once the point has been located in the triangulation.
 
@@ -598,9 +598,9 @@ for random points \cgalCite{d-vrtdd-09}.
 
 The displacement of a vertex \f$ v\f$ at a point \f$ p\f$ to a new location \f$ p'\f$, first checks whether the triangulation embedding remains
 planar or not after moving \f$ v\f$ to \f$ p'\f$. If yes, it moves \f$ v\f$ to \f$ p'\f$ and simply performs a sequence of flips
-to restore the Delaunay property, which is \f$ O(d)\f$ where \f$ d\f$ is the degree of the vertex after the displacement.
+to restore the Delaunay property, which is \f$ O(d)\f$ where \f$ d\f$ is the degree of the vertex after the displacement. 
 Otherwise, the displacement is done by inserting a vertex at the new location,
-and removing the obsolete vertex.
+and removing the obsolete vertex. 
 The complexity is \f$ O(n)\f$ in the worst case, but only \f$ O(1 + \delta \sqrt{n})\f$ for evenly distributed vertices in the unit square, where \f$ \delta\f$ is the Euclidean distance between the new and old locations.
 
 After having performed a point location, the
@@ -608,20 +608,20 @@ nearest neighbor of a point is found in time \f$ O(n)\f$ in the
 worst case, but in time \f$ O(1)\f$
 for vertices distributed uniformly at random and any query point.
 
-\subsection Subsection_2D_Triangulations_Delaunay_Terrain Example: a Delaunay Terrain
+\subsection Subsection_2D_Triangulations_Delaunay_Terrain Example: a Delaunay Terrain 
 
-The following code creates a Delaunay triangulation with
-the usual Euclidean metric for the vertical projection of a
+The following code creates a Delaunay triangulation with 
+the usual Euclidean metric for the vertical projection of a 
 terrain model. The points have elevation, that is they are 3D points,
 but the predicates used to build the Delaunay triangulation
-are computed using only the \f$ x\f$ and \f$ y\f$ coordinates
+are computed using only the \f$ x\f$ and \f$ y\f$ coordinates 
 of these points.
 
 The class `Projection_traits_xy_3<K>` is part of the 2D and 3D Linear Geometric Kernel.
 
 \cgalExample{Triangulation_2/terrain.cpp}
 
-\subsection Subsection_2D_Triangulations_Voronoi Example: Voronoi Diagram
+\subsection Subsection_2D_Triangulations_Voronoi Example: Voronoi Diagram 
 
 The following code computes the edges of Voronoi diagram
 of a set of data points
@@ -629,9 +629,9 @@ and counts the number of finite edges and the number of rays
 of this diagram
 \cgalExample{Triangulation_2/voronoi.cpp}
 
-\subsection Subsection_2D_Triangulations_Cropped_Voronoi Example: Print Voronoi Diagram Edges Restricted to a Rectangle
+\subsection Subsection_2D_Triangulations_Cropped_Voronoi Example: Print Voronoi Diagram Edges Restricted to a Rectangle 
 
-The following code computes the Delaunay triangulation of a set of points and prints the Voronoi edges
+The following code computes the Delaunay triangulation of a set of points and prints the Voronoi edges 
 restricted to a given rectangle.
 
 \cgalFigureBegin{figurecropped_voronoi,cropped_voronoi.png}
@@ -640,11 +640,11 @@ Voronoi diagram (in red) of the black points restricted to the blue rectangle.
 
 \cgalExample{Triangulation_2/print_cropped_voronoi.cpp}
 
-\section Section_2D_Triangulations_Regular Regular Triangulations
+\section Section_2D_Triangulations_Regular Regular Triangulations 
 
-\subsection Subsection_2D_Triangulations_Regular_Description Description
+\subsection Subsection_2D_Triangulations_Regular_Description Description 
 
-Let \f$ { PW} = \{(p_i, w_i) | i = 1, \ldots , n \}\f$ be a set of
+Let \f$ { PW} = \{(p_i, w_i) | i = 1, \ldots , n \}\f$ be a set of 
 weighted points where each \f$ p_i\f$ is a point and each \f$ w_i\f$
 is a scalar called the weight of point \f$ p_i\f$.
 Alternatively, each weighted point \f$ (p_i, w_i)\f$ can be regarded
@@ -654,18 +654,18 @@ of \f$ p_i\f$) with center \f$ p_i\f$ and radius \f$ r_i=\sqrt{w_i}\f$.
 The power diagram of the set \f$ { PW}\f$ is a space partition in which
 each cell corresponds to a sphere \f$ (p_i, w_i)\f$ of \f$ { PW}\f$
 and is the locus of points \f$ p\f$ whose power with respect to \f$ (p_i, w_i)\f$
-is less than its power with respect to any other sphere
+is less than its power with respect to any other sphere 
 in \f$ { PW}\f$. In the two-dimensional space,
-the dual of this diagram is a triangulation
-whose domain covers the convex hull of the set
+the dual of this diagram is a triangulation 
+whose domain covers the convex hull of the set 
 \f$ { P}= \{ p_i | i = 1, \ldots , n \}\f$ of center points
 and whose vertices form a subset of \f$ { P}\f$.
 Such a triangulation is called a regular triangulation.
 Three points \f$ p_i, p_j\f$ and \f$ p_k\f$ of \f$ { P}\f$
 form a triangle in the regular triangulation of \f$ { PW}\f$
-iff there is a point \f$ p\f$ of the plane with equal
+iff there is a point \f$ p\f$ of the plane with equal 
 powers with respect to \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$
-and \f$ (p_k, w_k)\f$ and such that this power
+and \f$ (p_k, w_k)\f$ and such that this power 
 is less than the power of \f$ p\f$
 with respect to any other sphere in \f$ { PW}\f$.
 
@@ -673,7 +673,7 @@ Let us defined the power product of two weighted points
 \f$ (p_i, w_i)\f$ and \f$ (p_j, w_j)\f$ as:
 \f[ \Pi(p_i, w_i, p_j, w_j) = p_ip_j ^2 - w_i - w_j . \f]
 \f$ \Pi(p_i, w_i, p_j, 0)\f$ is simply the power of point \f$ p_j\f$
-with respect to the sphere \f$ (p_i, w_i)\f$, and two weighted points
+with respect to the sphere \f$ (p_i, w_i)\f$, and two weighted points 
 are said to be orthogonal if their power product is null.
 The power circle of three weighted points
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$
@@ -683,7 +683,7 @@ and \f$ (p_k, w_k)\f$ is defined as the unique circle
 and \f$ (p_k, w_k)\f$.
 
 The regular triangulation of the sets \f$ { PW}\f$
-satisfies the following <I>regular property</I> (which just reduces to the
+satisfies the following <I>regular property</I> (which just reduces to the 
 Delaunay property when all the weights are null):
 a triangle \f$ p_ip_jp_k\f$ is a face of the regular triangulation
 of \f$ { PW}\f$ iff the power product of any weighted point
@@ -691,7 +691,7 @@ of \f$ { PW}\f$ iff the power product of any weighted point
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$ and \f$ (p_k, w_k)\f$ is positive or null.
 We call power test of \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$, \f$ (p_k, w_k)\f$,
 and \f$ (p_l, w_l)\f$, the predicates which amount to compute
-the sign of
+the sign of 
 the power product of \f$ (p_l, w_l)\f$ with respect to
 the power circle of
 \f$ (p_i, w_i)\f$, \f$ (p_j, w_j)\f$ and \f$ (p_k, w_k)\f$.
@@ -722,18 +722,18 @@ Alternatively, the regular triangulation
 of the weighted points set \f$ { PW}\f$
 can be obtained as the projection
 on the two dimensional plane of the convex hull of the set of three
-dimensional points
+dimensional points 
 \f$ { P'}= \{ (p_i,p_i ^2 - w_i ) | i = 1, \ldots , n \}\f$.
 
 The class `Regular_triangulation_2<Traits, Tds>`
 is designed to maintain the
 regular triangulation of a set of \f$ 2d\f$ weighted points.
 It derives from the class `Triangulation_2<Traits, Tds>`.
-The functions `insert` and
+The functions `insert` and 
 `remove` are overwritten to handle weighted points
 and maintain the regular
 property.
-The function `move()` is not
+The function `move()` is not 
 overwritten and thus does not preserve the regular property.
 The vertices of the regular triangulation
 of a set of weighted points \f$ {PW}\f$ correspond only to a subset
@@ -745,14 +745,14 @@ triangulation.
 Such a point is called a hidden point.
 Because hidden points can reappear later on as vertices
 when some other point is removed,
-they have to be stored somewhere.
+they have to be stored somewhere. 
 The regular triangulation store those points in special vertices, called
-hidden vertices.
+hidden vertices. 
 A hidden point can reappear as vertex of the triangulation
 only when the two dimensional face that hides it
 is removed from the triangulation. To deal with this feature,
 each face of a regular triangulation stores a list of hidden vertices.
-The points in those vertices
+The points in those vertices 
 are reinserted in the triangulation when the face
 is removed.
 
@@ -764,7 +764,7 @@ the vertices and edges of the dual power diagrams.
 The geometric traits class of a regular triangulation
 must provide a weighted point type
 and a power test on these weighted points.
-The concept
+The concept 
 `RegularTriangulationTraits_2`,
 is a refinement of the concept
 `TriangulationTraits_2`. All \cgal kernels are a model for the traits concept
@@ -778,31 +778,31 @@ includes a Boolean data member to mark the hidden state of the vertex.
 Therefore \cgal defines the concept
 `RegularTriangulationVertexBase_2` which refine
 the concept `TriangulationVertexBase_2`
-and provides a default model
+and provides a default model 
 for this concept.
 
 The face base type of a regular triangulation
 is required to provide a list of hidden vertices,
 designed to store the points hidden by the face. It has to be a model
 of the concept `RegularTriangulationFaceBase_2`.
-\cgal provides the templated class
+\cgal provides the templated class 
 `Regular_triangulation_face_base_2<Traits>`
 as a default base class for faces of regular triangulations.
 
-\subsection Subsection_2D_Triangulations_Regular_Example Example: a Regular Triangulation
+\subsection Subsection_2D_Triangulations_Regular_Example Example: a Regular Triangulation 
 
-The following code creates a regular triangulation
+The following code creates a regular triangulation 
 of a set of weighted points and output the number
 of vertices and the number of hidden vertices.
 
 \cgalExample{Triangulation_2/regular.cpp}
 
-\section Section_2D_Triangulations_Constrained Constrained Triangulations
+\section Section_2D_Triangulations_Constrained Constrained Triangulations 
 
 A constrained triangulation is a triangulation of a set of points
-that has to include among its edges
+that has to include among its edges 
 a given set of polylines joining the points. The
-polylines are called *constraints*. The corresponding
+polylines are called *constraints*. The corresponding 
 edges are called *constrained edges*.
 
 The endpoints of constrained edges are of course vertices of the
@@ -810,8 +810,8 @@ triangulation. However, the triangulation may
 include other vertices as well.
 There are three versions of constrained triangulations.
 <UL>
-<LI>In the basic version, the constrained triangulation
-does not handle intersecting constraints, and the set of input
+<LI>In the basic version, the constrained triangulation 
+does not handle intersecting constraints, and the set of input 
 constraints is required to be a set of segments that do not intersect,
 except possibly at their endpoints. Any number of constrained edges
 may share the same endpoint. Constrained edges may be vertical or
@@ -820,7 +820,7 @@ have zero length.
 In those versions, input constraints may consist of intersecting,
 overlapping or partially overlapping segments.
 The triangulation introduces additional vertices at each point that
-is the proper intersection point of two
+is the proper intersection point of two 
 constraints. A single constraint intersecting other
 constraints will then appear as several constrained edges in the triangulation.
 There are two ways to deal with intersecting constraints.
@@ -861,10 +861,10 @@ from a list of pairs of points which represent the constraints.
 
 The class `Constrained_triangulation_2<Traits,Tds,Itag>`
 overrides the insertion and removal of a point to take care of the
-information about constrained edges. The class also allows the user
+information about constrained edges. The class also allows the user 
 online insertion of a new constraint, given as sequence of points,
 or the removal of a constraint.
-In the current version, the function `move()` is not
+In the current version, the function `move()` is not 
 overwritten and thus does not handle vertices of constraints.
 
 In order to retrieve the constrained edges of a constraint, or
@@ -880,8 +880,8 @@ as it avoids the cascading of intersection computations.
 The geometric traits class of a constraint triangulation
 has to be a model
 of the concept `TriangulationTraits_2`.
-When intersections of input constraints are supported,
-the geometric traits class has to be a model
+When intersections of input constraints are supported, 
+the geometric traits class has to be a model 
 of the concept `ConstrainedTriangulationTraits_2`,
 which refines the concept `TriangulationTraits_2`
 providing additional function object types
@@ -889,7 +889,7 @@ to compute the intersection of two segments.
 
 \subsection Triangulation_2TheFaceBaseClassofaConstrained The Face Base Class of a Constrained Triangulation
 
-The information about constrained edges is stored in the
+The information about constrained edges is stored in the 
 faces of the triangulation. The face base of a Constrained Triangulation
 has to be a model for the concept `ConstrainedTriangulationFaceBase_2`
 which refines the concept `TriangulationFaceBase_2`.
@@ -909,7 +909,7 @@ Constrained and Constrained Delaunay triangulation: the constraining edges are t
 \cgalFigureEnd
 
 
-\section Section_2D_Triangulations_Constrained_Delaunay Constrained Delaunay Triangulations
+\section Section_2D_Triangulations_Constrained_Delaunay Constrained Delaunay Triangulations 
 
 A constrained Delaunay triangulation is a triangulation with
 constrained edges which try to be as much Delaunay as possible.
@@ -919,16 +919,16 @@ necessarily fulfill the empty circle property
 but they fulfill a weaker *constrained empty circle property*.
 To state this property,
 it is convenient to think of constrained
-edges as blocking the view. Then, a triangulation is
+edges as blocking the view. Then, a triangulation is 
 constrained Delaunay iff
 the circumscribing circle
-of any facet encloses
+of any facet encloses 
 no vertex visible
 from the interior of the facet.
 As in the case of constrained triangulations, three different versions
 of Delaunay constrained triangulations are provided. The first version
 handles a set of constraints which do not intersect except possibly
-at the endpoints. The two other versions
+at the endpoints. The two other versions 
 handle intersecting input constraints. One of them
 is designed to be robust
 when used in conjunction with a geometric traits class
@@ -942,7 +942,7 @@ The \cgal class
 is designed to represent
 constrained Delaunay triangulations.
 
-As in the case of constrained triangulations, the third parameter
+As in the case of constrained triangulations, the third parameter 
 `Itag` is the intersection tag
 and serves to choose how intersecting constraints
 are dealt with. It can be instantiated with one of the following
@@ -958,7 +958,7 @@ derives from
 the class `Constrained_triangulation_2<Traits,Tds,Itag>`.
 
 The constrained Delaunay triangulation
-has member functions to override the
+has member functions to override the 
 insertion and removal of a point or of a constraint.
 Each of those member functions takes care
 to restore
@@ -967,13 +967,13 @@ property.
 
 \subsection Triangulation_2TheGeometricTraits_2 The Geometric Traits
 
-The geometric traits class
+The geometric traits class 
 of a constrained Delaunay triangulation is required
 to provide the `side_of_oriented_circle` predicate as the geometric traits
 class of a Delaunay triangulation, and has to be a model of the concept
 `DelaunayTriangulationTraits_2`. When intersecting input
 constraints
-is supported, the geometric traits class is further required
+is supported, the geometric traits class is further required 
 to provide function objects to compute constraints intersections.
 Then, the geometric traits class has to be at the same time a model
 of the concept `ConstrainedTriangulationTraits_2`.
@@ -987,19 +987,19 @@ and the face base class
 of a constrained Delaunay triangulation has to be a model
 of `ConstrainedTriangulationFaceBase_2`.
 
-\subsection Subsection_2D_Triangulations_Constrained_Delaunay_Example Example: a Constrained Delaunay Triangulation
+\subsection Subsection_2D_Triangulations_Constrained_Delaunay_Example Example: a Constrained Delaunay Triangulation 
 
 The following code inserts a set of intersecting constraint segments
-into a triangulation
+into a triangulation 
 and counts the number of constrained edges of the
 resulting triangulation.
 
 \cgalExample{Triangulation_2/constrained.cpp}
 
-\subsection Subsection_2D_Triangulations_Polygon_triangulation Example: Triangulating a Polygonal Domain
+\subsection Subsection_2D_Triangulations_Polygon_triangulation Example: Triangulating a Polygonal Domain 
 
 The following code inserts two nested polygons into a constrained Delaunay triangulation and counts the number of facets that
-are inside the domain delimited by these polygons. Note that the following code does not work if the
+are inside the domain delimited by these polygons. Note that the following code does not work if the 
 boundaries of the polygons intersect.
 
 \cgalFigureBegin{figuretri_domain,tri_domain.png}
@@ -1012,7 +1012,7 @@ Triangulation (in blue) of the domain delimited by the red polygons.
 
 The class `Constrained_triangulation_plus_2<Tr>`
 provides a constrained triangulation with an additional data
-structure
+structure 
 that keeps track of the input constraints and of their refinement
 in the triangulation.
 The class `Constrained_triangulation_plus_2<Tr>`
@@ -1047,7 +1047,7 @@ For a pair `(fh,i)` it is the edge of the face `*fh`, which is opposite to the `
 A <em>constrained edge</em> `e` is an edge of a constrained triangulation `ct`, for which `ct.is_constrained(e)` returns `true`.
 
 A <em>constraint</em> is a polyline which is given as input (in the simplest case just a segment), and
-which is split into constrained edges in the triangulation.
+which is split into constrained edges in the triangulation. 
 
 The type `Subconstraint` is defined as `typedef std::pair<Vertex_handle,Vertex_handle> Subconstraint`.  The two vertex handles must
 be the vertices of a constrained edge.
@@ -1061,7 +1061,7 @@ and offer a `Constrained_edges_iterator`.
 The class `Constrained_triangulation_plus_2` additionally provides the means to
 - traverse all the constraints of the triangulation using an iterator of type `Constraint_iterator` the value type of which is `Constraint_id`,
 - obtain all constraints that induce a constrained edge or a subconstraint,
-- traverse the sequence of vertices of a constraint  using an iterator of type `Vertices_in_constraint_iterator`, the value type of which is `Vertex_handle`
+- traverse the sequence of vertices of a constraint  using an iterator of type `Vertices_in_constraint_iterator`, the value type of which is `Vertex_handle` 
 - traverse the subconstraints in the triangulation  using an iterator of type `Subconstraint_iterator`, the value type of which is `Subconstraint`.
 
 Note that the `Constrained_edges_iterator` and the `Subconstraint_iterator` are quite similar.
@@ -1108,8 +1108,8 @@ define an input segment that induce `e`.
 The following code inserts two polyline constraints into a triangulation.
 Note that if the triangulation supports intersections we can have
 arbitrary complicated overlapping polylines.  They can share
-any number of edges, and a polyline may pass several times through
-the same edge.
+any number of edges, and a polyline may pass several times through 
+the same edge.  
 
 
 
@@ -1117,21 +1117,37 @@ For an edge we can further find out how many and which polyline
 constraints pass through it. For an edge we can obtain an iterator
 range with value type `Constrained_triangulation_plus_2::Context`.
 From a context we can obtain the `Constrained_triangulation_plus_2::Constraint_id`, and an iterator
-pointing at the vertex in the polyline constraint that passes
+pointing at the vertex in the polyline constraint that passes 
 through the edge.
 
 
 
 \cgalExample{Triangulation_2/polylines_triangulation.cpp}
 
-\section Section_2D_Triangulations_Hierarchy The Triangulation Hierarchy
+\subsection Triangulation_2ExampleBuildingFromSoup Example: Building a Triangulated Arrangement of Polylines from a Segment Soup
+
+The `Constrained_triangulation_plus_2` structure is initialized by a
+set of polylines. As users may only be able to provide a disconnected
+segment soup as input, a member function \link
+Constrained_triangulation_plus_2::split_subconstraint_graph_into_constraints()
+`split_subconstraint_graph_into_constraints()` \endlink is provided:
+this function identifies the polylines by connecting segments until a
+vertex whose degree is different from 2 is reached.
+
+The following code shows how a "blind" insertion of disconnected
+segments can be processed into a set of well-defined polyline
+constraints in a `Constrained_triangulation_plus_2`:
+
+\cgalExample{Triangulation_2/segment_soup_to_polylines.cpp}
+
+\section Section_2D_Triangulations_Hierarchy The Triangulation Hierarchy 
 
 The class `Triangulation_hierarchy_2<Tr>`
 implements a triangulation augmented with
 a data structure to efficiently answer point location queries.
-The data structure is a hierarchy
+The data structure is a hierarchy 
 of triangulations. The triangulation at the lowest level is
-the original triangulation where operations and point location are to
+the original triangulation where operations and point location are to 
 be performed.
 Then at each succeeding level, the data structure
 stores a triangulation of a small random sample of the vertices
@@ -1144,7 +1160,7 @@ is found through a linear walk performed from
 the nearest neighbor found at the preceding level.
 Because the number of vertices in each triangulation is only a small
 fraction of the number of vertices of the preceding triangulation,
-the data structure remains small and achieves fast point location
+the data structure remains small and achieves fast point location 
 queries on real
 data. As proved in \cgalCite{d-iirdt-98}, this structure has an optimal behavior
 when it is built for Delaunay triangulations.
@@ -1154,7 +1170,7 @@ which is to be instantiated by one of the \cgal triangulation
 classes.
 
 The class `Triangulation_hierarchy_2<Tr>` inherits from the
-triangulation type passed as template parameter `Tr`.
+triangulation type passed as template parameter `Tr`. 
 The `insert`, `move`, and `remove` member functions
 are overwritten to update the data structure at each operation.
 The locate queries are also overwritten to take advantage of the data
@@ -1162,30 +1178,30 @@ structure for a fast processing.
 
 \subsection Triangulation_2TheVertexofaTriangulation The Vertex of a Triangulation Hierarchy
 
-The base vertex class of a triangulation hierarchy
+The base vertex class of a triangulation hierarchy 
 has to be a model of the
 concept
 `TriangulationHierarchyVertexBase_2` which extends
 the concept `TriangulationVertexBase_2`.
 This extension adds
-access and setting member functions
-for two pointers to the corresponding vertices in the
+access and setting member functions 
+for two pointers to the corresponding vertices in the 
 triangulations of the next and preceding levels.
 
 \cgal provides the class `Triangulation_hierarchy_vertex_base_2<Vb>`
-which is a model for the concept
+which is a model for the concept 
 `TriangulationHierarchyVertexBase_2`.
 This class is templated by a parameter `Vb`
 which is to be instantiated by a model of the concept
 `TriangulationVertexBase_2`.
 The class `Triangulation_hierarchy_vertex_base_2<Vb>` inherits
 from its template parameter `Vb`.
-This design enables the usage of
+This design enables the usage of 
 either the default
 vertex class or a user customized
 vertex class with additional functionalities  for `Vb`.
 
-\subsection Subsection_2D_Triangulations_Hierarchy_Examples Examples For the Use of a Triangulation Hierarchy
+\subsection Subsection_2D_Triangulations_Hierarchy_Examples Examples For the Use of a Triangulation Hierarchy 
 
 The following program is an example
 for the standard use of a triangulation hierarchy
@@ -1202,7 +1218,7 @@ a triangulation hierarchy in conjunction with a constrained triangulation with a
 
 
 
-\section Section_2D_Triangulations_Flexibility Flexibility
+\section Section_2D_Triangulations_Flexibility Flexibility 
 
 \subsection Triangulation_2UsingCustomizedVerticesand Using Customized Vertices and Faces
 
@@ -1216,7 +1232,7 @@ which the user can instantiate with his own customized classes.
 
 The most useful flexibility however comes from the fact
 that the triangulation data structure itself has two template
-parameters to be instantiated by
+parameters to be instantiated by 
 classes for the vertices and faces of the triangulation.
 Using his own customized classes to instantiate these
 parameters, the user can easily build up a triangulation with additional
@@ -1236,23 +1252,23 @@ structure, and there is a cyclic dependency on template parameter.
 The cyclic dependency in triangulations software design.
 \cgalFigureEnd
 
-Previously, this cyclic dependency was avoided by
+Previously, this cyclic dependency was avoided by 
 using only `void*` pointers in the interface of base classes.
 These `void*` were converted to appropriate types at the
 triangulation data structure levels. This solution had some drawbacks
-: mainly the user could not add in the vertices or faces of the
-triangulation a functionality related to types defined by
+: mainly the user could not add in the vertices or faces of the 
+triangulation a functionality related to types defined by 
 the triangulation data structure, for instance a handle to a vertex,
-and he was lead to use himself
+and he was lead to use himself 
 `void*` pointers).
 The new solution to resolve the template dependency
-is based on a rebind mechanism similar to the mechanism used in the
+is based on a rebind mechanism similar to the mechanism used in the 
 standard allocator class std::allocator. The rebind mechanism
-is described in Section \ref TDS_2D_default "The Default Triangulation Data Structure"
+is described in Section \ref TDS_2D_default "The Default Triangulation Data Structure" 
 of Chapter \ref Chapter_2D_Triangulation_Data_Structure "2D Triangulation Data Structure".
 For now, we will just notice that the design
 requires
-the existence in the vertex and face base classes
+the existence in the vertex and face base classes 
 of a nested template class
 `Rebind_TDS` defining a type `Other` used by
 the rebinding mechanism.
@@ -1263,17 +1279,17 @@ base classes parameters.
 
 \subsection Triangulation_2AddingColors Adding Colors
 
-The first example corresponds to a case where the user wishes to add in
+The first example corresponds to a case where the user wishes to add in 
 the vertices or faces of the triangulation an additional information
 that does not depend on types provided
-by the triangulation data structure.
+by the triangulation data structure. 
 In that case, predefined classes
 `Triangulation_vertex_base_with_info_2<Info,Traits,Vb>`
 or `Triangulation_face_base_with_info_2<Info,Traits,Vb>`
 can be used. Those classes have
 a template parameter `Info` devoted to
 handle additional information.
-The following example shows how to add a
+The following example shows how to add a 
 `Color` in the triangulation faces.
 
 \cgalExample{Triangulation_2/colored_face.cpp}
@@ -1287,8 +1303,8 @@ The second example adds a `std::string` in the vertices of a terrain.
 \subsection Triangulation_2AddingHandles Adding Handles
 
 This example shows how the user can still
-derive and plug in his own vertex
-or face class when he would like to have
+derive and plug in his own vertex 
+or face class when he would like to have 
 additional functionalities depending on types provided by the triangulation
 data structure.
 
@@ -1300,10 +1316,10 @@ The most efficient method to insert (weighted) points in a
 Delaunay (or regular) triangulation is to provide an iterator
 range over (weighted) points to the insert function. However, an iterator range of
 (weighted) points does not allow the user to set different information to each vertex.
-To solve this problem, in the case the vertex type of the triangulation
+To solve this problem, in the case the vertex type of the triangulation 
 is a model of the concept `TriangulationVertexBaseWithInfo_2`
-(such as `Triangulation_vertex_base_with_info_2`), we provide three examples
-doing the same operation: set an unsigned integer as the information
+(such as `Triangulation_vertex_base_with_info_2`), we provide three examples 
+doing the same operation: set an unsigned integer as the information 
 of each vertex. The value of this unsigned integer is the initial order
 of the corresponding point given in the range.
 
@@ -1333,10 +1349,10 @@ is dereferenced only once per point during the insertion.
 The code of this package is the result of a long development
 process. Here follows a tentative list of people
 who added their stone to this package:
-Jean-Daniel Boissonnat, Herv&eacute; Br&ouml;nnimann,
+Jean-Daniel Boissonnat, Herv&eacute; Br&ouml;nnimann, 
 Olivier Devillers, Andreas Fabri, Fr&eacute;d&eacute;ric Fichel,
 Julia Fl&ouml;totto, Monique Teillaud and Mariette Yvinec.
 
-*/
+*/ 
 } /* namespace CGAL */
 

--- a/Triangulation_2/doc/Triangulation_2/dependencies
+++ b/Triangulation_2/doc/Triangulation_2/dependencies
@@ -4,6 +4,7 @@ STL_Extension
 Algebraic_foundations
 Circulator
 Stream_support
+BGL
 TDS_2
 Triangulation_3
 Spatial_sorting

--- a/Triangulation_2/doc/Triangulation_2/examples.txt
+++ b/Triangulation_2/doc/Triangulation_2/examples.txt
@@ -19,5 +19,6 @@
 \example Triangulation_2/voronoi.cpp
 \example Triangulation_2/copy_triangulation_2.cpp
 \example Triangulation_2/polylines_triangulation.cpp
+\example Triangulation_2/segment_soup_to_polylines.cpp
 \example Triangulation_2/draw_triangulation_2.cpp
 */

--- a/Triangulation_2/examples/Triangulation_2/segment_soup_to_polylines.cpp
+++ b/Triangulation_2/examples/Triangulation_2/segment_soup_to_polylines.cpp
@@ -1,0 +1,51 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Constrained_triangulation_plus_2.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel                 K;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K>                     CDT;
+typedef CGAL::Constrained_triangulation_plus_2<CDT>                       CDTP;
+
+typedef CDTP::Point                                                       Point;
+typedef CDTP::Constraint_id                                               Cid;
+typedef CDTP::Vertex_handle                                               Vertex_handle;
+
+int main()
+{
+  CDTP cdtp;
+
+  // First polyline
+  cdtp.insert_constraint(Point(0,0), Point(1,1));
+  cdtp.insert_constraint(Point(1,1), Point(2,2));
+  cdtp.insert_constraint(Point(2,2), Point(3,3));
+
+  // Second polyline that cuts the first one in 2
+  cdtp.insert_constraint(Point(1,1), Point(1,2));
+  cdtp.insert_constraint(Point(1,2), Point(1,3));
+
+  // Third polyline
+  cdtp.insert_constraint(Point(10,10), Point(20,20));
+  cdtp.insert_constraint(Point(20,20), Point(30,30));
+
+  // Fourth polyline
+  cdtp.insert_constraint(Point(100,100), Point(200,200));
+
+  // Segment soup of 8 segments as input
+  std::cout << "Input CDT+ has " << cdtp.number_of_constraints() << " constraints/subconstraints" << std::endl;
+
+  std::cout << "Splitting subconstraints graph into constraints" << std::endl;
+  cdtp.split_subconstraint_graph_into_constraints();
+
+  // 5 polylines as output
+  std::cout << "Output CDT+ has " << cdtp.number_of_constraints() << " constraints:" << std::endl;
+
+  for (CDTP::Constraint_id cid : cdtp.constraints())
+  {
+    std::cout << " *";
+    for (CDTP::Vertex_handle vh : cdtp.vertices_in_constraint(cid))
+      std::cout << " (" << vh->point() << ")";
+    std::cout << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-//
+// 
 //
 // Author(s)     : Andreas Fabri, Mariette Yvinec
 
@@ -21,6 +21,7 @@
 #include <CGAL/triangulation_assertions.h>
 #include <CGAL/Polygon_2.h>
 #include <CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h>
+#include <CGAL/Triangulation_2/internal/CTP2_subconstraint_graph.h>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
 
@@ -56,25 +57,25 @@ public:
   }
 }; // end class template Pct2_vertex_handle_less_xy
 
-// Tr the base triangulation class
+// Tr the base triangulation class 
 // Tr has to be Constrained or Constrained_Delaunay with Constrained_triangulation_plus_vertex_base
 
 template < class Tr_ = Default >
-class Constrained_triangulation_plus_2
-  : public
-Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
+class Constrained_triangulation_plus_2  
+  : public  
+Default::Get< Tr_, Constrained_Delaunay_triangulation_2< 
                       Exact_predicates_inexact_constructions_kernel
-                      , Triangulation_data_structure_2<
+                      , Triangulation_data_structure_2< 
                             Triangulation_vertex_base_2<Exact_predicates_inexact_constructions_kernel>
                           , Constrained_triangulation_face_base_2<Exact_predicates_inexact_constructions_kernel>
                           >
                       , CGAL::Exact_predicates_tag
                       > >::type
 {
-  typedef typename
-  Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
+  typedef typename 
+  Default::Get< Tr_, Constrained_Delaunay_triangulation_2< 
                   Exact_predicates_inexact_constructions_kernel
-                  , Triangulation_data_structure_2<
+                  , Triangulation_data_structure_2< 
                         Triangulation_vertex_base_2<Exact_predicates_inexact_constructions_kernel>
                       , Constrained_triangulation_face_base_2<Exact_predicates_inexact_constructions_kernel>
                       >
@@ -88,7 +89,7 @@ Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
     typedef typename CDT::Vertex_handle Vertex_handle;
     typedef typename CDT::Face_handle Face_handle;
   private:
-    typedef boost::tuple<Vertex_handle, Vertex_handle, Vertex_handle> TFace;
+    typedef boost::tuple<Vertex_handle, Vertex_handle, Vertex_handle> TFace; 
     std::vector<TFace> faces;
     CDT& cdt;
 
@@ -110,8 +111,8 @@ Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
     void
     write_faces(OutputIterator out)
     {
-      for(typename std::vector<TFace>::reverse_iterator
-            it = faces.rbegin(); it != faces.rend(); ++it) {
+      for(typename std::vector<TFace>::reverse_iterator 
+            it = faces.rbegin(); it != faces.rend(); ++it) { 
         Face_handle fh;
         if(cdt.is_face(boost::get<0>(*it), boost::get<1>(*it), boost::get<2>(*it), fh)){
           *out++ = fh;
@@ -126,7 +127,7 @@ public:
   typedef Constrained_triangulation_plus_2<Tr_> Self;
   typedef Tr                                   Base;
 
-
+  
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
   using Triangulation::vertices_begin;
   using Triangulation::vertices_end;
@@ -169,29 +170,29 @@ public:
   typedef Tag_false                                Periodic_tag;
 
   // for user interface with the constraint hierarchy
-  typedef typename Constraint_hierarchy::Vertex_it
+  typedef typename Constraint_hierarchy::Vertex_it 
                                             Vertices_in_constraint_iterator;
 
   typedef Iterator_range<Vertices_in_constraint_iterator> Vertices_in_constraint;
-
+  
   typedef typename Constraint_hierarchy::Point_it
                                             Points_in_constraint_iterator;
   typedef Iterator_range<Points_in_constraint_iterator> Points_in_constraint;
-
+  
   typedef typename Constraint_hierarchy::Context          Context;
   typedef typename Constraint_hierarchy::Context_iterator Context_iterator;
   typedef Iterator_range<Context_iterator>                Contexts;
-
+  
   typedef typename Constraint_hierarchy::C_iterator   Constraint_iterator;
   typedef Iterator_range<Constraint_iterator> Constraints;
-
+  
   typedef typename Constraint_hierarchy::Subconstraint_iterator  Subconstraint_iterator;
   typedef Iterator_range<Subconstraint_iterator> Subconstraints;
-
-  typedef typename Constraint_hierarchy::Constraint_id Constraint_id;
-
+  
+  typedef typename Constraint_hierarchy::Constraint_id Constraint_id;   
+                                            
   typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
-
+  
   using Triangulation::geom_traits;
   using Triangulation::cw;
   using Triangulation::ccw;
@@ -199,14 +200,14 @@ public:
 
 protected:
   Constraint_hierarchy hierarchy;
-
+ 
 public:
   Constraint_hierarchy& hierarchy_ref()
   {
     return hierarchy;
   }
 
-  Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits())
+  Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits()) 
     : Triangulation(gt)
     , hierarchy(Vh_less_xy(this))
   { }
@@ -226,8 +227,8 @@ public:
 
   template<class InputIterator>
   Constrained_triangulation_plus_2(InputIterator first,
-                                   InputIterator last,
-                                   const Geom_traits& gt=Geom_traits() )
+				   InputIterator last,
+				   const Geom_traits& gt=Geom_traits() )
      : Triangulation(gt)
      , hierarchy(Vh_less_xy(this))
   {
@@ -237,7 +238,7 @@ public:
 
 
   Constrained_triangulation_plus_2(const std::list<std::pair<Point,Point> > &constraints,
-                                   const Geom_traits& gt=Geom_traits() )
+				   const Geom_traits& gt=Geom_traits() )
     : Triangulation(gt)
      , hierarchy(Vh_less_xy(this))
   {
@@ -250,12 +251,12 @@ public:
   void swap(Constrained_triangulation_plus_2 &ctp);
 
   // INSERTION
-  Vertex_handle insert(const Point& a,
-                       Face_handle start = Face_handle() );
+  Vertex_handle insert(const Point& a, 
+		       Face_handle start = Face_handle() );
   Vertex_handle insert(const Point& p,
-                       Locate_type lt,
-                       Face_handle loc, int li );
-
+		       Locate_type lt,
+		       Face_handle loc, int li );
+  
   Constraint_id insert_constraint(const Point& a, const Point& b)
   {
     Vertex_handle va= insert(a);
@@ -263,14 +264,14 @@ public:
     // close to point a
     // Otherwise, to start here is as good as elsewhere
     Vertex_handle vb = insert(b, va->face());
-    return insert_constraint(va, vb);
+    return insert_constraint(va, vb); 
   }
 
-  Constraint_id insert_constraint(const Constraint& c)
+  Constraint_id insert_constraint(const Constraint& c) 
   {
     return insert_constraint(c.first, c.second);
   }
-
+  
   Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb)
   {
     // protects against inserting a zero length constraint
@@ -279,7 +280,7 @@ public:
     }
     // protects against inserting twice the same constraint
     Constraint_id cid = hierarchy.insert_constraint_old_API(va, vb);
-    if (va != vb && (cid != Constraint_id(nullptr)) )  insert_subconstraint(va,vb);
+    if (va != vb && (cid != Constraint_id(nullptr)) )  insert_subconstraint(va,vb); 
 
     return cid;
   }
@@ -315,6 +316,22 @@ public:
     return n;
   }
   */
+
+  void split_subconstraint_graph_into_constraints(const std::function<bool(Vertex_handle)>& is_terminal
+                                                  = std::function<bool(Vertex_handle)>())
+  {
+    internal::CTP2_graph_visitor<Self> visitor(*this);
+    if (is_terminal)
+      CGAL::split_graph_into_polylines (internal::CTP2_subconstraint_graph<Self>(*this), visitor,
+                                        [&is_terminal](Vertex_handle vh,
+                                                       const internal::CTP2_subconstraint_graph<Self>&) -> bool
+                                        {
+                                          return is_terminal(vh);
+                                        });
+    else
+      CGAL::split_graph_into_polylines (internal::CTP2_subconstraint_graph<Self>(*this), visitor);
+  }
+
   Vertex_handle push_back(const Point& p)
   {
     return insert(p);
@@ -326,7 +343,7 @@ public:
   }
 
   // for backward compatibility
-  // not const Point&, because otherwise VC6/7 messes it up with
+  // not const Point&, because otherwise VC6/7 messes it up with 
   // the insert that takes an iterator range
   Constraint_id insert(Point a, Point b) { return insert_constraint(a, b); }
   Constraint_id insert(Vertex_handle va, Vertex_handle  vb) { return insert_constraint(va,vb); }
@@ -353,8 +370,8 @@ public:
 
 
   Vertices_in_constraint_iterator
-  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
-                              Vertex_handle vh)
+  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
+			      Vertex_handle vh)
   {
     return insert_vertex_in_constraint(cid, pos, vh, Emptyset_iterator());
   }
@@ -368,8 +385,8 @@ public:
 
   template <class OutputIterator>
   Vertices_in_constraint_iterator
-  remove_vertex_from_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
-                                OutputIterator out)
+  remove_vertex_from_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
+				OutputIterator out)
   {
     if(pos == vertices_in_constraint_begin(cid)){
       ++pos;
@@ -410,7 +427,7 @@ public:
       ++pos;
       tail = hierarchy.split(cid,pos);
     }
-
+  
     Constraint_id aux = insert_constraint(a, b, std::back_inserter(fc));
     pos = vertices_in_constraint_end(aux);
     --pos;
@@ -435,8 +452,8 @@ public:
   // Writes the modified faces to out
   template <class OutputIterator>
   Vertices_in_constraint_iterator
-  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
-                              Vertex_handle vh, OutputIterator out)
+  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
+			      Vertex_handle vh, OutputIterator out)
   {
     // Insertion before the first vertex
     if(pos == vertices_in_constraint_begin(cid)){
@@ -444,7 +461,7 @@ public:
       Constraint_id head = insert_constraint(vh, *pos, out);
       hierarchy.concatenate2(head, cid);
       return vertices_in_constraint_begin(cid);
-    }
+    } 
 
     // Insertion after the last vertex
     if(pos == vertices_in_constraint_end(cid)){
@@ -457,7 +474,7 @@ public:
       return pos;
     }
     Vertex_handle b = *pos;
-    --pos;
+    --pos;    
     Vertex_handle a = *pos;
     ++pos;
     Face_container<Constrained_triangulation_plus_2> fc(*this);
@@ -466,7 +483,7 @@ public:
     vcit = beg;
     ++beg;
     // If the constraint consists only of a segment, and we want to insert
-    // in the middle
+    // in the middle 
     if((pos == vcit) && (beg == vertices_in_constraint_end(cid))){
       //std::cout << "insertion in constraint which is a segment" << std::endl;
       Constraint_id aux1 = insert_constraint(a, vh, std::back_inserter(fc));
@@ -477,7 +494,7 @@ public:
       remove_constraint(aux1, std::back_inserter(fc));
       fc.write_faces(out);
       return pos;
-
+      
     }
     Constraint_id head = 0, tail = 0;
     Vertices_in_constraint_iterator bit = vertices_in_constraint_begin(cid);
@@ -496,9 +513,9 @@ public:
     --eit;
     if(pos != eit){
       //std::cout << "split tail" << std::endl;
-      tail = split(cid, pos);
+      tail = split(cid, pos);    
     }
-
+    
     // make the new constraint
     Constraint_id aux1 = insert_constraint(a, vh, std::back_inserter(fc));
     Constraint_id aux2 = insert_constraint(vh, b, std::back_inserter(fc));
@@ -534,7 +551,7 @@ public:
       hint = vh->face();
       // no duplicates
       if(vertices.empty() || (vertices.back() != vh)){
-        vertices.push_back(vh);
+	vertices.push_back(vh);
       }
     }
     int n = vertices.size();
@@ -542,24 +559,24 @@ public:
       return nullptr;
     }
     Constraint_id ca = hierarchy.insert_constraint(vertices[0],vertices[1]);
-    insert_subconstraint(vertices[0],vertices[1], std::back_inserter(fc));
+    insert_subconstraint(vertices[0],vertices[1], std::back_inserter(fc)); 
 
     if(n>2){
       for(int j=1; j<n-1; j++){
-        hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
-        insert_subconstraint(vertices[j], vertices[j+1], std::back_inserter(fc));
+	hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
+	insert_subconstraint(vertices[j], vertices[j+1], std::back_inserter(fc));
       }
     }
     for(Vertices_in_constraint_iterator vcit = vertices_in_constraint_begin(ca);
-        vcit != vertices_in_constraint_end(ca);
-        vcit++){
+	vcit != vertices_in_constraint_end(ca);
+	vcit++){
       insert_incident_faces(vcit, out);
     }
     //AF    vertices_in_constraint_begin(ca)->fixed() = true;
     // Vertices_in_constraint_iterator end = boost::prior(vertices_in_constraint_end(ca));
     // end->fixed() = true;
     fc.write_faces(out);
-
+    
     return ca;
   }
 
@@ -575,7 +592,7 @@ private:
       hint = vh->face();
       // no duplicates
       if(vertices.empty() || (vertices.back() != vh)){
-        vertices.push_back(vh);
+	vertices.push_back(vh);
       }
     }
     if(is_polygon && (vertices.size()>1) && (vertices.front() != vertices.back())){
@@ -587,26 +604,26 @@ private:
       return nullptr;
     }
     CGAL_assertion(n >= 2);
-
+    
     Constraint_id ca = hierarchy.insert_constraint(vertices[0],vertices[1]);
-    insert_subconstraint(vertices[0],vertices[1]);
+    insert_subconstraint(vertices[0],vertices[1]); 
 
     if(n>2){
       for(std::size_t j=1; j<n-1; j++){
-        hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
-        insert_subconstraint(vertices[j], vertices[j+1]);
+	hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
+	insert_subconstraint(vertices[j], vertices[j+1]);
       }
     }
-
+ 
     // fix first and last, one is redundant for is_polygon == true
     // vertices.front()->fixed() = true;
     // vertices.back()->fixed() = true;
 
     return ca;
   }
-
+  
 public:
-
+  
   void
   file_output(std::ostream& os) const
   {
@@ -631,9 +648,9 @@ public:
 
   void file_input(std::istream& is)
   {
-
+    
     is >> static_cast<Tr&>(*this);
-
+    
     std::vector<Vertex_handle> V;
     V.reserve(number_of_vertices());
     for(Vertex_iterator vit = vertices_begin(); vit != vertices_end() ; ++vit){
@@ -646,7 +663,7 @@ public:
     while(is >> n){
       is >> i0 >> i1;
       cid = insert_constraint(V[i0],V[i1]);
-
+    
       for(int i = 2; i < n; i++){
         i0 = i1;
         is >> i1;
@@ -656,7 +673,7 @@ public:
     }
   }
 
-
+  
   template <class OutputIterator>
   typename Constrained_triangulation_plus_2<Tr>::Constraint_id
   insert_constraint(Vertex_handle va, Vertex_handle vb, OutputIterator out)
@@ -667,11 +684,11 @@ public:
     }
     // protects against inserting twice the same constraint
     Constraint_id cid = hierarchy.insert_constraint(va, vb);
-    if (va != vb && (cid != nullptr) )  insert_subconstraint(va,vb,out);
-
+    if (va != vb && (cid != nullptr) )  insert_subconstraint(va,vb,out); 
+  
     for(Vertices_in_constraint_iterator vcit = vertices_in_constraint_begin(cid);
-        vcit != vertices_in_constraint_end(cid);
-        vcit++){
+	vcit != vertices_in_constraint_end(cid);
+	vcit++){
       insert_incident_faces(vcit, out);
     }
     return cid;
@@ -696,26 +713,26 @@ public:
                           Vertex_handle vaa,
                           Vertex_handle vbb,
                           Exact_predicates_tag);
-
+ 
   // REMOVAL
 
   template <class OutputIterator>
   void remove_constraint(Constraint_id cid, OutputIterator out)
   {
     std::list<Vertex_handle> vertices(hierarchy.vertices_in_constraint_begin(cid),
-                                      hierarchy.vertices_in_constraint_end(cid));
+				      hierarchy.vertices_in_constraint_end(cid));
 
     hierarchy.remove_constraint(cid);
-    for(typename std::list<Vertex_handle>::iterator it = vertices.begin(),
-          succ = it;
-        ++succ != vertices.end();
-        ++it){
+    for(typename std::list<Vertex_handle>::iterator it = vertices.begin(), 
+	  succ = it; 
+	++succ != vertices.end(); 
+	++it){
       if(! is_subconstraint(*it, *succ)){ // this checks whether other constraints pass
-        Face_handle fh;
-        int i;
-        bool b = Triangulation::is_edge(*it, *succ, fh, i);
-        CGAL_assume(b);
-        Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
+	Face_handle fh;
+	int i;
+	bool b = Triangulation::is_edge(*it, *succ, fh, i);
+	CGAL_assume(b);
+	Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
       }
     }
   }
@@ -724,18 +741,18 @@ public:
     remove_constraint(cid, Emptyset_iterator());
   }
 
-
+ 
   void simplify(Vertices_in_constraint_iterator v)
   {
     Vertices_in_constraint_iterator u = boost::prior(v);
     Vertices_in_constraint_iterator w = boost::next(v);
     bool unew = (*u != *w);
     hierarchy.simplify(u,v,w);
-
+    
     Triangulation::remove_incident_constraints(*v);
-
+  
     Triangulation::remove(*v);
-
+  
     if(unew){
       Triangulation::insert_constraint(*u, *w);
     }
@@ -759,10 +776,10 @@ public:
 
   // split a constraint in two constraints, so that vcit becomes the first
   // vertex of the new constraint
-  // returns the new constraint
+  // returns the new constraint 
   Constraint_id
   split(Constraint_id first, Vertices_in_constraint_iterator vcit);
-
+  
   // Query of the constraint hierarchy
   Constraint_iterator constraints_begin() const;
   Constraint_iterator constraints_end()   const;
@@ -770,7 +787,7 @@ public:
   {
     return Constraints(constraints_begin(),constraints_end());
   }
-
+  
   Subconstraint_iterator subconstraints_begin() const;
   Subconstraint_iterator subconstraints_end() const;
 
@@ -778,31 +795,31 @@ public:
   {
     return Subconstraints(subconstraints_begin(),subconstraints_end());
   }
+  
+  Context   context(Vertex_handle va, Vertex_handle vb); //AF: const; 
 
-  Context   context(Vertex_handle va, Vertex_handle vb); //AF: const;
-
-  bool is_subconstraint(Vertex_handle va,
-                        Vertex_handle vb);
-  size_type number_of_enclosing_constraints(Vertex_handle va,
+  bool is_subconstraint(Vertex_handle va, 
+			Vertex_handle vb);
+  size_type number_of_enclosing_constraints(Vertex_handle va, 
                                             Vertex_handle vb) const;
-  Context_iterator   contexts_begin(Vertex_handle va,
-                                    Vertex_handle vb) const;
-  Context_iterator   contexts_end(Vertex_handle va,
-                                  Vertex_handle vb) const;
+  Context_iterator   contexts_begin(Vertex_handle va, 
+				    Vertex_handle vb) const;
+  Context_iterator   contexts_end(Vertex_handle va, 
+				  Vertex_handle vb) const;
 
   Contexts contexts(Vertex_handle va, Vertex_handle vb) const
   {
     return Contexts(contexts_begin(va,vb),contexts_end(va,vb));
   }
-
+  
   Vertices_in_constraint_iterator vertices_in_constraint_begin(Constraint_id cid) const;
   Vertices_in_constraint_iterator vertices_in_constraint_end(Constraint_id cid) const;
-
+  
   Vertices_in_constraint vertices_in_constraint(Constraint_id cid) const
   {
     return Vertices_in_constraint(vertices_in_constraint_begin(cid), vertices_in_constraint_end(cid));
   }
-
+  
   Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
   Points_in_constraint_iterator points_in_constraint_end(Constraint_id cid) const ;
 
@@ -838,12 +855,12 @@ protected:
         fc++;
       }while(fc != done);
     }
-  }
+  }  
 
 
 void
 insert_subconstraint(Vertex_handle vaa,
-                     Vertex_handle vbb)
+		     Vertex_handle vbb)
   {
     insert_subconstraint(vaa,vbb,Emptyset_iterator());
   }
@@ -854,9 +871,9 @@ insert_subconstraint(Vertex_handle vaa,
 template <class OutputItertator>
 void
 insert_subconstraint(Vertex_handle vaa,
-                     Vertex_handle vbb,
-                     OutputItertator out)
-  // insert the subconstraint [vaa vbb]
+		     Vertex_handle vbb,
+		     OutputItertator out)
+  // insert the subconstraint [vaa vbb] 
   // it will eventually be split into several subconstraints
 {
   std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
@@ -866,7 +883,7 @@ insert_subconstraint(Vertex_handle vaa,
     boost::tie(vaa,vbb) = stack.top();
     stack.pop();
     CGAL_triangulation_precondition( vaa != vbb);
-
+  
     Vertex_handle vi;
 
     Face_handle fr;
@@ -879,11 +896,11 @@ insert_subconstraint(Vertex_handle vaa,
       }
       continue;
     }
-
+      
     List_faces intersected_faces;
     List_edges conflict_boundary_ab, conflict_boundary_ba;
-
-    bool intersection  = this->find_intersected_faces(
+     
+    bool intersection  = this->find_intersected_faces( 
                                                       vaa, vbb,
                                                       intersected_faces,
                                                       conflict_boundary_ab,
@@ -893,10 +910,10 @@ insert_subconstraint(Vertex_handle vaa,
     if ( intersection) {
       if (vi != vaa && vi != vbb) {
         hierarchy.split_constraint(vaa,vbb,vi);
-        stack.push(std::make_pair(vaa,vi));
-        stack.push(std::make_pair(vi,vbb));
+        stack.push(std::make_pair(vaa,vi)); 
+        stack.push(std::make_pair(vi,vbb)); 
       }
-      else stack.push(std::make_pair(vaa,vbb));
+      else stack.push(std::make_pair(vaa,vbb));  
 
       continue;
     }
@@ -937,7 +954,7 @@ insert_subconstraint(Vertex_handle vaa,
 
     if (vi != vbb) {
       hierarchy.split_constraint(vaa,vbb,vi);
-      stack.push(std::make_pair(vi,vbb));
+      stack.push(std::make_pair(vi,vbb)); 
     }
   }
 }
@@ -954,7 +971,7 @@ public:
 #if defined(_MSC_VER)
   std::ptrdiff_t insert(InputIterator first, InputIterator last, int i = 0)
 #else
-    std::ptrdiff_t insert(InputIterator first, InputIterator last)
+    std::ptrdiff_t insert(InputIterator first, InputIterator last) 
 #endif
   {
 #if defined(_MSC_VER)
@@ -983,7 +1000,7 @@ copy_triangulation(const Constrained_triangulation_plus_2 &ctp)
 {
   Base::copy_triangulation(ctp);
   //the following assumes that the triangulation and its copy
-  // iterate on their vertices in the same order
+  // iterate on their vertices in the same order 
   std::map<Vertex_handle,Vertex_handle> vmap;
   Vertex_iterator vit = ctp.vertices_begin();
   Vertex_iterator vvit = this->vertices_begin();
@@ -1004,7 +1021,7 @@ swap(Constrained_triangulation_plus_2 &ctp)
 }
 
 template < class Tr >
-inline
+inline 
 typename Constrained_triangulation_plus_2<Tr>::Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
 insert(const Point& a, Face_handle start)
@@ -1042,17 +1059,17 @@ insert(const Point& a, Locate_type lt, Face_handle loc, int li)
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i,
-          Vertex_handle vaa,
-          Vertex_handle vbb)
+intersect(Face_handle f, int i, 
+	  Vertex_handle vaa,
+	  Vertex_handle vbb) 
 {
   return intersect(f, i, vaa, vbb, Intersection_tag());
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
 Constrained_triangulation_plus_2<Tr>::
 intersect(Face_handle, int,
           Vertex_handle,
@@ -1076,13 +1093,13 @@ intersect(Face_handle, int,
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i,
-          Vertex_handle vaa,
-          Vertex_handle vbb,
-          Exact_intersections_tag)
-// compute the intersection of the constraint edge (f,i)
+intersect(Face_handle f, int i, 
+	  Vertex_handle vaa,
+	  Vertex_handle vbb,
+	  Exact_intersections_tag)
+// compute the intersection of the constraint edge (f,i) 
 // with the subconstraint (vaa,vbb) being inserted
 // insert the intersection point
 // (the  constraint edge (f,i) will be split in hierarchy by insert)
@@ -1110,16 +1127,16 @@ intersect(Face_handle f, int i,
   CGAL_triangulation_assertion(ok);
 
   Vertex_handle vi = insert(pi, Triangulation::EDGE, f, i);
-  return vi;
+  return vi; 
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>::Vertex_handle
+typename Constrained_triangulation_plus_2<Tr>::Vertex_handle 
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i,
-          Vertex_handle vaa,
-          Vertex_handle vbb,
-          Exact_predicates_tag)
+intersect(Face_handle f, int i, 
+	  Vertex_handle vaa,
+	  Vertex_handle vbb,
+	  Exact_predicates_tag)
 {
   Vertex_handle  vcc, vdd;
   vcc = f->vertex(cw(i));
@@ -1141,7 +1158,7 @@ intersect(Face_handle f, int i,
     case 0 : vi = vaa; break;
     case 1 : vi = vbb; break;
     case 2 : vi = vcc; break;
-    case 3 : vi = vdd; break;
+    case 3 : vi = vdd; break; 
     }
     if(vi == vaa || vi == vbb) {
       Triangulation::remove_constrained_edge(f, i);
@@ -1154,15 +1171,15 @@ intersect(Face_handle f, int i,
 
   // vi == vc or vi == vd may happen even if intersection==true
   // due to approximate construction of the intersection
-  if (vi != vcc && vi != vdd) {
+  if (vi != vcc && vi != vdd) { 
     hierarchy.split_constraint(vcc,vdd,vi);
-    insert_subconstraint(vcc,vi);
+    insert_subconstraint(vcc,vi); 
     insert_subconstraint(vi, vdd);
-  }
+  } 
   else {
     insert_subconstraint(vcc,vdd);
   }
-  return vi;
+  return vi; 
 }
 
   // CONCATENATE AND SPLIT
@@ -1177,7 +1194,7 @@ Constrained_triangulation_plus_2<Tr>::concatenate(Constraint_id first, Constrain
 
   // split a constraint in two constraints, so that vcit becomes the first
   // vertex of the new constraint
-  // returns the new constraint
+  // returns the new constraint 
 template <class Tr>
 typename Constrained_triangulation_plus_2<Tr>::Constraint_id
 Constrained_triangulation_plus_2<Tr>::split(Constraint_id first, Vertices_in_constraint_iterator vcit)
@@ -1188,8 +1205,8 @@ Constrained_triangulation_plus_2<Tr>::split(Constraint_id first, Vertices_in_con
 
 template <class Tr>
 std::ostream &
-operator<<(std::ostream& os,
-           const Constrained_triangulation_plus_2<Tr> &ct)
+operator<<(std::ostream& os, 
+	   const Constrained_triangulation_plus_2<Tr> &ct)
 {
   ct.file_output(os);
   return os ;
@@ -1197,8 +1214,8 @@ operator<<(std::ostream& os,
 
 template <class Tr>
 std::istream &
-operator>>(std::istream& is,
-           Constrained_triangulation_plus_2<Tr> &ct)
+operator>>(std::istream& is, 
+	   Constrained_triangulation_plus_2<Tr> &ct)
 {
   ct.file_input(is);
   return is ;
@@ -1258,13 +1275,13 @@ context(Vertex_handle va, Vertex_handle vb) // AF: const
 
 
 template <class Tr>
-inline
+inline 
 typename Constrained_triangulation_plus_2<Tr>::size_type
 Constrained_triangulation_plus_2<Tr>::
 number_of_enclosing_constraints(Vertex_handle va, Vertex_handle vb) const
 {
- return static_cast<size_type>
-   (hierarchy.number_of_enclosing_constraints(va,vb));
+ return static_cast<size_type> 
+   (hierarchy.number_of_enclosing_constraints(va,vb)); 
 }
 
 template <class Tr>
@@ -1272,7 +1289,7 @@ inline bool
 Constrained_triangulation_plus_2<Tr>::
 is_subconstraint(Vertex_handle va, Vertex_handle vb)
 {
- return hierarchy.is_subconstrained_edge(va,vb);
+ return hierarchy.is_subconstrained_edge(va,vb); 
 }
 
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -6,7 +6,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
-// 
+//
 //
 // Author(s)     : Andreas Fabri, Mariette Yvinec
 
@@ -57,25 +57,25 @@ public:
   }
 }; // end class template Pct2_vertex_handle_less_xy
 
-// Tr the base triangulation class 
+// Tr the base triangulation class
 // Tr has to be Constrained or Constrained_Delaunay with Constrained_triangulation_plus_vertex_base
 
 template < class Tr_ = Default >
-class Constrained_triangulation_plus_2  
-  : public  
-Default::Get< Tr_, Constrained_Delaunay_triangulation_2< 
+class Constrained_triangulation_plus_2
+  : public
+Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
                       Exact_predicates_inexact_constructions_kernel
-                      , Triangulation_data_structure_2< 
+                      , Triangulation_data_structure_2<
                             Triangulation_vertex_base_2<Exact_predicates_inexact_constructions_kernel>
                           , Constrained_triangulation_face_base_2<Exact_predicates_inexact_constructions_kernel>
                           >
                       , CGAL::Exact_predicates_tag
                       > >::type
 {
-  typedef typename 
-  Default::Get< Tr_, Constrained_Delaunay_triangulation_2< 
+  typedef typename
+  Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
                   Exact_predicates_inexact_constructions_kernel
-                  , Triangulation_data_structure_2< 
+                  , Triangulation_data_structure_2<
                         Triangulation_vertex_base_2<Exact_predicates_inexact_constructions_kernel>
                       , Constrained_triangulation_face_base_2<Exact_predicates_inexact_constructions_kernel>
                       >
@@ -89,7 +89,7 @@ Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
     typedef typename CDT::Vertex_handle Vertex_handle;
     typedef typename CDT::Face_handle Face_handle;
   private:
-    typedef boost::tuple<Vertex_handle, Vertex_handle, Vertex_handle> TFace; 
+    typedef boost::tuple<Vertex_handle, Vertex_handle, Vertex_handle> TFace;
     std::vector<TFace> faces;
     CDT& cdt;
 
@@ -111,8 +111,8 @@ Default::Get< Tr_, Constrained_Delaunay_triangulation_2<
     void
     write_faces(OutputIterator out)
     {
-      for(typename std::vector<TFace>::reverse_iterator 
-            it = faces.rbegin(); it != faces.rend(); ++it) { 
+      for(typename std::vector<TFace>::reverse_iterator
+            it = faces.rbegin(); it != faces.rend(); ++it) {
         Face_handle fh;
         if(cdt.is_face(boost::get<0>(*it), boost::get<1>(*it), boost::get<2>(*it), fh)){
           *out++ = fh;
@@ -127,7 +127,7 @@ public:
   typedef Constrained_triangulation_plus_2<Tr_> Self;
   typedef Tr                                   Base;
 
-  
+
 #ifndef CGAL_CFG_USING_BASE_MEMBER_BUG_2
   using Triangulation::vertices_begin;
   using Triangulation::vertices_end;
@@ -170,29 +170,29 @@ public:
   typedef Tag_false                                Periodic_tag;
 
   // for user interface with the constraint hierarchy
-  typedef typename Constraint_hierarchy::Vertex_it 
+  typedef typename Constraint_hierarchy::Vertex_it
                                             Vertices_in_constraint_iterator;
 
   typedef Iterator_range<Vertices_in_constraint_iterator> Vertices_in_constraint;
-  
+
   typedef typename Constraint_hierarchy::Point_it
                                             Points_in_constraint_iterator;
   typedef Iterator_range<Points_in_constraint_iterator> Points_in_constraint;
-  
+
   typedef typename Constraint_hierarchy::Context          Context;
   typedef typename Constraint_hierarchy::Context_iterator Context_iterator;
   typedef Iterator_range<Context_iterator>                Contexts;
-  
+
   typedef typename Constraint_hierarchy::C_iterator   Constraint_iterator;
   typedef Iterator_range<Constraint_iterator> Constraints;
-  
+
   typedef typename Constraint_hierarchy::Subconstraint_iterator  Subconstraint_iterator;
   typedef Iterator_range<Subconstraint_iterator> Subconstraints;
-  
-  typedef typename Constraint_hierarchy::Constraint_id Constraint_id;   
-                                            
+
+  typedef typename Constraint_hierarchy::Constraint_id Constraint_id;
+
   typedef std::pair<Vertex_handle, Vertex_handle> Subconstraint;
-  
+
   using Triangulation::geom_traits;
   using Triangulation::cw;
   using Triangulation::ccw;
@@ -200,14 +200,14 @@ public:
 
 protected:
   Constraint_hierarchy hierarchy;
- 
+
 public:
   Constraint_hierarchy& hierarchy_ref()
   {
     return hierarchy;
   }
 
-  Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits()) 
+  Constrained_triangulation_plus_2(const Geom_traits& gt=Geom_traits())
     : Triangulation(gt)
     , hierarchy(Vh_less_xy(this))
   { }
@@ -227,8 +227,8 @@ public:
 
   template<class InputIterator>
   Constrained_triangulation_plus_2(InputIterator first,
-				   InputIterator last,
-				   const Geom_traits& gt=Geom_traits() )
+                                   InputIterator last,
+                                   const Geom_traits& gt=Geom_traits() )
      : Triangulation(gt)
      , hierarchy(Vh_less_xy(this))
   {
@@ -238,7 +238,7 @@ public:
 
 
   Constrained_triangulation_plus_2(const std::list<std::pair<Point,Point> > &constraints,
-				   const Geom_traits& gt=Geom_traits() )
+                                   const Geom_traits& gt=Geom_traits() )
     : Triangulation(gt)
      , hierarchy(Vh_less_xy(this))
   {
@@ -251,12 +251,12 @@ public:
   void swap(Constrained_triangulation_plus_2 &ctp);
 
   // INSERTION
-  Vertex_handle insert(const Point& a, 
-		       Face_handle start = Face_handle() );
+  Vertex_handle insert(const Point& a,
+                       Face_handle start = Face_handle() );
   Vertex_handle insert(const Point& p,
-		       Locate_type lt,
-		       Face_handle loc, int li );
-  
+                       Locate_type lt,
+                       Face_handle loc, int li );
+
   Constraint_id insert_constraint(const Point& a, const Point& b)
   {
     Vertex_handle va= insert(a);
@@ -264,14 +264,14 @@ public:
     // close to point a
     // Otherwise, to start here is as good as elsewhere
     Vertex_handle vb = insert(b, va->face());
-    return insert_constraint(va, vb); 
+    return insert_constraint(va, vb);
   }
 
-  Constraint_id insert_constraint(const Constraint& c) 
+  Constraint_id insert_constraint(const Constraint& c)
   {
     return insert_constraint(c.first, c.second);
   }
-  
+
   Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb)
   {
     // protects against inserting a zero length constraint
@@ -280,7 +280,7 @@ public:
     }
     // protects against inserting twice the same constraint
     Constraint_id cid = hierarchy.insert_constraint_old_API(va, vb);
-    if (va != vb && (cid != Constraint_id(nullptr)) )  insert_subconstraint(va,vb); 
+    if (va != vb && (cid != Constraint_id(nullptr)) )  insert_subconstraint(va,vb);
 
     return cid;
   }
@@ -343,7 +343,7 @@ public:
   }
 
   // for backward compatibility
-  // not const Point&, because otherwise VC6/7 messes it up with 
+  // not const Point&, because otherwise VC6/7 messes it up with
   // the insert that takes an iterator range
   Constraint_id insert(Point a, Point b) { return insert_constraint(a, b); }
   Constraint_id insert(Vertex_handle va, Vertex_handle  vb) { return insert_constraint(va,vb); }
@@ -370,8 +370,8 @@ public:
 
 
   Vertices_in_constraint_iterator
-  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
-			      Vertex_handle vh)
+  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
+                              Vertex_handle vh)
   {
     return insert_vertex_in_constraint(cid, pos, vh, Emptyset_iterator());
   }
@@ -385,8 +385,8 @@ public:
 
   template <class OutputIterator>
   Vertices_in_constraint_iterator
-  remove_vertex_from_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
-				OutputIterator out)
+  remove_vertex_from_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
+                                OutputIterator out)
   {
     if(pos == vertices_in_constraint_begin(cid)){
       ++pos;
@@ -427,7 +427,7 @@ public:
       ++pos;
       tail = hierarchy.split(cid,pos);
     }
-  
+
     Constraint_id aux = insert_constraint(a, b, std::back_inserter(fc));
     pos = vertices_in_constraint_end(aux);
     --pos;
@@ -452,8 +452,8 @@ public:
   // Writes the modified faces to out
   template <class OutputIterator>
   Vertices_in_constraint_iterator
-  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos, 
-			      Vertex_handle vh, OutputIterator out)
+  insert_vertex_in_constraint(Constraint_id cid, Vertices_in_constraint_iterator pos,
+                              Vertex_handle vh, OutputIterator out)
   {
     // Insertion before the first vertex
     if(pos == vertices_in_constraint_begin(cid)){
@@ -461,7 +461,7 @@ public:
       Constraint_id head = insert_constraint(vh, *pos, out);
       hierarchy.concatenate2(head, cid);
       return vertices_in_constraint_begin(cid);
-    } 
+    }
 
     // Insertion after the last vertex
     if(pos == vertices_in_constraint_end(cid)){
@@ -474,7 +474,7 @@ public:
       return pos;
     }
     Vertex_handle b = *pos;
-    --pos;    
+    --pos;
     Vertex_handle a = *pos;
     ++pos;
     Face_container<Constrained_triangulation_plus_2> fc(*this);
@@ -483,7 +483,7 @@ public:
     vcit = beg;
     ++beg;
     // If the constraint consists only of a segment, and we want to insert
-    // in the middle 
+    // in the middle
     if((pos == vcit) && (beg == vertices_in_constraint_end(cid))){
       //std::cout << "insertion in constraint which is a segment" << std::endl;
       Constraint_id aux1 = insert_constraint(a, vh, std::back_inserter(fc));
@@ -494,7 +494,7 @@ public:
       remove_constraint(aux1, std::back_inserter(fc));
       fc.write_faces(out);
       return pos;
-      
+
     }
     Constraint_id head = 0, tail = 0;
     Vertices_in_constraint_iterator bit = vertices_in_constraint_begin(cid);
@@ -513,9 +513,9 @@ public:
     --eit;
     if(pos != eit){
       //std::cout << "split tail" << std::endl;
-      tail = split(cid, pos);    
+      tail = split(cid, pos);
     }
-    
+
     // make the new constraint
     Constraint_id aux1 = insert_constraint(a, vh, std::back_inserter(fc));
     Constraint_id aux2 = insert_constraint(vh, b, std::back_inserter(fc));
@@ -551,7 +551,7 @@ public:
       hint = vh->face();
       // no duplicates
       if(vertices.empty() || (vertices.back() != vh)){
-	vertices.push_back(vh);
+        vertices.push_back(vh);
       }
     }
     int n = vertices.size();
@@ -559,24 +559,24 @@ public:
       return nullptr;
     }
     Constraint_id ca = hierarchy.insert_constraint(vertices[0],vertices[1]);
-    insert_subconstraint(vertices[0],vertices[1], std::back_inserter(fc)); 
+    insert_subconstraint(vertices[0],vertices[1], std::back_inserter(fc));
 
     if(n>2){
       for(int j=1; j<n-1; j++){
-	hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
-	insert_subconstraint(vertices[j], vertices[j+1], std::back_inserter(fc));
+        hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
+        insert_subconstraint(vertices[j], vertices[j+1], std::back_inserter(fc));
       }
     }
     for(Vertices_in_constraint_iterator vcit = vertices_in_constraint_begin(ca);
-	vcit != vertices_in_constraint_end(ca);
-	vcit++){
+        vcit != vertices_in_constraint_end(ca);
+        vcit++){
       insert_incident_faces(vcit, out);
     }
     //AF    vertices_in_constraint_begin(ca)->fixed() = true;
     // Vertices_in_constraint_iterator end = boost::prior(vertices_in_constraint_end(ca));
     // end->fixed() = true;
     fc.write_faces(out);
-    
+
     return ca;
   }
 
@@ -592,7 +592,7 @@ private:
       hint = vh->face();
       // no duplicates
       if(vertices.empty() || (vertices.back() != vh)){
-	vertices.push_back(vh);
+        vertices.push_back(vh);
       }
     }
     if(is_polygon && (vertices.size()>1) && (vertices.front() != vertices.back())){
@@ -604,26 +604,26 @@ private:
       return nullptr;
     }
     CGAL_assertion(n >= 2);
-    
+
     Constraint_id ca = hierarchy.insert_constraint(vertices[0],vertices[1]);
-    insert_subconstraint(vertices[0],vertices[1]); 
+    insert_subconstraint(vertices[0],vertices[1]);
 
     if(n>2){
       for(std::size_t j=1; j<n-1; j++){
-	hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
-	insert_subconstraint(vertices[j], vertices[j+1]);
+        hierarchy.append_constraint(ca, vertices[j], vertices[j+1]);
+        insert_subconstraint(vertices[j], vertices[j+1]);
       }
     }
- 
+
     // fix first and last, one is redundant for is_polygon == true
     // vertices.front()->fixed() = true;
     // vertices.back()->fixed() = true;
 
     return ca;
   }
-  
+
 public:
-  
+
   void
   file_output(std::ostream& os) const
   {
@@ -648,9 +648,9 @@ public:
 
   void file_input(std::istream& is)
   {
-    
+
     is >> static_cast<Tr&>(*this);
-    
+
     std::vector<Vertex_handle> V;
     V.reserve(number_of_vertices());
     for(Vertex_iterator vit = vertices_begin(); vit != vertices_end() ; ++vit){
@@ -663,7 +663,7 @@ public:
     while(is >> n){
       is >> i0 >> i1;
       cid = insert_constraint(V[i0],V[i1]);
-    
+
       for(int i = 2; i < n; i++){
         i0 = i1;
         is >> i1;
@@ -673,7 +673,7 @@ public:
     }
   }
 
-  
+
   template <class OutputIterator>
   typename Constrained_triangulation_plus_2<Tr>::Constraint_id
   insert_constraint(Vertex_handle va, Vertex_handle vb, OutputIterator out)
@@ -684,11 +684,11 @@ public:
     }
     // protects against inserting twice the same constraint
     Constraint_id cid = hierarchy.insert_constraint(va, vb);
-    if (va != vb && (cid != nullptr) )  insert_subconstraint(va,vb,out); 
-  
+    if (va != vb && (cid != nullptr) )  insert_subconstraint(va,vb,out);
+
     for(Vertices_in_constraint_iterator vcit = vertices_in_constraint_begin(cid);
-	vcit != vertices_in_constraint_end(cid);
-	vcit++){
+        vcit != vertices_in_constraint_end(cid);
+        vcit++){
       insert_incident_faces(vcit, out);
     }
     return cid;
@@ -713,26 +713,26 @@ public:
                           Vertex_handle vaa,
                           Vertex_handle vbb,
                           Exact_predicates_tag);
- 
+
   // REMOVAL
 
   template <class OutputIterator>
   void remove_constraint(Constraint_id cid, OutputIterator out)
   {
     std::list<Vertex_handle> vertices(hierarchy.vertices_in_constraint_begin(cid),
-				      hierarchy.vertices_in_constraint_end(cid));
+                                      hierarchy.vertices_in_constraint_end(cid));
 
     hierarchy.remove_constraint(cid);
-    for(typename std::list<Vertex_handle>::iterator it = vertices.begin(), 
-	  succ = it; 
-	++succ != vertices.end(); 
-	++it){
+    for(typename std::list<Vertex_handle>::iterator it = vertices.begin(),
+          succ = it;
+        ++succ != vertices.end();
+        ++it){
       if(! is_subconstraint(*it, *succ)){ // this checks whether other constraints pass
-	Face_handle fh;
-	int i;
-	bool b = Triangulation::is_edge(*it, *succ, fh, i);
-	CGAL_assume(b);
-	Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
+        Face_handle fh;
+        int i;
+        bool b = Triangulation::is_edge(*it, *succ, fh, i);
+        CGAL_assume(b);
+        Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
       }
     }
   }
@@ -741,18 +741,18 @@ public:
     remove_constraint(cid, Emptyset_iterator());
   }
 
- 
+
   void simplify(Vertices_in_constraint_iterator v)
   {
     Vertices_in_constraint_iterator u = boost::prior(v);
     Vertices_in_constraint_iterator w = boost::next(v);
     bool unew = (*u != *w);
     hierarchy.simplify(u,v,w);
-    
+
     Triangulation::remove_incident_constraints(*v);
-  
+
     Triangulation::remove(*v);
-  
+
     if(unew){
       Triangulation::insert_constraint(*u, *w);
     }
@@ -776,10 +776,10 @@ public:
 
   // split a constraint in two constraints, so that vcit becomes the first
   // vertex of the new constraint
-  // returns the new constraint 
+  // returns the new constraint
   Constraint_id
   split(Constraint_id first, Vertices_in_constraint_iterator vcit);
-  
+
   // Query of the constraint hierarchy
   Constraint_iterator constraints_begin() const;
   Constraint_iterator constraints_end()   const;
@@ -787,7 +787,7 @@ public:
   {
     return Constraints(constraints_begin(),constraints_end());
   }
-  
+
   Subconstraint_iterator subconstraints_begin() const;
   Subconstraint_iterator subconstraints_end() const;
 
@@ -795,31 +795,31 @@ public:
   {
     return Subconstraints(subconstraints_begin(),subconstraints_end());
   }
-  
-  Context   context(Vertex_handle va, Vertex_handle vb); //AF: const; 
 
-  bool is_subconstraint(Vertex_handle va, 
-			Vertex_handle vb);
-  size_type number_of_enclosing_constraints(Vertex_handle va, 
+  Context   context(Vertex_handle va, Vertex_handle vb); //AF: const;
+
+  bool is_subconstraint(Vertex_handle va,
+                        Vertex_handle vb);
+  size_type number_of_enclosing_constraints(Vertex_handle va,
                                             Vertex_handle vb) const;
-  Context_iterator   contexts_begin(Vertex_handle va, 
-				    Vertex_handle vb) const;
-  Context_iterator   contexts_end(Vertex_handle va, 
-				  Vertex_handle vb) const;
+  Context_iterator   contexts_begin(Vertex_handle va,
+                                    Vertex_handle vb) const;
+  Context_iterator   contexts_end(Vertex_handle va,
+                                  Vertex_handle vb) const;
 
   Contexts contexts(Vertex_handle va, Vertex_handle vb) const
   {
     return Contexts(contexts_begin(va,vb),contexts_end(va,vb));
   }
-  
+
   Vertices_in_constraint_iterator vertices_in_constraint_begin(Constraint_id cid) const;
   Vertices_in_constraint_iterator vertices_in_constraint_end(Constraint_id cid) const;
-  
+
   Vertices_in_constraint vertices_in_constraint(Constraint_id cid) const
   {
     return Vertices_in_constraint(vertices_in_constraint_begin(cid), vertices_in_constraint_end(cid));
   }
-  
+
   Points_in_constraint_iterator points_in_constraint_begin(Constraint_id cid) const;
   Points_in_constraint_iterator points_in_constraint_end(Constraint_id cid) const ;
 
@@ -855,12 +855,12 @@ protected:
         fc++;
       }while(fc != done);
     }
-  }  
+  }
 
 
 void
 insert_subconstraint(Vertex_handle vaa,
-		     Vertex_handle vbb)
+                     Vertex_handle vbb)
   {
     insert_subconstraint(vaa,vbb,Emptyset_iterator());
   }
@@ -871,9 +871,9 @@ insert_subconstraint(Vertex_handle vaa,
 template <class OutputItertator>
 void
 insert_subconstraint(Vertex_handle vaa,
-		     Vertex_handle vbb,
-		     OutputItertator out)
-  // insert the subconstraint [vaa vbb] 
+                     Vertex_handle vbb,
+                     OutputItertator out)
+  // insert the subconstraint [vaa vbb]
   // it will eventually be split into several subconstraints
 {
   std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
@@ -883,7 +883,7 @@ insert_subconstraint(Vertex_handle vaa,
     boost::tie(vaa,vbb) = stack.top();
     stack.pop();
     CGAL_triangulation_precondition( vaa != vbb);
-  
+
     Vertex_handle vi;
 
     Face_handle fr;
@@ -896,11 +896,11 @@ insert_subconstraint(Vertex_handle vaa,
       }
       continue;
     }
-      
+
     List_faces intersected_faces;
     List_edges conflict_boundary_ab, conflict_boundary_ba;
-     
-    bool intersection  = this->find_intersected_faces( 
+
+    bool intersection  = this->find_intersected_faces(
                                                       vaa, vbb,
                                                       intersected_faces,
                                                       conflict_boundary_ab,
@@ -910,10 +910,10 @@ insert_subconstraint(Vertex_handle vaa,
     if ( intersection) {
       if (vi != vaa && vi != vbb) {
         hierarchy.split_constraint(vaa,vbb,vi);
-        stack.push(std::make_pair(vaa,vi)); 
-        stack.push(std::make_pair(vi,vbb)); 
+        stack.push(std::make_pair(vaa,vi));
+        stack.push(std::make_pair(vi,vbb));
       }
-      else stack.push(std::make_pair(vaa,vbb));  
+      else stack.push(std::make_pair(vaa,vbb));
 
       continue;
     }
@@ -954,7 +954,7 @@ insert_subconstraint(Vertex_handle vaa,
 
     if (vi != vbb) {
       hierarchy.split_constraint(vaa,vbb,vi);
-      stack.push(std::make_pair(vi,vbb)); 
+      stack.push(std::make_pair(vi,vbb));
     }
   }
 }
@@ -971,7 +971,7 @@ public:
 #if defined(_MSC_VER)
   std::ptrdiff_t insert(InputIterator first, InputIterator last, int i = 0)
 #else
-    std::ptrdiff_t insert(InputIterator first, InputIterator last) 
+    std::ptrdiff_t insert(InputIterator first, InputIterator last)
 #endif
   {
 #if defined(_MSC_VER)
@@ -1000,7 +1000,7 @@ copy_triangulation(const Constrained_triangulation_plus_2 &ctp)
 {
   Base::copy_triangulation(ctp);
   //the following assumes that the triangulation and its copy
-  // iterate on their vertices in the same order 
+  // iterate on their vertices in the same order
   std::map<Vertex_handle,Vertex_handle> vmap;
   Vertex_iterator vit = ctp.vertices_begin();
   Vertex_iterator vvit = this->vertices_begin();
@@ -1021,7 +1021,7 @@ swap(Constrained_triangulation_plus_2 &ctp)
 }
 
 template < class Tr >
-inline 
+inline
 typename Constrained_triangulation_plus_2<Tr>::Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
 insert(const Point& a, Face_handle start)
@@ -1059,17 +1059,17 @@ insert(const Point& a, Locate_type lt, Face_handle loc, int li)
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i, 
-	  Vertex_handle vaa,
-	  Vertex_handle vbb) 
+intersect(Face_handle f, int i,
+          Vertex_handle vaa,
+          Vertex_handle vbb)
 {
   return intersect(f, i, vaa, vbb, Intersection_tag());
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
 intersect(Face_handle, int,
           Vertex_handle,
@@ -1093,13 +1093,13 @@ intersect(Face_handle, int,
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle 
+typename Constrained_triangulation_plus_2<Tr>:: Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i, 
-	  Vertex_handle vaa,
-	  Vertex_handle vbb,
-	  Exact_intersections_tag)
-// compute the intersection of the constraint edge (f,i) 
+intersect(Face_handle f, int i,
+          Vertex_handle vaa,
+          Vertex_handle vbb,
+          Exact_intersections_tag)
+// compute the intersection of the constraint edge (f,i)
 // with the subconstraint (vaa,vbb) being inserted
 // insert the intersection point
 // (the  constraint edge (f,i) will be split in hierarchy by insert)
@@ -1127,16 +1127,16 @@ intersect(Face_handle f, int i,
   CGAL_triangulation_assertion(ok);
 
   Vertex_handle vi = insert(pi, Triangulation::EDGE, f, i);
-  return vi; 
+  return vi;
 }
 
 template <class Tr>
-typename Constrained_triangulation_plus_2<Tr>::Vertex_handle 
+typename Constrained_triangulation_plus_2<Tr>::Vertex_handle
 Constrained_triangulation_plus_2<Tr>::
-intersect(Face_handle f, int i, 
-	  Vertex_handle vaa,
-	  Vertex_handle vbb,
-	  Exact_predicates_tag)
+intersect(Face_handle f, int i,
+          Vertex_handle vaa,
+          Vertex_handle vbb,
+          Exact_predicates_tag)
 {
   Vertex_handle  vcc, vdd;
   vcc = f->vertex(cw(i));
@@ -1158,7 +1158,7 @@ intersect(Face_handle f, int i,
     case 0 : vi = vaa; break;
     case 1 : vi = vbb; break;
     case 2 : vi = vcc; break;
-    case 3 : vi = vdd; break; 
+    case 3 : vi = vdd; break;
     }
     if(vi == vaa || vi == vbb) {
       Triangulation::remove_constrained_edge(f, i);
@@ -1171,15 +1171,15 @@ intersect(Face_handle f, int i,
 
   // vi == vc or vi == vd may happen even if intersection==true
   // due to approximate construction of the intersection
-  if (vi != vcc && vi != vdd) { 
+  if (vi != vcc && vi != vdd) {
     hierarchy.split_constraint(vcc,vdd,vi);
-    insert_subconstraint(vcc,vi); 
+    insert_subconstraint(vcc,vi);
     insert_subconstraint(vi, vdd);
-  } 
+  }
   else {
     insert_subconstraint(vcc,vdd);
   }
-  return vi; 
+  return vi;
 }
 
   // CONCATENATE AND SPLIT
@@ -1194,7 +1194,7 @@ Constrained_triangulation_plus_2<Tr>::concatenate(Constraint_id first, Constrain
 
   // split a constraint in two constraints, so that vcit becomes the first
   // vertex of the new constraint
-  // returns the new constraint 
+  // returns the new constraint
 template <class Tr>
 typename Constrained_triangulation_plus_2<Tr>::Constraint_id
 Constrained_triangulation_plus_2<Tr>::split(Constraint_id first, Vertices_in_constraint_iterator vcit)
@@ -1205,8 +1205,8 @@ Constrained_triangulation_plus_2<Tr>::split(Constraint_id first, Vertices_in_con
 
 template <class Tr>
 std::ostream &
-operator<<(std::ostream& os, 
-	   const Constrained_triangulation_plus_2<Tr> &ct)
+operator<<(std::ostream& os,
+           const Constrained_triangulation_plus_2<Tr> &ct)
 {
   ct.file_output(os);
   return os ;
@@ -1214,8 +1214,8 @@ operator<<(std::ostream& os,
 
 template <class Tr>
 std::istream &
-operator>>(std::istream& is, 
-	   Constrained_triangulation_plus_2<Tr> &ct)
+operator>>(std::istream& is,
+           Constrained_triangulation_plus_2<Tr> &ct)
 {
   ct.file_input(is);
   return is ;
@@ -1275,13 +1275,13 @@ context(Vertex_handle va, Vertex_handle vb) // AF: const
 
 
 template <class Tr>
-inline 
+inline
 typename Constrained_triangulation_plus_2<Tr>::size_type
 Constrained_triangulation_plus_2<Tr>::
 number_of_enclosing_constraints(Vertex_handle va, Vertex_handle vb) const
 {
- return static_cast<size_type> 
-   (hierarchy.number_of_enclosing_constraints(va,vb)); 
+ return static_cast<size_type>
+   (hierarchy.number_of_enclosing_constraints(va,vb));
 }
 
 template <class Tr>
@@ -1289,7 +1289,7 @@ inline bool
 Constrained_triangulation_plus_2<Tr>::
 is_subconstraint(Vertex_handle va, Vertex_handle vb)
 {
- return hierarchy.is_subconstrained_edge(va,vb); 
+ return hierarchy.is_subconstrained_edge(va,vb);
 }
 
 

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/CTP2_subconstraint_graph.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/CTP2_subconstraint_graph.h
@@ -5,7 +5,7 @@
 // $URL$
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
-// 
+//
 //
 // Author(s)     : Simon Giraudot
 
@@ -53,24 +53,24 @@ public:
   typedef boost::transform_iterator<Subconstr_uf, typename CTP2::Subconstraint_iterator> edge_iterator;
 
   CTP2_subconstraint_graph (CTP2& ctp2) : ctp2(ctp2) { }
-  
+
   friend Iterator_range<vertex_iterator> vertices (const CTP2_subconstraint_graph& g)
   {
     return make_range (vertex_iterator(g.ctp2.finite_vertices_begin()),
                        vertex_iterator(g.ctp2.finite_vertices_end()));
   }
-  
+
   friend Iterator_range<edge_iterator> edges (const CTP2_subconstraint_graph& g)
   {
     return make_range (boost::make_transform_iterator(g.ctp2.subconstraints_begin(), Subconstr_uf(Subconstr_map())),
                        boost::make_transform_iterator(g.ctp2.subconstraints_end(), Subconstr_uf(Subconstr_map())));
   }
-  
+
   friend vertex_descriptor source (edge_descriptor ed, const CTP2_subconstraint_graph&)
   {
     return ed.first;
   }
-  
+
   friend vertex_descriptor target (edge_descriptor ed, const CTP2_subconstraint_graph&)
   {
     return ed.second;
@@ -90,13 +90,13 @@ private:
 public:
 
   CTP2_graph_visitor (CTP2& ctp2) : ctp2 (ctp2) { }
-  
+
   void start_new_polyline()
   {
     latest_vertex = typename CTP2::Vertex_handle();
     current = typename CTP2::Constraint_id();
   }
-  
+
   void add_node (typename CTP2::Vertex_handle vh)
   {
     if (latest_vertex != typename CTP2::Vertex_handle())
@@ -110,7 +110,7 @@ public:
     }
     latest_vertex = vh;
   }
-  
+
   void end_polyline()
   {
     for (typename CTP2::Constraint_id id : to_remove)

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/CTP2_subconstraint_graph.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/CTP2_subconstraint_graph.h
@@ -1,0 +1,126 @@
+// Copyright (c) 2020  GeometryFactory (France).  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+// 
+//
+// Author(s)     : Simon Giraudot
+
+#ifndef CGAL_CTP2_SUBCONSTRAINT_GRAPH_H
+#define CGAL_CTP2_SUBCONSTRAINT_GRAPH_H
+
+#include <CGAL/license/Triangulation_2.h>
+
+#include <CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h>
+#include <CGAL/boost/graph/split_graph_into_polylines.h>
+
+#include <CGAL/property_map.h>
+
+namespace CGAL
+{
+
+namespace internal
+{
+
+template <typename CTP2>
+class CTP2_subconstraint_graph
+{
+  CTP2& ctp2;
+public:
+
+  typedef typename CTP2::Vertex_handle vertex_descriptor;
+  typedef typename CTP2::Subconstraint edge_descriptor;
+  typedef boost::undirected_tag directed_category;
+  typedef boost::disallow_parallel_edge_tag edge_parallel_category;
+  struct CTP2_graph_traversal_category :
+    public virtual boost::bidirectional_graph_tag,
+    public virtual boost::adjacency_graph_tag,
+    public virtual boost::edge_list_graph_tag,
+    public virtual boost::vertex_list_graph_tag
+  { };
+  typedef CTP2_graph_traversal_category traversal_category;
+  typedef internal::Dereference_to_handle_enforcer<
+            CTP2,
+            typename CTP2::Finite_vertices_iterator,
+            vertex_descriptor>                                                vertex_iterator;
+
+  typedef typename CTP2::Subconstraint_iterator::value_type Subconstr_it_v_t;
+  typedef First_of_pair_property_map<Subconstr_it_v_t> Subconstr_map;
+  typedef Property_map_to_unary_function<Subconstr_map> Subconstr_uf;
+  typedef boost::transform_iterator<Subconstr_uf, typename CTP2::Subconstraint_iterator> edge_iterator;
+
+  CTP2_subconstraint_graph (CTP2& ctp2) : ctp2(ctp2) { }
+  
+  friend Iterator_range<vertex_iterator> vertices (const CTP2_subconstraint_graph& g)
+  {
+    return make_range (vertex_iterator(g.ctp2.finite_vertices_begin()),
+                       vertex_iterator(g.ctp2.finite_vertices_end()));
+  }
+  
+  friend Iterator_range<edge_iterator> edges (const CTP2_subconstraint_graph& g)
+  {
+    return make_range (boost::make_transform_iterator(g.ctp2.subconstraints_begin(), Subconstr_uf(Subconstr_map())),
+                       boost::make_transform_iterator(g.ctp2.subconstraints_end(), Subconstr_uf(Subconstr_map())));
+  }
+  
+  friend vertex_descriptor source (edge_descriptor ed, const CTP2_subconstraint_graph&)
+  {
+    return ed.first;
+  }
+  
+  friend vertex_descriptor target (edge_descriptor ed, const CTP2_subconstraint_graph&)
+  {
+    return ed.second;
+  }
+};
+
+
+template <typename CTP2>
+class CTP2_graph_visitor
+{
+private:
+  CTP2& ctp2;
+  std::vector<typename CTP2::Constraint_id> to_remove;
+  typename CTP2::Constraint_id current;
+  typename CTP2::Vertex_handle latest_vertex;
+
+public:
+
+  CTP2_graph_visitor (CTP2& ctp2) : ctp2 (ctp2) { }
+  
+  void start_new_polyline()
+  {
+    latest_vertex = typename CTP2::Vertex_handle();
+    current = typename CTP2::Constraint_id();
+  }
+  
+  void add_node (typename CTP2::Vertex_handle vh)
+  {
+    if (latest_vertex != typename CTP2::Vertex_handle())
+    {
+      to_remove.push_back (ctp2.context(latest_vertex, vh).id());
+      typename CTP2::Constraint_id cid = ctp2.insert_constraint(latest_vertex, vh);
+      if (current == typename CTP2::Constraint_id())
+        current = cid;
+      else
+        current = ctp2.concatenate (current, cid);
+    }
+    latest_vertex = vh;
+  }
+  
+  void end_polyline()
+  {
+    for (typename CTP2::Constraint_id id : to_remove)
+      ctp2.remove_constraint(id);
+    to_remove.clear();
+  }
+};
+
+} // namespace internal
+
+} // namespace CGAL
+
+#endif // CGAL_CTP2_SUBCONSTRAINT_GRAPH_H


### PR DESCRIPTION
## Rationale

The _Constrained Delaunay Triangulation Plus 2_ is a very useful structure to embed a set of polyline and process it (for example, for _Polyline Simplification_ in CGAL). The main difficulty to use it is that the full polylines must be passed (and thus known) to the CDT+ structure: in some cases, users may only have a segment soup as input and thus may not know how this soup decomposes into a set of polylines.

CGAL provides a function [`CGAL::split_graph_into_polylines()`](https://doc.cgal.org/latest/BGL/group__PkgBGLRef.html#ga99ea6bf193f1194db5e523e713c82fb9) that performs such an operation (dividing a set of segment soup into a set of polylines, using vertices of degree `!= 2` as endpoints). One solution to the problem described above is to first preprocess the segment soup into a polyline set and then to pass this polyline set to the CDT+, but it has two drawbacks:

- it is not user-friendly (there's always some work to do to make the segment soup model the right BGL concept)
- it is not optimal: the subconstraints in the CDT+ already forms a graph and can be directly used

This small feature simply adds a member function `split_subconstraint_graph_into_constraints()` to the CDT+ structure. This function just instantiates the right data structures to wrap the subconstraint graph and call `split_graph_into_polylines()` on it. It allows to do the following:

```c++
std::vector<std::pair<Point_2, Point_2> > segment_soup;

CDTP cdtp;
for (const std::pair<Point_2, Point_2>& s : segment_soup)
   cdtp.insert_constraint (s.first, s.second);

cdtp.split_subconstraint_graph_into_constraints();
```

## Summary of API changes

A new member function `CGAL::Constrained_triangulation_plus_2::split_subconstraint_graph_into_constraints()` is provided.

## CHANGES.md

`TODO`

## Submission

* [__New User Manual Subsection + example__](https://cgal.geometryfactory.com/~sgiraudot/CDTP_split/Triangulation_2/index.html#title35)
* [__Reference Manual of `CGAL::Constrained_triangulation_plus_2::split_subconstraint_graph_into_constraints()`__](https://cgal.geometryfactory.com/~sgiraudot/CDTP_split/Triangulation_2/classCGAL_1_1Constrained__triangulation__plus__2.html#adea77f5db5cd4dfae302e4502f1caa85)
* Pre-approuved by @lrineau, 12 March 2020.

## Status

- Developed and locally tested (GNU/Linux)
- [Small Feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/CDT%2B_Split_Subconstraint_Graph_Into_Constraints)