### PR TITLE
Fix uninitialized member in Triangulation_vertex_base_with_info_2.h

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_vertex_base_with_info_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_vertex_base_with_info_2.h
@@ -39,16 +39,16 @@ public:
   };
 
   Triangulation_vertex_base_with_info_2()
-    : Vb() {}
+    : Vb(), _info{} {}
 
   Triangulation_vertex_base_with_info_2(const Point & p)
-    : Vb(p) {}
+    : Vb(p), _info{} {}
 
   Triangulation_vertex_base_with_info_2(const Point & p, Face_handle c)
-    : Vb(p, c) {}
+    : Vb(p, c), _info{} {}
 
   Triangulation_vertex_base_with_info_2(Face_handle c)
-    : Vb(c) {}
+    : Vb(c), _info{} {}
 
   const Info& info() const { return _info; }
   Info&       info()       { return _info; }


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (_info) in Triangulation_vertex_base_with_info_2.h

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors