### PR TITLE
Use [[no_unique_address]] for info in vertex/cell

### DIFF
--- a/Triangulation/include/CGAL/Triangulation_full_cell.h
+++ b/Triangulation/include/CGAL/Triangulation_full_cell.h
@@ -42,7 +42,7 @@ public:
     typedef typename TriangulationTraits::Point_d       Point_d;
 
 private: // DATA MEMBERS
-    Data    data_;
+    CGAL_NO_UNIQUE_ADDRESS Data    data_;
 
 public:
 

--- a/Triangulation/include/CGAL/Triangulation_vertex.h
+++ b/Triangulation/include/CGAL/Triangulation_vertex.h
@@ -45,7 +45,7 @@ public:
 
 private: // DATA MEMBERS
     Point       point_;
-    Data        data_;
+    CGAL_NO_UNIQUE_ADDRESS Data        data_;
 
 public:
     template< typename T >


### PR DESCRIPTION
## Summary of Changes

In 3d there are separate classes for the case with_info. In dD, it is a single class. Since by default there is no data, avoid wasting space using the relevant attribute. I didn't check if this really saves anything, but it shouldn't hurt.

## Release Management

* Affected package(s): Triangulation