### PR TITLE
Use ctest in travis

### DIFF
--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -103,8 +103,6 @@ cd $ROOT
     fi
   fi
   IFS=$' '
-  mkdir build
-  cd build
   mkdir -p build-travis
   cd build-travis
   WITHDEMOS=ON
@@ -120,7 +118,7 @@ cd $ROOT
 
 
   mytime cmake -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DBUILD_TESTING=ON -DWITH_tests=ON -DWITH_examples=ON -DWITH_demos=$WITHDEMOS ..
-  mytime ctest -j2 -L $ARG -E execution___of__ --output-on-failure
+  mytime ctest -j2 -L $ARG'([_][A-Z]|$)'  -E execution___of__ --output-on-failure
 
 
 

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -35,41 +35,41 @@ cd $ROOT
     cd ..
     IFS=$old_IFS
     mytime zsh $ROOT/Scripts/developer_scripts/test_merge_of_branch HEAD
-    #test dependencies 
+    #test dependencies
     cd $ROOT
     mytime bash Scripts/developer_scripts/cgal_check_dependencies.sh --check_headers /usr/bin/doxygen
 
     cd .travis
-  	#parse current matrix and check that no package has been forgotten
+    #parse current matrix and check that no package has been forgotten
 
-	  IFS=$'\n'
-	  COPY=0
-	  MATRIX=()
-	  for LINE in $(cat "$PWD/packages.txt")
-	  do
-	        MATRIX+="$LINE "
-	  done
-	
-	  PACKAGES=()
-	  cd ..
-  	for f in *
-	  do
-	    if [ -d  "$f/package_info/$f" ]
-	        then
-	                PACKAGES+="$f "
-	        fi
-	  done	
-	
-	  DIFFERENCE=$(echo ${MATRIX[@]} ${PACKAGES[@]} | tr ' ' '\n' | sort | uniq -u)
-	  IFS=$' '
-	  if [ "${DIFFERENCE[0]}" != "" ]
-	  then
-	        echo "The matrix and the actual package list differ : ."
-					echo ${DIFFERENCE[*]}
+    IFS=$'\n'
+    COPY=0
+    MATRIX=()
+    for LINE in $(cat "$PWD/packages.txt")
+    do
+          MATRIX+="$LINE "
+    done
+
+    PACKAGES=()
+    cd ..
+    for f in *
+    do
+      if [ -d  "$f/package_info/$f" ]
+          then
+                  PACKAGES+="$f "
+          fi
+    done
+
+    DIFFERENCE=$(echo ${MATRIX[@]} ${PACKAGES[@]} | tr ' ' '\n' | sort | uniq -u)
+    IFS=$' '
+    if [ "${DIFFERENCE[0]}" != "" ]
+    then
+          echo "The matrix and the actual package list differ : ."
+          echo ${DIFFERENCE[*]}
             echo "You should run generate_travis.sh."
-	        exit 1
-	  fi
-	  echo "Matrix is up to date."
+          exit 1
+    fi
+    echo "Matrix is up to date."
     #check if non standard cgal installation works
     cd $ROOT
     mkdir build_test
@@ -117,13 +117,13 @@ cd $ROOT
       EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
       ;;
   esac
-  
-  
-  mytime cmake -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DBUILD_TESTING=ON -DWITH_tests=ON -DWITH_examples=ON -DWITH_demos=$WITHDEMOS ..
-  mytime ctest -j2 -L $ARG --output-on-failure
-  
 
-  
+
+  mytime cmake -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DBUILD_TESTING=ON -DWITH_tests=ON -DWITH_examples=ON -DWITH_demos=$WITHDEMOS ..
+  mytime ctest -j2 -L $ARG -E execution___of__ --output-on-failure
+
+
+
 done
 IFS=$old_IFS
 # Local Variables:

--- a/.travis/build_package.sh
+++ b/.travis/build_package.sh
@@ -8,29 +8,7 @@ function mytime {
   /usr/bin/time -f "Spend time of %C: %E (real)" "$@"
 }
 
-function build_examples {
-  mkdir -p build-travis
-  cd build-travis
-  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCGAL_BUILD_THREE_DOC=TRUE ..
-  mytime make -j2 VERBOSE=1
-}
 
-function build_tests {
-  build_examples
-}
-
-function build_demo {
-  mkdir -p build-travis
-  cd build-travis
-  EXTRA_CXX_FLAGS=
-  case "$CC" in
-    clang*)
-      EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
-      ;;
-  esac
-  mytime cmake -DCGAL_DIR="/usr/local/lib/cmake/CGAL" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" ..
-  mytime make -j2 VERBOSE=1
-}
 old_IFS=$IFS
 IFS=$' '
 ROOT="$PWD/.."
@@ -116,7 +94,7 @@ cd $ROOT
   fi
   IFS=$old_IFS
 
-  if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && [ "$ARG" != Polyhedron_demo ]; then
+  if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     DO_IGNORE=FALSE
     . $ROOT/.travis/test_package.sh "$ROOT" "$ARG"
     echo "DO_IGNORE is $DO_IGNORE"
@@ -125,66 +103,27 @@ cd $ROOT
     fi
   fi
   IFS=$' '
-  EXAMPLES="$ARG/examples/$ARG"
-  TEST="$ARG/test/$ARG" 
-  DEMOS=$ROOT/$ARG/demo/*
+  mkdir build
+  cd build
+  mkdir -p build-travis
+  cd build-travis
+  WITHDEMOS=ON
+  if [ "$ARG" = "Polyhedron" ]; then
+    WITHDEMOS=OFF
+  fi
+  EXTRA_CXX_FLAGS=
+  case "$CC" in
+    clang*)
+      EXTRA_CXX_FLAGS="-Werror=inconsistent-missing-override"
+      ;;
+  esac
+  
+  
+  mytime cmake -DCMAKE_CXX_FLAGS="${CXX_FLAGS} ${EXTRA_CXX_FLAGS}" -DCGAL_DONT_OVERRIDE_CMAKE_FLAGS:BOOL=ON -DBUILD_TESTING=ON -DWITH_tests=ON -DWITH_examples=ON -DWITH_demos=$WITHDEMOS ..
+  mytime ctest -j2 -L $ARG --output-on-failure
+  
 
-  if [ -d "$ROOT/$EXAMPLES" ]
-  then
-    cd $ROOT/$EXAMPLES
-    if [ -f ./CMakeLists.txt ]; then
-      build_examples
-    else
-      for dir in ./*
-      do
-        if [ -f $dir/CMakeLists.txt ]; then
-          cd $ROOT/$EXAMPLES/$dir
-          build_examples
-        fi
-      done
-    fi
-  elif [ "$ARG" != Polyhedron_demo ]; then
-    echo "No example found for $ARG"
-  fi
-
-  if [ -d "$ROOT/$TEST" ]
-  then
-    cd $ROOT/$TEST
-    if [ -f ./CMakeLists.txt ]; then
-      build_tests
-    else
-      for dir in ./*
-      do
-        if [ -f $dir/CMakeLists.txt ]; then
-          cd $ROOT/$TEST/$dir
-          build_tests
-        fi
-      done
-    fi
-  elif [ "$ARG" != Polyhedron_demo ]; then
-    echo "No test found for $ARG"
-  fi
-  #Packages like Periodic_3_triangulation_3 contain multiple demos
-  for DEMO in $DEMOS; do
-    DEMO=${DEMO#"$ROOT"}
-    echo $DEMO
-  	#If there is no demo subdir, try in GraphicsView
-    if [ ! -d "$ROOT/$DEMO" ] || [ ! -f "$ROOT/$DEMO/CMakeLists.txt" ]; then
-     DEMO="GraphicsView/demo/$ARG"
-    fi
-	  if [ "$ARG" != Polyhedron ] && [ -d "$ROOT/$DEMO" ]
-  	then
-      cd $ROOT/$DEMO
-      build_demo
-    elif [ "$ARG" != Polyhedron_demo ]; then
-      echo "No demo found for $ARG"
-	  fi
-  done
-  if [ "$ARG" = Polyhedron_demo ]; then
-    DEMO=Polyhedron/demo/Polyhedron
-    cd "$ROOT/$DEMO"
-    build_demo
-  fi
+  
 done
 IFS=$old_IFS
 # Local Variables:

--- a/Installation/test/Installation/CMakeLists.txt
+++ b/Installation/test/Installation/CMakeLists.txt
@@ -122,10 +122,15 @@ function(CGAL_installation_test_find_package_version mode)
   file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/build-test_find_package_version_${mode}")
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build-test_find_package_version_${mode})
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_find_package_version_${mode})
+
   configure_file(test_find_package.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/test_find_package_version_${mode}/CMakeLists.txt)
   add_test(NAME test_find_package_version_${mode}
-    COMMAND ${CMAKE_COMMAND} -S ${CMAKE_CURRENT_BINARY_DIR}/test_find_package_version_${mode} -B ${CMAKE_CURRENT_BINARY_DIR}/build-test_find_package_version_${mode} -DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=ON)
+    COMMAND ${CMAKE_COMMAND} -DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=ON ${CMAKE_CURRENT_BINARY_DIR}/test_find_package_version_${mode}
+    )
   cgal_setup_test_properties(test_find_package_version_${mode})
+  set_property(TEST test_find_package_version_${mode}
+    PROPERTY
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build-test_find_package_version_${mode})
 endfunction()
 
 CGAL_installation_test_find_package_version(less)


### PR DESCRIPTION
## Summary of Changes

Use ctest in travis to avoid skipping tests when the architecture of the package differs from the usual (i.e BGL examples).
