### PR TITLE
Do not create isolated vertices

### DIFF
--- a/Surface_mesher/examples/Surface_mesher/mesh_an_implicit_function.cpp
+++ b/Surface_mesher/examples/Surface_mesher/mesh_an_implicit_function.cpp
@@ -2,6 +2,10 @@
 #include <CGAL/Complex_2_in_triangulation_3.h>
 #include <CGAL/make_surface_mesh.h>
 #include <CGAL/Implicit_surface_3.h>
+#include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <fstream>
 
 // default triangulation for Surface_mesher
 typedef CGAL::Surface_mesh_default_triangulation_3 Tr;
@@ -17,6 +21,8 @@ typedef GT::FT FT;
 typedef FT (*Function)(Point_3);
 
 typedef CGAL::Implicit_surface_3<GT, Function> Surface_3;
+
+typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
 
 FT sphere_function (Point_3 p) {
   const FT x2=p.x()*p.x(), y2=p.y()*p.y(), z2=p.z()*p.z();
@@ -38,6 +44,11 @@ int main() {
                                                      0.1); // distance bound
   // meshing surface
   CGAL::make_surface_mesh(c2t3, surface, criteria, CGAL::Non_manifold_tag());
+
+  Surface_mesh sm;
+  CGAL::facets_in_complex_2_to_triangle_mesh(c2t3, sm);
+  std::ofstream out("sphere.off");
+  out << sm << std::endl;
 
   std::cout << "Final number of points: " << tr.number_of_vertices() << "\n";
 }

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
@@ -63,8 +63,9 @@ output_surface_facets_to_medit (std::ostream& os, const C2t3& c2t3)
       vit != tr.finite_vertices_end();
       ++vit)
   {
-    if(V.find(vit) != V.end()){
-      V[vit] = inum++;
+    auto it = V.find(vit);
+    if(it != V.end()){
+      *it = inum++;
       Point p = static_cast<Point>(vit->point());
       os << p.x() << " " << p.y() << " " << p.z() << " 0 \n";
     }

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
@@ -65,7 +65,7 @@ output_surface_facets_to_medit (std::ostream& os, const C2t3& c2t3)
   {
     auto it = V.find(vit);
     if(it != V.end()){
-      *it = inum++;
+      it->second = inum++;
       Point p = static_cast<Point>(vit->point());
       os << p.x() << " " << p.y() << " " << p.z() << " 0 \n";
     }

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
@@ -41,19 +41,33 @@ output_surface_facets_to_medit (std::ostream& os, const C2t3& c2t3)
 
   //os << std::setprecision(20);
 
+  std::map<Vertex_handle, int> V;
+
+  for(typename C2t3::Facet_iterator
+        fit = c2t3.facets_begin(),
+        end = c2t3.facets_end();
+      fit != end; ++fit)
+  {
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 1))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 2))] = 0;
+  }
+
   // Finite vertices coordinates.
   os << "Vertices\n"
-     << tr.number_of_vertices() << " \n";
+     << V.size() << " \n";
 
-  std::map<Vertex_handle, int> V;
+
   int inum = 0;
   for(Finite_vertices_iterator vit = tr.finite_vertices_begin();
       vit != tr.finite_vertices_end();
       ++vit)
   {
-    V[vit] = inum++;
-    Point p = static_cast<Point>(vit->point());
-    os << p.x() << " " << p.y() << " " << p.z() << " 0 \n";
+    if(V.find(vit) != V.end()){
+      V[vit] = inum++;
+      Point p = static_cast<Point>(vit->point());
+      os << p.x() << " " << p.y() << " " << p.z() << " 0 \n";
+    }
   }
 
 

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_medit.h
@@ -19,6 +19,7 @@
 
 #include <iomanip>
 #include <stack>
