### PR TITLE
Fix uninitialized member in File_writer_VRML_2.h

### DIFF
--- a/Stream_support/include/CGAL/IO/File_writer_VRML_2.h
+++ b/Stream_support/include/CGAL/IO/File_writer_VRML_2.h
@@ -27,7 +27,7 @@ class CGAL_EXPORT File_writer_VRML_2 {
     std::ostream*      m_out;
     std::size_t        m_facets;
 public:
-    File_writer_VRML_2() {}
+    File_writer_VRML_2() : m_out(nullptr), m_facets(0) {}
     std::ostream& out() const { return *m_out; }
     void write_header( std::ostream& o,
                        std::size_t vertices,


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (m_out, m_facets) in File_writer_VRML_2.h

## Release Management

* Affected package(s): Stream_support
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors