### PR TITLE
Allow -DNDEBUG and CGAL_nnn_assertions at the same time

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
@@ -37,6 +37,8 @@
 
 #include <CGAL/Curved_kernel_via_analysis_2/Sweep_curves_adapter_2.h>
 
+#include <CGAL/kernel_assertions.h>
+
 namespace CGAL {
 
 namespace internal {

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Arc_2.h
@@ -1818,8 +1818,7 @@ protected:
      */
     void _check_arc_interior() const {
 
-#if !(defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-        || defined(NDEBUG))
+#if !(defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS))
 
         if(is_vertical()) {
             Coordinate_1 x0 = _minpoint().x();

--- a/Bounding_volumes/include/CGAL/Approximate_min_ellipsoid_d/Approximate_min_ellipsoid_d_configure.h
+++ b/Bounding_volumes/include/CGAL/Approximate_min_ellipsoid_d/Approximate_min_ellipsoid_d_configure.h
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <iomanip>
 
-#if (defined(CGAL_NO_ASSERTIONS) || defined(NDEBUG))
+#if defined(CGAL_NO_ASSERTIONS)
   #undef CGAL_APPEL_ASSERTION_MODE
   #undef CGAL_APPEL_EXP_ASSERTION_MODE
   #undef CGAL_APPEL_LOG_MODE

--- a/Convex_hull_2/include/CGAL/Convex_hull_2/ch_akl_toussaint_impl.h
+++ b/Convex_hull_2/include/CGAL/Convex_hull_2/ch_akl_toussaint_impl.h
@@ -285,8 +285,7 @@ ch_akl_toussaint(ForwardIterator first, ForwardIterator last,
     internal::ch_akl_toussaint_assign_points_to_regions(std::next(std::get<3>(ranges)),last,left_turn,e,w,n,s,region1,region2,region3,region4,ch_traits);
   }
 
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
@@ -336,8 +335,7 @@ ch_akl_toussaint(ForwardIterator first, ForwardIterator last,
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits)
   );
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();

--- a/Convex_hull_2/include/CGAL/Convex_hull_2/ch_assertions.h
+++ b/Convex_hull_2/include/CGAL/Convex_hull_2/ch_assertions.h
@@ -15,7 +15,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -28,8 +28,7 @@
 #undef CGAL_ch_assertion_msg
 #undef CGAL_ch_assertion_code
 
-#if defined(CGAL_CH_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_CH_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_ch_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/Convex_hull_2.h>
@@ -51,8 +50,7 @@
 #undef CGAL_ch_exactness_assertion_code
 
 #if defined(CGAL_CH_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_ch_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_ch_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_exactness_assertion_code(CODE)
@@ -72,8 +70,7 @@
 
 #if defined(CGAL_CH_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_assertion_code(CODE)
@@ -93,8 +90,7 @@
 
 #if defined(CGAL_CH_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_assertion_code(CODE)
@@ -115,8 +111,7 @@
 #undef CGAL_ch_precondition_msg
 #undef CGAL_ch_precondition_code
 
-#if defined(CGAL_CH_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_CH_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_ch_precondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_precondition_code(CODE)
@@ -135,8 +130,7 @@
 #undef CGAL_ch_exactness_precondition_code
 
 #if defined(CGAL_CH_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_ch_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_exactness_precondition_code(CODE)
@@ -155,8 +149,7 @@
 #undef CGAL_ch_expensive_precondition_code
 
 #if defined(CGAL_CH_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_precondition_code(CODE)
@@ -176,8 +169,7 @@
 
 #if defined(CGAL_CH_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_precondition_code(CODE)
@@ -198,8 +190,7 @@
 #undef CGAL_ch_postcondition_msg
 #undef CGAL_ch_postcondition_code
 
-#if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_ch_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_postcondition_code(CODE)
@@ -218,8 +209,7 @@
 #undef CGAL_ch_exactness_postcondition_code
 
 #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_ch_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_exactness_postcondition_code(CODE)
@@ -238,8 +228,7 @@
 #undef CGAL_ch_expensive_postcondition_code
 
 #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_postcondition_code(CODE)
@@ -259,8 +248,7 @@
 
 #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_postcondition_code(CODE)
@@ -281,8 +269,7 @@
 #undef CGAL_ch_warning_msg
 #undef CGAL_ch_warning_code
 
-#if defined(CGAL_CH_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_CH_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_ch_warning(EX) (static_cast<void>(0))
 #  define CGAL_ch_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_warning_code(CODE)
@@ -301,8 +288,7 @@
 #undef CGAL_ch_exactness_warning_code
 
 #if defined(CGAL_CH_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_ch_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_ch_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_exactness_warning_code(CODE)
@@ -321,8 +307,7 @@
 #undef CGAL_ch_expensive_warning_code
 
 #if defined(CGAL_CH_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_warning_code(CODE)
@@ -342,8 +327,7 @@
 
 #if defined(CGAL_CH_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_CH_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_CH_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_ch_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_ch_expensive_exactness_warning_code(CODE)

--- a/Convex_hull_2/include/CGAL/Convex_hull_2/ch_bykat_impl.h
+++ b/Convex_hull_2/include/CGAL/Convex_hull_2/ch_bykat_impl.h
@@ -68,8 +68,7 @@ ch_bykat(InputIterator first, InputIterator last,
       *result = a;  ++result;
       return result;
   }
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
@@ -110,8 +109,7 @@ ch_bykat(InputIterator first, InputIterator last,
           P.begin(), P.end(), \
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits));
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();
@@ -164,8 +162,7 @@ ch_bykat_with_threshold(InputIterator   first, InputIterator last,
       *result = a;  ++result;
       return result;
   }
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
@@ -234,8 +231,7 @@ ch_bykat_with_threshold(InputIterator   first, InputIterator last,
           Pbegin, Pend, \
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits));
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();

--- a/Convex_hull_2/include/CGAL/Convex_hull_2/ch_graham_andrew_impl.h
+++ b/Convex_hull_2/include/CGAL/Convex_hull_2/ch_graham_andrew_impl.h
@@ -90,8 +90,7 @@ ch_graham_andrew_scan( BidirectionalIterator first,
 
   typedef typename std::vector< BidirectionalIterator >::iterator std_iterator;
   std_iterator  stack_iter = S.begin();
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   typedef  typename Traits::Point_2     Point_2;
@@ -108,8 +107,7 @@ ch_graham_andrew_scan( BidirectionalIterator first,
           first, last, \
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits));
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();
@@ -208,8 +206,7 @@ ch_graham_andrew( InputIterator  first,
       return result;
   }
 
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
@@ -225,8 +222,7 @@ ch_graham_andrew( InputIterator  first,
           V.begin(), V.end(), \
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits));
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();
@@ -254,15 +250,13 @@ ch_lower_hull_scan( InputIterator  first,
       return result;
   }
 
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
   #endif // no postconditions ...
   ch_graham_andrew_scan( V.begin(), V.end(), res, ch_traits);
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();
@@ -285,15 +279,13 @@ ch_upper_hull_scan( InputIterator  first,
   std::sort( V.begin(), V.end(), ch_traits.less_xy_2_object() );
   if (equal_points( *(V.begin()), *(V.rbegin())) )
   { return result; }
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   Tee_for_output_iterator<OutputIterator,Point_2> res(result);
   #endif // no postconditions ...
   ch_graham_andrew_scan( V.rbegin(), V.rend(), res, ch_traits);
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();

--- a/Convex_hull_2/include/CGAL/Convex_hull_2/ch_jarvis_impl.h
+++ b/Convex_hull_2/include/CGAL/Convex_hull_2/ch_jarvis_impl.h
@@ -45,8 +45,7 @@ ch_jarvis_march(ForwardIterator first, ForwardIterator last,
 
   Equal_2     equal_points = ch_traits.equal_2_object();
 
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   OutputIterator  res(result);
   #else
   typedef   typename Traits::Point_2               Point_2;
@@ -91,8 +90,7 @@ ch_jarvis_march(ForwardIterator first, ForwardIterator last,
           first, last, \
           res.output_so_far_begin(), res.output_so_far_end(), \
           ch_traits));
-  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-    || defined(NDEBUG)
+  #if defined(CGAL_CH_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
   return res;
   #else
   return res.to_output_iterator();

--- a/Kernel_23/include/CGAL/kernel_assertions.h
+++ b/Kernel_23/include/CGAL/kernel_assertions.h
@@ -19,7 +19,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -32,8 +32,7 @@
 #undef CGAL_kernel_assertion_msg
 #undef CGAL_kernel_assertion_code
 
-#if defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_kernel_assertion(EX) (static_cast<void>(0))
 #  define CGAL_kernel_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_assertion_code(CODE)
@@ -52,8 +51,7 @@
 #undef CGAL_kernel_exactness_assertion_code
 
 #if defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_kernel_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_assertion_code(CODE)
@@ -73,8 +71,7 @@
 
 #if defined(CGAL_KERNEL_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_assertion_code(CODE)
@@ -94,8 +91,7 @@
 
 #if defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_assertion_code(CODE)
@@ -116,8 +112,7 @@
 #undef CGAL_kernel_precondition_msg
 #undef CGAL_kernel_precondition_code
 
-#if defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_kernel_precondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_precondition_code(CODE)
@@ -136,8 +131,7 @@
 #undef CGAL_kernel_exactness_precondition_code
 
 #if defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_kernel_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_precondition_code(CODE)
@@ -156,8 +150,7 @@
 #undef CGAL_kernel_expensive_precondition_code
 
 #if defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_precondition_code(CODE)
@@ -177,8 +170,7 @@
 
 #if defined(CGAL_KERNEL_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_precondition_code(CODE)
@@ -199,8 +191,7 @@
 #undef CGAL_kernel_postcondition_msg
 #undef CGAL_kernel_postcondition_code
 
-#if defined(CGAL_KERNEL_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_KERNEL_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_kernel_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_postcondition_code(CODE)
@@ -219,8 +210,7 @@
 #undef CGAL_kernel_exactness_postcondition_code
 
 #if defined(CGAL_KERNEL_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_kernel_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_postcondition_code(CODE)
@@ -239,8 +229,7 @@
 #undef CGAL_kernel_expensive_postcondition_code
 
 #if defined(CGAL_KERNEL_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_postcondition_code(CODE)
@@ -260,8 +249,7 @@
 
 #if defined(CGAL_KERNEL_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_postcondition_code(CODE)
@@ -282,8 +270,7 @@
 #undef CGAL_kernel_warning_msg
 #undef CGAL_kernel_warning_code
 
-#if defined(CGAL_KERNEL_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_KERNEL_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_kernel_warning(EX) (static_cast<void>(0))
 #  define CGAL_kernel_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_warning_code(CODE)
@@ -302,8 +289,7 @@
 #undef CGAL_kernel_exactness_warning_code
 
 #if defined(CGAL_KERNEL_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_kernel_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_exactness_warning_code(CODE)
@@ -322,8 +308,7 @@
 #undef CGAL_kernel_expensive_warning_code
 
 #if defined(CGAL_KERNEL_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_warning_code(CODE)
@@ -343,8 +328,7 @@
 
 #if defined(CGAL_KERNEL_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_KERNEL_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_kernel_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_kernel_expensive_exactness_warning_code(CODE)

--- a/Partition_2/include/CGAL/Partition_2/partition_approx_convex_2.h
+++ b/Partition_2/include/CGAL/Partition_2/partition_approx_convex_2.h
@@ -230,7 +230,7 @@ OutputIterator partition_approx_convex_2(InputIterator first,
    }
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS)  || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    OutputIterator res(result);
 #else
    typedef typename Traits::Polygon_2                  Polygon_2;
