### PR TITLE
Remove 'const' markers in Polyhedron-modifying functions

### DIFF
--- a/Polyhedron/include/CGAL/boost/graph/graph_traits_Polyhedron_3.h
+++ b/Polyhedron/include/CGAL/boost/graph/graph_traits_Polyhedron_3.h
@@ -287,7 +287,7 @@ template<class Gt, class I, CGAL_HDS_PARAM_, class A>
 void
 set_face(typename boost::graph_traits< CGAL::Polyhedron_3<Gt,I,HDS,A> >::halfedge_descriptor h
   , typename boost::graph_traits< CGAL::Polyhedron_3<Gt,I,HDS,A> >::face_descriptor f
-  , const CGAL::Polyhedron_3<Gt,I,HDS,A>&)
+  , CGAL::Polyhedron_3<Gt,I,HDS,A>&)
 {
   // set_face has become private in the halfedge provided by
   // polyhedron for unknown reasons, although it used to be public
@@ -313,7 +313,7 @@ template<class Gt, class I, CGAL_HDS_PARAM_, class A>
 void
 set_halfedge(typename boost::graph_traits< CGAL::Polyhedron_3<Gt,I,HDS,A> >::vertex_descriptor v
   , typename boost::graph_traits< CGAL::Polyhedron_3<Gt,I,HDS,A> >::halfedge_descriptor h
-  , const CGAL::Polyhedron_3<Gt,I,HDS,A>&)
+  , CGAL::Polyhedron_3<Gt,I,HDS,A>&)
 {
   typedef typename CGAL::Polyhedron_3<Gt,I,HDS,A>::Vertex::Base Sneak;
   static_cast<Sneak&>(*v).set_halfedge(h);


### PR DESCRIPTION
## Summary of Changes

Extra `const` noticed by @sloriot on one overload of `set_halfedge()`, which creates ambiguities when `HalfedgeDS_vector` is used (and somehow everything is fine otherwise...).

## Release Management

* Affected package(s): `Polyhedron`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

