### PR TITLE
STL Extensions: Small List

### DIFF
--- a/STL_Extension/include/CGAL/Small_list.h
+++ b/STL_Extension/include/CGAL/Small_list.h
@@ -226,7 +226,10 @@ public:
     if (next == m_first)
       push_front(t);
     else if (next == nullptr)
+    {
       push_back(t);
+      return iterator(m_last, m_last);
+    }
     else
     {
       Node* n = m_pool.allocate();
@@ -238,7 +241,7 @@ public:
       ++ m_size;
     }
 
-    return next->prev();
+    return iterator(m_last, next->prev());
   }
 
   iterator erase(iterator first, iterator last)

--- a/STL_Extension/include/CGAL/Small_list.h
+++ b/STL_Extension/include/CGAL/Small_list.h
@@ -1,0 +1,346 @@
+// Copyright (c) 2020  GeometryFactory (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Simon Giraudot
+
+#ifndef CGAL_SMALL_LIST_H
+#define CGAL_SMALL_LIST_H
+
+#include <CGAL/assertions.h>
+#include <CGAL/tags.h>
+
+#include <boost/iterator/iterator_facade.hpp>
+
+namespace CGAL
+{
+
+namespace internal
+{
+
+template <typename T>
+class Small_list_node
+{
+private:
+  using Self = Small_list_node<T>;
+
+  T m_value;
+  Self* m_prev;
+  Self* m_next;
+
+public:
+
+  Small_list_node() : m_prev(nullptr), m_next(nullptr) { }
+
+  Self* prev() const { return m_prev; }
+  Self* next() const { return m_next; }
+  const T& value() const { return m_value; }
+        T& value()       { return m_value; }
+
+  friend void connect (Self* a, Self* b)
+  {
+    CGAL_assertion (a->m_next == nullptr && b->m_prev == nullptr);
+    a->m_next = b;
+    b->m_prev = a;
+  }
+
+  friend void disconnect (Self* a, Self* b)
+  {
+    CGAL_assertion (a->m_next == b && b->m_prev == a);
+    a->m_next = nullptr;
+    b->m_prev = nullptr;
+  }
+
+};
+
+template <typename T, std::size_t StackSize>
+class Small_list_memory_pool
+{
+  T m_pool[StackSize];
+  std::size_t m_next;
+
+public:
+
+  Small_list_memory_pool() : m_next(0) { }
+
+  Small_list_memory_pool (const Small_list_memory_pool&) = delete;
+
+  T* allocate()
+  {
+    if (m_next < StackSize)
+      return m_pool + (m_next ++);
+    return new T;
+  }
+
+  void deallocate (T* t)
+  {
+    if (m_pool <= t && t < m_pool + StackSize)
+    {
+      // If pointer was the last one allocated, we can use again this
+      // chunk of memory
+      if (t == m_pool + (StackSize - 1))
+        m_next = StackSize - 1;
+    }
+    else
+      delete t;
+  }
+};
+
+template<typename T, typename ReverseTag>
+class Small_list_iterator
+  : public boost::iterator_facade<Small_list_iterator<T, ReverseTag>,
+                                  T,
+                                  std::bidirectional_iterator_tag>
+{
+  using Self = Small_list_iterator<T, ReverseTag>;
+  using Node = Small_list_node<T>;
+
+public:
+  Small_list_iterator(Node* last = nullptr,
+                      Node* node = nullptr)
+    : m_node (node), m_last (last) { }
+
+  Node* node() { return m_node; }
+
+private:
+  friend class boost::iterator_core_access;
+  void increment() { increment(ReverseTag()); }
+  void decrement()
+  {
+    if (m_node == nullptr)
+      m_node = m_last;
+    else
+      decrement(ReverseTag());
+  }
+
+  // forward iterator
+  void increment (const Tag_false&) { m_node = m_node->next(); }
+  void decrement (const Tag_false&) { m_node = m_node->prev(); }
+
+  // reverse iterator
+  void increment (const Tag_true&) { m_node = m_node->prev(); }
+  void decrement (const Tag_true&) { m_node = m_node->next(); }
+
+  bool equal(const Self& other) const { return (this->m_node == other.m_node); }
+  T& dereference() const { return const_cast<T&>(m_node->value()); }
+
+  Node* m_node;
+  Node* m_last;
+};
+
+} // namespace internal
+
+template <typename T, std::size_t StackSize>
+class Small_list
+{
+private:
+
+  using Node = internal::Small_list_node<T>;
+  using Pool = internal::Small_list_memory_pool<Node, StackSize>;
+
+public:
+
+  using iterator = internal::Small_list_iterator<T, Tag_false>;
+  using reverse_iterator = internal::Small_list_iterator<T, Tag_true>;
+  using const_iterator = iterator;
+  using value_type = T;
+
+private:
+
+  Pool m_pool;
+  Node* m_first;
+  Node* m_last;
+  std::size_t m_size;
+
+public:
+
+  Small_list()
+    : m_first (nullptr)
+    , m_last (nullptr)
+    , m_size (0) { }
+
+  Small_list(const Small_list& other)
+    : m_first (nullptr)
+    , m_last (nullptr)
+    , m_size (0)
+  {
+    std::copy (other.begin(), other.end(),
+               std::back_inserter (*this));
+  }
+
+  ~Small_list() { clear(); }
+
+  bool empty() const { return (m_size == 0); }
+  std::size_t size() const { return m_size; }
+
+  void push_back (const T& t)
+  {
+    Node* n = m_pool.allocate();
+    n->value() = t;
+    if (empty())
+    {
+      m_first = n;
+      m_last = n;
+    }
+    else
+    {
+      connect (m_last, n);
+      m_last = n;
+    }
+    ++ m_size;
+  }
+
+  void push_front (const T& t)
+  {
+    Node* n = m_pool.allocate();
+    n->value() = t;
+    if (empty())
+    {
+      m_first = n;
+      m_last = n;
+    }
+    else
+    {
+      connect (n, m_first);
+      m_first = n;
+    }
+    ++ m_size;
+  }
+
+  const_iterator begin() const { return const_iterator (m_last, m_first); }
+  const_iterator end() const { return const_iterator (m_last); }
+  iterator begin() { return iterator (m_last, m_first); }
+  iterator end() { return iterator (m_last); }
+  reverse_iterator rbegin() { return reverse_iterator (m_first, m_last); }
+  reverse_iterator rend() { return reverse_iterator (m_first); }
+
+  iterator insert (iterator it, const T& t)
+  {
+    Node* next = it.node();
+
+    if (next == m_first)
+      push_front(t);
+    else if (next == nullptr)
+      push_back(t);
+    else
+    {
+      Node* n = m_pool.allocate();
+      n->value() = t;
+      Node* prev = next->prev();
+      disconnect (prev, next);
+      connect (prev, n);
+      connect (n, next);
+      ++ m_size;
+    }
+
+    return next->prev();
+  }
+
+  iterator erase(iterator first, iterator last)
+  {
+    if (first == last)
+      return last;
+
+    Node* firstn = first.node();
+    CGAL_assertion (firstn != nullptr);
+
+    Node* beyondn = last.node();
+    Node* lastn = (beyondn == nullptr ? m_last : beyondn->prev());
+
+    Node* n = firstn;
+    while (n != lastn)
+    {
+      Node* next = n->next();
+      disconnect (n, n->next());
+      if (n != firstn)
+      {
+        m_pool.deallocate(n);
+        -- m_size;
+      }
+      n = next;
+    }
+
+    if (lastn != m_last)
+    {
+      disconnect (lastn, beyondn);
+      connect (firstn, beyondn);
+    }
+    else
+      m_last = firstn;
+
+    m_pool.deallocate (lastn);
+    -- m_size;
+
+    return erase (first);
+  }
+
+  iterator erase(iterator it)
+  {
+    Node* n = it.node();
+    CGAL_assertion (n != nullptr);
+
+    Node* out = nullptr;
+    if (m_size == 1)
+    {
+      m_first = nullptr;
+      m_last = nullptr;
+    }
+    else if (n == m_first)
+    {
+      m_first = n->next();
+      disconnect(n, m_first);
+      out = m_first;
+    }
+    else if (n == m_last)
+    {
+      m_last = n->prev();
+      disconnect (m_last, n);
+    }
+    else
+    {
+      Node* prev = n->prev();
+      Node* next = n->next();
+      disconnect (prev, n);
+      disconnect (n, next);
+      connect (prev, next);
+      out = next;
+    }
+
+    m_pool.deallocate(n);
+    -- m_size;
+    return out;
+  }
+
+  void clear()
+  {
+    if (m_size == 0)
+      return;
+
+    Node* n = m_first;
+    while (n != nullptr)
+    {
+      Node* next = n->next();
+      m_pool.deallocate(n);
+      n = next;
+    }
+
+    m_first = nullptr;
+    m_last = nullptr;
+    m_size = 0;
+  }
+
+  const T& front() const { return m_first->value(); }
+        T& front()       { return m_first->value(); }
+  const T& back() const { return m_last->value(); }
+        T& back()       { return m_last->value(); }
+
+};
+
+} // namespace CGAL
+
+#endif // CGAL_SMALL_LIST_H

--- a/STL_Extension/include/CGAL/Small_list.h
+++ b/STL_Extension/include/CGAL/Small_list.h
@@ -72,8 +72,11 @@ public:
 
   T* allocate()
   {
+    CGAL_BRANCH_PROFILER("allocations on Small_list exceeding stack size", tmp);
     if (m_next < StackSize)
       return m_pool + (m_next ++);
+
+    CGAL_BRANCH_PROFILER_BRANCH(tmp);
     return new T;
   }
 

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -42,9 +42,9 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_Uncertain.cpp" )
   create_single_source_cgal_program( "test_vector.cpp" )
   create_single_source_cgal_program( "test_join_iterators.cpp" )
+  create_single_source_cgal_program( "test_Small_list.cpp" )
 else()
 
     message(STATUS "This program requires the CGAL library, and will not be compiled.")
 
 endif()
-

--- a/STL_Extension/test/STL_Extension/test_Small_list.cpp
+++ b/STL_Extension/test/STL_Extension/test_Small_list.cpp
@@ -1,0 +1,118 @@
+#include <CGAL/Small_list.h>
+#include <CGAL/Real_timer.h>
+#include <CGAL/Random.h>
+
+#include <list>
+
+constexpr std::size_t nb_tests = 1000000;
+constexpr std::size_t max_size = 2;
+
+typedef std::list<int> Standard_list;
+typedef CGAL::Small_list<int, max_size> Small_list;
+
+template <typename ListType>
+double speed_test (std::size_t nb_min, std::size_t nb_max)
+{
+  CGAL::Real_timer t;
+  t.start();
+  CGAL::Random rand(0);
+  for (std::size_t i = 0; i < nb_tests; ++ i)
+  {
+    ListType list;
+    std::size_t nb = rand.get_int(nb_min, nb_max);
+    for (std::size_t j = 0; j < nb; ++ j)
+      list.push_back (rand.get_int(0, 1000000));
+  }
+  t.stop();
+
+  return t.time();
+}
+
+int main()
+{
+  std::cerr << "[Small list sanity check]" << std::endl;
+  {
+    Small_list list;
+    CGAL_assertion (list.size() == 0);
+    CGAL_assertion (list.empty());
+
+    std::cerr << "push_back() 0 1 2 3 4" << std::endl;
+    list.push_back (0);
+    list.push_back (1);
+    list.push_back (2);
+    list.push_back (3);
+    list.push_back (4);
+    CGAL_assertion (list.size() == 5);
+
+    std::cerr << "begin() / end()" << std::endl;
+    for (const int& i : list)
+      std::cerr << i << " ";
+    std::cerr << std::endl;
+    std::cerr << "rbegin() / rend()" << std::endl;
+    for (auto it = list.rbegin(); it != list.rend(); ++ it)
+      std::cerr << *it << " ";
+    std::cerr << std::endl;
+
+    auto it1 = list.begin();
+    auto it2 = list.end();
+    ++ it1;
+    -- it2;
+    std::cerr << "erase(1, 4)" << std::endl;
+    list.erase(it1, it2);
+    CGAL_assertion (list.size() == 2);
+
+    std::cerr << "begin() / end()" << std::endl;
+    for (const int& i : list)
+      std::cerr << i << " ";
+    std::cerr << std::endl;
+    std::cerr << "rbegin() / rend()" << std::endl;
+    for (auto it = list.rbegin(); it != list.rend(); ++ it)
+      std::cerr << *it << " ";
+    std::cerr << std::endl;
+
+    std::cerr << "insert(begin(), 6)" << std::endl;
+    list.insert(list.begin(), 6);
+    std::cerr << "begin() / end()" << std::endl;
+    for (const int& i : list)
+      std::cerr << i << " ";
+    std::cerr << std::endl;
+    std::cerr << "rbegin() / rend()" << std::endl;
+    for (auto it = list.rbegin(); it != list.rend(); ++ it)
+      std::cerr << *it << " ";
+    std::cerr << std::endl;
+
+    std::cerr << "erase(begin(), end())" << std::endl;
+    list.erase(list.begin(), list.end());
+    CGAL_assertion (list.size() == 0);
+    CGAL_assertion (list.empty());
+  }
+
+  std::cerr << "[Speed test with all insertions smaller than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size - 2, max_size)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<Small_list>(max_size - 2, max_size)
+            << "s" << std::endl
+            << "   (should be much faster)" << std::endl;
+
+  std::cerr << "[Speed test with ~50% insertions smaller than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size - 2, max_size + 2)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<Small_list>(max_size - 2, max_size + 2)
+            << "s" << std::endl
+            << "   (should still be slightly faster)" << std::endl;
+
+  std::cerr << "[Speed test with all insertions greater than max_size]" << std::endl
+            << " * Standard list:   "
+            << speed_test<Standard_list>(max_size + 2, max_size + 4)
+            << "s" << std::endl
+            << " * List with stack: "
+            << speed_test<Small_list>(max_size + 2, max_size + 4)
+            << "s" << std::endl
+            << "   (shouldn't be faster)" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/STL_Extension/test/STL_Extension/test_Small_list.cpp
+++ b/STL_Extension/test/STL_Extension/test_Small_list.cpp
@@ -5,7 +5,7 @@
 #include <list>
 
 constexpr std::size_t nb_tests = 1000000;
-constexpr std::size_t max_size = 2;
+constexpr std::size_t max_size = 10;
 
 typedef std::list<int> Standard_list;
 typedef CGAL::Small_list<int, max_size> Small_list;

--- a/STL_Extension/test/STL_Extension/test_Small_list.cpp
+++ b/STL_Extension/test/STL_Extension/test_Small_list.cpp
@@ -70,8 +70,8 @@ int main()
       std::cerr << *it << " ";
     std::cerr << std::endl;
 
-    std::cerr << "insert(begin(), 6)" << std::endl;
-    list.insert(list.begin(), 6);
+    std::cerr << "insert(begin()+1, 6)" << std::endl;
+    list.insert(++ list.begin(), 6);
     std::cerr << "begin() / end()" << std::endl;
     for (const int& i : list)
       std::cerr << i << " ";
@@ -89,28 +89,28 @@ int main()
 
   std::cerr << "[Speed test with all insertions smaller than max_size]" << std::endl
             << " * Standard list:   "
-            << speed_test<Standard_list>(max_size - 2, max_size)
+            << speed_test<Standard_list>(max_size - 4, max_size)
             << "s" << std::endl
             << " * List with stack: "
-            << speed_test<Small_list>(max_size - 2, max_size)
+            << speed_test<Small_list>(max_size - 4, max_size)
             << "s" << std::endl
             << "   (should be much faster)" << std::endl;
 
   std::cerr << "[Speed test with ~50% insertions smaller than max_size]" << std::endl
             << " * Standard list:   "
-            << speed_test<Standard_list>(max_size - 2, max_size + 2)
+            << speed_test<Standard_list>(max_size - 2, max_size + 3)
             << "s" << std::endl
             << " * List with stack: "
-            << speed_test<Small_list>(max_size - 2, max_size + 2)
+            << speed_test<Small_list>(max_size - 2, max_size + 3)
             << "s" << std::endl
             << "   (should still be slightly faster)" << std::endl;
 
   std::cerr << "[Speed test with all insertions greater than max_size]" << std::endl
             << " * Standard list:   "
-            << speed_test<Standard_list>(max_size + 2, max_size + 4)
+            << speed_test<Standard_list>(max_size + 10, max_size + 20)
             << "s" << std::endl
             << " * List with stack: "
-            << speed_test<Small_list>(max_size + 2, max_size + 4)
+            << speed_test<Small_list>(max_size + 10, max_size + 20)
             << "s" << std::endl
             << "   (shouldn't be faster)" << std::endl;
 

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2.h
@@ -21,12 +21,12 @@
  * Definition of the Surface_sweep_2 class.
  */
 
-#include <list>
 #include <vector>
 
 #include <CGAL/Object.h>
 #include <CGAL/No_intersection_surface_sweep_2.h>
 #include <CGAL/Surface_sweep_2/Curve_pair.h>
+#include <CGAL/Small_list.h>
 #include <boost/unordered_set.hpp>
 #include <CGAL/algorithm.h>
 
@@ -96,7 +96,7 @@ public:
 
   typedef typename Event::Attribute                     Attribute;
 
-  typedef std::list<Subcurve*>                          Subcurve_container;
+  typedef Small_list<Subcurve*, 4>                      Subcurve_container;
   typedef typename Subcurve_container::iterator         Subcurve_iterator;
 
   typedef typename Base::Status_line_iterator           Status_line_iterator;

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_event_base.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_overlap_event_base.h
@@ -22,7 +22,8 @@
  * Defintion of the No_overlap_event_base class.
  */
 
-#include <list>
+#include <CGAL/Small_list.h>
+
 
 namespace CGAL {
 namespace Surface_sweep_2 {
@@ -65,7 +66,7 @@ public:
   typedef typename internal::Arr_complete_right_side_category<Gt2>::Category
                                                         Right_side_category;
 
-  typedef std::list<Subcurve*>                          Subcurve_container;
+  typedef Small_list<Subcurve*, 4>                      Subcurve_container;
   typedef typename Subcurve_container::iterator         Subcurve_iterator;
   typedef typename Subcurve_container::const_iterator   Subcurve_const_iterator;
   typedef typename Subcurve_container::reverse_iterator


### PR DESCRIPTION
## Summary of Changes

This PR replaces https://github.com/CGAL/cgal/pull/4921: the goal is still the same, having an equivalent of `boost::container::small_vector` but for a `std::list`-like structure. A small memory chunk is statically allocated, which can improve performances in cases where users know at compile-time that their list will rarely exceed a certain size.

Instead of a general allocator which turned out to be an overly-complicated and unsatisfying solution due to the constraints of the STL Allocator API, this is "just" a `Small_list` data structure. It provides pretty much the same gains of performances while being less general.

I added a test to STL Extension package, and the testsuites of Surface Sweep, Arrangement and Boolean Operations (which all use it) all pass without errors. Not all methods of `std::list` were implemented, only those necessary for surface sweep, but the other ones can always be added later if someone sees some interest in them.

## Release Management

* Affected package(s): STL Extensions, Surface Sweep + packages that rely on it (Arrangement, etc.)