### PR TITLE
Layout on the bibliography page

### DIFF
--- a/Documentation/doc/resources/1.8.13/stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/stylesheet.css
@@ -1245,10 +1245,12 @@ dl.citelist dt {
         font-weight:bold;
         margin-right:10px;
         padding:5px;
+        text-align:right;
+        width:52px;
 }
 
 dl.citelist dd {
-        margin:2px 0;
+        margin:2px 0 2px 72px;
         padding:5px 0;
 }
 

--- a/Documentation/doc/resources/1.8.14/stylesheet.css
+++ b/Documentation/doc/resources/1.8.14/stylesheet.css
@@ -1245,10 +1245,12 @@ dl.citelist dt {
         font-weight:bold;
         margin-right:10px;
         padding:5px;
+        text-align:right;
+        width:52px;
 }
 
 dl.citelist dd {
-        margin:2px 0;
+        margin:2px 0 2px 72px;
         padding:5px 0;
 }
 

--- a/Documentation/doc/resources/1.8.4/stylesheet.css
+++ b/Documentation/doc/resources/1.8.4/stylesheet.css
@@ -1079,10 +1079,12 @@ dl.citelist dt {
         font-weight:bold;
         margin-right:10px;
         padding:5px;
+        text-align:right;
+        width:52px;
 }
 
 dl.citelist dd {
-        margin:2px 0;
+        margin:2px 0 2px 72px;
         padding:5px 0;
 }
 


### PR DESCRIPTION
When having a bit a long citation description, the description runs, in the HTML output on the bibliography page, into 3 or more lines where the 3rd and following lines continue underneath the citation number like:
```
 [1]  Eric Berberich, Arno Eigenwillig, Michael Hemmer, Susan Hert, Lutz Kettner, Kurt Mehlhorn, Joachim Reichel, Susanne Schmitt, Elmar Schömer, and Nicola Wolpert. Exacus: Efficient and exact
      algorithms for curves and surfaces. In Gerth S. Brodal and Stefano Leonardi, editors, 13th Annual European Symposium on Algorithms (ESA 2005), volume 3669 of Lecture Notes in Computer Science,
pages 155–166, Palma de Mallorca, Spain, October 2005. European Association for Theoretical Computer Science (EATCS), Springer.
```

The example was found  in e.g. https://doc.cgal.org/latest/Algebraic_foundations/citelist.html

- corrected the "overflow"
- made the citation number right aligned

(proposed pull request for doxygen: https://github.com/doxygen/doxygen/pull/7955)

