### PR TITLE
[Point Set 3] Fix broken properties and types

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -17,6 +17,7 @@
 
 
 #include <stack>
+#include <typeindex>
 
 #include <CGAL/Surface_mesh/Properties.h>
 
@@ -933,15 +934,15 @@ public:
   /*!
     \brief Returns a vector of pairs that describe properties and associated types.
   */
-  std::vector<std::pair<std::string, std::type_info> > properties_and_types() const
+  std::vector<std::pair<std::string, std::type_index> > properties_and_types() const
   {
     std::vector<std::string> prop = m_base.properties();
     prop.erase (prop.begin()); // remove "index"
     prop.erase (prop.begin()); // remove "point"
 
-    std::vector<std::pair<std::string, std::type_info> > out; out.reserve (prop.size());
+    std::vector<std::pair<std::string, std::type_index> > out; out.reserve (prop.size());
     for (std::size_t i = 0; i < prop.size(); ++ i)
-      out.push_back (std::make_pair (prop[i], m_base.get_type(prop[i])));
+      out.push_back (std::make_pair (prop[i], std::type_index(m_base.get_type(prop[i]))));
     return out;
   }
 

--- a/Point_set_3/test/Point_set_3/point_set_test.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test.cpp
@@ -106,6 +106,11 @@ int main (int, char**)
   point_set.add_property_map<int> ("label", 0);
   point_set.add_property_map<double> ("intensity", 0.0);
 
+  auto pnt = point_set.properties_and_types();
+  std::cerr << "Properties = " << std::endl;
+  for (const auto& p : pnt)
+    std::cerr << " * " << p.first << " with type " << p.second.name() << std::endl;
+
   test (point_set.base().n_properties() == 4, "point set should have 4 properties.");
 
   Point p_before = *(point_set.points().begin());


### PR DESCRIPTION
## Summary of Changes

The function `Point_set_3::properties_and_types()` returned a pair of `std::string` and `std::type_info`, which lead to a compilation error as `std::type_info` is not copyable. This is fixed by using the C++11 [`std::type_index`](https://en.cppreference.com/w/cpp/types/type_index) class (which is specifically done for cases like this one).

## Release Management

* Affected package(s): Point Set 3
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/5368

