### PR TITLE
Fix unchecked return value warning in SM_point_locator.h

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
@@ -493,7 +493,7 @@ public:
           Sphere_segment first_half(p,p.antipode(),c);
           Sphere_segment second_part(p.antipode(),p,c);
           if(!do_intersect_internally(ei->circle(), first_half, p_res)) {
-            do_intersect_internally(ei->circle(), second_part, p_res);
+            (void)do_intersect_internally(ei->circle(), second_part, p_res);
           }
         }
 


### PR DESCRIPTION
## Summary of Changes

In SM_point_locator.h a call to `do_intersect_internally` doesn't require the return value to be checked. It's customary to cast the function to void to indicate  "Yes, I've decided to ignore the return value from this call"

## Release Management

* Affected package(s): Nef_S2
* Issue(s) solved (if any): bugfix / cleaning
* License and copyright ownership: Returned to CGAL authors.

