### PR TITLE
Double defined ID seg_coord_global

### DIFF
--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Segment_coordinates_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Segment_coordinates_2.h
@@ -199,10 +199,10 @@ private:
 // Global functions
 
 /*!
-   \anchor seg_coord_global
  * \relates Segment_coordinates_2
  * This is a global function that takes both vertices of a segment and computes segment coordinates at a given query point with respect to these vertices.
 
+   \anchor seg_coord_global
 \tparam Traits must be a model of the concept `BarycentricTraits_2`.
 
 */


### PR DESCRIPTION
It is better to define the anchor in the detailed section of a method as when it is in the brief description it will be shown in the overview of the functions (top of the page) and in the detailed description.
This is due to the `REPEAT_BRIE=YES` setting.

See pages: Barycentric_coordinates_2/classCGAL_1_1Barycentric__coordinates_1_1Segment__coordinates__2.html and Barycentric_coordinates_2/index.html