+#include <unordered_map>
 
 namespace CGAL {
 
@@ -41,7 +42,7 @@ output_surface_facets_to_medit (std::ostream& os, const C2t3& c2t3)
 
   //os << std::setprecision(20);
 
-  std::map<Vertex_handle, int> V;
+  std::unordered_map<Vertex_handle, int> V;
 
   for(typename C2t3::Facet_iterator
         fit = c2t3.facets_begin(),

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
@@ -17,7 +17,7 @@
 
 #include <CGAL/disable_warnings.h>
 
-#include <map>
+#include <unordered_map>
 
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
@@ -39,7 +39,7 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
   vtkCellArray* const vtk_cells = vtkCellArray::New();
 
 
-  std::map<Vertex_handle, vtkIdType> V;
+  std::unordered_map<Vertex_handle, vtkIdType> V;
   vtkIdType inum = 0;
 
   for(typename C2T3::Facet_iterator
@@ -61,13 +61,14 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
       vit != end;
       ++vit)
   {
-    if(V.find(vit) != V.end()){
+    auto it = V.find(vit);
+    if(it != V.end()){
       typedef typename Triangulation::Point Point;
       const Point& p = vit->point();
       vtk_points->InsertNextPoint(CGAL::to_double(p.x()),
                                   CGAL::to_double(p.y()),
                                   CGAL::to_double(p.z()));
-      V[vit] = inum++;
+      it->second = inum++;
     }
   }
   for(typename C2T3::Facet_iterator

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
@@ -48,8 +48,8 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
       fit != end; ++fit)
   {
     V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
-    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
-    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 1))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 2))] = 0;
   }
 
   vtk_points->Allocate(V.size());

--- a/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
+++ b/Surface_mesher/include/CGAL/IO/Complex_2_in_triangulation_3_to_vtk.h
@@ -38,11 +38,22 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
   vtkPoints* const vtk_points = vtkPoints::New();
   vtkCellArray* const vtk_cells = vtkCellArray::New();
 
-  vtk_points->Allocate(c2t3.triangulation().number_of_vertices());
-  vtk_cells->Allocate(c2t3.number_of_facets());
 
   std::map<Vertex_handle, vtkIdType> V;
   vtkIdType inum = 0;
+
+  for(typename C2T3::Facet_iterator
+        fit = c2t3.facets_begin(),
+        end = c2t3.facets_end();
+      fit != end; ++fit)
+  {
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
+    V[fit->first->vertex(tr.vertex_triple_index(fit->second, 0))] = 0;
+  }
+
+  vtk_points->Allocate(V.size());
+  vtk_cells->Allocate(c2t3.number_of_facets());
 
   for(typename Triangulation::Finite_vertices_iterator
         vit = tr.finite_vertices_begin(),
@@ -50,12 +61,14 @@ vtkPolyData* output_c2t3_to_vtk_polydata(const C2T3& c2t3,
       vit != end;
       ++vit)
   {
-    typedef typename Triangulation::Point Point;
-    const Point& p = vit->point();
-    vtk_points->InsertNextPoint(CGAL::to_double(p.x()),
-                                CGAL::to_double(p.y()),
-                                CGAL::to_double(p.z()));
-    V[vit] = inum++;
+    if(V.find(vit) != V.end()){
+      typedef typename Triangulation::Point Point;
+      const Point& p = vit->point();
+      vtk_points->InsertNextPoint(CGAL::to_double(p.x()),
+                                  CGAL::to_double(p.y()),
+                                  CGAL::to_double(p.z()));
+      V[vit] = inum++;
+    }
   }
   for(typename C2T3::Facet_iterator
         fit = c2t3.facets_begin(),

--- a/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
+++ b/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
@@ -19,7 +19,7 @@
 #include <CGAL/disable_warnings.h>
 
 #include <CGAL/boost/graph/Euler_operations.h>
-#include <map>
+#include <unordered_map>
 #include <stack>
 
 namespace CGAL{
@@ -59,7 +59,7 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
   const typename Tr::size_type number_of_facets = c2t3.number_of_facets();
   {
     //used to set indices of vertices
-    std::map<Vertex_handle, int> V;
+    std::unordered_map<Vertex_handle, int> V;
 
     // Finite vertices coordinates.
     Finite_facets_iterator fit = tr.finite_facets_begin();
@@ -135,7 +135,8 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
         vit != tr.finite_vertices_end();
         ++vit)
     {
-      if(V.find(vit)!= V.end()){
+      auto it = V.find(vit);
+      if(it != V.end()){
         typename boost::graph_traits<TriangleMesh>::vertex_descriptor v = add_vertex(graph);
         vertices.push_back(v);
         put(vpmap,
@@ -145,7 +146,7 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
                     vit->point().y(),
                     vit->point().z())
             );
-        V[vit] = inum++;
+        it->second = inum++;
       }
     }
     //add faces

--- a/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
+++ b/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
@@ -58,6 +58,9 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
   VertexPointMap vpmap = get(boost::vertex_point, graph);
   const typename Tr::size_type number_of_facets = c2t3.number_of_facets();
   {
+    //used to set indices of vertices
+    std::map<Vertex_handle, int> V;
+
     // Finite vertices coordinates.
     Finite_facets_iterator fit = tr.finite_facets_begin();
     std::set<Facet> oriented_set;
@@ -65,7 +68,7 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
 
     CGAL_assertion_code(typename Tr::size_type nb_facets = 0; )
 
-        while (oriented_set.size() != number_of_facets) {
+    while (oriented_set.size() != number_of_facets) {
       while ( fit->first->is_facet_on_surface(fit->second) == false ||
               oriented_set.find(*fit) != oriented_set.end() ||
 
@@ -105,12 +108,17 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
           (top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 0))->point().z()
            + top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 1))->point().z()
            + top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 2))->point().z())/3.;
-      double z =
-          (fit->first->vertex(tr.vertex_triple_index(fit->second, 0))->point().z()
-           + fit->first->vertex(tr.vertex_triple_index(fit->second, 1))->point().z()
-           + fit->first->vertex(tr.vertex_triple_index(fit->second, 2))->point().z())/3.;
-      if (top_z < z)
+      Vertex_handle v0 = fit->first->vertex(tr.vertex_triple_index(fit->second, 0));
+      Vertex_handle v1 = fit->first->vertex(tr.vertex_triple_index(fit->second, 1));
+      Vertex_handle v2 = fit->first->vertex(tr.vertex_triple_index(fit->second, 2));
+      double z = (v0->point().z() + v1->point().z() + v2->point().z())/3.;
+      if (top_z < z){
         top_facet = fit;
+      }
+      // we just put them in the map and index them later
+      V[v0] = 0;
+      V[v1] = 0;
+      V[v2] = 0;
     }
     // - orient the facet with max z towards +Z axis
     Vertex_handle v0 = top_facet->first->vertex(tr.vertex_triple_index(top_facet->second, 0));
@@ -120,8 +128,6 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
     const Vector Z(0, 0, 1);
     bool regular_orientation = (Z * normal >= 0);
 
-    //used to set indices of vertices
-    std::map<Vertex_handle, int> V;
     int inum = 0;
     //add vertices
     std::vector<typename boost::graph_traits<TriangleMesh>::vertex_descriptor> vertices;
@@ -129,17 +135,18 @@ void facets_in_complex_2_to_triangle_mesh(const C2T3& c2t3, TriangleMesh& graph)
         vit != tr.finite_vertices_end();
         ++vit)
     {
-
-      typename boost::graph_traits<TriangleMesh>::vertex_descriptor v = add_vertex(graph);
-      vertices.push_back(v);
-      put(vpmap,
-          v,
-           Point_3(
-            vit->point().x(),
-            vit->point().y(),
-            vit->point().z())
-          );
-      V.insert(std::make_pair(vit, inum++));
+      if(V.find(vit)!= V.end()){
+        typename boost::graph_traits<TriangleMesh>::vertex_descriptor v = add_vertex(graph);
+        vertices.push_back(v);
+        put(vpmap,
+            v,
+            Point_3(
+                    vit->point().x(),
+                    vit->point().y(),
+                    vit->point().z())
+            );
+        V[vit] = inum++;
+      }
     }
     //add faces
     for(typename std::set<Facet>::const_iterator fit =


### PR DESCRIPTION
## Summary of Changes

Do not create isolated vertices when creating a `Surface_mesh` from a `C2T3`.

There is nothing to do for the 3D equivalent `facets_in_complex_3_to_triangle_mesh()`.

## Todo 
- [x]  check the other functions which write to vtk, medit,...

## Release Management

* Affected package(s): Surface_mesher  
* Issue(s) solved (if any): fix #4970
* License and copyright ownership: no change

