### PR TITLE
Fix arrangement demo compiling without CORE

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementDemoWindow.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementDemoWindow.cpp
@@ -280,9 +280,9 @@ void ArrangementDemoWindow::updateInputType(QAction* a)
   tab->activateCurveInputCallback(curveType);
 }
 
-#ifdef CGAL_USE_CORE
 void ArrangementDemoWindow::on_actionAddAlgebraicCurve_triggered()
 {
+#ifdef CGAL_USE_CORE
   AlgebraicCurveInputDialog newDialog;
 
   if (newDialog.exec() == QDialog::Accepted)
@@ -312,10 +312,12 @@ void ArrangementDemoWindow::on_actionAddAlgebraicCurve_triggered()
     algCurveInputCallback->generate(cv);
     if (is_first_curve) currentTab->adjustViewport();
   }
+#endif
 }
 
 void ArrangementDemoWindow::on_actionAddRationalCurve_triggered()
 {
+#ifdef CGAL_USE_CORE
   RationalCurveInputDialog newDialog;
 
   if (newDialog.exec() == QDialog::Accepted)
@@ -346,8 +348,8 @@ void ArrangementDemoWindow::on_actionAddRationalCurve_triggered()
     algCurveInputCallback->generate(cv);
     if (is_first_curve) currentTab->adjustViewport();
   }
-}
 #endif
+}
 
 void ArrangementDemoWindow::on_actionQuit_triggered() { qApp->exit(); }
 

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementDemoWindow.h
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementDemoWindow.h
@@ -78,10 +78,8 @@ public Q_SLOTS:
   void on_actionMerge_toggled(bool);
   void on_actionSplit_toggled(bool);
   void on_actionFill_toggled(bool);
-#ifdef CGAL_USE_CORE
   void on_actionAddAlgebraicCurve_triggered();
   void on_actionAddRationalCurve_triggered();
-#endif
 
 Q_SIGNALS:
   void modelChanged();

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/RationalTypes.h
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/RationalTypes.h
@@ -12,10 +12,10 @@
 #ifndef ARRANGEMENT_DEMO_RATIONAL_TYPES_H
 #define ARRANGEMENT_DEMO_RATIONAL_TYPES_H
 
+#include <CGAL/Cartesian.h>
+#include <CGAL/Point_2.h>
 #ifdef CGAL_USE_CORE
   #include <CGAL/CORE_BigRat.h>
-  #include <CGAL/Cartesian.h>
-  #include <CGAL/Point_2.h>
 #else
   #include <CGAL/Exact_rational.h>
 #endif


### PR DESCRIPTION
## Summary of Changes

Includes were wrongly guarded by a CORE macro definition. Tested it locally with GMP without CORE.

## Release Management

* Affected package(s): Arrangement_on_surface_2 Demo
* License and copyright ownership: License used by CGAL

