### PR TITLE
Fix uninitialized member in Gmpfr_type.h

### DIFF
--- a/Number_types/include/CGAL/GMP/Gmpfr_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfr_type.h
@@ -71,7 +71,7 @@ bool operator==(const Gmpfr&,const Gmpz&);
 struct Gmpfr_rep{
         mpfr_t floating_point_number;
         bool clear_on_destruction;
-        Gmpfr_rep():clear_on_destruction(true){}
+        Gmpfr_rep() : floating_point_number{}, clear_on_destruction(true) {}
         ~Gmpfr_rep(){
                 if(clear_on_destruction)
                         mpfr_clear(floating_point_number);


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (floating_point_number) in Gmpfr_type.h

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors