### PR TITLE
Fix uninitialized members in Ray_hit_generator2.h

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
@@ -69,7 +69,8 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
   bool vertex_added;
 
  public:
-  Ray_hit_generator2(Vector_3 d, Vertex_handle v) : dir(d), vs(v) {}
+  Ray_hit_generator2(Vector_3 d, Vertex_handle v)
+    : dir(d), vs(v), sncp(nullptr), pl(nullptr), edge_splitted(false), vertex_added(false) {}
 
   Vertex_handle create_vertex_on_first_hit(const Ray_3& r) {
 


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (sncp, pl, edge_splitted, vertex_added) in Ray_hit_generator2.h

## Release Management

* Affected package(s): Convex_decomposition_3
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors