### PR TITLE
Documentation: Add a page that explains how to use cmake

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/cmakelist_script.txt
+++ b/Documentation/doc/Documentation/Developer_manual/cmakelist_script.txt
@@ -37,4 +37,6 @@ cases, it might still be required to create the script manually, for
 instance, if some source files/executables need a different linking than
 other source files.
 
+The section \subpage devman_create_and_use_a_cmakelist explains further how to do so.
+
 */

--- a/Documentation/doc/Documentation/Developer_manual/cmakelist_script.txt
+++ b/Documentation/doc/Documentation/Developer_manual/cmakelist_script.txt
@@ -35,8 +35,6 @@ This options should suffice to create `CMakeLists.txt` script
 for most directories containing programs. However, in some special
 cases, it might still be required to create the script manually, for
 instance, if some source files/executables need a different linking than
-other source files.
-
-The section \subpage devman_create_and_use_a_cmakelist explains further how to do so.
+other source files. The Section \subpage devman_create_and_use_a_cmakelist provides more details.
 
 */

--- a/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
+++ b/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
@@ -1,10 +1,10 @@
 /*!
-\page devman_create_and_use_a_cmakelist How to use %CGAL with CMake
+\page devman_create_and_use_a_cmakelist How to use \cgal with CMake
 
-This page will explain how to manually create a CMakeLists.txt file to link a custom program with CGAL.
+This page will explain how to manually create a CMakeLists.txt file to link a custom program with \cgal.
 A base can be created using the script `cgal_create_CMakeLists`. Its usage is detailed in Section \ref devman_create_cgal_CMakeLists.
-\section seclink Linking with CGAL
-To link with the CGAL library, use the following :
+\section seclink Linking with \cgal
+To link with the \cgal library, use the following :
 \code
 find_package(CGAL)
 add_executable(my_executable my_source_file.cpp)
@@ -18,7 +18,7 @@ find_package(CGAL REQUIRED COMPONENTS Core)
 target_link_libraries(my_executable CGAL::CGAL CGAL::CGAL_Core)
 \endcode
 
-There are also some cmake macros to link with CGAL dependenciesthat can be found in
+There are also some cmake macros to link with \cgal dependencies that can be found in
 the section \subpage thirdparty.
 
 \note The CGAL targets define the following compiler flags :
@@ -26,7 +26,7 @@ the section \subpage thirdparty.
   - `/fp:strict /fp:except-` with MSVC
 
 \section secexample Minimal Example Using Qt5
-This section describes a minimal example of a program that uses %CGAL and Qt5 for some GUI features.
+This section describes a minimal example of a program that uses \cgal and Qt5 for some GUI features.
 
 \subsection subcmake CMakeLists.txt
 \dontinclude Surface_mesh/CMakeLists.txt

--- a/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
+++ b/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
@@ -1,5 +1,5 @@
 /*!
-\page devman_create_and_use_a_cmakelist How to use CGAL with CMake
+\page devman_create_and_use_a_cmakelist How to use %CGAL with CMake
 
 This page will explain how to manually create a CMakeLists.txt file to link a custom program with CGAL.
 A base can be created using the script `cgal_create_CMakeLists`. Its usage is detailed in Section \ref devman_create_cgal_CMakeLists.
@@ -18,57 +18,27 @@ find_package(CGAL REQUIRED COMPONENTS Core)
 target_link_libraries(my_executable CGAL::CGAL CGAL::CGAL_Core)
 \endcode
 
-There are also some cmake macros to link with CGAL dependencies. For example, to link with eigen, you can use
-
-\code
-CGAL_target_use_Eigen(<target>)
-\endcode
-For more details on these macros, see \subpage thirdparty.
+There are also some cmake macros to link with CGAL dependenciesthat can be found in
+the section \subpage thirdparty.
 
 \note The CGAL targets define the following compiler flags :
   - `-frounding-math` with gcc
   - `/fp:strict /fp:except-` with MSVC
 
 \section secexample Minimal Example Using Qt5
-This section describes a minimal example of a program that uses CGAL and Qt5 for some GUI features.
+This section describes a minimal example of a program that uses %CGAL and Qt5 for some GUI features.
 
 \subsection subcmake CMakeLists.txt
-\code
-cmake_minimum_required(VERSION 3.1)
-project(test_cgal)
-#CGAL_Qt5 is needed for the drawing and CGAL_Core is needed for this special Kernel.
-find_package(CGAL REQUIRED COMPONENTS Qt5 Core)
-if(CGAL_FOUND AND CGAL_Qt5_FOUND)
-  #required to use basic_viewer
-  add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
-  #create the executable of the application
-  add_executable(test_ test.cpp)
-  #link it with the required CGAL libraries
-  target_link_libraries(test_ CGAL::CGAL CGAL::CGAL_Qt5 CGAL::CGAL_Core)
-else()
-  message("ERROR: this program requires CGAL and CGAL_Qt5 and will not be compiled.")
-endif()
+\dontinclude Surface_mesh/CMakeLists.txt
+\skip cmake
+\until if ( CGAL_FOUND )
+\skip #create the executable of the application
+\until "draw_surface_mesh.cpp"
+\skip if(CGAL_Qt5_FOUND )
+\until target_link_libraries(draw_surface_mesh PUBLIC CGAL::CGAL_Qt5)
+\skip endif
+\until #end of the file
 
-\endcode
-\subsection subtestcpp test.cpp
-\code{.cpp}
-#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/boost/graph/helpers.h>
-#include <CGAL/draw_surface_mesh.h>
-
-typedef CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt K;
-typedef K::Point_3 Point;
-typedef CGAL::Surface_mesh<Point> Mesh;
-
-
-int main()
-{
-  Mesh m;
-  CGAL::make_icosahedron<Mesh, Point>(m);
-  CGAL::draw(m);
-  return 0;
-}
-
-\endcode
+\subsection subexcpp draw_surface_mesh.cpp
+\include Surface_mesh/draw_surface_mesh.cpp
 */

