### PR TITLE
STL Extension: Small Stack Allocator

### DIFF
--- a/STL_Extension/include/CGAL/Small_stack_allocator.h
+++ b/STL_Extension/include/CGAL/Small_stack_allocator.h
@@ -93,7 +93,11 @@ class Small_stack_allocator
 {
 public:
 
-  using value_type = T;
+  using pointer =               T*;
+  using const_pointer =   const T*;
+  using reference =             T&;
+  using const_reference = const T&;
+  using value_type =            T ;
 
   template <typename T2, std::size_t MaxSize2>
   friend class Small_stack_allocator;
@@ -129,6 +133,25 @@ public:
   {
     m_pool.deallocate (p, n);
   }
+
+  // Functions construct and destroy are not used by modern compilers
+  // and are deprecated from the Allocator concept in C++17. They are
+  // included to comply with older compilers and should be removed at
+  // some point.
+
+  template <typename U, typename ... Args>
+  void construct (U* u, Args&& ... args)
+  {
+    ::new (static_cast<void*>(u))
+      U (std::forward<Args> (args)...);
+  }
+
+  template <typename U>
+  void destroy (U* u)
+  {
+    u->~U();
+  }
+
 };
 
 } // namespace CGAL

--- a/STL_Extension/include/CGAL/Small_stack_allocator.h
+++ b/STL_Extension/include/CGAL/Small_stack_allocator.h
@@ -52,7 +52,7 @@ public:
     }
 
     // Else, fallback to `new` allocation
-    return new T[n];
+    return static_cast<T*>(::operator new(n * sizeof(T)));
   }
 
   void deallocate (T* p, std::size_t n)
@@ -69,7 +69,7 @@ public:
     }
     // Else, delete it
     else
-      delete[] p;
+      ::operator delete(p);
   }
 
 };

--- a/STL_Extension/include/CGAL/Small_stack_allocator.h
+++ b/STL_Extension/include/CGAL/Small_stack_allocator.h
@@ -125,12 +125,13 @@ public:
 
   Small_stack_allocator() { }
 
-  // Do not copy pool
+  // Allow copy from any rebound class (do not copy pool)
   Small_stack_allocator(const Small_stack_allocator&) { }
-  Small_stack_allocator& operator= (const Small_stack_allocator&)
-  {
-    return Small_stack_allocator();
-  }
+  template <typename T2>
+  Small_stack_allocator(const Small_stack_allocator<T2, MaxSize>&) { }
+
+  // Delete assignment
+  Small_stack_allocator& operator= (const Small_stack_allocator&) = delete;
 
   T* allocate (std::size_t n)
   {

--- a/STL_Extension/include/CGAL/Small_stack_allocator.h
+++ b/STL_Extension/include/CGAL/Small_stack_allocator.h
@@ -94,9 +94,12 @@ public:
 
   Small_stack_allocator() { }
 
-  // Forbid copy/assignment
-  Small_stack_allocator (const Small_stack_allocator&) = delete;
-  Small_stack_allocator& operator=  (const Small_stack_allocator&) = delete;
+  // Do not copy pool
+  Small_stack_allocator(const Small_stack_allocator&) { }
+  Small_stack_allocator& operator=  (const Small_stack_allocator&)
+  {
+    return Small_stack_allocator();
+  }
 
   T* allocate (std::size_t n)
   {

--- a/STL_Extension/include/CGAL/Small_stack_allocator.h
+++ b/STL_Extension/include/CGAL/Small_stack_allocator.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2020  GeometryFactory (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Simon Giraudot
+
+#ifndef CGAL_SMALL_STACK_ALLOCATOR_H
+#define CGAL_SMALL_STACK_ALLOCATOR_H
+
+#include <CGAL/Profile_counter.h>
+
+#include <cstdlib>
+
+
+namespace CGAL
+{
+
+namespace internal
+{
+
+template <typename T, std::size_t MaxSize>
+class Small_stack_allocator_pool
+{
+  T m_pool[MaxSize];
+  std::size_t m_next;
+
+public:
+
+  Small_stack_allocator_pool ()
+    : m_next(0) { }
+  ~Small_stack_allocator_pool() { }
+
+  // Forbid copy/assignment
+  Small_stack_allocator_pool (const Small_stack_allocator_pool&) = delete;
+  Small_stack_allocator_pool& operator= (const Small_stack_allocator_pool&) = delete;
+
+  T* allocate (std::size_t n)
+  {
+    CGAL_BRANCH_PROFILER("stack allocations / total allocations of Small_stack_allocator", prof);
+    if (m_next + n < MaxSize)
+    {
+      CGAL_BRANCH_PROFILER_BRANCH(prof);
+      T* out = m_pool + m_next;
+      m_next += n;
+      return out;
+    }
+
+    return new T[n];
+  }
+
+  void deallocate (T* p, std::size_t n)
+  {
+    if (m_pool <= p && p < m_pool + MaxSize)
+    {
+      std::size_t pos = static_cast<std::size_t>(p - m_pool);
+      if (pos + n == m_next)
+        m_next = pos;
+    }
+    else
+      delete[] p;
+  }
+
+};
+
+} // namespace internal
+
+template <typename T, std::size_t MaxSize>
+class Small_stack_allocator
+{
+public:
+
+  using value_type = T;
+
+  template <typename T2, std::size_t MaxSize2>
+  friend class Small_stack_allocator;
+
+  template <typename T2>
+  struct rebind
+  {
+    using other = Small_stack_allocator<T2, MaxSize>;
+  };
+
+private:
+
+  using Pool = internal::Small_stack_allocator_pool<T, MaxSize>;
+  Pool m_pool;
+
+public:
+
+  Small_stack_allocator() { }
+
+  // Forbid copy/assignment
+  Small_stack_allocator (const Small_stack_allocator&) = delete;
+  Small_stack_allocator& operator=  (const Small_stack_allocator&) = delete;
+
+  T* allocate (std::size_t n)
+  {
+    return m_pool.allocate(n);
+  }
+
+  void deallocate (T* p, std::size_t n)
+  {
+    m_pool.deallocate (p, n);
+  }
+};
+
+
+} // namespace CGAL
+
+
+
+#endif // CGAL_SMALL_STACK_ALLOCATOR_H

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -42,9 +42,9 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_Uncertain.cpp" )
   create_single_source_cgal_program( "test_vector.cpp" )
   create_single_source_cgal_program( "test_join_iterators.cpp" )
+  create_single_source_cgal_program( "test_Small_stack_allocator.cpp" )
 else()
 
     message(STATUS "This program requires the CGAL library, and will not be compiled.")
 
 endif()
-

--- a/STL_Extension/test/STL_Extension/test_Small_stack_allocator.cpp
+++ b/STL_Extension/test/STL_Extension/test_Small_stack_allocator.cpp
@@ -1,0 +1,63 @@
+#include <CGAL/Small_stack_allocator.h>
+#include <CGAL/Real_timer.h>
+#include <CGAL/Random.h>
+
+#include <list>
+
+constexpr std::size_t nb_tests = 10000000;
+
+typedef std::list<int> Standard_list;
+
+constexpr std::size_t max_size = 4;
+typedef CGAL::Small_stack_allocator<int, max_size> SSA;
+typedef std::list<int, SSA> List_with_small_stack;
+
+template <typename ListType>
+double speed_test (std::size_t nb_min, std::size_t nb_max)
+{
+  CGAL::Real_timer t;
+  t.start();
+  CGAL::Random rand(0);
+  for (std::size_t i = 0; i < nb_tests; ++ i)
+  {
+    ListType list;
+    std::size_t nb = rand.get_int(nb_min, nb_max);
+    for (std::size_t j = 0; j < nb; ++ j)
+      list.push_back (rand.get_int(0, 1000000));
+  }
+  t.stop();
+
+  return t.time();
+}
+
+int main()
+{
+  std::cerr << "[Speed test with all insertions smaller than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size - 2, max_size)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<List_with_small_stack>(max_size - 2, max_size)
+            << "s" << std::endl
+            << "   (should be much faster)" << std::endl;
+
+  std::cerr << "[Speed test with ~50% insertions smaller than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size - 2, max_size + 2)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<List_with_small_stack>(max_size - 2, max_size + 2)
+            << "s" << std::endl
+            << "   (should still be slightly faster)" << std::endl;
+
+  std::cerr << "[Speed test with all insertions greater than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size + 2, max_size + 4)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<List_with_small_stack>(max_size + 2, max_size + 4)
+            << "s" << std::endl
+            << "   (shouldn't be faster)" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_event_base.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_event_base.h
@@ -17,6 +17,9 @@
 
 #include <CGAL/license/Surface_sweep_2.h>
 
+#include <CGAL/Small_stack_allocator.h>
+
+
 /*! \file
  *
  * Defintion of the No_overlap_event_base class.
@@ -65,7 +68,8 @@ public:
   typedef typename internal::Arr_complete_right_side_category<Gt2>::Category
                                                         Right_side_category;
 
-  typedef std::list<Subcurve*>                          Subcurve_container;
+  typedef Small_stack_allocator<Subcurve*, 4>           Subcurve_allocator;
+  typedef std::list<Subcurve*, Subcurve_allocator>      Subcurve_container;
   typedef typename Subcurve_container::iterator         Subcurve_iterator;
   typedef typename Subcurve_container::const_iterator   Subcurve_const_iterator;
   typedef typename Subcurve_container::reverse_iterator


### PR DESCRIPTION
## Summary of Changes

When a lot of containers are instantiated and are expected to contain a small number of elements, it can be interesting to use static allocation (through `std::array` or C-array style structures) to avoid the cost of dynamic allocation for every small container instantiated. This is the principle behind `boost::container::small_vector` for example.

This PR introduces `CGAL::Small_stack_allocator` which aims at generalizing this principle to other types of container, like `std::list`.

This PR makes this allocator used in the Event structure of the `Surface_sweep_2` package: in that case, events keep track of their adjacent curves through `std::list` data structures. In practice, lots of events can be instantiated but usually, only a few curves are adjacent to an event, so the `std::list` rarely grow to more than 1 or 2 curves. Using the small stack allocator allows to speed up computation by a factor up to 15% in my experimentation.

Note that this small stack allocator could maybe be used in other places that I don't know of.

## Release Management

* Affected package(s): STL Extensions, Surface Sweep + packages that rely on it (Arrangement, etc.)
