### PR TITLE
Some noexcept, swap, etc to help Handle* types

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Point_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Point_2.h
@@ -50,6 +50,15 @@ public:
   PointC2(const FT &hx, const FT &hy, const FT &hw)
     : base(hx, hy, hw) {}
 
+  friend void swap(Self& a, Self& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Vector_2_>)
+#endif
+  {
+    using std::swap;
+    swap(a.base, b.base);
+  }
+
   const FT& x() const
   {
       return base.x();

--- a/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
@@ -47,6 +47,15 @@ public:
   PointC3(const FT &x, const FT &y, const FT &z, const FT &w)
     : base(x, y, z, w) {}
 
+  friend void swap(PointC3& a, PointC3& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Vector_3>)
+#endif
+  {
+    using std::swap;
+    swap(a.base, b.base);
+  }
+
   const FT & x() const
   {
       return base.x();

--- a/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
@@ -24,6 +24,7 @@ namespace CGAL {
 template < class R_ >
 class PointC3
 {
+  typedef PointC3<R_>                       Self;
   typedef typename R_::Vector_3             Vector_3;
   typedef typename R_::Point_3              Point_3;
   typedef typename R_::Aff_transformation_3 Aff_transformation_3;
@@ -47,7 +48,7 @@ public:
   PointC3(const FT &x, const FT &y, const FT &z, const FT &w)
     : base(x, y, z, w) {}
 
-  friend void swap(PointC3& a, PointC3& b)
+  friend void swap(Self& a, Self& b)
 #ifdef __cpp_lib_is_swappable
     noexcept(std::is_nothrow_swappable_v<Vector_3>)
 #endif

--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
@@ -27,6 +27,7 @@ namespace CGAL {
 template < class R_ >
 class VectorC2
 {
+  typedef VectorC2<R_>                      Self;
   typedef typename R_::FT                   FT;
   typedef typename R_::Point_2              Point_2;
   typedef typename R_::Vector_2             Vector_2;
@@ -54,6 +55,15 @@ public:
   VectorC2(const FT &hx, const FT &hy, const FT &hw)
     : base( hw != FT(1) ? CGAL::make_array<FT>(hx/hw, hy/hw)
                         : CGAL::make_array(hx, hy) ) {}
+
+  friend void swap(Self& a, Self& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Base>)
+#endif
+  {
+    using std::swap;
+    swap(a.base, b.base);
+  }
 
   const FT & x() const
   {

--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
@@ -27,6 +27,7 @@ template < class R_ >
 class VectorC3
 {
 // https://doc.cgal.org/latest/Manual/devman_code_format.html#secprogramming_conventions
+  typedef VectorC3<R_>                      Self;
   typedef typename R_::FT                   FT_;
   typedef typename R_::Point_3              Point_3;
   typedef typename R_::Vector_3             Vector_3;
@@ -70,7 +71,7 @@ public:
     : base( w != FT_(1) ? CGAL::make_array<FT_>(x/w, y/w, z/w)
                        : CGAL::make_array(x, y, z) ) {}
 
-  friend void swap(VectorC3& a, VectorC3& b)
+  friend void swap(Self& a, Self& b)
 #ifdef __cpp_lib_is_swappable
     noexcept(std::is_nothrow_swappable_v<Base>)
 #endif

--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
@@ -70,6 +70,15 @@ public:
     : base( w != FT_(1) ? CGAL::make_array<FT_>(x/w, y/w, z/w)
                        : CGAL::make_array(x, y, z) ) {}
 
+  friend void swap(VectorC3& a, VectorC3& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Base>)
+#endif
+  {
+    using std::swap;
+    swap(a.base, b.base);
+  }
+
   const FT_ & x() const
   {
       return get_pointee_or_identity(base)[0];

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -731,6 +731,9 @@ public :
     PTR = new Lazy_rep_0<AT,ET,E2A>(std::move(e));
   }
 
+  friend void swap(Lazy& a, Lazy& b) noexcept
+  { swap(static_cast<Handle&>(a), static_cast<Handle&>(b)); }
+
   const AT& approx() const
   { return ptr()->approx(); }
 

--- a/Kernel_23/include/CGAL/Point_2.h
+++ b/Kernel_23/include/CGAL/Point_2.h
@@ -48,12 +48,12 @@ public:
   typedef RPoint_2 Rep;
   typedef typename R_::Cartesian_const_iterator_2 Cartesian_const_iterator;
 
-  const Rep& rep() const
+  const Rep& rep() const noexcept
   {
     return *this;
   }
 
-  Rep& rep()
+  Rep& rep() noexcept
   {
     return *this;
   }
@@ -83,6 +83,15 @@ public:
   Point_2(const RT& hx, const RT& hy, const RT& hw)
     : RPoint_2(typename R::Construct_point_2()(Return_base_tag(), hx, hy, hw))
   {}
+
+  friend void swap(Self& a, Self& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Rep>)
+#endif
+  {
+    using std::swap;
+    swap(a.rep(), b.rep());
+  }
 
   typename cpp11::result_of<typename R::Compute_x_2(Point_2)>::type
   x() const

--- a/Kernel_23/include/CGAL/Point_3.h
+++ b/Kernel_23/include/CGAL/Point_3.h
@@ -46,12 +46,12 @@ public:
   typedef typename R_::Kernel_base::Point_3  Rep;
   typedef typename R_::Cartesian_const_iterator_3 Cartesian_const_iterator;
 
-  const Rep& rep() const
+  const Rep& rep() const noexcept
   {
     return *this;
   }
 
-  Rep& rep()
+  Rep& rep() noexcept
   {
     return *this;
   }
@@ -80,6 +80,15 @@ public:
   Point_3(const RT& hx, const RT& hy, const RT& hz, const RT& hw)
     : Rep(typename R::Construct_point_3()(Return_base_tag(), hx, hy, hz, hw))
   {}
+
+  friend void swap(Point_3& a, Point_3& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Rep>)
+#endif
+  {
+    using std::swap;
+    swap(a.rep(), b.rep());
+  }
 
   typename cpp11::result_of<typename R::Compute_x_3( Point_3)>::type
   x() const

--- a/Kernel_23/include/CGAL/Point_3.h
+++ b/Kernel_23/include/CGAL/Point_3.h
@@ -81,7 +81,7 @@ public:
     : Rep(typename R::Construct_point_3()(Return_base_tag(), hx, hy, hz, hw))
   {}
 
-  friend void swap(Point_3& a, Point_3& b)
+  friend void swap(Self& a, Self& b)
 #ifdef __cpp_lib_is_swappable
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif

--- a/Kernel_23/include/CGAL/Vector_2.h
+++ b/Kernel_23/include/CGAL/Vector_2.h
@@ -54,12 +54,12 @@ public:
   typedef RVector_2 Rep;
   typedef typename R_::Cartesian_const_iterator_2 Cartesian_const_iterator;
 
-  const Rep& rep() const
+  const Rep& rep() const noexcept
   {
     return *this;
   }
 
-  Rep& rep()
+  Rep& rep() noexcept
   {
     return *this;
   }
@@ -92,6 +92,15 @@ public:
 
   Vector_2(const RT &x, const RT &y, const RT &w)
       : RVector_2(typename R::Construct_vector_2()(Return_base_tag(), x,y,w)) {}
+
+  friend void swap(Self& a, Self& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Rep>)
+#endif
+  {
+    using std::swap;
+    swap(a.rep(), b.rep());
+  }
 
 
   typename cpp11::result_of<typename R::Compute_x_2(Vector_2)>::type

--- a/Kernel_23/include/CGAL/Vector_3.h
+++ b/Kernel_23/include/CGAL/Vector_3.h
@@ -93,7 +93,7 @@ public:
   Vector_3(const RT& x, const RT& y, const RT& z, const RT& w)
     : Rep(typename R::Construct_vector_3()(Return_base_tag(), x, y, z, w)) {}
 
-  friend void swap(Vector_3& a, Vector_3& b)
+  friend void swap(Self& a, Self& b)
 #ifdef __cpp_lib_is_swappable
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif

--- a/Kernel_23/include/CGAL/Vector_3.h
+++ b/Kernel_23/include/CGAL/Vector_3.h
@@ -93,6 +93,15 @@ public:
   Vector_3(const RT& x, const RT& y, const RT& z, const RT& w)
     : Rep(typename R::Construct_vector_3()(Return_base_tag(), x, y, z, w)) {}
 
+  friend void swap(Vector_3& a, Vector_3& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Rep>)
+#endif
+  {
+    using std::swap;
+    swap(a.rep(), b.rep());
+  }
+
   Direction_3 direction() const
   {
     return R().construct_direction_3_object()(*this);

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
@@ -51,12 +51,12 @@ public:
   typedef typename Get_type<Kbase, Point_tag>::type      Rep;
   //typedef typename CGAL::decay<typename boost::result_of<CPI(Rep,Begin_tag)>::type>::type Cartesian_const_iterator;
 
-  const Rep& rep() const
+  const Rep& rep() const noexcept
   {
     return *this;
   }
 
-  Rep& rep()
+  Rep& rep() noexcept
   {
     return *this;
   }
@@ -101,6 +101,14 @@ public:
   Point_d(Origin&& v)
     : Rep(CPBase()(std::move(v))) {}
 
+  friend void swap(Self& a, Self& b)
+#ifdef __cpp_lib_is_swappable
+    noexcept(std::is_nothrow_swappable_v<Rep>)
+#endif
+    {
+      using std::swap;
+      swap(a.rep(), b.rep());
+    }
 
   decltype(auto) cartesian(int i)const{
 	  return CCBase()(rep(),i);

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -222,20 +222,23 @@ public:
   Gmpq& operator*=(const Gmpq &q);
   Gmpq& operator/=(const Gmpq &q);
 
-  bool operator==(const Gmpq &q) const { return mpq_equal(this->mpq(), q.mpq()) != 0;}
-  bool operator< (const Gmpq &q) const { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
+  bool operator==(const Gmpq &q) const noexcept { return mpq_equal(this->mpq(), q.mpq()) != 0;}
+  bool operator< (const Gmpq &q) const noexcept { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
 
-  double to_double() const;
-  Sign sign() const;
+  double to_double() const noexcept;
+  Sign sign() const noexcept;
 
-  const mpq_t & mpq() const { return Ptr()->mpQ; }
-  mpq_t & mpq() { return ptr()->mpQ; }
+  const mpq_t & mpq() const noexcept { return Ptr()->mpQ; }
+  mpq_t & mpq() noexcept { return ptr()->mpQ; }
 
+  friend void swap(Gmpq &x, Gmpq &y) noexcept { x.Base::swap(y); }
+#ifdef CGAL_PROFILE
   ~Gmpq()
   {
      CGAL_HISTOGRAM_PROFILER("[Gmpq sizes in log2 scale]",
                              (unsigned) ( ::log(double(size())) / ::log(double(2)) )  );
   }
+#endif
 
   // Interoperability with int
   Gmpq& operator+=(int z){return (*this)+= Gmpq(z);}
@@ -446,12 +449,12 @@ Gmpq& Gmpq::operator/=(const Gmpz &z){
 
 inline
 double
-Gmpq::to_double() const
+Gmpq::to_double() const noexcept
 { return mpq_get_d(mpq()); }
 
 inline
 Sign
-Gmpq::sign() const
+Gmpq::sign() const noexcept
 { return static_cast<Sign>(mpq_sgn(mpq())); }
 
 inline

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -383,6 +383,9 @@ public :
   typename boost::disable_if<is_implicit_convertible<ET1,ET>,int>::type=0)
     : Base(new Lazy_lazy_exact_Cst<ET, ET1>(x)){}
 
+  friend void swap(Lazy_exact_nt& a, Lazy_exact_nt& b) noexcept
+  { swap(static_cast<Base&>(a), static_cast<Base&>(b)); }
+
   Self operator+ () const
   { return *this; }
 

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -68,6 +68,8 @@ class Handle
       return *this;
     }
 
+    friend void swap(Handle& a, Handle& b) noexcept { std::swap(a.PTR, b.PTR); }
+
     void reset()
     {
       if (PTR)

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -39,13 +39,15 @@ class Handle
     
     typedef std::ptrdiff_t Id_type ;
     
-    Handle()
+    Handle() noexcept
 	: PTR(static_cast<Rep*>(0)) {}
 
-    Handle(const Handle& x)
+    // FIXME: if the precondition throws in a noexcept function, the program terminates
+    Handle(const Handle& x) noexcept
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       PTR = x.PTR;
+      CGAL_assume (PTR->count > 0);
       PTR->count++;
     }
 
@@ -56,7 +58,7 @@ class Handle
     }
 
     Handle&
-    operator=(const Handle& x)
+    operator=(const Handle& x) noexcept
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       x.PTR->count++;
@@ -77,11 +79,11 @@ class Handle
     }
 
     int
-    refs()  const { return PTR->count; }
+    refs()  const noexcept { return PTR->count; }
 
-    Id_type id() const { return PTR - static_cast<Rep*>(0); }
+    Id_type id() const noexcept { return PTR - static_cast<Rep*>(0); }
 
-    bool identical(const Handle& h) const { return PTR == h.PTR; }
+    bool identical(const Handle& h) const noexcept { return PTR == h.PTR; }
 
   protected:
     Rep* PTR;
@@ -89,7 +91,7 @@ class Handle
 
 //inline Handle::Id_type id(const Handle& x) { return x.id() ; }
 
-inline bool identical(const Handle &h1, const Handle &h2) { return h1.identical(h2); }
+inline bool identical(const Handle &h1, const Handle &h2) noexcept { return h1.identical(h2); }
 
 } //namespace CGAL
 

--- a/STL_Extension/include/CGAL/Handle_for.h
+++ b/STL_Extension/include/CGAL/Handle_for.h
@@ -102,7 +102,7 @@ public:
         ptr_ = p;
     }
 
-    Handle_for(const Handle_for& h)
+    Handle_for(const Handle_for& h) noexcept
       : ptr_(h.ptr_)
     {
 	CGAL_assume (ptr_->count > 0);
@@ -110,7 +110,7 @@ public:
     }
 
     Handle_for&
-    operator=(const Handle_for& h)
+    operator=(const Handle_for& h) noexcept
     {
         Handle_for tmp = h;
         swap(tmp);
@@ -132,7 +132,7 @@ public:
     //        from e.g. using nullptr as a ptr value, but this is drastic.
 
     Handle_for&
-    operator=(Handle_for && h)
+    operator=(Handle_for && h) noexcept
     {
         swap(h);
         return *this;
@@ -164,15 +164,15 @@ public:
         *this = t;
     }
 
-    Id_type id() const { return Ptr() - static_cast<T const*>(0); }
+    Id_type id() const noexcept { return Ptr() - static_cast<T const*>(0); }
     
-    bool identical(const Handle_for& h) const { return Ptr() == h.Ptr(); }
+    bool identical(const Handle_for& h) const noexcept { return Ptr() == h.Ptr(); }
 
 
     // Ptr() is the "public" access to the pointer to the object.
     // The non-const version asserts that the instance is not shared.
     const element_type *
-    Ptr() const
+    Ptr() const noexcept
     {
        return &(ptr_->t);
     }
@@ -188,25 +188,25 @@ public:
     */
 
     bool
-    is_shared() const
+    is_shared() const noexcept
     {
 	return ptr_->count > 1;
     }
 
     bool
-    unique() const
+    unique() const noexcept
     {
 	return !is_shared();
     }
 
     long
-    use_count() const
+    use_count() const noexcept
     {
 	return ptr_->count;
     }
 
     void
-    swap(Handle_for& h)
+    swap(Handle_for& h) noexcept
     {
       std::swap(ptr_, h.ptr_);
     }
@@ -222,11 +222,11 @@ protected:
     // ptr() is the protected access to the pointer.  Both const and non-const.
     // Redundant with Ptr().
     element_type *
-    ptr()
+    ptr() noexcept
     { return &(ptr_->t); }
 
     const element_type *
-    ptr() const
+    ptr() const noexcept
     { return &(ptr_->t); }
 };
 


### PR DESCRIPTION
## Summary of Changes

The most important part is noexcept on the copy constructors. I assumed that the destructors of the types we put in there don't throw, it would be possible to make it conditionally noexcept, but that doesn't seem worth the trouble.
There is an issue with the precondition in the copy constructor of Handle: noexcept means that it cannot throw an exception it will terminate instead. I think the gains of noexcept far outweigh the possibility to catch such an exception.

## Release Management

* Affected package(s): Number_types, STL_Extension