### PR TITLE
Intersection_3: Add tests for do_intersect(Tet_3, Tet_3)

### DIFF
--- a/Intersections_3/test/Intersections_3/tetrahedron.cpp
+++ b/Intersections_3/test/Intersections_3/tetrahedron.cpp
@@ -22,7 +22,16 @@ int main()
 {
   Point p(0,0,0), q(10,0,0), r(10,10,0), s(0, 10,10);
   Point p2(1,1,1), q2(20,20,20), r2(0,0,20);
-  Tetrahedron tet(p,q,r,s);
+  Tetrahedron tet(p,q,r,s),
+      tet2(p, Point(9,0,0), Point(15, 15, 0), Point(0, 15, 10)),
+      v_v(p,Point(-10,0,0),Point(-10,-10,0), Point(0,-10,-10)),
+      v_e(Point(-10,0,0), Point(0,0,10), Point(0,0,-10), Point(-10,10,0)),
+      v_f(Point(-10,0,0), Point(0,-10,-10), Point(0,-10,10), Point(0,10,0)),
+      e_e(Point(-10,0,0), Point(-15,0,0), Point(0,5,10), Point(0,10,5)),
+      e_f(Point(0,15,15), Point(-15,0,0), Point(0,-11,10), Point(0,10,-11)),
+      f_f(Point(10,10,10), q, r, s),
+      tet3(Point(-1,0,0), Point(-10,0,0), Point(-10,-10,0), Point(0,-10,-10));
+
   Sphere sp(p2,1.0);
 
   CGAL::do_intersect(tet,Triangle(p2,q2,r2));
@@ -51,6 +60,17 @@ int main()
   CGAL::do_intersect(Line(p2,q2), sp);
   CGAL::do_intersect(Ray(p2,q2), sp);
   CGAL::do_intersect(Segment(p2,q2), sp);
+
+  CGAL_assertion(CGAL::do_intersect(tet, v_e));
+  CGAL_assertion(CGAL::do_intersect(tet, v_f));
+  CGAL_assertion(CGAL::do_intersect(tet, v_v));
+  CGAL_assertion(CGAL::do_intersect(tet, tet2));
+  CGAL_assertion(CGAL::do_intersect(tet, e_e));
+  CGAL_assertion(CGAL::do_intersect(tet, e_f));
+  CGAL_assertion(CGAL::do_intersect(tet, f_f));
+
+  CGAL_assertion(!CGAL::do_intersect(tet, tet3));
+
 
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes
Add tests for do_intersect(tet_3, tet_3) for the following intersections:

- vertex/vertex
- vertex/edge
- vertex/face
- edge/edge
- edge/face
- face/face
- tet_3/tet_3 (full intersection)

and one test for 2 tets not intersecting

## Release Management

* Affected package(s): Intersection_3
* Issue(s) solved (if any): fix #4913 
