### PR TITLE
Enable Boost.Multiprecision with MSVC and recent boost

### DIFF
--- a/Number_types/include/CGAL/boost_mp.h
+++ b/Number_types/include/CGAL/boost_mp.h
@@ -20,8 +20,8 @@
 // easy solution.
 // MSVC had trouble with versions <= 1.69:
 // https://github.com/boostorg/multiprecision/issues/98
-#if !defined CGAL_DISABLE_GMP && !defined CGAL_DO_NOT_USE_BOOST_MP && \
-    BOOST_VERSION >= 106300 && (!defined _MSC_VER || BOOST_VERSION >= 107000)
+#if !defined CGAL_DO_NOT_USE_BOOST_MP && BOOST_VERSION >= 106300 && \
+    (!defined _MSC_VER || BOOST_VERSION >= 107000)
 #define CGAL_USE_BOOST_MP 1
 
 #include <CGAL/functional.h> // *ary_function

--- a/Number_types/include/CGAL/boost_mp.h
+++ b/Number_types/include/CGAL/boost_mp.h
@@ -18,9 +18,10 @@
 // It is easier to disable this number type completely for old versions.
 // Before 1.63, I/O is broken.  Again, disabling the whole file is just the
 // easy solution.
-// TODO: MSVC has trouble with versions <= 1.69, reenable once 1.70 has been
-// tested. https://github.com/boostorg/multiprecision/issues/98
-#if !defined CGAL_DISABLE_GMP && !defined CGAL_DO_NOT_USE_BOOST_MP && BOOST_VERSION >= 106300 && !defined _MSC_VER
+// MSVC had trouble with versions <= 1.69:
+// https://github.com/boostorg/multiprecision/issues/98
+#if !defined CGAL_DISABLE_GMP && !defined CGAL_DO_NOT_USE_BOOST_MP && \
+    BOOST_VERSION >= 106300 && (!defined _MSC_VER || BOOST_VERSION >= 107000)
 #define CGAL_USE_BOOST_MP 1
 
 #include <CGAL/functional.h> // *ary_function


### PR DESCRIPTION
## Summary of Changes

In #3406, the plan was

> * disable boost.multiprecision for MSVC for CGAL-4.14,
> * and reenable it for 4.15, after 1.70 has been released.

But apart from a reminder in #4495 it was forgotten.

This branch is completely untested, the whole point is for the testsuite to run on it (I checked and there is at least one platform with msvc and a recent enough boost).

## Release Management

* Affected package(s): Number_types