### PR TITLE
Travis: Use another PPA for boost

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -11,7 +11,7 @@ function mytime {
 function build_examples {
   mkdir -p build-travis
   cd build-travis
-  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCGAL_BUILD_THREE_DOC=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_boost_serialization=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_boost_iostreams=TRUE ..
+  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" ..
   mytime make -j2 VERBOSE=1
 }
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,7 +2,7 @@
 
 [ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
 DONE=0
-sudo add-apt-repository ppa:mhier/libboost-latest -y
+sudo add-apt-repository ppa:mikhailnov/pulseeffects -y
 sudo apt-get update
 
 while [ $DONE = 0 ]
@@ -10,7 +10,7 @@ do
   DONE=1 && sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-10 zsh \
 flex bison cmake graphviz libgmp-dev libmpfr-dev libmpfi-dev zlib1g-dev libeigen3-dev  \
 qtbase5-dev libqt5sql5-sqlite libqt5opengl5-dev qtscript5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qml-module-qtgraphicaleffects libopencv-dev mesa-common-dev libmetis-dev libglu1-mesa-dev \
-libboost1.73-dev || DONE=0 && sudo apt-get update
+libboost1.72-dev || DONE=0 && sudo apt-get update
 done
 exit 0
 


### PR DESCRIPTION
## Summary of Changes
As we found out, the boost versions on the mhier PPA is not fitted for CGAL, as they are not built with zlib and bzip2, which is needed for Classification. 

As a reminder, the problem is that the components iostreams and serialization are found, but they are missing all the parts we use, which leads to linking errors. I don't think there is an easy way to detect if those components are built correctly, so I decided to use another ppa for boost, one that does build the two components correcly. 

In #4933, I tried to use CMAKE_DISABLE_FIND_PACKAGE to block iostreams and serialization, but for some reason it doesn't work on linux. (I say on linux because I use it in the cgal-swig-bindings in the windows CI and it is not ignored like it is on travis) .

