### PR TITLE
Polyhedron Demo: Fix c3t3 colors after optimization

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -87,6 +87,14 @@ Meshing_thread* cgal_code_mesh_3(QList<const SMesh*> pMeshes,
   std::cerr << " done (" << timer.time() * 1000 << " ms)" << std::endl;
 
   Scene_c3t3_item* p_new_item = new Scene_c3t3_item(surface_only);
+  if(polylines.empty()) {
+    if(protect_features) {
+      p_new_item->set_sharp_edges_angle(sharp_edges_angle);
+    }
+    else if (protect_borders) {
+      p_new_item->set_detect_borders(true);
+    }
+  }
 
   QString tooltip = QString("<div>From \"") + filename +
     QString("\" with the following mesh parameters"

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin.cpp
@@ -524,10 +524,9 @@ treat_result(Scene_c3t3_item& source_item,
                             static_cast<float>(bbox.ymin() + bbox.ymax())/2.f,
                             static_cast<float>(bbox.zmin() + bbox.zmax())/2.f);
 
-    result_item.setColor(QColor(59,74,226));
+    result_item.setColor(source_item.color());
     result_item.setRenderingMode(source_item.renderingMode());
     result_item.set_data_item(source_item.data_item());
-
     source_item.setVisible(false);
 
     const Scene_interface::Item_id index = scene->mainSelectionIndex();
@@ -539,6 +538,7 @@ treat_result(Scene_c3t3_item& source_item,
   else
   {
     result_item.update_histogram();
+    result_item.invalidateOpenGLBuffers();
 
     const Scene_interface::Item_id index = scene->mainSelectionIndex();
     scene->itemChanged(index);

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Optimization_plugin_cgal_code.cpp
@@ -141,6 +141,10 @@ Optimizer_thread* cgal_code_optimization(Scene_c3t3_item& c3t3_item,
       return NULL;
     }
     Polyhedral_mesh_domain* sm_domain = new Polyhedral_mesh_domain(*smesh);
+    if(c3t3_item.get_sharp_edges_angle() != -1 )
+      sm_domain->detect_features(c3t3_item.get_sharp_edges_angle());
+    else if(c3t3_item.get_detect_borders())
+      sm_domain->detect_borders();
 
     // Create thread
     typedef Optimization_function<Polyhedral_mesh_domain,Parameters> Opt_function;

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -347,6 +347,8 @@ struct Scene_c3t3_item_priv {
     cnc_are_shown = false;
     is_aabb_tree_built = false;
     alphaSlider = NULL;
+    sharp_edges_angle = -1;
+    detect_borders = false;
   }
   void computeIntersection(const Primitive& facet);
   void fill_aabb_tree() {
@@ -501,6 +503,9 @@ struct Scene_c3t3_item_priv {
   bool is_valid;
   bool is_surface;
   bool last_intersection;
+  //only for optimizers
+  double sharp_edges_angle;
+  bool detect_borders;
 
   void push_normal(std::vector<float>& normals, const EPICK::Vector_3& n) const
   {
@@ -2105,6 +2110,13 @@ Scene_c3t3_item* Scene_c3t3_item::clone() const
 {
   return new Scene_c3t3_item(d->c3t3, d->is_surface);
 }
+
+void Scene_c3t3_item::set_sharp_edges_angle(double a) { d->sharp_edges_angle = a; }
+double Scene_c3t3_item::get_sharp_edges_angle() { return d->sharp_edges_angle; }
+
+void Scene_c3t3_item::set_detect_borders(bool b) { d->detect_borders = b;}
+bool Scene_c3t3_item::get_detect_borders() { return d->detect_borders; }
+
 
 #include "Scene_c3t3_item.moc"
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.h
@@ -155,6 +155,12 @@ public:
 
   QColor get_histogram_color(const double v) const;
 
+  void set_sharp_edges_angle(double d);
+  double get_sharp_edges_angle();
+
+  void set_detect_borders(bool b);
+  bool get_detect_borders();
+
   void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
 
   void initializeBuffers(Viewer_interface *) const Q_DECL_OVERRIDE;


### PR DESCRIPTION
## Summary of Changes
When performing optimizations on a c3t3, the original domain is lost, and a new one is re-created according to the type of the original meshed item (surface_mesh, segmented image or implicit function), with default values.

In the case of a surface_mesh, the default behavior when claling mesh_3 is to detect features, with a sharp_edges_angle_bound parameter set to 60. This is not the default behaviour in optimizers, so the results clearly differ, as there are no patch ids in the second case. 
To "fix" this behaviour, I added two members (and accessors) to the c3t3_item, to store at the meshing time if we detect the features or not. Using these, those two parameters are retrieved in the optimizer pass, allowing to rebuild the right patch ids in the domain. 
There was also a wrong color set in the new optimized item, and now it is the source item's that is used.

## Release Management

* Affected package(s): Demo
* Issue(s) solved (if any): fix #4935
