### PR TITLE
PMP: remove_self_intersections() fixes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
@@ -1335,6 +1335,14 @@ bool remove_self_intersections_with_hole_filling(std::vector<typename boost::gra
   out.close();
 #endif
 
+  if(!is_simple_3(cc_border_hedges, tmesh, vpm, gt))
+  {
+#ifdef CGAL_PMP_REMOVE_SELF_INTERSECTION_DEBUG
+    std::cout << "Hole filling cannot handle non-simple border" << std::endl;
+#endif
+    return false;
+  }
+
 #ifdef CGAL_PMP_REMOVE_SELF_INTERSECTIONS_NO_CONSTRAINTS_IN_HOLE_FILLING
   // Do not try to impose sharp edge constraints if we are not doing local-only self intersections removal
   local_self_intersection_removal = false;


### PR DESCRIPTION
## Summary of Changes

Fix two cases where the algorithm attempted to use a bad patch, which led to rightful assertions/segfault.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): --
* Feature/Small Feature (if any): --
* License and copyright ownership: No changes.

