### PR TITLE
Labeled_mesh_domain_3: Fix the `value_outside` parameter

### DIFF
--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -843,7 +843,7 @@ protected:
                                                       false>           Wrapper;
     return Wrapper(image,
                    transform_fct,
-                   transform_fct(value_outside));
+                   value_outside) ;
   }
 
   template <typename FT, typename FT2, typename Functor>


### PR DESCRIPTION
## Summary of Changes

Fixes a bug introduced in CGAL-4.13 (PR #2739).

cc: @sloriot 

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #2739
* License and copyright ownership: N/A

