### PR TITLE
Tetrahedral Remeshing - fix the list of authors

### DIFF
--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
@@ -14,17 +14,25 @@
 \cgalPkgPicture{bimba_back_small.png}
 
 \cgalPkgSummaryBegin
-\cgalPkgAuthors{Jane Tournois, Noura Faraj}
+\cgalPkgAuthors{Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur}
 \cgalPkgDesc{
 The package provides a function for remeshing tetrahedral meshes,
-targetting high quality meshes with respect to dihedral angles.}
+targeting high quality meshes with respect to dihedral angles.
+This practical iterative remeshing algorithm is designed to remesh
+multi-material tetrahedral meshes, by iteratively performing a sequence of
+elementary operations such as edge splits, edge collapses, edge flips,
+and vertex relocations following a Laplacian smoothing.
+The algorithm results in high-quality uniform isotropic meshes,
+with the desired mesh density,
+while preserving the input geometric curve and surface features.
+}
 \cgalPkgManuals{Chapter_Tetrahedral_Remeshing,PkgTetrahedralRemeshingRef}
 \cgalPkgSummaryEnd
 
 \cgalPkgShortInfoBegin
 \cgalPkgSince{5.1}
 \cgalPkgDependsOn{\ref PkgTriangulation3}
-\cgalPkgBib{faraj2016mvr}
+\cgalPkgBib{cgal:tftb-tr}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
 \cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd

--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/Tetrahedral_remeshing.txt
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/Tetrahedral_remeshing.txt
@@ -6,7 +6,7 @@ namespace CGAL {
 \anchor userchaptertetrahedralremeshing
 
 \cgalAutoToc
-\authors Jane Tournois, Noura Faraj
+\authors Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 \image html bimba_back.png
 \image latex bimba_back.png

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_cell_base_3.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_cell_base_3.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_TET_ADAPTIVE_REMESHING_CELL_BASE_3_H
 #define CGAL_TET_ADAPTIVE_REMESHING_CELL_BASE_3_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_triangulation_3.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_triangulation_3.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_TETRAHEDRAL_REMESHING_TRIANGULATION_H
 #define CGAL_TETRAHEDRAL_REMESHING_TRIANGULATION_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_vertex_base_3.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Remeshing_vertex_base_3.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_TET_ADAPTIVE_REMESHING_VERTEX_BASE_3_H
 #define CGAL_TET_ADAPTIVE_REMESHING_VERTEX_BASE_3_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Sizing_field.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Sizing_field.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_SIZING_FIELD_H
 #define CGAL_SIZING_FIELD_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Uniform_sizing_field.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/Uniform_sizing_field.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_UNIFORM_SIZING_FIELD_H
 #define CGAL_UNIFORM_SIZING_FIELD_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_TETRAHEDRAL_REMESHING_FMLS_H
 #define CGAL_TETRAHEDRAL_REMESHING_FMLS_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_INTERNAL_COLLAPSE_SHORT_EDGES_H
 #define CGAL_INTERNAL_COLLAPSE_SHORT_EDGES_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_TR_INTERNAL_COMPUTE_C3T3_STATISTICS_H
 #define CGAL_TR_INTERNAL_COMPUTE_C3T3_STATISTICS_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_INTERNAL_FLIP_EDGES_H
 #define CGAL_INTERNAL_FLIP_EDGES_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_INTERNAL_SMOOTH_VERTICES_H
 #define CGAL_INTERNAL_SMOOTH_VERTICES_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_INTERNAL_SPLIT_LONG_EDGES_H
 #define CGAL_INTERNAL_SPLIT_LONG_EDGES_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef TETRAHEDRAL_REMESHING_IMPL_H
 #define TETRAHEDRAL_REMESHING_IMPL_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef CGAL_INTERNAL_TET_REMESHING_HELPERS_H
 #define CGAL_INTERNAL_TET_REMESHING_HELPERS_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/tetrahedral_remeshing_io.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/tetrahedral_remeshing_io.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #include <CGAL/IO/io.h>
 

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
 //
-// Author(s)     : Jane Tournois, Noura Faraj
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
 
 #ifndef TETRAHEDRAL_REMESHING_H
 #define TETRAHEDRAL_REMESHING_H


### PR DESCRIPTION
## Summary of Changes

This PR fixes the list of authors for the whole "Tetrahedral remeshing" package, fixes the package bibtex key, and adds a longer "short description" to the package.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

