### PR TITLE
Representation of `__` in typewrite font versus code

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
@@ -101,70 +101,70 @@ the following table.
     <TD ALIGN=LEFT NOWRAP>
 GNU 3.2.1
     <TD ALIGN=LEFT NOWRAP>
-<TT>__GNUC__</TT>
+`__GNUC__`
     <TD ALIGN=LEFT NOWRAP>
 3
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 GNU 3.2.1
     <TD ALIGN=LEFT NOWRAP>
-<TT>__GNUC_MINOR__</TT>
+`__GNUC_MINOR__`
     <TD ALIGN=LEFT NOWRAP>
 2
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 GNU 3.2.1
     <TD ALIGN=LEFT NOWRAP>
-<TT>__GNUC_PATCHLEVEL__</TT>
+`__GNUC_PATCHLEVEL__`
     <TD ALIGN=LEFT NOWRAP>
 1
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Microsoft VC7.1
     <TD ALIGN=LEFT NOWRAP>
-<TT>_MSC_VER</TT>
+`_MSC_VER`
     <TD ALIGN=LEFT NOWRAP>
 1310
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Microsoft VC8.0
     <TD ALIGN=LEFT NOWRAP>
-<TT>_MSC_VER</TT>
+`_MSC_VER`
     <TD ALIGN=LEFT NOWRAP>
 1400
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Intel 11.1
     <TD ALIGN=LEFT NOWRAP>
-<TT>__INTEL_COMPILER</TT>
+`__INTEL_COMPILER`
     <TD ALIGN=LEFT NOWRAP>
 1110
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Clang 2.9
     <TD ALIGN=LEFT NOWRAP>
-<TT>__clang_major__</TT>
+`__clang_major__`
     <TD ALIGN=LEFT NOWRAP>
 2
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Clang 2.9
     <TD ALIGN=LEFT NOWRAP>
-<TT>__clang_minor__</TT>
+`__clang_minor__`
     <TD ALIGN=LEFT NOWRAP>
 9
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 SUN 5.3
     <TD ALIGN=LEFT NOWRAP>
-<TT>__SUNPRO_CC</TT>
+`__SUNPRO_CC`
     <TD ALIGN=LEFT NOWRAP>
 0x530
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 SUN 5.10
     <TD ALIGN=LEFT NOWRAP>
-<TT>__SUNPRO_CC</TT>
+`__SUNPRO_CC`
     <TD ALIGN=LEFT NOWRAP>
 0x5100
 </TABLE>
@@ -178,17 +178,17 @@ There are also flags to identify the architecture.
     <TD ALIGN=LEFT NOWRAP>
 SGI
     <TD ALIGN=LEFT NOWRAP>
-<TT>__sgi</TT>
+`__sgi`
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 SUN
     <TD ALIGN=LEFT NOWRAP>
-<TT>__sun</TT>
+`__sun`
   <TR>
     <TD ALIGN=LEFT NOWRAP>
 Linux
     <TD ALIGN=LEFT NOWRAP>
-<TT>__linux</TT>
+`__linux`
 </TABLE>
 </TABLE>
 


### PR DESCRIPTION
Seen the discussion with the doxygen pull request https://github.com/doxygen/doxygen/pull/7782 and the subsequent regression, I think it is better to signal the words like `__GNUC__` really as code by using back-ticks in the code.

## Summary of Changes

Representation of `<TT>__GNUC__</TT>` and friends as code and not in a typewriter font.
## Release Management

* Affected package(s): Documentation / Manual

- Before changes (in CGAL):
  ![res_ERR](https://user-images.githubusercontent.com/5223533/89730442-e0a5a100-da3e-11ea-84a9-7dd4d3685f44.jpg)

- After changes in CGAL and before doxygen https://github.com/doxygen/doxygen/pull/7782
  ![res_OK](https://user-images.githubusercontent.com/5223533/89730454-fb781580-da3e-11ea-9d0e-4c844f2c4583.jpg)


