### PR TITLE
Add "binary" expression in file open of registration_with_OpenGR example

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -25,7 +25,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -36,7 +36,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -21,28 +21,37 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-  const char* fname1 = (argc>1)?argv[1]:"data/hippo1.ply";
-  const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
+  const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
+	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
+	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns1),
+	std::ifstream input(fname_in1, std::ios::binary);
+  if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+  if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
             normal_map (Normal_map())))
   {
-    std::cerr << "Error: cannot read file " << fname1 << std::endl;
+    std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
     return EXIT_FAILURE;
   }
   input.close();
 
-  input.open(fname2);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns2),
+  input.open(fname_in2, std::ios::binary);
+  if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+  if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).
             normal_map (Normal_map())))
   {
-    std::cerr << "Error: cannot read file " << fname2 << std::endl;
+    std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
     return EXIT_FAILURE;
   }
   input.close();
@@ -69,7 +78,7 @@ int main(int argc, const char** argv)
                                       params::point_map(Point_map())
                                       .normal_map(Normal_map()));
 
-  std::ofstream out("pwns2_aligned.ply");
+  std::ofstream out(fname_output);
   if (!out ||
       !CGAL::write_ply_points(
         out, pwns2,
@@ -81,7 +90,7 @@ int main(int argc, const char** argv)
 
   std::cout << "Registration score: " << score << ".\n"
             << "Transformed version of " << fname2
-            << " written to pwn2_aligned.ply.\n";
+            << " written to " << fnameOut << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -21,76 +21,76 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-  const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
+	const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
 	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
-	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned.ply";
+	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned_opengr.ply";
 
-  std::vector<Pwn> pwns1, pwns2;
+	std::vector<Pwn> pwns1, pwns2;
 	std::ifstream input(fname_in1, std::ios::binary);
-  if (!input)
+	if (!input)
 	{
 		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
 		return EXIT_FAILURE;
 	}
-  if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
-            CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
+		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<Pwn>()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  input.open(fname_in2, std::ios::binary);
-  if (!input)
+	input.open(fname_in2, std::ios::binary);
+	if (!input)
 	{
 		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
 		return EXIT_FAILURE;
 	}
-  if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
-            CGAL::parameters::point_map (Point_map()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
+		CGAL::parameters::point_map(Point_map()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  // EITHER call the registration method Super4PCS from OpenGR to get the transformation to apply to pwns2
-  // std::pair<K::Aff_transformation_3, double> res =
-    CGAL::OpenGR::compute_registration_transformation(pwns1, pwns2,
-                                                      params::point_map(Point_map())
-                                                      .normal_map(Normal_map())
-                                                      .number_of_samples(200)
-                                                      .maximum_running_time(60)
-                                                      .accuracy(0.01),
-                                                      params::point_map(Point_map())
-                                                      .normal_map(Normal_map()));
+	// EITHER call the registration method Super4PCS from OpenGR to get the transformation to apply to pwns2
+	// std::pair<K::Aff_transformation_3, double> res =
+	CGAL::OpenGR::compute_registration_transformation(pwns1, pwns2,
+		params::point_map(Point_map())
+		.normal_map(Normal_map())
+		.number_of_samples(200)
+		.maximum_running_time(60)
+		.accuracy(0.01),
+		params::point_map(Point_map())
+		.normal_map(Normal_map()));
 
-  // OR call the registration method Super4PCS from OpenGR and apply the transformation to pwn2
-  double score =
-    CGAL::OpenGR::register_point_sets(pwns1, pwns2,
-                                      params::point_map(Point_map())
-                                      .normal_map(Normal_map())
-                                      .number_of_samples(200)
-                                      .maximum_running_time(60)
-                                      .accuracy(0.01),
-                                      params::point_map(Point_map())
-                                      .normal_map(Normal_map()));
+	// OR call the registration method Super4PCS from OpenGR and apply the transformation to pwn2
+	double score =
+		CGAL::OpenGR::register_point_sets(pwns1, pwns2,
+			params::point_map(Point_map())
+			.normal_map(Normal_map())
+			.number_of_samples(200)
+			.maximum_running_time(60)
+			.accuracy(0.01),
+			params::point_map(Point_map())
+			.normal_map(Normal_map()));
 
-  std::ofstream out(fname_output);
-  if (!out ||
-      !CGAL::write_ply_points(
-        out, pwns2,
-        CGAL::parameters::point_map(Point_map()).
-        normal_map(Normal_map())))
-  {
-    return EXIT_FAILURE;
-  }
+	std::ofstream out(fname_output);
+	if (!out ||
+		!CGAL::write_ply_points(
+			out, pwns2,
+			CGAL::parameters::point_map(Point_map()).
+			normal_map(Normal_map())))
+	{
+		return EXIT_FAILURE;
+	}
 
-  std::cout << "Registration score: " << score << ".\n"
-            << "Transformed version of " << fname2
-            << " written to " << fnameOut << std::endl;
+	std::cout << "Registration score: " << score << ".\n"
+		<< "Transformed version of " << fname_in2
+		<< " written to " << fname_output << std::endl;
 
-  return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -21,37 +21,28 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-  const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
-	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
-	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned.ply";
+  const char* fname1 = (argc>1)?argv[1]:"data/hippo1.ply";
+  const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-	std::ifstream input(fname_in1, std::ios::binary);
-  if (!input)
-	{
-		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
-		return EXIT_FAILURE;
-	}
-  if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
+  std::ifstream input(fname1);
+  if (!input ||
+      !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
             normal_map (Normal_map())))
   {
-    std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
+    std::cerr << "Error: cannot read file " << fname1 << std::endl;
     return EXIT_FAILURE;
   }
   input.close();
 
-  input.open(fname_in2, std::ios::binary);
-  if (!input)
-	{
-		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
-		return EXIT_FAILURE;
-	}
-  if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
+  input.open(fname2);
+  if (!input ||
+      !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).
             normal_map (Normal_map())))
   {
-    std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
+    std::cerr << "Error: cannot read file " << fname2 << std::endl;
     return EXIT_FAILURE;
   }
   input.close();
@@ -78,7 +69,7 @@ int main(int argc, const char** argv)
                                       params::point_map(Point_map())
                                       .normal_map(Normal_map()));
 
