### PR TITLE
Add missing `Aff_transformationC3::print` and `Aff_transformationH2::operator<<`

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_3.h
@@ -178,6 +178,9 @@ public:
   Aff_transformation_3 operator*(const Aff_transformationC3 &t) const
   { return (*this->Ptr()) * (*t.Ptr()); }
 
+  std::ostream &
+  print(std::ostream &os) const;
+
   bool operator==(const Aff_transformationC3 &t)const
   {
     for(int i=0; i<3; ++i)
@@ -197,13 +200,21 @@ protected:
 };
 
 
+template < class R >
+std::ostream&
+Aff_transformationC3<R>::print(std::ostream &os) const
+{
+  this->Ptr()->print(os);
+  return os;
+}
+
 #ifndef CGAL_NO_OSTREAM_INSERT_AFF_TRANSFORMATIONC3
 template < class R >
-std::ostream &operator<<(std::ostream &os,
-                         const Aff_transformationC3<R> &t)
+std::ostream&
+operator<<(std::ostream &os, const Aff_transformationC3<R> &t)
 {
-    t.print(os);
-    return os;
+  t.print(os);
+  return os;
 }
 #endif // CGAL_NO_OSTREAM_INSERT_AFF_TRANSFORMATIONC3
 

--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
@@ -192,8 +192,8 @@ public:
   virtual std::ostream &print(std::ostream &os) const
   {
     os <<"Aff_transformationC3("<<t11<<' '<<t12<<' '<<t13<<' '<<t14<<std::endl;
-    os <<"                    "<< t21<<' '<<t22<<' '<<t23<<' '<<t24<<std::endl;
-    os <<"                    "<< t31<<' '<<t32<<' '<<t33<<' '<<t34<<")";
+    os <<"                     "<<t21<<' '<<t22<<' '<<t23<<' '<<t24<<std::endl;
+    os <<"                     "<<t31<<' '<<t32<<' '<<t33<<' '<<t34<<")";
     return os;
   }
 

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/Aff_transformationH2.h
@@ -783,6 +783,17 @@ operator*(const Aff_transformationH2<R>& right_argument) const
 }
 
 template <class R>
+std::ostream&
+operator<<(std::ostream& out, const Aff_transformationH2<R>& t)
+{
+  typename R::RT RT0(0);
+  Aff_transformation_repH2<R> r = t.Ptr()->general_form();
+  return out << "| "<< r.a << ' ' << r.b << ' ' << r.c << " |\n"
+             << "| "<< r.d << ' ' << r.e << ' ' << r.f << " |\n"
+             << "| "<< RT0 << ' ' << RT0 << ' ' << r.g << " |\n";
+}
+
+template <class R>
 Aff_transformationH2<R>
 _general_transformation_composition( Aff_transformation_repH2<R> l,
                                      Aff_transformation_repH2<R> r )


### PR DESCRIPTION
## Summary of Changes

Fixes an issue with a missing `print` method in `Aff_transformationC3`. Said method was being called in the overloaded output `operator<<(std::ostream&)` function.

It also includes a tiny tweak to the way the transformation is represented, adding a missing space just before subsequent matrix rows beyond the first one.

## Release Management

* Affected package(s): Kernel_23
* Issue(s) solved (if any): fix #4698
* Feature/Small Feature (if any): N/A