### PR TITLE
PMP::isotropic_remeshing - fix is_corner(v)

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1470,7 +1470,9 @@ private:
       unsigned int nb_incident_features = 0;
       for(halfedge_descriptor h : halfedges_around_target(v, mesh_))
       {
-        if (is_on_border(h) || is_on_patch_border(h))
+        halfedge_descriptor hopp = opposite(h, mesh_);
+        if ( is_on_border(h) || is_on_patch_border(h)
+          || is_on_border(hopp) || is_on_patch_border(hopp))
           ++nb_incident_features;
         if (nb_incident_features > 2)
           return true;


### PR DESCRIPTION
## Summary of Changes

`is_corner(v)` should count both incoming and outgoing halfedges around `v`, because the `Halfedge_status` is not symmetric.

This PR fixes (at least) the case where `v` is part of the border of a facet selection, and an end-vertex of a constrained edge. One incident edge was being collapsed in the wrong direction because the corner-status of `v` was wrong.

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

@xiaoXiaoCam @lrineau this patch should fix the issue you met
