### PR TITLE
CGAL_Ipelets: Fix after merge in master.

### DIFF
--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -140,6 +140,10 @@ if(IPE_FOUND AND IPE_VERSION)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS simple_triangulation)
   target_link_libraries(simple_triangulation CGAL::Eigen3_support
                         ${IPE_LIBRARIES})
+  target_include_directories(simple_triangulation BEFORE PRIVATE ${IPE_INCLUDE_DIR})
+  if (WITH_IPE_7)
+      target_compile_definitions(simple_triangulation PRIVATE CGAL_USE_IPE_7)
+    endif()
   cgal_add_compilation_test(simple_triangulation)
 
 else()

--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -32,15 +32,11 @@ if(NOT TARGET CGAL::Eigen3_support)
   return()
 endif()
 
-find_package(IPE 6)
+find_package(IPE 7)
 
 if(IPE_FOUND)
-  if (${IPE_VERSION} EQUAL "7")
-    set(WITH_IPE_7 ON)
-  elseif(${IPE_VERSION} EQUAL "6")
-    set(WITH_IPE_7 OFF)
-  else()
-    message("-- Error: ${IPE_VERSION} is not a supported version of IPE (only 6 and 7 are).")
+  if ( NOT ${IPE_VERSION} EQUAL "7")
+    message("-- Error: ${IPE_VERSION} is not a supported version of IPE (only 7 is).")
     set(IPE_FOUND FALSE)
   endif()
 endif()
@@ -52,7 +48,6 @@ if(IPE_FOUND AND IPE_VERSION)
   #setting installation directory
   get_filename_component(IPE_LIBRARY_DIR ${IPE_LIBRARIES} PATH)
   if (IPE_FOUND AND NOT IPELET_INSTALL_DIR)
-    if (WITH_IPE_7)
       remove_leading_zero(IPE_MINOR_VERSION_1)
       remove_leading_zero(IPE_MINOR_VERSION_2)
       set(INSTALL_PATHS "${IPE_LIBRARY_DIR}/ipe/7.${IPE_MINOR_VERSION_1}.${IPE_MINOR_VERSION_2}/ipelets/")
@@ -62,24 +57,6 @@ if(IPE_FOUND AND IPE_VERSION)
                     DOC "The folder where ipelets will be installed"
                     ENV IPELETPATH
                    )
-    else()
-      foreach (VER RANGE 28 40)
-        string(REPLACE XX ${VER} PATHC "${IPE_LIBRARY_DIR}/ipe/6.0preXX/ipelets/" )
-        set(INSTALL_PATHS ${INSTALL_PATHS} ${PATHC})
-      endforeach()
-      set(INSTALL_PATHS ${INSTALL_PATHS} ${PATHC})
-      set(INSTALL_PATHS ${INSTALL_PATHS} /usr/lib64/ipe/6.0/ipelets)
-      set(INSTALL_PATHS ${INSTALL_PATHS} /usr/lib/ipe/6.0/ipelets)
-
-      find_library(
-        IPELET_INSTALL_DIR_FILES
-        NAMES align
-        PATHS ${INSTALL_PATHS} ENV IPELETPATH)
-      if(IPELET_INSTALL_DIR_FILES)
-        get_filename_component(IPELET_INSTALL_DIR ${IPELET_INSTALL_DIR_FILES}
-                               PATH)
-      endif()
-    endif()
   endif()
 
   set(CGAL_IPELETS ${CGAL_IPELETS})
@@ -116,18 +93,13 @@ if(IPE_FOUND AND IPE_VERSION)
   foreach(IPELET ${CGAL_IPELETS})
     add_library(CGAL_${IPELET} MODULE ${IPELET}.cpp)
     target_include_directories(CGAL_${IPELET} BEFORE PRIVATE ${IPE_INCLUDE_DIR})
