### PR TITLE
Mesh_2: Make it deterministic

### DIFF
--- a/Mesh_2/include/CGAL/Delaunay_mesh_face_base_2.h
+++ b/Mesh_2/include/CGAL/Delaunay_mesh_face_base_2.h
@@ -17,6 +17,7 @@
 
 
 #include <CGAL/Constrained_Delaunay_triangulation_face_base_2.h>
+#include <CGAL/Has_timestamp.h>
 
 namespace CGAL {
 
@@ -67,6 +68,18 @@ public:
   /** compatibility with CGAL-3.2 */
   inline
   void set_marked(const bool b) { in_domain=b; }
+
+  
+    typedef Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+  std::size_t time_stamp_;
+  
 };
 
 } // namespace CGAL

--- a/Mesh_2/include/CGAL/Delaunay_mesh_face_base_2.h
+++ b/Mesh_2/include/CGAL/Delaunay_mesh_face_base_2.h
@@ -69,8 +69,8 @@ public:
   inline
   void set_marked(const bool b) { in_domain=b; }
 
-  
-    typedef Tag_true Has_timestamp;
+
+  typedef Tag_true Has_timestamp;
 
   std::size_t time_stamp() const {
     return time_stamp_;
@@ -79,7 +79,7 @@ public:
     time_stamp_ = ts;
   }
   std::size_t time_stamp_;
-  
+
 };
 
 } // namespace CGAL

--- a/Mesh_2/test/Mesh_2/reproductibility.cpp
+++ b/Mesh_2/test/Mesh_2/reproductibility.cpp
@@ -1,0 +1,106 @@
+//#define CGAL_MESH_2_DEBUG_BAD_FACES
+//#define CGAL_MESH_2_DEBUG_CLUSTERS
+
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Delaunay_mesh_size_criteria_2.h>
+#include <CGAL/Delaunay_mesh_face_base_2.h>
+#include <CGAL/Delaunay_mesher_2.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <fstream>
+#include <iostream>
+
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+using Vb = CGAL::Triangulation_vertex_base_2<K>;
+using Fb = CGAL::Delaunay_mesh_face_base_2<K>;
+using Tds = CGAL::Triangulation_data_structure_2<Vb, Fb>;
+using CDT = CGAL::Constrained_Delaunay_triangulation_2<K, Tds, CGAL::Exact_predicates_tag>;
+using Criteria = CGAL::Delaunay_mesh_size_criteria_2<CDT>;
+using Mesher =  CGAL::Delaunay_mesher_2<CDT, Criteria>;
+
+using Vertex_handle = CDT::Vertex_handle;
+using Point = CDT::Point;
+
+int main(int argc, char* argv[])
+{
+  std::string path = argv[0];
+  path = path.substr(0, path.rfind('/') + 1);
+
+  std::cout << "Current dir:" << path << std::endl;
+
+  auto triangulate = [&path](int index)
+  {
+    CDT cdt;
+
+    auto write_tr = [&](const std::string& filename)
+    {
+//       std::ofstream file(path + filename + "_" + std::to_string(index) + ".off");
+//
+//       cdt.file_output(file);
+//       file.close();
+    };
+
+    Vertex_handle va = cdt.insert(Point(-0.74397572, -0.54545455));
+    Vertex_handle vb = cdt.insert(Point(-0.13526831, -1));
+    Vertex_handle vc = cdt.insert(Point(0.067634156, -1));
+    Vertex_handle vd = cdt.insert(Point(0.33817078, -0.54545455));
+    Vertex_handle ve = cdt.insert(Point(0.74397572, 0.27272727));
+    Vertex_handle vf = cdt.insert(Point(0.74397572, 0.54545455));
+    Vertex_handle vg = cdt.insert(Point(0.067634156, 1));
+    Vertex_handle vh = cdt.insert(Point(-0.13526831, 1));
+    Vertex_handle vi = cdt.insert(Point(-0.74397572, -0.18181818));
+
+    cdt.insert_constraint(va, vb);
+    cdt.insert_constraint(vb, vc);
+    cdt.insert_constraint(vc, vd);
+    cdt.insert_constraint(vd, ve);
+    cdt.insert_constraint(ve, vf);
+    cdt.insert_constraint(vf, vg);
+    cdt.insert_constraint(vg, vh);
+    cdt.insert_constraint(vh, vi);
+    cdt.insert_constraint(vi, va);
+
+    const std::vector<Point> points{
+      Point(0.65605132, 0.43821259),
+      Point(0.23073753, -0.4476739),
+      Point(-0.037496007, -0.93636364),
+      Point(-0.00095596601, 0.88181818),
+      Point(-0.62452925, -0.30720903),
+      Point(-0.69663181, -0.45045525),
+    };
+
+    cdt.insert(points.cbegin(), points.cend());
+
+    std::cout << "Meshing: " << index << std::endl;
+
+    std::cout << "Number of vertices before: " << cdt.number_of_vertices() << std::endl;
+
+    write_tr("before_refine");
+
+    Mesher mesher(cdt);
+    mesher.set_criteria(Criteria(0.125, 0.05*std::sqrt(2)));
+
+//     mesher.clear_seeds();
+//     mesher.init();
+
+    mesher.refine_mesh();
+
+    write_tr("after_refine");
+
+    std::cout << "Number of vertices after: " << cdt.number_of_vertices() << std::endl;
+
+    return cdt.number_of_vertices();
+  };
+
+  const size_t ref_number_of_vertices = triangulate(0);
+
+  for (int i = 1; i < 20; ++i)
+  {
+    const size_t number_of_vertices = triangulate(i);
+    if (ref_number_of_vertices != number_of_vertices)
+      return 1;
+  }
+
+  return 0;
+}
+

--- a/Mesh_2/test/Mesh_2/reproductibility.cpp
+++ b/Mesh_2/test/Mesh_2/reproductibility.cpp
@@ -8,7 +8,9 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
+#include <sstream>
 #include <iostream>
+#include <string>
 
 using K = CGAL::Exact_predicates_inexact_constructions_kernel;
 using Vb = CGAL::Triangulation_vertex_base_2<K>;
@@ -89,15 +91,18 @@ int main(int argc, char* argv[])
 
     std::cout << "Number of vertices after: " << cdt.number_of_vertices() << std::endl;
 
-    return cdt.number_of_vertices();
+    std::stringstream ss;
+    ss << cdt;
+    
+    return ss.str();
   };
 
-  const size_t ref_number_of_vertices = triangulate(0);
+  const std::string ref_cdts = triangulate(0);
 
   for (int i = 1; i < 20; ++i)
   {
-    const size_t number_of_vertices = triangulate(i);
-    if (ref_number_of_vertices != number_of_vertices)
+    const std::string cdts = triangulate(i);
+    if (ref_cdts != cdts)
       return 1;
   }
 

--- a/Mesh_2/test/Mesh_2/reproductibility.cpp
+++ b/Mesh_2/test/Mesh_2/reproductibility.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
 
     std::stringstream ss;
     ss << cdt;
-    
+
     return ss.str();
   };
 
@@ -108,4 +108,3 @@ int main(int argc, char* argv[])
 
   return 0;
 }
-

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -1039,7 +1039,7 @@ insert_dim_up(Vertex_handle w,  bool orient)
                         f->neighbor(0),
                         f->neighbor(1),
                         f->neighbor(2));
-                        
+
         f->set_vertex(dim,v);
         g->set_vertex(dim,w);
         set_adjacency(f, dim, g, dim);

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -982,6 +982,7 @@ insert_in_edge(Face_handle f, int i)
     flip(n,in);
     }
 
+
   return v;
 }
 
@@ -1002,26 +1003,94 @@ insert_dim_up(Vertex_handle w,  bool orient)
   set_dimension( dimension() + 1);
   Face_handle f1;
   Face_handle f2;
