### PR TITLE
flush the buffer

### DIFF
--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_model_complexty_control.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_model_complexty_control.cpp
@@ -95,8 +95,11 @@ int main()
         else {
        const std::string& output_file = "data/building_result-0.05.off";
        std::ofstream output_stream(output_file.c_str());
-       if (output_stream && CGAL::write_off(output_stream, model))
+       if (output_stream && CGAL::write_off(output_stream, model)) {
+                        // flush the buffer
+                        output_stream << std::flush;
                         std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+       }
                 else {
            std::cerr << " Failed saving file." << std::endl;
            return EXIT_FAILURE;
@@ -113,8 +116,11 @@ int main()
         else {
        const std::string& output_file = "data/building_result-0.5.off";
        std::ofstream output_stream(output_file.c_str());
-       if (output_stream && CGAL::write_off(output_stream, model))
+       if (output_stream && CGAL::write_off(output_stream, model)) {
+                        // flush the buffer
+                        output_stream << std::flush;
                         std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+       }
                 else {
            std::cerr << " Failed saving file." << std::endl;
            return EXIT_FAILURE;
@@ -131,8 +137,11 @@ int main()
         else {
                 const std::string& output_file = "data/building_result-0.7.off";
                 std::ofstream output_stream(output_file.c_str());
-                if (output_stream && CGAL::write_off(output_stream, model))
+                if (output_stream && CGAL::write_off(output_stream, model)) {
+                        // flush the buffer
+                        output_stream << std::flush;
                         std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+                }
                 else {
                         std::cerr << " Failed saving file." << std::endl;
                         return EXIT_FAILURE;

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
@@ -94,8 +94,11 @@ int main()
         // Saves the mesh model
     const std::string& output_file("data/ball_result.off");
     std::ofstream output_stream(output_file.c_str());
-    if (output_stream && CGAL::write_off(output_stream, model))
+    if (output_stream && CGAL::write_off(output_stream, model)) {
+                // flush the buffer
+                output_stream << std::flush;
                 std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+    }
         else {
         std::cerr << " Failed saving file." << std::endl;
         return EXIT_FAILURE;

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_with_region_growing.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_with_region_growing.cpp
@@ -178,8 +178,11 @@ int main()
   t.reset();
   const std::string& output_file("data/cube_result.off");
   std::ofstream output_stream(output_file.c_str());
-  if (output_stream && CGAL::write_off(output_stream, model))
+  if (output_stream && CGAL::write_off(output_stream, model)) {
+    // flush the buffer
+    output_stream << std::flush;
     std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+  }
   else {
     std::cerr << " Failed saving file." << std::endl;
     return EXIT_FAILURE;

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_without_input_planes.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_without_input_planes.cpp
@@ -129,8 +129,11 @@ int main()
 
         const std::string& output_file("data/cube_result.off");
         std::ofstream output_stream(output_file.c_str());
-        if (output_stream && CGAL::write_off(output_stream, model))
+        if (output_stream && CGAL::write_off(output_stream, model)) {
+                // flush the buffer
+                output_stream << std::flush;
                 std::cout << " Done. Saved to " << output_file << ". Time: " << t.time() << " sec." << std::endl;
+        }
         else {
                 std::cerr << " Failed saving file." << std::endl;
                 return EXIT_FAILURE;
@@ -143,8 +146,11 @@ int main()
         algo.output_candidate_faces(candidate_faces);
         const std::string& candidate_faces_file("data/cube_candidate_faces.off");
         std::ofstream candidate_stream(candidate_faces_file.c_str());
-        if (candidate_stream && CGAL::write_off(candidate_stream, candidate_faces))
+        if (candidate_stream && CGAL::write_off(candidate_stream, candidate_faces)) {
+                // flush the buffer
+                output_stream << std::flush;
                 std::cout << "Candidate faces saved to " << candidate_faces_file << "." << std::endl;
+        }
 
         return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary of Changes

After using the code `CGAL::write_off()`, we should flush the buffer immediately so that the result data can be written into a certain file.  If not, we may get an empty file when reading this file next line.

## Release Management
* Affected package(s):  Polygonal_surface_reconstruction