### PR TITLE
Fix uninitialized member in Triangulation_line_face_circulator.h

### DIFF
--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Triangulation_line_face_circulator_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Triangulation_line_face_circulator_2.h
@@ -148,7 +148,7 @@ Triangulation_line_face_circulator_2<Triangulation>::
 Triangulation_line_face_circulator_2(Vertex_handle v,
                                      const Triangulation* tr,
                                      const Point& dir)
-  :pos(), _tr(tr), s(undefined)
+  :pos(), _tr(tr), s(undefined), i(-1)
   // begin at the face incident to v, traversed by the ray from v to
   // dir
   // or null iterator


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (i) in Triangulation_line_face_circulator.h
Note: `i` is set to `-1` in other constructors.

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors