### PR TITLE
Tet remeshing - fix peeling of slivers

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -137,6 +137,41 @@ typename Tr::Geom_traits::FT min_dihedral_angle(const Tr& tr,
                             c->vertex(3));
 }
 
+template<typename C3t3>
+bool is_peelable(const C3t3& c3t3,
+                 const typename C3t3::Cell_handle ch,
+                 std::array<bool, 4>& facets_on_surface)
+{
+  typedef typename C3t3::Triangulation::Geom_traits::FT FT;
+  typedef typename C3t3::Facet                          Facet;
+
+  if(!c3t3.is_in_complex(ch))
+    return false;
+
+  bool on_surface = false;
+  for (int i = 0; i < 4; ++i)
+  {
+    facets_on_surface[i] = !c3t3.is_in_complex(ch->neighbor(i));
+    on_surface = on_surface || facets_on_surface[i];
+  }
+  if(!on_surface)
+    return false;
+
+  FT area_on_surface = 0.;
+  FT area_inside = 0.;
+  for (int i = 0; i < 4; ++i)
+  {
+    Facet f(ch, i);
+    const FT facet_area = CGAL::approximate_sqrt(c3t3.triangulation().triangle(f).squared_area());
+    if(facets_on_surface[i])
+      area_on_surface += facet_area;
+    else
+      area_inside += facet_area;
+  }
+
+  return (area_inside < 1.5 * area_on_surface);
+}
+
 template<typename Tr>
 typename Tr::Geom_traits::Vector_3 facet_normal(const Tr& tr,
                                                 const typename Tr::Facet& f)
@@ -1334,17 +1369,19 @@ void dump_cells_with_small_dihedral_angle(const Tr& tr,
        cit != tr.finite_cells_end(); ++cit)
   {
     Cell_handle c = cit;
-    if ( c->subdomain_index() != Subdomain_index()
-         && cell_select(c)
-         && min_dihedral_angle(tr, c) < angle_bound)
+    if (c->subdomain_index() != Subdomain_index() && cell_select(c))
     {
-
-      cells.push_back(c);
-      indices.push_back(c->subdomain_index());
+      double dh = min_dihedral_angle(tr, c);
+      if (dh < angle_bound)
+      {
+        cells.push_back(c);
+        indices.push_back(c->subdomain_index());
+      }
     }
   }
   std::cout << "bad cells : " << cells.size() << std::endl;
   dump_cells<Tr>(cells, indices, filename);
+  dump_cells_off(cells, tr, "bad_cells.off");
 }
 
 template<typename Tr>

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -232,12 +232,10 @@ void tetrahedral_isotropic_remeshing(
   std::size_t nb_extra_iterations = 3;
   remesher.remesh(max_it, nb_extra_iterations);
 
-#ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   const double angle_bound = 5.0;
   Tetrahedral_remeshing::debug::dump_cells_with_small_dihedral_angle(tr,
     angle_bound, cell_select, "bad_cells.mesh");
-#endif
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   Tetrahedral_remeshing::internal::compute_statistics(tr,
     cell_select, "statistics_end.txt");
 #endif
@@ -428,7 +426,7 @@ void tetrahedral_isotropic_remeshing(
   std::size_t nb_extra_iterations = 3;
   remesher.remesh(max_it, nb_extra_iterations);
 
-#ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   const double angle_bound = 5.0;
   Tetrahedral_remeshing::debug::dump_cells_with_small_dihedral_angle(
     c3t3.triangulation(),


### PR DESCRIPTION
## Summary of Changes

Some flat tetrahedra incident to the boundary, with small dihedral angles can be "peeled" off the internal C3t3. This should include slivers, caps, blades...

This PR introduces a new criterion on areas of internal facets vs surface facets, to select these cells.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

