### PR TITLE
Move assignment operators

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Halfedge.h
+++ b/Nef_3/include/CGAL/Nef_3/Halfedge.h
@@ -100,6 +100,17 @@ class Halfedge_base
           return *this;
         }
 
+      Halfedge_base<Refs>& operator=(Halfedge_base<Refs>&& e) noexcept
+        { center_vertex_ = std::move(e.center_vertex_);
+          point_ = std::move(e.point_);
+          mark_ = std::move(e.mark_);
+          twin_ = std::move(e.twin_);
+          out_sedge_ = std::move(e.out_sedge_);
+          incident_sface_ = std::move(e.incident_sface_);
+          info_ = 0;
+          return *this;
+        }
+
       Vertex_handle& center_vertex() { return center_vertex_; }
       Vertex_const_handle center_vertex() const { return center_vertex_; }
 

--- a/Nef_3/include/CGAL/Nef_3/SHalfedge.h
+++ b/Nef_3/include/CGAL/Nef_3/SHalfedge.h
@@ -114,6 +114,22 @@ class SHalfedge_base  {
         return *this;
       }
 
+    SHalfedge_base<Refs>& operator=(SHalfedge_base<Refs>&& e) noexcept
+      {
+        source_ = std::move(e.source_);
+        sprev_ = std::move(e.sprev_);
+        snext_ = std::move(e.snext_);
+        incident_sface_ = std::move(e.incident_sface_);
+        twin_ = std::move(e.twin_);
+        prev_ = std::move(e.prev_);
+        next_ = std::move(e.next_);
+        facet_ = std::move(e.facet_);
+        info_ = 0;
+        mark_ = std::move(e.mark_);
+        circle_ = std::move(e.circle_);
+        return *this;
+      }
+
     Mark& mark() { return mark_; }
     const Mark& mark() const { return mark_; }
 

--- a/Nef_3/include/CGAL/Nef_3/SHalfloop.h
+++ b/Nef_3/include/CGAL/Nef_3/SHalfloop.h
@@ -75,6 +75,15 @@ class SHalfloop_base {
         return *this;
       }
 
+    SHalfloop_base<Refs>& operator=(SHalfloop_base<Refs>&& l) noexcept
+      { twin_ = std::move(l.twin_);
+        incident_sface_ = std::move(l.incident_sface_);
+        facet_ = std::move(l.facet_);
+        mark_ = std::move(l.mark_);
+        circle_ = std::move(l.circle_);
+        return *this;
+      }
+
     Mark& mark() { return mark_;}
     const Mark& mark() const { return mark_; }
 

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -369,8 +369,15 @@ protected:
   }
 
   Nef_polyhedron_3& operator=(const Nef_polyhedron_3<Kernel,Items, Mark>& N1) {
-    Base::operator=(N1);
+    Base::operator=(N1); // copy the handle
     set_snc(snc());
+    return (*this);
+  }
+
+  Nef_polyhedron_3& operator=(Nef_polyhedron_3<Kernel,Items, Mark>&& N1) noexcept {
+    N1.set_snc(snc()); // N1.set_snc sets N1.sncp_ not N1.snc_
+    Base::operator=(std::move(N1)); // swap the handles
+    set_snc(snc()); // snc() will return N1.snc_
     return (*this);
   }
 

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -68,6 +68,13 @@ class Handle
       return *this;
     }
 
+    Handle&
+    operator=(Handle&& x) noexcept
+    {
+      swap(*this,x);
+      return *this;
+    }
+
     friend void swap(Handle& a, Handle& b) noexcept { std::swap(a.PTR, b.PTR); }
 
     void reset()

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -51,6 +51,12 @@ class Handle
       PTR->count++;
     }
 
+    Handle(Handle&& x) noexcept
+      : PTR(x.PTR)
+    {
+      x.PTR = static_cast<Rep*>(0);
+    }
+
     ~Handle()
     {
         if ( PTR && (--PTR->count == 0))


### PR DESCRIPTION
## Summary of Changes

The static analysis recommends, as a low priority, adding move assignment operators for various classes. I have implemented them using the swap idiom which is exception-safe. 

For Gmpq_type an assignment operator isn't needed because the class has no members, adding a defaulted move assignment operator suppresses the analysis warnings. However adding a move assignment operator when a copy assignment operator isn't explicitly declared deletes the copy assignment operator, which then causes compile errors. Likewise for the copy constructor, these therefore also have to be declared defaulted. I don't think declaring these defaulted member functions introduces any extra code generation.

## Release Management

* Affected package(s): Nef_3, STL_extension, Number_types
* Issue(s) solved (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

