### PR TITLE
Surface_mesh: Fix sm_remove test

### DIFF
--- a/Surface_mesh/test/Surface_mesh/sm_remove.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_remove.cpp
@@ -98,11 +98,6 @@ int main()
   {
     m.clear();
 
-    auto l_vprop = m.add_property_map<Vertex_index, int>("vprop").first;
-    auto l_hprop = m.add_property_map<Halfedge_index, int>("hprop").first;
-    auto l_fprop = m.add_property_map<Face_index, int>("fprop").first;
-    auto l_eprop = m.add_property_map<Edge_index, int>("eprop").first;
-
     auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
     auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
     auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").first;

--- a/Surface_mesh/test/Surface_mesh/sm_remove.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_remove.cpp
@@ -118,10 +118,6 @@ int main()
     assert( &vremoved.array() == &l_vremoved.array() );
     assert( &eremoved.array() == &l_eremoved.array() );
     assert( &fremoved.array() == &l_fremoved.array() );
-    assert( &vprop.array() != &l_vprop.array() );
-    assert( &hprop.array() != &l_hprop.array() );
-    assert( &fprop.array() != &l_fprop.array() );
-    assert( &eprop.array() != &l_eprop.array() );
   }
 
   return 0;


### PR DESCRIPTION
## Summary of Changes
Assertions sometimes appear in the test `sm_remove` . We concluded that sometimes, memory is reused and assertions  that test adresses are different fail. So I removed those assertions.

## Release Management

* Affected package(s):Surface_mesh