### PR TITLE
Basic_viewer: Minor fixes

### DIFF
--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -1239,7 +1239,7 @@ protected:
     setKeyDescription(::Qt::Key_Minus+::Qt::ControlModifier, "Decrease size of vertices");
     setKeyDescription(::Qt::Key_PageDown, "Increase light (all colors, use shift/alt/ctrl for one rgb component)");
     setKeyDescription(::Qt::Key_PageUp, "Decrease light (all colors, use shift/alt/ctrl for one rgb component)");
-    setKeyDescription(::Qt::Key_Less, "Toggles 2D mode only");
+    setKeyDescription(::Qt::Key_O, "Toggles 2D mode only");
 
     // Light default parameters
     glLineWidth(m_size_edges);
@@ -1448,7 +1448,7 @@ protected:
                      arg(m_ambient_color.x()).arg(m_ambient_color.y()).arg(m_ambient_color.z()));
       update();
     }
-    else if ((e->key()==::Qt::Key_Less) && (modifiers==::Qt::NoButton))
+    else if ((e->key()==::Qt::Key_O) && (modifiers==::Qt::NoButton))
     {
       bool old_2D=is_two_dimensional();
       m_no_2D_mode=!m_no_2D_mode;

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -3840,18 +3840,13 @@ void CGAL::QGLViewer::initFromDOMElement(const QDomElement &element) {
       setAxisIsDrawn(DomUtils::boolFromDom(child, "axisIsDrawn", false));
       setGridIsDrawn(DomUtils::boolFromDom(child, "gridIsDrawn", false));
       setFPSIsDisplayed(DomUtils::boolFromDom(child, "FPSIsDisplayed", false));
-      // See comment below.
-      tmpCameraIsEdited = DomUtils::boolFromDom(child, "cameraIsEdited", false);
-      // setTextIsEnabled(DomUtils::boolFromDom(child, "textIsEnabled", true));
     }
 
     if (child.tagName() == "Geometry") {
       setFullScreen(DomUtils::boolFromDom(child, "fullScreen", false));
 
-      if (isFullScreen()) {
-        prevPos_.setX(DomUtils::intFromDom(child, "prevPosX", 0));
-        prevPos_.setY(DomUtils::intFromDom(child, "prevPosY", 0));
-      } else {
+      if (!isFullScreen())
+      {
         int width = DomUtils::intFromDom(child, "width", 600);
         int height = DomUtils::intFromDom(child, "height", 400);
         topLevelWidget()->resize(width, height);
@@ -3863,15 +3858,6 @@ void CGAL::QGLViewer::initFromDOMElement(const QDomElement &element) {
         topLevelWidget()->move(pos);
       }
     }
-
-    if (child.tagName() == "Camera") {
-      connectAllCameraKFIInterpolatedSignals(false);
-      camera()->initFromDOMElement(child);
-      connectAllCameraKFIInterpolatedSignals();
-    }
-
-    if ((child.tagName() == "ManipulatedFrame") && (manipulatedFrame()))
-      manipulatedFrame()->initFromDOMElement(child);
 
     child = child.nextSibling().toElement();
   }


### PR DESCRIPTION
## Summary of Changes

 - Use O instead of < as it doesn't work on some keyboards (mine, for example)
 - Remove the Camera state from the settings saved, as it is supposed to be overridden by the recenter, and sometimes, if the said state is broken enough, the user is unable to visualize anything even after re-launching the app.