### PR TITLE
Nef_2: Fix a warning in an debug code

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/debug.h
+++ b/Nef_2/include/CGAL/Nef_2/debug.h
@@ -59,8 +59,7 @@
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
- std::cerr<< " "<<t<<std::endl; \
- std::cerr.flush()
+ std::cerr<< " "<<t<<std::endl;
 #else
 #define CGAL_NEF_TRACEN(t)
 #endif


### PR DESCRIPTION
## Summary of Changes

https://github.com/CGAL/cgal/blob/ac3f1101a31fe8553e78ec8ad6b637d70ed95b55/Nef_2/include/CGAL/Nef_2/debug.h#L61-L63

https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.2-I-14/Convex_decomposition_3/TestReport_lrineau_Ubuntu-latest-GCC6.gz
```
/mnt/testsuite/include/CGAL/Nef_2/debug.h:61:28: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   61 | #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
      |                            ^~
/mnt/testsuite/include/CGAL/Nef_2/debug.h:61:28: note: in definition of macro 'CGAL_NEF_TRACEN'
   61 | #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
      |                            ^~
/mnt/testsuite/include/CGAL/Nef_2/debug.h:63:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
   63 |  std::cerr.flush()
      |  ^~~
/mnt/testsuite/include/CGAL/Nef_2/debug.h:63:2: note: in definition of macro 'CGAL_NEF_TRACEN'
   63 |  std::cerr.flush()
      |  ^~~
```

- `std::cerr` is already unbufferized, and `std::flush` does nothing
  on it,
- and anyway, `std::endl` calls `std::flush`.

## Release Management

* Affected package(s): Nef_2, Nef_3


