### PR TITLE
C++20 fixes

### DIFF
--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Polygon_2_curve_iterator.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Polygon_2_curve_iterator.h
@@ -60,9 +60,9 @@ public:
     Edge_const_iterator m_curr_edge;   // points to the current edge iterator
 
 public:
-    Polygon_2_curve_iterator< X_monotone_curve_2_, Polygon_ >(){}
+    Polygon_2_curve_iterator(){}
 
-    Polygon_2_curve_iterator< X_monotone_curve_2_, Polygon_ >
+    Polygon_2_curve_iterator
       (const Polygon* pgn, Edge_const_iterator ci) : m_pgn(pgn),
                                                      m_curr_edge(ci) {}
 

--- a/Boolean_set_operations_2/include/CGAL/Gps_circle_segment_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_circle_segment_traits_2.h
@@ -27,7 +27,7 @@ class Gps_circle_segment_traits_2 :
   public Gps_traits_2<Arr_circle_segment_traits_2<Kernel_, Filer_> >
 {
 public:
-  Gps_circle_segment_traits_2<Kernel_, Filer_>(bool use_cache = false) :
+  Gps_circle_segment_traits_2(bool use_cache = false) :
     Gps_traits_2<Arr_circle_segment_traits_2<Kernel_, Filer_> >()
   {
     this->m_use_cache = use_cache;

--- a/Inscribed_areas/include/CGAL/Largest_empty_iso_rectangle_2.h
+++ b/Inscribed_areas/include/CGAL/Largest_empty_iso_rectangle_2.h
@@ -233,12 +233,11 @@ public:
   ~Largest_empty_iso_rectangle_2();
 
   //! An operator=
-  Largest_empty_iso_rectangle_2<T>&
-    operator =(const Largest_empty_iso_rectangle_2<T>& ler);
+  Largest_empty_iso_rectangle_2&
+    operator =(const Largest_empty_iso_rectangle_2& ler);
 
   //! A copy constructor
-  Largest_empty_iso_rectangle_2<T>(
-               const Largest_empty_iso_rectangle_2<T>& ler);
+  Largest_empty_iso_rectangle_2(const Largest_empty_iso_rectangle_2& ler);
 
   struct Internal_point {
     Point_2 x_part;// the x coordinate of the point

--- a/Interpolation/include/CGAL/interpolation_functions.h
+++ b/Interpolation/include/CGAL/interpolation_functions.h
@@ -34,7 +34,7 @@ struct Data_access
   typedef typename Map::mapped_type   Data_type;
   typedef typename Map::key_type      Key_type;
 
-  Data_access<Map>(const Map& m): map(m){}
+  Data_access(const Map& m): map(m){}
 
   std::pair< Data_type, bool>
   operator()(const Key_type& p) const

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -238,9 +238,9 @@ public:
 
   bool operator==(const Gmpq &q) const noexcept { return mpq_equal(this->mpq(), q.mpq()) != 0;}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpq&q) const noexcept { return mpq_cmp(this->mpq(), q.mpq()) <=> 0; }
+  std::strong_ordering operator<=>(const Gmpq&q) const { return mpq_cmp(this->mpq(), q.mpq()) <=> 0; }
 #else
-  bool operator< (const Gmpq &q) const noexcept { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
+  bool operator< (const Gmpq &q) const { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
 #endif
 
   double to_double() const noexcept;
@@ -264,7 +264,7 @@ public:
   Gmpq& operator*=(int z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(int z){return (*this)/= Gmpq(z);}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(int z) const noexcept { return mpq_cmp_si(mpq(),z,1) <=> 0; }
+  std::strong_ordering operator<=>(int z) const { return mpq_cmp_si(mpq(),z,1) <=> 0; }
 #else
   bool  operator==(int z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (int z) const {return mpq_cmp_si(mpq(),z,1)<0;}
@@ -277,7 +277,7 @@ public:
   Gmpq& operator*=(long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long z){return (*this)/= Gmpq(z);}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(long z) const noexcept { return mpq_cmp_si(mpq(),z,1) <=> 0; }
+  std::strong_ordering operator<=>(long z) const { return mpq_cmp_si(mpq(),z,1) <=> 0; }
 #else
   bool  operator==(long z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (long z) const {return mpq_cmp_si(mpq(),z,1)<0;}
@@ -290,7 +290,7 @@ public:
   Gmpq& operator*=(long long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long long z){return (*this)/= Gmpq(z);}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(long long z) const noexcept { return *this <=> Gmpq(z); }
+  std::strong_ordering operator<=>(long long z) const { return *this <=> Gmpq(z); }
 #else
   bool  operator==(long long z) const {return (*this)== Gmpq(z);}
   bool  operator< (long long z) const {return (*this)<  Gmpq(z);}
@@ -303,7 +303,7 @@ public:
   Gmpq& operator*=(double d){return (*this)*= Gmpq(d);}
   Gmpq& operator/=(double d){return (*this)/= Gmpq(d);}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(double d) const noexcept { return *this <=> Gmpq(d); }
+  std::strong_ordering operator<=>(double d) const { return *this <=> Gmpq(d); }
 #else
   bool  operator==(double d) const {return (*this)== Gmpq(d);}
   bool  operator< (double d) const {return (*this)<  Gmpq(d);}
@@ -316,7 +316,7 @@ public:
   Gmpq& operator*=(const Gmpz&);
   Gmpq& operator/=(const Gmpz&);
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpz& z) const noexcept { return *this <=> Gmpq(z); }
+  std::strong_ordering operator<=>(const Gmpz& z) const { return *this <=> Gmpq(z); }
 #else
   bool  operator==(const Gmpz &z) const {return (*this)== Gmpq(z);}
   bool  operator< (const Gmpz &z) const {return (*this)<  Gmpq(z);}
@@ -329,7 +329,7 @@ public:
   Gmpq& operator*=(const Gmpfr &f){return (*this)*= Gmpq(f);}
   Gmpq& operator/=(const Gmpfr &f){return (*this)/= Gmpq(f);}
 #if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpfr& f) const noexcept { return 0 <=> mpfr_cmp_q(f.fr(),mpq()); }
+  std::strong_ordering operator<=>(const Gmpfr& f) const { return 0 <=> mpfr_cmp_q(f.fr(),mpq()); }
 #else
   bool  operator==(const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())==0;}
   bool  operator< (const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())>0;}

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -35,10 +35,6 @@
 #include <CGAL/Handle_for.h>
 #include <CGAL/Profile_counter.h>
 
-#if __cpp_impl_three_way_comparison >= 201907L
-# include <compare>
-#endif
-
 #if defined(BOOST_MSVC)
 #  pragma warning(push)
 #  pragma warning(disable:4146)
@@ -65,17 +61,8 @@ private:
 
 
 class Gmpq
-  : Handle_for<Gmpq_rep>
-#if __cpp_impl_three_way_comparison >= 201907L
-  , boost::field_operators2< Gmpq, int
-  , boost::field_operators2< Gmpq, long
-  , boost::field_operators2< Gmpq, long long
-  , boost::field_operators2< Gmpq, double
-  , boost::field_operators2< Gmpq, Gmpz
-  , boost::field_operators2< Gmpq, Gmpfr
-    > > > > > >
-#else
-  , boost::totally_ordered1< Gmpq
+  : Handle_for<Gmpq_rep>,
+    boost::totally_ordered1< Gmpq
   , boost::ordered_field_operators2< Gmpq, int
   , boost::ordered_field_operators2< Gmpq, long
   , boost::ordered_field_operators2< Gmpq, long long
@@ -83,7 +70,6 @@ class Gmpq
   , boost::ordered_field_operators2< Gmpq, Gmpz
   , boost::ordered_field_operators2< Gmpq, Gmpfr
     > > > > > > >
-#endif
 {
   typedef Handle_for<Gmpq_rep> Base;
 public:
@@ -237,11 +223,7 @@ public:
   Gmpq& operator/=(const Gmpq &q);
 
   bool operator==(const Gmpq &q) const noexcept { return mpq_equal(this->mpq(), q.mpq()) != 0;}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpq&q) const { return mpq_cmp(this->mpq(), q.mpq()) <=> 0; }
-#else
   bool operator< (const Gmpq &q) const { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
-#endif
 
   double to_double() const noexcept;
   Sign sign() const noexcept;
@@ -263,78 +245,54 @@ public:
   Gmpq& operator-=(int z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(int z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(int z){return (*this)/= Gmpq(z);}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(int z) const { return mpq_cmp_si(mpq(),z,1) <=> 0; }
-#else
   bool  operator==(int z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (int z) const {return mpq_cmp_si(mpq(),z,1)<0;}
   bool  operator> (int z) const {return mpq_cmp_si(mpq(),z,1)>0;}
-#endif
 
   // Interoperability with long
   Gmpq& operator+=(long z){return (*this)+= Gmpq(z);}
   Gmpq& operator-=(long z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long z){return (*this)/= Gmpq(z);}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(long z) const { return mpq_cmp_si(mpq(),z,1) <=> 0; }
-#else
   bool  operator==(long z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (long z) const {return mpq_cmp_si(mpq(),z,1)<0;}
   bool  operator> (long z) const {return mpq_cmp_si(mpq(),z,1)>0;}
-#endif
 
   // Interoperability with long long
   Gmpq& operator+=(long long z){return (*this)+= Gmpq(z);}
   Gmpq& operator-=(long long z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(long long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long long z){return (*this)/= Gmpq(z);}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(long long z) const { return *this <=> Gmpq(z); }
-#else
   bool  operator==(long long z) const {return (*this)== Gmpq(z);}
   bool  operator< (long long z) const {return (*this)<  Gmpq(z);}
   bool  operator> (long long z) const {return (*this)>  Gmpq(z);}
-#endif
 
   // Interoperability with double
   Gmpq& operator+=(double d){return (*this)+= Gmpq(d);}
   Gmpq& operator-=(double d){return (*this)-= Gmpq(d);}
   Gmpq& operator*=(double d){return (*this)*= Gmpq(d);}
   Gmpq& operator/=(double d){return (*this)/= Gmpq(d);}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(double d) const { return *this <=> Gmpq(d); }
-#else
   bool  operator==(double d) const {return (*this)== Gmpq(d);}
   bool  operator< (double d) const {return (*this)<  Gmpq(d);}
   bool  operator> (double d) const {return (*this)>  Gmpq(d);}
-#endif
 
   // Interoperability with Gmpz
   Gmpq& operator+=(const Gmpz&);
   Gmpq& operator-=(const Gmpz&);
   Gmpq& operator*=(const Gmpz&);
   Gmpq& operator/=(const Gmpz&);
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpz& z) const { return *this <=> Gmpq(z); }
-#else
   bool  operator==(const Gmpz &z) const {return (*this)== Gmpq(z);}
   bool  operator< (const Gmpz &z) const {return (*this)<  Gmpq(z);}
   bool  operator> (const Gmpz &z) const {return (*this)>  Gmpq(z);}
-#endif
 
   // Interoperability with Gmpfr
   Gmpq& operator+=(const Gmpfr &f){return (*this)+= Gmpq(f);}
   Gmpq& operator-=(const Gmpfr &f){return (*this)-= Gmpq(f);}
   Gmpq& operator*=(const Gmpfr &f){return (*this)*= Gmpq(f);}
   Gmpq& operator/=(const Gmpfr &f){return (*this)/= Gmpq(f);}
-#if __cpp_impl_three_way_comparison >= 201907L
-  std::strong_ordering operator<=>(const Gmpfr& f) const { return 0 <=> mpfr_cmp_q(f.fr(),mpq()); }
-#else
   bool  operator==(const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())==0;}
   bool  operator< (const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())>0;}
   bool  operator> (const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())<0;}
-#endif
 };
 
 

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -35,6 +35,10 @@
 #include <CGAL/Handle_for.h>
 #include <CGAL/Profile_counter.h>
 
+#if __cpp_impl_three_way_comparison >= 201907L
+# include <compare>
+#endif
+
 #if defined(BOOST_MSVC)
 #  pragma warning(push)
 #  pragma warning(disable:4146)
@@ -61,8 +65,17 @@ private:
 
 
 class Gmpq
-  : Handle_for<Gmpq_rep>,
-    boost::totally_ordered1< Gmpq
+  : Handle_for<Gmpq_rep>
+#if __cpp_impl_three_way_comparison >= 201907L
+  , boost::field_operators2< Gmpq, int
+  , boost::field_operators2< Gmpq, long
+  , boost::field_operators2< Gmpq, long long
+  , boost::field_operators2< Gmpq, double
+  , boost::field_operators2< Gmpq, Gmpz
+  , boost::field_operators2< Gmpq, Gmpfr
+    > > > > > >
+#else
+  , boost::totally_ordered1< Gmpq
   , boost::ordered_field_operators2< Gmpq, int
   , boost::ordered_field_operators2< Gmpq, long
   , boost::ordered_field_operators2< Gmpq, long long
@@ -70,6 +83,7 @@ class Gmpq
   , boost::ordered_field_operators2< Gmpq, Gmpz
   , boost::ordered_field_operators2< Gmpq, Gmpfr
     > > > > > > >
+#endif
 {
   typedef Handle_for<Gmpq_rep> Base;
 public:
@@ -223,7 +237,11 @@ public:
   Gmpq& operator/=(const Gmpq &q);
 
   bool operator==(const Gmpq &q) const noexcept { return mpq_equal(this->mpq(), q.mpq()) != 0;}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(const Gmpq&q) const noexcept { return mpq_cmp(this->mpq(), q.mpq()) <=> 0; }
+#else
   bool operator< (const Gmpq &q) const noexcept { return mpq_cmp(this->mpq(), q.mpq()) < 0; }
+#endif
 
   double to_double() const noexcept;
   Sign sign() const noexcept;
@@ -245,54 +263,78 @@ public:
   Gmpq& operator-=(int z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(int z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(int z){return (*this)/= Gmpq(z);}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(int z) const noexcept { return mpq_cmp_si(mpq(),z,1) <=> 0; }
+#else
   bool  operator==(int z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (int z) const {return mpq_cmp_si(mpq(),z,1)<0;}
   bool  operator> (int z) const {return mpq_cmp_si(mpq(),z,1)>0;}
+#endif
 
   // Interoperability with long
   Gmpq& operator+=(long z){return (*this)+= Gmpq(z);}
   Gmpq& operator-=(long z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long z){return (*this)/= Gmpq(z);}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(long z) const noexcept { return mpq_cmp_si(mpq(),z,1) <=> 0; }
+#else
   bool  operator==(long z) const {return mpq_cmp_si(mpq(),z,1)==0;}
   bool  operator< (long z) const {return mpq_cmp_si(mpq(),z,1)<0;}
   bool  operator> (long z) const {return mpq_cmp_si(mpq(),z,1)>0;}
+#endif
 
   // Interoperability with long long
   Gmpq& operator+=(long long z){return (*this)+= Gmpq(z);}
   Gmpq& operator-=(long long z){return (*this)-= Gmpq(z);}
   Gmpq& operator*=(long long z){return (*this)*= Gmpq(z);}
   Gmpq& operator/=(long long z){return (*this)/= Gmpq(z);}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(long long z) const noexcept { return *this <=> Gmpq(z); }
+#else
   bool  operator==(long long z) const {return (*this)== Gmpq(z);}
   bool  operator< (long long z) const {return (*this)<  Gmpq(z);}
   bool  operator> (long long z) const {return (*this)>  Gmpq(z);}
+#endif
 
   // Interoperability with double
   Gmpq& operator+=(double d){return (*this)+= Gmpq(d);}
   Gmpq& operator-=(double d){return (*this)-= Gmpq(d);}
   Gmpq& operator*=(double d){return (*this)*= Gmpq(d);}
   Gmpq& operator/=(double d){return (*this)/= Gmpq(d);}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(double d) const noexcept { return *this <=> Gmpq(d); }
+#else
   bool  operator==(double d) const {return (*this)== Gmpq(d);}
   bool  operator< (double d) const {return (*this)<  Gmpq(d);}
   bool  operator> (double d) const {return (*this)>  Gmpq(d);}
+#endif
 
   // Interoperability with Gmpz
   Gmpq& operator+=(const Gmpz&);
   Gmpq& operator-=(const Gmpz&);
   Gmpq& operator*=(const Gmpz&);
   Gmpq& operator/=(const Gmpz&);
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(const Gmpz& z) const noexcept { return *this <=> Gmpq(z); }
+#else
   bool  operator==(const Gmpz &z) const {return (*this)== Gmpq(z);}
   bool  operator< (const Gmpz &z) const {return (*this)<  Gmpq(z);}
   bool  operator> (const Gmpz &z) const {return (*this)>  Gmpq(z);}
+#endif
 
   // Interoperability with Gmpfr
   Gmpq& operator+=(const Gmpfr &f){return (*this)+= Gmpq(f);}
   Gmpq& operator-=(const Gmpfr &f){return (*this)-= Gmpq(f);}
   Gmpq& operator*=(const Gmpfr &f){return (*this)*= Gmpq(f);}
   Gmpq& operator/=(const Gmpfr &f){return (*this)/= Gmpq(f);}
+#if __cpp_impl_three_way_comparison >= 201907L
+  std::strong_ordering operator<=>(const Gmpfr& f) const noexcept { return 0 <=> mpfr_cmp_q(f.fr(),mpq()); }
+#else
   bool  operator==(const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())==0;}
   bool  operator< (const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())>0;}
   bool  operator> (const Gmpfr &f) const {return mpfr_cmp_q(f.fr(),mpq())<0;}
+#endif
 };
 
 

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -438,6 +438,69 @@ public :
     return *this = new Lazy_exact_Div<ET>(*this, b);
   }
 
+  // Mixed comparisons with int.
+  friend bool operator<(const Lazy_exact_nt& a, int b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = a.approx() < b;
+    if (is_certain(res))
+      return res;
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return a.exact() < b;
+  }
+
+  friend bool operator>(const Lazy_exact_nt& a, int b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = b < a.approx();
+    if (is_certain(res))
+      return get_certain(res);
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return b < a.exact();
+  }
+
+  friend bool operator==(const Lazy_exact_nt& a, int b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = b == a.approx();
+    if (is_certain(res))
+      return get_certain(res);
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return b == a.exact();
+  }
+
+
+  // Mixed comparisons with double.
+  friend bool operator<(const Lazy_exact_nt& a, double b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = a.approx() < b;
+    if (is_certain(res))
+      return res;
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return a.exact() < b;
+  }
+
+  friend bool operator>(const Lazy_exact_nt& a, double b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = b < a.approx();
+    if (is_certain(res))
+      return res;
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return b < a.exact();
+  }
+
+  friend bool operator==(const Lazy_exact_nt& a, double b)
+  {
+    CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
+    Uncertain<bool> res = b == a.approx();
+    if (is_certain(res))
+      return res;
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
+    return b == a.exact();
+  }
+
   // % kills filtering
   Self & operator%=(const Self& b)
   {
@@ -560,84 +623,6 @@ operator%(const Lazy_exact_nt<ET>& a, const Lazy_exact_nt<ET>& b)
   CGAL_precondition(b != 0);
   return Lazy_exact_nt<ET>(a) %= b;
 }
-
-
-
-// Mixed operators with int.
-template <typename ET>
-bool
-operator<(const Lazy_exact_nt<ET>& a, int b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = a.approx() < b;
-  if (is_certain(res))
-    return res;
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return a.exact() < b;
-}
-
-template <typename ET>
-bool
-operator>(const Lazy_exact_nt<ET>& a, int b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = b < a.approx();
-  if (is_certain(res))
-    return get_certain(res);
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return b < a.exact();
-}
-
-template <typename ET>
-bool
-operator==(const Lazy_exact_nt<ET>& a, int b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = b == a.approx();
-  if (is_certain(res))
-    return get_certain(res);
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return b == a.exact();
-}
-
-
-// Mixed operators with double.
-template <typename ET>
-bool
-operator<(const Lazy_exact_nt<ET>& a, double b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = a.approx() < b;
-  if (is_certain(res))
-    return res;
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return a.exact() < b;
-}
-
-template <typename ET>
-bool
-operator>(const Lazy_exact_nt<ET>& a, double b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = b < a.approx();
-  if (is_certain(res))
-    return res;
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return b < a.exact();
-}
-
-template <typename ET>
-bool
-operator==(const Lazy_exact_nt<ET>& a, double b)
-{
-  CGAL_BRANCH_PROFILER(std::string(" failures/calls to   : ") + std::string(CGAL_PRETTY_FUNCTION), tmp);
-  Uncertain<bool> res = b == a.approx();
-  if (is_certain(res))
-    return res;
-  CGAL_BRANCH_PROFILER_BRANCH(tmp);
-  return b == a.exact();
-}
-
 
 
 template <typename ET1, typename ET2>

--- a/Number_types/include/CGAL/MP_Float.h
+++ b/Number_types/include/CGAL/MP_Float.h
@@ -109,8 +109,8 @@ MP_Float operator%(const MP_Float &a, const MP_Float &b);
 
 class MP_Float : boost::totally_ordered1<MP_Float
 #ifdef _MSC_VER
-                 , boost::equality_comparable2<MP_Float, int
-                 , boost::equality_comparable2<MP_Float, double
+                 , boost::ordered_ring_operators2<MP_Float, int
+                 , boost::ordered_ring_operators2<MP_Float, double
                  > >
 #endif
                  >
@@ -237,11 +237,13 @@ public:
   { return (a.v == b.v) && (a.v.empty() || (a.exp == b.exp)); }
 
 #ifdef _MSC_VER
-  // Needed because without /permissive-, it makes hidden friends visible (operator== from Quotient)
-  friend bool operator==(const MP_Float &a, int b)
-  { return a == MP_Float(b); }
-  friend bool operator==(const MP_Float &a, double b)
-  { return a == MP_Float(b); }
+  // Needed because without /permissive-, it makes hidden friends visible (from Quotient)
+  friend bool operator==(const MP_Float &a, int    b) { return a == MP_Float(b); }
+  friend bool operator==(const MP_Float &a, double b) { return a == MP_Float(b); }
+  friend bool operator< (const MP_Float &a, int    b) { return a <  MP_Float(b); }
+  friend bool operator< (const MP_Float &a, double b) { return a <  MP_Float(b); }
+  friend bool operator> (const MP_Float &a, int    b) { return a >  MP_Float(b); }
+  friend bool operator> (const MP_Float &a, double b) { return a >  MP_Float(b); }
 #endif
 
   exponent_type max_exp() const

--- a/Number_types/include/CGAL/MP_Float.h
+++ b/Number_types/include/CGAL/MP_Float.h
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <boost/operators.hpp>
 
 // MP_Float : multiprecision scaled integers.
 
@@ -106,7 +107,13 @@ MP_Float operator*(const MP_Float &a, const MP_Float &b);
 MP_Float operator%(const MP_Float &a, const MP_Float &b);
 
 
-class MP_Float
+class MP_Float : boost::totally_ordered1<MP_Float
+#ifdef _MSC_VER
+                 , boost::equality_comparable2<MP_Float, int
+                 , boost::equality_comparable2<MP_Float, double
+                 > >
+#endif
+                 >
 {
 public:
   typedef short          limb;
@@ -222,6 +229,20 @@ public:
   MP_Float& operator-=(const MP_Float &a) { return *this = *this - a; }
   MP_Float& operator*=(const MP_Float &a) { return *this = *this * a; }
   MP_Float& operator%=(const MP_Float &a) { return *this = *this % a; }
+
+  friend bool operator<(const MP_Float &a, const MP_Float &b)
+  { return INTERN_MP_FLOAT::compare(a, b) == SMALLER; }
+
+  friend bool operator==(const MP_Float &a, const MP_Float &b)
+  { return (a.v == b.v) && (a.v.empty() || (a.exp == b.exp)); }
+
+#ifdef _MSC_VER
+  // Needed because without /permissive-, it makes hidden friends visible (operator== from Quotient)
+  friend bool operator==(const MP_Float &a, int b)
+  { return a == MP_Float(b); }
+  friend bool operator==(const MP_Float &a, double b)
+  { return a == MP_Float(b); }
+#endif
 
   exponent_type max_exp() const
   {
@@ -364,30 +385,6 @@ division(const MP_Float & n, const MP_Float & d);
 inline
 void swap(MP_Float &m, MP_Float &n)
 { m.swap(n); }
-
-inline
-bool operator<(const MP_Float &a, const MP_Float &b)
-{ return INTERN_MP_FLOAT::compare(a, b) == SMALLER; }
-
-inline
-bool operator>(const MP_Float &a, const MP_Float &b)
-{ return b < a; }
-
-inline
-bool operator>=(const MP_Float &a, const MP_Float &b)
-{ return ! (a < b); }
-
-inline
-bool operator<=(const MP_Float &a, const MP_Float &b)
-{ return ! (a > b); }
-
-inline
-bool operator==(const MP_Float &a, const MP_Float &b)
-{ return (a.v == b.v) && (a.v.empty() || (a.exp == b.exp)); }
-
-inline
-bool operator!=(const MP_Float &a, const MP_Float &b)
-{ return ! (a == b); }
 
 MP_Float
 approximate_sqrt(const MP_Float &d);

--- a/Number_types/include/CGAL/Quotient.h
+++ b/Number_types/include/CGAL/Quotient.h
@@ -129,13 +129,13 @@ class Quotient
   Quotient<NT>& operator*= (const CGAL_double(NT)& r);
   Quotient<NT>& operator/= (const CGAL_double(NT)& r);
 
-  friend bool operator==(const Quotient<NT>& x, const Quotient<NT>& y)
+  friend bool operator==(const Quotient& x, const Quotient& y)
   { return x.num * y.den == x.den * y.num; }
-  friend bool operator==(const Quotient<NT>& x, const NT& y)
+  friend bool operator==(const Quotient& x, const NT& y)
   { return x.den * y == x.num; }
-  friend inline bool operator==(const Quotient<NT>& x, const CGAL_int(NT) & y)
+  friend inline bool operator==(const Quotient& x, const CGAL_int(NT) & y)
   { return x.den * y == x.num; }
-  friend inline bool operator==(const Quotient<NT>& x, const CGAL_double(NT) & y)
+  friend inline bool operator==(const Quotient& x, const CGAL_double(NT) & y)
   { return x.den * y == x.num; } // Uh?
 
   Quotient<NT>&    normalize();

--- a/Number_types/include/CGAL/Quotient.h
+++ b/Number_types/include/CGAL/Quotient.h
@@ -129,6 +129,15 @@ class Quotient
   Quotient<NT>& operator*= (const CGAL_double(NT)& r);
   Quotient<NT>& operator/= (const CGAL_double(NT)& r);
 
+  friend bool operator==(const Quotient<NT>& x, const Quotient<NT>& y)
+  { return x.num * y.den == x.den * y.num; }
+  friend bool operator==(const Quotient<NT>& x, const NT& y)
+  { return x.den * y == x.num; }
+  friend inline bool operator==(const Quotient<NT>& x, const CGAL_int(NT) & y)
+  { return x.den * y == x.num; }
+  friend inline bool operator==(const Quotient<NT>& x, const CGAL_double(NT) & y)
+  { return x.den * y == x.num; } // Uh?
+
   Quotient<NT>&    normalize();
 
   const NT&   numerator()   const { return num; }
@@ -436,31 +445,6 @@ NT
 quotient_truncation(const Quotient<NT>& r)
 { return (r.num / r.den); }
 
-
-
-template <class NT>
-CGAL_MEDIUM_INLINE
-bool
-operator==(const Quotient<NT>& x, const Quotient<NT>& y)
-{ return x.num * y.den == x.den * y.num; }
-
-template <class NT>
-CGAL_MEDIUM_INLINE
-bool
-operator==(const Quotient<NT>& x, const NT& y)
-{ return x.den * y == x.num; }
-
-template <class NT>
-inline
-bool
-operator==(const Quotient<NT>& x, const CGAL_int(NT) & y)
-{ return x.den * y == x.num; }
-
-template <class NT>
-inline
-bool
-operator==(const Quotient<NT>& x, const CGAL_double(NT) & y)
-{ return x.den * y == x.num; }
 
 
 

--- a/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
+++ b/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
@@ -190,9 +190,18 @@ template <class NT_>
 class Polynomial
   : public Handle_with_policy< internal::Polynomial_rep<NT_> >,
     public boost::ordered_field_operators1< Polynomial<NT_> ,
+#if __cpp_impl_three_way_comparison >= 201907L
+           boost::less_than_comparable2< Polynomial<NT_> , NT_ ,
+           boost::less_than_comparable2< Polynomial<NT_> , CGAL_icoeff(NT_),
+           boost::less_than_comparable2< Polynomial<NT_> , CGAL_int(NT_),
+           boost::field_operators2< Polynomial<NT_> , NT_ ,
+           boost::field_operators2< Polynomial<NT_> , CGAL_icoeff(NT_),
+           boost::field_operators2< Polynomial<NT_> , CGAL_int(NT_)  > > > > > > >
+#else
            boost::ordered_field_operators2< Polynomial<NT_> , NT_ ,
            boost::ordered_field_operators2< Polynomial<NT_> , CGAL_icoeff(NT_),
            boost::ordered_field_operators2< Polynomial<NT_> , CGAL_int(NT_)  > > > >
+#endif
 {
   typedef typename internal::Innermost_coefficient_type<NT_>::Type Innermost_coefficient_type;
 public:

--- a/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
+++ b/Polynomial/include/CGAL/Polynomial/Polynomial_type.h
@@ -190,18 +190,9 @@ template <class NT_>
 class Polynomial
   : public Handle_with_policy< internal::Polynomial_rep<NT_> >,
     public boost::ordered_field_operators1< Polynomial<NT_> ,
-#if __cpp_impl_three_way_comparison >= 201907L
-           boost::less_than_comparable2< Polynomial<NT_> , NT_ ,
-           boost::less_than_comparable2< Polynomial<NT_> , CGAL_icoeff(NT_),
-           boost::less_than_comparable2< Polynomial<NT_> , CGAL_int(NT_),
-           boost::field_operators2< Polynomial<NT_> , NT_ ,
-           boost::field_operators2< Polynomial<NT_> , CGAL_icoeff(NT_),
-           boost::field_operators2< Polynomial<NT_> , CGAL_int(NT_)  > > > > > > >
-#else
            boost::ordered_field_operators2< Polynomial<NT_> , NT_ ,
            boost::ordered_field_operators2< Polynomial<NT_> , CGAL_icoeff(NT_),
            boost::ordered_field_operators2< Polynomial<NT_> , CGAL_int(NT_)  > > > >
-#endif
 {
   typedef typename internal::Innermost_coefficient_type<NT_>::Type Innermost_coefficient_type;
 public:
@@ -966,6 +957,52 @@ public:
     }
 
     friend Polynomial<NT> operator - <> (const Polynomial<NT>&);
+
+    //
+    // Comparison Operators
+    //
+
+    // polynomials only
+    friend bool operator == (const Polynomial& p1, const Polynomial& p2) {
+      CGAL_precondition(p1.degree() >= 0);
+      CGAL_precondition(p2.degree() >= 0);
+      if (p1.is_identical(p2)) return true;
+      if (p1.degree() != p2.degree()) return false;
+      for (int i = p1.degree(); i >= 0; i--) if (p1[i] != p2[i]) return false;
+      return true;
+    }
+    friend bool operator < (const Polynomial& p1, const Polynomial& p2)
+    { return ( p1.compare(p2) < 0 ); }
+
+    // operators NT
+    friend bool operator == (const Polynomial& p, const NT& num)  {
+      CGAL_precondition(p.degree() >= 0);
+      return p.degree() == 0 && p[0] == num;
+    }
+    friend bool operator < (const Polynomial& p,const NT& num)
+    { return ( p.compare(num) < 0 );}
+    friend bool operator > (const Polynomial& p,const NT& num)
+    { return ( p.compare(num) > 0 );}
+
+    // compare int #################################
+    friend bool operator == (const Polynomial& p, const CGAL_int(NT)& num)  {
+      CGAL_precondition(p.degree() >= 0);
+      return p.degree() == 0 && p[0] == NT(num);
+    }
+    friend bool operator < (const Polynomial& p, const CGAL_int(NT)& num)
+    { return ( p.compare(NT(num)) < 0 );}
+    friend bool operator > (const Polynomial& p, const CGAL_int(NT)& num)
+    { return ( p.compare(NT(num)) > 0 );}
+
+    // compare icoeff ###################################
+    friend bool operator == (const Polynomial& p, const CGAL_icoeff(NT)& num)  {
+      CGAL_precondition(p.degree() >= 0);
+      return p.degree() == 0 && p[0] == NT(num);
+    }
+    friend bool operator < (const Polynomial& p, const CGAL_icoeff(NT)& num)
+    { return ( p.compare(NT(num)) < 0 );}
+    friend bool operator > (const Polynomial& p, const CGAL_icoeff(NT)& num)
+    { return ( p.compare(NT(num)) > 0 );}
 }; // class Polynomial<NT_>
 
 // Arithmetic Operators, Part III:
@@ -1007,102 +1044,6 @@ Polynomial<NT> operator * (const Polynomial<NT>& p1,
   return p;
 }
 
-
-//
-// Comparison Operators
-//
-
-// polynomials only
-template <class NT> inline
-bool operator == (const Polynomial<NT>& p1, const Polynomial<NT>& p2) {
-  CGAL_precondition(p1.degree() >= 0);
-  CGAL_precondition(p2.degree() >= 0);
-  if (p1.is_identical(p2)) return true;
-  if (p1.degree() != p2.degree()) return false;
-  for (int i = p1.degree(); i >= 0; i--) if (p1[i] != p2[i]) return false;
-  return true;
-}
-template <class NT> inline
-bool operator < (const Polynomial<NT>& p1, const Polynomial<NT>& p2)
-{ return ( p1.compare(p2) < 0 ); }
-template <class NT> inline
-bool operator > (const Polynomial<NT>& p1, const Polynomial<NT>& p2)
-{ return ( p1.compare(p2) > 0 ); }
-
-// operators NT
-template <class NT> inline
-bool operator == (const NT& num, const Polynomial<NT>& p) {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == num;
-}
-template <class NT> inline
-bool operator == (const Polynomial<NT>& p, const NT& num)  {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == num;
-}
-template <class NT> inline
-bool operator < (const NT& num, const Polynomial<NT>& p)
-{ return ( p.compare(num) > 0 );}
-template <class NT> inline
-bool operator < (const Polynomial<NT>& p,const NT& num)
-{ return ( p.compare(num) < 0 );}
-template <class NT> inline
-bool operator > (const NT& num, const Polynomial<NT>& p)
-{ return ( p.compare(num) < 0 );}
-template <class NT> inline
-bool operator > (const Polynomial<NT>& p,const NT& num)
-{ return ( p.compare(num) > 0 );}
-
-
-// compare int #################################
-template <class NT> inline
-bool operator == (const CGAL_int(NT)& num, const Polynomial<NT>& p)  {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == NT(num);
-}
-template <class NT> inline
-bool operator == (const Polynomial<NT>& p, const CGAL_int(NT)& num)  {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == NT(num);
-}
-template <class NT> inline
-bool operator < (const CGAL_int(NT)& num, const Polynomial<NT>& p)
-{ return ( p.compare(NT(num)) > 0 );}
-template <class NT> inline
-bool operator < (const Polynomial<NT>& p, const CGAL_int(NT)& num)
-{ return ( p.compare(NT(num)) < 0 );}
-template <class NT> inline
-bool operator > (const CGAL_int(NT)& num, const Polynomial<NT>& p)
-{ return ( p.compare(NT(num)) < 0 );}
-template <class NT> inline
-bool operator > (const Polynomial<NT>& p, const CGAL_int(NT)& num)
-{ return ( p.compare(NT(num)) > 0 );}
-
-// compare icoeff ###################################
-template <class NT> inline
-bool operator == (const CGAL_icoeff(NT)& num, const Polynomial<NT>& p)  {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == NT(num);
-}
-template <class NT> inline
-bool operator == (const Polynomial<NT>& p, const CGAL_icoeff(NT)& num)  {
-  CGAL_precondition(p.degree() >= 0);
-  return p.degree() == 0 && p[0] == NT(num);
-}
-template <class NT> inline
-bool operator < (const CGAL_icoeff(NT)& num, const Polynomial<NT>& p)
-{ return ( p.compare(NT(num)) > 0 );}
-template <class NT> inline
-bool operator < (const Polynomial<NT>& p, const CGAL_icoeff(NT)& num)
-{ return ( p.compare(NT(num)) < 0 );}
-
-
-template <class NT> inline
-bool operator > (const CGAL_icoeff(NT)& num, const Polynomial<NT>& p)
-{ return ( p.compare(NT(num)) < 0 );}
-template <class NT> inline
-bool operator > (const Polynomial<NT>& p, const CGAL_icoeff(NT)& num)
-{ return ( p.compare(NT(num)) > 0 );}
 
 //
 // Algebraically non-trivial operations

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -718,7 +718,7 @@ void Concurrent_compact_container<T, Allocator>::clear()
     size_type s = it->second;
     for (pointer pp = p + 1; pp != p + s - 1; ++pp) {
       if (type(pp) == USED)
-        m_alloc.destroy(pp);
+        std::allocator_traits<allocator_type>::destroy(m_alloc, pp);
     }
     m_alloc.deallocate(p, s);
   }

--- a/Union_find/include/CGAL/Union_find.h
+++ b/Union_find/include/CGAL/Union_find.h
@@ -114,7 +114,7 @@ public:
 #ifdef _MSC_VER
     typedef CGAL_ALLOCATOR(Union_find_struct)                allocator;
 #else
-    typedef typename std::allocator_traits<A>::rebind_alloc<Union_find_struct> allocator;
+    typedef typename std::allocator_traits<A>::template rebind_alloc<Union_find_struct> allocator;
 #endif
 
 private:

--- a/Union_find/include/CGAL/Union_find.h
+++ b/Union_find/include/CGAL/Union_find.h
@@ -114,8 +114,7 @@ public:
 #ifdef _MSC_VER
     typedef CGAL_ALLOCATOR(Union_find_struct)                allocator;
 #else
-    typedef typename A::template rebind<Union_find_struct>   Rebind;
-    typedef typename Rebind::other                           allocator;
+    typedef typename std::allocator_traits<A>::rebind_alloc<Union_find_struct> allocator;
 #endif
 
 private:


### PR DESCRIPTION
## Summary of Changes

The important part is the changes to Quotient and Lazy_exact_nt so the code actually works with -std=c++20 and recent compilers.
The change to Gmpq is an experiment (on a very simple type), I first thought I would handle the others that way, but `operator<=>` is harder to work with than I expected. One idiotic detail is that std::strong_ordering is essentially an int that can be -1, 0, or 1, but they do not provide any direct way to convert to/from such an int. Also, using a non-standard return type for <=> seems less acceptable than for the traditional operators.
I think more work will be needed on this topic, but let's first unbreak things.

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): partial #4615