### PR TITLE
Allow Classification package to be used without Boost IO Stream and Serialization

### DIFF
--- a/Classification/include/CGAL/Classification/ETHZ/Random_forest_classifier.h
+++ b/Classification/include/CGAL/Classification/ETHZ/Random_forest_classifier.h
@@ -38,10 +38,12 @@
 
 #include <CGAL/tags.h>
 
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#endif
 
 #ifdef BOOST_MSVC
 #  pragma warning(pop)
@@ -98,6 +100,9 @@ public:
     than the ones used by `other`, and in the same order.
 
   */
+#if defined(DOXYGEN_RUNNING) || \
+  (defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && \
+   defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION))
   Random_forest_classifier (const Random_forest_classifier& other,
                             const Feature_set& features)
     : m_labels (other.m_labels), m_features (features), m_rfc (nullptr)
@@ -106,6 +111,7 @@ public:
     other.save_configuration(stream);
     this->load_configuration(stream);
   }
+#endif
 
   /// \cond SKIP_IN_MANUAL
   ~Random_forest_classifier ()
@@ -280,6 +286,9 @@ public:
     The output file is written in an GZIP container that is readable
     by the `load_configuration()` method.
   */
+#if defined(DOXYGEN_RUNNING) || \
+  (defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && \
+   defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION))
   void save_configuration (std::ostream& output) const
   {
     boost::iostreams::filtering_ostream outs;
@@ -288,6 +297,7 @@ public:
     boost::archive::text_oarchive oas(outs);
     oas << BOOST_SERIALIZATION_NVP(*m_rfc);
   }
+#endif
 
   /*!
     \brief Loads a configuration from the stream `input`.
@@ -298,6 +308,9 @@ public:
     the ones present when the file was generated using
     `save_configuration()`.
   */
+#if defined(DOXYGEN_RUNNING) || \
+  (defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && \
+   defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION))
   void load_configuration (std::istream& input)
   {
     CGAL::internal::liblearning::RandomForest::ForestParams params;
@@ -311,6 +324,7 @@ public:
     boost::archive::text_iarchive ias(ins);
     ias >> BOOST_SERIALIZATION_NVP(*m_rfc);
   }
+#endif
 
 /// @}
 

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
@@ -40,7 +40,9 @@
 #endif
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/normal_distribution.hpp>
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
 #include <boost/serialization/vector.hpp>
+#endif
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
@@ -93,6 +95,7 @@ struct ForestParams {
         min_samples_per_node(5),
         sample_reduction(0.368f)
     {}
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
@@ -105,6 +108,7 @@ struct ForestParams {
         ar & BOOST_SERIALIZATION_NVP(min_samples_per_node);
         ar & BOOST_SERIALIZATION_NVP(sample_reduction);
     }
+#endif
 };
 
 struct QuadraticSplitter {
@@ -149,6 +153,7 @@ struct QuadraticSplitter {
             data_points[i_sample] = std::make_pair(sample_fval, sample_class);
         }
     }
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
@@ -156,6 +161,7 @@ struct QuadraticSplitter {
         ar & BOOST_SERIALIZATION_NVP(w);
         ar & BOOST_SERIALIZATION_NVP(threshold);
     }
+#endif
 };
 
 struct LinearSplitter {
@@ -187,12 +193,14 @@ struct LinearSplitter {
             data_points[i_sample] = std::make_pair(sample_fval, sample_class);
         }
     }
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
         ar & BOOST_SERIALIZATION_NVP(w);
         ar & BOOST_SERIALIZATION_NVP(threshold);
     }
+#endif
 };
 
 struct AxisAlignedSplitter {
@@ -232,12 +240,14 @@ struct AxisAlignedSplitter {
         data_points.push_back(std::make_pair(sample_fval, sample_class));
       }
     }
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
         ar & BOOST_SERIALIZATION_NVP(feature);
         ar & BOOST_SERIALIZATION_NVP(threshold);
     }
+#endif
 };
 
 struct AxisAlignedRandomSplitGenerator {

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/forest.hpp
@@ -223,12 +223,14 @@ public:
         return sum/trees.size();
     }
 #endif
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /* version */)
     {
         ar & BOOST_SERIALIZATION_NVP(params);
         ar & BOOST_SERIALIZATION_NVP(trees);
     }
+#endif
 
     void get_feature_usage (std::vector<std::size_t>& count) const
     {

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/node-gini.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/node-gini.hpp
@@ -97,11 +97,13 @@ public:
         return std::make_pair(best_thresh, float(best_loss));
     }
 
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /* version */)
     {
         ar & boost::serialization::make_nvp("base",  boost::serialization::base_object< Node< NodeGini<Splitter>, ForestParams, Splitter > >(*this));
     }
