### PR TITLE
[RANSAC] Fix detection of automatic parameter selection

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -511,13 +511,16 @@ namespace CGAL {
 
       // Minimum number of points has been set?
       m_options.min_points =
-        (m_options.min_points >= m_num_available_points) ?
+        (m_options.min_points == (std::numeric_limits<std::size_t>::max)()) ?
           (std::size_t)((FT)0.01 * m_num_available_points) :
           m_options.min_points;
       m_options.min_points = (m_options.min_points < 10) ? 10 : m_options.min_points;
 
       // Initializing the shape index
       m_shape_index.assign(m_num_available_points, -1);
+
+      if (m_options.min_points > m_num_available_points)
+        return true;
 
       // List of all randomly drawn candidates
       // with the minimum number of points


### PR DESCRIPTION
## Summary of Changes

When using `min_points` greater than the total number of points, RANSAC was silently recomputing `min_points=0.01*nb_points`, because it wrongly assumed the automatic detection was required. This PR fixes that.

## Release Management

* Affected package(s): Shape Detection
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/5250

