### PR TITLE
Arrangement 2: Enhanced CCB Merging for Surface Sweep

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
@@ -478,7 +478,16 @@ public:
   const Inner_ccb* inner_ccb() const
   {
     CGAL_precondition(is_on_inner_ccb());
-    return (reinterpret_cast<const Inner_ccb*>(_clean_pointer(this->p_comp)));
+
+    const Inner_ccb* out = reinterpret_cast<const Inner_ccb*>(_clean_pointer(this->p_comp));
+    if (out->is_valid())
+      return out;
+    // else
+    while (!out->is_valid())
+      out = out->next();
+    const_cast<Halfedge*>(this)->set_inner_ccb(out);
+
+    return out;
   }
 
   /*! Get an incident inner CCB (non-const version).
@@ -487,11 +496,20 @@ public:
   Inner_ccb* inner_ccb()
   {
     CGAL_precondition(is_on_inner_ccb());
-    return (reinterpret_cast<Inner_ccb*>(_clean_pointer(this->p_comp)));
+
+    Inner_ccb* out = reinterpret_cast<Inner_ccb*>(_clean_pointer(this->p_comp));
+    if (out->is_valid())
+      return out;
+    // else
+    while (!out->is_valid())
+      out = out->next();
+    set_inner_ccb(out);
+
+    return out;
   }
 
   /*! Set the incident inner CCB. */
-  void set_inner_ccb(Inner_ccb *ic)
+  void set_inner_ccb(const Inner_ccb *ic)
   {
     // Set the component pointer and set its LSB.
     this->p_comp = _set_lsb(ic);
@@ -768,18 +786,27 @@ public:
   typedef typename Face::Inner_ccb_iterator  Inner_ccb_iterator;
 
 private:
-  Face* p_f;                  // The face the contains the CCB in its interior.
+  union
+  {
+    Face* f;                  // The face the contains the CCB in its interior.
+    Arr_inner_ccb* icc;       // next inner CCB in chain to valid icc
+  } f_or_icc;
   Inner_ccb_iterator  iter;   // The inner CCB identifier.
-  bool iter_is_not_singular;
+  enum
+  {
+    ITER_IS_SINGULAR,
+    ITER_IS_NOT_SINGULAR,
+    INVALID
+  } status;
 
 public:
   /*! Default constructor. */
-  Arr_inner_ccb() : p_f(nullptr), iter_is_not_singular(false) {}
+  Arr_inner_ccb() : status(ITER_IS_SINGULAR) { f_or_icc.f = nullptr; }
 
   /*! Copy constructor. */
   Arr_inner_ccb(const Arr_inner_ccb& other) :
-    p_f(other.p_f), iter_is_not_singular(other.iter_is_not_singular)
-  { if (other.iter_is_not_singular) iter = other.iter; }
+    f_or_icc(other.f_or_icc), status(other.status)
+  { if (other.status == ITER_IS_NOT_SINGULAR) iter = other.iter; }
 
   /*! Get a halfedge along the component (const version). */
   const Halfedge* halfedge() const { return (*iter); }
@@ -791,33 +818,63 @@ public:
   void set_halfedge(Halfedge *he) { *iter = he; }
 
   /*! Get the incident face (const version). */
-  const Face* face() const { return (p_f); }
+  const Face* face() const
+  {
+    CGAL_assertion (status != INVALID);
+    return f_or_icc.f;
+  }
 
   /*! Get the incident face (non-const version). */
-  Face* face() { return (p_f); }
+  Face* face()
+  {
+    CGAL_assertion (status != INVALID);
+    return f_or_icc.f;
+  }
 
   /*! Set the incident face. */
-  void set_face(Face* f) { p_f = f; }
+  void set_face(Face* f)
+  {
+    CGAL_assertion (status != INVALID);
+    f_or_icc.f = f;
+  }
 
   /*! Get the iterator (const version). */
   Inner_ccb_iterator iterator() const
   {
-    CGAL_assertion(iter_is_not_singular);
+    CGAL_assertion(status == ITER_IS_NOT_SINGULAR);
     return (iter);
   }
 
   /*! Get the iterator (non-const version). */
   Inner_ccb_iterator iterator()
   {
-    CGAL_assertion(iter_is_not_singular);
+    CGAL_assertion(status == ITER_IS_NOT_SINGULAR);
     return (iter);
   }
 
   /*! Set the inner CCB iterator. */
   void set_iterator(Inner_ccb_iterator it)
   {
+    CGAL_assertion (status != INVALID);
     iter = it;
-    iter_is_not_singular = true;
+    status = ITER_IS_NOT_SINGULAR;
+  }
+
+  /*! Check validity */
+  bool is_valid() const { return (status != INVALID); }
+
+  /*! Get the next CCB to primary chain. */
+  Arr_inner_ccb* next() const
+  {
+    CGAL_assertion (status == INVALID);
+    return f_or_icc.icc;
+  }
+
+  /*! Set the next CCB to primary chain. */
+  void set_next(Arr_inner_ccb* next)
+  {
+    status = INVALID;
+    f_or_icc.icc = next;
   }
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
@@ -2741,6 +2741,8 @@ _insert_at_vertices(DHalfedge* he_to,
 
       if (m_sweep_mode)
       {
+        // Inner CCB are obtained using Halfedge::inner_ccb() which
+        // performs path reduction and always return valid iCCB
         CGAL_assertion(ic1->is_valid());
         CGAL_assertion(ic2->is_valid());
         ic2->set_next(ic1);

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
@@ -2739,14 +2739,22 @@ _insert_at_vertices(DHalfedge* he_to,
       he1->set_inner_ccb(ic1);
       he2->set_inner_ccb(ic1);
 
-      // Make all halfedges along ic2 to point to ic1.
-      DHalfedge* curr;
+      if (m_sweep_mode)
+      {
+        CGAL_assertion(ic1->is_valid());
+        CGAL_assertion(ic2->is_valid());
+        ic2->set_next(ic1);
+      }
+      else
+      {
+        // Make all halfedges along ic2 to point to ic1.
+        DHalfedge* curr;
+        for (curr = he2->next(); curr != he1; curr = curr->next())
+          curr->set_inner_ccb(ic1);
 
-      for (curr = he2->next(); curr != he1; curr = curr->next())
-        curr->set_inner_ccb(ic1);
-
-      // Delete the redundant inner CCB.
-      _dcel().delete_inner_ccb(ic2);
+        // Delete the redundant inner CCB.
+        _dcel().delete_inner_ccb(ic2);
+      }
 
       // Notify the observers that we have merged the two inner CCBs.
       _notify_after_merge_inner_ccb(fh, (Halfedge_handle(he1))->ccb());

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_on_surface_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_on_surface_2.h
@@ -1531,7 +1531,7 @@ public:
    * Cleans the inner CCB if sweep mode was used, by removing all
    * non-valid inner CCBs
    */
-  void clean_inner_ccbs()
+  void clean_inner_ccbs_after_sweep()
   {
     for (DHalfedge_iter he = _dcel().halfedges_begin();
          he != _dcel().halfedges_end(); ++ he)
@@ -1543,10 +1543,12 @@ public:
       if (ic1->is_valid())
         continue;
 
+      // Calling Halfedge::inner_ccb() reduces the path and makes the
+      // halfedge point to a correct CCB
       DInner_ccb* ic2 = he->inner_ccb();
-      if (!ic2->halfedge()->is_on_inner_ccb()
-          || ic2->halfedge()->inner_ccb_no_redirect() != ic2)
-        ic2->set_halfedge(&(*he));
+      CGAL_USE(ic2);
+      CGAL_assertion (ic2->halfedge()->is_on_inner_ccb()
+                      && ic2->halfedge()->inner_ccb_no_redirect() == ic2);
     }
 
     typename Dcel::Inner_ccb_iterator it = _dcel().inner_ccbs_begin();

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_construction_ss_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_construction_ss_visitor.h
@@ -281,7 +281,7 @@ void Arr_construction_ss_visitor<Hlpr, Vis>::before_sweep()
 template <typename Hlpr, typename Vis>
 void Arr_construction_ss_visitor<Hlpr, Vis>::after_sweep()
 {
-  m_arr->clean_inner_ccbs();
+  m_arr->clean_inner_ccbs_after_sweep();
   m_arr->set_sweep_mode(false);
 }
 

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_construction_ss_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_construction_ss_visitor.h
@@ -142,6 +142,9 @@ public:
   /* A notification issued before the sweep process starts. */
   inline void before_sweep();
 
+  /* A notification issued after the sweep process stops. */
+  inline void after_sweep();
+
   /*!
    * A notification invoked before the sweep-line starts handling the given
    * event.
@@ -267,7 +270,21 @@ private:
 // Notifies the helper that the sweep process now starts.
 template <typename Hlpr, typename Vis>
 void Arr_construction_ss_visitor<Hlpr, Vis>::before_sweep()
-{ m_helper.before_sweep(); }
+{
+  m_helper.before_sweep();
+  m_arr->set_sweep_mode(true);
+}
+
+
+//-----------------------------------------------------------------------------
+// A notification issued after the sweep process stops.
+template <typename Hlpr, typename Vis>
+void Arr_construction_ss_visitor<Hlpr, Vis>::after_sweep()
+{
+  m_arr->clean_inner_ccbs();
+  m_arr->set_sweep_mode(false);
+}
+
 
 //-----------------------------------------------------------------------------
 // A notification invoked before the sweep-line starts handling the given

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_ss_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_ss_visitor.h
@@ -552,6 +552,8 @@ Arr_overlay_ss_visitor<OvlHlpr, OvlTr, Vis>::update_event(Event* e,
 template <typename OvlHlpr, typename OvlTr, typename Vis>
 void Arr_overlay_ss_visitor<OvlHlpr, OvlTr, Vis>::after_sweep()
 {
+  Base::after_sweep();
+
   // Notify boundary vertices:
   typename Vertex_map::iterator it;
   for (it = m_vertices_map.begin(); it != m_vertices_map.end(); ++it) {


### PR DESCRIPTION
_Release note: (Because 5.0 branch was deleted, [the previous PR](https://github.com/CGAL/cgal/pull/4875) was closed and we can't seem to open it again. Please refer to this PR for previous reviews.)_

## Summary of Changes

This PR replaces https://github.com/CGAL/cgal/pull/4851.

As said in the previous PR, _when merging 2 inner CCBs, all halfedges of one of the CCB are traversed again and updated, which can lead to an explosion of complexity, for example when computing the arrangement of a very large holes with many concavities_.

This new PR uses a similar approach than the previous one (using temporary redirections of inner CCBs towards a valid one and cleaning everything afterwards). The differences are:
- instead of union set, we simply keep, for each inner CCB, a pointer to another CCB: these pointers form chains to a valid CCB. These chains are shortened everytime we access an inner CCB. This is, in a way, a union find in-place. There is no need for a dependency to Union_find anymore
- we use a union of `Face*` / `Inner_ccb*` instead of the current face pointer in the inner CCB class, and we replace a boolean by an enum to determine if the inner CCB is valid (`Face*` is used) or not (it's just a garbage object that chains to a correct one via `Inner_ccb`). This mechanism makes the memory overhead = 0
- the valid inner CCB is always accessed through `Halfedge::inner_ccb()` without having to go through functions of AOS2, which makes the changes far less invasive and ensures we don't break anything (testsuite is fine)
- we use the construction visitor to make sure this mode is only used when sweeping (not when merging manually)

The resulting accelerations are the same (up to 40x faster in master's worst case scenario, 30% in common datasets).

## Release Management

* Affected package(s): `Arrangement_2` + packages that depend on it (Boolean Op, Surface Sweep, etc.)