### PR TITLE
add include of other modules

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -159,7 +159,17 @@ endforeach()
 cgal_setup_module_path()
 
 set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_Boost_IOStreams.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_Boost_Serialization.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_Eigen.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_GLPK.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_LASLIB.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_OpenCV.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_OpenGR.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_SCIP.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_target_use_TBB.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_TensorFlow.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_target_use_pointmatcher.cmake)
 
 include("${CGAL_MODULES_DIR}/CGAL_parse_version_h.cmake")
 cgal_parse_version_h( "${CGAL_INSTALLATION_PACKAGE_DIR}/include/CGAL/version.h"


### PR DESCRIPTION
update issue #4736

Issue Description:
I found there is only "CGAL_target_use_TBB.cmake" available when performing vcpkg installation on Windows OS, where I run

PATH_TO_VCPKG> ./vcpkg.exe install cgal[qt]:x64-windows

As provided in CGAL/cgal/Installation/cmake/modules, there should be CGAL_target_use_[Boost_IOStreams/Boost_Serialization/Eigen/GLPK/LASLIB/OpenCV/OpenGR/SCIP/TBB/TensorFlow/pointmatcher] available in vcpkg installation under share/cgal.

So If a compilation using Eigen, CMake will pop up a CMake Error indicating: Unknown CMake command "CGAL_target_use_Eigen".