### PR TITLE
Tetrahedral remeshing : fix a bug in collapse

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -129,14 +129,14 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(
 
       if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, item->c3t3().triangulation()))
       {
+        item->c3t3().rescan_after_load_of_triangulation();
         for( C3t3::Triangulation::Finite_cells_iterator
              cit = item->c3t3().triangulation().finite_cells_begin();
              cit != item->c3t3().triangulation().finite_cells_end();
              ++cit)
         {
-            CGAL_assertion(cit->info() >= 0);
-            if(cit->info() != 0)
-              item->c3t3().add_to_complex(cit, cit->info());
+            if(cit->subdomain_index() != C3t3::Triangulation::Cell::Subdomain_index())
+              item->c3t3().add_to_complex(cit, cit->subdomain_index());
             for(int i=0; i < 4; ++i)
             {
               if(cit->surface_patch_index(i)>0)

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -925,7 +925,8 @@ collapse(const typename C3t3::Cell_handle ch,
       {
         if (c3t3.is_in_complex(eiv0, eiv1))
         {
-          c3t3.add_to_complex(eiv0, vkept, c3t3.curve_index(eiv0, eiv1));
+          if (!c3t3.is_in_complex(eiv0, vkept))
+            c3t3.add_to_complex(eiv0, vkept, c3t3.curve_index(eiv0, eiv1));
           c3t3.remove_from_complex(eiv0, eiv1);
         }
       }
@@ -933,7 +934,8 @@ collapse(const typename C3t3::Cell_handle ch,
       {
         if (c3t3.is_in_complex(eiv0, eiv1))
         {
-          c3t3.add_to_complex(vkept, eiv1, c3t3.curve_index(eiv0, eiv1));
+          if (!c3t3.is_in_complex(vkept, eiv1))
+            c3t3.add_to_complex(vkept, eiv1, c3t3.curve_index(eiv0, eiv1));
           c3t3.remove_from_complex(eiv0, eiv1);
         }
       }

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -318,6 +318,9 @@ private:
     std::size_t nbe = 0;
     std::size_t nbv = 0;
 #endif
+    //update number_of_cells and number_of_facets in c3t3
+    m_c3t3.rescan_after_load_of_triangulation();
+
     //tag cells
     for (Cell_handle cit : tr().finite_cell_handles())
     {


### PR DESCRIPTION
## Summary of Changes

In a C3t3, an edge cannot be added to the complex if it is already there.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* Issue(s) solved (if any): fix #4808

