### PR TITLE
Solver_interface: docs bug fix

### DIFF
--- a/Solver_interface/doc/Solver_interface/Concepts/DiagonalizeTraits.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/DiagonalizeTraits.h
@@ -21,7 +21,6 @@ follows:
 
 \cgalHasModel `CGAL::Eigen_diagonalize_traits`
 */
-
 template <typename FT, unsigned int dim = 3>
 class DiagonalizeTraits
 {

--- a/Solver_interface/doc/Solver_interface/Concepts/MixedIntegerProgramTraits.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/MixedIntegerProgramTraits.h
@@ -1,16 +1,13 @@
-
-
 class MixedIntegerProgramTraits
 
-
 /*!
+\ingroup PkgSolverInterfaceConcepts
 \cgalConcept
 
 `MixedIntegerProgramVariable` is a concept of a variable in
 a Mixed Integer Programming (MIP) problem.
 
 \cgalHasModel `CGAL::Variable<FT>`
-
 */
 template <typename FT>
 class MixedIntegerProgramVariable
@@ -25,7 +22,7 @@ public:
         typedef unspecified_type FT;
 
         /*!
-        A variable can be continuous, integer, or binary
+        A variable can be continuous, integer, or binary.
         */
         enum Variable_type { CONTINUOUS, INTEGER, BINARY };
 
@@ -43,10 +40,10 @@ public:
         /// \name Operations
         /// @{
 
-        /// Returns the variable type
+        /// Returns the variable type.
         Variable_type variable_type() const;
 
-        /// Sets/Changes the variable type
+        /// Sets/Changes the variable type.
         void set_variable_type(Variable_type t);
 
         /*!
@@ -69,26 +66,26 @@ public:
         */
         void set_index(int idx);
 
-        /// Returns the solver that owns this variable
+        /// Returns the solver that owns this variable.
         const MixedIntegerProgramTraits* solver() const;
         MixedIntegerProgramTraits* solver();
 
-        /// Sets the lower bound
+        /// Sets the lower bound.
         void set_lower_bound(FT lb);
 
-        /// Sets the upper bound
+        /// Sets the upper bound.
         void set_upper_bound(FT ub);
 
-        /// Sets both lower and upper bounds
+        /// Sets both lower and upper bounds.
         void set_bounds(FT lb, FT ub);
 
-        /// Gets the lower bound
+        /// Gets the lower bound.
         FT lower_bound() const;
 
-        /// Gets the upper bound
+        /// Gets the upper bound.
         FT upper_bound() const;
 
-        /// Gets both lower and upper bounds
+        /// Gets both lower and upper bounds.
         void get_bounds(FT& lb, FT& ub) const;
 
         /// Gets the infinity threshold (e.g., 1e20).
@@ -108,17 +105,15 @@ public:
 
 }; /* end MixedIntegerProgramVariable */
 
+/*!
+\ingroup PkgSolverInterfaceConcepts
+\cgalConcept
 
+`MixedIntegerProgramLinearConstraint` is a concept of a linear
+constraint in a Mixed Integer Programming (MIP) problem.
 
-   /*!
-
-   \cgalConcept
-
-   `MixedIntegerProgramLinearConstraint` is a concept of a linear
-   constraint in a Mixed Integer Programming (MIP) problem.
-
-   \cgalHasModel `CGAL::Linear_constraint<FT>`
-   */
+\cgalHasModel `CGAL::Linear_constraint<FT>`
+*/
 template <typename FT>
 class MixedIntegerProgramLinearConstraint
 {
@@ -155,26 +150,26 @@ public:
         */
         void set_index(int idx);
 
-        /// Returns the solver that owns this constraint
+        /// Returns the solver that owns this constraint.
         const MixedIntegerProgramTraits* solver() const;
         MixedIntegerProgramTraits* solver();
 
-        /// Sets the lower bound
+        /// Sets the lower bound.
         void set_lower_bound(FT lb);
 
-        /// Sets the upper bound
+        /// Sets the upper bound.
         void set_upper_bound(FT ub);
 
-        /// Sets both lower and upper bounds
+        /// Sets both lower and upper bounds.
         void set_bounds(FT lb, FT ub);
 
-        /// Gets the lower bound
+        /// Gets the lower bound.
         FT lower_bound() const;
 
-        /// Gets the upper bound
+        /// Gets the upper bound.
         FT upper_bound() const;
 
-        /// Gets both lower and upper bounds
+        /// Gets both lower and upper bounds.
         void get_bounds(FT& lb, FT& ub) const;
 
         /// Gets the infinity threshold (e.g., 1e20).
@@ -207,17 +202,15 @@ public:
 
 }; /* end MixedIntegerProgramLinearConstraint */
 
