### PR TITLE
Compile without MPFR and GMP

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/RS/dyadic.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/dyadic.h
@@ -13,8 +13,12 @@
 
 #include <stdio.h>
 #include <math.h>
+#ifdef CGAL_USE_GMP
 #include <gmp.h>
+#endif
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 #include <CGAL/assertions.h>
 
 // for c++, compile with -lgmpxx

--- a/Algebraic_kernel_d/include/CGAL/RS/signat_1.h
+++ b/Algebraic_kernel_d/include/CGAL/RS/signat_1.h
@@ -15,7 +15,9 @@
 #include <CGAL/Polynomial_traits_d.h>
 #include "exact_signat_1.h"
 //#include <boost/mpl/assert.hpp>
+#ifdef CGAL_USE_GMP
 #include <gmp.h>
+#endif
 
 namespace CGAL{
 namespace RS_AK1{

--- a/CGAL_Core/include/CGAL/CORE/Gmp.h
+++ b/CGAL_Core/include/CGAL/CORE/Gmp.h
@@ -15,7 +15,9 @@
 #define _CORE_GMP_H_
 
 #include <CGAL/CORE/Impl.h>
+#ifdef CGAL_USE_GMP
 #include <gmp.h>
+#endif
 
 namespace CORE {
 

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -19,8 +19,12 @@ int main() {
 // conversion with loss of data
 // warning on - applied on unsigned number
 
-#include "gmp.h"
+#ifdef CGAL_USE_GMP
+#include <gmp.h>
+#endif
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 
 bool get_version_info(const LPCTSTR name,
                       int& major,

--- a/Number_types/include/CGAL/GMP/Gmpfi_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfi_type.h
@@ -13,7 +13,9 @@
 
 #include <CGAL/config.h>
 #include <CGAL/gmp.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 #include <CGAL/GMP/Gmpfr_type.h>
 #include <CGAL/GMP/Gmpq_type.h>
 #include <mpfi.h>

--- a/Number_types/include/CGAL/GMP/Gmpfr_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpfr_type.h
@@ -14,7 +14,9 @@
 #include <CGAL/disable_warnings.h>
 
 #include <CGAL/gmp.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 #include <boost/operators.hpp>
 #include <CGAL/Handle_for.h>
 #include <CGAL/GMP/Gmpz_type.h>

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -27,7 +27,9 @@
 #include <CGAL/GMP/Gmpfr_type.h>
 
 #include <CGAL/gmp.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 #include <utility>
 #include <string>
 

--- a/Number_types/include/CGAL/GMP/Gmpz_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpz_type.h
@@ -22,7 +22,9 @@
 #include <CGAL/IO/io.h>
 
 #include <CGAL/gmp.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 
 #include <boost/operators.hpp>
 #include <CGAL/Handle_for.h>

--- a/Number_types/include/CGAL/GMP/Gmpzf_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpzf_type.h
@@ -18,7 +18,9 @@
 #include <CGAL/tss.h>
 #include <CGAL/Handle_for.h>
 #include <CGAL/gmp.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 #include <CGAL/Quotient.h>
 #include <CGAL/GMP/Gmpz_type.h>
 #include <boost/operators.hpp>

--- a/Number_types/include/CGAL/gmp.h
+++ b/Number_types/include/CGAL/gmp.h
@@ -19,7 +19,9 @@
                                      // warning on - applied on unsigned number
 #endif
 
+#ifdef CGAL_USE_GMP
 #include <gmp.h>
+#endif
 
 
 #if defined(BOOST_MSVC)

--- a/Number_types/include/CGAL/gmpxx.h
+++ b/Number_types/include/CGAL/gmpxx.h
@@ -31,7 +31,9 @@
 #define CGAL_GMPXX_H
 
 #include <cstring> // needed by GMP 4.1.4 since <gmpxx.h> misses it.
+#ifdef CGAL_USE_GMPXX
 #include <gmpxx.h>
+#endif
 #include <utility>
 
 #include <CGAL/mpz_class.h>

--- a/Number_types/include/CGAL/gmpxx_coercion_traits.h
+++ b/Number_types/include/CGAL/gmpxx_coercion_traits.h
@@ -22,8 +22,12 @@
 #include <CGAL/Coercion_traits.h>
 
 #include <cstring> // needed by GMP 4.1.4 since <gmpxx.h> misses it.
+#ifdef CGAL_USE_GMPXX
 #include <gmpxx.h>
+#endif
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
 
 namespace CGAL {
 

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -22,8 +22,12 @@
 #include <CGAL/number_utils.h>
 #include <CGAL/double.h>
 #include <CGAL/IO/io.h>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
+#ifdef CGAL_USE_GMPXX
 #include <gmpxx.h>
+#endif
 
 // This file gathers the necessary adaptors so that the following
 // C++ number types that come with GMP can be used by CGAL :

--- a/Number_types/include/CGAL/mpz_class.h
+++ b/Number_types/include/CGAL/mpz_class.h
@@ -33,8 +33,12 @@
 #include <CGAL/number_utils.h>
 #include <CGAL/double.h>
 #include <boost/type_traits/is_same.hpp>
+#ifdef CGAL_USE_MPFR
 #include <mpfr.h>
+#endif
+#ifdef CGAL_USE_GMPXX
 #include <gmpxx.h>
+#endif
 
 #define CGAL_CHECK_GMP_EXPR                                             \
     CGAL_static_assertion(                                                \


### PR DESCRIPTION

## Summary of Changes

For configurations with CGAL_NO_GMP and CGAL_NO_MPFR, includes
to MPFR, GMP, GMPXX are usually removed by #ifdefs
This change adds the missing #ifdefs to ensure that CGAL compiles
when MPFR or GMP do not exist.


