### PR TITLE
Viewer zoom to rectangle

### DIFF
--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -895,13 +895,17 @@ Vec Camera::pointUnderPixel(const QPoint &pixel, bool &found) const {
 
 /*! Moves the Camera so that the entire scene is visible.
 
- Simply calls fitSphere() on a sphere defined by sceneCenter() and
- sceneRadius().
+ Calls fitSphere() on a sphere defined by sceneCenter() and
+ sceneRadius(), and resets the default FOV.
 
  You will typically use this method in CGAL::QGLViewer::init() after you defined a new
  sceneRadius(). */
 CGAL_INLINE_FUNCTION
-void Camera::showEntireScene() { fitSphere(sceneCenter(), sceneRadius()); }
+void Camera::showEntireScene()
+{
+  setFieldOfView(CGAL_PI/4.0);
+  fitSphere(sceneCenter(), sceneRadius());
+}
 
 /*! Moves the Camera so that its sceneCenter() is projected on the center of the
  window. The orientation() and fieldOfView() are unchanged.

--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -2115,7 +2115,7 @@ void Camera::initFromDOMElement(const QDomElement &element) {
   while (!child.isNull()) {
     if (child.tagName() == "Parameters") {
       // #CONNECTION# Default values set in constructor
-      setFieldOfView(DomUtils::qrealFromDom(child, "fieldOfView", CGAL_PI / 4.0));
+      //setFieldOfView(DomUtils::qrealFromDom(child, "fieldOfView", CGAL_PI / 4.0));
       setZNearCoefficient(
           DomUtils::qrealFromDom(child, "zNearCoefficient", 0.005));
       setZClippingCoefficient(

--- a/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
@@ -371,8 +371,7 @@ void ManipulatedCameraFrame::mouseMoveEvent(QMouseEvent *const event,
     break;
   }
 
-  case ZOOM_ON_REGION:
-  case NO_MOUSE_ACTION:
+  default:
     break;
   }
 

--- a/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame_impl.h
@@ -424,6 +424,23 @@ void ManipulatedCameraFrame::wheelEvent(QWheelEvent *const event,
         inverseTransformOf(Vec(0.0, 0.0, 0.2 * flySpeed() * event->angleDelta().y())));
     Q_EMIT manipulated();
     break;
+  case ZOOM_FOV:
+  {
+    qreal delta = - wheelDelta(event);//- sign to keep the same behavior as for the ZOOM action.
+    qreal new_fov = delta/100 + camera->fieldOfView();
+    if(new_fov > CGAL_PI/180.0)
+    {
+      new_fov = delta + camera->fieldOfView();
+    }
+    if(new_fov > CGAL_PI/4.0)
+      new_fov = CGAL_PI/4.0;
+    if( new_fov >= 0.0)
+    {
+      camera->setFieldOfView(new_fov);
+    }
+    Q_EMIT manipulated();
+    break;
+  }
   default:
     break;
   }
@@ -447,7 +464,10 @@ void ManipulatedCameraFrame::wheelEvent(QWheelEvent *const event,
   // isManipulated() returns false. But then fastDraw would not be used with
   // wheel. Detecting the last wheel event and forcing a final draw() is done
   // using the timer_.
-  action_ = NO_MOUSE_ACTION;
+  if(action_ != ZOOM_FOV)
+    action_ = NO_MOUSE_ACTION;
+  //else done after postDraw().
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
@@ -458,7 +458,7 @@ void ManipulatedFrame::mouseMoveEvent(QMouseEvent *const event,
     // These MouseAction values make no sense for a manipulatedFrame
     break;
 
-  case NO_MOUSE_ACTION:
+  default:
     // Possible when the ManipulatedFrame is a MouseGrabber. This method is then
     // called without startAction because of mouseTracking.
     break;

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -606,6 +606,25 @@ void CGAL::QGLViewer::postDraw() {
     painter.drawRect(QRect(camera()->frame()->pressPos_, mapFromGlobal(QCursor::pos())));
     painter.end();
   }
+
+  //zoom_fov indicator
+  if(camera()->frame()->action_ == qglviewer::ZOOM_FOV)
+  {
+    QPainter painter(this);
+    QPoint bot(width()-30,height()/2-0.33*height()),
+           top(width()-30, height()/2+0.33*height());
+    int fov_height = (top.y()-bot.y())*camera()->fieldOfView()*4.0/CGAL_PI + bot.y();
+
+
+    painter.setPen(QColor(120,120,120));
+    painter.drawLine(bot, top);
+    painter.fillRect(QRect(QPoint(width()-40, fov_height+10),
+                           QPoint(width()-20, fov_height-10)),
+                     QColor(120,120,120));
+    painter.end();
+    camera()->frame()->action_= qglviewer::NO_MOUSE_ACTION;
+  }
+
 }
 
 
@@ -740,6 +759,7 @@ void CGAL::QGLViewer::setDefaultMouseBindings() {
 
     setWheelBinding(modifiers, mh, qglviewer::ZOOM);
   }
+  setWheelBinding(::Qt::Key_Z, ::Qt::NoModifier, qglviewer::CAMERA, qglviewer::ZOOM_FOV);
 
   // Z o o m   o n   r e g i o n
   setMouseBinding(::Qt::ShiftModifier, ::Qt::MidButton, qglviewer::CAMERA, qglviewer::ZOOM_ON_REGION);
@@ -760,6 +780,7 @@ void CGAL::QGLViewer::setDefaultMouseBindings() {
   // A c t i o n s   w i t h   k e y   m o d i f i e r s
   setMouseBinding(::Qt::Key_Z, ::Qt::NoModifier, ::Qt::LeftButton, qglviewer::ZOOM_ON_PIXEL);
   setMouseBinding(::Qt::Key_Z, ::Qt::NoModifier, ::Qt::RightButton, qglviewer::ZOOM_TO_FIT);
+
 
 #ifdef Q_OS_MAC
   // Specific Mac bindings for touchpads. Two fingers emulate a wheelEvent which
@@ -2730,14 +2751,16 @@ void CGAL::QGLViewer::setWheelBinding(::Qt::Key key, ::Qt::KeyboardModifiers mod
                                 bool withConstraint) {
   //#CONNECTION# ManipulatedFrame::wheelEvent and
   // ManipulatedCameraFrame::wheelEvent switches
-  if ((action != qglviewer::ZOOM) && (action != qglviewer::MOVE_FORWARD) &&
-      (action != qglviewer::MOVE_BACKWARD) && (action != qglviewer::NO_MOUSE_ACTION)) {
+  if ((action != qglviewer::ZOOM) && (action != qglviewer::ZOOM_FOV) &&
+      (action != qglviewer::MOVE_FORWARD) && (action != qglviewer::MOVE_BACKWARD)
+      && (action != qglviewer::NO_MOUSE_ACTION)) {
     qWarning("Cannot bind %s to wheel",
              mouseActionString(action).toLatin1().constData());
     return;
   }
 
-  if ((handler == qglviewer::FRAME) && (action != qglviewer::ZOOM) && (action != qglviewer::NO_MOUSE_ACTION)) {
+  if ((handler == qglviewer::FRAME) && (action != qglviewer::ZOOM)
+      && (action != qglviewer::NO_MOUSE_ACTION)) {
     qWarning("Cannot bind %s to FRAME wheel",
              mouseActionString(action).toLatin1().constData());
     return;

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -598,6 +598,14 @@ void CGAL::QGLViewer::postDraw() {
   if (displayMessage_)
     drawText(10, height() - 10, message_);
 
+  //zoom region
+  if(camera()->frame()->action_ == qglviewer::ZOOM_ON_REGION)
+  {
+    QPainter painter(this);
+    painter.setPen(QColor(120,120,120));
+    painter.drawRect(QRect(camera()->frame()->pressPos_, mapFromGlobal(QCursor::pos())));
+    painter.end();
+  }
 }
 
 

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -1665,6 +1665,8 @@ QString CGAL::QGLViewer::mouseActionString(qglviewer::MouseAction ma) {
                          "SCREEN_TRANSLATE mouse action");
   case CGAL::qglviewer::ZOOM_ON_REGION:
     return CGAL::QGLViewer::tr("Zooms on region for", "ZOOM_ON_REGION mouse action");
+  case CGAL::qglviewer::ZOOM_FOV:
+    return CGAL::QGLViewer::tr("Changes the FOV to emulate an optical zoom for ", "ZOOM_FOV mouse action");
   }
   return QString();
 }

--- a/GraphicsView/include/CGAL/Qt/viewer_actions.h
+++ b/GraphicsView/include/CGAL/Qt/viewer_actions.h
@@ -79,7 +79,8 @@ enum MouseAction {
   ROLL,
   DRIVE,
   SCREEN_TRANSLATE,
-  ZOOM_ON_REGION
+  ZOOM_ON_REGION,
+  ZOOM_FOV
 };
 
 enum SnapShotBackground {


### PR DESCRIPTION
## Summary of Changes

Add a "real zoom" as new feature for the basic viewer and demo. It changes te field of view in order to emulate an optical zoom (instead of simply translating the camera closer as we currently do). It allows to bypass the clipping problem (when the camera is too close of an item and it goes through it).

It is triggered by maintaining the Z key and using the wheel.

## Release Management

* Affected package(s): GraphicsView