### PR TITLE
Use FT instead of RT

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -119,8 +119,8 @@ CGAL_Kernel_pred(Compare_dihedral_angle_3,
 		 compare_dihedral_angle_3_object)
 CGAL_Kernel_pred(Compare_distance_2,
 		 compare_distance_2_object)
-CGAL_Kernel_pred_RT(Compare_distance_3,
-                    compare_distance_3_object)
+CGAL_Kernel_pred(Compare_distance_3,
+                 compare_distance_3_object)
 CGAL_Kernel_pred_RT(Compare_power_distance_2,
                     compare_power_distance_2_object)
 CGAL_Kernel_pred_RT(Compare_power_distance_3,


### PR DESCRIPTION
`Compare_distance_3` is a generic functor that is comparing
the returned value of Squared_distance_3. If called to
compare the distance of a point to a plane/segment/triangle
a division is used leading to runtime error.

Links in the code to the division:
https://github.com/CGAL/cgal/blob/master/Distance_3/include/CGAL/squared_distance_3_1.h#L140
https://github.com/CGAL/cgal/blob/master/Distance_3/include/CGAL/squared_distance_3_0.h#L202