### PR TITLE
Optimize trivial predicates

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Filtered_predicate.h
@@ -37,6 +37,10 @@ namespace CGAL {
 //   not, or we let all this up to the compiler optimizer to figure out ?
 // - Some caching could be done at the Point_2 level.
 
+// Protection is undocumented and currently always true, meaning that it
+// assumes a default rounding mode of round-to-nearest. false would correspond
+// to a default of round-towards-infinity, so interval arithmetic does not
+// require protection but regular code may.
 
 template <class EP, class AP, class C2E, class C2A, bool Protection = true>
 class Filtered_predicate

--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_functors.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_functors.h
@@ -137,7 +137,7 @@ template<class R_> struct Compute_cartesian_coordinate {
         typedef typename Get_type<R, RT_tag>::type RT;
         typedef typename R::Vector_ first_argument_type;
         typedef int second_argument_type;
-        typedef Tag_true Is_exact;
+        typedef Tag_true Uses_no_arithmetic;
         typedef decltype(std::declval<const first_argument_type>()[0]) result_type;
 
         template <typename index_type>
@@ -153,7 +153,7 @@ template<class R_> struct Construct_cartesian_const_iterator {
         typedef typename R::LA_vector S_;
         typedef typename R::Point_cartesian_const_iterator result_type;
         // same as Vector
-        typedef Tag_true Is_exact;
+        typedef Tag_true Uses_no_arithmetic;
 
         result_type operator()(argument_type const& v,Begin_tag)const{
                 return S_::vector_begin(v);
@@ -282,7 +282,7 @@ template<class R_> struct PV_dimension {
         typedef typename R::Vector_ argument_type;
         typedef int result_type;
         typedef typename R::LA_vector LA;
-        typedef Tag_true Is_exact;
+        typedef Tag_true Uses_no_arithmetic;
 
         template<class T>
         result_type operator()(T const& v) const {

--- a/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
@@ -39,6 +39,7 @@ namespace CGAL {
 //   not, or we let all this up to the compiler optimizer to figure out ?
 // - Some caching could be done at the Point_2 level.
 
+// FIXME: understand and document what the parameter 'Protection' means exactly
 
 template <class K, class EP, class AP, class C2E, class C2A, bool Protection = true>
 class Filtered_predicate2

--- a/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Filtered_predicate2.h
@@ -39,7 +39,11 @@ namespace CGAL {
 //   not, or we let all this up to the compiler optimizer to figure out ?
 // - Some caching could be done at the Point_2 level.
 
-// FIXME: understand and document what the parameter 'Protection' means exactly
+// Protection has a different meaning than in Filtered_predicate, it says
+// whether we need to set the rounding mode: some predicates only do
+// comparisons and don't need it. Probably this should be done inside this
+// class, based on Uses_no_arithmetic, but I have some doubts about C2A,
+// converting a long long to Interval_nt requires protection.
 
 template <class K, class EP, class AP, class C2E, class C2A, bool Protection = true>
 class Filtered_predicate2
@@ -88,7 +92,6 @@ public:
       catch (Uncertain_conversion_exception&) {}
     }
     CGAL_BRANCH_PROFILER_BRANCH(tmp);
-    Protect_FPU_rounding<!Protection> p(CGAL_FE_TONEAREST);
     return ep(c2e(std::forward<Args>(args))...);
   }
 };

--- a/NewKernel_d/include/CGAL/NewKernel_d/Lazy_cartesian.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Lazy_cartesian.h
@@ -294,7 +294,9 @@ struct Lazy_cartesian :
     template<class T,class D> struct Functor<T,D,Predicate_tag> {
             typedef typename Get_functor<Approximate_kernel, T>::type FA;
             typedef typename Get_functor<Exact_kernel, T>::type FE;
-            typedef Filtered_predicate2<Lazy_cartesian,FE,FA,C2E,C2A> type;
+            // Careful if operator< for Interval_nt ever starts using arithmetic...
+            // Not done directly in Filtered_predicate2 because of C2A
+            typedef Filtered_predicate2<Lazy_cartesian,FE,FA,C2E,C2A,!Uses_no_arithmetic<FA>::value> type;
     };
     template<class T,class D> struct Functor<T,D,Compute_tag> {
             typedef Lazy_construction2<T,Kernel> type;

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Hyperplane.h
@@ -127,7 +127,7 @@ template <class R_> struct Hyperplane_translation {
   CGAL_FUNCTOR_INIT_IGNORE(Hyperplane_translation)
   typedef typename Get_type<R_, Hyperplane_tag>::type        Hyperplane;
   typedef typename Get_type<R_, FT_tag>::type result_type;
-  // TODO: Is_exact?
+  // TODO: Uses_no_arithmetic?
   result_type operator()(Hyperplane const&s)const{
     return s.translation();
   }

--- a/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Types/Sphere.h
@@ -83,7 +83,7 @@ template <class R_> struct Squared_radius {
   CGAL_FUNCTOR_INIT_IGNORE(Squared_radius)
   typedef typename Get_type<R_, Sphere_tag>::type        Sphere;
   typedef typename Get_type<R_, FT_tag>::type const&        result_type;
-  // TODO: Is_exact?
+  // TODO: Uses_no_arithmetic?
   result_type operator()(Sphere const&s)const{
     return s.squared_radius();
   }

--- a/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/function_objects_cartesian.h
@@ -1108,7 +1108,7 @@ template<class R_> struct Less_point_cartesian_coordinate : private Store_kernel
         typedef typename Get_functor<R, Compute_point_cartesian_coordinate_tag>::type Cc;
         // TODO: This is_exact thing should be reengineered.
         // the goal is to have a way to tell: don't filter this
-        typedef typename CGAL::Is_exact<Cc> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<Cc> Uses_no_arithmetic;
 
         template<class V,class W,class I>
         result_type operator()(V const&a, W const&b, I i)const{
@@ -1128,7 +1128,7 @@ template<class R_> struct Compare_point_cartesian_coordinate : private Store_ker
         typedef typename Get_functor<R, Compute_point_cartesian_coordinate_tag>::type Cc;
         // TODO: This is_exact thing should be reengineered.
         // the goal is to have a way to tell: don't filter this
-        typedef typename CGAL::Is_exact<Cc> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<Cc> Uses_no_arithmetic;
 
         template<class V,class W,class I>
         result_type operator()(V const&a, W const&b, I i)const{
@@ -1148,7 +1148,7 @@ template<class R_> struct Compare_lexicographically : private Store_kernel<R_> {
         typedef typename Get_functor<R, Construct_ttag<Point_cartesian_const_iterator_tag> >::type CI;
         // TODO: This is_exact thing should be reengineered.
         // the goal is to have a way to tell: don't filter this
-        typedef typename CGAL::Is_exact<CI> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<CI> Uses_no_arithmetic;
 
         template<class V,class W>
         result_type operator()(V const&a, W const&b)const{
@@ -1176,7 +1176,7 @@ template<class R_> struct Less_lexicographically : private Store_kernel<R_> {
         typedef R_ R;
         typedef typename Get_type<R, Bool_tag>::type result_type;
         typedef typename Get_functor<R, Compare_lexicographically_tag>::type CL;
-        typedef typename CGAL::Is_exact<CL> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<CL> Uses_no_arithmetic;
 
         template <class V, class W>
         result_type operator() (V const&a, W const&b) const {
@@ -1194,7 +1194,7 @@ template<class R_> struct Less_or_equal_lexicographically : private Store_kernel
         typedef R_ R;
         typedef typename Get_type<R, Bool_tag>::type result_type;
         typedef typename Get_functor<R, Compare_lexicographically_tag>::type CL;
-        typedef typename CGAL::Is_exact<CL> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<CL> Uses_no_arithmetic;
 
         template <class V, class W>
         result_type operator() (V const&a, W const&b) const {
@@ -1214,7 +1214,7 @@ template<class R_> struct Equal_points : private Store_kernel<R_> {
         typedef typename Get_functor<R, Construct_ttag<Point_cartesian_const_iterator_tag> >::type CI;
         // TODO: This is_exact thing should be reengineered.
         // the goal is to have a way to tell: don't filter this
-        typedef typename CGAL::Is_exact<CI> Is_exact;
+        typedef typename CGAL::Uses_no_arithmetic<CI> Uses_no_arithmetic;
 
         template<class V,class W>
         result_type operator()(V const&a, W const&b)const{

--- a/NewKernel_d/include/CGAL/NewKernel_d/functor_properties.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/functor_properties.h
@@ -24,7 +24,7 @@ namespace CGAL {
   template<class T> \
   struct Is_pretty<T,true> : T::Is_pretty {}
 
-CGAL_STRAWBERRY(Is_exact);
+CGAL_STRAWBERRY(Uses_no_arithmetic);
 CGAL_STRAWBERRY(Is_fast);
 CGAL_STRAWBERRY(Is_stored);
 #undef CGAL_STRAWBERRY


### PR DESCRIPTION
## Summary of Changes

Some predicates do not perform any arithmetic operation and only do comparisons. For Epick_d, we can do them directly with `double`, no need for intervals. For Epeck_d, we do use intervals, but we do not need to set the rounding mode.

This last optimization might be a little bit risky. First, interval comparisons might at some point in the future require protection. Second, other operations might happen outside of the predicate, in particular the conversion to approximate (C2A), and some operations like constructing an interval from `int64_t` do require protection. I think that the restriction to Epeck_d (where we already have intervals) and to a small list of predicates makes this ok... :crossed_fingers:

## Release Management

* Affected package(s): NewKernel_d