### PR TITLE
Allow an inexact version of bisector when no sqrt is available.

### DIFF
--- a/Algebraic_foundations/include/CGAL/number_utils.h
+++ b/Algebraic_foundations/include/CGAL/number_utils.h
@@ -302,13 +302,13 @@ to_interval( const Real_embeddable& x) {
 }
 
 template <typename NT>
-NT approximate_sqrt(const NT& nt, CGAL::Field_tag)
+NT approximate_sqrt(const NT& nt, CGAL::Null_functor)
 {
   return NT(sqrt(CGAL::to_double(nt)));
 }
 
-template <typename NT>
-NT approximate_sqrt(const NT& nt, CGAL::Field_with_sqrt_tag)
+template <typename NT, typename Sqrt>
+NT approximate_sqrt(const NT& nt, Sqrt sqrt)
 {
   return sqrt(nt);
 }
@@ -317,8 +317,8 @@ template <typename NT>
 NT approximate_sqrt(const NT& nt)
 {
   typedef CGAL::Algebraic_structure_traits<NT> AST;
-  typedef typename AST::Algebraic_category Algebraic_category;
-  return approximate_sqrt(nt, Algebraic_category());
+  typedef typename AST::Sqrt Sqrt;
+  return approximate_sqrt(nt, Sqrt());
 }
 
 CGAL_NTS_END_NAMESPACE

