### PR TITLE
Mesh_3: Fix std::atomic wrong function 

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_surface_cell_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_surface_cell_base_3.h
@@ -97,7 +97,7 @@ public:
   {
     CGAL_precondition(facet>=0 && facet<4);
     char current_bits = bits_;
-    while (bits_.compare_and_swap(current_bits | (1 << facet), current_bits) != current_bits)
+    while (bits_.compare_exchange_weak(current_bits, current_bits | (1 << facet)) )
     {
       current_bits = bits_;
     }
@@ -108,7 +108,7 @@ public:
   {
     CGAL_precondition(facet>=0 && facet<4);
     char current_bits = bits_;
-    while (bits_.compare_and_swap(current_bits & (15 & ~(1 << facet)), current_bits) != current_bits)
+    while (bits_.compare_exchange_weak(current_bits, current_bits & (15 & ~(1 << facet))))
     {
       current_bits = bits_;
     }

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -60,6 +60,7 @@ if ( CGAL_FOUND )
   create_single_source_cgal_program( "test_mesh_3_issue_1554.cpp" )
   create_single_source_cgal_program( "test_mesh_polyhedral_domain_with_features_deprecated.cpp" )
   create_single_source_cgal_program( "test_meshing_with_one_step.cpp" )
+  create_single_source_cgal_program( "test_mesh_cell_base_3.cpp")
 
   foreach(target
       test_boost_has_xxx
@@ -91,6 +92,7 @@ if ( CGAL_FOUND )
       test_c3t3_extract_subdomains_boundaries
       test_mesh_3_issue_1554
       test_mesh_polyhedral_domain_with_features_deprecated
+      test_mesh_cell_base_3
       test_meshing_with_one_step.cpp)
     if(TARGET ${target})
       target_link_libraries(${target} PUBLIC CGAL::Eigen_support)
@@ -111,6 +113,7 @@ if ( CGAL_FOUND )
         test_mesh_capsule_var_distance_bound
         test_mesh_3_issue_1554
         test_mesh_polyhedral_domain_with_features_deprecated
+        test_mesh_cell_base_3
         )
       if(TARGET ${target})
         target_link_libraries(${target} PUBLIC CGAL::TBB_support)

--- a/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
@@ -1,0 +1,100 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/IO/facets_in_complex_3_to_triangle_mesh.h>
+
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_3/tet_soup_to_c3t3.h>
+#include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
+#include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
+#include <CGAL/Mesh_cell_base_3.h>
+
+#include <CGAL/tags.h>
+
+#include <iostream>
+#include <fstream>
+
+int main (int argc, char** argv){
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel                 K;
+  typedef CGAL::Polyhedral_mesh_domain_with_features_3<K>                     Polyhedral_mesh_domain;
+
+  // Traits classes
+  typedef CGAL::Kernel_traits<Polyhedral_mesh_domain>::Kernel                 Robust_intersections_traits;
+  typedef CGAL::details::Mesh_geom_traits_generator<
+            Robust_intersections_traits>::type                                Robust_K;
+#ifdef CGAL_LINKED_WITH_TBB
+  typedef CGAL::Parallel_tag Concurrency_tag;
+#else
+  typedef CGAL::Sequential_tag Concurrency_tag;
+#endif
+
+  // Triangulation
+  typedef CGAL::Mesh_cell_base_3<Robust_K, Polyhedral_mesh_domain>    Cell_base;
+  typedef CGAL::Triangulation_cell_base_with_info_3<int, Robust_K, Cell_base> Cell_base_with_info;
+  typedef CGAL::Mesh_triangulation_3<Polyhedral_mesh_domain,
+                                     Robust_intersections_traits,
+                                     Concurrency_tag,
+                                     CGAL::Default,
+                                     Cell_base_with_info>::type               Tr;
+
+  typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+
+
+  // Open file
+  std::ifstream in (argc > 1 ? argv[1] : "data/elephant.mesh",
+                    std::ios_base::in);
+  if(!in) {
+    std::cerr << "Error! Cannot open file " << argv[1] << std::endl;
+    return 1;
+  }
+  C3t3 c3t3;
+  if(CGAL::build_triangulation_from_file<C3t3::Triangulation, true>(in, c3t3.triangulation()))
+  {
+    for( C3t3::Triangulation::Finite_cells_iterator
+         cit = c3t3.triangulation().finite_cells_begin();
+         cit != c3t3.triangulation().finite_cells_end();
+         ++cit)
+    {
+      CGAL_assertion(cit->subdomain_index() >= 0);
+      c3t3.add_to_complex(cit, cit->subdomain_index());
+      for(int i=0; i < 4; ++i)
+      {
+        if(cit->surface_patch_index(i)>0)
+        {
+          c3t3.add_to_complex(cit, i, cit->surface_patch_index(i));
+        }
+      }
+    }
+
+    //if there is no facet in the complex, we add the border facets.
+    if(c3t3.number_of_facets_in_complex() == 0)
+    {
+      for( C3t3::Triangulation::All_cells_iterator
+           cit = c3t3.triangulation().all_cells_begin();
+           cit != c3t3.triangulation().all_cells_end();
+           ++cit)
+      {
+        if(c3t3.triangulation().is_infinite(cit))
+        {
+          for(int i=0; i<4; ++i)
+          {
+            if(!c3t3.triangulation().is_infinite(cit, i))
+              c3t3.add_to_complex(cit, i, 1);
+          }
+        }
+      }
+    }
+  }
+
+  CGAL::Polyhedron_3<K> poly;
+  CGAL::facets_in_complex_3_to_triangle_mesh(c3t3, poly);
+
+  std::cout << "Graph has " << num_faces(poly) << " faces" << std::endl;
+  std::cout << "Graph has " << num_vertices(poly) << " vertices" << std::endl;
+
+  std::ofstream out("graph.off");
+  out << poly;
+
+  CGAL_assertion(is_valid(poly));
+  return EXIT_SUCCESS;
+}

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
@@ -22,6 +22,8 @@ endif()
 # Use Eigen for Mesh_3
 find_package(Eigen3 3.1.0 REQUIRED) #(3.1.0 or greater)
 include(CGAL_Eigen_support)
+find_package(TBB QUIET)
+include(CGAL_TBB_support)
 
 # Creating entries for all C++ files with "main" routine
 # ##########################################################
@@ -32,3 +34,6 @@ create_single_source_cgal_program( "tetrahedral_remeshing_from_mesh.cpp")
 
 create_single_source_cgal_program( "mesh_and_remesh_polyhedral_domain_with_features.cpp" )
 target_link_libraries(mesh_and_remesh_polyhedral_domain_with_features PUBLIC CGAL::Eigen_support)
+if(TARGET CGAL::TBB_support)
+target_link_libraries(mesh_and_remesh_polyhedral_domain_with_features PRIVATE CGAL::TBB_support)
+endif()

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
@@ -25,6 +25,14 @@ include(CGAL_Eigen_support)
 find_package(TBB QUIET)
 include(CGAL_TBB_support)
 
+# Concurrent Mesh_3
+option(CGAL_ACTIVATE_CONCURRENT_MESH_3 "Activate parallelism in Mesh_3" OFF)
+if(CGAL_ACTIVATE_CONCURRENT_MESH_3 OR ENV{CGAL_ACTIVATE_CONCURRENT_MESH_3})
+  add_definitions(-DCGAL_CONCURRENT_MESH_3)
+  find_package(TBB REQUIRED)
+  include(CGAL_TBB_support)
+endif()
+
 # Creating entries for all C++ files with "main" routine
 # ##########################################################
 create_single_source_cgal_program( "tetrahedral_remeshing_example.cpp" )
@@ -34,6 +42,6 @@ create_single_source_cgal_program( "tetrahedral_remeshing_from_mesh.cpp")
 
 create_single_source_cgal_program( "mesh_and_remesh_polyhedral_domain_with_features.cpp" )
 target_link_libraries(mesh_and_remesh_polyhedral_domain_with_features PUBLIC CGAL::Eigen_support)
-if(TARGET CGAL::TBB_support)
-target_link_libraries(mesh_and_remesh_polyhedral_domain_with_features PRIVATE CGAL::TBB_support)
+if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TARGET CGAL::TBB_support)
+  target_link_libraries(mesh_and_remesh_polyhedral_domain_with_features PRIVATE CGAL::TBB_support)
 endif()

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
@@ -14,8 +14,14 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
 
+#ifdef CGAL_CONCURRENT_MESH_3
+typedef CGAL::Parallel_tag Concurrency_tag;
+#else
+typedef CGAL::Sequential_tag Concurrency_tag;
+#endif
+
 // Triangulation for Meshing
-typedef CGAL::Mesh_triangulation_3<Mesh_domain, CGAL::Default, CGAL::Default>::type Tr;
+typedef CGAL::Mesh_triangulation_3<Mesh_domain, CGAL::Default, Concurrency_tag>::type Tr;
 typedef CGAL::Mesh_complex_3_in_triangulation_3<
   Tr, Mesh_domain::Corner_index, Mesh_domain::Curve_index> C3t3;
 


### PR DESCRIPTION
## Summary of Changes
Fix `std::atomic::compare_and_swap()` that doesn't wxist into `compare_exchange_weak()`


## Release Management

* Affected package(s):Tetrahedral_remeshing, Mesh_3
* Issue(s) solved (if any): fix #5216 
