### PR TITLE
Surface Sweep + Arr Overlay: Init with indexed edges

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
@@ -90,6 +90,11 @@ public:
   /*! Destructor. */
   virtual ~Arr_vertex_base() {}
 
+  // Access/modification for pointer squatting
+  void* inc() const { return p_inc; }
+  void set_inc(void * inc) const
+  { const_cast<Arr_vertex_base&>(*this).p_inc = inc; }
+
   /*! Check if the point pointer is nullptr. */
   bool has_null_point() const { return (p_pt == nullptr); }
 
@@ -286,8 +291,6 @@ public:
   typedef Arr_vertex<V,H,F>           Vertex;
   typedef Arr_halfedge<V,H,F>         Halfedge;
   typedef Arr_isolated_vertex<V,H,F>  Isolated_vertex;
-
-  mutable std::size_t index;
 
   /*! Default constructor. */
   Arr_vertex() {}

--- a/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
@@ -287,6 +287,8 @@ public:
   typedef Arr_halfedge<V,H,F>         Halfedge;
   typedef Arr_isolated_vertex<V,H,F>  Isolated_vertex;
 
+  mutable std::size_t index;
+
   /*! Default constructor. */
   Arr_vertex() {}
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -57,14 +57,14 @@ public:
     return arr1.number_of_vertices() + arr2.number_of_vertices();
   }
 
-  std::size_t source_index (const Curve& c) const
-  {
-    return reinterpret_cast<std::size_t>(halfedge(c)->source()->inc());
-  }
-
-  std::size_t target_index (const Curve& c) const
+  std::size_t min_end_index (const Curve& c) const
   {
     return reinterpret_cast<std::size_t>(halfedge(c)->target()->inc());
+  }
+
+  std::size_t max_end_index (const Curve& c) const
+  {
+    return reinterpret_cast<std::size_t>(halfedge(c)->source()->inc());
   }
 
   const Curve& curve (const Curve& c) const
@@ -258,7 +258,7 @@ overlay(const Arrangement_on_surface_2<GeometryTraitsA_2, TopologyTraitsA>& arr1
   if (total_iso_verts == 0) {
     // Clear the result arrangement and perform the sweep to construct it.
     arr.clear();
-    if (std::is_same<typename Agt2::Base_traits_2::Bottom_side_category,
+    if (std::is_same<typename Agt2::Bottom_side_category,
                      Arr_contracted_side_tag>::value)
       surface_sweep.sweep (xcvs_vec.begin(), xcvs_vec.end());
     else
@@ -297,7 +297,7 @@ overlay(const Arrangement_on_surface_2<GeometryTraitsA_2, TopologyTraitsA>& arr1
 
   // Clear the result arrangement and perform the sweep to construct it.
   arr.clear();
-  if (std::is_same<typename Agt2::Base_traits_2::Bottom_side_category,
+  if (std::is_same<typename Agt2::Bottom_side_category,
       Arr_contracted_side_tag>::value)
     surface_sweep.sweep(xcvs_vec.begin(), xcvs_vec.end(),
                         pts_vec.begin(), pts_vec.end());

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -297,8 +297,16 @@ overlay(const Arrangement_on_surface_2<GeometryTraitsA_2, TopologyTraitsA>& arr1
 
   // Clear the result arrangement and perform the sweep to construct it.
   arr.clear();
-  surface_sweep.sweep(xcvs_vec.begin(), xcvs_vec.end(),
-                      pts_vec.begin(), pts_vec.end());
+  if (std::is_same<typename Agt2::Base_traits_2::Bottom_side_category,
+      Arr_contracted_side_tag>::value)
+    surface_sweep.sweep(xcvs_vec.begin(), xcvs_vec.end(),
+                        pts_vec.begin(), pts_vec.end());
+  else
+    surface_sweep.indexed_sweep (xcvs_vec,
+                                 Indexed_sweep_accessor
+                                 <Arr_a, Arr_b, Ovl_x_monotone_curve_2>
+                                 (arr1, arr2),
+                                 pts_vec.begin(), pts_vec.end());
   xcvs_vec.clear();
   pts_vec.clear();
 }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -84,16 +84,18 @@ public:
   void before_init() const
   {
     std::size_t idx = 0;
-    backup_inc.reserve (nb_vertices());
+    backup_inc.resize (nb_vertices());
     for (typename Arr1::Vertex_const_iterator vit = arr1.vertices_begin();
          vit != arr1.vertices_end(); ++vit, ++idx)
     {
+      CGAL_assertion (idx < backup_inc.size());
       backup_inc[idx] = vit->inc();
       vit->set_inc (reinterpret_cast<void*>(idx));
     }
     for (typename Arr2::Vertex_const_iterator vit = arr2.vertices_begin();
          vit != arr2.vertices_end(); ++vit, ++idx)
     {
+      CGAL_assertion (idx < backup_inc.size());
       backup_inc[idx] = vit->inc();
       vit->set_inc (reinterpret_cast<void*>(idx));
     }
@@ -105,10 +107,16 @@ public:
     std::size_t idx = 0;
     for (typename Arr1::Vertex_const_iterator vit = arr1.vertices_begin();
          vit != arr1.vertices_end(); ++vit, ++idx)
+    {
+      CGAL_assertion (idx < backup_inc.size());
       vit->set_inc (backup_inc[idx]);
+    }
     for (typename Arr2::Vertex_const_iterator vit = arr2.vertices_begin();
          vit != arr2.vertices_end(); ++vit, ++idx)
+    {
+      CGAL_assertion (idx < backup_inc.size());
       vit->set_inc (backup_inc[idx]);
+    }
   }
 
 private:

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -59,12 +59,12 @@ public:
 
   std::size_t source_index (const Curve& c) const
   {
-    return reinterpret_cast<std::size_t>(halfedge(c)->target()->inc());
+    return reinterpret_cast<std::size_t>(halfedge(c)->source()->inc());
   }
 
   std::size_t target_index (const Curve& c) const
   {
-    return reinterpret_cast<std::size_t>(halfedge(c)->source()->inc());
+    return reinterpret_cast<std::size_t>(halfedge(c)->target()->inc());
   }
 
   const Curve& curve (const Curve& c) const
@@ -258,10 +258,14 @@ overlay(const Arrangement_on_surface_2<GeometryTraitsA_2, TopologyTraitsA>& arr1
   if (total_iso_verts == 0) {
     // Clear the result arrangement and perform the sweep to construct it.
     arr.clear();
-    surface_sweep.indexed_sweep (xcvs_vec,
-                                 Indexed_sweep_accessor
-                                 <Arr_a, Arr_b, Ovl_x_monotone_curve_2>
-                                 (arr1, arr2));
+    if (std::is_same<typename Agt2::Base_traits_2::Bottom_side_category,
+                     Arr_contracted_side_tag>::value)
+      surface_sweep.sweep (xcvs_vec.begin(), xcvs_vec.end());
+    else
+      surface_sweep.indexed_sweep (xcvs_vec,
+                                   Indexed_sweep_accessor
+                                   <Arr_a, Arr_b, Ovl_x_monotone_curve_2>
+                                   (arr1, arr2));
     xcvs_vec.clear();
     return;
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -59,12 +59,20 @@ public:
 
   std::size_t min_end_index (const Curve& c) const
   {
-    return reinterpret_cast<std::size_t>(halfedge(c)->target()->inc());
+    if (c.red_halfedge_handle() != typename Curve::HH_red())
+      return reinterpret_cast<std::size_t>(c.red_halfedge_handle()->target()->inc());
+    // else
+    CGAL_assertion (c.blue_halfedge_handle() != typename Curve::HH_blue());
+    return reinterpret_cast<std::size_t>(c.blue_halfedge_handle()->target()->inc());
   }
 
   std::size_t max_end_index (const Curve& c) const
   {
-    return reinterpret_cast<std::size_t>(halfedge(c)->source()->inc());
+    if (c.red_halfedge_handle() != typename Curve::HH_red())
+      return reinterpret_cast<std::size_t>(c.red_halfedge_handle()->source()->inc());
+    // else
+    CGAL_assertion (c.blue_halfedge_handle() != typename Curve::HH_blue());
+    return reinterpret_cast<std::size_t>(c.blue_halfedge_handle()->source()->inc());
   }
 
   const Curve& curve (const Curve& c) const
@@ -103,16 +111,6 @@ public:
 
 private:
 
-  typename Curve::Halfedge_handle halfedge (const Curve& c) const
-  {
-    if (c.red_halfedge_handle() == typename Curve::Halfedge_handle())
-    {
-      CGAL_assertion (c.blue_halfedge_handle() != typename Curve::Halfedge_handle());
-      return c.blue_halfedge_handle();
-    }
-    // else
-    return c.red_halfedge_handle();
-  }
 };
 
 /*! Compute the overlay of two input arrangements.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_overlay_2.h
@@ -80,6 +80,7 @@ public:
     return c;
   }
 
+  // Initializes indices by squatting Vertex::inc();
   void before_init() const
   {
     std::size_t idx = 0;
@@ -98,6 +99,7 @@ public:
     }
   }
 
+  // Restores state of arrangements before index squatting
   void after_init() const
   {
     std::size_t idx = 0;

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
@@ -134,6 +134,7 @@ public:
   class Ex_x_monotone_curve_2 {
   public:
     typedef Base_x_monotone_curve_2             Base;
+    typedef Halfedge_handle_blue                Halfedge_handle;
 
   protected:
     Base m_base_xcv;                              // The base curve.

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
@@ -134,7 +134,8 @@ public:
   class Ex_x_monotone_curve_2 {
   public:
     typedef Base_x_monotone_curve_2             Base;
-    typedef Halfedge_handle_blue                Halfedge_handle;
+    typedef Halfedge_handle_red HH_red;
+    typedef Halfedge_handle_blue HH_blue;
 
   protected:
     Base m_base_xcv;                              // The base curve.

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -310,11 +310,11 @@ public:
   }
 
   /*!
-    Run the indexed sweep-line algorithm on a given range of
+    runs the indexed sweep-line algorithm on a given range of
     x-monotone curves and accessor. The main difference from the
-    original sweep() function is that the accessor allows to get
+    original `sweep()` function is that the accessor allows to get
     indices of end-points and avoid checking several times in the
-    event queue when the same vertex as several incident edges.
+    event queue when the same vertex has several incident edges.
 
     \param edges A range of edges
     \param accessor An object providing, for a value_type `e` of
@@ -340,11 +340,11 @@ public:
   }
 
   /*!
-    Run the indexed sweep-line algorithm on a given range of
+    runs the indexed sweep-line algorithm on a given range of
     x-monotone curves and accessor. The main difference from the
-    original sweep() function is that the accessor allows to get
+    original `sweep()` function is that the accessor allows to get
     indices of end-points and avoid checking several times in the
-    event queue when the same vertex as several incident edges.
+    event queue when the same vertex has several incident edges.
 
     Variant with action event points (if a curve passed through an
     action point, it will be split).
@@ -375,7 +375,6 @@ public:
     _init_indexed_sweep(edges, accessor);
     accessor.after_init();
     _init_points(action_points_begin, action_points_end, Event::ACTION);
-    //m_visitor->after_init();
     _sweep();
     _complete_sweep();
     m_visitor->after_sweep();

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -322,6 +322,24 @@ public:
     m_visitor->after_sweep();
   }
 
+  template <typename EdgeRange, typename Accessor,
+            typename PointInputIterator>
+  void indexed_sweep (const EdgeRange& edges,
+                      const Accessor& accessor,
+                      PointInputIterator action_points_begin,
+                      PointInputIterator action_points_end)
+  {
+    m_visitor->before_sweep();
+    accessor.before_init();
+    _init_indexed_sweep(edges, accessor);
+    accessor.after_init();
+    _init_points(action_points_begin, action_points_end, Event::ACTION);
+    //m_visitor->after_init();
+    _sweep();
+    _complete_sweep();
+    m_visitor->after_sweep();
+  }
+
   /*! Get an iterator for the first subcurve in the status line. */
   Status_line_iterator status_line_begin() { return m_statusLine.begin(); }
 

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -408,8 +408,8 @@ protected:
       (m_subCurves + index)->set_hint(this->m_statusLine.end());
       (m_subCurves + index)->init (curve);
 
-      _init_curve_end(curve, ARR_MAX_END, m_subCurves + index, events, target);
-      _init_curve_end(curve, ARR_MIN_END, m_subCurves + index, events, source);
+      _init_curve_end(curve, ARR_MAX_END, m_subCurves + index, events, source);
+      _init_curve_end(curve, ARR_MIN_END, m_subCurves + index, events, target);
 
       ++ index;
     }

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -424,6 +424,17 @@ protected:
     _init_curves(curves_begin, curves_end);     // initialize the curves
   }
 
+  /*! Initiliaze the sweep algorithm. */
+  template <typename EdgeRange, typename Accessor>
+  void _init_indexed_sweep(const EdgeRange& edges,
+                           const Accessor& accessor)
+  {
+    m_num_of_subCurves =
+      static_cast<unsigned int>(std::distance(edges.begin(), edges.end()));
+    _init_structures();
+    _init_indexed_curves(edges, accessor);     // initialize the curves
+  }
+
   /*! Initialize the data structures for the sweep-line algorithm. */
   virtual void _init_structures();
 

--- a/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/No_intersection_surface_sweep_2.h
@@ -314,7 +314,9 @@ public:
                       const Accessor& accessor)
   {
     m_visitor->before_sweep();
+    accessor.before_init();
     _init_indexed_sweep(edges, accessor);
+    accessor.after_init();
     _sweep();
     _complete_sweep();
     m_visitor->after_sweep();

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
@@ -316,18 +316,30 @@ _init_curve_end(const X_monotone_curve_2& cv, Arr_curve_end ind, Subcurve* sc,
   // Create the corresponding event and push it into the event queue.
   std::pair<Event*, bool> pair_res;
 
-  const Point_2& pt = (ind == ARR_MIN_END) ?
-    m_traits->construct_min_vertex_2_object()(cv) :
-    m_traits->construct_max_vertex_2_object()(cv);
+  if (m_traits->is_closed_2_object()(cv, ind)) {
+    // The curve end is closed and thus associated with a valid endpoint.
+    const Point_2& pt = (ind == ARR_MIN_END) ?
+      m_traits->construct_min_vertex_2_object()(cv) :
+      m_traits->construct_max_vertex_2_object()(cv);
 
-  pair_res = ((ps_x == ARR_INTERIOR) && (ps_y == ARR_INTERIOR)) ?
-    _push_event(pt, end_attr, ps_x, ps_y, sc, events, index) :
-    _push_event(cv, ind, end_attr, ps_x, ps_y, sc, pt, events, index);
+    pair_res = ((ps_x == ARR_INTERIOR) && (ps_y == ARR_INTERIOR)) ?
+      _push_event(pt, end_attr, ps_x, ps_y, sc, events, index) :
+      _push_event(cv, ind, end_attr, ps_x, ps_y, sc, pt, events, index);
 
-  // Inform the visitor in case we updated an existing event.
-  Event* e = pair_res.first;
-  CGAL_assertion(e->is_closed());
-  m_visitor->update_event(e, pt, cv, ind, pair_res.second);
+    // Inform the visitor in case we updated an existing event.
+    Event* e = pair_res.first;
+    CGAL_assertion(e->is_closed());
+    m_visitor->update_event(e, pt, cv, ind, pair_res.second);
+  }
+  else {
+    // The curve end is open, insert it into the event queue.
+    pair_res = _push_event(cv, ind, end_attr, ps_x, ps_y, sc);
+
+    // Inform the visitor in case we updated an existing event.
+    Event* e = pair_res.first;
+    CGAL_assertion(! e->is_closed());
+    _update_event_at_open_boundary(e, cv, ind, pair_res.second);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
@@ -301,6 +301,35 @@ _init_curve_end(const X_monotone_curve_2& cv, Arr_curve_end ind, Subcurve* sc)
   }
 }
 
+template <typename Vis>
+void No_intersection_surface_sweep_2<Vis>::
+_init_curve_end(const X_monotone_curve_2& cv, Arr_curve_end ind, Subcurve* sc,
+                std::vector<Event_queue_iterator>& events, std::size_t index)
+{
+  // Get the boundary conditions of the curve end.
+  const Attribute  end_attr =
+    (ind == ARR_MIN_END) ? Event::LEFT_END : Event::RIGHT_END;
+
+  Arr_parameter_space ps_x = m_traits->parameter_space_in_x_2_object()(cv, ind);
+  Arr_parameter_space ps_y = m_traits->parameter_space_in_y_2_object()(cv, ind);
+
+  // Create the corresponding event and push it into the event queue.
+  std::pair<Event*, bool> pair_res;
+
+  const Point_2& pt = (ind == ARR_MIN_END) ?
+    m_traits->construct_min_vertex_2_object()(cv) :
+    m_traits->construct_max_vertex_2_object()(cv);
+
+  pair_res = ((ps_x == ARR_INTERIOR) && (ps_y == ARR_INTERIOR)) ?
+    _push_event(pt, end_attr, ps_x, ps_y, sc, events, index) :
+    _push_event(cv, ind, end_attr, ps_x, ps_y, sc, pt, events, index);
+
+  // Inform the visitor in case we updated an existing event.
+  Event* e = pair_res.first;
+  CGAL_assertion(e->is_closed());
+  m_visitor->update_event(e, pt, cv, ind, pair_res.second);
+}
+
 //-----------------------------------------------------------------------------
 // Handle the subcurves to the left of the current event point.
 //
@@ -673,6 +702,72 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const Point_2& pt,
   return (std::make_pair(e, !exist));
 }
 
+template <typename Vis>
+std::pair<typename No_intersection_surface_sweep_2<Vis>::Event*, bool>
+No_intersection_surface_sweep_2<Vis>::_push_event(const Point_2& pt,
+                                                  Attribute type,
+                                                  Arr_parameter_space ps_x,
+                                                  Arr_parameter_space ps_y,
+                                                  Subcurve* sc,
+                                                  std::vector<Event_queue_iterator>& events,
+                                                  std::size_t index)
+{
+  Event* e;
+
+  std::pair<Event_queue_iterator, bool>
+    pair_res = std::make_pair (events[index], true);
+
+  // If event does not exist
+  if (events[index] == Event_queue_iterator())
+  {
+    // Still look for the curve end in the event queue in case two
+    // point are the the same in the vertex range
+    m_queueEventLess.set_parameter_space_in_x(ps_x);
+    m_queueEventLess.set_parameter_space_in_y(ps_y);
+    pair_res = m_queue->find_lower(pt, m_queueEventLess);
+  }
+
+  bool exist = pair_res.second;
+  if (! exist) {
+    // The point is not found in the event queue - create a new event and
+    // insert it into the queue.
+    e = _allocate_event(pt, type, ps_x, ps_y);
+  }
+  else {
+    events[index] = pair_res.first;
+    // The event associated with the given point already exists in the queue,
+    // so we just have to update it.
+    e = *(pair_res.first);
+    CGAL_assertion(e->is_closed());
+
+    e->set_attribute(type);
+  }
+
+  // If we are given a subcurve that the event represents one of its
+  // endpoints, update the event and the subcurve records accordingly.
+  // Note that this must be done before we actually insert the new event
+  // into the event queue.
+  _add_curve(e, sc, type);
+
+  // Insert the new event into the queue using the hint we got when we
+  // looked for it.
+  if (! exist)
+    events[index] = m_queue->insert_before(pair_res.first, e);
+
+#ifdef CGAL_SS_VERBOSE
+  if (! exist) {
+    CGAL_SS_PRINT_NEW_EVENT(pt, e);
+  }
+  else {
+    CGAL_SS_PRINT_UPDATE_EVENT(pt, e);
+  }
+#endif
+
+  // Return the resulting event and a flag indicating whether we have created
+  // a new event.
+  return (std::make_pair(e, !exist));
+}
+
 //-----------------------------------------------------------------------------
 // Push an event point associated with a curve end into the event queue.
 //
@@ -732,6 +827,72 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const X_monotone_curve_2& cv,
   // Insert the new event into the queue using the hint we got when we
   // looked for it.
   if (! exist) m_queue->insert_before(pair_res.first, e);
+
+  return (std::make_pair(e, !exist));
+}
+
+template <typename Vis>
+std::pair<typename No_intersection_surface_sweep_2<Vis>::Event*, bool>
+No_intersection_surface_sweep_2<Vis>::_push_event(const X_monotone_curve_2& cv,
+                                                  Arr_curve_end ind,
+                                                  Attribute type,
+                                                  Arr_parameter_space ps_x,
+                                                  Arr_parameter_space ps_y,
+                                                  Subcurve* sc,
+                                                  const Point_2& pt,
+                                                  std::vector<Event_queue_iterator>& events,
+                                                  std::size_t index)
+{
+  Event* e;
+
+  std::pair<Event_queue_iterator, bool>
+    pair_res = std::make_pair (events[index], true);
+
+  // If event does not exist
+  if (events[index] == Event_queue_iterator())
+  {
+    // Still look for the curve end in the event queue in case two
+    // point are the the same in the vertex range
+
+    m_queueEventLess.set_parameter_space_in_x(ps_x);
+    m_queueEventLess.set_parameter_space_in_y(ps_y);
+    m_queueEventLess.set_index(ind);
+
+    pair_res =
+      m_queue->find_lower(cv, m_queueEventLess);
+  }
+
+  bool exist = pair_res.second;
+
+  if (! exist) {
+    // The curve end is not found in the event queue - create a new event and
+    // insert it into the queue.
+    // The curve end is closed and so it is associated with a valid
+    // point.
+    e = _allocate_event(pt, type, ps_x, ps_y);
+  }
+  else {
+    events[index] = pair_res.first;
+
+    // The event associated with the given curve end already exists in the
+    // queue, so we just have to update it.
+    e = *(pair_res.first);
+    CGAL_assertion((e->parameter_space_in_x() == ps_x) &&
+                   (e->parameter_space_in_y() == ps_y));
+
+    e->set_attribute(type);
+  }
+
+  // If we are given a subcurve that the event represents one of its
+  // endpoints, update the event and the subcurve records accordingly.
+  // Note that this must be done before we actually insert the new event
+  // into the event queue.
+  _add_curve(e, sc, type);
+
+  // Insert the new event into the queue using the hint we got when we
+  // looked for it.
+  if (! exist)
+    events[index] = m_queue->insert_before(pair_res.first, e);
 
   return (std::make_pair(e, !exist));
 }


### PR DESCRIPTION
## Summary of Changes

When performing a sweep on a set of connected segments, the connectivity is actually lost (disconnected segments are passed to the sweep) and found again through the event comparator (if two segments have the same endpoint, then this endpoint will only trigger one event), which is an unnecessarily costly operation.

This PR adds a new function `indexed_sweep()` to surface sweep which takes a range of edges with an accessor to get indices and some other information, so that each vertex only trigger one event without the need to use the comparison operator in the multiset of events. A set of indexed events is maintained accordingly during the initialization. The rest of the sweep is the same as without indices.

This indexed sweep if used in `Arr_overlay_2.h` (except when geodesic traits are used as the duplication of top and bottom vertices make it not usable so far). It could be used in other places: namely, we have experimented constructing General Polygon Sets this way and it does work well, but it's not included in this PR as we have a better lead for improving GPS (not using a sweep at all).

In practice, this speeds up boolean operations by up to 30%.

## Release Management

* Affected package(s): Surface Sweep, Arrangement_2, Boolean Operations, etc.
