### PR TITLE
Fix examples/Mesh_3/mesh_implicit_domains.cpp

### DIFF
--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -173,6 +173,7 @@ if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TARGET CGAL::TBB_support)
     mesh_3D_image_variable_size
     mesh_3D_image_with_custom_initialization
     mesh_3D_image_with_features
+    mesh_implicit_domains
     mesh_implicit_sphere
     mesh_implicit_sphere_variable_size
     mesh_optimization_example

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -470,7 +470,7 @@ public:
   std::string debug_info_element_impl(const Cell_handle &ch) const
   {
     std::stringstream sstr;
-    sstr << "Cell { " << std::endl
+    sstr << "Cell " << (void*)(ch.operator->()) << " { " << std::endl
     << "  " << *ch->vertex(0) << std::endl
     << "  " << *ch->vertex(1) << std::endl
     << "  " << *ch->vertex(2) << std::endl

--- a/Mesh_3/include/CGAL/Mesh_3/mesh_standard_cell_criteria.h
+++ b/Mesh_3/include/CGAL/Mesh_3/mesh_standard_cell_criteria.h
@@ -104,7 +104,7 @@ protected:
     if ( size > min_sq_length*sq_radius_edge_bound_  )
     {
 #ifdef CGAL_MESH_3_DEBUG_CELL_CRITERIA
-      std::cerr << "bad cell (radius-edge bound): radius-edge["
+      std::cerr << "bad cell " << (void*)(ch.operator->()) << " (radius-edge bound): radius-edge["
                 << size/min_sq_length << "] bound[" << sq_radius_edge_bound_
                 << "]\n" ;
 #endif
@@ -185,7 +185,7 @@ protected:
     if ( size > sq_radius_bound_ )
     {
 #ifdef CGAL_MESH_3_DEBUG_CELL_CRITERIA
-      std::cerr << "bad cell (radius bound): size[" << size
+      std::cerr << "bad cell " << (void*)(ch.operator->()) << " (radius bound): size[" << size
                 << "] bound[" << sq_radius_bound_ << "]\n" ;
 #endif
       return Is_bad(Quality(sq_radius_bound_/size));
@@ -262,7 +262,7 @@ protected:
     if ( size > sq_bound )
     {
 #ifdef CGAL_MESH_3_DEBUG_CELL_CRITERIA
-      std::cerr << "bad cell (radius bound): size[" << size
+      std::cerr << "bad cell " << (void*)(ch.operator->()) << " (radius bound): size[" << size
       << "] bound[" << sq_bound << "]\n" ;
 #endif
       return Is_bad(Quality(sq_bound/size));

--- a/Mesher_level/include/CGAL/Meshes/Double_map_container.h
+++ b/Mesher_level/include/CGAL/Meshes/Double_map_container.h
@@ -42,12 +42,25 @@ namespace CGAL {
         return m.empty();
       }
 
+#if CGAL_MESHES_DEBUG_DOUBLE_MAP
+      template <typename Element_type>
+      std::ostream& debug_element(std::ostream& os, const Element_type& e) {
+        return os << (void*)(e.operator->());
+      }
+
+      template <typename Cell_handle>
+      std::ostream& debug_element(std::ostream& os, const std::pair<Cell_handle, int>& e) {
+        return os << "Facet{" << (void*)(e.first.operator->()) << ", " << e.second << "}";
+      }
+#endif
+
       Element get_next_element_impl()
       {
         CGAL_assertion(!m.empty());
 #if CGAL_MESHES_DEBUG_DOUBLE_MAP
-        std::cerr << "get_next_element_impl(" << &*(m.front()->second)
-                  << ")\n";
+        std::cerr << "get_next_element_impl(";
+        debug_element(std::cerr, m.front()->second);
+        std::cerr << ")\n";
 #endif
         return m.front()->second;
 
@@ -56,7 +69,9 @@ namespace CGAL {
       void add_bad_element(const Element& e, const Quality& q)
       {
 #if CGAL_MESHES_DEBUG_DOUBLE_MAP
-        std::cerr << "add_bad_element(" << &*e << ")\n";
+        std::cerr << "add_bad_element(";
+        debug_element(std::cerr, e);
+        std::cerr << ")\n";
 #endif
         m.insert(e, q);
       }
@@ -69,7 +84,9 @@ namespace CGAL {
       void remove_element(const Element& e)
       {
 #if CGAL_MESHES_DEBUG_DOUBLE_MAP
-        std::cerr << "remove_element(" << &*e << ")\n";
+        std::cerr << "remove_element(";
+        debug_element(std::cerr, e);
+        std::cerr << ")\n";
 #endif
         m.erase(e);
       }


### PR DESCRIPTION
## Summary of Changes

The error was actually due to an mismatch between `CGAL_LINKED_WITH_TBB` and `CGAL_CONCURRENT_MESH_3`. See #5375.

For CGAL-5.3 we should clean that up!

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: N/A
The error was actually due to an mismatch between `CGAL_LINKED_WITH_TBB`
and `CGAL_CONCURRENT_MESH_3`.

For CGAL-5.3 we should clean that up!The error was actually due to an mismatch between `CGAL_LINKED_WITH_TBB`
and `CGAL_CONCURRENT_MESH_3`.

For CGAL-5.3 we should clean that up!