### PR TITLE
replaced throw() with noexcept

### DIFF
--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -161,7 +161,7 @@ assign(T& t, const Object& o)
 struct Bad_object_cast
   : public std::bad_cast
 {
-    virtual const char * what() const throw()
+    virtual const char * what() const noexcept
     {
         return "CGAL::bad_object_cast: "
                "failed conversion using CGAL::object_cast";

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -67,7 +67,7 @@ public:
   Uncertain_conversion_exception(const std::string &s)
     : std::range_error(s) {}
 
-  ~Uncertain_conversion_exception() throw() {}
+  ~Uncertain_conversion_exception() noexcept {}
 };
 
 

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -66,8 +66,6 @@ class Uncertain_conversion_exception
 public:
   Uncertain_conversion_exception(const std::string &s)
     : std::range_error(s) {}
-
-  ~Uncertain_conversion_exception() noexcept {}
 };
 
 

--- a/STL_Extension/include/CGAL/exceptions.h
+++ b/STL_Extension/include/CGAL/exceptions.h
@@ -97,8 +97,6 @@ public:
     m_msg( msg)
     {}
 
-    ~Failure_exception() noexcept {}
-
     //! the name of the library that issues this message.
     std::string      library() const { return m_lib; }
 

--- a/STL_Extension/include/CGAL/exceptions.h
+++ b/STL_Extension/include/CGAL/exceptions.h
@@ -97,7 +97,7 @@ public:
     m_msg( msg)
     {}
 
-    ~Failure_exception() throw() {}
+    ~Failure_exception() noexcept {}
 
     //! the name of the library that issues this message.
     std::string      library() const { return m_lib; }

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
@@ -68,7 +68,7 @@ Swaps the Regular_triangulation_cell_base_with_weighted_circumcenter_3 and `othe
 This function should be preferred to an assignment or the copy constructor
 if `other` is deleted thereafter.
 */
-void swap (Regular_triangulation_cell_base_with_weighted_circumcenter_3& other) throw();
+void swap (Regular_triangulation_cell_base_with_weighted_circumcenter_3& other) noexcept;
 
 /// @}
 

--- a/Triangulation_3/include/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
@@ -132,7 +132,7 @@ public:
       return *weighted_circumcenter_;
   }
 
-  void swap (Regular_triangulation_cell_base_with_weighted_circumcenter_3& other) throw()
+  void swap (Regular_triangulation_cell_base_with_weighted_circumcenter_3& other) noexcept
   {
     std::swap(static_cast<Cb&>(*this), static_cast<Cb&>(other));
     std::swap(weighted_circumcenter_, other.weighted_circumcenter_);


### PR DESCRIPTION
## Summary of Changes
**Small change:** replaced all `throw()` with `noexcept`

_throw() is equivalent to noexcept(true) but was deprecated with C++11 and will be removed with C++20._ [source](https://www.modernescpp.com/index.php/c-core-guidelines-the-noexcept-specifier-and-operator)