### PR TITLE
Calculate indices only when required.

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -275,7 +275,6 @@ where |M| is a sphere map and |F| is a sface.}*/
 
 private:
 std::string get_svertex_index(SVertex_const_handle) const;
-std::string get_shalfedge_index(SHalfedge_const_handle e) const;
 
 }; // SM_const_decorator
 
@@ -291,20 +290,14 @@ get_svertex_index(SVertex_const_handle v) const
 }
 
 template <typename SM_>
-std::string SM_const_decorator<SM_>::
-get_shalfedge_index(SHalfedge_const_handle e) const
-{
-  Object_index<SHalfedge_const_handle>
-    EI(shalfedges_begin(),shalfedges_end(),'e');
-  return EI(e);
-}
-
-template <typename SM_>
 void SM_const_decorator<SM_>::
 check_integrity_and_topological_planarity(bool faces) const
 {
   CGAL_NEF_TRACEN("check_integrity_and_topological_planarity:");
-
+#ifdef CGAL_USE_TRACE
+  Object_index<SHalfedge_const_iterator>
+    EI(shalfedges_begin(),shalfedges_end(),'e');
+#endif
   SVertex_const_handle v;
   int iso_vert_num=0;
   /* check the source links of out edges and count isolated vertices */
@@ -316,7 +309,7 @@ check_integrity_and_topological_planarity(bool faces) const
     } else {
       CGAL_assertion_code(SHalfedge_const_handle e=first_out_edge(v));
       CGAL_assertion_msg(e != SHalfedge_const_handle(), get_svertex_index(v).c_str());
-      CGAL_NEF_TRACEN(v->point()<<" "<<get_shalfedge_index(e));
+      CGAL_NEF_TRACEN(v->point()<<" "<<EI[first_out_edge(v)]);
       CGAL_assertion_msg(e->source() == v, get_svertex_index(v).c_str());
     }
   }

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -273,36 +273,51 @@ The macros are then |CGAL_forall_svertices(v,M)|,
 |CGAL_forall_sfaces(f,M)|, |CGAL_forall_sface_cycles_of(fc,F)|
 where |M| is a sphere map and |F| is a sface.}*/
 
+private:
+std::string get_svertex_index(SVertex_const_handle) const;
+std::string get_shalfedge_index(SHalfedge_const_handle e) const;
+
 }; // SM_const_decorator
 
 
+
+template <typename SM_>
+std::string SM_const_decorator<SM_>::
+get_svertex_index(SVertex_const_handle v) const
+{
+  Object_index<SVertex_const_handle>
+    VI(svertices_begin(),svertices_end(),'v');
+  return VI(v);
+}
+
+template <typename SM_>
+std::string SM_const_decorator<SM_>::
+get_shalfedge_index(SHalfedge_const_handle e) const
+{
+  Object_index<SHalfedge_const_handle>
+    EI(shalfedges_begin(),shalfedges_end(),'e');
+  return EI(e);
+}
 
 template <typename SM_>
 void SM_const_decorator<SM_>::
 check_integrity_and_topological_planarity(bool faces) const
 {
   CGAL_NEF_TRACEN("check_integrity_and_topological_planarity:");
-  using CGAL::Object_index;
-  Object_index<SVertex_const_iterator>
-    VI(svertices_begin(),svertices_end(),'v');
-  Object_index<SHalfedge_const_iterator>
-    EI(shalfedges_begin(),shalfedges_end(),'e');
-  Object_index<SFace_const_iterator>
-    FI(sfaces_begin(),sfaces_end(),'f');
+
   SVertex_const_handle v;
   int iso_vert_num=0;
   /* check the source links of out edges and count isolated vertices */
   CGAL_forall_svertices(v,*this) {
     if ( is_isolated(v) ) {
       if ( faces )
-        CGAL_assertion_msg(v->incident_sface() != SFace_const_handle(), VI(v).c_str());
+        CGAL_assertion_msg(v->incident_sface() != SFace_const_handle(), get_svertex_index(v).c_str());
       ++iso_vert_num;
     } else {
-      CGAL_assertion_msg(first_out_edge(v) != SHalfedge_const_handle(),
-      VI(v).c_str());
-      CGAL_NEF_TRACEN(v->point()<<" "<<EI(first_out_edge(v)));
-      CGAL_assertion_msg(first_out_edge(v)->source() == v,
-                         VI(v).c_str());
+      CGAL_assertion_code(SHalfedge_const_handle e=first_out_edge(v));
+      CGAL_assertion_msg(e != SHalfedge_const_handle(), get_svertex_index(v).c_str());
+      CGAL_NEF_TRACEN(v->point()<<" "<<get_shalfedge_index(e));
+      CGAL_assertion_msg(e->source() == v, get_svertex_index(v).c_str());
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

Calculate Object_index hash tables as needed i.e when the assertion fails, or when trace message is built.

## Release Management

* Affected package(s): Nef_3, Nef_S2
* Issue(s) solved (if any): fix #5379
* Feature/Small Feature (if any): performance/speed
* License and copyright ownership: Returned to CGAL authors.