-  std::ofstream out(fname_output);
+  std::ofstream out("pwns2_aligned.ply");
   if (!out ||
       !CGAL::write_ply_points(
         out, pwns2,
@@ -90,7 +81,7 @@ int main(int argc, const char** argv)
 
   std::cout << "Registration score: " << score << ".\n"
             << "Transformed version of " << fname2
-            << " written to " << fnameOut << std::endl;
+            << " written to pwn2_aligned.ply.\n";
 
   return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -21,76 +21,76 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-	const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
+  const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
 	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
-	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned_opengr.ply";
+	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned.ply";
 
-	std::vector<Pwn> pwns1, pwns2;
+  std::vector<Pwn> pwns1, pwns2;
 	std::ifstream input(fname_in1, std::ios::binary);
-	if (!input)
+  if (!input)
 	{
 		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
 		return EXIT_FAILURE;
 	}
-	if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
-		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<Pwn>()).
-		normal_map(Normal_map())))
-	{
-		std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
-		return EXIT_FAILURE;
-	}
-	input.close();
+  if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
+            CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
+            normal_map (Normal_map())))
+  {
+    std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
+    return EXIT_FAILURE;
+  }
+  input.close();
 
-	input.open(fname_in2, std::ios::binary);
-	if (!input)
+  input.open(fname_in2, std::ios::binary);
+  if (!input)
 	{
 		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
 		return EXIT_FAILURE;
 	}
-	if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
-		CGAL::parameters::point_map(Point_map()).
-		normal_map(Normal_map())))
-	{
-		std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
-		return EXIT_FAILURE;
-	}
-	input.close();
+  if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
+            CGAL::parameters::point_map (Point_map()).
+            normal_map (Normal_map())))
+  {
+    std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
+    return EXIT_FAILURE;
+  }
+  input.close();
 
-	// EITHER call the registration method Super4PCS from OpenGR to get the transformation to apply to pwns2
-	// std::pair<K::Aff_transformation_3, double> res =
-	CGAL::OpenGR::compute_registration_transformation(pwns1, pwns2,
-		params::point_map(Point_map())
-		.normal_map(Normal_map())
-		.number_of_samples(200)
-		.maximum_running_time(60)
-		.accuracy(0.01),
-		params::point_map(Point_map())
-		.normal_map(Normal_map()));
+  // EITHER call the registration method Super4PCS from OpenGR to get the transformation to apply to pwns2
+  // std::pair<K::Aff_transformation_3, double> res =
+    CGAL::OpenGR::compute_registration_transformation(pwns1, pwns2,
+                                                      params::point_map(Point_map())
+                                                      .normal_map(Normal_map())
+                                                      .number_of_samples(200)
+                                                      .maximum_running_time(60)
+                                                      .accuracy(0.01),
+                                                      params::point_map(Point_map())
+                                                      .normal_map(Normal_map()));
 
-	// OR call the registration method Super4PCS from OpenGR and apply the transformation to pwn2
-	double score =
-		CGAL::OpenGR::register_point_sets(pwns1, pwns2,
-			params::point_map(Point_map())
-			.normal_map(Normal_map())
-			.number_of_samples(200)
-			.maximum_running_time(60)
-			.accuracy(0.01),
-			params::point_map(Point_map())
-			.normal_map(Normal_map()));
+  // OR call the registration method Super4PCS from OpenGR and apply the transformation to pwn2
+  double score =
+    CGAL::OpenGR::register_point_sets(pwns1, pwns2,
+                                      params::point_map(Point_map())
+                                      .normal_map(Normal_map())
+                                      .number_of_samples(200)
+                                      .maximum_running_time(60)
+                                      .accuracy(0.01),
+                                      params::point_map(Point_map())
+                                      .normal_map(Normal_map()));
 
-	std::ofstream out(fname_output);
-	if (!out ||
-		!CGAL::write_ply_points(
-			out, pwns2,
-			CGAL::parameters::point_map(Point_map()).
-			normal_map(Normal_map())))
-	{
-		return EXIT_FAILURE;
-	}
+  std::ofstream out(fname_output);
+  if (!out ||
+      !CGAL::write_ply_points(
+        out, pwns2,
+        CGAL::parameters::point_map(Point_map()).
+        normal_map(Normal_map())))
+  {
+    return EXIT_FAILURE;
+  }
 
-	std::cout << "Registration score: " << score << ".\n"
-		<< "Transformed version of " << fname_in2
-		<< " written to " << fname_output << std::endl;
+  std::cout << "Registration score: " << score << ".\n"
+            << "Transformed version of " << fname2
+            << " written to " << fnameOut << std::endl;
 
-	return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -39,7 +39,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
@@ -24,65 +24,74 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-  const char* fname1 = (argc>1)?argv[1]:"data/hippo1.ply";
-  const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
+	const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
+	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
+	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned_opengr_pointmatcher.ply";
 
