### PR TITLE
PMP: Split_cc missing reserve

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -30,6 +30,7 @@
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/boost/graph/Face_filtered_graph.h>
 #include <CGAL/boost/graph/copy_face_graph.h>
+#include <CGAL/Container_helper.h>
 
 #include <CGAL/assertions.h>
 #include <CGAL/tuple.h>
@@ -973,7 +974,7 @@ void split_connected_components_impl(FIMap fim,
     }
     nb_patches+=1;
   }
-
+  CGAL::internal::reserve(range, nb_patches);
   for(faces_size_type i=0; i<nb_patches; ++i)
   {
     CGAL::Face_filtered_graph<PolygonMesh, FIMap, VIMap, HIMap>


### PR DESCRIPTION
## Summary of Changes

Adds the missing reserve() in the split_cc_impl algorithm.
## Release Management

* Affected package(s):PMP
