### PR TITLE
Gsoc2020 Smart Pointer fix in Classification and Point_set_processing_3 sameer

### DIFF
--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -40,6 +40,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <memory>
+
 #include <CGAL/Real_timer.h>
 #include <CGAL/demangle.h>
 
@@ -149,9 +151,9 @@ private:
 
   struct Scale
   {
-    Neighborhood* neighborhood;
-    Planimetric_grid* grid;
-    Local_eigen_analysis* eigen;
+    std::unique_ptr<Neighborhood> neighborhood;
+    std::unique_ptr<Planimetric_grid> grid;
+    std::unique_ptr<Local_eigen_analysis> eigen;
     float voxel_size;
 
     Scale (const FaceListGraph& input,
@@ -164,7 +166,7 @@ private:
     {
       CGAL::Real_timer t;
       t.start();
-      neighborhood = new Neighborhood (input);
+      neighborhood = std::make_unique<Neighborhood> (input);
       t.stop();
 
       CGAL_CLASSIFICATION_CERR << "Neighborhood computed in " << t.time() << " second(s)" << std::endl;
@@ -172,7 +174,7 @@ private:
       t.reset();
       t.start();
 
-      eigen = new Local_eigen_analysis
+      eigen = std::make_unique<Local_eigen_analysis>
         (Local_eigen_analysis::create_from_face_graph
          (input, neighborhood->n_ring_neighbor_query(nb_scale + 1),
           ConcurrencyTag(), DiagonalizeTraits()));
@@ -186,31 +188,12 @@ private:
       t.start();
 
       if (lower_grid == nullptr)
-        grid = new Planimetric_grid (range, point_map, bbox, this->voxel_size);
+        grid = std::make_unique<Planimetric_grid> (range, point_map, bbox, this->voxel_size);
       else
-        grid = new Planimetric_grid(lower_grid);
+        grid = std::unique_ptr<Planimetric_grid> (lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();
-    }
-    ~Scale()
-    {
-      if (neighborhood != nullptr)
-        delete neighborhood;
-      if (grid != nullptr)
-        delete grid;
-      delete eigen;
-    }
-
-    void reduce_memory_footprint(bool delete_neighborhood)
-    {
-      delete grid;
-      grid = nullptr;
-      if (delete_neighborhood)
-      {
-        delete neighborhood;
-        neighborhood = nullptr;
-      }
     }
 
     float grid_resolution() const { return voxel_size; }
@@ -220,7 +203,7 @@ private:
   };
 
   Iso_cuboid_3 m_bbox;
-  std::vector<Scale*> m_scales;
+  std::vector<std::unique_ptr<Scale> > m_scales;
 
   const FaceListGraph& m_input;
   Face_range m_range;
@@ -265,7 +248,7 @@ public:
 
     m_scales.reserve (nb_scales);
 
-    m_scales.push_back (new Scale (m_input, m_range, m_point_map, m_bbox, voxel_size, 0));
+    m_scales.push_back (std::make_unique<Scale> (m_input, m_range, m_point_map, m_bbox, voxel_size, 0));
 
     if (voxel_size == -1.f)
       voxel_size = m_scales[0]->grid_resolution();
@@ -273,7 +256,7 @@ public:
     for (std::size_t i = 1; i < nb_scales; ++ i)
     {
       voxel_size *= 2;
-      m_scales.push_back (new Scale (m_input, m_range, m_point_map, m_bbox, voxel_size, i, m_scales[i-1]->grid));
+      m_scales.push_back (std::make_unique<Scale> (m_input, m_range, m_point_map, m_bbox, voxel_size, i, (m_scales[i-1]->grid).get()));
     }
     t.stop();
     CGAL_CLASSIFICATION_CERR << "Scales computed in " << t.time() << " second(s)" << std::endl;
@@ -281,21 +264,6 @@ public:
   }
 
   /// @}
-
-  /// \cond SKIP_IN_MANUAL
-  virtual ~Mesh_feature_generator()
-  {
-    clear();
-  }
-
-  void reduce_memory_footprint()
-  {
-    for (std::size_t i = 0; i < m_scales.size(); ++ i)
-    {
-      m_scales[i]->reduce_memory_footprint(i > 0);
-    }
-  }
-  /// \endcond
 
 
   /// \name Feature Generation
@@ -407,14 +375,6 @@ public:
 
   /// @}
 
-private:
-
-  void clear()
-  {
-    for (std::size_t i = 0; i < m_scales.size(); ++ i)
-      delete m_scales[i];
-    m_scales.clear();
-  }
 
 };
 

--- a/Classification/include/CGAL/Classification/Planimetric_grid.h
+++ b/Classification/include/CGAL/Classification/Planimetric_grid.h
@@ -21,6 +21,8 @@
 
 #include <CGAL/assertions.h>
 
+#include <memory>
+
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/cstdint.hpp>
 
@@ -48,11 +50,15 @@ namespace Classification {
   */
 
 template <typename GeomTraits, typename PointRange, typename PointMap>
-class Planimetric_grid
+class Planimetric_grid : public std::enable_shared_from_this< Planimetric_grid< GeomTraits, PointRange, PointMap> >
 {
 public:
   typedef typename GeomTraits::Point_3 Point_3;
   typedef typename GeomTraits::Iso_cuboid_3 Iso_cuboid_3;
+
+  std::shared_ptr<Planimetric_grid< GeomTraits, PointRange, PointMap> > get_ptr(){
+    return this->shared_from_this();
+  }
 
 private:
   typedef Image<std::vector<boost::uint32_t> > Image_indices;

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -152,7 +152,7 @@ private:
   {
     std::unique_ptr<Neighborhood> neighborhood;
     std::unique_ptr<Planimetric_grid> grid;
-    std::unique<Local_eigen_analysis> eigen;
+    std::unique_ptr<Local_eigen_analysis> eigen;
     float voxel_size;
 
     Scale (const PointRange& input, PointMap point_map,
@@ -205,7 +205,7 @@ private:
   };
 
   Iso_cuboid_3 m_bbox;
-  std::vector<Scale*> m_scales;
+  std::vector<std::unique_ptr<Scale> > m_scales;
 
   const PointRange& m_input;
   PointMap m_point_map;

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
@@ -76,7 +76,7 @@ public:
   std::atomic<bool>& interrupted() { return *m_interrupted; }
   void join()
   {
-    if (m_thread->joinable())
+    if (m_thread != nullptr)
       m_thread->join();
   }
 


### PR DESCRIPTION
This PR solves #4590 by using smart pointers in place of raw pointers in two packages `Classification` and `Point_set_processing_3`.

## Summary of Changes

In `Classification` package changes are made in files `mesh_feature_generator.h` and `Point_set_feature_generator.h`,  and in `Point_set_processing_3` package modified file is `parallel_callback.h`. In both the packeges `std::unique_ptr` and `std::shared_ptr` are used appropriately in place of raw pointers.

## Release Management

* Affected package(s): `Classification` and `Point_set_processing_3`
* Issue(s) solved (if any): fix #4590
* Feature/Small Feature (if any): enhancement
