### PR TITLE
Protect MSVC specific compilation flags with $<COMPILE_LANGUAGE:CXX>

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -119,12 +119,23 @@ function(CGAL_setup_CGAL_dependencies target)
   # Now setup compilation flags
   if(MSVC)
     target_compile_options(${target} ${keyword}
-      "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS"
-      "/fp:strict"
-      "/fp:except-"
-      "/wd4503"  # Suppress warnings C4503 about "decorated name length exceeded"
-      "/bigobj"  # Use /bigobj by default
-      )
+      "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")
+    if(CMAKE_VERSION VERSION_LESS 3.11)
+      target_compile_options(${target} ${keyword}
+        /fp:strict
+        /fp:except-
+        /wd4503  # Suppress warnings C4503 about "decorated name length exceeded"
+        /bigobj  # Use /bigobj by default
+        )
+    else()
+      # The MSVC generator supports `$<COMPILE_LANGUAGE: >` since CMake 3.11.
+      target_compile_options(${target} ${keyword}
+        $<$<COMPILE_LANGUAGE:CXX>:/fp:strict>
+        $<$<COMPILE_LANGUAGE:CXX>:/fp:except->
+        $<$<COMPILE_LANGUAGE:CXX>:/wd4503>  # Suppress warnings C4503 about "decorated name length exceeded"
+        $<$<COMPILE_LANGUAGE:CXX>:/bigobj>  # Use /bigobj by default
+        )
+    endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     message( STATUS "Using Intel Compiler. Adding -fp-model strict" )
     if(WIN32)


### PR DESCRIPTION
## Summary of Changes

Protect MSVC specific compilation flags with `$<COMPILE_LANGUAGE:CXX>`, to fix issue #4571.

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #4571
* License and copyright ownership: maintenance by GF
