### PR TITLE
Introducing CMake option CGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY

### DIFF
--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -201,6 +201,15 @@ if(CGAL_DOC_CREATE_LOGS)
   file(MAKE_DIRECTORY "${CGAL_DOC_LOG_DIR}")
 endif()
 
+option(CGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY "Use CGAL special doxygen setting EXTRACT_ALL_NO_DETAILED_IF_EMPTY." ON)
+if(CGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY)
+  set(CGAL_OPT_EXTRACT_ALL_NO_DETAILED_IF_EMPTY "EXTRACT_ALL_NO_DETAILED_IF_EMPTY = YES")
+else()
+  # The default is NO, so we could leave it out, but it is better to have a commented out placeholder
+  # this will work for versions with and without the setting.
+  set(CGAL_OPT_EXTRACT_ALL_NO_DETAILED_IF_EMPTY "#EXTRACT_ALL_NO_DETAILED_IF_EMPTY = NO")
+endif()
+
 #we use two directories for the generation/reading of tag files to prevent issues
 #if the targets are built in parallel
 set(CGAL_DOC_TAG_GEN_DIR "${CMAKE_BINARY_DIR}/doc_gen_tags")

--- a/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.14/BaseDoxyfile.in
@@ -493,17 +493,13 @@ LOOKUP_CACHE_SIZE      = 0
 
 EXTRACT_ALL            = YES
 
-#---------------------------------------------------------------------------
-# Build related configuration options
-#---------------------------------------------------------------------------
-
 # When the EXTRACT_ALL tag is set to YES and a member or class as no
 # documentation, no detailed section will be produced if the
 # EXTRACT_ALL_NO_DETAILED_IF_EMPTY tag is set to YES. This tag has no effect if
 # the EXTRACT_ALL tag is set to NO.
 # The default value is: NO.
 
-EXTRACT_ALL_NO_DETAILED_IF_EMPTY                                        = YES
+${CGAL_OPT_EXTRACT_ALL_NO_DETAILED_IF_EMPTY}
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.


### PR DESCRIPTION
When (re)generating the documentation from the sources and not using the, internally patched CGAL, doxygen version one gets messages about:
```
warning: ignoring unsupported tag 'EXTRACT_ALL_NO_DETAILED_IF_EMPTY'
```

By introducing the option `CGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY` this doxygen setting can be steered
- option not supplied to cmake, will use as if specified  `-DCGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY=ON`
- option supplied to cmake as `-DCGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY=ON` will write the line `EXTRACT_ALL_NO_DETAILED_IF_EMPTY = YES` in the doxygen configuration
- option supplied to cmake as `-DCGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY=OFF` will write the line `#EXTRACT_ALL_NO_DETAILED_IF_EMPTY = NO` in the doxygen configuration, so just using the default setting of `NO` line could be omitted but it is better to have a placeholder