@@ -244,7 +244,7 @@ OutputIterator partition_approx_convex_2(InputIterator first,
                                    res.output_so_far_end(), traits));
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS)  || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    return res;
 #else
    return res.to_output_iterator();

--- a/Partition_2/include/CGAL/Partition_2/partition_assertions.h
+++ b/Partition_2/include/CGAL/Partition_2/partition_assertions.h
@@ -15,7 +15,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -28,8 +28,7 @@
 #undef CGAL_partition_assertion_msg
 #undef CGAL_partition_assertion_code
 
-#if defined(CGAL_PARTITION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_PARTITION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_partition_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/Partition_2.h>
@@ -51,8 +50,7 @@
 #undef CGAL_partition_exactness_assertion_code
 
 #if defined(CGAL_PARTITION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_partition_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_partition_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_exactness_assertion_code(CODE)
@@ -72,8 +70,7 @@
 
 #if defined(CGAL_PARTITION_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_assertion_code(CODE)
@@ -93,8 +90,7 @@
 
 #if defined(CGAL_PARTITION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_assertion_code(CODE)
@@ -115,8 +111,7 @@
 #undef CGAL_partition_precondition_msg
 #undef CGAL_partition_precondition_code
 
-#if defined(CGAL_PARTITION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_PARTITION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_partition_precondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_precondition_code(CODE)
@@ -135,8 +130,7 @@
 #undef CGAL_partition_exactness_precondition_code
 
 #if defined(CGAL_PARTITION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_partition_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_exactness_precondition_code(CODE)
@@ -155,8 +149,7 @@
 #undef CGAL_partition_expensive_precondition_code
 
 #if defined(CGAL_PARTITION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_precondition_code(CODE)
@@ -176,8 +169,7 @@
 
 #if defined(CGAL_PARTITION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_precondition_code(CODE)
@@ -198,8 +190,7 @@
 #undef CGAL_partition_postcondition_msg
 #undef CGAL_partition_postcondition_code
 
-#if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_partition_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_postcondition_code(CODE)
@@ -218,8 +209,7 @@
 #undef CGAL_partition_exactness_postcondition_code
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_partition_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_exactness_postcondition_code(CODE)
@@ -238,8 +228,7 @@
 #undef CGAL_partition_expensive_postcondition_code
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_postcondition_code(CODE)
@@ -259,8 +248,7 @@
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_postcondition_code(CODE)
@@ -281,8 +269,7 @@
 #undef CGAL_partition_warning_msg
 #undef CGAL_partition_warning_code
 
-#if defined(CGAL_PARTITION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_PARTITION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_partition_warning(EX) (static_cast<void>(0))
 #  define CGAL_partition_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_warning_code(CODE)
@@ -301,8 +288,7 @@
 #undef CGAL_partition_exactness_warning_code
 
 #if defined(CGAL_PARTITION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_partition_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_partition_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_exactness_warning_code(CODE)
@@ -321,8 +307,7 @@
 #undef CGAL_partition_expensive_warning_code
 
 #if defined(CGAL_PARTITION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_warning_code(CODE)
@@ -342,8 +327,7 @@
 
 #if defined(CGAL_PARTITION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_PARTITION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_PARTITION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_partition_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_partition_expensive_exactness_warning_code(CODE)

--- a/Partition_2/include/CGAL/Partition_2/partition_greene_approx_convex_2.h
+++ b/Partition_2/include/CGAL/Partition_2/partition_greene_approx_convex_2.h
@@ -798,7 +798,7 @@ OutputIterator partition_greene_approx_convex_2(InputIterator first,
    typedef typename Traits::Polygon_2                        Polygon_2;
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS) || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    OutputIterator res(result);
 #else
 
@@ -829,7 +829,7 @@ OutputIterator partition_greene_approx_convex_2(InputIterator first,
                                    res.output_so_far_end(), traits));
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS) || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    return res;
 #else
    return res.to_output_iterator();

--- a/Partition_2/include/CGAL/Partition_2/partition_optimal_convex_2.h
+++ b/Partition_2/include/CGAL/Partition_2/partition_optimal_convex_2.h
@@ -512,7 +512,7 @@ OutputIterator partition_optimal_convex_2(InputIterator first,
 
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS)   || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    OutputIterator res(result);
 #else
    typedef typename Traits::Polygon_2                      Polygon_2;
@@ -567,7 +567,7 @@ OutputIterator partition_optimal_convex_2(InputIterator first,
    }
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS)  || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    return res;
 #else
    return res.to_output_iterator();

--- a/Partition_2/include/CGAL/Partition_2/partition_y_monotone_2.h
+++ b/Partition_2/include/CGAL/Partition_2/partition_y_monotone_2.h
@@ -418,7 +418,7 @@ OutputIterator partition_y_monotone_2(InputIterator first,
    typedef Circulator_from_iterator<I>                     Circulator;
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS) || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    OutputIterator res(result);
 #else
    typedef typename Traits::Polygon_2                      Polygon_2;
@@ -490,7 +490,7 @@ OutputIterator partition_y_monotone_2(InputIterator first,
                                        res.output_so_far_end(), traits));
 
 #if defined(CGAL_PARTITION_NO_POSTCONDITIONS) || \
-    defined(CGAL_NO_POSTCONDITIONS) || defined(NDEBUG)
+    defined(CGAL_NO_POSTCONDITIONS)
    return res;
 #else
    return res.to_output_iterator();

--- a/Point_set_processing_3/include/CGAL/point_set_processing_assertions.h
+++ b/Point_set_processing_3/include/CGAL/point_set_processing_assertions.h
@@ -20,7 +20,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -33,8 +33,7 @@
 #undef CGAL_point_set_processing_assertion_msg
 #undef CGAL_point_set_processing_assertion_code
 
-#if defined(CGAL_POINT_SET_PROCESSING_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POINT_SET_PROCESSING_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_point_set_processing_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/Point_set_processing_3.h>
@@ -56,8 +55,7 @@
 #undef CGAL_point_set_processing_exactness_assertion_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_point_set_processing_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_assertion_code(CODE)
@@ -77,8 +75,7 @@
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_assertion_code(CODE)
@@ -98,8 +95,7 @@
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_assertion_code(CODE)
@@ -120,8 +116,7 @@
 #undef CGAL_point_set_processing_precondition_msg
 #undef CGAL_point_set_processing_precondition_code
 
-#if defined(CGAL_POINT_SET_PROCESSING_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POINT_SET_PROCESSING_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_point_set_processing_precondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_precondition_code(CODE)
@@ -140,8 +135,7 @@
 #undef CGAL_point_set_processing_exactness_precondition_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_point_set_processing_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_precondition_code(CODE)