--- a/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
+++ b/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
@@ -1,17 +1,17 @@
 /*!
-\page devman_create_and_use_a_cmakelist How to use \cgal with CMake
+\page devman_create_and_use_a_cmakelist How to use CGAL with CMake
 
-This page will explain how to manually create a CMakeLists.txt file to link a custom program with \cgal.
+This page will explain how to manually create a `CMakeLists.txt` file to link a custom program with \cgal.
 A base can be created using the script `cgal_create_CMakeLists`. Its usage is detailed in Section \ref devman_create_cgal_CMakeLists.
-\section seclink Linking with \cgal
-To link with the \cgal library, use the following :
+\section seclink Linking with CGAL
+To link with the \cgal library, use the following:
 \code
 find_package(CGAL)
 add_executable(my_executable my_source_file.cpp)
 target_link_libraries(my_executable CGAL::CGAL)
 \endcode
 
-Other CGAL libraries are linked similarly. For example, with CGAL_Core:
+Other \cgal libraries are linked similarly. For example, with `CGAL_Core`:
 
 \code
 find_package(CGAL REQUIRED COMPONENTS Core)
@@ -21,7 +21,7 @@ target_link_libraries(my_executable CGAL::CGAL CGAL::CGAL_Core)
 There are also some cmake macros to link with \cgal dependencies that can be found in
 the section \subpage thirdparty.
 
-\note The CGAL targets define the following compiler flags :
+\note The \cgal targets define the following compiler flags:
   - `-frounding-math` with gcc
   - `/fp:strict /fp:except-` with MSVC
 

--- a/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
+++ b/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
@@ -1,0 +1,74 @@
+/*!
+\page devman_create_and_use_a_cmakelist How to use CGAL with CMake
+
+This page will explain how to manually create a CMakeLists.txt file to link a custom program with CGAL.
+A base can be created using the script `cgal_create_CMakeLists`. Its usage is detailed in Section \ref devman_create_cgal_CMakeLists.
+\section seclink Linking with CGAL
+To link with the CGAL library, use the following :
+\code
+find_package(CGAL)
+add_executable(my_executable my_source_file.cpp)
+target_link_libraries(my_executable CGAL::CGAL)
+\endcode
+
+Other CGAL libraries are linked similarly. For example, with CGAL_Core:
+
+\code
+find_package(CGAL REQUIRED COMPONENTS Core)
+target_link_libraries(my_executable CGAL::CGAL CGAL::CGAL_Core)
+\endcode
+
+There are also some cmake macros to link with CGAL dependencies. For example, to link with eigen, you can use
+
+\code
+CGAL_target_use_Eigen(<target>)
+\endcode
+For more details on these macros, see \subpage thirdparty.
+
+\note The CGAL targets define the following compiler flags :
+  - `-frounding-math` with gcc
+  - `/fp:strict /fp:except-` with MSVC
+
+\section secexample Minimal Example Using Qt5
+This section describes a minimal example of a program that uses CGAL and Qt5 for some GUI features.
+
+\subsection subcmake CMakeLists.txt
+\code
+cmake_minimum_required(VERSION 3.1)
+project(test_cgal)
+#CGAL_Qt5 is needed for the drawing and CGAL_Core is needed for this special Kernel.
+find_package(CGAL REQUIRED COMPONENTS Qt5 Core)
+if(CGAL_FOUND AND CGAL_Qt5_FOUND)
+  #required to use basic_viewer
+  add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
+  #create the executable of the application
+  add_executable(test_ test.cpp)
+  #link it with the required CGAL libraries
+  target_link_libraries(test_ CGAL::CGAL CGAL::CGAL_Qt5 CGAL::CGAL_Core)
+else()
+  message("ERROR: this program requires CGAL and CGAL_Qt5 and will not be compiled.")
+endif()
+
+\endcode
+\subsection subtestcpp test.cpp
+\code{.cpp}
+#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/draw_surface_mesh.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt K;
+typedef K::Point_3 Point;
+typedef CGAL::Surface_mesh<Point> Mesh;
+
+
+int main()
+{
+  Mesh m;
+  CGAL::make_icosahedron<Mesh, Point>(m);
+  CGAL::draw(m);
+  return 0;
+}
+
+\endcode
+*/

