### PR TITLE
Add a precondition checking for degeneracies before calling intersection

### DIFF
--- a/Intersections_2/test/Intersections_2/test_intersections_2.cpp
+++ b/Intersections_2/test/Intersections_2/test_intersections_2.cpp
@@ -701,9 +701,9 @@ struct Test
     check_no_intersection  (Rec(p(-2, -6), p( 6, 3)), p(-2, -7));
 
     // point intersection
-    check_intersection     (Rec(p(-1,  4), p(-1, 4)), p(-1, 4), p(-1, 4)); // degenerate rectange (0d)
-    check_intersection     (Rec(p(-2,  4), p(-2, 7)), p(-2, 6), p(-2, 6)); // degenerate rectange (1d)
-    check_intersection     (Rec(p(-2,  4), p(-2, 7)), p(-2, 7), p(-2, 7)); // degenerate rectange (1d)
+//    check_intersection     (Rec(p(-1,  4), p(-1, 4)), p(-1, 4), p(-1, 4)); // degenerate rectange (0d)
+//    check_intersection     (Rec(p(-2,  4), p(-2, 7)), p(-2, 6), p(-2, 6)); // degenerate rectange (1d)
+//    check_intersection     (Rec(p(-2,  4), p(-2, 7)), p(-2, 7), p(-2, 7)); // degenerate rectange (1d)
     check_intersection     (Rec(p(-3,  0), p( 4, 2)), p(-3, 2), p(-3, 2)); // on vertex
     check_intersection     (Rec(p( 7,  8), p( 9, 9)), p( 8, 9), p( 8, 9)); // on edge
     check_intersection     (Rec(p(-2,  0), p( 6, 7)), p( 1, 1), p( 1, 1)); // within

--- a/Intersections_3/test/Intersections_3/test_point_3_intersections.cpp
+++ b/Intersections_3/test/Intersections_3/test_point_3_intersections.cpp
@@ -73,8 +73,8 @@ void test_P_Pl()
 {
   typedef CGAL::Point_3<K> P;
   typedef CGAL::Plane_3<K> Pl;
-  P p(0.99,0.99,0.99);
-  Pl pl(P(-1.0,-1.0,-1.0), P(1.0,1.0,1.0), P(0.0,0.0,0.0));
+  P p(22,33,0);
+  Pl pl(P(0.0,0.0,0.0), P(1.0,0.0,0.0), P(0.0,1.0,0.0));
   assert(CGAL::do_intersect(p, pl));
   CGAL::Object o = CGAL::intersection(p,pl);
   P res;

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -3533,7 +3533,13 @@ namespace CommonKernelFunctors {
     template <class T1, class T2>
     typename Intersection_traits<K, T1, T2>::result_type
     operator()(const T1& t1, const T2& t2) const
-    { return Intersections::internal::intersection(t1, t2, K()); }
+    {
+      K k;
+      CGAL_assertion_code(typename K::Is_degenerate_2 is_degenerate = k.is_degenerate_2_object();)
+      CGAL_precondition( !is_degenerate(t1));
+      CGAL_precondition( !is_degenerate(t2));
+      return Intersections::internal::intersection(t1, t2, k);
+    }
   };
 
   template <typename K>
@@ -3561,11 +3567,24 @@ namespace CommonKernelFunctors {
     template <class T1, class T2>
     typename cpp11::result_of< Intersect_3(T1, T2) >::type
     operator()(const T1& t1, const T2& t2) const
-    { return Intersections::internal::intersection(t1, t2, K() ); }
+    {
+      K k;
+      CGAL_assertion_code(typename K::Is_degenerate_3 is_degenerate = k.is_degenerate_3_object();)
+      CGAL_precondition( !is_degenerate(t1));
+      CGAL_precondition( !is_degenerate(t2));
+      return Intersections::internal::intersection(t1, t2, k);
+    }
 
     typename boost::optional< boost::variant< typename K::Point_3, typename K::Line_3, typename K::Plane_3 > >
     operator()(const Plane_3& pl1, const Plane_3& pl2, const Plane_3& pl3)const
-    { return Intersections::internal::intersection(pl1, pl2, pl3, K() ); }
+    {
+      K k;
+      CGAL_assertion_code(typename K::Is_degenerate_3 is_degenerate = k.is_degenerate_3_object();)
+      CGAL_precondition( !is_degenerate(pl1));
+      CGAL_precondition( !is_degenerate(pl2));
+      CGAL_precondition( !is_degenerate(pl3));
+      return Intersections::internal::intersection(pl1, pl2, pl3, K() );
+    }
   };
 
   template <typename K>
@@ -3577,6 +3596,7 @@ namespace CommonKernelFunctors {
     typedef typename K::Ray_2             Ray_2;
     typedef typename K::Segment_2         Segment_2;
     typedef typename K::Triangle_2        Triangle_2;
+    typedef typename K::Point_2           Point_2;
     typedef typename K::Circle_3          Circle_3;
   public:
     typedef typename K::Boolean           result_type;
@@ -3608,6 +3628,10 @@ namespace CommonKernelFunctors {
     result_type
     operator()( const Circle_3& c) const
     { return c.rep().is_degenerate(); }
+
+    result_type
+    operator()( const Point_2& ) const
+    { return false; }
   };
 
   template <typename K>
@@ -3622,6 +3646,7 @@ namespace CommonKernelFunctors {
     typedef typename K::Sphere_3          Sphere_3;
     typedef typename K::Triangle_3        Triangle_3;
     typedef typename K::Tetrahedron_3     Tetrahedron_3;
+    typedef typename K::Point_3           Point_3;
   public:
     typedef typename K::Boolean           result_type;
 
@@ -3661,6 +3686,9 @@ namespace CommonKernelFunctors {
     operator()( const Circle_3& t) const
     { return t.rep().is_degenerate(); }
 
+    result_type
+    operator()( const Point_3& ) const
+    { return false; }
   };
 
   template <typename K>

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_all_linear_intersections.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_all_linear_intersections.h
@@ -63,7 +63,7 @@ void test_linear_intersections()
     Point_2(-1,1)
   };
 
-  Iso_rectangle_2 iso_rectangle_2(points_2D[0], points_2D[1]);
+  Iso_rectangle_2 iso_rectangle_2(points_2D[0], points_2D[2]);
   Line_2 line_2(points_2D[0], points_2D[1]);
   Ray_2 ray_2(points_2D[0], points_2D[1]);
   Segment_2 segment_2(points_2D[0], points_2D[1]);


### PR DESCRIPTION
Provided the fact that I have to update some tests, maybe we do not want that (or at least turn the precondition into a warning). Shall we do the same for `do_intersect`?