### PR TITLE
Fix bug with self intersecting bezier curves + with CORE::Polynomial

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_cache.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_cache.h
@@ -653,7 +653,7 @@ void _Bezier_cache<NtTraits>::_self_intersection_params
   //   II: Y(t) - Y(s) / (t - s) = 0
   //
   Integer                 *coeffs;
-  int                      i, k;
+  int                      i;
 
   // Consruct the bivariate polynomial that corresponds to Equation I.
   // Note that we represent a bivariate polynomial as a vector of univariate
@@ -667,12 +667,11 @@ void _Bezier_cache<NtTraits>::_self_intersection_params
   coeffs = new Integer [degX];
 
   for (i = 0; i < degX; i++)
-  {
-    for (k = i + 1; k < degX; k++)
-      coeffs[k - i - 1] = nt_traits.get_coefficient (polyX, k);
+    coeffs[i] = nt_traits.get_coefficient(polyX, i + 1);
 
-    coeffsX_st[i] = nt_traits.construct_polynomial (coeffs, degX - i - 1);
-  }
+  for (i = 0; i < degX; i++)
+    coeffsX_st[degX - i - 1] =
+        nt_traits.construct_polynomial(coeffs + i, degX - i - 1);
 
   delete[] coeffs;
 
@@ -685,12 +684,11 @@ void _Bezier_cache<NtTraits>::_self_intersection_params
   coeffs = new Integer [degY];
 
   for (i = 0; i < degY; i++)
-  {
-    for (k = i + 1; k < degY; k++)
-      coeffs[k - i - 1] = nt_traits.get_coefficient (polyY, k);
+    coeffs[i] = nt_traits.get_coefficient(polyY, i + 1);
 
-    coeffsY_st[i] = nt_traits.construct_polynomial (coeffs, degY - i - 1);
-  }
+  for (i = 0; i < degY; i++)
+    coeffsY_st[degY - i - 1] =
+        nt_traits.construct_polynomial(coeffs + i, degY - i - 1);
 
   delete[] coeffs;
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_point_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_point_2.h
@@ -1641,17 +1641,43 @@ void _Bezier_point_2_rep<RatKer, AlgKer, NtTrt, BndTrt>::_make_exact
   const Algebraic      t_min = nt_traits.convert (orig2.point_bound().t_min);
   const Algebraic      t_max = nt_traits.convert (orig2.point_bound().t_max);
 
