### PR TITLE
Fix uninitialized members in utility.h

### DIFF
--- a/STL_Extension/include/CGAL/utility.h
+++ b/STL_Extension/include/CGAL/utility.h
@@ -89,7 +89,9 @@ public:
   T2 second;
   T3 third;
 
-  Triple() {}
+  Triple()
+  : first{}, second{}, third{}
+  {}
 
   Triple(const T1& a, const T2& b, const T3& c)
   : first(a), second(b), third(c)


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized members (first, second, third) in utility.h

## Release Management

* Affected package(s): STL_Extension
* Issue(s) solved (if any): fix #5181
* License and copyright ownership: Returned to CGAL authors