### PR TITLE
Do not use convex test in basic viewer while it is not robust.

### DIFF
--- a/GraphicsView/include/CGAL/Buffer_for_vao.h
+++ b/GraphicsView/include/CGAL/Buffer_for_vao.h
@@ -440,13 +440,13 @@ public:
 
     if (m_points_of_face.size()==3)
     { triangular_face_end_internal(normal); } // Triangle: no need to triangulate
-    else if (is_current_face_convex(normal))
+   /* else if (is_current_face_convex(normal))
     {
       if (m_points_of_face.size()==4)
       { convex_quadrangular_face_end_internal(normal); } // Convex quad
       else
       { convex_face_end_internal(normal); } // Convex face with > 4 vertices
-    }
+    }*/
     else
     { // Non convex and more than 3 points: we triangulate
       nonconvex_face_end_internal(normal);


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

The function is_facet_convex has a bug (cf issue #4002).
 
This PR remove the use of this function for the basic viewer, allowing to draw correctly non convex faces.
The code will be reintroduced when #4002 will be solved.

## Release Management

* Affected package(s): GraphicsView

