### PR TITLE
Heat Method: remove wrapper around deleted function

### DIFF
--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -898,16 +898,6 @@ public:
   }
 
   /**
-   * get estimated distance from the current source set to a vertex `vd`.
-   * \warning The return type is `double` even when used with an exact kernel.
-   */
-  double
-  estimate_geodesic_distance(vertex_descriptor vd) const
-  {
-    return base().estimate_geodesic_distance(vd);
-  }
-
-  /**
    * returns the source set.
    */
   const Vertex_const_range&
@@ -915,7 +905,6 @@ public:
   {
     return base().sources();
   }
-
 
   /**
    * fills the distance property map with the estimated geodesic distance of each vertex to the closest source vertex.

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -342,7 +342,6 @@ private:
         //then go back to top of the stack
       }
     }
-    std::cout<< a << " edges were flipped: " << std::endl;
   }
 
 


### PR DESCRIPTION
That function was initially called distance(), but when the base distance was removed, its upper level wasn't removed (https://github.com/CGAL/cgal/commit/27bfd0521dd36150e77119588260b1fbb5058a8c).

Initially reported on cgal-discuss by @seb-tourneux (2020-04-24 16:56 CEST)

## Release Management

* Affected package(s): `Heat_method_3`
* License and copyright ownership: no changes