-  std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns1),
-            CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname1 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	std::vector<Pwn> pwns1, pwns2;
+	std::ifstream input(fname_in1, std::ios::binary);
+	if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
+		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<Pwn>()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  input.open(fname2);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns2),
-            CGAL::parameters::point_map (Point_map()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname2 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	input.open(fname_in2, std::ios::binary);
+	if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
+		CGAL::parameters::point_map(Point_map()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  std::cerr << "Computing registration transformation using OpenGR Super4PCS.." << std::endl;
-  // First, compute registration transformation using OpenGR Super4PCS
-  K::Aff_transformation_3 res =
-    std::get<0>( // get first of pair, which is the transformation
-      CGAL::OpenGR::compute_registration_transformation
-        (pwns1, pwns2,
-         params::point_map(Point_map()).normal_map(Normal_map()),
-         params::point_map(Point_map()).normal_map(Normal_map()))
-    );
+	std::cerr << "Computing registration transformation using OpenGR Super4PCS.." << std::endl;
+	// First, compute registration transformation using OpenGR Super4PCS
+	K::Aff_transformation_3 res =
+		std::get<0>( // get first of pair, which is the transformation
+			CGAL::OpenGR::compute_registration_transformation
+			(pwns1, pwns2,
+				params::point_map(Point_map()).normal_map(Normal_map()),
+				params::point_map(Point_map()).normal_map(Normal_map()))
+			);
 
-  std::cerr << "Computing registration transformation using PointMatcher ICP, "
-            << "taking transformation computed by OpenGR Super4PCS as initial transformation.." << std::endl;
-  // Then, compute registration transformation using PointMatcher ICP, taking transformation computed
-  // by OpenGR as initial transformation, and apply the transformation to pwns2
-  // bool converged =
-    CGAL::pointmatcher::register_point_sets
-      (pwns1, pwns2,
-       params::point_map(Point_map()).normal_map(Normal_map()),
-       params::point_map(Point_map()).normal_map(Normal_map())
-       .transformation(res));
+	std::cerr << "Computing registration transformation using PointMatcher ICP, "
+		<< "taking transformation computed by OpenGR Super4PCS as initial transformation.." << std::endl;
+	// Then, compute registration transformation using PointMatcher ICP, taking transformation computed
+	// by OpenGR as initial transformation, and apply the transformation to pwns2
+	// bool converged =
+	CGAL::pointmatcher::register_point_sets
+	(pwns1, pwns2,
+		params::point_map(Point_map()).normal_map(Normal_map()),
+		params::point_map(Point_map()).normal_map(Normal_map())
+		.transformation(res));
 
-  std::ofstream out("pwns2_aligned.ply");
-  if (!out ||
-      !CGAL::write_ply_points(
-        out, pwns2,
-        CGAL::parameters::point_map(Point_map()).
-        normal_map(Normal_map())))
-  {
-    return EXIT_FAILURE;
-  }
+	std::ofstream out(fname_output);
+	if (!out ||
+		!CGAL::write_ply_points(
+			out, pwns2,
+			CGAL::parameters::point_map(Point_map()).
+			normal_map(Normal_map())))
+	{
+		return EXIT_FAILURE;
+	}
 
-  std::cerr << "Transformed version of " << fname2
-            << " written to pwn2_aligned.ply.\n";
+	std::cerr << "Transformed version of " << fname_in2
+		<< " written to " << fname_output << std::endl;
 
-  return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
@@ -24,74 +24,65 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-	const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
-	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
-	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned_opengr_pointmatcher.ply";
+  const char* fname1 = (argc>1)?argv[1]:"data/hippo1.ply";
+  const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
-	std::vector<Pwn> pwns1, pwns2;
-	std::ifstream input(fname_in1, std::ios::binary);
-	if (!input)
-	{
-		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
-		return EXIT_FAILURE;
-	}
-	if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
-		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<Pwn>()).
-		normal_map(Normal_map())))
-	{
-		std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
-		return EXIT_FAILURE;
-	}
-	input.close();
+  std::vector<Pwn> pwns1, pwns2;
+  std::ifstream input(fname1);
+  if (!input ||
+      !CGAL::read_ply_points(input, std::back_inserter(pwns1),
+            CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
+            normal_map (Normal_map())))
+  {
+    std::cerr << "Error: cannot read file " << fname1 << std::endl;
+    return EXIT_FAILURE;
+  }
+  input.close();
 
