### PR TITLE
Mesh_3 global optimizers - improve projection to surface

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -3441,6 +3441,8 @@ get_least_square_surface_plane(const Vertex_handle& v,
 
   // Get adjacent surface points
   std::vector<Bare_point> surface_point_vector;
+  std::vector<typename C3T3::Triangulation::Triangle> triangles;
+
   typename Facet_vector::iterator fit = facets.begin(), fend = facets.end();
   for ( ; fit != fend; ++fit )
   {
@@ -3460,6 +3462,8 @@ get_least_square_surface_plane(const Vertex_handle& v,
       const Bare_point& bp = tr_.get_closest_point(cp(position),
                                                    cell->get_facet_surface_center(i));
       surface_point_vector.push_back(bp);
+
+      triangles.push_back(c3t3_.triangulation().triangle(*fit));
     }
   }
 
@@ -3470,11 +3474,19 @@ get_least_square_surface_plane(const Vertex_handle& v,
   // Compute least square fitting plane
   Plane_3 plane;
   Bare_point point;
-  CGAL::linear_least_squares_fitting_3(surface_point_vector.begin(),
-                                       surface_point_vector.end(),
+//  CGAL::linear_least_squares_fitting_3(surface_point_vector.begin(),
+//                                       surface_point_vector.end(),
+//                                       plane,
+//                                       point,
+//                                       Dimension_tag<0>(),
+//                                       tr_.geom_traits(),
+//                                       Default_diagonalize_traits<FT, 3>());
+
+  CGAL::linear_least_squares_fitting_3(triangles.begin(),
+                                       triangles.end(),
                                        plane,
                                        point,
-                                       Dimension_tag<0>(),
+                                       Dimension_tag<2>(),
                                        tr_.geom_traits(),
                                        Default_diagonalize_traits<FT, 3>());
 

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -3420,6 +3420,7 @@ get_least_square_surface_plane(const Vertex_handle& v,
                                Bare_point& reference_point,
                                Surface_patch_index patch_index) const
 {
+  typedef typename C3T3::Triangulation::Triangle Triangle;
   typename Gt::Construct_point_3 cp = tr_.geom_traits().construct_point_3_object();
 
   // Get incident facets
@@ -3440,47 +3441,40 @@ get_least_square_surface_plane(const Vertex_handle& v,
   const Weighted_point& position = tr_.point(v);
 
   // Get adjacent surface points
-  std::vector<Bare_point> surface_point_vector;
-  std::vector<typename C3T3::Triangulation::Triangle> triangles;
+  std::vector<Triangle> triangles;
+  typename C3T3::Facet ref_facet;
 
-  typename Facet_vector::iterator fit = facets.begin(), fend = facets.end();
-  for ( ; fit != fend; ++fit )
+  for (typename C3T3::Facet f : facets)
   {
-    if ( c3t3_.is_in_complex(*fit) &&
+    if ( c3t3_.is_in_complex(f) &&
          (patch_index == Surface_patch_index() ||
-          c3t3_.surface_patch_index(*fit) == patch_index) )
+          c3t3_.surface_patch_index(f) == patch_index) )
     {
-      const Cell_handle cell = fit->first;
-      const int i = fit->second;
+      ref_facet = f;
+
+      const Cell_handle cell = f.first;
+      const int i = f.second;
 
       // In the case of a periodic triangulation, the incident facets of a point
       // do not necessarily have the same offsets. Worse, the surface centers
       // might not have the same offset as their facet. Thus, no solution except
-      // calling a function 'get_closest_point(p, q)' that simply returns q
+      // calling a function 'get_closest_triangle(p, t)' that simply returns t
       // for a non-periodic triangulation, and checks all possible offsets for
       // periodic triangulations
-      const Bare_point& bp = tr_.get_closest_point(cp(position),
-                                                   cell->get_facet_surface_center(i));
-      surface_point_vector.push_back(bp);
 
-      triangles.push_back(c3t3_.triangulation().triangle(*fit));
+      Triangle t = c3t3_.triangulation().triangle(f);
+      Triangle ct = tr_.get_closest_triangle(cp(position), t);
+      triangles.push_back(ct);
     }
   }
 
   // In some cases point is not a real surface point
-  if ( surface_point_vector.empty() )
+  if ( triangles.empty() )
     return boost::none;
 
   // Compute least square fitting plane
   Plane_3 plane;
   Bare_point point;
-//  CGAL::linear_least_squares_fitting_3(surface_point_vector.begin(),
-//                                       surface_point_vector.end(),
-//                                       plane,
-//                                       point,
-//                                       Dimension_tag<0>(),
-//                                       tr_.geom_traits(),
-//                                       Default_diagonalize_traits<FT, 3>());
 
   CGAL::linear_least_squares_fitting_3(triangles.begin(),
                                        triangles.end(),
@@ -3490,7 +3484,7 @@ get_least_square_surface_plane(const Vertex_handle& v,
                                        tr_.geom_traits(),
                                        Default_diagonalize_traits<FT, 3>());
 
-  reference_point = surface_point_vector.front();
+  reference_point = ref_facet.first->get_facet_surface_center(ref_facet.second);
 
   return plane;
 }

--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -3452,9 +3452,6 @@ get_least_square_surface_plane(const Vertex_handle& v,
     {
       ref_facet = f;
 
-      const Cell_handle cell = f.first;
-      const int i = f.second;
-
       // In the case of a periodic triangulation, the incident facets of a point
       // do not necessarily have the same offsets. Worse, the surface centers
       // might not have the same offset as their facet. Thus, no solution except

--- a/Mesh_3/include/CGAL/Mesh_3/Lloyd_move.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Lloyd_move.h
@@ -551,7 +551,6 @@ private:
 
     Cell_circulator current_cell = tr.incident_cells(edge);
     Cell_circulator done = current_cell;
-    CGAL_assertion(c3t3.is_in_complex(current_cell));
 
     // a & b are fixed points
     const Weighted_point& wa = tr.point(v);
@@ -561,7 +560,6 @@ private:
     const Weighted_point& a_b = tr.point(current_cell, current_cell->index(v));
     Vector_3 ba = Vector_3(cp(a_b), b);
     ++current_cell;
-    CGAL_assertion(c3t3.is_in_complex(current_cell));
     CGAL_assertion(current_cell != done);
 
     // c & d are moving points
@@ -573,7 +571,6 @@ private:
 
     while ( current_cell != done )
     {
-      CGAL_assertion(c3t3.is_in_complex(current_cell));
       Bare_point d = tr.dual(current_cell);
       const Weighted_point& a_d = tr.point(current_cell, current_cell->index(v));
       Vector_3 da = Vector_3(cp(a_d), d);

--- a/Mesh_3/include/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_triangulation_3.h
@@ -78,12 +78,12 @@ public:
   // possibilities). To allow Periodic_3_mesh_3 to use Mesh_3's files,
   // each mesh triangulation implements its own version.
 
-  Bare_point get_closest_point(const Bare_point& /*p*/, const Bare_point& q) const
+  const Bare_point& get_closest_point(const Bare_point& /*p*/, const Bare_point& q) const
   {
     return q;
   }
 
-  Triangle get_closest_triangle(const Bare_point& /*p*/, const Triangle& t) const
+  const Triangle& get_closest_triangle(const Bare_point& /*p*/, const Triangle& t) const
   {
     return t;
   }

--- a/Mesh_3/include/CGAL/Mesh_triangulation_3.h
+++ b/Mesh_3/include/CGAL/Mesh_triangulation_3.h
@@ -59,6 +59,7 @@ public:
   typedef typename Geom_traits::FT                            FT;
   typedef typename Base::Bare_point                           Bare_point;
   typedef typename Base::Weighted_point                       Weighted_point;
+  typedef typename Base::Triangle                             Triangle;
 
   typedef typename Base::Vertex_handle                        Vertex_handle;
   typedef typename Base::Cell_handle                          Cell_handle;
@@ -80,6 +81,11 @@ public:
   Bare_point get_closest_point(const Bare_point& /*p*/, const Bare_point& q) const
   {
     return q;
+  }
+
+  Triangle get_closest_triangle(const Bare_point& /*p*/, const Triangle& t) const
+  {
+    return t;
   }
 
   void set_point(const Vertex_handle v,

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
@@ -502,17 +502,14 @@ public:
             construct_point(std::make_pair(ct[1], Offset(i - 1, j - 1, k - 1))),
             construct_point(std::make_pair(ct[2], Offset(i - 1, j - 1, k - 1))));
 
-          for(int v = 0; v < 3; ++v) {//vertices
-            const Bare_point& ttv = tt[v];
-            const FT sq_dist = csd(p, ttv);
+          const FT sq_dist = csd(p, tt);
 
-            if(sq_dist == FT(0))
-              return rt;
+          if(sq_dist == FT(0))
+            return rt;
 
-            if(sq_dist < min_sq_dist) {
-              rt = tt;
-              min_sq_dist = sq_dist;
-            }
+          if(sq_dist < min_sq_dist) {
+            rt = tt;
+            min_sq_dist = sq_dist;
           }
         }
       }

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
@@ -471,6 +471,42 @@ public:
     return cwp(get_closest_point(cp(wp), cp(wq)), cw(wq));
   }
 
+  Triangle get_closest_triangle(const Bare_point& p, const Triangle& t) const
+  {
+    Triangle rt;
+    const std::array<Bare_point, 3> ct = { canonicalize_point(t[0]),
+                                           canonicalize_point(t[1]),
+                                           canonicalize_point(t[2]) };
+    FT min_sq_dist = std::numeric_limits<FT>::infinity();
+
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+
+          const Triangle tt(
+            construct_point(std::make_pair(ct[0], Offset(i - 1, j - 1, k - 1))),
+            construct_point(std::make_pair(ct[1], Offset(i - 1, j - 1, k - 1))),
+            construct_point(std::make_pair(ct[2], Offset(i - 1, j - 1, k - 1))));
+
+          for (int v = 0; v < 3; ++v) {//vertices
+            const Bare_point ttv = tt[v];
+            FT sq_dist = geom_traits().compute_squared_distance_3_object()(p, ttv);
+
+            if (sq_dist < min_sq_dist)
+            {
+              rt = tt;
+              min_sq_dist = sq_dist;
+            }
+            if(min_sq_dist == 0.)
+              return rt;
+          }
+        }
+      }
+    }
+
+    return rt;
+  }
+
   // Warning: This is a periodic version that computes the smallest possible
   // distances between p and q, and between p and r FOR ALL POSSIBLE OFFSETS
   // before comparing these distances.

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
@@ -444,10 +444,10 @@ public:
     const Bare_point cq = canonicalize_point(q);
     FT min_sq_dist = std::numeric_limits<FT>::infinity();
 
-    for(int i = 0; i < 3; ++i) {
-      for(int j = 0; j < 3; ++j) {
-        for(int k = 0; k < 3; ++k) {
-          const Bare_point tcq = construct_point(std::make_pair(cq, Offset(i-1, j-1, k-1)));
+    for(int i = -1; i < 2; ++i) {
+      for(int j = -1; j < 2; ++j) {
+        for(int k = -1; k < 2; ++k) {
+          const Bare_point tcq = construct_point(std::make_pair(cq, Offset(i, j, k)));
           FT sq_dist = geom_traits().compute_squared_distance_3_object()(p, tcq);
 
           if(sq_dist < min_sq_dist)
@@ -473,34 +473,29 @@ public:
 
   Triangle get_closest_triangle(const Bare_point& p, const Triangle& t) const
   {
-    typename Geom_traits::Less_xyz_3 less = geom_traits().less_xyz_3_object();
     typename Geom_traits::Construct_vector_3 cv = geom_traits().construct_vector_3_object();
     typename Geom_traits::Construct_translated_point_3 tr = geom_traits().construct_translated_point_3_object();
     typename Geom_traits::Compute_squared_distance_3 csd = geom_traits().compute_squared_distance_3_object();
 
-    //canonicalize t
-    std::size_t min_p_id = 0;
-    if(less(t[1], t[min_p_id]))
-      min_p_id = 1;
-    if(less(t[2], t[min_p_id]))
-      min_p_id = 2;
-
-    Bare_point canon_min_p = canonicalize_point(t[min_p_id]);
-    Vector_3 move_to_canonical = cv(t[min_p_id], canon_min_p);
-    const std::array<Bare_point, 3> ct = { (min_p_id == 0) ? canon_min_p : tr(t[0], move_to_canonical),
-                                           (min_p_id == 1) ? canon_min_p : tr(t[1], move_to_canonical),
-                                           (min_p_id == 2) ? canon_min_p : tr(t[2], move_to_canonical) };
+    // It doesn't matter which point we use to canonicalize the triangle as P3M3 is necessarily
+    // in one cover and we have to look at all the neighboring copies anyway since we do not
+    // have control of 'p'.
+    Bare_point canon_p0 = canonicalize_point(t[0]);
+    Vector_3 move_to_canonical = cv(t[0], canon_p0);
+    const std::array<Bare_point, 3> ct = { canon_p0,
+                                           tr(t[1], move_to_canonical),
+                                           tr(t[2], move_to_canonical) };
 
     FT min_sq_dist = std::numeric_limits<FT>::infinity();
     Triangle rt;
-    for(int i = 0; i < 3; ++i) {
-      for(int j = 0; j < 3; ++j) {
-        for(int k = 0; k < 3; ++k) {
+    for(int i = -1; i < 2; ++i) {
+      for(int j = -1; j < 2; ++j) {
+        for(int k = -1; k < 2; ++k) {
 
           const Triangle tt(
-            construct_point(std::make_pair(ct[0], Offset(i - 1, j - 1, k - 1))),
-            construct_point(std::make_pair(ct[1], Offset(i - 1, j - 1, k - 1))),
-            construct_point(std::make_pair(ct[2], Offset(i - 1, j - 1, k - 1))));
+            construct_point(std::make_pair(ct[0], Offset(i, j, k))),
+            construct_point(std::make_pair(ct[1], Offset(i, j, k))),
+            construct_point(std::make_pair(ct[2], Offset(i, j, k))));
 
           const FT sq_dist = csd(p, tt);
 

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_triangulation_3.h
@@ -473,12 +473,22 @@ public:
 
   Triangle get_closest_triangle(const Bare_point& p, const Triangle& t) const
   {
-    Triangle rt;
-    const std::array<Bare_point, 3> ct = { canonicalize_point(t[0]),
-                                           canonicalize_point(t[1]),
-                                           canonicalize_point(t[2]) };
-    FT min_sq_dist = std::numeric_limits<FT>::infinity();
+    //canonicalize t
+    Bare_point min_p = t[0];
+    if (t[1] < min_p) {
+      min_p = t[1];
+    }
+    if (t[2] < min_p) {
+      min_p = t[2];
+    }
 
+    Vector_3 move_to_canonical(min_p, canonicalize_point(min_p));
+    const std::array<Bare_point, 3> ct = { t[0] + move_to_canonical,
+                                           t[1] + move_to_canonical,
+                                           t[2] + move_to_canonical };
+
+    FT min_sq_dist = std::numeric_limits<FT>::infinity();
+    Triangle rt;
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
         for (int k = 0; k < 3; ++k) {


### PR DESCRIPTION
When global optimizers (ODT or Lloyd) of Mesh_3 compute moves for surface vertices (`v` has dimension 2), the move is computed as follows :
- compute the 3D move of `v`, taking its incident inside cells into account,
- project the resulting point to the surface to which `v` belongs. 

The projection uses the normal to a plane estimated by PCA, using as input the **surface Delaunay balls centers** of the surface facets incident to `v`.
If the projection is not precise enough, it can happen that the projected point is moved _inside_ a protecting ball, though it should not.

It turns out that using a plane estimated by PCA, using as input the **facets** incident to `v` themselves (triangles) is more accurate, provide a better projection vector, and avoid projection inside a protecting ball.

## Summary of Changes

Change `CGAL::linear_least_squares_fitting_3(points)` to `CGAL::linear_least_squares_fitting_3(triangles)` for projection of surface points, in global optimizers.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

@MaelRL can you please help me find what needs to be changed in/for Periodic_3_Mesh_3?