### PR TITLE
Fix Yade high precision Real compilation

### DIFF
--- a/Principal_component_analysis/include/CGAL/PCA_util.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util.h
@@ -657,7 +657,8 @@ assemble_covariance_matrix_3(InputIterator first,
        t[0].y(), t[1].y(), 0.0,
                    t[0].z(), t[1].z(), 1.0};
     Matrix transformation = init_matrix<FT>(3,delta);
-    FT length = std::sqrt(t.squared_length());
+    using std::sqrt;
+    FT length = sqrt(t.squared_length());
 
 		// skip zero measure primitives
     if(length == (FT)0.0)

--- a/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
@@ -575,7 +575,8 @@ assemble_covariance_matrix_3(InputIterator first,
     transformation << t[0].x(), t[1].x(), 0.0, 
                       t[0].y(), t[1].y(), 0.0,
                       t[0].z(), t[1].z(), 1.0;
-    FT length = std::sqrt(t.squared_length());
+    using std::sqrt;
+    FT length = sqrt(t.squared_length());
 
     // skip zero measure primitives
     if(length == (FT)0.0)

--- a/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_segments_2.h
+++ b/Principal_component_analysis/include/CGAL/linear_least_squares_fitting_segments_2.h
@@ -91,7 +91,8 @@ linear_least_squares_fitting_2(InputIterator first,
     FT delta[4] = {t[0].x(), t[1].x(), 
 		   t[0].y(), t[1].y()};
     Matrix transformation = init_matrix<FT>(2,delta);
-    FT length = std::sqrt(t.squared_length());
+    using std::sqrt;
+    FT length = sqrt(t.squared_length());
     CGAL_assertion(length != 0.0);
 
     // Find the 2nd order moment for the segment wrt to the origin by an affine transformation.

--- a/Principal_component_analysis_LGPL/include/CGAL/centroid.h
+++ b/Principal_component_analysis_LGPL/include/CGAL/centroid.h
@@ -129,7 +129,9 @@ centroid(InputIterator begin,
       it++)
   {
     const Segment& s = *it;
-    FT length = std::sqrt(std::abs(s.squared_length()));
+    using std::abs;
+    using std::sqrt;
+    FT length = sqrt(abs(s.squared_length()));
     Point c = K().construct_midpoint_2_object()(s[0],s[1]);
     v = v + length * (c - ORIGIN);
     sum_lengths += length;

--- a/Principal_component_analysis_LGPL/include/CGAL/centroid.h
+++ b/Principal_component_analysis_LGPL/include/CGAL/centroid.h
@@ -449,7 +449,8 @@ centroid(InputIterator begin,
       it++)
   {
     const Segment& s = *it;
-    FT length = std::sqrt(s.squared_length());
+    using std::sqrt;
+    FT length = sqrt(s.squared_length());
     Point c = CGAL::midpoint(s.source(),s.target());
     // Point c = K().construct_midpoint_3_object()(s[0],s[1]);
     //Point c = Point((s[0][0] + s[1][0])/2.0, (s[0][1] + s[1][1])/2.0, (s[0][2] + s[1][2])/2.0);


### PR DESCRIPTION
This one partially fixes #4527 - first commit is all that is necessary to fix compiling Yade. Second commit is because the changes were extremely similar to the first commit, so I felt they were appropriate.

The `std::abs` though looks very strange there, it's called on an always positive value of `squared_length`, unless you expect complex numbers to be in play?

## Release Management

* Affected package(s): PCA
* Feature/Small Feature (if any): N/A
* License and copyright ownership: license already used by CGAL

