### PR TITLE
Fix uninitialized member in Triangulation_ds_iterators_3.h

### DIFF
--- a/TDS_3/include/CGAL/internal/Triangulation_ds_iterators_3.h
+++ b/TDS_3/include/CGAL/internal/Triangulation_ds_iterators_3.h
@@ -40,6 +40,7 @@ public:
   typedef typename Tds::Cell_iterator            Cell_iterator;
 
   Triangulation_ds_facet_iterator_3()
+    : _tds(nullptr)
     {}
 
   Triangulation_ds_facet_iterator_3(const Tds * tds)


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (_tds) in Triangulation_ds_iterators_3.h

## Release Management

* Affected package(s): TDS_3
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors