### PR TITLE
update input arguments for draw_triangulation_2.cpp and draw_voroni_diagram_2.cpp

### DIFF
--- a/Triangulation_2/examples/Triangulation_2/draw_triangulation_2.cpp
+++ b/Triangulation_2/examples/Triangulation_2/draw_triangulation_2.cpp
@@ -7,8 +7,8 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Triangulation_2<K>                            Triangulation;
 typedef Triangulation::Point                                Point;
 
-int main() {
-  std::ifstream in("data/triangulation_prog1.cin");
+int main(int argc, char* argv[]) {
+  std::ifstream in((argc>1)?argv[1]:"data/triangulation_prog1.cin");
   std::istream_iterator<Point> begin(in);
   std::istream_iterator<Point> end;
 

--- a/Voronoi_diagram_2/examples/Voronoi_diagram_2/draw_voronoi_diagram_2.cpp
+++ b/Voronoi_diagram_2/examples/Voronoi_diagram_2/draw_voronoi_diagram_2.cpp
@@ -19,10 +19,10 @@ typedef CGAL::Voronoi_diagram_2<DT,AT,AP>                                    VD;
 // typedef for the result type of the point location
 typedef AT::Site_2                    Site_2;
 
-int main()
+int main(int argc, char* argv[])
 {
   VD vd;
-  std::ifstream ifs("data/data4.dt.cin");
+  std::ifstream ifs((argc>1)?argv[1]:"data/data4.dt.cin");
   assert(ifs);
 
   Site_2 t;


### PR DESCRIPTION
CGAL needs to create a simple viewer for each data structure. The simple viewer example for all available viewers allows to passing arguments in the main function except these two: draw_triangulation_2.cpp and draw_voroni_diagram_2.cpp.

The edit here will allow users to pass arguments in the example.