### PR TITLE
3D Demo: Display Surface_mesh properties

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
@@ -3,7 +3,8 @@ include( polyhedron_demo_macros )
   polyhedron_demo_plugin(camera_positions_plugin
     Camera_positions_plugin
     Camera_positions_list
-    ${cameraUI_FILES})
+    ${cameraUI_FILES}
+    KEYWORDS Viewer)
 
   target_link_libraries( camera_positions_plugin PUBLIC demo_framework)
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/CMakeLists.txt
@@ -1,6 +1,6 @@
 include( polyhedron_demo_macros )
 if(TARGET CGAL::Eigen_support)
   qt5_wrap_ui( display_propertyUI_FILES Display_property.ui )
-  polyhedron_demo_plugin(display_property_plugin Display_property_plugin ${display_propertyUI_FILES})
+  polyhedron_demo_plugin(display_property_plugin Display_property_plugin ${display_propertyUI_FILES} KEYWORDS Viewer)
   target_link_libraries(display_property_plugin PUBLIC scene_surface_mesh_item scene_points_with_normal_item scene_color_ramp CGAL::Eigen_support)
 endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -207,6 +207,9 @@
       </item>
       <item>
        <widget class="QComboBox" name="propertyBox">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
         <item>
          <property name="text">
           <string>Smallest Angle Per Face</string>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>492</height>
+    <height>508</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,20 +16,117 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
+     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
       <item>
-       <widget class="QLabel" name="legendLabel">
-        <property name="text">
-         <string>RAMP DISPLAYING</string>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
         </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>127</width>
+           <height>430</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QLabel" name="legendLabel">
+            <property name="text">
+             <string>RAMP DISPLAYING</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout">
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="1">
          <widget class="QPushButton" name="colorizeButton">
           <property name="text">
            <string>Colorize</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QTabWidget" name="colorChoiceWidget">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <widget class="QWidget" name="ramp_tab">
+           <attribute name="title">
+            <string>Ramp</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <widget class="QGroupBox" name="groupBox_2">
+              <property name="title">
+               <string>Ramp Colors</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <item>
+                <widget class="QPushButton" name="minColorButton">
+                 <property name="text">
+                  <string>Color Min...</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="maxColorButton">
+                 <property name="text">
+                  <string>Color Max...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="map_tab">
+           <attribute name="title">
+            <string>Map</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <item>
+             <widget class="QPushButton" name="initColorButton">
+              <property name="text">
+               <string>Initial Color...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QPushButton" name="sourcePointsButton">
+          <property name="text">
+           <string>Select Source Points</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -54,53 +151,6 @@
             </widget>
            </item>
           </layout>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-           <string>Ramp Colors</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <item>
-            <widget class="QPushButton" name="minColorButton">
-             <property name="text">
-              <string>Color Min...</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="maxColorButton">
-             <property name="text">
-              <string>Color Max...</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QPushButton" name="sourcePointsButton">
-          <property name="text">
-           <string>Select Source Points</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string/>
-          </property>
          </widget>
         </item>
         <item row="1" column="1">
@@ -170,11 +220,6 @@
         <item>
          <property name="text">
           <string>Heat Intensity</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Thread_id</string>
          </property>
         </item>
         <item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property.ui
@@ -174,6 +174,11 @@
         </item>
         <item>
          <property name="text">
+          <string>Thread_id</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
           <string>Heat Intensity (Intrinsic Delaunay)</string>
          </property>
         </item>

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -1782,7 +1782,7 @@ private:
     maxBox = *(end-1);
     dock_widget->minBox->setValue(minBox);
     dock_widget->maxBox->setValue(maxBox);
-    //fill v:color pmap
+    //fill f:color pmap
     SMesh::Property_map<face_descriptor, CGAL::Color> fcolors =
         smesh.add_property_map<face_descriptor, CGAL::Color >("f:color", CGAL::Color()).first;
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -1245,7 +1245,7 @@ private:
     const std::size_t size = (std::min)(color_map.size(), (std::size_t)256);
     const int text_height = 20;
     const int height = text_height*size + text_height;
-    const int width = 90;
+    const int width = 140;
     const int cell_width = width/3;
     const int top_margin = 15;
     const int left_margin = 5;
