### PR TITLE
Default disable NEF trace macros

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/debug.h
+++ b/Nef_2/include/CGAL/Nef_2/debug.h
@@ -16,15 +16,14 @@
 #include <iostream>
 
 #ifdef NDEBUG
-#undef CGAL_NEF_DEBUG
-#define CGAL_NEF_DEBUG 1
+#undef CGAL_USE_TRACE
 #endif
 
 #ifndef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 1
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
   static int debugthread=1;
 #endif
 
@@ -35,40 +34,40 @@
 #undef CGAL_NEF_CTRACEN
 #undef CGAL_NEF_SETDTHREAD
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_SETDTHREAD(l) debugthread=l
 #else
 #define CGAL_NEF_SETDTHREAD(l)
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_TRACE(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<<" "<<t; }
 #else
 #define CGAL_NEF_TRACE(t) (static_cast<void>(0))
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_TRACEV(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<<" "<<#t<<" = "<<(t)<<std::endl; }
 #else
 #define CGAL_NEF_TRACEV(t) (static_cast<void>(0))
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<< " "<<t<<std::endl; }
 #else
 #define CGAL_NEF_TRACEN(t) (static_cast<void>(0))
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_CTRACE(b,t) if(b) {std::cerr<<" "<<t;} else {std::cerr<<" 0"}
 #else
 #define CGAL_NEF_CTRACE(b,t) (static_cast<void>(0))
 #endif
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
 #define CGAL_NEF_CTRACEN(b,t) if(b){ std::cerr<<" "<<t<<"\n";} else {std::cerr<<" 0\n"}
 #else
 #define CGAL_NEF_CTRACEN(b,t) (static_cast<void>(0))

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -524,19 +524,18 @@ else {
     Segment_3 s = S.front().second;
     S.pop_front();
     if( n->is_leaf()) {
-#ifndef NDEBUG
+
       CGAL_assertion_code(
-      if( first_segment) {
-        first_segment = false;
-        CGAL_NEF_TRACEN("operator++: prev_segment=(none), segment="<<s);
-      }
-      else {
-        CGAL_assertion( prev_segment.target() == s.source());
-        CGAL_assertion( prev_segment.direction() == s.direction());
-        CGAL_NEF_TRACEN("operator++: prev_segment="<<prev_segment<<", segment="<<s);
-      }
-      prev_segment = s);
-#endif
+        if( first_segment) {
+          first_segment = false;
+          CGAL_NEF_TRACEN("operator++: prev_segment=(none), segment="<<s);
+        } else {
+          CGAL_assertion( prev_segment.target() == s.source());
+          CGAL_assertion( prev_segment.direction() == s.direction());
+          CGAL_NEF_TRACEN("operator++: prev_segment="<<prev_segment<<", segment="<<s);
+        }
+        prev_segment = s);
+
       node = n;
       break;
     }

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -660,7 +660,7 @@ public:
                cet->source()->twin() == ce->source() )
             break;
 
-#ifndef NDEBUG
+#ifdef CGAL_USE_TRACE
       if( cet->circle() != ce->circle().opposite() )
         CGAL_NEF_TRACEN("assertion failed!");
 


### PR DESCRIPTION
## Summary of Changes

This ensures that the trace macros `CGAL_NEF_TRACE.*` are disabled unless the user specifically enables them by defining `CGAL_USE_TRACE`. `NDEBUG` also ensures `CGAL_USE_TRACE` is undefined.


## Release Management

* Affected package(s): Nef_2, Nef_3
* Issue(s) solved (if any): fix #5240
* License and copyright ownership: Returned to CGAL authors.

