### PR TITLE
Adding specific code for Tet + Bbox_3 do_intersect as it should be ok…

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -161,23 +161,30 @@ do_intersect(const typename K::Tetrahedron_3 &tet,
 }
 
 template <class K>
-inline
-typename K::Boolean
-do_intersect(const typename K::Tetrahedron_3 &tet,
-             const CGAL::Bbox_3 &bb,
-             const K & k)
-{
-  return do_intersect_tetrahedron_bounded(bb, tet, typename K::Point_3(bb.xmin(), bb.ymin(), bb.zmin()), k);
+inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
+                                        const CGAL::Bbox_3 &bb, const K &k) {
+  // Swap arguments. 
+  return do_intersect(bb, tet, k);
 }
 
-  template <class K>
-inline
-typename K::Boolean
-do_intersect(const CGAL::Bbox_3 &bb,
-             const typename K::Tetrahedron_3 &tet,
-             const K & k)
-{
-  return do_intersect_tetrahedron_bounded(bb, tet, typename K::Point_3(bb.xmin(), bb.ymin(), bb.zmin()), k);
+// BBox_3 sphecific code since it's ok for BBox_3 to degenerate.
+template <class K>
+inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
+                                        const typename K::Tetrahedron_3 &tet,
+                                        const K &k) {
+  using Tr = CGAL::Triangle_3<K>;
+  typename K::Boolean result = do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
+  if (certainly(result)) return result;
+  result = result || do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
+  if (certainly(result)) return result;
+  result = result || do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
+  if (certainly(result)) return result;
+  result = result || do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
+  if (certainly(result)) return result;
+  result = result ||
+           k.has_on_bounded_side_3_object()(
+               tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
+  return result;
 }
 
 } // namespace internal

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -167,27 +167,34 @@ inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
   return do_intersect(bb, tet, k);
 }
 
-// BBox_3 sphecific code since its ok for BBox_3 to degenerate.
+// BBox_3 sphecific code since it is ok for BBox_3 to degenerate.
 template <class K>
 inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
                                         const typename K::Tetrahedron_3 &tet,
                                         const K &k) {
   using Tr = CGAL::Triangle_3<K>;
-  using Boolean = typename K::Boolean;
-  Boolean result = false;
+  typename K::Boolean result = false;
+  typename K::Boolean b = false;
 
-  result = result | do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
-  if (certainly(result)) return result;
-  result = result | do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
-  if (certainly(result)) return result;
-  result = result | do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
-  if (certainly(result)) return result;
-  result = result | do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
-  if (certainly(result)) return result;
+  b = do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
+  if (certainly(b)) return b;
+  if (is_indeterminate(b)) result = b;
+  b = do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
+  if (certainly(b)) return b;
+  if (is_indeterminate(b)) result = b;
+  b = do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
+  if (certainly(b)) return b;
+  if (is_indeterminate(b)) result = b;
+  b = do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
+  if (certainly(b)) return b;
+  if (is_indeterminate(b)) result = b;
 
-  return result |
-         k.has_on_bounded_side_3_object()(
-             tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
+  b = k.has_on_bounded_side_3_object()(
+      tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
+  if (certainly(b)) return b;
+  if (is_indeterminate(b)) result = b;
+
+  return result;
 }
 
 } // namespace internal

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -167,7 +167,7 @@ inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
   return do_intersect(bb, tet, k);
 }
 
-// BBox_3 sphecific code since it is ok for BBox_3 to degenerate.
+// BBox_3 specific code since it is ok for BBox_3 to degenerate.
 template <class K>
 inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
                                         const typename K::Tetrahedron_3 &tet,

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -167,13 +167,16 @@ inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
   return do_intersect(bb, tet, k);
 }
 
-// BBox_3 sphecific code since it's ok for BBox_3 to degenerate.
+// BBox_3 sphecific code since its ok for BBox_3 to degenerate.
 template <class K>
 inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
                                         const typename K::Tetrahedron_3 &tet,
                                         const K &k) {
   using Tr = CGAL::Triangle_3<K>;
-  typename K::Boolean result = do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
+  using Boolean = typename K::Boolean;
+  Boolean result = false;
+
+  result = result | do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
   if (certainly(result)) return result;
   result = result | do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
   if (certainly(result)) return result;
@@ -181,10 +184,10 @@ inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
   if (certainly(result)) return result;
   result = result | do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
   if (certainly(result)) return result;
-  result = result |
-           k.has_on_bounded_side_3_object()(
-               tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
-  return result;
+
+  return result |
+         k.has_on_bounded_side_3_object()(
+             tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
 }
 
 } // namespace internal

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -163,7 +163,7 @@ do_intersect(const typename K::Tetrahedron_3 &tet,
 template <class K>
 inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
                                         const CGAL::Bbox_3 &bb, const K &k) {
-  // Swap arguments. 
+  // Swap arguments.
   return do_intersect(bb, tet, k);
 }
 

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -175,13 +175,13 @@ inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
   using Tr = CGAL::Triangle_3<K>;
   typename K::Boolean result = do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
   if (certainly(result)) return result;
-  result = result || do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
+  result = result | do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
   if (certainly(result)) return result;
-  result = result || do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
+  result = result | do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
   if (certainly(result)) return result;
-  result = result || do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
+  result = result | do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
   if (certainly(result)) return result;
-  result = result ||
+  result = result |
            k.has_on_bounded_side_3_object()(
                tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
   return result;

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -172,25 +172,25 @@ template <class K>
 inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
                                         const typename K::Tetrahedron_3 &tet,
                                         const K &k) {
-  using Tr = CGAL::Triangle_3<K>;
+  typename K::Construct_triangle_3 tr = k.construct_triangle_3_object();
   typename K::Boolean result = false;
   typename K::Boolean b = false;
 
-  b = do_intersect(aabb, Tr(tet[0], tet[1], tet[2]), k);
+  b = do_intersect(aabb, tr(tet[0], tet[1], tet[2]), k);
   if (certainly(b)) return b;
   if (is_indeterminate(b)) result = b;
-  b = do_intersect(aabb, Tr(tet[1], tet[2], tet[3]), k);
+  b = do_intersect(aabb, tr(tet[1], tet[2], tet[3]), k);
   if (certainly(b)) return b;
   if (is_indeterminate(b)) result = b;
-  b = do_intersect(aabb, Tr(tet[2], tet[3], tet[0]), k);
+  b = do_intersect(aabb, tr(tet[2], tet[3], tet[0]), k);
   if (certainly(b)) return b;
   if (is_indeterminate(b)) result = b;
-  b = do_intersect(aabb, Tr(tet[3], tet[0], tet[1]), k);
+  b = do_intersect(aabb, tr(tet[3], tet[0], tet[1]), k);
   if (certainly(b)) return b;
   if (is_indeterminate(b)) result = b;
 
   b = k.has_on_bounded_side_3_object()(
-      tet, typename K::Point_3(aabb.xmin(), aabb.ymin(), aabb.zmin()));
+      tet, k.construct_point_3_object()(aabb.xmin(), aabb.ymin(), aabb.zmin()));
   if (certainly(b)) return b;
   if (is_indeterminate(b)) result = b;
 


### PR DESCRIPTION
… for Bbox_3 to degenerate.

Adding specific code for Tet + Bbox_3 do_intersect as it should be ok for Bbox_3 to degenerate. 

The previous code failed in case Bbox_3 is degenerate. 

I use the result = result || predicate(); to keep the maybe inside result. 
If certain the code returns early. 
I also avoid the %4 as this is a slow operation, but not sure that this is worth compared to the rest.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

