### PR TITLE
Testsuite rework the timeout of run_testsuite

### DIFF
--- a/Testsuite/test/run_testsuite_with_cmake
+++ b/Testsuite/test/run_testsuite_with_cmake
@@ -16,9 +16,9 @@ TESTSUITE_LDFLAGS=""
 
 CURRENTDIR=`pwd`
 ERRORFILE=${CURRENTDIR}/error.txt
-if [ -n "$CGAL_TEST_PLATFORM" ]; then 
+if [ -n "$CGAL_TEST_PLATFORM" ]; then
     PLATFORM=$CGAL_TEST_PLATFORM
-else 
+else
     PLATFORM=no-platform
 fi
 if [ -n "${CGAL_TIMEOUT_PROG+x}" ]; then
@@ -39,9 +39,9 @@ process_tree()
   local pid=$1
   local result=
   echo $pid
-  ps -a | awk '!/^ +PID/ {print $1 " " $2}' | { 
-      while read apid appid; do 
-	  if [ "$appid" = "$pid" ]; then 
+  ps -a | awk '!/^ +PID/ {print $1 " " $2}' | {
+      while read apid appid; do
+	  if [ "$appid" = "$pid" ]; then
 	      process_tree $apid
 	  fi
       done
@@ -58,11 +58,11 @@ wait_for_process()
     period=$3
     while [ $cycles -ne 0 ]
     do
-        cycles=`expr $cycles - 1`  
+        cycles=`expr $cycles - 1`
 # send SIGCONT to the process and check the exit value of kill.
 # If the process still exists, the call to kill succeeds (and the signal is
 # ignored).
-        
+
         kill -CONT $pid 2>kill_output 1>/dev/null;   terminated=$?
 # But under CYGWIN the exit status is not to be trusted.
 	if [ $terminated -eq 0 ]; then
@@ -94,7 +94,7 @@ wait_for_process()
 	    # Bash, the Bash manual states that it ignores SIGTERM.
 	    # However, it does not catch SIGHUP. That is why the first
 	    # signal send is SIGHUP.
-	    case "`uname`" in 
+	    case "`uname`" in
 		CYGWIN*)
 		    pids=`process_tree $pid`;;
 		*) pids=$pid;;
@@ -104,7 +104,7 @@ wait_for_process()
 	    # If SIGHUP was not enough, SIGKILL will finish the job, 10s after.
 	    for p in $pids; do kill -KILL $p 2>/dev/null; done
 	fi
-        return 1  
+        return 1
     fi
     return 0
 }
@@ -136,8 +136,8 @@ test_directory()
 {
   cd "$CURRENTDIR"
   if [ -d $1 ] ; then
-    echo "DIRECTORY $1:"                
-    echo                                
+    echo "DIRECTORY $1:"
+    echo
 
     echo "DIRECTORY $1:"                 >> "$ERRORFILE"
     echo                                 >> "$ERRORFILE"
@@ -202,7 +202,7 @@ test_directory()
       printf "      # Running time: %s (seconds)\n\n" "$DURATION" >> "$ERROR_OUTPUT"
       cat current_compiler_output >> "$COMPILER_OUTPUT"
       cat current_compiler_output
-      rm -f current_compiler_output 
+      rm -f current_compiler_output
 
       if [ -f error.txt ] ; then
         cat error.txt >> "$ERRORFILE"
@@ -227,18 +227,18 @@ test_directory()
 
 run_testsuite()
 {
-  
+
   echo "---------------------------------------------------------------"
-  echo "- Testing platform $PLATFORM"                         
+  echo "- Testing platform $PLATFORM"
   echo "---------------------------------------------------------------"
-  echo                                                                  
+  echo
 
   echo "---------------------------------------------------------------" >> "$ERRORFILE"
   echo "- TEST RESULTS FROM PLATFORM $PLATFORM"                          >> "$ERRORFILE"
   echo "---------------------------------------------------------------" >> "$ERRORFILE"
   echo                                                                   >> "$ERRORFILE"
 
-  case "`uname`" in 
+  case "`uname`" in
       CYGWIN*)
           PATH=`cygpath "$CGAL_DIR"`/bin:`cygpath "$CGAL_DIR"`/lib:$PATH
           export PATH
@@ -258,4 +258,3 @@ else
 fi
 
 run_testsuite
-

--- a/Testsuite/test/run_testsuite_with_cmake
+++ b/Testsuite/test/run_testsuite_with_cmake
@@ -21,6 +21,11 @@ if [ -n "$CGAL_TEST_PLATFORM" ]; then
 else 
     PLATFORM=no-platform
 fi
+if [ -n "${CGAL_TIMEOUT_PROG+x}" ]; then
+    TIMEOUT=$CGAL_TIMEOUT_PROG
+else
+    TIMEOUT=`which timeout`
+fi
 
 #clear the error file
 rm -f "$ERRORFILE"
@@ -111,12 +116,17 @@ run_local_cgal_test()
     MAKEFLAGS=
     export MAKEFLAGS
 
-    eval ./cgal_test_with_cmake > current_compiler_output 2>&1
+    if [ -n "$TIMEOUT" ]; then
+        "$TIMEOUT" $(( $TIME_PERIOD * 5 )) ./cgal_test_with_cmake > current_compiler_output 2>&1
+    else
+        ./cgal_test_with_cmake > current_compiler_output 2>&1
+    fi
     exit_value=$?
     if [ $exit_value -ne 0 ]
     then
          printf "%s\n" "$exit_value" > test_failure
     fi
+    return $exit_value
 }
 
 #test_directory <directory> <already_here>
