### PR TITLE
Fix uninitialized member in Triangulation_3.h

### DIFF
--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -447,7 +447,8 @@ private:
     const Self *t;
 
   public:
-    Infinite_tester() {}
+    Infinite_tester()
+      : t(nullptr) {}
 
     Infinite_tester(const Self *tr)
       : t(tr) {}


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (t) in Triangulation_3.h

## Release Management

* Affected package(s): Triangulation_3
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors