### PR TITLE
SMP: Fix image not appearing in doc

### DIFF
--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Doxyfile.in
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Doxyfile.in
@@ -13,5 +13,6 @@ HTML_EXTRA_FILES           =  ${CGAL_PACKAGE_DOC_DIR}/fig/nefertiti.jpg \
                               ${CGAL_PACKAGE_DOC_DIR}/fig/LSCM_new.jpg \
                               ${CGAL_PACKAGE_DOC_DIR}/fig/conformal_new.jpg \
                               ${CGAL_PACKAGE_DOC_DIR}/fig/authalic_new.jpg \
+                              ${CGAL_PACKAGE_DOC_DIR}/fig/iterative_authalic.jpg \
                               ${CGAL_PACKAGE_DOC_DIR}/fig/floater_new.jpg \
                               ${CGAL_PACKAGE_DOC_DIR}/fig/hand_base.jpg \


### PR DESCRIPTION
The image on https://cgal.geometryfactory.com/CGAL/doc/master/Surface_mesh_parameterization/index.html#title11 is not appearing, because the figure was missing from the list of external html files.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* License and copyright ownership: no changes
