### PR TITLE
Fix typo in doc circulator.h

### DIFF
--- a/Circulator/doc/Circulator/CGAL/circulator.h
+++ b/Circulator/doc/Circulator/CGAL/circulator.h
@@ -619,7 +619,7 @@ Iterator_tag query_circulator_or_iterator( const I& i);
 /*!
 \ingroup PkgHandlesAndCirculatorsFunctions
 
-This functiona matches for type `C` if the iterator category of `C` belongs to a circulator.
+This function matches for type `C` if the iterator category of `C` belongs to a circulator.
 
 \sa `Circulator_tag`
 \sa `Circulator_traits`


### PR DESCRIPTION
## Summary of Changes

Fix typo `functiona` -> `function`

## Release Management

* Affected package(s): Handles and circulators
* Issue(s) solved (if any): documentation bugfix 
* License and copyright ownership: no change