### PR TITLE
Two bug fixes in Surface mesh topology package

### DIFF
--- a/Surface_mesh_topology/examples/Surface_mesh_topology/edgewidth_lcc.cpp
+++ b/Surface_mesh_topology/examples/Surface_mesh_topology/edgewidth_lcc.cpp
@@ -14,7 +14,8 @@ double cycle_length(const LCC_3& lcc, const Path_on_surface& cycle)
   double res=0;
   for (std::size_t i=0; i<cycle.length(); ++i)
   { res+=std::sqrt
-        (CGAL::squared_distance(lcc.point(cycle.get_next_dart(i)), lcc.point(cycle[i]))); }
+      (CGAL::squared_distance(lcc.point(cycle[i]),
+                              lcc.point(lcc.other_extremity(cycle[i])))); }
   return res;
 }
 

--- a/Surface_mesh_topology/examples/Surface_mesh_topology/shortest_noncontractible_cycle.cpp
+++ b/Surface_mesh_topology/examples/Surface_mesh_topology/shortest_noncontractible_cycle.cpp
@@ -15,7 +15,8 @@ double cycle_length(const LCC_3& lcc, const Path_on_surface& cycle)
   double res=0;
   for (std::size_t i=0; i<cycle.length(); ++i)
   { res+=std::sqrt
-        (CGAL::squared_distance(lcc.point(cycle.get_next_dart(i)), lcc.point(cycle[i]))); }
+        (CGAL::squared_distance(lcc.point(cycle[i]),
+                                lcc.point(lcc.other_extremity(cycle[i])))); }
   return res;
 }
 

--- a/Surface_mesh_topology/examples/Surface_mesh_topology/unsew_edgewidth_repeatedly.cpp
+++ b/Surface_mesh_topology/examples/Surface_mesh_topology/unsew_edgewidth_repeatedly.cpp
@@ -81,7 +81,10 @@ int main(int argc, char* argv[])
 {
   std::cout<<"Program unsew_edgewidth_repeatedly started."<<std::endl;
   std::string filename(argc==1?"data/double-torus.off":argv[1]);
+
+#ifdef CGAL_USE_BASIC_VIEWER
   bool draw=(argc<3?false:std::string(argv[2])=="-draw");
+#endif // CGAL_USE_BASIC_VIEWER
 
   std::ifstream inp(filename);
   if (inp.fail())
@@ -153,7 +156,6 @@ int main(int argc, char* argv[])
   while(cycle_exist);
 
 #ifdef CGAL_USE_BASIC_VIEWER
-
   if (draw)
   {
     Draw_functor df(is_root, belong_to_cycle);

--- a/Surface_mesh_topology/include/CGAL/Face_graph_wrapper.h
+++ b/Surface_mesh_topology/include/CGAL/Face_graph_wrapper.h
@@ -455,6 +455,12 @@ public:
         run(mmap.get_fg(), *it);
     }
 
+    size_type index(Dart_const_handle it) const
+    {
+      return internal::Index_from_halfedge_descriptor<HEG>::
+        run(mmap.get_fg(), it);
+    }
+
   private:
     const Self & mmap;
     mutable typename Self::size_type msize;

--- a/Surface_mesh_topology/include/CGAL/Path_on_surface.h
+++ b/Surface_mesh_topology/include/CGAL/Path_on_surface.h
@@ -133,6 +133,10 @@ public:
     m_is_closed=false;
   }
 
+  /// @return true iff the prev index exists
+  bool prev_index_exists(std::size_t i) const
+  { return is_closed() || i>0; }
+
   /// @return true iff the next index exists
   bool next_index_exists(std::size_t i) const
   { return is_closed() || i<(m_path.size()-1); }
@@ -164,25 +168,25 @@ public:
   { return get_ith_dart(i); }
 
   /// @return the dart before the ith dart of the path,
-  ///          nullptr if such a dart does not exist.
+  ///          Map::null_handle if such a dart does not exist.
   Dart_const_handle get_prev_dart(std::size_t i) const
   {
     CGAL_assertion(i<m_path.size());
-    if (i==0 && !is_closed()) return nullptr;
+    if (i==0 && !is_closed()) return Map::null_handle;
     return m_path[prev_index(i)];
   }
 
   /// @return the dart after the ith dart of the path,
-  ///          nullptr if such a dart does not exist.
+  ///          Map::null_handle if such a dart does not exist.
   Dart_const_handle get_next_dart(std::size_t i) const
   {
     CGAL_assertion(i<m_path.size());
-    if (i==m_path.size()-1 && !is_closed()) return nullptr;
+    if (i==m_path.size()-1 && !is_closed()) return Map::null_handle;
     return m_path[next_index(i)];
   }
 
   /// @return the flip before the ith flip of the path,
-  ///          nullptr if such a flip does not exist.
+  ///          false if such a flip does not exist.
   bool get_prev_flip(std::size_t i) const
   {
     CGAL_assertion(i<m_path.size());
@@ -191,7 +195,7 @@ public:
   }
 
   /// @return the flip after the ith flip of the path,
-  ///          nullptr if such a flip does not exist.
+  ///          false if such a flip does not exist.
   bool get_next_flip(std::size_t i) const
   {
     CGAL_assertion(i<m_path.size());
@@ -322,7 +326,7 @@ public:
   bool can_be_pushed_by_label(const std::string& e, bool flip=false) const
   {
     Dart_const_handle dh=get_map().get_dart_labeled(e);
-    if (dh==nullptr) { return false; }
+    if (dh==Map::null_handle) { return false; }
     return can_be_pushed(dh, flip);
   }
 
@@ -334,7 +338,7 @@ public:
     for (std::string e; std::getline(iss, e, ' '); )
     {
       Dart_const_handle dh=get_map().get_dart_labeled(e);
-      if (dh!=nullptr) { push_back(dh, false, update_isclosed); }
+      if (dh!=Map::null_handle) { push_back(dh, false, update_isclosed); }
     }
   }
 