-    if (WITH_IPE_7)
-      target_compile_definitions(CGAL_${IPELET} PRIVATE CGAL_USE_IPE_7)
-    endif()
 
     add_to_cached_list(CGAL_EXECUTABLE_TARGETS CGAL_${IPELET})
     target_link_libraries(CGAL_${IPELET} PRIVATE CGAL::CGAL CGAL::Eigen3_support
                                                  ${IPE_LIBRARIES})
     if(IPELET_INSTALL_DIR)
       install(TARGETS CGAL_${IPELET} DESTINATION ${IPELET_INSTALL_DIR})
-      if (WITH_IPE_7)
-        install(FILES ./lua/libCGAL_${IPELET}.lua DESTINATION ${IPELET_INSTALL_DIR}) #only for ipe 7
-      endif()
+      install(FILES ./lua/libCGAL_${IPELET}.lua DESTINATION ${IPELET_INSTALL_DIR}) #only for ipe 7
     endif ()
     cgal_add_compilation_test(CGAL_${IPELET})
   endforeach(IPELET)

--- a/CGAL_ipelets/demo/CGAL_ipelets/generator.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/generator.cpp
@@ -110,11 +110,7 @@ void generator::protected_run(int fn)
   else
     segments.reserve(nbelements);
 
-  #ifdef CGAL_USE_IPE_7
   get_IpePage()->deselectAll();
