### PR TITLE
Scripts - collect dlls for Polyhedron demo with cygwin

### DIFF
--- a/Maintenance/public_release/scripts/precompiled_demos_zips
+++ b/Maintenance/public_release/scripts/precompiled_demos_zips
@@ -11,41 +11,41 @@ rm -rf Interpolation_Demo
 rm -rf Triangulation_3_Geomview_demos_Demo
 
 # CGAL<=3.7
-pushd AABB_tree_Demo;                   zip ../AABB_demo.zip          *    ;      popd
-pushd Alpha_shapes_3_Demo;              zip ../alpha_shape_3.zip      *    ;      popd
-pushd Bounding_volumes_Demo;            zip ../bounding_volumes_2.zip *    ;      popd
-pushd Circular_kernel_2_Demo;           zip ../circular_kernel.zip    *    ;      popd
-pushd Periodic_3_triangulation_3_Demo;  zip ../periodic_3_triangulation_3.zip *;  popd
-pushd Periodic_Lloyd_3_Demo;            zip ../periodic_3_lloyd.zip *;            popd
-pushd Polyhedron_Demo;                  zip -r ../polyhedron_3.zip *       ;      popd
-pushd Segment_Delaunay_graph_2_Demo;    zip ../segment_voronoi_diagram_2.zip *;   popd
-pushd Surface_mesher_Demo;              zip ../surface_mesher.zip *;              popd
-pushd Triangulation_2_Demo;
-  zip ../regular_triangulation_2.zip Regular_triangulation_2.exe
-  zip ../constrained_delaunay_triangulation_2.zip Constrained_Delaunay_triangulation_2.exe
-  zip ../delaunay_triangulation_2.zip Delaunay_triangulation_2.exe
+pushd AABB_tree_Demo_with_dlls;                   zip ../AABB_demo.zip          *    ;      popd
+pushd Alpha_shapes_3_Demo_with_dlls;              zip ../alpha_shape_3.zip      *    ;      popd
+pushd Bounding_volumes_Demo_with_dlls;            zip ../bounding_volumes_2.zip *    ;      popd
+pushd Circular_kernel_2_Demo_with_dlls;           zip ../circular_kernel.zip    *    ;      popd
+pushd Periodic_3_triangulation_3_Demo_with_dlls;  zip ../periodic_3_triangulation_3.zip *;  popd
+pushd Periodic_Lloyd_3_Demo_with_dlls;            zip ../periodic_3_lloyd.zip *;            popd
+pushd Polyhedron_Demo_with_dlls;                  zip -r ../polyhedron_3.zip *       ;      popd
+pushd Segment_Delaunay_graph_2_Demo_with_dlls;    zip ../segment_voronoi_diagram_2.zip *;   popd
+pushd Surface_mesher_Demo_with_dlls;              zip ../surface_mesher.zip *;              popd
+pushd Triangulation_2_Demo_with_dlls;
+  zip ../regular_triangulation_2.zip Regular_triangulation_2.exe *.dll platforms;
+  zip ../constrained_delaunay_triangulation_2.zip Constrained_Delaunay_triangulation_2.exe *.dll platforms;
+  zip ../delaunay_triangulation_2.zip Delaunay_triangulation_2.exe *.dll platforms;
 popd
 
 # CGAL-3.8
