### PR TITLE
Advancing front: Fix deprecated array

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_structured.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_structured.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <array>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Shape_detection/Efficient_RANSAC.h>
@@ -36,7 +37,7 @@ typedef CGAL::Triangulation_data_structure_3<LVb,LCb> Tds;
 typedef CGAL::Delaunay_triangulation_3<Kernel,Tds> Triangulation_3;
 typedef Triangulation_3::Vertex_handle Vertex_handle;
 
-typedef CGAL::cpp11::array<std::size_t,3> Facet;
+typedef std::array<std::size_t,3> Facet;
 
 
 // Functor to init the advancing front algorithm with indexed points

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_surface_mesh.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_surface_mesh.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <array>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Advancing_front_surface_reconstruction.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/array.h>
 #include <CGAL/disable_warnings.h>
 
 typedef std::array<std::size_t,3> Facet;


### PR DESCRIPTION
## Summary of Changes

Replace CGAL::cpp11::array with std::array in an Advancing_front example.
## Release Management

* Affected package(s):Advancing_front
