### PR TITLE
Mesh_3: fix a warning

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1246,7 +1246,7 @@ private:
         }
       }
 
-      return surface;
+      return surface ? surface : Surface_patch();
     }
 
 

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1224,8 +1224,8 @@ private:
       if(update_c3t3)
       {
         // Update status in c3t3
-        if(surface != boost::none)
-          c3t3_.add_to_complex(facet, surface.get());
+        if((bool)surface)
+          c3t3_.add_to_complex(facet, *surface);
         else
           c3t3_.remove_from_complex(facet);
       }
@@ -2054,7 +2054,7 @@ private:
                                        true); /* update surface centers */
       // false means "do not update the c3t3"
       if ( c3t3_.is_in_complex(*fit) != (bool)sp ||
-           ((bool)sp && !(c3t3_.surface_patch_index(*fit) == sp.get()) ) )
+           ((bool)sp && !(c3t3_.surface_patch_index(*fit) == *sp) ) )
         return false;
     }
 


### PR DESCRIPTION
## Summary of Changes

```
.../CGAL/Mesh_3/C3T3_helpers.h:1249:14: warning: ‘*((void*)& surface +4)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1249 |       return surface;
      |              ^~~~~~~
```
The patch of https://github.com/CGAL/cgal/commit/25eeff801bd102fcbc5050d3556bad4b661e2582 is a trick that avoids to copy an optional that the compiler flagged as "may be empty". 

## Release Management

* Affected package(s): Mesh_3


