### PR TITLE
Fix dispatch do_intersect(Tetrahedron_3, Bbox_3)

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Tetrahedron_3_Bounded_3_do_intersect.h
@@ -160,13 +160,6 @@ do_intersect(const typename K::Tetrahedron_3 &tet,
   return do_intersect_tetrahedron_bounded(sp, tet, tet[0], k);
 }
 
-template <class K>
-inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
-                                        const CGAL::Bbox_3 &bb, const K &k) {
-  // Swap arguments.
-  return do_intersect(bb, tet, k);
-}
-
 // BBox_3 specific code since it is ok for BBox_3 to degenerate.
 template <class K>
 inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
@@ -195,6 +188,14 @@ inline typename K::Boolean do_intersect(const CGAL::Bbox_3 &aabb,
   if (is_indeterminate(b)) result = b;
 
   return result;
+}
+
+
+template <class K>
+inline typename K::Boolean do_intersect(const typename K::Tetrahedron_3 &tet,
+                                        const CGAL::Bbox_3 &bb, const K &k) {
+  // Swap arguments.
+  return do_intersect(bb, tet, k);
 }
 
 } // namespace internal


### PR DESCRIPTION
## Summary of Changes

Moving do_intersect(Tetrahedron_3, Bbox_3) below do_intersect(Bbox_3, Tetrahedron_3)

Before do_intersect(Tetrahedron_3, Bbox_3)  called do_intersect(Iso_cuboid_3, Tetrahedron_3), which compiled due to implicit conversion. 
AFAIKT it even worked, up to instances with degenerated Bbox_3/Iso_cuboid_3 executed in debug mode.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

