### PR TITLE
Fix the move-semantic of Triangulation_hierarchy_3

### DIFF
--- a/STL_Extension/include/CGAL/array.h
+++ b/STL_Extension/include/CGAL/array.h
@@ -46,7 +46,8 @@ namespace CGAL {
 // It's also untrue that this is not documented...  It is !
 
 template< typename T, typename... Args >
-constexpr std::array< T, 1 + sizeof...(Args) >
+BOOST_CXX14_CONSTEXPR
+std::array< T, 1 + sizeof...(Args) >
 make_array(const T & t, const Args & ... args)
 {
   std::array< T, 1 + sizeof...(Args) > a = { { t, static_cast<T>(args)... } };

--- a/STL_Extension/include/CGAL/array.h
+++ b/STL_Extension/include/CGAL/array.h
@@ -61,7 +61,7 @@ struct Construct_array
   template <typename T, typename... Args>
   constexpr
   std::array<T, 1 + sizeof...(Args)>
-  operator()(const T& t, const Args& ... args)
+  operator()(const T& t, const Args& ... args) const
   {
     return make_array (t, args...);
   }

--- a/STL_Extension/include/CGAL/array.h
+++ b/STL_Extension/include/CGAL/array.h
@@ -18,6 +18,7 @@
 #else
 #  include <boost/array.hpp>
 #endif
+#include <utility>
 
 namespace CGAL {
 
@@ -67,6 +68,19 @@ struct Construct_array
     return make_array (t, args...);
   }
 };
+
+template <std::size_t...Is, typename T>
+constexpr std::array<T, sizeof...(Is)>
+make_filled_array_aux(const T& value, std::index_sequence<Is...>)
+{
+  return {(static_cast<void>(Is), value)...};
+}
+
+template <std::size_t N, typename T>
+constexpr std::array<T, N> make_filled_array(const T& value)
+{
+  return make_filled_array_aux(value, std::make_index_sequence<N>());
+}
 
 } //namespace CGAL
 

--- a/STL_Extension/include/CGAL/array.h
+++ b/STL_Extension/include/CGAL/array.h
@@ -13,11 +13,7 @@
 #define CGAL_ARRAY_H
 
 #include <CGAL/config.h>
-#ifndef CGAL_CFG_NO_CPP0X_ARRAY
-#  include <array>
-#else
-#  include <boost/array.hpp>
-#endif
+#include <array>
 #include <utility>
 
 namespace CGAL {
@@ -50,8 +46,7 @@ namespace CGAL {
 // It's also untrue that this is not documented...  It is !
 
 template< typename T, typename... Args >
-inline
-std::array< T, 1 + sizeof...(Args) >
+constexpr std::array< T, 1 + sizeof...(Args) >
 make_array(const T & t, const Args & ... args)
 {
   std::array< T, 1 + sizeof...(Args) > a = { { t, static_cast<T>(args)... } };
@@ -63,7 +58,9 @@ make_array(const T & t, const Args & ... args)
 struct Construct_array
 {
   template <typename T, typename... Args>
-  std::array<T, 1 + sizeof...(Args)> operator()(const T& t, const Args& ... args)
+  constexpr
+  std::array<T, 1 + sizeof...(Args)>
+  operator()(const T& t, const Args& ... args)
   {
     return make_array (t, args...);
   }

--- a/Testsuite/include/CGAL/Testsuite/Triangulation_23/test_move_semantic.h
+++ b/Testsuite/include/CGAL/Testsuite/Triangulation_23/test_move_semantic.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2021  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Laurent Rineau
+//
+
+
+#include <cassert>
+
+namespace CGAL {
+  namespace Testsuite {
+    namespace Triangulation_23 {
+      template <typename Tr>
+      void test_move_semantic(Tr source_tr) {
+        const auto dimension = source_tr.dimension();
+        const auto nb_of_vertices = source_tr.number_of_vertices();
+        auto check_triangulation_validity = [&](const Tr& tr) {
+          assert(tr.is_valid());
+          assert(tr.number_of_vertices() == nb_of_vertices);
+          assert(tr.dimension() == dimension);
+        };
+        auto check_moved_from_triangulation = [](const Tr& tr_copy) {
+          assert(tr_copy.dimension() == -2);
+          assert(tr_copy.number_of_vertices() + 1 == 0);
+        };
+        auto check_empty_triangulation = [](const Tr& tr_copy2) {
+          assert(tr_copy2.dimension() == -1);
+          assert(tr_copy2.number_of_vertices() == 0);
+        };
+        // move constructor
+        {
+          Tr tr_copy(source_tr);
+          check_triangulation_validity(tr_copy);
+
+          Tr tr_move_constructed(std::move(tr_copy));
+          check_triangulation_validity(tr_move_constructed);
+          check_moved_from_triangulation(tr_copy);
+
+          Tr tr_copy2(source_tr);
+          Tr tr_move_constructed2(std::move(tr_copy2));
+          check_moved_from_triangulation(tr_copy2);
+          tr_copy2.clear();
+          check_empty_triangulation(tr_copy2);
+
+          Tr tr_copy3(source_tr);
+          Tr tr_move_constructed3(std::move(tr_copy3));
+          check_moved_from_triangulation(tr_copy3);
+          tr_copy3 = source_tr;
+          check_triangulation_validity(tr_copy3);
+        }
+        // move-assignment
+        {
+          Tr tr_copy4(source_tr);
+          Tr tr_move_assigned;
+          tr_move_assigned = std::move(tr_copy4);
+          check_triangulation_validity(tr_move_assigned);
+          check_moved_from_triangulation(tr_copy4);
+        }
+      };
+    }
+  }
+}

--- a/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
@@ -37,6 +37,7 @@
 #include <map>
 #include <vector>
 #include <array>
+#include <CGAL/array.h>
 
 namespace CGAL {
 
@@ -82,7 +83,14 @@ public:
 #endif
 
  private:
-  // here is the stack of triangulations which form the hierarchy
+  void init_hierarchy() {
+    hierarchy[0] = this;
+    for(int i=1; i<Triangulation_hierarchy_2__maxlevel; ++i)
+      hierarchy[i] = &hierarchy_triangulations[i-1];
+  }
+
+ // here is the stack of triangulations which form the hierarchy
+  std::array<Tr_Base,Triangulation_hierarchy_2__maxlevel-1> hierarchy_triangulations;
   std::array<Tr_Base*,Triangulation_hierarchy_2__maxlevel> hierarchy;
   boost::rand48  random;
 
@@ -93,13 +101,10 @@ public:
   Triangulation_hierarchy_2(Triangulation_hierarchy_2&& other)
     noexcept( noexcept(Tr_Base(std::move(other))) )
     : Tr_Base(std::move(other))
+    , hierarchy_triangulations(std::move(other.hierarchy_triangulations))
     , random(std::move(other.random))
   {
-    hierarchy[0] = this;
-    for(int i=1; i<Triangulation_hierarchy_2__maxlevel; ++i) {
-      hierarchy[i] = other.hierarchy[i];
-      other.hierarchy[i] = nullptr;
-    }
+    init_hierarchy();
   }
 
   template<class InputIterator>
@@ -107,10 +112,7 @@ public:
                             const Geom_traits& traits = Geom_traits())
     : Tr_Base(traits)
   {
-    hierarchy[0] = this;
-    for(int i=1;i<Triangulation_hierarchy_2__maxlevel;++i)
-      hierarchy[i] = new Tr_Base(traits);
-
+    init_hierarchy();
     insert (first, beyond);
   }
 
@@ -120,15 +122,11 @@ public:
     noexcept( noexcept(Triangulation_hierarchy_2(std::move(other))) )
   {
     static_cast<Tr_Base&>(*this) = std::move(other);
-    hierarchy[0] = this;
-    for(int i=1; i<Triangulation_hierarchy_2__maxlevel; ++i) {
-      hierarchy[i] = other.hierarchy[i];
-      other.hierarchy[i] = nullptr;
-    }
+    hierarchy_triangulations = std::move(other.hierarchy_triangulations);
     return *this;
   }
 
-  ~Triangulation_hierarchy_2();
+  ~Triangulation_hierarchy_2() = default;
 
   //Helping
   void copy_triangulation(const Triangulation_hierarchy_2 &tr);
@@ -293,10 +291,11 @@ template <class Tr_>
 Triangulation_hierarchy_2<Tr_>::
 Triangulation_hierarchy_2(const Geom_traits& traits)
   : Tr_Base(traits)
+  , hierarchy_triangulations(
+           make_filled_array<Triangulation_hierarchy_2__maxlevel-1,
+                             Tr_Base>(traits))
 {
-  hierarchy[0] = this;
-  for(int i=1;i<Triangulation_hierarchy_2__maxlevel;++i)
-    hierarchy[i] = new Tr_Base(traits);
+  init_hierarchy();
 }
 
 
@@ -304,12 +303,8 @@ Triangulation_hierarchy_2(const Geom_traits& traits)
 template <class Tr_>
 Triangulation_hierarchy_2<Tr_>::
 Triangulation_hierarchy_2(const Triangulation_hierarchy_2<Tr_> &tr)
-    : Tr_Base()
+  : Triangulation_hierarchy_2(tr.geom_traits())
 {
-  // create an empty triangulation to be able to delete it !
-  hierarchy[0] = this;
-  for(int i=1;i<Triangulation_hierarchy_2__maxlevel;++i)
-    hierarchy[i] = new Tr_Base(tr.geom_traits());
   copy_triangulation(tr);
 }
 
@@ -392,23 +387,9 @@ void
 Triangulation_hierarchy_2<Tr_>::
 swap(Triangulation_hierarchy_2<Tr_> &tr)
 {
-  Tr_Base* temp;
   Tr_Base::swap(tr);
-  for(int i= 1; i<Triangulation_hierarchy_2__maxlevel; ++i){
-    temp = hierarchy[i];
-    hierarchy[i] = tr.hierarchy[i];
-    tr.hierarchy[i]= temp;
-  }
-}
-
-template <class Tr_>
-Triangulation_hierarchy_2<Tr_>::
-~Triangulation_hierarchy_2()
-{
-  clear();
-  for(int i= 1; i<Triangulation_hierarchy_2__maxlevel; ++i){
-    delete hierarchy[i];
-  }
+  using std::swap;
+  swap(hierarchy_triangulations, tr.hierarchy_triangulations);
 }
 
 template <class Tr_>

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
@@ -31,6 +31,7 @@
 #include <CGAL/_test_fct_is_infinite.h>
 #include <CGAL/_test_triangulation_iterators.h>
 #include <CGAL/_test_triangulation_circulators.h>
+#include <CGAL/Testsuite/Triangulation_23/test_move_semantic.h>
 
 
 template <class Triangul>
@@ -281,6 +282,15 @@ _test_cls_triangulation_short_2( const Triangul &)
   assert( T2_3_4.number_of_vertices() == 11 );
   assert( T2_3_4.is_valid() );
 
+  /****************************/
+  /******* MOVE SEMANTIC*******/
+
+  std::cout << "    move constructors and move assignment" << std::endl;
+  namespace test_tr_23 = CGAL::Testsuite::Triangulation_23;
+  test_tr_23::test_move_semantic(T0_1);
+  test_tr_23::test_move_semantic(T1_5);
+  test_tr_23::test_move_semantic(T2_8);
+  test_tr_23::test_move_semantic(T2_3);
 
   /*********************************************/
   /****** FINITE/INFINITE VERTICES/FACES *******/

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -114,6 +114,7 @@ public:
     , random(std::move(other.random))
   {
     hierarchy[0] = this;
+    other.hierarchy[0] = nullptr;
     for(int i=1; i<maxlevel; ++i) {
       hierarchy[i] = other.hierarchy[i];
       other.hierarchy[i] = nullptr;
@@ -503,7 +504,8 @@ void
 Triangulation_hierarchy_3<Tr>::
 clear()
 {
-  for(int i=0;i<maxlevel;++i)
+  if(hierarchy[0] == nullptr) return; // moved-from object
+  for(int i=1;i<maxlevel;++i)
     hierarchy[i]->clear();
 }
 

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -157,8 +157,7 @@ public:
     noexcept( noexcept(Triangulation_hierarchy_3(std::move(other))) )
   {
     static_cast<Tr_Base&>(*this) = std::move(other);
-    hierarchy_triangulations = std::move(hierarchy_triangulations);
-    init_hierarchy();
+    hierarchy_triangulations = std::move(other.hierarchy_triangulations);
     return *this;
   }
 

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -51,6 +51,7 @@
 #include <boost/mpl/if.hpp>
 
 #include <array>
+#include <CGAL/array.h>
 
 #endif //CGAL_TRIANGULATION_3_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 
@@ -92,18 +93,6 @@ public:
 
 private:
 
-  template <std::size_t...Is>
-  constexpr std::array<Tr_Base, sizeof...(Is)>
-  make_array_of_triangulations(const Geom_traits& traits, std::index_sequence<Is...>)
-  {
-    return {{(static_cast<void>(Is), traits)...}};
-  }
-  template <std::size_t N>
-  constexpr std::array<Tr_Base, N> create_array_of_triangulation(const Geom_traits& traits)
-  {
-    return make_array_of_triangulations(traits, std::make_index_sequence<N>());
-  }
-
   void init_hierarchy() {
     hierarchy[0] = this;
     for(int i=1; i<maxlevel; ++i)
@@ -140,7 +129,7 @@ public:
   Triangulation_hierarchy_3(InputIterator first, InputIterator last,
                             const Geom_traits& traits = Geom_traits())
     : Tr_Base(traits)
-    , hierarchy_triangulations(create_array_of_triangulation<maxlevel-1>(traits))
+    , hierarchy_triangulations(make_filled_array<maxlevel-1, Tr_Base>(traits))
   {
     init_hierarchy();
     insert(first, last);
@@ -465,7 +454,7 @@ template <class Tr >
 Triangulation_hierarchy_3<Tr>::
 Triangulation_hierarchy_3(const Geom_traits& traits)
   : Tr_Base(traits)
-  , hierarchy_triangulations(create_array_of_triangulation<maxlevel-1>(traits))
+  , hierarchy_triangulations(make_filled_array<maxlevel-1, Tr_Base>(traits))
 {
   init_hierarchy();
 }

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -167,8 +167,8 @@ public:
   void swap(Triangulation_hierarchy_3 &tr)
   {
     Tr_Base::swap(tr);
-    for(int i=1; i<maxlevel; ++i)
-      std::swap(hierarchy[i], tr.hierarchy[i]);
+    using std::swap;
+    swap(hierarchy_triangulations, tr.hierarchy_triangulations);
   };
 
   void clear();

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -432,8 +432,7 @@ _test_cls_delaunay_3(const Triangulation &)
     assert(T_move_constructed.number_of_vertices() == 4);
     assert(T_move_constructed.is_valid());
     assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() == -1);
-    assert(T_copy.is_valid());
+    assert(T_copy.number_of_vertices() + 1 == 0);
   }
 
    // Affectation :

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -421,7 +421,20 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T1.number_of_vertices() == 0);
   assert(T1.is_valid());
 
-
+  // move constructor
+  {
+    Cls T_copy(T0);
+    assert(T_copy.dimension() == 3);
+    assert(T_copy.number_of_vertices() == 4);
+    assert(T_copy.is_valid());
+    Cls T_move_constructed(std::move(T_copy));
+    assert(T_move_constructed.dimension() == 3);
+    assert(T_move_constructed.number_of_vertices() == 4);
+    assert(T_move_constructed.is_valid());
+    assert(T_copy.dimension() == -2);
+    assert(T_copy.number_of_vertices() == -1);
+    assert(T_copy.is_valid());
+  }
 
    // Affectation :
   T1=T0;

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -433,6 +433,11 @@ _test_cls_delaunay_3(const Triangulation &)
     assert(T_move_constructed.is_valid());
     assert(T_copy.dimension() == -2);
     assert(T_copy.number_of_vertices() + 1 == 0);
+
+    Cls T_copy2(T0);
+    Cls T_move_constructed2(std::move(T_copy2));
+    T_copy2.clear();
+    assert(T_copy2 == Cls());
   }
 
    // Affectation :

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -438,6 +438,11 @@ _test_cls_delaunay_3(const Triangulation &)
     Cls T_move_constructed2(std::move(T_copy2));
     T_copy2.clear();
     assert(T_copy2 == Cls());
+
+    Cls T_copy3(T0);
+    Cls T_move_constructed3(std::move(T_copy3));
+    T_copy3 = T0;
+    assert(T_copy3 == T0);
   }
 
    // Affectation :

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -1209,9 +1209,10 @@ _test_cls_delaunay_3(const Triangulation &)
       for (int i=0; i<10; i++)
         tri.insert(Point(i+1, i+2, i+3));
 
-      return std::move(tri); // the move prevents the NRVO
+      return tri;
     };
-    Triangulation t = Triangulate();
+    auto t = Triangulate();
+    auto t2 = std::move(t);
   }
 }
 

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -1228,6 +1228,18 @@ _test_cls_delaunay_3(const Triangulation &)
                 _test_remove_cluster<Triangulation>();
   }
 
+  // Test from issue https://github.com/CGAL/cgal/issues/5396
+  {
+    auto Triangulate = []() -> Triangulation
+    {
+      Triangulation tri;
+      for (int i=0; i<10; i++)
+        tri.insert(Point(i+1, i+2, i+3));
+
+      return std::move(tri); // the move prevents the NRVO
+    };
+    Triangulation t = Triangulate();
+  }
 }
 
 #endif // CGAL_TEST_CLS_DELAUNAY_C

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -31,6 +31,7 @@
 #include <CGAL/Random.h>
 #include <CGAL/Testsuite/use.h>
 #include <CGAL/internal/Has_nested_type_Bare_point.h>
+#include <CGAL/Testsuite/Triangulation_23/test_move_semantic.h>
 
 // Accessory set of functions to differentiate between
 // Delaunay::nearest_vertex[_in_cell] and
@@ -421,41 +422,8 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T1.number_of_vertices() == 0);
   assert(T1.is_valid());
 
-  // move constructor
-  {
-    Cls T_copy(T0);
-    assert(T_copy.dimension() == 3);
-    assert(T_copy.number_of_vertices() == 4);
-    assert(T_copy.is_valid());
-    Cls T_move_constructed(std::move(T_copy));
-    assert(T_move_constructed.dimension() == 3);
-    assert(T_move_constructed.number_of_vertices() == 4);
-    assert(T_move_constructed.is_valid());
-    assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() + 1 == 0);
-
-    Cls T_copy2(T0);
-    Cls T_move_constructed2(std::move(T_copy2));
-    T_copy2.clear();
-    assert(T_copy2 == Cls());
-
-    Cls T_copy3(T0);
-    Cls T_move_constructed3(std::move(T_copy3));
-    T_copy3 = T0;
-    assert(T_copy3 == T0);
-  }
-  // move-assignment
-  {
-    Cls T_copy4(T0);
-    Cls T_move_assigned;
-    T_move_assigned = std::move(T_copy4);
-    assert(T_copy4.dimension() == -2);
-    assert(T_copy4.number_of_vertices() + 1 == 0);
-    assert(T_move_assigned.dimension() == 3);
-    assert(T_move_assigned.number_of_vertices() == 4);
-    assert(T_move_assigned.is_valid());
-    assert(T_move_assigned == T0);
-  }
+  namespace test_tr_23 = CGAL::Testsuite::Triangulation_23;
+  test_tr_23::test_move_semantic(T0);
 
    // Affectation :
   T1=T0;
