### PR TITLE
Mesh_3: Display thread IDs

### DIFF
--- a/BGL/include/CGAL/draw_face_graph.h
+++ b/BGL/include/CGAL/draw_face_graph.h
@@ -5,7 +5,7 @@
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
 //
 // Author(s)     : Guillaume Damiand <guillaume.damiand@liris.cnrs.fr>
 //                 Laurent Rineau <laurent.rineau@cgal.org>

--- a/BGL/include/CGAL/draw_face_graph.h
+++ b/BGL/include/CGAL/draw_face_graph.h
@@ -1,0 +1,183 @@
+// Copyright (c) 2018-2020 GeometryFactory (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Guillaume Damiand <guillaume.damiand@liris.cnrs.fr>
+//                 Laurent Rineau <laurent.rineau@cgal.org>
+
+#ifndef CGAL_DRAW_FACE_GRAPH_H
+#define CGAL_DRAW_FACE_GRAPH_H
+
+#ifdef CGAL_USE_BASIC_VIEWER
+
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <CGAL/Dynamic_property_map.h>
+#include <CGAL/Random.h>
+
+namespace CGAL
+{
+
+// Default color functor; user can change it to have its own face color
+struct DefaultColorFunctorFaceGraph
+{
+  template<typename Graph>
+  CGAL::Color operator()(const Graph&,
+                         typename boost::graph_traits<Graph>::face_descriptor fh) const
+  {
+    if (fh==boost::graph_traits<Graph>::null_face()) // use to get the mono color
+      return CGAL::Color(100, 125, 200); // R G B between 0-255
+
+    return get_random_color(CGAL::get_default_random());
+  }
+};
+
+class SimpleFaceGraphViewerQt : public Basic_viewer_qt
+{
+  using Base = Basic_viewer_qt;
+
+public:
+  SimpleFaceGraphViewerQt(QWidget* parent) :
+    Base(parent, "", false, true, true, true, false),
+    m_compute_elements_impl([]{})
+  {
+  }
+
+  /// Construct the viewer.
+  /// @param amesh the surface mesh to view
+  /// @param title the title of the window
+  /// @param anofaces if true, do not draw faces (faces are not computed; this can be
+  ///        usefull for very big object where this time could be long)
+  template <typename SM>
+  SimpleFaceGraphViewerQt(QWidget* parent,
+                          const SM& amesh,
+                          const char* title="Basic Surface_mesh Viewer",
+                          bool anofaces=false) :
+    SimpleFaceGraphViewerQt(parent, amesh, title, anofaces, DefaultColorFunctorFaceGraph())
+  {
+  }
+
+  template <typename SM, typename ColorFunctor>
+  SimpleFaceGraphViewerQt(QWidget* parent,
+                          const SM& amesh,
+                          const char* title,
+                          bool anofaces,
+                          ColorFunctor fcolor) :
+    // First draw: no vertex; edges, faces; mono-color; inverse normal
+    Base(parent, title, false, true, true, true, false),
+    m_compute_elements_impl(compute_elements_functor(amesh, anofaces, fcolor))
+  {
+  }
+
+  void init() override {
+    compute_elements();
+    Base::init();
+  }
+
+  void compute_elements() {
+    m_compute_elements_impl();
+  }
+
+  template <typename SM, typename ColorFunctor>
+  void set_face_graph(const SM& amesh,
+                      bool anofaces,
+                      ColorFunctor fcolor) {
+    m_compute_elements_impl = compute_elements_functor(amesh, anofaces, fcolor);
+  }
+
+  template <typename SM, typename ColorFunctor>
+  void set_face_graph(const SM& amesh,
+                      bool anofaces=false) {
+    set_mesh(amesh, anofaces, DefaultColorFunctorFaceGraph());
+  }
+protected:
+  template <typename SM, typename ColorFunctor>
+  std::function<void()>
+  compute_elements_functor(const SM& sm,
+                           bool anofaces,
+                           ColorFunctor fcolor)
+  {
+    using Point =
+        typename boost::property_map_value<SM, CGAL::vertex_point_t>::type;
+    using Kernel = typename CGAL::Kernel_traits<Point>::Kernel;
+    using Vector = typename Kernel::Vector_3;
+
+    auto vnormals = get(CGAL::dynamic_vertex_property_t<Vector>(), sm);
+    {
+      // temporary face property map needed by `compute_normals`
+      auto fpm = get(CGAL::dynamic_face_property_t<Vector>(), sm);
+
+      CGAL::Polygon_mesh_processing::compute_normals(sm, vnormals, fpm);
+    }
+
+    // This function return a lambda expression, type-erased in a
+    // `std::function<void()>` object.
+    return [this, &sm, vnormals, anofaces, fcolor]()
+    {
+      this->clear();
+
+      auto point_pmap = get(CGAL::vertex_point, sm);
+      if (!anofaces)
+      {
+        for (auto fh: faces(sm))
+        {
+          if (fh!=boost::graph_traits<SM>::null_face())
+          {
+            CGAL::Color c=fcolor(sm, fh);
+            face_begin(c);
+            auto hd=halfedge(fh, sm);
+            const auto first_hd = hd;
+            do
+              {
+                auto v = source(hd, sm);
+                add_point_in_face(get(point_pmap, v), get(vnormals, v));
+                hd=next(hd, sm);
+              }
+            while(hd!=first_hd);
+            face_end();
+          }
+        }
+      }
+
+      for (auto e: edges(sm))
+      {
+        add_segment(get(point_pmap, source(halfedge(e, sm), sm)),
+                    get(point_pmap, target(halfedge(e, sm), sm)));
+      }
+
+      for (auto v: vertices(sm))
+      {
+        this->add_point(get(point_pmap, v));
+      }
+    };
+  }
+
+  virtual void keyPressEvent(QKeyEvent *e)
+  {
+    // Test key pressed:
+    //    const ::Qt::KeyboardModifiers modifiers = e->modifiers();
+    //    if ((e->key()==Qt::Key_PageUp) && (modifiers==Qt::NoButton)) { ... }
+
+    // Call: * compute_elements() if the model changed, followed by
+    //       * redraw() if some viewing parameters changed that implies some
+    //                  modifications of the buffers
+    //                  (eg. type of normal, color/mono)
+    //       * update() just to update the drawing
+
+    // Call the base method to process others/classicals key
+    Base::keyPressEvent(e);
+  }
+
+protected:
+  std::function<void()> m_compute_elements_impl;
+};
+
+} // End namespace CGAL
+
+#endif // CGAL_USE_BASIC_VIEWER
+
+#endif // CGAL_DRAW_SURFACE_MESH_H

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -570,6 +570,12 @@ public:
     { return m_buffer_for_colored_faces.face_end(); }
   }
 
