### PR TITLE
Fix uninitialized member in Volume.h

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Volume.h
+++ b/Nef_3/include/CGAL/Nef_3/Volume.h
@@ -47,7 +47,7 @@ class Volume_base  {
 
  public:
 
-  Volume_base() {}
+  Volume_base() : mark_{} {}
 
   Volume_base(Mark m) : mark_(m) {}
 


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (mark_) in Volume.h

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors