### PR TITLE
CI auto doc : filter 

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -63,7 +63,7 @@ jobs:
           git clone https://CGAL:${{ secrets.PUSH_TO_CGAL_GITHUB_IO_TOKEN }}@github.com/CGAL/cgal.github.io.git --depth=5
           mkdir -p build_doc && cd build_doc && cmake ../Documentation/doc
 
-      - name: Upload Doc
+      - name: Build and Upload Doc
         if: steps.get_round.outputs.result != 'stop'
         run: |
           set -ex
@@ -73,7 +73,13 @@ jobs:
           if ! egrep -q "\/$PR_NUMBER\/$ROUND" tmp.html; then
             mkdir -p cgal.github.io/${PR_NUMBER}/$ROUND
             cd build_doc && make -j2 doc && make -j2 doc_with_postprocessing
-            cp -r ./doc_output/* ../cgal.github.io/${PR_NUMBER}/$ROUND
+            #list impacted packages
+            LIST_OF_FILES=$(git diff --name-only cgal/master... |cut -d/ -f1 |uniq |sort | xargs -I {} ls -d {}/package_info 2>/dev/null  |cut -d/ -f1)
+            for f in $LIST_OF_FILES
+            do
+              cp -r ./doc_output/$f ../cgal.github.io/${PR_NUMBER}/$ROUND    
+            done
+            cp -r ./doc_output/Manual ../cgal.github.io/${PR_NUMBER}/$ROUND    
             cd ../cgal.github.io
             egrep -v " ${PR_NUMBER}\." index.html > tmp.html
             echo "<li><a href=https://cgal.github.io/${PR_NUMBER}/$ROUND/Manual/index.html>Manual for PR ${PR_NUMBER} ($ROUND).</a></li>" >> ./tmp.html

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -84,7 +84,7 @@ jobs:
             egrep -v " ${PR_NUMBER}\." index.html > tmp.html
             echo "<li><a href=https://cgal.github.io/${PR_NUMBER}/$ROUND/Manual/index.html>Manual for PR ${PR_NUMBER} ($ROUND).</a></li>" >> ./tmp.html
             mv tmp.html index.html
-            git add ${PR_NUMBER}/$ROUND && git commit -q -a -m "Add ${PR_NUMBER} $ROUND" && git push -q -u origin master
+            git add ${PR_NUMBER}/$ROUND && git commit -q --amend -m "base commit" && git push -q -f -u origin master
           else
             exit 1
           fi

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -74,8 +74,8 @@ jobs:
             mkdir -p cgal.github.io/${PR_NUMBER}/$ROUND
             cd build_doc && make -j2 doc && make -j2 doc_with_postprocessing
             #list impacted packages
-            LIST_OF_FILES=$(git diff --name-only cgal/master... |cut -d/ -f1 |uniq |sort | xargs -I {} ls -d {}/package_info 2>/dev/null  |cut -d/ -f1)
-            for f in $LIST_OF_FILES
+            LIST_OF_PKGS=$(git diff --name-only cgal/master... |cut -s -d/ -f1 |sort -u | xargs -I {} ls -d {}/package_info 2>/dev/null  |cut -d/ -f1)
+            for f in $LIST_OF_PKGS
             do
               cp -r ./doc_output/$f ../cgal.github.io/${PR_NUMBER}/$ROUND    
             done

--- a/.github/workflows/delete_doc.yml
+++ b/.github/workflows/delete_doc.yml
@@ -21,7 +21,7 @@ jobs:
          egrep -v " ${PR_NUMBER}\." index.html > tmp.html
          if [ -n "$(diff -q ./index.html ./tmp.html)" ]; then
            mv tmp.html index.html
-           #git rm -r ${PR_NUMBER} && git commit -a --amend && git push -f -u origin master
-           git commit -a -m "Remove ${PR_NUMBER}" && git push -u origin master
+           #git commit -a -m "Remove ${PR_NUMBER}" && git push -u origin master
          fi
+           git rm -r ${PR_NUMBER} && git commit -a --amend -m"base commit" && git push -f -u origin master
 

--- a/.github/workflows/delete_doc.yml
+++ b/.github/workflows/delete_doc.yml
@@ -21,7 +21,7 @@ jobs:
          egrep -v " ${PR_NUMBER}\." index.html > tmp.html
          if [ -n "$(diff -q ./index.html ./tmp.html)" ]; then
            mv tmp.html index.html
-         #git rm -r ${PR_NUMBER} && git commit -a -m "Remove ${PR_NUMBER}" && git push -u origin master
+           #git rm -r ${PR_NUMBER} && git commit -a --amend && git push -f -u origin master
            git commit -a -m "Remove ${PR_NUMBER}" && git push -u origin master
          fi
 


### PR DESCRIPTION
## Summary of Changes
Attempts to drastically reduce the size of our github pages repo to avoid build errors.
 - Filter doc to push to only keep impacted packages
 - Remove directory from repo after PR closure
 - Always amend and force push to keep the history size at a strict minimum

## Release Management

* Affected package(s):