### PR TITLE
Point Set Processing: Remove outdated precondition

### DIFF
--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -364,7 +364,6 @@ edge_aware_upsample_point_set(
                                        &&sharpness_angle <= 90);
   CGAL_point_set_processing_precondition(edge_sensitivity >= 0
                                        &&edge_sensitivity <= 1);
-  CGAL_point_set_processing_precondition(neighbor_radius > 0);
 
   edge_sensitivity *= 10;  // just project [0, 1] to [0, 10].
 


### PR DESCRIPTION
## Summary of Changes

In `edge_aware_upsample_point_set()`, there is a precondition `neighbor_radius > 0` while the default value of `neighbor_radius` is `-1`. It is documented that the neighbor radius is set automatically if lower than a factor of the average spacing, so the default value is correct and the precondition is wrong. I removed it.

## Release Management

* Affected package(s): PSP