--- a/Algebraic_foundations/include/CGAL/number_utils.h
+++ b/Algebraic_foundations/include/CGAL/number_utils.h
@@ -316,6 +316,9 @@ NT approximate_sqrt(const NT& nt, Sqrt sqrt)
 template <typename NT>
 NT approximate_sqrt(const NT& nt)
 {
+  // the initial version of this function was using Algebraic_category
+  // for the dispatch but some ring type (like Gmpz) provides a Sqrt
+  // functor even if not being Field_with_sqrt.
   typedef CGAL::Algebraic_structure_traits<NT> AST;
   typedef typename AST::Sqrt Sqrt;
   return approximate_sqrt(nt, Sqrt());

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC2.h
@@ -246,8 +246,8 @@ bisector_of_linesC2(const FT &pa, const FT &pb, const FT &pc,
                     FT &a, FT &b, FT &c)
 {
   // We normalize the equations of the 2 lines, and we then add them.
-  FT n1 = CGAL_NTS sqrt(CGAL_NTS square(pa) + CGAL_NTS square(pb));
-  FT n2 = CGAL_NTS sqrt(CGAL_NTS square(qa) + CGAL_NTS square(qb));
+  FT n1 = CGAL_NTS approximate_sqrt( FT(CGAL_NTS square(pa) + CGAL_NTS square(pb)) );
+  FT n2 = CGAL_NTS approximate_sqrt( FT(CGAL_NTS square(qa) + CGAL_NTS square(qb)) );
   a = n2 * pa + n1 * qa;
   b = n2 * pb + n1 * qb;
   c = n2 * pc + n1 * qc;

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -366,10 +366,10 @@ bisector_of_planesC3(const FT &pa, const FT &pb, const FT &pc, const FT &pd,
                      FT &a, FT &b, FT &c, FT &d)
 {
   // We normalize the equations of the 2 planes, and we then add them.
-  FT n1 = CGAL_NTS sqrt(CGAL_NTS square(pa) + CGAL_NTS square(pb) +
-                        CGAL_NTS square(pc));
-  FT n2 = CGAL_NTS sqrt(CGAL_NTS square(qa) + CGAL_NTS square(qb) +
-                        CGAL_NTS square(qc));
+  FT n1 = CGAL_NTS approximate_sqrt( FT(CGAL_NTS square(pa) + CGAL_NTS square(pb) +
+                        CGAL_NTS square(pc)) );
+  FT n2 = CGAL_NTS approximate_sqrt( FT(CGAL_NTS square(qa) + CGAL_NTS square(qb) +
+                        CGAL_NTS square(qc)) );
   a = n2 * pa + n1 * qa;
   b = n2 * pb + n1 * qb;
   c = n2 * pc + n1 * qc;

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -355,8 +355,10 @@ through the intersection of `l1` and `l2`.
 If `l1` and `l2` are parallel, then the bisector is defined as the line
 which has the same direction as `l1`, and which is at the same distance
 from `l1` and `l2`.
-This function requires that `Kernel::RT` supports the `sqrt()`
-operation.
+If `Kernel::FT` is not a model of `FieldWithSqrt`
+an approximation of the square root will be used in this function,
+impacting the exactness of the result even with a (exact) multiprecision
+number type.
 */
 template <typename Kernel>
 CGAL::Line_2<Kernel> bisector(const CGAL::Line_2<Kernel> &l1,
@@ -379,8 +381,10 @@ passes through the intersection of `h1` and `h2`.
 If `h1` and `h2` are parallel, then the bisector is defined as the
 plane which has the same oriented normal vector as `l1`, and which is at
 the same distance from `h1` and `h2`.
-This function requires that `Kernel::RT` supports the `sqrt()`
-operation.
+If `Kernel::FT` is not a model of `FieldWithSqrt`
+an approximation of the square root will be used in this function,
+impacting the exactness of the result even with a (exact) multiprecision
+number type.
 */
 template <typename Kernel>
 CGAL::Plane_3<Kernel> bisector(const CGAL::Plane_3<Kernel> &h1,

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -357,7 +357,7 @@ which has the same direction as `l1`, and which is at the same distance
 from `l1` and `l2`.
 If `Kernel::FT` is not a model of `FieldWithSqrt`
 an approximation of the square root will be used in this function,
-impacting the exactness of the result even with a (exact) multiprecision
+impacting the exactness of the result even with an (exact) multiprecision
 number type.
 */
 template <typename Kernel>
@@ -383,7 +383,7 @@ plane which has the same oriented normal vector as `l1`, and which is at
 the same distance from `h1` and `h2`.
 If `Kernel::FT` is not a model of `FieldWithSqrt`
 an approximation of the square root will be used in this function,
-impacting the exactness of the result even with a (exact) multiprecision
+impacting the exactness of the result even with an (exact) multiprecision
 number type.
 */
 template <typename Kernel>

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -3848,8 +3848,10 @@ public:
     If `l1` and `l2` are parallel, then the bisector is defined as the line
     which has the same direction as `l1`, and which is at the same distance
     from `l1` and `l2`.
-    This function requires that `Kernel::RT` supports the `sqrt()`
-    operation.
+    If `Kernel::FT` is not a model of `FieldWithSqrt`
+    an approximation of the square root will be used in this function,
+    impacting the exactness of the result even with a (exact) multiprecision
+    number type.
   */
   Kernel::Line_2 operator()(const Kernel::Line_2&l1,
                             const Kernel::Line_2&l2);
@@ -3891,8 +3893,10 @@ public:
     If `h1` and `h2` are parallel, then the bisector is defined as the
     plane which has the same oriented normal vector as `h1`, and which is at
     the same distance from `h1` and `h2`.
-    This function requires that `Kernel::RT` supports the `sqrt()`
-    operation.
+    If `Kernel::FT` is not a model of `FieldWithSqrt`
+    an approximation of the square root will be used in this function,
+    impacting the exactness of the result even with a (exact) multiprecision
+    number type.
   */
   Kernel::Plane_3 operator()(const Kernel::Plane_3&h1,
                              const Kernel::Plane_3&h2);

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -3850,7 +3850,7 @@ public:
     from `l1` and `l2`.
     If `Kernel::FT` is not a model of `FieldWithSqrt`
     an approximation of the square root will be used in this function,
-    impacting the exactness of the result even with a (exact) multiprecision
+    impacting the exactness of the result even with an (exact) multiprecision
     number type.
   */
   Kernel::Line_2 operator()(const Kernel::Line_2&l1,
@@ -3895,7 +3895,7 @@ public:
     the same distance from `h1` and `h2`.
     If `Kernel::FT` is not a model of `FieldWithSqrt`
     an approximation of the square root will be used in this function,
-    impacting the exactness of the result even with a (exact) multiprecision
+    impacting the exactness of the result even with an (exact) multiprecision
     number type.
   */
   Kernel::Plane_3 operator()(const Kernel::Plane_3&h1,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -3848,10 +3848,6 @@ public:
     If `l1` and `l2` are parallel, then the bisector is defined as the line
     which has the same direction as `l1`, and which is at the same distance
     from `l1` and `l2`.
-    If `Kernel::FT` is not a model of `FieldWithSqrt`
-    an approximation of the square root will be used in this function,
-    impacting the exactness of the result even with an (exact) multiprecision
-    number type.
   */
   Kernel::Line_2 operator()(const Kernel::Line_2&l1,
                             const Kernel::Line_2&l2);
@@ -3893,10 +3889,6 @@ public:
     If `h1` and `h2` are parallel, then the bisector is defined as the
     plane which has the same oriented normal vector as `h1`, and which is at
     the same distance from `h1` and `h2`.
-    If `Kernel::FT` is not a model of `FieldWithSqrt`
-    an approximation of the square root will be used in this function,
-    impacting the exactness of the result even with an (exact) multiprecision
-    number type.
   */
   Kernel::Plane_3 operator()(const Kernel::Plane_3&h1,
                              const Kernel::Plane_3&h2);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
@@ -53,7 +53,6 @@ _test_fct_line_2(const R& )
  std::cout << "Testing functions Line_2" ;
 
  typedef typename  R::RT       RT;
- typedef typename  R::FT       FT;
  typedef typename  R::Point_2  Point_2;
  typedef typename  R::Line_2   Line_2;
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_line_2.h
@@ -18,22 +18,9 @@
 #ifndef CGAL__TEST_FCT_LINE_2_H
 #define CGAL__TEST_FCT_LINE_2_H
 
-// Accessory function testing functions that require sqrt().
-// Doesn't instantiate anything if RT doesn't support sqrt().
 template <class R>
 bool
-_test_fct_line_sqrt_2(const R&, CGAL::Tag_false)
-{
-//  bool UNTESTED_STUFF_BECAUSE_SQRT_IS_NOT_SUPPORTED;
-  std::cout << std::endl
-            << "NOTE : FT doesn't support sqrt(),"
-               " hence some functions are not tested." << std::endl;
-  return true;
-}
-
-template <class R>
-bool
-_test_fct_line_sqrt_2(const R&, CGAL::Tag_true)
+_test_fct_line_sqrt_2(const R&)
 {
  typedef typename  R::Point_2  Point_2;
  typedef typename  R::Line_2   Line_2;
@@ -178,13 +165,9 @@ _test_fct_line_2(const R& )
  assert(bl1.oriented_side(p2) == CGAL::ON_POSITIVE_SIDE);
  assert( CGAL::parallel(bl1, bl2) );
 
- // More tests, that require sqrt().
- {
-     typedef ::CGAL::Algebraic_structure_traits<FT> AST;
-     static const bool has_sqrt =
-         ! ::boost::is_same< ::CGAL::Null_functor, typename AST::Sqrt >::value;
-     _test_fct_line_sqrt_2(R(), ::CGAL::Boolean_tag<has_sqrt>());
- }
+ // More tests, that require sqrt() or use approx.
+  _test_fct_line_sqrt_2(R());
+
  std::cout << "done" << std::endl;
  return true;
 }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
@@ -17,22 +17,9 @@
 #ifndef CGAL__TEST_FCT_PLANE_3_H
 #define CGAL__TEST_FCT_PLANE_3_H
 
-// Accessory function testing functions that require sqrt().
-// Doesn't instantiate anything if RT doesn't support sqrt().
 template <class R>
 bool
-_test_fct_plane_sqrt_3(const R&, CGAL::Tag_false)
-{
-//  bool UNTESTED_STUFF_BECAUSE_SQRT_IS_NOT_SUPPORTED;
-  std::cout << std::endl
-            << "NOTE : FT doesn't support sqrt(),"
-               " hence some functions are not tested." << std::endl;
-  return true;
-}
-
-template <class R>
-bool
-_test_fct_plane_sqrt_3(const R&, CGAL::Tag_true)
+_test_fct_plane_sqrt_3(const R&)
 {
  typedef typename  R::Point_3  Point_3;
  typedef typename  R::Plane_3  Plane_3;
@@ -97,11 +84,8 @@ _test_fct_plane_3(const R& )
  assert(   CGAL::parallel(h1, h2) );
  assert( ! CGAL::parallel(h1, h5) );
 
- // More tests, that require sqrt().
- typedef ::CGAL::Algebraic_structure_traits<FT> AST;
- static const bool has_sqrt =
-     ! ::boost::is_same< ::CGAL::Null_functor, typename AST::Sqrt >::value;
- _test_fct_plane_sqrt_3(R(), ::CGAL::Boolean_tag<has_sqrt>());
+ // More tests, that require sqrt() or use approx.
+ _test_fct_plane_sqrt_3(R());
 
  std::cout << "done" << std::endl;
  return true;

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
@@ -53,7 +53,6 @@ _test_fct_plane_3(const R& )
  std::cout << "Testing functions Plane_3" ;
 
  typedef typename  R::RT       RT;
- typedef typename  R::FT       FT;
  typedef typename  R::Point_3  Point_3;
  typedef typename  R::Plane_3  Plane_3;
 


### PR DESCRIPTION
Fixes #5111