### PR TITLE
Add an extra operator to have an exact plane

### DIFF
--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9271,7 +9271,7 @@ public:
 
   /*!
     returns \ref CGAL::ON_ORIENTED_BOUNDARY,
-    \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
+    \ref CGAL::ON_NEGATIVE_SIDE, or \ref CGAL::ON_POSITIVE_SIDE,
     depending on the position of `p` relative to the oriented plane `h`.
   */
   Oriented_side operator()(const Kernel::Plane_3&h,
@@ -9279,7 +9279,7 @@ public:
 
   /*!
     returns \ref CGAL::ON_ORIENTED_BOUNDARY,
-    \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
+    \ref CGAL::ON_NEGATIVE_SIDE, or \ref CGAL::ON_POSITIVE_SIDE,
     depending on the position of `p` relative to the oriented plane constructed
     from `plane_point` and `plane_vector`.
   */
@@ -9289,7 +9289,7 @@ public:
 
   /*!
     returns \ref CGAL::ON_ORIENTED_BOUNDARY,
-    \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
+    \ref CGAL::ON_NEGATIVE_SIDE, or \ref CGAL::ON_POSITIVE_SIDE,
     depending on the position of `p` relative to the oriented tetrahedron `t`.
   */
   Oriented_side operator()(const Kernel::Tetrahedron_3&t,
@@ -9297,7 +9297,7 @@ public:
 
   /*!
     returns \ref CGAL::ON_ORIENTED_BOUNDARY,
-    \ref CGAL::ON_NEGATIVE_SIDE, or the \ref CGAL::ON_POSITIVE_SIDE,
+    \ref CGAL::ON_NEGATIVE_SIDE, or \ref CGAL::ON_POSITIVE_SIDE,
     depending on the position of `p` relative to the oriented sphere `s`.
   */
   Oriented_side operator()(const Kernel::Sphere_3& s,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9280,6 +9280,16 @@ public:
   /*!
     returns \ref CGAL::ON_ORIENTED_BOUNDARY,
     \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
+    depending on the position of `p` relative to the oriented plane constructed
+    from `plane_point` and `plane_vector`.
+  */
+  Oriented_side operator()(const Kernel::Point_3& plane_point,
+                           const Kernel::Vector_3& plane_vector,
+                           const Kernel::Point_3&p);
+
+  /*!
+    returns \ref CGAL::ON_ORIENTED_BOUNDARY,
+    \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
     depending on the position of `p` relative to the oriented tetrahedron `t`.
   */
   Oriented_side operator()(const Kernel::Tetrahedron_3&t,

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -3787,6 +3787,7 @@ namespace CommonKernelFunctors {
   class Oriented_side_3
   {
     typedef typename K::Point_3        Point_3;
+    typedef typename K::Vector_3       Vector_3;
     typedef typename K::Tetrahedron_3  Tetrahedron_3;
     typedef typename K::Plane_3        Plane_3;
     typedef typename K::Sphere_3       Sphere_3;
@@ -3800,6 +3801,12 @@ namespace CommonKernelFunctors {
     result_type
     operator()( const Plane_3& pl, const Point_3& p) const
     { return pl.rep().oriented_side(p); }
+
+    result_type
+    operator()( const Point_3& plane_pt, const Vector_3& plane_normal, const Point_3& query) const
+    {
+      return typename K::Construct_plane_3()(plane_pt, plane_normal).rep().oriented_side(query);
+    }
 
     result_type
     operator()( const Tetrahedron_3& t, const Point_3& p) const

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -747,6 +747,7 @@ test_new_3(const R& rep)
         = rep.oriented_side_3_object();
   Oriented_side tmp39 = oriented_side(h2,p2);
                 tmp39 = oriented_side(sp9,p2);
+                tmp39 = oriented_side(p2,v1,p2);
   (void) tmp39;
 
   typename R::Bounded_side_3 bounded_side


### PR DESCRIPTION
Add an extra operator to construct the plane inside the predicate so that the plane is exact.