@@ -1291,7 +1291,7 @@ private:
   {
     // Create a legend_ and display it
     const int height = 256;
-    const int width = 90;
+    const int width = 140;
     const int cell_width = width/3;
     const int top_margin = 5;
     const int left_margin = 5;
@@ -1334,15 +1334,16 @@ private:
     // draw min value and max value
     painter.setPen(Qt::blue);
     QRect min_text_rect(left_margin + cell_width+10,drawing_height - top_margin,
-                        50, text_height);
+                        100, text_height);
     painter.drawText(min_text_rect, Qt::AlignCenter, tr("%1").arg(min_value, 0, 'f', 1));
 
     QRect max_text_rect(left_margin + cell_width+10, drawing_height - top_margin - 200,
-                        50, text_height);
+                        100, text_height);
     painter.drawText(max_text_rect, Qt::AlignCenter, tr("%1").arg(max_value, 0, 'f', 1));
 
     dock_widget->legendLabel->setPixmap(legend_);
   }
+
   double scaled_jacobian(const face_descriptor& f , const SMesh &mesh);
   QList<QAction*> _actions;
   Color_ramp color_ramp;

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -1573,6 +1573,112 @@ private:
     return false;
   }
 
+  bool DisplayPropertyPlugin::treat_point_property(std::string name, Point_set* sm)
+  {
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::int8_t>   Int8_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::uint8_t>  Uint8_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::int16_t>  Int16_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::uint16_t> Uint16_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::int32_t>  Int32_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::uint32_t> Uint32_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::int64_t>  Int64_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, boost::uint64_t> Uint64_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, float>           Float_map;
+    typedef typename SMesh::template Property_map<vertex_descriptor, double>          Double_map;
+
+    bool okay = false;
+    {
+      Int8_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::int8_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Uint8_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::uint8_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Int16_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::int16_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Uint16_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::uint16_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Int32_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::int32_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Uint32_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::uint32_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Int64_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::int64_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Uint64_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,boost::uint64_t>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Float_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,float>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+
+    {
+      Double_map pmap;
+      std::tie(pmap, okay) = sm->property_map<vertex_descriptor,double>(name);
+      if(okay)
+      {
+        return displayVertexProperty(*sm, pmap);
+      }
+    }
+    return false;
+  }
+
   bool DisplayPropertyPlugin::treat_vertex_property(std::string name, SMesh* sm)
   {
     typedef typename SMesh::template Property_map<vertex_descriptor, boost::int8_t>   Int8_map;

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -1244,7 +1244,7 @@ private:
     // Create a legend_ and display it
     const std::size_t size = (std::min)(color_map.size(), (std::size_t)256);
     const int text_height = 20;
-    const int height = text_height*size + text_height;
+    const int height = text_height*static_cast<int>(size) + text_height;
     const int width = 140;
     const int cell_width = width/3;
     const int top_margin = 15;
@@ -1585,6 +1585,7 @@ private:
         return displayVertexProperty(*sm, pmap);
       }
     }
+    return false;
   }
 
   bool DisplayPropertyPlugin::treat_face_property(std::string name, SMesh* sm)
@@ -1690,6 +1691,7 @@ private:
         return displayFaceProperty(*sm, pmap);
       }
     }
+    return false;
   }
 
   template<typename PM>
@@ -1837,5 +1839,6 @@ private:
     }
     return true;
   }
+
 #include "Display_property_plugin.moc"
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -1,35 +1,35 @@
 include( polyhedron_demo_macros )
 
-polyhedron_demo_plugin(gocad_plugin GOCAD_io_plugin KEYWORDS IO)
+polyhedron_demo_plugin(gocad_plugin GOCAD_io_plugin KEYWORDS Viewer)
 target_link_libraries(gocad_plugin PUBLIC scene_surface_mesh_item)
 
 qt5_wrap_ui( funcUI_FILES Function_dialog.ui )
-polyhedron_demo_plugin(io_implicit_function_plugin Implicit_function_io_plugin ${funcUI_FILES} KEYWORDS IO Mesh_3)
+polyhedron_demo_plugin(io_implicit_function_plugin Implicit_function_io_plugin ${funcUI_FILES} KEYWORDS Viewer Mesh_3)
 target_link_libraries(io_implicit_function_plugin PUBLIC scene_implicit_function_item)
 
-polyhedron_demo_plugin(nef_io_plugin Nef_io_plugin KEYWORDS IO)
+polyhedron_demo_plugin(nef_io_plugin Nef_io_plugin KEYWORDS Viewer)
 target_link_libraries(nef_io_plugin PUBLIC scene_nef_polyhedron_item)
 
