### PR TITLE
[Poisson Reconstruction] Compatibility with Simple Cartesian

### DIFF
--- a/Number_types/include/CGAL/NT_converter.h
+++ b/Number_types/include/CGAL/NT_converter.h
@@ -61,12 +61,34 @@ struct NT_converter < NT1, double >
     }
 };
 
+template < class NT1 >
+struct NT_converter < NT1, float >
+  : public CGAL::cpp98::unary_function< NT1, float >
+{
+    float
+    operator()(const NT1 &a) const
+    {
+        return static_cast<float>(to_double(a));
+    }
+};
+
 template <>
 struct NT_converter < double, double >
   : public CGAL::cpp98::unary_function< double, double >
 {
     const double &
     operator()(const double &a) const
+    {
+        return a;
+    }
+};
+
+template <>
+struct NT_converter < float, float >
+  : public CGAL::cpp98::unary_function< float, float >
+{
+    const float &
+    operator()(const float &a) const
     {
         return a;
     }

--- a/Point_set_processing_3/include/CGAL/compute_average_spacing.h
+++ b/Point_set_processing_3/include/CGAL/compute_average_spacing.h
@@ -81,7 +81,7 @@ compute_average_spacing(const typename NeighborQuery::Kernel::Point_3& query, //
      boost::make_function_output_iterator
      ([&](const Point& p)
       {
-        sum_distances += std::sqrt(CGAL::squared_distance (query,p));
+        sum_distances += CGAL::approximate_sqrt(CGAL::squared_distance (query,p));
         ++ i;
       }));
 

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_mesh_cell_criteria_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_mesh_cell_criteria_3.h
@@ -27,15 +27,16 @@ namespace Poisson {
 
 template <class Tr>
 class Constant_sizing_field {
-  double sq_radius_bound;
+  typedef typename Tr::FT FT;
+  FT sq_radius_bound;
 public:
-  double cell_radius_bound() const { return CGAL::sqrt(sq_radius_bound); }
+  FT cell_radius_bound() const { return CGAL::approximate_sqrt(sq_radius_bound); }
 
-  Constant_sizing_field(double sq_radius_bound = 0.)
+  Constant_sizing_field(FT sq_radius_bound = 0.)
     : sq_radius_bound(sq_radius_bound) {}
 
   template <typename Point>
-  double operator()(const Point&) const { return sq_radius_bound; }
+  FT operator()(const Point&) const { return sq_radius_bound; }
 }; // end class Constant_sizing_field
 
 } // end namespace Poisson

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
@@ -110,18 +110,19 @@ struct Poisson_visitor {
 // The wrapper stores only pointers to the two functors.
 template <typename F1, typename F2>
 struct Special_wrapper_of_two_functions_keep_pointers {
+  typedef typename F2::FT FT;
   F1 *f1;
   F2 *f2;
   Special_wrapper_of_two_functions_keep_pointers(F1* f1, F2* f2)
     : f1(f1), f2(f2) {}
 
   template <typename X>
-  double operator()(const X& x) const {
+  FT operator()(const X& x) const {
     return (std::max)((*f1)(x), CGAL::square((*f2)(x)));
   }
 
   template <typename X>
-  double operator()(const X& x) {
+  FT operator()(const X& x) {
     return (std::max)((*f1)(x), CGAL::square((*f2)(x)));
   }
 }; // end struct Special_wrapper_of_two_functions_keep_pointers<F1, F2>
@@ -211,7 +212,7 @@ private:
   {
   private:
     std::atomic<Cache_state> m_state;
-    std::array<double, 9> m_bary;
+    std::array<FT, 9> m_bary;
   public:
     Cached_bary_coord() : m_state (UNINITIALIZED) { }
 
@@ -242,8 +243,8 @@ private:
 
     void set_initialized() { m_state = INITIALIZED; }
 
-    const double& operator[] (const std::size_t& idx) const { return m_bary[idx]; }
-    double& operator[] (const std::size_t& idx) { return m_bary[idx]; }
+    const FT& operator[] (const std::size_t& idx) const { return m_bary[idx]; }
+    FT& operator[] (const std::size_t& idx) { return m_bary[idx]; }
   };
 
   // Wrapper for thread safety of maintained cell hint for fast

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -96,7 +96,7 @@ namespace CGAL {
     typedef typename Kernel::Sphere_3 Sphere;
 
     typedef CGAL::Poisson_reconstruction_function<Kernel> Poisson_reconstruction_function;
-    typedef CGAL::Surface_mesh_default_triangulation_3 STr;
+    typedef typename CGAL::Surface_mesher::Surface_mesh_default_triangulation_3_generator<Kernel>::Type STr;
     typedef CGAL::Surface_mesh_complex_2_in_triangulation_3<STr> C2t3;
     typedef CGAL::Implicit_surface_3<Kernel, Poisson_reconstruction_function> Surface_3;
 

--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -94,6 +94,7 @@ namespace CGAL {
     typedef typename boost::property_traits<PointMap>::value_type Point;
     typedef typename Kernel_traits<Point>::Kernel Kernel;
     typedef typename Kernel::Sphere_3 Sphere;
+    typedef typename Kernel::FT FT;
 
     typedef CGAL::Poisson_reconstruction_function<Kernel> Poisson_reconstruction_function;
     typedef typename CGAL::Surface_mesher::Surface_mesh_default_triangulation_3_generator<Kernel>::Type STr;
@@ -106,10 +107,10 @@ namespace CGAL {
 
     Point inner_point = function.get_inner_point();
     Sphere bsphere = function.bounding_sphere();
-    double radius = std::sqrt(bsphere.squared_radius());
+    FT radius = CGAL::approximate_sqrt(bsphere.squared_radius());
 
-    double sm_sphere_radius = 5.0 * radius;
-    double sm_dichotomy_error = sm_distance * spacing / 1000.0;
+    FT sm_sphere_radius = 5.0 * radius;
+    FT sm_dichotomy_error = sm_distance * spacing / 1000.0;
 
     Surface_3 surface(function,
                       Sphere (inner_point, sm_sphere_radius * sm_sphere_radius),


### PR DESCRIPTION
## Summary of Changes

Poisson currently only compiles with Epick (see https://github.com/CGAL/cgal/issues/5431). This PR makes it compile with simple cartesian (both using double and float). However, the code rarely works at runtime (because it is based on Delaunay triangulation which are not robust without exact predicates), so I couldn't add a test for this.

I have tried to make it compile with Epeck, but it required many changes (including changes in Surface Mesher) and ended up breaking the Epick version, so I figured it was not worth the trouble.

## Release Management

* Affected package(s): Poisson
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/5431

