### PR TITLE
[Small Feature] Parallel Outlier Removal

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -24,6 +24,11 @@ Release History
 ### Point Set Processing
  - Add a function `CGAL::cluster_point_set()` that segments a point
    cloud into connected components based on a distance threshold.
+ - **Breaking change:** `CGAL::remove_outliers()` has been
+   parallelized and thus has a new template parameter
+   `ConcurrencyTag`. To update your code simply add as first template
+   parameter `CGAL::Sequential_tag` or `CGAL::Parallel_tag` when
+   calling this function.
 
 ### 2D Triangulations
  - Add function `split_subconstraint_graph_into_constraints()` to

--- a/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
@@ -643,11 +643,12 @@ computed and stored as colors in a PLY file:
 
 \section Point_set_processing_3OutlierRemoval Outlier Removal
 
-Function `remove_outliers()` deletes a user-specified fraction
-of outliers from an input point set. More specifically, it sorts the
-input points in increasing order of average squared distances to their
-nearest neighbors and deletes the points with largest value. The user
-can either specify a fixed number of nearest neighbors or a fixed
+Function `remove_outliers()` deletes a user-specified fraction of
+outliers from an input point set. More specifically, it partitions the
+input points with respect to the average squared distances to their
+nearest neighbors and deletes the points with largest value, either
+partitionning with a threshold or removing a fixed percentage. The
+user can either specify a fixed number of nearest neighbors or a fixed
 spherical neighborhood radius.
 
 \subsection Point_set_processing_3Example_outlier_removal Example

--- a/Point_set_processing_3/examples/Point_set_processing_3/remove_outliers_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/remove_outliers_example.cpp
@@ -39,7 +39,7 @@ int main(int argc, char*argv[])
   // FIRST OPTION //
   // I don't know the ratio of outliers present in the point set
   std::vector<Point>::iterator first_to_remove
