### PR TITLE
PMP fairing cotangent weights issue fix

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
@@ -150,9 +150,9 @@ public:
     Vector a = get(ppmap(), v0) - get(ppmap(), v1);
     Vector b = get(ppmap(), v2) - get(ppmap(), v1);
 
-    double dot_ab = a*b;
-    double dot_aa = a.squared_length();
-    double dot_bb = b.squared_length();
+    double dot_ab = CGAL::to_double(a * b);
+    double dot_aa = CGAL::to_double(a.squared_length());
+    double dot_bb = CGAL::to_double(b.squared_length());
     double lb = -0.999, ub = 0.999;
     double cosine = dot_ab / CGAL::sqrt(dot_aa) / CGAL::sqrt(dot_bb);
     cosine = (cosine < lb) ? lb : cosine;
@@ -863,6 +863,45 @@ public:
 
   double w_ij(halfedge_descriptor he) {
 
+    return cotangent_functor(he) * 2.0;
+  }
+};
+
+// Cotangent_value_Meyer has been changed to the version:
+// Cotangent_value_Meyer_secure to avoid imprecisions from 
+// the issue #4706 - https://github.com/CGAL/cgal/issues/4706.
+template<
+class PolygonMesh, class VertexPointMap = typename boost::property_map<PolygonMesh, vertex_point_t>::type>
+class Cotangent_weight_with_voronoi_area_fairing_secure {
+  
+  typedef PolygonMesh PM;
+  typedef VertexPointMap VPMap;
+  Voronoi_area<PM, VPMap> voronoi_functor;
+  Cotangent_weight<PM, VPMap, Cotangent_value_Meyer_secure<PM, VPMap> > cotangent_functor;
+
+public:
+  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_) : 
+  voronoi_functor(pmesh_, get(CGAL::vertex_point, pmesh_)), 
+  cotangent_functor(pmesh_, get(CGAL::vertex_point, pmesh_))
+  { }
+
+  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_, VPMap vpmap_) : 
+  voronoi_functor(pmesh_, vpmap_), 
+  cotangent_functor(pmesh_, vpmap_)
+  { }
+
+  PM& pmesh() {
+    return voronoi_functor.pmesh();
+  }
+
+  typedef typename boost::graph_traits<PM>::halfedge_descriptor halfedge_descriptor;
+  typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
+
+  double w_i(vertex_descriptor v_i) {
+    return 0.5 / voronoi_functor(v_i);
+  }
+
+  double w_ij(halfedge_descriptor he) {
     return cotangent_functor(he) * 2.0;
   }
 };

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/Weights.h
@@ -868,25 +868,25 @@ public:
 };
 
 // Cotangent_value_Meyer has been changed to the version:
-// Cotangent_value_Meyer_secure to avoid imprecisions from 
+// Cotangent_value_Meyer_secure to avoid imprecisions from
 // the issue #4706 - https://github.com/CGAL/cgal/issues/4706.
 template<
 class PolygonMesh, class VertexPointMap = typename boost::property_map<PolygonMesh, vertex_point_t>::type>
 class Cotangent_weight_with_voronoi_area_fairing_secure {
-  
+
   typedef PolygonMesh PM;
   typedef VertexPointMap VPMap;
   Voronoi_area<PM, VPMap> voronoi_functor;
   Cotangent_weight<PM, VPMap, Cotangent_value_Meyer_secure<PM, VPMap> > cotangent_functor;
 
 public:
-  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_) : 
-  voronoi_functor(pmesh_, get(CGAL::vertex_point, pmesh_)), 
+  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_) :
+  voronoi_functor(pmesh_, get(CGAL::vertex_point, pmesh_)),
   cotangent_functor(pmesh_, get(CGAL::vertex_point, pmesh_))
   { }
 
-  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_, VPMap vpmap_) : 
-  voronoi_functor(pmesh_, vpmap_), 
+  Cotangent_weight_with_voronoi_area_fairing_secure(PM& pmesh_, VPMap vpmap_) :
+  voronoi_functor(pmesh_, vpmap_),
   cotangent_functor(pmesh_, vpmap_)
   { }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -146,7 +146,11 @@ namespace internal {
 #endif
 
     typedef typename GetVertexPointMap < TriangleMesh, NamedParameters>::type VPMap;
-    typedef CGAL::internal::Cotangent_weight_with_voronoi_area_fairing<TriangleMesh, VPMap>
+
+    // Cotangent_weight_with_voronoi_area_fairing has been changed to the version:
+    // Cotangent_weight_with_voronoi_area_fairing_secure to avoid imprecisions from 
+    // the issue #4706 - https://github.com/CGAL/cgal/issues/4706.
+    typedef CGAL::internal::Cotangent_weight_with_voronoi_area_fairing_secure<TriangleMesh, VPMap>
       Default_Weight_calculator;
 
     VPMap vpmap_ = choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/fair.h
@@ -148,7 +148,7 @@ namespace internal {
     typedef typename GetVertexPointMap < TriangleMesh, NamedParameters>::type VPMap;
 
     // Cotangent_weight_with_voronoi_area_fairing has been changed to the version:
-    // Cotangent_weight_with_voronoi_area_fairing_secure to avoid imprecisions from 
+    // Cotangent_weight_with_voronoi_area_fairing_secure to avoid imprecisions from
     // the issue #4706 - https://github.com/CGAL/cgal/issues/4706.
     typedef CGAL::internal::Cotangent_weight_with_voronoi_area_fairing_secure<TriangleMesh, VPMap>
       Default_Weight_calculator;


### PR DESCRIPTION
## Summary of Changes

This PR proposes a fix for the issue #4706.

The issue was the imprecise computation of the cotangent weights used to set up an optimization problem. I changed them to the other version that has already been a part of the package.

I based this PR on the `4.14-branch`.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): fix #4706
* Feature/Small Feature (if any): not a feature
* License and copyright ownership: no changes