--- a/Surface_mesh_topology/include/CGAL/Polygonal_schema.h
+++ b/Surface_mesh_topology/include/CGAL/Polygonal_schema.h
@@ -62,22 +62,22 @@ namespace Surface_mesh_topology {
                        std::unordered_map<std::string, Dart_handle>&
                        edge_label_to_dart)
       {
-        if (dart_same_label!=nullptr && dart_opposite_label!=nullptr)
+        if (dart_same_label!=CMap::null_handle && dart_opposite_label!=CMap::null_handle)
         {
           std::cerr<<"Polygonal_schema ERROR: "<<"both labels "<<s
                    <<" and "<<internal::opposite_label(s)
                    <<" are already added in the surface."
                    <<" This label can not be use anymore."<<std::endl;
-          return nullptr;
+          return CMap::null_handle;
         }
 
-        if (dart_same_label!=nullptr)
+        if (dart_same_label!=CMap::null_handle)
         {
           std::cerr<<"Polygonal_schema ERROR: "<<"label "<<s
                    <<" is already added in the surface."
                    <<" Since the surface is orientable, this label can "
                    <<"not be use anymore."<<std::endl;
-          return nullptr;
+          return CMap::null_handle;
         }
 
         Dart_handle res=cmap.create_dart();
@@ -87,7 +87,7 @@ namespace Surface_mesh_topology {
         if (prev_dart!=cmap.null_handle)
         { cmap.template link_beta<1>(prev_dart, res); }
 
-        if (dart_opposite_label!=nullptr)
+        if (dart_opposite_label!=CMap::null_handle)
         { cmap.template link_beta<2>(res, dart_opposite_label); }
 
         return res;
@@ -111,13 +111,13 @@ namespace Surface_mesh_topology {
                        std::unordered_map<std::string, Dart_handle>&
                        edge_label_to_dart)
       {
-        if (dart_same_label!=nullptr && dart_opposite_label!=nullptr)
+        if (dart_same_label!=GMap::null_handle && dart_opposite_label!=GMap::null_handle)
         {
           std::cerr<<"Polygonal_schema ERROR: "<<"both labels "<<s
                    <<" and "<<internal::opposite_label(s)
                    <<" are already added in the surface."
                    <<" This label can not be use anymore."<<std::endl;
-          return nullptr;
+          return GMap::null_handle;
         }
 
         Dart_handle res=gmap.create_dart();
@@ -127,8 +127,8 @@ namespace Surface_mesh_topology {
         if (prev_dart!=gmap.null_handle)
         { gmap.template link_alpha<1>(res, gmap.template alpha<0>(prev_dart)); }
 
-        if (dart_same_label!=nullptr)
-        { // Here dart_same_label!=nullptr
+        if (dart_same_label!=GMap::null_handle)
+        { // Here dart_same_label!=GMap::null_handle
           std::string s2=internal::opposite_label(s);
           edge_label_to_dart[s2]=dh2;
           gmap.info(dh2).m_label=s2;
@@ -136,11 +136,11 @@ namespace Surface_mesh_topology {
           gmap.template sew<2>(res, dart_same_label);
         }
         else
-        { // Here either dart_opposite_label!=nullptr, or both are nullptr
+        { // Here either dart_opposite_label!=GMap::null_handle, or both are GMap::null_handle
           edge_label_to_dart[s]=res;
           gmap.info(res).m_label=s;
 
-          if (dart_opposite_label!=nullptr)
+          if (dart_opposite_label!=GMap::null_handle)
           {
             std::string s2=internal::opposite_label(s);
             edge_label_to_dart[s2]=res;
@@ -304,7 +304,7 @@ namespace Surface_mesh_topology {
         std::cerr<<"Polygonal_schema ERROR: "
                  <<"you try to end a facet"
                  <<" but the facet is not yet started."<<std::endl;
-        return nullptr;
+        return Map::null_handle;
       }
       CGAL_assertion( first_dart!=this->null_handle &&
                                   prev_dart!=this->null_handle );
@@ -314,12 +314,12 @@ namespace Surface_mesh_topology {
       return first_dart;
     }
 
-    /// @return dart with the given label, nullptr if this dart does not exist.
+    /// @return dart with the given label, Map::null_handle if this dart does not exist.
     Dart_handle get_dart_labeled(const std::string& s) const
     {
       auto ite=edge_label_to_dart.find(s);
       if (ite==edge_label_to_dart.end())
-      { return nullptr; }
+      { return Map::null_handle; }
 
       return ite->second;
     }

--- a/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Shortest_noncontractible_cycle.h
+++ b/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Shortest_noncontractible_cycle.h
@@ -159,8 +159,8 @@ public:
 
   template <class WeightFunctor>
   Path compute_shortest_non_contractible_cycle(typename WeightFunctor::Weight_t* length,
-                                              const WeightFunctor& wf,
-                                              bool display_time=false)
+                                               const WeightFunctor& wf,
+                                               bool display_time=false)
   {
     CGAL::Timer t;
     if (display_time)


### PR DESCRIPTION

## Summary of Changes

1. computation of cycle lengths, when some halfedges are flip;
2. when we use of face graph wrapper with surface mesh we can not use nullptr.

## Release Management

* Affected package(s): Surface_mesh_topology