+  virtual void redraw()
+  {
+    initialize_buffers();
+    update();
+  }
+
 protected:
   // Shortcuts to simplify function calls.
   template<typename KPoint>
@@ -1218,12 +1224,6 @@ protected:
       }
       glEnable(GL_LIGHTING);
     }
-  }
-
-  virtual void redraw()
-  {
-    initialize_buffers();
-    update();
   }
 
   virtual void init()

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -362,6 +362,31 @@ public:
       vao[i].destroy();
   }
 
+  void set_draw_vertices(bool b) {
+    m_draw_vertices = b;
+  }
+  void set_draw_edges(bool b) {
+    m_draw_edges = b;
+  }
+  void set_draw_rays(bool b) {
+    m_draw_rays = b;
+  }
+  void set_draw_lines(bool b) {
+    m_draw_lines = b;
+  }
+  void set_draw_faces(bool b) {
+    m_draw_faces = b;
+  }
+  void set_use_mono_color(bool b) {
+    m_use_mono_color = b;
+  }
+  void set_inverse_normal(bool b) {
+    m_inverse_normal = b;
+  }
+  void set_draw_text(bool b) {
+    m_draw_text = b;
+  }
+
   void clear()
   {
     for (unsigned int i=0; i<LAST_INDEX; ++i)

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -323,6 +323,25 @@ public:
                                &arrays[FLAT_NORMAL_COLORED_FACES],
                                &arrays[SMOOTH_NORMAL_COLORED_FACES])
   {
+    // Define 'Control+Q' as the new exit shortcut (default was 'Escape')
+    setShortcut(qglviewer::EXIT_VIEWER, ::Qt::CTRL+::Qt::Key_Q);
+
+    // Add custom key description (see keyPressEvent).
+    setKeyDescription(::Qt::Key_E, "Toggles edges display");
+    setKeyDescription(::Qt::Key_M, "Toggles mono color");
+    setKeyDescription(::Qt::Key_N, "Inverse direction of normals");
+    setKeyDescription(::Qt::Key_S, "Switch between flat/Gouraud shading display");
+    setKeyDescription(::Qt::Key_T, "Toggles text display");
+    setKeyDescription(::Qt::Key_U, "Move camera direction upside down");
+    setKeyDescription(::Qt::Key_V, "Toggles vertices display");
+    setKeyDescription(::Qt::Key_W, "Toggles faces display");
+    setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
+    setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
+    setKeyDescription(::Qt::Key_Plus+::Qt::ControlModifier, "Increase size of vertices");
+    setKeyDescription(::Qt::Key_Minus+::Qt::ControlModifier, "Decrease size of vertices");
+    setKeyDescription(::Qt::Key_PageDown, "Increase light (all colors, use shift/alt/ctrl for one rgb component)");
+    setKeyDescription(::Qt::Key_PageUp, "Decrease light (all colors, use shift/alt/ctrl for one rgb component)");
+
     if (title[0]==0)
       setWindowTitle("CGAL Basic Viewer");
     else
@@ -1212,25 +1231,6 @@ protected:
     // Restore previous viewer state.
     restoreStateFromFile();
     initializeOpenGLFunctions();
-
-    // Define 'Control+Q' as the new exit shortcut (default was 'Escape')
-    setShortcut(qglviewer::EXIT_VIEWER, ::Qt::CTRL+::Qt::Key_Q);
-
-    // Add custom key description (see keyPressEvent).
-    setKeyDescription(::Qt::Key_E, "Toggles edges display");
-    setKeyDescription(::Qt::Key_M, "Toggles mono color");
-    setKeyDescription(::Qt::Key_N, "Inverse direction of normals");
-    setKeyDescription(::Qt::Key_S, "Switch between flat/Gouraud shading display");
-    setKeyDescription(::Qt::Key_T, "Toggles text display");
-    setKeyDescription(::Qt::Key_U, "Move camera direction upside down");
-    setKeyDescription(::Qt::Key_V, "Toggles vertices display");
-    setKeyDescription(::Qt::Key_W, "Toggles faces display");
-    setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
-    setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
-    setKeyDescription(::Qt::Key_Plus+::Qt::ControlModifier, "Increase size of vertices");
-    setKeyDescription(::Qt::Key_Minus+::Qt::ControlModifier, "Decrease size of vertices");
-    setKeyDescription(::Qt::Key_PageDown, "Increase light (all colors, use shift/alt/ctrl for one rgb component)");
-    setKeyDescription(::Qt::Key_PageUp, "Decrease light (all colors, use shift/alt/ctrl for one rgb component)");
 
     // Light default parameters
     glLineWidth(m_size_edges);

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -8,7 +8,11 @@ if ( CGAL_MESH_3_VERBOSE )
   add_definitions(-DCGAL_MESH_3_VERBOSE)
 endif()
 
-find_package(CGAL COMPONENTS ImageIO)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+find_package(Qt5 COMPONENTS Widgets)
+
+find_package(CGAL COMPONENTS ImageIO Qt5)
 find_package(Boost)
 
 option(CGAL_ACTIVATE_CONCURRENT_MESH_3 "Activate parallelism in Mesh_3" OFF)
@@ -76,8 +80,15 @@ target_link_libraries(mesh_polyhedral_domain_with_surface_inside PUBLIC CGAL::Ei
 create_single_source_cgal_program( "remesh_polyhedral_surface.cpp" )
 target_link_libraries(remesh_polyhedral_surface PUBLIC CGAL::Eigen_support)
 
-create_single_source_cgal_program( "remesh_polyhedral_surface_sm.cpp" )
-target_link_libraries(remesh_polyhedral_surface_sm PUBLIC CGAL::Eigen_support)
+create_single_source_cgal_program( "remesh_polyhedral_surface_sm.cpp" draw_c3t3_surface.h)
+target_link_libraries(remesh_polyhedral_surface_sm PUBLIC CGAL::Eigen_support CGAL::CGAL_Qt5)
+target_compile_definitions(remesh_polyhedral_surface_sm PUBLIC CGAL_USE_BASIC_VIEWER QT_NO_KEYWORDS)
+target_include_directories(remesh_polyhedral_surface_sm PUBLIC .)
+
+create_single_source_cgal_program( "draw_mesh_surface.cpp" draw_c3t3_surface.h)
+target_link_libraries(draw_mesh_surface PUBLIC CGAL::Eigen_support CGAL::CGAL_Qt5)
+target_compile_definitions(draw_mesh_surface PUBLIC CGAL_USE_BASIC_VIEWER QT_NO_KEYWORDS)
+target_include_directories(draw_mesh_surface PUBLIC .)
 
 create_single_source_cgal_program( "mesh_polyhedral_domain_with_features.cpp" )
 target_link_libraries(mesh_polyhedral_domain_with_features PUBLIC CGAL::Eigen_support)
@@ -150,7 +161,8 @@ if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TARGET CGAL::TBB_support)
       mesh_polyhedral_domain_with_features
       mesh_polyhedral_domain_with_features_sm
       mesh_polyhedral_domain_with_lipschitz_sizing
-      mesh_two_implicit_spheres_with_balls)
+      mesh_two_implicit_spheres_with_balls
+      remesh_polyhedral_surface_sm)
     if(TARGET ${target})
       target_link_libraries(${target} PUBLIC CGAL::TBB_support)
     endif()

--- a/Mesh_3/examples/Mesh_3/draw_c3t3_surface.h
+++ b/Mesh_3/examples/Mesh_3/draw_c3t3_surface.h
@@ -1,0 +1,265 @@
+#include <CGAL/Qt/Basic_viewer_qt.h>
+#include <QApplication>
+#include <QColor>
+#include <QVariantAnimation>
+#include <QSpinBox>
+#include <QSlider>
+#include <QShortcut>
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+#include <algorithm>
+#include <thread>
+#include <cstdlib>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/IO/facets_in_complex_3_to_triangle_mesh.h>
+#include <boost/iterator/filter_iterator.hpp>
+#include "ui_draw_c3t3_surface.h"
+
+template <typename Mesh>
+int draw_c3t3_surface_from_surface_mesh(const Mesh& mesh)
+{
+#if defined(CGAL_TEST_SUITE)
+  bool cgal_test_suite=true;
+#else
+  bool cgal_test_suite=qEnvironmentVariableIsSet("CGAL_TEST_SUITE");
+#endif
+
+  if (cgal_test_suite) return EXIT_SUCCESS;
+
+  int argc=1;
+  const char* argv[2]={"surface_mesh_viewer","\0"};
+  QApplication app(argc,const_cast<char**>(argv));
+
+  using Point =
+    typename boost::property_map_value<Mesh, CGAL::vertex_point_t>::type;
+  using Kernel = typename CGAL::Kernel_traits<Point>::Kernel;
+  using Vector = typename Kernel::Vector_3;
+
+  auto vnormals = get(CGAL::dynamic_vertex_property_t<Vector>(), mesh);
+  {
+    // temporary face property map needed by `compute_normals`
+    auto fpm = get(CGAL::dynamic_face_property_t<Vector>(), mesh);
+
+    CGAL::Polygon_mesh_processing::compute_normals(mesh, vnormals, fpm);
+  }
+
+  Ui_Window ui_window;
+  QWidget window(app.activeWindow());
+  ui_window.setupUi(&window);
+  using Viewer = CGAL::Basic_viewer_qt;
+  Viewer* viewer = ui_window.viewer;
+  auto threadBox = ui_window.threadBox;
+  auto timelineSlider = ui_window.timelineSlider;
+  auto timelineBox = ui_window.timelineBox;
+  new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), &window,
+                SLOT(close()));
+
+  viewer->set_draw_edges(false);
+  viewer->set_draw_vertices(true);
+  using graph_traits = boost::graph_traits<Mesh>;
+  using v_descriptor_t = typename graph_traits::vertex_descriptor;
+  std::cerr << "Properties:\n";
+  for(auto p: mesh.template properties<v_descriptor_t>()) {
+    std::cerr << "  \"" << p << "\"\n";
+  }
+  auto v_thread_id_pair =
+      mesh.template property_map<v_descriptor_t, int>("v:thread_id");
+  if(! v_thread_id_pair.second ) {
+    std::cerr << "Missing property map v:thread_id\n";
+    return EXIT_FAILURE;
+  }
+  auto v_thread_id = v_thread_id_pair.first;
+  auto v_timestamp_pair =
+      mesh.template property_map<v_descriptor_t, int>("v:timestamp");
+  if(! v_timestamp_pair.second ) {
+    std::cerr << "Missing property map v:timestamp\n";
+    return EXIT_FAILURE;
+  }
+  auto v_timestamp = v_timestamp_pair.first;
+  {
+    auto it_pair = std::minmax_element(vertices(mesh).first,
+                                       vertices(mesh).second,
+                                       [&](auto v1, auto v2) {
+                                         return get(v_timestamp, v1) < get(v_timestamp, v2);
+                                       });
+    auto it_min = it_pair.first;
+    auto it_max = it_pair.second;
+    if(it_min != it_max) {
+      auto min_ = get(v_timestamp, *it_min);
+      auto max_ = get(v_timestamp, *it_max);
+      timelineSlider->setMinimum(min_);
+      timelineSlider->setMaximum(max_);
+      timelineBox->setMinimum(min_);
+      timelineBox->setMaximum(max_);
+      timelineSlider->setValue(max_);
+      timelineBox->setValue(max_);
+    }
+  }
+  {
+    auto it_pair = std::minmax_element(vertices(mesh).first,
+                                       vertices(mesh).second,
+                                       [&](auto v1, auto v2) {
+                                         return get(v_thread_id, v1) < get(v_thread_id, v2);
+                                       });
+    auto it_min = it_pair.first;
+    auto it_max = it_pair.second;
+    if(it_min != it_max) {
+      threadBox->setMinimum(get(v_thread_id, *it_min));
+      threadBox->setMaximum(get(v_thread_id, *it_max));
+      threadBox->setValue(get(v_thread_id, *it_min));
+      std::cerr << "Threads: [ #" << threadBox->minimum()
+                << " - #" << threadBox->maximum() << "]\n";
+    }
+  }
+  {
+    auto first = vertices(mesh).first;
+    auto end = vertices(mesh).second;
+    auto filter = [&](auto v) {
+      return get(v_thread_id, v)  > 0;
+    };
+    auto filter_begin = boost::make_filter_iterator(std::cref(filter), first, end);
+    auto filter_end  = boost::make_filter_iterator(std::cref(filter), end, end);
+    auto it = std::min_element(filter_begin,
+                               filter_end,
+                               [&](auto v1, auto v2) {
+                                 return get(v_timestamp, v1) < get(v_timestamp, v2);
+                               });
+    if(it != filter_end) {
+      const auto min_timestamp_of_non_0_thread = *it;
+      timelineSlider->setMinimum(min_timestamp_of_non_0_thread);
+      timelineBox->setMinimum(min_timestamp_of_non_0_thread);
+      std::cerr << "Timeline: [ " << min_timestamp_of_non_0_thread
+                << " - " << timelineBox->maximum() << " ]\n";
+    }
+  }
+
+
+  QVariantAnimation rainbow_colors;
+
+  rainbow_colors.setKeyValueAt(0.0f, QVariant{ QColor::fromRgbF(0.75, 0.75, 1.  ) });
+  rainbow_colors.setKeyValueAt(0.2f, QVariant{ QColor::fromRgbF(0.  , 0.  , 1.  ) });
+  rainbow_colors.setKeyValueAt(0.4f, QVariant{ QColor::fromRgbF(0.  , 1.  , 0.  ) });
+  rainbow_colors.setKeyValueAt(0.6f, QVariant{ QColor::fromRgbF(1.  , 1.  , 0.  ) });
+  rainbow_colors.setKeyValueAt(0.8f, QVariant{ QColor::fromRgbF(1.  , 0.  , 0.  ) });
+  rainbow_colors.setKeyValueAt(1.0f, QVariant{ QColor::fromRgbF(0.5 , 0.  , 0.  ) });
+  rainbow_colors.setDuration(1000);
+
+  auto fromQColor = [](QColor c) -> CGAL::Color {
+    return {
+      (unsigned char)c.red(),
+      (unsigned char)c.green(),
+      (unsigned char)c.blue()
+    };
+  };
+
+  auto get_color = [&](double key) {
+    rainbow_colors.setCurrentTime(1000 * key);
+    return fromQColor( rainbow_colors.currentValue().value<QColor>() );
+  };
+
+  auto draw_mesh = [&]() {
+    for(auto fh : faces(mesh)) {
+      viewer->face_begin(CGAL::gray());
+      auto hd=mesh.halfedge(fh);
+      do
+        {
+          auto v = mesh.source(hd);
+          viewer->add_point_in_face(mesh.point(v), get(vnormals, v));
+          hd=mesh.next(hd);
+        }
+      while(hd!=mesh.halfedge(fh));
+      viewer->face_end();
+    }
+  };
+  bool call_redraw = false;
+  std::function<void()> recompute_elements = [&]() {
+    viewer->clear();
+    draw_mesh();
+    const auto thread_id_to_display = threadBox->value();
+    const auto max_timestamp = timelineSlider->value();
+    std::cerr << "Display thread #" << thread_id_to_display << '\n';
+    std::cerr << "Max timestamp: " << max_timestamp << '\n';
+    auto min = threadBox->minimum();
+    auto delta = threadBox->maximum()-threadBox->minimum();
+    for(auto v : vertices(mesh)) {
+      const auto ts = get(v_timestamp, v);
+      const auto thread_id = get(v_thread_id, v);
+      if((thread_id_to_display == 0 || thread_id == thread_id_to_display) &&
+         ts < max_timestamp)
+      {
+        CGAL::Color c = get_color(((0.+thread_id) - min) / delta);
+        viewer->add_point(mesh.point(v), c);
+      }
+    }
+    if(call_redraw) viewer->redraw();
+  };
+
+  QObject::connect(threadBox, QOverload<int>::of(&QSpinBox::valueChanged),
+                   recompute_elements);
+  QObject::connect(timelineSlider, &QAbstractSlider::valueChanged,
+                   recompute_elements);
+  recompute_elements();
+  window.show();
+  call_redraw = true;
+  return app.exec();
+}
+
+
+template <typename C3t3>
+auto draw_c3t3_surface(const C3t3& c3t3)
+{
+  std::map<std::thread::id, int> mapping;
+#if CGAL_MESH_3_STATS_THREADS
+  {
+    int patch_id_nb = 0;
+    for(auto facet: CGAL::make_range(c3t3.facets_in_complex_begin(),
+                                     c3t3.facets_in_complex_end()))
+      {
+        auto& cell = facet.first;
+        auto& index = facet.second;
+        int& patch_id = mapping[cell->thread_ids[index]];
+        if(patch_id == 0) patch_id = ++patch_id_nb;
+        cell->set_surface_patch_index(index, patch_id);
+        facet = c3t3.triangulation().mirror_facet(facet);
+        cell->set_surface_patch_index(index, patch_id);
+      }
+  }
+#endif
+
+  using Tr_geom_traits = typename C3t3::Triangulation::Geom_traits;
+  using Point_3 = typename Tr_geom_traits::Point_3;
+  using Mesh = CGAL::Surface_mesh<Point_3>;
+  Mesh surface_mesh;
+  CGAL::facets_in_complex_3_to_triangle_mesh(c3t3, surface_mesh);
+
+#if CGAL_MESH_3_STATS_THREADS
+  auto point_pmap = get(CGAL::vertex_point, surface_mesh);
+  auto thread_pmap =
+      surface_mesh
+          .template add_property_map<typename Mesh::Vertex_index, int>(
+              "v:thread_id")
+          .first;
+  auto time_pmap =
+      surface_mesh
+          .template add_property_map<typename Mesh::Vertex_index, int>(
+              "v:timestamp")
+          .first;
+
+  auto vit = c3t3.triangulation().finite_vertices_begin();
+  auto vend = c3t3.triangulation().finite_vertices_end();
+  std::unordered_map<Point_3, typename C3t3::Triangulation::Vertex_handle>
+      point_to_vertices;
+  for (auto v : c3t3.triangulation().all_vertex_handles()) {
+    point_to_vertices[v->point().point()] = v;
+  }
+  for(auto v: vertices(surface_mesh)) {
+    CGAL_assertion(vit != vend);
+    const auto point = get(point_pmap, v);
+    auto vh = point_to_vertices[point];
+    put(thread_pmap, v, mapping[vh->thread_id]);
+    put(time_pmap, v, vh->time_stamp());
+    ++vit;
+  }
+#endif
+  draw_c3t3_surface_from_surface_mesh(surface_mesh);
+  return surface_mesh;
+}

--- a/Mesh_3/examples/Mesh_3/draw_c3t3_surface.ui
+++ b/Mesh_3/examples/Mesh_3/draw_c3t3_surface.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Window</class>
+ <widget class="QWidget" name="Window">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>541</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Display c2t3</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="CGAL::Basic_viewer_qt" name="viewer" native="true"/>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>&amp;Timeline</string>
+       </property>
+       <property name="buddy">
+        <cstring>timelineSlider</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Thread &amp;id</string>
+       </property>
+       <property name="buddy">
+        <cstring>threadBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QSlider" name="timelineSlider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="timelineBox"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="threadBox"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CGAL::Basic_viewer_qt</class>
+   <extends>QWidget</extends>
+   <header location="global">CGAL/Qt/Basic_viewer_qt.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>timelineBox</tabstop>
+  <tabstop>timelineSlider</tabstop>
+  <tabstop>threadBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>timelineSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>timelineBox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>421</x>
+     <y>221</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>504</x>
+     <y>227</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>timelineBox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>timelineSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>504</x>
+     <y>207</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>435</x>
+     <y>219</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Mesh_3/examples/Mesh_3/draw_mesh_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/draw_mesh_surface.cpp
@@ -1,0 +1,23 @@
+#include "draw_c3t3_surface.h"
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <fstream>
+
+using Kernel= CGAL::Simple_cartesian<double>;
+using Point = Kernel::Point_3;
+using Mesh = CGAL::Surface_mesh<Point>;
+
+using Polyhedron = Mesh;
+
+#include "ui_draw_c3t3_surface.h"
+
+int main(int argc, char* argv[])
+{
+  Mesh mesh;
+  std::ifstream in1((argc>1)?argv[1]:"data/elephant.off");
+  std::string comments;
+  CGAL::read_ply(in1, mesh, comments);
+  std::cerr << "comments: " << comments << '\n';
+
+  return draw_c3t3_surface_from_surface_mesh(mesh);
+}

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface_sm.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface_sm.cpp
@@ -1,20 +1,29 @@
+#define CGAL_MESH_3_VERBOSE 1
+#define CGAL_MESH_3_STATS_THREADS 1
+#define CGAL_CONCURRENT_COMPACT_CONTAINER_APPROXIMATE_SIZE 1
+
+#include "draw_c3t3_surface.h"
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
 
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/IO/PLY_writer.h>
+
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Surface_mesh<K::Point_3> Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K, Polyhedron> Mesh_domain;
 
+using Kernel = K;
+
 // Triangulation
-typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,CGAL::Parallel_tag>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
   Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_index> C3t3;
 
@@ -24,11 +33,12 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
-int main()
+int main(int argc, char*argv[])
 {
+  const char* fname = (argc>1)?argv[1]:"data/lion-head.off";
   // Load a polyhedron
   Polyhedron poly;
-  std::ifstream input("data/lion-head.off");
+  std::ifstream input(fname);
   input >> poly;
 
   if (!CGAL::is_triangle_mesh(poly)){
@@ -48,18 +58,25 @@ int main()
   domain.detect_features(); //includes detection of borders
 
   // Mesh criteria
-  Mesh_criteria criteria(edge_size = 0.025,
-                         facet_angle = 25,
-                         facet_size = 0.1,
-                         facet_distance = 0.001);
+  // Mesh_criteria criteria(edge_size = 0.03,
+  //                        facet_angle = 25, facet_size = 0.03, facet_distance = 0.003,
+  //                        cell_radius_edge_ratio = 3, cell_size = 0.5);
+  Mesh_criteria criteria(edge_size = 0.003,
+                         facet_angle = 25, facet_size = 0.003, facet_distance = 0.0003,
+                         cell_radius_edge_ratio = 3, cell_size = 0.05);
 
   // Mesh generation
-  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria, no_perturb(), no_exude());
+  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria, no_perturb(), no_exude(), manifold());
 
