### PR TITLE
Mesh_3: now uses tbb:task_group instead of tbb::task (deprecated)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -426,7 +426,7 @@ private:
       }
 
       if ( m_mgo.is_time_limit_reached() )
-        tbb::task::self().cancel_group_execution();
+        m_mgo.cancel_group_execution();
     }
   };
 
@@ -539,12 +539,16 @@ private:
         // restricted delaunay
         if ( m_mgo.is_time_limit_reached() )
         {
-          tbb::task::self().cancel_group_execution();
+          m_mgo.cancel_group_execution();
           break;
         }
       }
     }
   };
+
+  void cancel_group_execution() {
+    tbb_task_group_context.cancel_group_execution();
+  }
 #endif // CGAL_LINKED_WITH_TBB
 
   // -----------------------------------
@@ -566,6 +570,9 @@ private:
 
 #ifdef CGAL_MESH_3_OPTIMIZER_VERBOSE
   mutable FT sum_moves_;
+#endif
+#ifdef CGAL_LINKED_WITH_TBB
+  tbb::task_group_context tbb_task_group_context;
 #endif
 };
 
@@ -935,6 +942,7 @@ update_mesh(const Moves_vector& moves,
         Self, C3T3_helpers, Tr, Moves_vector,
         Moving_vertices_set, Outdated_cell_set>(
           *this, helper_, moves, moving_vertices, outdated_cells)
+      , tbb_task_group_context
     );
   }
   // Sequential

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -815,8 +815,6 @@ status() const
 {
 #ifdef CGAL_LINKED_WITH_TBB
   if(boost::is_convertible<Concurrency_tag, Parallel_tag>::value) {
-    const WorksharingDataStructureType* ws_ds =
-      this->get_worksharing_data_structure();
     return Mesher_status(
 #  if CGAL_CONCURRENT_COMPACT_CONTAINER_APPROXIMATE_SIZE
                          approximate_number_of_vertices(Concurrency_tag()),
@@ -825,7 +823,7 @@ status() const
                          approximate_number_of_vertices(CGAL::Sequential_tag()),
 #endif
                          0,
-                         ws_ds->approximate_number_of_enqueued_element());
+                         0);
   }
   else
 #endif // with TBB

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -477,6 +477,12 @@ protected:
   /// Insert facet into refinement queue
   void insert_bad_facet(Facet facet, const Quality& quality)
   {
+#if CGAL_MESH_3_VERY_VERBOSE
+    std::stringstream s;
+    s << "insert_bad_facet(" << debug_info_element_impl(facet) << ", ...) by thread "
+      << std::this_thread::get_id() << '\n';
+    std::cerr << s.str();
+#endif
     // Insert the facet and its mirror
     this->add_bad_element(
       this->from_facet_to_refinement_queue_element(facet, mirror_facet(facet)),

--- a/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifdef CGAL_LINKED_WITH_TBB
-# include <tbb/task.h>
+# include <tbb/task_group.h>
 #endif
 
 #include <boost/format.hpp>
@@ -335,10 +335,10 @@ protected:
   Lock_data_structure *
     get_lock_data_structure()                       const { return 0; }
   void unlock_all_elements()                        const {}
-  void create_root_task()                           const {}
+  void create_task_group()                          const {}
   bool flush_work_buffers()                         const { return true; }
   void wait_for_all()                               const {}
-  void destroy_root_task()                          const {}
+  void destroy_trask_group()                        const {}
   template <typename Func, typename PVertex>
   void enqueue_work(Func, const PVertex &)          const {}
 
@@ -373,36 +373,34 @@ protected:
     m_lock_ds.unlock_all_points_locked_by_this_thread();
   }
 
-  void create_root_task() const
+  void create_task_group() const
   {
-    m_empty_root_task = new( tbb::task::allocate_root() ) tbb::empty_task;
-    m_empty_root_task->set_ref_count(1);
+    m_task_group = new tbb::task_group;
   }
 
   bool flush_work_buffers() const
   {
-    m_empty_root_task->set_ref_count(1);
-    bool keep_flushing = m_worksharing_ds.flush_work_buffers(*m_empty_root_task);
+    bool keep_flushing = m_worksharing_ds.flush_work_buffers(*m_task_group);
     wait_for_all();
     return keep_flushing;
   }
 
   void wait_for_all() const
   {
-    m_empty_root_task->wait_for_all();
+    m_task_group->wait();
   }
 
-  void destroy_root_task() const
+  void destroy_trask_group() const
   {
-    tbb::task::destroy(*m_empty_root_task);
-    m_empty_root_task = 0;
+    delete m_task_group;
+    m_task_group = 0;
   }
 
   template <typename Func, typename PVertex>
   void enqueue_work(Func f, const PVertex &pv) const
   {
-    CGAL_assertion(m_empty_root_task != 0);
-    m_worksharing_ds.enqueue_work(f, pv, *m_empty_root_task);
+    CGAL_assertion(m_task_group != 0);
+    m_worksharing_ds.enqueue_work(f, pv, *m_task_group);
   }
 
   void increment_erase_counter(const Vertex_handle &vh) const
@@ -410,12 +408,16 @@ protected:
     vh->increment_erase_counter();
   }
 
+  void cancel() const {
+    return m_task_group->cancel();
+  }
+
 public:
 
 protected:
   mutable Lock_data_structure           m_lock_ds;
   mutable Mesh_3::Auto_worksharing_ds   m_worksharing_ds;
-  mutable tbb::task                    *m_empty_root_task;
+  mutable tbb::task_group               *m_task_group;
 };
 #endif // CGAL_LINKED_WITH_TBB
 
@@ -704,7 +706,7 @@ private:
       } while (!could_lock_zone);
 
       if ( m_sliver_perturber.is_time_limit_reached() )
-        tbb::task::self().cancel_group_execution();
+        m_sliver_perturber.cancel();
     }
   };
 #endif
@@ -933,7 +935,7 @@ perturb(const FT& sliver_bound, PQueue& pqueue, Visitor& visitor) const
   // Parallel
   if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
   {
-    this->create_root_task();
+    this->create_task_group();
 
     while (pqueue.size() > 0)
     {
@@ -957,7 +959,7 @@ perturb(const FT& sliver_bound, PQueue& pqueue, Visitor& visitor) const
 # endif
     }
 
-    this->destroy_root_task();
+    this->destroy_trask_group();
   }
   // Sequential
   else

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -55,7 +55,7 @@
 #endif
 
 #ifdef CGAL_LINKED_WITH_TBB
-# include <tbb/task.h>
+# include <tbb/task_group.h>
 #endif
 
 
@@ -122,10 +122,10 @@ protected:
 
   Lock_data_structure * get_lock_data_structure()   const { return 0; }
   void unlock_all_elements()                        const {}
-  void create_root_task()                           const {}
+  void create_task_group()                          const {}
   bool flush_work_buffers()                         const { return true; }
   void wait_for_all()                               const {}
-  void destroy_root_task()                          const {}
+  void destroy_trask_group()                        const {}
   template <typename Func>
   void enqueue_work(Func, FT)                       const {}
 
@@ -225,36 +225,34 @@ protected:
     m_lock_ds.unlock_all_points_locked_by_this_thread();
   }
 
-  void create_root_task() const
+  void create_task_group() const
   {
-    m_empty_root_task = new( tbb::task::allocate_root() ) tbb::empty_task;
-    m_empty_root_task->set_ref_count(1);
+    m_task_group = new tbb::task_group;
   }
 
   bool flush_work_buffers() const
   {
-    m_empty_root_task->set_ref_count(1);
-    bool keep_flushing = m_worksharing_ds.flush_work_buffers(*m_empty_root_task);
+    bool keep_flushing = m_worksharing_ds.flush_work_buffers(*m_task_group);
     wait_for_all();
     return keep_flushing;
   }
 
   void wait_for_all() const
   {
-    m_empty_root_task->wait_for_all();
+    m_task_group->wait();
   }
 
-  void destroy_root_task() const
+  void destroy_trask_group() const
   {
-    tbb::task::destroy(*m_empty_root_task);
-    m_empty_root_task = 0;
+    delete m_task_group;
+    m_task_group = 0;
   }
 
   template <typename Func>
   void enqueue_work(Func f, FT value) const
   {
-    CGAL_assertion(m_empty_root_task != 0);
-    m_worksharing_ds.enqueue_work(f, value, *m_empty_root_task);
+    CGAL_assertion(m_task_group != 0);
+    m_worksharing_ds.enqueue_work(f, value, *m_task_group);
   }
 
 public:
@@ -311,9 +309,14 @@ protected:
                   Erase_from_queue(cells_queue_));
   }
 
+  void cancel() {
+    CGAL_assertion(m_task_group != nullptr);
+    m_task_group->cancel();
+  }
+
   mutable Lock_data_structure                 m_lock_ds;
   mutable Mesh_3::Auto_worksharing_ds         m_worksharing_ds;
-  mutable tbb::task                          *m_empty_root_task;
+  mutable tbb::task_group                     *m_task_group;
 
 private:
   Tet_priority_queue cells_queue_;
@@ -781,7 +784,7 @@ private:
       }
 
       if ( m_sliver_exuder.is_time_limit_reached() )
-        tbb::task::self().cancel_group_execution();
+        m_sliver_exuder.cancel();
     }
   };
 #endif
@@ -920,7 +923,7 @@ pump_vertices(FT sliver_criterion_limit,
   // Parallel
   if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
   {
-    this->create_root_task();
+    this->create_task_group();
 
     while (!this->cells_queue_empty())
     {
@@ -947,7 +950,7 @@ pump_vertices(FT sliver_criterion_limit,
 # endif
     }
 
-    this->destroy_root_task();
+    this->destroy_trask_group();
   }
   // Sequential
   else

--- a/Mesh_3/include/CGAL/Meshes/Filtered_multimap_container.h
+++ b/Mesh_3/include/CGAL/Meshes/Filtered_multimap_container.h
@@ -120,10 +120,16 @@ namespace CGAL {
     template<typename Container>
     void splice_local_lists_impl(Container &container)
     {
+#ifdef CGAL_MESH_3_VERY_VERBOSE
+      std::cerr << "Filtered_multimap_container::splice_local_lists_impl()\n";
+#endif
       for(typename LocalList::iterator it_list = m_local_lists.begin() ;
           it_list != m_local_lists.end() ;
           ++it_list )
       {
+#ifdef CGAL_MESH_3_VERY_VERBOSE
+        std::cerr << "  - " << it_list->size() << " elements\n";
+#endif
         container.insert(it_list->begin(), it_list->end());
         it_list->clear();
       }


### PR DESCRIPTION
## Summary of Changes

Mesh_3, now uses `tbb:task_group` instead of `tbb::task` (deprecated). Fixes #4872.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #4872
* License and copyright ownership: maintenance by GF

