### PR TITLE
Fix uninitialized member in File_writer_OFF.h

### DIFF
--- a/Stream_support/include/CGAL/IO/File_writer_OFF.h
+++ b/Stream_support/include/CGAL/IO/File_writer_OFF.h
@@ -29,8 +29,8 @@ class CGAL_EXPORT File_writer_OFF {
     std::ostream*           m_out;
     File_header_OFF         m_header;
 public:
-    File_writer_OFF( bool verbose = false) : m_header( verbose) {}
-    File_writer_OFF( const File_header_OFF& h) : m_header( h) {}
+    File_writer_OFF( bool verbose = false) : m_out(nullptr), m_header( verbose) {}
+    File_writer_OFF( const File_header_OFF& h) : m_out(nullptr), m_header( h) {}
 
     std::ostream&           out()          { return *m_out;   }
     File_header_OFF&        header()       { return m_header; }


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (m_out) in File_writer_OFF.h

## Release Management

* Affected package(s): Stream_support
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors