### PR TITLE
Defined CGAL_CXX20 and replaced [=] with [this] for C++ 20

### DIFF
--- a/Box_intersection_d/include/CGAL/box_intersection_d.h
+++ b/Box_intersection_d/include/CGAL/box_intersection_d.h
@@ -191,8 +191,13 @@ void box_intersection_segment_tree_d(
 
         // Specify "copy by value" otherwise the values of iterators for next (i,j) iterations
         // become shared with different lambdas being run in parallel, and things go wrong
+        #ifndef CGAL_CXX20
         g.run([=]{ Box_intersection_d::segment_tree( r1_start, r1_end, r2_start, r2_end,
                                                      inf, sup, callback, traits, cutoff, dim, in_order); });
+        #else
+        g.run([=,this]{ Box_intersection_d::segment_tree( r1_start, r1_end, r2_start, r2_end,
+                                                            inf, sup, callback, traits, cutoff, dim, in_order); });
+        #endif
       }
     }
 

--- a/Box_intersection_d/include/CGAL/box_intersection_d.h
+++ b/Box_intersection_d/include/CGAL/box_intersection_d.h
@@ -191,13 +191,8 @@ void box_intersection_segment_tree_d(
 
         // Specify "copy by value" otherwise the values of iterators for next (i,j) iterations
         // become shared with different lambdas being run in parallel, and things go wrong
-        #ifndef CGAL_CXX20
         g.run([=]{ Box_intersection_d::segment_tree( r1_start, r1_end, r2_start, r2_end,
                                                      inf, sup, callback, traits, cutoff, dim, in_order); });
-        #else
-        g.run([=,this]{ Box_intersection_d::segment_tree( r1_start, r1_end, r2_start, r2_end,
-                                                            inf, sup, callback, traits, cutoff, dim, in_order); });
-        #endif
       }
     }
 

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -298,6 +298,10 @@
 #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #  define CGAL_CXX17 1
 #endif
+// Same for C++20
+#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
+#  define CGAL_CXX20 1
+#endif
 
 #if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || BOOST_VERSION < 105000
 #define CGAL_CFG_NO_STD_HASH 1

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -259,9 +259,15 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
           SIGNAL(selectionChanged ( const QItemSelection & , const QItemSelection & ) ),
           this, SLOT(selectionChanged()));
   // setup menu filtering
+  #ifndef CGAL_CXX20
   connect(sceneView->selectionModel(),
           QOverload<const QItemSelection & , const QItemSelection &>::of(&QItemSelectionModel::selectionChanged),
           this, [=](){filterOperations(false);});
+  #else
+  connect(sceneView->selectionModel(),
+          QOverload<const QItemSelection & , const QItemSelection &>::of(&QItemSelectionModel::selectionChanged),
+          this, [=,this](){filterOperations(false);});
+  #endif
 
   sceneView->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(sceneView, SIGNAL(customContextMenuRequested(const QPoint & )),
@@ -364,8 +370,15 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
   // Load plugins, and re-enable actions that need it.
   operationSearchBar.setPlaceholderText("Filter...");
   searchAction->setDefaultWidget(&operationSearchBar);
+  
+  #ifndef CGAL_CXX20
   connect(&operationSearchBar, &QLineEdit::textChanged,
           this, [=](){filterOperations(true);});
+  #else
+  connect(&operationSearchBar, &QLineEdit::textChanged,
+          this, [=,this](){filterOperations(true);});
+  #endif
+
   loadPlugins();
   accepted_keywords.clear();
 

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -370,7 +370,7 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
   // Load plugins, and re-enable actions that need it.
   operationSearchBar.setPlaceholderText("Filter...");
   searchAction->setDefaultWidget(&operationSearchBar);
-  
+
   #ifndef CGAL_CXX20
   connect(&operationSearchBar, &QLineEdit::textChanged,
           this, [=](){filterOperations(true);});

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -259,15 +259,10 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
           SIGNAL(selectionChanged ( const QItemSelection & , const QItemSelection & ) ),
           this, SLOT(selectionChanged()));
   // setup menu filtering
-  #ifndef CGAL_CXX20
+
   connect(sceneView->selectionModel(),
-          QOverload<const QItemSelection & , const QItemSelection &>::of(&QItemSelectionModel::selectionChanged),
-          this, [=](){filterOperations(false);});
-  #else
-  connect(sceneView->selectionModel(),
-          QOverload<const QItemSelection & , const QItemSelection &>::of(&QItemSelectionModel::selectionChanged),
-          this, [=,this](){filterOperations(false);});
-  #endif
+      QOverload<const QItemSelection & , const QItemSelection &>::of(&QItemSelectionModel::selectionChanged),
+      this, [this](){filterOperations(false);});
 
   sceneView->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(sceneView, SIGNAL(customContextMenuRequested(const QPoint & )),
@@ -371,13 +366,8 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
   operationSearchBar.setPlaceholderText("Filter...");
   searchAction->setDefaultWidget(&operationSearchBar);
 
-  #ifndef CGAL_CXX20
   connect(&operationSearchBar, &QLineEdit::textChanged,
-          this, [=](){filterOperations(true);});
-  #else
-  connect(&operationSearchBar, &QLineEdit::textChanged,
-          this, [=,this](){filterOperations(true);});
-  #endif
+          this, [this](){filterOperations(true);});
 
   loadPlugins();
   accepted_keywords.clear();


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Defined `CGAL_CXX20` for fixing deprecations in C++ 20
Similar to `CGAL_CXX17`
checked on clang 10.0.1-1

Replaced `[=]` with `[=,this]` in 2 places for C++ 20 in Polyhedron Demo 
checked on g++ 14

## Release Management

* Affected package(s): [Installation](https://github.com/CGAL/cgal/tree/master/Installation), [Polyhedron Demo](https://github.com/CGAL/cgal/blob/master/Polyhedron/demo/Polyhedron/MainWindow.cpp)
* Issue(s) solved (if any): partially fixes #5020
* Feature/Small Feature (if any): Defined CGAL_CXX20, replaced [=] for C++ 20
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

