### PR TITLE
Fix use of uninitialized variable in SM_overlayer.h

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
@@ -2118,7 +2118,7 @@ complete_face_support(SVertex_iterator v_start, SVertex_iterator v_end,
 { CGAL_NEF_TRACEN("complete_face_support");
   for (SVertex_iterator v = v_start; v != v_end; ++v) {
     CGAL_NEF_TRACEN("VERTEX = "<<PH(v));
-    Mark m_buffer[2];
+    Mark m_buffer[2] {};
     SHalfedge_handle e_below = halfedge_below(v);
     if ( v == v_start ) {
       for (int i=0; i<2; ++i){


### PR DESCRIPTION
## Summary of Changes

Fix CWE-457: Use of Uninitialized Variable in SM_overlayer.h

In the function `complete_face_support`, after a number of itterations of ` for (SVertex_iterator v = v_start; v != v_end; ++v) `, `v == v_start` can be false, `e_below != SHalfedge_handle()` can be false, and `!is_isolated(v)` can be false meaning `m_buffer` is uninitalised.

`m_buffer` is then dereferenced in the line:

https://github.com/CGAL/cgal/blob/98fafe4ef186037a8c63c04d041da18f34bbe0b3/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h#L2151 

leading to undefined behaviour.

## Release Management

* Affected package(s): pkg::Nef_S2
* Issue(s) solved (if any): security/bugfix
* License and copyright ownership: Returned to CGAL authors
