### PR TITLE
Force pyquery 1.4.1

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           set -x
           sudo apt-get update && sudo apt-get install -y graphviz ssh bibtex2html
-          sudo pip install lxml pyquery
+          sudo pip install lxml 
+          sudo pip install 'pyquery==1.4.1' # it seems to be the last py2 compatible version
           wget --no-verbose -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen/build_1_8_13/bin/doxygen
           sudo mv doxygen_exe /usr/bin/doxygen
           sudo chmod +x /usr/bin/doxygen


### PR DESCRIPTION
## Summary of Changes
The last pyquery version to be compatible with python 2, which we still use in outr scripts, is 1.4.1. 
## Release Management

* Affected package(s):CI