### PR TITLE
Removing false include CGAL/license/Polyhedron.h

### DIFF
--- a/Stream_support/include/CGAL/IO/write_vtk.h
+++ b/Stream_support/include/CGAL/IO/write_vtk.h
@@ -13,8 +13,6 @@
 #ifndef CGAL_WRITE_VTK_IO_H
 #define CGAL_WRITE_VTK_IO_H
 
-#include <CGAL/license/Polyhedron.h>
-
 #include <fstream>
 #include <vector>
 template <class FT>


### PR DESCRIPTION
write_vtk.h is under LGPL and does not require a license file.

