### PR TITLE
PMP:: Use operator<  instead of operator> as OM only implements the former

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -19,6 +19,7 @@
 \example Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
 \example Polygon_mesh_processing/corefinement_difference_remeshed.cpp
 \example Polygon_mesh_processing/corefinement_mesh_union.cpp
+\example Polygon_mesh_processing/corefinement_OM_union.cpp
 \example Polygon_mesh_processing/corefinement_mesh_union_and_intersection.cpp
 \example Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
 \example Polygon_mesh_processing/detect_features_example.cpp

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -95,6 +95,10 @@ if(OpenMesh_FOUND)
   target_link_libraries(compute_normals_example_OM
                         PRIVATE ${OPENMESH_LIBRARIES})
 
+  create_single_source_cgal_program("corefinement_OM_union.cpp")
+  target_link_libraries(corefinement_OM_union
+                        PRIVATE ${OPENMESH_LIBRARIES})
+
   if(TARGET CGAL::Eigen3_support)
     create_single_source_cgal_program("hole_filling_example_OM.cpp")
     target_link_libraries(hole_filling_example_OM PRIVATE CGAL::Eigen3_support

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_OM_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_OM_union.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <OpenMesh/Core/IO/MeshIO.hh>
 #include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
 
@@ -9,9 +10,57 @@
 #include <fstream>
 #include <iostream>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel     K;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel   K; // default kernel for OpenMesh point type
+typedef CGAL::Exact_predicates_exact_constructions_kernel     EK; // alternatice kernel we want to use
 typedef OpenMesh::PolyMesh_ArrayKernelT< >                    Mesh;
 
+
+typedef boost::property_map<Mesh, CGAL::dynamic_vertex_property_t<EK::Point_3> >::type Exact_point_map;
+
+struct Exact_vertex_point_map
+{
+  // typedef for the property map
+  typedef boost::property_traits<Exact_point_map>::value_type value_type;
+  typedef boost::property_traits<Exact_point_map>::reference reference;
+  typedef boost::property_traits<Exact_point_map>::category category;
+  typedef boost::property_traits<Exact_point_map>::key_type key_type;
+
+  // exterior references
+  Exact_point_map exact_point_map;
+  Mesh* tm_ptr;
+
+  // Converters
+  CGAL::Cartesian_converter<K, EK> to_exact;
+  CGAL::Cartesian_converter<EK, K> to_input;
+
+  Exact_vertex_point_map()
+    : tm_ptr(nullptr)
+  {}
+
+  Exact_vertex_point_map(const Exact_point_map& ep, Mesh& tm)
+    : exact_point_map(ep)
+    , tm_ptr(&tm)
+  {
+    for (key_type v : vertices(tm))
+      put(exact_point_map, v, to_exact(get(boost::vertex_point, tm, v)));
+  }
+
+  friend
+  reference get(const Exact_vertex_point_map& map, key_type k)
+  {
+    CGAL_precondition(map.tm_ptr!=nullptr);
+    return get(map.exact_point_map, k);
+  }
+
+  friend
+  void put(const Exact_vertex_point_map& map, key_type k, const EK::Point_3& p)
+  {
+    CGAL_precondition(map.tm_ptr!=nullptr);
+    put(map.exact_point_map, k, p);
+    // create the input point from the exact one
+    put(boost::vertex_point, *map.tm_ptr, k, map.to_input(p));
+  }
+};
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -26,7 +75,21 @@ int main(int argc, char* argv[])
   OpenMesh::IO::read_mesh(mesh2, filename2);
 
   Mesh out;
-  bool valid_union = PMP::corefine_and_compute_union(mesh1,mesh2, out);
+
+  // Create exact map properties
+  Exact_point_map pm_1  = get(CGAL::dynamic_vertex_property_t<EK::Point_3>(), mesh1);
+  Exact_point_map pm_2  = get(CGAL::dynamic_vertex_property_t<EK::Point_3>(), mesh2);
+  Exact_point_map pm_out  = get(CGAL::dynamic_vertex_property_t<EK::Point_3>(), out);
+
+  // Create exact vertex point map that will provide the point to another kernel and fill the default map
+  Exact_vertex_point_map vpm_1(pm_1, mesh1);
+  Exact_vertex_point_map vpm_2(pm_2, mesh2);
+  Exact_vertex_point_map vpm_out(pm_out, out);
+
+  bool valid_union = PMP::corefine_and_compute_union(mesh1, mesh2, out,
+    CGAL::parameters::vertex_point_map(vpm_1),
+    CGAL::parameters::vertex_point_map(vpm_2),
+    CGAL::parameters::vertex_point_map(vpm_out));
 
   if (valid_union)
   {

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_OM_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_OM_union.cpp
@@ -1,0 +1,39 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <OpenMesh/Core/IO/MeshIO.hh>
+#include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
+
+#include <CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h>
+
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+
+#include <fstream>
+#include <iostream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel     K;
+typedef OpenMesh::PolyMesh_ArrayKernelT< >                    Mesh;
+
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+int main(int argc, char* argv[])
+{
+  const char* filename1 = (argc > 1) ? argv[1] : "data/blobby.off";
+  const char* filename2 = (argc > 2) ? argv[2] : "data/eight.off";
+
+  Mesh mesh1, mesh2;
+
+  OpenMesh::IO::read_mesh(mesh1, filename1);
+  OpenMesh::IO::read_mesh(mesh2, filename2);
+
+  Mesh out;
+  bool valid_union = PMP::corefine_and_compute_union(mesh1,mesh2, out);
+
+  if (valid_union)
+  {
+    std::cout << "Union was successfully computed\n";
+    OpenMesh::IO::write_mesh(out, "union.off");
+    return 0;
+  }
+  std::cout << "Union could not be computed\n";
+  return 1;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp
@@ -11,7 +11,6 @@ typedef CGAL::Exact_predicates_exact_constructions_kernel EK;
 typedef CGAL::Surface_mesh<K::Point_3> Mesh;
 typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
 typedef Mesh::Property_map<vertex_descriptor,EK::Point_3> Exact_point_map;
-typedef Mesh::Property_map<vertex_descriptor,bool> Exact_point_computed;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 namespace params = PMP::parameters;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -325,7 +325,7 @@ class Intersection_of_triangle_meshes
       case ON_EDGE  :
       {
         h1=opposite(ipt.info_1,tm1);
-        if (h1>ipt.info_1) h1=ipt.info_1;
+        if (ipt.info_1 < h1) h1=ipt.info_1;
       }
       break;
       case ON_FACE :
@@ -340,7 +340,7 @@ class Intersection_of_triangle_meshes
       case ON_EDGE  :
       {
         h2=opposite(ipt.info_2,tm2);
-        if (h2>ipt.info_2) h2=ipt.info_2;
+        if (ipt.info_2 < h2) h2=ipt.info_2;
       }
       break;
       case ON_FACE :
@@ -350,7 +350,7 @@ class Intersection_of_triangle_meshes
     }
 
     Key key(ipt.type_1, ipt.type_2, h1, h2);
-    if (&tm1==&tm2 && h1>h2)
+    if (&tm1==&tm2 && h2<h1)
       key=Key(ipt.type_2, ipt.type_1, h2, h1);
 
     std::pair<typename std::map<Key,Node_id>::iterator,bool> res=

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -53,8 +53,8 @@ namespace internal{
     {}
 
     typedef bool result_type;
-    template <class vertex_descriptor>
-    bool operator()(vertex_descriptor v1, vertex_descriptor v2) const
+    template <class vertex_descriptor1, class vertex_descriptor2>
+    bool operator()(vertex_descriptor1 v1, vertex_descriptor2 v2) const
     {
       return CGAL::SMALLER == compare_z(get(vpmap, v1), get(vpmap, v2));
     }

--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -43,7 +43,10 @@ public:
   }
 
   bool
-  operator!=(const OMesh_edge& other) { return !(*this == other); }
+  operator!=(const OMesh_edge& other) const
+  {
+    return !(*this == other);
+  }
 
   Halfedge_handle
   opposite() const { return Halfedge_handle((halfedge_.idx() & 1) ? halfedge_.idx()-1 : halfedge_.idx()+1); }


### PR DESCRIPTION
## Summary of Changes

Change the comparison operator for descriptors in the corefinement code so that it works with OpenMesh.

## Release Management

* Affected package(s): PMP


