### PR TITLE
Remove documentation warning  from Surface_mesh_approximation

### DIFF
--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -1829,7 +1829,7 @@ private:
   }
 
   /*!
-   * @brief subdivides a chord recursively in range `[@a chord_begin, @a chord_end).`
+   * @brief subdivides a chord recursively in range `[chord_begin, chord_end)`.
    * @param chord_begin begin iterator of the chord
    * @param chord_end end iterator of the chord
    * @param subdivision_ratio the chord recursive split error threshold


### PR DESCRIPTION
When running the documentation generation we get the warning like:
```
warning: end of comment block while expecting command </tt>
```

This is due to the `.` (dot) inside the back-tick span (it is seen as the end of the brief description).
Also the `@a` has no meaning in this span.

