### PR TITLE
Obsolete doxygen setting COLS_IN_ALPHA_INDEX

### DIFF
--- a/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
@@ -1188,13 +1188,6 @@ VERBATIM_HEADERS       = NO
 
 ALPHABETICAL_INDEX     = NO
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
-
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
 # can be used to specify a prefix (or a list of prefixes) that should be ignored


### PR DESCRIPTION
In the doxygen version 1.9.0 the setting `COLS_IN_ALPHA_INDEX` has been made obsolete and generates a warning during building.
As the default value is used it can also be removed (doxygen will automatically take the default value in the older versions).


