### PR TITLE
Make f square-free in Construct_curve_2 (fix #2224)

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -427,7 +427,11 @@ public:
 
       Curve_analysis_2 operator()
         (const Polynomial_2& f) const {
-        return _m_kernel->curve_cache_2()(f);
+        if (_m_kernel->is_square_free_2_object()(f)) {
+          return _m_kernel->curve_cache_2()(f);
+        } else {
+          return _m_kernel->curve_cache_2()(_m_kernel->make_square_free_2_object()(f));
+        }
       }
 
     protected:


### PR DESCRIPTION
Documentation in Curve_analysis_2 suggests that this was intended behavior, but not added.