### PR TITLE
Windows, FPU.h: replace `_control_fp` by SSE2 intrisics

### DIFF
--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -75,8 +75,8 @@ extern "C" {
 // Pure and safe SSE2 mode (g++ -mfpmath=sse && (-msse2 || -march=pentium4))
 // can be detected by :
 // TODO : see what Intel and VC++ have to say about this.
-#if defined __FLT_EVAL_METHOD__ && defined __SSE2_MATH__ && \
-      (__FLT_EVAL_METHOD__ == 0 || __FLT_EVAL_METHOD__ == 1)
+#if defined _M_X64 || ( defined __FLT_EVAL_METHOD__ && defined __SSE2_MATH__ && \
+                        (__FLT_EVAL_METHOD__ == 0 || __FLT_EVAL_METHOD__ == 1) )
 #  define CGAL_SAFE_SSE2
 #  include <xmmintrin.h>
 #endif
@@ -90,7 +90,7 @@ extern "C" {
 #if !defined CGAL_IA_NO_X86_OVER_UNDER_FLOW_PROTECT && \
   (((defined __i386__ || defined __x86_64__) && !defined CGAL_SAFE_SSE2) \
    || defined __ia64__ \
-   || defined _M_IX86 || defined _M_X64 || defined _M_IA64 \
+   || defined _M_IX86 || defined _M_IA64 \
    || (defined FLT_EVAL_METHOD && FLT_EVAL_METHOD != 0 && FLT_EVAL_METHOD != 1))
 #  define CGAL_FPU_HAS_EXCESS_PRECISION
 #endif


### PR DESCRIPTION
## Summary of Changes

Windows, FPU.h: replace `_control_fp` by SSE2 intrisics. Fix #2135

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): fix #2135 
* License and copyright ownership: N/A

Cc: @afabri please check if that accelerates on Windows
