### PR TITLE
Shape_detection: Fix warnings.

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
@@ -142,7 +142,7 @@ namespace Shape_detection {
           continue;
 
         CGAL_precondition(
-          seed_index >= 0 && seed_index < m_input_range.size());
+          seed_index < m_input_range.size());
 
         // Try to grow a new region from the index of the seed item.
         if (!m_visited[seed_index]) {
@@ -187,7 +187,7 @@ namespace Shape_detection {
           continue;
 
         CGAL_precondition(
-          seed_index >= 0 && seed_index < m_input_range.size());
+          seed_index < m_input_range.size());
 
         if (!m_visited[seed_index])
           *(output++) = seed_index;
@@ -251,7 +251,7 @@ namespace Shape_detection {
             continue;
 
           CGAL_precondition(
-            neighbor_index >= 0 && neighbor_index < m_input_range.size());
+            neighbor_index < m_input_range.size());
 
           if (!m_visited[neighbor_index] &&
             m_region_type.is_part_of_region(item_index, neighbor_index, region)) {

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/Least_squares_plane_fit_region.h
@@ -200,7 +200,6 @@ namespace Polygon_mesh {
       const std::size_t query_index,
       const std::vector<std::size_t>&) const {
 
-      CGAL_precondition(query_index >= 0);
       CGAL_precondition(query_index < m_face_range.size());
 
       const auto face = *(m_face_range.begin() + query_index);
@@ -252,7 +251,6 @@ namespace Polygon_mesh {
       CGAL_precondition(region.size() > 0);
       if (region.size() == 1) { // create new reference plane and normal
 
-        CGAL_precondition(region[0] >= 0);
         CGAL_precondition(region[0] < m_face_range.size());
 
         // The best fit plane will be a plane through this face centroid with
@@ -271,7 +269,6 @@ namespace Polygon_mesh {
         std::vector<Local_point_3> points;
         for (std::size_t i = 0; i < region.size(); ++i) {
 
-          CGAL_precondition(region[i] >= 0);
           CGAL_precondition(region[i] < m_face_range.size());
 
           const auto face = *(m_face_range.begin() + region[i]);

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/One_ring_neighbor_query.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing_on_polygon_mesh/One_ring_neighbor_query.h
@@ -113,7 +113,6 @@ namespace Polygon_mesh {
 
       neighbors.clear();
 
-      CGAL_precondition(query_index >= 0);
       CGAL_precondition(query_index < m_face_range.size());
 
       const auto query_face = *(m_face_range.begin() + query_index);

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
@@ -88,8 +88,8 @@ namespace internal {
 
     bool operator()(const std::size_t i, const std::size_t j) const {
 
-      CGAL_precondition(i >= 0 && i < m_scores.size());
-      CGAL_precondition(j >= 0 && j < m_scores.size());
+      CGAL_precondition(i < m_scores.size());
+      CGAL_precondition(j < m_scores.size());
 
       return m_scores[i] > m_scores[j];
     }
@@ -129,7 +129,6 @@ namespace internal {
       points.clear();
       for (std::size_t i = 0; i < region.size(); ++i) {
 
-        CGAL_precondition(region[i] >= 0);
         CGAL_precondition(region[i] < input_range.size());
 
         const auto& key = *(input_range.begin() + region[i]);


### PR DESCRIPTION
## Summary of Changes

At several places, there are tests for positiveness of  `std::size_t`s. I removed them in this PR to silence related warnings.
## Release Management

* Affected package(s):Shape_detection
