### PR TITLE
Calculate normals for facets more efficiently

### DIFF
--- a/Nef_3/include/CGAL/normal_vector_newell_3.h
+++ b/Nef_3/include/CGAL/normal_vector_newell_3.h
@@ -38,7 +38,7 @@ void newell_single_step_3( const Handle& p, const Handle& q, Vector& n, const Ho
   const RT& phw = p.hw();
   const RT& qhw = q.hw();
   const RT& nhw = n.hw();
-  const RT& sq = phw * phw * qhw * qhw;
+  const RT& sq = square(phw) * square(qhw);
   const RT& phyqhw = p.hy() * qhw;
   const RT& qhyphw = q.hy() * phw;
   const RT& phxqhw = p.hx() * qhw;
@@ -72,23 +72,23 @@ CGAL_MEDIUM_INLINE
 void newell_single_step_3( const Handle& p, const Handle& q, Vector& n, const Cartesian_tag&)
 {
   typedef typename Kernel_traits<Vector>::Kernel::FT FT;
-  const FT& phy = p.hy();
-  const FT& qhy = q.hy();
-  const FT& phx = p.hx();
-  const FT& qhx = q.hx();
-  const FT& phz = p.hz();
-  const FT& qhz = q.hz();
+  const FT& py = p.y();
+  const FT& qy = q.y();
+  const FT& px = p.x();
+  const FT& qx = q.x();
+  const FT& pz = p.z();
+  const FT& qz = q.z();
 
   n = Vector(
-    n.hx()
-        + ( phy - qhy )
-        * ( phz + qhz ),
-    n.hy()
-        + ( phz - qhz )
-        * ( phx + qhx ),
-    n.hz()
-        + ( phx - qhx )
-        * ( phy + qhy )
+    n.x()
+        + ( py - qy )
+        * ( pz + qz ),
+    n.y()
+        + ( pz - qz )
+        * ( px + qx ),
+    n.z()
+        + ( px - qx )
+        * ( py + qy )
     );
 }
 

--- a/Nef_3/include/CGAL/normal_vector_newell_3.h
+++ b/Nef_3/include/CGAL/normal_vector_newell_3.h
@@ -95,9 +95,7 @@ void newell_single_step_3( const Handle& p, const Handle& q, Vector& n, const Ca
 template <class IC>
 bool is_triangle_3( const IC& first )
 {
-    IC last(first);
-    ++last; ++last; ++last;
-    return first==last;
+    return std::next(first,3) == first;
 }
 
 }

--- a/Nef_3/include/CGAL/normal_vector_newell_3.h
+++ b/Nef_3/include/CGAL/normal_vector_newell_3.h
@@ -112,10 +112,12 @@ void normal_vector_newell_3( IC first, IC last, Vector& n )
     // three.
 {
     CGAL_assertion( !CGAL::is_empty_range( first, last));
+
     if(internal_nef::is_triangle_3(first)) {
-      n = orthogonal_vector(*first,*(++first),*(++first));
+      n = orthogonal_vector(*first,*(std::next(first)),*(std__next(first,2)));
       return;
     }
+
 
     typedef typename Kernel_traits<Vector>::Kernel R;
     // Compute facet normals via the Newell-method as described in
@@ -140,10 +142,13 @@ template <class IC, class Vector, class VertexPointMap>
 void normal_vector_newell_3( IC first, IC last, VertexPointMap vpm, Vector& n )
 {
     CGAL_assertion( !CGAL::is_empty_range( first, last));
+
     if(internal_nef::is_triangle_3(first)) {
-      n = orthogonal_vector(get(vpm,*first),get(vpm,*(++first)),get(vpm,*(++first)));
+
+      n = orthogonal_vector(get(vpm,*first),get(vpm,*(std::next(first))),get(vpm,*(std::next(first,2))));
       return;
     }
+
 
     typedef typename Kernel_traits<Vector>::Kernel R;
     // Compute facet normals via the Newell-method as described in

--- a/Nef_3/include/CGAL/normal_vector_newell_3.h
+++ b/Nef_3/include/CGAL/normal_vector_newell_3.h
@@ -114,7 +114,7 @@ void normal_vector_newell_3( IC first, IC last, Vector& n )
     CGAL_assertion( !CGAL::is_empty_range( first, last));
 
     if(internal_nef::is_triangle_3(first)) {
-      n = orthogonal_vector(*first,*(std::next(first)),*(std__next(first,2)));
+      n = orthogonal_vector(*first,*(std::next(first)),*(std::next(first,2)));
       return;
     }
 


### PR DESCRIPTION
## Summary of Changes

Implemented the performance improvements as discussed in #5379

* Optimise for Cartesian and Homogeneous kernels
* Use locals instead of multiple functions calls and recalculations
* Use `orthogonal_vector` for triangles

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5379
* Feature/Small Feature (if any): performance enhancement.
* License and copyright ownership: Returned to CGAL authors.

