### PR TITLE
Demo isotropic_remeshing_plugin - keep selection valid

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -471,16 +471,11 @@ public Q_SLOTS:
         {
           selection_item->polyhedron_item()->setItemIsMulticolor(false);
         }
-
-
-        selection_item->polyhedron_item()->polyhedron()->collect_garbage(visitor);
-
-        selection_item->reset_numbers();
-
+        selection_item->setKeepSelectionValid(Scene_polyhedron_selection_item::Edge);
         selection_item->polyhedron_item()->invalidateOpenGLBuffers();
         Q_EMIT selection_item->polyhedron_item()->itemChanged();
-
         selection_item->invalidateOpenGLBuffers();
+        selection_item->setKeepSelectionValid(Scene_polyhedron_selection_item::None);
       }
       else if (poly_item)
       {

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -520,16 +520,10 @@ public Q_SLOTS:
         Update_indices_visitor visitor(selection_item->selected_vertices,
                                        selection_item->selected_edges,
                                        selection_item->selected_facets,
-                                       *selection_item->polyhedron());
+                                       pmesh);
         selection_item->polyhedron_item()->polyhedron()->collect_garbage(visitor);
 
-        //recollect sharp edges
-        boost::property_map<FaceGraph, CGAL::edge_is_feature_t>::type eif
-          = get(CGAL::edge_is_feature, pmesh);
-        for (edge_descriptor e : edges(pmesh))
-          eif[e] = false;
-        for (edge_descriptor e : selection_item->selected_edges)
-          eif[e] = true;
+        selection_item->reset_numbers();
 
         selection_item->polyhedron_item()->invalidateOpenGLBuffers();
         Q_EMIT selection_item->polyhedron_item()->itemChanged();

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -300,51 +300,6 @@ public:
       std::cout << "No selected or boundary edges to be split" << std::endl;
   }
 
-
-  struct Update_indices_visitor
-  {
-    Scene_polyhedron_selection_item::Selection_set_vertex& m_vertices;
-    Scene_polyhedron_selection_item::Selection_set_edge&   m_edges;
-    Scene_polyhedron_selection_item::Selection_set_facet&  m_facets;
-    FaceGraph& m_mesh;
-
-    Update_indices_visitor(Scene_polyhedron_selection_item::Selection_set_vertex& vertices,
-                           Scene_polyhedron_selection_item::Selection_set_edge&   edges,
-                           Scene_polyhedron_selection_item::Selection_set_facet&  facets,
-                           FaceGraph& mesh)
-      : m_vertices(vertices), m_edges(edges), m_facets(facets), m_mesh(mesh)
-    {}
-
-    template<typename V2V, typename E2E, typename F2F>
-    void operator()(const V2V& v2v, const E2E& e2e, const F2F& f2f)
-    {
-      //in *2* maps,
-      //left is old simplex, right is new simplex
-
-      Scene_polyhedron_selection_item::Selection_set_vertex new_vertices;
-      Scene_polyhedron_selection_item::Selection_set_edge   new_edges;
-      Scene_polyhedron_selection_item::Selection_set_facet  new_facets;
-
-      for(vertex_descriptor v : m_vertices)
-        new_vertices.insert(v2v[v]);
-      m_vertices.clear();
-      m_vertices.insert(new_vertices.begin(), new_vertices.end());
-
-      for (edge_descriptor e : m_edges)
-      {
-        halfedge_descriptor h = halfedge(e, m_mesh);
-        new_edges.insert(edge(e2e[h], m_mesh));
-      }
-      m_edges.clear();
-      m_edges.insert(new_edges.begin(), new_edges.end());
-
-      for (face_descriptor f : m_facets)
-        new_facets.insert(f2f[f]);
-      m_facets.clear();
-      m_facets.insert(new_facets.begin(), new_facets.end());
-    }
-  };
-
 public Q_SLOTS:
   void isotropic_remeshing()
   {
@@ -517,10 +472,7 @@ public Q_SLOTS:
           selection_item->polyhedron_item()->setItemIsMulticolor(false);
         }
 
-        Update_indices_visitor visitor(selection_item->selected_vertices,
-                                       selection_item->selected_edges,
-                                       selection_item->selected_facets,
-                                       pmesh);
+
         selection_item->polyhedron_item()->polyhedron()->collect_garbage(visitor);
 
         selection_item->reset_numbers();

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -2138,6 +2138,13 @@ void Scene_polyhedron_selection_item::selected_HL(const std::set<fg_edge_descrip
   Q_EMIT itemChanged();
 }
 
