### PR TITLE
Demo: Fix id_printing

### DIFF
--- a/Polyhedron/demo/Polyhedron/include/id_printing.h
+++ b/Polyhedron/demo/Polyhedron/include/id_printing.h
@@ -569,7 +569,7 @@ int zoomToId(const Mesh& mesh,
                   get(ppmap, vh).y() + offset.y,
                   get(ppmap, vh).z() + offset.z);
         typename boost::graph_traits<Mesh>::halfedge_descriptor hf = halfedge(vh, mesh);
-        if(CGAL::is_border_edge(hf, mesh))
+        if(CGAL::is_border(hf, mesh))
         {
           hf = opposite(hf, mesh);
         }


### PR DESCRIPTION
## Summary of Changes
Near border edges, Print_id may cause a crash because we test is_border_edge() instead of is_border() on the selected halfedge. 
This PR fixes that.
## Release Management

* Issue(s) solved (if any): fix #5002
