### PR TITLE
Testsuite: Filter labels in results collection

### DIFF
--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -71,9 +71,10 @@ tests_per_label = defaultdict(list)
 for t_id in range(0, len(tests)):
     t = tests[t_id]
     for l in t['Labels']:
-        label = l.replace("_Tests","")
-        labels.add(label)
-        tests_per_label[label].append(t)
+        if "_Tests" in l or "_Examples" in l or "_Demo" in l:
+            label = l.replace("_Tests","")
+            labels.add(label)
+            tests_per_label[label].append(t)
 
 with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                                                   tester=tester_name,


### PR DESCRIPTION
## Summary of Changes

CTests adds a line per label in the results of the testsuite. 
In this PR, I filter the labels to only keep those with _Tests, _Examples or _Demo. It will prevent `CGAL_cmake_testsuite` and `CGAL_build_system` from being added, when they are really only subtests of the label Installation.
## Release Management

* Affected package(s):Testsuite
