### PR TITLE
Fix warnings with Arrangement Demo

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h
@@ -233,8 +233,8 @@ public:
         }
         // The current intersection object is an intersection point:
         // Copy it as is.
-        const Intersection_point* ip = boost::get<Intersection_point>(&item);
-        *oi++ = Intersection_result(*ip);
+        Intersection_result ip = *boost::get<Intersection_point>(&item);
+        *oi++ = ip;
       }
 
       return oi;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Curve_data_aux.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Curve_data_aux.h
@@ -59,7 +59,7 @@ private:
 public:
 
   /*! Default constructor. */
-  _Curve_data_ex ()
+  _Curve_data_ex () : BaseCurveType (), m_data {}
   {}
 
   /*!

--- a/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
@@ -104,6 +104,7 @@ public:
     _Linear_object_cached_2() :
       has_source(true),
       has_target(true),
+      is_right(false),
       is_vert(false),
       is_horiz(false),
       has_pos_slope(false),


### PR DESCRIPTION
## Summary of Changes

Initialize missing member in `_Linear_object_cached`, and workaround a faulty gcc warning with boost variant.

I reproduced the warnings locally with boost 1.69, 1.70, and couldn't with boost 1.71 building with `-m32` flag. Trunk version of gcc pointed at this line as the source of the warning:
https://github.com/CGAL/cgal/blob/b4a536047d098d586a89982146fd094dd97b41aa/Arrangement_on_surface_2/include/CGAL/Arr_curve_data_traits_2.h#L236-L237
and at boost::variant move constructor. Avoiding boost::variant move constructor removed the warnings with gcc trunk and gcc 10.

I checked the constructors of the "maybe uninitialized" classes, and couldn't find any uninitialized members except for `_Linear_object_cached` (which did not reduce the number of warnings), so I think these warnings are false positives.

The warnings are not related to the demo, I reproduced them using a simple example that computes the overlay of two arrangements with history, so I think the changes to the package are warranted.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* License and copyright ownership: the license used by CGAL