### PR TITLE
Graphics_view: Upgrade glsl version in basic_viewer_shaders

### DIFF
--- a/AABB_tree/demo/AABB_tree/AABB_demo.cpp
+++ b/AABB_tree/demo/AABB_tree/AABB_demo.cpp
@@ -19,12 +19,12 @@
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
 #include <QMimeData>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char **argv)
 {
 
-  CGAL::init_ogl_context(4,3);
+  CGAL::Qt::init_ogl_context(4,3);
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");
   app.setOrganizationName("INRIA");

--- a/AABB_tree/demo/AABB_tree/AABB_demo.cpp
+++ b/AABB_tree/demo/AABB_tree/AABB_demo.cpp
@@ -19,24 +19,12 @@
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
 #include <QMimeData>
-
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char **argv)
 {
-  QSurfaceFormat fmt;
-#ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
-#else
-  fmt.setVersion(4, 3);
-#endif
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+
+  CGAL::init_ogl_context(4,3);
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");
   app.setOrganizationName("INRIA");

--- a/AABB_tree/demo/AABB_tree/AABB_demo.cpp
+++ b/AABB_tree/demo/AABB_tree/AABB_demo.cpp
@@ -23,14 +23,24 @@
 
 int main(int argc, char **argv)
 {
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setVersion(4, 1);
+#else
+  fmt.setVersion(4, 3);
+#endif
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");
   app.setOrganizationName("INRIA");
   app.setApplicationName("AABB tree demo");
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  app.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
   // Import resources from libCGALQt (Qt5).
   CGAL_QT_INIT_RESOURCES;

--- a/AABB_tree/demo/AABB_tree/MainWindow.cpp
+++ b/AABB_tree/demo/AABB_tree/MainWindow.cpp
@@ -45,6 +45,7 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow()
 {
+  m_pViewer->makeCurrent();
   delete ui;
 }
 

--- a/AABB_tree/demo/AABB_tree/Scene.cpp
+++ b/AABB_tree/demo/AABB_tree/Scene.cpp
@@ -156,11 +156,11 @@ void Scene::compile_shaders()
     const char tex_fragment_source[] =
     {
         "#version 150 \n"
-        "uniform sampler2D texture;\n"
+        "uniform sampler2D s_texture;\n"
         "in highp vec2 texc;\n"
         "out highp vec4 out_color; \n"
         "void main(void) { \n"
-        "out_color = texture2D(texture, texc.st);\n"
+        "out_color = vec4(texture(s_texture, texc));\n"
         "} \n"
         "\n"
     };

--- a/AABB_tree/demo/AABB_tree/Scene.cpp
+++ b/AABB_tree/demo/AABB_tree/Scene.cpp
@@ -91,8 +91,8 @@ void Scene::compile_shaders()
     //Vertex source code
     const char vertex_source[] =
     {
-        "#version 120 \n"
-        "attribute highp vec4 vertex;\n"
+        "#version 150 \n"
+        "in highp vec4 vertex;\n"
         "uniform highp mat4 mvp_matrix;\n"
         "uniform highp mat4 f_matrix;\n"
         "void main(void)\n"
@@ -103,10 +103,11 @@ void Scene::compile_shaders()
     //Vertex source code
     const char fragment_source[] =
     {
-        "#version 120 \n"
+        "#version 150 \n"
         "uniform highp vec4 color; \n"
+        "out highp vec4 out_color; \n"
         "void main(void) { \n"
-        "gl_FragColor = color; \n"
+        "out_color = color; \n"
         "} \n"
         "\n"
     };
@@ -139,26 +140,27 @@ void Scene::compile_shaders()
     //Vertex source code
     const char tex_vertex_source[] =
     {
-        "#version 120 \n"
-        "attribute highp vec4 vertex;\n"
-        "attribute highp vec2 tex_coord; \n"
+        "#version 150 \n"
+        "in highp vec4 vertex;\n"
+        "in highp vec2 tex_coord; \n"
         "uniform highp mat4 mvp_matrix;\n"
         "uniform highp mat4 f_matrix;\n"
-        "varying highp vec2 texc;\n"
+        "out highp vec2 texc;\n"
         "void main(void)\n"
         "{\n"
         "   gl_Position = mvp_matrix * f_matrix * vertex;\n"
-        "    texc = tex_coord;\n"
+        "   texc = tex_coord;\n"
         "}"
     };
     //Vertex source code
     const char tex_fragment_source[] =
     {
-        "#version 120 \n"
+        "#version 150 \n"
         "uniform sampler2D texture;\n"
-        "varying highp vec2 texc;\n"
+        "in highp vec2 texc;\n"
+        "out highp vec4 out_color; \n"
         "void main(void) { \n"
-        "gl_FragColor = texture2D(texture, texc.st);\n"
+        "out_color = texture2D(texture, texc.st);\n"
         "} \n"
         "\n"
     };
@@ -1319,12 +1321,8 @@ void Scene::deactivate_cutting_plane()
 }
 void Scene::initGL()
 {
-    gl = new QOpenGLFunctions_2_1();
-   if(!gl->initializeOpenGLFunctions())
-    {
-        qFatal("ERROR : OpenGL Functions not initialized. Check your OpenGL Verison (should be >=3.3)");
-        exit(1);
-    }
+    gl = new QOpenGLFunctions();
+    gl->initializeOpenGLFunctions();
 
     gl->glGenTextures(1, &textureId);
     compile_shaders();

--- a/AABB_tree/demo/AABB_tree/Scene.h
+++ b/AABB_tree/demo/AABB_tree/Scene.h
@@ -86,7 +86,7 @@ public:
 
 private:
     // member data
-    QOpenGLFunctions_2_1 *gl;
+    QOpenGLFunctions *gl;
     Bbox m_bbox;
     Polyhedron *m_pPolyhedron;
     std::list<Point> m_points;

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
@@ -8,15 +8,27 @@
 
 int main(int argc, char** argv)
 {
- QApplication application(argc,argv);
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setVersion(4, 1);
+#else
+  fmt.setVersion(4, 3);
+#endif
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+
+  //for Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
+
+  QApplication application(argc,argv);
 
   application.setOrganizationDomain("geometryfactory.com");
   application.setOrganizationName("GeometryFactory");
   application.setApplicationName("Alpha Shape Reconstruction");
-  //for Windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  application.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
   // Import resources from libCGALQt (Qt5).
   // See https://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
@@ -5,27 +5,13 @@
 
 
 #include <CGAL/Qt/resources.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char** argv)
 {
-  QSurfaceFormat fmt;
-#ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
-#else
-  fmt.setVersion(4, 3);
-#endif
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-
-  //for Windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+  CGAL::init_ogl_context(4,3);
 
   QApplication application(argc,argv);
-
   application.setOrganizationDomain("geometryfactory.com");
   application.setOrganizationName("GeometryFactory");
   application.setApplicationName("Alpha Shape Reconstruction");

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Alpha_shape_3.cpp
@@ -5,11 +5,11 @@
 
 
 #include <CGAL/Qt/resources.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char** argv)
 {
-  CGAL::init_ogl_context(4,3);
+  CGAL::Qt::init_ogl_context(4,3);
 
   QApplication application(argc,argv);
   application.setOrganizationDomain("geometryfactory.com");

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.cpp
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.cpp
@@ -29,14 +29,14 @@ void Viewer::compile_shaders()
     //Vertex source code
     const char vertex_source[] =
     {
-         "#version 120 \n"
-        "attribute highp vec4 vertex;\n"
-        "attribute highp vec3 normal;\n"
+         "#version 150 \n"
+        "in highp vec4 vertex;\n"
+        "in highp vec3 normal;\n"
 
         "uniform highp mat4 mvp_matrix;\n"
         "uniform highp mat4 mv_matrix; \n"
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
+        "out highp vec4 fP; \n"
+        "out highp vec3 fN; \n"
         "void main(void)\n"
         "{\n"
         "   fP = mv_matrix * vertex; \n"
@@ -47,15 +47,16 @@ void Viewer::compile_shaders()
     //Fragment source code
     const char fragment_source[] =
     {
-        "#version 120 \n"
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
+        "#version 150 \n"
+        "in highp vec4 fP; \n"
+        "in highp vec3 fN; \n"
         "uniform highp vec4 color; \n"
         "uniform highp vec4 light_pos;  \n"
         "uniform highp vec4 light_diff; \n"
         "uniform highp vec4 light_spec; \n"
         "uniform highp vec4 light_amb;  \n"
         "uniform float spec_power ; \n"
+        "out highp vec4 out_color; \n"
 
         "void main(void) { \n"
 
@@ -70,7 +71,7 @@ void Viewer::compile_shaders()
         "   highp vec4 diffuse = abs(dot(N,L)) * light_diff * color; \n"
         "   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-        "gl_FragColor = light_amb*color + diffuse + specular ; \n"
+        "out_color = light_amb*color + diffuse + specular ; \n"
         "} \n"
         "\n"
     };
@@ -105,8 +106,8 @@ rendering_program.bind();
 //Vertex source code
 const char vertex_source_points[] =
 {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
 
     "uniform highp mat4 mvp_matrix;\n"
     "uniform highp float point_size;\n"
@@ -119,11 +120,12 @@ const char vertex_source_points[] =
 //Vertex source code
 const char fragment_source_points[] =
 {
-    "#version 120 \n"
+    "#version 150 \n"
     "uniform highp vec4 color; \n"
+    "out highp vec4 out_color; \n"
 
     "void main(void) { \n"
-    "gl_FragColor = color; \n"
+    "out_color = color; \n"
     "} \n"
     "\n"
 };

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.h
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/Viewer.h
@@ -21,6 +21,7 @@ public:
   Viewer(QWidget* parent);
   ~Viewer()
   {
+    makeCurrent();
     buffers[0].destroy();
     buffers[1].destroy();
     buffers[2].destroy();

--- a/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
@@ -1,9 +1,9 @@
 #include "Viewer.h"
 #include <qapplication.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 int main(int argc, char** argv)
 {
-  CGAL::init_ogl_context(4,3);
+  CGAL::Qt::init_ogl_context(4,3);
   QApplication application(argc,argv);
   // Instantiate the viewer.
   Viewer viewer;

--- a/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
@@ -3,15 +3,25 @@
 
 int main(int argc, char** argv)
 {
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setVersion(4, 1);
+#else
+  fmt.setVersion(4, 3);
+#endif
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
   // Read command lines arguments.
+  //for Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
   QApplication application(argc,argv);
 
   // Instantiate the viewer.
   Viewer viewer;
-  //for Windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  application.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
   viewer.setWindowTitle("Intersection points of randomly generated circles.");
 
   // Make the viewer window visible on screen.

--- a/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Circular_kernel_3.cpp
@@ -1,25 +1,10 @@
 #include "Viewer.h"
 #include <qapplication.h>
-
+#include <CGAL/Qt/Context_initialization.h>
 int main(int argc, char** argv)
 {
-  QSurfaceFormat fmt;
-#ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
-#else
-  fmt.setVersion(4, 3);
-#endif
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  // Read command lines arguments.
-  //for Windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+  CGAL::init_ogl_context(4,3);
   QApplication application(argc,argv);
-
   // Instantiate the viewer.
   Viewer viewer;
   viewer.setWindowTitle("Intersection points of randomly generated circles.");

--- a/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
@@ -11,6 +11,14 @@ Viewer::Viewer(QWidget* parent )
 {
     extension_is_found = false;
 }
+Viewer::~Viewer()
+{
+  makeCurrent();
+  for(int i=0; i<3; ++i)
+    vao[i].destroy();
+  for(int i=0; i<9; ++i)
+    buffers[i].destroy();
+}
 
 void Viewer::compile_shaders()
 {

--- a/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Viewer.cpp
@@ -32,16 +32,16 @@ void Viewer::compile_shaders()
     //Vertex source code
     const char vertex_source[] =
     {
-        "#version 120 \n"
-        "attribute highp vec4 vertex;\n"
-        "attribute highp vec3 normal;\n"
-        "attribute highp vec4 center;\n"
+        "#version 150 \n"
+        "in highp vec4 vertex;\n"
+        "in highp vec3 normal;\n"
+        "in highp vec4 center;\n"
 
         "uniform highp mat4 mvp_matrix;\n"
         "uniform highp mat4 mv_matrix; \n"
 
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
+        "out highp vec4 fP; \n"
+        "out highp vec3 fN; \n"
         "void main(void)\n"
         "{\n"
         "   fP = mv_matrix * vertex; \n"
@@ -52,15 +52,16 @@ void Viewer::compile_shaders()
     //Vertex source code
     const char fragment_source[] =
     {
-        "#version 120 \n"
-        "varying highp vec4 fP; \n"
-        "varying highp vec3 fN; \n"
+        "#version 150 \n"
+        "in highp vec4 fP; \n"
+        "in highp vec3 fN; \n"
         "uniform highp vec4 color; \n"
         "uniform highp vec4 light_pos;  \n"
         "uniform highp vec4 light_diff; \n"
         "uniform highp vec4 light_spec; \n"
         "uniform highp vec4 light_amb;  \n"
         "uniform float spec_power ; \n"
+        "out highp vec4 out_color; \n"
 
         "void main(void) { \n"
 
@@ -75,7 +76,7 @@ void Viewer::compile_shaders()
         "   highp vec4 diffuse = max(dot(N,L), 0.0) * light_diff * color; \n"
         "   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-        "gl_FragColor = light_amb*color + diffuse  ; \n"
+        "out_color = light_amb*color + diffuse  ; \n"
         "} \n"
         "\n"
     };
@@ -111,8 +112,8 @@ void Viewer::compile_shaders()
              //Vertex source code
              const char vertex_source_no_ext[] =
              {
-                 "#version 120 \n"
-                 "attribute highp vec4 vertex;\n"
+                 "#version 150 \n"
+                 "in highp vec4 vertex;\n"
                  "uniform highp mat4 mvp_matrix;\n"
                  "void main(void)\n"
                  "{\n"
@@ -123,10 +124,11 @@ void Viewer::compile_shaders()
              //Vertex source code
              const char fragment_source_no_ext[] =
              {
-                 "#version 120 \n"
+                 "#version 150 \n"
                  "uniform highp vec4 color; \n"
+                 "out highp vec4 out_color; \n"
                  "void main(void) { \n"
-                 "gl_FragColor = color; \n"
+                 "out_color = color; \n"
                  "} \n"
                  "\n"
              };

--- a/Circular_kernel_3/demo/Circular_kernel_3/Viewer.h
+++ b/Circular_kernel_3/demo/Circular_kernel_3/Viewer.h
@@ -13,6 +13,7 @@ class Viewer : public CGAL::QGLViewer
 {
 public:
     Viewer(QWidget* parent = 0);
+    ~Viewer();
   GLuint dl_nb;
 protected :
   virtual void draw();

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -54,27 +54,6 @@
 
 namespace CGAL
 {
-int& code_to_call_before_creation_of_QCoreApplication(int& i) {
-  QSurfaceFormat fmt;
-#ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
-#else
-  fmt.setVersion(4, 3);
-#endif
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
-#endif
-
-  //We set the locale to avoid any trouble with VTK
-  setlocale(LC_ALL, "C");
-  return i;
-}
 //------------------------------------------------------------------------------
 const char vertex_source_color[] =
   {

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -58,17 +58,17 @@ namespace CGAL
 //------------------------------------------------------------------------------
 const char vertex_source_color[] =
   {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
-    "attribute highp vec3 normal;\n"
-    "attribute highp vec3 color;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
+    "in highp vec3 normal;\n"
+    "in highp vec3 color;\n"
 
     "uniform highp mat4 mvp_matrix;\n"
     "uniform highp mat4 mv_matrix; \n"
 
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
-    "varying highp vec4 fColor; \n"
+    "out highp vec4 fP; \n"
+    "out highp vec3 fN; \n"
+    "out highp vec4 fColor; \n"
 
     "uniform highp float point_size; \n"
     "void main(void)\n"
@@ -83,15 +83,16 @@ const char vertex_source_color[] =
 
 const char fragment_source_color[] =
   {
-    "#version 120 \n"
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
-    "varying highp vec4 fColor; \n"
+    "#version 150 \n"
+    "in highp vec4 fP; \n"
+    "in highp vec3 fN; \n"
+    "in highp vec4 fColor; \n"
     "uniform highp vec4 light_pos;  \n"
     "uniform highp vec4 light_diff; \n"
     "uniform highp vec4 light_spec; \n"
     "uniform highp vec4 light_amb;  \n"
     "uniform float spec_power ; \n"
+    "out vec4 out_color; \n"
 
     "void main(void) { \n"
     "   highp vec3 L = light_pos.xyz - fP.xyz; \n"
@@ -104,18 +105,18 @@ const char fragment_source_color[] =
     "   highp vec3 R = reflect(-L, N); \n"
     "   highp vec4 diffuse = max(dot(N,L), 0.0) * light_diff * fColor; \n"
     "   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
-    "   gl_FragColor = light_amb*fColor + diffuse  ; \n"
+    "   out_color = light_amb*fColor + diffuse  ; \n"
     "} \n"
     "\n"
   };
 
 const char vertex_source_p_l[] =
   {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
-    "attribute highp vec3 color;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
+    "in highp vec3 color;\n"
     "uniform highp mat4 mvp_matrix;\n"
-    "varying highp vec4 fColor; \n"
+    "out highp vec4 fColor; \n"
     "uniform highp float point_size; \n"
     "void main(void)\n"
     "{\n"
@@ -127,10 +128,11 @@ const char vertex_source_p_l[] =
 
 const char fragment_source_p_l[] =
   {
-    "#version 120 \n"
-    "varying highp vec4 fColor; \n"
+    "#version 150 \n"
+    "in highp vec4 fColor; \n"
+    "out vec4 out_color; \n"
     "void main(void) { \n"
-    "gl_FragColor = fColor; \n"
+    "out_color = fColor; \n"
     "} \n"
     "\n"
   };

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -54,7 +54,27 @@
 
 namespace CGAL
 {
+int& code_to_call_before_creation_of_QCoreApplication(int& i) {
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setVersion(4, 1);
+#else
+  fmt.setVersion(4, 3);
+#endif
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
 
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
+#endif
+
+  //We set the locale to avoid any trouble with VTK
+  setlocale(LC_ALL, "C");
+  return i;
+}
 //------------------------------------------------------------------------------
 const char vertex_source_color[] =
   {

--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -358,6 +358,7 @@ public:
 
   ~Basic_viewer_qt()
   {
+    makeCurrent();
     for (unsigned int i=0; i<NB_VBO_BUFFERS; ++i)
       buffers[i].destroy();
 

--- a/GraphicsView/include/CGAL/Qt/Context_initialization.h
+++ b/GraphicsView/include/CGAL/Qt/Context_initialization.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2021  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Maxime Gimeno
+
+#ifndef CGAL_QT_CONTEXT_INITIALIZATION_H
+#define CGAL_QT_CONTEXT_INITIALIZATION_H
+namespace CGAL
+{
+void init_ogl_context(int major, int minor) {
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setVersion(4, 1);
+#else
+  fmt.setVersion(4, 3);
+#endif
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
+#endif
+
+  //We set the locale to avoid any trouble with VTK
+  setlocale(LC_ALL, "C");
+  return i;
+}
+
+}
+
+#endif // CGAL_QT_CONTEXT_INITIALIZATION_H

--- a/GraphicsView/include/CGAL/Qt/Context_initialization.h
+++ b/GraphicsView/include/CGAL/Qt/Context_initialization.h
@@ -12,14 +12,22 @@
 
 #ifndef CGAL_QT_CONTEXT_INITIALIZATION_H
 #define CGAL_QT_CONTEXT_INITIALIZATION_H
+
 namespace CGAL
 {
-void init_ogl_context(int major, int minor) {
+inline void init_ogl_context(int major, int minor) {
   QSurfaceFormat fmt;
 #ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
+  if(major == 4)
+  {
+    fmt.setVersion(4, 1);
+  }
+  else
+  {
+     fmt.setVersion(major, minor);
+  }
 #else
-  fmt.setVersion(4, 3);
+  fmt.setVersion(major, minor);
 #endif
   fmt.setRenderableType(QSurfaceFormat::OpenGL);
   fmt.setProfile(QSurfaceFormat::CoreProfile);
@@ -33,7 +41,6 @@ void init_ogl_context(int major, int minor) {
 
   //We set the locale to avoid any trouble with VTK
   setlocale(LC_ALL, "C");
-  return i;
 }
 
 }

--- a/GraphicsView/include/CGAL/Qt/init_ogl_context.h
+++ b/GraphicsView/include/CGAL/Qt/init_ogl_context.h
@@ -13,6 +13,11 @@
 #ifndef CGAL_QT_CONTEXT_INITIALIZATION_H
 #define CGAL_QT_CONTEXT_INITIALIZATION_H
 
+#include <CGAL/license/GraphicsView.h>
+
+
+#include <QSurfaceFormat>
+#include <QCoreApplication>
 namespace CGAL
 {
 namespace Qt
@@ -37,9 +42,7 @@ inline void init_ogl_context(int major, int minor) {
   QSurfaceFormat::setDefaultFormat(fmt);
 
   //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
-#endif
 
   //We set the locale to avoid any trouble with VTK
   setlocale(LC_ALL, "C");

--- a/GraphicsView/include/CGAL/Qt/init_ogl_context.h
+++ b/GraphicsView/include/CGAL/Qt/init_ogl_context.h
@@ -15,6 +15,8 @@
 
 namespace CGAL
 {
+namespace Qt
+{
 inline void init_ogl_context(int major, int minor) {
   QSurfaceFormat fmt;
 #ifdef Q_OS_MAC
@@ -43,6 +45,6 @@ inline void init_ogl_context(int major, int minor) {
   setlocale(LC_ALL, "C");
 }
 
-}
-
+} //end Qt
+} //end CGAL
 #endif // CGAL_QT_CONTEXT_INITIALIZATION_H

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -216,16 +216,6 @@ void CGAL::QGLViewer::initializeGL() {
          || QCoreApplication::arguments().contains(QStringLiteral("--old")))
 
     {
-      format.setDepthBufferSize(24);
-      format.setStencilBufferSize(8);
-      format.setVersion(2,0);
-      format.setRenderableType(QSurfaceFormat::OpenGLES);
-      format.setSamples(0);
-      format.setOption(QSurfaceFormat::DebugContext);
-      QSurfaceFormat::setDefaultFormat(format);
-
-      needNewContext();
-      qDebug()<<"GL 4.3 context initialization failed. ";
       is_ogl_4_3 = false;
     }
     else

--- a/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
@@ -14,6 +14,7 @@
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
 #include <CGAL/assertions_behaviour.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 // Global random
 CGAL::Random myrandom;
@@ -23,10 +24,7 @@ int main(int argc, char** argv)
   // std::cout<<"Size of dart: "<<sizeof(LCC::Dart)<<std::endl;
   CGAL::set_error_behaviour(CGAL::ABORT);
 
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+  CGAL::init_ogl_context(4,3);
   QApplication application(argc,argv);
 
   application.setOrganizationDomain("cgal.org");

--- a/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
@@ -14,7 +14,7 @@
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
 #include <CGAL/assertions_behaviour.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 // Global random
 CGAL::Random myrandom;
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
   // std::cout<<"Size of dart: "<<sizeof(LCC::Dart)<<std::endl;
   CGAL::set_error_behaviour(CGAL::ABORT);
 
-  CGAL::init_ogl_context(4,3);
+  CGAL::Qt::init_ogl_context(4,3);
   QApplication application(argc,argv);
 
   application.setOrganizationDomain("cgal.org");

--- a/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_demo.cpp
@@ -23,15 +23,15 @@ int main(int argc, char** argv)
   // std::cout<<"Size of dart: "<<sizeof(LCC::Dart)<<std::endl;
   CGAL::set_error_behaviour(CGAL::ABORT);
 
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
   QApplication application(argc,argv);
 
   application.setOrganizationDomain("cgal.org");
   application.setOrganizationName("CNRS and LIRIS' Establishments");
   application.setApplicationName("3D Linear Cell Complex");
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  application.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
   // Import resources from libCGALQt5
   // See https://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Linear_cell_complex/examples/Linear_cell_complex/basic_viewer.h
+++ b/Linear_cell_complex/examples/Linear_cell_complex/basic_viewer.h
@@ -17,7 +17,7 @@
 
 #include <CGAL/Qt/qglviewer.h>
 #include <QKeyEvent>
-#include <QOpenGLFunctions_2_1>
+#include <QOpenGLFunctions>
 #include <QOpenGLVertexArrayObject>
 #include <QGLBuffer>
 #include <QOpenGLShaderProgram>
@@ -43,15 +43,15 @@ typedef Local_kernel::Vector_3 Local_vector;
 //Vertex source code
 const char vertex_source_mono[] =
   {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
-    "attribute highp vec3 normal;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
+    "in highp vec3 normal;\n"
 
     "uniform highp mat4 mvp_matrix;\n"
     "uniform highp mat4 mv_matrix; \n"
 
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
+    "out highp vec4 fP; \n"
+    "out highp vec3 fN; \n"
     "void main(void)\n"
     "{\n"
     "   fP = mv_matrix * vertex; \n"
@@ -62,17 +62,17 @@ const char vertex_source_mono[] =
 
 const char vertex_source_color[] =
   {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
-    "attribute highp vec3 normal;\n"
-    "attribute highp vec3 color;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
+    "in highp vec3 normal;\n"
+    "in highp vec3 color;\n"
 
     "uniform highp mat4 mvp_matrix;\n"
     "uniform highp mat4 mv_matrix; \n"
 
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
-    "varying highp vec4 fColor; \n"
+    "out highp vec4 fP; \n"
+    "out highp vec3 fN; \n"
+    "out highp vec4 fColor; \n"
     "void main(void)\n"
     "{\n"
     "   fP = mv_matrix * vertex; \n"
@@ -85,15 +85,16 @@ const char vertex_source_color[] =
 //Vertex source code
 const char fragment_source_mono[] =
   {
-    "#version 120 \n"
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
+    "#version 150 \n"
+    "in highp vec4 fP; \n"
+    "in highp vec3 fN; \n"
     "uniform highp vec4 color; \n"
     "uniform highp vec4 light_pos;  \n"
     "uniform highp vec4 light_diff; \n"
     "uniform highp vec4 light_spec; \n"
     "uniform highp vec4 light_amb;  \n"
     "uniform float spec_power ; \n"
+    "out highp vec4 out_color; \n"
 
     "void main(void) { \n"
 
@@ -108,22 +109,23 @@ const char fragment_source_mono[] =
     "   highp vec4 diffuse = max(dot(N,L), 0.0) * light_diff * color; \n"
     "   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-    "gl_FragColor = light_amb*color + diffuse  ; \n"
+    "out_color = light_amb*color + diffuse  ; \n"
     "} \n"
     "\n"
   };
 
 const char fragment_source_color[] =
   {
-    "#version 120 \n"
-    "varying highp vec4 fP; \n"
-    "varying highp vec3 fN; \n"
-    "varying highp vec4 fColor; \n"
+    "#version 150 \n"
+    "in highp vec4 fP; \n"
+    "in highp vec3 fN; \n"
+    "in highp vec4 fColor; \n"
     "uniform highp vec4 light_pos;  \n"
     "uniform highp vec4 light_diff; \n"
     "uniform highp vec4 light_spec; \n"
     "uniform highp vec4 light_amb;  \n"
     "uniform float spec_power ; \n"
+    "out highp vec4 out_color; \n"
 
     "void main(void) { \n"
 
@@ -138,7 +140,7 @@ const char fragment_source_color[] =
     "   highp vec4 diffuse = max(dot(N,L), 0.0) * light_diff * fColor; \n"
     "   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec; \n"
 
-    "gl_FragColor = light_amb*fColor + diffuse  ; \n"
+    "out_color = light_amb*fColor + diffuse  ; \n"
     "} \n"
     "\n"
   };
@@ -146,8 +148,8 @@ const char fragment_source_color[] =
 //Vertex source code
 const char vertex_source_p_l[] =
   {
-    "#version 120 \n"
-    "attribute highp vec4 vertex;\n"
+    "#version 150 \n"
+    "in highp vec4 vertex;\n"
     "uniform highp mat4 mvp_matrix;\n"
     "void main(void)\n"
     "{\n"
@@ -157,10 +159,11 @@ const char vertex_source_p_l[] =
 //Vertex source code
 const char fragment_source_p_l[] =
   {
-    "#version 120 \n"
+    "#version 150 \n"
     "uniform highp vec4 color; \n"
+    "out highp vec4 out_color; \n"
     "void main(void) { \n"
-    "gl_FragColor = color; \n"
+    "out_color = color; \n"
     "} \n"
     "\n"
   };
@@ -194,7 +197,7 @@ typename K::Vector_3 compute_normal_of_face(const std::vector<typename K::Point_
   return (typename K::Construct_scaled_vector_3()(normal, 1.0/nb));
 }
 
-class Basic_viewer : public CGAL::QGLViewer, public QOpenGLFunctions_2_1
+class Basic_viewer : public CGAL::QGLViewer, public QOpenGLFunctions
 {
   struct Vertex_info
   {

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -406,7 +406,7 @@ void draw(const CGAL_LCC_TYPE& alcc,
   {
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     SimpleLCCViewerQt<CGAL_LCC_TYPE, DrawingFunctorLCC>
       mainwindow(app.activeWindow(), &alcc, title, nofill, drawing_functor);
     mainwindow.show();

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -13,9 +13,9 @@
 #define CGAL_DRAW_LCC_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
+#include <CGAL/Qt/init_ogl_context.h>
 
 #include <CGAL/Linear_cell_complex_operations.h>
 #include <CGAL/Random.h>

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -13,6 +13,7 @@
 #define CGAL_DRAW_LCC_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -404,9 +405,10 @@ void draw(const CGAL_LCC_TYPE& alcc,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     SimpleLCCViewerQt<CGAL_LCC_TYPE, DrawingFunctorLCC>
       mainwindow(app.activeWindow(), &alcc, title, nofill, drawing_functor);
     mainwindow.show();

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -13,7 +13,7 @@
 #define CGAL_DRAW_LCC_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -405,7 +405,7 @@ void draw(const CGAL_LCC_TYPE& alcc,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Nef_3/include/CGAL/draw_nef_3.h
+++ b/Nef_3/include/CGAL/draw_nef_3.h
@@ -15,10 +15,10 @@
 
 #include <CGAL/license/Nef_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Nef_3/SNC_iteration.h>
 #include <CGAL/circulator.h>
 #include <CGAL/Random.h>

--- a/Nef_3/include/CGAL/draw_nef_3.h
+++ b/Nef_3/include/CGAL/draw_nef_3.h
@@ -15,6 +15,7 @@
 
 #include <CGAL/license/Nef_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -253,9 +254,10 @@ void draw(const CGAL_NEF3_TYPE &anef,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc = 1;
     const char *argv[2] = {"nef_polyhedron_viewer", "\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc), const_cast<char **>(argv));
+    QApplication app(argc, const_cast<char **>(argv));
     DefaultColorFunctorNefPolyhedron fcolor;
     SimpleNefPolyhedronViewerQt<CGAL_NEF3_TYPE,
                                 DefaultColorFunctorNefPolyhedron>

--- a/Nef_3/include/CGAL/draw_nef_3.h
+++ b/Nef_3/include/CGAL/draw_nef_3.h
@@ -255,7 +255,7 @@ void draw(const CGAL_NEF3_TYPE &anef,
   {
     int argc = 1;
     const char *argv[2] = {"nef_polyhedron_viewer", "\0"};
-    QApplication app(argc, const_cast<char **>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc), const_cast<char **>(argv));
     DefaultColorFunctorNefPolyhedron fcolor;
     SimpleNefPolyhedronViewerQt<CGAL_NEF3_TYPE,
                                 DefaultColorFunctorNefPolyhedron>

--- a/Nef_3/include/CGAL/draw_nef_3.h
+++ b/Nef_3/include/CGAL/draw_nef_3.h
@@ -15,7 +15,7 @@
 
 #include <CGAL/license/Nef_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -254,7 +254,7 @@ void draw(const CGAL_NEF3_TYPE &anef,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc = 1;
     const char *argv[2] = {"nef_polyhedron_viewer", "\0"};
     QApplication app(argc, const_cast<char **>(argv));

--- a/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
@@ -262,7 +262,7 @@ void draw(const CGAL_P2T2_TYPE& ap2t2,
   {
     int argc=1;
     const char* argv[2]={"p2t2_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorP2T2 fcolor;
     SimplePeriodic2Triangulation2ViewerQt<CGAL_P2T2_TYPE,
                                           DefaultColorFunctorP2T2>

--- a/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
@@ -14,10 +14,10 @@
 
 #include <CGAL/license/Periodic_2_triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Random.h>
 

--- a/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
@@ -14,7 +14,7 @@
 
 #include <CGAL/license/Periodic_2_triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -261,7 +261,7 @@ void draw(const CGAL_P2T2_TYPE& ap2t2,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"p2t2_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/draw_periodic_2_triangulation_2.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/license/Periodic_2_triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -260,9 +261,10 @@ void draw(const CGAL_P2T2_TYPE& ap2t2,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"p2t2_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     DefaultColorFunctorP2T2 fcolor;
     SimplePeriodic2Triangulation2ViewerQt<CGAL_P2T2_TYPE,
                                           DefaultColorFunctorP2T2>

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/Scene.h
@@ -76,6 +76,7 @@ public:
   }
 
   ~Scene() {
+    ui->viewer->makeCurrent();
     for(int i=0; i<24; i++)
         buffers[i].destroy();
     for(int i=0; i<12; i++)

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
@@ -1,15 +1,11 @@
 #include "MainWindow.h"
 
 #include <QApplication>
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char *argv[])
 {
-  QSurfaceFormat fmt;
-  fmt.setVersion(2, 1);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
+  init_ogl_context(2,1);
   QApplication a(argc, argv);
   MainWindow w;
   //w.ui->setupUi(w);

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
@@ -4,6 +4,12 @@
 
 int main(int argc, char *argv[])
 {
+  QSurfaceFormat fmt;
+  fmt.setVersion(2, 1);
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
   QApplication a(argc, argv);
   MainWindow w;
   //w.ui->setupUi(w);

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/periodic_3_triangulation_3_demo.cpp
@@ -1,11 +1,11 @@
 #include "MainWindow.h"
 
 #include <QApplication>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char *argv[])
 {
-  init_ogl_context(2,1);
+  CGAL::Qt::init_ogl_context(2,1);
   QApplication a(argc, argv);
   MainWindow w;
   //w.ui->setupUi(w);

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
@@ -4,15 +4,20 @@
 
 int main(int argc, char** argv)
 {
+  QSurfaceFormat fmt;
+  fmt.setVersion(2, 1);
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
   QApplication application(argc,argv);
-
   application.setOrganizationDomain("inria.fr");
   application.setOrganizationName("INRIA");
   application.setApplicationName("3D Periodic Lloyd");
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  application.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
   // Import resources from libCGAL (QT5).
   // See https://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
@@ -1,12 +1,12 @@
 #include "MainWindow.h"
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char** argv)
 {
 
-  CGAL::init_ogl_context(2, 1);
+  CGAL::Qt::init_ogl_context(2, 1);
 
   QApplication application(argc,argv);
   application.setOrganizationDomain("inria.fr");

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Periodic_Lloyd_3.cpp
@@ -1,19 +1,13 @@
 #include "MainWindow.h"
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char** argv)
 {
-  QSurfaceFormat fmt;
-  fmt.setVersion(2, 1);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+
+  CGAL::init_ogl_context(2, 1);
+
   QApplication application(argc,argv);
   application.setOrganizationDomain("inria.fr");
   application.setOrganizationName("INRIA");

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Viewer.h
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/Viewer.h
@@ -27,6 +27,7 @@ public:
   {}
   ~Viewer()
   {
+    makeCurrent();
    for(int i=0; i<4; i++)
    {
     buffers[i].destroy();

--- a/Point_set_3/include/CGAL/draw_point_set_3.h
+++ b/Point_set_3/include/CGAL/draw_point_set_3.h
@@ -15,6 +15,7 @@
 
 #include <CGAL/license/Point_set_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -100,9 +101,10 @@ void draw(const Point_set_3<P, V>& apointset,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"point_set_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     SimplePointSetViewerQt<Point_set_3<P, V> > mainwindow(app.activeWindow(),
                                                           apointset,
                                                           title);

--- a/Point_set_3/include/CGAL/draw_point_set_3.h
+++ b/Point_set_3/include/CGAL/draw_point_set_3.h
@@ -15,7 +15,6 @@
 
 #include <CGAL/license/Point_set_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -36,6 +35,7 @@ void draw(const PS& aps);
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Point_set_3.h>
 #include <CGAL/Random.h>
 

--- a/Point_set_3/include/CGAL/draw_point_set_3.h
+++ b/Point_set_3/include/CGAL/draw_point_set_3.h
@@ -15,7 +15,7 @@
 
 #include <CGAL/license/Point_set_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -101,7 +101,7 @@ void draw(const Point_set_3<P, V>& apointset,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"point_set_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Point_set_3/include/CGAL/draw_point_set_3.h
+++ b/Point_set_3/include/CGAL/draw_point_set_3.h
@@ -102,7 +102,7 @@ void draw(const Point_set_3<P, V>& apointset,
   {
     int argc=1;
     const char* argv[2]={"point_set_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     SimplePointSetViewerQt<Point_set_3<P, V> > mainwindow(app.activeWindow(),
                                                           apointset,
                                                           title);

--- a/Polygon/include/CGAL/draw_polygon_2.h
+++ b/Polygon/include/CGAL/draw_polygon_2.h
@@ -124,7 +124,7 @@ void draw(const CGAL::Polygon_2<T, C>& ap2,
   {
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     SimplePolygon2ViewerQt<CGAL::Polygon_2<T, C> >
       mainwindow(app.activeWindow(), ap2, title);
     mainwindow.show();

--- a/Polygon/include/CGAL/draw_polygon_2.h
+++ b/Polygon/include/CGAL/draw_polygon_2.h
@@ -18,7 +18,6 @@
 #define CGAL_DRAW_POLYGON_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -39,7 +38,7 @@ void draw(const P& ap);
 #endif
 
 #ifdef CGAL_USE_BASIC_VIEWER
-
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Polygon_2.h>
 #include <CGAL/Random.h>
 

--- a/Polygon/include/CGAL/draw_polygon_2.h
+++ b/Polygon/include/CGAL/draw_polygon_2.h
@@ -18,7 +18,7 @@
 #define CGAL_DRAW_POLYGON_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -123,7 +123,7 @@ void draw(const CGAL::Polygon_2<T, C>& ap2,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Polygon/include/CGAL/draw_polygon_2.h
+++ b/Polygon/include/CGAL/draw_polygon_2.h
@@ -18,6 +18,7 @@
 #define CGAL_DRAW_POLYGON_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -122,9 +123,10 @@ void draw(const CGAL::Polygon_2<T, C>& ap2,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     SimplePolygon2ViewerQt<CGAL::Polygon_2<T, C> >
       mainwindow(app.activeWindow(), ap2, title);
     mainwindow.show();

--- a/Polygon/include/CGAL/draw_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/draw_polygon_with_holes_2.h
@@ -140,7 +140,7 @@ void draw(const CGAL::Polygon_with_holes_2<T, C>& ap2,
   {
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     SimplePolygonWithHoles2ViewerQt<CGAL::Polygon_with_holes_2<T, C> >
       mainwindow(app.activeWindow(), ap2, title);
     mainwindow.show();

--- a/Polygon/include/CGAL/draw_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/draw_polygon_with_holes_2.h
@@ -18,7 +18,6 @@
 #define CGAL_DRAW_POLYGON_WITH_HOLES_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -38,7 +37,7 @@ void draw(const PH& aph);
 #endif
 
 #ifdef CGAL_USE_BASIC_VIEWER
-
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Polygon_with_holes_2.h>
 #include <CGAL/Random.h>
 

--- a/Polygon/include/CGAL/draw_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/draw_polygon_with_holes_2.h
@@ -18,6 +18,7 @@
 #define CGAL_DRAW_POLYGON_WITH_HOLES_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -138,9 +139,10 @@ void draw(const CGAL::Polygon_with_holes_2<T, C>& ap2,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     SimplePolygonWithHoles2ViewerQt<CGAL::Polygon_with_holes_2<T, C> >
       mainwindow(app.activeWindow(), ap2, title);
     mainwindow.show();

--- a/Polygon/include/CGAL/draw_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/draw_polygon_with_holes_2.h
@@ -18,7 +18,7 @@
 #define CGAL_DRAW_POLYGON_WITH_HOLES_2_H
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef DOXYGEN_RUNNING
 namespace CGAL {
@@ -139,7 +139,7 @@ void draw(const CGAL::Polygon_with_holes_2<T, C>& ap2,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -374,6 +374,7 @@ Viewer::Viewer(QWidget* parent,
 
 Viewer::~Viewer()
 {
+  makeCurrent();
     QSettings viewer_settings;
     viewer_settings.setValue("cam_pos",
                              QString("%1,%2,%3")

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -14,10 +14,9 @@
 
 #include <CGAL/license/Polyhedron.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
-
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Random.h>
 

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -14,7 +14,7 @@
 
 #include <CGAL/license/Polyhedron.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -209,7 +209,7 @@ void draw(const CGAL_POLY_TYPE& apoly,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"polyhedron_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/license/Polyhedron.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -208,9 +209,10 @@ void draw(const CGAL_POLY_TYPE& apoly,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"polyhedron_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     DefaultColorFunctorPolyhedron fcolor;
     SimplePolyhedronViewerQt<CGAL_POLY_TYPE, DefaultColorFunctorPolyhedron>
       mainwindow(app.activeWindow(), apoly, title, nofill, fcolor);

--- a/Polyhedron/include/CGAL/draw_polyhedron.h
+++ b/Polyhedron/include/CGAL/draw_polyhedron.h
@@ -210,7 +210,7 @@ void draw(const CGAL_POLY_TYPE& apoly,
   {
     int argc=1;
     const char* argv[2]={"polyhedron_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorPolyhedron fcolor;
     SimplePolyhedronViewerQt<CGAL_POLY_TYPE, DefaultColorFunctorPolyhedron>
       mainwindow(app.activeWindow(), apoly, title, nofill, fcolor);

--- a/Principal_component_analysis/demo/Principal_component_analysis/MainWindow.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/MainWindow.cpp
@@ -48,6 +48,7 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow()
 {
+        m_pViewer->makeCurrent();
         delete ui;
 }
 

--- a/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
@@ -21,6 +21,16 @@
 
 int main(int argc, char **argv)
 {
+  QSurfaceFormat fmt;
+  fmt.setVersion(2, 1);
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
+
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");
   app.setOrganizationName("INRIA");

--- a/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
@@ -18,11 +18,11 @@
 #include "MainWindow.h"
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char **argv)
 {
-  CGAL::init_ogl_context(2, 1);
+  CGAL::Qt::init_ogl_context(2, 1);
 
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");

--- a/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/PCA_demo.cpp
@@ -18,18 +18,11 @@
 #include "MainWindow.h"
 #include <QApplication>
 #include <CGAL/Qt/resources.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char **argv)
 {
-  QSurfaceFormat fmt;
-  fmt.setVersion(2, 1);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
+  CGAL::init_ogl_context(2, 1);
 
   QApplication app(argc, argv);
   app.setOrganizationDomain("inria.fr");

--- a/Principal_component_analysis/demo/Principal_component_analysis/Scene.cpp
+++ b/Principal_component_analysis/demo/Principal_component_analysis/Scene.cpp
@@ -28,6 +28,7 @@ Scene::Scene()
 
 Scene::~Scene()
 {
+
     delete m_pPolyhedron;
 }
 

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -29,10 +29,10 @@ void draw(const SM& asm);
 
 #include <CGAL/license/Surface_mesh.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Random.h>
 

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -29,7 +29,7 @@ void draw(const SM& asm);
 
 #include <CGAL/license/Surface_mesh.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -209,7 +209,7 @@ void draw(const Surface_mesh<K>& amesh,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"surface_mesh_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -29,6 +29,7 @@ void draw(const SM& asm);
 
 #include <CGAL/license/Surface_mesh.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -208,9 +209,10 @@ void draw(const Surface_mesh<K>& amesh,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"surface_mesh_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     DefaultColorFunctorSM fcolor;
     SimpleSurfaceMeshViewerQt<Surface_mesh<K>, DefaultColorFunctorSM>
       mainwindow(app.activeWindow(), amesh, title, nofill, fcolor);

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -210,7 +210,7 @@ void draw(const Surface_mesh<K>& amesh,
   {
     int argc=1;
     const char* argv[2]={"surface_mesh_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorSM fcolor;
     SimpleSurfaceMeshViewerQt<Surface_mesh<K>, DefaultColorFunctorSM>
       mainwindow(app.activeWindow(), amesh, title, nofill, fcolor);

--- a/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
+++ b/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
@@ -18,7 +18,7 @@
 #include <initializer_list>
 #include <CGAL/draw_linear_cell_complex.h>
 #include <CGAL/Path_on_surface.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -410,7 +410,7 @@ void draw(const Mesh& alcc,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
+++ b/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
@@ -18,10 +18,10 @@
 #include <initializer_list>
 #include <CGAL/draw_linear_cell_complex.h>
 #include <CGAL/Path_on_surface.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Random.h>
 
 namespace CGAL {

--- a/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
+++ b/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
@@ -411,7 +411,7 @@ void draw(const Mesh& alcc,
   {
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     Face_graph_with_path_viewer<Mesh, DrawingFunctor> mainwindow(app.activeWindow(),
                                                                  alcc, &paths, amark,
                                                                  title, nofill,

--- a/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
+++ b/Surface_mesh_topology/include/CGAL/draw_face_graph_with_paths.h
@@ -18,6 +18,7 @@
 #include <initializer_list>
 #include <CGAL/draw_linear_cell_complex.h>
 #include <CGAL/Path_on_surface.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -409,9 +410,10 @@ void draw(const Mesh& alcc,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"lccviewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     Face_graph_with_path_viewer<Mesh, DrawingFunctor> mainwindow(app.activeWindow(),
                                                                  alcc, &paths, amark,
                                                                  title, nofill,

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/license/Triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -144,9 +145,10 @@ void draw(const CGAL_T2_TYPE& at2,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     DefaultColorFunctorT2 fcolor;
     SimpleTriangulation2ViewerQt<CGAL_T2_TYPE, DefaultColorFunctorT2>
       mainwindow(app.activeWindow(), at2, title, nofill, fcolor);

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -22,6 +22,35 @@
 
 namespace CGAL
 {
+namespace internal_test{
+
+
+int& code_to_call_before_creation_of_QCoreApplication(int& i) {
+  QSurfaceFormat fmt;
+#ifdef Q_OS_MAC
+  fmt.setDepthBufferSize(24);
+  fmt.setStencilBufferSize(8);
+  fmt.setVersion(2,0);
+  fmt.setRenderableType(QSurfaceFormat::OpenGLES);
+  fmt.setSamples(0);
+#else
+  fmt.setVersion(4, 3);
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+#endif
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+
+  //for windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
+#endif
+
+  //We set the locale to avoid any trouble with VTK
+  setlocale(LC_ALL, "C");
+  return i;
+}
+}
 
 // Default color functor; user can change it to have its own face color
 struct DefaultColorFunctorT2
@@ -146,7 +175,7 @@ void draw(const CGAL_T2_TYPE& at2,
   {
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::internal_test::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorT2 fcolor;
     SimpleTriangulation2ViewerQt<CGAL_T2_TYPE, DefaultColorFunctorT2>
       mainwindow(app.activeWindow(), at2, title, nofill, fcolor);

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -14,10 +14,10 @@
 
 #include <CGAL/license/Triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Triangulation_2.h>
 #include <CGAL/Random.h>
 

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -14,7 +14,7 @@
 
 #include <CGAL/license/Triangulation_2.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -145,7 +145,7 @@ void draw(const CGAL_T2_TYPE& at2,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -22,31 +22,6 @@
 
 namespace CGAL
 {
-namespace internal_test{
-
-
-int& code_to_call_before_creation_of_QCoreApplication(int& i) {
-  QSurfaceFormat fmt;
-#ifdef Q_OS_MAC
-  fmt.setVersion(4, 1);
-#else
-  fmt.setVersion(4, 3);
-#endif
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QCoreApplication::setAttribute(::Qt::AA_UseDesktopOpenGL);
-#endif
-
-  //We set the locale to avoid any trouble with VTK
-  setlocale(LC_ALL, "C");
-  return i;
-}
-}
 
 // Default color functor; user can change it to have its own face color
 struct DefaultColorFunctorT2
@@ -171,7 +146,7 @@ void draw(const CGAL_T2_TYPE& at2,
   {
     int argc=1;
     const char* argv[2]={"t2_viewer","\0"};
-    QApplication app(CGAL::internal_test::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorT2 fcolor;
     SimpleTriangulation2ViewerQt<CGAL_T2_TYPE, DefaultColorFunctorT2>
       mainwindow(app.activeWindow(), at2, title, nofill, fcolor);

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -28,17 +28,12 @@ namespace internal_test{
 int& code_to_call_before_creation_of_QCoreApplication(int& i) {
   QSurfaceFormat fmt;
 #ifdef Q_OS_MAC
-  std::cout<<"Running on mac"<<std::endl;
-  fmt.setDepthBufferSize(24);
-  fmt.setStencilBufferSize(8);
-  fmt.setVersion(2,0);
-  fmt.setRenderableType(QSurfaceFormat::OpenGLES);
-  fmt.setSamples(0);
+  fmt.setVersion(4, 1);
 #else
   fmt.setVersion(4, 3);
+#endif
   fmt.setRenderableType(QSurfaceFormat::OpenGL);
   fmt.setProfile(QSurfaceFormat::CoreProfile);
-#endif
   fmt.setOption(QSurfaceFormat::DebugContext);
   QSurfaceFormat::setDefaultFormat(fmt);
 

--- a/Triangulation_2/include/CGAL/draw_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/draw_triangulation_2.h
@@ -28,6 +28,7 @@ namespace internal_test{
 int& code_to_call_before_creation_of_QCoreApplication(int& i) {
   QSurfaceFormat fmt;
 #ifdef Q_OS_MAC
+  std::cout<<"Running on mac"<<std::endl;
   fmt.setDepthBufferSize(24);
   fmt.setStencilBufferSize(8);
   fmt.setVersion(2,0);

--- a/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
+++ b/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
@@ -13,11 +13,11 @@
 
 #include "MainWindow.h"
 #include <QApplication>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 int main(int argc, char** argv)
 {
-  CGAL::init_ogl_context(2, 1);
+  CGAL::Qt::init_ogl_context(2, 1);
 
   QApplication app(argc, argv);
 

--- a/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
+++ b/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
@@ -13,19 +13,12 @@
 
 #include "MainWindow.h"
 #include <QApplication>
+#include <CGAL/Qt/Context_initialization.h>
 
 int main(int argc, char** argv)
 {
-  QSurfaceFormat fmt;
-  fmt.setVersion(2, 1);
-  fmt.setRenderableType(QSurfaceFormat::OpenGL);
-  fmt.setProfile(QSurfaceFormat::CoreProfile);
-  fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-  //for windows
-  #if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-  #endif
+  CGAL::init_ogl_context(2, 1);
+
   QApplication app(argc, argv);
 
   app.setOrganizationDomain("inria.fr");

--- a/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
+++ b/Triangulation_3/demo/Triangulation_3/T3_demo.cpp
@@ -16,15 +16,21 @@
 
 int main(int argc, char** argv)
 {
+  QSurfaceFormat fmt;
+  fmt.setVersion(2, 1);
+  fmt.setRenderableType(QSurfaceFormat::OpenGL);
+  fmt.setProfile(QSurfaceFormat::CoreProfile);
+  fmt.setOption(QSurfaceFormat::DebugContext);
+  QSurfaceFormat::setDefaultFormat(fmt);
+  //for windows
+  #if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+  #endif
   QApplication app(argc, argv);
 
   app.setOrganizationDomain("inria.fr");
   app.setOrganizationName("INRIA");
   app.setApplicationName("3D Triangulation Demo");
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  app.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
   MainWindow mw;
   mw.show();

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -152,7 +152,7 @@ void draw(const CGAL_T3_TYPE& at3,
   {
     int argc=1;
     const char* argv[2]={"t3_viewer","\0"};
-    QApplication app(argc,const_cast<char**>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
     DefaultColorFunctorT3 fcolor;
     SimpleTriangulation3ViewerQt<CGAL_T3_TYPE, DefaultColorFunctorT3>
       mainwindow(app.activeWindow(), at3, title, nofill, fcolor);

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -14,7 +14,7 @@
 
 #include <CGAL/license/Triangulation_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -151,7 +151,7 @@ void draw(const CGAL_T3_TYPE& at3,
 
   if (!cgal_test_suite)
   {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t3_viewer","\0"};
     QApplication app(argc,const_cast<char**>(argv));

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -14,10 +14,10 @@
 
 #include <CGAL/license/Triangulation_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Triangulation_3.h>
 #include <CGAL/Random.h>
 

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/license/Triangulation_3.h>
 #include <CGAL/Qt/Basic_viewer_qt.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -150,9 +151,10 @@ void draw(const CGAL_T3_TYPE& at3,
 
   if (!cgal_test_suite)
   {
+    init_ogl_context(4,3);
     int argc=1;
     const char* argv[2]={"t3_viewer","\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc),const_cast<char**>(argv));
+    QApplication app(argc,const_cast<char**>(argv));
     DefaultColorFunctorT3 fcolor;
     SimpleTriangulation3ViewerQt<CGAL_T3_TYPE, DefaultColorFunctorT3>
       mainwindow(app.activeWindow(), at3, title, nofill, fcolor);

--- a/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
@@ -14,7 +14,7 @@
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
 #include <CGAL/license/Voronoi_diagram_2.h>
-#include <CGAL/Qt/Context_initialization.h>
+#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -317,7 +317,7 @@ void draw(const CGAL_VORONOI_TYPE &av2,
 #endif
 
   if (!cgal_test_suite) {
-    init_ogl_context(4,3);
+    CGAL::Qt::init_ogl_context(4,3);
     int argc = 1;
     const char *argv[2] = {"voronoi_2_viewer", "\0"};
     QApplication app(argc, const_cast<char **>(argv));

--- a/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
@@ -14,10 +14,10 @@
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
 #include <CGAL/license/Voronoi_diagram_2.h>
-#include <CGAL/Qt/init_ogl_context.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
+#include <CGAL/Qt/init_ogl_context.h>
 #include <CGAL/Random.h>
 #include <CGAL/Triangulation_utils_2.h>
 #include <CGAL/Voronoi_diagram_2/Face.h>

--- a/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
@@ -318,7 +318,7 @@ void draw(const CGAL_VORONOI_TYPE &av2,
   if (!cgal_test_suite) {
     int argc = 1;
     const char *argv[2] = {"voronoi_2_viewer", "\0"};
-    QApplication app(argc, const_cast<char **>(argv));
+    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc), const_cast<char **>(argv));
     DefaultColorFunctorV2 fcolor;
     SimpleVoronoiDiagram2ViewerQt<CGAL_VORONOI_TYPE, DefaultColorFunctorV2>
         mainwindow(app.activeWindow(), av2, title, nofill,

--- a/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
+++ b/Voronoi_diagram_2/include/CGAL/draw_voronoi_diagram_2.h
@@ -14,6 +14,7 @@
 
 #include <CGAL/Qt/Basic_viewer_qt.h>
 #include <CGAL/license/Voronoi_diagram_2.h>
+#include <CGAL/Qt/Context_initialization.h>
 
 #ifdef CGAL_USE_BASIC_VIEWER
 
@@ -316,9 +317,10 @@ void draw(const CGAL_VORONOI_TYPE &av2,
 #endif
 
   if (!cgal_test_suite) {
+    init_ogl_context(4,3);
     int argc = 1;
     const char *argv[2] = {"voronoi_2_viewer", "\0"};
-    QApplication app(CGAL::code_to_call_before_creation_of_QCoreApplication(argc), const_cast<char **>(argv));
+    QApplication app(argc, const_cast<char **>(argv));
     DefaultColorFunctorV2 fcolor;
     SimpleVoronoiDiagram2ViewerQt<CGAL_VORONOI_TYPE, DefaultColorFunctorV2>
         mainwindow(app.activeWindow(), av2, title, nofill,


### PR DESCRIPTION
## Summary of Changes

Recent MacOS distributions do not support GLGL 120, so I upgraded to 150. 
I also added a function call in every `draw_XXX_example`, that should set up  the more recent context possible to use for the examples. 
That should fix the macOS bug that prevent the drawing of edges and points, but the edge size will probably be stuck at 1 as most drivers don't implement other sizes (cf https://stackoverflow.com/questions/34866964/opengl-gllinewidth-doesnt-change-size-of-lines). 

## Release Management

* Affected package(s):GraphicsView
