### PR TITLE
Fix forward-declarations of CGAL::Surface_mesh

### DIFF
--- a/Installation/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
+++ b/Installation/include/CGAL/Surface_mesh/Surface_mesh_fwd.h
@@ -17,7 +17,7 @@
 namespace CGAL {
 
 // fwdS for the public interface
-template<typename K>
+template<typename P>
 class Surface_mesh;
 
   

--- a/Surface_mesh/include/CGAL/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh.h
@@ -21,7 +21,7 @@
 namespace CGAL {
 
 // fwdS for the public interface
-template<typename K>
+template<typename P>
 class Surface_mesh;
 
 }


### PR DESCRIPTION
## Summary of Changes

Fix forward-declarations of `CGAL::Surface_mesh`.

In the forward-declaration, the template parameters do not matter, but they do if the code is parsed by an IDE (with IntelliSense for example): in that case, the contextual information, while typing, is wrong.

## Release Management

* Affected package(s): Surface_mesh


