### PR TITLE
Add move ctor and move assign to Side_of_triangle_mesh

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -181,7 +181,6 @@ public:
     box = tree.bbox();
   }
 
-#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
   /**
   * Constructor moving an instance of Side_of_triangle_mesh to a new memory
   * location with minimal memory copy.
@@ -200,7 +199,6 @@ public:
   {
     other.own_tree = false;
   }
-#endif
 
   ~Side_of_triangle_mesh()
   {
@@ -213,7 +211,6 @@ public:
   }
 
 public:
-#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
   /**
   * Assign operator moving an instance of Side_of_triangle_mesh to this
   * location with minimal memory copy.
@@ -234,7 +231,6 @@ public:
     #endif
     return *this;
   }
-#endif
 
   /**
    * returns the location of a query point

--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -181,6 +181,27 @@ public:
     box = tree.bbox();
   }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+  /**
+  * Constructor moving an instance of Side_of_triangle_mesh to a new memory
+  * location with minimal memory copy.
+  * @param other The instance to be moved
+  */
+  Side_of_triangle_mesh(Side_of_triangle_mesh&& other) :
+    tm_ptr{other.tm_ptr},
+    opt_vpm{std::move(other.opt_vpm)},
+    own_tree{other.own_tree},
+    box{other.box},
+    #ifdef CGAL_HAS_THREADS
+      atomic_tree_ptr{other.atomic_tree_ptr.load()}
+    #else
+      tree_ptr{other.tree_ptr}
+    #endif
+  {
+    other.own_tree = false;
+  }
+#endif
+
   ~Side_of_triangle_mesh()
   {
     if (own_tree)
@@ -192,6 +213,29 @@ public:
   }
 
 public:
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+  /**
+  * Assign operator moving an instance of Side_of_triangle_mesh to this
+  * location with minimal memory copy.
+  * @param other The instance to be moved
+  * @return A reference to this
+  */
+  Side_of_triangle_mesh& operator=(Side_of_triangle_mesh&& other)
+  {
+    tm_ptr = other.tm_ptr;
+    opt_vpm = std::move(other.opt_vpm);
+    own_tree = other.own_tree;
+    box = other.box;
+    other.own_tree = false;
+    #ifdef CGAL_HAS_THREADS
+      atomic_tree_ptr = atomic_tree_ptr.load();
+    #else
+      tree_ptr = other.tree_ptr;
+    #endif
+    return *this;
+  }
+#endif
+
   /**
    * returns the location of a query point
    * @param point the query point to be located with respect to the input

--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -187,14 +187,14 @@ public:
   * @param other The instance to be moved
   */
   Side_of_triangle_mesh(Side_of_triangle_mesh&& other) :
-    tm_ptr{other.tm_ptr},
+    tm_ptr{std::move(other.tm_ptr)},
     opt_vpm{std::move(other.opt_vpm)},
-    own_tree{other.own_tree},
-    box{other.box},
+    own_tree{std::move(other.own_tree)},
+    box{std::move(other.box)},
     #ifdef CGAL_HAS_THREADS
       atomic_tree_ptr{other.atomic_tree_ptr.load()}
     #else
-      tree_ptr{other.tree_ptr}
+      tree_ptr{std::move(other.tree_ptr)}
     #endif
   {
     other.own_tree = false;
@@ -219,15 +219,15 @@ public:
   */
   Side_of_triangle_mesh& operator=(Side_of_triangle_mesh&& other)
   {
-    tm_ptr = other.tm_ptr;
+    tm_ptr = std::move(other.tm_ptr);
     opt_vpm = std::move(other.opt_vpm);
-    own_tree = other.own_tree;
-    box = other.box;
+    own_tree = std::move(other.own_tree);
+    box = std::move(other.box);
     other.own_tree = false;
     #ifdef CGAL_HAS_THREADS
       atomic_tree_ptr = atomic_tree_ptr.load();
     #else
-      tree_ptr = other.tree_ptr;
+      tree_ptr = std::move(other.tree_ptr);
     #endif
     return *this;
   }

--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -186,20 +186,10 @@ public:
   * location with minimal memory copy.
   * @param other The instance to be moved
   */
-  Side_of_triangle_mesh(Side_of_triangle_mesh&& other) :
-    tm_ptr{std::move(other.tm_ptr)},
-    opt_vpm{std::move(other.opt_vpm)},
-    own_tree{std::move(other.own_tree)},
-    box{std::move(other.box)},
-    #ifdef CGAL_HAS_THREADS
-      atomic_tree_ptr{other.atomic_tree_ptr.load()}
-    #else
-      tree_ptr{std::move(other.tree_ptr)}
-    #endif
+  Side_of_triangle_mesh(Side_of_triangle_mesh&& other)
   {
-    other.own_tree = false;
+    *this = std::move(other);
   }
-
   ~Side_of_triangle_mesh()
   {
     if (own_tree)


### PR DESCRIPTION
## Summary of Changes

Add move ctor and move assign to Side_of_triangle_mesh.
These are only added, if `BOOST_NO_CXX11_RVALUE_REFERENCES` is defined

## Release Management

* Affected package(s): `Polygon_mesh_processing`

