### PR TITLE
Fix uninitialized member in Gmpz_type.h

### DIFF
--- a/Number_types/include/CGAL/GMP/Gmpz_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpz_type.h
@@ -43,7 +43,7 @@ struct Gmpz_rep
 // maybe the mpz_init_set* functions should move back to Gmpz_rep.
 // But then we should use the Storage_traits::construct/get...
 
-  mpz_t mpZ;
+  mpz_t mpZ; /* coverity[member_decl] */
 
   Gmpz_rep() {}
   ~Gmpz_rep() { mpz_clear(mpZ); }


### PR DESCRIPTION
## Summary of Changes

Fix warning about uninitialized member (mpZ) in Gmpz_type.h

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors