### PR TITLE
Arrangement: Avoid constructing Segment_2/Line_2 objects when possible

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
@@ -1464,7 +1464,7 @@ public:
 
   /*! Create a bounding box for the segment.
    */
-  CGAL_DEPRECATED Bbox_2 bbox() const;
+  Bbox_2 bbox() const;
 };
 
 //! \brief constructs default.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
@@ -190,6 +190,10 @@ public:
     /// \name Modifiers
     //@{
 
+    /*! Set the (lexicographically) left endpoint.
+     * \param p the point to set.
+     * \pre p lies on the supporting line to the left of the right endpoint.
+     */
     void set_left(const Point_2& p);
 
     /*! Set the (lexicographically) right endpoint.
@@ -1174,9 +1178,9 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::_Segment_cached_2() :
 //! \brief constructs a segment from a Kernel segment.
 template <typename Kernel>
 Arr_segment_traits_2<Kernel>::
-_Segment_cached_2::_Segment_cached_2(const Segment_2& seg)
-  : m_is_vert(false)
-  , m_is_computed(false)
+_Segment_cached_2::_Segment_cached_2(const Segment_2& seg) :
+  m_is_vert(false),
+  m_is_computed(false)
 {
   Kernel kernel;
   auto vertex_ctr = kernel.construct_vertex_2_object();
@@ -1284,8 +1288,7 @@ template <typename Kernel>
 const typename Kernel::Line_2&
 Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const
 {
-  if (!m_is_computed)
-  {
+  if (!m_is_computed) {
     Kernel kernel;
     m_l = kernel.construct_line_2_object()(m_ps, m_pt);
     m_is_vert = kernel.is_vertical_2_object()(m_l);
@@ -1299,8 +1302,7 @@ template <typename Kernel>
 bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::is_vertical() const
 {
   // Force computation of line is orientation is still unknown
-  if (!m_is_computed)
-    line();
+  if (! m_is_computed) line();
   CGAL_precondition(!m_is_degen);
   return m_is_vert;
 }
@@ -1462,12 +1464,7 @@ public:
 
   /*! Create a bounding box for the segment.
    */
-  Bbox_2 bbox() const
-  {
-    Kernel kernel;
-    auto construct_bbox = kernel.construct_bbox_2_object();
-    return construct_bbox(this->m_ps) + construct_bbox(this->m_pt);
-  }
+  CGAL_DEPRECATED Bbox_2 bbox() const;
 };
 
 //! \brief constructs default.
@@ -1519,6 +1516,15 @@ Arr_segment_2<Kernel> Arr_segment_2<Kernel>::flip() const
   return Arr_segment_2(this->line(), this->target(), this->source(),
                        ! (this->is_directed_right()), this->is_vertical(),
                        this->is_degenerate());
