### PR TITLE
[Scale Space] Fix warning, comparing size_t with 0 is always true

### DIFF
--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
@@ -265,7 +265,7 @@ public:
    */
   Facet_const_iterator shell_begin( std::size_t shell ) const
   {
-    CGAL_assertion( shell >= 0 && shell < _shells.size() );
+    CGAL_assertion( shell < _shells.size() );
     return _shells[ shell ];
   }
   /// gives an iterator to the first triple in a given shell.
@@ -277,7 +277,7 @@ public:
    */
   Facet_iterator shell_begin( std::size_t shell )
   {
-    CGAL_assertion( shell >= 0 && shell < _shells.size() );
+    CGAL_assertion( shell < _shells.size() );
     return _shells[ shell ];
   }
 
@@ -288,7 +288,7 @@ public:
    */
   Facet_const_iterator shell_end( std::size_t shell ) const
   {
-    CGAL_assertion( shell >= 0 && shell < _shells.size() );
+    CGAL_assertion( shell < _shells.size() );
     if( shell == _shells.size()-1 )
       return _surface.end();
     return _shells[ shell+1 ];
@@ -303,7 +303,7 @@ public:
    */
   Facet_iterator shell_end( std::size_t shell )
   {
-    CGAL_assertion( shell >= 0 && shell < _shells.size() );
+    CGAL_assertion( shell < _shells.size() );
     if( shell == _shells.size()-1 )
         return _surface.end();
     return _shells[ shell+1 ];


### PR DESCRIPTION
## Summary of Changes

When testing that the index is in the right range, it's useless to test `>= 0` considering the index is unsigned. This raises some warnings on recent compilers.

## Release Management

* Affected package(s): Scale Space