-  // Output the facets of the c3t3 to an OFF file. The facets will not be
-  // oriented.
-  std::ofstream off_file("out.off");
-  c3t3.output_boundary_to_off(off_file);
+  // Output
+  dump_c3t3(c3t3, "out");
 
-  return off_file.fail() ? EXIT_FAILURE : EXIT_SUCCESS;
+  {
+    using Mesh = CGAL::Surface_mesh<K::Point_3>;
+    Mesh surface_mesh = draw_c3t3_surface(c3t3);
+
+    std::ofstream out("out.ply");
+    out.precision(17);
+    write_ply(out, surface_mesh, "essai");
+  }
 }

--- a/Mesh_3/include/CGAL/Compact_mesh_cell_base_3.h
+++ b/Mesh_3/include/CGAL/Compact_mesh_cell_base_3.h
@@ -32,6 +32,9 @@
 
 #include <boost/type_traits/is_same.hpp>
 
+#if CGAL_MESH_3_STATS_THREADS
+#  include <thread>
+#endif
 
 #ifdef CGAL_LINKED_WITH_TBB
 # include <atomic>
@@ -309,6 +312,10 @@ public:
   }
 
 public:
+#if CGAL_MESH_3_STATS_THREADS
+  std::array<std::thread::id, 4> thread_ids;
+#endif
+
   // Constructors
   Compact_mesh_cell_base_3()
     : surface_index_table_()

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -39,6 +39,9 @@
 #include <iostream>
 #include <fstream>
 
+#if CGAL_MESH_3_STATS_THREADS
+#  include <thread>
+#endif
 
 #ifdef CGAL_LINKED_WITH_TBB
   #include <atomic>
