### PR TITLE
Fix iterator invalidation bug

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -1697,7 +1697,9 @@ bool remove_degenerate_faces(const FaceRange& face_range,
     std::map<edge_descriptor, bool> are_degenerate_edges;
 
     // use a copy of the set to avoid iterator invalidation
-    std::set<face_descriptor> degenerate_face_set_copy(degenerate_face_set);
+    std::vector<face_descriptor> degenerate_face_set_copy(degenerate_face_set.size());
+    std::copy(degenerate_face_set.begin(), degenerate_face_set.end(),
+              degenerate_face_set_copy.begin());
     for(face_descriptor fd : degenerate_face_set_copy)
     {
       for(halfedge_descriptor hd : halfedges_around_face(halfedge(fd, tmesh), tmesh))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -1696,7 +1696,9 @@ bool remove_degenerate_faces(const FaceRange& face_range,
   {
     std::map<edge_descriptor, bool> are_degenerate_edges;
 
-    for(face_descriptor fd : degenerate_face_set)
+    // use a copy of the set to avoid iterator invalidation
+    std::set<face_descriptor> degenerate_face_set_copy(degenerate_face_set);
+    for(face_descriptor fd : degenerate_face_set_copy)
     {
       for(halfedge_descriptor hd : halfedges_around_face(halfedge(fd, tmesh), tmesh))
       {


### PR DESCRIPTION
## Summary of Changes

There is an iterator invalidation bug when looping over `degenerate_face_set` and modifying it at the same time (see [this page on cppreference](https://en.cppreference.com/w/cpp/container#Iterator_invalidation) for details on iterator invalidation).

On some meshes it can causes segmentation faults. If required I can upload a .off file containing a mesh for which it's the case (but I don't have a minimal example, only a 156K .off file).

I fix that by simply iterating over a copy of `degenerate_face_set` rather than the original one (while still modifying the original one). It might not be the most computationally efficient way to do it (it involves creating a copy of the set), but it does fix the bug in one line of code. 

## Release Management

* Affected package(s): Polygon Mesh Processing