### PR TITLE
Triangulation_3: Add a static assert so that Parallel_tag can only be used with TBB

### DIFF
--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -56,6 +56,7 @@
 #endif
 
 #include <boost/type_traits/is_convertible.hpp>
+#include <type_traits>
 
 namespace CGAL {
 
@@ -130,6 +131,10 @@ public:
   >::type                                                Cell_range;
 
 # else
+  CGAL_static_assertion_msg
+    (!(std::is_convertible<Concurrency_tag, Parallel_tag>::value),
+     "In CGAL triangulations, `Parallel_tag` can only be used with the Intel TBB library. "
+     "Make TBB available in the build system and then define the macro `CGAL_LINKED_WITH_TBB`.");
   typedef Compact_container<Cell>                        Cell_range;
 #endif
 

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -55,7 +55,6 @@
 #  include <tbb/scalable_allocator.h>
 #endif
 
-#include <boost/type_traits/is_convertible.hpp>
 #include <type_traits>
 
 namespace CGAL {
@@ -123,9 +122,9 @@ public:
   // Cells
   // N.B.: Concurrent_compact_container requires TBB
 #ifdef CGAL_LINKED_WITH_TBB
-  typedef typename boost::mpl::if_c
+  typedef typename std::conditional
   <
-    boost::is_convertible<Concurrency_tag, Parallel_tag>::value,
+    std::is_convertible<Concurrency_tag, Parallel_tag>::value,
     Concurrent_compact_container<Cell, tbb::scalable_allocator<Cell> >,
     Compact_container<Cell>
   >::type                                                Cell_range;
@@ -141,9 +140,9 @@ public:
   // Vertices
   // N.B.: Concurrent_compact_container requires TBB
 #ifdef CGAL_LINKED_WITH_TBB
-  typedef typename boost::mpl::if_c
+  typedef typename std::conditional
   <
-    boost::is_convertible<Concurrency_tag, Parallel_tag>::value,
+    std::is_convertible<Concurrency_tag, Parallel_tag>::value,
     Concurrent_compact_container<Vertex, tbb::scalable_allocator<Vertex> >,
     Compact_container<Vertex>
   >::type                                                Vertex_range;


### PR DESCRIPTION
## Summary of Changes

I am trying to fix the PR https://github.com/CGAL/cgal/pull/4364 (the one of the small feature [Patch_to_concurrency_in_CGAL](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Patch_to_concurrency_in_CGAL).

If `Parallel_tag` is used with Triangulation_3/Mesh_3, but `CGAL_LINKED_WITH_TBB` is not defined, there there is a compilation error:
```
.../TDS_3/include/CGAL/Triangulation_data_structure_3.h:134:6: error: static assertion failed: In CGAL triangulations, `Parallel_tag` can only be used with the Intel TBB library. Make TBB available in the build system and then define the macro `CGAL_LINKED_WITH_TBB`.
  134 |     (!(std::is_convertible<Concurrency_tag, Parallel_tag>::value),
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Breaking change?
I am wondering if that is a breaking change, that should be documented. 
  - It seems `CGAL_LINKED_WITH_TBB` is not documented anywhere in CGAL.
  - The `Parallel_tag` is documented to require TBB, in that way:
    > Parallel algorithms require the program to be linked against the Intel TBB library.
    
    (from https://doc.cgal.org/latest/Triangulation_3/index.html#title8).

So, could it pass as a single "bug-fix", without any small feature or additional documentation?

## Release Management

* Affected package(s): Triangulation_3 and Mesh_3
* Issue(s) solved (if any): fix #5375 .
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: N/A

