### PR TITLE
Fix uncaught exceptions

### DIFF
--- a/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_list.h
@@ -395,7 +395,11 @@ public:
         // halfedges, and f faces. The reservation sizes are a hint for
         // optimizing storage allocation. They are not used here.
 
-    ~HalfedgeDS_list() { clear(); }
+    ~HalfedgeDS_list() noexcept {
+      try {
+        clear();
+      } catch (...) {}
+    }
 
     HalfedgeDS_list( const Self& hds)
     :  vertices( hds.vertices),

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -442,12 +442,15 @@ friend std::ostream& operator<<
 }
 
 
-~Node() {
+~Node() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+{
   CGAL_NEF_TRACEN("~Node: deleting node...");
-  if( !is_leaf()) {
-    delete left_node;
-    delete right_node;
-  }
+  CGAL_destructor_assertion_catch(
+    if( !is_leaf()) {
+      delete left_node;
+      delete right_node;
+    }
+  );
 }
 
 private:
@@ -1103,9 +1106,12 @@ bool update( Node* node,
   return (left_updated || right_updated);
 }
 
-~K3_tree() {
+~K3_tree() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+{
   CGAL_NEF_TRACEN("~K3_tree: deleting root...");
-  delete root;
+  CGAL_destructor_assertion_catch(
+    delete root;
+  );
 }
 
 private:

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -126,7 +126,8 @@ public:
 
   virtual void add_vertex(Vertex_handle) {}
 
-  virtual ~SNC_point_locator() {
+  virtual ~SNC_point_locator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  {
     CGAL_NEF_CLOG("");
     CGAL_NEF_CLOG("construction_time:  "<<ct_t.time());
     CGAL_NEF_CLOG("pointlocation_time: "<<pl_t.time());
@@ -422,8 +423,9 @@ public:
     return updated;
   }
 
-  virtual ~SNC_point_locator_by_spatial_subdivision() {
-    CGAL_warning(initialized ||
+  virtual ~SNC_point_locator_by_spatial_subdivision() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  {
+    CGAL_destructor_warning(initialized ||
                  candidate_provider == 0); // required?
     if(initialized)
       delete candidate_provider;

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -229,7 +229,12 @@ public:
   Sphere_map(bool = false) : boundary_item_(boost::none),
     svertices_(), sedges_(), sfaces_(), shalfloop_() {}
 
-  ~Sphere_map() { clear(); }
+  ~Sphere_map() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  {
+    CGAL_destructor_assertion_catch(
+      clear();
+    );
+  }
 
   Sphere_map(const Self& D) : boundary_item_(boost::none),
     svertices_(D.svertices_),

--- a/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
@@ -73,7 +73,12 @@ class Nef_polyhedron_S2_rep {
 public:
   Nef_polyhedron_S2_rep() : sm_() {}
   Nef_polyhedron_S2_rep(const Self&) : sm_() {}
-  ~Nef_polyhedron_S2_rep() { sm_.clear(); }
+  ~Nef_polyhedron_S2_rep() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  {
+    CGAL_destructor_assertion_catch(
+      sm_.clear();
+    );
+  }
 };
 
 /*{\Moptions print_title=yes }*/

--- a/STL_Extension/include/CGAL/Handle_for.h
+++ b/STL_Extension/include/CGAL/Handle_for.h
@@ -149,12 +149,14 @@ public:
         return *this;
     }
 
-    ~Handle_for()
+    ~Handle_for() noexcept
     {
-      if (--(ptr_->count) == 0) {
-        Allocator_traits::destroy(allocator, ptr_);
-        allocator.deallocate( ptr_, 1);
-      }
+      try{
+        if (--(ptr_->count) == 0) {
+          Allocator_traits::destroy(allocator, ptr_);
+          allocator.deallocate( ptr_, 1);
+        }
+      } catch(...) {}
     }
 
     void

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -445,9 +445,11 @@ public:
     (*node).prev_link = node;
     insert(begin(), x.begin(), x.end());
   }
-  ~In_place_list() {
-    erase(begin(), end());
-    put_node(node);
+  ~In_place_list() noexcept {
+    try {
+      erase(begin(), end());
+      put_node(node);
+    } catch(...) {}
   }
 
   Self& operator=(const Self& x);

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -79,6 +79,7 @@ inline bool possibly(Uncertain<bool> c);
 #if defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_assertion(EX) (static_cast<void>(0))
 #  define CGAL_destructor_assertion(EX) (static_cast<void>(0))
+#  define CGAL_destructor_assertion_catch(CODE) CODE
 #  define CGAL_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_assertion_code(CODE)
 #  ifdef CGAL_ASSUME
@@ -94,9 +95,11 @@ inline bool possibly(Uncertain<bool> c);
 #  if __cpp_lib_uncaught_exceptions || ( _MSVC_LANG >= 201703L )  // C++17
 #    define CGAL_destructor_assertion(EX) \
      (CGAL::possibly(EX)||(std::uncaught_exceptions() > 0)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
+#  define CGAL_destructor_assertion_catch(CODE) try{ CODE } catch(...) { if(std::uncaught_exceptions() <= 0) throw; }
 #  else // use C++03 `std::uncaught_exception()`
 #    define CGAL_destructor_assertion(EX) \
      (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
+#  define CGAL_destructor_assertion_catch(CODE) try{ CODE } catch(...) { if(!std::uncaught_exception()) throw; }
 #  endif // use C++03 `std::uncaught_exception()`
 #  define CGAL_assertion_msg(EX,MSG)                                    \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__, MSG))
@@ -293,11 +296,19 @@ inline bool possibly(Uncertain<bool> c);
 
 #if defined(CGAL_NO_WARNINGS)
 #  define CGAL_warning(EX) (static_cast<void>(0))
+#  define CGAL_destructor_warning(EX) (static_cast<void>(0))
 #  define CGAL_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_warning_code(CODE)
 #else
 #  define CGAL_warning(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::warning_fail( # EX , __FILE__, __LINE__))
+#  if __cpp_lib_uncaught_exceptions || ( _MSVC_LANG >= 201703L )  // C++17
+#    define CGAL_destructor_warning(EX) \
+     (CGAL::possibly(EX)||(std::uncaught_exceptions() > 0)?(static_cast<void>(0)): ::CGAL::warning_fail( # EX , __FILE__, __LINE__))
+#  else // use C++03 `std::uncaught_exception()`
+#    define CGAL_destructor_warning(EX) \
+     (CGAL::possibly(EX)||std::uncaught_exception()?(static_cast<void>(0)): ::CGAL::warning_fail( # EX , __FILE__, __LINE__))
+#  endif // use C++03 `std::uncaught_exception()`
 #  define CGAL_warning_msg(EX,MSG) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::warning_fail( # EX , __FILE__, __LINE__, MSG))
 #  define CGAL_warning_code(CODE) CODE

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
@@ -164,7 +164,7 @@ private:
   Ref_counted_base& operator=( Ref_counted_base const &);
 protected:
   Ref_counted_base(): mCount(0) {}
-  virtual ~Ref_counted_base() {}
+  virtual ~Ref_counted_base() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL) {}
 public:
     void AddRef() const { ++mCount; }
     void Release() const

--- a/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
+++ b/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
@@ -30,7 +30,12 @@ class VRML_2_ostream
 public:
   VRML_2_ostream() : m_os(nullptr) {}
   VRML_2_ostream(std::ostream& o) : m_os(&o) { header(); }
-  ~VRML_2_ostream() { close(); }
+  ~VRML_2_ostream() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  {
+    CGAL_destructor_assertion_catch(
+      close();
+    );
+  }
 
   void open(std::ostream& o) { m_os = &o; header(); }
   void close()


### PR DESCRIPTION
## Summary of Changes

In a previous issue ( #451 ) a `CGAL_destructor_assertion` macro was added to handle assertions made within destructors. When an exception is thrown from a destructor while the stack is being unwound, the existence of any uncaught exceptions cause the program to terminate immediately, without correct error handling. Sometimes it's safe to throw an exception even while std::uncaught_exception() == true. For example, if stack unwinding causes an object to be destructed, the destructor for that object could run code that throws an exception as long as the exception is caught by some catch block before escaping the destructor. That said coverity static analysis has found several places in the codebase where this is not the case, i.e the destructor calls some code which makes a `CGAL_assertion()` of some form or another, but doesn't catch the exception.

I propose a new macro:

```c++
#define CGAL_destructor_assertion_catch(CODE) try{ CODE } catch(...) { if(std::uncaught_exceptions() <= 0) throw; }
```

This preserves the assertion exception by rethrowing it if the stack is **not** being unwound and there are no uncaught exceptions. But in the case where we are recovering from an exception already, only that exception is preserved. A program which demonstrates this behaviour can be seen here: http://cpp.sh/6p7ka

This macro has then been applied to all places identified by static analysis as potentially throwing exceptions from CGAL_assertions. As before ( in #451 ) the `CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)` macro has to be applied, where needed.

An additional Macro `CGAL_destructor_warning` was also added, this replicates the behaviour of `CGAL_destructor_assertion`, except emits a `::CGAL::warning_fail`

## Release Management

* Affected package(s): several.
* Feature/Small Feature (if any): bugfix
* Link to compiled documentation (obligatory for small feature). I will add documentation if in principle the idea is acceptable.
* License and copyright ownership: Returned to CGAL authors

