### PR TITLE
Poisson Reconstruction: Fix thread safety

### DIFF
--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -30,6 +30,13 @@ if ( CGAL_FOUND )
     # Executables that require Eigen 3.1
     create_single_source_cgal_program( "poisson_reconstruction_test.cpp" )
 
+    find_package(TBB)
+    if (TBB_FOUND)
+      create_single_source_cgal_program( "poisson_and_parallel_mesh_3.cpp" )
+      CGAL_target_use_TBB(poisson_and_parallel_mesh_3)
+    else()
+      message(STATUS "NOTICE: test with parallel Mesh_3 needs TBB and will not be compiled.")
+    endif()
   else()
 
     message(STATUS "NOTICE: Some of the executables in this directory need Eigen 3.1 (or greater) and will not be compiled.")
@@ -41,4 +48,3 @@ else()
     message(STATUS "NOTICE: This program requires the CGAL library, and will not be compiled.")
 
 endif()
-

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_and_parallel_mesh_3.cpp
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_and_parallel_mesh_3.cpp
@@ -1,0 +1,78 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Poisson_reconstruction_function.h>
+#include <CGAL/Point_with_normal_3.h>
+#include <CGAL/property_map.h>
+#include <CGAL/IO/read_xyz_points.h>
+
+#include <CGAL/Labeled_mesh_domain_3.h>
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_criteria_3.h>
+#include <CGAL/make_mesh_3.h>
+
+#include <vector>
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef Kernel::FT FT;
+typedef Kernel::Point_3 Point_3;
+typedef Kernel::Vector_3 Vector_3;
+
+typedef std::pair<Point_3, Vector_3> Pwn;
+typedef CGAL::First_of_pair_property_map<Pwn> Point_map;
+typedef CGAL::Second_of_pair_property_map<Pwn> Vector_map;
+
+typedef CGAL::Poisson_reconstruction_function<Kernel> Poisson;
+
+typedef CGAL::Labeled_mesh_domain_3<Kernel> Implicit_domain;
+typedef CGAL::Mesh_triangulation_3<Implicit_domain, CGAL::Default,
+                                   CGAL::Parallel_tag>::type Mesh_tr;
+typedef CGAL::Mesh_complex_3_in_triangulation_3<Mesh_tr> C3t3;
+typedef CGAL::Mesh_criteria_3<Mesh_tr> Mesh_criteria;
+
+int main(int, char**)
+{
+  std::vector<Pwn> points;
+
+  std::ifstream stream("data/oni.pwn");
+  if (!stream ||
+      !CGAL::read_xyz_points
+      (stream, std::back_inserter(points),
+       CGAL::parameters::
+       point_map(Point_map()).
+       normal_map(Vector_map())))
+  {
+    std::cerr << "Error: cannot read file" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+	Poisson poisson (points.begin(), points.end(), Point_map(), Vector_map());
+	if (!poisson.compute_implicit_function())
+  {
+    std::cerr << "Error: cannot compute implicit function" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+	CGAL::Bbox_3 bbox
+    = CGAL::bbox_3 (boost::make_transform_iterator
+                    (points.begin(),
+                     CGAL::Property_map_to_unary_function<Point_map>()),
+                    boost::make_transform_iterator
+                    (points.end(),
+                     CGAL::Property_map_to_unary_function<Point_map>()));
+
+	Implicit_domain domain
+    = Implicit_domain::create_implicit_mesh_domain
+    (poisson, bbox);
+
+	Mesh_criteria criteria (CGAL::parameters::facet_angle = 30,
+                          CGAL::parameters::facet_size = 4,
+                          CGAL::parameters::facet_distance = 0.1);
+	C3t3 c3t3 = CGAL::make_mesh_3<C3t3> (domain, criteria,
+                                       CGAL::parameters::manifold());
+
+  return EXIT_SUCCESS;
+}

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_and_parallel_mesh_3.cpp
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/poisson_and_parallel_mesh_3.cpp
@@ -49,14 +49,14 @@ int main(int, char**)
     return EXIT_FAILURE;
   }
 
-	Poisson poisson (points.begin(), points.end(), Point_map(), Vector_map());
-	if (!poisson.compute_implicit_function())
+  Poisson poisson (points.begin(), points.end(), Point_map(), Vector_map());
+  if (!poisson.compute_implicit_function())
   {
     std::cerr << "Error: cannot compute implicit function" << std::endl;
     return EXIT_FAILURE;
   }
 
-	CGAL::Bbox_3 bbox
+  CGAL::Bbox_3 bbox
     = CGAL::bbox_3 (boost::make_transform_iterator
                     (points.begin(),
                      CGAL::Property_map_to_unary_function<Point_map>()),
@@ -64,14 +64,14 @@ int main(int, char**)
                     (points.end(),
                      CGAL::Property_map_to_unary_function<Point_map>()));
 
-	Implicit_domain domain
+  Implicit_domain domain
     = Implicit_domain::create_implicit_mesh_domain
     (poisson, bbox);
 
-	Mesh_criteria criteria (CGAL::parameters::facet_angle = 30,
+  Mesh_criteria criteria (CGAL::parameters::facet_angle = 30,
                           CGAL::parameters::facet_size = 4,
                           CGAL::parameters::facet_distance = 0.1);
-	C3t3 c3t3 = CGAL::make_mesh_3<C3t3> (domain, criteria,
+  C3t3 c3t3 = CGAL::make_mesh_3<C3t3> (domain, criteria,
                                        CGAL::parameters::manifold());
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary of Changes

Poisson reconstruction had a couple of problems when used with parallel `Mesh_3` as some structures were not thread-safe:
- a lazy cache mechanism to store barycentric coordinates of cells
- a global cell hint for fast locate

This PR fixes these 2 problems using atomic variables. It also adds a test for this specific case. This test triggers and assertion fail on master and succeeds on this branch.

## Release Management

* Affected package(s): Poisson Surface Reconstruction
* Issue(s) solved (if any): [cgal-discuss:  make_mesh_3 assertion violation in Triangulation_ds_cell_base_3](http://cgal-discuss.949826.n4.nabble.com/make-mesh-3-assertion-violation-in-Triangulation-ds-cell-base-3-td4665230.html)
