### PR TITLE
Superfluous space in link

### DIFF
--- a/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
+++ b/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
@@ -26,7 +26,7 @@
 \cgalPkgDependsOn{\ref PkgConvexHull3}
 \cgalPkgBib{cgal:obb}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo, polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Shape_detection/doc/Shape_detection/PackageDescription.txt
+++ b/Shape_detection/doc/Shape_detection/PackageDescription.txt
@@ -74,7 +74,7 @@ on a polygon mesh.}
 \cgalPkgSince{4.7}
 \cgalPkgBib{cgal:ovja-pssd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo, polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd


### PR DESCRIPTION
The texts in the ALIASES are taken literally and therefore should be (in this case) no space after the comma as this results in a space ion the resulting link and thus a file not found.
