### PR TITLE
Triangulation_23: Grab return of construct_point() by reference when possible

### DIFF
--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_filtered_traits_2.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_filtered_traits_2.h
@@ -174,6 +174,7 @@ public:
   //---------------------------------
   typedef typename CK_traits::Construct_object_2     Construct_object_2;
   typedef typename CK_traits::Assign_2               Assign_2;
+  typedef typename CK_traits::Construct_point_2      Construct_point_2;
 
   // CONSTRUCTIONS
   //--------------
@@ -338,6 +339,10 @@ public:
     return Construct_object_2();
   }
 
+  Construct_point_2
+  construct_point_2_object() const {
+    return Construct_point_2();
+  }
 
   // CONSTRUCTIONS
   //--------------

--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_traits_2.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_traits_2.h
@@ -84,6 +84,8 @@ public:
 
   // CONSTRUCTIONS
   //--------------
+  typedef typename Kernel::Construct_point_2      Construct_point_2;
+
   // vertex and dual site
   typedef CGAL_APOLLONIUS_GRAPH_2_NS::Construct_Apollonius_vertex_2<Kernel>
   /*                                      */ Construct_Apollonius_vertex_2;
@@ -151,6 +153,10 @@ public:
     return Construct_object_2();
   }
 
+  Construct_point_2
+  construct_point_2_object() const {
+    return Construct_point_2();
+  }
 
   // CONSTRUCTIONS
   //--------------

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -659,7 +659,8 @@ public:
   // but       point()          -like functions have return type Point
 
   template<typename P> // can be Point or Point_3
-  Point_3 construct_point(const P& p) const {
+  typename boost::result_of<const typename GT::Construct_point_3(const P&)>::type
+  construct_point(const P& p) const {
     return geom_traits().construct_point_3_object()(p);
   }
 

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -30,11 +30,6 @@
 
 #include <CGAL/basic.h>
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/random/linear_congruential.hpp>
-#include <boost/random/uniform_smallint.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/unordered_map.hpp>
 #include <CGAL/internal/Periodic_3_triangulation_iterators_3.h>
 #include <CGAL/Periodic_3_triangulation_ds_cell_base_3.h>
 #include <CGAL/Periodic_3_triangulation_ds_vertex_base_3.h>
@@ -56,6 +51,13 @@
 #include <CGAL/Triangulation_structural_filtering_traits.h>
 #include <CGAL/determinant.h>
 #endif // no CGAL_NO_STRUCTURAL_FILTERING
+
+#include <boost/random/linear_congruential.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/utility/result_of.hpp>
+#include <boost/unordered_map.hpp>
 
 #include <iostream>
 #include <algorithm>

--- a/Periodic_3_triangulation_3/include/CGAL/internal/Periodic_3_Delaunay_triangulation_remove_traits_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/internal/Periodic_3_Delaunay_triangulation_remove_traits_3.h
@@ -49,7 +49,7 @@ public:
 
   using Base::operator();
 
-  const Point_3& operator()(const Point_3& p) { return p; }
+  const Point_3& operator()(const Point_3& p) const { return p; }
 };
 
 template < class Traits_, class Functor_ >

--- a/Periodic_3_triangulation_3/include/CGAL/internal/Periodic_3_regular_triangulation_remove_traits_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/internal/Periodic_3_regular_triangulation_remove_traits_3.h
@@ -58,7 +58,7 @@ public:
 
   using Base::operator(); // for K::Weighted_point_3 to Point_3
 
-  Point_3 operator()(const Weighted_point_3& wp) {
+  Point_3 operator()(const Weighted_point_3& wp) const {
     return std::make_pair(operator()(wp.first), wp.second /* offset */);
   }
 };

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Filtered_traits_base_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Filtered_traits_base_2.h
@@ -177,6 +177,7 @@ public:
   //---------------------------------
   typedef typename CK::Construct_object_2     Construct_object_2;
   typedef typename CK::Assign_2               Assign_2;
+  typedef typename CK::Construct_point_2      Construct_point_2;
 
   // CONSTRUCTIONS
   //--------------
@@ -374,6 +375,11 @@ public:
   Construct_object_2
   construct_object_2_object() const { 
     return Construct_object_2();
+  }
+
+  Construct_point_2
+  construct_point_2_object() const {
+    return Construct_point_2();
   }
 
   // CONSTRUCTIONS

