### PR TITLE
Fix structurally dead code in SNC_simplify.h

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -191,16 +191,6 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
     return (sp1 == sp2.antipode());
   }
 
-  bool simplify_redundant_box_vertex(Vertex_handle v, bool snc_computed) {
-    //CGAL_warning("altered code");
-    return false;
-    if(snc_computed) return false;
-    if(!Infi_box::is_redundant_box_vertex(*v)) return false;
-    this->sncp()->delete_vertex(v);
-    simplified = true;
-    return true;
-  }
-
   bool simplify_redundant_vertex_in_volume(Vertex_handle v) {
     if(is_part_of_volume(v)) {
       //      CGAL_NEF_TRACEN("mark("<<IO->index(v)<<")="<<v->mark()<<", "<<
@@ -295,7 +285,6 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
     while( v != (*this->sncp()).vertices_end()) {
       Vertex_iterator v_next(v);
       ++v_next;
-      if(!simplify_redundant_box_vertex(v, snc_computed))
         if(!simplify_redundant_vertex_in_volume(v))
           if(!simplify_redundant_vertex_on_facet(v))
             simplify_redundant_vertex_on_edge(v, snc_computed);


### PR DESCRIPTION
## Summary of Changes

In SNC_simplify.h the function  simplify_redundant_box_vertex unconditionally returns false.

https://github.com/CGAL/cgal/blob/a848e52552a9205124b7ae13c7bcd2b860eb4530/Nef_3/include/CGAL/Nef_3/SNC_simplify.h#L194-L202

This function should probably be removed as it is effectively not in use.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