-	input.open(fname_in2, std::ios::binary);
-	if (!input)
-	{
-		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
-		return EXIT_FAILURE;
-	}
-	if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
-		CGAL::parameters::point_map(Point_map()).
-		normal_map(Normal_map())))
-	{
-		std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
-		return EXIT_FAILURE;
-	}
-	input.close();
+  input.open(fname2);
+  if (!input ||
+      !CGAL::read_ply_points(input, std::back_inserter(pwns2),
+            CGAL::parameters::point_map (Point_map()).
+            normal_map (Normal_map())))
+  {
+    std::cerr << "Error: cannot read file " << fname2 << std::endl;
+    return EXIT_FAILURE;
+  }
+  input.close();
 
-	std::cerr << "Computing registration transformation using OpenGR Super4PCS.." << std::endl;
-	// First, compute registration transformation using OpenGR Super4PCS
-	K::Aff_transformation_3 res =
-		std::get<0>( // get first of pair, which is the transformation
-			CGAL::OpenGR::compute_registration_transformation
-			(pwns1, pwns2,
-				params::point_map(Point_map()).normal_map(Normal_map()),
-				params::point_map(Point_map()).normal_map(Normal_map()))
-			);
+  std::cerr << "Computing registration transformation using OpenGR Super4PCS.." << std::endl;
+  // First, compute registration transformation using OpenGR Super4PCS
+  K::Aff_transformation_3 res =
+    std::get<0>( // get first of pair, which is the transformation
+      CGAL::OpenGR::compute_registration_transformation
+        (pwns1, pwns2,
+         params::point_map(Point_map()).normal_map(Normal_map()),
+         params::point_map(Point_map()).normal_map(Normal_map()))
+    );
 
-	std::cerr << "Computing registration transformation using PointMatcher ICP, "
-		<< "taking transformation computed by OpenGR Super4PCS as initial transformation.." << std::endl;
-	// Then, compute registration transformation using PointMatcher ICP, taking transformation computed
-	// by OpenGR as initial transformation, and apply the transformation to pwns2
-	// bool converged =
-	CGAL::pointmatcher::register_point_sets
-	(pwns1, pwns2,
-		params::point_map(Point_map()).normal_map(Normal_map()),
-		params::point_map(Point_map()).normal_map(Normal_map())
-		.transformation(res));
+  std::cerr << "Computing registration transformation using PointMatcher ICP, "
+            << "taking transformation computed by OpenGR Super4PCS as initial transformation.." << std::endl;
+  // Then, compute registration transformation using PointMatcher ICP, taking transformation computed
+  // by OpenGR as initial transformation, and apply the transformation to pwns2
+  // bool converged =
+    CGAL::pointmatcher::register_point_sets
+      (pwns1, pwns2,
+       params::point_map(Point_map()).normal_map(Normal_map()),
+       params::point_map(Point_map()).normal_map(Normal_map())
+       .transformation(res));
 
-	std::ofstream out(fname_output);
-	if (!out ||
-		!CGAL::write_ply_points(
-			out, pwns2,
-			CGAL::parameters::point_map(Point_map()).
-			normal_map(Normal_map())))
-	{
-		return EXIT_FAILURE;
-	}
+  std::ofstream out("pwns2_aligned.ply");
+  if (!out ||
+      !CGAL::write_ply_points(
+        out, pwns2,
+        CGAL::parameters::point_map(Point_map()).
+        normal_map(Normal_map())))
+  {
+    return EXIT_FAILURE;
+  }
 
-	std::cerr << "Transformed version of " << fname_in2
-		<< " written to " << fname_output << std::endl;
+  std::cerr << "Transformed version of " << fname2
+            << " written to pwn2_aligned.ply.\n";
 
