### PR TITLE
[Shape Detection] Fix nonnull warning in deprecated Region Growing

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/deprecated/Region_growing.h
+++ b/Shape_detection/include/CGAL/Shape_detection/deprecated/Region_growing.h
@@ -688,7 +688,10 @@ namespace Shape_detection {
           p->m_indices.clear();
           std::copy (index_container.begin(), index_container.end(),
                      std::back_inserter (p->m_indices));
-          dynamic_cast<Plane_shape*>(p)->update (optimal_plane);
+
+          Plane_shape* ps = dynamic_cast<Plane_shape*>(p);
+          CGAL_assume (ps != nullptr);
+          ps->update (optimal_plane);
           m_extracted_shapes->push_back (boost::shared_ptr<Shape>(p));
         }
         else


### PR DESCRIPTION
## Summary of Changes

Check that the pointer is non null after dynamic cast.

## Release Management

* Affected package(s): Shape Detection