### PR TITLE
Demo mesh_3_plugin: fix a compilation error with MSVC 2015

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -214,6 +214,7 @@ private:
     Scene_polylines_item* polylines_item;
   };
   struct Image_mesh_items {
+    Image_mesh_items(gsl::not_null<Scene_image_item*> ptr) : image_item(ptr) {}
     gsl::not_null<Scene_image_item*> image_item;
     Scene_polylines_item* polylines_item = nullptr;
   };
@@ -302,7 +303,7 @@ boost::optional<QString> Mesh_3_plugin::get_items_or_return_error_string() const
       else if (auto image_item =
                    qobject_cast<Scene_image_item*>(scene->item(ind))) {
         if (!items)
-          items = Image_mesh_items{make_not_null(image_item), nullptr};
+          items = Image_mesh_items{make_not_null(image_item)};
         else
           return tr("An image items cannot be mixed with other items type");
       }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -302,7 +302,7 @@ boost::optional<QString> Mesh_3_plugin::get_items_or_return_error_string() const
       else if (auto image_item =
                    qobject_cast<Scene_image_item*>(scene->item(ind))) {
         if (!items)
-          items = Image_mesh_items{make_not_null(image_item)};
+          items = Image_mesh_items{make_not_null(image_item), nullptr};
         else
           return tr("An image items cannot be mixed with other items type");
       }


### PR DESCRIPTION
## Summary of Changes

PR https://github.com/CGAL/cgal/pull/4074 introduced a compilation error with MSVC 2015, that was not correctly detected by the testsuite.

MSVC 2015 is wrong: the code is correct because, even if the struct `Image_mesh_items` has two members, the second one has a default member initializer.

## Release Management

Fix only in `master`, because the PR #4074 was merged in `master`, for CGAL-5.1.

* Affected package(s): Polyhedron demo
* Issue(s) solved (if any): fix #4074 



