### PR TITLE
Fix uninitialized member in Segment_2_Segment_2.h

### DIFF
--- a/Intersections_2/include/CGAL/Intersections_2/Segment_2_Segment_2.h
+++ b/Intersections_2/include/CGAL/Intersections_2/Segment_2_Segment_2.h
@@ -274,10 +274,10 @@ do_intersect(const typename K::Segment_2 &seg1,
 template <class K>
 class Segment_2_Segment_2_pair {
 public:
-    enum Intersection_results {NOT_COMPUTED_YET, NO_INTERSECTION, POINT, SEGMENT};
+    enum Intersection_results {NO_INTERSECTION, POINT, SEGMENT, UNKNOWN};
     Segment_2_Segment_2_pair(typename K::Segment_2 const *seg1,
                             typename K::Segment_2 const *seg2)
-            : _seg1(seg1), _seg2(seg2), _known(false), _result(NOT_COMPUTED_YET) {}
+            : _seg1(seg1), _seg2(seg2), _known(false), _result(UNKNOWN) {}
 
     Intersection_results intersection_type() const;
 

--- a/Intersections_2/include/CGAL/Intersections_2/Segment_2_Segment_2.h
+++ b/Intersections_2/include/CGAL/Intersections_2/Segment_2_Segment_2.h
@@ -274,10 +274,10 @@ do_intersect(const typename K::Segment_2 &seg1,
 template <class K>
 class Segment_2_Segment_2_pair {
 public:
-    enum Intersection_results {NO_INTERSECTION, POINT, SEGMENT};
+    enum Intersection_results {NOT_COMPUTED_YET, NO_INTERSECTION, POINT, SEGMENT};
     Segment_2_Segment_2_pair(typename K::Segment_2 const *seg1,
                             typename K::Segment_2 const *seg2)
-            : _seg1(seg1), _seg2(seg2), _known(false) {}
+            : _seg1(seg1), _seg2(seg2), _known(false), _result(NOT_COMPUTED_YET) {}
 
     Intersection_results intersection_type() const;
 


### PR DESCRIPTION
## Summary of Changes

Added NOT_COMPUTED_YET to enum (similar enum member is present in Line_2_Line_2.h)

Fix uninitialized member  (_result) in Segment_2_Segment_2.h

## Release Management

* Affected package(s): Intersections_2
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors