### PR TITLE
fix edge_to_faces key in Collect_face_bbox_per_edge_bbox

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -57,7 +57,7 @@ public:
     halfedge_descriptor fh = face_box.info();
     halfedge_descriptor eh = edge_box.info();
 
-    edge_to_faces[eh].insert(face(fh, tm_faces));
+	edge_to_faces[edge(eh,tm_edges)].insert(face(fh, tm_faces));
   }
 
   void operator()( const Box* face_box_ptr, const Box* edge_box_ptr) const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -57,7 +57,7 @@ public:
     halfedge_descriptor fh = face_box.info();
     halfedge_descriptor eh = edge_box.info();
 
-	edge_to_faces[edge(eh,tm_edges)].insert(face(fh, tm_faces));
+    edge_to_faces[edge(eh,tm_edges)].insert(face(fh, tm_faces));
   }
 
   void operator()( const Box* face_box_ptr, const Box* edge_box_ptr) const


### PR DESCRIPTION
## Summary of Changes

fix compile error when using Collect_face_bbox_per_edge_bbox as callback when DO_NOT_HANDLE_COPLANAR_FACES is defined