### PR TITLE
Fix warnings [-Wnon-c-typedef-for-linkage] In Ridges and Jet_fitting

### DIFF
--- a/Jet_fitting_3/examples/Jet_fitting_3/PolyhedralSurf.h
+++ b/Jet_fitting_3/examples/Jet_fitting_3/PolyhedralSurf.h
@@ -145,7 +145,7 @@ HEdge_PM<TPoly> get_hepm(boost::edge_weight_t, TPoly& )
 struct Wrappers_VFH:public CGAL::Polyhedron_items_3 {
   // wrap vertex
   template < class Refs, class Traits > struct Vertex_wrapper {
-    typedef struct {
+    typedef struct FGeomTraits {
     public:
       typedef typename Traits::Point_3 Point_3;
     } FGeomTraits;
@@ -158,7 +158,7 @@ struct Wrappers_VFH:public CGAL::Polyhedron_items_3 {
   template < class Refs, class Traits > struct Face_wrapper {
     //typedef typename Traits::Vector_3 Vector_3;
     //all types needed by the facet...
-    typedef struct {
+    typedef struct FGeomTraits {
     public:
       typedef typename Traits::Vector_3 Vector_3;
     } FGeomTraits;

--- a/Ridges_3/examples/Ridges_3/PolyhedralSurf.h
+++ b/Ridges_3/examples/Ridges_3/PolyhedralSurf.h
@@ -43,7 +43,7 @@ struct Wrappers_VFH:public CGAL::Polyhedron_items_3 {
   template < class Refs, class Traits > struct Face_wrapper {
     //typedef typename Traits::Vector_3 Vector_3;
     //all types needed by the facet...
-    typedef struct {
+    typedef struct FGeomTraits {
     public:
        typedef typename Traits::Vector_3 Vector_3;
      } FGeomTraits;

--- a/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
+++ b/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
@@ -23,7 +23,7 @@ int main()
 #include <CGAL/Random.h>
 #include <CGAL/use.h>
 
-# include <tbb/task_scheduler_init.h>
+# include <tbb/global_control.h>
 # include <tbb/parallel_for.h>
 # include <atomic>
 
@@ -451,7 +451,7 @@ int main()
     std::cout << "cc2: " << it->rnd << " / " << std::endl;
   }*/
 
-  tbb::task_scheduler_init init(1);
+  tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
   test_time_stamps<CGAL::Concurrent_compact_container<Node_1> >();
   return 0;
 }

--- a/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
+++ b/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
@@ -22,7 +22,7 @@ int main()
 #include <CGAL/Concurrent_compact_container.h>
 #include <CGAL/Random.h>
 #include <CGAL/use.h>
-
+#define TBB_PREVIEW_GLOBAL_CONTROL 1
 # include <tbb/global_control.h>
 # include <tbb/parallel_for.h>
 # include <atomic>


### PR DESCRIPTION
## Summary of Changes

Fix warnings `[-Wnon-c-typedef-for-linkage]`, emitted by clang. Example of such a warning:
```
.../test/Jet_fitting_3_Examples/PolyhedralSurf.h:148:19: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
    typedef struct {
                  ^
                   FGeomTraits
.../test/Jet_fitting_3_Examples/PolyhedralSurf.h:149:5: note: type is not C-compatible due to this member declaration
    public:
    ^~~~~~~
.../test/Jet_fitting_3_Examples/PolyhedralSurf.h:151:7: note: type is given name FGeomTraits for linkage purposes by this typedef declaration
    } FGeomTraits;
      ^
```
from https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.1.1-I-252/Jet_fitting_3_Examples/TestReport_lrineau_ArchLinux-clang-CXX17-Release.gz

## Release Management

* Affected package(s): Ridges, Jet_fitting


