### PR TITLE
Prevent dynamically bind references to null pointer.

### DIFF
--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -134,7 +134,7 @@ namespace internal {
     typedef std::bidirectional_iterator_tag   iterator_category;
 
     In_place_list_const_iterator() : node(0) {}
-    In_place_list_const_iterator( Iterator i) : node(&*i) {}
+    In_place_list_const_iterator(Iterator i) : node(i.operator->()) {}
     In_place_list_const_iterator(const T* x) : node(x) {}
 
     bool     operator==( const Self& x) const { return node == x.node; }


### PR DESCRIPTION
## Summary of Changes
This is a manually-generated change. Ensure that behavior and style are
preserved by carefully inspecting the diff.