-	return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -39,7 +39,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
@@ -24,135 +24,144 @@ namespace params = CGAL::parameters;
 
 int main(int argc, const char** argv)
 {
-  const char* fname1 = (argc>1)?argv[1]:"data/hippo1.ply";
-  const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
+	const char* fname_in1 = (argc > 1) ? argv[1] : "data/hippo1.ply";
+	const char* fname_in2 = (argc > 2) ? argv[2] : "data/hippo2.ply";
+	const char* fname_output = (argc > 3) ? argv[3] : "data/hippo_aligned_pointmatcher.ply";
 
-  std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns1),
-            CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname1 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	std::vector<Pwn> pwns1, pwns2;
+	std::ifstream input(fname_in1, std::ios::binary);
+	if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns1),
+		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<Pwn>()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in1 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  input.open(fname2);
-  if (!input ||
-      !CGAL::read_ply_points(input, std::back_inserter(pwns2),
-            CGAL::parameters::point_map (Point_map()).
-            normal_map (Normal_map())))
-  {
-    std::cerr << "Error: cannot read file " << fname2 << std::endl;
-    return EXIT_FAILURE;
-  }
-  input.close();
+	input.open(fname_in2, std::ios::binary);
+	if (!input)
+	{
+		std::cerr << "Error: cannot open file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+	if (!CGAL::read_ply_points(input, std::back_inserter(pwns2),
+		CGAL::parameters::point_map(Point_map()).
+		normal_map(Normal_map())))
+	{
+		std::cerr << "Error: cannot read file " << fname_in2 << std::endl;
+		return EXIT_FAILURE;
+	}
+	input.close();
 
-  //
-  // Prepare ICP config
-  //
-  using CGAL::pointmatcher::ICP_config;
+	//
+	// Prepare ICP config
+	//
+	using CGAL::pointmatcher::ICP_config;
 
-  // Possible config modules/components: https://libpointmatcher.readthedocs.io/en/latest/Configuration/#configuration-of-an-icp-chain
-  // See documentation of optional named parameters for CGAL PM ICP configuration / pointmatcher config module mapping
+	// Possible config modules/components: https://libpointmatcher.readthedocs.io/en/latest/Configuration/#configuration-of-an-icp-chain
+	// See documentation of optional named parameters for CGAL PM ICP configuration / pointmatcher config module mapping
 
-  // Prepare point set 1 filters (PM::ReferenceDataPointsFilters)
-  std::vector<ICP_config> point_set_1_filters;
-  point_set_1_filters.push_back( ICP_config { /*.name=*/"MinDistDataPointsFilter"       , /*.params=*/{ {"minDist", "0.5" }}  } );
-  point_set_1_filters.push_back( ICP_config { /*.name=*/"RandomSamplingDataPointsFilter", /*.params=*/{ {"prob"   , "0.05"}}  } );
+	// Prepare point set 1 filters (PM::ReferenceDataPointsFilters)
+	std::vector<ICP_config> point_set_1_filters;
+	point_set_1_filters.push_back(ICP_config{ /*.name=*/"MinDistDataPointsFilter"       , /*.params=*/{ {"minDist", "0.5" }} });
+	point_set_1_filters.push_back(ICP_config{ /*.name=*/"RandomSamplingDataPointsFilter", /*.params=*/{ {"prob"   , "0.05"}} });
 
-  // Prepare point set 2 filters (PM::ReadingDataPointsFilters)
-  std::vector<ICP_config> point_set_2_filters;
-  point_set_2_filters.push_back( ICP_config { /*.name=*/"MinDistDataPointsFilter"       , /*.params=*/{ {"minDist", "0.5" }}  } );
-  point_set_2_filters.push_back( ICP_config { /*.name=*/"RandomSamplingDataPointsFilter", /*.params=*/{ {"prob"   , "0.05"}}  } );
+	// Prepare point set 2 filters (PM::ReadingDataPointsFilters)
+	std::vector<ICP_config> point_set_2_filters;
+	point_set_2_filters.push_back(ICP_config{ /*.name=*/"MinDistDataPointsFilter"       , /*.params=*/{ {"minDist", "0.5" }} });
+	point_set_2_filters.push_back(ICP_config{ /*.name=*/"RandomSamplingDataPointsFilter", /*.params=*/{ {"prob"   , "0.05"}} });
 