+#endif
 };
 
 }

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/node.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/node.hpp
@@ -21,8 +21,15 @@
 #define CGAL_INTERNAL_LIBLEARNING_RANDOMFORESTS_NODE_H
 #include "../dataview.h"
 #include "common-libraries.hpp"
+
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
 #include <boost/serialization/scoped_ptr.hpp>
 #include <boost/serialization/vector.hpp>
+#else
+#include <boost/scoped_ptr.hpp>
+#include <vector>
+#endif
+
 #if VERBOSE_NODE_LEARNING
 #include <cstdio>
 #endif
@@ -228,6 +235,7 @@ public:
         right->train(samples, labels, sample_idxes + offset_right, n_samples_right, split_generator, gen);
     }
 
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
@@ -243,6 +251,7 @@ public:
           ar & BOOST_SERIALIZATION_NVP(right);
         }
     }
+#endif
 
     void get_feature_usage (std::vector<std::size_t>& count) const
     {

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/tree.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/tree.hpp
@@ -18,7 +18,11 @@
 #define CGAL_INTERNAL_LIBLEARNING_RANDOMFOREST_TREE_H
 #include "../dataview.h"
 #include "common-libraries.hpp"
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
 #include <boost/serialization/scoped_ptr.hpp>
+#else
+#include <boost/scoped_ptr.hpp>
+#endif
 
 namespace CGAL { namespace internal {
 
@@ -115,12 +119,16 @@ public:
         return n_common/sqrt((n_common + n_1)*(n_common + n_2));
     }
 #endif
+
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
     template <typename Archive>
     void serialize(Archive& ar, unsigned /*version*/)
     {
         ar & BOOST_SERIALIZATION_NVP(params);
         ar & BOOST_SERIALIZATION_NVP(root_node);
     }
+#endif
+
     void get_feature_usage (std::vector<std::size_t>& count) const
     {
       root_node->get_feature_usage(count);

--- a/Installation/cmake/modules/CGAL_target_use_Boost_IOStreams.cmake
+++ b/Installation/cmake/modules/CGAL_target_use_Boost_IOStreams.cmake
@@ -6,7 +6,7 @@ set(CGAL_target_use_Boost_IOStreams_included TRUE)
 function(CGAL_target_use_Boost_IOStreams target)
 
   if( WIN32 )
-    # to avoid a warning with old cmake 
+    # to avoid a warning with old cmake
     set(_Boost_BZIP2_HEADERS             "boost/iostreams/filter/bzip2.hpp")
     set(_Boost_ZLIB_HEADERS              "boost/iostreams/filter/zlib.hpp")
     find_package( Boost OPTIONAL_COMPONENTS bzip2 zlib)
@@ -19,7 +19,7 @@ function(CGAL_target_use_Boost_IOStreams target)
   else()
     target_link_libraries(${target} PUBLIC ${Boost_IOSTREAMS_LIBRARY})
   endif()
-  
+
   if( WIN32 )
     if (Boost_ZLIB_FOUND AND Boost_BZIP2_FOUND)
       target_link_libraries(${target} PUBLIC ${Boost_ZLIB_LIBRARY} ${Boost_BZIP2_LIBRARY})
@@ -35,5 +35,7 @@ function(CGAL_target_use_Boost_IOStreams target)
       return()
     endif()
   endif()
+
+  target_compile_options( ${target} PUBLIC -DCGAL_LINKED_WITH_BOOST_IOSTREAMS)
 
 endfunction()

--- a/Installation/cmake/modules/CGAL_target_use_Boost_Serialization.cmake
+++ b/Installation/cmake/modules/CGAL_target_use_Boost_Serialization.cmake
@@ -11,4 +11,6 @@ function(CGAL_target_use_Boost_Serialization target)
     target_link_libraries(${target} PUBLIC ${Boost_SERIALIZATION_LIBRARY})
   endif()
 
+  target_compile_options( ${target} PUBLIC -DCGAL_LINKED_WITH_BOOST_SERIALIZATION)
+
 endfunction()


### PR DESCRIPTION
## Summary of Changes

First step of an on-going work to get rid of dependencies to _Boost IO Streams_ and _Boost Serialization_. Currently, compiling any program using CGAL Classification without these creates a compilation error (or at least a link error). While this is consistent with the documentation that states that these 2 Boost packages are hard dependencies of Classification, in practice only `CGAL::Classification::ETHZ::Random_forest::save_configuration()` and `CGAL::Classification::ETHZ::Random_forest::load_configuration()` depend on them.

This PR adds some CMake definitions and preprocessor conditions to make Classification usable without _Boost IO Streams_ and _Serialization_ (provided, of course, that the IO functions of the Random Forest are not used). This does not change anything from a user point of view (documentation is unchanged) but it should unlock the pip situation for @maxGimeno until new dependence-free IO functions are introduced.

## Release Management

* Affected package(s): Classification