### PR TITLE
Add move-semantic for c3t3, and a test

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -191,6 +191,20 @@ public:
     init(number_of_cells_, rhs.number_of_cells_);
   }
 
+  /// Move constructor
+  Mesh_complex_3_in_triangulation_3_base(Self&& rhs)
+    : Base()
+    , tr_(std::move(rhs.tr_))
+    , edge_facet_counter_(std::move(rhs.edge_facet_counter_))
+    , manifold_info_initialized_(std::exchange(rhs.manifold_info_initialized_, false))
+  {
+    Init_number_of_elements<Concurrency_tag> init;
+    init(number_of_facets_, rhs.number_of_facets_);
+    init(number_of_cells_, rhs.number_of_cells_);
+    init(rhs.number_of_facets_); // set to 0
+    init(rhs.number_of_cells_); // set to 0
+  }
+
   /// Destructor
   ~Mesh_complex_3_in_triangulation_3_base() {}
 
@@ -203,6 +217,13 @@ public:
 
   /// Assignment operator
   Self& operator=(Self rhs)
+  {
+    swap(rhs);
+    return *this;
+  }
+
+  /// Assignment operator, also serves as move-assignment
+  Self& operator=(Self&& rhs)
   {
     swap(rhs);
     return *this;
@@ -861,6 +882,11 @@ private:
     {
       a = b;
     }
+    template<typename T>
+    void operator()(T& a)
+    {
+      a = 0;
+    }
   };
 
   template<typename Concurrency_tag2, typename dummy = void>
@@ -887,6 +913,11 @@ private:
     void operator()(T& a, const T& b)
     {
       a = b.load();
+    }
+    template<typename T>
+    void operator()(T& a)
+    {
+      a = 0;
     }
   };
 

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -111,13 +111,15 @@ public:
    */
   Mesh_complex_3_in_triangulation_3(const Self& rhs);
 
-  /**
-   * Destructor
-   */
-  virtual ~Mesh_complex_3_in_triangulation_3() {}
+  /// Move constructor
+  Mesh_complex_3_in_triangulation_3(Self&& rhs)
+    : Base(std::move(rhs))
+    , edges_(std::move(rhs.edges_))
+    , corners_(std::move(rhs.corners_))
+  {}
 
   /**
-   * Assignement operator
+   * Assignement operator, also serves as move-assignement
    */
   Self& operator=(Self rhs)
   {

--- a/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -101,21 +101,21 @@ public:
   /**
    * Constructor
    */
-  Mesh_complex_3_in_triangulation_3()
-    : Base()
-    , edges_()
-    , corners_() {}
+  Mesh_complex_3_in_triangulation_3() = default;
 
   /**
    * Copy constructor
    */
   Mesh_complex_3_in_triangulation_3(const Self& rhs);
 
-  /// Move constructor
+  /**
+   * Move constructor
+   */
   Mesh_complex_3_in_triangulation_3(Self&& rhs)
     : Base(std::move(rhs))
     , edges_(std::move(rhs.edges_))
     , corners_(std::move(rhs.corners_))
+    , far_vertices_(std::move(rhs.far_vertices_))
   {}
 
   /**
@@ -146,6 +146,7 @@ public:
     Base::clear();
     edges_.clear();
     corners_.clear();
+    far_vertices_.clear();
   }
 
   /// Import Base functions

--- a/Mesh_3/test/Mesh_3/test_c3t3.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3.cpp
@@ -37,6 +37,10 @@ struct Tester
 
   typedef typename CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
   typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+  typedef CGAL::Mesh_3::Mesh_complex_3_in_triangulation_3_base<Tr,
+    CGAL::Sequential_tag> C3t3_base_sequential;
+  typedef CGAL::Mesh_3::Mesh_complex_3_in_triangulation_3_base<Tr,
+    CGAL::Parallel_tag> C3t3_base_parallel;
 
   typedef typename Tr::Bare_point Bare_point;
   typedef typename Tr::Weighted_point Weighted_point;
@@ -120,6 +124,35 @@ struct Tester
     assert(c3t3.is_in_complex(ch));
     assert(c3t3.subdomain_index(ch) == subdomain_index);
 
+    //-------------------------------------------------------
+    // Test move construction
+    //-------------------------------------------------------
+    C3t3 c3t3_moved{std::move(c3t3)};
+    assert(c3t3_moved.is_valid());
+    assert(c3t3.is_valid());
+    assert(ch == (Cell_handle)c3t3_moved.cells_in_complex_begin());
+    assert(c3t3_moved.number_of_cells_in_complex() == 1);
+    assert(c3t3_moved.number_of_cells_in_complex() ==
+           (size_type)std::distance(c3t3_moved.cells_in_complex_begin(),
+                                    c3t3_moved.cells_in_complex_end()));
+    assert(c3t3_moved.is_in_complex(ch));
+    assert(c3t3_moved.subdomain_index(ch) == subdomain_index);
+
+    assert(c3t3.number_of_cells_in_complex() == 0);
+    assert(c3t3.number_of_cells_in_complex() == (size_type)std::distance(c3t3.cells_in_complex_begin(),
+                                                                         c3t3.cells_in_complex_end()));
+    c3t3 = std::move(c3t3_moved);
+    assert(ch == (Cell_handle)c3t3.cells_in_complex_begin());
+    assert(c3t3.number_of_cells_in_complex() == 1);
+    assert(c3t3.number_of_cells_in_complex() == (size_type)std::distance(c3t3.cells_in_complex_begin(),
+                                                                         c3t3.cells_in_complex_end()));
+    assert(c3t3.is_in_complex(ch));
+    assert(c3t3.subdomain_index(ch) == subdomain_index);
+
+    assert(c3t3_moved.number_of_cells_in_complex() == 0);
+    assert(c3t3_moved.number_of_cells_in_complex() ==
+           (size_type)std::distance(c3t3_moved.cells_in_complex_begin(),
+                                    c3t3_moved.cells_in_complex_end()));
     // -----------------------------------
     // Test Cell_in_complex_iterator
     // The goal here is to test operators and conversion on iterator type


### PR DESCRIPTION
## Summary of Changes

Add move-semantic for c3t3. Required for #4803.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: maintenance by GF

