### PR TITLE
Fix a bug in <CGAL/Constrained_triangulation_2.h>

### DIFF
--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -1320,7 +1320,7 @@ namespace handle {
   template <class H> struct Hash_functor;
 
   template<class DSC, bool Const>
-  struct Hash_functor<CC_iterator<DSC, Const>>{
+  struct Hash_functor<CC_iterator<DSC, Const> >{
     std::size_t
     operator()(const CC_iterator<DSC, Const>& i)
     {

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -995,8 +995,8 @@ intersect(Face_handle f, int i,
 
   Vertex_handle vi;
   if ( !ok) {  //intersection detected but not computed
-    int i = limit_intersection(geom_traits(), pa, pb, pc, pd, itag);
-    switch(i){
+    int int_index = limit_intersection(geom_traits(), pa, pb, pc, pd, itag);
+    switch(int_index){
     case 0 : vi = vaa; break;
     case 1 : vi = vbb; break;
     case 2 : vi = vcc; break;

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -54,18 +54,20 @@ namespace internal {
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   struct Indentation_level {
-    int n = 0;
+    int n;
+    Indentation_level() : n(0) {}
     friend std::ostream& operator<<(std::ostream& os, Indentation_level level) {
       return os << std::string(2*level.n, ' ');
     }
     Indentation_level& operator++() { ++n; return *this; }
     Indentation_level& operator--() { --n; return *this; }
     struct Exit_guard {
+      Exit_guard(Indentation_level& level): level(level) { ++level; }
+      Exit_guard(const Exit_guard& other) : level(other.level) { ++level; }
       Indentation_level& level;
       ~Exit_guard() { --level; }
     };
-    Exit_guard exit_guard() { return Exit_guard{*this}; }
-    Exit_guard open_new_scope() { return Exit_guard{++*this}; }
+    Exit_guard open_new_scope() { return Exit_guard(*this); }
   } cdt_2_indent_level;
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
 
@@ -712,7 +714,7 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
             << "CT_2::insert_constraint( #" << vaa->time_stamp() << "= " << vaa->point()
             << " , #" << vbb->time_stamp() << "= " << vbb->point()
             << " )\n";
-  auto exit_guard = CGAL::internal::cdt_2_indent_level.open_new_scope();
+  internal::Indentation_level::Exit_guard exit_guard = CGAL::internal::cdt_2_indent_level.open_new_scope();
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   while(! stack.empty()){
     boost::tie(vaa,vbb) = stack.top();

--- a/Triangulation_2/test/Triangulation_2/issue_4405.cpp
+++ b/Triangulation_2/test/Triangulation_2/issue_4405.cpp
@@ -9,13 +9,43 @@ typedef CGAL::Epick Kernel;
 typedef Kernel::FT FieldNumberType;
 typedef Kernel::Point_2 Point2;
 typedef Kernel::Point_3 Point3;
+
+template <typename Vb>
+class My_vertex_base : public Vb {
+  std::size_t time_stamp_;
+public:
+  My_vertex_base() : Vb(), time_stamp_(-1) {
+  }
+
+  My_vertex_base(const My_vertex_base& other) :
+    Vb(other),
+    time_stamp_(other.time_stamp_)
+  {}
+
+  typedef CGAL::Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+
+  template < class TDS >
+  struct Rebind_TDS {
+    typedef typename Vb::template Rebind_TDS<TDS>::Other Vb2;
+    typedef My_vertex_base<Vb2> Other;
+  };
+};
+
 struct FaceInfo2
 {
   unsigned long long m_id;
 };
 typedef CGAL::Projection_traits_xy_3<Kernel> TriangulationTraits;
 typedef CGAL::Triangulation_vertex_base_with_id_2<TriangulationTraits> VertexBaseWithId;
-typedef CGAL::Triangulation_vertex_base_2<TriangulationTraits, VertexBaseWithId> VertexBase;
+typedef My_vertex_base<VertexBaseWithId> Vb2;
+typedef CGAL::Triangulation_vertex_base_2<TriangulationTraits, Vb2> VertexBase;
 typedef CGAL::Triangulation_face_base_with_info_2<FaceInfo2, Kernel> FaceBaseWithInfo;
 typedef CGAL::Constrained_triangulation_face_base_2<TriangulationTraits, FaceBaseWithInfo> FaceBase;
 typedef CGAL::Triangulation_data_structure_2<VertexBase, FaceBase> TriangulationData;

--- a/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
@@ -36,9 +36,9 @@ public:
 };
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
-using Vb = My_vertex_base<CGAL::Triangulation_vertex_base_2<EPIC>>;
+typedef My_vertex_base<CGAL::Triangulation_vertex_base_2<EPIC> > Vb;
 #else
-using Vb = CGAL::Triangulation_vertex_base_2<K>;
+typedef CGAL::Triangulation_vertex_base_2<K> Vb;
 #endif
 
 typedef CGAL::Constrained_triangulation_face_base_2<EPIC> Fb;

--- a/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
@@ -1,3 +1,4 @@
+#define CGAL_CDT_2_DEBUG_INTERSECTIONS 1
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Constrained_triangulation_plus_2.h>
@@ -5,7 +6,41 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel EPIC;
 typedef EPIC::Point_2 Point_2;
-typedef CGAL::Triangulation_vertex_base_2<EPIC> Vb;
+
+template <typename Vb>
+class My_vertex_base : public Vb {
+  std::size_t time_stamp_;
+public:
+  My_vertex_base() : Vb(), time_stamp_(-1) {
+  }
+
+  My_vertex_base(const My_vertex_base& other) :
+    Vb(other),
+    time_stamp_(other.time_stamp_)
+  {}
+
+  typedef CGAL::Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+
+  template < class TDS >
+  struct Rebind_TDS {
+    typedef typename Vb::template Rebind_TDS<TDS>::Other Vb2;
+    typedef My_vertex_base<Vb2> Other;
+  };
+};
+
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+using Vb = My_vertex_base<CGAL::Triangulation_vertex_base_2<EPIC>>;
+#else
+using Vb = CGAL::Triangulation_vertex_base_2<K>;
+#endif
+
 typedef CGAL::Constrained_triangulation_face_base_2<EPIC> Fb;
 typedef CGAL::Triangulation_data_structure_2<Vb, Fb> TDS;
 typedef CGAL::Exact_predicates_tag Itag;
@@ -14,6 +49,7 @@ typedef CGAL::Constrained_triangulation_plus_2<CDT> CDTp2;
 
 template <class CDT>
 void test() {
+  std::cerr.precision(17);
   CDT cdt;
   cdt.insert_constraint(Point_2(  48.0923419883269,   299.7232779774145  ),
                         Point_2(  66.05373710316852,  434.231770798343   ));


### PR DESCRIPTION
## Summary of Changes

Fix a bug in `<CGAL/Constrained_triangulation_2.h>`

The function parameter was locally shadowed by a local `int i` variable!

Then the edge `(f, i)` in the call `remove_constrained_edge(f, i)` was the wrong one!

The bug was introduced by ecfd82e287378977a325ae34e21087a2075a05cd, ten years ago.

The bug was only triggered on degenerated cases, when two constraints intersect, but the code failed to compute the intersection. Then, if the intersection vertex `vi` was either `vaa` or `vbb` (and not `vcc` or `vdd`), then the edge `(f, i)` was the wrong one._Please use the following template to help us managing pull requests.

## Release Management

* Affected package(s): Triangulation_2
* License and copyright ownership: maintenance by GeometryFactory