@@ -968,6 +971,11 @@ Mesh_complex_3_in_triangulation_3_base<Tr,Ct>::add_to_complex(
     Facet mirror = tr_.mirror_facet(std::make_pair(cell,i));
     set_surface_patch_index(cell, i, index);
     set_surface_patch_index(mirror.first, mirror.second, index);
+#if CGAL_MESH_3_STATS_THREADS
+    const auto id = std::this_thread::get_id();
+    cell->thread_ids[i] = id;
+    mirror.first->thread_ids[mirror.second] = id;
+#endif // CGAL_MESH_3_STATS_THREADS
     ++number_of_facets_;
     if(manifold_info_initialized_) {
       for(int j = 0; j < 3; ++j)

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -52,6 +52,10 @@
 #include <boost/type_traits/is_convertible.hpp>
 #include <sstream>
 
+#if CGAL_MESH_3_STATS_THREADS
+#  include <thread>
+#endif
+
 namespace CGAL {
 
 namespace Mesh_3 {
@@ -322,6 +326,10 @@ public:
   /// Job to do after insertion
   void after_insertion_impl(const Vertex_handle& v)
   {
+#if CGAL_MESH_3_STATS_THREADS
+    v->thread_id = std::this_thread::get_id();
+#endif
+
     restore_restricted_Delaunay(v);
   }
 

--- a/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
@@ -29,6 +29,10 @@
 #include <CGAL/Has_timestamp.h>
 #include <CGAL/tags.h>
 
+#if CGAL_MESH_3_STATS_THREADS
+#  include <thread>
+#endif
+
 namespace CGAL {
 
 // Without erase counter
@@ -113,6 +117,10 @@ public:
   // Types
   typedef typename MD::Index                      Index;
   typedef typename GT::FT                         FT;
+
+#if CGAL_MESH_3_STATS_THREADS
+  std::thread::id thread_id;
+#endif
 
   // Constructor
   Mesh_vertex_base_3()

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018  ETH Zurich (Switzerland).
+// Copyright (c) 2018-2020  ETH Zurich (Switzerland).
 // All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org).
@@ -18,174 +18,11 @@
 #ifdef CGAL_USE_BASIC_VIEWER
 
 #include <CGAL/Polyhedron_3.h>
+#include <CGAL/draw_face_graph.h>
 #include <CGAL/Random.h>
 
 namespace CGAL
 {
-
-// Default color functor; user can change it to have its own face color
-struct DefaultColorFunctorPolyhedron
-{
-  template<typename Polyhedron>
-  static CGAL::Color run(const Polyhedron&,
-                         typename Polyhedron::Facet_const_handle fh)
-  {
-    if (fh==boost::graph_traits<Polyhedron>::null_face()) // use to get the mono color
-      return CGAL::Color(100, 125, 200); // R G B between 0-255
-
-    CGAL::Random random((unsigned int)(std::size_t)(&(*fh)));
-    return get_random_color(random);
-  }
-};
-
-// Viewer class for Polyhedron
-template<class Polyhedron, class ColorFunctor>
-class SimplePolyhedronViewerQt : public Basic_viewer_qt
-{
-  typedef Basic_viewer_qt Base;
-  typedef typename Polyhedron::Traits Kernel;
-  typedef typename Polyhedron::Halfedge_const_handle Halfedge_const_handle;
-  typedef typename Polyhedron::Vertex_const_handle Vertex_const_handle;
-  typedef typename Polyhedron::Facet_const_handle Facet_const_handle;
-
-public:
-  /// Construct the viewer.
-  /// @param apoly the polyhedron to view
-  /// @param title the title of the window
-  /// @param anofaces if true, do not draw faces (faces are not computed; this can be
-  ///        usefull for very big object where this time could be long)
-  SimplePolyhedronViewerQt(QWidget* parent,
-                           const Polyhedron& apoly,
-                           const char* title="Basic Polyhedron Viewer",
-                           bool anofaces=false,
-                           const ColorFunctor& fcolor=ColorFunctor()) :
-    // First draw: no vertex; edges, faces; mono-color; inverse normal
-    Base(parent, title, false, true, true, true, false),
-    poly(apoly),
-    m_nofaces(anofaces),
-    m_fcolor(fcolor)
-  {
-    compute_elements();
-  }
-
-protected:
-  void compute_face(Facet_const_handle fh)
-  {
-    CGAL::Color c=m_fcolor.run(poly, fh);
-    face_begin(c);
-    Halfedge_const_handle he=fh->facet_begin();
-    do
-    {
-      add_point_in_face(he->vertex()->point(),
-                        get_vertex_normal(he));
-      he=he->next();
-    }
-    while (he!=fh->facet_begin());
-    face_end();
-  }
-
-  void compute_edge(Halfedge_const_handle he)
-  {
-    add_segment(he->vertex()->point(),
-                he->opposite()->vertex()->point());
-    // We can use add_segment(p1, p2, c) with c a CGAL::Color to add a colored segment
-  }
-
-  void compute_vertex(Vertex_const_handle vh)
-  {
-    add_point(vh->point());
-    // We can use add_point(p, c) with c a CGAL::Color to add a colored point
-  }
-
-  void compute_elements()
-  {
-    clear();
-
-    if (!m_nofaces)
-    {
-      for(typename Polyhedron::Facet_const_iterator f=poly.facets_begin();
-          f!=poly.facets_end(); f++)
-      {
-        if (f!=boost::graph_traits<Polyhedron>::null_face())
-        { compute_face(f); }
-      }
-    }
-
-    for ( typename Polyhedron::Halfedge_const_iterator e=poly.halfedges_begin();
-          e!=poly.halfedges_end(); ++e)
-    {
-      if (e<e->opposite())
-      { compute_edge(e); }
-    }
-
-    for ( typename Polyhedron::Vertex_const_iterator v=poly.vertices_begin();
-          v!=poly.vertices_end(); ++v)
-    { compute_vertex(v); }
-  }
-
-  virtual void keyPressEvent(QKeyEvent *e)
-  {
-    // Test key pressed:
-    //    const ::Qt::KeyboardModifiers modifiers = e->modifiers();
-    //    if ((e->key()==Qt::Key_PageUp) && (modifiers==Qt::NoButton)) { ... }
-
-    // Call: * compute_elements() if the model changed, followed by
-    //       * redraw() if some viewing parameters changed that implies some
-    //                  modifications of the buffers
-    //                  (eg. type of normal, color/mono)
-    //       * update() just to update the drawing
-
-    // Call the base method to process others/classicals key
-    Base::keyPressEvent(e);
-  }
-
-protected:
-  Local_vector get_face_normal(Halfedge_const_handle he)
-  {
-    Local_vector normal=CGAL::NULL_VECTOR;
-    Halfedge_const_handle end=he;
-    unsigned int nb=0;
-    do
-    {
-      internal::newell_single_step_3
-        (this->get_local_point(he->vertex()->point()),
-         this->get_local_point(he->next()->vertex()->point()),
-         normal);
-      ++nb;
-      he=he->next();
-    }
-    while (he!=end);
-    assert(nb>0);
-    return (typename Local_kernel::Construct_scaled_vector_3()(normal, 1.0/nb));
-  }
-
-  Local_vector get_vertex_normal(Halfedge_const_handle he)
-  {
-    Local_vector normal=CGAL::NULL_VECTOR;
-    Halfedge_const_handle end=he;
-    do
-    {
-      if (!he->is_border())
-      {
-        Local_vector n=get_face_normal(he);
-        normal=typename Local_kernel::Construct_sum_of_vectors_3()(normal, n);
-      }
-      he=he->next()->opposite();
-    }
-    while (he!=end);
-
-    if (!typename Local_kernel::Equal_3()(normal, CGAL::NULL_VECTOR))
-    { normal=(typename Local_kernel::Construct_scaled_vector_3()
-              (normal, 1.0/CGAL::sqrt(normal.squared_length()))); }
-
-    return normal;
-  }
-
-protected:
-  const Polyhedron& poly;
-  bool m_nofaces;
-  const ColorFunctor& m_fcolor;
-};
 
 // Specialization of draw function.
 #define CGAL_POLY_TYPE CGAL::Polyhedron_3 \
@@ -211,9 +48,8 @@ void draw(const CGAL_POLY_TYPE& apoly,
     int argc=1;
     const char* argv[2]={"polyhedron_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));
-    DefaultColorFunctorPolyhedron fcolor;
-    SimplePolyhedronViewerQt<CGAL_POLY_TYPE, DefaultColorFunctorPolyhedron>
-      mainwindow(app.activeWindow(), apoly, title, nofill, fcolor);
+    SimpleFaceGraphViewerQt
+      mainwindow(app.activeWindow(), apoly, title, nofill);
     mainwindow.show();
     app.exec();
   }

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 GeometryFactory (France)
+// Copyright (c) 2018-2020 GeometryFactory (France)
 // All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org).
@@ -36,167 +36,9 @@ void draw(const SM& asm);
 #ifdef CGAL_USE_BASIC_VIEWER
 
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/Random.h>
-
+#include <CGAL/draw_face_graph.h>
 namespace CGAL
 {
-
-// Default color functor; user can change it to have its own face color
-struct DefaultColorFunctorSM
-{
-  template<typename SM>
-  CGAL::Color operator()(const SM&,
-                         typename SM::Face_index fh) const
-  {
-    if (fh==boost::graph_traits<SM>::null_face()) // use to get the mono color
-      return CGAL::Color(100, 125, 200); // R G B between 0-255
-
-    CGAL::Random random((unsigned int)fh);
-    return get_random_color(random);
-  }
-};
-
-class SimpleSurfaceMeshViewerQt : public Basic_viewer_qt
-{
-  using Base = Basic_viewer_qt;
-
-public:
-  /// Construct the viewer.
-  /// @param amesh the surface mesh to view
-  /// @param title the title of the window
-  /// @param anofaces if true, do not draw faces (faces are not computed; this can be
-  ///        usefull for very big object where this time could be long)
-  template <typename SM>
-  SimpleSurfaceMeshViewerQt(QWidget* parent,
-                            const SM& amesh,
-                            const char* title="Basic Surface_mesh Viewer",
-                            bool anofaces=false)
-    : SimpleSurfaceMeshViewerQt(parent, amesh, title, anofaces, DefaultColorFunctorSM())
-  {
-  }
-
-  template <typename SM, typename ColorFunctor>
-  SimpleSurfaceMeshViewerQt(QWidget* parent,
-                            const SM& amesh,
-                            const char* title,
-                            bool anofaces,
-                            ColorFunctor fcolor) :
-    // First draw: no vertex; edges, faces; mono-color; inverse normal
-    Base(parent, title, false, true, true, true, false),
-    m_compute_elements_impl(compute_elements_functor(amesh, anofaces, fcolor))
-  {
-  }
-
-  void init() override {
-    compute_elements();
-    Base::init();
-  }
-
-  void compute_elements() {
-    m_compute_elements_impl();
-  }
-
-  template <typename SM, typename ColorFunctor>
-  void set_mesh(const SM& amesh,
-                bool anofaces=false,
-                ColorFunctor fcolor=DefaultColorFunctorSM()) {
-    m_compute_elements_impl = compute_elements_functor(amesh, anofaces, fcolor);
-    redraw();
-  }
-
-protected:
-  template <typename SM, typename ColorFunctor>
-  std::function<void()>
-  compute_elements_functor(const SM& sm,
-                           bool anofaces,
-                           ColorFunctor fcolor)
-  {
-    using Point = typename SM::Point;
-    using Kernel = typename CGAL::Kernel_traits<Point>::Kernel;
-    using Vector = typename Kernel::Vector_3;
-
-    auto vnormals = get(CGAL::dynamic_vertex_property_t<Vector>(), sm);
-    {
-      // temporary face property map needed by `compute_normals`
-      auto fpm = get(CGAL::dynamic_face_property_t<Vector>(), sm);
-
-      CGAL::Polygon_mesh_processing::compute_normals(sm, vnormals, fpm);
-    }
-
-    // This function return a lambda expression, type-erased in a
-    // `std::function<void()>` object.
-    return [this, &sm, vnormals, anofaces, fcolor]()
-    {
-      this->clear();
-
-      if (!anofaces)
-      {
-        for (typename SM::Face_range::iterator f=sm.faces().begin();
-             f!=sm.faces().end(); ++f)
-        {
-          if (*f!=boost::graph_traits<SM>::null_face())
-            { this->compute_face(sm, vnormals, *f, fcolor); }
-        }
-      }
-
-      for (typename SM::Edge_range::iterator e=sm.edges().begin();
-           e!=sm.edges().end(); ++e)
-      { this->compute_edge(sm, *e); }
-
-      for (typename SM::Vertex_range::iterator v=sm.vertices().begin();
-           v!=sm.vertices().end(); ++v)
-      { this->compute_vertex(sm, *v); }
-    };
-  }
-
-  template <typename SM, typename VNormals, typename face_descriptor, typename ColorFunctor>
-  void compute_face(const SM& sm, VNormals vnormals,
-                    face_descriptor fh, const ColorFunctor& fcolor)
-  {
-    CGAL::Color c=fcolor(sm, fh);
-    face_begin(c);
-    auto hd=sm.halfedge(fh);
-    do
-    {
-      auto v = sm.source(hd);
-      add_point_in_face(sm.point(v), get(vnormals, v));
-      hd=sm.next(hd);
-    }
-    while(hd!=sm.halfedge(fh));
-    face_end();
-  }
-
-  template <typename SM, typename edge_descriptor>
-  void compute_edge(const SM& sm, edge_descriptor e)
-  {
-    add_segment(sm.point(sm.source(sm.halfedge(e))),
-                sm.point(sm.target(sm.halfedge(e))));
-  }
-
-  template <typename SM, typename vertex_descriptor>
-  void compute_vertex(const SM& sm, vertex_descriptor vh)
-  { add_point(sm.point(vh)); }
-
-
-  virtual void keyPressEvent(QKeyEvent *e)
-  {
-    // Test key pressed:
-    //    const ::Qt::KeyboardModifiers modifiers = e->modifiers();
-    //    if ((e->key()==Qt::Key_PageUp) && (modifiers==Qt::NoButton)) { ... }
-
-    // Call: * compute_elements() if the model changed, followed by
-    //       * redraw() if some viewing parameters changed that implies some
-    //                  modifications of the buffers
-    //                  (eg. type of normal, color/mono)
-    //       * update() just to update the drawing
-
-    // Call the base method to process others/classicals key
-    Base::keyPressEvent(e);
-  }
-
-protected:
-  std::function<void()> m_compute_elements_impl;
-};
 
 // Specialization of draw function.
 template<class K>
@@ -215,8 +57,8 @@ void draw(const Surface_mesh<K>& amesh,
     int argc=1;
     const char* argv[2]={"surface_mesh_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));
-    SimpleSurfaceMeshViewerQt mainwindow(app.activeWindow(), amesh, title,
-                                         nofill);
+    SimpleFaceGraphViewerQt mainwindow(app.activeWindow(), amesh, title,
+                                       nofill);
     mainwindow.show();
     app.exec();
   }


### PR DESCRIPTION
## Summary of Changes

Based on #4876, display graphically the thread IDs of vertices in a C3t3 produced by Mesh_3.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: GeometryFactory