-        // Prepare matcher function
-  ICP_config matcher { /*.name=*/"KDTreeMatcher", /*.params=*/{ {"knn", "1"}, {"epsilon", "3.16"} } };
+	// Prepare matcher function
+	ICP_config matcher{ /*.name=*/"KDTreeMatcher", /*.params=*/{ {"knn", "1"}, {"epsilon", "3.16"} } };
 
-  // Prepare outlier filters
-  std::vector<ICP_config> outlier_filters;
-  outlier_filters.push_back( ICP_config { /*.name=*/"TrimmedDistOutlierFilter", /*.params=*/{ {"ratio", "0.75" }}  } );
+	// Prepare outlier filters
+	std::vector<ICP_config> outlier_filters;
+	outlier_filters.push_back(ICP_config{ /*.name=*/"TrimmedDistOutlierFilter", /*.params=*/{ {"ratio", "0.75" }} });
 
-  // Prepare error minimizer
-  ICP_config error_minimizer { /*.name=*/"PointToPointErrorMinimizer"};
+	// Prepare error minimizer
+	ICP_config error_minimizer{ /*.name=*/"PointToPointErrorMinimizer" };
 
-  // Prepare transformation checker
-  std::vector<ICP_config> transformation_checkers;
-  transformation_checkers.push_back( ICP_config { /*.name=*/"CounterTransformationChecker", /*.params=*/{ {"maxIterationCount", "150" }}  } );
-  transformation_checkers.push_back( ICP_config { /*.name=*/"DifferentialTransformationChecker", /*.params=*/{ {"minDiffRotErr"  , "0.001" },
-                                                                                                       {"minDiffTransErr", "0.01"  },
-                                                                                                       {"smoothLength"   , "4"     } }
-                                                } );
-  // Prepare inspector
-  ICP_config inspector { /*.name=*/"NullInspector" };
+	// Prepare transformation checker
+	std::vector<ICP_config> transformation_checkers;
+	transformation_checkers.push_back(ICP_config{ /*.name=*/"CounterTransformationChecker", /*.params=*/{ {"maxIterationCount", "150" }} });
+	transformation_checkers.push_back(ICP_config{ /*.name=*/"DifferentialTransformationChecker", /*.params=*/{ {"minDiffRotErr"  , "0.001" },
+																										 {"minDiffTransErr", "0.01"  },
+																										 {"smoothLength"   , "4"     } }
+		});
+	// Prepare inspector
+	ICP_config inspector{ /*.name=*/"NullInspector" };
 
-  // Prepare logger
-  ICP_config logger { /*.name=*/"FileLogger" };
+	// Prepare logger
+	ICP_config logger{ /*.name=*/"FileLogger" };
 
-  const K::Aff_transformation_3 identity_transform = K::Aff_transformation_3(CGAL::Identity_transformation());
+	const K::Aff_transformation_3 identity_transform = K::Aff_transformation_3(CGAL::Identity_transformation());
 
-  // EITHER call the ICP registration method pointmatcher to get the transformation to apply to pwns2
-  std::pair<K::Aff_transformation_3, bool> res =
-  CGAL::pointmatcher::compute_registration_transformation
-    (pwns1, pwns2,
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_1_filters)
-     .matcher(matcher)
-     .outlier_filters(outlier_filters)
-     .error_minimizer(error_minimizer)
-     .transformation_checkers(transformation_checkers)
-     .inspector(inspector)
-     .logger(logger),
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_2_filters)
-     .transformation(identity_transform) /* initial transform for pwns2.
-                                          * default value is already identity transform.
-                                          * a proper initial transform could be given, for example,
-                                          * a transform returned from a coarse registration algorithm.
-                                          * */
-     );
+	// EITHER call the ICP registration method pointmatcher to get the transformation to apply to pwns2
+	std::pair<K::Aff_transformation_3, bool> res =
+		CGAL::pointmatcher::compute_registration_transformation
+		(pwns1, pwns2,
+			params::point_map(Point_map()).normal_map(Normal_map())
+			.point_set_filters(point_set_1_filters)
+			.matcher(matcher)
+			.outlier_filters(outlier_filters)
+			.error_minimizer(error_minimizer)
+			.transformation_checkers(transformation_checkers)
+			.inspector(inspector)
+			.logger(logger),
+			params::point_map(Point_map()).normal_map(Normal_map())
+			.point_set_filters(point_set_2_filters)
+			.transformation(identity_transform) /* initial transform for pwns2.
+												 * default value is already identity transform.
+												 * a proper initial transform could be given, for example,
+												 * a transform returned from a coarse registration algorithm.
+												 * */
+		);
 
