### PR TITLE
Fix error in HSV/RGB color conversion

### DIFF
--- a/Stream_support/include/CGAL/IO/Color.h
+++ b/Stream_support/include/CGAL/IO/Color.h
@@ -221,8 +221,6 @@ public:
   /*!
     replaces the rgb values of the colors by the conversion to rgb of
     the hsv values given as parameters.
-
-    Double values given as parameters should take range between 0 and 1.
   */
   void set_hsv (double hue,
                 double saturation,
@@ -232,8 +230,8 @@ public:
     saturation /= 100.;
     value /= 100.;
     double C = value*saturation;
-    int hh = (int)(hue/60.);
-    double X = C * (1-std::abs (hh % 2 - 1));
+    double hh = (hue/60.);
+    double X = C * (1-std::abs(std::fmod(hh, 2) - 1));
     double r = 0, g = 0, b = 0;
 
     if( hh>=0 && hh<1 )


### PR DESCRIPTION
## Summary of Changes

The function `CGAL::Color::set_hsv` ignores (most of) the value of `hue`, because for some reason `(hue/60.)` is converted to an integer. I changed two lines in the color conversion code and it now has the expected behaviour.

I also removed one line of documentation because it was inconsistent with the code.

## Release Management

* Affected package(s): IO Streams

