### PR TITLE
Fix bug in point_position in the bezier traits

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -959,11 +959,12 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::point_position
 
 
   if ( p.is_rational() ){
-    const Rational& px = ((Rat_point_2) p).x();
+    const Rational px = ((Rat_point_2) p).x();
 
     Integer denom_px=nt_traits.denominator(px);
     Integer numer_px=nt_traits.numerator(px);
-    Polynomial poly_px = CGAL::sign(numer_px) == ZERO ? Polynomial() : nt_traits.construct_polynomial(&numer_px,0);
+    Integer poly_px_scale = numer_px * _curve.x_norm();
+    Polynomial poly_px = CGAL::sign(numer_px) == ZERO ? Polynomial() : nt_traits.construct_polynomial(&poly_px_scale,0);
     Polynomial poly_x = nt_traits.scale(_curve.x_polynomial(),denom_px) - poly_px;
 
     std::vector <Algebraic> roots;


### PR DESCRIPTION
## Summary of Changes

In `point_position` in the case when `p` is rational, the following equation is solved:
```
curve.x_polynomial() / norm_x = numerator(p.x) / denominator(p.x) 
<=>
curve.x_polynomial() *  denominator(p.x) = numerator(p.x) * norm_x 
```
to find the point where `X(t) = p.x`, and then compute `Y(t)` and compare it to `p.y` to determine whether `p` lies above or below the curve. The bug was that `norm_x` was not multiplied to `numerator(p.x)`

## Release Management

* Affected package(s):  2D Arrangements
* Issue(s) solved (if any): fix #94
* License and copyright ownership: The license used by CGAL