@@ -160,8 +154,7 @@
 #undef CGAL_point_set_processing_expensive_precondition_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_precondition_code(CODE)
@@ -181,8 +174,7 @@
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_precondition_code(CODE)
@@ -203,8 +195,7 @@
 #undef CGAL_point_set_processing_postcondition_msg
 #undef CGAL_point_set_processing_postcondition_code
 
-#if defined(CGAL_POINT_SET_PROCESSING_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POINT_SET_PROCESSING_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_point_set_processing_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_postcondition_code(CODE)
@@ -223,8 +214,7 @@
 #undef CGAL_point_set_processing_exactness_postcondition_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_point_set_processing_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_postcondition_code(CODE)
@@ -243,8 +233,7 @@
 #undef CGAL_point_set_processing_expensive_postcondition_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_postcondition_code(CODE)
@@ -264,8 +253,7 @@
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_postcondition_code(CODE)
@@ -286,8 +274,7 @@
 #undef CGAL_point_set_processing_warning_msg
 #undef CGAL_point_set_processing_warning_code
 
-#if defined(CGAL_POINT_SET_PROCESSING_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POINT_SET_PROCESSING_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_point_set_processing_warning(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_warning_code(CODE)
@@ -306,8 +293,7 @@
 #undef CGAL_point_set_processing_exactness_warning_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_point_set_processing_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_exactness_warning_code(CODE)
@@ -326,8 +312,7 @@
 #undef CGAL_point_set_processing_expensive_warning_code
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_warning_code(CODE)
@@ -347,8 +332,7 @@
 
 #if defined(CGAL_POINT_SET_PROCESSING_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POINT_SET_PROCESSING_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_point_set_processing_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_point_set_processing_expensive_exactness_warning_code(CODE)

--- a/Poisson_surface_reconstruction_3/include/CGAL/surface_reconstruction_points_assertions.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/surface_reconstruction_points_assertions.h
@@ -19,7 +19,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -32,8 +32,7 @@
 #undef CGAL_surface_reconstruction_points_assertion_msg
 #undef CGAL_surface_reconstruction_points_assertion_code
 
-#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_surface_reconstruction_points_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/Poisson_surface_reconstruction_3.h>
@@ -55,8 +54,7 @@
 #undef CGAL_surface_reconstruction_points_exactness_assertion_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_surface_reconstruction_points_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_assertion_code(CODE)
@@ -76,8 +74,7 @@
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_assertion_code(CODE)
@@ -97,8 +94,7 @@
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_assertion_code(CODE)
@@ -119,8 +115,7 @@
 #undef CGAL_surface_reconstruction_points_precondition_msg
 #undef CGAL_surface_reconstruction_points_precondition_code
 
-#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_surface_reconstruction_points_precondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_precondition_code(CODE)
@@ -139,8 +134,7 @@
 #undef CGAL_surface_reconstruction_points_exactness_precondition_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_surface_reconstruction_points_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_precondition_code(CODE)
@@ -159,8 +153,7 @@
 #undef CGAL_surface_reconstruction_points_expensive_precondition_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_precondition_code(CODE)
@@ -180,8 +173,7 @@
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_precondition_code(CODE)
@@ -202,8 +194,7 @@
 #undef CGAL_surface_reconstruction_points_postcondition_msg
 #undef CGAL_surface_reconstruction_points_postcondition_code
 
-#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_surface_reconstruction_points_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_postcondition_code(CODE)
@@ -222,8 +213,7 @@
 #undef CGAL_surface_reconstruction_points_exactness_postcondition_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_surface_reconstruction_points_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_postcondition_code(CODE)
@@ -242,8 +232,7 @@
 #undef CGAL_surface_reconstruction_points_expensive_postcondition_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_postcondition_code(CODE)
@@ -263,8 +252,7 @@
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_postcondition_code(CODE)
@@ -285,8 +273,7 @@
 #undef CGAL_surface_reconstruction_points_warning_msg
 #undef CGAL_surface_reconstruction_points_warning_code
 
-#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_surface_reconstruction_points_warning(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_warning_code(CODE)
@@ -305,8 +292,7 @@
 #undef CGAL_surface_reconstruction_points_exactness_warning_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_surface_reconstruction_points_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_exactness_warning_code(CODE)
@@ -325,8 +311,7 @@
 #undef CGAL_surface_reconstruction_points_expensive_warning_code
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_warning_code(CODE)
@@ -346,8 +331,7 @@
 
 #if defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_SURFACE_RECONSTRUCTION_POINTS_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_surface_reconstruction_points_expensive_exactness_warning_code(CODE)

--- a/Polygon/include/CGAL/Polygon_2/polygon_assertions.h
+++ b/Polygon/include/CGAL/Polygon_2/polygon_assertions.h
@@ -19,7 +19,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -35,8 +35,7 @@
 
 #ifndef CGAL_POLYGON_ASSERTIONS_H
 #define CGAL_POLYGON_ASSERTIONS_H
-#if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-|| defined(NDEBUG)
+#if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 namespace CGAL{
 inline void set_use_polygon_assertions(bool){}
 inline bool get_use_polygon_assertions(){return true;}
@@ -57,8 +56,7 @@ inline void set_use_polygon_assertions(bool b)
 #endif
 #endif // CGAL_POLYGON_ASSERTIONS_H
 
-#if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_polygon_assertion(EX) (static_cast<void>(0))
 #  define CGAL_polygon_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_assertion_code(CODE)
@@ -77,8 +75,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_exactness_assertion_code
 
 #if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_polygon_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_assertion_code(CODE)
@@ -98,8 +95,7 @@ inline void set_use_polygon_assertions(bool b)
 
 #if defined(CGAL_POLYGON_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_assertion_code(CODE)
@@ -119,8 +115,7 @@ inline void set_use_polygon_assertions(bool b)
 
 #if defined(CGAL_POLYGON_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_assertion_code(CODE)
@@ -141,8 +136,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_precondition_msg
 #undef CGAL_polygon_precondition_code
 
-#if defined(CGAL_POLYGON_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POLYGON_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_polygon_precondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_precondition_code(CODE)
@@ -161,8 +155,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_exactness_precondition_code
 
 #if defined(CGAL_POLYGON_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_polygon_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_precondition_code(CODE)
