### PR TITLE
PMP: Fix copy-paste error leading to wrong dynamic pmap sizes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
@@ -1185,13 +1185,13 @@ std::size_t snap_borders(TriangleMesh& tm_A,
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor        halfedge_descriptor;
 
-  std::vector<halfedge_descriptor> border_vertices_1;
-  border_halfedges(tm_A, std::back_inserter(border_vertices_1));
-  std::vector<halfedge_descriptor> border_vertices_2;
-  border_halfedges(tm_B, std::back_inserter(border_vertices_2));
+  std::vector<halfedge_descriptor> border_vertices_A;
+  border_halfedges(tm_A, std::back_inserter(border_vertices_A));
+  std::vector<halfedge_descriptor> border_vertices_B;
+  border_halfedges(tm_B, std::back_inserter(border_vertices_B));
 
-  return internal::snap_non_conformal<ConcurrencyTag>(border_vertices_1, tm_A, tolerance_map_A,
-                                                      border_vertices_2, tm_B, tolerance_map_B,
+  return internal::snap_non_conformal<ConcurrencyTag>(border_vertices_A, tm_A, tolerance_map_A,
+                                                      border_vertices_B, tm_B, tolerance_map_B,
                                                       false /*not self snapping*/, np_A, np_B);
 }
 
@@ -1211,19 +1211,19 @@ std::size_t snap_borders(TriangleMesh& tm_A,
   typedef CGAL::dynamic_vertex_property_t<FT>                                    Vertex_property_tag;
   typedef typename boost::property_map<TriangleMesh, Vertex_property_tag>::type  Tolerance_map;
 
-  std::vector<halfedge_descriptor> border_vertices_1;
-  std::vector<halfedge_descriptor> border_vertices_2;
-  border_halfedges(tm_A, std::back_inserter(border_vertices_1));
-  border_halfedges(tm_B, std::back_inserter(border_vertices_2));
+  std::vector<halfedge_descriptor> border_vertices_A;
+  std::vector<halfedge_descriptor> border_vertices_B;
+  border_halfedges(tm_A, std::back_inserter(border_vertices_A));
+  border_halfedges(tm_B, std::back_inserter(border_vertices_B));
 
   const FT tol_mx(std::numeric_limits<double>::max());
   Tolerance_map tolerance_map_A = get(Vertex_property_tag(), tm_A);
-  internal::assign_tolerance_with_local_edge_length_bound(border_vertices_1, tolerance_map_A, tol_mx, tm_A, np_A);
-  Tolerance_map tolerance_map_B = get(Vertex_property_tag(), tm_A);
-  internal::assign_tolerance_with_local_edge_length_bound(border_vertices_2, tolerance_map_B, tol_mx, tm_B, np_B);
+  internal::assign_tolerance_with_local_edge_length_bound(border_vertices_A, tolerance_map_A, tol_mx, tm_A, np_A);
+  Tolerance_map tolerance_map_B = get(Vertex_property_tag(), tm_B);
+  internal::assign_tolerance_with_local_edge_length_bound(border_vertices_B, tolerance_map_B, tol_mx, tm_B, np_B);
 
-  return internal::snap_non_conformal<ConcurrencyTag>(border_vertices_1, tm_A, tolerance_map_A,
-                                                      border_vertices_2, tm_B, tolerance_map_B,
+  return internal::snap_non_conformal<ConcurrencyTag>(border_vertices_A, tm_A, tolerance_map_A,
+                                                      border_vertices_B, tm_B, tolerance_map_B,
                                                       false /*no self snapping*/, np_A, np_B);
 }
 


### PR DESCRIPTION
## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: No change

