### PR TITLE
Random_numbers : re-activate the seed printing in cgal_only

### DIFF
--- a/Random_numbers/include/CGAL/Random.h
+++ b/Random_numbers/include/CGAL/Random.h
@@ -232,7 +232,7 @@ public:
 
 inline Random& get_default_random()
 {
-#if (defined( CGAL_TEST_SUITE ) || defined( CGAL_PRINT_SEED )) && !defined(CGAL_HEADER_ONLY)
+#if defined( CGAL_TEST_SUITE ) || defined( CGAL_PRINT_SEED )
   internal::Random_print_seed rps;
   CGAL_STATIC_THREAD_LOCAL_VARIABLE(Random, default_random, rps);
 #else


### PR DESCRIPTION
## Summary of Changes
`Random_print_seed()` was fixed in 4.9 but `get_random_seed()` was not updated.
## Release Management

* Affected package(s):Random_numbers
