### PR TITLE
static filter for 2d Side_of_oriented_sphere

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_static_filters.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_static_filters.h
@@ -15,37 +15,46 @@
 #include <CGAL/Dimension.h>
 #include <CGAL/internal/Static_filters/tools.h> // bug, should be included by the next one
 #include <CGAL/internal/Static_filters/Orientation_2.h>
+#include <CGAL/internal/Static_filters/Side_of_oriented_circle_2.h>
 #include <boost/mpl/if.hpp>
 
 namespace CGAL {
 namespace SFA { // static filter adapter
 // Note that this would be quite a bit simpler without stateful kernels
+template <class Base_,class R_> struct Adapter_2 {
+        typedef typename Get_type<R_, Point_tag>::type        Point;
+        typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
+        typedef typename Get_functor<Base_, Orientation_of_points_tag>::type Orientation_base;
+        typedef typename Get_functor<Base_, Side_of_oriented_sphere_tag>::type Side_of_oriented_circle_base;
+        struct Point_2 {
+                R_ const&r; CC const&c; Point const& p;
+                Point_2(R_ const&r_, CC const&c_, Point const&p_):r(r_),c(c_),p(p_){}
+                decltype(auto) x()const{return c(p,0);}
+                decltype(auto) y()const{return c(p,1);}
+        };
+        struct Vector_2 {};
+        struct Circle_2 {};
+        struct Orientation_2 {
+                typedef typename Get_type<R_, Orientation_tag>::type result_type;
+                auto operator()(Point_2 const&A, Point_2 const&B, Point_2 const&C)const{
+                        Point const* t[3]={&A.p,&B.p,&C.p};
+                        return Orientation_base(A.r)(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+3));
+                }
+        };
+        struct Side_of_oriented_circle_2 {
+                typedef typename Get_type<R_, Oriented_side_tag>::type result_type;
+                auto operator()(Point_2 const&A, Point_2 const&B, Point_2 const&C, Point_2 const&D)const{
+                        Point const* t[3]={&A.p,&B.p,&C.p};
+                        return Side_of_oriented_circle_base(A.r)(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+3),D.p);
+                }
+        };
+};
 template <class Base_,class R_> struct Orientation_of_points_2 : private Store_kernel<R_> {
         CGAL_FUNCTOR_INIT_STORE(Orientation_of_points_2)
         typedef typename Get_type<R_, Point_tag>::type        Point;
         typedef typename Get_type<R_, Orientation_tag>::type result_type;
-        typedef typename Get_type<R_, FT_tag>::type FT;
         typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
-        typedef typename Get_functor<Base_, Orientation_of_points_tag>::type Orientation_base;
-        // TODO: Move this out for easy reuse
-        struct Adapter {
-                struct Point_2 {
-                        R_ const&r; CC const&c; Point const& p;
-                        Point_2(R_ const&r_, CC const&c_, Point const&p_):r(r_),c(c_),p(p_){}
-                        // use result_of instead?
-                        typename CC::result_type x()const{return c(p,0);}
-                        typename CC::result_type y()const{return c(p,1);}
-                };
-                struct Vector_2 {};
-                struct Circle_2 {};
-                struct Orientation_2 {
-                        typedef typename Orientation_of_points_2::result_type result_type;
-                        result_type operator()(Point_2 const&A, Point_2 const&B, Point_2 const&C)const{
-                                Point const* t[3]={&A.p,&B.p,&C.p};
-                                return Orientation_base(A.r)(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+3));
-                        }
-                };
-        };
+        typedef Adapter_2<Base_, R_> Adapter;
         template<class Iter> result_type operator()(Iter f, Iter CGAL_assertion_code(e))const{
                 CC c(this->kernel());
                 Point const& A=*f;
@@ -54,6 +63,22 @@ template <class Base_,class R_> struct Orientation_of_points_2 : private Store_k
                 CGAL_assertion(++f==e);
                 typedef typename Adapter::Point_2 P;
                 return typename internal::Static_filters_predicates::Orientation_2<Adapter>()(P(this->kernel(),c,A),P(this->kernel(),c,B),P(this->kernel(),c,C));
+        }
+};
+template <class Base_,class R_> struct Side_of_oriented_sphere_2 : private Store_kernel<R_> {
+        CGAL_FUNCTOR_INIT_STORE(Side_of_oriented_sphere_2)
+        typedef typename Get_type<R_, Point_tag>::type        Point;
+        typedef typename Get_type<R_, Oriented_side_tag>::type result_type;
+        typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
+        typedef Adapter_2<Base_, R_> Adapter;
+        template<class Iter> result_type operator()(Iter f, Iter CGAL_assertion_code(e), Point const& D)const{
+                CC c(this->kernel());
+                Point const& A=*f;
+                Point const& B=*++f;
+                Point const& C=*++f;
+                CGAL_assertion(++f==e);
+                typedef typename Adapter::Point_2 P;
+                return typename internal::Static_filters_predicates::Side_of_oriented_circle_2<Adapter>()(P(this->kernel(),c,A),P(this->kernel(),c,B),P(this->kernel(),c,C),P(this->kernel(),c,D));
         }
 };
 }
@@ -79,6 +104,9 @@ struct Cartesian_static_filters<Dimension_tag<2>, R_, Derived_> : public R_ {
                         SFA::Orientation_of_points_2<R_,Derived>
                         //        >::type
                                 type;
+        };
+        template <class D> struct Functor <Side_of_oriented_sphere_tag,D> {
+                typedef SFA::Side_of_oriented_sphere_2<R_,Derived> type;
         };
 };
 


### PR DESCRIPTION
## Summary of Changes

Not sure where this static filter stuff is going (wrapping the Kernel_23 functions is ugly, but duplicating code wouldn't be better), it was just there to prove that it is possible, but it might as well be a bit useful by wrapping a predicate that is important for triangulations. It would be more useful if it was also used with Dynamic_dimension_tag, but that's for some other time.

## Release Management

* Affected package(s): NewKernel_d