@@ -488,6 +456,7 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T1_0.dimension()==1);
   assert(T1_0.number_of_vertices()==n);
   assert(T1_0.is_valid());
+  test_tr_23::test_move_semantic(T1_0);
   std::cout << "    Constructor7 " << std::endl;
   Cls T1_1;
   n = T1_1.insert(l2.begin(),l2.end());
@@ -548,6 +517,8 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T2_0.dimension()==2);
   assert(T2_0.number_of_vertices()==8);
 
+  test_tr_23::test_move_semantic(T2_0);
+
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
@@ -595,6 +566,8 @@ _test_cls_delaunay_3(const Triangulation &)
   assert(T3_0.is_valid());
   assert(T3_0.number_of_vertices()==125);
   assert(T3_0.dimension()==3);
+
+  test_tr_23::test_move_semantic(T3_0);
 
   if (del) {
     std::cout << "    deletion in Delaunay - grid case - (dim 3) " <<

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -444,6 +444,18 @@ _test_cls_delaunay_3(const Triangulation &)
     T_copy3 = T0;
     assert(T_copy3 == T0);
   }
+  // move-assignment
+  {
+    Cls T_copy4(T0);
+    Cls T_move_assigned;
+    T_move_assigned = std::move(T_copy4);
+    assert(T_copy4.dimension() == -2);
+    assert(T_copy4.number_of_vertices() + 1 == 0);
+    assert(T_move_assigned.dimension() == 3);
+    assert(T_move_assigned.number_of_vertices() == 4);
+    assert(T_move_assigned.is_valid());
+    assert(T_move_assigned == T0);
+  }
 
    // Affectation :
   T1=T0;

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -215,5 +215,10 @@ _test_cls_regular_3(const Triangulation &)
     assert(T_move_constructed == T);
     assert(T_copy.dimension() == -2);
     assert(T_copy.number_of_vertices() + 1 == 0);
