### PR TITLE
Fix uninitialized member in Edge_sorter.h

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Edge_sorter.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Edge_sorter.h
@@ -212,7 +212,7 @@ template<typename Nef_, typename FTComparison, typename Container>
   SNC_point_locator* pl;
 
  public:
-  Edge_sorter(Container& cin) : c(cin) {}
+  Edge_sorter(Container& cin) : c(cin), sncp(nullptr), pl(nullptr) {}
 
   void operator()(SNC_and_PL& sncpl) {
     sncp = sncpl.sncp;


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (sncp, pl) in Edge_sorter.h

## Release Management

* Affected package(s): Convex_decomposition
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors