### PR TITLE
Fix errors and warnings for C++20

### DIFF
--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_hierarchy_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_hierarchy_3.h
@@ -523,7 +523,7 @@ random_level()
        && hierarchy[level_mult_cover]->number_of_sheets() == make_array(1,1,1) )
     ++level_mult_cover;
 
-  boost::geometric_distribution<> proba(1.0/ratio);
+  boost::geometric_distribution<> proba(1.0/static_cast<double>(ratio));
   boost::variate_generator<boost::rand48&, boost::geometric_distribution<> >
       die(random, proba);
   return (std::min)(die()-1, level_mult_cover);

--- a/Ridges_3/test/Ridges_3/PolyhedralSurf.h
+++ b/Ridges_3/test/Ridges_3/PolyhedralSurf.h
@@ -43,12 +43,13 @@ struct Wrappers_VFH:public CGAL::Polyhedron_items_3 {
   template < class Refs, class Traits > struct Face_wrapper {
     //typedef typename Traits::Vector_3 Vector_3;
     //all types needed by the facet...
-    typedef struct {
-    public:
-       typedef typename Traits::Vector_3 Vector_3;
-     } FGeomTraits;
+    struct FGeomTraits {
+      public:
+         typedef typename Traits::Vector_3 Vector_3;
+    };
+    typedef FGeomTraits FGT;
     //custom type instantiated...
-    typedef My_facet < Refs, CGAL::Tag_true, FGeomTraits > Face;
+    typedef My_facet < Refs, CGAL::Tag_true, FGT > Face;
   };
 };
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes warnings and errors about things that are deprecated/removed from c++20 and fail in the CGAL testsuite.

## Release Management

* Affected package(s): Periodic_3_Triangulation_3, Ridges_3
* License and copyright ownership: unchanged