+
+    Cls T_copy2(T);
+    Cls T_move_constructed2(std::move(T_copy2));
+    T_copy2.clear();
+    assert(T_copy2 == Cls());
   }
 }

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -214,7 +214,6 @@ _test_cls_regular_3(const Triangulation &)
     Triangulation T_move_constructed(std::move(T_copy));
     assert(T_move_constructed == T);
     assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() == -1);
-    assert(T_copy.is_valid());
+    assert(T_copy.number_of_vertices() + 1 == 0);
   }
 }

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -205,6 +205,16 @@ _test_cls_regular_3(const Triangulation &)
             << T.number_of_vertices() << std::endl;
   assert(T.is_valid());
   assert(T.dimension()==3);
+
+  // move constructor
+  {
+    Triangulation T_copy(T);
+    assert(T_copy == T);
+    assert(T_copy == T);
+    Triangulation T_move_constructed(std::move(T_copy));
+    assert(T_move_constructed == T);
+    assert(T_copy.dimension() == -2);
+    assert(T_copy.number_of_vertices() == -1);
+    assert(T_copy.is_valid());
+  }
 }
-
-

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -220,5 +220,10 @@ _test_cls_regular_3(const Triangulation &)
     Cls T_move_constructed2(std::move(T_copy2));
     T_copy2.clear();
     assert(T_copy2 == Cls());
+
+    Cls T_copy3(T);
+    Cls T_move_constructed3(std::move(T_copy3));
+    T_copy3 = T;
+    assert(T_copy3 == T);
   }
 }

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -226,4 +226,15 @@ _test_cls_regular_3(const Triangulation &)
     T_copy3 = T;
     assert(T_copy3 == T);
   }
+  // move-assignment
+  {
+    Cls T_copy4(T);
+    Cls T_move_assigned;
+    T_move_assigned = std::move(T_copy4);
+    assert(T_copy4.dimension() == -2);
+    assert(T_copy4.number_of_vertices() + 1 == 0);
+    assert(T_move_assigned.dimension() == 3);
+    assert(T_move_assigned.is_valid());
+    assert(T_move_assigned == T);
+  }
 }

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_regular_3.h
@@ -17,6 +17,8 @@
 #include <list>
 #include <type_traits>
 #include <CGAL/use.h>
+#include <CGAL/Testsuite/Triangulation_23/test_move_semantic.h>
+
 template <class Triangulation>
 void
 _test_cls_regular_3(const Triangulation &)
@@ -206,35 +208,6 @@ _test_cls_regular_3(const Triangulation &)
   assert(T.is_valid());
   assert(T.dimension()==3);
 
-  // move constructor
-  {
-    Triangulation T_copy(T);
-    assert(T_copy == T);
-    assert(T_copy == T);
-    Triangulation T_move_constructed(std::move(T_copy));
-    assert(T_move_constructed == T);
-    assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() + 1 == 0);
-
-    Cls T_copy2(T);
-    Cls T_move_constructed2(std::move(T_copy2));
-    T_copy2.clear();
-    assert(T_copy2 == Cls());
-
-    Cls T_copy3(T);
-    Cls T_move_constructed3(std::move(T_copy3));
-    T_copy3 = T;
-    assert(T_copy3 == T);
-  }
-  // move-assignment
-  {
-    Cls T_copy4(T);
-    Cls T_move_assigned;
-    T_move_assigned = std::move(T_copy4);
-    assert(T_copy4.dimension() == -2);
-    assert(T_copy4.number_of_vertices() + 1 == 0);
-    assert(T_move_assigned.dimension() == 3);
-    assert(T_move_assigned.is_valid());
-    assert(T_move_assigned == T);
-  }
+  namespace test_tr_23 = CGAL::Testsuite::Triangulation_23;
+  test_tr_23::test_move_semantic(T);
 }

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -23,6 +23,7 @@
 #include <CGAL/Random.h>
 #include <CGAL/Testsuite/use.h>
 #include <CGAL/use.h>
+#include <CGAL/Testsuite/Triangulation_23/test_move_semantic.h>
 
 template <class Triangulation, class Container>
 bool check_all_are_finite(Triangulation* tr, const Container& cont)
@@ -286,41 +287,8 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T1.number_of_vertices() == 0);
   assert(T1.is_valid());
 
-  // move constructor
-  {
-    Cls T_copy(T0);
-    assert(T_copy.dimension() == 3);
-    assert(T_copy.number_of_vertices() == 4);
-    assert(T_copy.is_valid());
-    Cls T_move_constructed(std::move(T_copy));
-    assert(T_move_constructed.dimension() == 3);
-    assert(T_move_constructed.number_of_vertices() == 4);
-    assert(T_move_constructed.is_valid());
-    assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() + 1 == 0);
-
-    Cls T_copy2(T0);
-    Cls T_move_constructed2(std::move(T_copy2));
-    T_copy2.clear();
-    assert(T_copy2 == Cls());
-
-    Cls T_copy3(T0);
-    Cls T_move_constructed3(std::move(T_copy3));
-    T_copy3 = T0;
-    assert(T_copy3 == T0);
-  }
-  // move-assignment
-  {
-    Cls T_copy4(T0);
-    Cls T_move_assigned;
-    T_move_assigned = std::move(T_copy4);
-    assert(T_copy4.dimension() == -2);
-    assert(T_copy4.number_of_vertices() + 1 == 0);
-    assert(T_move_assigned.dimension() == 3);
-    assert(T_move_assigned.number_of_vertices() == 4);
-    assert(T_move_assigned.is_valid());
-    assert(T_move_assigned == T0);
-  }
+  namespace test_tr_23 = CGAL::Testsuite::Triangulation_23;
+  test_tr_23::test_move_semantic(T0);
 
    // Assignment
   T1=T0;
@@ -397,12 +365,14 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T2_0.dimension()==1);
   assert(T2_0.number_of_vertices()==3);
 
+  test_tr_23::test_move_semantic(T2_0);
 
   v0=T2_0.insert(p4);
   assert(T2_0.is_valid());
   assert(T2_0.dimension()==2);
   assert(T2_0.number_of_vertices()==4);
 
+  test_tr_23::test_move_semantic(T2_0);
 
   v0=T2_0.insert(p5);
   v0=T2_0.insert(p6);
@@ -413,6 +383,8 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T2_0.is_valid());
   assert(T2_0.dimension()==2);
   assert(T2_0.number_of_vertices()==8);
+
+  test_tr_23::test_move_semantic(T2_0);
 
   if (! del) // to avoid doing the following tests for both Delaunay
     // and non Delaunay triangulations
@@ -436,6 +408,8 @@ _test_cls_triangulation_3(const Triangulation &)
   assert( T2_1.number_of_vertices() == m*n );
   assert( T2_1.dimension()==2 );
   assert( T2_1.is_valid() );
+
+  test_tr_23::test_move_semantic(T2_1);
 
   std::cout << "    Constructor11 " << std::endl;
   // 3-dimensional triangulations

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -298,6 +298,11 @@ _test_cls_triangulation_3(const Triangulation &)
     assert(T_move_constructed.is_valid());
     assert(T_copy.dimension() == -2);
     assert(T_copy.number_of_vertices() + 1 == 0);
