### PR TITLE
Fix dead code warning in Mpzf.h

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -281,7 +281,9 @@ struct Mpzf {
       if(data()[-1] >= mini) return; // TODO: when mini==2, no need to check
       delete[] (data() - (pool::extra+1)); // too small, useless
     }
+#ifndef CGAL_MPZF_USE_CACHE
     if(mini<2) mini=2;
+#endif
     data() = (new mp_limb_t[mini+(pool::extra+1)]) + (pool::extra+1);
     data()[-1] = mini;
   }


### PR DESCRIPTION
## Summary of Changes

In the following code the `if mini <= cache_size` statement, where cache_size is defined as 8 the only way it can reach the code after the If body, is when mini is > 8, this means that the later check `if(mini < 2)` is always false.
 
https://github.com/CGAL/cgal/blob/97123fc3c725d2d9d489d7c70d88f3b1af5c572d/Number_types/include/CGAL/Mpzf.h#L272-L285

This commit just adds an  `#ifndef CGAL_MPZF_USE_CACHE` around the second if, since its only relevant when not using the cache. This wards off the error in static code analysis.

## Release Management

* Affected package(s): Number_types
* Feature/Small Feature (if any): small/bugfix
* License and copyright ownership: Returned to CGAL authors.

