### PR TITLE
Add envelope free functions that accept traits object

### DIFF
--- a/Envelope_2/doc/Envelope_2/CGAL/envelope_2.h
+++ b/Envelope_2/doc/Envelope_2/CGAL/envelope_2.h
@@ -47,13 +47,13 @@ Reusing the same traits object improves speed if the traits class caches data.
 The lower envelope is represented using the output minimization diagram `diag`.
 
 \tparam InputIterator must be an input iterator with value type `EnvelopeDiagram::X_monotone_curve_2`.
-\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
 \tparam EnvelopeDiagram must be a model of the concept `EnvelopeDiagram_1`.
+\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
 */
-template<class InputIterator, class Traits, class EnvelopeDiagram>
+template<class InputIterator, class EnvelopeDiagram, class Traits>
 void lower_envelope_x_monotone_2
 (InputIterator begin, InputIterator end,
-const Traits* traits, EnvelopeDiagram& diag);
+EnvelopeDiagram& diag, const Traits& traits);
 
 } /* namespace CGAL */
 
@@ -106,12 +106,12 @@ Reusing the same traits object improves speed if the traits class caches data.
 The upper envelope is represented using the output maximization diagram `diag`.
 
 \tparam InputIterator must be an input iterator with value type `EnvelopeDiagram::X_monotone_curve_2`.
-\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
 \tparam EnvelopeDiagram must be a model of the concept `EnvelopeDiagram_1`.
+\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
 */
-template<class InputIterator, class Traits, class EnvelopeDiagram>
+template<class InputIterator, class EnvelopeDiagram, class Traits>
 void upper_envelope_x_monotone_2
 (InputIterator begin, InputIterator end,
-const Traits* traits, EnvelopeDiagram& diag);
+EnvelopeDiagram& diag, const Traits& traits);
 
 } /* namespace CGAL */