-  // OR call the ICP registration method from pointmatcher and apply the transformation to pwn2
-  bool converged =
-  CGAL::pointmatcher::register_point_sets
-    (pwns1, pwns2,
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_1_filters)
-     .matcher(matcher)
-     .outlier_filters(outlier_filters)
-     .error_minimizer(error_minimizer)
-     .transformation_checkers(transformation_checkers)
-     .inspector(inspector)
-     .logger(logger),
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_2_filters)
-     .transformation(res.first) /* pass the above computed transformation as initial transformation.
-                                * as a result, the registration will require less iterations to converge.
-                                * */
-     );
+	// OR call the ICP registration method from pointmatcher and apply the transformation to pwn2
+	bool converged =
+		CGAL::pointmatcher::register_point_sets
+		(pwns1, pwns2,
+			params::point_map(Point_map()).normal_map(Normal_map())
+			.point_set_filters(point_set_1_filters)
+			.matcher(matcher)
+			.outlier_filters(outlier_filters)
+			.error_minimizer(error_minimizer)
+			.transformation_checkers(transformation_checkers)
+			.inspector(inspector)
+			.logger(logger),
+			params::point_map(Point_map()).normal_map(Normal_map())
+			.point_set_filters(point_set_2_filters)
+			.transformation(res.first) /* pass the above computed transformation as initial transformation.
+									   * as a result, the registration will require less iterations to converge.
+									   * */
+		);
 
-  if (converged)
-    std::cerr << "Success" << std::endl;
-  else
-  {
-    std::cerr << "Failure" << std::endl;
-    return EXIT_FAILURE;
-  }
+	if (converged)
+		std::cerr << "Success" << std::endl;
+	else
+	{
+		std::cerr << "Failure" << std::endl;
+		return EXIT_FAILURE;
+	}
 
-  std::ofstream out("pwns2_aligned.ply");
-  if (!out ||
-      !CGAL::write_ply_points(
-        out, pwns2,
-        CGAL::parameters::point_map(Point_map()).
-        normal_map(Normal_map())))
-  {
-    return EXIT_FAILURE;
-  }
+	std::ofstream out(fname_output);
+	if (!out ||
+		!CGAL::write_ply_points(
+			out, pwns2,
+			CGAL::parameters::point_map(Point_map()).
+			normal_map(Normal_map())))
+	{
+		return EXIT_FAILURE;
+	}
 
-  std::cout << "Transformed version of " << fname2
-            << " written to pwn2_aligned.ply.\n";
+	std::cout << "Transformed version of " << fname_in2
+		<< " written to " << fname_output << std::endl;
 
-  return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary of Changes
`registration_with_OpenGR` example can't be compilled without this small change:
```c++
std::ifstream input(fname_in1);
```
to
```c++
std::ifstream input(fname_in1, std::ios::binary);
```
`data/hippo1.ply` and `data/hippo2.ply` are in binary_little_endian format. So `read_ply_points` can't read them if they aren't opened in binary mode.

Also add a specific error if a file can't be open and a new argument to pass the output filename


## Release Management

* Affected package(s): Point_set_processing_3

