### PR TITLE
Add mollification step to avoid degenerate faces

### DIFF
--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -285,6 +285,29 @@ private:
     return CGAL::sqrt(S*(S-a)*(S-b)*(S-c));
   }
 
+  // Mollification strategy to avoid degeneracies
+  void
+  mollify(double delta)
+  {
+    // compute smallest length epsilon we can add to
+    // all edges to ensure that the strict triangle
+    // inequality holds with a tolerance of delta
+    double epsilon = 0;
+    for(halfedge_descriptor hd : halfedges(m_intrinsic_tm)) {
+      halfedge_descriptor hd2 = next(hd, m_intrinsic_tm);
+      halfedge_descriptor hd3 = next(hd2,m_intrinsic_tm);
+      Index i = get(edge_id_map, edge(hd,m_intrinsic_tm));
+      Index j = get(edge_id_map, edge(hd2,m_intrinsic_tm));
+      Index k = get(edge_id_map, edge(hd3,m_intrinsic_tm));
+      double ineq = edge_lengths[j] + edge_lengths[k] - edge_lengths[i];
+      epsilon = std::max(epsilon, std::max(0., delta-ineq));
+    }
+    // update edge lengths
+    for(edge_descriptor ed : edges(m_intrinsic_tm)) {
+        Index i = get(edge_id_map, ed);
+        edge_lengths[i] += epsilon;
+    }
+  }
 
   void
   loop_over_edges(edge_stack stack, std::vector<int>& marked_edges)
@@ -365,13 +388,16 @@ private:
     Index edge_i = 0;
     VertexPointMap vpm_intrinsic_tm = get(boost::vertex_point,m_intrinsic_tm);
 
+    double min_length = (std::numeric_limits<double>::max)();
     for(edge_descriptor ed : edges(m_intrinsic_tm)) {
       edge_lengths[edge_i] = CGAL::sqrt(to_double(squared_distance(get(vpm_intrinsic_tm, source(ed,m_intrinsic_tm)),
                                                                    get(vpm_intrinsic_tm, target(ed,m_intrinsic_tm)))));
         //  Polygon_mesh_processing::edge_length(halfedge(ed,m_intrinsic_tm),m_intrinsic_tm);
+      if (edge_lengths[edge_i] != 0 && edge_lengths[edge_i] < min_length) min_length = edge_lengths[edge_i];
       put(edge_id_map, ed, edge_i++);
       stack.push(ed);
     }
+    mollify(min_length*1e-4);
     loop_over_edges(stack, mark_edges);
     //now that edges are calculated, go through and for each face, calculate the vertex positions around it
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes the infinite loop problem from [issue #5010](https://github.com/CGAL/cgal/issues/5010) by implementing the "mollification" step from
[N. Sharp & K. Crane "A Laplacian for Nonmanifold Triangle Meshes" (2020)](https://www.cs.cmu.edu/~kmcrane/Projects/NonmanifoldLaplace/NonmanifoldLaplace.pdf) (section 4.5).

Basically, the problem arises from degenerate faces (triangles) in the input mesh. These degenerate faces can be "removed" by increasing the length of all edges in the mesh by a small, constant amount `epsilon` until no input triangle is degenerate. This constant depends on a user-defined tolerance value `delta`, which is the tolerance with which we want the (strict) triangle inequality to hold in each triangle. According to the paper, this method will not significantly distort the Laplacian of the mesh.

The paper does not discuss the choice of the user-defined tolerance `delta`. I decided to use an arbitrary value of `(min_length*1e-4)` where `min_length` is the minimum non-zero edge length in the mesh. This seems to work well enough, and in any case if the mesh is already free of degenerate faces to begin with, the mollification step should not change the end result.


## Release Management

* Affected package: Heat_method_3
* Issue solved: fix [issue #5010](https://github.com/CGAL/cgal/issues/5010)

