### PR TITLE
Fix wpoint transform

### DIFF
--- a/Kernel_23/include/CGAL/Weighted_point_2.h
+++ b/Kernel_23/include/CGAL/Weighted_point_2.h
@@ -171,7 +171,7 @@ public:
 
   Weighted_point_2 transform(const Aff_transformation_2 &t) const
   {
-    return Weighted_point_2(t.transform(point(),weight()));
+    return Weighted_point_2(t.transform(point()),weight());
   }
 
 };

--- a/Kernel_23/include/CGAL/Weighted_point_3.h
+++ b/Kernel_23/include/CGAL/Weighted_point_3.h
@@ -186,7 +186,7 @@ public:
 
   Weighted_point_3 transform(const Aff_transformation_3 &t) const
   {
-    return Weighted_point_3(t.transform(point(),weight()));
+    return Weighted_point_3(t.transform(point()),weight());
   }
 
 };


### PR DESCRIPTION
## Summary of Changes

This is a small fix for applying transformations to weighted points. For both 2 and 3 dimensional weighted points the right brace was misplaced leading to errors.

## Release Management

* Affected package(s): `Kernel_23`
* License and copyright ownership: no change

