### PR TITLE
Fix locate_with_AABB_tree(Point, ..._) with default point pmap

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
@@ -1667,12 +1667,13 @@ locate_with_AABB_tree(const typename internal::Location_traits<TriangleMesh, Nam
 {
   typedef typename internal::Location_traits<TriangleMesh, NamedParameters>::Point         Point;
   typedef internal::Point_to_Point_3<TriangleMesh, Point>                                  P_to_P3;
-  typedef typename boost::property_traits<Point3VPM>::value_type                           Point_3;
-  CGAL_static_assertion((std::is_same<Point_3, typename P_to_P3::Point_3>::value));
 
   typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type                      Geom_traits;
   typedef typename CGAL::AABB_face_graph_triangle_primitive<TriangleMesh, Point3VPM>       Primitive;
   typedef typename CGAL::AABB_traits<Geom_traits, Primitive>                               AABB_traits;
+
+  typedef typename Primitive::Point                                                        Point_3;
+  CGAL_static_assertion((std::is_same<Point_3, typename P_to_P3::Point_3>::value));
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type            VertexPointMap;
   typedef internal::Point_to_Point_3_VPM<TriangleMesh, VertexPointMap>                     WrappedVPM;


### PR DESCRIPTION
## Summary of Changes

Fix `locate_with_AABB_tree(Point, ..._)` with default point pmap (`CGAL::Default`). The compilation error was:
```
.../Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h:1697:55: error: no type
      named 'value_type' in 'boost::property_traits<CGAL::Default>'
  typedef typename boost::property_traits<Point3VPM>::value_type                           Point_3;
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~

``` 

@MaelRL Probably I should have updated the testsuite, to test that possibility. But the testsuite uses complicated vertex point pmaps. I do not know how to test with `CGAL::Default` as the pmap. Maybe in the example?

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #4277 (merged in CGAL-5.0)
* License and copyright ownership: maintenance by GF

