### PR TITLE
Incorrect definition of ccProd

### DIFF
--- a/Documentation/doc/resources/1.8.13/header.html
+++ b/Documentation/doc/resources/1.8.13/header.html
@@ -32,7 +32,7 @@ $extrastylesheet
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/Documentation/doc/resources/1.8.13/header_package.html
+++ b/Documentation/doc/resources/1.8.13/header_package.html
@@ -56,7 +56,7 @@ $extrastylesheet
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/Documentation/doc/resources/1.8.14/header.html
+++ b/Documentation/doc/resources/1.8.14/header.html
@@ -32,7 +32,7 @@ $extrastylesheet
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/Documentation/doc/resources/1.8.14/header_package.html
+++ b/Documentation/doc/resources/1.8.14/header_package.html
@@ -56,7 +56,7 @@ $extrastylesheet
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/Documentation/doc/resources/1.8.4/header.html
+++ b/Documentation/doc/resources/1.8.4/header.html
@@ -36,7 +36,7 @@ $search
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/Documentation/doc/resources/1.8.4/header_package.html
+++ b/Documentation/doc/resources/1.8.4/header_package.html
@@ -53,7 +53,7 @@ MathJax.Hub.Config({
 }
 
 \def\ccProd #1#2#3{
-  \sum_{#1}^{#2}{#3}
+  \prod_{#1}^{#2}{#3}
 }\)
 </span>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->


### PR DESCRIPTION
The ccProd macro for formulas is defined as `\sum_{#1}^{#2}{#3}` but this should be `\prod_{#1}^{#2}{#3}`, probably a cut and paste error from ccSum.
Only place where ccProd is used in the (code) documentation is: Polynomial/doc/Polynomial/Concepts/PolynomialTraits_d--Resultant.h

