### PR TITLE
Tetrahedral Remeshing - fix the two-layer issue

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -849,15 +849,16 @@ void get_edge_info(const typename C3t3::Edge& edge,
   //feature edges and feature vertices
   if (dim0 < 2 || dim1 < 2)
   {
+    if (!topology_test(edge, c3t3, cell_selector))
+    {
+#ifdef CGAL_DEBUG_TET_REMESHING_IN_PLUGIN
+      nb_topology_test++;
+#endif
+      return;
+    }
+
     if (c3t3.is_in_complex(edge))
     {
-      if (!topology_test(edge, c3t3, cell_selector))
-      {
-#ifdef CGAL_DEBUG_TET_REMESHING_IN_PLUGIN
-        nb_topology_test++;
-#endif
-        return;
-      }
       const std::size_t nb_si_v0 = nb_incident_subdomains(v0, c3t3);
       const std::size_t nb_si_v1 = nb_incident_subdomains(v1, c3t3);
 
@@ -874,6 +875,19 @@ void get_edge_info(const typename C3t3::Edge& edge,
           update_v0 = true;
         if (!c3t3.is_in_complex(v1))
           update_v1 = true;
+      }
+    }
+    else
+    {
+      if (dim0 == 2 && is_boundary_edge(v0, v1, c3t3, cell_selector))
+      {
+        update_v0 = true;
+        return;
+      }
+      else if(dim1 == 2 && is_boundary_edge(v0, v1, c3t3, cell_selector))
+      {
+        update_v1 = true;
+        return;
       }
     }
     return;


### PR DESCRIPTION
## Summary of Changes

Before this PR, tetrahedral remeshing was always ending with at least 2 layer of tetrahedra on each patch of surface.
This PR fixes the collapse of edges on surface that have only one endvertex on a polyline feature (one vertex on a surface, one on a polyline feature or a corner).

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

