### PR TITLE
PMP isotropic remeshing - fix collapsibilty check

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1315,7 +1315,7 @@ private:
       {
         if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
           return false;
-        else if (next_on_patch_border(h) == hopp)
+        else if (next_on_patch_border(h) == hopp && prev_on_patch_border(h) == hopp)
           return false; //isolated patch border
         else
           return true;


### PR DESCRIPTION
## Summary of Changes

Edge collapse is allowed for a dart, and is forbidden for an isolated constrained edge.
This PR fixes an inconsistency in the collapsibility check functions (which could cause a crash).

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

