### PR TITLE
Kernel_d:   Deal with deprecated result_type

### DIFF
--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -37,7 +37,7 @@ namespace CGAL {
     struct equal_to {
       typedef bool result_type;
 
-      bool operator()(const T &lhs, const T &rhs) const
+      result_type operator()(const T &lhs, const T &rhs) const
       {
         return lhs == rhs;
       }
@@ -48,23 +48,13 @@ namespace CGAL {
     struct minus {
       typedef T result_type;
 
-      T operator()(const T &lhs, const T &rhs) const
+      result_type operator()(const T &lhs, const T &rhs) const
       {
         return lhs - rhs;
       }
 
     };
 
-    template <typename T>
-    struct multiplies {
-      typedef T result_type;
-
-      T operator()(const T &lhs, const T &rhs) const
-      {
-        return lhs * rhs;
-      }
-
-    };
   } // namespace Kernel_d
 
   template < typename Point_, typename Functor_ >
@@ -314,7 +304,7 @@ namespace CGAL {
               Iter;
       Iter b(ptr()->upper, ptr()->lower, Begin());
       Iter e(ptr()->upper, ptr()->lower, Cartesian_end());
-      return std::accumulate(b, e, RT(1), Kernel_d::multiplies<RT>());
+      return std::accumulate(b, e, RT(1), std::multiplies<RT>());
     }
 
     RT volume_denominator() const

--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -46,7 +46,7 @@ namespace CGAL {
 
     template <typename T>
     struct minus {
-      typedef bool result_type;
+      typedef T result_type;
 
       T operator()(const T &lhs, const T &rhs) const
       {
@@ -57,7 +57,7 @@ namespace CGAL {
 
     template <typename T>
     struct multiplies {
-      typedef bool result_type;
+      typedef T result_type;
 
       T operator()(const T &lhs, const T &rhs) const
       {

--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -121,9 +121,12 @@ namespace CGAL {
     typedef typename Point::Homogeneous_const_iterator  Iterator;
     typedef Homogeneous_iterator<Point,Functor>         Self;
 
-    typedef typename Functor::result_type  value_type;
-    typedef value_type&                    reference;
-    typedef value_type*                    pointer;
+    typedef typename Kernel_traits<Point>::Kernel::RT RT;
+    typedef decltype(std::declval<Functor>()(
+        *std::declval<Iterator>() * std::declval<RT>(),
+        *std::declval<Iterator>() * std::declval<RT>())) value_type;
+    typedef value_type                     reference;
+    typedef const value_type*              pointer;
     typedef std::ptrdiff_t                 difference_type;
     typedef std::input_iterator_tag        iterator_category;
 
@@ -131,7 +134,6 @@ namespace CGAL {
 
     Iterator pb, qb;
     Functor f;
-    typedef typename Kernel_traits<Point>::Kernel::RT RT;
     RT hp, hq; // homogenizing coordinates
 
   public:
@@ -280,7 +282,7 @@ namespace CGAL {
 
     RT volume_nominator() const
     {
-      typedef typename CIRT::template Iterator<Point_d, std::minus<RT> >::type
+      typedef typename CIRT::template Iterator<Point_d,std::minus<RT> >::type
               Iter;
       Iter b(ptr()->upper, ptr()->lower, Begin());
       Iter e(ptr()->upper, ptr()->lower, Cartesian_end());

--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <numeric>
 #include <cstddef>
+#include <iterator>
 
 namespace CGAL {
 
@@ -32,29 +33,6 @@ namespace CGAL {
     struct Begin {};
     struct End {};
     struct Cartesian_end {};
-
-    template <typename T>
-    struct equal_to {
-      typedef bool result_type;
-
-      result_type operator()(const T &lhs, const T &rhs) const
-      {
-        return lhs == rhs;
-      }
-
-    };
-
-    template <typename T>
-    struct minus {
-      typedef T result_type;
-
-      result_type operator()(const T &lhs, const T &rhs) const
-      {
-        return lhs - rhs;
-      }
-
-    };
-
   } // namespace Kernel_d
 
   template < typename Point_, typename Functor_ >
@@ -64,7 +42,13 @@ namespace CGAL {
     typedef typename Point::Cartesian_const_iterator  Iterator;
     typedef Cartesian_iterator<Point,Functor>         Self;
 
-    typedef typename Functor::result_type  value_type;
+
+    typedef typename std::iterator_traits<Iterator>::value_type
+                                                      Coordinate_type;
+
+    typedef decltype(
+        std::declval<Functor>()(std::declval<Coordinate_type>(),
+                                std::declval<Coordinate_type>())) value_type;
     typedef value_type&                    reference;
     typedef value_type*                    pointer;
     typedef std::ptrdiff_t                 difference_type;
@@ -300,7 +284,7 @@ namespace CGAL {
 
     RT volume_nominator() const
     {
-      typedef typename CIRT::template Iterator<Point_d,Kernel_d::minus<RT> >::type
+      typedef typename CIRT::template Iterator<Point_d, std::minus<RT> >::type
               Iter;
       Iter b(ptr()->upper, ptr()->lower, Begin());
       Iter e(ptr()->upper, ptr()->lower, Cartesian_end());
@@ -396,7 +380,7 @@ public:
     bool is_degenerate() const
     {
       typedef typename CIRT::
-              template Iterator<Point_d,Kernel_d::equal_to<RT> >::type Iter;
+              template Iterator<Point_d,std::equal_to<RT> >::type Iter;
       // omit homogenizing coordinates
       Iter e(ptr()->lower, ptr()->upper, Cartesian_end());
       return

--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -32,6 +32,39 @@ namespace CGAL {
     struct Begin {};
     struct End {};
     struct Cartesian_end {};
+
+    template <typename T>
+    struct equal_to {
+      typedef bool result_type;
+
+      bool operator()(const T &lhs, const T &rhs) const
+      {
+        return lhs == rhs;
+      }
+
+    };
+
+    template <typename T>
+    struct minus {
+      typedef bool result_type;
+
+      T operator()(const T &lhs, const T &rhs) const
+      {
+        return lhs - rhs;
+      }
+
+    };
+
+    template <typename T>
+    struct multiplies {
+      typedef bool result_type;
+
+      T operator()(const T &lhs, const T &rhs) const
+      {
+        return lhs * rhs;
+      }
+
+    };
   } // namespace Kernel_d
 
   template < typename Point_, typename Functor_ >
@@ -277,11 +310,11 @@ namespace CGAL {
 
     RT volume_nominator() const
     {
-      typedef typename CIRT::template Iterator<Point_d,std::minus<RT> >::type
+      typedef typename CIRT::template Iterator<Point_d,Kernel_d::minus<RT> >::type
               Iter;
       Iter b(ptr()->upper, ptr()->lower, Begin());
       Iter e(ptr()->upper, ptr()->lower, Cartesian_end());
-      return std::accumulate(b, e, RT(1), std::multiplies<RT>());
+      return std::accumulate(b, e, RT(1), Kernel_d::multiplies<RT>());
     }
 
     RT volume_denominator() const
@@ -373,7 +406,7 @@ public:
     bool is_degenerate() const
     {
       typedef typename CIRT::
-              template Iterator<Point_d,std::equal_to<RT> >::type Iter;
+              template Iterator<Point_d,Kernel_d::equal_to<RT> >::type Iter;
       // omit homogenizing coordinates
       Iter e(ptr()->lower, ptr()->upper, Cartesian_end());
       return

--- a/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Iso_box_d.h
@@ -42,15 +42,11 @@ namespace CGAL {
     typedef typename Point::Cartesian_const_iterator  Iterator;
     typedef Cartesian_iterator<Point,Functor>         Self;
 
-
-    typedef typename std::iterator_traits<Iterator>::value_type
-                                                      Coordinate_type;
-
-    typedef decltype(
-        std::declval<Functor>()(std::declval<Coordinate_type>(),
-                                std::declval<Coordinate_type>())) value_type;
-    typedef value_type&                    reference;
-    typedef value_type*                    pointer;
+    typedef decltype(std::declval<Functor>()(
+        *std::declval<Iterator>(),
+        *std::declval<Iterator>()))        value_type;
+    typedef value_type                     reference;
+    typedef const value_type*              pointer;
     typedef std::ptrdiff_t                 difference_type;
     typedef std::input_iterator_tag        iterator_category;
 
@@ -96,7 +92,7 @@ namespace CGAL {
       return tmp;
     }
 
-    value_type operator*()  const { return f(*pb, *qb); }
+    reference  operator*()  const { return f(*pb, *qb); }
     pointer    operator->() const { return &(**this); }
 
     const Functor& functor() const { return f; }


### PR DESCRIPTION
Fix for the [`Kernel_d`](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-I-52/Kernel_d/TestReport_Blake_Windows_MSVCPreview-Release-64bits.gz)  testsuite with `/c++-latest` for VC++.

## Summary of Changes

Add the trivial functions in the namespace `CGAL::Kernel_d`.

## Release Management

* Affected package(s): Kernel_d


