### PR TITLE
Fix uninitialized member in Straight_skeleton_builder_events_2.h

### DIFF
--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_events_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_events_2.h
@@ -54,6 +54,7 @@ public:
     :
      mTriedge   (aTriedge)
     ,mTrisegment(aTrisegment)
+    ,mTime{}
   {}
 
   virtual ~ Event_2() {}


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (mTime) in Straight_skeleton_builder_events_2.h

## Release Management

* Affected package(s): Straight_skeleton
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors