### PR TITLE
Fix segmentation fault in destructor of Handle_for_virtual.h

### DIFF
--- a/STL_Extension/include/CGAL/Handle_for_virtual.h
+++ b/STL_Extension/include/CGAL/Handle_for_virtual.h
@@ -79,6 +79,7 @@ class Handle_for_virtual
 
     ~Handle_for_virtual()
     {
+      if(!ptr) return;
       ptr->remove_reference();
       if ( !ptr->is_referenced() )
           delete ptr;


### PR DESCRIPTION
## Summary of Changes

Fixes null pointer dereference in the destructor of `Handle_for_virtual` which can be caused as demonstrated in #5338 

## Release Management

* Affected package(s): STL Extension
* Issue(s) solved (if any): fix #5338, partially fix #5342
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

