### PR TITLE
Disable boost_serialization and iostreams

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -11,7 +11,7 @@ function mytime {
 function build_examples {
   mkdir -p build-travis
   cd build-travis
-  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCGAL_BUILD_THREE_DOC=TRUE ..
+  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCGAL_BUILD_THREE_DOC=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_boost_serialization=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_boost_iostreams=TRUE ..
   mytime make -j2 VERBOSE=1
 }
 


### PR DESCRIPTION
## Summary of Changes
Use -DCMAKE_DISABLE_FIND_PACKAGE_XXX to keep travis to test the classification IO system, as we don't have a working version of boost for that.

## Release Management

* Issue(s) solved (if any): fix #4929