+/*!
+\ingroup PkgSolverInterfaceConcepts
+\cgalConcept
 
+`MixedIntegerProgramLinearObjective` is a concept of the linear
+objective function in a Mixed Integer Programming (MIP) problem.
 
-   /*!
-
-   \cgalConcept
-
-   `MixedIntegerProgramLinearObjective` is a concept of the linear
-   objective function in a Mixed Integer Programming (MIP) problem.
-
-   \cgalHasModel `CGAL::Linear_objective<FT>`
-   */
+\cgalHasModel `CGAL::Linear_objective<FT>`
+*/
 template <typename FT>
 class MixedIntegerProgramLinearObjective
 {
@@ -225,7 +218,7 @@ public:
         /// \name Types
         /// @{
 
-        /// The objective sense (i.e., optimization direction)
+        /// The objective sense (i.e., optimization direction).
         enum Sense { MINIMIZE, MAXIMIZE, UNDEFINED };
 
         /// @}
@@ -275,10 +268,8 @@ public:
 
 }; /* end MixedIntegerProgramLinearObjective */
 
-
-
 /*!
-\ingroup PkgSolverConcepts
+\ingroup PkgSolverInterfaceConcepts
 \cgalConcept
 
 @brief Concept describing the set of requirements for (constrained or unconstrained)
@@ -290,12 +281,10 @@ to solve the problem.
 \cgalHasModel `CGAL::GLPK_mixed_integer_program_traits<T>`
 \cgalHasModel `CGAL::SCIP_mixed_integer_program_traits<T>`
 */
-
 template <typename FT>
 class MixedIntegerProgramTraits
 {
 public:
-
         /// \name Creation
         /// @{
 
@@ -335,42 +324,42 @@ public:
         ///                  solver is destroyed.
         MixedIntegerProgramLinearObjective* create_objective(Sense sense);
 
-        /// Returns the number of variables
+        /// Returns the number of variables.
         std::size_t number_of_variables() const;
 
-        /// Returns the variables
+        /// Returns the variables.
         const std::vector<MixedIntegerProgramVariable*>& variables() const;
         std::vector<MixedIntegerProgramVariable*>& variables();
 
-        /// Returns the number of constraints
+        /// Returns the number of constraints.
         std::size_t number_of_constraints() const;
 
-        /// Returns the constraints
+        /// Returns the constraints.
         const std::vector<MixedIntegerProgramLinearConstraint*>& constraints() const;
         std::vector<MixedIntegerProgramLinearConstraint*>& constraints();
 
-        /// Returns the number of continuous variables
+        /// Returns the number of continuous variables.
         std::size_t number_of_continuous_variables() const;
 
-        /// Returns the number of integer variables
+        /// Returns the number of integer variables.
         std::size_t number_of_integer_variables() const;
 
-        /// Returns the number of binary variables
+        /// Returns the number of binary variables.
         std::size_t number_of_binary_variables() const;
 
-        /// Returns true if all variables are continuous
+        /// Returns true if all variables are continuous.
         bool is_continuous() const;
 
-        /// Returns true if this is a mixed integer program
+        /// Returns true if this is a mixed integer program.
         bool is_mixed_integer_program() const;
 
-        /// Returns true if this is an integer program
+        /// Returns true if this is an integer program.
         bool is_integer_program() const;
 
-        /// Returns true if binary program
+        /// Returns true if binary program.
         bool is_binary_program() const;
 
-        /// Returns the objective
+        /// Returns the objective.
         const MixedIntegerProgramLinearObjective * objective() const;
         MixedIntegerProgramLinearObjective * objective();
 
@@ -391,4 +380,5 @@ public:
         void clear();
 
         /// @}
+
 }; /* end MixedIntegerProgramTraits */

