### PR TITLE
Surface_mesh_segmentation: Fix citation (wrong case)

### DIFF
--- a/Surface_mesh_segmentation/include/CGAL/mesh_segmentation.h
+++ b/Surface_mesh_segmentation/include/CGAL/mesh_segmentation.h
@@ -72,7 +72,7 @@ sdf_values( const TriangleMesh& triangle_mesh,
  * \ingroup PkgSurfaceMeshSegmentationRef
  * @brief Function computing the Shape Diameter Function over a surface mesh.
  *
- * This function implements the Shape Diameter Function (SDF) as described in \cgalCite{shapira2008consistent}.
+ * This function implements the Shape Diameter Function (SDF) as described in \cgalCite{Shapira2008Consistent}.
  * It is possible to compute raw SDF values (without post-processing). In such a case,
  * -1 is used to indicate when no SDF value could be computed for a facet.
  *
@@ -160,7 +160,7 @@ sdf_values_postprocessing(const TriangleMesh& triangle_mesh,
  * A segment is a set of connected facets which are placed under the same cluster (see \cgalFigureRef{Cluster_vs_segment}).
  *
  * \note Log-normalization is applied on `sdf_values_map` before segmentation.
- *       As described in the original paper \cgalCite{shapira2008consistent},
+ *       As described in the original paper \cgalCite{Shapira2008Consistent},
  *       this normalization is done to preserve thin parts of the mesh
  *       by increasing the distance between smaller SDF values and reducing
  *       it between larger ones.


### PR DESCRIPTION
## Summary of Changes

Fix a citation error, caught by recent builds of Doxygen (since doxygen/doxygen@fa520f975a0893c0d123c1cafec63206bf737794).

## Release Management

* Affected package(s): Surface_mesh_segmentation
* License and copyright ownership: n/a
