### PR TITLE
Fix uninitialized member in SNC_io_parser.h

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
@@ -1090,7 +1090,10 @@ public:
 
 template <typename EW>
 SNC_io_parser<EW>::SNC_io_parser(std::istream& is, SNC_structure& W) :
-  Base(W), in(is), out(std::cout) {
+  Base(W), in(is), out(std::cout),
+  reduce(false), sorted(false), addInfiBox(false),
+  i(0), vn(0), en(0), fn(0), cn(0), sen(0), sln(0), sfn(0)
+{
   W.clear();
   CGAL_assertion(W.is_empty());
   verbose = false;
@@ -1101,11 +1104,13 @@ template <typename EW>
 SNC_io_parser<EW>::SNC_io_parser(std::ostream& os, SNC_structure& W,
                                  bool sort, bool reduce_) :
   Base(W), in(std::cin), out(os),
+  addInfiBox(false),
   FI(W.halffacets_begin(),W.halffacets_end(),'F'),
   CI(W.volumes_begin(),W.volumes_end(),'C'),
   SEI(W.shalfedges_begin(),W.shalfedges_end(),'e'),
   SLI(W.shalfloops_begin(),W.shalfloops_end(),'l'),
   SFI(W.sfaces_begin(),W.sfaces_end(),'f'),
+  i(0),
   vn(W.number_of_vertices()),
   en(W.number_of_halfedges()),
   fn(W.number_of_halffacets()),


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (reduce, sorted, addInfiBox, i, vn, en, fn, cn, sen, sln, sfn) in SNC_io_parser.h

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors