### PR TITLE
Don't segfault on empty Nef_nary_x

### DIFF
--- a/Nef_3/include/CGAL/Nef_nary_intersection_3.h
+++ b/Nef_3/include/CGAL/Nef_nary_intersection_3.h
@@ -52,7 +52,8 @@ class Nef_nary_intersection_3 {
   }
 
   Polyhedron get_intersection() {
-
+    if (queue.empty())
+      return empty;
     while(queue.size() > 1)
       intersect();
     inserted = 0;

--- a/Nef_3/include/CGAL/Nef_nary_union_3.h
+++ b/Nef_3/include/CGAL/Nef_nary_union_3.h
@@ -52,7 +52,8 @@ class Nef_nary_union_3 {
   }
 
   Polyhedron get_union() {
-
+    if (queue.empty())
+      return empty;
     while(queue.size() > 1)
       unite();
     inserted = 0;


### PR DESCRIPTION
## Summary of Changes

Don't segfault on `Nef_nary_union_3::get_union()` and intersection with empty queue due to the call to front() on empty std::list() (= UB). There is already a member `empty`, so I think this check was intended but just forgotten.

## Release Management

* Affected package(s): Nef_3
* License and copyright ownership: None significant change. Hereby transfer ownership to respective owners.

Also I noticed the similarity between Nef_nary_union_3 and Nef_nary_intersection_3. Probably they can be parametrized using std::plus and std::multiplies from <functional>. Although get_union/get_intersection would ideally be renamed to get_result() for this to make the most sense.

Also Nef_nary_intersection_3 appears to be undocumented.