### PR TITLE
Fix nullptr issue in Hash_functor

### DIFF
--- a/Hash_map/include/CGAL/Handle_hash_function.h
+++ b/Hash_map/include/CGAL/Handle_hash_function.h
@@ -19,6 +19,7 @@
 #define CGAL_HANDLE_HASH_FUNCTION_H
 
 #include <CGAL/config.h>
+#include <CGAL/In_place_list.h>
 #include <cstddef>
 
 namespace CGAL {
@@ -35,6 +36,16 @@ namespace internal{
       {
         return std::size_t(&*h) /
           sizeof( typename std::iterator_traits<H>::value_type);
+      }
+    };
+
+    template <>
+    template <class T, class Alloc>
+    struct Hash_functor<In_place_list_const_iterator<T, Alloc>> {
+      std::size_t operator()(const In_place_list_const_iterator<T, Alloc>& h) {
+        return std::size_t(h.operator->()) /
+               sizeof(typename std::iterator_traits<
+                      In_place_list_const_iterator<T, Alloc>>::value_type);
       }
     };
   }

--- a/Hash_map/include/CGAL/Handle_hash_function.h
+++ b/Hash_map/include/CGAL/Handle_hash_function.h
@@ -39,7 +39,6 @@ namespace internal{
       }
     };
 
-    template <>
     template <class T, class Alloc>
     struct Hash_functor<In_place_list_const_iterator<T, Alloc>> {
       std::size_t operator()(const In_place_list_const_iterator<T, Alloc>& h) {


### PR DESCRIPTION
## Summary of Changes

During the call to `SM_clone` it may happen that an initial
`SFace_const_handle` is used for a lookup into a `Unique_hash_map`,
which triggers UB.

This commit adds a template specialization for
`Inplace_list_const_iterator`, because not all values for `H` provider
`operator->` and `Inplace_list_const_iterator` seemed to be the only
type having an issue.
## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