+  Face_handle f3;
 
   const int dim = dimension(); //it is the resulting dimension
 
   switch (dim) {
-  case -1:
+  case -1: // v is the infinite vertex of the T2
     f1 = create_face(v,Vertex_handle(),Vertex_handle());
     v->set_face(f1);
     break;
-  case 0 :
+  case 0 : // v is the first finite vertex of the T2
     f1 = face_iterator_base_begin();
     f2 = create_face(v,Vertex_handle(),Vertex_handle());
     set_adjacency(f1, 0, f2, 0);
     v->set_face(f2);
     break;
-  case 1 :
-  case 2 :
-    {
+  case 1 : // v is the second finite vertex of the T2
+
+     f1 = face_iterator_base_begin();
+     f2 = f1->neighbor(0);
+
+     f2->set_vertex(1, v);
+     v->set_face(f2);
+     f1->set_vertex(1, f1->vertex(0));
+     f1->set_vertex(0, v);
+     f1->set_neighbor(1, f2);
+     f3 = create_face(f1->vertex(1), f2->vertex(0), Vertex_handle(),
+                                  f2, f1,Face_handle());
+     f1->set_neighbor(0,f3);
+     f2->set_neighbor(1,f3);
+     break;
+
+  case 2 : // v is the vertex making the T2 2D
+  {
+    if (orient) {
+      Face_iterator ib = face_iterator_base_begin();
+      Face_iterator ib_end = face_iterator_base_end();
+      for (; ib != ib_end; ++ib) {
+        ib->reorient();
+      }
+    }
+    std::list<Face_handle> faces_list;
+    Face_handle f = face_iterator_base_begin();
+    while (f->vertex(0) != w) {
+      f = f->neighbor(1);
+    }
+    Face_handle left = f;
+//    std::cout << left->vertex(1)->point() << std::endl;
+    f = f->neighbor(0);
+    while (f->vertex(1) != w) {
+      faces_list.push_back(f);
+      f = f->neighbor(0);
+    }
+    Face_handle right = f;
+ //   std::cout << right->vertex(0)->point() << std::endl;
+    Face_handle g, le = left;
+
+    left->set_vertex(2, w);
+    right->set_vertex(2, w);
+    left->set_vertex(0, v);
+    right->set_vertex(1, v);
+    // faces_list now only contains faces for which we create new neighbor(2)s
+    typename std::list<Face_handle>::iterator lfit = faces_list.begin();
+    int index = 2; // for connecting with left
+    for (; lfit != faces_list.end(); ++lfit) {
+      f = *lfit;
+      g = create_face(f->vertex(1),
+                      f->vertex(0),
+                      v);
+      f->set_vertex(2,w);
+
+    //  std::cout << "f " << &(*f) << " " << f->vertex(0)->point() << "  " <<  f->vertex(1)->point() << std::endl;
+   //   std::cout << "w = " << &*(w) << std::endl;
+
+      set_adjacency(f, 2, g, 2);
+      set_adjacency(le, index, g, 0);
+      index = 1; // for connecting new faces
+      le = g;
+    }
+    set_adjacency(g, 1, right, 2);
+    v->set_face(g);
+    w->set_face(left);
+  }
+  break;
+#if 0
       std::list<Face_handle> faces_list;
       Face_iterator ib= face_iterator_base_begin();
       Face_iterator ib_end = face_iterator_base_end();
+
       for (; ib != ib_end ; ++ib){
         faces_list.push_back( ib);
       }
@@ -1032,16 +1101,17 @@ insert_dim_up(Vertex_handle w,  bool orient)
 
       for ( ; lfit != faces_list.end() ; ++lfit) {
         f = * lfit;
-        // g = create_face(f); //calls copy constructor of face
+        g = create_face(f); //calls copy constructor of face
+        /*
         g = create_face(f->vertex(0),
                         f->vertex(1),
                         f->vertex(2),
                         f->neighbor(0),
                         f->neighbor(1),
                         f->neighbor(2));
-
-        f->set_vertex(dim,v);
-        g->set_vertex(dim,w);
+        */
+        f->set_vertex(dim,w);
+        g->set_vertex(dim,v);
         set_adjacency(f, dim, g, dim);
         if (f->has_vertex(w)) to_delete.push_back(g); // flat face to delete
       }
@@ -1088,9 +1158,11 @@ insert_dim_up(Vertex_handle w,  bool orient)
       v->set_face( *(faces_list.begin()));
     }
     break;
+#endif
   default:
     CGAL_triangulation_assertion(false);
     break;  }
+
   return v;
 }
 

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -1032,7 +1032,14 @@ insert_dim_up(Vertex_handle w,  bool orient)
 
       for ( ; lfit != faces_list.end() ; ++lfit) {
         f = * lfit;
-        g = create_face(f); //calls copy constructor of face
+        // g = create_face(f); //calls copy constructor of face
+        g = create_face(f->vertex(0),
+                        f->vertex(1),
+                        f->vertex(2),
+                        f->neighbor(0),
+                        f->neighbor(1),
+                        f->neighbor(2));
+                        
         f->set_vertex(dim,v);
         g->set_vertex(dim,w);
         set_adjacency(f, dim, g, dim);

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -986,7 +986,7 @@ insert_in_edge(Face_handle f, int i)
   return v;
 }
 
-#if 1  // master
+#if 0  // master
 
 template <  class Vb, class Fb>
 typename Triangulation_data_structure_2<Vb,Fb>::Vertex_handle
@@ -1126,21 +1126,27 @@ insert_dim_up(Vertex_handle w,  bool orient)
     break;
 
   case 1 : // v is the second finite vertex of the T2
