### PR TITLE
Use a small_vector in Delaunay_triangulation

### DIFF
--- a/Triangulation/include/CGAL/Delaunay_triangulation.h
+++ b/Triangulation/include/CGAL/Delaunay_triangulation.h
@@ -21,6 +21,7 @@
 #include <CGAL/Dimension.h>
 #include <CGAL/Default.h>
 
+#include <boost/container/small_vector.hpp>
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 
 #include <algorithm>
@@ -792,7 +793,7 @@ Delaunay_triangulation<DCTraits, TDS>
 {
     CGAL_precondition_msg( ! is_infinite(s), "full cell must be finite");
     CGAL_expensive_precondition( POSITIVE == orientation(s) );
-    typedef std::vector<const Point *> Points;
+    typedef boost::container::small_vector<const Point *, 8> Points;
     Points points(current_dimension() + 2);
     int i(0);
     for( ; i <= current_dimension(); ++i )


### PR DESCRIPTION
## Summary of Changes

Use a small_vector in Delaunay_triangulation. It is only used locally in a function, and its size is at most the dimension + 2.

Making the vector thread_local would work as well, but we already had a small_vector in Triangulation.h.

This saves about 7% on Delaunay for some specific point sets.

## Release Management

* Affected package(s): Triangulation