### PR TITLE
[PSP/RANSAC] Fix warnings

### DIFF
--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -212,8 +212,8 @@ update_new_point(
 
     for (unsigned int j = 0; j < candidate_num; j++)
     {
-      FT psi = std::exp(-std::pow(1 - normal_cadidate[j] * t.normal, 2)
-                       / sharpness_bandwidth);
+      FT psi = std::exp(-std::pow(FT(1) - normal_cadidate[j] * t.normal, FT(2))
+                            / sharpness_bandwidth);
       FT project_diff_t_v = (t.pt - new_v.pt) * t.normal;
       FT weight = psi * theta;
 
@@ -435,7 +435,8 @@ edge_aware_upsample_point_set(
                                                       FT(neighbor_radius));
 
   //
-  FT cos_sigma = static_cast<FT>(std::cos(CGAL::to_double(sharpness_angle) / 180.0 * CGAL_PI));
+  FT cos_sigma = static_cast<FT>(std::cos(FT(CGAL::to_double(sharpness_angle))
+                                          / FT(180) * FT(CGAL_PI)));
   FT sharpness_bandwidth = std::pow((CGAL::max)((FT)1e-8, (FT)1.0 - cos_sigma), 2);
 
   FT sum_density = 0.0;

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -1030,8 +1030,10 @@ namespace CGAL {
     }
 
     inline FT stop_probability(std::size_t largest_candidate, std::size_t num_pts, std::size_t num_candidates, std::size_t octree_depth) const {
-      return (std::min<FT>)(std::pow((FT) 1.f - (FT) largest_candidate
-                                     / (FT(num_pts) * (octree_depth+1) * (1 << (m_required_samples - 1))), (int) num_candidates), (FT) 1);
+      return (std::min<FT>)(std::pow(FT(1) - FT(largest_candidate)
+                                     / (FT(num_pts) * FT(octree_depth+1)
+                                        * FT(1 << (m_required_samples - 1))),
+                                     int(num_candidates)), FT(1));
     }
 
   private:


### PR DESCRIPTION
## Summary of Changes

Fix 3 conversion warnings when using float kernel:
- [1 in RANSAC](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-55/Shape_detection/TestReport_Blake_Windows_MSVCPreview-Release-64bits.gz)
- [2 in PSP](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-55/Point_set_processing_3/TestReport_Blake_Windows_MSVCPreview-Release-64bits.gz)

## Release Management

* Affected package(s): Shape Detection / PSP
* Based on 5.2 as the RANSAC warning was probably introduced by https://github.com/CGAL/cgal/pull/5234