@@ -181,8 +174,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_expensive_precondition_code
 
 #if defined(CGAL_POLYGON_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_precondition_code(CODE)
@@ -202,8 +194,7 @@ inline void set_use_polygon_assertions(bool b)
 
 #if defined(CGAL_POLYGON_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_precondition_code(CODE)
@@ -224,8 +215,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_postcondition_msg
 #undef CGAL_polygon_postcondition_code
 
-#if defined(CGAL_POLYGON_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POLYGON_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_polygon_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_postcondition_code(CODE)
@@ -244,8 +234,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_exactness_postcondition_code
 
 #if defined(CGAL_POLYGON_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_polygon_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_postcondition_code(CODE)
@@ -264,8 +253,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_expensive_postcondition_code
 
 #if defined(CGAL_POLYGON_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_postcondition_code(CODE)
@@ -285,8 +273,7 @@ inline void set_use_polygon_assertions(bool b)
 
 #if defined(CGAL_POLYGON_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_postcondition_code(CODE)
@@ -307,8 +294,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_warning_msg
 #undef CGAL_polygon_warning_code
 
-#if defined(CGAL_POLYGON_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_POLYGON_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_polygon_warning(EX) (static_cast<void>(0))
 #  define CGAL_polygon_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_warning_code(CODE)
@@ -327,8 +313,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_exactness_warning_code
 
 #if defined(CGAL_POLYGON_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_polygon_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_exactness_warning_code(CODE)
@@ -347,8 +332,7 @@ inline void set_use_polygon_assertions(bool b)
 #undef CGAL_polygon_expensive_warning_code
 
 #if defined(CGAL_POLYGON_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_warning_code(CODE)
@@ -368,8 +352,7 @@ inline void set_use_polygon_assertions(bool b)
 
 #if defined(CGAL_POLYGON_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_POLYGON_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_POLYGON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_polygon_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_polygon_expensive_exactness_warning_code(CODE)

--- a/Polytope_distance_d/include/CGAL/Width_3.h
+++ b/Polytope_distance_d/include/CGAL/Width_3.h
@@ -687,8 +687,7 @@ class Width_3 {
 
     std::vector<Vertex_handle> apv;
 #if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))\
-  || defined(NDEBUG))
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)))
       typename InputDA::Vertex_iterator vtxitass = P.vertices_begin();
       while(vtxitass!=P.vertices_end()) {
         RT px,py,pz,ph;
@@ -745,8 +744,7 @@ class Width_3 {
     DEBUGENDL(INITIAL_VF_PAIR,"Initial Plane E2: ",A<<" "<<B<<" "<<C<<" "<<D);
 
 #if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))\
-  || defined(NDEBUG))
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)))
       CGAL_expensive_assertion(D!=K && D!=0);
       DEBUGMSG(ASSERTION_OUTPUT,"A real plane E2 has been computed. "
                <<"ASSERTION OK.");
@@ -1058,8 +1056,7 @@ class Width_3 {
           DEBUGMSG(EE_COMPUTATION,"Now we check if the provided "
                    <<"solution is a feasible one.");
 #if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))\
-  || defined(NDEBUG))
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)))
             RT px,py,pz,ph;
             tco.get_point_coordinates(p,px,py,pz,ph);
             CGAL_expensive_assertion(a*px+b*py+c*pz+k*ph>=0);
@@ -1411,14 +1408,12 @@ class Width_3 {
       DEBUGMSG(WIDTH_3_CONVEX,"All plane equations of all facets computed.");
 
       //ensure all flags are false
-#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-      || defined(NDEBUG))
+#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS))
         int halfedgecount=0;
 #endif
         Halfedge_handle esf=P.halfedges_begin();
         while(esf!=P.halfedges_end()) {
-#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-      || defined(NDEBUG))
+#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS))
           ++halfedgecount;
 #endif
           DEBUGENDL(EDGE_INITIALIZING,"Edge e: "
@@ -1429,8 +1424,7 @@ class Width_3 {
           ++esf;
         }
 
-#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-      || defined(NDEBUG))
+#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS))
       CGAL_assertion(int(P.size_of_halfedges())==halfedgecount);
       DEBUGENDL(WIDTH_3_CONVEX,"Visited all ",halfedgecount
                 <<" halfedges. ASSERTION OK.");
@@ -1446,8 +1440,7 @@ class Width_3 {
       initial_VF_pair(dao,f,P,go_on);
 
 #if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))\
-  || defined(NDEBUG))
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)))
         Vertex_iterator vtxass=P.vertices_begin();
         while(vtxass!=P.vertices_end()) {
           RT px,py,pz,ph;
@@ -1523,8 +1516,7 @@ class Width_3 {
         }
       }
 #if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))\
