### PR TITLE
Add an option to corefine to refine only one mesh

### DIFF
--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -56,7 +56,7 @@ or <A HREF="https://msdn.microsoft.com/en-us/library/1fe2x6kt(v=vs.140).aspx">`h
 The \stl comes with the compiler, and as such no installation is required.
 
 \subsection thirdpartyBoost Boost
-<b>Version 1.62 or later</b>
+<b>Version 1.66 or later</b>
 
 The \sc{Boost} libraries are a set of portable C++ source libraries.
 Most of \sc{Boost} libraries are header-only, but a few of them need to be compiled or

--- a/Documentation/doc/resources/1.8.13/menu_version.js
+++ b/Documentation/doc/resources/1.8.13/menu_version.js
@@ -1,15 +1,15 @@
 (function() {
   'use strict';
 
-  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+))\//;
+  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+)(-beta\d)?)\//;
   var url_local =  /.*\/doc_output\//;
-  var current_version_local = '5.1-beta1'
+  var current_version_local = '5.0.3'
   var all_versions = [
       'master',
       'latest',
-      '5.1-beta1',
-      '5.0.2',
-      '4.14.3',
+      '5.1-beta2',
+      '5.0.3',
+      '4.14.2',
       '4.13.2',
       '4.12.2',
       '4.11.3',

--- a/Documentation/doc/resources/1.8.14/menu_version.js
+++ b/Documentation/doc/resources/1.8.14/menu_version.js
@@ -1,15 +1,15 @@
 (function() {
   'use strict';
 
-  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+))\//;
+  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+)(-beta\d)?)\//;
   var url_local =  /.*\/doc_output\//;
-  var current_version_local = '5.1-beta1'
+  var current_version_local = '5.0.3'
   var all_versions = [
       'master',
       'latest',
-      '5.1-beta1',
-      '5.0.2',
-      '4.14.3',
+      '5.1-beta2',
+      '5.0.3',
+      '4.14.2',
       '4.13.2',
       '4.12.2',
       '4.11.3',

--- a/Documentation/doc/resources/1.8.4/menu_version.js
+++ b/Documentation/doc/resources/1.8.4/menu_version.js
@@ -1,15 +1,15 @@
 (function() {
   'use strict';
 
-  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+))\//;
+  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(master|latest|(\d\.\d+|\d\.\d+\.\d+)(-beta\d)?)\//;
   var url_local =  /.*\/doc_output\//;
-  var current_version_local = '5.1-beta1'
+  var current_version_local = '5.0.3'
   var all_versions = [
       'master',
       'latest',
-      '5.1-beta1',
-      '5.0.2',
-      '4.14.3',
+      '5.1-beta2',
+      '5.0.3',
+      '4.14.2',
       '4.13.2',
       '4.12.2',
       '4.11.3',

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -4,7 +4,7 @@ Release History
 [Release 5.1](https://github.com/CGAL/cgal/releases/tag/releases%2FCGAL-5.1)
 -----------
 
-Release date: July 2020
+Release date: September 2020
 
 ### [Tetrahedral Remeshing](https://doc.cgal.org/5.1/Manual/packages.html#PkgTetrahedralRemeshing) (new package)
 
@@ -33,6 +33,7 @@ Release date: July 2020
 ### Installation
 
 -   The CGAL\_Core library no longer requires `Boost.Thread`, even if the g++ compiler is used.
+-   The minimal supported version of Boost is now 1.66.0.
 
 ### [Tutorials](https://doc.cgal.org/5.1/Manual/tutorials.html)
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -518,7 +518,6 @@ generic_clip_impl(
   *
   *
   * \cgalNamedParamsBegin
-<<<<<<< HEAD
   *   \cgalParamNBegin{vertex_point_map}
   *     \cgalParamDescription{a property map associating points to the vertices of `tm` (resp. `clipper`)}
   *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%vertex_descriptor`

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -826,7 +826,6 @@ bool clip(TriangleMesh& tm,
   *                     Setting this option to `true` will automatically set `throw_on_self_intersection` to `false`
   *                     and `clip_volume` to `false`.}
   *   \cgalParamNEnd
-  *   \cgalParamNEnd
   *
   * \cgalNamedParamsEnd
 */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -703,11 +703,6 @@ corefine_and_compute_difference(      TriangleMesh& tm1,
  *                      If this option is set to `true` for one mesh,
  *                      the other mesh is no longer required to be without self-intersection.}
  *   \cgalParamNEnd
- *   \cgalParamBegin{do_not_modify} 
- *                                  If this parameter is set to `true` for both meshes nothing will be done.
- *                                  If this option is set to `true` for one mesh,
- *                                  the other mesh is no longer required to be without self-intersection.
- *   \cgalParamEnd
  * \cgalNamedParamsEnd
  *
  */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
@@ -125,6 +125,7 @@ public:
 
   void set_vertex_id(vertex_descriptor v, Node_id node_id, const TriangleMesh& tm)
   {
+    CGAL_use(tm);
     CGAL_assertion(&tm == &tm1);
     vertex_to_node_id1.insert( std::make_pair(v, node_id) );
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
@@ -24,6 +24,7 @@
 
 #include <CGAL/property_map.h>
 #include <CGAL/Default.h>
+#include <CGAL/use.h>
 
 #include <boost/dynamic_bitset.hpp>
 
@@ -125,7 +126,7 @@ public:
 
   void set_vertex_id(vertex_descriptor v, Node_id node_id, const TriangleMesh& tm)
   {
-    CGAL_use(tm);
+    CGAL_USE(tm);
     CGAL_assertion(&tm == &tm1);
     vertex_to_node_id1.insert( std::make_pair(v, node_id) );
   }

--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -284,7 +284,6 @@ public:
     typedef typename AABB_tree::AABB_traits AABB_traits;
     typedef internal::Default_tree_helper<AABB_tree> Helper;
     Helper helper;
-    typename AABB_traits::Bounding_box bbox = helper.get_tree_bbox(*tree_ptr);
 
     static const unsigned int seed = 1340818006;
     CGAL::Random rg(seed); // seed some value for make it easy to debug


### PR DESCRIPTION
If `tm1` is self-intersecting and you do not need to refine `tm2` (that is self-intersection free) you can now call `corefine(tm1, tm2, params::all_default(), params::do_not_modify(true))` or `corefine(tm2,tm1, params::do_not_modify(true))`.*

## Release 

Affected package(s): `Polygon_mesh_processing`
Issue(s) solved (if any): -
Feature/Small Feature (if any): [Here](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Corefine_only_one_mesh)  -- **Pre-approved** on 2020/08/04
Link to compiled documentation (obligatory for small feature):
![Screenshot from 2020-06-17 08-34-50](https://user-images.githubusercontent.com/1224632/84863637-8824d980-b075-11ea-88c6-cdd095659b2f.png)

