### PR TITLE
Surface_mesh: fix clear()

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -39,7 +39,7 @@ Release History
 
 ### Surface Mesh
 
- - The function `CGAL::Surface_mesh::clear()` now removes all non-default properties instead of just emptying them. 
+ - **Breaking change**: The function `CGAL::Surface_mesh::clear()` now removes all non-default properties instead of just emptying them. 
 
 Release 5.0
 -----------

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -37,6 +37,10 @@ Release History
    is given an optional template parameter `ConcurrencyTag` (default
    value remains `CGAL::Sequential_tag` for backward compatibility).
 
+### Surface Mesh
+
+ - The function `CGAL::Surface_mesh::clear()` now removes all non-default properties instead of just emptying them. 
+
 Release 5.0
 -----------
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2838,20 +2838,33 @@ void
 Surface_mesh<P>::
 clear()
 {
-    vprops_.resize(0);
-    hprops_.resize(0);
-    eprops_.resize(0);
-    fprops_.resize(0);
+  vprops_.clear();
+  hprops_.clear();
+  eprops_.clear();
+  fprops_.clear();
 
-    vprops_.shrink_to_fit();
-    hprops_.shrink_to_fit();
-    eprops_.shrink_to_fit();
-    fprops_.shrink_to_fit();
+  vprops_.resize(0);
+  hprops_.resize(0);
+  eprops_.resize(0);
+  fprops_.resize(0);
 
-    removed_vertices_ = removed_edges_ = removed_faces_ = 0;
-    vertices_freelist_ = edges_freelist_ = faces_freelist_ = (std::numeric_limits<size_type>::max)();
-    garbage_ = false;
-    anonymous_property_ = 0;
+  vprops_.shrink_to_fit();
+  hprops_.shrink_to_fit();
+  eprops_.shrink_to_fit();
+  fprops_.shrink_to_fit();
+
+  vconn_    = add_property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
+  hconn_    = add_property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
+  fconn_    = add_property_map<Face_index, Face_connectivity>("f:connectivity").first;
+  vpoint_   = add_property_map<Vertex_index, Point>("v:point").first;
+  vremoved_ = add_property_map<Vertex_index, bool>("v:removed", false).first;
+  eremoved_ = add_property_map<Edge_index, bool>("e:removed", false).first;
+  fremoved_ = add_property_map<Face_index, bool>("f:removed", false).first;
+
+  removed_vertices_ = removed_edges_ = removed_faces_ = 0;
+  vertices_freelist_ = edges_freelist_ = faces_freelist_ = (std::numeric_limits<size_type>::max)();
+  garbage_ = false;
+  anonymous_property_ = 0;
 }
 
 //-----------------------------------------------------------------------------

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1129,6 +1129,8 @@ public:
   }
 
     /// removes all vertices, halfedge, edges and faces. Collects garbage and clears all properties.
+    ///
+    /// After calling this method, the object is the same as a newly constructed object. The additional properties (such as normal vectors) are also removed and must thus be re-added if needed.
     void clear();
 
 


### PR DESCRIPTION
## Summary of Changes
The function clear() of the Surface_mesh celars the property_maps but does not remove them. 
This PR remove all the maps in clear(), then creates the default maps again.

## Release Management

* Affected package(s):Surface_mesh
