### PR TITLE
Segment Delaunay Graph demos: Use CGAL::cpp98::random_shuffle()

### DIFF
--- a/GraphicsView/demo/Segment_Delaunay_graph_2/include/CGAL/Constraints_loader.h
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/include/CGAL/Constraints_loader.h
@@ -3,6 +3,7 @@
 
 #include <CGAL/config.h>
 #include <CGAL/Bbox_2.h>
+#include <CGAL/algorithm.h>
 #include <CGAL/Timer.h>
 #include <vector>
 #include <utility>
@@ -96,7 +97,7 @@ class Constraints_loader {
     for(Points_iterator it = points.begin(); it != points.end(); ++it) {
       indices.push_back(it);
     }
-    std::random_shuffle(indices.begin(), indices.end());
+    CGAL::cpp98::random_shuffle(indices.begin(), indices.end());
     CGAL::spatial_sort(indices.begin(), indices.end(),
                        sort_traits);
 

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/include/CGAL/Constraints_loader.h
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/include/CGAL/Constraints_loader.h
@@ -3,6 +3,7 @@
 
 #include <CGAL/config.h>
 #include <CGAL/Bbox_2.h>
+#include <CGAL/algorithm.h>
 #include <CGAL/Timer.h>
 #include <vector>
 #include <utility>
@@ -96,7 +97,7 @@ class Constraints_loader {
     for(Points_iterator it = points.begin(); it != points.end(); ++it) {
       indices.push_back(it);
     }
-    std::random_shuffle(indices.begin(), indices.end());
+    CGAL::cpp98::random_shuffle(indices.begin(), indices.end());
     CGAL::spatial_sort(indices.begin(), indices.end(),
                        sort_traits);
 


### PR DESCRIPTION

## Summary of Changes

Fix the SDG demos by using `CGAL::cpp98::random_shuffle()`   as `std::random_shuffle()`  is going to disappear for `std::shuffle`. 

## Release Management

* Affected package(s): SDG
* Issue(s) solved (if any): fixes two items of #5374   

