### PR TITLE
Fix uninitialized member in Mpzf.h

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -253,15 +253,21 @@ struct Mpzf {
   typedef Mpzf_impl::no_pool<mp_limb_t*,Mpzf> pool;
 //#endif
 
-  mp_limb_t* data_; /* data_[0] is never 0 (except possibly for 0). */
+  /* data_[0] is never 0 (except possibly for 0). */
+  mp_limb_t* data_; /* coverity[member_decl] */
+
   inline mp_limb_t*& data() { return data_; }
   inline mp_limb_t const* data() const { return data_; }
 
 #ifdef CGAL_MPZF_USE_CACHE
   mp_limb_t cache[cache_size + 1];
 #endif
-  int size; /* Number of relevant limbs in data_. */
-  int exp; /* The number is data_ (an integer) * 2 ^ (64 * exp). */
+  /* Number of relevant limbs in data_. */
+  int size; /* coverity[member_decl] */
+
+  /* The number is data_ (an integer) * 2 ^ (64 * exp). */
+  int exp; /* coverity[member_decl] */
+
   typedef int Exponent_type;
   typedef int Size_type;
 
@@ -300,6 +306,8 @@ struct Mpzf {
     pool::push(data());
   }
 
+  // These constructors intentionally
+  // don't initialize any members
   Mpzf(noalloc){}
   Mpzf(allocate,int i) { init(i); }
 


### PR DESCRIPTION
## Summary of Changes

Fix warnings about uninitialized members (data_, size, exp) in Mpzf.h

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors