### PR TITLE
Hilbert sort 3D, slow clang linking

### DIFF
--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
@@ -83,8 +83,12 @@ struct Hilbert_cmp_3<K,2,false>
 
 } // namespace internal
 
+#ifdef __clang__
+#define CGAL_VISIBILITY_MACRO __attribute__ ((visibility ("hidden")))
+#endif
+
 template <class K, class ConcurrencyTag>
-class Hilbert_sort_median_3
+class CGAL_VISIBILITY_MACRO Hilbert_sort_median_3
 {
 public:
   typedef Hilbert_sort_median_3<K, ConcurrencyTag> Self;

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
@@ -85,6 +85,8 @@ struct Hilbert_cmp_3<K,2,false>
 
 #ifdef __clang__
 #define CGAL_VISIBILITY_MACRO __attribute__ ((visibility ("hidden")))
+#else
+#define CGAL_VISIBILITY_MACRO __attribute__ ((visibility ("default")))
 #endif
 
 template <class K, class ConcurrencyTag>

--- a/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
+++ b/Spatial_sorting/include/CGAL/Hilbert_sort_median_3.h
@@ -86,7 +86,7 @@ struct Hilbert_cmp_3<K,2,false>
 #ifdef __clang__
 #define CGAL_VISIBILITY_MACRO __attribute__ ((visibility ("hidden")))
 #else
-#define CGAL_VISIBILITY_MACRO __attribute__ ((visibility ("default")))
+#define CGAL_VISIBILITY_MACRO
 #endif
 
 template <class K, class ConcurrencyTag>


### PR DESCRIPTION
Linking of the CGAL tests and examples, which depend on the Hilbert sort, with the clang compiler is very slow due to the recursion sort. The templated member function is called recursively 8 times. We have no problems with calling this function 4 times, but when calling it 5 and more times, which is required for Hilbert sort on 3D points, the linking time increases very quickly. This affects several packages.

The problem is experienced only with -03 optimizations turned on. There is no such problem with -01. By looking at the difference between -01 and -03, we figured out that the problem comes when the `-fvisibility-inlines-hidden` optimization is omitted, which is the case for -03. This optimization gives inline C++ member functions hidden visibility by default. So, one way to fix the problem is to turn on this flag for all tests globally, but this does not fix the problem but only hides it.

Over [this link](https://gist.github.com/ax3l/ba17f4bb1edb5885a6bd01f58de4d542) there is a discussion on what can be done. This PR brings this local solution to the Hilbert sort 3D and it works on my machine but should be tested for other platforms.

The change is: I have added a macro with the attribute that hides the interior class with the recursion. The class is not public anyway. If you know a better solution, please let me know so that I could test it.

## Release Management

* Affected package(s): Spatial_sorting
* Issue(s) solved (if any): slow linking in the clang test suite
* Feature/Small Feature (if any): bug
* License and copyright ownership: no change

