### PR TITLE
Bypass coplanarity assertion for triangular facets.

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -201,7 +201,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
     Vertex_around_face_circulator<PolygonMesh> vafc(halfedge(f,P),P), done(vafc);
     Vector_3 v;
     normal_vector_newell_3(vafc, done, pmap, v);
-    int i = get(fimap,f);
+    std::size_t i = get(fimap,f);
     normals[i] = -v;
     CGAL_assertion_code(num_edges[i] = circulator_size(vafc));
   }
@@ -253,7 +253,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       if(is_border(pe_prev,P))
         with_border = true;
       else {
-        int i = get(fimap,face(pe_prev,P));
+        std::size_t i = get(fimap,face(pe_prev,P));
         Plane ss_plane( CGAL::ORIGIN, normals[i]);
         Sphere_circle ss_circle(ss_plane);
         CGAL_assertion_code(if(num_edges[i] > 3) {
@@ -286,7 +286,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       with_border = true;
       e = sv_prev->out_sedge();
     } else {
-      int i = get(fimap,face(pe_prev,P));
+      std::size_t i = get(fimap,face(pe_prev,P));
       Plane ss_plane( CGAL::ORIGIN, normals[i]);
       Sphere_circle ss_circle(ss_plane);
 

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -192,21 +192,18 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
   typedef Halfedge_around_target_circulator<PolygonMesh>
                                Halfedge_around_vertex_const_circulator;
 
-  struct Face_info
-  {
-    Vector_3 normal;
-    CGAL_assertion_code(std::size_t num_edges;)
-  };
-
   PMap pmap = get(CGAL::vertex_point,P);
 
-  std::vector<Face_info> face_info(num_faces(P));
+  std::vector<Vector_3> normals(num_faces(P));
+  CGAL_assertion_code(std::vector<std::size_t>  num_edges(num_faces(P));)
 
   for(face_descriptor f : faces(P)){
     Vertex_around_face_circulator<PolygonMesh> vafc(halfedge(f,P),P), done(vafc);
     Vector_3 v;
     normal_vector_newell_3(vafc, done, pmap, v);
-    face_info[get(fimap,f)] = {-v,CGAL_assertion_code(circulator_size(vafc))};
+    int i = get(fimap,f);
+    normals[i] = -v;
+    CGAL_assertion_code(num_edges[i] = circulator_size(vafc));
   }
 
   Face_graph_index_adder<typename SNC_structure::Items,
@@ -256,11 +253,10 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       if(is_border(pe_prev,P))
         with_border = true;
       else {
-        const Face_info& fi=face_info[get(fimap,face(pe_prev,P))];
-        Plane ss_plane( CGAL::ORIGIN, fi.normal);
+        int i = get(fimap,face(pe_prev,P));
+        Plane ss_plane( CGAL::ORIGIN, normals[i]);
         Sphere_circle ss_circle(ss_plane);
-
-        CGAL_assertion_code(if(fi.num_edges > 3) {
+        CGAL_assertion_code(if(num_edges[i] > 3) {
           CGAL_assertion(ss_circle.has_on(sp));
           CGAL_assertion(ss_circle.has_on(sv_prev->point()));
         };)
@@ -290,11 +286,11 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       with_border = true;
       e = sv_prev->out_sedge();
     } else {
-      const Face_info& fi=face_info[get(fimap,face(pe_prev,P))];
-      Plane ss_plane( CGAL::ORIGIN, fi.normal);
+      int i = get(fimap,face(pe_prev,P));
+      Plane ss_plane( CGAL::ORIGIN, normals[i]);
       Sphere_circle ss_circle(ss_plane);
 
-      CGAL_assertion_code(if(fi.num_edges > 3) {
+      CGAL_assertion_code(if(num_edges[i] > 3) {
         CGAL_assertion(ss_circle.has_on(sp_0));
         CGAL_assertion(ss_circle.has_on(sv_prev->point()));
       };)

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -195,7 +195,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
   struct Face_info
   {
     Vector_3 normal;
-    CGAL_assertion_code(std::size_t num_edges);
+    CGAL_assertion_code(std::size_t num_edges;)
   };
 
   PMap pmap = get(CGAL::vertex_point,P);
@@ -261,7 +261,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
         CGAL_assertion_code(if(fi.num_edges > 3) {
           CGAL_assertion(ss_circle.has_on(sp));
           CGAL_assertion(ss_circle.has_on(sv_prev->point()));
-        });
+        };)
 
         SHalfedge_handle e = SM.new_shalfedge_pair(sv_prev, sv);
         e->circle() = ss_circle;
@@ -295,7 +295,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       CGAL_assertion_code(if(fi.num_edges > 3) {
         CGAL_assertion(ss_circle.has_on(sp_0));
         CGAL_assertion(ss_circle.has_on(sv_prev->point()));
-      });
+      };)
 
       e = SM.new_shalfedge_pair(sv_prev, sv_0);
       e->circle() = ss_circle;

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -214,10 +214,12 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
 
 
   for(vertex_descriptor pv : vertices(P) ) {
+
+    Point_3 npv = get(pmap,pv);
     Vertex_handle nv = S.new_vertex();
-    nv->point() = get(pmap,pv);
+    nv->point() = npv;
     nv->mark() = true;
-    CGAL_NEF_TRACEN("v "<< get(pmap,pv));
+    CGAL_NEF_TRACEN("v "<< npv);
 
     SM_decorator SM(&*nv);
     Halfedge_around_vertex_const_circulator pec(pv,P), pec_prev(pec), done(pec);
@@ -226,7 +228,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
     // CGAL_assertion( pe != 0 );
 
     Point_3 pe_target_0(get(pmap,target(opposite(pe,P),P)));
-    Point_3 sp_point_0(CGAL::ORIGIN+(pe_target_0 - get(pmap,pv)));
+    Point_3 sp_point_0(CGAL::ORIGIN+(pe_target_0 - npv));
     Sphere_point sp_0(sp_point_0);
     SVertex_handle sv_0 = SM.new_svertex(sp_0);
     sv_0->mark() = true;
@@ -239,11 +241,11 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
     bool with_border = false;
     do {
       CGAL_assertion(face(pe_prev,P) == face(opposite(pe,P),P));
-      CGAL_assertion(get(pmap,target(pe_prev,P)) == get(pmap,pv));
-      CGAL_assertion(get(pmap,target(pe,P)) == get(pmap,pv));
+      CGAL_assertion(get(pmap,target(pe_prev,P)) == npv);
+      CGAL_assertion(get(pmap,target(pe,P)) == npv);
 
       Point_3 pe_target = get(pmap,target(opposite(pe,P),P));
-      Point_3 sp_point = CGAL::ORIGIN+(pe_target - get(pmap,pv));
+      Point_3 sp_point = CGAL::ORIGIN+(pe_target - npv);
       Sphere_point sp(sp_point);
       SVertex_handle sv = SM.new_svertex(sp);
       sv->mark() = true;
@@ -280,8 +282,8 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
     while( pec != done );
 
     CGAL_assertion(face(pe_prev,P) == face(opposite(*pe_0,P),P));
-    CGAL_assertion(get(pmap,target(pe_prev,P)) == get(pmap,pv));
-    CGAL_assertion(get(pmap,target(*pe_0,P)) == get(pmap,pv));
+    CGAL_assertion(get(pmap,target(pe_prev,P)) == npv);
+    CGAL_assertion(get(pmap,target(*pe_0,P)) == npv);
 
     SHalfedge_handle e;
     if(is_border(pe_prev,P)) {

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -212,7 +212,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
 
   for(vertex_descriptor pv : vertices(P) ) {
 
-    Point_3 npv = get(pmap,pv);
+    typename boost::property_traits<PMap>::reference npv = get(pmap,pv);
     Vertex_handle nv = S.new_vertex();
     nv->point() = npv;
     nv->mark() = true;


### PR DESCRIPTION
## Summary of Changes

Bypass coplanarity assertion for triangular facets in `polygon_mesh_to_nef_3`

When walking the edges of a triangular facet, it is known that the 3 points of the facet will always be on a plane defined by the facet normal, so the assertions are not necessary.

The PR also removes duplicate hash table lookups of the point variable `pv`.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5379 
* Feature/Small Feature (if any): performance/speed
* License and copyright ownership: Returned to CGAL authors

