### PR TITLE
[RANSAC] Fix ptrdiff overflow

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Shape_base.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Shape_base.h
@@ -623,7 +623,7 @@ namespace CGAL {
                                const std::ptrdiff_t n,
                                FT &low,
                                FT &high) {
-      const FT xn = double(x) * double(n);
+      const FT xn = FT(double(x) * double(n));
       const FT q = FT(xn * double(UN - x) * (UN - n) / (UN - 1));
       const FT sq = CGAL::sqrt(q);
       low  = (xn - sq) / UN;

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Shape_base.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Shape_base.h
@@ -623,10 +623,11 @@ namespace CGAL {
                                const std::ptrdiff_t n,
                                FT &low,
                                FT &high) {
-      const FT q = FT(x * n * double(UN - x) * (UN - n) / (UN - 1));
+      const FT xn = double(x) * double(n);
+      const FT q = FT(xn * double(UN - x) * (UN - n) / (UN - 1));
       const FT sq = CGAL::sqrt(q);
-      low  = (x * n - sq) / UN;
-      high = (x * n + sq)/UN;
+      low  = (xn - sq) / UN;
+      high = (xn + sq)/UN;
 
       if (!is_finite<FT>(low) || !is_finite<FT>(high)) {
         low = high = 0;


### PR DESCRIPTION
## Summary of Changes

The validity test I recently added revealed another bug on 32 bits platforms (see [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.2-I-61/Shape_detection/TestReport_lrineau_Fedora-32-Release.gz) for example) where, in some cases, no shapes are detected at all.

It was tricky but I finally figured out the reason: at some point, there is a multiplication of `std::ptrdiff_t` numbers that might lead to very large number and thus overflow in 32 bits (leading to computing the square root of a negative number, leading to NaN, etc.). In practise, they are multiplied to create double, so I fixed the bug by converting them _before_ multiplying them.

## Release Management

* Affected package(s): Shape Detection