-    = CGAL::remove_outliers
+    = CGAL::remove_outliers<CGAL::Parallel_if_available_tag>
     (points,
      nb_neighbors,
      CGAL::parameters::threshold_percent (100.). // No limit on the number of outliers to remove

--- a/Point_set_processing_3/examples/Point_set_processing_3/remove_outliers_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/remove_outliers_example.cpp
@@ -55,7 +55,7 @@ int main(int argc, char*argv[])
   // I know the ratio of outliers present in the point set
   const double removed_percentage = 5.0; // percentage of points to remove
 
-  points.erase(CGAL::remove_outliers
+  points.erase(CGAL::remove_outliers<CGAL::Parallel_if_available_tag>
                (points,
                 nb_neighbors,
                 CGAL::parameters::threshold_percent(removed_percentage). // Minimum percentage to remove

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -224,7 +224,7 @@ remove_outliers(
                             return p.first < threshold_distance * threshold_distance;
                           });
 
-  if (std::distance (sorted_points.begin(), f2r) < first_index_to_remove)
+  if (static_cast<std::size_t>(std::distance (sorted_points.begin(), f2r)) < first_index_to_remove)
   {
     std::nth_element (f2r,
                       sorted_points.begin() + first_index_to_remove,

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -88,7 +88,9 @@ compute_avg_knn_sq_distance_3(
    \ingroup PkgPointSetProcessing3Algorithms
    Removes outliers:
    - computes average squared distance to the nearest neighbors,
-   - and sorts the points in increasing order of average distance.
+   - and partitions the points either using a threshold on the of
+     average distance or selecting a fixed percentage of points with
+     the highest average distances
 
    This method modifies the order of input points so as to pack all remaining points first,
    and returns an iterator over the first point to remove (see erase-remove idiom).
@@ -96,6 +98,8 @@ compute_avg_knn_sq_distance_3(
 
    \pre `k >= 2`
 
+   \tparam ConcurrencyTag enables sequential versus parallel algorithm. Possible values are `Sequential_tag`,
+                          `Parallel_tag`, and `Parallel_if_available_tag`.
    \tparam PointRange is a model of `Range`. The value type of
    its iterator is the key type of the named parameter `point_map`.
 

--- a/Point_set_processing_3/test/Point_set_processing_3/remove_outliers_test.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/remove_outliers_test.cpp
@@ -50,8 +50,9 @@ void test_avg_knn_sq_distance(std::deque<Point>& points, // input point set
             << nb_neighbors_remove_outliers << ")...\n";
 
   // Removes outliers using erase-remove idiom
-  points.erase(CGAL::remove_outliers(points, nb_neighbors_remove_outliers,
-                                     CGAL::parameters::threshold_percent(removed_percentage)),
+  points.erase(CGAL::remove_outliers<CGAL::Parallel_if_available_tag>
+               (points, nb_neighbors_remove_outliers,
+                CGAL::parameters::threshold_percent(removed_percentage)),
                points.end());
 
   // Optional: after erase(), use Scott Meyer's "swap trick" to trim excess capacity
@@ -139,4 +140,3 @@ int main(int argc, char * argv[])
   std::cerr << "Tool returned " << accumulated_fatal_err << std::endl;
   return accumulated_fatal_err;
 }
-

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
@@ -63,9 +63,10 @@ int main(int argc, char*argv[])
   ///////////////////////////////////////////////////////////////////
   //! [Outlier removal]
 
-  CGAL::remove_outliers (points,
-                         24, // Number of neighbors considered for evaluation
-                         points.parameters().threshold_percent (5.0)); // Percentage of points to remove
+  CGAL::remove_outliers<CGAL::Sequential_tag>
+    (points,
+     24, // Number of neighbors considered for evaluation
+     points.parameters().threshold_percent (5.0)); // Percentage of points to remove
 
   std::cout << points.number_of_removed_points()
             << " point(s) are outliers." << std::endl;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
@@ -40,12 +40,13 @@ struct Outlier_removal_functor
   {
     // Computes outliers
     *result =
-      CGAL::remove_outliers(*points,
-                            nb_neighbors,
-                            points->parameters().
-                            threshold_percent(removed_percentage).
-                            threshold_distance(distance_threshold).
-                            callback (*(this->callback())));
+      CGAL::remove_outliers<CGAL::Parallel_if_available_tag>
+      (*points,
+       nb_neighbors,
+       points->parameters().
+       threshold_percent(removed_percentage).
+       threshold_distance(distance_threshold).
+       callback (*(this->callback())));
   }
 };
 


### PR DESCRIPTION
## Rationale

Many algorithms in _Point Set Processing_ are parallelized, but `CGAL::remove_outliers()` is not: the main reason is that it originally filled a `std::multimap` structure which is hard to parallelize.

This small feature adds a `ConcurrencyTag` template parameter to `CGAL::remove_outliers()` similarly to what already exists in other PSP functions. The algorithm has also changed slightly in the sense that it does not sort points anymore: apart from that, the output partition (which point is outlier, which point is inlier) is unchanged.

A parallel variant of the algorithm is added, and the sequential version is also made faster (around 1.7x faster in my experiments).

In practice:
- replacing the `std::multimap` by a `std::vector` filled first and sorted afterwards makes the algorithm 1.3x faster than master version
- replacing the sorting by a `std::partition` (for threshold-based version) and `std::nth_element` (for the percentage-based version) makes the algorithm 1.7x faster than master version
- parallelization of the vector filling on a quad-core processor makes the algorithm 5.4x faster than master version


## Summary of API changes

A new template parameter `ConcurrencyTag` is added to `CGAL::remove_outliers()`. Documentation is changed to make it clear that points are not sorted but only partitioned.

## License and copyright ownership

(no change)

## CHANGES.md

```markdown
### Point Set Processing
 - **Breaking change:** `CGAL::remove_outliers()` has been
   parallelized and thus has a new template parameter
   `ConcurrencyTag`. To update your code simply add as first template
   parameter `CGAL::Sequential_tag` or `CGAL::Parallel_tag` when
   calling this function.
```

## Submission

* [__User Manual__](https://cgal.geometryfactory.com/~sgiraudot/PSP-Parallelize_outlier_removal-GF/Point_set_processing_3/index.html#title33)
* [__Reference Manual__](https://cgal.geometryfactory.com/~sgiraudot/PSP-Parallelize_outlier_removal-GF/Point_set_processing_3/group__PkgPointSetProcessing3Algorithms.html#ga1ab1dcee59caadde50572c5a504cc41a)

## Status

* Developed and locally tested (GNU/Linux)
* [Small Feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Parallel_Outlier_Removal), pre-approved Andreas Fabri 16:21, 16 April 2020 (CEST)
