### PR TITLE
Remove CMAKE_CXX_STANDARD commands in cmake scripts

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
@@ -3,9 +3,6 @@
 cmake_minimum_required(VERSION 3.1...3.15)
 project(Arrangement_on_surface_2_Demo)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.
   cmake_policy(SET CMP0053 OLD)

--- a/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
@@ -11,10 +11,6 @@ project(Minkowski_sum_2_Tests)
 #   return()
 # endif()
 
-# # Use C++11 for this directory and its sub-directories.
-# set(CMAKE_CXX_STANDARD 11)
-# set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-
 find_package(CGAL REQUIRED COMPONENTS Core)
 
 include(${CGAL_USE_FILE})

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -16,10 +16,6 @@ if(has_cpp11 LESS 0)
   return()
 endif()
 
-# Use C++11 for this directory and its sub-directories.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-
 #Defines flags to emulate windows behavior for linking error generation
 if(CMAKE_CXX_COMPILER_ID EQUAL Clang
    OR CMAKE_COMPILER_IS_GNUCC

--- a/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
@@ -13,9 +13,6 @@ if(has_cpp11 LESS 0)
   return()
 endif()
 
-# Use C++11 for this directory and its sub-directories.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 find_package(CGAL REQUIRED)
 

--- a/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
@@ -20,9 +20,6 @@ if(has_cpp11 LESS 0)
   return()
 endif()
 
-# Use C++11 for this directory and its sub-directories.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 find_package(CGAL REQUIRED)
 

--- a/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
@@ -4,8 +4,6 @@
 cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Benchmarks)
 
-set(CMAKE_CXX_STANDARD 11)
-
 find_package(CGAL REQUIRED COMPONENTS Core)
 
 include(${CGAL_USE_FILE})

--- a/Shape_detection/examples/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/examples/Shape_detection/CMakeLists.txt
@@ -4,8 +4,6 @@
 cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Examples)
 
-set(CMAKE_CXX_STANDARD 11)
-
 find_package(CGAL REQUIRED COMPONENTS Core)
 
 include(${CGAL_USE_FILE})

--- a/Shape_detection/test/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/test/Shape_detection/CMakeLists.txt
@@ -4,8 +4,6 @@
 cmake_minimum_required(VERSION 3.1...3.15)
 project(Shape_detection_Tests)
 
-set(CMAKE_CXX_STANDARD 11)
-
 find_package(CGAL REQUIRED COMPONENTS Core)
 
 include(${CGAL_USE_FILE})


### PR DESCRIPTION
## Summary of Changes
CGAL now requires c++14, so the CMAKE_CXX_STANDARD instructions in our CMake scripts have become useless. 
This PR removes them.

## Release Management


* Issue(s) solved (if any): fix #5311
