### PR TITLE
Tetrahedral_remeshing - fix the cell selection

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -1174,7 +1174,7 @@ bool can_be_collapsed(const typename C3T3::Edge& e,
   }
   else
   {
-    return true;
+    return is_selected(e, c3t3, cell_selector);
   }
 }
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -426,6 +426,7 @@ public:
     boost::unordered_map<Vertex_handle, std::size_t> vertex_id;
     std::vector<Vector_3> smoothed_positions(nbv, CGAL::NULL_VECTOR);
     std::vector<int> neighbors(nbv, -1);
+    std::vector<bool> free_vertex(nbv, false);//are vertices free to move? indices are in `vertex_id`
 
     //collect ids
     std::size_t id = 0;
@@ -439,10 +440,14 @@ public:
     inc_cells(nbv, boost::container::small_vector<Cell_handle, 40>());
     for (const Cell_handle c : tr.finite_cell_handles())
     {
+      const bool cell_is_selected = cell_selector(c);
+
       for (int i = 0; i < 4; ++i)
       {
         const std::size_t idi = vertex_id[c->vertex(i)];
         inc_cells[idi].push_back(c);
+        if(cell_is_selected)
+          free_vertex[idi] = true;
       }
     }
 
@@ -487,6 +492,9 @@ public:
       for (Vertex_handle v : tr.finite_vertex_handles())
       {
         const std::size_t& vid = vertex_id.at(v);
+        if (!free_vertex[vid])
+          continue;
+
         if (neighbors[vid] > 1)
         {
           Vector_3 smoothed_position = smoothed_positions[vid] / neighbors[vid];
@@ -602,10 +610,10 @@ public:
 
       for (Vertex_handle v : tr.finite_vertex_handles())
       {
-        if (v->in_dimension() != 2)
+        const std::size_t& vid = vertex_id.at(v);
+        if (!free_vertex[vid] || v->in_dimension() != 2)
           continue;
 
-        const std::size_t& vid = vertex_id.at(v);
         if (neighbors[vid] > 1)
         {
           Vector_3 smoothed_position = smoothed_positions[vid] / static_cast<FT>(neighbors[vid]);
@@ -686,6 +694,9 @@ public:
     for (Vertex_handle v : tr.finite_vertex_handles())
     {
       const std::size_t& vid = vertex_id.at(v);
+      if (!free_vertex[vid])
+        continue;
+
       if (c3t3.in_dimension(v) == 3 && neighbors[vid] > 1)
       {
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -224,7 +224,7 @@ bool can_be_split(const typename C3T3::Edge& e,
   }
   else
   {
-    return true;
+    return is_selected(e, c3t3, cell_selector);
   }
 }
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -650,6 +650,15 @@ bool is_internal(const typename C3t3::Edge& edge,
   return true;
 }
 
+template<typename C3T3, typename CellSelector>
+bool is_selected(const typename C3T3::Triangulation::Edge& e,
+                 const C3T3& c3t3,
+                 CellSelector cell_selector)
+{
+  return is_boundary(c3t3, e, cell_selector)
+      || is_internal(e, c3t3, cell_selector);
+}
+
 template<typename Gt>
 void normalize(typename Gt::Vector_3& v, const Gt& gt)
 {

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -602,6 +602,7 @@ bool is_outside(const typename C3t3::Edge & edge,
   return true; //all incident cells are outside or infinite
 }
 
+// is `v` part of the selection of cells that should be remeshed?
 template<typename C3t3, typename CellSelector>
 bool is_selected(const typename C3t3::Vertex_handle v,
                  const C3t3& c3t3,
@@ -650,13 +651,22 @@ bool is_internal(const typename C3t3::Edge& edge,
   return true;
 }
 
+// is `e` part of the selection of cells that should be remeshed?
 template<typename C3T3, typename CellSelector>
 bool is_selected(const typename C3T3::Triangulation::Edge& e,
                  const C3T3& c3t3,
                  CellSelector cell_selector)
 {
-  return is_boundary(c3t3, e, cell_selector)
-      || is_internal(e, c3t3, cell_selector);
+  typedef typename C3T3::Triangulation::Cell_circulator Cell_circulator;
+  Cell_circulator circ = c3t3.triangulation().incident_cells(e);
+  Cell_circulator done = circ;
+  do
+  {
+    if (cell_selector(circ))
+      return true;
+  } while (++circ != done);
+
+  return false;
 }
 
 template<typename Gt>


### PR DESCRIPTION
## Summary of Changes

The use of `cell_selector` in `CGAL::tetrahedral_isotropic_remeshing()`, that allows to remesh only a (sub)set of selected cells of the input mesh, was broken in several places of the code.
This PR fixes it.

@xiaoXiaoCam thank you for the bug report. This PR should fix your issue

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

