### PR TITLE
Warning in surface mesh topology

### DIFF
--- a/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Path_on_surface_with_rle.h
+++ b/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Path_on_surface_with_rle.h
@@ -81,8 +81,7 @@ public:
 
   Light_MQ(const Local_map& m): m_map(m)
   {}
-  Light_MQ(const Light_MQ& lmq): m_map(lmq.m_map)
-  {}
+  Light_MQ(const Light_MQ&) = default;
 
   const Local_map& get_local_map() const
   { return m_map; }
@@ -143,16 +142,7 @@ public:
   #endif //CGAL_PWRLE_TURN_V2
   {}
 
-  Path_on_surface_with_rle(const Self& apath): m_MQ(apath.m_MQ),
-                                               m_path(apath.m_path),
-                                               m_is_closed(apath.m_is_closed),
-                                               m_length(apath.m_length),
-                                               m_use_only_positive(apath.m_use_only_positive),
-                                               m_use_only_negative(apath.m_use_only_negative)
-#ifdef CGAL_PWRLE_TURN_V2
-                                             , m_darts_ids(apath.m_darts_ids)
-#endif //CGAL_PWRLE_TURN_V2
-  {}
+  Path_on_surface_with_rle(const Self&) = default;
 
   /// Creates a Path_on_surface_with_rle from a Path_on_surface.
   /// If use_only_positive, consider only positive flats and not negative ones.

--- a/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Path_on_surface_with_rle.h
+++ b/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Path_on_surface_with_rle.h
@@ -81,6 +81,8 @@ public:
 
   Light_MQ(const Local_map& m): m_map(m)
   {}
+  Light_MQ(const Light_MQ& lmq): m_map(lmq.m_map)
+  {}
 
   const Local_map& get_local_map() const
   { return m_map; }
@@ -139,6 +141,17 @@ public:
   #ifdef CGAL_PWRLE_TURN_V2
     , m_darts_ids(darts_ids)
   #endif //CGAL_PWRLE_TURN_V2
+  {}
+
+  Path_on_surface_with_rle(const Self& apath): m_MQ(apath.m_MQ),
+                                               m_path(apath.m_path),
+                                               m_is_closed(apath.m_is_closed),
+                                               m_length(apath.m_length),
+                                               m_use_only_positive(apath.m_use_only_positive),
+                                               m_use_only_negative(apath.m_use_only_negative)
+#ifdef CGAL_PWRLE_TURN_V2
+                                             , m_darts_ids(apath.m_darts_ids)
+#endif //CGAL_PWRLE_TURN_V2
   {}
 
   /// Creates a Path_on_surface_with_rle from a Path_on_surface.


### PR DESCRIPTION
## Summary of Changes

Add copy constructor in `Path_on_surface_with_rle` to remove a warning (`implicitly-declared is deprecated [-Wdeprecated-copy]`).

## Release Management

* Affected package(s): Surface_mesh_topology
* Issue(s) solved (if any): partial fix #5373

