### PR TITLE
Heat_method_3 - avoid degenerate faces

### DIFF
--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -480,7 +480,8 @@ public:
   template<class VertexDistanceMap>
   void estimate_geodesic_distances(VertexDistanceMap vdm)
   {
-    CGAL_precondition(!internal::has_degenerate_faces(triangle_mesh(), vertex_point_map()));
+    CGAL_precondition(
+      !CGAL::Heat_method_3::internal::has_degenerate_faces(triangle_mesh(), vertex_point_map()));
 
     if(is_empty(tm)){
       return;
@@ -738,7 +739,8 @@ struct Base_helper<TriangleMesh, Traits, Intrinsic_Delaunay, LA, VertexPointMap>
   template <class VertexDistanceMap>
   void estimate_geodesic_distances(VertexDistanceMap vdm)
   {
-    CGAL_precondition(!internal::has_degenerate_faces(this->m_idt.triangle_mesh()));
+    CGAL_precondition(
+      !CGAL::Heat_method_3::internal::has_degenerate_faces(this->m_idt.triangle_mesh()));
     base().estimate_geodesic_distances(this->m_idt.vertex_distance_map(vdm));
   }
 };

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -770,7 +770,6 @@ struct Base_helper<TriangleMesh, Traits, Intrinsic_Delaunay, LA, VertexPointMap>
  *         is used as default
  * \tparam Traits a model of `HeatMethodTraits_3`. The default is the Kernel of the value type
  *         of the vertex point map (extracted using `Kernel_traits`).
- * \pre
  */
 template <typename TriangleMesh,
           typename Mode = Direct,

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -52,6 +52,14 @@ struct Intrinsic_Delaunay
 {};
 
 namespace internal {
+  template<typename TriangleMesh>
+  bool has_degenerate_faces(const TriangleMesh& tm);
+
+  template<typename TriangleMesh, typename VertexPointMap>
+  bool has_degenerate_faces(const TriangleMesh& tm, VertexPointMap vpm);
+}
+
+namespace internal {
 template <typename TriangleMesh,
           typename Traits,
           typename LA,

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -738,9 +738,7 @@ struct Base_helper<TriangleMesh, Traits, Intrinsic_Delaunay, LA, VertexPointMap>
   template <class VertexDistanceMap>
   void estimate_geodesic_distances(VertexDistanceMap vdm)
   {
-    CGAL_precondition(!internal::has_degenerate_faces(this->m_idt.triangle_mesh(),
-                                                      this->m_idt.vertex_point_map()));
-
+    CGAL_precondition(!internal::has_degenerate_faces(this->m_idt.triangle_mesh()));
     base().estimate_geodesic_distances(this->m_idt.vertex_distance_map(vdm));
   }
 };


### PR DESCRIPTION
## Summary of Changes

Degenerate faces in the input triangle mesh cause an infinite loop in `loop_over_edges()`.
This PR adds a precondition to avoid degenerate faces in input.

## Release Management

* Affected package(s): Heat_method_3
* Issue(s) solved (if any): fix #5010 
* License and copyright ownership: unchanged

