### PR TITLE
Polyhedron_demo: Fix off_plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1505,10 +1505,9 @@ bool
 Scene_surface_mesh_item::save(std::ostream& out) const
 {
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  out.precision(17);
-    out << *(d->smesh_);
-    QApplication::restoreOverrideCursor();
-    return (bool) out;
+  CGAL::write_OFF(out, *(d->smesh_), CGAL::parameters::stream_precision(17));
+  QApplication::restoreOverrideCursor();
+  return (bool) out;
 }
 
 bool


### PR DESCRIPTION
## Summary of Changes
Restore the precision 17 in the writing of a surface mesh in off.