+    {
+      f1 = face_iterator_base_begin();
+      f2 = f1->neighbor(0);
 
-     f1 = face_iterator_base_begin();
-     f2 = f1->neighbor(0);
-
-     f2->set_vertex(1, v);
-     v->set_face(f2);
-     f1->set_vertex(1, f1->vertex(0));
-     f1->set_vertex(0, v);
-     f1->set_neighbor(1, f2);
-     f3 = create_face(f1->vertex(1), f2->vertex(0), Vertex_handle(),
-                      f2, f1,Face_handle());
-     f1->set_neighbor(0,f3);
-     f2->set_neighbor(1,f3);
-
-     break;
+      Vertex_handle nv = v;
+      if(! orient){
+        nv = f2->vertex(0);
+        f2->set_vertex(0,v);
+        v->set_face(f2);
+      }
+      f2->set_vertex(1, nv);
+      nv->set_face(f2);
+      f1->set_vertex(1, f1->vertex(0));
+      f1->set_vertex(0, nv);
+      f1->set_neighbor(1, f2);
+      f3 = create_face(f1->vertex(1), f2->vertex(0), Vertex_handle(),
+                       f2, f1,Face_handle());
+      f1->set_neighbor(0,f3);
+      f2->set_neighbor(1,f3);
+    }
+    break;
 
   case 2 : // v is the vertex making the T2 2D
     {

--- a/TDS_2/test/TDS_2/include/CGAL/_test_cls_tds_2.h
+++ b/TDS_2/test/TDS_2/include/CGAL/_test_cls_tds_2.h
@@ -210,8 +210,29 @@ _test_cls_tds_2( const Tds &)
 
   assert(td45.is_valid() && td45.number_of_vertices() == 4 && td45.number_of_faces() == 4);
 
-  Face_handle f0_0 = td45.faces_begin();
-  Face_handle f0_1 = f0_0++;
+  Face_handle f0_0, f0_1;
+
+  {
+    int count = 0;
+    for (Face_iterator it = td45.faces_begin(); it != td45.faces_end(); ++it) {
+      if (it->has_vertex(v345) && it->has_vertex(v145) && it->has_vertex(v245)) {
+        f0_0 = it;
+        ++count;
+      }
+    }
+    assert(count == 1);
+  }
+  {
+    int count = 0;
+    for (Face_iterator it = td45.faces_begin(); it != td45.faces_end(); ++it) {
+      if (it->has_vertex(v045) && it->has_vertex(v245) && it->has_vertex(v345)) {
+        f0_1 = it;
+        ++count;
+      }
+    }
+    assert(count == 1);
+  }
+
 
   Vertex_handle v445 = td45.insert_in_face(f0_0);
   Vertex_handle v545 = td45.insert_in_face(f0_1);
@@ -230,7 +251,6 @@ _test_cls_tds_2( const Tds &)
       fcf_0 = fc1;
     }
   } while(++fc1 != fc1e);
-
 
   Face_circulator fc2 = td45.incident_faces(v545), fc2e(fc2);
   do {

--- a/TDS_2/test/TDS_2/include/CGAL/_test_cls_tds_2.h
+++ b/TDS_2/test/TDS_2/include/CGAL/_test_cls_tds_2.h
@@ -324,10 +324,14 @@ _test_cls_tds_2( const Tds &)
   // dim_down
   std::cout << "    dim_down" << std::endl;
   Tds td5;
-  Vertex_handle v5_0 = td5.insert_first();
-  Vertex_handle v5_1 = td5.insert_second();
-  Vertex_handle v5_2 = td5.insert_dim_up(v5_1, false);
-  Vertex_handle v5_3 = td5.insert_dim_up();
+  Vertex_handle v5_0 = td5.insert_first();             // infinite vertex
+  Vertex_handle v5_1 = td5.insert_second();            // 0D
+  Vertex_handle v5_2 = td5.insert_dim_up(v5_1, false); //
+  Vertex_handle v5_3 = td5.insert_dim_up(v5_0);         // 2D must not be Vertex_handle()
+
+  std::cout << td5 << std::endl;
+  assert(td5.is_valid());
+
   (void)v5_0; (void)v5_2; // Hush unused warnings
   Face_handle f5_0 = v5_3->face();
   int i = f5_0->index(v5_3);


### PR DESCRIPTION
## Summary of Changes

Use a time stamper for the mesh face base class.  This makes the construction deterministic.
The `Edge_iterator` is also deterministic as it compares face handles which means comparing time stamps.

We decided not to document the time stamp mechanism, and not to document that the mesh generator is deterministic.

I tried it with two more test cases: the contour of norway, as well as many segments all intersecting in a single point in order to have more complicated clusters.

### Todo: 
- [ ]  We have to look at `create_face()` which makes a copy of a face, which messes up the time stamper.
- [ ] Is there more to make deterministic?  
- [ ] It probably needs more complicated test cases.

## Release Management

* Affected package(s): Mesh_2
* Issue(s) solved (if any): fix #4681

* License and copyright ownership: unchanged INRIA

