### PR TITLE
Travis: Don't compute dependencies if a package is missing.

### DIFF
--- a/.travis/test_package.sh
+++ b/.travis/test_package.sh
@@ -5,11 +5,17 @@
 
 DO_IGNORE=FALSE
 cd $1
-if [ ! -f "$2/package_info/$2/dependencies" ];then 
+
+if [ ! -d "$2" ]; then
+  echo "$2 : MISSING PACKAGE. Ignoring."
+  DO_IGNORE=TRUE
+  exit 1
+fi
+  
+  
+if [ ! -f "$2/package_info/$2/dependencies" ];then
   echo "No dependencies found for $2"
-  bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
-  
-  
+  bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen	
   exit 1
 fi
 LIST_OF_FILES=$(git diff --name-only origin/master... |cut -d/ -f1 |uniq |sort)


### PR DESCRIPTION

## Summary of Changes
The point is to avoid getting dependencies differencies in a package if some 3rd party lib is not install for that specific job.
