### PR TITLE
Spatial_searching: Pass custom traits to the Fuzzy_sphere object constructor

### DIFF
--- a/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
+++ b/Spatial_searching/examples/Spatial_searching/searching_polyhedron_vertices_with_fuzzy_sphere.cpp
@@ -30,19 +30,15 @@ int main(int argc, char* argv[])
   in  >> mesh;
 
   Vertex_point_pmap vppmap = get(CGAL::vertex_point,mesh);
+  Traits traits(vppmap);
+  Tree tree(vertices(mesh).begin(), vertices(mesh).end(), Splitter(), traits);
 
-  // Insert number_of_data_points in the tree
-  Tree tree(vertices(mesh).begin(),
-            vertices(mesh).end(),
-            Splitter(),
-            Traits(vppmap)
-  );
   Point_3 query(0.0, 0.0, 0.0);
   double radius = 0.5;
   double epsilon = 0.01;
 
   // search vertices
-  CGAL::Fuzzy_sphere<Traits> fz(query, radius, epsilon);
+  CGAL::Fuzzy_sphere<Traits> fz(query, radius, epsilon, traits);
   
   //collect vertices that are inside the sphere
   std::list<vertex_descriptor> result;


### PR DESCRIPTION
## Summary of Changes

The traits also must be passed to the fuzzy sphere, otherwise it relies on the default VPM being correct and being the VPM passed to the tree.

## Release Management

* Affected package(s): `Spatial_searching`

