### PR TITLE
Fix leaking memory in Alpha_shape_mesher

### DIFF
--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
@@ -180,6 +180,11 @@ public:
 
   }
 
+  ~Alpha_shape_mesher ()
+  {
+    clear_surface();
+  }
+
   /// \cond SKIP_IN_MANUAL
   template <typename InputIterator, typename OutputIterator>
   void operator() (InputIterator begin, InputIterator end, OutputIterator output)


### PR DESCRIPTION
## Summary of Changes

This small PR addresses the bug reported in #4988. 

## Release Management

* Affected package(s): Scale_space_reconstruction_3
* Issue(s) solved (if any): fix #4988 
* Feature/Small Feature (if any): bug fix
* Link to compiled documentation (obligatory for small feature): no changes
* License and copyright ownership: no changes

