### PR TITLE
Point Set Processing - Fix missing std::ios::binary tag in some examples

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_OpenGR.cpp
@@ -25,7 +25,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -36,7 +36,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_opengr_pointmatcher_pipeline.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -39,7 +39,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).

--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char** argv)
   const char* fname2 = (argc>2)?argv[2]:"data/hippo2.ply";
 
   std::vector<Pwn> pwns1, pwns2;
-  std::ifstream input(fname1);
+  std::ifstream input(fname1, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns1),
             CGAL::parameters::point_map (CGAL::First_of_pair_property_map<Pwn>()).
@@ -39,7 +39,7 @@ int main(int argc, const char** argv)
   }
   input.close();
 
-  input.open(fname2);
+  input.open(fname2, std::ios::binary);
   if (!input ||
       !CGAL::read_ply_points(input, std::back_inserter(pwns2),
             CGAL::parameters::point_map (Point_map()).


### PR DESCRIPTION
## Summary of Changes

Windows requires `std::ios::binary` tag to properly read binary input. It was missing from the registration examples.

## Release Management

* Affected package(s): PSP
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/5315

