### PR TITLE
Fix dereference after null check in Nef_3/Vertex.h

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -343,7 +343,7 @@ class Vertex_base {
         valid = valid && (sfaces_last_  != nullptr && sfaces_last_  != SFace_iterator());
         valid = valid && (shalfloop_ != nullptr && shalfloop_ != SHalfloop_iterator());
 
-        if(shalfedges_begin_ == sncp()->shalfedges_end()) {         // point in volume or on plane, which is either isolated or has one outgoing edge
+        if(valid && shalfedges_begin_ == sncp()->shalfedges_end()) {         // point in volume or on plane, which is either isolated or has one outgoing edge
           if(shalfloop_ != sncp()->shalfloops_end())
             valid = valid && (++SFace_const_iterator(sfaces_begin_) == sfaces_last_);
           else


### PR DESCRIPTION
## Summary of Changes

In the following code `sncp_` is checked for a null pointer, implying that it can be null, however later on the code calls `sncp()` which dereferences `sncp_` without checking for null.

https://github.com/CGAL/cgal/blob/077937383555a61e5b23460fc21cf75f3f005018/Nef_3/include/CGAL/Nef_3/Vertex.h#L337-L346

Simply adding a check for `valid` to the if ensures no fault in this scenario.

## Release Management

* Affected package(s): Nef_3
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

