### PR TITLE
Tetrahedral remeshing - fix compare_subdomains()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 sudo: required
 git:
   depth: 3
@@ -58,7 +58,7 @@ install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash .travis/install.sh
-  - export CXX=clang++ CC=clang;
+  - export CXX=clang++-10 CC=clang-10;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
   - sudo mv doxygen_exe /usr/bin/doxygen

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,7 +7,7 @@ sudo apt-get update
 
 while [ $DONE = 0 ]
 do
-  DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang zsh \
+  DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-10 zsh \
 flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  \
 qtbase5-dev libqt5sql5-sqlite libqt5opengl5-dev qtscript5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qml-module-qtgraphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
 libboost1.73-dev || DONE=0 && sudo apt-get update

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,13 +2,15 @@
 
 [ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 DONE=0
+sudo add-apt-repository ppa:mhier/libboost-latest
 sudo apt-get update
+
 while [ $DONE = 0 ]
 do
   DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang zsh \
-flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  libboost-dev \
-libboost-system-dev libboost-program-options-dev libboost-thread-dev libboost-iostreams-dev \
+flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  \
 qtbase5-dev libqt5sql5-sqlite libqt5opengl5-dev qtscript5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qml-module-qtgraphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
+libboost
 || DONE=0 && sudo apt-get update
 done
 exit 0

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,7 +2,7 @@
 
 [ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 DONE=0
-sudo add-apt-repository ppa:mhier/libboost-latest
+sudo add-apt-repository ppa:mhier/libboost-latest -y
 sudo apt-get update
 
 while [ $DONE = 0 ]
@@ -10,8 +10,7 @@ do
   DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang zsh \
 flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  \
 qtbase5-dev libqt5sql5-sqlite libqt5opengl5-dev qtscript5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qml-module-qtgraphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
-libboost
-|| DONE=0 && sudo apt-get update
+libboost1.73-dev || DONE=0 && sudo apt-get update
 done
 exit 0
 

--- a/.travis/template.txt
+++ b/.travis/template.txt
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 sudo: required
 git:
   depth: 3
@@ -12,7 +12,7 @@ install:
   - echo "$PWD"
   - if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$PACKAGE" != CHECK ]; then  DO_IGNORE=FALSE;  for ARG in $(echo "$PACKAGE");do if [ "$ARG" = "Maintenance" ]; then continue; fi; . $PWD/.travis/test_package.sh "$PWD" "$ARG";  echo "DO_IGNORE is $DO_IGNORE";  if [ "$DO_IGNORE" = "FALSE" ]; then  break; fi; done; if [ "$DO_IGNORE" = "TRUE" ]; then travis_terminate 0; fi;fi
   - /usr/bin/time -f 'Spend time of %C -- %E (real)' bash .travis/install.sh
-  - export CXX=clang++ CC=clang;
+  - export CXX=clang++-10 CC=clang-10;
 before_script:
   - wget -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen_exe
   - sudo mv doxygen_exe /usr/bin/doxygen

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -25,6 +25,8 @@
 
 #include <CGAL/IO/File_binary_mesh_3.h>
 
+#include <boost/container/flat_set.hpp>
+
 namespace CGAL
 {
 namespace Tetrahedral_remeshing
@@ -761,20 +763,20 @@ Subdomain_relation compare_subdomains(const typename C3t3::Vertex_handle v0,
 {
   typedef typename C3t3::Subdomain_index Subdomain_index;
 
-  std::vector<Subdomain_index> subdomains_v0;
-  incident_subdomains(v0, c3t3, std::back_inserter(subdomains_v0));
-  std::sort(subdomains_v0.begin(), subdomains_v0.end());
+  boost::container::flat_set<Subdomain_index> subdomains_v0;
+  incident_subdomains(v0, c3t3,
+    std::inserter(subdomains_v0, subdomains_v0.begin()));
 
-  std::vector<Subdomain_index> subdomains_v1;
-  incident_subdomains(v1, c3t3, std::back_inserter(subdomains_v1));
-  std::sort(subdomains_v1.begin(), subdomains_v1.end());
+  boost::container::flat_set<Subdomain_index> subdomains_v1;
+  incident_subdomains(v1, c3t3,
+    std::inserter(subdomains_v1, subdomains_v1.begin()));
 
   if (subdomains_v0.size() == subdomains_v1.size())
   {
-    for (unsigned int i = 0; i < subdomains_v0.size(); i++)
-      if (subdomains_v0[i] != subdomains_v1[i])
-        return DIFFERENT;
-    return EQUAL;
+    if(std::equal(subdomains_v0.begin(), subdomains_v0.end(), subdomains_v1.begin()))
+      return EQUAL;
+    else
+      return DIFFERENT;
   }
   else
   {

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -17,6 +17,7 @@
 
 #include <utility>
 #include <array>
+#include <iterator>
 
 #include <CGAL/Point_3.h>
 #include <CGAL/Weighted_point_3.h>
@@ -26,6 +27,7 @@
 #include <CGAL/IO/File_binary_mesh_3.h>
 
 #include <boost/container/flat_set.hpp>
+#include <boost/container/small_vector.hpp >
 
 namespace CGAL
 {
@@ -762,12 +764,15 @@ Subdomain_relation compare_subdomains(const typename C3t3::Vertex_handle v0,
                                       const C3t3& c3t3)
 {
   typedef typename C3t3::Subdomain_index Subdomain_index;
+  typedef boost::container::flat_set<Subdomain_index,
+    std::less<Subdomain_index>,
+    boost::container::small_vector<Subdomain_index, 30> > Set_of_subdomains;
 
-  boost::container::flat_set<Subdomain_index> subdomains_v0;
+  Set_of_subdomains subdomains_v0;
   incident_subdomains(v0, c3t3,
     std::inserter(subdomains_v0, subdomains_v0.begin()));
 
-  boost::container::flat_set<Subdomain_index> subdomains_v1;
+  Set_of_subdomains subdomains_v1;
   incident_subdomains(v1, c3t3,
     std::inserter(subdomains_v1, subdomains_v1.begin()));
 
@@ -780,13 +785,14 @@ Subdomain_relation compare_subdomains(const typename C3t3::Vertex_handle v0,
   }
   else
   {
-    std::vector<Subdomain_index>
-    intersection((std::min)(subdomains_v0.size(), subdomains_v1.size()), -1);
-    typename std::vector<Subdomain_index>::iterator
+    boost::container::small_vector<Subdomain_index, 30>
+      intersection((std::min)(subdomains_v0.size(), subdomains_v1.size()), -1);
+    typename boost::container::small_vector<Subdomain_index, 30>::iterator
     end_it = std::set_intersection(subdomains_v0.begin(), subdomains_v0.end(),
                                    subdomains_v1.begin(), subdomains_v1.end(),
                                    intersection.begin());
-    std::ptrdiff_t intersection_size = (end_it - intersection.begin());
+    std::ptrdiff_t intersection_size =
+      std::distance(intersection.begin(), end_it);
 
     if (subdomains_v0.size() > subdomains_v1.size()
         && intersection_size == std::ptrdiff_t(subdomains_v1.size()))

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -27,7 +27,7 @@
 #include <CGAL/IO/File_binary_mesh_3.h>
 
 #include <boost/container/flat_set.hpp>
-#include <boost/container/small_vector.hpp >
+#include <boost/container/small_vector.hpp>
 
 namespace CGAL
 {


### PR DESCRIPTION
## Summary of Changes

In `compare_subdomains(v1, v2)` compared `std::vector` were not made unique!
It was always returning `DIFFERENT` in presence of different numbers of incident cells for `v0` and `v1`.

Here is a small example of what tetrahedral remeshing can now do. First screenshot is the output of Mesh_3, and then remeshed with a super coarse target edge length.

![remeshing_of_cuboid](https://user-images.githubusercontent.com/11311305/88406206-a6969700-cdd0-11ea-921d-5c508d77e872.png)


## Release Management

* Affected package(s): Tetrahedral remeshing
* License and copyright ownership: unchanged

