### PR TITLE
PMP::isotropic_remeshing() - fix remeshing with patch ids

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1523,14 +1523,9 @@ private:
       // tag patch border halfedges
       BOOST_FOREACH(halfedge_descriptor h, halfedges(mesh_))
       {
-        if (status(h)==PATCH && status(opposite(h, mesh_))!=PATCH)
-        {
-          set_status(h, PATCH_BORDER);
-          has_border_ = true;
-        }
         if (status(h) == PATCH
-          && status(opposite(h, mesh_)) == PATCH
-          && get_patch_id(face(h, mesh_)) != get_patch_id(face(opposite(h, mesh_), mesh_)))
+          && (   status(opposite(h, mesh_)) != PATCH
+              || get_patch_id(face(h, mesh_)) != get_patch_id(face(opposite(h, mesh_), mesh_))))
         {
           set_status(h, PATCH_BORDER);
           has_border_ = true;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1528,6 +1528,13 @@ private:
           set_status(h, PATCH_BORDER);
           has_border_ = true;
         }
+        if (status(h) == PATCH
+          && status(opposite(h, mesh_)) == PATCH
+          && get_patch_id(face(h, mesh_)) != get_patch_id(face(opposite(h, mesh_), mesh_)))
+        {
+          set_status(h, PATCH_BORDER);
+          has_border_ = true;
+        }
       }
 
       // update status using constrained edge map

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -611,7 +611,6 @@ public Q_SLOTS:
         }
         if (fpmap_valid)
         {
-          PMP::connected_components(pmesh, fpmap, PMP::parameters::edge_is_constrained_map(eif));
           poly_item->setItemIsMulticolor(true);
           poly_item->show_feature_edges(true);
         }


### PR DESCRIPTION
## Summary of Changes

This PR fixes `PMP::isotropic_remeshing()` when it is used with a `face_patch_map` and no constrained edges.
It should consider interface polylines as constrained edges, so that they can be (or not, depending on the protection parameter) resampled but never "broken".

Moreover, it is what is documented.

Until now, the polyline interfaces were simply not taken into account.

## Release Management

* Affected package(s): PMP