+void Scene_polyhedron_selection_item::reset_numbers()
+{
+  d->num_faces = num_faces(*poly_item->polyhedron());
+  d->num_vertices = num_vertices(*poly_item->polyhedron());
+  d->num_edges = num_edges(*poly_item->polyhedron());
+}
+
 void Scene_polyhedron_selection_item::init(Scene_face_graph_item* poly_item, QMainWindow* mw)
 {
   this->poly_item = poly_item;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -95,6 +95,7 @@ struct Scene_polyhedron_selection_item_priv{
   {
     filtered_graph = nullptr;
     item->setProperty("classname", QString("surface_mesh"));
+    keep_selection_valid = Scene_polyhedron_selection_item::None;
   }
 
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer) const;
@@ -201,6 +202,7 @@ struct Scene_polyhedron_selection_item_priv{
   std::size_t num_faces;
   std::size_t num_vertices;
   std::size_t num_edges;
+  Scene_polyhedron_selection_item::SelectionTypes keep_selection_valid;
 };
 typedef Scene_polyhedron_selection_item_priv Priv;
 
@@ -2179,22 +2181,26 @@ void Scene_polyhedron_selection_item::init(Scene_face_graph_item* poly_item, QMa
   connect(&k_ring_selector,SIGNAL(isCurrentlySelected(Scene_facegraph_item_k_ring_selection*)), this, SIGNAL(isCurrentlySelected(Scene_facegraph_item_k_ring_selection*)));
    k_ring_selector.init(poly_item, mw, Active_handle::VERTEX, -1);
   connect(&k_ring_selector, SIGNAL(resetIsTreated()), this, SLOT(resetIsTreated()));
+
   connect(poly_item, &Scene_surface_mesh_item::itemChanged, this, [this](){
     std::size_t new_num_faces = num_faces(*this->poly_item->face_graph());
     std::size_t new_num_vertices = num_vertices(*this->poly_item->face_graph());
     std::size_t new_num_edges = num_edges(*this->poly_item->face_graph());
 
-    if(new_num_faces != d->num_faces)
+    if(new_num_faces != d->num_faces
+       && !d->keep_selection_valid.testFlag(Facet))
     {
       selected_facets.clear();
       d->num_faces = new_num_faces ;
     }
-    if(new_num_vertices!= d->num_vertices)
+    if(new_num_vertices!= d->num_vertices
+       && !d->keep_selection_valid.testFlag(Vertex))
     {
       selected_vertices.clear();
       d->num_vertices = new_num_vertices ;
     }
-    if(new_num_edges!= d->num_edges)
+    if(new_num_edges!= d->num_edges
+       && !d->keep_selection_valid.testFlag(Edge))
     {
       selected_edges.clear();
       d->num_edges = new_num_edges ;
@@ -2628,4 +2634,31 @@ void Scene_polyhedron_selection_item::updateDisplayedIds(QEvent* e)
       poly_item->updateIds(vh);
     }
   }
+}
+
+void Scene_polyhedron_selection_item::poly_item_changed()
+{
+  if(d->keep_selection_valid != None)
+  {
+    Update_indices_visitor visitor(selected_vertices,
+                                   selected_edges,
+                                   selected_facets,
+                                   *polyhedron());
+    polyhedron()->collect_garbage(visitor);
+  }
+  else
+  {
+    if(!d->keep_selection_valid.testFlag(Vertex))
+      remove_erased_handles<fg_vertex_descriptor>();
+    if(!d->keep_selection_valid.testFlag(Edge))
+      remove_erased_handles<fg_edge_descriptor>();
+    if(!d->keep_selection_valid.testFlag(Facet))
+      remove_erased_handles<fg_face_descriptor>();
+  }
+  compute_normal_maps();
+}
+
+void Scene_polyhedron_selection_item::setKeepSelectionValid(SelectionTypes type)
+{
+  d->keep_selection_valid = type;
 }

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -276,6 +276,8 @@ public:
     return selected_vertices.empty() && selected_edges.empty() && selected_facets.empty();
   }
 
+  void reset_numbers();
+
   void compute_bbox() const
   {
     // Workaround a bug in g++-4.8.3:

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -1057,7 +1057,7 @@ protected :
       for(vertex_descriptor v : m_vertices)
       {
         if(v2v[v] != boost::graph_traits<SMesh>::null_vertex()
-           && int(v2v[v])  < m_mesh.number_of_vertices())
+           && int(v2v[v])  < static_cast<int>(m_mesh.number_of_vertices()))
           new_vertices.insert(v2v[v]);
       }
       m_vertices.clear();
@@ -1067,7 +1067,7 @@ protected :
       {
         halfedge_descriptor h = halfedge(e, m_mesh);
         if(e2e[h] != boost::graph_traits<SMesh>::null_halfedge()
-           && int(e2e[h])  < m_mesh.number_of_halfedges())
+           && int(e2e[h])  < static_cast<int>(m_mesh.number_of_halfedges()))
           new_edges.insert(edge(e2e[h], m_mesh));
       }
       m_edges.clear();
@@ -1075,7 +1075,7 @@ protected :
 
       for (face_descriptor f : m_facets)
         if(f2f[f] != boost::graph_traits<SMesh>::null_face()
-           && int(f2f[f])  < m_mesh.number_of_faces())
+           && int(f2f[f])  < static_cast<int>(m_mesh.number_of_faces()))
           new_facets.insert(f2f[f]);
       m_facets.clear();
       m_facets.insert(new_facets.begin(), new_facets.end());


### PR DESCRIPTION
## Summary of Changes

In the demo, the `isotropic_remeshing_plugin` was invalidating the set of selected edges (resp. vertices, facets) given as input via the selection plugin, because of the modifications made to the mesh associated with the call to `surface_mesh->collect_garbage()`.

This PR uses the visitor in `surface_mesh->collect_garbage(visitor)` to keep selection valid after remeshing and garbage collection.

This PR follows PR #4978 in the case we have a selection_item with selected edges

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