-  #else
-  get_IpePage()->DeselectAll();
-  #endif
 
   switch(fn){
     case 0:{//random point in a circle

--- a/CGAL_ipelets/demo/CGAL_ipelets/hull.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/hull.cpp
@@ -126,7 +126,6 @@ void enveloppeIpelet::protected_run(int fn)
       Vsite0.insert(Vsite0.end(),*(Vsite0.begin()+1));
       std::vector<ASite>::iterator Vsiteite0 = Vsite0.begin();
       std::vector<ASite>::iterator Vsiteite00 = Vsite0.end()-2;
-      #ifdef CGAL_USE_IPE_7
       for(std::vector<ASite>::iterator it=Vsiteite00 ; it!=Vsiteite0 ; --it){//draw precise convex hull computing tangency point to circles
         double c_rad = it->weight();
         if(c_rad!=0){
@@ -155,36 +154,6 @@ void enveloppeIpelet::protected_run(int fn)
       ipe::Shape shape;
       shape.appendSubPath(SSPseg_ipe);
       get_IpePage()->append(ipe::EPrimarySelected,CURRENTLAYER,new ipe::Path(CURRENTATTRIBUTES,shape));
-      #else
-      for(std::vector<ASite>::iterator it=Vsiteite00 ; it!=Vsiteite0 ; --it){//draw precise convex hull computing tangency point to circles
-        double c_rad = it->weight();
-        if(c_rad!=0){
-          Point_2 p_pt = (it-1)->point();  //previous neighbor
-          Point_2 c_pt = it->point();
-          Point_2 n_pt = (it+1)->point(); //next neighbor
-          double p_rad = (it-1)->weight();
-          double n_rad = (it+1)->weight();
-          IpeVector pt_ipe=tangency_point(c_rad,p_rad,c_pt,p_pt);
-          IpeVector pt_ipe0=tangency_point(c_rad,n_rad,c_pt,n_pt,-1);
-
-          if(it!=Vsiteite00)
-            SSPseg_ipe->AppendSegment(pt_ipe1,pt_ipe0);
-          SSPseg_ipe->AppendArc(IpeMatrix(c_rad,0,0,c_rad,c_pt.x(),c_pt.y()),pt_ipe0,pt_ipe);
-          pt_ipe1=pt_ipe;
-        }
-        else{
-          Point_2 c_pt = it->point();
-          IpeVector pt_ipe=IpeVector(c_pt.x(),c_pt.y());
-          if(it!=Vsiteite00)
-            SSPseg_ipe->AppendSegment(pt_ipe1,pt_ipe);
-          pt_ipe1=pt_ipe;
-        }
-      }
-      SSPseg_ipe->SetClosed(true);
-      IpePath* obj_ipe1 = new IpePath(get_IpeletHelper()->Attributes());
-      obj_ipe1 -> AddSubPath(SSPseg_ipe);
-      get_IpePage()->push_back(IpePgObject(IpePgObject::ESecondary,get_IpeletHelper()->CurrentLayer(),obj_ipe1));
-      #endif
     }
     break;
 

--- a/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base.h
+++ b/CGAL_ipelets/include/CGAL/CGAL_Ipelet_base.h
@@ -13,8 +13,4 @@
 
 #include <CGAL/config.h>
 
-#ifdef CGAL_USE_IPE_7
 #include <CGAL/CGAL_Ipelet_base_v7.h>
-#else
-#include <CGAL/CGAL_Ipelet_base_v6.h>
-#endif

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1056,9 +1056,6 @@ because OpenCV_FOUND is false")
       message(STATUS "Skip header \"CGAL/CGAL_ipelet_base.h\" \
 because IPE_FOUND is false.")
     endif()
-    if("${IPE_VERSION}" EQUAL "7")
-      set(compile_options "${compile_options} -DCGAL_USE_IPE_7")
-    endif()
 
     if(CGAL_ENABLE_CHECK_HEADERS)
       set(flag "-fsyntax-only")

--- a/Installation/cmake/modules/FindIPE.cmake
+++ b/Installation/cmake/modules/FindIPE.cmake
@@ -26,7 +26,7 @@ else()
 
   if(IPE_INCLUDE_DIR)
     file(READ "${IPE_INCLUDE_DIR}/ipebase.h" IPEBASE_H)
-    string(REGEX MATCH "IPELIB_VERSION[ ]*=[ ]*([7])([0-9][0-9])([0-9][0-9]);" FOUND_IPE_VERSION "${IPEBASE_H}")
+    string(REGEX MATCH "IPELIB_VERSION[ ]*=[ ]*([6789])([0-9][0-9])([0-9][0-9]);" FOUND_IPE_VERSION "${IPEBASE_H}")
     if (FOUND_IPE_VERSION)
       set(IPE_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "Ipe version major number")
       set(IPE_MINOR_VERSION_1 ${CMAKE_MATCH_2} CACHE INTERNAL "Ipe version minor number")

--- a/Installation/cmake/modules/FindIPE.cmake
+++ b/Installation/cmake/modules/FindIPE.cmake
@@ -10,14 +10,14 @@
 # Is it already configured?
 if (IPE_INCLUDE_DIR AND IPE_LIBRARIES AND IPE_FULL_VERSION)
   set(IPE_FOUND TRUE)
-else()  
-  find_path(IPE_INCLUDE_DIR 
+else()
+  find_path(IPE_INCLUDE_DIR
             NAMES ipelib.h
             PATHS /usr/include
                   /usr/local/include
            )
 
-  find_library(IPE_LIBRARIES 
+  find_library(IPE_LIBRARIES
                NAMES ipe
                PATHS /usr/lib
                      /usr/local/lib
@@ -26,7 +26,7 @@ else()
 
   if(IPE_INCLUDE_DIR)
     file(READ "${IPE_INCLUDE_DIR}/ipebase.h" IPEBASE_H)
-    string(REGEX MATCH "IPELIB_VERSION[ ]*=[ ]*([67])([0-9][0-9])([0-9][0-9]);" FOUND_IPE_VERSION "${IPEBASE_H}")
+    string(REGEX MATCH "IPELIB_VERSION[ ]*=[ ]*([7])([0-9][0-9])([0-9][0-9]);" FOUND_IPE_VERSION "${IPEBASE_H}")
     if (FOUND_IPE_VERSION)
       set(IPE_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "Ipe version major number")
       set(IPE_MINOR_VERSION_1 ${CMAKE_MATCH_2} CACHE INTERNAL "Ipe version minor number")


### PR DESCRIPTION
## Summary of Changes

Restore missing lines in CMakelists that propagated the Ipe version to use to simple_triangulation
## Release Management

* Affected package(s):CGAL_ipelets
