### PR TITLE
[Classification] Fix Boost optional dependencies

### DIFF
--- a/Classification/include/CGAL/Classification/ETHZ/Random_forest_classifier.h
+++ b/Classification/include/CGAL/Classification/ETHZ/Random_forest_classifier.h
@@ -290,14 +290,10 @@ public:
     The output file is written in a binary format that is readable by
     the `load_configuration()` method.
   */
-#if defined(DOXYGEN_RUNNING) || \
-  (defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && \
-   defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION))
   void save_configuration (std::ostream& output) const
   {
     m_rfc->write(output);
   }
-#endif
 
   /*!
     \brief loads a configuration from the stream `input`.
@@ -314,9 +310,6 @@ public:
     format for ETHZ Random Forest changed in CGAL 5.2.
 
   */
-#if defined(DOXYGEN_RUNNING) || \
-  (defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && \
-   defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION))
   void load_configuration (std::istream& input)
   {
     CGAL::internal::liblearning::RandomForest::ForestParams params;
@@ -324,7 +317,6 @@ public:
 
     m_rfc->read(input);
   }
-#endif
 
   /// @}
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -60,7 +60,7 @@ if(TARGET CGAL::Eigen3_support)
     scene_surface_mesh_item
     scene_selection_item
     scene_color_ramp
-    CGAL::Eigen_support)
+    CGAL::Eigen3_support)
 
   if(TARGET CGAL::Boost_serialization_support AND TARGET CGAL::Boost_iostreams_support)
     target_link_libraries(classification_plugin PUBLIC

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -2,25 +2,14 @@ include(polyhedron_demo_macros)
 
 if(TARGET CGAL::Eigen3_support)
 
-  set(Classification_dependencies_met TRUE)
-
   find_package(Boost OPTIONAL_COMPONENTS serialization iostreams)
   include(CGAL_Boost_serialization_support)
   include(CGAL_Boost_iostreams_support)
-  if(NOT TARGET CGAL::Boost_serialization_support)
+  if(NOT TARGET CGAL::Boost_serialization_support OR NOT TARGET CGAL::Boost_iostreams_support)
     message(
       STATUS
-        "NOTICE: Boost Serialization not found. Classification plugin won't be available."
+        "NOTICE: Boost IO Streams and/or Serialization not found, reading deprecated Classification config files won't be possible."
     )
-    set(Classification_dependencies_met FALSE)
-  endif()
-
-  if(NOT TARGET CGAL::Boost_iostreams_support)
-    message(
-      STATUS
-        "NOTICE: Boost IOStreams not found. Classification plugin won't be available."
-    )
-    set(Classification_dependencies_met FALSE)
   endif()
 
   find_package(OpenCV QUIET COMPONENTS core ml) # Need core + machine learning
@@ -35,7 +24,6 @@ if(TARGET CGAL::Eigen3_support)
       STATUS
         "NOTICE: OpenCV was not found. OpenCV random forest predicate for classification won't be available."
     )
-
   endif()
 
   find_package(TensorFlow QUIET)
@@ -53,44 +41,47 @@ if(TARGET CGAL::Eigen3_support)
     )
   endif()
 
-  if(Classification_dependencies_met)
-    qt5_wrap_ui(classificationUI_FILES Classification_widget.ui
-                Classification_advanced_widget.ui)
-    polyhedron_demo_plugin(
-      classification_plugin
-      Classification_plugin
-      Point_set_item_classification.cpp
-      Cluster_classification.cpp
-      Surface_mesh_item_classification.cpp
-      ${classificationUI_FILES}
-      KEYWORDS
-      Classification)
-    target_link_libraries(
-      classification_plugin
-      PUBLIC scene_points_with_normal_item
-             scene_polylines_item
-             scene_polygon_soup_item
-             scene_surface_mesh_item
-             scene_selection_item
-             scene_color_ramp
-             CGAL::Eigen3_support
-             CGAL::Boost_serialization_support
-             CGAL::Boost_iostreams_support)
+  qt5_wrap_ui(classificationUI_FILES Classification_widget.ui
+    Classification_advanced_widget.ui)
+  polyhedron_demo_plugin(
+    classification_plugin
+    Classification_plugin
+    Point_set_item_classification.cpp
+    Cluster_classification.cpp
+    Surface_mesh_item_classification.cpp
+    ${classificationUI_FILES}
+    KEYWORDS
+    Classification)
+  target_link_libraries(
+    classification_plugin
+    PUBLIC scene_points_with_normal_item
+    scene_polylines_item
+    scene_polygon_soup_item
+    scene_surface_mesh_item
+    scene_selection_item
+    scene_color_ramp
+    CGAL::Eigen_support)
 
-    if(OpenCV_FOUND)
-      target_link_libraries(classification_plugin PUBLIC CGAL::OpenCV_support)
-    endif()
-    if(TensorFlow_FOUND)
-      target_link_libraries(classification_plugin
-                            PUBLIC CGAL::TensorFlow_support)
-    endif()
-    if(TBB_FOUND)
-      target_link_libraries(classification_plugin PUBLIC CGAL::TBB_support)
-    endif()
-
-    add_dependencies(classification_plugin point_set_selection_plugin
-                     selection_plugin)
+  if(TARGET CGAL::Boost_serialization_support AND TARGET CGAL::Boost_iostreams_support)
+    target_link_libraries(classification_plugin PUBLIC
+      CGAL::Boost_serialization_support
+      CGAL::Boost_iostreams_support)
   endif()
+
+  if(TARGET CGAL::OpenCV_support)
+    target_link_libraries(classification_plugin PUBLIC CGAL::OpenCV_support)
+  endif()
+
+  if(TARGET CGAL::TensorFlow_support)
+    target_link_libraries(classification_plugin PUBLIC CGAL::TensorFlow_support)
+  endif()
+
+  if(TARGET CGAL::TBB_support)
+    target_link_libraries(classification_plugin PUBLIC CGAL::TBB_support)
+  endif()
+
+  add_dependencies(classification_plugin point_set_selection_plugin
+    selection_plugin)
 
 else()
   message(

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Classification_plugin.cpp
@@ -708,7 +708,12 @@ public Q_SLOTS:
       filename = QFileDialog::getOpenFileName(mw,
                                               tr("Open ETHZ random forest configuration"),
                                               ".",
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
                                               "ETHZ random forest configuration (*.bin);Deprecated compressed ETHZ random forest configuration (*.gz);All Files (*)");
+#else
+                                              "ETHZ random forest configuration (*.bin);All Files (*)");
+#endif
+
 #ifdef CGAL_LINKED_WITH_OPENCV
     else if (classifier == CGAL_CLASSIFICATION_OPENCV_NUMBER) // Random Forest (OpenCV)
       filename = QFileDialog::getOpenFileName(mw,

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Item_classification_base.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Item_classification_base.h
@@ -235,10 +235,12 @@ public:
         m_ethz = new ETHZ_random_forest (m_labels, m_features);
       std::ifstream f (filename, std::ios_base::in | std::ios_base::binary);
 
+#if defined(CGAL_LINKED_WITH_BOOST_IOSTREAMS) && defined(CGAL_LINKED_WITH_BOOST_SERIALIZATION)
       // Handle deprecated files
       if (std::string(filename).find(".gz") != std::string::npos)
         m_ethz->load_deprecated_configuration(f);
       else
+#endif
         m_ethz->load_configuration (f);
     }
     else if (classifier == CGAL_CLASSIFICATION_OPENCV_NUMBER)


### PR DESCRIPTION
## Summary of Changes

The dependency to Boost IO Stream and Serialization has been removed since https://github.com/CGAL/cgal/pull/4626.
This PR fixes 2 problems:
- the `save_configuration()` / `load_configuration()` were still enclosed in `#ifdef` about Boost, whereas they don't depend on it anymore
- the dependency is now optional for compiling the plugin, considering it's just used to load deprecated configuration files (everything else works without it)

## Release Management

* Affected package(s): Classification + Demo