--- a/Envelope_2/doc/Envelope_2/CGAL/envelope_2.h
+++ b/Envelope_2/doc/Envelope_2/CGAL/envelope_2.h
@@ -40,6 +40,28 @@ namespace CGAL {
 /*!
 \ingroup PkgEnvelope2Ref
 
+Computes the lower envelope of a set of \f$ x\f$-monotone curves in
+\f$ \mathbb{R}^2\f$, as given by the range `[begin, end)` with the help
+of the arrangement traits object `traits` responsible for their creation.
+Reusing the same traits object improves speed if the traits class caches data.
+The lower envelope is represented using the output minimization diagram `diag`.
+
+\tparam InputIterator must be an input iterator with value type `EnvelopeDiagram::X_monotone_curve_2`.
+\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
+\tparam EnvelopeDiagram must be a model of the concept `EnvelopeDiagram_1`.
+*/
+template<class InputIterator, class Traits, class EnvelopeDiagram>
+void lower_envelope_x_monotone_2
+(InputIterator begin, InputIterator end,
+const Traits* traits, EnvelopeDiagram& diag);
+
+} /* namespace CGAL */
+
+namespace CGAL {
+
+/*!
+\ingroup PkgEnvelope2Ref
+
 Computes the upper envelope of a set of curves in \f$ \mathbb{R}^2\f$,
 as given by the range `[begin, end)`. The upper envelope is
 represented using the output maximization diagram `diag`.
@@ -69,5 +91,27 @@ template<class InputIterator, class EnvelopeDiagram>
 void upper_envelope_x_monotone_2
 (InputIterator begin, InputIterator end,
 EnvelopeDiagram& diag);
+
+} /* namespace CGAL */
+
+namespace CGAL {
+
+/*!
+\ingroup PkgEnvelope2Ref
+
+Computes the upper envelope of a set of \f$ x\f$-monotone curves in
+\f$ \mathbb{R}^2\f$, as given by the range `[begin, end)` with the help
+of the arrangement traits object `traits` responsbile for their creation.
+Reusing the same traits object improves speed if the traits class caches data.
+The upper envelope is represented using the output maximization diagram `diag`.
+
+\tparam InputIterator must be an input iterator with value type `EnvelopeDiagram::X_monotone_curve_2`.
+\tparam Traits must be a model of the concept `ArrangementXMonotoneTraits_2`.
+\tparam EnvelopeDiagram must be a model of the concept `EnvelopeDiagram_1`.
+*/
+template<class InputIterator, class Traits, class EnvelopeDiagram>
+void upper_envelope_x_monotone_2
+(InputIterator begin, InputIterator end,
+const Traits* traits, EnvelopeDiagram& diag);
 
 } /* namespace CGAL */

--- a/Envelope_2/include/CGAL/Envelope_2/Env_divide_and_conquer_2.h
+++ b/Envelope_2/include/CGAL/Envelope_2/Env_divide_and_conquer_2.h
@@ -62,9 +62,9 @@ protected:
   typedef Arr_traits_adaptor_2<Traits_2>           Traits_adaptor_2;
 
   // Data members:
-  Traits_adaptor_2  *traits;        // The traits object.
-  bool               own_traits;    // Whether we own the traits object.
-  Envelope_type      env_type;      // Either LOWER or UPPER.
+  const Traits_adaptor_2  *traits;        // The traits object.
+  bool                     own_traits;    // Whether we own the traits object.
+  Envelope_type            env_type;      // Either LOWER or UPPER.
 
   // Copy constructor and assignment operator - not supported.
   Envelope_divide_and_conquer_2 (const Self& );

--- a/Envelope_2/include/CGAL/envelope_2.h
+++ b/Envelope_2/include/CGAL/envelope_2.h
@@ -101,7 +101,7 @@ void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
  * \param diag Output: The minimization diagram.
  * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
  */
-template <class InputIterator, class EnvelopeDiagram, class Traits>
+template <class InputIterator, class Traits, class EnvelopeDiagram>
 void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
                                   const Traits* traits, EnvelopeDiagram& diag)
 {
@@ -148,7 +148,7 @@ void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
  * \param diag Output: The maximization diagram.
  * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
  */
-template <class InputIterator, class EnvelopeDiagram, class Traits>
+template <class InputIterator, class Traits, class EnvelopeDiagram>
 void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
                                   const Traits* traits, EnvelopeDiagram& diag)
 {

--- a/Envelope_2/include/CGAL/envelope_2.h
+++ b/Envelope_2/include/CGAL/envelope_2.h
@@ -94,6 +94,30 @@ void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
 }
 
 /*!
+ * Compute the lower envelope of a range of x-monotone curves.
+ * \param begin An iterator for the first x-monotone curve.
+ * \param end A past-the-end iterator for the x-monotone curves.
+ * \param traits The arrangement traits responsible for the x-monotone curves
+ * \param diag Output: The minimization diagram.
+ * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
+ */
+template <class InputIterator, class EnvelopeDiagram, class Traits>
+void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
+                                  const Traits* traits, EnvelopeDiagram& diag)
+{
+  typedef typename EnvelopeDiagram::Traits_2                       Traits_2;
+  typedef Envelope_divide_and_conquer_2<Traits_2, EnvelopeDiagram> Envelope_2;
+
+  Envelope_2      env{traits};
+
+  env.insert_x_monotone_curves (begin, end,
+                                true,              // Lower envelope.
+                                diag);
+
+  return;
+}
+
+/*!
  * Compute the upper envelope of a range of x-monotone curves.
  * \param begin An iterator for the first x-monotone curve.
  * \param end A past-the-end iterator for the x-monotone curves.
@@ -108,6 +132,30 @@ void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
   typedef Envelope_divide_and_conquer_2<Traits_2, EnvelopeDiagram> Envelope_2;
 
   Envelope_2      env;
+
+  env.insert_x_monotone_curves (begin, end,
+                                false,          // Upper envelope.
+                                diag);
+
+  return;
+}
+
+/*!
+ * Compute the upper envelope of a range of x-monotone curves.
+ * \param begin An iterator for the first x-monotone curve.
+ * \param end A past-the-end iterator for the x-monotone curves.
+ * \param traits The arrangement traits responsible for the x-monotone curves
+ * \param diag Output: The maximization diagram.
+ * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
+ */
+template <class InputIterator, class EnvelopeDiagram, class Traits>
+void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
+                                  const Traits* traits, EnvelopeDiagram& diag)
+{
+  typedef typename EnvelopeDiagram::Traits_2                       Traits_2;
+  typedef Envelope_divide_and_conquer_2<Traits_2, EnvelopeDiagram> Envelope_2;
+
+  Envelope_2      env{traits};
 
   env.insert_x_monotone_curves (begin, end,
                                 false,          // Upper envelope.

--- a/Envelope_2/include/CGAL/envelope_2.h
+++ b/Envelope_2/include/CGAL/envelope_2.h
@@ -97,18 +97,18 @@ void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
  * Compute the lower envelope of a range of x-monotone curves.
  * \param begin An iterator for the first x-monotone curve.
  * \param end A past-the-end iterator for the x-monotone curves.
- * \param traits The arrangement traits responsible for the x-monotone curves
  * \param diag Output: The minimization diagram.
+ * \param traits The arrangement traits responsible for the x-monotone curves.
  * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
  */
-template <class InputIterator, class Traits, class EnvelopeDiagram>
+template <class InputIterator, class EnvelopeDiagram, class Traits>
 void lower_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
-                                  const Traits* traits, EnvelopeDiagram& diag)
+                                  EnvelopeDiagram& diag, const Traits& traits)
 {
   typedef typename EnvelopeDiagram::Traits_2                       Traits_2;
   typedef Envelope_divide_and_conquer_2<Traits_2, EnvelopeDiagram> Envelope_2;
 
-  Envelope_2      env{traits};
+  Envelope_2      env{&traits};
 
   env.insert_x_monotone_curves (begin, end,
                                 true,              // Lower envelope.
@@ -144,18 +144,18 @@ void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
  * Compute the upper envelope of a range of x-monotone curves.
  * \param begin An iterator for the first x-monotone curve.
  * \param end A past-the-end iterator for the x-monotone curves.
- * \param traits The arrangement traits responsible for the x-monotone curves
  * \param diag Output: The maximization diagram.
+ * \param traits The arrangement traits responsible for the x-monotone curves.
  * \pre The value-type of the iterator is Traits::X_monotone_curve_2.
  */
-template <class InputIterator, class Traits, class EnvelopeDiagram>
+template <class InputIterator, class EnvelopeDiagram, class Traits>
 void upper_envelope_x_monotone_2 (InputIterator begin, InputIterator end,
-                                  const Traits* traits, EnvelopeDiagram& diag)
+                                  EnvelopeDiagram& diag, const Traits& traits)
 {
   typedef typename EnvelopeDiagram::Traits_2                       Traits_2;
   typedef Envelope_divide_and_conquer_2<Traits_2, EnvelopeDiagram> Envelope_2;
 
-  Envelope_2      env{traits};
+  Envelope_2      env{&traits};
 
   env.insert_x_monotone_curves (begin, end,
                                 false,          // Upper envelope.


### PR DESCRIPTION
## Summary of Changes

Add a couple of free functions (`upper_envelope_x_monotone_2` and `lower_envelope_x_monotone_2`) that accept the arrangement traits object. The already existing functions resulted in the envelope creating its own traits object, and thus losing the cache, making future operations slower. 

So in #4818 instead of
```C++
  Diagram_1 diagram;
  CGAL::lower_envelope_x_monotone_2(
	  monotone_curves.begin(), monotone_curves.end(), diagram);
```
We would
```C++
  Diagram_1 diagram;
  CGAL::lower_envelope_x_monotone_2(
	  monotone_curves.begin(), monotone_curves.end(), arr.traits(), diagram);
```
where `arr` is the arrangement.

## Release Management

* Affected package(s): Envelope_2
* Issue(s) solved (if any): fix #4818
* License and copyright ownership: The license used by CGAL