### PR TITLE
Polyhedron demo - get the sharp edges back after remeshing

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -608,6 +608,12 @@ public Q_SLOTS:
                .number_of_relaxation_steps(nb_smooth)
                .edge_is_constrained_map(ecm)
                .relax_constraints(smooth_features));
+
+          //recollect sharp edges
+          for(edge_descriptor e : edges(pmesh))
+            eif[e] = false;
+          for(edge_descriptor e : edges_to_protect)
+            eif[e] = true;
         }
         if (fpmap_valid)
         {


### PR DESCRIPTION
## Summary of Changes

When doing the following sequence of operations :
- open/create a triangulated surface mesh,
- detect sharp features with the corresponding menu,
- call "Isotropic Remeshing",

detected sharp features were geometrically preserved, but not properly colored in red, nor properly stored for later use, in the demo.

This PR fixes that issue. Now sharp features are still the valid ones after remeshing.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