--- a/Solver_interface/doc/Solver_interface/Concepts/NormalEquationSparseLinearAlgebraTraits_d.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/NormalEquationSparseLinearAlgebraTraits_d.h
@@ -1,6 +1,5 @@
 /*!
 \ingroup PkgSolverInterfaceConcepts
-
 \cgalConcept
 
 Concept describing the set of requirements for solving the normal equation \f$ A^t A X = A^t B \f$,
@@ -10,7 +9,6 @@ Concept describing the set of requirements for solving the normal equation \f$ A
 
 \cgalHasModel `CGAL::Eigen_solver_traits<T>`
 */
-
 class NormalEquationSparseLinearAlgebraTraits_d
 {
 public:
@@ -70,4 +68,3 @@ bool normal_equation_solver(const Matrix& A, const Vector& B, Vector& X);
 /// @}
 
 }; /* end NormalEquationSparseLinearAlgebraTraits_d */
-

--- a/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
@@ -1,13 +1,11 @@
 /*!
 \ingroup PkgSolverInterfaceConcepts
-
 \cgalConcept
 
 The concept `SparseLinearAlgebraTraits_d` is used to solve sparse linear systems <I>A\f$ \times \f$ X = B</I>.
 
 \cgalHasModel `CGAL::Eigen_solver_traits<T>`
 */
-
 class SparseLinearAlgebraTraits_d
 {
 public:
@@ -68,7 +66,6 @@ by a sparse matrix.
 
 \sa `SparseLinearAlgebraTraits_d`
 \sa `SparseLinearAlgebraTraits_d::Matrix`
-
 */
 class SparseLinearAlgebraTraits_d::Vector
 {
@@ -126,7 +123,6 @@ NT& operator[](Index row);
 }; /* end Vector */
 
 /*!
-
 \cgalConcept
 
 `SparseLinearAlgebraTraits_d::Matrix` is a concept of a sparse matrix class.
@@ -149,7 +145,6 @@ public:
 Index type
 */
 typedef unspecified_type Index;
-
 
 /*!
 
@@ -214,8 +209,8 @@ in the matrix by setting `new_coef` to `true`.
 void set_coef(Index row, Index column, NT value, bool new_coef = false);
 
 /*!
-swaps the content of `*this` and `m`
- */
+Swaps the content of `*this` and `m`.
+*/
 void swap(Matrix& m);
 
 /// Multiplication with a scalar.

--- a/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraWithFactorTraits_d.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraWithFactorTraits_d.h
@@ -1,4 +1,3 @@
-
 /*!
 \ingroup PkgSolverInterfaceConcepts
 \cgalConcept
@@ -11,7 +10,6 @@ method to solve the system for different right-hand vectors.
 
 \cgalHasModel `CGAL::Eigen_solver_traits<T>`
 */
-
 class SparseLinearAlgebraWithFactorTraits_d {
 public:
 
@@ -48,4 +46,3 @@ bool linear_solver(const Matrix& B, Vector& X);
 /// @}
 
 }; /* end SparseLinearAlgebraWithFactorTraits_d */
-

--- a/Solver_interface/doc/Solver_interface/Concepts/SvdTraits.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/SvdTraits.h
@@ -98,12 +98,12 @@ public:
 
   /*!
     Return the number of rows of the matrix.
-   */
+  */
   size_t number_of_rows();
 
   /*!
     Return the number of columns of the matrix.
-   */
+  */
   size_t number_of_columns();
 
   /*!
@@ -117,4 +117,3 @@ public:
   */
   void set(size_t i, size_t j, const FT value);
 };
