### PR TITLE
Documentation: add warning about doc of master gf

### DIFF
--- a/Documentation/doc/resources/1.8.13/menu_version.js
+++ b/Documentation/doc/resources/1.8.13/menu_version.js
@@ -53,7 +53,7 @@
   }
 
   function patch_url(url, new_version) {
-    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){  
+    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){
       return url.replace(url_re, 'doc.cgal.org/' + new_version + '/');
     }
     else{
@@ -74,7 +74,7 @@
       var motherNode=$("#back-nav ul")[0];
       var node = document.createElement("LI");
       var spanNode = document.createElement("SPAN");
-      var titleNode =document.createTextNode("CGAL Version: "); 
+      var titleNode =document.createTextNode("CGAL Version: ");
       var textNode = document.createTextNode("x.y");
       spanNode.setAttribute("class", "version_menu");
       spanNode.appendChild(textNode);
@@ -99,4 +99,4 @@
         }
      }
   });
-})(); 
+})();

--- a/Documentation/doc/resources/1.8.13/menu_version.js
+++ b/Documentation/doc/resources/1.8.13/menu_version.js
@@ -28,8 +28,8 @@
 
       let first_element = top_elt.childNodes[0];
       let new_div = document.createElement("p");
-      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
-      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> development branch of CGAL. It might diverge from the official releases.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; display: inline-block;"
       let OK = top_elt.insertBefore(new_div, first_element);
     }
     var buf = ['<select>'];

--- a/Documentation/doc/resources/1.8.13/menu_version.js
+++ b/Documentation/doc/resources/1.8.13/menu_version.js
@@ -23,6 +23,15 @@
   ];
 
   function build_select(current_version) {
+    if( current_version == 'master') {
+      let top_elt = document.getElementById("top");
+
+      let first_element = top_elt.childNodes[0];
+      let new_div = document.createElement("p");
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      let OK = top_elt.insertBefore(new_div, first_element);
+    }
     var buf = ['<select>'];
     $.each(all_versions, function(id) {
       var version = all_versions[id];

--- a/Documentation/doc/resources/1.8.14/menu_version.js
+++ b/Documentation/doc/resources/1.8.14/menu_version.js
@@ -53,7 +53,7 @@
   }
 
   function patch_url(url, new_version) {
-    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){  
+    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){
       return url.replace(url_re, 'doc.cgal.org/' + new_version + '/');
     }
     else{
@@ -74,7 +74,7 @@
       var motherNode=$("#back-nav ul")[0];
       var node = document.createElement("LI");
       var spanNode = document.createElement("SPAN");
-      var titleNode =document.createTextNode("CGAL Version: "); 
+      var titleNode =document.createTextNode("CGAL Version: ");
       var textNode = document.createTextNode("x.y");
       spanNode.setAttribute("class", "version_menu");
       spanNode.appendChild(textNode);
@@ -99,4 +99,4 @@
         }
      }
   });
-})(); 
+})();

--- a/Documentation/doc/resources/1.8.14/menu_version.js
+++ b/Documentation/doc/resources/1.8.14/menu_version.js
@@ -28,8 +28,8 @@
 
       let first_element = top_elt.childNodes[0];
       let new_div = document.createElement("p");
-      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
-      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> development branch of CGAL. It might diverge from the official releases.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; display: inline-block;"
       let OK = top_elt.insertBefore(new_div, first_element);
     }
     var buf = ['<select>'];

--- a/Documentation/doc/resources/1.8.14/menu_version.js
+++ b/Documentation/doc/resources/1.8.14/menu_version.js
@@ -23,6 +23,15 @@
   ];
 
   function build_select(current_version) {
+    if( current_version == 'master') {
+      let top_elt = document.getElementById("top");
+
+      let first_element = top_elt.childNodes[0];
+      let new_div = document.createElement("p");
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      let OK = top_elt.insertBefore(new_div, first_element);
+    }
     var buf = ['<select>'];
     $.each(all_versions, function(id) {
       var version = all_versions[id];

--- a/Documentation/doc/resources/1.8.4/menu_version.js
+++ b/Documentation/doc/resources/1.8.4/menu_version.js
@@ -53,7 +53,7 @@
   }
 
   function patch_url(url, new_version) {
-    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){  
+    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){
       return url.replace(url_re, 'doc.cgal.org/' + new_version + '/');
     }
     else{
@@ -74,7 +74,7 @@
       var motherNode=$("#back-nav ul")[0];
       var node = document.createElement("LI");
       var spanNode = document.createElement("SPAN");
-      var titleNode =document.createTextNode("CGAL Version: "); 
+      var titleNode =document.createTextNode("CGAL Version: ");
       var textNode = document.createTextNode("x.y");
       spanNode.setAttribute("class", "version_menu");
       spanNode.appendChild(textNode);
@@ -99,4 +99,4 @@
         }
      }
   });
-})(); 
+})();

--- a/Documentation/doc/resources/1.8.4/menu_version.js
+++ b/Documentation/doc/resources/1.8.4/menu_version.js
@@ -28,8 +28,8 @@
 
       let first_element = top_elt.childNodes[0];
       let new_div = document.createElement("p");
-      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
-      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> development branch of CGAL. It might diverge from the official releases.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; display: inline-block;"
       let OK = top_elt.insertBefore(new_div, first_element);
     }
     var buf = ['<select>'];

--- a/Documentation/doc/resources/1.8.4/menu_version.js
+++ b/Documentation/doc/resources/1.8.4/menu_version.js
@@ -23,6 +23,15 @@
   ];
 
   function build_select(current_version) {
+    if( current_version == 'master') {
+      let top_elt = document.getElementById("top");
+
+      let first_element = top_elt.childNodes[0];
+      let new_div = document.createElement("p");
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-familly: monospace;" href="https://github.com/CGAL/cgal/tree/master">master</a> branch of CGAL, that is not yet released.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; width: max-content;"
+      let OK = top_elt.insertBefore(new_div, first_element);
+    }
     var buf = ['<select>'];
     $.each(all_versions, function(id) {
       var version = all_versions[id];


### PR DESCRIPTION
## Summary of Changes

This PR adds a warning on top of the documentation of `master`, so that users are not confused.

![Screenshot_20200602_105131](https://user-images.githubusercontent.com/5746675/83500421-09e60600-a4bf-11ea-817f-0f81e62ce50d.png)

## Release Management

* Affected package(s): Documentation

