### PR TITLE
Convex_hull_3: Fix constness

### DIFF
--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -42,8 +42,6 @@ endif()
 # Creating entries for all C++ files with "main" routine
 # ##########################################################
 
-create_single_source_cgal_program( "is_strongly_convex_3.cpp" )
-
 create_single_source_cgal_program( "dynamic_hull_3.cpp" )
 
 create_single_source_cgal_program( "dynamic_hull_LCC_3.cpp" )

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 # Creating entries for all C++ files with "main" routine
 # ##########################################################
 
+create_single_source_cgal_program( "is_strongly_convex_3.cpp" )
+
 create_single_source_cgal_program( "dynamic_hull_3.cpp" )
 
 create_single_source_cgal_program( "dynamic_hull_LCC_3.cpp" )

--- a/Convex_hull_3/include/CGAL/convexity_check_3.h
+++ b/Convex_hull_3/include/CGAL/convexity_check_3.h
@@ -195,7 +195,7 @@ bool CGAL_is_strongly_convex_3(const Polyhedron& P, Point_3<R>*)
 template<class Polyhedron>
 bool is_strongly_convex_3(const Polyhedron& P)
 {
-  typedef typename boost::property_map<Polyhedron, vertex_point_t>::type Ppmap;
+  typedef typename boost::property_map<Polyhedron, vertex_point_t>::const_type Ppmap;
   typedef typename boost::property_traits<Ppmap>::value_type Point_3;
 
   return CGAL_is_strongly_convex_3(P, reinterpret_cast<Point_3*>(0));

--- a/Convex_hull_3/include/CGAL/convexity_check_3.h
+++ b/Convex_hull_3/include/CGAL/convexity_check_3.h
@@ -187,13 +187,13 @@ bool is_strongly_convex_3(const Polyhedron& P, const Traits& traits)
 }
 
 template<class Polyhedron, class R>
-bool CGAL_is_strongly_convex_3(Polyhedron& P, Point_3<R>*)
+bool CGAL_is_strongly_convex_3(const Polyhedron& P, Point_3<R>*)
 {
   return is_strongly_convex_3(P, R());
 }
 
 template<class Polyhedron>
-bool is_strongly_convex_3(Polyhedron& P)
+bool is_strongly_convex_3(const Polyhedron& P)
 {
   typedef typename boost::property_map<Polyhedron, vertex_point_t>::type Ppmap;
   typedef typename boost::property_traits<Ppmap>::value_type Point_3;
@@ -204,7 +204,7 @@ bool is_strongly_convex_3(Polyhedron& P)
 template <class ForwardIterator, class Polyhedron, class Traits>
 bool all_points_inside( ForwardIterator first,
                         ForwardIterator last,
-                        Polyhedron& P,
+                        const Polyhedron& P,
                         const Traits&  traits)
 {
   typedef typename Traits::Plane_3                           Plane_3;


### PR DESCRIPTION
##  Summary of Changes

Add `const`  in the signature of several functions.  The problem did not show up in the examples and testsuite as the polyhedron passed to these functions is not const.      It shows up in the example put on [gist.gitub.com](https://gist.github.com/afabri/ec9cb00c0c321d91389649b858576782)

This PR should replace PR #5146

## Release Management

* Affected package(s): Convex_hull_3


