### PR TITLE
Kernel_23: Fix affine transformations of weighted points

### DIFF
--- a/Kernel_23/include/CGAL/Weighted_point_2.h
+++ b/Kernel_23/include/CGAL/Weighted_point_2.h
@@ -180,7 +180,7 @@ public:
 
   Weighted_point_2 transform(const Aff_transformation_2 &t) const
   {
-    return Weighted_point_2(t.transform(point(),weight()));
+    return Weighted_point_2(t.transform(point()),weight());
   }
 
 };

--- a/Kernel_23/include/CGAL/Weighted_point_3.h
+++ b/Kernel_23/include/CGAL/Weighted_point_3.h
@@ -195,7 +195,7 @@ public:
 
   Weighted_point_3 transform(const Aff_transformation_3 &t) const
   {
-    return Weighted_point_3(t.transform(point(),weight()));
+    return Weighted_point_3(t.transform(point()),weight());
   }
 
 };

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
@@ -69,6 +69,8 @@ _test_cls_aff_transformation_2(const R& )
  CGAL::Point_2<R>  p3( n1, n0, n4 );        // (-3, 0)
  CGAL::Point_2<R>  p4( n7, n2,-n6 );        // ( 4,11)
 
+ CGAL::Weighted_point_2<R>  wp4( p4, n1 );
+
  CGAL::Direction_2<R> d0(n13, n0);
  CGAL::Direction_2<R> d1(n0, n13);
  CGAL::Direction_2<R> dir = (p2 - p4).direction();
@@ -78,6 +80,7 @@ _test_cls_aff_transformation_2(const R& )
  CGAL::Point_2<R>   tp2;
  CGAL::Point_2<R>   tp3;
  CGAL::Point_2<R>   tp4;
+ CGAL::Weighted_point_2<R>   twp4;
  CGAL::Segment_2<R> seg(p1,p2);
  CGAL::Segment_2<R> tseg;
  CGAL::Ray_2<R>     ray(p3,p2);
@@ -166,11 +169,14 @@ _test_cls_aff_transformation_2(const R& )
     tp2 = p2.transform( a[i] );
     tp3 = p3.transform( a[i] );
     tp4 = p4.transform( a[i] );
+    twp4 = wp4.transform( a[i] );
     tseg = seg.transform( a[i] );
     tray = ray.transform( a[i] );
     tlin = lin.transform( a[i] );
     ttri = tri.transform( a[i] );
     tisor= isor.transform( a[i]);
+    assert( twp4.point() == tp4 );
+    assert( twp4.weight() == wp4.weight() );
     assert( tseg == CGAL::Segment_2<R>(tp1, tp2) );
     assert( tray == CGAL::Ray_2<R>(tp3, tp2) );
     assert( tlin == CGAL::Line_2<R>(tp2, tp4) || nonexact);
@@ -179,11 +185,13 @@ _test_cls_aff_transformation_2(const R& )
 
     inv = a[i].inverse();
     tp4  = tp4.transform(  inv );
+    twp4 = twp4.transform( inv );
     tseg = tseg.transform( inv );
     tray = tray.transform( inv );
     tlin = tlin.transform( inv );
     ttri = ttri.transform( inv );
     assert( tp4  == p4  || nonexact );
+    assert( twp4 == wp4 || nonexact );
     assert( tseg == seg || nonexact );
     assert( tray == ray || nonexact );
     assert( tlin == lin || nonexact );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_3.h
@@ -67,6 +67,7 @@ _test_cls_aff_transformation_3(const R& )
  CGAL::Point_3<R>  p2( n5, n4,-n12, n4 );   // ( 5, 1,-4)
  CGAL::Point_3<R>  p3( n1, n0, n14, n4 );   // (-3, 0, 7)
  CGAL::Point_3<R>  p4( n7, n2, n8, -n6 );   // ( 4,11, 9)
+ CGAL::Weighted_point_3<R> wp4( p4, n7 );
 
  CGAL::Direction_3<R> d0(n13, n0, n0);
  CGAL::Direction_3<R> d1(n0, n13, n0);
@@ -81,6 +82,7 @@ _test_cls_aff_transformation_3(const R& )
  CGAL::Point_3<R>   tp2;
  CGAL::Point_3<R>   tp3;
  CGAL::Point_3<R>   tp4;
+ CGAL::Weighted_point_3<R>   twp4;
  CGAL::Segment_3<R> seg(p1,p2);
  CGAL::Segment_3<R> tseg;
  CGAL::Ray_3<R>     ray(p3,p2);
@@ -180,12 +182,15 @@ _test_cls_aff_transformation_3(const R& )
     tp2 = p2.transform( a[i] );
     tp3 = p3.transform( a[i] );
     tp4 = p4.transform( a[i] );
+    twp4 = wp4.transform( a[i] );
     tpla = pla.transform( a[i] );
     tseg = seg.transform( a[i] );
     tray = ray.transform( a[i] );
     tlin = lin.transform( a[i] );
     ttri = tri.transform( a[i] );
     ttet = tet.transform( a[i] );
+    assert( twp4.point() == tp4 );
+    assert( twp4.weight() == wp4.weight() );
     assert( tpla == CGAL::Plane_3<R>( tp1, tp2, tp3) || nonexact );
     assert( tseg == CGAL::Segment_3<R>(tp1, tp2) );
     assert( tray == CGAL::Ray_3<R>(tp3, tp2) );
@@ -194,6 +199,7 @@ _test_cls_aff_transformation_3(const R& )
     assert( ttet == CGAL::Tetrahedron_3<R>(tp1, tp2, tp3, tp4) );
     inv = a[i].inverse();
     tp4  = tp4.transform(  inv );
+    twp4 = twp4.transform( inv );
     tpla = tpla.transform( inv );
     tseg = tseg.transform( inv );
     tray = tray.transform( inv );
@@ -201,6 +207,7 @@ _test_cls_aff_transformation_3(const R& )
     ttri = ttri.transform( inv );
     ttet = ttet.transform( inv );
     assert( tp4  == p4 || nonexact );
+    assert( twp4 == wp4 || nonexact );
     assert( tpla == pla || nonexact );
     assert( tseg == seg || nonexact );
     assert( tray == ray || nonexact );


### PR DESCRIPTION
## Summary of Changes

Same fix as in PR https://github.com/CGAL/cgal/pull/5038 by @thomasp85, but rebased onto 4.14 and adding missing tests.

## Release Management

* Affected package(s): `Kernel_23`
* License and copyright ownership: no change

