### PR TITLE
Document Power_center_d, Power_distance_d (renamed)

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -15,6 +15,14 @@ Release date: December 2020
 -   Added the function `CGAL::halfspace_intersection_interior_point_3()` that can be used to retrieve
     the point that is the most interior a convex closed volume defined by the intersection of a set of halfspaces.
 
+### [dD Geometry Kernel](https://doc.cgal.org/5.2/Manual/packages.html#PkgKernelD)
+
+-   The kernels [`Epick_d`](https://doc.cgal.org/5.2/Kernel_d/structCGAL_1_1Epick__d.html)
+    and [`Epeck_d`](https://doc.cgal.org/5.2/Kernel_d/structCGAL_1_1Epeck__d.html) gain two new functors:
+    [`Compute_power_product_d`](https://doc.cgal.org/5.2/Kernel_d/classCGAL_1_1Epeck__d_1_1Compute__power__product__d.html)
+    and [`Construct_power_sphere_d`](https://doc.cgal.org/5.2/Kernel_d/classCGAL_1_1Epeck__d_1_1Construct__power__sphere__d.html),
+    to deal with weighted points.
+
 
 [Release 5.1](https://github.com/CGAL/cgal/releases/tag/releases%2FCGAL-5.1)
 -----------

--- a/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
@@ -149,9 +149,26 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
+class Power_center_d {
+public:
+/*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
+    \pre A is affinely independent.
+    \tparam ForwardIterator has `Epeck_d::Weighted_point_d` as value type.
+    */
+template<class ForwardIterator>
+Weighted_point_d operator()(ForwardIterator first, ForwardIterator last);
+};
+class Compute_power_product_d {
+public:
+/*! returns the power product (aka power distance) of the weighted points `pw` and `qw`, that is, the squared Euclidean distance between the points minus their weights.
+ */
+FT operator()(Weighted_point_d pw, Weighted_point_d qw);
+};
 Construct_circumcenter_d construct_circumcenter_d_object();
+Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
+Power_center_d power_center_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epeck_d */
 } /* end namespace CGAL */

--- a/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
@@ -149,7 +149,7 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
-class Construct_power_center_d {
+class Construct_power_sphere_d {
 public:
 /*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
     \pre A is affinely independent.
@@ -168,7 +168,7 @@ Construct_circumcenter_d construct_circumcenter_d_object();
 Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
-Construct_power_center_d construct_power_center_d_object();
+Construct_power_sphere_d construct_power_sphere_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epeck_d */
 } /* end namespace CGAL */

--- a/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epeck_d.h
@@ -149,7 +149,7 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
-class Power_center_d {
+class Construct_power_center_d {
 public:
 /*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
     \pre A is affinely independent.
@@ -168,7 +168,7 @@ Construct_circumcenter_d construct_circumcenter_d_object();
 Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
-Power_center_d power_center_d_object();
+Construct_power_center_d construct_power_center_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epeck_d */
 } /* end namespace CGAL */

--- a/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
@@ -138,9 +138,26 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
+class Power_center_d {
+public:
+/*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
+    \pre A is affinely independent.
+    \tparam ForwardIterator has `Epick_d::Weighted_point_d` as value type.
+    */
+template<class ForwardIterator>
+Weighted_point_d operator()(ForwardIterator first, ForwardIterator last);
+};
+class Compute_power_product_d {
+public:
+/*! returns the power product (aka power distance) of the weighted points `pw` and `qw`, that is, the squared Euclidean distance between the points minus their weights.
+ */
+FT operator()(Weighted_point_d pw, Weighted_point_d qw);
+};
 Construct_circumcenter_d construct_circumcenter_d_object();
+Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
+Power_center_d power_center_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epick_d */
 } /* end namespace CGAL */

--- a/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
@@ -138,7 +138,7 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
-class Construct_power_center_d {
+class Construct_power_sphere_d {
 public:
 /*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
     \pre A is affinely independent.
@@ -157,7 +157,7 @@ Construct_circumcenter_d construct_circumcenter_d_object();
 Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
-Construct_power_center_d construct_power_center_d_object();
+Construct_power_sphere_d construct_power_sphere_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epick_d */
 } /* end namespace CGAL */

--- a/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Epick_d.h
@@ -138,7 +138,7 @@ public:
 template<class ForwardIterator>
 Bounded_side operator()(ForwardIterator first, ForwardIterator last, const Weighted_point_d&p);
 };
-class Power_center_d {
+class Construct_power_center_d {
 public:
 /*! returns a weighted point on the affine hull of the weighted points of `A=tuple[first,last)` at power distance 0 of each of them. In other words, this returns the smallest sphere orthogonal to the spheres of A.
     \pre A is affinely independent.
@@ -157,7 +157,7 @@ Construct_circumcenter_d construct_circumcenter_d_object();
 Compute_power_product_d compute_power_product_d_object();
 Compute_squared_radius_d compute_squared_radius_d_object();
 Compute_squared_radius_smallest_orthogonal_sphere_d compute_squared_radius_smallest_orthogonal_sphere_d_object();
-Power_center_d power_center_d_object();
+Construct_power_center_d construct_power_center_d_object();
 Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object();
 }; /* end Epick_d */
 } /* end namespace CGAL */

--- a/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
@@ -59,7 +59,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         typedef typename Get_functor<Base, Side_of_oriented_sphere_tag>::type Side_of_oriented_sphere_d;
         typedef typename Get_functor<Base, Power_side_of_power_sphere_tag>::type Power_side_of_power_sphere_d;
         typedef typename Get_functor<Base, Power_side_of_bounded_power_circumsphere_tag>::type Power_side_of_bounded_power_sphere_d;
-        typedef typename Get_functor<Base, Power_center_tag>::type Construct_power_center_d;
+        typedef typename Get_functor<Base, Power_center_tag>::type Construct_power_sphere_d;
         typedef typename Get_functor<Base, Power_distance_tag>::type Compute_power_product_d;
         typedef typename Get_functor<Base, Contained_in_affine_hull_tag>::type Contained_in_affine_hull_d;
         typedef typename Get_functor<Base, Construct_flat_orientation_tag>::type Construct_flat_orientation_d;
@@ -222,7 +222,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         Side_of_oriented_sphere_d side_of_oriented_sphere_d_object()const{ return Side_of_oriented_sphere_d(*this); }
         Power_side_of_power_sphere_d power_side_of_power_sphere_d_object()const{ return Power_side_of_power_sphere_d(*this); }
         Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object()const{ return Power_side_of_bounded_power_sphere_d(*this); }
-        Construct_power_center_d construct_power_center_d_object()const{ return Construct_power_center_d(*this); }
+        Construct_power_sphere_d construct_power_sphere_d_object()const{ return Construct_power_sphere_d(*this); }
         Compute_power_product_d compute_power_product_d_object()const{ return Compute_power_product_d(*this); }
         Side_of_bounded_sphere_d side_of_bounded_sphere_d_object()const{ return Side_of_bounded_sphere_d(*this); }
         Contained_in_affine_hull_d contained_in_affine_hull_d_object()const{ return Contained_in_affine_hull_d(*this); }

--- a/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
@@ -59,7 +59,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         typedef typename Get_functor<Base, Side_of_oriented_sphere_tag>::type Side_of_oriented_sphere_d;
         typedef typename Get_functor<Base, Power_side_of_power_sphere_tag>::type Power_side_of_power_sphere_d;
         typedef typename Get_functor<Base, Power_side_of_bounded_power_circumsphere_tag>::type Power_side_of_bounded_power_sphere_d;
-        typedef typename Get_functor<Base, Power_center_tag>::type Power_center_d;
+        typedef typename Get_functor<Base, Power_center_tag>::type Construct_power_center_d;
         typedef typename Get_functor<Base, Power_distance_tag>::type Compute_power_product_d;
         typedef typename Get_functor<Base, Contained_in_affine_hull_tag>::type Contained_in_affine_hull_d;
         typedef typename Get_functor<Base, Construct_flat_orientation_tag>::type Construct_flat_orientation_d;
@@ -222,7 +222,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         Side_of_oriented_sphere_d side_of_oriented_sphere_d_object()const{ return Side_of_oriented_sphere_d(*this); }
         Power_side_of_power_sphere_d power_side_of_power_sphere_d_object()const{ return Power_side_of_power_sphere_d(*this); }
         Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object()const{ return Power_side_of_bounded_power_sphere_d(*this); }
-        Power_center_d power_center_d_object()const{ return Power_center_d(*this); }
+        Construct_power_center_d construct_power_center_d_object()const{ return Construct_power_center_d(*this); }
         Compute_power_product_d compute_power_product_d_object()const{ return Compute_power_product_d(*this); }
         Side_of_bounded_sphere_d side_of_bounded_sphere_d_object()const{ return Side_of_bounded_sphere_d(*this); }
         Contained_in_affine_hull_d contained_in_affine_hull_d_object()const{ return Contained_in_affine_hull_d(*this); }

--- a/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Kernel_d_interface.h
@@ -60,7 +60,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         typedef typename Get_functor<Base, Power_side_of_power_sphere_tag>::type Power_side_of_power_sphere_d;
         typedef typename Get_functor<Base, Power_side_of_bounded_power_circumsphere_tag>::type Power_side_of_bounded_power_sphere_d;
         typedef typename Get_functor<Base, Power_center_tag>::type Power_center_d;
-        typedef typename Get_functor<Base, Power_distance_tag>::type Power_distance_d;
+        typedef typename Get_functor<Base, Power_distance_tag>::type Compute_power_product_d;
         typedef typename Get_functor<Base, Contained_in_affine_hull_tag>::type Contained_in_affine_hull_d;
         typedef typename Get_functor<Base, Construct_flat_orientation_tag>::type Construct_flat_orientation_d;
         typedef typename Get_functor<Base, In_flat_orientation_tag>::type In_flat_orientation_d;
@@ -223,7 +223,7 @@ template <class Base_> struct Kernel_d_interface : public Base_ {
         Power_side_of_power_sphere_d power_side_of_power_sphere_d_object()const{ return Power_side_of_power_sphere_d(*this); }
         Power_side_of_bounded_power_sphere_d power_side_of_bounded_power_sphere_d_object()const{ return Power_side_of_bounded_power_sphere_d(*this); }
         Power_center_d power_center_d_object()const{ return Power_center_d(*this); }
-        Power_distance_d power_distance_d_object()const{ return Power_distance_d(*this); }
+        Compute_power_product_d compute_power_product_d_object()const{ return Compute_power_product_d(*this); }
         Side_of_bounded_sphere_d side_of_bounded_sphere_d_object()const{ return Side_of_bounded_sphere_d(*this); }
         Contained_in_affine_hull_d contained_in_affine_hull_d_object()const{ return Contained_in_affine_hull_d(*this); }
         Contained_in_linear_hull_d contained_in_linear_hull_d_object()const{ return Contained_in_linear_hull_d(*this); }

--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -215,7 +215,7 @@ void test2(){
   //PDW pdw Kinit(point_drop_weight_d_object);
   PDW const& pdw = cp;
   PW pw Kinit(compute_weight_d_object);
-  PoD pod Kinit(power_distance_d_object);
+  PoD pod Kinit(compute_power_product_d_object);
   PSBPS psbps Kinit(power_side_of_bounded_power_sphere_d_object);
   CSRSOS csrsos Kinit(compute_squared_radius_smallest_orthogonal_sphere_d_object);
 

--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -718,14 +718,14 @@ void test4(){
   typedef typename Ker::Weighted_point_d WP;
   typedef typename Ker::Construct_circumcenter_d CCc;
   typedef typename Ker::Equal_d E;
-  typedef typename Ker::Power_center_d PC;
-  typedef typename Ker::Power_distance_d PoD;
+  typedef typename Ker::Construct_power_sphere_d PC;
+  typedef typename Ker::Compute_power_product_d PoD;
   typedef typename Ker::Affine_rank_d AR;
   Ker k(4);
   CCc ccc Kinit(construct_circumcenter_d_object);
   E ed Kinit(equal_d_object);
-  PC pc Kinit(power_center_d_object);
-  PoD pod Kinit(power_distance_d_object);
+  PC pc Kinit(construct_power_sphere_d_object);
+  PoD pod Kinit(compute_power_product_d_object);
   AR ar Kinit(affine_rank_d_object);
   auto mkpt=[](auto...x){double l[]{(double)x...};return P(std::begin(l), std::end(l));};
   P tab1[]={mkpt(15,20,40,80),mkpt(10,23,36,80),mkpt(10,20,40,85),mkpt(10,15,40,80),mkpt(13,20,40,76)};

--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -142,7 +142,7 @@ void test2(){
   typedef typename K1::Compute_squared_radius_d SR;
   typedef typename K1::Translated_point_d TP;
   typedef typename K1::Power_center_d PC;
-  typedef typename K1::Power_distance_d PoD;
+  typedef typename K1::Compute_power_product_d PoD;
   typedef typename K1::Construct_weighted_point_d CWP;
   typedef typename K1::Power_side_of_bounded_power_sphere_d PSBPS;
   typedef typename K1::Compute_squared_radius_smallest_orthogonal_sphere_d CSRSOS;

--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -141,7 +141,7 @@ void test2(){
   typedef typename K1::Construct_max_vertex_d CMV;
   typedef typename K1::Compute_squared_radius_d SR;
   typedef typename K1::Translated_point_d TP;
-  typedef typename K1::Power_center_d PC;
+  typedef typename K1::Construct_power_center_d PC;
   typedef typename K1::Compute_power_product_d PoD;
   typedef typename K1::Construct_weighted_point_d CWP;
   typedef typename K1::Power_side_of_bounded_power_sphere_d PSBPS;
@@ -210,7 +210,7 @@ void test2(){
   CMV cMv Kinit(construct_max_vertex_d_object);
   SR sr Kinit(compute_squared_radius_d_object);
   TP tp Kinit(translated_point_d_object);
-  PC pc Kinit(power_center_d_object);
+  PC pc Kinit(construct_power_center_d_object);
   CWP cwp Kinit(construct_weighted_point_d_object);
   //PDW pdw Kinit(point_drop_weight_d_object);
   PDW const& pdw = cp;

--- a/NewKernel_d/test/NewKernel_d/Epick_d.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d.cpp
@@ -141,7 +141,7 @@ void test2(){
   typedef typename K1::Construct_max_vertex_d CMV;
   typedef typename K1::Compute_squared_radius_d SR;
   typedef typename K1::Translated_point_d TP;
-  typedef typename K1::Construct_power_center_d PC;
+  typedef typename K1::Construct_power_sphere_d PC;
   typedef typename K1::Compute_power_product_d PoD;
   typedef typename K1::Construct_weighted_point_d CWP;
   typedef typename K1::Power_side_of_bounded_power_sphere_d PSBPS;
@@ -210,7 +210,7 @@ void test2(){
   CMV cMv Kinit(construct_max_vertex_d_object);
   SR sr Kinit(compute_squared_radius_d_object);
   TP tp Kinit(translated_point_d_object);
-  PC pc Kinit(construct_power_center_d_object);
+  PC pc Kinit(construct_power_sphere_d_object);
   CWP cwp Kinit(construct_weighted_point_d_object);
   //PDW pdw Kinit(point_drop_weight_d_object);
   PDW const& pdw = cp;


### PR DESCRIPTION
## Summary of Changes

Document 2 existing functors of `Ep[ie]ck_d`. To try and make reviewers happy, I renamed `Power_distance_d` to `Compute_power_product_d` so it matches the names in `Kernel_23`. `Power_center_d` does not seem to have an equivalent in 2D/3D, where you can get the point, but you have to compute the radius/weight separately afterwards (computing both together can save a few operations).

## Release Management

* Affected package(s): `NewKernel_d`
* Feature/Small Feature (if any): https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/More_Weighted_point_d_functors
* Link to compiled documentation (obligatory for small feature) [here](https://geometrica.saclay.inria.fr/team/Marc.Glisse/tmp/cgal-power/Kernel_d/structCGAL_1_1Epick__d.html)