### PR TITLE
Intersections_3 - fix do_intersect(Plane_3, Plane_3, Plane_3) in master

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/intersection_3_1_impl.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/intersection_3_1_impl.h
@@ -1573,9 +1573,9 @@ do_intersect(const Plane_3<R>& plane1, const Plane_3<R>& plane2, const R&)
 template <class R>
 inline bool
 do_intersect(const Plane_3<R> &plane1, const Plane_3<R> &plane2,
-             const Plane_3<R> &plane3, const R&)
+             const Plane_3<R> &plane3, const R& r)
 {
-  return bool(intersection(plane1, plane2, plane3));
+  return bool(intersection(plane1, plane2, plane3, r));
 }
 
 

--- a/Intersections_3/test/Intersections_3/test_intersections_3.cpp
+++ b/Intersections_3/test/Intersections_3/test_intersections_3.cpp
@@ -228,6 +228,7 @@ struct Test {
     Pl pl3(0,0,1,0);
 
     // Generic intersection.
+    assert(CGAL::do_intersect(pl1, pl2, pl3));
     CGAL::Object o = CGAL::intersection(pl1, pl2, pl3);
     P p;
     assert(assign(p, o));
@@ -236,9 +237,11 @@ struct Test {
     // Empty intersection.
     Pl pl4(1,0,0,1); // pl4 is // to pl1.
 
+    assert(!CGAL::do_intersect(pl1, pl2, pl4));
     CGAL::Object o2 = CGAL::intersection(pl1, pl2, pl4);
     assert(o2.is_empty());
 
+    assert(!CGAL::do_intersect(pl1, pl4, pl2));
     CGAL::Object o3 = CGAL::intersection(pl1, pl4, pl2);
     assert(o3.is_empty());
 
@@ -246,12 +249,14 @@ struct Test {
     Pl pl5(1,1,0,0); // pl1, pl2, pl5 intersect in the line l.
     L l;
 
+    assert(CGAL::do_intersect(pl1, pl2, pl5));
     CGAL::Object o4 = CGAL::intersection(pl1, pl2, pl5);
     assert(assign(l, o4));
 
     assert(l == L(P(0,0,0), P(0,0,1)));
 
     // Intersection in a plane.
+    assert(CGAL::do_intersect(pl1, pl1, pl1));
     CGAL::Object o5 = CGAL::intersection(pl1, pl1, pl1);
     Pl pl;
     assert(assign(pl, o5));

--- a/Kernel_23/doc/Kernel_23/CGAL/intersections.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/intersections.h
@@ -58,6 +58,12 @@ In three-dimensional space, the types `Type1` and
 - `Tetrahedron_3<Kernel>`.
 */
 bool do_intersect(Type1<Kernel> obj1, Type2<Kernel> obj2);
+
+/*!
+checks whether `obj1`, `obj2` and `obj3` intersect.
+*/
+bool do_intersect(Plane_3<Kernel> obj1, Plane_3<Kernel> obj2, Plane_3<Kernel> obj3);
+
 /// @}
 
 


### PR DESCRIPTION
This PR is a duplicate of PR #5022 (target is CGAL-5.0.4), that fixes the conflicts with `master` (target is CGAL-5.2).

## Summary of Changes

Fix compilation of `CGAL::do_intersect(Plane_3, Plane_3, Plane_3)`, test it, and document it.

## Release Management

* Affected package(s): Kernel_23, Intersections_3
* Issue(s) solved (if any):  fix #5013 
* License and copyright ownership: unchanged