+}
+
+//! \brief creates a bounding box for the segment.
+template <typename Kernel>
+Bbox_2 Arr_segment_2<Kernel>::bbox() const
+{
+  Kernel kernel;
+  auto construct_bbox = kernel.construct_bbox_2_object();
+  return construct_bbox(this->m_ps) + construct_bbox(this->m_pt);
 }
 
 /*! Exporter for the segment class used by the traits-class.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
@@ -82,11 +82,16 @@ public:
     typedef typename Kernel::Point_2               Point_2;
 
   protected:
-    Line_2 m_l;               // the line that supports the segment.
+    mutable Line_2 m_l;       // the line that supports the segment.
     Point_2 m_ps;             // the source point of the segment.
     Point_2 m_pt;             // the target point of the segment.
     bool m_is_directed_right; // is (lexicographically) directed left to right.
-    bool m_is_vert;           // is this a vertical segment.
+    mutable enum              // is this a vertical segment.
+    {
+      UNKNOWN,                  // If the line is not computed
+      REGULAR,                  // If the line is computed and not vertical
+      VERTICAL                  // If the line is computed and vertical
+    } m_is_vert;
     bool m_is_degen;          // is the segment degenerate (a single point).
 
   public:
@@ -189,10 +194,6 @@ public:
     /// \name Modifiers
     //@{
 
-    /*! Set the (lexicographically) left endpoint.
-     * \param p the point to set.
-     * \pre p lies on the supporting line to the left of the right endpoint.
-     */
     void set_left(const Point_2& p);
 
     /*! Set the (lexicographically) right endpoint.
@@ -1169,7 +1170,7 @@ public:
 template <typename Kernel>
 Arr_segment_traits_2<Kernel>::_Segment_cached_2::_Segment_cached_2() :
   m_is_directed_right(false),
-  m_is_vert(false),
+  m_is_vert(UNKNOWN),
   m_is_degen(true)
 {}
 
@@ -1177,6 +1178,7 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::_Segment_cached_2() :
 template <typename Kernel>
 Arr_segment_traits_2<Kernel>::
 _Segment_cached_2::_Segment_cached_2(const Segment_2& seg)
+  : m_is_vert(UNKNOWN)
 {
   Kernel kernel;
   auto vertex_ctr = kernel.construct_vertex_2_object();
@@ -1189,9 +1191,6 @@ _Segment_cached_2::_Segment_cached_2(const Segment_2& seg)
   m_is_directed_right = (res == SMALLER);
 
   CGAL_precondition_msg(! m_is_degen, "Cannot construct a degenerate segment.");
-
-  m_l = kernel.construct_line_2_object()(seg);
-  m_is_vert = kernel.is_vertical_2_object()(seg);
 }
 
 //! \brief Constructs a segment from two endpoints.
@@ -1200,7 +1199,8 @@ Arr_segment_traits_2<Kernel>::
 _Segment_cached_2::_Segment_cached_2(const Point_2& source,
                                      const Point_2& target) :
   m_ps(source),
-  m_pt(target)
+  m_pt(target),
+  m_is_vert(UNKNOWN)
 {
   Kernel kernel;
 
@@ -1209,9 +1209,6 @@ _Segment_cached_2::_Segment_cached_2(const Point_2& source,
   m_is_directed_right = (res == SMALLER);
 
   CGAL_precondition_msg(! m_is_degen, "Cannot construct a degenerate segment.");
-
-  m_l = kernel.construct_line_2_object()(source, target);
-  m_is_vert = kernel.is_vertical_2_object()(m_l);
 }
 
 //! \brief constructs a segment from two endpoints on a supporting line.
@@ -1232,7 +1229,7 @@ _Segment_cached_2::_Segment_cached_2(const Line_2& line,
      Segment_assertions::_assert_is_point_on(target, m_l,
                                              Has_exact_division()));
 
-  m_is_vert = kernel.is_vertical_2_object()(m_l);
+  m_is_vert = (kernel.is_vertical_2_object()(m_l) ? VERTICAL : REGULAR);
 
   Comparison_result res = kernel.compare_xy_2_object()(m_ps, m_pt);
   m_is_degen = (res == EQUAL);
@@ -1251,7 +1248,7 @@ _Segment_cached_2(const Line_2& line,
   m_ps(source),
   m_pt(target),
   m_is_directed_right(is_directed_right),
-  m_is_vert(is_vert),
+  m_is_vert(is_vert ? VERTICAL : REGULAR),
   m_is_degen(is_degen)
 {}
 
@@ -1283,12 +1280,27 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::operator=(const Segment_2& seg)
 //! \brief obtains the supporting line.
 template <typename Kernel>
 const typename Kernel::Line_2&
-Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const { return m_l; }
+Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const
+{
+  if (m_is_vert == UNKNOWN)
+  {
+    Kernel kernel;
+    m_l = kernel.construct_line_2_object()(m_ps, m_pt);
+    m_is_vert = (kernel.is_vertical_2_object()(m_l) ? VERTICAL : REGULAR);
+  }
+  return m_l;
+}
 
 //! \brief determines whether the curve is vertical.
 template <typename Kernel>
 bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::is_vertical() const
-{ return m_is_vert; }
+{
+  // Force computation of line is orientation is still unknown
+  if (m_is_vert == UNKNOWN)
+    line();
+  CGAL_precondition(!m_is_degen);
+  return (m_is_vert == VERTICAL);
+}
 
 //! \brief determines whether the curve is degenerate.
 template <typename Kernel>

--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Polygon_2_curve_iterator.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Polygon_2_curve_iterator.h
@@ -52,7 +52,7 @@ public:
 
 
     typedef Polygon_                                      Polygon;
-    typedef typename Polygon::Edge_const_iterator         Edge_const_iterator;
+    typedef typename Polygon::Vertex_pair_iterator        Edge_const_iterator;
     typedef typename Edge_const_iterator::difference_type difference_type;
 
   private:
@@ -78,7 +78,7 @@ public:
 
     X_monotone_curve_2 operator*()
     {
-      return X_monotone_curve_2(*m_curr_edge);
+      return X_monotone_curve_2(m_curr_edge->first, m_curr_edge->second);
     }
 
     Polygon_2_curve_ptr<X_monotone_curve_2> operator->()

--- a/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
@@ -103,8 +103,8 @@ public:
     std::pair<Curve_const_iterator, Curve_const_iterator>
     operator()(const General_polygon_2& pgn) const
     {
-      Curve_const_iterator c_begin(&pgn, pgn.edges_begin());
-      Curve_const_iterator c_end(&pgn, pgn.edges_end());
+      Curve_const_iterator c_begin(&pgn, pgn.vertex_pairs_begin());
+      Curve_const_iterator c_end(&pgn, pgn.vertex_pairs_end());
 
       return (std::make_pair(c_begin, c_end));
     }

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -132,6 +132,9 @@ class Polygon_2 {
     typedef Polygon_2_edge_iterator<Traits_P,Container_P> Edge_const_iterator;
     typedef Polygon_2_const_edge_circulator<Traits_P,
                                             Container_P> Edge_const_circulator;
+
+    typedef Polygon_2_edge_iterator<Traits_P,Container_P,
+                                    Tag_false> Vertex_pair_iterator;
 #endif // DOXYGEN_RUNNING
     /// @}
 
@@ -296,6 +299,13 @@ class Polygon_2 {
       { return Edge_const_circulator(vertices_circulator()); }
 
     /// @}
+
+    /// \cond SKIP_IN_MANUAL
+    Vertex_pair_iterator vertex_pairs_begin() const
+    { return Vertex_pair_iterator(&d_container, d_container.begin()); }
+    Vertex_pair_iterator vertex_pairs_end() const
+    { return Vertex_pair_iterator(&d_container, d_container.end()); }
+    /// \endcond
 
     /// \name Predicates
     /// @{

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_edge_iterator.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_edge_iterator.h
@@ -35,17 +35,26 @@ private:
     Segment m_seg;
 };
 
-template <class Traits_, class Container_>
+template <class Traits_, class Container_,
+          class ConstructSegment = Tag_true>
 class Polygon_2_edge_iterator {
   public:
+    typedef Polygon_2_edge_iterator<Traits_, Container_, ConstructSegment> Self;
     typedef typename std::iterator_traits<typename Container_::iterator>::iterator_category iterator_category;
     typedef typename Traits_::Segment_2 Segment_2;
-    typedef typename Traits_::Segment_2 value_type;
+    typedef typename Traits_::Point_2 Point_2;
+    typedef std::pair<std::reference_wrapper<const Point_2>,
+                      std::reference_wrapper<const Point_2> > Point_pair;
+
+    typedef typename std::conditional<ConstructSegment::value,
+                                      Segment_2, Point_pair>::type
+            value_type;
+
     typedef Container_ Container;
     typedef typename Container_::const_iterator const_iterator;
     typedef typename Container_::difference_type difference_type;
-    typedef Segment_2*           pointer;
-    typedef Segment_2&           reference;
+    typedef value_type*           pointer;
+    typedef value_type&           reference;
   private:
     const Container_* container;   // needed for dereferencing the last edge
     const_iterator first_vertex;   // points to the first vertex of the edge
@@ -55,18 +64,22 @@ class Polygon_2_edge_iterator {
       : container(c), first_vertex(f) {}
 
     bool operator==(
-      const Polygon_2_edge_iterator<Traits_, Container_>& x) const
+      const Self& x) const
     {
       return first_vertex == x.first_vertex;
     }
 
     bool operator!=(
-      const Polygon_2_edge_iterator<Traits_, Container_>& x) const
+      const Self& x) const
     {
       return !(first_vertex == x.first_vertex);
     }
 
-    Segment_2 operator*() const {
+    value_type operator*() const {
+      return make_value_type(ConstructSegment());
+    }
+
+    Segment_2 make_value_type (const Tag_true&) const {
       const_iterator second_vertex = first_vertex;
       ++second_vertex;
       if (second_vertex == container->end())
@@ -76,81 +89,90 @@ class Polygon_2_edge_iterator {
       return construct_segment_2(*first_vertex, *second_vertex);
     }
 
-    Polygon_2__Segment_ptr<Segment_2> operator->() const
-        {return Polygon_2__Segment_ptr<Segment_2>(operator*());}
+    Point_pair make_value_type (const Tag_false&) const {
+      const_iterator second_vertex = first_vertex;
+      ++second_vertex;
+      if (second_vertex == container->end())
+        second_vertex = container->begin();
+      return std::make_pair (std::cref(*first_vertex), std::cref(*second_vertex));
+    }
 
-    Polygon_2_edge_iterator<Traits_, Container_>& operator++() {
+
+    Polygon_2__Segment_ptr<value_type> operator->() const
+        {return Polygon_2__Segment_ptr<value_type>(operator*());}
+
+    Self& operator++() {
       ++first_vertex;
       return *this;
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_> operator++(int) {
-      Polygon_2_edge_iterator<Traits_, Container_> tmp = *this;
+    Self operator++(int) {
+      Self tmp = *this;
       ++*this;
       return tmp;
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_>& operator--() {
+    Self& operator--() {
       --first_vertex;
       return *this;
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_> operator--(int) {
-      Polygon_2_edge_iterator<Traits_, Container_> tmp = *this;
+    Self operator--(int) {
+      Self tmp = *this;
       --*this;
       return tmp;
     }
 
 // random access iterator requirements
-    Polygon_2_edge_iterator<Traits_, Container_>&
+    Self&
     operator+=(difference_type n) {
       first_vertex += n;
       return *this;
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_>
+    Self
     operator+(difference_type n) const {
-      return Polygon_2_edge_iterator<Traits_, Container_>(
+      return Self(
         container, first_vertex + n);
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_>&
+    Self&
     operator-=(difference_type n) {
       return (*this) -= n;
     }
 
-    Polygon_2_edge_iterator<Traits_, Container_>
+    Self
     operator-(difference_type n) const {
-      return Polygon_2_edge_iterator<Traits_, Container_>(
+      return Self(
         container, first_vertex - n);
     }
 
     difference_type
-    operator-(const Polygon_2_edge_iterator<Traits_, Container_>& a) const {
+    operator-(const Self& a) const {
       return first_vertex - a.first_vertex;
     }
 
-    Segment_2 operator[](int n) const {
-      return *Polygon_2_edge_iterator<Traits_, Container_>(
+    value_type operator[](int n) const {
+      return *Self(
         container, first_vertex+n);
     }
 
-    bool operator<(const Polygon_2_edge_iterator<Traits_, Container_>& a) const
+    bool operator<(const Self& a) const
     {
       return first_vertex < a.first_vertex;
     }
 
-    bool operator>(const Polygon_2_edge_iterator<Traits_, Container_>& a) const
+    bool operator>(const Self& a) const
     {
       return first_vertex > a.first_vertex;
     }
 
-    bool operator<=(const Polygon_2_edge_iterator<Traits_, Container_>& a) const
+    bool operator<=(const Self& a) const
     {
       return first_vertex <= a.first_vertex;
     }
 
-    bool operator>=(const Polygon_2_edge_iterator<Traits_, Container_>& a) const
+    bool operator>=(const Self& a) const
     {
       return first_vertex >= a.first_vertex;
     }
@@ -158,15 +180,15 @@ class Polygon_2_edge_iterator {
 };
 
 
-template <class Traits_,  class Container_>
+template <class Traits_,  class Container_, class ConstructSegment>
 typename Container_::difference_type
-distance_type(const Polygon_2_edge_iterator<Traits_,Container_>&)
+distance_type(const Polygon_2_edge_iterator<Traits_,Container_,Container_>&)
 { return Container_::difference_type(); }
 
 template <class Traits_,  class Container_>
 typename Traits_::Segment_2*
-value_type(const Polygon_2_edge_iterator<Traits_,Container_>&)
-{ return (typename Traits_::Segment_2 *)(0); }
+value_type(const Polygon_2_edge_iterator<Traits_,Container_,Tag_true>&)
+{ return (typename Polygon_2_edge_iterator<Traits_,Container_,Tag_true>::value_type *)(0); }
 
 
 //-----------------------------------------------------------------------//


### PR DESCRIPTION
## Summary of Changes

This PR is another small enhancement for arrangement:

- we define an alternative undocumented edge iterator for `Polygon_2` which does not construct any `Segment_2` object but just returns pairs of Points (pairs of reference wrappers to be precise). This allows, when constructing a GPS from a Polygon, to avoid the cost of constructing very short-living `Segment_2`
- when constructing an `Arr_segment_2`, we don't construct the `Line_2` support immediately but delay this construction until it's needed. This is especially useful in conjunction with https://github.com/CGAL/cgal/pull/4861 when intersections of segments are discarded early (some segments' line support may not need to be computed at all). To do so, I replace the boolean `is_vert` by an enum (to have a `UNKNOWN` value when the line is not computed). Of course, it would also be possible to add another boolean but it seems more memory-friendly like this.

These 2 tricks allow to reduce computation time of boolean operations using GPS by around 5%.

## Release Management

* Affected package(s): Polygon 2, Arrangement, etc.
