### PR TITLE
[Bugfix] PSP Jet Smoothing do not alter points when reading them

### DIFF
--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -192,26 +192,42 @@ jet_smooth_point_set(
   Point_set_processing_3::internal::Callback_wrapper<ConcurrencyTag>
     callback_wrapper (callback, nb_points);
 
+  std::vector<typename Kernel::Point_3> smoothed (points.size());
+
+  typedef boost::zip_iterator
+     <boost::tuple<iterator,
+                   typename std::vector<typename Kernel::Point_3>::iterator> > Zip_iterator;
+
   CGAL::for_each<ConcurrencyTag>
-    (points,
-     [&](value_type vt)
+    (CGAL::make_range (boost::make_zip_iterator (boost::make_tuple (points.begin(), smoothed.begin())),
+                       boost::make_zip_iterator (boost::make_tuple (points.end(), smoothed.end()))),
+     [&](const typename Zip_iterator::reference& t)
      {
        if (callback_wrapper.interrupted())
          return false;
 
-       put (point_map, vt,
-            CGAL::internal::jet_smooth_point<SvdTraits>
-            (get (point_map, vt), neighbor_query,
-             k,
-             neighbor_radius,
-             degree_fitting,
-             degree_monge));
+       get<1>(t) = CGAL::internal::jet_smooth_point<SvdTraits>
+         (get (point_map, get<0>(t)), neighbor_query,
+          k,
+          neighbor_radius,
+          degree_fitting,
+          degree_monge);
        ++ callback_wrapper.advancement();
 
        return true;
      });
 
   callback_wrapper.join();
+
+  // Finally, update points
+  CGAL::for_each<ConcurrencyTag>
+    (CGAL::make_range (boost::make_zip_iterator (boost::make_tuple (points.begin(), smoothed.begin())),
+                       boost::make_zip_iterator (boost::make_tuple (points.end(), smoothed.end()))),
+     [&](const typename Zip_iterator::reference& t)
+     {
+       put (point_map, get<0>(t), get<1>(t));
+       return true;
+     });
 }
 
 

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -28,6 +28,8 @@
 #include <CGAL/boost/graph/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
 
+#include <boost/iterator/zip_iterator.hpp>
+
 #include <iterator>
 #include <list>
 

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -155,7 +155,6 @@ jet_smooth_point_set(
 
   // basic geometric types
   typedef typename PointRange::iterator iterator;
-  typedef typename iterator::value_type value_type;
   typedef typename CGAL::GetPointMap<PointRange, NamedParameters>::type PointMap;
   typedef typename Point_set_processing_3::GetK<PointRange, NamedParameters>::Kernel Kernel;
   typedef typename GetSvdTraits<NamedParameters>::type SvdTraits;


### PR DESCRIPTION
## Summary of Changes

I introduced a bug with https://github.com/CGAL/cgal/pull/4552: because points are not longer copied in the KD Tree, altering the point cloud means altering the KD Tree. In the case of the jet smoothing, that means that the projection was computed on a subset of points that could contain already altered points (whereas it should be computed on the original points). In parallel mode, it's even worse because some points could be read and written at the same time, I did not spot this possibility when I wrote it…

Anyway, this PR separates computation of new points from their update and fixes it.

## Release Management

* Affected package(s): Point Set Processing