### PR TITLE
Fix uninitialized member in Polyhedron_incremental_builder_3.h

### DIFF
--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -187,7 +187,12 @@ public:
         // internal state. The previous polyhedral surface in `h'
         // remains unchanged. The incremental builder adds the new
         // polyhedral surface to the old one.
-      : m_error( false), m_verbose( verbose), hds(h) {
+      : m_error( false), m_verbose( verbose), hds(h),
+        rollback_v(0), rollback_f(0), rollback_h(0),
+        new_vertices(0), new_faces(0), w1(0), w2(0),
+        v1(0), first_vertex(false), last_vertex(false),
+        new_halfedges(0)
+    {
         CGAL_assertion_code(check_protocoll = 0;)
     }
 


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members ( rollback_v, rollback_f, rollback_h, new_vertices, new_faces, w1, w2, v1, first_vertex, last_vertex, new_halfedges) in Polyhedron_incremental_builder_3.h

## Release Management

* Affected package(s): Polyhedron
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors