### PR TITLE
Triangulation_3: Construct double to avoid VC++ warning C5055

### DIFF
--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -863,7 +863,7 @@ int
 Triangulation_hierarchy_3<Tr>::
 random_level()
 {
-  boost::geometric_distribution<> proba(1.0/ratio);
+  boost::geometric_distribution<> proba(1.0/double(ratio));
   boost::variate_generator<boost::rand48&, boost::geometric_distribution<> > die(random, proba);
 
   return (std::min)(die(), (int)maxlevel)-1;


### PR DESCRIPTION
## Summary of Changes

Construct a `double` from the `enum`  to avoid the warning seen in
the [testsuite ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-29/Triangulation_3/TestReport_Blake_Windows_MSVCPreview-Release-64bits.gz) with a VC++ preview release:
 `C:\cgal_test\CGAL-5.3-Ic-29\include\CGAL/Triangulation_hierarchy_3.h(866): warning C5055: operator '/': deprecated between enumerations and floating-point types` 

The "better" fix is in #5310 but it needs a more modern C++ so let's apply that later.

## Release Management

* Affected package(s): Triangulatyion_3
* License and copyright ownership:  unchanged
* partially fixes #5342

