### PR TITLE
PSP_3: Remove debug output

### DIFF
--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -381,8 +381,6 @@ edge_aware_upsample_point_set(
   double neighbor_radius = choose_parameter(get_parameter(np, internal_np::neighbor_radius), -1);
   std::size_t number_of_output_points = choose_parameter(get_parameter(np, internal_np::number_of_output_points), 1000);
 
-  std::cerr << sharpness_angle << " " << edge_sensitivity << " " << neighbor_radius
-            << " " << number_of_output_points << std::endl;
   // trick in case the output iterator add points to the input container
   typename PointRange::const_iterator begin = points.begin();
   typename PointRange::const_iterator end = points.end();


### PR DESCRIPTION
Just a minor patch: I think this output was for debug purpose.
