### PR TITLE
Remove "unused-but-set-parameter" warnings

### DIFF
--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -882,12 +882,12 @@ namespace internal {
     }
 
     // Construction from nullptr
-    CC_iterator (std::nullptr_t CGAL_assertion_code(n))
+    CC_iterator (std::nullptr_t /*CGAL_assertion_code(n)*/)
 #ifdef CGAL_COMPACT_CONTAINER_DEBUG_TIME_STAMP
       : ts(0)
 #endif
     {
-      CGAL_assertion (n == nullptr);
+      //CGAL_assertion (n == nullptr);
       m_ptr.p = nullptr;
     }
 
@@ -1090,18 +1090,18 @@ namespace internal {
   template < class DSC, bool Const >
   inline
   bool operator==(const CC_iterator<DSC, Const> &rhs,
-                  std::nullptr_t CGAL_assertion_code(n))
+                  std::nullptr_t /*CGAL_assertion_code(n)*/)
   {
-    CGAL_assertion( n == nullptr);
+    //CGAL_assertion( n == nullptr);
     return rhs.operator->() == nullptr;
   }
 
   template < class DSC, bool Const >
   inline
   bool operator!=(const CC_iterator<DSC, Const> &rhs,
-                  std::nullptr_t CGAL_assertion_code(n))
+                  std::nullptr_t /*CGAL_assertion_code(n)*/)
   {
-    CGAL_assertion( n == nullptr);
+    //CGAL_assertion( n == nullptr);
     return rhs.operator->() != nullptr;
   }
 

--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -132,10 +132,10 @@ class Object
 
 #ifndef CGAL_NO_DEPRECATED_CODE
     // The comparisons with nullptr are only there for Nef...
-    bool operator==(std::nullptr_t CGAL_assertion_code(n)) const
-    { CGAL_assertion(n == 0); return empty(); }
-    bool operator!=(std::nullptr_t CGAL_assertion_code(n)) const
-    { CGAL_assertion(n == 0); return !empty(); }
+  bool operator==(std::nullptr_t /*CGAL_assertion_code(n)*/) const
+  { /*CGAL_assertion(n == 0);*/ return empty(); }
+  bool operator!=(std::nullptr_t /*CGAL_assertion_code(n)*/) const
+  { /*CGAL_assertion(n == 0);*/ return !empty(); }
 #endif // CGAL_NO_DEPRECATED_CODE
 
 };

--- a/TDS_2/include/CGAL/Triangulation_ds_circulators_2.h
+++ b/TDS_2/include/CGAL/Triangulation_ds_circulators_2.h
@@ -71,8 +71,8 @@ public:
   bool operator!=(const Face_handle &fh) const { return pos != fh; }
 
   bool is_empty() const;
-  bool operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
-  bool operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
+  bool operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
+  bool operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
 
   Face&
   operator*() const
@@ -152,8 +152,8 @@ public:
   { return pos->vertex(_ri) != vh; }
 
   bool is_empty() const;
-  bool operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
-  bool operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
+  bool operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
+  bool operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
 
   Vertex&
   operator*() const
@@ -231,8 +231,8 @@ public:
   bool operator==(const Edge_circulator &vc) const;
   bool operator!=(const Edge_circulator &vc) const;
   bool is_empty() const;
-  bool operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
-  bool operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const;
+  bool operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
+  bool operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const;
 
   Edge*  operator->() const {
     edge.first=pos;
@@ -338,18 +338,18 @@ return (_v == Vertex_handle() ||  pos == Face_handle() );
 template < class Tds >
 inline bool
 Triangulation_ds_face_circulator_2<Tds> ::
-operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return (_v == Vertex_handle() ||  pos == Face_handle() );
 }
 
 template < class Tds >
 inline bool
 Triangulation_ds_face_circulator_2<Tds> ::
-operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return ! (*this == nullptr);
 }
 
@@ -462,18 +462,18 @@ is_empty() const
 template < class Tds >
 inline bool
 Triangulation_ds_vertex_circulator_2<Tds> ::
-operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return (_v == Vertex_handle() || pos == Face_handle());
 }
 
 template < class Tds >
 inline bool
 Triangulation_ds_vertex_circulator_2<Tds> ::
-operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return !(*this == nullptr);
 }
 
@@ -584,18 +584,18 @@ is_empty() const
 template < class Tds >
 inline bool
 Triangulation_ds_edge_circulator_2<Tds> ::
-operator==(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator==(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return (_v == Vertex_handle() || pos == Face_handle());
 }
 
 template < class Tds >
 inline bool
 Triangulation_ds_edge_circulator_2<Tds> ::
-operator!=(std::nullptr_t CGAL_triangulation_assertion_code(n)) const
+operator!=(std::nullptr_t /*CGAL_triangulation_assertion_code(n)*/) const
 {
-  CGAL_triangulation_assertion( n == nullptr);
+  //CGAL_triangulation_assertion( n == nullptr);
   return !(*this == nullptr);
 }
 


### PR DESCRIPTION

## Summary of Changes

When compiling draw_linear_cell_complex.cpp example with -Wall -Wextra, I have 23 warnings:
   parameter ‘n’ set but not used [-Wunused-but-set-parameter]
 
 This probably comes from the fact that the methods use std::nullptr_t and thus the assertion (n == nullptr) is removed since it is always true.
 
 There are probably other places where this problem occurs.
 
## Release Management

* Affected package(s): STL_Extension and TDS_2

