### PR TITLE
Modify facet size criterion to avoid unfortunate dent in an example

### DIFF
--- a/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/mesh_implicit_shape.cpp
+++ b/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/mesh_implicit_shape.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     Periodic_mesh_domain::create_implicit_mesh_domain(schwarz_p, canonical_cube);
 
   Periodic_mesh_criteria criteria(facet_angle = 30,
-                                  facet_size = 0.05 * domain_size,
+                                  facet_size = 0.035 * domain_size,
                                   facet_distance = 0.025 * domain_size,
                                   cell_radius_edge_ratio = 2.,
                                   cell_size = 0.05);


### PR DESCRIPTION
## Summary of Changes

With the previous facet size criterion, the restricted Delauany has an
unfortunate choice of restricted facets, making it look like an unwanted hole.

See also this comment: https://github.com/CGAL/cgal/issues/5046#issuecomment-739922611

## Release Management

* Affected package(s): `P3M3`
* Issue(s) solved (if any): fix #5046
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

