### PR TITLE
Mesh_3: fix use of TBB in examples/Mesh_3/CMakeLists.txt (conflicts with master)

### DIFF
--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -119,7 +119,7 @@ if ( CGAL_FOUND )
 #    create_single_source_cgal_program( "mesh_polyhedral_surface_tolerance_region.cpp" )
 #    create_single_source_cgal_program( "mesh_polyhedral_edge_tolerance_region.cpp" )
 
-    if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TBB_FOUND AND TARGET ${target})
+    if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TBB_FOUND)
       foreach(target
         mesh_3D_image
         mesh_3D_image_variable_size
@@ -137,7 +137,9 @@ if ( CGAL_FOUND )
         mesh_polyhedral_domain_with_features_sm
         mesh_polyhedral_domain_with_lipschitz_sizing
         mesh_two_implicit_spheres_with_balls)
-        CGAL_target_use_TBB(${target})
+        if(TARGET ${target})
+          CGAL_target_use_TBB(${target})
+        endif()
       endforeach()
     endif()
 

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -134,6 +134,7 @@ if ( CGAL_FOUND )
         mesh_polyhedral_domain
         mesh_polyhedral_domain_sm
         mesh_polyhedral_domain_with_features
+        mesh_polyhedral_domain_with_features_sm
         mesh_polyhedral_domain_with_lipschitz_sizing
         mesh_two_implicit_spheres_with_balls)
         CGAL_target_use_TBB(${target})

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -121,21 +121,21 @@ if ( CGAL_FOUND )
 
     if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TBB_FOUND AND TARGET ${target})
       foreach(target
-        mesh_3D_image_with_features
         mesh_3D_image
-        mesh_polyhedral_domain
+        mesh_3D_image_variable_size
         mesh_3D_image_with_custom_initialization
-        mesh_two_implicit_spheres_with_balls
-        mesh_optimization_lloyd_example
-        mesh_optimization_example
+        mesh_3D_image_with_features
         mesh_implicit_sphere
-        mesh_polyhedral_complex_sm
         mesh_implicit_sphere_variable_size
-        mesh_polyhedral_domain_sm
-        mesh_polyhedral_domain_with_lipschitz_sizing
+        mesh_optimization_example
+        mesh_optimization_lloyd_example
         mesh_polyhedral_complex
+        mesh_polyhedral_complex_sm
+        mesh_polyhedral_domain
+        mesh_polyhedral_domain_sm
         mesh_polyhedral_domain_with_features
-        mesh_3D_image_variable_size)
+        mesh_polyhedral_domain_with_lipschitz_sizing
+        mesh_two_implicit_spheres_with_balls)
         CGAL_target_use_TBB(${target})
       endforeach()
     endif()
@@ -143,4 +143,3 @@ if ( CGAL_FOUND )
 else()
   message(STATUS "This program requires the CGAL library, and will not be compiled.")
 endif()
-


### PR DESCRIPTION
## Summary of Changes

Fix use of TBB in `examples/Mesh_3/CMakeLists.txt`. I have introduced that bug in 4.14.1 with #4157.

This PR conflicts with `master` because of #4636. PR #4842 the equivalent PR for `master`.

## Release Management

* Affected package(s): Mesh_3