-pushd Largest_empty_rect_2_Demo;        zip ../largest_empty_rect_2.zip *;           popd
-pushd Apollonius_graph_2_Demo;          zip ../apollonius_graph_2.zip *;             popd
-pushd Stream_lines_2_Demo;              zip ../streamlines.zip *;                    popd
-pushd Triangulation_3_Demo;             zip ../triangulation_3.zip *;                popd
-#pushd Circular_kernel_3_Demo;           zip ../triangulation_3.zip *;                popd
-pushd Alpha_shapes_2_Demo;              zip ../alpha_shapes_2.zip *;                 popd
-pushd Generator_Demo;                   zip ../generator.zip *;                      popd
-pushd L1_Voronoi_diagram_2_Demo;        zip ../l1_voronoi_diagram_2.zip *;           popd
-pushd Snap_rounding_2_Demo;             zip ../snap_rounding_2.zip *;                popd
-pushd Spatial_searching_2_Demo;         zip ../spatial_searching.zip *;              popd
+pushd Largest_empty_rect_2_Demo_with_dlls;        zip ../largest_empty_rect_2.zip *;           popd
+pushd Apollonius_graph_2_Demo_with_dlls;          zip ../apollonius_graph_2.zip *;             popd
+pushd Stream_lines_2_Demo_with_dlls;              zip ../streamlines.zip *;                    popd
+pushd Triangulation_3_Demo_with_dlls;             zip ../triangulation_3.zip *;                popd
+#pushd Circular_kernel_3_Demo_with_dlls;           zip ../triangulation_3.zip *;                popd
+pushd Alpha_shapes_2_Demo_with_dlls;              zip ../alpha_shapes_2.zip *;                 popd
+pushd Generator_Demo_with_dlls;                   zip ../generator.zip *;                      popd
+pushd L1_Voronoi_diagram_2_Demo_with_dlls;        zip ../l1_voronoi_diagram_2.zip *;           popd
+pushd Snap_rounding_2_Demo_with_dlls;             zip ../snap_rounding_2.zip *;                popd
+pushd Spatial_searching_2_Demo_with_dlls;         zip ../spatial_searching.zip *;              popd
 
 # CGAL-4.0
-pushd Linear_cell_complex_Demo;         zip ../linear_cell_complex_3.zip *;          popd
+pushd Linear_cell_complex_Demo_with_dlls;         zip ../linear_cell_complex_3.zip *;          popd
 
 # CGAL-4.2 but was forgot -> published with 4.3
-pushd Arrangement_on_surface_2_Demo;    zip ../arrangements_2.zip *;                 popd
+pushd Arrangement_on_surface_2_Demo_with_dlls;    zip ../arrangements_2.zip *;                 popd
 
 # CGAL-4.5
-pushd Periodic_2_triangulation_2_Demo;  zip ../Periodic_2_Delaunay_triangulation_2.zip *;
+pushd Periodic_2_triangulation_2_Demo_with_dlls;  zip ../Periodic_2_Delaunay_triangulation_2.zip *;
                                                                                      popd
 # probably an error, in CGAL-4.5:
 rm -rf Surface_mesh_deformation_Demo
@@ -54,18 +54,18 @@ rm -rf Surface_mesh_deformation_Demo
 rm -rf Circular_kernel_3_Demo
 
 # CGAL-4.6
-pushd Polyline_simplification_2_Demo;   zip ../polyline_simplification_2.zip *;      popd
+pushd Polyline_simplification_2_Demo_with_dlls;   zip ../polyline_simplification_2.zip *;      popd
 
 # CGAL-4.7
-pushd Segment_Delaunay_graph_Linf_2_Demo; zip ../segment_voronoi_diagram_2.zip *;    popd
+pushd Segment_Delaunay_graph_Linf_2_Demo_with_dlls; zip ../segment_voronoi_diagram_2.zip *;    popd
 
 # CGAL-4.8
-pushd Optimal_transportation_reconstruction_2_Demo; zip ../otr2.zip *;               popd
+pushd Optimal_transportation_reconstruction_2_Demo_with_dlls; zip ../otr2.zip *;               popd
 #missing demos
-pushd Polygon_Demo; zip ../polygon.zip *;               popd
-pushd Principal_component_analysis_Demo; zip ../pca.zip *;               popd
-pushd Hyperbolic_triangulation_2_Demo; zip ../Hyperbolic_Delaunay_triangulation_2.zip *;               popd
-pushd Periodic_4_hyperbolic_triangulation_2_Demo; zip ../Periodic_4_hyperbolic_Delaunay_triangulation_2.zip *;               popd
+pushd Polygon_Demo_with_dlls; zip ../polygon.zip *;               popd
+pushd Principal_component_analysis_Demo_with_dlls; zip ../pca.zip *;               popd
+pushd Hyperbolic_triangulation_2_Demo_with_dlls; zip ../Hyperbolic_Delaunay_triangulation_2.zip *;               popd
+pushd Periodic_4_hyperbolic_triangulation_2_Demo_with_dlls; zip ../Periodic_4_hyperbolic_Delaunay_triangulation_2.zip *;               popd
 
 # check
 echo CHECK now. The following lines should be empty.

--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -624,9 +624,9 @@ if [ -f '${LIST_TEST_PACKAGES}' ]; then
 
   mkdir '${CGAL_BINARY_DIR}/test'
 
-  cp '${CGAL_TEST_DIR}/collect_cgal_testresults_from_cmake'  '${CGAL_BINARY_DIR}/test'
-  cp '${CGAL_TEST_DIR}/makefile2'                            '${CGAL_BINARY_DIR}/test'
-  cp '${CGAL_TEST_DIR}/run_testsuite_with_cmake'             '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/collect_cgal_testresults_from_cmake' '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/makefile2'                           '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/run_testsuite_with_cmake'            '${CGAL_BINARY_DIR}/test'
 
   for PACKAGE in \`source '${LIST_TEST_PACKAGES}' '${CGAL_ROOT}'\`; do
 
@@ -649,39 +649,27 @@ else
 fi
 nice ${NICE_OPTIONS} make ${MAKE_OPTS} -k -fmakefile2;
 EOF
-for file in "${CGAL_BINARY_DIR}/localtestscript" "${CGAL_BINARY_DIR}/localtestscript-redo-results-collection"; do
-     cat >> "$file" <<EOF
+    for file in "${CGAL_BINARY_DIR}/localtestscript" "${CGAL_BINARY_DIR}/localtestscript-redo-results-collection"; do
+      cat >> "$file" <<EOF
 echo 'COLLECTING RESULTS';
 ./collect_cgal_testresults_from_cmake;
 if [ -n "\$COLLECT_DEMOS_BINARIES" ]; then
- echo 'COLLECTING DEMOS BINARIES';
- echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test"
- cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test"
+  echo 'COLLECTING DEMOS BINARIES';
+  echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test"
+  cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test"
 EOF
- cat >> "$file" <<'EOF'
- for demo_dir in *_Demo; do
-   echo "pushd ${demo_dir}"
-   pushd "${demo_dir}"
-   bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls"
-   mv "${demo_dir}_with_dlls" ..
-   popd
- done
+  cat >> "$file" <<'EOF'
+  for demo_dir in *_Demo; do
+    echo "pushd ${demo_dir}"
+    pushd "${demo_dir}"
+    bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls"
+    mv "${demo_dir}_with_dlls" ..
+    popd
+  done
 EOF
 cat >> "$file" <<EOF
- tar czvf "${CGAL_TEST_DIR}/demos_${CGAL_TESTER}_${PLATFORM}.tar.gz" *_Demo_with_dlls/*
+  tar czvf "${CGAL_TEST_DIR}/demos_${CGAL_TESTER}_${PLATFORM}.tar.gz" *_Demo_with_dlls/*
 fi
-echo 'COPYING RESULTS';
-cp "results_${CGAL_TESTER}_${PLATFORM}.tar.gz" "results_${CGAL_TESTER}_${PLATFORM}.txt" "${CGAL_TEST_DIR}";
-cd ..;
-EOF
-   done
-   if [ -z "${KEEP_TESTS}" ]; then
-     cat >> "${CGAL_BINARY_DIR}/localtestscript" <<EOF
-echo 'REMOVING LOCAL_TEST_DIR';
-rm -rf '${CGAL_BINARY_DIR}/test'
-EOF
-fi
-
 echo 'COPYING RESULTS';
 cp 'results_${CGAL_TESTER}_${PLATFORM}.tar.gz' 'results_${CGAL_TESTER}_${PLATFORM}.txt' '${CGAL_TEST_DIR}';
 cd ..;

--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -655,8 +655,8 @@ echo 'COLLECTING RESULTS';
 ./collect_cgal_testresults_from_cmake;
 if [ -n "\$COLLECT_DEMOS_BINARIES" ]; then
   echo 'COLLECTING DEMOS BINARIES';
-  echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test"
-  cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test"
+  echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test \"\""
+  cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test \"\""
 EOF
   cat >> "$file" <<'EOF'
   for demo_dir in *_Demo; do

--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -624,9 +624,9 @@ if [ -f '${LIST_TEST_PACKAGES}' ]; then
 
   mkdir '${CGAL_BINARY_DIR}/test'
 
-  cp '${CGAL_TEST_DIR}/collect_cgal_testresults_from_cmake' '${CGAL_BINARY_DIR}/test'
-  cp '${CGAL_TEST_DIR}/makefile2'                           '${CGAL_BINARY_DIR}/test'
-  cp '${CGAL_TEST_DIR}/run_testsuite_with_cmake'            '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/collect_cgal_testresults_from_cmake'  '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/makefile2'                            '${CGAL_BINARY_DIR}/test'
+  cp '${CGAL_TEST_DIR}/run_testsuite_with_cmake'             '${CGAL_BINARY_DIR}/test'
 
   for PACKAGE in \`source '${LIST_TEST_PACKAGES}' '${CGAL_ROOT}'\`; do
 
@@ -649,14 +649,39 @@ else
 fi
 nice ${NICE_OPTIONS} make ${MAKE_OPTS} -k -fmakefile2;
 EOF
-    for file in "${CGAL_BINARY_DIR}/localtestscript" "${CGAL_BINARY_DIR}/localtestscript-redo-results-collection"; do
-      cat >> "$file" <<EOF
+for file in "${CGAL_BINARY_DIR}/localtestscript" "${CGAL_BINARY_DIR}/localtestscript-redo-results-collection"; do
+     cat >> "$file" <<EOF
 echo 'COLLECTING RESULTS';
 ./collect_cgal_testresults_from_cmake;
 if [ -n "\$COLLECT_DEMOS_BINARIES" ]; then
-  echo 'COLLECTING DEMOS BINARIES';
-  tar czvf '${CGAL_TEST_DIR}/demos_${CGAL_TESTER}_${PLATFORM}.tar.gz' *_Demo/*.exe *_Demo/*.dll *_Demo/*/*.dll *_Demo/*/*/*.dll
+ echo 'COLLECTING DEMOS BINARIES';
+ echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test"
+ cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test"
+EOF
+ cat >> "$file" <<'EOF'
+ for demo_dir in *_Demo; do
+   echo "pushd ${demo_dir}"
+   pushd "${demo_dir}"
+   bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls"
+   mv "${demo_dir}_with_dlls" ..
+   popd
+ done
+EOF
+cat >> "$file" <<EOF
+ tar czvf "${CGAL_TEST_DIR}/demos_${CGAL_TESTER}_${PLATFORM}.tar.gz" *_Demo_with_dlls/*
 fi
+echo 'COPYING RESULTS';
+cp "results_${CGAL_TESTER}_${PLATFORM}.tar.gz" "results_${CGAL_TESTER}_${PLATFORM}.txt" "${CGAL_TEST_DIR}";
+cd ..;
+EOF
+   done
+   if [ -z "${KEEP_TESTS}" ]; then
+     cat >> "${CGAL_BINARY_DIR}/localtestscript" <<EOF
+echo 'REMOVING LOCAL_TEST_DIR';
+rm -rf '${CGAL_BINARY_DIR}/test'
+EOF
+fi
+
 echo 'COPYING RESULTS';
 cp 'results_${CGAL_TESTER}_${PLATFORM}.tar.gz' 'results_${CGAL_TESTER}_${PLATFORM}.txt' '${CGAL_TEST_DIR}';
 cd ..;

--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -662,7 +662,7 @@ EOF
   for demo_dir in *_Demo; do
     echo "pushd ${demo_dir}"
     pushd "${demo_dir}"
-    bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls \"\""
+    bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls" ""
     mv "${demo_dir}_with_dlls" ..
     popd
   done

--- a/Scripts/developer_scripts/autotest_cgal
+++ b/Scripts/developer_scripts/autotest_cgal
@@ -655,14 +655,14 @@ echo 'COLLECTING RESULTS';
 ./collect_cgal_testresults_from_cmake;
 if [ -n "\$COLLECT_DEMOS_BINARIES" ]; then
   echo 'COLLECTING DEMOS BINARIES';
-  echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test \"\""
-  cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test \"\""
+  echo "cp ${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh ${CGAL_BINARY_DIR}/test"
+  cp "${CGAL_TEST_DIR}/../developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh" "${CGAL_BINARY_DIR}/test"
 EOF
   cat >> "$file" <<'EOF'
   for demo_dir in *_Demo; do
     echo "pushd ${demo_dir}"
     pushd "${demo_dir}"
-    bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls"
+    bash ../cgal_demo_copy_all_dlls_cygwin.sh "${demo_dir}_with_dlls \"\""
     mv "${demo_dir}_with_dlls" ..
     popd
   done

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #use this script from inside the build directory of the Polyhedron demo
+#Needs the Qt5_DIR env variable set to <Qt5_ROOT>/lib/cmake/Qt5
 
 declare config="Release"
 
@@ -29,9 +30,10 @@ for file in "${files[@]}"; do
 
   # list and copy dependencies
   cygcheck "$file" | while read -r dll ; do
-  
+
     copy_dll "$dll" "$target_directory"
-  
+
   done; #check dependencies
-    
 done #loop over directories
+mkdir -p "$target_directory/platforms"
+cp "$Qt5_DIR/../../../plugins/platforms/qwindows.dll" "$target_directory/platforms"

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -12,9 +12,9 @@ fi
 
 copy_dll()
 {
-  local dll_full_path="`cygpath --unix --absolute $1`"
-  echo "copy " $dll_full_path " to " $2
-  cp $dll_full_path $2
+  local dll_full_path=$(cygpath --unix --absolute "$1")
+  echo "copy $dll_full_path to $2"
+  cp "$dll_full_path" "$2"
 }
 
 
@@ -25,12 +25,12 @@ files+=(Plugins/*/$config/*.dll)
 for file in "${files[@]}"; do
 
   # copy exe or dll
-  copy_dll $file $target_directory
+  copy_dll "$file" "$target_directory"
 
   # list and copy dependencies
-  cygcheck $file | while read -r dll ; do
+  cygcheck "$file" | while read -r dll ; do
   
-    copy_dll $dll $target_directory
+    copy_dll "$dll" "$target_directory"
   
   done; #check dependencies
     

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#use this script from inside the build directory of the Polyhedron demo
+
+declare config="Release"
+
+declare target_directory="CGAL_demo_with_dlls"
+if [[ ! -d "$target_directory" ]]
+then
+  mkdir $target_directory
+fi
+
+copy_dll()
+{
+  local dll_full_path="`cygpath --unix --absolute $1`"
+  echo "copy " $dll_full_path " to " $2
+  cp $dll_full_path $2
+}
+
+
+files=($config/*.exe)
+files+=($config/*.dll)
+files+=(Plugins/*/$config/*.dll)
+
+for file in "${files[@]}"; do
+
+  # copy exe or dll
+  copy_dll $file $target_directory
+
+  # list and copy dependencies
+  cygcheck $file | while read -r dll ; do
+  
+    copy_dll $dll $target_directory
+  
+  done; #check dependencies
+    
+done #loop over directories

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -3,9 +3,13 @@
 #use this script from inside the build directory of the Polyhedron demo
 #Needs the Qt5_DIR env variable set to <Qt5_ROOT>/lib/cmake/Qt5
 
-declare config="Release"
+#No config : in autotest_cgal we use NMake as generator
+#If you are using Visual as Generator, declare config="Release"
 
-declare target_directory="CGAL_demo_with_dlls"
+
+declare config="$PWD"
+declare target_directory="$1"
+
 if [[ ! -d "$target_directory" ]]
 then
   mkdir $target_directory
@@ -34,6 +38,6 @@ for file in "${files[@]}"; do
     copy_dll "$dll" "$target_directory"
 
   done; #check dependencies
+  mkdir -p "$target_directory/platforms"
+  cp "$Qt5_DIR/../../../plugins/platforms/qwindows.dll" "$target_directory/platforms"
 done #loop over directories
-mkdir -p "$target_directory/platforms"
-cp "$Qt5_DIR/../../../plugins/platforms/qwindows.dll" "$target_directory/platforms"

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -20,7 +20,7 @@ copy_dll()
   local dll_full_path=$(cygpath --unix --absolute "$1")
   echo "copy $dll_full_path to $2"
   #remove all dlls from system and Visual
-  if ! [[ "$dll_full_path" =~ "Visual" ]] && ! [[ "$dll_full_path" =~ "system32" ]]; then
+  if ! [[ "$dll_full_path" =~ "api-ms-win" ]] && ! [[ "$dll_full_path" =~ "system32" ]]; then
     cp "$dll_full_path" "$2"
   fi
 }

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -7,7 +7,7 @@
 #If using MSVC Generator, declare config="Release"
 
 
-declare config=""
+declare config="$2"
 declare target_directory="$1"
 
 if [[ ! -d "$target_directory" ]]

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -19,7 +19,10 @@ copy_dll()
 {
   local dll_full_path=$(cygpath --unix --absolute "$1")
   echo "copy $dll_full_path to $2"
-  cp "$dll_full_path" "$2"
+  #remove all dlls from system and Visual
+  if ! [[ "$dll_full_path" =~ "Visual" ]] && ! [[ "$dll_full_path" =~ "system32" ]]; then
+    cp "$dll_full_path" "$2"
+  fi
 }
 
 

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -4,10 +4,10 @@
 #Needs the Qt5_DIR env variable set to <Qt5_ROOT>/lib/cmake/Qt5
 
 #No config : in autotest_cgal we use NMake as generator
-#If you are using Visual as Generator, declare config="Release"
+#If using MSVC Generator, declare config="Release"
 
 
-declare config="$PWD"
+declare config=""
 declare target_directory="$1"
 
 if [[ ! -d "$target_directory" ]]
@@ -23,9 +23,9 @@ copy_dll()
 }
 
 
-files=($config/*.exe)
-files+=($config/*.dll)
-files+=(Plugins/*/$config/*.dll)
+files=($PWD/$config/*.exe)
+files+=($PWD/$config/*.dll)
+files+=($PWD/Plugins/*/$config/*.dll)
 
 for file in "${files[@]}"; do
 
@@ -38,6 +38,6 @@ for file in "${files[@]}"; do
     copy_dll "$dll" "$target_directory"
 
   done; #check dependencies
-  mkdir -p "$target_directory/platforms"
-  cp "$Qt5_DIR/../../../plugins/platforms/qwindows.dll" "$target_directory/platforms"
 done #loop over directories
+mkdir -p "$target_directory/platforms"
+cp "$Qt5_DIR/../../../plugins/platforms/qwindows.dll" "$target_directory/platforms"


### PR DESCRIPTION
## Summary of Changes

This PR introduces a new bash script for cygwin that collects all needed `.exe` and `.dll` to run the Polyhedron demo and its plugins.
It should be run from inside the demo build directory.
Maybe we should make it more general so that it can be used directly in the release creation process @lrineau @maxGimeno ?

## Release Management

* Affected package(s): Scripts

## TODO
- [x] Once the archive is OK, chancge the scripts for the doc that make the links to the demo