### PR TITLE
Fix a warning

### DIFF
--- a/Classification/examples/Classification/gis_tutorial_example.cpp
+++ b/Classification/examples/Classification/gis_tutorial_example.cpp
@@ -669,7 +669,7 @@ int main (int argc, char** argv)
   }
 
   std::size_t nb_vertices
-    = std::accumulate (polylines.begin(), polylines.end(), 0,
+    = std::accumulate (polylines.begin(), polylines.end(), 0u,
                        [](std::size_t size, const std::vector<Point_3>& poly) -> std::size_t
                        { return size + poly.size(); });
 


### PR DESCRIPTION
## Summary of Changes

Fix a warning

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\include\numeric(35): warning C4267: '=': conversion from 'size_t' to '_Ty', possible loss of data
        with
        [
            _Ty=int
        ]
C:\cgal_test\CGAL-5.2-I-14\cmake\platforms\Windows_MSVC-2019-Community-Release-64bits\test\Classification_Examples\gis_tutorial_example.cpp(674): note: see reference to function template instantiation '_Ty std::accumulate<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<std::vector<CGAL::Point_3<Kernel_>,std::allocator<CGAL::Point_3<Kernel_>>>>>>,int,main::<lambda_f241736352025ce40037bac2971f2e7f>>(const _InIt,const _InIt,_Ty,_Fn)' being compiled
        with
        [
            _Ty=int,
            Kernel_=CGAL::Epick,
            _InIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<std::vector<CGAL::Point_3<CGAL::Epick>,std::allocator<CGAL::Point_3<CGAL::Epick>>>>>>,
            _Fn=main::<lambda_f241736352025ce40037bac2971f2e7f>
        ]
```

## Release Management

* Affected package(s): Classification