--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Traits_base_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2/Traits_base_2.h
@@ -105,6 +105,7 @@ public:
   //-------------------------------
   typedef typename Kernel::Construct_object_2     Construct_object_2;
   typedef typename Kernel::Assign_2               Assign_2;
+  typedef typename Kernel::Construct_point_2      Construct_point_2;
 
   // CONSTRUCTIONS
   //--------------
@@ -193,6 +194,11 @@ public:
   Construct_object_2
   construct_object_2_object() const { 
     return Construct_object_2();
+  }
+
+  Construct_point_2
+  construct_point_2_object() const {
+    return Construct_point_2();
   }
 
   // CONSTRUCTIONS

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -128,6 +128,8 @@ public:
   typedef typename Tds::Halfedge_iterator      All_halfedges_iterator;
   typedef typename Tds::Vertex_iterator        All_vertices_iterator;
 
+  typedef typename Gt::Construct_point_2       Construct_point_2;
+
   class Perturbation_order
   {
     const Self *t;
@@ -277,7 +279,9 @@ public:
                Face_handle &fr) const;
 
   // GEOMETRIC FEATURES AND CONSTRUCTION
-  Point_2 construct_point(const Point& p) const;
+  typename boost::result_of<const Construct_point_2(const Point&)>::type
+  construct_point(const Point& p) const { return geom_traits().construct_point_2_object()(p); }
+
   const Point& point(Face_handle c, int i) const;
   const Point& point(Vertex_handle v) const;
   Segment segment(Face_handle f, int i) const;
@@ -595,7 +599,6 @@ std::ptrdiff_t insert(InputIterator first, InputIterator last)
 
   std::vector<Point> points (first, last);
 
-  typedef typename Geom_traits::Construct_point_2 Construct_point_2;
   typedef typename boost::result_of<const Construct_point_2(const Point&)>::type Ret;
   typedef CGAL::internal::boost_::function_property_map<Construct_point_2, Point, Ret> fpmap;
   typedef CGAL::Spatial_sort_traits_adapter_2<Geom_traits, fpmap> Search_traits_2;
@@ -965,14 +968,6 @@ is_face(Vertex_handle v1,
         Face_handle &fr) const
 {
   return _tds.is_face(v1, v2, v3, fr);
-}
-
-template <class Gt, class Tds >
-typename Triangulation_2<Gt, Tds>::Point_2
-Triangulation_2<Gt, Tds>::
-construct_point(const Point& p) const
-{
-  return geom_traits().construct_point_2_object()(p);
 }
 
 template <class Gt, class Tds >

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -433,6 +433,8 @@ public:
 
   typedef typename Tds::Simplex                Simplex;
 
+  typedef typename GT::Construct_point_3       Construct_point_3;
+
 private:
   // This class is used to generate the Finite_*_iterators.
   class Infinite_tester
@@ -553,7 +555,8 @@ protected:
 
 public:
   template<typename P> // Point or Point_3
-  Point_3 construct_point(const P& p) const
+  typename boost::result_of<const Construct_point_3(const P&)>::type
+  construct_point(const P& p) const
   {
     return geom_traits().construct_point_3_object()(p);
   }
@@ -1127,7 +1130,6 @@ public:
     // Nevertheless, to make it more generic (that is, allowing the user to pass
     // a `Point` type that is not GT::Point_3), we still use the spatial sort
     // adapter traits and Construct_point_3 here.
-    typedef typename Geom_traits::Construct_point_3 Construct_point_3;
     typedef typename boost::result_of<const Construct_point_3(const Point&)>::type Ret;
     typedef CGAL::internal::boost_::function_property_map<Construct_point_3, Point, Ret> fpmap;
     typedef CGAL::Spatial_sort_traits_adapter_3<Geom_traits, fpmap> Search_traits_3;


### PR DESCRIPTION
## Summary of Changes

`Point_3 construct_point(const P&)` (function introduced when dealing with weighted points in https://github.com/CGAL/cgal/pull/2102) should not return a copy when `P := Point_3`.

Gains ~5-10% of runtime.

## Release Management

* Affected package(s): `Triangulation_23`
* Issue(s) solved (if any): -

