### PR TITLE
Rename 'D' to 'Dimension'

### DIFF
--- a/Spatial_searching/doc/Spatial_searching/Concepts/FuzzyQueryItem.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/FuzzyQueryItem.h
@@ -18,7 +18,7 @@ public:
 /*!
 Dimension Tag.
 */
-typedef unspecified_type D;
+typedef unspecified_type Dimension;
 
 /*!
 represents a `d`-dimensional point.
@@ -53,13 +53,13 @@ bool contains_point_given_as_coordinates(Coord_iterator begin, Coord_iterator en
 Test whether the inner approximation of the spatial object intersects a rectangle
 associated with a node of a tree.
 */
-bool inner_range_intersects(const Kd_tree_rectangle<FT,D>& rectangle) const;
+bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const;
 
 /*!
 Test whether the outer approximation of the spatial object encloses the rectangle
 associated with a node of a tree.
 */
-bool outer_range_contains(const Kd_tree_rectangle<FT,D>& rectangle) const;
+bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const;
 
 /// @}
 

--- a/Spatial_searching/doc/Spatial_searching/Concepts/FuzzyQueryItem.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/FuzzyQueryItem.h
@@ -36,27 +36,27 @@ typedef unspecified_type FT;
 /// @{
 
 /*!
-Test whether the query item contains `p`.
+tests whether the query item contains `p`.
 */
 bool contains(Point_d p) const;
 
 /*!
-Optional: must be defined when used with a `Kd_tree` where `EnablePointsCache`
-is set to `Tag_true`.
-Test whether the query item contains the point whose Cartesian coordinates
+\note Optional: must be defined when used with a `Kd_tree` where `EnablePointsCache` is set to `Tag_true`.
+
+tests whether the query item contains the point whose Cartesian coordinates
 are contained in the range [`begin`, `end`).
 */
 template <typename Coord_iterator>
 bool contains_point_given_as_coordinates(Coord_iterator begin, Coord_iterator end) const;
 
 /*!
-Test whether the inner approximation of the spatial object intersects a rectangle
+tests whether the inner approximation of the spatial object intersects a rectangle
 associated with a node of a tree.
 */
 bool inner_range_intersects(const Kd_tree_rectangle<FT,Dimension>& rectangle) const;
 
 /*!
-Test whether the outer approximation of the spatial object encloses the rectangle
+tests whether the outer approximation of the spatial object encloses the rectangle
 associated with a node of a tree.
 */
 bool outer_range_contains(const Kd_tree_rectangle<FT,Dimension>& rectangle) const;


### PR DESCRIPTION
## Summary of Changes

The type `D` was not a real requirement as none of the models provided by CGAL actually provided this typedef, but it's in the concept to explicit the dimension requirements between the KD-tree and the object.

Renamed to `Dimension` to match the actual code.

## Release Management

* Affected package(s): `Spatial_searching`
* Issue(s) solved (if any): fix #5178
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

