### PR TITLE
CT_plus_2: fix a pair of typos in the documentation

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -245,9 +245,9 @@ Inserts a polyline defined by the points in the range `[first,last)`
 and returns the constraint id.
 The polyline is considered as a closed curve if the first and last point are equal or if  `close == true`. This enables for example passing the vertex range of a `Polygon_2`.
 When traversing the vertices of a closed polyline constraint with a  `Vertices_in_constraint_iterator` the first and last vertex are the same.
-In case the range is empty `Constraint_id()`is returned.
+In case the range is empty `Constraint_id()` is returned.
 In case all points are equal the point is inserted but no constraint,
-and `Constraint_id()`is returned.
+and `Constraint_id()` is returned.
 \tparam PointIterator must be an `InputIterator` with the value type `Point`.
 */
 template < class PointIterator>


### PR DESCRIPTION
## Summary of Changes

Fix a typo in [the documentation of `CGAL::Constrained_triangulation_plus_2<Tr>::insert_constraint(..)`][1].

[1]: https://doc.cgal.org/4.14.3/Triangulation_2/classCGAL_1_1Constrained__triangulation__plus__2.html#aaaa7c59fac3307b1e55f9fbd4353d043

## Release Management

* Affected package(s): Triangulation_2


