### PR TITLE
Fix initialization of Bbox_3 in edge_aware_upsample_point_set()

### DIFF
--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Rich_grid.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Rich_grid.h
@@ -195,15 +195,19 @@ void Rich_grid<Kernel>::init(std::vector<Rich_point<Kernel> > &vert,
 
   radius = _radius;
 
-  x_side = (unsigned int)ceil((bbox.xmax() - bbox.xmin()) / radius);
-  y_side = (unsigned int)ceil((bbox.ymax() - bbox.ymin()) / radius);
-  z_side = (unsigned int)ceil((bbox.zmax() - bbox.zmin()) / radius);
+  std::size_t x_size = (std::size_t)ceil((bbox.xmax() - bbox.xmin()) / radius);
+  std::size_t y_size = (std::size_t)ceil((bbox.ymax() - bbox.ymin()) / radius);
+  std::size_t z_size = (std::size_t)ceil((bbox.zmax() - bbox.zmin()) / radius);
 
-  x_side = (x_side > 0) ? x_side : 1;
-  y_side = (y_side > 0) ? y_side : 1;
-  z_side = (z_side > 0) ? z_side : 1;
+  x_size = (x_size > 0) ? x_size : 1;
+  y_size = (y_size > 0) ? y_size : 1;
+  z_size = (z_size > 0) ? z_size : 1;
 
-  indices.resize(x_side * y_side * z_side + 1, -1);
+  indices.resize(x_size * y_size * z_size + 1, -1);
+
+  x_side = int(x_size);
+  y_side = int(y_size);
+  z_side = int(z_size);
 
   std::sort(rich_points.begin(), rich_points.end(), Z_Sort<Kernel>());
 

--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -388,7 +388,7 @@ edge_aware_upsample_point_set(
 
   // copy rich point set
   std::vector<Rich_point> rich_point_set(number_of_input);
-  CGAL::Bbox_3 bbox(0., 0., 0., 0., 0., 0.);
+  CGAL::Bbox_3 bbox;
 
   typename PointRange::const_iterator it = begin; // point iterator
   for(unsigned int i = 0; it != end; ++it, ++i)


### PR DESCRIPTION
## Summary of Changes

`CGAL::edge_aware_upsample_point_set()` produced a segfault in some cases. This came from 2 problems combined:

1. The size of a `std::vector` was computed using `int` variables: in the bug case, an overly large vector was created, but the `int` silently overflowed with an incorrect size instead of triggering a `std::bad_alloc`
2. At some point, the `CGAL::Bbox_3` of the point cloud was initialized with all values to 0, which is obviously wrong as it means that the origin is always included, which is not necessarily the case.

What happens is that for point clouds far away from the origin, the size of a `std::vector` computed from the bbox size becomes overly large. Because of the `int` overflow, this is not detected, the vector is constructed with the wrong size, and at some point an access to an index greater than this size is done, which leads to a seg fault.

Obviously, fixing the bbox initialization (with default constructor) fixes the bug, but I still changed the construction of the vector using `std::size_t` sizes, just to make sure that if something similary ever happens, we'll at least get a `std::bad_alloc` exception.

## Release Management

* Affected package(s): PSP
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/4662
