### PR TITLE
Fix eating extra whitespace in CORE::BigRat

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/Gmp_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Gmp_impl.h
@@ -198,10 +198,6 @@ io_read (std::istream &i, mpq_ptr q)
       ok = true;
     }
 
-  if (i.flags() & ios::skipws)
-    while (isspace(c) && i.get(c)) // skip whitespace
-      ;
-
   if (c == '/') // there's a denominator
     {
       bool zero2 = false;


### PR DESCRIPTION
## Summary of Changes

CORE::BigRat parses rational numbers in the form `<digit>* <whitespace>* '/' <whitespace>* <digit>*`. This causes eating extra whitespace (including new line characters) when parsing a rational that doesn't have a denominator. Arrangement IO uses the new line character to denote a new piece of information, which causes problems.

The change is to parse rationals in the form `<digit>* '/' <whitespace>* <digit>*` which is in line with what Gmpq IO does.

## Release Management

* Affected package(s): Core
* Issue(s) solved (if any): fix #5003
* License and copyright ownership: The license used by CGAL.