### PR TITLE
Allow to use compact container or concurrent compact container for CMap, GMap and LCC

### DIFF
--- a/Combinatorial_map/include/CGAL/Cell_attribute.h
+++ b/Combinatorial_map/include/CGAL/Cell_attribute.h
@@ -23,16 +23,16 @@ namespace CGAL {
   template <class, class>
   class Concurrent_compact_container;
 
-  template<unsigned int, class, class>
+  template<unsigned int, class, class, class>
   class Combinatorial_map_storage_1;
 
-  template<unsigned int, class, class>
+  template<unsigned int, class, class, class>
   class Generalized_map_storage_1;
 
-  template<unsigned int, unsigned int, class, class, class>
+  template<unsigned int, unsigned int, class, class, class, class>
   class CMap_linear_cell_complex_storage_1;
 
-  template<unsigned int, unsigned int, class, class, class>
+  template<unsigned int, unsigned int, class, class, class, class>
   class GMap_linear_cell_complex_storage_1;
 
   namespace internal {
@@ -108,16 +108,16 @@ namespace CGAL {
                                     OnMerge, OnSplit, WithID>:
       public Add_id<WithID>
   {
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>
@@ -218,16 +218,16 @@ namespace CGAL {
   class Cell_attribute_without_info<Refs, Tag_true,
                                     OnMerge, OnSplit, WithID>: public Add_id<WithID>
   {
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>
@@ -334,16 +334,16 @@ namespace CGAL {
   class Cell_attribute<Refs, void, Tag_, OnMerge, OnSplit, WithID> :
     public Cell_attribute_without_info<Refs, Tag_, OnMerge, OnSplit, WithID>
   {
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>
@@ -374,16 +374,16 @@ namespace CGAL {
     public Cell_attribute_without_info<Refs, Tag_, OnMerge, OnSplit, WithID>,
     public Info_for_cell_attribute<Info_>
   {
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_fwd.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_fwd.h
@@ -13,6 +13,7 @@
 #define COMBINATORIAL_MAP_FWD_H 1
 
 #include <CGAL/memory.h>
+#include <CGAL/tags.h>
 
 namespace CGAL {
 
@@ -23,7 +24,7 @@ struct Combinatorial_map_min_items;
 struct Generic_map_min_items;
 #endif
 
-template<unsigned int d_, class Items_, class Alloc_ >
+template<unsigned int d_, class Items_, class Alloc_, class Concurrent_tag=CGAL::Tag_false >
 class Combinatorial_map_storage_1;
 
 template < unsigned int d_, class Refs_,
@@ -33,7 +34,7 @@ template < unsigned int d_, class Refs_,
            class Items_=Generic_map_min_items,
 #endif
            class Alloc_=CGAL_ALLOCATOR(int),
-           class Storage_= Combinatorial_map_storage_1<d_, Items_, Alloc_> >
+           class Storage_= Combinatorial_map_storage_1<d_, Items_, Alloc_, CGAL::Tag_false> >
 class Combinatorial_map_base;
 
 template < unsigned int d_,
@@ -43,7 +44,7 @@ template < unsigned int d_,
            class Items_=Generic_map_min_items,
 #endif
            class Alloc_=CGAL_ALLOCATOR(int),
-           class Storage_= Combinatorial_map_storage_1<d_, Items_, Alloc_> >
+           class Storage_= Combinatorial_map_storage_1<d_, Items_, Alloc_, CGAL::Tag_false> >
 class Combinatorial_map;
 
 } // CGAL

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -64,7 +64,7 @@ namespace CGAL {
 
     typedef typename internal::Container_type
                  <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
-    
+
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;
     typedef typename Dart_container::size_type             size_type;

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages.h
@@ -13,6 +13,7 @@
 #define CGAL_COMBINATORIAL_MAP_STORAGES_H 1
 
 #include <CGAL/Compact_container.h>
+#include <CGAL/Concurrent_compact_container.h>
 #include <CGAL/Dart.h>
 #include <CGAL/Handle_hash_function.h>
 #include <bitset>
@@ -28,17 +29,20 @@ namespace CGAL {
   namespace internal {
     template <typename M>
     struct Combinatorial_map_helper;
+
+    template<typename Concurrent_tag, class T, class Alloc_>
+    struct Container_type;
   }
 
   /** @file Combinatorial_map_storages.h
    * Definition of storages for dD Combinatorial map.
    */
   // Storage of darts with compact container, beta with handles
-  template<unsigned int d_, class Items_, class Alloc_ >
+  template<unsigned int d_, class Items_, class Alloc_, class Concurrent_tag >
   class Combinatorial_map_storage_1
   {
   public:
-    typedef Combinatorial_map_storage_1<d_, Items_, Alloc_> Self;
+    typedef Combinatorial_map_storage_1<d_, Items_, Alloc_, Concurrent_tag> Self;
     typedef CGAL::Tag_false Use_index;
 
     typedef internal::Combinatorial_map_helper<Self>      Helper;
@@ -57,8 +61,10 @@ namespace CGAL {
 
     typedef std::allocator_traits<Alloc_> Allocator_traits;
     typedef typename Allocator_traits::template rebind_alloc<Dart> Dart_allocator;
-    typedef Compact_container<Dart, Dart_allocator>        Dart_container;
 
+    typedef typename internal::Container_type
+                 <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
+    
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;
     typedef typename Dart_container::size_type             size_type;
@@ -70,7 +76,9 @@ namespace CGAL {
     typedef Alloc_ Alloc;
     template <typename T>
     struct Container_for_attributes :
-      public Compact_container<T, typename std::allocator_traits<Alloc_>::template rebind_alloc<T> >
+      public internal::Container_type
+                     <Concurrent_tag, T,
+                      typename std::allocator_traits<Alloc_>::template rebind_alloc<T>>::type
     {};
     /// Typedef for attributes
     typedef typename internal::template Get_attributes_tuple<Dart_wrapper>::type
@@ -425,9 +433,9 @@ namespace CGAL {
   };
 
   /// null_handle
-  template < unsigned int d_, class Items_, class Alloc_ >
-  const typename Combinatorial_map_storage_1<d_, Items_, Alloc_>::Null_handle_type
-  Combinatorial_map_storage_1<d_, Items_, Alloc_>::null_handle = nullptr;
+  template < unsigned int d_, class Items_, class Alloc_, class Concurrent_tag >
+  const typename Combinatorial_map_storage_1<d_, Items_, Alloc_, Concurrent_tag>::Null_handle_type
+  Combinatorial_map_storage_1<d_, Items_, Alloc_, Concurrent_tag>::null_handle = nullptr;
 
 } // namespace CGAL
 

--- a/Combinatorial_map/include/CGAL/Dart.h
+++ b/Combinatorial_map/include/CGAL/Dart.h
@@ -26,16 +26,16 @@ namespace CGAL {
   template <class, class>
   class Concurrent_compact_container;
 
-  template<unsigned int, class, class>
+  template<unsigned int, class, class, class>
   class Combinatorial_map_storage_1;
 
-  template<unsigned int, class, class>
+  template<unsigned int, class, class, class>
   class Generalized_map_storage_1;
 
-  template<unsigned int, unsigned int, class, class, class>
+  template<unsigned int, unsigned int, class, class, class, class>
   class CMap_linear_cell_complex_storage_1;
 
-  template<unsigned int, unsigned int, class, class, class>
+  template<unsigned int, unsigned int, class, class, class, class>
   class GMap_linear_cell_complex_storage_1;
 
   namespace internal {
@@ -60,16 +60,16 @@ namespace CGAL {
   struct Dart_without_info: public Add_id<WithId>
   {
   public:
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>
@@ -210,10 +210,10 @@ namespace CGAL {
   template <unsigned int d, typename Refs, class WithID=Tag_false>
   struct CGAL_DEPRECATED Dart : public Dart_without_info<d, Refs, WithID>
   {
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>
@@ -310,16 +310,16 @@ namespace CGAL {
   struct Dart : public Dart_without_info<d, Refs, WithID>
   {
   public:
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Combinatorial_map_storage_1;
 
-    template<unsigned int, class, class>
+    template<unsigned int, class, class, class>
     friend class Generalized_map_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class CMap_linear_cell_complex_storage_1;
 
-    template<unsigned int, unsigned int, class, class, class>
+    template<unsigned int, unsigned int, class, class, class, class>
     friend class GMap_linear_cell_complex_storage_1;
 
     template <class, class, class, class>

--- a/Combinatorial_map/include/CGAL/internal/Combinatorial_map_utility.h
+++ b/Combinatorial_map/include/CGAL/internal/Combinatorial_map_utility.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/tuple.h>
 #include <CGAL/Compact_container.h>
+#include <CGAL/Concurrent_compact_container.h>
 #include <iostream>
 
 #include <boost/type_traits/is_same.hpp>
@@ -591,6 +592,18 @@ namespace CGAL
         static void run(Ts& ... t)
         { Foreach_static_restricted_except<Functor, j, Attributes>::run(t...); }
       };
+  };
+
+  // Helper class to define container type depending on the Concurrent_tag
+  template<typename Concurrent_tag, class T, class Alloc_>
+  struct Container_type
+  {
+    typedef CGAL::Compact_container<T, Alloc_> type;
+  };
+  template<class T, class Alloc_>
+  struct Container_type<CGAL::Tag_true, T, Alloc_>
+  {
+    typedef CGAL::Concurrent_compact_container<T, Alloc_> type;
   };
 
 } //namespace internal

--- a/Generalized_map/include/CGAL/Generalized_map_fwd.h
+++ b/Generalized_map/include/CGAL/Generalized_map_fwd.h
@@ -13,10 +13,11 @@
 #define GENERALIZED_MAP_FWD_H 1
 
 #include <CGAL/memory.h>
+#include <CGAL/tags.h>
 
 namespace CGAL {
 
-template<unsigned int d_, class Items_, class Alloc_ >
+template<unsigned int d_, class Items_, class Alloc_, class Concurrent_tag=CGAL::Tag_false >
 class Generalized_map_storage_1;
 
 struct Generic_map_min_items;
@@ -24,13 +25,13 @@ struct Generic_map_min_items;
 template < unsigned int d_, class Refs,
            class Items_=Generic_map_min_items,
            class Alloc_=CGAL_ALLOCATOR(int),
-           class Storage_= Generalized_map_storage_1<d_, Items_, Alloc_> >
+           class Storage_= Generalized_map_storage_1<d_, Items_, Alloc_, CGAL::Tag_false> >
 class Generalized_map_base;
 
 template < unsigned int d_,
            class Items_=Generic_map_min_items,
            class Alloc_=CGAL_ALLOCATOR(int),
-           class Storage_= Generalized_map_storage_1<d_, Items_, Alloc_> >
+           class Storage_= Generalized_map_storage_1<d_, Items_, Alloc_, CGAL::Tag_false> >
 class Generalized_map;
 
 } // CGAL

--- a/Generalized_map/include/CGAL/Generalized_map_storages.h
+++ b/Generalized_map/include/CGAL/Generalized_map_storages.h
@@ -61,7 +61,7 @@ namespace CGAL {
 
     typedef typename internal::Container_type
                  <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
-    
+
 
     typedef typename Dart_container::iterator             Dart_handle;
     typedef typename Dart_container::const_iterator       Dart_const_handle;

--- a/Generalized_map/include/CGAL/Generalized_map_storages.h
+++ b/Generalized_map/include/CGAL/Generalized_map_storages.h
@@ -13,6 +13,7 @@
 #define CGAL_GENERALIZED_MAP_STORAGES_H 1
 
 #include <CGAL/Compact_container.h>
+#include <CGAL/Concurrent_compact_container.h>
 #include <CGAL/Dart.h>
 #include <CGAL/Handle_hash_function.h>
 #include <bitset>
@@ -28,6 +29,9 @@ namespace CGAL {
   namespace internal {
     template <typename M>
     struct Combinatorial_map_helper;
+
+    template<typename Concurrent_tag, class T, class Alloc_>
+    struct Container_type;
   }
 
   /** @file Generalized_map_storages.h
@@ -35,11 +39,11 @@ namespace CGAL {
    */
 
   // Storage of darts with compact container, alpha with handles
-  template<unsigned int d_, class Items_, class Alloc_ >
+  template<unsigned int d_, class Items_, class Alloc_, class Concurrent_tag >
   class Generalized_map_storage_1
   {
   public:
-    typedef Generalized_map_storage_1<d_, Items_, Alloc_> Self;
+    typedef Generalized_map_storage_1<d_, Items_, Alloc_, Concurrent_tag> Self;
     typedef CGAL::Tag_false Use_index;
 
     typedef internal::Combinatorial_map_helper<Self>      Helper;
@@ -55,7 +59,9 @@ namespace CGAL {
     typedef std::allocator_traits<Alloc_> Allocator_traits;
     typedef typename Allocator_traits::template rebind_alloc<Dart> Dart_allocator;
 
-    typedef Compact_container<Dart, Dart_allocator>       Dart_container;
+    typedef typename internal::Container_type
+                 <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
+    
 
     typedef typename Dart_container::iterator             Dart_handle;
     typedef typename Dart_container::const_iterator       Dart_const_handle;
@@ -69,7 +75,9 @@ namespace CGAL {
 
     template <typename T>
     struct Container_for_attributes :
-      public Compact_container<T, typename std::allocator_traits<Alloc_>::template rebind_alloc<T> >
+      public internal::Container_type
+                     <Concurrent_tag, T,
+                      typename std::allocator_traits<Alloc_>::template rebind_alloc<T>>::type
     {};
     /// Typedef for attributes
     typedef typename internal::template Get_attributes_tuple<Dart_wrapper>::type
@@ -412,9 +420,9 @@ namespace CGAL {
   };
 
   /// null_handle
-  template < unsigned int d_, class Items_, class Alloc_ >
-  const typename Generalized_map_storage_1<d_, Items_, Alloc_>::Null_handle_type
-  Generalized_map_storage_1<d_, Items_, Alloc_>::null_handle = nullptr;
+  template < unsigned int d_, class Items_, class Alloc_, class Concurrent_tag >
+  const typename Generalized_map_storage_1<d_, Items_, Alloc_, Concurrent_tag>::Null_handle_type
+  Generalized_map_storage_1<d_, Items_, Alloc_, Concurrent_tag>::null_handle = nullptr;
 
 } // namespace CGAL
 

--- a/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages.h
@@ -75,7 +75,7 @@ namespace CGAL {
 
     typedef typename internal::Container_type
                  <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
-    
+
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;
     typedef typename Dart_container::size_type             size_type;

--- a/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages.h
@@ -13,6 +13,7 @@
 #define CGAL_CMAP_LINEAR_CELL_COMPLEX_STORAGES_H 1
 
 #include <CGAL/Compact_container.h>
+#include <CGAL/Concurrent_compact_container.h>
 #include <CGAL/Dart.h>
 #include <CGAL/Handle_hash_function.h>
 #include <bitset>
@@ -28,6 +29,9 @@ namespace CGAL {
   namespace internal {
     template <typename M>
     struct Combinatorial_map_helper;
+
+    template<typename Concurrent_tag, class T, class Alloc_>
+    struct Container_type;
   }
 
   /** @file CMap_linear_cell_complex_storages.h
@@ -40,7 +44,7 @@ namespace CGAL {
   // as template parameter of Dart_wrapper. If we inherit, Self is not
   // the correct type).
   template<unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
+           class Traits_, class Items_, class Alloc_, class Concurrent_tag >
   class CMap_linear_cell_complex_storage_1
   {
   public:
@@ -49,7 +53,7 @@ namespace CGAL {
     typedef typename Traits_::FT     FT;
 
     typedef CMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-    Items_, Alloc_> Self;
+    Items_, Alloc_, Concurrent_tag> Self;
     typedef CGAL::Tag_false Use_index;
 
     typedef internal::Combinatorial_map_helper<Self>      Helper;
@@ -69,8 +73,9 @@ namespace CGAL {
     typedef std::allocator_traits<Alloc_> Allocator_traits;
     typedef typename Allocator_traits::template rebind_alloc<Dart> Dart_allocator;
 
-    typedef Compact_container<Dart, Dart_allocator>        Dart_container;
-
+    typedef typename internal::Container_type
+                 <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
+    
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;
     typedef typename Dart_container::size_type             size_type;
@@ -80,12 +85,12 @@ namespace CGAL {
 
     typedef Items_ Items;
     typedef Alloc_ Alloc;
-
     template <typename T>
     struct Container_for_attributes :
-      public Compact_container<T, typename std::allocator_traits<Alloc_>::template rebind_alloc<T> >
+      public internal::Container_type
+                     <Concurrent_tag, T,
+                      typename std::allocator_traits<Alloc_>::template rebind_alloc<T>>::type
     {};
-
     /// Typedef for attributes
     typedef typename internal::template Get_attributes_tuple<Dart_wrapper>::type
                                    Attributes;
@@ -463,11 +468,11 @@ namespace CGAL {
 
   /// null_handle
   template<unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
+           class Traits_, class Items_, class Alloc_, class Concurrent_tag >
   const typename CMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::Null_handle_type
+                                         Items_, Alloc_, Concurrent_tag>::Null_handle_type
   CMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                Items_, Alloc_>::null_handle = nullptr;
+                                Items_, Alloc_, Concurrent_tag>::null_handle = nullptr;
 
 } // namespace CGAL
 

--- a/Linear_cell_complex/include/CGAL/GMap_linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/GMap_linear_cell_complex_storages.h
@@ -70,7 +70,7 @@ namespace CGAL {
 
     typedef typename internal::Container_type
                  <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
-    
+
 
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;

--- a/Linear_cell_complex/include/CGAL/GMap_linear_cell_complex_storages.h
+++ b/Linear_cell_complex/include/CGAL/GMap_linear_cell_complex_storages.h
@@ -28,6 +28,9 @@ namespace CGAL {
   namespace internal {
     template <typename M>
     struct Combinatorial_map_helper;
+
+    template<typename Concurrent_tag, class T, class Alloc_>
+    struct Container_type;
   }
 
   /** @file GMap_linear_cell_complex_storages.h
@@ -40,7 +43,7 @@ namespace CGAL {
   // as template parameter of Dart_wrapper. If we inherit, Self is not
   // the correct type).
   template<unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
+           class Traits_, class Items_, class Alloc_, class Concurrent_tag >
   class GMap_linear_cell_complex_storage_1
   {
   public:
@@ -49,7 +52,7 @@ namespace CGAL {
     typedef typename Traits_::FT     FT;
 
     typedef GMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-    Items_, Alloc_> Self;
+    Items_, Alloc_, Concurrent_tag> Self;
     typedef CGAL::Tag_false Use_index;
 
     typedef internal::Combinatorial_map_helper<Self>      Helper;
@@ -65,7 +68,9 @@ namespace CGAL {
     typedef std::allocator_traits<Alloc_> Allocator_traits;
     typedef typename Allocator_traits::template rebind_alloc<Dart> Dart_allocator;
 
-    typedef Compact_container<Dart, Dart_allocator>        Dart_container;
+    typedef typename internal::Container_type
+                 <Concurrent_tag, Dart, Dart_allocator>::type Dart_container;
+    
 
     typedef typename Dart_container::iterator              Dart_handle;
     typedef typename Dart_container::const_iterator        Dart_const_handle;
@@ -79,7 +84,9 @@ namespace CGAL {
 
     template <typename T>
     struct Container_for_attributes :
-        public Compact_container<T, typename std::allocator_traits<Alloc_>::template rebind_alloc<T> >
+      public internal::Container_type
+                     <Concurrent_tag, T,
+                      typename std::allocator_traits<Alloc_>::template rebind_alloc<T>>::type
     {};
     /// Typedef for attributes
     typedef typename internal::template Get_attributes_tuple<Dart_wrapper>::type
@@ -446,11 +453,11 @@ namespace CGAL {
 
   /// null_handle
   template <unsigned int d_, unsigned int ambient_dim,
-           class Traits_, class Items_, class Alloc_ >
+           class Traits_, class Items_, class Alloc_, class Concurrent_tag >
   const typename GMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                         Items_, Alloc_>::Null_handle_type
+                                         Items_, Alloc_, Concurrent_tag>::Null_handle_type
   GMap_linear_cell_complex_storage_1<d_, ambient_dim, Traits_,
-                                Items_, Alloc_>::null_handle = nullptr;
+                                Items_, Alloc_, Concurrent_tag>::null_handle = nullptr;
 } // namespace CGAL
 
 #if  (BOOST_GCC >= 40900)

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_fwd.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_fwd.h
@@ -19,11 +19,11 @@
 namespace CGAL {
 
 template<unsigned int d_, unsigned int ambient_dim,
-         class Traits_, class Items_, class Alloc_ >
+         class Traits_, class Items_, class Alloc_, class Concurrent_tag=CGAL::Tag_false >
 class CMap_linear_cell_complex_storage_1;
 
 template<unsigned int d_, unsigned int ambient_dim,
-         class Traits_, class Items_, class Alloc_ >
+         class Traits_, class Items_, class Alloc_, class Concurrent_tag=CGAL::Tag_false >
 class GMap_linear_cell_complex_storage_1;
 
 template <unsigned int d>
@@ -62,7 +62,7 @@ template < unsigned int d_, unsigned int ambient_dim = d_,
            class CMap = Combinatorial_map_base,
            class Storage_ = CMap_linear_cell_complex_storage_1<d_, ambient_dim,
                                                                Traits_, Items_,
-                                                               Alloc_> >
+                                                               Alloc_, CGAL::Tag_false> >
   class Linear_cell_complex_for_combinatorial_map;
 
   template < unsigned int d_, unsigned int ambient_dim = d_,
@@ -73,7 +73,7 @@ template < unsigned int d_, unsigned int ambient_dim = d_,
              class CMap = Generalized_map_base,
              class Storage_ = GMap_linear_cell_complex_storage_1<d_, ambient_dim,
                                                                  Traits_, Items_,
-                                                                 Alloc_> >
+                                                                 Alloc_, CGAL::Tag_false> >
     class Linear_cell_complex_for_generalized_map;
 
 #if !defined(CGAL_NO_DEPRECATED_CODE)
@@ -89,7 +89,7 @@ template < unsigned int d_, unsigned int ambient_dim = d_,
              class CMap = Combinatorial_map_base,
              class Storage_ = CMap_linear_cell_complex_storage_1<d_, ambient_dim,
                                                                  Traits_, Items_,
-                                                                 Alloc_> >
+                                                                 Alloc_, CGAL::Tag_false> >
   class Linear_cell_complex;
 #endif
 

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -476,6 +476,42 @@ public:
     return m_alloc;
   }
 
+  // Returns the index of the iterator "cit", i.e. the number n so that
+  // operator[](n)==*cit.
+  // Complexity : O(#blocks) = O(sqrt(capacity())).
+  // This function is mostly useful for purposes of efficient debugging at
+  // higher levels.
+  size_type index(const_iterator cit) const
+  {
+    // We use the block structure to provide an efficient version :
+    // we check if the address is in the range of each block.
+
+    assert(cit != end());
+
+    const_pointer c = &*cit;
+    size_type res=0;
+
+    Mutex::scoped_lock lock(m_mutex);
+
+    for (typename All_items::const_iterator it = m_all_items.begin(),
+         itend = m_all_items.end(); it != itend; ++it) {
+      const_pointer p = it->first;
+      size_type s = it->second;
+
+      // Are we in the address range of this block (excluding first and last
+      // elements) ?
+      if ( p<c && c<(p+s-1) )
+      {
+        CGAL_assertion_msg( (c-p)+p == c, "wrong alignment of iterator");
+        return res+(c-p-1);
+      }
+
+      res += s-2;
+    }
+
+    return (size_type)-1; // cit does not belong to this compact container
+  }
+
   // Returns whether the iterator "cit" is in the range [begin(), end()].
   // Complexity : O(#blocks) = O(sqrt(capacity())).
   // This function is mostly useful for purposes of efficient debugging at


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Add a tag to the storage classes of CMap, GMap and LCC, allowing to choose to use either Compact_container (default) or Concurrent_compact_container as underlying container.

These classes are undocumented, and by default Compact_container is used; thus there is no change in documented API, nor in user code.

Also add index method in Concurrent_compact_container: this method exists only in Compact_container.

## Release Management

* Affected package(s): CMap, GMap, LCC

