### PR TITLE
Fix unknown behavior that changed in Visual 2019

### DIFF
--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -341,17 +341,25 @@ public:
   iterator
   emplace(const Args&... args)
   {
+    typedef CCC_internal::Erase_counter_strategy<
+      CCC_internal::has_increment_erase_counter<T>::value> EraseCounterStrategy;
     FreeList * fl = get_free_list();
     pointer ret = init_insert(fl);
+    auto erase_counter = EraseCounterStrategy::erase_counter(*ret);;
     new (ret) value_type(args...);
+    EraseCounterStrategy::set_erase_counter(*ret, erase_counter);
     return finalize_insert(ret, fl);
   }
 
   iterator insert(const T &t)
   {
+    typedef CCC_internal::Erase_counter_strategy<
+      CCC_internal::has_increment_erase_counter<T>::value> EraseCounterStrategy;
     FreeList * fl = get_free_list();
     pointer ret = init_insert(fl);
+    auto erase_counter = EraseCounterStrategy::erase_counter(*ret);;
     std::allocator_traits<allocator_type>::construct(m_alloc, ret, t);
+    EraseCounterStrategy::set_erase_counter(*ret, erase_counter);
     return finalize_insert(ret, fl);
   }
 


### PR DESCRIPTION
## Summary of Changes
The Concurrent_compact_container uses some undefined behavior to  maintain time_stamps and some other things, including a counter that is not initialized during construction. 
In Vicual Studio 2019, the behavior of the std::atomic constructor changed, breaking this counter, leading to bugs at least in Mesh_3. This PR fixes it.
## Release Management

* Affected package(s):STL_Extension
* Issue(s) solved (if any): fix #4796 