-

--- a/Solver_interface/doc/Solver_interface/Solver_interface.txt
+++ b/Solver_interface/doc/Solver_interface/Solver_interface.txt
@@ -27,6 +27,7 @@ high performance libraries, e.g.,
 <a href = "http://www.gurobi.com/"> Gurobi </a>.
 
 
+
 \section SectionSolverDiagonalize Matrix Diagonalization
 
 The concept `DiagonalizeTraits<T,dim>` defines an interface for the
@@ -41,6 +42,7 @@ class:
 \cgalExample{Solver_interface/diagonalize_matrix.cpp}
 
 
+
 \section SectionSolverSVD Singular Value Decomposition
 
 The concept `SvdTraits` defines an interface for solving in the least
@@ -52,7 +54,6 @@ Here is a simple example that shows how to handle matrices, vectors
 and this solver:
 
 \cgalExample{Solver_interface/singular_value_decomposition.cpp}
-
 
 
 
@@ -102,14 +103,13 @@ formulating and solving (constrained or unconstrained) mixed integer
 programs. It can also be used for general linear programs.
 
 The field type is `double`. We provide two models of this concept:
-`GLPK_mixed_integer_program_traits` using \ref thirdpartyGLPK and
-`SCIP_mixed_integer_program_traits` using \ref thirdpartySCIP.
+`CGAL::GLPK_mixed_integer_program_traits` using \ref thirdpartyGLPK and
+`CGAL::SCIP_mixed_integer_program_traits` using \ref thirdpartySCIP.
 
 Here is an example that shows how to formulate and solve a simple
-mixed integer programs using this solver.
+mixed integer program using this solver.
 
 \cgalExample{Solver_interface/mixed_integer_program.cpp}
-
 
 
 
@@ -132,4 +132,3 @@ with the help of Andreas Fabri.
 
 */
 } /* namespace CGAL */
-

