### PR TITLE
Nef_2: fix misleading indentation

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/debug.h
+++ b/Nef_2/include/CGAL/Nef_2/debug.h
@@ -43,35 +43,33 @@
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACE(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
- std::cerr<<" "<<t; \
- std::cerr.flush()
+    { std::cerr<<" "<<t; }
 #else
 #define CGAL_NEF_TRACE(t)
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACEV(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
- std::cerr<<" "<<#t<<" = "<<(t)<<std::endl; \
- std::cerr.flush()
+    { std::cerr<<" "<<#t<<" = "<<(t)<<std::endl; }
 #else
 #define CGAL_NEF_TRACEV(t)
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
- std::cerr<< " "<<t<<std::endl;
+    { std::cerr<< " "<<t<<std::endl; }
 #else
 #define CGAL_NEF_TRACEN(t)
 #endif
 
 #ifndef NDEBUG
-#define CGAL_NEF_CTRACE(b,t) if(b) std::cerr<<" "<<t; else std::cerr<<" 0"
+#define CGAL_NEF_CTRACE(b,t) if(b) {std::cerr<<" "<<t;} else {std::cerr<<" 0"}
 #else
 #define CGAL_NEF_CTRACE(b,t)
 #endif
 
 #ifndef NDEBUG
-#define CGAL_NEF_CTRACEN(b,t) if(b) std::cerr<<" "<<t<<"\n"; else std::cerr<<" 0\n"
+#define CGAL_NEF_CTRACEN(b,t) if(b){ std::cerr<<" "<<t<<"\n";} else {std::cerr<<" 0\n"}
 #else
 #define CGAL_NEF_CTRACEN(b,t)
 #endif

--- a/Nef_2/include/CGAL/Nef_2/debug.h
+++ b/Nef_2/include/CGAL/Nef_2/debug.h
@@ -45,33 +45,33 @@
 #define CGAL_NEF_TRACE(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<<" "<<t; }
 #else
-#define CGAL_NEF_TRACE(t)
+#define CGAL_NEF_TRACE(t) (static_cast<void>(0))
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACEV(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<<" "<<#t<<" = "<<(t)<<std::endl; }
 #else
-#define CGAL_NEF_TRACEV(t)
+#define CGAL_NEF_TRACEV(t) (static_cast<void>(0))
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_TRACEN(t) if((debugthread%CGAL_NEF_DEBUG)==0) \
     { std::cerr<< " "<<t<<std::endl; }
 #else
-#define CGAL_NEF_TRACEN(t)
+#define CGAL_NEF_TRACEN(t) (static_cast<void>(0))
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_CTRACE(b,t) if(b) {std::cerr<<" "<<t;} else {std::cerr<<" 0"}
 #else
-#define CGAL_NEF_CTRACE(b,t)
+#define CGAL_NEF_CTRACE(b,t) (static_cast<void>(0))
 #endif
 
 #ifndef NDEBUG
 #define CGAL_NEF_CTRACEN(b,t) if(b){ std::cerr<<" "<<t<<"\n";} else {std::cerr<<" 0\n"}
 #else
-#define CGAL_NEF_CTRACEN(b,t)
+#define CGAL_NEF_CTRACEN(b,t) (static_cast<void>(0))
 #endif
 
 #endif // CGAL_NEF_2_DEBUG_H


### PR DESCRIPTION

## Summary of Changes

Remove the `std::flush` which is not needed for `std::cerr` and put parenthesis.

## Release Management

* Affected package(s): Nef_2
* Issue(s) solved (if any): fix #5312

