### PR TITLE
Polyhedron demo: filter the AABB_tree representation

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -578,7 +578,7 @@ public:
     #ifdef CGAL_HAS_THREADS
     mutable CGAL_MUTEX build_mutex; // mutex used to protect const calls inducing build() and build_kd_tree()
     #endif
-
+  public:
     const Node* root_node() const {
       CGAL_assertion(size() > 1);
 
@@ -596,7 +596,7 @@ public:
       }
       return m_p_root_node;
     }
-
+  private:
     const Primitive& singleton_data() const {
       CGAL_assertion(size() == 1);
       return *m_primitives.begin();

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -722,9 +722,9 @@ private:
              int lvl)
    {
      //traversed lvl by lvl, so one push_back should be enough.
-     if(boxes.size() <= lvl )
+     if(static_cast<int>(boxes.size()) <= lvl )
        boxes.push_back(std::vector<Bbox>());
-     CGAL_assertion(boxes.size() > lvl);
+     CGAL_assertion(static_cast<int>(boxes.size()) > lvl);
      boxes[lvl].push_back(node.bbox());
 
      // Recursive traversal
@@ -1425,7 +1425,7 @@ void Polyhedron_demo_cut_plugin::cut()
   if(!plane_item)
     return;
 
-  for(std::size_t id =0; id < CGAL::Three::Three::scene()->numberOfEntries(); ++id)
+  for(int id =0; id < CGAL::Three::Three::scene()->numberOfEntries(); ++id)
   {
     Scene_item* item = CGAL::Three::Three::scene()->item(id);
     Scene_aabb_item* aabb_item = qobject_cast<Scene_aabb_item*>(item);

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -560,7 +560,7 @@ public:
     traversal(tree.size(), *tree.root_node(), 0);
     lvlSlider = new QSlider(Qt::Horizontal);
     lvlSlider->setMinimum(-1);
-    lvlSlider->setMaximum(boxes.size()-1);
+    lvlSlider->setMaximum(static_cast<int>(boxes.size())-1);
     lvlSlider->setValue(-1);
     lvlSlider->setPageStep(1);
     const CGAL::Bbox_3 bbox = tree.bbox();

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -1433,7 +1433,6 @@ void Polyhedron_demo_cut_plugin::cut()
       continue;
     }
     aabb_item->invalidateOpenGLBuffers();
-    break;
   }
 
   switch(plane_item->cutPlaneType())

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Cut_plugin.cpp
@@ -644,7 +644,9 @@ public:
     return
       tr("<p><b>%1</b> (mode: %2, color: %3)<br />"
          "<i>AABB_tree</i></p>"
-         "<p>Number of nodes: %4</p>")
+         "<p>Number of nodes: %4</p>"
+         "<p><b>Instructions:</b><br>Check <i>Only Intersected Boxes</i> in the item's menu to filter out the boxes of the tree that are not intersected by the plane.<br>"
+         "Use the cursor <i>Tree level</i> to only print the boxes of the Nth level. The most left-hand level is the full Tree.</p>")
       .arg(this->name())
       .arg(this->renderingModeName())
       .arg(this->color().name())


### PR DESCRIPTION
## Summary of Changes
The Scene_aabb_item is not very readable, as it shows every box of the tree of a surface mesh.  
In this PR, I added options in the menu of the item to display only the Nth level of the tree and or only the intersected cells (by the cut plane) : 
- The basic tree of an elephant:

![full](https://user-images.githubusercontent.com/11310805/90867062-1cbcf800-e395-11ea-979d-2715e39c79e8.png)

- the new menu: 
![menu](https://user-images.githubusercontent.com/11310805/90867068-1dee2500-e395-11ea-81bd-f32113a10d8c.png)

- the new tooltip:

![tooltip](https://user-images.githubusercontent.com/11310805/90867378-95bc4f80-e395-11ea-9200-2ee680d39ccf.png)

- Only one level of the same tree:

![lvl](https://user-images.githubusercontent.com/11310805/90867067-1dee2500-e395-11ea-9eda-5a03ff1c4279.png)

-  The same level intersected by the plane:

![plane](https://user-images.githubusercontent.com/11310805/90867070-1e86bb80-e395-11ea-8e15-1d944d3a8bdb.png)



## Release Management

* Issue(s) solved (if any): fix #4909 
