### PR TITLE
Installation: Fix in Qt5 module

### DIFF
--- a/GraphicsView/src/CGAL_Qt5/CMakeLists.txt
+++ b/GraphicsView/src/CGAL_Qt5/CMakeLists.txt
@@ -42,14 +42,25 @@ install(
   DESTINATION "${CGAL_INSTALL_INC_DIR}/CGAL/Qt"
   COMPONENT CGAL_Qt5)
 if(CGAL_HEADER_ONLY)
-  install(
-    DIRECTORY "../../demo/resources/"
-    DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/resources"
-    COMPONENT CGAL_Qt5)
-  install(
-    DIRECTORY "../../demo/icons/"
-    DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/icons"
-    COMPONENT CGAL_Qt5)
+  if(EXISTS ${CGAL_MODULES_DIR}/demo/resources)
+    install(
+      DIRECTORY "${CGAL_MODULES_DIR}/demo/resources/"
+      DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/resources"
+      COMPONENT CGAL_Qt5)
+    install(
+      DIRECTORY "${CGAL_MODULES_DIR}/demo/icons/"
+      DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/icons"
+      COMPONENT CGAL_Qt5)
+  else()
+    install(
+      DIRECTORY "../../demo/resources/"
+      DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/resources"
+      COMPONENT CGAL_Qt5)
+    install(
+      DIRECTORY "../../demo/icons/"
+      DESTINATION "${CGAL_INSTALL_CMAKE_DIR}/demo/icons"
+      COMPONENT CGAL_Qt5)
+  endif()
 endif()
 
 message("libCGAL_Qt5 is configured")

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -158,6 +158,8 @@ if(EXISTS ${GIT_REPO}/Maintenance/release_building/public_release_name)
   file(COPY "${GIT_REPO}/Maintenance/release_building/public_release_name"
     DESTINATION "${release_dir}/doc")
 endif()
+file(COPY ${GIT_REPO}/GraphicsView/demo/resources ${GIT_REPO}/GraphicsView/demo/icons
+  DESTINATION "${release_dir}/cmake/modules")
 
 #create VERSION
 file(WRITE ${release_dir}/VERSION "${CGAL_VERSION}")


### PR DESCRIPTION
## Summary of Changes
Check if /demo exists before copying its content.

It might look like I'm only treating a symptom instead of the disease, but this error only seems to occur in the "library" tarball, from which it is impossible to build the demos because they are not included anyway. 
## Release Management

* Affected package(s):Installation, CGAL_Qt5
