### PR TITLE
Fix NewKernel_d/Eigen compatibility

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
@@ -34,16 +34,18 @@
 namespace CGAL {
 
 template < typename FT_, typename Dim_,
-#if 1
+#ifndef CGAL_NEWKERNEL_D_USE_EIGEN_VECTOR
+# if 1
          typename Vec_=Mix_vector<Array_vector<FT_, Dim_>,
                                   Vector_vector<FT_, Dim_>,
                                   FT_, Dim_>,
-#elif 0
+# elif 0
          typename Vec_=Array_vector<FT_, Dim_>,
-#elif 0
+# else
          typename Vec_=Vector_vector<FT_, Dim_>,
+# endif
 #else
-         // Dangerous because of alignment. Ok on x86_64 without AVX.
+         // Dangerous before C++17 because of alignment. Ok on x86_64 without AVX.
          typename Vec_=LA_eigen<FT_, Dim_>,
 #endif
          typename LA_=LA_eigen<FT_,Dim_> >

--- a/NewKernel_d/include/CGAL/NewKernel_d/LA_eigen/constructors.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/LA_eigen/constructors.h
@@ -91,11 +91,9 @@ namespace CGAL {
     };
 
     struct Initializer_list {
-      // Fix T==NT?
-      template<class T>
-        result_type operator()(std::initializer_list<T> l) const {
-          return Iterator()(l.size(),l.begin(),l.end());
-        }
+      result_type operator()(std::initializer_list<NT> l) const {
+        return Iterator()(l.size(),l.begin(),l.end());
+      }
     };
 
     struct Values {

--- a/NewKernel_d/test/NewKernel_d/Epick_d_eigen.cpp
+++ b/NewKernel_d/test/NewKernel_d/Epick_d_eigen.cpp
@@ -1,0 +1,6 @@
+#if  __cpp_aligned_new  >= 201606L
+# define CGAL_NEWKERNEL_D_USE_EIGEN_VECTOR 1
+# include "Epick_d.cpp"
+#else
+int main(){}
+#endif

--- a/Number_types/include/CGAL/Interval_nt.h
+++ b/Number_types/include/CGAL/Interval_nt.h
@@ -1594,6 +1594,16 @@ namespace Eigen {
     };
   };
 
+  template<class A, class B, class C>struct ScalarBinaryOpTraits;
+  template<bool b, typename BinaryOp>
+    struct ScalarBinaryOpTraits<CGAL::Interval_nt<b>, double, BinaryOp> {
+      typedef CGAL::Interval_nt<b> ReturnType;
+    };
+  template<bool b, typename BinaryOp>
+    struct ScalarBinaryOpTraits<double, CGAL::Interval_nt<b>, BinaryOp> {
+      typedef CGAL::Interval_nt<b> ReturnType;
+    };
+
   namespace internal {
     template<class> struct significant_decimals_impl;
     template<bool b>


### PR DESCRIPTION
## Summary of Changes

Since it isn't tested, there was some bitrot in the code to use Eigen vectors in NewKernel_d (instead of std::vector/std::array). Tested locally with
```diff
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_base.h
@@ -34,7 +34,7 @@
 namespace CGAL {
 
 template < typename FT_, typename Dim_,
-#if 1
+#if 0
          typename Vec_=Mix_vector<Array_vector<FT_, Dim_>,
                                   Vector_vector<FT_, Dim_>,
                                   FT_, Dim_>,
```

## Release Management

* Affected package(s): Number_types, NewKernel_d