### PR TITLE
bitrot in Kernel_[23]_interface

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_functors.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_LA_functors.h
@@ -50,7 +50,7 @@ template<class R_,class Zero_> struct Construct_LA_vector
           // Makes no sense for an unknown dimension.
                 return typename Constructor::Dimension()(this->kernel().dimension());
         }
-        result_type operator()(result_type const& v)const{
+        result_type const& operator()(result_type const& v)const{
                 return v;
         }
         result_type operator()(result_type&& v)const{

--- a/NewKernel_d/include/CGAL/NewKernel_d/Kernel_2_interface.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Kernel_2_interface.h
@@ -79,10 +79,11 @@ template <class Base_> struct Kernel_2_interface : public Base_ {
                 Side_of_oriented_circle_2(Kernel const&k):sos(k){}
                 result_type operator()(Point_2 const&a, Point_2 const&b, Point_2 const&c, Point_2 const&d) {
                         //return sos(a,b,c,d);
-                        Point_2 const* t[4]={&a,&b,&c,&d};
-                        return sos(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+4));
+                        Point_2 const* t[4]={&a,&b,&c};
+                        return sos(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+3), d);
                 }
         };
+        typedef typename Get_functor<Base, Construct_ttag<Point_tag> >::type Construct_point_2;
         Less_x_2 less_x_2_object()const{ return Less_x_2(*this); }
         Less_y_2 less_y_2_object()const{ return Less_y_2(*this); }
         Compare_x_2 compare_x_2_object()const{ return Compare_x_2(*this); }
@@ -90,6 +91,7 @@ template <class Base_> struct Kernel_2_interface : public Base_ {
         Compare_distance_2 compare_distance_2_object()const{ return Compare_distance_2(*this); }
         Orientation_2 orientation_2_object()const{ return Orientation_2(*this); }
         Side_of_oriented_circle_2 side_of_oriented_circle_2_object()const{ return Side_of_oriented_circle_2(*this); }
+        Construct_point_2 construct_point_2_object()const{ return Construct_point_2(*this); }
 };
 }
 

--- a/NewKernel_d/include/CGAL/NewKernel_d/Kernel_3_interface.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Kernel_3_interface.h
@@ -76,10 +76,11 @@ template <class Base_> struct Kernel_3_interface : public Base_ {
                 Side_of_oriented_sphere_3(Kernel const&k):sos(k){}
                 result_type operator()(Point_3 const&a, Point_3 const&b, Point_3 const&c, Point_3 const&d, Point_3 const&e) {
                         //return sos(a,b,c,d);
-                        Point_3 const* t[5]={&a,&b,&c,&d,&e};
-                        return sos(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+5));
+                        Point_3 const* t[5]={&a,&b,&c,&d};
+                        return sos(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+4),e);
                 }
         };
+        typedef typename Get_functor<Base, Construct_ttag<Point_tag> >::type Construct_point_3;
 
         // I don't have the Coplanar predicates (yet)
 
@@ -88,6 +89,7 @@ template <class Base_> struct Kernel_3_interface : public Base_ {
         Compare_distance_3 compare_distance_3_object()const{ return Compare_distance_3(*this); }
         Orientation_3 orientation_3_object()const{ return Orientation_3(*this); }
         Side_of_oriented_sphere_3 side_of_oriented_sphere_3_object()const{ return Side_of_oriented_sphere_3(*this); }
+        Construct_point_3 construct_point_3_object()const{ return Construct_point_3(*this); }
 };
 }
 


### PR DESCRIPTION
## Summary of Changes

Just some bitrot in the code to give NewKernel_d an interface compatible with Kernel_23.
If all my pending PRs get merged, then I can build a 2D Delaunay triangulation with Eigen vectors as Point_2 as fast as the usual Epick.

```c++
#define CGAL_NEWKERNEL_D_USE_EIGEN_VECTOR 1
#include <CGAL/Epick_d.h>
#include <CGAL/NewKernel_d/Kernel_2_interface.h>
#include <CGAL/Triangulation_structural_filtering_traits.h>

namespace CGAL {
struct Epick_2_help1
: Cartesian_filter_K<
    Cartesian_base_d<double, CGAL::Dimension_tag<2>>,
    Cartesian_base_d<Interval_nt_advanced, CGAL::Dimension_tag<2>>,
    Cartesian_base_d<internal::Exact_field_selector<double>::Type, CGAL::Dimension_tag<2>>
  >
{
};
struct Epick_2_help2
: Cartesian_filter_K<
    Epick_2_help1,
    Cartesian_base_d<Interval_nt_advanced, CGAL::Dimension_tag<2>>,
    Cartesian_base_d<internal::Exact_ring_selector<double>::Type, CGAL::Dimension_tag<2>>,
    Functors_without_division<CGAL::Dimension_tag<2>>::type
  >
{ };
struct Epick_2_help3
: Cartesian_static_filters<CGAL::Dimension_tag<2>,Epick_2_help2,Epick_2_help3 >
{ };
struct Epick_2
: Kernel_2_interface<Epick_2_help3>
{ };
template <>
struct Triangulation_structural_filtering_traits<Epick_2> {
  typedef Tag_true Use_structural_filtering_tag;
};
}
typedef CGAL::Epick_2 K;

//#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
//typedef CGAL::Exact_predicates_inexact_constructions_kernel  K;

#include <CGAL/Delaunay_triangulation_2.h>
#include <CGAL/Timer.h>
#include <iostream>
#include <random>

typedef CGAL::Delaunay_triangulation_2<K>                    DT;
typedef DT::Point                                            Point_2;
static_assert(std::is_same<Point_2, Eigen::Vector2d>::value, "");
typedef CGAL::Timer                                          Timer;

int main(int argc,char** argv)
{
  int n = (argc > 1) ? atoi(argv[1]) : 100000;
  std::vector<Point_2> points;
  points.reserve( n );

  std::mt19937 gen(1234);
  std::uniform_real_distribution<> dis(1.0, 2.0);
  for(int i=0;i<n;++i)points.emplace_back(dis(gen),dis(gen));

  Timer timer;
  timer.start();
  DT dt;
  dt.insert(points.begin(), points.end());
  timer.stop();
  std::size_t N = dt.number_of_vertices();

  std::cout << N << " points of type " << typeid(Point_2).name() << std::endl;
  std::cout << timer.time() << " seconds\n";

}
```

Delaunay 2D is probably the limit of what works currently, many Kernel_23 functors are missing, it is just convenient to have something minimal working, also to check for performance differences.

I might add a test at some point (or just a file in benchmark), but this is undocumented, unused code, and the test above depends on other unmerged PRs anyway.

## Release Management

* Affected package(s): NewKernel_d