--- a/Documentation/doc/Documentation/Doxyfile.in
+++ b/Documentation/doc/Documentation/Doxyfile.in
@@ -12,7 +12,8 @@ LAYOUT_FILE         = ${CGAL_DOC_RESOURCE_DIR}/DoxygenLayout.xml
 GENERATE_TAGFILE    = ${CGAL_DOC_TAG_GEN_DIR}/Manual.tag
 EXAMPLE_PATH        = ${CGAL_Convex_hull_2_EXAMPLE_DIR} \
                       ${CGAL_Kernel_23_EXAMPLE_DIR} \
-                      ${CGAL_Poisson_surface_reconstruction_3_EXAMPLE_DIR}
+                      ${CGAL_Poisson_surface_reconstruction_3_EXAMPLE_DIR} \
+                      ${CGAL_Surface_mesh_EXAMPLE_DIR}
 FILTER_PATTERNS     = *.txt=${CMAKE_BINARY_DIR}/pkglist_filter
 
 HTML_EXTRA_FILES += ${CGAL_DOC_RESOURCE_DIR}/hacks.js \

--- a/Documentation/doc/Documentation/Getting_started.txt
+++ b/Documentation/doc/Documentation/Getting_started.txt
@@ -9,7 +9,7 @@ The following pages describe how to use \cgal on different environments
 
 - \subpage thirdparty gives information (supported versions, download links) of the required and optional third party libraries.
 
-- \subpage devman_create_and_use_a_cmakelist explains how to use CMake to link a program with CGAL.
+- \subpage devman_create_and_use_a_cmakelist explains how to use CMake to link a program with \cgal.
 
 The following pages cover advanced installation options
 

--- a/Documentation/doc/Documentation/Getting_started.txt
+++ b/Documentation/doc/Documentation/Getting_started.txt
@@ -9,6 +9,8 @@ The following pages describe how to use \cgal on different environments
 
 - \subpage thirdparty gives information (supported versions, download links) of the required and optional third party libraries.
 
+- \subpage devman_create_and_use_a_cmakelist explains how to use CMake to link a program with CGAL.
+
 The following pages cover advanced installation options
 
 - \subpage configurationvariables gives information about which CMake variables can be used to help

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -5,7 +5,6 @@
 cmake_minimum_required(VERSION 3.1...3.15)
 project( Surface_mesh_Examples )
 
-
 if(POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   if(NOT POLICY CMP0070)
@@ -14,13 +13,16 @@ if(POLICY CMP0053)
     cmake_policy(SET CMP0053 NEW)
   endif()
 endif()
+
 if(POLICY CMP0071)
     cmake_policy(SET CMP0071 NEW)
 endif()
 
-find_package(CGAL COMPONENTS Qt5)
+#CGAL_Qt5 is needed for the drawing.
+find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 if(CGAL_Qt5_FOUND)
+  #required to use basic_viewer
   add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
 endif()
 
@@ -37,10 +39,15 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "sm_memory.cpp" )
   create_single_source_cgal_program( "sm_properties.cpp" )
 
+  #create the executable of the application
+
   create_single_source_cgal_program("draw_surface_mesh.cpp")
   create_single_source_cgal_program("sm_draw_small_faces.cpp")
   create_single_source_cgal_program("check_orientation.cpp")
   if(CGAL_Qt5_FOUND )
+
+    #link it with the required CGAL libraries
+
     target_link_libraries(draw_surface_mesh PUBLIC CGAL::CGAL_Qt5)
     target_link_libraries(sm_draw_small_faces PUBLIC CGAL::CGAL_Qt5)
   endif()
@@ -50,4 +57,4 @@ else()
     message(STATUS "This program requires the CGAL library, and will not be compiled.")
 
 endif()
-
+#end of the file


### PR DESCRIPTION
## Summary of Changes

Adds page in the developer manual that explains how to create a CMakeLists to use with CGAL.
## Release Management

* Affected package(s):Manual
* Issue(s) solved (if any): fix #3105
* Link to compiled documentation (obligatory for small feature) 
[Getting Started ](https://cgal.geometryfactory.com/~mgimeno/doc/CMakeTuto/Manual/general_intro.html)
[the new page](https://cgal.geometryfactory.com/~mgimeno/doc/CMakeTuto/Manual/devman_create_and_use_a_cmakelist.html)

