### PR TITLE
CI: Better capture for auto doc build

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -18,7 +18,11 @@ jobs:
            if(asso == 'OWNER' || asso == 'MEMBER') {
              const body = context.payload.comment.body
              if(body.includes("build:")) {
-               return body.replace('build:','')
+               const re = /\/build:(\w+)\s*/;
+               if(re.test(body)){
+                 const res = re.exec(body)
+                 return res[1];
+               }
              }
            }
            return 'stop'


### PR DESCRIPTION
Only capture between : and the first whitespace if there is one. Also requires `/build:` instead of `build:`
