### PR TITLE
Tetrahedral remeshing - fix edge split step

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -53,7 +53,20 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
     (point(v1->point()), point(v2->point()));
 
   //backup subdomain info of incident cells before making changes
-  short dimension = (std::max)((std::max)(1, c3t3.in_dimension(v1)), c3t3.in_dimension(v2));
+  short dimension;
+  if(c3t3.is_in_complex(e))
+    dimension = 1;
+  else
+  {
+    const std::size_t nb_patches = nb_incident_surface_patches(e, c3t3);
+    if(nb_patches == 1)
+      dimension = 2;
+    else if(nb_patches == 0)
+      dimension = 3;
+    else
+      CGAL_assertion(false);//e should be in complex
+  }
+
   boost::unordered_map<Facet, Subdomain_index> cells_info;
   boost::unordered_map<Facet, std::pair<Vertex_handle, Surface_patch_index> > facets_info;
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -53,7 +53,7 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
     (point(v1->point()), point(v2->point()));
 
   //backup subdomain info of incident cells before making changes
-  short dimension;
+  short dimension = 0;
   if(c3t3.is_in_complex(e))
     dimension = 1;
   else
@@ -66,6 +66,7 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
     else
       CGAL_assertion(false);//e should be in complex
   }
+  CGAL_assertion(dimension > 0);
 
   boost::unordered_map<Facet, Subdomain_index> cells_info;
   boost::unordered_map<Facet, std::pair<Vertex_handle, Surface_patch_index> > facets_info;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -608,6 +608,9 @@ public:
       Tetrahedral_remeshing::internal::compute_statistics(
         tr(), m_cell_selector, ossi.str().c_str());
 #endif
+#ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
+      CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3); 
+#endif
     }
 
     while (it_nb < max_it + nb_extra_iterations)

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1004,12 +1004,11 @@ template<typename C3t3>
 void check_surface_patch_indices(const C3t3& c3t3)
 {
   typedef typename C3t3::Vertex_handle Vertex_handle;
-  typedef typename C3t3::Surface_patch_index Surface_patch_index;
   for (Vertex_handle v : c3t3.triangulation().finite_vertex_handles())
   {
     if (v->in_dimension() != 2)
       continue;
-    CGAL_assertion(surface_patch_index(v, c3t3) != Surface_patch_index());
+    CGAL_assertion(surface_patch_index(v, c3t3) != typename C3t3::Surface_patch_index());
   }
 }
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1000,6 +1000,19 @@ void dump_polylines(const CellRange& cells, const char* filename)
   ofs.close();
 }
 
+template<typename C3t3>
+void check_surface_patch_indices(const C3t3& c3t3)
+{
+  typedef typename C3t3::Vertex_handle Vertex_handle;
+  typedef typename C3t3::Surface_patch_index Surface_patch_index;
+  for (Vertex_handle v : c3t3.triangulation().finite_vertex_handles())
+  {
+    if (v->in_dimension() != 2)
+      continue;
+    CGAL_assertion(surface_patch_index(v, c3t3) != Surface_patch_index());
+  }
+}
+
 template<typename Tr>
 bool are_cell_orientations_valid(const Tr& tr)
 {


### PR DESCRIPTION
## Summary of Changes

During the splitting edges step, some vertices could get a wrong value for their `dimension` (the smallest dimension of the geometric components they belong to), because an edge can have its 2 end vertices on some surface patches/feature polylines, and still be in the interior of the domain.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* Issue(s) solved (if any): fix #5235 
* License and copyright ownership: unchanged