-  || defined(NDEBUG))
+  || (!defined(CGAL_KERNEL_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)))
       Facet_handle fass=P.facets_begin();
       while(fass!=P.facets_end()) {
         std::vector<Vertex_handle> apvass;

--- a/Polytope_distance_d/include/CGAL/Width_polyhedron_3.h
+++ b/Polytope_distance_d/include/CGAL/Width_polyhedron_3.h
@@ -194,8 +194,7 @@ class Data_access {
     res=it->second;
   }
 
-#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-      || defined(NDEBUG))
+#if !(defined(CGAL_KERNEL_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS))
   int size_of_impassable() {
     return(int(impassable_halfedges.size()));
   }

--- a/STL_Extension/include/CGAL/multiset_assertions.h
+++ b/STL_Extension/include/CGAL/multiset_assertions.h
@@ -14,7 +14,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -27,8 +27,7 @@
 #undef CGAL_multiset_assertion_msg
 #undef CGAL_multiset_assertion_code
 
-#if defined(CGAL_MULTISET_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_MULTISET_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_multiset_assertion(EX) (static_cast<void>(0))
 #  define CGAL_multiset_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_assertion_code(CODE)
@@ -47,8 +46,7 @@
 #undef CGAL_multiset_exactness_assertion_code
 
 #if defined(CGAL_MULTISET_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_multiset_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_assertion_code(CODE)
@@ -68,8 +66,7 @@
 
 #if defined(CGAL_MULTISET_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_assertion_code(CODE)
@@ -89,8 +86,7 @@
 
 #if defined(CGAL_MULTISET_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_assertion_code(CODE)
@@ -111,8 +107,7 @@
 #undef CGAL_multiset_precondition_msg
 #undef CGAL_multiset_precondition_code
 
-#if defined(CGAL_MULTISET_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_MULTISET_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_multiset_precondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_precondition_code(CODE)
@@ -131,8 +126,7 @@
 #undef CGAL_multiset_exactness_precondition_code
 
 #if defined(CGAL_MULTISET_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_multiset_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_precondition_code(CODE)
@@ -151,8 +145,7 @@
 #undef CGAL_multiset_expensive_precondition_code
 
 #if defined(CGAL_MULTISET_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_precondition_code(CODE)
@@ -172,8 +165,7 @@
 
 #if defined(CGAL_MULTISET_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_precondition_code(CODE)
@@ -194,8 +186,7 @@
 #undef CGAL_multiset_postcondition_msg
 #undef CGAL_multiset_postcondition_code
 
-#if defined(CGAL_MULTISET_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_MULTISET_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_multiset_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_postcondition_code(CODE)
@@ -214,8 +205,7 @@
 #undef CGAL_multiset_exactness_postcondition_code
 
 #if defined(CGAL_MULTISET_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_multiset_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_postcondition_code(CODE)
@@ -234,8 +224,7 @@
 #undef CGAL_multiset_expensive_postcondition_code
 
 #if defined(CGAL_MULTISET_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_postcondition_code(CODE)
@@ -255,8 +244,7 @@
 
 #if defined(CGAL_MULTISET_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_postcondition_code(CODE)
@@ -277,8 +265,7 @@
 #undef CGAL_multiset_warning_msg
 #undef CGAL_multiset_warning_code
 
-#if defined(CGAL_MULTISET_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_MULTISET_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_multiset_warning(EX) (static_cast<void>(0))
 #  define CGAL_multiset_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_warning_code(CODE)
@@ -297,8 +284,7 @@
 #undef CGAL_multiset_exactness_warning_code
 
 #if defined(CGAL_MULTISET_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_multiset_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_exactness_warning_code(CODE)
@@ -317,8 +303,7 @@
 #undef CGAL_multiset_expensive_warning_code
 
 #if defined(CGAL_MULTISET_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_warning_code(CODE)
@@ -338,8 +323,7 @@
 
 #if defined(CGAL_MULTISET_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_MULTISET_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_MULTISET_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_multiset_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_multiset_expensive_exactness_warning_code(CODE)

--- a/STL_Extension/include/CGAL/triangulation_assertions.h
+++ b/STL_Extension/include/CGAL/triangulation_assertions.h
@@ -14,7 +14,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -27,8 +27,7 @@
 #undef CGAL_triangulation_assertion_msg
 #undef CGAL_triangulation_assertion_code
 
-#if defined(CGAL_TRIANGULATION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TRIANGULATION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_triangulation_assertion(EX) (static_cast<void>(0))
 
 
@@ -49,8 +48,7 @@
 #undef CGAL_triangulation_exactness_assertion_code
 
 #if defined(CGAL_TRIANGULATION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_triangulation_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_assertion_code(CODE)
@@ -70,8 +68,7 @@
 
 #if defined(CGAL_TRIANGULATION_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_assertion_code(CODE)
@@ -91,8 +88,7 @@
 
 #if defined(CGAL_TRIANGULATION_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_assertion_code(CODE)
@@ -113,8 +109,7 @@
 #undef CGAL_triangulation_precondition_msg
 #undef CGAL_triangulation_precondition_code
 
-#if defined(CGAL_TRIANGULATION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TRIANGULATION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_triangulation_precondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_precondition_code(CODE)
@@ -133,8 +128,7 @@
 #undef CGAL_triangulation_exactness_precondition_code
 
 #if defined(CGAL_TRIANGULATION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_triangulation_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_precondition_code(CODE)
@@ -153,8 +147,7 @@
 #undef CGAL_triangulation_expensive_precondition_code
 
 #if defined(CGAL_TRIANGULATION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_precondition_code(CODE)
@@ -174,8 +167,7 @@
 
 #if defined(CGAL_TRIANGULATION_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_precondition_code(CODE)
@@ -196,8 +188,7 @@
 #undef CGAL_triangulation_postcondition_msg
 #undef CGAL_triangulation_postcondition_code
 
-#if defined(CGAL_TRIANGULATION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TRIANGULATION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_triangulation_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_postcondition_code(CODE)
@@ -216,8 +207,7 @@
 #undef CGAL_triangulation_exactness_postcondition_code
 
 #if defined(CGAL_TRIANGULATION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_triangulation_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_postcondition_code(CODE)
@@ -236,8 +226,7 @@
 #undef CGAL_triangulation_expensive_postcondition_code
 
 #if defined(CGAL_TRIANGULATION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_postcondition_code(CODE)
@@ -257,8 +246,7 @@
 
 #if defined(CGAL_TRIANGULATION_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_postcondition_code(CODE)
@@ -279,8 +267,7 @@
 #undef CGAL_triangulation_warning_msg
 #undef CGAL_triangulation_warning_code
 
-#if defined(CGAL_TRIANGULATION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TRIANGULATION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_triangulation_warning(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_warning_code(CODE)
@@ -299,8 +286,7 @@
 #undef CGAL_triangulation_exactness_warning_code
 
 #if defined(CGAL_TRIANGULATION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_triangulation_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_exactness_warning_code(CODE)
@@ -319,8 +305,7 @@
 #undef CGAL_triangulation_expensive_warning_code
 
 #if defined(CGAL_TRIANGULATION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_warning_code(CODE)
@@ -340,8 +325,7 @@
 
 #if defined(CGAL_TRIANGULATION_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_TRIANGULATION_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TRIANGULATION_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_triangulation_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_triangulation_expensive_exactness_warning_code(CODE)

--- a/Scripts/scripts/cgal_create_assertions.sh
+++ b/Scripts/scripts/cgal_create_assertions.sh
@@ -48,7 +48,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -61,8 +61,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_assertion_msg
 #undef CGAL_xxx_assertion_code
 
-#if defined(CGAL_XXX_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_XXX_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_xxx_assertion(EX) (static_cast<void>(0))
 #  define CGAL_xxx_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_assertion_code(CODE)
@@ -81,8 +80,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_exactness_assertion_code
 
 #if defined(CGAL_XXX_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_xxx_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_assertion_code(CODE)
@@ -102,8 +100,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 #if defined(CGAL_XXX_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_assertion_code(CODE)
@@ -123,8 +120,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 #if defined(CGAL_XXX_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_assertion_code(CODE)
@@ -145,8 +141,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_precondition_msg
 #undef CGAL_xxx_precondition_code
 
-#if defined(CGAL_XXX_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_XXX_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_xxx_precondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_precondition_code(CODE)
@@ -165,8 +160,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_exactness_precondition_code
 
 #if defined(CGAL_XXX_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_xxx_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_precondition_code(CODE)
@@ -185,8 +179,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_expensive_precondition_code
 
 #if defined(CGAL_XXX_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_precondition_code(CODE)
@@ -206,8 +199,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 #if defined(CGAL_XXX_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_precondition_code(CODE)
@@ -228,8 +220,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_postcondition_msg
 #undef CGAL_xxx_postcondition_code
 
-#if defined(CGAL_XXX_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_XXX_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_xxx_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_postcondition_code(CODE)
@@ -248,8 +239,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_exactness_postcondition_code
 
 #if defined(CGAL_XXX_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_xxx_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_postcondition_code(CODE)
@@ -268,8 +258,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_expensive_postcondition_code
 
 #if defined(CGAL_XXX_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_postcondition_code(CODE)
@@ -289,8 +278,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 #if defined(CGAL_XXX_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_postcondition_code(CODE)
@@ -311,8 +299,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_warning_msg
 #undef CGAL_xxx_warning_code
 
-#if defined(CGAL_XXX_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_XXX_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_xxx_warning(EX) (static_cast<void>(0))
 #  define CGAL_xxx_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_warning_code(CODE)
@@ -331,8 +318,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_exactness_warning_code
 
 #if defined(CGAL_XXX_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_xxx_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_exactness_warning_code(CODE)
@@ -351,8 +337,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 #undef CGAL_xxx_expensive_warning_code
 
 #if defined(CGAL_XXX_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_warning_code(CODE)
@@ -372,8 +357,7 @@ sed -e "s/XXX_/${nameUC}/g" -e "s/xxx_/${nameLC}/g" <<"EOF" \
 
 #if defined(CGAL_XXX_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_XXX_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_XXX_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_xxx_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_xxx_expensive_exactness_warning_code(CODE)

--- a/SearchStructures/include/CGAL/Tree_assertions.h
+++ b/SearchStructures/include/CGAL/Tree_assertions.h
@@ -15,7 +15,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -28,8 +28,7 @@
 #undef CGAL_Tree_assertion_msg
 #undef CGAL_Tree_assertion_code
 
-#if defined(CGAL_TREE_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TREE_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_Tree_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/SearchStructures.h>
@@ -51,8 +50,7 @@
 #undef CGAL_Tree_exactness_assertion_code
 
 #if defined(CGAL_TREE_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_Tree_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_assertion_code(CODE)
@@ -72,8 +70,7 @@
 
 #if defined(CGAL_TREE_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_assertion_code(CODE)
@@ -93,8 +90,7 @@
 
 #if defined(CGAL_TREE_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_assertion_code(CODE)
@@ -115,8 +111,7 @@
 #undef CGAL_Tree_precondition_msg
 #undef CGAL_Tree_precondition_code
 
-#if defined(CGAL_TREE_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TREE_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_Tree_precondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_precondition_code(CODE)
@@ -135,8 +130,7 @@
 #undef CGAL_Tree_exactness_precondition_code
 
 #if defined(CGAL_TREE_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_Tree_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_precondition_code(CODE)
@@ -155,8 +149,7 @@
 #undef CGAL_Tree_expensive_precondition_code
 
 #if defined(CGAL_TREE_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_precondition_code(CODE)
@@ -176,8 +169,7 @@
 
 #if defined(CGAL_TREE_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_precondition_code(CODE)
@@ -198,8 +190,7 @@
 #undef CGAL_Tree_postcondition_msg
 #undef CGAL_Tree_postcondition_code
 
-#if defined(CGAL_TREE_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TREE_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_Tree_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_postcondition_code(CODE)
@@ -218,8 +209,7 @@
 #undef CGAL_Tree_exactness_postcondition_code
 
 #if defined(CGAL_TREE_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_Tree_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_postcondition_code(CODE)
@@ -238,8 +228,7 @@
 #undef CGAL_Tree_expensive_postcondition_code
 
 #if defined(CGAL_TREE_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_postcondition_code(CODE)
@@ -259,8 +248,7 @@
 
 #if defined(CGAL_TREE_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_postcondition_code(CODE)
@@ -281,8 +269,7 @@
 #undef CGAL_Tree_warning_msg
 #undef CGAL_Tree_warning_code
 
-#if defined(CGAL_TREE_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_TREE_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_Tree_warning(EX) (static_cast<void>(0))
 #  define CGAL_Tree_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_warning_code(CODE)
@@ -301,8 +288,7 @@
 #undef CGAL_Tree_exactness_warning_code
 
 #if defined(CGAL_TREE_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_Tree_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_exactness_warning_code(CODE)
@@ -321,8 +307,7 @@
 #undef CGAL_Tree_expensive_warning_code
 
 #if defined(CGAL_TREE_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_warning_code(CODE)
@@ -342,8 +327,7 @@
 
 #if defined(CGAL_TREE_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_TREE_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_TREE_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_Tree_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_Tree_expensive_exactness_warning_code(CODE)

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/assertions.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/assertions.h
@@ -16,8 +16,7 @@
 
 #if defined(CGAL_STRAIGHT_SKELETON_NO_POSTCONDITIONS) \
   || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_STRAIGHT_SKELETON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STRAIGHT_SKELETON_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_stskel_expensive_postcondition(EX)         (static_cast<void>(0))
 #  define CGAL_stskel_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_stskel_expensive_postcondition_code(CODE)

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/assertions.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/assertions.h
@@ -13,6 +13,7 @@
 
 #include <CGAL/license/Straight_skeleton_2.h>
 
+#include <CGAL/assertions.h>
 
 #if defined(CGAL_STRAIGHT_SKELETON_NO_POSTCONDITIONS) \
   || defined(CGAL_NO_POSTCONDITIONS) \

--- a/Stream_lines_2/include/CGAL/streamlines_assertions.h
+++ b/Stream_lines_2/include/CGAL/streamlines_assertions.h
@@ -15,7 +15,7 @@
 
 // Note that this header file is intentionnaly not protected with a
 // macro (as <cassert>). Calling it a second time with another value
-// for NDEBUG for example must make a difference.
+// for CGAL_NO_ASSERTIONS for example must make a difference.
 
 #include <CGAL/assertions.h>
 
@@ -28,8 +28,7 @@
 #undef CGAL_streamlines_assertion_msg
 #undef CGAL_streamlines_assertion_code
 
-#if defined(CGAL_STREAMLINES_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_STREAMLINES_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS)
 #  define CGAL_streamlines_assertion(EX) (static_cast<void>(0))
 
 #include <CGAL/license/Stream_lines_2.h>
@@ -51,8 +50,7 @@
 #undef CGAL_streamlines_exactness_assertion_code
 
 #if defined(CGAL_STREAMLINES_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_streamlines_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_assertion_code(CODE)
@@ -72,8 +70,7 @@
 
 #if defined(CGAL_STREAMLINES_NO_ASSERTIONS) \
   || defined(CGAL_NO_ASSERTIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_assertion(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_assertion_code(CODE)
@@ -93,8 +90,7 @@
 
 #if defined(CGAL_STREAMLINES_NO_ASSERTIONS) || defined(CGAL_NO_ASSERTIONS) \
   || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_exactness_assertion(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_assertion_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_assertion_code(CODE)
@@ -115,8 +111,7 @@
 #undef CGAL_streamlines_precondition_msg
 #undef CGAL_streamlines_precondition_code
 
-#if defined(CGAL_STREAMLINES_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_STREAMLINES_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS)
 #  define CGAL_streamlines_precondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_precondition_code(CODE)
@@ -135,8 +130,7 @@
 #undef CGAL_streamlines_exactness_precondition_code
 
 #if defined(CGAL_STREAMLINES_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_streamlines_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_precondition_code(CODE)
@@ -155,8 +149,7 @@
 #undef CGAL_streamlines_expensive_precondition_code
 
 #if defined(CGAL_STREAMLINES_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_precondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_precondition_code(CODE)
@@ -176,8 +169,7 @@
 
 #if defined(CGAL_STREAMLINES_NO_PRECONDITIONS) || defined(CGAL_NO_PRECONDITIONS) \
   || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_exactness_precondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_precondition_code(CODE)
@@ -198,8 +190,7 @@
 #undef CGAL_streamlines_postcondition_msg
 #undef CGAL_streamlines_postcondition_code
 
-#if defined(CGAL_STREAMLINES_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || defined(NDEBUG)
+#if defined(CGAL_STREAMLINES_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS)
 #  define CGAL_streamlines_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_postcondition_code(CODE)
@@ -218,8 +209,7 @@
 #undef CGAL_streamlines_exactness_postcondition_code
 
 #if defined(CGAL_STREAMLINES_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_streamlines_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_postcondition_code(CODE)
@@ -238,8 +228,7 @@
 #undef CGAL_streamlines_expensive_postcondition_code
 
 #if defined(CGAL_STREAMLINES_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_postcondition_code(CODE)
@@ -259,8 +248,7 @@
 
 #if defined(CGAL_STREAMLINES_NO_POSTCONDITIONS) || defined(CGAL_NO_POSTCONDITIONS) \
   || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_exactness_postcondition(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_postcondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_postcondition_code(CODE)
@@ -281,8 +269,7 @@
 #undef CGAL_streamlines_warning_msg
 #undef CGAL_streamlines_warning_code
 
-#if defined(CGAL_STREAMLINES_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || defined(NDEBUG)
+#if defined(CGAL_STREAMLINES_NO_WARNINGS) || defined(CGAL_NO_WARNINGS)
 #  define CGAL_streamlines_warning(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_warning_code(CODE)
@@ -301,8 +288,7 @@
 #undef CGAL_streamlines_exactness_warning_code
 
 #if defined(CGAL_STREAMLINES_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))
 #  define CGAL_streamlines_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_exactness_warning_code(CODE)
@@ -321,8 +307,7 @@
 #undef CGAL_streamlines_expensive_warning_code
 
 #if defined(CGAL_STREAMLINES_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_warning(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_warning_code(CODE)
@@ -342,8 +327,7 @@
 
 #if defined(CGAL_STREAMLINES_NO_WARNINGS) || defined(CGAL_NO_WARNINGS) \
   || (!defined(CGAL_STREAMLINES_CHECK_EXACTNESS) && !defined(CGAL_CHECK_EXACTNESS))\
-  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE)) \
-  || defined(NDEBUG)
+  || (!defined(CGAL_STREAMLINES_CHECK_EXPENSIVE) && !defined(CGAL_CHECK_EXPENSIVE))
 #  define CGAL_streamlines_expensive_exactness_warning(EX) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_warning_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_streamlines_expensive_exactness_warning_code(CODE)


### PR DESCRIPTION
## Summary of Changes

Remove NDEBUG from various nnn_assertions.h files as it is already visible through `CGAL_NO_ASSERTIONS`, `CGAL_NO_PRECONDITIONS`, `CGAL_NO_POSTCONDITIONS`, `CGAL_NO_WARNINGS`

Include missing header files for files which reference the above defines.

## Release Management

* Affected package(s): Arrangement_on_surface_2, Convex_hull_2,Kernel_23,Partition_2,Point_set_processing_3,Poisson_surface_reconstruction_3,Polygon,Polytope_distance_d, STL_Extension, Scripts, SearchStructures, Straight_skeleton_2, Stream_lines_2

* Issue(s) solved (if any): fix #5240 
* Feature/Small Feature (if any): small feature
* License and copyright ownership: Returned to CGAL authors.