+
+    Cls T_copy2(T0);
+    Cls T_move_constructed2(std::move(T_copy2));
+    T_copy2.clear();
+    assert(T_copy2 == Cls());
   }
 
    // Assignment

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -303,6 +303,11 @@ _test_cls_triangulation_3(const Triangulation &)
     Cls T_move_constructed2(std::move(T_copy2));
     T_copy2.clear();
     assert(T_copy2 == Cls());
+
+    Cls T_copy3(T0);
+    Cls T_move_constructed3(std::move(T_copy3));
+    T_copy3 = T0;
+    assert(T_copy3 == T0);
   }
 
    // Assignment

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -309,6 +309,18 @@ _test_cls_triangulation_3(const Triangulation &)
     T_copy3 = T0;
     assert(T_copy3 == T0);
   }
+  // move-assignment
+  {
+    Cls T_copy4(T0);
+    Cls T_move_assigned;
+    T_move_assigned = std::move(T_copy4);
+    assert(T_copy4.dimension() == -2);
+    assert(T_copy4.number_of_vertices() + 1 == 0);
+    assert(T_move_assigned.dimension() == 3);
+    assert(T_move_assigned.number_of_vertices() == 4);
+    assert(T_move_assigned.is_valid());
+    assert(T_move_assigned == T0);
+  }
 
    // Assignment
   T1=T0;

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -286,7 +286,20 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T1.number_of_vertices() == 0);
   assert(T1.is_valid());
 
-
+  // move constructor
+  {
+    Cls T_copy(T0);
+    assert(T_copy.dimension() == 3);
+    assert(T_copy.number_of_vertices() == 4);
+    assert(T_copy.is_valid());
+    Cls T_move_constructed(std::move(T_copy));
+    assert(T_move_constructed.dimension() == 3);
+    assert(T_move_constructed.number_of_vertices() == 4);
+    assert(T_move_constructed.is_valid());
+    assert(T_copy.dimension() == -2);
+    assert(T_copy.number_of_vertices() == -1);
+    assert(T_copy.is_valid());
+  }
 
    // Assignment
   T1=T0;

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -297,8 +297,7 @@ _test_cls_triangulation_3(const Triangulation &)
     assert(T_move_constructed.number_of_vertices() == 4);
     assert(T_move_constructed.is_valid());
     assert(T_copy.dimension() == -2);
-    assert(T_copy.number_of_vertices() == -1);
-    assert(T_copy.is_valid());
+    assert(T_copy.number_of_vertices() + 1 == 0);
   }
 
    // Assignment


### PR DESCRIPTION
## Summary of Changes

### What is fixed by this pull-request
This PR started as a fix for the issue https://github.com/CGAL/cgal/issues/5396.

Then I have discovered that, in the PR https://github.com/CGAL/cgal/pull/4496, I had not implemented a test-suite for the move-semantic.

I have also discovered that a moved-from triangulation, since #4496, is not a valid CGAL triangulation: it has an empty TDS, and thus no infinite vertex, and as such has:
  - `dimension()==2`,
  - `number_of_vertices() == -1` (or `number_of_vertices() + 1 == 0`, to avoid a warning).


### The solution

- Add a testsuite for the move-semantic:
  - check that a move-constructed triangulation is equivalent to its source,
  - check the strange state of move-from triangulation (`dimension()==2`),
  - check that a moved-from triangulation:
    - can be destroyed,
    - can be assigned,
    - and can be restored to the default-constructed (empty) triangulation with `clear()`.
- Re-implement the internals of `Triangulation_hierarchy_3` so that a default-constructed hierarchy does not allocate: the levels from 1 to `maxlevel-1` are stored as data-members (in a `std::array`). That allows to satisfy the new testsuite.

### The TODO-list
- [x] Add documentation about moved-from triangulations (*Edit:* done, because we decided not to document anything)
- [x] Implement the same for 2D triangulations

## Release Management

* Affected package(s): Triangulation_3, Triangulation_2
* Issue(s) solved (if any): fix #5396
* License and copyright ownership: maintenance by GeometryFactory, copyright transfered to Inria Sophia-Antipolis.

