### PR TITLE
Fix uninitialized member in Single_wall_creator.h

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator.h
@@ -74,7 +74,7 @@ class Single_wall_creator : public Modifier_base<typename Nef_::SNC_and_PL> {
 
  public:
   Single_wall_creator(SVertex_handle e, Vector_3 d)
-    : ein(e), dir(d)
+    : ein(e), dir(d), sncp(nullptr), pl(nullptr)
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
     , index1(0), index2(0)
 #endif


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (sncp, pl) in Single_wall_creator.h

## Release Management

* Affected package(s): Convex_decomposition
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors

