### PR TITLE
Fix CTest issues with CGAL_Qt5

### DIFF
--- a/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
+++ b/Installation/cmake/modules/CGAL_CreateSingleSourceCGALProgram.cmake
@@ -57,15 +57,6 @@ function(create_single_source_cgal_program firstfile )
       set(NO_TESTING TRUE)
     endif()
 
-    if(POLICY CMP0064)
-      # CMake 3.4 or later
-      if(NOT NO_TESTING)
-        cgal_add_test(${exe_name})
-      else()
-        cgal_add_test(${exe_name} NO_EXECUTION)
-      endif()
-    endif()
-
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS ${exe_name} )
 
     target_link_libraries(${exe_name} PRIVATE CGAL::CGAL)
@@ -76,6 +67,15 @@ function(create_single_source_cgal_program firstfile )
     endforeach()
     if(CGAL_3RD_PARTY_LIBRARIES)
       target_link_libraries(${exe_name} PRIVATE ${CGAL_3RD_PARTY_LIBRARIES})
+    endif()
+
+    if(POLICY CMP0064)
+      # CMake 3.4 or later
+      if(NOT NO_TESTING)
+        cgal_add_test(${exe_name})
+      else()
+        cgal_add_test(${exe_name} NO_EXECUTION)
+      endif()
     endif()
 
   else()

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -120,23 +120,25 @@ function(cgal_add_compilation_test exe_name)
     set_property(TEST "compilation_of__${exe_name}"
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
   endif()
-  get_property(linked_libraries TARGET "${exe_name}" PROPERTY LINK_LIBRARIES)
-#  message(STATUS "${exe_name} depends on ${linked_libraries}")
-  string(FIND "${linked_libraries}" "CGAL::CGAL_Qt5" link_with_CGAL_Qt5)
-  if(link_with_CGAL_Qt5 STRGREATER "-1" AND
-      NOT TARGET compilation_of__CGAL_Qt5_moc_and_resources)
-    # This custom target is useless. It is used only as a flag to
-    # detect that the test has already been created.
-    add_custom_target(compilation_of__CGAL_Qt5_moc_and_resources)
-    add_dependencies( compilation_of__CGAL_Qt5_moc_and_resources CGAL_Qt5_moc_and_resources )
-    add_test(NAME "compilation_of__CGAL_Qt5_moc_and_resources"
-      COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "compilation_of__CGAL_Qt5_moc_and_resources" --config "$<CONFIG>")
-    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
-      APPEND PROPERTY LABELS "CGAL_build_system")
-    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
-      PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
-    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
-      APPEND PROPERTY DEPENDS "check_build_system")
+  if(TARGET CGAL_Qt5_moc_and_resources) # if CGAL_Qt5 was searched, and is header-only
+    get_property(linked_libraries TARGET "${exe_name}" PROPERTY LINK_LIBRARIES)
+    #  message(STATUS "${exe_name} depends on ${linked_libraries}")
+    string(FIND "${linked_libraries}" "CGAL::CGAL_Qt5" link_with_CGAL_Qt5)
+    if(link_with_CGAL_Qt5 STRGREATER "-1" AND
+        NOT TARGET compilation_of__CGAL_Qt5_moc_and_resources)
+      # This custom target is useless. It is used only as a flag to
+      # detect that the test has already been created.
+      add_custom_target(compilation_of__CGAL_Qt5_moc_and_resources)
+      add_dependencies( compilation_of__CGAL_Qt5_moc_and_resources CGAL_Qt5_moc_and_resources )
+      add_test(NAME "compilation_of__CGAL_Qt5_moc_and_resources"
+        COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "compilation_of__CGAL_Qt5_moc_and_resources" --config "$<CONFIG>")
+      set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+        APPEND PROPERTY LABELS "CGAL_build_system")
+      set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+        PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
+      set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+        APPEND PROPERTY DEPENDS "check_build_system")
+    endif()
   endif()
 endfunction(cgal_add_compilation_test)
 

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -110,7 +110,7 @@ function(cgal_add_compilation_test exe_name)
     add_test(NAME "check_build_system"
       COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "cgal_check_build_system" --config "$<CONFIG>")
     set_property(TEST "check_build_system"
-      APPEND PROPERTY LABELS "${PROJECT_NAME}")
+      APPEND PROPERTY LABELS "CGAL_build_system")
     if(POLICY CMP0066) # cmake 3.7 or later
       set_property(TEST "check_build_system"
         PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
@@ -119,6 +119,24 @@ function(cgal_add_compilation_test exe_name)
   if(POLICY CMP0066) # cmake 3.7 or later
     set_property(TEST "compilation_of__${exe_name}"
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
+  endif()
+  get_property(linked_libraries TARGET "${exe_name}" PROPERTY LINK_LIBRARIES)
+#  message(STATUS "${exe_name} depends on ${linked_libraries}")
+  string(FIND "${linked_libraries}" "CGAL::CGAL_Qt5" link_with_CGAL_Qt5)
+  if(link_with_CGAL_Qt5 STRGREATER "-1" AND
+      NOT TARGET compilation_of__CGAL_Qt5_moc_and_resources)
+    # This custom target is useless. It is used only as a flag to
+    # detect that the test has already been created.
+    add_custom_target(compilation_of__CGAL_Qt5_moc_and_resources)
+    add_dependencies( compilation_of__CGAL_Qt5_moc_and_resources CGAL_Qt5_moc_and_resources )
+    add_test(NAME "compilation_of__CGAL_Qt5_moc_and_resources"
+      COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "compilation_of__CGAL_Qt5_moc_and_resources" --config "$<CONFIG>")
+    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+      APPEND PROPERTY LABELS "CGAL_build_system")
+    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+      PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
+    set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
+      APPEND PROPERTY DEPENDS "check_build_system")
   endif()
 endfunction(cgal_add_compilation_test)
 


### PR DESCRIPTION
## Summary of Changes

Fix CTest issues with CGAL_Qt5

Add a target `compilation_of__CGAL_Qt5_moc_and_resources`, and a corresponding CTest test, so that `CGAL_Qt5_moc_and_resources` is always compiled first, when needed. That will fix CTest race-conditions, where `CGAL_Qt5_moc_and_resources` was being compiled by several CTest test at the same time.

## Release Management

* Affected package(s): Installation


This PR is expected to fix the Travis issues that are currently in all branches, since we merged #5078.
