### PR TITLE
Allow Epec in Refine_edges_with_clusters

### DIFF
--- a/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
@@ -273,8 +273,10 @@ private:
         const Point m = midpoint(a, b);
 
         typename Geom_traits::Vector_2 v = vector(a,m);
-        v = scaled_vector(v,CGAL_NTS sqrt(c.minimum_squared_length /
-                                      squared_distance(a,b)));
+        v = scaled_vector(
+            v, CGAL_NTS sqrt(CGAL::to_double(c.minimum_squared_length /
+                                             squared_distance(a, b))));
+
 
         Point i = translate(a,v), i2(i);
 

--- a/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Refine_edges_with_clusters.h
@@ -274,8 +274,8 @@ private:
 
         typename Geom_traits::Vector_2 v = vector(a,m);
         v = scaled_vector(
-            v, CGAL_NTS sqrt(CGAL::to_double(c.minimum_squared_length /
-                                             squared_distance(a, b))));
+            v, CGAL_NTS sqrt(CGAL_NTS to_double(c.minimum_squared_length /
+                                                squared_distance(a, b))));
 
 
         Point i = translate(a,v), i2(i);


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Allow instantiation of Refine_edges_with_clusters with Epec
.
Use CGAL::to_double before calling sqrt, this should be a null op with Epic, while avoiding cascaded constructions for Epec. 

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

