### PR TITLE
AABB: Fix extra underscore in the documentation of the VPM template parameter

### DIFF
--- a/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_face_graph_triangle_primitive.h
@@ -98,7 +98,7 @@ class AABB_face_graph_triangle_primitive
   }
 
 public:
-  #ifdef DOXYGEN_RUNNING
+#ifdef DOXYGEN_RUNNING
   /// \name Types
   /// @{
   /*!
@@ -122,18 +122,32 @@ public:
   If `OneFaceGraphPerTree` is CGAL::Tag_true, constructs a `Shared_data` object from a reference to the polyhedon `graph`.
   */
   static unspecified_type construct_shared_data( FaceGraph& graph );
-  #else
+#else
   typedef typename Base::Id Id;
-  #endif
+#endif
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
   // constructors
+
+#ifdef DOXYGEN_RUNNING
   /*!
+    constructs a primitive.
+
     \tparam Iterator an input iterator with `Id` as value type.
+
+    If `VertexPointPMap` is the default of the class, an additional constructor
+    is available with `vppm` set to `get(vertex_point, graph)`.
+  */
+  template <class Iterator>
+  AABB_face_graph_triangle_primitive(Iterator it, const FaceGraph& graph, VertexPointPMap vppm);
+
+  /*!
     constructs a primitive.
     If `VertexPointPMap` is the default of the class, an additional constructor
     is available with `vppm` set to `get(vertex_point, graph)`.
   */
+  AABB_face_graph_triangle_primitive(face_descriptor fd, const FaceGraph& graph, VertexPointPMap vppm);
+#else
   template <class Iterator>
   AABB_face_graph_triangle_primitive(Iterator it, const FaceGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(make_id(*it, graph, OneFaceGraphPerTree())),
@@ -141,18 +155,12 @@ public:
             Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
   {}
 
-  /*!
-    constructs a primitive.
-    If `VertexPointPMap` is the default of the class, an additional constructor
-    is available with `vppm` set to `get(vertex_point, graph)`.
-  */
   AABB_face_graph_triangle_primitive(face_descriptor fd, const FaceGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(make_id(fd, graph, OneFaceGraphPerTree())),
             Triangle_property_map(const_cast<FaceGraph*>(&graph),vppm),
             Point_property_map(const_cast<FaceGraph*>(&graph),vppm) )
   {}
 
-#ifndef DOXYGEN_RUNNING
   template <class Iterator>
   AABB_face_graph_triangle_primitive(Iterator it, const FaceGraph& graph)
     : Base( Id_(make_id(*it, graph, OneFaceGraphPerTree())),

--- a/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
@@ -140,14 +140,27 @@ public:
 #endif
   typedef typename boost::graph_traits<HalfedgeGraph>::edge_descriptor edge_descriptor;
 
+#ifdef DOXYGEN_RUNNING
   /*!
   constructs a primitive.
+
   \tparam Iterator is an input iterator with `Id` as value type.
+
   This \ref AABB_tree/AABB_halfedge_graph_edge_example.cpp "example" gives a way to call this constructor
   using the insert-by-range method of the class `AABB_tree<Traits>`.
   If `VertexPointPMap` is the default of the class, an additional constructor
   is available with `vppm` set to `boost::get(vertex_point, graph)`.
   */
+  template <class Iterator>
+  AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph, VertexPointPMap vppm);
+
+  /*!
+  constructs a primitive.
+  If `VertexPointPMap` is the default of the class, an additional constructor
+  is available with `vppm` set to `boost::get(vertex_point, graph)`.
+  */
+  AABB_halfedge_graph_segment_primitive(edge_descriptor ed, const HalfedgeGraph& graph, VertexPointPMap vppm);
+#else
   template <class Iterator>
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(make_id(*it, graph, OneHalfedgeGraphPerTree())),
@@ -155,18 +168,12 @@ public:
             Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
   {}
 
-  /*!
-  constructs a primitive.
-  If `VertexPointPMap` is the default of the class, an additional constructor
-  is available with `vppm` set to `boost::get(vertex_point, graph)`.
-  */
   AABB_halfedge_graph_segment_primitive(edge_descriptor ed, const HalfedgeGraph& graph, VertexPointPMap_ vppm)
     : Base( Id_(make_id(ed, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph), vppm),
             Point_property_map(const_cast<HalfedgeGraph*>(&graph), vppm) )
   {}
 
-  #ifndef DOXYGEN_RUNNING
   template <class Iterator>
   AABB_halfedge_graph_segment_primitive(Iterator it, const HalfedgeGraph& graph)
     : Base( Id_(make_id(*it, graph, OneHalfedgeGraphPerTree())),
@@ -177,7 +184,7 @@ public:
     : Base( Id_(make_id(ed, graph, OneHalfedgeGraphPerTree())),
             Segment_property_map(const_cast<HalfedgeGraph*>(&graph)),
             Point_property_map(const_cast<HalfedgeGraph*>(&graph)) ){}
-  #endif
+#endif
 
   /// \internal
   typedef internal::Cstr_shared_data<HalfedgeGraph, Base, Segment_property_map, Point_property_map, OneHalfedgeGraphPerTree> Cstr_shared_data;


### PR DESCRIPTION
## Summary of Changes

This is a residual of the usage of `CGAL::Default` in the class templates.

Fix it by also documenting constructors in a `#ifdef DOXYGEN_RUNNING` block, like the types.

## Release Management

* Affected package(s): `AABB_tree`
* Issue(s) solved (if any): fix #4907
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

