### PR TITLE
HalfedgeDS/Kernel_d: Fix ambiguous comparison errors with C++20

### DIFF
--- a/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
@@ -262,6 +262,8 @@ public:
     bool operator!=( std::nullptr_t p) const { return !(*this == p); }
     bool operator==( const Self& i) const { return  It::operator==(i); }
     bool operator!=( const Self& i) const { return !(*this == i); }
+    bool operator==( const It& i) const { return  It::operator==(i); }
+    bool operator!=( const It& i) const { return !(*this == i); }
 
     Self& operator++() {
         this->nt = (*this->nt).next();

--- a/Kernel_d/include/CGAL/Kernel_d/Direction_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Direction_d.h
@@ -62,6 +62,10 @@ class Direction_d : public pR::Direction_d_base
   { return Base::operator==(w); }
   bool operator!=(const Self& w) const
   { return Base::operator!=(w); }
+  bool operator==(const Base& w) const
+  { return Base::operator==(w); }
+  bool operator!=(const Base& w) const
+  { return Base::operator!=(w); }
 };
 
 } //namespace CGAL

--- a/Kernel_d/include/CGAL/Kernel_d/Hyperplane_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Hyperplane_d.h
@@ -75,6 +75,10 @@ public:
   { return Base::operator==(w); }
   bool operator!=(const Self& w) const
   { return Base::operator!=(w); }
+  bool operator==(const Base& w) const
+  { return Base::operator==(w); }
+  bool operator!=(const Base& w) const
+  { return Base::operator!=(w); }
 };
 
 } //namespace CGAL

--- a/Kernel_d/include/CGAL/Kernel_d/Vector_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Vector_d.h
@@ -91,6 +91,10 @@ class Vector_d : public pR::Vector_d_base
   { return Base::operator==(w); }
   bool operator!=(const Self& w) const
   { return Base::operator!=(w); }
+  bool operator==(const Base& w) const
+  { return Base::operator==(w); }
+  bool operator!=(const Base& w) const
+  { return Base::operator!=(w); }
 
 };
 

--- a/Nef_2/include/CGAL/Nef_2/iterator_tools.h
+++ b/Nef_2/include/CGAL/Nef_2/iterator_tools.h
@@ -48,6 +48,12 @@ public:
     bool operator!=( const Self& i) const {
         return !(*this == i);
     }
+    bool operator==( const Iter& i ) const {
+      return Iter::operator==(i);
+    }
+    bool operator!=( const Iter& i) const {
+        return !(*this == i);
+    }
 
     Self& operator++() {
       Move move;

--- a/Nef_2/include/CGAL/Nef_polynomial.h
+++ b/Nef_2/include/CGAL/Nef_polynomial.h
@@ -69,6 +69,41 @@ class Nef_polynomial
       CGAL_STATIC_THREAD_LOCAL_VARIABLE(NT, R_, 1);
       return R_;
     }
+
+  friend bool operator==(const Nef_polynomial<NT> &a, const Nef_polynomial<NT> &b)
+  {
+    return a.polynomial() == b.polynomial();
+  }
+
+  friend bool operator==(const Nef_polynomial<NT> &a, const NT& b)
+  {
+    return a.polynomial() == b;
+  }
+
+  friend bool operator==(const Nef_polynomial<NT> &a, int b)
+  {
+    return a.polynomial() == b;
+  }
+
+  friend bool operator<(const Nef_polynomial<NT> &a, const Nef_polynomial<NT> &b)
+  {
+    return a.polynomial() < b.polynomial();
+  }
+
+  friend bool operator<(const Nef_polynomial<NT> &a, const NT& b)
+  {
+    return a.polynomial() < b;
+  }
+
+  friend bool operator<(const Nef_polynomial<NT> &a, int b)
+  {
+    return a.polynomial() < b;
+  }
+
+  friend bool operator>(const Nef_polynomial<NT> &a, int b)
+  {
+    return a.polynomial() > b;
+  }
 };
 
 template <class NT>
@@ -84,42 +119,6 @@ Nef_polynomial<NT> operator-(const Nef_polynomial<NT> &a)
 {
   return - a.polynomial();
 }
-
-template <class NT>
-inline
-bool operator<(const Nef_polynomial<NT> &a, const Nef_polynomial<NT> &b)
-{
-  return a.polynomial() < b.polynomial();
-}
-
-template <class NT>
-inline
-bool operator==(const Nef_polynomial<NT> &a, const Nef_polynomial<NT> &b)
-{
-  return a.polynomial() == b.polynomial();
-}
-
-template <class NT>
-inline
-bool operator==(const Nef_polynomial<NT> &a, int b)
-{
-  return a.polynomial() == b;
-}
-
-template <class NT>
-inline
-bool operator<(const Nef_polynomial<NT> &a, int b)
-{
-  return a.polynomial() < b;
-}
-
-template <class NT>
-inline
-bool operator>(const Nef_polynomial<NT> &a, int b)
-{
-  return a.polynomial() > b;
-}
-
 
 #undef CGAL_double
 #undef CGAL_int


### PR DESCRIPTION
## Summary of Changes

Fix compilation errors
```
/home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Kernel_d/afftrafo-test.cpp:136:31: error: use of overloaded operator '==' is ambiguous (with operand types 'VectorHd<CGAL::VectorHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >::RT, CGAL::VectorHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >::LA>' (aka 'VectorHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >') and 'Vector_d<CGAL::Homogeneous_d<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > > >')
    CGAL_TEST(v.transform(at9)==3*v){}
              ~~~~~~~~~~~~~~~~^ ~~~
/home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Kernel_d/include/CGAL/test_macros.h:10:28: note: expanded from macro 'CGAL_TEST'
                           ^
/mnt/testsuite/include/CGAL/Kernel_d/VectorHd.h:350:6: note: candidate function
bool operator==(const VectorHd<RT,LA>& w) const
     ^
/mnt/testsuite/include/CGAL/Kernel_d/Vector_d.h:90:8: note: candidate function (with reversed parameter order)
  bool operator==(const Self& w) const
       ^
```

```
/home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Kernel_d/afftrafo-test.cpp:141:33: error: use of overloaded operator '==' is ambiguous (with operand types 'DirectionHd<CGAL::DirectionHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >::RT, CGAL::DirectionHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >::LA>' (aka 'DirectionHd<__gmp_expr<mpz_t, mpz_t>, CGAL::Linear_algebraHd<__gmp_expr<mpz_t, mpz_t>, std::allocator<__gmp_expr<mpz_t, mpz_t> > > >') and 'Direction' (aka 'Direction_d<Homogeneous_d<__gmp_expr<__mpz_struct [1], __mpz_struct [1]> > >'))
    CGAL_TEST(dir.transform(at9)==dir){}
              ~~~~~~~~~~~~~~~~~~^ ~~~
/home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Kernel_d/include/CGAL/test_macros.h:10:28: note: expanded from macro 'CGAL_TEST'
                           ^
/mnt/testsuite/include/CGAL/Kernel_d/DirectionHd.h:181:6: note: candidate function
bool operator==(const DirectionHd<RT,LA>& w) const
     ^
/mnt/testsuite/include/CGAL/Kernel_d/Direction_d.h:61:8: note: candidate function (with reversed parameter order)
  bool operator==(const Self& w) const
       ^
```
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.1-I-171/Kernel_d/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz

## Release Management

* Affected package(s): Kernel_d

