### PR TITLE
Remove cpp11::(tuple|get)

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -619,6 +619,7 @@ using std::max;
 
 //
 // Compatibility with CGAL-4.14.
+#ifndef CGAL_NO_DEPRECATED_CODE
 //
 // That is temporary, and will be replaced by a namespace alias, as
 // soon as we can remove cpp11::result_of, and <CGAL/atomic.h> and
@@ -655,7 +656,7 @@ namespace CGAL {
   using cpp11::array;
   using cpp11::copy_n;
 } // end of the temporary compatibility with CGAL-4.14
-
+#endif // CGAL_NO_DEPRECATED_CODE
 namespace CGAL {
 
 // Typedef for the type of nullptr.

--- a/Spatial_searching/include/CGAL/Orthogonal_incremental_neighbor_search.h
+++ b/Spatial_searching/include/CGAL/Orthogonal_incremental_neighbor_search.h
@@ -23,7 +23,7 @@
 #include <memory>
 #include <CGAL/Kd_tree.h>
 #include <CGAL/Euclidean_distance.h>
-#include <CGAL/tuple.h>
+#include <tuple> // std::get for tuple
 
 namespace CGAL {
 


### PR DESCRIPTION
## Summary of Changes

Remove cpp11. And use `#ifdef CGAL_NO_DEPRECATED_CODE` around the backward
compatibility code in `<CGAL/config.h>`.

Version of #4774 for CGAL-5.0.x, restricted to `<CGAL/config.h>` and `Spatial_searching`.

## Release Management

* Affected package(s): Spatial_searching