+  bool self_intersecting = (org_it1->curve().id() == org_it2->curve().id());
+
   for (intr_it = intr_list.begin(); intr_it != intr_list.end(); ++intr_it)
   {
-    if (CGAL::compare (intr_it->s, s_min) != SMALLER &&
-        CGAL::compare (intr_it->s, s_max) != LARGER &&
-        CGAL::compare (intr_it->t, t_min) != SMALLER &&
-        CGAL::compare (intr_it->t, t_max) != LARGER)
+    auto in_bounding_interval =
+      [](const auto& s_, const auto& s_min_, const auto& s_max_) -> bool {
+      return CGAL::compare(s_, s_min_) != SMALLER &&
+             CGAL::compare(s_, s_max_) != LARGER;
+    };
+
+    bool st_in_st_range = in_bounding_interval(intr_it->s, s_min, s_max) &&
+                          in_bounding_interval(intr_it->t, t_min, t_max);
+    bool ts_in_st_range = false;
+
+    if (st_in_st_range)
     {
       // Update the originators.
-      orig1.set_parameter (intr_it->s);
-      orig2.set_parameter (intr_it->t);
+      orig1.set_parameter(intr_it->s);
+      orig2.set_parameter(intr_it->t);
+    }
+    else if (self_intersecting)
+    {
+      // check whether s is in t range, and t is in s range
+      // s and t can be interchanged in case of self intersections
+      ts_in_st_range = in_bounding_interval(intr_it->t, s_min, s_max) &&
+                       in_bounding_interval(intr_it->s, t_min, t_max);
 
+      if (ts_in_st_range)
+      {
+        // Update the originators.
+        orig1.set_parameter(intr_it->t);
+        orig2.set_parameter(intr_it->s);
+      }
+    }
+
+    if (st_in_st_range || ts_in_st_range)
+    {
       // Set the exact point coordinates.
       p_alg_x = new Algebraic (intr_it->x);
       p_alg_y = new Algebraic (intr_it->y);

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -1139,10 +1139,11 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
     Originator_iterator  org = p.get_originator(_curve, _xid);
 
     CGAL_assertion(org != p.originators_end());
-    CGAL_assertion(_inc_to_right != cv._inc_to_right);
 
     if (org->point_bound().type == Bez_point_bound::VERTICAL_TANGENCY_PT)
     {
+      CGAL_assertion(_inc_to_right != cv._inc_to_right);
+
       if (! p.is_exact())
       {
         // Comparison based on the control polygon of the bounded vertical

--- a/CGAL_Core/include/CGAL/CORE/poly/Poly.tcc
+++ b/CGAL_Core/include/CGAL/CORE/poly/Poly.tcc
@@ -670,19 +670,20 @@ Polynomial<NT> Polynomial<NT>::pseudoRemainder (
   contract();         // Let A = (*this).  Contract A.
   Polynomial<NT> tmpB(B);
   tmpB.contract();    // local copy of B
+  int bTrueDegree = tmpB.degree;
   C = NT(1);  // Initialized to C=1.
-  if (B.degree == -1)  {
+  if (bTrueDegree == -1)  {
     core_error("ERROR in Polynomial<NT>::pseudoRemainder :\n    -- divide by zero polynomial", __FILE__, __LINE__, false);
     return Polynomial(0);  // Unit Polynomial (arbitrary!)
   }
-  if (B.degree > degree) {
+  if (bTrueDegree > degree) {
     return Polynomial(); // Zero Polynomial
     // CHECK: 1*THIS = 0*B + THAT,  deg(THAT) < deg(B)
   }
 
   Polynomial<NT> Quo;  // accumulate the return polynomial, Quo
   Polynomial<NT> tmpQuo;
-  while (degree >= B.degree) {  // INVARIANT: C*A = B*Quo + (*this)
+  while (degree >= bTrueDegree) {  // INVARIANT: C*A = B*Quo + (*this)
     tmpQuo = reduceStep(tmpB);  // Let (*this) be (*oldthis), which
                                 // is transformed into (*newthis). Then,
                                 //     c*(*oldthis) = B*m + (*newthis)


### PR DESCRIPTION
## Summary of Changes

For #4817 it was 2 bugs at play:
1. A bug in "pseudoRemainder" in CORE::Polynomial. Can be reproduced using this example
```C++
// This will segfault

#include <CGAL/CORE_BigInt.h>
#include <CGAL/CORE_BigRat.h>
#include <CGAL/CORE_Expr.h>
#include <CGAL/CORE/poly/Poly.h>

int main()
{
  using Polynomial = CORE::Polynomial<CORE::BigInt>;

  Polynomial poly(
      "6292610697842286811635955139693732935009542961033344667036418048-"
      "103819018355033897838248246203466232014668376703031553190065602560*x+"
      "389958343406394061055782957406169075627518035964428754926430060544*x^2-"
      "944918087329222432316982976498054054571260048471617675425124188160*x^3+"
      "1211824183851140903767601657701759440881940385941369372497424678912*x^4-"
      "699316777172893143445259888350571697548316324857460168144464117760*x^5+"
      "144953133353533471687425668682375878986597384576189365099121606656*x^6+"
      "0*x^7+0*x^8+0*x^9+0*x^10+0*x^11+0*x^12");

  // uncommenting this fixes the problem
  // poly.contract();

  auto derivative = Polynomial{poly}.differentiate();
  auto x = CORE::gcd(poly, derivative);
}
```
2. A bug in how polynomials were laid out to be passed to the resultant function in the Bezier traits.

I checked the correctness of this change using the demo by making self intersecting curves and by checking the vertices of the arrangement in #4817 against a visualization of the curve.

For #4918, the assertion was placed incorrectly
https://github.com/CGAL/cgal/blob/3f8916e0cb42466770b727511eae25730ad79b0c/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h#L1142-L1146
This asserts that vertices originating from the same curve divide the curve into 2 x_monotone curves having different directions. This is only true for vertical tangencies. In case of self intersections, they would have the same direction.
This is "compare_to_left" function. Its twin "compare_to_right" has it right
https://github.com/CGAL/cgal/blob/3f8916e0cb42466770b727511eae25730ad79b0c/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h#L1010-L1015

For #4920 when finding exact intersections between 2 curves, you solve the polynomials and get a number of "(t, s)" pairs. "t" is the param for the first, while "s" is for the second. You then find the one that lies in the approximated interval bound. However when the two curves are the same (self intersections) you need to try swapping "(s, t)" as well. This is because the function that finds self intersections doesn't report both of the duplicate pair: (t, s) and (s, t).

## Release Management

* Affected package(s): Arrangement_2, CORE
* Issue(s) solved (if any): fix #4817 fix #4918 fix #4920
* License and copyright ownership: The license used by CGAL.

