### PR TITLE
remove hardcoded kernel

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -554,7 +554,7 @@ class Intersection_of_triangle_meshes
 
       CGAL_assertion(&tm1!=&tm2 || f1!=f2);
 
-      typedef CGAL::Exact_predicates_exact_constructions_kernel EK;
+      typedef typename Node_vector::Exact_kernel EK;
       typedef Coplanar_intersection<TriangleMesh, EK> Cpl_inter_pt;
       std::list<Cpl_inter_pt> inter_pts;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_nodes.h
@@ -44,13 +44,16 @@ template <class TriangleMesh,
 class Intersection_nodes<TriangleMesh, VertexPointMap1, VertexPointMap2, false, false>
 {
 //typedefs
+public:
+  typedef CGAL::Exact_predicates_exact_constructions_kernel        Exact_kernel;
+private:
+//typedefs
   typedef typename boost::property_traits<VertexPointMap1>::value_type  Point_3;
   CGAL_static_assertion((std::is_same<typename boost::property_traits<VertexPointMap1>::value_type,
                                       typename boost::property_traits<VertexPointMap2>::value_type>::value));
 
   typedef typename Kernel_traits<Point_3>::Kernel                  Input_kernel;
   typedef std::vector <Point_3>                                    Nodes_vector;
-  typedef CGAL::Exact_predicates_exact_constructions_kernel        Exact_kernel;
   typedef CGAL::Cartesian_converter<Exact_kernel,Input_kernel>  Exact_to_double;
   typedef boost::graph_traits<TriangleMesh>                                  GT;
   typedef typename GT::halfedge_descriptor                  halfedge_descriptor;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_of_coplanar_triangles_3.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_of_coplanar_triangles_3.h
@@ -17,7 +17,6 @@
 
 
 #include <CGAL/Polygon_mesh_processing/internal/Corefinement/Intersection_type.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/property_map.h>
 
@@ -27,17 +26,16 @@ namespace CGAL{
 namespace Polygon_mesh_processing {
 namespace Corefinement{
 
-template <class TriangleMesh, class VertexPointMap1, class VertexPointMap2>
+template <class TriangleMesh, class Exact_kernel, class VertexPointMap1, class VertexPointMap2>
 struct Intersect_coplanar_faces_3
 {
  // typedefs
   typedef typename boost::property_traits<VertexPointMap1>::value_type Point;
 
   CGAL_static_assertion((std::is_same<typename boost::property_traits<VertexPointMap1>::value_type,
-                                      typename boost::property_traits<VertexPointMap1>::value_type>::value));
+                                      typename boost::property_traits<VertexPointMap2>::value_type>::value));
 
   typedef typename CGAL::Kernel_traits<Point>::Kernel Input_kernel;
-  typedef CGAL::Exact_predicates_exact_constructions_kernel Exact_kernel;
 
   typedef boost::graph_traits<TriangleMesh> GT;
   typedef typename GT::halfedge_descriptor halfedge_descriptor;
@@ -304,7 +302,7 @@ void intersection_coplanar_faces(
 
   halfedge_descriptor h1=halfedge(f1,tm1), h2=halfedge(f2,tm2);
 
-  Intersect_coplanar_faces_3<TriangleMesh, VertexPointMap1, VertexPointMap2>
+  Intersect_coplanar_faces_3<TriangleMesh, Exact_kernel,  VertexPointMap1, VertexPointMap2>
     intersect_cpln(tm1, tm2, vpm1, vpm2);
 
   // We will add in `inter_pts` the initial triangle of h1


### PR DESCRIPTION
Use Node_vector to deduce the exact kernel instead of hardcoding it.
Fixes #5322 