--- a/Solver_interface/include/CGAL/GLPK_mixed_integer_program_traits.h
+++ b/Solver_interface/include/CGAL/GLPK_mixed_integer_program_traits.h
@@ -20,7 +20,7 @@
 
 namespace CGAL {
 
-        /// \ingroup PkgSolver
+        /// \ingroup PkgSolverInterfaceRef
         ///
         /// This class provides an interface for formulating and solving
         /// mixed integer programs (constrained or unconstrained) using
@@ -28,8 +28,8 @@ namespace CGAL {
         ///
         /// \ref thirdpartyGLPK must be available on the system.
         /// \note For better performance, please consider using
-        ///                  `SCIP_mixed_integer_program_traits`, or derive a new
-        ///                  model from `Mixed_integer_program_traits`.
+        ///                  `CGAL::SCIP_mixed_integer_program_traits`, or derive a new
+        ///                  model from `CGAL::Mixed_integer_program_traits`.
         ///
         /// \cond SKIP_IN_MANUAL
         /// \tparam FT Number type
@@ -38,7 +38,6 @@ namespace CGAL {
         /// \cgalModels `MixedIntegerProgramTraits`
         ///
         /// \sa `SCIP_mixed_integer_program_traits`
-
         template <typename FT>
         class GLPK_mixed_integer_program_traits : public Mixed_integer_program_traits<FT>
         {

--- a/Solver_interface/include/CGAL/Mixed_integer_program_traits.h
+++ b/Solver_interface/include/CGAL/Mixed_integer_program_traits.h
@@ -96,7 +96,9 @@ namespace CGAL {
         };
         /// \endcond
 
-        /// The variables of mixed integer programs.
+        /// \ingroup PkgSolverInterfaceRef
+        ///
+        /// The variable of a mixed integer program.
         ///
         /// \cgalModels `MixedIntegerProgramVariable`
         template <typename FT>
@@ -193,7 +195,10 @@ namespace CGAL {
         };
         /// \endcond
 
-        /// The linear constraint.
+        /// \ingroup PkgSolverInterfaceRef
+        ///
+        /// The linear constraint of a mixed integer program.
+        ///
         /// \cgalModels `MixedIntegerProgramLinearConstraint`
         template <typename FT>
         class Linear_constraint : public Linear_expression<FT>, public Bound<FT>
@@ -222,7 +227,9 @@ namespace CGAL {
         };
 
 
-        /// The linear objective.
+        /// \ingroup PkgSolverInterfaceRef
+        ///
+        /// The linear objective of a mixed integer program.
         ///
         /// \cgalModels `MixedIntegerProgramLinearObjective`
         ///
@@ -256,16 +263,16 @@ namespace CGAL {
                 /// \endcond
         };
 
-        /// \ingroup PkgSolver
+        /// \ingroup PkgSolverInterfaceRef
         ///
-        /// The class `Mixed_integer_program_traits` provides an interface for
+        /// The class `CGAL::Mixed_integer_program_traits` provides an interface for
         /// formulating and solving (constrained or unconstrained) mixed integer
         /// programs. It can also be used for general linear programs.
         /// \note The solve() function is virtual and thus this class cannot be
         ///                  instantiated directly. Client code should use the inherited
-        ///       classes, i.e., `GLPK_mixed_integer_program_traits` or
-        ///                  `SCIP_mixed_integer_program_traits`. Alternatively, use
-        ///       `Mixed_integer_program_traits` as a base to derive a new model
+        ///       classes, i.e., `CGAL::GLPK_mixed_integer_program_traits` or
+        ///                  `CGAL::SCIP_mixed_integer_program_traits`. Alternatively, use
+        ///       `CGAL::Mixed_integer_program_traits` as a base to derive a new model
         ///       (using e.g., <a href = "https://projects.coin-or.org/Cbc"> CBC </a>,
         ///       <a href = "http://www.gurobi.com/"> Gurobi </a> for better
         ///       performance).
@@ -275,7 +282,6 @@ namespace CGAL {
         /// \endcond
         ///
         /// \cgalModels `MixedIntegerProgramTraits`
-
         template <typename FT>
         class Mixed_integer_program_traits
         {

--- a/Solver_interface/include/CGAL/SCIP_mixed_integer_program_traits.h
+++ b/Solver_interface/include/CGAL/SCIP_mixed_integer_program_traits.h
@@ -20,7 +20,7 @@
 
 namespace CGAL {
 
-        /// \ingroup PkgSolver
+        /// \ingroup PkgSolverInterfaceRef
         ///
         /// This class provides an interface for formulating and solving
         /// mixed integer programs (constrained or unconstrained) using
@@ -35,7 +35,6 @@ namespace CGAL {
         /// \cgalModels `MixedIntegerProgramTraits`
         ///
         /// \sa `GLPK_mixed_integer_program_traits`
-
         template <typename FT>
         class SCIP_mixed_integer_program_traits : public Mixed_integer_program_traits<FT>
         {


### PR DESCRIPTION
## Summary of Changes

This PR fixes internal doc links in the `Solver_interface` package. It does not affect any code!
In particular, the `MixedIntegerProgramTraits` concept and its associated concepts were not included in the reference manual. The corresponding models had wrong internal references as well. In order to find them, the user had to search for them in the `Class and Concept List` section, which is super inconvenient. This PR also fixes a few small typos. The latter concept has been added for the first time in CGAL 5.0, if I am not mistaken.

## Release Management

* Affected package(s): Solver_interface
* Issue(s) solved (if any): no issues
* Feature/Small Feature (if any): not a feature
* Link to compiled documentation (obligatory for small feature): [docs](https://cgal.geometryfactory.com/~danston/Solver_interface/index.html)
* License and copyright ownership: no changes

