### PR TITLE
[PSP] Fix neighbor query fallback

### DIFF
--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Neighbor_query.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Neighbor_query.h
@@ -112,7 +112,7 @@ public:
 
   template <typename OutputIterator>
   void get_iterators (const Point& query, unsigned int k, FT neighbor_radius,
-                      OutputIterator output, bool fallback_k_if_sphere_empty = true) const
+                      OutputIterator output, unsigned int fallback_k_if_sphere_empty = 3) const
   {
     if (neighbor_radius != FT(0))
     {
@@ -142,11 +142,10 @@ public:
       catch (const Maximum_points_reached_exception&)
       { }
 
-      // Fallback, if less than 3 points are return, search for the 3
+      // Fallback, if not enough  points are return, search for the knn
       // first points
-      if (fallback_k_if_sphere_empty && nb < 3)
-        k = 3;
-      // Else, no need to search for K nearest neighbors
+      if (nb < fallback_k_if_sphere_empty)
+        k = fallback_k_if_sphere_empty;
       else
         k = 0;
     }
@@ -173,14 +172,14 @@ public:
 
   template <typename OutputIterator>
   void get_points (const Point& query, unsigned int k, FT neighbor_radius,
-                   OutputIterator output) const
+                   OutputIterator output, unsigned int fallback_k_if_sphere_empty = 3) const
   {
     return get_iterators(query, k, neighbor_radius,
                          boost::make_function_output_iterator
                          ([&](const input_iterator& it)
                           {
                             *(output ++) = get (m_point_map, *it);
-                          }));
+                          }), fallback_k_if_sphere_empty);
   }
 };
 

--- a/Point_set_processing_3/include/CGAL/cluster_point_set.h
+++ b/Point_set_processing_3/include/CGAL/cluster_point_set.h
@@ -209,7 +209,7 @@ std::size_t cluster_point_set (PointRange& points,
 
       neighbors.clear();
       neighbor_query.get_iterators (get (point_map, p), 0, neighbor_radius,
-                                    std::back_inserter (neighbors), false);
+                                    std::back_inserter (neighbors), 0);
 
       for (const iterator& it : neighbors)
       {

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -70,7 +70,10 @@ jet_estimate_normal(const typename NeighborQuery::Point_3& query, ///< point to 
   typedef typename Monge_jet_fitting::Monge_form Monge_form;
 
   std::vector<Point> points;
-  neighbor_query.get_points (query, k, neighbor_radius, std::back_inserter(points));
+
+  // query using as fallback minimum requires nb points for jet fitting (d+1)*(d+2)/2
+  neighbor_query.get_points (query, k, neighbor_radius, std::back_inserter(points),
+                             (degree_fitting + 1) * (degree_fitting + 2) / 2);
 
   // performs jet fitting
   Monge_jet_fitting monge_fit;

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -75,7 +75,10 @@ jet_smooth_point(
   typedef typename Monge_jet_fitting::Monge_form Monge_form;
 
   std::vector<Point> points;
-  neighbor_query.get_points (query, k, neighbor_radius, std::back_inserter(points));
+
+  // query using as fallback minimum requires nb points for jet fitting (d+1)*(d+2)/2
+  neighbor_query.get_points (query, k, neighbor_radius, std::back_inserter(points),
+                             (degree_fitting + 1) * (degree_fitting + 2) / 2);
 
   // performs jet fitting
   Monge_jet_fitting monge_fit;


### PR DESCRIPTION
## Summary of Changes

When performing a neighbor query using a range with fixed radius, problems may occur if no point was found in the radius, which lead me to add a fallback mode using k=3 if no point was found (which seemed like the minimum number of points to fit a plane for example, provided they are not collinear).

While debugging the bindings of CGAL, @maxGimeno encountered a bug which made me realize that these (internal) parameter should vary depending on the algorithm: in that case, the algorithms that use the _Jet Fitting_ package have a precondition on the minimum number of neighbors, so I fixed the bug by using this value as the fallback value.

The neighbor query class did not exist in CGAL 5.0 so this is a fix for master only.

## Release Management

* Affected package(s): Point Set Processing