### PR TITLE
Prevent dynamic binding of references to null pointers

### DIFF
--- a/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
+++ b/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
@@ -270,9 +270,9 @@ inline void
 Triangulation_ds_face_base_2<TDS> ::
 set_neighbors(Face_handle n0,Face_handle n1, Face_handle n2)
 {
-  CGAL_triangulation_precondition( this != &*n0 );
-  CGAL_triangulation_precondition( this != &*n1 );
-  CGAL_triangulation_precondition( this != &*n2 );
+  CGAL_triangulation_precondition( this != n0.operator->() );
+  CGAL_triangulation_precondition( this != n1.operator->() );
+  CGAL_triangulation_precondition( this != n2.operator->() );
   N[0] = n0;
   N[1] = n1;
   N[2] = n2;


### PR DESCRIPTION
## Summary of Changes
This is a manually-generated change. Ensure that behavior and style are
preserved by carefully inspecting the diff.


