### PR TITLE
Incorrect HTML code in relation with \cgalAdvancedEnd

### DIFF
--- a/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
@@ -297,7 +297,7 @@ ALIASES                = "sc{1}=<span style=\"font-variant: small-caps;\">\1</sp
                          "cgalDebugEnd=\htmlonly[block] </div> \endhtmlonly" \
                          "cgalDebugFunction=This is a function for debugging purpose." \
                          "cgalAdvancedBegin=^^ \htmlonly[block] <div class=\"CGALAdvanced\"> <div>Advanced</div> \endhtmlonly ^^" \
-                         "cgalAdvancedEnd=^^ \htmlonly[block] </div> \endhtmlonly" \
+                         "cgalAdvancedEnd=\noop ^^ \htmlonly[block] </div> \endhtmlonly" \
                          "cgalAdvancedFunction=This is an advanced function." \
                          "cgalAdvancedClass=This is an advanced class." \
                          "cgalAdvancedType=This is an advanced type." \


### PR DESCRIPTION
Due to some subtle interactions between used doxygen commands and the defined `\cgalAdvancedEnd` incorrect HTML code is generated.
This was shown by `xmllint` (and some options) as
```
parser error : Opening and ending tag mismatch: div line</td></tr>
```
With the `\noop` "trick" this can here be overcome.

The presented output though looked OK.

Problems were found for the packages:
- Periodic_2_triangulation_2
- Point_set_3
- TDS_3
- Triangulation
- Triangulation_2

