### PR TITLE
Arrangement:  Use Compact Container for DCEL

### DIFF
--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/isolated_vertices.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/isolated_vertices.cpp
@@ -27,9 +27,10 @@ int main()
   arr.insert_at_vertices(s4, v4, v1);
 
   // Remove the isolated vertices located in the unbounded face.
-  Arrangement::Vertex_iterator curr, next = arr.vertices_begin();
-  for (curr = next++; curr != arr.vertices_end(); curr = next++) {
+  Arrangement::Vertex_iterator iter = arr.vertices_begin();
+  while (iter != arr.vertices_end()) {
     // Keep an iterator to the next vertex, as curr might be deleted.
+    Arrangement::Vertex_iterator curr = iter ++;
     if (curr->is_isolated() && curr->face() == uf)
       arr.remove_isolated_vertex(curr);
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
@@ -28,7 +28,7 @@
 #include <list>
 #include <map>
 #include <CGAL/N_step_adaptor_derived.h>
-#include <CGAL/In_place_list.h>
+#include <CGAL/Compact_container.h>
 #include <CGAL/function_objects.h>
 #include <CGAL/Iterator_project.h>
 #include <CGAL/Arrangement_2/Arrangement_2_iterators.h>
@@ -90,6 +90,9 @@ public:
 
   /*! Destructor. */
   virtual ~Arr_vertex_base() {}
+
+  void* for_compact_container() const { return static_cast<void*>(p_pt); }
+  void for_compact_container(void* ptr) { p_pt = static_cast<Point*>(ptr); }
 
   // Access/modification for pointer squatting
   void* inc() const { return p_inc; }
@@ -182,6 +185,9 @@ public:
 
   /*! Destructor. */
   virtual ~Arr_halfedge_base() {}
+
+  void* for_compact_container() const { return static_cast<void*>(p_cv); }
+  void for_compact_container(void* ptr) { p_cv = static_cast<X_monotone_curve*>(ptr); }
 
   /*! Check if the curve pointer is nullptr. */
   bool has_null_curve() const { return (p_cv == nullptr); }
@@ -284,7 +290,7 @@ template <class V, class H, class F> class Arr_isolated_vertex;
  * The default arrangement DCEL vertex class.
  */
 template <class V, class H, class F>
-class Arr_vertex : public V, public In_place_list_base<Arr_vertex<V,H,F> >
+class Arr_vertex : public V
 {
 public:
 
@@ -351,8 +357,7 @@ public:
  * The default arrangement DCEL halfedge class.
  */
 template <class V, class H, class F>
-class Arr_halfedge : public H,
-                     public In_place_list_base<Arr_halfedge<V,H,F> >
+class Arr_halfedge : public H
 {
 public:
   typedef H                     Base;
@@ -532,7 +537,7 @@ public:
  */
 template <class V, class H, class F>
 class Arr_face : public F,
-                 public In_place_list_base<Arr_face<V,H,F> >
+                 public Compact_container_base
 {
 public:
   typedef F                            Base;
@@ -723,7 +728,7 @@ public:
  * Representation of an outer CCB.
  */
 template <class V, class H, class F>
-class Arr_outer_ccb : public In_place_list_base<Arr_outer_ccb<V,H,F> > {
+class Arr_outer_ccb {
 public:
   typedef Arr_outer_ccb<V,H,F>               Self;
   typedef Arr_halfedge<V,H,F>                Halfedge;
@@ -743,6 +748,9 @@ public:
   Arr_outer_ccb(const Arr_outer_ccb& other) :
     p_f(other.p_f), iter_is_not_singular(other.iter_is_not_singular)
   { if (other.iter_is_not_singular) iter = other.iter; }
+
+  void* for_compact_container() const { return static_cast<void*>(p_f); }
+  void for_compact_container(void* ptr) { p_f = static_cast<Face*>(ptr); }
 
   /*! Get a halfedge along the component (const version). */
   const Halfedge* halfedge() const { return (*iter); }
@@ -788,7 +796,7 @@ public:
  * Representation of an inner CCB.
  */
 template <class V, class H, class F>
-class Arr_inner_ccb : public In_place_list_base<Arr_inner_ccb<V,H,F> >
+class Arr_inner_ccb : public Compact_container_base
 {
 public:
   typedef Arr_inner_ccb<V,H,F>               Self;
@@ -908,8 +916,7 @@ public:
  * Representation of an isolated vertex.
  */
 template <class V, class H, class F>
-class Arr_isolated_vertex :
-public In_place_list_base<Arr_isolated_vertex<V,H,F> > {
+class Arr_isolated_vertex {
 public:
   typedef Arr_isolated_vertex<V,H,F>                Self;
   typedef Arr_face<V,H,F>                           Face;
@@ -928,6 +935,9 @@ public:
   Arr_isolated_vertex(const Arr_isolated_vertex& other) :
     p_f(other.p_f), iter_is_not_singular(other.iter_is_not_singular)
   { if (other.iter_is_not_singular) iv_it = other.iv_it; }
+
+  void* for_compact_container() const { return static_cast<void*>(p_f); }
+  void for_compact_container(void* ptr) { p_f = static_cast<Face*>(ptr); }
 
   /*! Get the containing face (const version). */
   const Face* face() const { return (p_f); }
@@ -979,13 +989,6 @@ public:
   typedef Inner_ccb                   Hole;
 
 protected:
-  // The vetices, halfedges and faces are stored in three in-place lists.
-  typedef In_place_list<Vertex, false>           Vertex_list;
-  typedef In_place_list<Halfedge, false>         Halfedge_list;
-  typedef In_place_list<Face, false>             Face_list;
-  typedef In_place_list<Outer_ccb, false>        Outer_ccb_list;
-  typedef In_place_list<Inner_ccb, false>        Inner_ccb_list;
-  typedef In_place_list<Isolated_vertex, false>  Iso_vert_list;
 
     typedef std::allocator_traits<Allocator> Allocator_traits;
     typedef typename Allocator_traits::template rebind_alloc<Vertex>          Vertex_allocator;
@@ -994,6 +997,13 @@ protected:
     typedef typename Allocator_traits::template rebind_alloc<Outer_ccb>       Outer_ccb_allocator;
     typedef typename Allocator_traits::template rebind_alloc<Inner_ccb>       Inner_ccb_allocator;
     typedef typename Allocator_traits::template rebind_alloc<Isolated_vertex> Iso_vert_allocator;
+
+  typedef Compact_container<Vertex, Vertex_allocator>             Vertex_list;
+  typedef Compact_container<Halfedge, Halfedge_allocator>         Halfedge_list;
+  typedef Compact_container<Face, Face_allocator>                 Face_list;
+  typedef Compact_container<Outer_ccb, Outer_ccb_allocator>       Outer_ccb_list;
+  typedef Compact_container<Inner_ccb, Inner_ccb_allocator>       Inner_ccb_list;
+  typedef Compact_container<Isolated_vertex, Iso_vert_allocator>  Iso_vert_list;
 
 public:
   typedef typename Halfedge_list::size_type              Size;
@@ -1010,13 +1020,6 @@ protected:
   Outer_ccb_list      out_ccbs;             // The outer CCBs.
   Inner_ccb_list      in_ccbs;              // The inner CCBs.
   Iso_vert_list       iso_verts;            // The isolated vertices.
-
-  Vertex_allocator    vertex_alloc;         // An allocator for vertices.
-  Halfedge_allocator  halfedge_alloc;       // An allocator for halfedges.
-  Face_allocator      face_alloc;           // An allocator for faces.
-  Outer_ccb_allocator out_ccb_alloc;        // An allocator for outer CCBs.
-  Inner_ccb_allocator in_ccb_alloc;         // An allocator for inner CCBs.
-  Iso_vert_allocator  iso_vert_alloc;       // Allocator for isolated vertices.
 
 public:
   // Definitions of iterators.
@@ -1144,10 +1147,7 @@ public:
   /*! Create a new vertex. */
   Vertex* new_vertex()
   {
-    Vertex* v = vertex_alloc.allocate(1);
-    std::allocator_traits<Vertex_allocator>::construct(vertex_alloc,v);
-    vertices.push_back(*v);
-    return v;
+    return &*vertices.emplace();
   }
 
   /*! Create a new pair of opposite halfedges. */
@@ -1167,37 +1167,25 @@ public:
   /*! Create a new face. */
   Face* new_face()
   {
-    Face* f = face_alloc.allocate(1);
-    std::allocator_traits<Face_allocator>::construct(face_alloc, f);
-    faces.push_back (*f);
-    return(f);
+    return &*faces.emplace();
   }
 
   /*! Create a new outer CCB. */
   Outer_ccb* new_outer_ccb()
   {
-    Outer_ccb* oc = out_ccb_alloc.allocate(1);
-    std::allocator_traits<Outer_ccb_allocator>::construct(out_ccb_alloc, oc);
-    out_ccbs.push_back(*oc);
-    return (oc);
+    return &*out_ccbs.emplace();
   }
 
   /*! Create a new inner CCB. */
   Inner_ccb* new_inner_ccb()
   {
-    Inner_ccb* ic = in_ccb_alloc.allocate(1);
-    std::allocator_traits<Inner_ccb_allocator>::construct(in_ccb_alloc, ic);
-    in_ccbs.push_back(*ic);
-    return (ic);
+    return &*in_ccbs.emplace();
   }
 
   /*! Create a new isolated vertex. */
   Isolated_vertex* new_isolated_vertex()
   {
-    Isolated_vertex* iv = iso_vert_alloc.allocate(1);
-    std::allocator_traits<Iso_vert_allocator>::construct(iso_vert_alloc, iv);
-    iso_verts.push_back(*iv);
-    return (iv);
+    return &*iso_verts.emplace();
   }
   //@}
 
@@ -1206,9 +1194,7 @@ public:
   /*! Delete an existing vertex. */
   void delete_vertex(Vertex* v)
   {
-    vertices.erase(v);
-    std::allocator_traits<Vertex_allocator>::destroy(vertex_alloc, v);
-    vertex_alloc.deallocate(v,1);
+    vertices.erase (vertices.iterator_to(*v));
   }
 
   /*! Delete an existing pair of opposite halfedges. */
@@ -1222,33 +1208,25 @@ public:
   /*! Delete an existing face. */
   void delete_face(Face* f)
   {
-    faces.erase(f);
-    std::allocator_traits<Face_allocator>::destroy(face_alloc, f);
-    face_alloc.deallocate(f, 1);
+    faces.erase (faces.iterator_to(*f));
   }
 
   /*! Delete an existing outer CCB. */
   void delete_outer_ccb(Outer_ccb* oc)
   {
-    out_ccbs.erase(oc);
-    std::allocator_traits<Outer_ccb_allocator>::destroy(out_ccb_alloc, oc);
-    out_ccb_alloc.deallocate(oc, 1);
+    out_ccbs.erase (out_ccbs.iterator_to(*oc));
   }
 
   /*! Delete an existing inner CCB. */
   void delete_inner_ccb(Inner_ccb* ic)
   {
-    in_ccbs.erase(ic);
-    std::allocator_traits<Inner_ccb_allocator>::destroy(in_ccb_alloc, ic);
-    in_ccb_alloc.deallocate(ic, 1);
+    in_ccbs.erase (in_ccbs.iterator_to(*ic));
   }
 
   /*! Delete an existing isolated vertex. */
   void delete_isolated_vertex(Isolated_vertex* iv)
   {
-    iso_verts.erase(iv);
-    std::allocator_traits<Iso_vert_allocator>::destroy(iso_vert_alloc, iv);
-    iso_vert_alloc.deallocate(iv, 1);
+    iso_verts.erase (iso_verts.iterator_to(*iv));
   }
 
   /*! Delete all DCEL features. */
@@ -1507,18 +1485,13 @@ protected:
   /*! Create a new halfedge. */
   Halfedge* _new_halfedge()
   {
-    Halfedge* h = halfedge_alloc.allocate(1);
-    std::allocator_traits<Halfedge_allocator>::construct(halfedge_alloc, h);
-    halfedges.push_back(*h);
-    return (h);
+    return &*halfedges.emplace();
   }
 
   /*! Delete an existing halfedge. */
   void _delete_halfedge(Halfedge* h)
   {
-    halfedges.erase(h);
-    std::allocator_traits<Halfedge_allocator>::destroy(halfedge_alloc,h);
-    halfedge_alloc.deallocate(h, 1);
+    halfedges.erase (halfedges.iterator_to(*h));
   }
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_2_iterators.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_2_iterators.h
@@ -288,6 +288,12 @@ public:
     iend (nt)
   {}
 
+  template <typename T>
+  I_Filtered_iterator (T* p) :
+    nt (pointer(p)),
+    iend (nt)
+  {}
+
   I_Filtered_iterator (Iterator it, Iterator end) :
     nt (it),
     iend (end)
@@ -303,6 +309,14 @@ public:
   {
     while (nt != iend && ! filt (*nt))
       ++nt;
+  }
+
+  template <typename P>
+  I_Filtered_iterator& operator= (const P* p)
+  {
+    nt = pointer(p);
+    iend =nt;
+    return *this;
   }
 
   /*! Access operations. */
@@ -439,6 +453,12 @@ public:
     iend (it)
   {}
 
+  template <typename T>
+  I_Filtered_const_iterator (T* p) :
+    nt (pointer(p)),
+    iend (nt)
+  {}
+
   I_Filtered_const_iterator (Iterator it, Iterator end) :
     nt (it),
     iend (end)
@@ -463,6 +483,14 @@ public:
   {
     //    while (nt != iend && ! filt (*nt))
     //      ++nt;
+  }
+
+  template <typename P>
+  I_Filtered_const_iterator& operator= (const P* p)
+  {
+    nt = pointer(p);
+    iend =nt;
+    return *this;
   }
 
   /*! Access operations. */

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
@@ -321,6 +321,7 @@ public:
         return It::operator==( It(nullptr));
     }
     bool operator!=( std::nullptr_t p) const { return !(*this == p); }
+    bool operator==( const It& i) const { return  It::operator==(i); }
     bool operator==( const Self& i) const { return  It::operator==(i); }
     bool operator!=( const Self& i) const { return !(*this == i); }
 

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
@@ -181,7 +181,7 @@ public:
 // CREATION
 // --------
 
-    _HalfedgeDS_facet_circ() : It(0) {}
+    _HalfedgeDS_facet_circ() : It(nullptr) {}
     //_HalfedgeDS_facet_circ( pointer p) : It(p) {}
     _HalfedgeDS_facet_circ( It i) : It(i) {}
 
@@ -200,7 +200,7 @@ public:
     bool operator!=( const Self& i) const { return !(*this == i); }
 
     Self& operator++() {
-        this->nt = (*this->nt).next();
+        this->nt = typename It::Iterator((*this->nt).next());
         return *this;
     }
     Self  operator++(int) {
@@ -241,7 +241,7 @@ public:
 // CREATION
 // --------
 
-    _HalfedgeDS_facet_const_circ() : It(0) {}
+    _HalfedgeDS_facet_const_circ() : It(nullptr) {}
     _HalfedgeDS_facet_const_circ( pointer p) : It(p) {}
     _HalfedgeDS_facet_const_circ( It i) : It(i) {}
 
@@ -266,7 +266,7 @@ public:
     bool operator!=( const It& i) const { return !(*this == i); }
 
     Self& operator++() {
-        this->nt = (*this->nt).next();
+        this->nt = typename It::Iterator((*this->nt).next());
         return *this;
     }
     Self  operator++(int) {
@@ -306,7 +306,7 @@ public:
 // CREATION
 // --------
 
-    _HalfedgeDS_vertex_circ() : It(0) {}
+    _HalfedgeDS_vertex_circ() : It(nullptr) {}
     //_HalfedgeDS_vertex_circ( pointer p) : It(p) {}
     _HalfedgeDS_vertex_circ( It i) : It(i) {}
 
@@ -325,7 +325,7 @@ public:
     bool operator!=( const Self& i) const { return !(*this == i); }
 
     Self& operator++() {
-        this->nt = (*this->nt).next()->opposite();
+        this->nt = typename It::Iterator((*this->nt).next()->opposite());
         return *this;
     }
     Self  operator++(int) {
@@ -338,7 +338,7 @@ public:
 // ---------------------------------
 
     Self& operator--() {
-        this->nt = (*this->nt).opposite()->prev();
+        this->nt = typename It::Iterator((*this->nt).opposite()->prev());
         return *this;
     }
     Self  operator--(int) {
@@ -366,7 +366,7 @@ public:
 // CREATION
 // --------
 
-    _HalfedgeDS_vertex_const_circ() : It(0) {}
+    _HalfedgeDS_vertex_const_circ() : It(nullptr) {}
     _HalfedgeDS_vertex_const_circ( pointer p) : It(p) {}
     _HalfedgeDS_vertex_const_circ( It i) : It(i) {}
 
@@ -389,7 +389,7 @@ public:
     bool operator!=( const Self& i) const { return !(*this == i); }
 
     Self& operator++() {
-        this->nt = (*this->nt).next()->opposite();
+      this->nt = typename It::Iterator((*this->nt).next()->opposite());
         return *this;
     }
     Self  operator++(int) {
@@ -402,7 +402,7 @@ public:
 // ---------------------------------
 
     Self& operator--() {
-        this->nt = (*this->nt).opposite()->prev();
+        this->nt = typename It::Iterator((*this->nt).opposite()->prev());
         return *this;
     }
     Self  operator--(int) {

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_iterator.h
@@ -213,7 +213,7 @@ public:
 // ---------------------------------
 
     Self& operator--() {
-        this->nt = (*this->nt).prev();
+        this->nt = typename It::Iterator((*this->nt).prev());
         return *this;
     }
     Self  operator--(int) {
@@ -279,7 +279,7 @@ public:
 // ---------------------------------
 
     Self& operator--() {
-        this->nt = (*this->nt).prev();
+        this->nt = typename It::Iterator((*this->nt).prev());
         return *this;
     }
     Self  operator--(int) {

--- a/Linear_cell_complex/demo/Linear_cell_complex/import_moka.h
+++ b/Linear_cell_complex/demo/Linear_cell_complex/import_moka.h
@@ -20,7 +20,7 @@ struct GDart
   Dart_handle dh;
   LCC::Vertex_attribute_handle vh;
 
-  GDart() : dh(NULL), vh(NULL)
+  GDart() : dh(nullptr), vh(nullptr)
   {}
 
   GDart(const GDart& adart) : dh(adart.dh),

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -875,6 +875,8 @@ namespace internal {
       m_ptr = nullptr;
     }
 
+    explicit CC_iterator(pointer ptr) : m_ptr(ptr) { }
+
     // Converting constructor from mutable to constant iterator
     template <bool OtherConst>
     CC_iterator(const CC_iterator<


### PR DESCRIPTION
## Summary of Changes

The DCEL data structure currently uses `In_place_list`. Although using the `fast_pool_allocator` already speeds this structure up, I experimented with the Compact Container and noticed it was more efficient.

- using CC instead of in place lists improves timings up to 15% (5% in average)
- most structures benefit from pointer squatting except for the face and inner CCB classes which are given an additional pointer (small memory overhead)
- using `fast_pool_allocator` remains more efficient than `std::allocator`

By running the testsuite locally, I got errors from iterators constructed from `0`. I replaced that by `nullptr` and it fixed the problems.

## Release Management

* Affected package(s): Arrangement and dependent packages (Surface Sweep, Boolean Operations, etc.)