### PR TITLE
Fix uninitialized member in iterator.h

### DIFF
--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -205,7 +205,7 @@ private:
 
 public:
   Halfedge_around_source_iterator()
-    : anchor(), pos(), g(0)
+    : anchor(), pos(), g(nullptr), winding(0)
   {}
 
   Halfedge_around_source_iterator(halfedge_descriptor hd, const Graph& g, int n=0)
@@ -305,7 +305,7 @@ private:
 
 public:
   Halfedge_around_target_iterator()
-    : anchor(), pos(), g(0)
+    : anchor(), pos(), g(nullptr), winding(0)
   {}
 
   Halfedge_around_target_iterator(halfedge_descriptor hd, const Graph& g, int n=0)


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (winding) in iterator.h

## Release Management

* Affected package(s): BGL
* Issue(s) solved (if any): fix #5181 
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: returned to cgal authors