-polyhedron_demo_plugin(off_plugin OFF_io_plugin KEYWORDS IO Mesh_3 PointSetProcessing Classification PMP)
+polyhedron_demo_plugin(off_plugin OFF_io_plugin KEYWORDS Viewer Mesh_3 PointSetProcessing Classification PMP)
 target_link_libraries(off_plugin PUBLIC scene_polygon_soup_item scene_points_with_normal_item scene_surface_mesh_item)
 
-polyhedron_demo_plugin(off_to_nef_plugin OFF_to_nef_io_plugin KEYWORDS IO)
+polyhedron_demo_plugin(off_to_nef_plugin OFF_to_nef_io_plugin KEYWORDS Viewer)
 target_link_libraries(off_to_nef_plugin PUBLIC scene_nef_polyhedron_item)
 
-polyhedron_demo_plugin(polylines_io_plugin Polylines_io_plugin KEYWORDS IO Mesh_3)
+polyhedron_demo_plugin(polylines_io_plugin Polylines_io_plugin KEYWORDS Viewer Mesh_3)
 target_link_libraries(polylines_io_plugin PUBLIC scene_polylines_item)
 
-polyhedron_demo_plugin(wkt_plugin WKT_io_plugin KEYWORDS IO PointSetProcessing Mesh_3)
+polyhedron_demo_plugin(wkt_plugin WKT_io_plugin KEYWORDS Viewer PointSetProcessing Mesh_3)
 target_link_libraries(wkt_plugin PUBLIC scene_polylines_item)
 
-polyhedron_demo_plugin(stl_plugin STL_io_plugin KEYWORDS IO PMP)
+polyhedron_demo_plugin(stl_plugin STL_io_plugin KEYWORDS Viewer PMP)
 target_link_libraries(stl_plugin PUBLIC scene_surface_mesh_item scene_polygon_soup_item)
 
 
-polyhedron_demo_plugin(surf_io_plugin Surf_io_plugin KEYWORDS IO PMP)
+polyhedron_demo_plugin(surf_io_plugin Surf_io_plugin KEYWORDS Viewer PMP)
 target_link_libraries(surf_io_plugin PUBLIC scene_surface_mesh_item)
 
-polyhedron_demo_plugin(lcc_io_plugin lcc_io_plugin KEYWORDS IO)
+polyhedron_demo_plugin(lcc_io_plugin lcc_io_plugin KEYWORDS Viewer)
 target_link_libraries(lcc_io_plugin PUBLIC scene_lcc_item)
 
 
@@ -44,7 +44,7 @@ if (VTK_FOUND)
       set(VTK_LIBRARIES VTK::CommonCore VTK::IOCore VTK::IOLegacy VTK::IOXML VTK::FiltersCore VTK::FiltersSources)
     endif()
     if(VTK_LIBRARIES)
-      polyhedron_demo_plugin(vtk_plugin VTK_io_plugin KEYWORDS IO Mesh_3)
+      polyhedron_demo_plugin(vtk_plugin VTK_io_plugin KEYWORDS Viewer Mesh_3)
       target_link_libraries(vtk_plugin PUBLIC scene_surface_mesh_item scene_polylines_item scene_c3t3_item scene_points_with_normal_item
                                        ${VTK_LIBRARIES})
 
@@ -57,7 +57,7 @@ if (VTK_FOUND)
 else()
   message(STATUS "NOTICE : the vtk IO plugin needs VTK 6.0 or greater and will not be compiled.")
 endif()
-polyhedron_demo_plugin(xyz_plugin XYZ_io_plugin KEYWORDS IO PointSetProcessing Classification)
+polyhedron_demo_plugin(xyz_plugin XYZ_io_plugin KEYWORDS Viewer PointSetProcessing Classification)
 target_link_libraries(xyz_plugin PUBLIC scene_points_with_normal_item)
 
 list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_rvalue_references has_cxx_rvalues)
@@ -68,12 +68,12 @@ if(has_cxx_rvalues LESS 0 OR has_cxx_variadic LESS 0)
 else()
   set(needed_cxx_features cxx_rvalue_references cxx_variadic_templates)
 
-  polyhedron_demo_plugin(ply_plugin PLY_io_plugin KEYWORDS IO PointSetProcessing Classification PMP)
+  polyhedron_demo_plugin(ply_plugin PLY_io_plugin KEYWORDS Viewer PointSetProcessing Classification PMP)
   target_link_libraries(ply_plugin PUBLIC scene_points_with_normal_item scene_polygon_soup_item scene_surface_mesh_item scene_textured_item)
   target_compile_features(ply_plugin PRIVATE ${needed_cxx_features})
 
   if (TARGET CGAL::LASLIB_support)
-    polyhedron_demo_plugin(las_plugin LAS_io_plugin KEYWORDS IO PointSetProcessing Classification)
+    polyhedron_demo_plugin(las_plugin LAS_io_plugin KEYWORDS Viewer PointSetProcessing Classification)
     target_link_libraries(las_plugin PUBLIC scene_points_with_normal_item CGAL::LASLIB_support)
     target_compile_features(las_plugin PRIVATE ${needed_cxx_features})
   else()
@@ -90,7 +90,7 @@ find_library(3MF_LIBRARIES NAMES 3MF DOC "Path to the lib3MF library")
 
 if(3MF_LIBRARIES AND 3MF_INCLUDE_DIR AND EXISTS "${3MF_INCLUDE_DIR}/Model/COM/NMR_DLLInterfaces.h")
   include_directories(${3MF_INCLUDE_DIR})
-  polyhedron_demo_plugin(3mf_io_plugin 3mf_io_plugin KEYWORDS IO PMP)
+  polyhedron_demo_plugin(3mf_io_plugin 3mf_io_plugin KEYWORDS Viewer PMP)
   target_link_libraries(3mf_io_plugin PRIVATE scene_surface_mesh_item scene_points_with_normal_item scene_polylines_item ${3MF_LIBRARIES})
 else()
   message(STATUS "NOTICE : The 3mf_io_plugin requires the lib3MF library in a version < 2.0, and will not be compiled.")

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
@@ -156,8 +156,16 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
     if(item->has_normals())
       item->setRenderingMode(CGAL::Three::Three::defaultPointSetRenderingMode());
     item->setName(fileinfo.completeBaseName());
+    Point_set::Property_map<int> test_prop = item->point_set()->add_property_map<int> ("test", 0).first;
+    int test=0;
+    for(Point_set::iterator it = item->point_set()->begin();
+        it != item->point_set()->end();++it)
+    {
+      test_prop[*it]=test++;
+    }
     QApplication::restoreOverrideCursor();
     ok = true;
+
     if(add_to_scene)
       CGAL::Three::Three::scene()->addItem(item);
     return QList<Scene_item*>()<<item;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
@@ -156,13 +156,7 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
     if(item->has_normals())
       item->setRenderingMode(CGAL::Three::Three::defaultPointSetRenderingMode());
     item->setName(fileinfo.completeBaseName());
-    Point_set::Property_map<int> test_prop = item->point_set()->add_property_map<int> ("test", 0).first;
-    int test=0;
-    for(Point_set::iterator it = item->point_set()->begin();
-        it != item->point_set()->end();++it)
-    {
-      test_prop[*it]=test++;
-    }
+
     QApplication::restoreOverrideCursor();
     ok = true;
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/PLY_io_plugin.cpp
@@ -4,6 +4,7 @@
 #include "Scene_points_with_normal_item.h"
 
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
+#include <CGAL/Surface_mesh/IO/PLY.h>
 #include <CGAL/Three/Three.h>
 #include <QInputDialog>
 #include <QApplication>
@@ -93,12 +94,16 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
   if (input_is_mesh) // Open mesh or polygon soup
   {
     // First try mesh
-    SMesh *surface_mesh = new SMesh();
     std::string comments;
-
-    if (CGAL::read_ply (in, *surface_mesh, comments))
+    Scene_surface_mesh_item* sm_item = new Scene_surface_mesh_item();
+    if (CGAL::read_ply(in, *sm_item->face_graph(), comments))
     {
-      Scene_surface_mesh_item* sm_item = new Scene_surface_mesh_item(surface_mesh);
+      if(sm_item->face_graph()->property_map<face_descriptor, int >("f:patch_id").second)
+      {
+        sm_item->setItemIsMulticolor(true);
+        sm_item->computeItemColorVectorAutomatically(true);
+      }
+      sm_item->invalidateOpenGLBuffers();
       sm_item->setName(fileinfo.completeBaseName());
       sm_item->comments() = comments;
       QApplication::restoreOverrideCursor();
@@ -106,6 +111,10 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
       if(add_to_scene)
         CGAL::Three::Three::scene()->addItem(sm_item);
       return QList<Scene_item*>()<<sm_item;
+    }
+    else
+    {
+      delete sm_item;
     }
 
     in.clear();

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 find_package(Boost QUIET OPTIONAL_COMPONENTS filesystem system)
 if(Boost_FILESYSTEM_FOUND)
   qt5_wrap_ui( imgUI_FILES Image_res_dialog.ui raw_image.ui)
-  polyhedron_demo_plugin(io_image_plugin Io_image_plugin Volume_plane_intersection.cpp Raw_image_dialog.cpp ${imgUI_FILES} ${VOLUME_MOC_OUTFILES} KEYWORDS IO Mesh_3)
+  polyhedron_demo_plugin(io_image_plugin Io_image_plugin Volume_plane_intersection.cpp Raw_image_dialog.cpp ${imgUI_FILES} ${VOLUME_MOC_OUTFILES} KEYWORDS Viewer Mesh_3)
   target_link_libraries(io_image_plugin PUBLIC scene_image_item ${VTK_LIBRARIES} CGAL::CGAL_ImageIO)
   if(VTK_LIBRARIES)
     target_compile_definitions(io_image_plugin PRIVATE CGAL_USE_VTK)
@@ -63,7 +63,7 @@ target_link_libraries(mesh_3_optimization_plugin PUBLIC scene_c3t3_item scene_su
    message(STATUS "The Mesh_3_optimization_plugin requires Eigen, which was not found, and will use a deprecated class to replace it. Warnings are to be expected.")
  endif()#eigen
 
-polyhedron_demo_plugin(c3t3_io_plugin C3t3_io_plugin KEYWORDS IO Mesh_3)
+polyhedron_demo_plugin(c3t3_io_plugin C3t3_io_plugin KEYWORDS Viewer Mesh_3)
 target_link_libraries(c3t3_io_plugin PUBLIC scene_c3t3_item)
 
 qt5_wrap_ui( ribUI_FILES  Rib_dialog.ui)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -77,7 +77,7 @@ polyhedron_demo_plugin(polyhedron_stitching_plugin Polyhedron_stitching_plugin K
 target_link_libraries(polyhedron_stitching_plugin PUBLIC scene_surface_mesh_item scene_polylines_item)
 
 qt5_wrap_ui( selectionUI_FILES Selection_widget.ui)
-polyhedron_demo_plugin(selection_plugin Selection_plugin ${selectionUI_FILES} KEYWORDS PMP IO Classification Mesh_3)
+polyhedron_demo_plugin(selection_plugin Selection_plugin ${selectionUI_FILES} KEYWORDS PMP Viewer Classification Mesh_3)
 target_link_libraries(selection_plugin PUBLIC scene_selection_item scene_points_with_normal_item scene_polylines_item)
 
 #to keep it simple to compile
@@ -111,7 +111,7 @@ if(TARGET CGAL::TBB_support)
   target_link_libraries(distance_plugin PUBLIC CGAL::TBB_support)
 endif()
 
-polyhedron_demo_plugin(detect_sharp_edges_plugin Detect_sharp_edges_plugin KEYWORDS IO Mesh_3 PMP)
+polyhedron_demo_plugin(detect_sharp_edges_plugin Detect_sharp_edges_plugin KEYWORDS Viewer Mesh_3 PMP)
 target_link_libraries(detect_sharp_edges_plugin PUBLIC scene_surface_mesh_item)
 
 qt5_wrap_ui( randomPerturbationUI_FILES Random_perturbation_dialog.ui)

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -67,7 +67,6 @@ public:
   {
     undo_();
     item->compute_normal_maps();
-    item->polyhedron_item()->invalidateOpenGLBuffers();
     item->invalidateOpenGLBuffers();
     item->redraw();
   }


### PR DESCRIPTION
## Summary of Changes

This PR modifies the Display_property_plugin to make it automatically detect any property map of the target Surface-mesh_item that has an arithmetic type as value_type, and display it with a color map or ramp.

Properties of the faces are visible in Flat mode, and properties of the vertices on Gouraud mode.

It works better with PLY IO, as it allows to save/load properties witha surface_mesh.
![display_screen_1](https://user-images.githubusercontent.com/11310805/88057110-e146c800-cb61-11ea-9494-1732ba1297d4.png)
![display_screen_2](https://user-images.githubusercontent.com/11310805/88057253-1b17ce80-cb62-11ea-8c6c-b5e4cd310646.png)
![display_screen_3](https://user-images.githubusercontent.com/11310805/88057420-587c5c00-cb62-11ea-92f0-225005da7c52.png)
![display_screen_4](https://user-images.githubusercontent.com/11310805/88057561-89f52780-cb62-11ea-92b1-1724f2f9740c.png)



