### PR TITLE
Replaced boost::(bind|bind2nd) with lambdas

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -284,7 +284,7 @@ public:
           break;
         default:
           CGAL_error();
-		  return;
+          return;
         }
 
         std::nth_element(first, middle, beyond,

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -270,26 +270,26 @@ public:
       {
         PrimitiveIterator middle = first + (beyond - first)/2; // C++20: std::midpoint
 
-        decltype(Traits::less_x) comparator;
+        auto lesser = Traits::less_x;
 
         switch(Traits::longest_axis(bbox))
         {
         case AT::CGAL_AXIS_X: // sort along x
-          comparator = Traits::less_x;
           break;
         case AT::CGAL_AXIS_Y: // sort along y
-          comparator = Traits::less_y;
+          lesser = Traits::less_y;
           break;
         case AT::CGAL_AXIS_Z: // sort along z
-          comparator = Traits::less_z;
+          lesser = Traits::less_z;
           break;
         default:
           CGAL_error();
+		  return;
         }
 
         std::nth_element(first, middle, beyond,
-                         [comparator, this](auto first, auto second) {
-                           return comparator(first, second, m_traits);
+                         [lesser, this](auto first, auto second) {
+                           return lesser(first, second, m_traits);
                          });
       }
   };

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -270,7 +270,7 @@ public:
       {
         PrimitiveIterator middle = first + (beyond - first)/2; // C++20: std::midpoint
 
-		decltype(Traits::less_x) comparator;
+        decltype(Traits::less_x) comparator;
 
         switch(Traits::longest_axis(bbox))
         {


### PR DESCRIPTION
## Summary of Changes
Implementation only
This branch aims to replace binds with lambdas where possible. 
## Motivation: 
> Prefer lambdas over bind
>> Effective Modern C++: Item 34

[@lrineau 's comment](https://github.com/CGAL/cgal/pull/1449#pullrequestreview-722195)