### PR TITLE
Typo in list of documentation typedefs

### DIFF
--- a/Shape_detection/doc/Shape_detection/Concepts/EfficientRANSACTraits.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/EfficientRANSACTraits.h
@@ -38,7 +38,7 @@ public:
   /// The circle type, only required if you want to detect tori
   typedef unspecified_type Circle_2;
   /// The 2D vector type, only required if you want to detect tori
-  typedef unspecified_type Vector_3;
+  typedef unspecified_type Vector_2;
 
   /// The number type of the Cartesian coordinates of types Point_3
   typedef unspecified_type FT;


### PR DESCRIPTION
I get a double defined ID (when running xmllint on the output) regarding the Vector_3 typedef.
In my opinion the second definition should be Vector_2 and not Vector_3.