@@ -152,23 +162,39 @@ test_directory()
       export PLATFORM TESTSUITE_CXXFLAGS TESTSUITE_LDFLAGS
       rm -f error.txt
       START=`date +%s`
-      run_local_cgal_test &
-
       TIME_PERIOD=1200
       if [ "$1" = "Polyhedron_Demo" ]; then
         TIME_PERIOD=2400
       fi
-      if wait_for_process "$!" "$TIME_PERIOD" "5"
-      then
-	if [ -f test_failure  ] ; then
-            exit_failure=`cat test_failure`
-	    rm -f test_failure
-	    echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERRORFILE"
-	    echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERROR_OUTPUT"
-	fi
+      if [ -n "$TIMEOUT" ]; then
+          run_local_cgal_test
+          return_code=$?
+          if [ $return_code -eq 124 ]; then
+	      echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERRORFILE"
+	      echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERROR_OUTPUT"
+          else
+	      if [ -f test_failure  ] ; then
+                  exit_failure=`cat test_failure`
+	          rm -f test_failure
+	          echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERRORFILE"
+	          echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERROR_OUTPUT"
+	      fi
+          fi
       else
-	echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERRORFILE"
-	echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERROR_OUTPUT"
+          run_local_cgal_test &
+
+          if wait_for_process "$!" "$TIME_PERIOD" "5"
+          then
+	      if [ -f test_failure  ] ; then
+                  exit_failure=`cat test_failure`
+	          rm -f test_failure
+	          echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERRORFILE"
+	          echo "ERROR: cgal_test_with_cmake exited with error condition $exit_value" >> "$ERROR_OUTPUT"
+	      fi
+          else
+	      echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERRORFILE"
+	      echo "ERROR: cgal_test_with_cmake did not finish within the time bound set" >> "$ERROR_OUTPUT"
+          fi
       fi
       STOP=`date +%s`
       DURATION=`expr "$STOP" - "$START"`

--- a/Testsuite/test/run_testsuite_with_cmake
+++ b/Testsuite/test/run_testsuite_with_cmake
@@ -25,6 +25,7 @@ if [ -n "${CGAL_TIMEOUT_PROG+x}" ]; then
     TIMEOUT=$CGAL_TIMEOUT_PROG
 else
     TIMEOUT=`which timeout`
+    [ -z "$TIMEOUT" ] && TIMEOUT=`which gtimeout`
 fi
 
 #clear the error file


### PR DESCRIPTION
## Summary of Changes

Use `timeout` if available, instead of a system of sleep/kill

The GNU coreutils software [timeout](https://man7.org/linux/man-pages/man1/timeout.1.html) is a perfect replacement for our buggy function `wait_for_process`.

This patch uses it when available. On Linux, brew, Cygwin, it is available in the `coreutils` package.

## Release Management

* Affected package(s): Testsuite, and thus all
* License and copyright ownership: maintenance by GeometryFactory

