### PR TITLE
Restore Dependencies Info

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1298,3 +1298,22 @@ if(NOT CGAL_BRANCH_BUILD AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/doc")
   # in a non-branch build this is the top-level CMakeLists.txt
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/doc")
 endif()
+
+#print some info about versions
+if(RUNNING_CGAL_AUTO_TEST)
+  find_package(Qt5 QUIET COMPONENTS Core)
+  if(NOT CGAL_DISABLE_GMP)
+    find_package(GMP)
+    find_package(MPFR)
+    find_package(Boost)
+    get_dependency_version(GMP)
+    get_dependency_version(MPFR)
+    message(
+      STATUS
+        "USING BOOST_VERSION = '${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}'"
+    )
+    if(Qt5_FOUND)
+      message(STATUS "USING Qt5_VERSION = '${Qt5Core_VERSION_STRING}'")
+    endif()#Qt5_FOUND
+  endif()#NOT CGAL_DISABLE_GMP
+endif()#RUNNING_CGAL_AUTO_TEST

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1302,18 +1302,20 @@ endif()
 #print some info about versions
 if(RUNNING_CGAL_AUTO_TEST)
   find_package(Qt5 QUIET COMPONENTS Core)
+  find_package(Boost)
   if(NOT CGAL_DISABLE_GMP)
     find_package(GMP)
     find_package(MPFR)
-    find_package(Boost)
     get_dependency_version(GMP)
     get_dependency_version(MPFR)
-    message(
-      STATUS
-        "USING BOOST_VERSION = '${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}'"
-    )
-    if(Qt5_FOUND)
-      message(STATUS "USING Qt5_VERSION = '${Qt5Core_VERSION_STRING}'")
-    endif()#Qt5_FOUND
+  elseif(WITH_LEDA)#CGAL_DISABLE_GMP
+    find_package(LEDA)
   endif()#NOT CGAL_DISABLE_GMP
+  message(
+    STATUS
+    "USING BOOST_VERSION = '${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}'"
+    )
+  if(Qt5_FOUND)
+    message(STATUS "USING Qt5_VERSION = '${Qt5Core_VERSION_STRING}'")
+  endif()#Qt5_FOUND
 endif()#RUNNING_CGAL_AUTO_TEST


### PR DESCRIPTION
## Summary of Changes
The versions of the dependency libraries were recovered throug the compilation of libCGAL, which was removed in #5063. This PR adds the code that were removed to get back those versions on the testsuite page.

##Release Management
This PR is a bug fix that only targets master because the bug  was introduced in master through #5063